### PR TITLE
feat: handle oog errors during broadcast

### DIFF
--- a/apps/tx-signer/src/config/env.config.ts
+++ b/apps/tx-signer/src/config/env.config.ts
@@ -4,11 +4,11 @@ export const envSchema = z.object({
   FUNDING_WALLET_MNEMONIC_V2: z.string(),
   DERIVATION_WALLET_MNEMONIC_V2: z.string(),
   RPC_NODE_ENDPOINT: z.string(),
-  GAS_DEFAULT_MULTIPLIER: z.number({ coerce: true }).default(1.5),
+  GAS_DEFAULT_MULTIPLIER: z.number({ coerce: true }).gt(1).default(1.4),
   // When a tx still lands out of gas, it is re-signed with gasLimit = on-chain gasUsed × this multiplier and rebroadcast.
   // gasUsed is the actual consumption measured on-chain, so a modest multiplier covers the extra settlement gas that
   // accrues between the failed attempt and the retry's inclusion height.
-  GAS_RECOVERY_MULTIPLIER: z.number({ coerce: true }).default(1.3),
+  GAS_RECOVERY_MULTIPLIER: z.number({ coerce: true }).gt(1).default(1.3),
   AVERAGE_GAS_PRICE: z.number({ coerce: true }).default(0.025),
   // TTL for unordered transactions: the chain keeps the tx hash in memory for this window to reject duplicates,
   // so it must be long enough to guarantee block inclusion but short enough to bound mempool memory.

--- a/apps/tx-signer/src/lib/signing-client/signing-client.service.spec.ts
+++ b/apps/tx-signer/src/lib/signing-client/signing-client.service.spec.ts
@@ -2,7 +2,7 @@ import { TxRaw } from "@akashnetwork/chain-sdk/private-types/cosmos.v1beta1";
 import { sha256 } from "@cosmjs/crypto";
 import { toHex } from "@cosmjs/encoding";
 import type { EncodeObject } from "@cosmjs/proto-signing";
-import type { IndexedTx } from "@cosmjs/stargate";
+import { BroadcastTxError, type IndexedTx } from "@cosmjs/stargate";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
@@ -93,7 +93,7 @@ describe(SigningClientService.name, () => {
       promise.catch(() => {});
       await vi.advanceTimersByTimeAsync(60_000);
 
-      await expect(promise).rejects.toThrow("Failed to sign and broadcast transaction");
+      await expect(promise).rejects.toThrow("Sign and broadcast succeeded but the transaction could not be found on-chain");
       expect(client.getTx).toHaveBeenCalledTimes(7);
     } finally {
       vi.useRealTimers();
@@ -125,17 +125,6 @@ describe(SigningClientService.name, () => {
     expect(result.code).toBe(11);
   });
 
-  it("returns the out-of-gas transaction without crashing when a usable retry gas limit cannot be derived", async () => {
-    const { service, client } = setup({ gasRecoveryMultiplier: NaN });
-    client.getTx.mockResolvedValue(outOfGasTx({ gasUsed: 100n, gasWanted: 80n }));
-
-    const result = await service.signAndBroadcast(createMessages(1));
-
-    // A NaN gas limit must never reach the signing client — degrade to returning the failed tx, don't throw.
-    expect(client.signUnordered).toHaveBeenCalledTimes(1);
-    expect(result.code).toBe(11);
-  });
-
   it("does not retry a transaction that fails with a non-out-of-gas error", async () => {
     const { service, client } = setup();
     client.getTx.mockResolvedValue(mock<IndexedTx>({ hash: "failed", code: 5, gasUsed: 40n, gasWanted: 80n, height: 100 }));
@@ -144,6 +133,59 @@ describe(SigningClientService.name, () => {
 
     expect(client.signUnordered).toHaveBeenCalledTimes(1);
     expect(result.code).toBe(5);
+  });
+
+  it("re-signs with a higher gas limit when the broadcast is rejected out of gas at CheckTx", async () => {
+    const { service, client } = setup();
+    client.broadcastTxSync.mockRejectedValueOnce(
+      new BroadcastTxError(11, "sdk", "out of gas in location: unordered tx; gasWanted: 40000, gasUsed: 50000: out of gas")
+    );
+
+    const result = await service.signAndBroadcast(createMessages(1));
+
+    expect(client.signUnordered).toHaveBeenCalledTimes(2);
+    // ceil(50000 gasUsed × 1.3 multiplier) = 65000.
+    expect(client.signUnordered).toHaveBeenLastCalledWith(expect.anything(), { granter: undefined, gas: 65000 });
+    expect(result.code).toBe(0);
+  });
+
+  it("throws the broadcast out-of-gas error after exhausting the retry limit", async () => {
+    const { service, client } = setup();
+    client.broadcastTxSync.mockRejectedValue(
+      new BroadcastTxError(11, "sdk", "out of gas in location: unordered tx; gasWanted: 40000, gasUsed: 50000: out of gas")
+    );
+
+    await expect(service.signAndBroadcast(createMessages(1))).rejects.toThrow(BroadcastTxError);
+    // 1 initial attempt + OUT_OF_GAS_RETRY_LIMIT (3) retries = 4 signs.
+    expect(client.signUnordered).toHaveBeenCalledTimes(4);
+  });
+
+  it("does not retry a broadcast error that is not out of gas", async () => {
+    const { service, client } = setup();
+    client.broadcastTxSync.mockRejectedValue(new BroadcastTxError(13, "sdk", "insufficient fee"));
+
+    await expect(service.signAndBroadcast(createMessages(1))).rejects.toThrow(BroadcastTxError);
+    expect(client.signUnordered).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry a code 11 broadcast error from another codespace whose log lacks the out-of-gas marker", async () => {
+    const { service, client } = setup();
+    // Some other module reuses error code 11; its log happens to carry gas figures but is not an out-of-gas abort.
+    client.broadcastTxSync.mockRejectedValue(new BroadcastTxError(11, "othermodule", "rejected; gasWanted: 40000, gasUsed: 50000"));
+
+    await expect(service.signAndBroadcast(createMessages(1))).rejects.toThrow(BroadcastTxError);
+    expect(client.signUnordered).toHaveBeenCalledTimes(1);
+    expect(client.broadcastTxSync).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry a broadcast out-of-gas log whose gasUsed is below gasWanted", async () => {
+    const { service, client } = setup();
+    // A genuine out-of-gas abort consumes at least the whole limit; gasUsed < gasWanted marks a non-genuine or malformed log.
+    client.broadcastTxSync.mockRejectedValue(new BroadcastTxError(11, "othermodule", "out of gas in location: unordered tx; gasWanted: 50000, gasUsed: 40000"));
+
+    await expect(service.signAndBroadcast(createMessages(1))).rejects.toThrow(BroadcastTxError);
+    expect(client.signUnordered).toHaveBeenCalledTimes(1);
+    expect(client.broadcastTxSync).toHaveBeenCalledTimes(1);
   });
 
   function createMessages(seed: number): readonly EncodeObject[] {

--- a/apps/tx-signer/src/lib/signing-client/signing-client.service.ts
+++ b/apps/tx-signer/src/lib/signing-client/signing-client.service.ts
@@ -5,9 +5,9 @@ import { createOtelLogger } from "@akashnetwork/logging/otel";
 import { sha256 } from "@cosmjs/crypto";
 import { toHex } from "@cosmjs/encoding";
 import type { EncodeObject } from "@cosmjs/proto-signing";
-import type { IndexedTx } from "@cosmjs/stargate";
+import { BroadcastTxError, type IndexedTx } from "@cosmjs/stargate";
 import type { RetryPolicy } from "cockatiel";
-import { ConstantBackoff, handleWhenResult, retry } from "cockatiel";
+import { ConstantBackoff, handleWhenResult, Policy, retry } from "cockatiel";
 
 import type { AppConfigService } from "@src/services/app-config/app-config.service";
 import type { SigningStargateWithUnorderedSupportClient } from "../signing-stargate-client-factory/signing-stargate-client.factory";
@@ -42,7 +42,8 @@ const OUT_OF_GAS_CODE = 11;
 export class SigningClientService {
   readonly #client: SigningStargateWithUnorderedSupportClient;
 
-  readonly #txRecoveryExecutor: RetryPolicy;
+  readonly #txPoller: RetryPolicy;
+  readonly #signAndBroadcastExecutor: RetryPolicy;
 
   readonly #gasRecoveryMultiplier: number;
 
@@ -50,7 +51,7 @@ export class SigningClientService {
 
   constructor(client: SigningStargateWithUnorderedSupportClient, config: AppConfigService, loggerContext = SigningClientService.name) {
     this.#client = client;
-    this.#txRecoveryExecutor = retry(
+    this.#txPoller = retry(
       handleWhenResult(res => !res),
       {
         maxAttempts: Math.ceil((config.get("UNORDERED_TX_TTL_MS") * TX_RECOVERY_WINDOW_FACTOR) / TX_RECOVERY_POLL_INTERVAL_MS),
@@ -58,6 +59,16 @@ export class SigningClientService {
       }
     );
     this.#gasRecoveryMultiplier = config.get("GAS_RECOVERY_MULTIPLIER");
+    this.#signAndBroadcastExecutor = retry(
+      new Policy({
+        errorFilter: error => this.#canRecoverFromOutOfGas(error),
+        resultFilter: result => this.#canRecoverFromOutOfGas(result)
+      }),
+      {
+        maxAttempts: OUT_OF_GAS_RETRY_LIMIT,
+        backoff: new ConstantBackoff(0)
+      }
+    );
     this.#logger = createOtelLogger({ context: loggerContext });
   }
 
@@ -69,70 +80,78 @@ export class SigningClientService {
     });
 
     try {
-      let gas: number | undefined;
+      let prevResult: unknown;
+      const tx = await this.#signAndBroadcastExecutor.execute(async context => {
+        const prevOutOfGasContext = this.#getOutOfGasContext(prevResult);
+        let gas: number | undefined;
 
-      for (let attempt = 0; ; attempt++) {
-        const txHash = await withSpan("SigningClientService.signAndBroadcast", async () => {
-          const signedTx = await this.#client.signUnordered(messages, { granter: options?.fee?.granter, gas });
-          return await this.#broadcast(signedTx);
-        });
-
-        const tx = await this.#tryRecoverTransaction(txHash);
-
-        if (!tx) {
-          const error = new Error("Failed to sign and broadcast transaction");
-          this.#logger.error({ event: "SIGN_AND_BROADCAST_TX_NOT_FOUND", txHash, error });
-          throw error;
-        }
-
-        if (this.#isOutOfGas(tx) && attempt < OUT_OF_GAS_RETRY_LIMIT) {
-          const nextGasLimit = this.#nextGasLimit(tx);
-
-          if (nextGasLimit !== undefined) {
-            gas = nextGasLimit;
-            this.#logger.warn({
-              event: "SIGN_AND_BROADCAST_OUT_OF_GAS_RETRY",
-              txHash,
-              attempt: attempt + 1,
-              gasWanted: Number(tx.gasWanted),
-              gasUsed: Number(tx.gasUsed),
-              nextGasLimit
-            });
-            continue;
-          }
-
-          // We can't derive a usable gas limit (e.g. a missing/misconfigured margin) — don't crash the sign flow, just
-          // return the out-of-gas tx as the terminal result, matching the behavior before gas recovery existed.
-          this.#logger.error({
-            event: "SIGN_AND_BROADCAST_OUT_OF_GAS_UNRECOVERABLE",
-            txHash,
-            gasWanted: Number(tx.gasWanted),
-            gasUsed: Number(tx.gasUsed)
+        if (prevOutOfGasContext) {
+          gas = this.#nextGasLimit(prevOutOfGasContext.gasUsed);
+          this.#logger.warn({
+            event: "SIGN_AND_BROADCAST_OUT_OF_GAS_RETRY",
+            attempt: context.attempt,
+            gasUsedInTx: prevOutOfGasContext.gasWanted,
+            gasRequired: prevOutOfGasContext.gasUsed,
+            nextGasLimit: gas
           });
         }
 
-        this.#logger.debug({ event: "SIGN_AND_BROADCAST_SUCCESS", txHash, height: tx.height, code: tx.code });
+        try {
+          const txHash = await withSpan("SigningClientService.signAndBroadcast", async () => {
+            const signedTx = await this.#client.signUnordered(messages, { granter: options?.fee?.granter, gas });
+            return await this.#broadcast(signedTx);
+          });
 
-        return tx;
-      }
+          const foundTx = await this.#pollTx(txHash);
+
+          if (!foundTx) {
+            this.#logger.error({ event: "SIGN_AND_BROADCAST_TX_NOT_FOUND", txHash });
+            throw new Error("Sign and broadcast succeeded but the transaction could not be found on-chain");
+          }
+
+          prevResult = foundTx;
+          return foundTx;
+        } catch (error) {
+          prevResult = error;
+          throw error;
+        }
+      });
+
+      this.#logger.debug({ event: "SIGN_AND_BROADCAST_SUCCESS", txHash: tx.hash, height: tx.height, code: tx.code });
+
+      return tx;
     } catch (error) {
       this.#logger.debug({ event: "SIGN_AND_BROADCAST_ERROR", error });
       throw error;
     }
   }
 
-  #isOutOfGas(tx: IndexedTx): boolean {
-    // Corroborate the code with the physical signature of an out-of-gas abort — execution consumed at least the whole
-    // gas limit — so a code 11 from a non-root codespace can't false-positive a retry.
-    return tx.code === OUT_OF_GAS_CODE && tx.gasUsed >= tx.gasWanted;
+  /**
+   * Recognizes an out-of-gas outcome from either surface it can appear on and returns the on-chain gas figures, or
+   * undefined when it isn't out of gas. A tx can run out of gas at CheckTx — `broadcastTxSync` rejects with a
+   * {@link BroadcastTxError} whose log carries the gas — or at DeliverTx — the committed {@link IndexedTx} exposes
+   * `gasUsed`/`gasWanted` directly. In both cases, corroborate the code with the physical signature of the abort (an
+   * out-of-gas marker in the log and execution having consumed at least the whole limit) so a code 11 from a non-root
+   * codespace can't false-positive a retry.
+   */
+  #getOutOfGasContext(outcome: unknown): OutOfGasInfo | undefined {
+    if (outcome instanceof BroadcastTxError) {
+      return outcome.code === OUT_OF_GAS_CODE ? parseOutOfGasLog(outcome.log) : undefined;
+    }
+
+    if (isIndexedTx(outcome) && outcome.code === OUT_OF_GAS_CODE && outcome.gasUsed >= outcome.gasWanted) {
+      return { gasWanted: Number(outcome.gasWanted), gasUsed: Number(outcome.gasUsed) };
+    }
+
+    return undefined;
   }
 
-  #nextGasLimit(tx: IndexedTx): number | undefined {
-    // `gasUsed` is where execution aborted, so the true requirement is at least this — the multiplier covers that plus the
-    // extra settlement gas that accrues between this failed attempt and the retry's (later) inclusion height. Guard the
-    // result: a non-integer (e.g. NaN from a missing multiplier) must never reach cosmjs `calculateFee`, which throws on one.
-    const nextGasLimit = Math.ceil(Number(tx.gasUsed) * this.#gasRecoveryMultiplier);
-    return Number.isSafeInteger(nextGasLimit) && nextGasLimit > 0 ? nextGasLimit : undefined;
+  #canRecoverFromOutOfGas(outcome: unknown): boolean {
+    return this.#getOutOfGasContext(outcome) !== undefined;
+  }
+
+  #nextGasLimit(gasUsed: number): number {
+    return Math.ceil(gasUsed * this.#gasRecoveryMultiplier);
   }
 
   async #broadcast(signedTx: TxRaw): Promise<string> {
@@ -149,10 +168,39 @@ export class SigningClientService {
     }
   }
 
-  async #tryRecoverTransaction(hash: string): Promise<IndexedTx | null> {
-    return await this.#txRecoveryExecutor.execute(context => {
-      this.#logger.debug({ event: "TX_RECOVERY_ATTEMPT", txHash: hash, attempt: context.attempt });
+  async #pollTx(hash: string): Promise<IndexedTx | null> {
+    return await this.#txPoller.execute(context => {
+      this.#logger.debug({ event: "TX_POLL_ATTEMPT", txHash: hash, attempt: context.attempt });
       return this.#client.getTx(hash);
     });
   }
+}
+
+interface OutOfGasInfo {
+  gasWanted: number;
+  gasUsed: number;
+}
+
+function isIndexedTx(value: unknown): value is IndexedTx {
+  return typeof value === "object" && value !== null && "gasUsed" in value && typeof (value as { gasUsed: unknown }).gasUsed === "bigint";
+}
+
+/** Explicit `ErrOutOfGas` marker the SDK writes into the abort log, used to corroborate the code before trusting the figures. */
+const OUT_OF_GAS_LOG_MARKER = /out\s+of\s+gas/i;
+const OUT_OF_GAS_LOG_PATTERN = /gasWanted:\s*(\d+),\s*gasUsed:\s*(\d+)/;
+function parseOutOfGasLog(log: string | undefined): OutOfGasInfo | undefined {
+  if (!log || !OUT_OF_GAS_LOG_MARKER.test(log)) {
+    return undefined;
+  }
+
+  const match = OUT_OF_GAS_LOG_PATTERN.exec(log);
+  if (!match) {
+    return undefined;
+  }
+
+  const gasWanted = Number(match[1]);
+  const gasUsed = Number(match[2]);
+
+  // Only a genuine out-of-gas abort consumes at least the whole limit; anything short is a code 11 from another codespace.
+  return gasUsed >= gasWanted ? { gasWanted, gasUsed } : undefined;
 }


### PR DESCRIPTION
## Why

Closes CON-663

## What

1. Handles OOG (out of gas) errors during tx broadcast
2. Lowers default GAS_MULTIPLIER. For most deployment related operations 1.3 works even better but for other transactions (e.g., MsgAccountDeposit, MsgUpdateDeployment) it can cause multiple retries to recover from OOG error


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved out-of-gas recovery for both broadcast failures and already-committed transactions by automatically retrying with a higher gas limit when eligible.
  * Refined retry behavior to avoid re-broadcasting for non-recoverable failures.
  * Enhanced transaction polling so failures when a transaction isn’t found on-chain now report a clearer terminal error.

* **Improvements**
  * Reduced the default gas recovery multiplier from 1.5 to 1.4 to better control gas over-allocation while keeping recovery support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->