### PR TITLE
fix: estimates unordered tx and adds out of gas retry

### DIFF
--- a/apps/tx-signer/package.json
+++ b/apps/tx-signer/package.json
@@ -37,6 +37,7 @@
     "@hono/zod-openapi": "0.18.4",
     "@opentelemetry/api": "^1.9.0",
     "cockatiel": "^3.2.1",
+    "cosmjs-types": "~0.11.0",
     "hono": "4.6.12",
     "http-errors": "^2.0.0",
     "lodash": "^4.17.21",

--- a/apps/tx-signer/src/config/env.config.ts
+++ b/apps/tx-signer/src/config/env.config.ts
@@ -4,7 +4,11 @@ export const envSchema = z.object({
   FUNDING_WALLET_MNEMONIC_V2: z.string(),
   DERIVATION_WALLET_MNEMONIC_V2: z.string(),
   RPC_NODE_ENDPOINT: z.string(),
-  GAS_SAFETY_MULTIPLIER: z.number({ coerce: true }).default(1.8),
+  GAS_DEFAULT_MULTIPLIER: z.number({ coerce: true }).default(1.5),
+  // When a tx still lands out of gas, it is re-signed with gasLimit = on-chain gasUsed × this multiplier and rebroadcast.
+  // gasUsed is the actual consumption measured on-chain, so a modest multiplier covers the extra settlement gas that
+  // accrues between the failed attempt and the retry's inclusion height.
+  GAS_RECOVERY_MULTIPLIER: z.number({ coerce: true }).default(1.3),
   AVERAGE_GAS_PRICE: z.number({ coerce: true }).default(0.025),
   // TTL for unordered transactions: the chain keeps the tx hash in memory for this window to reject duplicates,
   // so it must be long enough to guarantee block inclusion but short enough to bound mempool memory.

--- a/apps/tx-signer/src/lib/signing-client/signing-client.service.spec.ts
+++ b/apps/tx-signer/src/lib/signing-client/signing-client.service.spec.ts
@@ -1,15 +1,13 @@
-import { AuthInfo, TxBody } from "@akashnetwork/chain-sdk/private-types/cosmos.v1beta1";
+import { TxRaw } from "@akashnetwork/chain-sdk/private-types/cosmos.v1beta1";
 import { sha256 } from "@cosmjs/crypto";
-import { toBase64, toHex } from "@cosmjs/encoding";
-import type { EncodeObject, Registry } from "@cosmjs/proto-signing";
-import type { Account, IndexedTx, SigningStargateClient } from "@cosmjs/stargate";
-import { faker } from "@faker-js/faker";
+import { toHex } from "@cosmjs/encoding";
+import type { EncodeObject } from "@cosmjs/proto-signing";
+import type { IndexedTx } from "@cosmjs/stargate";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
-import { createAkashAddress } from "../../../test/seeders";
 import type { AppConfigService } from "../../services/app-config/app-config.service";
-import type { Wallet } from "../wallet/wallet";
+import type { SigningStargateWithUnorderedSupportClient } from "../signing-stargate-client-factory/signing-stargate-client.factory";
 import { SigningClientService } from "./signing-client.service";
 
 describe(SigningClientService.name, () => {
@@ -21,39 +19,28 @@ describe(SigningClientService.name, () => {
 
     expect(result.hash).toBe("broadcast-hash");
     expect(result.code).toBe(0);
+    expect(client.signUnordered).toHaveBeenCalledTimes(1);
     expect(client.broadcastTxSync).toHaveBeenCalledTimes(1);
     expect(client.getTx).toHaveBeenCalledWith("broadcast-hash");
   });
 
-  it("signs the transaction as unordered with a zero sequence and a future timeout", async () => {
-    const ttlMs = 120_000;
-    const { service, wallet } = setup({ ttlMs });
-    const before = Date.now();
+  it("forwards the fee granter to the signing client", async () => {
+    const { service, client } = setup();
 
-    await service.signAndBroadcast(createMessages(1));
+    await service.signAndBroadcast(createMessages(1), { fee: { granter: "akash1granter" } });
 
-    const [, signDoc] = wallet.signDirect.mock.calls[0];
-    const body = TxBody.decode(signDoc.bodyBytes);
-    const authInfo = AuthInfo.decode(signDoc.authInfoBytes);
-
-    expect(body.unordered).toBe(true);
-    expect(body.timeoutTimestamp).toBeInstanceOf(Date);
-    expect(body.timeoutTimestamp!.getTime()).toBeGreaterThanOrEqual(before + ttlMs);
-    expect(authInfo.signerInfos[0].sequence).toBe(0n);
+    expect(client.signUnordered).toHaveBeenCalledWith(expect.anything(), { granter: "akash1granter" });
   });
 
-  it("resolves multiple concurrent transactions and fetches account data only once", async () => {
-    const { service, client, wallet } = setup();
+  it("resolves multiple concurrent transactions independently", async () => {
+    const { service, client } = setup();
 
     const results = await Promise.all(Array.from({ length: 4 }, (_, index) => service.signAndBroadcast(createMessages(index))));
 
     expect(results).toHaveLength(4);
     expect(results.every(tx => tx.code === 0)).toBe(true);
+    expect(client.signUnordered).toHaveBeenCalledTimes(4);
     expect(client.broadcastTxSync).toHaveBeenCalledTimes(4);
-    expect(wallet.signDirect).toHaveBeenCalledTimes(4);
-    expect(client.getAccount).toHaveBeenCalledTimes(1);
-    expect(client.getChainId).toHaveBeenCalledTimes(1);
-    expect(wallet.getAccounts).toHaveBeenCalledTimes(1);
   });
 
   it("treats an 'already exists in cache' broadcast error as a successful broadcast", async () => {
@@ -69,12 +56,12 @@ describe(SigningClientService.name, () => {
   });
 
   it("does not let a failing transaction affect the others", async () => {
-    const { service, registry } = setup();
-    registry.encodeAsAny.mockImplementation((message: EncodeObject) => {
-      if (message.typeUrl === "/test.MsgFail") {
-        throw new Error("encoding failed");
+    const { service, client } = setup();
+    client.signUnordered.mockImplementation(async messages => {
+      if (messages.some(message => message.typeUrl === "/test.MsgFail")) {
+        throw new Error("signing failed");
       }
-      return { typeUrl: message.typeUrl, value: new TextEncoder().encode(JSON.stringify(message.value)) };
+      return signedTx();
     });
 
     const results = await Promise.allSettled([
@@ -113,75 +100,83 @@ describe(SigningClientService.name, () => {
     }
   });
 
-  it("reports pending transactions only while a broadcast is in flight", async () => {
-    const { service } = setup();
+  it("re-signs with a higher gas limit derived from the on-chain gasUsed when the transaction lands out of gas", async () => {
+    const { service, client } = setup();
+    client.getTx
+      .mockResolvedValueOnce(outOfGasTx({ gasUsed: 100n, gasWanted: 80n }))
+      .mockResolvedValueOnce(mock<IndexedTx>({ hash: "recovered", code: 0, height: 101 }));
 
-    expect(service.hasPendingTransactions).toBe(false);
+    const result = await service.signAndBroadcast(createMessages(1));
 
-    const promise = service.signAndBroadcast(createMessages(1));
-    expect(service.hasPendingTransactions).toBe(true);
+    expect(client.signUnordered).toHaveBeenCalledTimes(2);
+    // ceil(100 gasUsed × 1.3 margin) = 130.
+    expect(client.signUnordered).toHaveBeenLastCalledWith(expect.anything(), { granter: undefined, gas: 130 });
+    expect(result.code).toBe(0);
+  });
 
-    await promise;
-    expect(service.hasPendingTransactions).toBe(false);
+  it("stops retrying and returns the out-of-gas transaction after exhausting the retry limit", async () => {
+    const { service, client } = setup();
+    client.getTx.mockResolvedValue(outOfGasTx({ gasUsed: 100n, gasWanted: 80n }));
+
+    const result = await service.signAndBroadcast(createMessages(1));
+
+    // 1 initial attempt + OUT_OF_GAS_RETRY_LIMIT (3) retries = 4 signs.
+    expect(client.signUnordered).toHaveBeenCalledTimes(4);
+    expect(result.code).toBe(11);
+  });
+
+  it("returns the out-of-gas transaction without crashing when a usable retry gas limit cannot be derived", async () => {
+    const { service, client } = setup({ gasRecoveryMultiplier: NaN });
+    client.getTx.mockResolvedValue(outOfGasTx({ gasUsed: 100n, gasWanted: 80n }));
+
+    const result = await service.signAndBroadcast(createMessages(1));
+
+    // A NaN gas limit must never reach the signing client — degrade to returning the failed tx, don't throw.
+    expect(client.signUnordered).toHaveBeenCalledTimes(1);
+    expect(result.code).toBe(11);
+  });
+
+  it("does not retry a transaction that fails with a non-out-of-gas error", async () => {
+    const { service, client } = setup();
+    client.getTx.mockResolvedValue(mock<IndexedTx>({ hash: "failed", code: 5, gasUsed: 40n, gasWanted: 80n, height: 100 }));
+
+    const result = await service.signAndBroadcast(createMessages(1));
+
+    expect(client.signUnordered).toHaveBeenCalledTimes(1);
+    expect(result.code).toBe(5);
   });
 
   function createMessages(seed: number): readonly EncodeObject[] {
     return [{ typeUrl: "/test.MsgTest", value: { seed } }];
   }
 
-  function setup(input?: { ttlMs?: number }) {
-    const address = createAkashAddress();
-    const accountNumber = faker.number.int({ min: 1, max: 1000 });
-    const chainId = "test-chain";
+  function signedTx() {
+    return TxRaw.fromPartial({ bodyBytes: new Uint8Array([1]), authInfoBytes: new Uint8Array([2]), signatures: [new Uint8Array([3])] });
+  }
 
-    // A valid 33-byte compressed secp256k1 public key so the real encodeSecp256k1Pubkey pipeline accepts it.
-    const pubkey = new Uint8Array(33);
-    pubkey[0] = 0x02;
+  function outOfGasTx(input: { gasUsed: bigint; gasWanted: bigint }) {
+    return mock<IndexedTx>({ hash: "out-of-gas", code: 11, gasUsed: input.gasUsed, gasWanted: input.gasWanted, height: 100 });
+  }
 
-    const wallet = mock<Wallet>({
-      getFirstAddress: vi.fn().mockResolvedValue(address),
-      getAccounts: vi.fn().mockResolvedValue([{ address, algo: "secp256k1", pubkey }])
-    });
-    wallet.signDirect.mockImplementation(async (_address, signDoc) => ({
-      signature: { pub_key: { type: "", value: "" }, signature: toBase64(new Uint8Array(64)) },
-      signed: {
-        bodyBytes: signDoc.bodyBytes,
-        authInfoBytes: signDoc.authInfoBytes,
-        chainId: signDoc.chainId,
-        accountNumber: signDoc.accountNumber
-      }
-    }));
-
+  function setup(input?: { ttlMs?: number; gasRecoveryMultiplier?: number }) {
     const config = mock<AppConfigService>({
       get: vi.fn().mockImplementation(key => {
         const values = {
-          RPC_NODE_ENDPOINT: "http://localhost:26657",
-          GAS_SAFETY_MULTIPLIER: 1.2,
-          AVERAGE_GAS_PRICE: 0.025,
-          UNORDERED_TX_TTL_MS: input?.ttlMs ?? 180_000
+          UNORDERED_TX_TTL_MS: input?.ttlMs ?? 180_000,
+          GAS_RECOVERY_MULTIPLIER: input?.gasRecoveryMultiplier ?? 1.3
         };
         return values[key as keyof typeof values];
       })
     });
 
-    const registry = mock<Registry>({
-      encodeAsAny: vi.fn((message: EncodeObject) => ({
-        typeUrl: message.typeUrl,
-        value: new TextEncoder().encode(JSON.stringify(message.value))
-      }))
-    });
-
-    const client = mock<SigningStargateClient>({
-      getChainId: vi.fn().mockResolvedValue(chainId),
-      getAccount: vi.fn(async (addr: string) => mock<Account>({ address: addr, accountNumber })),
-      simulate: vi.fn().mockResolvedValue(2000),
+    const client = mock<SigningStargateWithUnorderedSupportClient>({
+      signUnordered: vi.fn().mockResolvedValue(signedTx()),
       broadcastTxSync: vi.fn(async (bytes: Uint8Array) => toHex(sha256(bytes))),
       getTx: vi.fn(async (hash: string) => mock<IndexedTx>({ hash, code: 0, height: 100 }))
     });
 
-    const createClientWithSigner = vi.fn(() => client);
-    const service = new SigningClientService(config, wallet, registry, createClientWithSigner);
+    const service = new SigningClientService(client, config);
 
-    return { service, client, wallet, registry, config, address, accountNumber, chainId };
+    return { service, client, config };
   }
 });

--- a/apps/tx-signer/src/lib/signing-client/signing-client.service.ts
+++ b/apps/tx-signer/src/lib/signing-client/signing-client.service.ts
@@ -1,20 +1,16 @@
-import { TxBody, TxRaw } from "@akashnetwork/chain-sdk/private-types/cosmos.v1beta1";
+import { TxRaw } from "@akashnetwork/chain-sdk/private-types/cosmos.v1beta1";
 import { withSpan } from "@akashnetwork/instrumentation";
+import type { LoggerService } from "@akashnetwork/logging";
 import { createOtelLogger } from "@akashnetwork/logging/otel";
-import { encodeSecp256k1Pubkey } from "@cosmjs/amino";
 import { sha256 } from "@cosmjs/crypto";
-import { fromBase64, toHex } from "@cosmjs/encoding";
-import type { EncodeObject, Registry } from "@cosmjs/proto-signing";
-import { encodePubkey, makeAuthInfoBytes, makeSignDoc } from "@cosmjs/proto-signing";
-import type { IndexedTx, SigningStargateClient } from "@cosmjs/stargate";
-import { calculateFee, GasPrice } from "@cosmjs/stargate";
+import { toHex } from "@cosmjs/encoding";
+import type { EncodeObject } from "@cosmjs/proto-signing";
+import type { IndexedTx } from "@cosmjs/stargate";
 import type { RetryPolicy } from "cockatiel";
 import { ConstantBackoff, handleWhenResult, retry } from "cockatiel";
 
 import type { AppConfigService } from "@src/services/app-config/app-config.service";
-import { memoizeAsync } from "../../caching/helpers/helpers";
-import type { CreateSigningStargateClient } from "../signing-stargate-client-factory/signing-stargate-client.factory";
-import type { Wallet } from "../wallet/wallet";
+import type { SigningStargateWithUnorderedSupportClient } from "../signing-stargate-client-factory/signing-stargate-client.factory";
 
 export interface SignAndBroadcastOptions {
   fee?: {
@@ -33,68 +29,39 @@ const TX_RECOVERY_POLL_INTERVAL_MS = 2_000;
 const TX_RECOVERY_WINDOW_FACTOR = 1.2;
 
 /**
- * Signs and broadcasts Akash transactions as {@link https://docs.cosmos.network/sdk/latest/reference/architecture/adr-070-unordered-account | unordered}
- * cosmos-sdk transactions: every tx sets `unordered: true`, a `timeoutTimestamp` TTL, and a zero sequence. The chain deduplicates by
- * tx hash within the TTL window instead of by account sequence, so transactions no longer need to be serialized or numbered — they can
- * be signed and broadcast fully concurrently, which removes the account-sequence-mismatch failure mode entirely.
+ * How many times a tx that lands out of gas is re-signed with a higher gas limit and rebroadcast. Gas for some messages
+ * (e.g. an escrow deposit settling accrued rent) grows with the block height they land in, so simulation structurally
+ * under-counts and the first attempt can land short. Each retry learns the actual on-chain `gasUsed`, so the limit climbs
+ * monotonically and converges within a couple of attempts.
  */
+const OUT_OF_GAS_RETRY_LIMIT = 3;
+
+/** Cosmos SDK `ErrOutOfGas` code (root `sdk` codespace). */
+const OUT_OF_GAS_CODE = 11;
+
 export class SigningClientService {
-  readonly #MEMO = "akash console";
-
-  readonly #FEES_DENOM = "uakt";
-
-  #client: SigningStargateClient;
-
-  #inFlightCount = 0;
+  readonly #client: SigningStargateWithUnorderedSupportClient;
 
   readonly #txRecoveryExecutor: RetryPolicy;
 
-  readonly #getChainId = memoizeAsync(() => this.#client.getChainId());
+  readonly #gasRecoveryMultiplier: number;
 
-  readonly #getAddress = memoizeAsync(() => this.wallet.getFirstAddress());
+  readonly #logger: LoggerService;
 
-  readonly #getAccountNumber = memoizeAsync(async () => {
-    const account = await this.#client.getAccount(await this.#getAddress());
-
-    if (!account) {
-      throw new Error("Failed to get account info");
-    }
-
-    return account.accountNumber;
-  });
-
-  readonly #getPubkey = memoizeAsync(async () => {
-    const [account] = await this.wallet.getAccounts();
-    return encodePubkey(encodeSecp256k1Pubkey(account.pubkey));
-  });
-
-  readonly #logger = createOtelLogger({ context: this.loggerContext });
-
-  get hasPendingTransactions() {
-    return this.#inFlightCount > 0;
-  }
-
-  constructor(
-    private readonly config: AppConfigService,
-    private readonly wallet: Wallet,
-    private readonly registry: Registry,
-    createClientWithSigner: CreateSigningStargateClient,
-    private readonly loggerContext = SigningClientService.name
-  ) {
-    this.#client = createClientWithSigner(this.config.get("RPC_NODE_ENDPOINT"), this.wallet, {
-      registry: this.registry
-    });
+  constructor(client: SigningStargateWithUnorderedSupportClient, config: AppConfigService, loggerContext = SigningClientService.name) {
+    this.#client = client;
     this.#txRecoveryExecutor = retry(
       handleWhenResult(res => !res),
       {
-        maxAttempts: Math.ceil((this.config.get("UNORDERED_TX_TTL_MS") * TX_RECOVERY_WINDOW_FACTOR) / TX_RECOVERY_POLL_INTERVAL_MS),
+        maxAttempts: Math.ceil((config.get("UNORDERED_TX_TTL_MS") * TX_RECOVERY_WINDOW_FACTOR) / TX_RECOVERY_POLL_INTERVAL_MS),
         backoff: new ConstantBackoff(TX_RECOVERY_POLL_INTERVAL_MS)
       }
     );
+    this.#gasRecoveryMultiplier = config.get("GAS_RECOVERY_MULTIPLIER");
+    this.#logger = createOtelLogger({ context: loggerContext });
   }
 
   async signAndBroadcast(messages: readonly EncodeObject[], options?: SignAndBroadcastOptions): Promise<IndexedTx> {
-    this.#inFlightCount++;
     this.#logger.debug({
       event: "SIGN_AND_BROADCAST_BEGIN",
       messageTypes: messages.map(m => m.typeUrl),
@@ -102,54 +69,70 @@ export class SigningClientService {
     });
 
     try {
-      const txHash = await withSpan("SigningClientService.signAndBroadcast", async () => {
-        const signedTx = await this.#signUnordered(messages, options);
-        return await this.#broadcast(signedTx);
-      });
+      let gas: number | undefined;
 
-      const tx = await this.#tryRecoverTransaction(txHash);
+      for (let attempt = 0; ; attempt++) {
+        const txHash = await withSpan("SigningClientService.signAndBroadcast", async () => {
+          const signedTx = await this.#client.signUnordered(messages, { granter: options?.fee?.granter, gas });
+          return await this.#broadcast(signedTx);
+        });
 
-      if (!tx) {
-        const error = new Error("Failed to sign and broadcast transaction");
-        this.#logger.error({ event: "SIGN_AND_BROADCAST_TX_NOT_FOUND", txHash, error });
-        throw error;
+        const tx = await this.#tryRecoverTransaction(txHash);
+
+        if (!tx) {
+          const error = new Error("Failed to sign and broadcast transaction");
+          this.#logger.error({ event: "SIGN_AND_BROADCAST_TX_NOT_FOUND", txHash, error });
+          throw error;
+        }
+
+        if (this.#isOutOfGas(tx) && attempt < OUT_OF_GAS_RETRY_LIMIT) {
+          const nextGasLimit = this.#nextGasLimit(tx);
+
+          if (nextGasLimit !== undefined) {
+            gas = nextGasLimit;
+            this.#logger.warn({
+              event: "SIGN_AND_BROADCAST_OUT_OF_GAS_RETRY",
+              txHash,
+              attempt: attempt + 1,
+              gasWanted: Number(tx.gasWanted),
+              gasUsed: Number(tx.gasUsed),
+              nextGasLimit
+            });
+            continue;
+          }
+
+          // We can't derive a usable gas limit (e.g. a missing/misconfigured margin) — don't crash the sign flow, just
+          // return the out-of-gas tx as the terminal result, matching the behavior before gas recovery existed.
+          this.#logger.error({
+            event: "SIGN_AND_BROADCAST_OUT_OF_GAS_UNRECOVERABLE",
+            txHash,
+            gasWanted: Number(tx.gasWanted),
+            gasUsed: Number(tx.gasUsed)
+          });
+        }
+
+        this.#logger.debug({ event: "SIGN_AND_BROADCAST_SUCCESS", txHash, height: tx.height, code: tx.code });
+
+        return tx;
       }
-
-      this.#logger.debug({ event: "SIGN_AND_BROADCAST_SUCCESS", txHash, height: tx.height });
-
-      return tx;
     } catch (error) {
       this.#logger.debug({ event: "SIGN_AND_BROADCAST_ERROR", error });
       throw error;
-    } finally {
-      this.#inFlightCount--;
     }
   }
 
-  async #signUnordered(messages: readonly EncodeObject[], options?: SignAndBroadcastOptions): Promise<TxRaw> {
-    const [address, chainId, accountNumber, pubkey] = await Promise.all([this.#getAddress(), this.#getChainId(), this.#getAccountNumber(), this.#getPubkey()]);
+  #isOutOfGas(tx: IndexedTx): boolean {
+    // Corroborate the code with the physical signature of an out-of-gas abort — execution consumed at least the whole
+    // gas limit — so a code 11 from a non-root codespace can't false-positive a retry.
+    return tx.code === OUT_OF_GAS_CODE && tx.gasUsed >= tx.gasWanted;
+  }
 
-    const fee = await this.#estimateFee(messages, this.#FEES_DENOM, options?.fee?.granter);
-
-    const bodyBytes = TxBody.encode(
-      TxBody.fromPartial({
-        messages: messages.map(message => this.registry.encodeAsAny(message)),
-        memo: this.#MEMO,
-        unordered: true,
-        timeoutTimestamp: new Date(Date.now() + this.config.get("UNORDERED_TX_TTL_MS"))
-      })
-    ).finish();
-
-    // sequence MUST be 0 for unordered transactions; the chain rejects a non-zero sequence when unordered is set.
-    const authInfoBytes = makeAuthInfoBytes([{ pubkey, sequence: 0 }], fee.amount, Number(fee.gas), fee.granter, fee.payer);
-    const signDoc = makeSignDoc(bodyBytes, authInfoBytes, chainId, accountNumber);
-    const { signature, signed } = await this.wallet.signDirect(address, signDoc);
-
-    return TxRaw.fromPartial({
-      bodyBytes: signed.bodyBytes,
-      authInfoBytes: signed.authInfoBytes,
-      signatures: [fromBase64(signature.signature)]
-    });
+  #nextGasLimit(tx: IndexedTx): number | undefined {
+    // `gasUsed` is where execution aborted, so the true requirement is at least this — the multiplier covers that plus the
+    // extra settlement gas that accrues between this failed attempt and the retry's (later) inclusion height. Guard the
+    // result: a non-integer (e.g. NaN from a missing multiplier) must never reach cosmjs `calculateFee`, which throws on one.
+    const nextGasLimit = Math.ceil(Number(tx.gasUsed) * this.#gasRecoveryMultiplier);
+    return Number.isSafeInteger(nextGasLimit) && nextGasLimit > 0 ? nextGasLimit : undefined;
   }
 
   async #broadcast(signedTx: TxRaw): Promise<string> {
@@ -171,14 +154,5 @@ export class SigningClientService {
       this.#logger.debug({ event: "TX_RECOVERY_ATTEMPT", txHash: hash, attempt: context.attempt });
       return this.#client.getTx(hash);
     });
-  }
-
-  async #estimateFee(messages: readonly EncodeObject[], denom: string, granter?: string) {
-    const gasEstimation = await this.#client.simulate(await this.#getAddress(), messages, this.#MEMO);
-    const estimatedGas = Math.ceil(gasEstimation * this.config.get("GAS_SAFETY_MULTIPLIER"));
-
-    const fee = calculateFee(estimatedGas, GasPrice.fromString(`${this.config.get("AVERAGE_GAS_PRICE")}${denom}`));
-
-    return granter ? { ...fee, granter } : fee;
   }
 }

--- a/apps/tx-signer/src/lib/signing-stargate-client-factory/signing-stargate-client.factory.spec.ts
+++ b/apps/tx-signer/src/lib/signing-stargate-client-factory/signing-stargate-client.factory.spec.ts
@@ -1,17 +1,25 @@
-import type { SigningStargateClient } from "@cosmjs/stargate";
+import { AuthInfo, SimulateResponse, TxBody, TxRaw } from "@akashnetwork/chain-sdk/private-types/cosmos.v1beta1";
+import { toBase64 } from "@cosmjs/encoding";
+import type { EncodeObject, Registry } from "@cosmjs/proto-signing";
+import type { Account } from "@cosmjs/stargate";
 import type { Comet38Client, RpcClient } from "@cosmjs/tendermint-rpc";
 import { faker } from "@faker-js/faker";
+import { SimulateRequest } from "cosmjs-types/cosmos/tx/v1beta1/service";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
+import { createAkashAddress } from "../../../test/seeders";
 import type { Wallet } from "../wallet/wallet";
-import { createSigningStargateClientFactory } from "./signing-stargate-client.factory";
+import type { UnorderedTxSignConfig } from "./signing-stargate-client.factory";
+import { createSigningStargateClientFactory, SigningStargateWithUnorderedSupportClient } from "./signing-stargate-client.factory";
+
+const SIGN_CONFIG: UnorderedTxSignConfig = { ttlMs: 180_000, gasMultiplier: 1.2, averageGasPrice: 0.025 };
 
 describe(createSigningStargateClientFactory.name, () => {
   it("builds an RpcClient via the injected factory and passes it to Comet38Client", () => {
     const endpoint = faker.internet.url();
     const signer = mock<Wallet>();
-    const mockClient = mock<SigningStargateClient>({});
+    const mockClient = mock<SigningStargateWithUnorderedSupportClient>({});
     const mockCometClient = mock<Comet38Client>();
     const mockRpcClient = mock<RpcClient>();
 
@@ -22,21 +30,21 @@ describe(createSigningStargateClientFactory.name, () => {
     } as unknown as typeof Comet38Client;
 
     const factory = createSigningStargateClientFactory(createRpcClient, MockComet38Client, mockFactory);
-    const result = factory(endpoint, signer);
+    const result = factory(endpoint, signer, { signConfig: SIGN_CONFIG });
 
     expect(createRpcClient).toHaveBeenCalledWith(endpoint);
     expect(MockComet38Client.create).toHaveBeenCalledWith(mockRpcClient);
-    expect(mockFactory).toHaveBeenCalledWith(mockCometClient, signer, {});
+    expect(mockFactory).toHaveBeenCalledWith(mockCometClient, signer, { signConfig: SIGN_CONFIG });
     expect(result).toBe(mockClient);
   });
 
-  it("forwards optional registry to the SigningStargateClient factory", () => {
+  it("forwards the registry and sign config to the client factory", () => {
     const endpoint = faker.internet.url();
     const signer = mock<Wallet>();
-    const mockClient = mock<SigningStargateClient>({});
+    const mockClient = mock<SigningStargateWithUnorderedSupportClient>({});
     const mockCometClient = mock<Comet38Client>();
     const mockRpcClient = mock<RpcClient>();
-    const registry = { encode: vi.fn() } as never;
+    const registry = mock<Registry>();
 
     const createRpcClient = vi.fn().mockReturnValue(mockRpcClient);
     const mockFactory = vi.fn().mockReturnValue(mockClient);
@@ -45,8 +53,125 @@ describe(createSigningStargateClientFactory.name, () => {
     } as unknown as typeof Comet38Client;
 
     const factory = createSigningStargateClientFactory(createRpcClient, MockComet38Client, mockFactory);
-    factory(endpoint, signer, { registry });
+    factory(endpoint, signer, { registry, signConfig: SIGN_CONFIG });
 
-    expect(mockFactory).toHaveBeenCalledWith(mockCometClient, signer, { registry });
+    expect(mockFactory).toHaveBeenCalledWith(mockCometClient, signer, { registry, signConfig: SIGN_CONFIG });
   });
+});
+
+describe(SigningStargateWithUnorderedSupportClient.name, () => {
+  it("signs an unordered transaction with a zero sequence and a future timeout", async () => {
+    const ttlMs = 120_000;
+    const { client } = setup({ ttlMs });
+    const before = Date.now();
+
+    const txRaw = await client.signUnordered(createMessages());
+
+    const body = TxBody.decode(txRaw.bodyBytes);
+    const authInfo = AuthInfo.decode(txRaw.authInfoBytes);
+
+    expect(body.unordered).toBe(true);
+    expect(body.timeoutTimestamp).toBeInstanceOf(Date);
+    expect(body.timeoutTimestamp!.getTime()).toBeGreaterThanOrEqual(before + ttlMs);
+    expect(authInfo.signerInfos[0].sequence).toBe(0n);
+  });
+
+  it("estimates gas by simulating the unordered tx body and applies the safety multiplier", async () => {
+    const { client, abciQuery } = setup({ gasUsed: 2000, gasMultiplier: 1.2 });
+
+    const txRaw = await client.signUnordered(createMessages());
+
+    // The gas must be simulated for the exact unordered tx that gets broadcast so the estimate accounts for the extra
+    // ante-handler nonce write; otherwise the tx lands out of gas (code 11).
+    const simulatedTxBytes = SimulateRequest.decode(abciQuery.mock.calls[0][0].data).txBytes;
+    expect(TxBody.decode(TxRaw.decode(simulatedTxBytes).bodyBytes).unordered).toBe(true);
+
+    // 2000 simulated gas × 1.2 safety multiplier = 2400.
+    expect(AuthInfo.decode(txRaw.authInfoBytes).fee!.gasLimit).toBe(2400n);
+  });
+
+  it("uses the provided gas limit verbatim and skips simulation when a gas override is passed", async () => {
+    const { client, abciQuery } = setup({ gasMultiplier: 1.3 });
+
+    const txRaw = await client.signUnordered(createMessages(), { gas: 5000 });
+
+    // The gas-recovery path must not re-simulate — the override comes from the actual on-chain gasUsed, which is more
+    // reliable than the simulate estimate that under-counted in the first place.
+    expect(abciQuery).not.toHaveBeenCalled();
+    expect(AuthInfo.decode(txRaw.authInfoBytes).fee!.gasLimit).toBe(5000n);
+  });
+
+  it("attaches the fee granter to the signed transaction when provided", async () => {
+    const { client } = setup();
+
+    const txRaw = await client.signUnordered(createMessages(), { granter: "akash1granter" });
+
+    expect(AuthInfo.decode(txRaw.authInfoBytes).fee!.granter).toBe("akash1granter");
+  });
+
+  it("fetches chain id and account data only once across concurrent signs", async () => {
+    const { client, wallet, getChainId, getAccount } = setup();
+
+    await Promise.all(Array.from({ length: 4 }, () => client.signUnordered(createMessages())));
+
+    expect(getChainId).toHaveBeenCalledTimes(1);
+    expect(getAccount).toHaveBeenCalledTimes(1);
+    expect(wallet.getAccounts).toHaveBeenCalledTimes(1);
+  });
+
+  function createMessages(): readonly EncodeObject[] {
+    return [{ typeUrl: "/test.MsgTest", value: {} }];
+  }
+
+  function setup(input?: { ttlMs?: number; gasUsed?: number; gasMultiplier?: number }) {
+    const address = createAkashAddress();
+    const accountNumber = faker.number.int({ min: 1, max: 1000 });
+    const gasUsed = input?.gasUsed ?? 2000;
+
+    // A valid 33-byte compressed secp256k1 public key so the real encodeSecp256k1Pubkey pipeline accepts it.
+    const pubkey = new Uint8Array(33);
+    pubkey[0] = 0x02;
+
+    const wallet = mock<Wallet>({
+      getAccounts: vi.fn().mockResolvedValue([{ address, algo: "secp256k1", pubkey }])
+    });
+    wallet.signDirect.mockImplementation(async (_address, signDoc) => ({
+      signature: { pub_key: { type: "", value: "" }, signature: toBase64(new Uint8Array(64)) },
+      signed: {
+        bodyBytes: signDoc.bodyBytes,
+        authInfoBytes: signDoc.authInfoBytes,
+        chainId: signDoc.chainId,
+        accountNumber: signDoc.accountNumber
+      }
+    }));
+
+    const registry = mock<Registry>({
+      encodeAsAny: vi.fn((message: EncodeObject) => ({
+        typeUrl: message.typeUrl,
+        value: new TextEncoder().encode(JSON.stringify(message.value))
+      }))
+    });
+
+    // Gas estimation runs the real #simulateRawTx through the query client, so mock the underlying ABCI query.
+    const abciQuery = vi.fn().mockResolvedValue({
+      code: 0,
+      value: SimulateResponse.encode(SimulateResponse.fromPartial({ gasInfo: { gasUsed: BigInt(gasUsed), gasWanted: BigInt(gasUsed) } })).finish(),
+      height: 1
+    });
+    const cometClient = mock<Comet38Client>({ abciQuery });
+
+    const client = SigningStargateWithUnorderedSupportClient.createWithSigner(cometClient, wallet, {
+      registry,
+      signConfig: {
+        ttlMs: input?.ttlMs ?? 180_000,
+        gasMultiplier: input?.gasMultiplier ?? 1.2,
+        averageGasPrice: 0.025
+      }
+    });
+
+    const getChainId = vi.spyOn(client, "getChainId").mockResolvedValue("test-chain");
+    const getAccount = vi.spyOn(client, "getAccount").mockResolvedValue(mock<Account>({ address, accountNumber }));
+
+    return { client, wallet, registry, cometClient, abciQuery, getChainId, getAccount, address, accountNumber };
+  }
 });

--- a/apps/tx-signer/src/lib/signing-stargate-client-factory/signing-stargate-client.factory.ts
+++ b/apps/tx-signer/src/lib/signing-stargate-client-factory/signing-stargate-client.factory.ts
@@ -1,35 +1,182 @@
-import type { Registry } from "@cosmjs/proto-signing";
-import { SigningStargateClient } from "@cosmjs/stargate";
-import type { RpcClient } from "@cosmjs/tendermint-rpc";
+import { TxBody, TxRaw } from "@akashnetwork/chain-sdk/private-types/cosmos.v1beta1";
+import { encodeSecp256k1Pubkey } from "@cosmjs/amino";
+import { fromBase64 } from "@cosmjs/encoding";
+import type { EncodeObject, OfflineSigner, Registry } from "@cosmjs/proto-signing";
+import type { OfflineDirectSigner } from "@cosmjs/proto-signing";
+import { encodePubkey, isOfflineDirectSigner, makeAuthInfoBytes, makeSignDoc } from "@cosmjs/proto-signing";
+import type { SigningStargateClientOptions } from "@cosmjs/stargate";
+import { calculateFee, createProtobufRpcClient, GasPrice, SigningStargateClient } from "@cosmjs/stargate";
+import type { CometClient, RpcClient } from "@cosmjs/tendermint-rpc";
 import { Comet38Client, HttpClient } from "@cosmjs/tendermint-rpc";
+import { SignMode } from "cosmjs-types/cosmos/tx/signing/v1beta1/signing";
+import { ServiceClientImpl, SimulateRequest } from "cosmjs-types/cosmos/tx/v1beta1/service";
 import { randomUUID } from "node:crypto";
 
 import type { Wallet } from "@src/lib/wallet/wallet";
+import { memoizeAsync } from "../../caching/helpers/helpers";
 import { RetryingRpcClient } from "../retrying-rpc-client/retrying-rpc-client";
 
-export type CreateSigningStargateClient = (endpoint: string, wallet: Wallet, options?: { registry?: Registry }) => SigningStargateClient;
+const MEMO = "akash console";
+const FEES_DENOM = "uakt";
+
+export interface UnorderedTxSignConfig {
+  /** Added to `Date.now()` to derive the tx `timeoutTimestamp` (the unordered-tx TTL). */
+  ttlMs: number;
+  /** Multiplier applied to the simulated gas to derive `gasWanted`. */
+  gasMultiplier: number;
+  /** Average gas price in {@link FEES_DENOM}, e.g. `0.025`. */
+  averageGasPrice: number;
+}
+
+type SimulatingSigningStargateClientOptions = SigningStargateClientOptions & { signConfig: UnorderedTxSignConfig };
+
+export class SigningStargateWithUnorderedSupportClient extends SigningStargateClient {
+  #queryClientService?: ServiceClientImpl;
+
+  readonly #signer: OfflineDirectSigner;
+
+  readonly #signConfig: UnorderedTxSignConfig;
+
+  readonly #getChainId = memoizeAsync(() => this.getChainId());
+
+  readonly #getFirstAccount = memoizeAsync(async () => (await this.#signer.getAccounts())[0]);
+
+  readonly #getAddress = memoizeAsync(async () => (await this.#getFirstAccount()).address);
+
+  readonly #getPubkey = memoizeAsync(async () => encodePubkey(encodeSecp256k1Pubkey((await this.#getFirstAccount()).pubkey)));
+
+  readonly #getAccountNumber = memoizeAsync(async () => {
+    const account = await this.getAccount(await this.#getAddress());
+
+    if (!account) {
+      throw new Error("Failed to get account info");
+    }
+
+    return account.accountNumber;
+  });
+
+  static createWithSigner(
+    cometClient: CometClient,
+    signer: OfflineSigner,
+    options: SimulatingSigningStargateClientOptions
+  ): SigningStargateWithUnorderedSupportClient {
+    return new SigningStargateWithUnorderedSupportClient(cometClient, signer, options);
+  }
+
+  protected constructor(cometClient: CometClient | undefined, signer: OfflineSigner, options: SimulatingSigningStargateClientOptions) {
+    super(cometClient, signer, options);
+
+    if (!isOfflineDirectSigner(signer)) {
+      throw new Error("SimulatingSigningStargateClient requires a direct signer");
+    }
+
+    this.#signer = signer;
+    this.#signConfig = options.signConfig;
+  }
+
+  /**
+   * Signs Akash transactions as {@link https://docs.cosmos.network/sdk/latest/reference/architecture/adr-070-unordered-account | unordered}
+   * cosmos-sdk transactions: every tx sets `unordered: true`, a `timeoutTimestamp` TTL, and a zero sequence. The chain deduplicates by
+   * tx hash within the TTL window instead of by account sequence, so transactions no longer need to be serialized or numbered — they can
+   * be signed and broadcast fully concurrently, which removes the account-sequence-mismatch failure mode entirely.
+   *
+   * Gas is estimated with {@link #simulateRawTx} rather than the inherited `simulate(signerAddress, messages, memo)`. cosmjs's `simulate`
+   * rebuilds its own tx body from just the messages and memo — it never sets `unordered`/`timeoutTimestamp` — so it undercounts gas: an
+   * unordered tx makes the ante handler write an entry to the unordered-nonce store to dedupe replays, and that extra store write is not
+   * exercised when simulating an ordered body. The real tx then consumes more gas than estimated and lands with `code: 11` ("out of gas
+   * in location: WriteFlat"). Simulating the exact body we broadcast makes the estimate account for that write.
+   *
+   * When `options.gas` is provided the simulation step is skipped and the value is used verbatim as the gas limit. This is the
+   * gas-recovery path: some messages (e.g. an escrow deposit that settles accrued rent) consume gas that grows with the block height
+   * they land in, so simulation structurally under-counts them. After such a tx lands out of gas the caller re-signs with a gas limit
+   * derived from the actual on-chain `gasUsed` — a far more reliable figure than re-simulating, which just repeats the under-count.
+   */
+  async signUnordered(messages: readonly EncodeObject[], options?: { granter?: string; gas?: number }): Promise<TxRaw> {
+    const [address, chainId, accountNumber, pubkey] = await Promise.all([this.#getAddress(), this.#getChainId(), this.#getAccountNumber(), this.#getPubkey()]);
+
+    const bodyBytes = this.#encodeTxBody(messages);
+    const fee = await this.#estimateFee(bodyBytes, pubkey, { granter: options?.granter, gas: options?.gas });
+
+    // sequence MUST be 0 for unordered transactions; the chain rejects a non-zero sequence when unordered is set.
+    const authInfoBytes = makeAuthInfoBytes([{ pubkey, sequence: 0 }], fee.amount, Number(fee.gas), fee.granter, fee.payer);
+    const signDoc = makeSignDoc(bodyBytes, authInfoBytes, chainId, accountNumber);
+    const { signature, signed } = await this.#signer.signDirect(address, signDoc);
+
+    return TxRaw.fromPartial({
+      bodyBytes: signed.bodyBytes,
+      authInfoBytes: signed.authInfoBytes,
+      signatures: [fromBase64(signature.signature)]
+    });
+  }
+
+  async #simulateRawTx(txBytes: Uint8Array): Promise<number> {
+    this.#queryClientService ??= new ServiceClientImpl(createProtobufRpcClient(this.forceGetQueryClient()));
+    const { gasInfo } = await this.#queryClientService.Simulate(SimulateRequest.fromPartial({ txBytes }));
+
+    if (!gasInfo) {
+      throw new Error("Failed to simulate transaction: no gas info returned");
+    }
+
+    return Number(gasInfo.gasUsed);
+  }
+
+  #encodeTxBody(messages: readonly EncodeObject[]): Uint8Array {
+    return TxBody.encode(
+      TxBody.fromPartial({
+        messages: messages.map(message => this.registry.encodeAsAny(message)),
+        memo: MEMO,
+        unordered: true,
+        timeoutTimestamp: new Date(Date.now() + this.#signConfig.ttlMs)
+      })
+    ).finish();
+  }
+
+  async #estimateFee(bodyBytes: Uint8Array, pubkey: ReturnType<typeof encodePubkey>, options: { granter?: string; gas?: number }) {
+    const gas = options.gas ?? (await this.#estimateGas(bodyBytes, pubkey));
+    const fee = calculateFee(gas, GasPrice.fromString(`${this.#signConfig.averageGasPrice}${FEES_DENOM}`));
+
+    return options.granter ? { ...fee, granter: options.granter } : fee;
+  }
+
+  async #estimateGas(bodyBytes: Uint8Array, pubkey: ReturnType<typeof encodePubkey>): Promise<number> {
+    // Empty fee with an unset sign mode: this keeps the node treating the tx as a gas simulation rather than one to
+    // execute (it skips signature verification when simulating). Sequence stays 0 to match the unordered tx we sign.
+    const authInfoBytes = makeAuthInfoBytes([{ pubkey, sequence: 0 }], [], 0, undefined, undefined, SignMode.SIGN_MODE_UNSPECIFIED);
+    const txBytes = TxRaw.encode(TxRaw.fromPartial({ bodyBytes, authInfoBytes, signatures: [new Uint8Array()] })).finish();
+
+    const gasEstimation = await this.#simulateRawTx(txBytes);
+    return Math.ceil(gasEstimation * this.#signConfig.gasMultiplier);
+  }
+}
+
+export type CreateSigningStargateClient = (
+  endpoint: string,
+  wallet: Wallet,
+  options: { registry?: Registry; signConfig: UnorderedTxSignConfig }
+) => SigningStargateWithUnorderedSupportClient;
 
 export const createSigningStargateClientFactory =
   (
     createRpcClient: (endpoint: string) => RpcClient,
     ProvidedComet38Client: typeof Comet38Client,
-    factory: typeof SigningStargateClient.createWithSigner
+    factory: typeof SigningStargateWithUnorderedSupportClient.createWithSigner
   ): CreateSigningStargateClient =>
-  (endpoint, signer, options = {}): SigningStargateClient => {
+  (endpoint, signer, options): SigningStargateWithUnorderedSupportClient => {
     const rpcClient = createRpcClient(endpoint);
     const cometClient = ProvidedComet38Client.create(rpcClient);
     return factory(cometClient, signer, options);
   };
 
 export const createSigningStargateClient: CreateSigningStargateClient = createSigningStargateClientFactory(
-  (endpoint: string) => new RetryingRpcClient(
-    new HttpClient({
-      url: endpoint,
-      headers: {
-        "X-Proxy-Key": randomUUID()
-      }
-    })
-  ),
+  (endpoint: string) =>
+    new RetryingRpcClient(
+      new HttpClient({
+        url: endpoint,
+        headers: {
+          "X-Proxy-Key": randomUUID()
+        }
+      })
+    ),
   Comet38Client,
-  SigningStargateClient.createWithSigner
+  SigningStargateWithUnorderedSupportClient.createWithSigner
 );

--- a/apps/tx-signer/src/lib/wallet/wallet.ts
+++ b/apps/tx-signer/src/lib/wallet/wallet.ts
@@ -1,8 +1,7 @@
 import type { AminoSignResponse, OfflineAminoSigner, StdSignDoc } from "@cosmjs/amino";
 import { makeCosmoshubPath, Secp256k1HdWallet } from "@cosmjs/amino";
-import type { DirectSignResponse, OfflineDirectSigner } from "@cosmjs/proto-signing";
+import type { DirectSecp256k1HdWalletOptions, DirectSignResponse, OfflineDirectSigner } from "@cosmjs/proto-signing";
 import { DirectSecp256k1HdWallet } from "@cosmjs/proto-signing";
-import type { DirectSecp256k1HdWalletOptions } from "@cosmjs/proto-signing/build/directsecp256k1hdwallet";
 
 export const WALLET_ADDRESS_PREFIX = "akash";
 

--- a/apps/tx-signer/src/services/tx-manager/tx-manager.service.spec.ts
+++ b/apps/tx-signer/src/services/tx-manager/tx-manager.service.spec.ts
@@ -70,21 +70,18 @@ describe(TxManagerService.name, () => {
 
       const { service, logger, derivedWallet, signingClientServiceFactory } = setup({
         derivedWalletAddress: address,
-        derivedSignAndBroadcast: vi.fn().mockResolvedValue(txResult),
-        hasPendingTransactions: false
+        derivedSignAndBroadcast: vi.fn().mockResolvedValue(txResult)
       });
 
       const result = await service.signAndBroadcastWithDerivedWallet(derivationIndex, messages, options);
 
-      expect(derivedWallet.getFirstAddress).toHaveBeenCalled();
       expect(signingClientServiceFactory).toHaveBeenCalledWith(derivedWallet);
       expect(logger.debug).toHaveBeenCalledWith({ event: "DERIVED_SIGNING_CLIENT_CREATE", derivationIndex });
       expect(result).toEqual(txResult);
     });
 
-    it("cleans up client when no pending transactions", async () => {
+    it("reuses the cached client across calls for the same derivation index", async () => {
       const derivationIndex = 1;
-      const address = createAkashAddress();
       const messages: EncodeObject[] = [
         {
           typeUrl: "/test.MsgTest",
@@ -97,46 +94,19 @@ describe(TxManagerService.name, () => {
         rawLog: "success"
       });
 
-      const { service, logger } = setup({
-        derivedWalletAddress: address,
-        derivedSignAndBroadcast: vi.fn().mockResolvedValue(txResult),
-        hasPendingTransactions: false
+      const { service, signingClientServiceFactory } = setup({
+        derivedWalletAddress: createAkashAddress(),
+        derivedSignAndBroadcast: vi.fn().mockResolvedValue(txResult)
       });
 
       await service.signAndBroadcastWithDerivedWallet(derivationIndex, messages);
-
-      expect(logger.debug).toHaveBeenCalledWith({ event: "DEDUPE_SIGNING_CLIENT_CLEAN_UP", derivationIndex });
-    });
-
-    it("keeps client when has pending transactions", async () => {
-      const derivationIndex = 1;
-      const address = createAkashAddress();
-      const messages: EncodeObject[] = [
-        {
-          typeUrl: "/test.MsgTest",
-          value: {}
-        }
-      ];
-      const txResult = mock<IndexedTx>({
-        code: 0,
-        hash: "tx-hash",
-        rawLog: "success"
-      });
-
-      const { service, logger } = setup({
-        derivedWalletAddress: address,
-        derivedSignAndBroadcast: vi.fn().mockResolvedValue(txResult),
-        hasPendingTransactions: true
-      });
-
       await service.signAndBroadcastWithDerivedWallet(derivationIndex, messages);
 
-      expect(logger.debug).not.toHaveBeenCalledWith({ event: "DEDUPE_SIGNING_CLIENT_CLEAN_UP", derivationIndex });
+      expect(signingClientServiceFactory).toHaveBeenCalledTimes(1);
     });
 
-    it("cleans up client even when transaction fails", async () => {
+    it("propagates the error when the transaction fails", async () => {
       const derivationIndex = 1;
-      const address = createAkashAddress();
       const messages: EncodeObject[] = [
         {
           typeUrl: "/test.MsgTest",
@@ -145,15 +115,12 @@ describe(TxManagerService.name, () => {
       ];
       const error = new Error("Transaction failed");
 
-      const { service, logger } = setup({
-        derivedWalletAddress: address,
-        derivedSignAndBroadcast: vi.fn().mockRejectedValue(error),
-        hasPendingTransactions: false
+      const { service } = setup({
+        derivedWalletAddress: createAkashAddress(),
+        derivedSignAndBroadcast: vi.fn().mockRejectedValue(error)
       });
 
       await expect(service.signAndBroadcastWithDerivedWallet(derivationIndex, messages)).rejects.toThrow("Transaction failed");
-
-      expect(logger.debug).toHaveBeenCalledWith({ event: "DEDUPE_SIGNING_CLIENT_CLEAN_UP", derivationIndex });
     });
   });
 
@@ -189,7 +156,6 @@ describe(TxManagerService.name, () => {
     derivedWalletAddress?: string;
     fundingSignAndBroadcast?: SigningClientService["signAndBroadcast"];
     derivedSignAndBroadcast?: SigningClientService["signAndBroadcast"];
-    hasPendingTransactions?: boolean;
   }) {
     const fundingWalletAddress = input?.fundingWalletAddress ?? createAkashAddress();
     const derivedWalletAddress = input?.derivedWalletAddress ?? createAkashAddress();
@@ -215,8 +181,7 @@ describe(TxManagerService.name, () => {
     });
 
     const derivedSigningClient = mock<SigningClientService>({
-      signAndBroadcast: input?.derivedSignAndBroadcast ?? vi.fn(),
-      hasPendingTransactions: input?.hasPendingTransactions ?? false
+      signAndBroadcast: input?.derivedSignAndBroadcast ?? vi.fn()
     });
 
     const walletFactory = vi.fn().mockImplementation((_index: number) => {

--- a/apps/tx-signer/src/services/tx-manager/tx-manager.service.ts
+++ b/apps/tx-signer/src/services/tx-manager/tx-manager.service.ts
@@ -15,7 +15,17 @@ const SIGNING_CLIENT_FACTORY: InjectionToken<SigningClientServiceFactory> = Symb
 container.register(SIGNING_CLIENT_FACTORY, {
   useFactory: c => {
     return (wallet: Wallet, loggerContext?: string) => {
-      return new SigningClientService(c.resolve(AppConfigService), wallet, c.resolve(TYPE_REGISTRY), createSigningStargateClient, loggerContext);
+      const config = c.resolve(AppConfigService);
+      const registry = c.resolve(TYPE_REGISTRY);
+      const client = createSigningStargateClient(config.get("RPC_NODE_ENDPOINT"), wallet, {
+        registry: registry,
+        signConfig: {
+          ttlMs: config.get("UNORDERED_TX_TTL_MS"),
+          gasMultiplier: config.get("GAS_DEFAULT_MULTIPLIER"),
+          averageGasPrice: config.get("AVERAGE_GAS_PRICE")
+        }
+      });
+      return new SigningClientService(client, config, loggerContext);
     };
   }
 });
@@ -53,14 +63,9 @@ container.register(WALLET_RESOURCES, {
   })
 });
 
-type CachedClient = {
-  address: string;
-  client: SigningClientService;
-};
-
 @singleton()
 export class TxManagerService {
-  readonly #clientsByDerivationIndex: Map<number, CachedClient> = new Map();
+  readonly #clientsByDerivationIndex: Map<number, SigningClientService> = new Map();
   readonly #DEFAULT_WALLET_VERSION: WalletVersion = "v2";
 
   constructor(
@@ -88,32 +93,20 @@ export class TxManagerService {
   }
 
   async signAndBroadcastWithDerivedWallet(derivationIndex: number, messages: readonly EncodeObject[], options?: SignAndBroadcastOptions) {
-    const { client } = await this.#getClient(derivationIndex);
-
-    try {
-      return await client.signAndBroadcast(messages, options);
-    } finally {
-      if (!client.hasPendingTransactions && this.#clientsByDerivationIndex.has(derivationIndex)) {
-        this.logger.debug({ event: "DEDUPE_SIGNING_CLIENT_CLEAN_UP", derivationIndex });
-        this.#clientsByDerivationIndex.delete(derivationIndex);
-      }
-    }
+    const client = this.#getClient(derivationIndex);
+    return await client.signAndBroadcast(messages, options);
   }
 
   async getDerivedWalletAddress(index: number) {
     return await this.getDerivedWallet(index).getFirstAddress();
   }
 
-  async #getClient(derivationIndex: number): Promise<CachedClient> {
+  #getClient(derivationIndex: number): SigningClientService {
     if (!this.#clientsByDerivationIndex.has(derivationIndex)) {
       const wallet = this.getDerivedWallet(derivationIndex);
-      const address = await wallet.getFirstAddress();
 
       this.logger.debug({ event: "DERIVED_SIGNING_CLIENT_CREATE", derivationIndex });
-      this.#clientsByDerivationIndex.set(derivationIndex, {
-        address,
-        client: this.signingClientServiceFactory(wallet)
-      });
+      this.#clientsByDerivationIndex.set(derivationIndex, this.signingClientServiceFactory(wallet));
     }
 
     return this.#clientsByDerivationIndex.get(derivationIndex)!;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4983,6 +4983,7 @@
         "@hono/zod-openapi": "0.18.4",
         "@opentelemetry/api": "^1.9.0",
         "cockatiel": "^3.2.1",
+        "cosmjs-types": "~0.11.0",
         "hono": "4.6.12",
         "http-errors": "^2.0.0",
         "lodash": "^4.17.21",
@@ -5139,6 +5140,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "apps/tx-signer/node_modules/cosmjs-types": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.11.0.tgz",
+      "integrity": "sha512-kDSkgHpRTrg1413jCNehT3P21+EBxZWFMBr9JEzVfmPiNdtuwAoLAkCYo7c7i/pTakAwyHsXbxOg8kkD+AN33w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.19"
       }
     },
     "apps/tx-signer/node_modules/ws": {
@@ -21322,6 +21332,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-8yQrvS6sMpSwIovhPOwfyNf2Wz6v/B62LFSVYQ85+Rq3tLsBIG7rP5geMxaijTUxSkrO6RzN/IRuIAADYQsleA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/react": "*"
       }


### PR DESCRIPTION
## Why

Closes CON-663

## What

1. Properly estimate gas for unordered transaction
2. Adds out of gas retry mechanism
3. Reduced `GAS_MULTIPLIER`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for unordered transactions with configurable timeouts.
  - Transactions can now include a fee granter.
  - Gas fees can be estimated automatically, while explicit gas limits skip estimation.
  - Signing clients are reused for repeated derived-wallet transactions.

- **Bug Fixes**
  - Automatically retries transactions that fail due to insufficient gas, using on-chain gas usage to calculate a higher limit.
  - Prevents retries for unrelated failures or invalid recovery settings.
  - Improved handling of transaction recovery and already-broadcast transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->