### PR TITLE
fix(deployment): show CPU-only cost per month in configure summary and modal

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentHeader/ConfigureDeploymentHeader.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentHeader/ConfigureDeploymentHeader.spec.tsx
@@ -4,6 +4,7 @@ import { Snackbar } from "@akashnetwork/ui/components";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
+import { getAvgCostPerMonth } from "@src/utils/priceUtils";
 import type { DeploymentCost } from "../useDeploymentCost/useDeploymentCost";
 import type { DeploymentFlow, DeploymentFlowActions } from "../useDeploymentFlow/useDeploymentFlow";
 import type { QuoteExpiry } from "../useQuoteExpiry/useQuoteExpiry";
@@ -122,6 +123,13 @@ describe(ConfigureDeploymentHeader.name, () => {
     expect(screen.getByText("/hr")).toBeInTheDocument();
   });
 
+  it("shows the cost per month for a CPU-only deployment so a cheap spec doesn't round to $0.00/hr", () => {
+    setup({ phase: "quoting", cost: { minPerBlock: 5, maxPerBlock: 5, denom: "uakt" }, hasGpu: false });
+    expect(screen.getByText("/month")).toBeInTheDocument();
+    expect(screen.queryByText("/hr")).not.toBeInTheDocument();
+    expect(screen.getByTestId("price")).toHaveTextContent(String(getAvgCostPerMonth(5)));
+  });
+
   it("passes the sdl and current selections through to the cost hook", () => {
     const { useDeploymentCost } = setup({
       phase: "quoting",
@@ -189,6 +197,7 @@ describe(ConfigureDeploymentHeader.name, () => {
     deployError?: { message?: string };
     deploy?: () => void;
     cost?: DeploymentCost | null;
+    hasGpu?: boolean;
     sdl?: string;
     expiry?: QuoteExpiry | null;
     cancelAndEdit?: () => void;
@@ -208,6 +217,7 @@ describe(ConfigureDeploymentHeader.name, () => {
     const useDeploymentCost = vi.fn(() => input.cost ?? null);
     const dependencies: typeof DEPENDENCIES = {
       useDeploymentResourceSummary: (() => "1 vCPU") as never,
+      useDeploymentHasGpu: () => input.hasGpu ?? true,
       useSnackbar: () => mock<ReturnType<(typeof DEPENDENCIES)["useSnackbar"]>>({ enqueueSnackbar }),
       Snackbar,
       generateSdl: () => GENERATED_SDL,

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentHeader/ConfigureDeploymentHeader.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentHeader/ConfigureDeploymentHeader.tsx
@@ -7,10 +7,10 @@ import { useSnackbar } from "notistack";
 
 import { PriceValue } from "@src/components/shared/PriceValue";
 import type { SdlBuilderFormValuesType } from "@src/types";
-import { perBlockToHourly } from "@src/utils/priceUtils";
+import { getAvgCostPerMonth, perBlockToHourly } from "@src/utils/priceUtils";
 import { generateSdl } from "@src/utils/sdl/sdlGenerator";
 import { validateGeneratedSdl } from "@src/utils/sdl/validateGeneratedSdl";
-import { useDeploymentResourceSummary } from "../DeploymentResourceSummary/useDeploymentResourceSummary";
+import { useDeploymentHasGpu, useDeploymentResourceSummary } from "../DeploymentResourceSummary/useDeploymentResourceSummary";
 import type { DeploymentCost } from "../useDeploymentCost/useDeploymentCost";
 import { useDeploymentCost } from "../useDeploymentCost/useDeploymentCost";
 import type { DeploymentFlow } from "../useDeploymentFlow/useDeploymentFlow";
@@ -19,6 +19,7 @@ import { useQuoteExpiry } from "../useQuoteExpiry/useQuoteExpiry";
 
 export const DEPENDENCIES = {
   useDeploymentResourceSummary,
+  useDeploymentHasGpu,
   useSnackbar,
   Snackbar,
   generateSdl,
@@ -33,6 +34,7 @@ type Props = { flow: DeploymentFlow; sdl: string; onDeploy: () => void; allPlace
 
 export const ConfigureDeploymentHeader: FC<Props> = ({ flow, sdl, onDeploy, allPlacementsHaveBids, dependencies: d = DEPENDENCIES }) => {
   const deploymentSummary = d.useDeploymentResourceSummary();
+  const showAsHourly = d.useDeploymentHasGpu();
   const { control, handleSubmit, getValues } = useFormContext<SdlBuilderFormValuesType>();
   const { enqueueSnackbar } = d.useSnackbar();
   const placements = useWatch({ control, name: "placements" });
@@ -102,7 +104,11 @@ export const ConfigureDeploymentHeader: FC<Props> = ({ flow, sdl, onDeploy, allP
           <DeploymentSummaryBlock label="Your deployment" value={deploymentSummary} />
           <div className="hidden h-12 w-px self-stretch bg-border md:block" aria-hidden="true" />
           <div className="flex flex-col items-start gap-0.5 xl:items-end">
-            <DeploymentSummaryBlock label="Deployment cost" value={<CostValue cost={cost} PriceValue={d.PriceValue} />} suffix={cost ? "/hr" : undefined} />
+            <DeploymentSummaryBlock
+              label="Deployment cost"
+              value={<CostValue cost={cost} showAsHourly={showAsHourly} PriceValue={d.PriceValue} />}
+              suffix={cost ? (showAsHourly ? "/hr" : "/month") : undefined}
+            />
             <div className="h-4">{expiry ? <QuoteExpiryLine expiry={expiry} CustomTooltip={d.CustomTooltip} /> : null}</div>
           </div>
         </div>
@@ -155,19 +161,24 @@ function DeploymentSummaryBlock({ label, value, suffix }: DeploymentSummaryBlock
 
 interface CostValueProps {
   cost: DeploymentCost | null;
+  showAsHourly: boolean;
   PriceValue: typeof DEPENDENCIES.PriceValue;
 }
 
-/** The header cost value: a dash before bids, a single hourly USD price when the bounds are equal, otherwise a min–max range. */
-function CostValue({ cost, PriceValue }: CostValueProps) {
+/**
+ * The header cost value: a dash before bids, a single price when the bounds are equal, otherwise a min–max
+ * range. Shown hourly for GPU deployments and monthly for CPU-only ones, matching the marketplace and review
+ * modal so the same spec never reads as `$0.00/hr` in one place and `$30/month` in another.
+ */
+function CostValue({ cost, showAsHourly, PriceValue }: CostValueProps) {
   if (!cost) return <>—</>;
+  const toDisplayValue = showAsHourly ? perBlockToHourly : getAvgCostPerMonth;
   if (cost.minPerBlock === cost.maxPerBlock) {
-    return <PriceValue denom={cost.denom} value={perBlockToHourly(cost.minPerBlock)} />;
+    return <PriceValue denom={cost.denom} value={toDisplayValue(cost.minPerBlock)} />;
   }
   return (
     <>
-      <PriceValue denom={cost.denom} value={perBlockToHourly(cost.minPerBlock)} /> -{" "}
-      <PriceValue denom={cost.denom} value={perBlockToHourly(cost.maxPerBlock)} />
+      <PriceValue denom={cost.denom} value={toDisplayValue(cost.minPerBlock)} /> - <PriceValue denom={cost.denom} value={toDisplayValue(cost.maxPerBlock)} />
     </>
   );
 }

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/ReviewAndDeployModal.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/ReviewAndDeployModal.spec.tsx
@@ -19,6 +19,16 @@ describe(ReviewAndDeployModal.name, () => {
     expect(screen.getAllByTestId("price")).toHaveLength(2);
   });
 
+  it("prices per placement and total by the hour when the deployment uses a GPU", () => {
+    setup({ hasGpu: true });
+    screen.getAllByTestId("price").forEach(price => expect(price).toHaveTextContent("hourly"));
+  });
+
+  it("prices per placement and total by the month for a CPU-only deployment", () => {
+    setup({ hasGpu: false });
+    screen.getAllByTestId("price").forEach(price => expect(price).toHaveTextContent("monthly"));
+  });
+
   it("confirms with onConfirm", async () => {
     const onConfirm = vi.fn();
     setup({ onConfirm });
@@ -45,7 +55,7 @@ describe(ReviewAndDeployModal.name, () => {
     expect(screen.getByRole("button", { name: /confirm and deploy/i })).toBeDisabled();
   });
 
-  function setup(input: { rows?: ReviewRow[]; pricedCount?: number; totalCount?: number; onConfirm?: () => void; onBack?: () => void }) {
+  function setup(input: { rows?: ReviewRow[]; pricedCount?: number; totalCount?: number; hasGpu?: boolean; onConfirm?: () => void; onBack?: () => void }) {
     const rows = input.rows ?? [
       { placementId: "p1", placementName: "placement-1", region: "Any region", providerName: "Dune Networks", price: { amount: "100", denom: "uakt" } }
     ];
@@ -54,7 +64,8 @@ describe(ReviewAndDeployModal.name, () => {
       pricedCount: input.pricedCount ?? rows.filter(row => row.price).length,
       totalCount: input.totalCount ?? rows.length
     });
-    const PricePerTimeUnit: typeof DEPENDENCIES.PricePerTimeUnit = () => <span data-testid="price" />;
+    const PricePerTimeUnit: typeof DEPENDENCIES.PricePerTimeUnit = ({ showAsHourly }) => <span data-testid="price">{showAsHourly ? "hourly" : "monthly"}</span>;
+    const useDeploymentHasGpu: typeof DEPENDENCIES.useDeploymentHasGpu = () => input.hasGpu ?? false;
     render(
       <ReviewAndDeployModal
         open
@@ -63,7 +74,7 @@ describe(ReviewAndDeployModal.name, () => {
         selections={{ p1: "akash1a/55/1/2" }}
         onConfirm={input.onConfirm ?? vi.fn()}
         onBack={input.onBack ?? vi.fn()}
-        dependencies={{ useReviewRows, PricePerTimeUnit }}
+        dependencies={{ useReviewRows, PricePerTimeUnit, useDeploymentHasGpu }}
       />
     );
   }

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/ReviewAndDeployModal.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/ReviewAndDeployModal.tsx
@@ -15,10 +15,11 @@ import { ArrowRight, Rocket } from "iconoir-react";
 import { PricePerTimeUnit } from "@src/components/shared/PricePerTimeUnit";
 import type { PlacementType } from "@src/types";
 import { PRICE_DISPLAY_PRECISION, udenomToDenom } from "@src/utils/mathHelpers";
+import { useDeploymentHasGpu } from "../DeploymentResourceSummary/useDeploymentResourceSummary";
 import type { ReviewRow } from "./useReviewRows";
 import { useReviewRows } from "./useReviewRows";
 
-export const DEPENDENCIES = { useReviewRows, PricePerTimeUnit };
+export const DEPENDENCIES = { useReviewRows, PricePerTimeUnit, useDeploymentHasGpu };
 
 interface Props {
   open: boolean;
@@ -36,6 +37,8 @@ interface Props {
  */
 export const ReviewAndDeployModal: FC<Props> = ({ open, dseq, placements, selections, onConfirm, onBack, dependencies: d = DEPENDENCIES }) => {
   const { rows, pricedCount, totalCount } = d.useReviewRows({ dseq, placements, selections });
+  /** Match the marketplace's cost unit: hourly for GPU (meaningful at that scale), monthly for CPU-only (so a cheap deployment reads as e.g. `$30/month` rather than rounding to `$0.00/hr`). */
+  const showAsHourly = d.useDeploymentHasGpu();
   /** Only deployable once every placement is selected and still has a live (priced) bid — a closed/stale bid leaves a row unpriced and would fail at create-lease. */
   const canConfirm = totalCount > 0 && rows.length === totalCount && pricedCount === totalCount;
   const preventDefault = (e: Event) => e.preventDefault();
@@ -68,7 +71,7 @@ export const ReviewAndDeployModal: FC<Props> = ({ open, dseq, placements, select
                     <d.PricePerTimeUnit
                       denom={row.price.denom}
                       perBlockValue={udenomToDenom(row.price.amount, PRICE_DISPLAY_PRECISION)}
-                      showAsHourly
+                      showAsHourly={showAsHourly}
                       abbreviated
                     />
                   ) : (
@@ -86,7 +89,7 @@ export const ReviewAndDeployModal: FC<Props> = ({ open, dseq, placements, select
                 {pricedCount} of {totalCount} {totalCount === 1 ? "placement" : "placements"} priced
               </p>
             </div>
-            <TotalPrice rows={rows} PricePerTimeUnit={d.PricePerTimeUnit} />
+            <TotalPrice rows={rows} showAsHourly={showAsHourly} PricePerTimeUnit={d.PricePerTimeUnit} />
           </div>
         </DialogV2Body>
 
@@ -105,14 +108,23 @@ export const ReviewAndDeployModal: FC<Props> = ({ open, dseq, placements, select
 };
 
 /**
- * Sums the selected offers' per-block prices and renders the hourly USD total through the shared price
- * component. Assumes a single denom across placements (one deployment shares a deposit denom), so it labels
- * the sum with the first priced row's denom; mixed denoms are not expected in this flow.
+ * Sums the selected offers' per-block prices and renders the USD total through the shared price component,
+ * hourly for GPU deployments and monthly for CPU-only ones to match the per-placement rows. Assumes a single
+ * denom across placements (one deployment shares a deposit denom), so it labels the sum with the first priced
+ * row's denom; mixed denoms are not expected in this flow.
  */
-function TotalPrice({ rows, PricePerTimeUnit: Price }: { rows: ReviewRow[]; PricePerTimeUnit: FC<ComponentProps<typeof PricePerTimeUnit>> }) {
+function TotalPrice({
+  rows,
+  showAsHourly,
+  PricePerTimeUnit: Price
+}: {
+  rows: ReviewRow[];
+  showAsHourly: boolean;
+  PricePerTimeUnit: FC<ComponentProps<typeof PricePerTimeUnit>>;
+}) {
   const priced = rows.filter((r): r is ReviewRow & { price: { amount: string; denom: string } } => !!r.price);
   if (priced.length === 0) return <span className="text-2xl font-bold">—</span>;
   const denom = priced[0].price.denom;
   const perBlockTotal = priced.reduce((sum, r) => sum + udenomToDenom(r.price.amount, PRICE_DISPLAY_PRECISION), 0);
-  return <Price denom={denom} perBlockValue={perBlockTotal} showAsHourly abbreviated className="text-2xl font-bold" />;
+  return <Price denom={denom} perBlockValue={perBlockTotal} showAsHourly={showAsHourly} abbreviated className="text-2xl font-bold" />;
 }


### PR DESCRIPTION
## Why

<!-- Fixes CON-___ (add the price-display unification issue id) -->

On the configure page the displayed cost unit was inconsistent. The compute-marketplace bid list already shows cost **hourly for GPU deployments and monthly for CPU-only ones** — so a cheap CPU-only spec reads as e.g. `$30/month` instead of rounding to a misleading `$0.00/hr`. But the header **"Deployment cost"** summary and the **Review and deploy** confirmation modal both hardcoded hourly, so the *same* deployment showed `$0.00/hr` in the summary/modal while the marketplace showed `$30/month`.

## What

Route the header summary and the review modal through the same `useDeploymentHasGpu` hook the bid list already uses, so the hourly-vs-monthly decision is made in one place across all three surfaces.

**deploy-web — configure header (`ConfigureDeploymentHeader`)**

- The "Deployment cost" value and its `/hr` ↔ `/month` suffix now follow GPU usage. Keeps the bespoke min–max range rendering and reuses the existing `getAvgCostPerMonth` util (identical math to `PricePerTimeUnit`'s monthly, so all three surfaces agree to the cent).

**deploy-web — review modal (`ReviewAndDeployModal`)**

- The per-placement rows and the total cost now take `showAsHourly` from the hook instead of a hardcoded flag.

Net effect: GPU deployments are unchanged (still hourly); CPU-only deployments now show `/month` in the summary and modal, matching the marketplace.

### Verification

- New spec coverage: GPU → hourly / CPU-only → monthly for the modal's rows **and** total, plus the header's CPU-only case (asserts the value equals `getAvgCostPerMonth`, not just the label).
- `npm run test:unit` green for both components (29 tests); ESLint clean; `tsc --noEmit` introduces no new errors over the pre-existing baseline (verified by stashing the change and diffing the erroring-file set).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Deployment cost display now switches between hourly and monthly pricing based on GPU availability (CPU-only shows monthly).
  * Updated the deployment header and review modal so price units, suffixes, and totals render consistently with the selected billing view.
  * Preserved existing behavior for missing costs (dash rendering) and for cost min–max range displays.
* **Tests**
  * Expanded unit tests to verify CPU-only versus GPU pricing labels and displayed values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->