### PR TITLE
fix(deployment): lock GPU and CC-GPU for trials on the configure page

### DIFF
--- a/apps/deploy-web/src/components/billing-usage/AddCreditsForm/AddCreditsForm.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AddCreditsForm/AddCreditsForm.tsx
@@ -5,15 +5,14 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import {
   Alert,
   AlertDescription,
-  Button,
   Label,
+  LoadingButton,
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-  Skeleton,
-  Spinner
+  Skeleton
 } from "@akashnetwork/ui/components";
 import { useQueryClient } from "@tanstack/react-query";
 
@@ -347,14 +346,14 @@ export function AddCreditsForm({ onDone, isWalletReady = true, onProcessingChang
           </Alert>
         )}
 
-        <Button
+        <LoadingButton
           type="submit"
-          className="w-full gap-2"
-          disabled={isProcessing || amount < topUpMinAmountUsd || isLoadingMethods || (isNewCard && isSetupLoading)}
+          className="w-full"
+          loading={isProcessing}
+          disabled={amount < topUpMinAmountUsd || isLoadingMethods || (isNewCard && isSetupLoading)}
         >
-          {isProcessing && <Spinner size="small" />}
           Purchase Credits
-        </Button>
+        </LoadingButton>
       </form>
 
       {threeDSecure.threeDSData?.clientSecret && (

--- a/apps/deploy-web/src/components/billing-usage/RedeemCouponForm/RedeemCouponForm.tsx
+++ b/apps/deploy-web/src/components/billing-usage/RedeemCouponForm/RedeemCouponForm.tsx
@@ -5,7 +5,6 @@ import { useForm } from "react-hook-form";
 import { FormattedNumber } from "react-intl";
 import { Alert, AlertDescription, AlertTitle, Form, FormField, FormInput, LoadingButton } from "@akashnetwork/ui/components";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { LoaderCircle } from "lucide-react";
 import { z } from "zod";
 
 import { usePaymentPolling } from "@src/context/PaymentPollingProvider";
@@ -177,13 +176,7 @@ export function RedeemCouponForm({ isWalletReady = true, onProcessingChange, onR
         )}
 
         <div className="space-y-2">
-          <LoadingButton
-            type="submit"
-            className="w-full"
-            loading={isProcessing}
-            disabled={!canSubmit}
-            loadingIndicator={<LoaderCircle className="mr-2 h-4 w-4 animate-spin text-current" aria-hidden="true" />}
-          >
+          <LoadingButton type="submit" className="w-full" loading={isProcessing} disabled={!canSubmit}>
             Redeem coupon
           </LoadingButton>
           {!isWalletReady && <p className="text-center text-sm text-muted-foreground">Setting up your account…</p>}

--- a/apps/deploy-web/src/components/billing-usage/RedeemCouponForm/RedeemCouponForm.tsx
+++ b/apps/deploy-web/src/components/billing-usage/RedeemCouponForm/RedeemCouponForm.tsx
@@ -5,6 +5,7 @@ import { useForm } from "react-hook-form";
 import { FormattedNumber } from "react-intl";
 import { Alert, AlertDescription, AlertTitle, Form, FormField, FormInput, LoadingButton } from "@akashnetwork/ui/components";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { LoaderCircle } from "lucide-react";
 import { z } from "zod";
 
 import { usePaymentPolling } from "@src/context/PaymentPollingProvider";
@@ -176,7 +177,13 @@ export function RedeemCouponForm({ isWalletReady = true, onProcessingChange, onR
         )}
 
         <div className="space-y-2">
-          <LoadingButton type="submit" className="w-full" loading={isProcessing} disabled={!canSubmit}>
+          <LoadingButton
+            type="submit"
+            className="w-full"
+            loading={isProcessing}
+            disabled={!canSubmit}
+            loadingIndicator={<LoaderCircle className="mr-2 h-4 w-4 animate-spin text-current" aria-hidden="true" />}
+          >
             Redeem coupon
           </LoadingButton>
           {!isWalletReady && <p className="text-center text-sm text-muted-foreground">Setting up your account…</p>}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ConfidentialComputeCard/ConfidentialComputeCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ConfidentialComputeCard/ConfidentialComputeCard.spec.tsx
@@ -162,7 +162,7 @@ describe(ConfidentialComputeCard.name, () => {
     it("shows the free-trial warning with an unlock CTA", () => {
       setup({ tee: "cpu", isGpuBlocked: true });
 
-      expect(screen.getByText(/GPU access isn't available on a free trial/i)).toBeInTheDocument();
+      expect(screen.getByText(/high-end GPUs aren't available on a free trial/i)).toBeInTheDocument();
       expect(screen.getByRole("button", { name: "Unlock high-end GPUs" })).toBeInTheDocument();
     });
 
@@ -196,7 +196,7 @@ describe(ConfidentialComputeCard.name, () => {
   it("does not show the free-trial warning when GPU is not blocked", () => {
     setup({ tee: "cpu" });
 
-    expect(screen.queryByText(/GPU access isn't available on a free trial/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/high-end GPUs aren't available on a free trial/i)).not.toBeInTheDocument();
     expect(screen.getByRole("radio", { name: "CPU-GPU" })).not.toBeDisabled();
   });
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ConfidentialComputeCard/ConfidentialComputeCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ConfidentialComputeCard/ConfidentialComputeCard.spec.tsx
@@ -1,7 +1,7 @@
 import type { PropsWithChildren } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { TooltipProvider } from "@akashnetwork/ui/components";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import type { SdlBuilderFormValuesType, ServiceType } from "@src/types";
 import { defaultServiceWithPlacement } from "@src/utils/sdl/data";
@@ -151,7 +151,64 @@ describe(ConfidentialComputeCard.name, () => {
     expect(screen.queryByText(/needs GPU resources/i)).not.toBeInTheDocument();
   });
 
-  function setup(input: { tee?: "cpu" | "cpu-gpu"; params?: ServiceType["params"]; profile?: Partial<ServiceType["profile"]>; locked?: boolean }) {
+  describe("when GPU is blocked for the trial", () => {
+    it("locks the CPU-GPU option while keeping CPU selectable", () => {
+      setup({ tee: "cpu", isGpuBlocked: true });
+
+      expect(screen.getByRole("radio", { name: "CPU-GPU" })).toBeDisabled();
+      expect(screen.getByRole("radio", { name: "CPU" })).not.toBeDisabled();
+    });
+
+    it("shows the free-trial warning with an unlock CTA", () => {
+      setup({ tee: "cpu", isGpuBlocked: true });
+
+      expect(screen.getByText(/GPU access isn't available on a free trial/i)).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Unlock high-end GPUs" })).toBeInTheDocument();
+    });
+
+    it("opens the unlock sheet when the unlock CTA is clicked", async () => {
+      const onUnlock = vi.fn();
+      setup({ tee: "cpu", isGpuBlocked: true, onUnlock });
+
+      await userEvent.click(screen.getByRole("button", { name: "Unlock high-end GPUs" }));
+
+      expect(onUnlock).toHaveBeenCalledTimes(1);
+    });
+
+    it("ignores a cpu-gpu selection defensively even if the disabled radio is triggered", async () => {
+      // Bypass the disabled radio to prove the setTee guard rejects cpu-gpu on its own; children (the real
+      // RadioGroupItems) are intentionally not rendered since they require the real RadioGroup context. Cast
+      // is needed because the real RadioGroup is a forwardRef component, structurally incompatible with a
+      // plain function component.
+      const RadioGroup = ((props: { onValueChange: (value: string) => void }) => (
+        <button type="button" onClick={() => props.onValueChange("cpu-gpu")}>
+          force-cpu-gpu
+        </button>
+      )) as unknown as typeof DEPENDENCIES.RadioGroup;
+      const { getValues } = setup({ tee: "cpu", isGpuBlocked: true, dependencies: { RadioGroup } });
+
+      await userEvent.click(screen.getByRole("button", { name: "force-cpu-gpu" }));
+
+      expect(getValues().services[0].params?.tee).toBe("cpu");
+    });
+  });
+
+  it("does not show the free-trial warning when GPU is not blocked", () => {
+    setup({ tee: "cpu" });
+
+    expect(screen.queryByText(/GPU access isn't available on a free trial/i)).not.toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "CPU-GPU" })).not.toBeDisabled();
+  });
+
+  function setup(input: {
+    tee?: "cpu" | "cpu-gpu";
+    params?: ServiceType["params"];
+    profile?: Partial<ServiceType["profile"]>;
+    locked?: boolean;
+    isGpuBlocked?: boolean;
+    onUnlock?: () => void;
+    dependencies?: Partial<typeof DEPENDENCIES>;
+  }) {
     const params = input.params ?? (input.tee ? { tee: input.tee } : undefined);
     const base = defaultServiceWithPlacement({ params });
     const values: SdlBuilderFormValuesType = {
@@ -169,7 +226,13 @@ describe(ConfidentialComputeCard.name, () => {
     render(
       <Wrapper>
         <TooltipProvider>
-          <ConfidentialComputeCard serviceIndex={0} locked={input.locked} dependencies={{ ...DEPENDENCIES }} />
+          <ConfidentialComputeCard
+            serviceIndex={0}
+            locked={input.locked}
+            isGpuBlocked={input.isGpuBlocked}
+            onUnlock={input.onUnlock}
+            dependencies={{ ...DEPENDENCIES, ...input.dependencies }}
+          />
         </TooltipProvider>
       </Wrapper>
     );

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ConfidentialComputeCard/ConfidentialComputeCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ConfidentialComputeCard/ConfidentialComputeCard.tsx
@@ -2,15 +2,16 @@ import type { FC } from "react";
 import { useCallback } from "react";
 import { useFormContext, useWatch } from "react-hook-form";
 import { Alert, CollapsibleCard, Label, RadioGroup, RadioGroupItem } from "@akashnetwork/ui/components";
-import { ShieldCheckIcon } from "lucide-react";
+import { LockIcon, ShieldCheckIcon } from "lucide-react";
 
 import { ConfidentialComputeResources } from "@src/components/deployments/ConfidentialComputeResources";
 import type { SdlBuilderFormValuesType } from "@src/types";
 import { buildFormTeeCarveout } from "@src/utils/confidentialCompute";
 import { defaultGpuModel } from "@src/utils/sdl/data";
 import { confidentialComputeTooltip } from "../cardTooltips";
+import { UnlockGpusButton } from "../UnlockGpusButton/UnlockGpusButton";
 
-export const DEPENDENCIES = { CollapsibleCard, RadioGroup, RadioGroupItem, Label, Alert, ConfidentialComputeResources };
+export const DEPENDENCIES = { CollapsibleCard, RadioGroup, RadioGroupItem, Label, Alert, ConfidentialComputeResources, UnlockGpusButton };
 
 type ServiceParams = NonNullable<SdlBuilderFormValuesType["services"][number]["params"]>;
 type TeeType = NonNullable<ServiceParams["tee"]>;
@@ -26,6 +27,14 @@ const DEFAULT_TEE: TeeType = "cpu";
 type Props = {
   serviceIndex: number;
   locked?: boolean;
+  /**
+   * True when the current (trial) user cannot request a GPU: the `cpu-gpu` option is locked and a warning with
+   * an add-credits CTA is shown. CPU-only TEE stays selectable (the backend never blocks it). Defaults to
+   * `false` so existing consumers/tests keep the unrestricted behavior.
+   */
+  isGpuBlocked?: boolean;
+  /** Opens the add-credits (unlock) sheet owned by the HardwareSection. */
+  onUnlock?: () => void;
   dependencies?: typeof DEPENDENCIES;
 };
 
@@ -47,7 +56,7 @@ type Props = {
  * reachable only when the pane is locked, where the short off-state hint just
  * tells the viewer no confidential compute is configured.
  */
-export const ConfidentialComputeCard: FC<Props> = ({ serviceIndex, locked = false, dependencies: d = DEPENDENCIES }) => {
+export const ConfidentialComputeCard: FC<Props> = ({ serviceIndex, locked = false, isGpuBlocked = false, onUnlock, dependencies: d = DEPENDENCIES }) => {
   const { control, getValues, setValue } = useFormContext<SdlBuilderFormValuesType>();
   const tee = useWatch({ control, name: `services.${serviceIndex}.params.tee` });
   const isEnabled = tee === "cpu" || tee === "cpu-gpu";
@@ -93,6 +102,8 @@ export const ConfidentialComputeCard: FC<Props> = ({ serviceIndex, locked = fals
 
   const setTee = useCallback(
     (value: TeeType | undefined) => {
+      // Defensive: never let a trial land on cpu-gpu even if the (disabled) radio is somehow triggered.
+      if (value === "cpu-gpu" && isGpuBlocked) return;
       const params = getValues(`services.${serviceIndex}.params`);
       const nextParams: ServiceParams = { ...params, tee: value };
       if (!value) {
@@ -105,7 +116,7 @@ export const ConfidentialComputeCard: FC<Props> = ({ serviceIndex, locked = fals
         enableGpu();
       }
     },
-    [enableGpu, getValues, serviceIndex, setValue]
+    [enableGpu, getValues, isGpuBlocked, serviceIndex, setValue]
   );
 
   const toggleConfidentialCompute = useCallback(
@@ -137,21 +148,33 @@ export const ConfidentialComputeCard: FC<Props> = ({ serviceIndex, locked = fals
           >
             {TEE_OPTIONS.map(option => {
               const id = `tee-${serviceIndex}-${option.value}`;
+              const optionBlocked = isGpuBlocked && option.value === "cpu-gpu";
               return (
                 <d.Label
                   key={option.value}
                   htmlFor={id}
                   className="flex items-start gap-3 rounded-md border border-zinc-200 p-3 font-normal dark:border-zinc-800"
                 >
-                  <d.RadioGroupItem id={id} value={option.value} aria-label={option.label} disabled={locked} className="mt-0.5" />
+                  <d.RadioGroupItem id={id} value={option.value} aria-label={option.label} disabled={locked || optionBlocked} className="mt-0.5" />
                   <span className="flex flex-col gap-0.5">
-                    <span className="text-sm font-medium">{option.label}</span>
+                    <span className="flex items-center gap-1.5 text-sm font-medium">
+                      {option.label}
+                      {optionBlocked && <LockIcon className="h-3 w-3 shrink-0 text-muted-foreground" aria-label="Requires credits" />}
+                    </span>
                     <span className="text-xs text-muted-foreground">{option.description}</span>
                   </span>
                 </d.Label>
               );
             })}
           </d.RadioGroup>
+          {isGpuBlocked && (
+            <d.Alert variant="warning">
+              <div className="flex flex-col items-start gap-1">
+                <span>GPU access isn&apos;t available on a free trial. Add credits to attest a GPU, or use CPU-only confidential compute.</span>
+                <d.UnlockGpusButton onUnlock={onUnlock} />
+              </div>
+            </d.Alert>
+          )}
           {gpuMismatch && (
             <d.Alert variant="warning">
               CPU-GPU confidential compute attests a GPU, so this service needs GPU resources. Enable the GPU card above so providers with confidential-compute

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ConfidentialComputeCard/ConfidentialComputeCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ConfidentialComputeCard/ConfidentialComputeCard.tsx
@@ -18,7 +18,7 @@ type TeeType = NonNullable<ServiceParams["tee"]>;
 
 const TEE_OPTIONS: { value: TeeType; label: string; description: string }[] = [
   { value: "cpu", label: "CPU", description: "Run inside a CPU-only Trusted Execution Environment." },
-  { value: "cpu-gpu", label: "CPU-GPU", description: "Attest the GPU as well — this enables the GPU card for this service." }
+  { value: "cpu-gpu", label: "CPU-GPU", description: "Attest the GPU as well. This enables the GPU card for this service." }
 ];
 
 /** TEE type a freshly enabled card defaults to. CPU is the least restrictive and needs no GPU resources. */
@@ -168,15 +168,15 @@ export const ConfidentialComputeCard: FC<Props> = ({ serviceIndex, locked = fals
             })}
           </d.RadioGroup>
           {isGpuBlocked && (
-            <d.Alert variant="warning">
-              <div className="flex flex-col items-start gap-1">
-                <span>GPU access isn&apos;t available on a free trial. Add credits to attest a GPU, or use CPU-only confidential compute.</span>
-                <d.UnlockGpusButton onUnlock={onUnlock} />
+            <d.Alert variant="warning" className="p-4">
+              <div className="flex flex-col items-start gap-2 text-sm">
+                <p>High-end GPUs aren&apos;t available on a free trial. Add credits to attest a GPU, or use CPU-only confidential compute.</p>
+                <d.UnlockGpusButton onUnlock={onUnlock} prominent />
               </div>
             </d.Alert>
           )}
           {gpuMismatch && (
-            <d.Alert variant="warning">
+            <d.Alert variant="warning" className="p-4 text-sm">
               CPU-GPU confidential compute attests a GPU, so this service needs GPU resources. Enable the GPU card above so providers with confidential-compute
               GPUs can bid.
             </d.Alert>

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/GpuCard/GpuCard.gated.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/GpuCard/GpuCard.gated.spec.tsx
@@ -51,6 +51,22 @@ describe("GpuCard trial gate", () => {
     expect(screen.queryByRole("button", { name: /unlock/i })).not.toBeInTheDocument();
   });
 
+  it("locks the 'Any model' option when the empty model is blocked for the trial", async () => {
+    const user = setup({ isBlockedModel: (_vendor, model) => model === "" || model === "h100" });
+
+    await user.click(screen.getByRole("combobox", { name: "GPU model" }));
+
+    expect(await screen.findByRole("option", { name: /any model/i })).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("keeps the 'Any model' option selectable when nothing is blocked", async () => {
+    const user = setup({});
+
+    await user.click(screen.getByRole("combobox", { name: "GPU model" }));
+
+    expect(await screen.findByRole("option", { name: /any model/i })).not.toHaveAttribute("aria-disabled", "true");
+  });
+
   function setup(input: { isBlockedModel?: (vendor?: string | null, model?: string | null) => boolean; onUnlock?: () => void }) {
     const values = defaultServiceWithPlacement({
       profile: {

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/GpuCard/GpuCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/GpuCard/GpuCard.tsx
@@ -249,6 +249,13 @@ function GpuModelFields({ serviceIndex, gpuIndex, gpuVendors, isLoading, isError
     [selectGpuModel, clearModel]
   );
 
+  /**
+   * On a trial, "Any model" is locked too (not just specific blocked models): it only draws a usable bid if an
+   * allowed-model provider happens to bid, otherwise the deployment spins with no explanation (CON-660). The
+   * predicate treats the empty model as blocked when the vendor exposes any blocked model.
+   */
+  const anyModelBlocked = isBlockedModel(vendor.field.value, "");
+
   const modelOptions = useMemo(
     () =>
       prioritizeGpuModels(models).map(model => {
@@ -318,7 +325,18 @@ function GpuModelFields({ serviceIndex, gpuIndex, gpuVendors, isLoading, isError
                 searchLabel="Search GPU models"
                 searchPlaceholder="Search models..."
                 notFoundMessage="No models found."
-                emptyOption={{ value: "", label: "Any model" }}
+                emptyOption={{
+                  value: "",
+                  disabled: anyModelBlocked,
+                  label: anyModelBlocked ? (
+                    <span className="flex items-center gap-1.5">
+                      Any model
+                      <LockIcon className="h-3 w-3 shrink-0 text-muted-foreground" aria-label="Requires credits" />
+                    </span>
+                  ) : (
+                    "Any model"
+                  )
+                }}
                 renderValue={modelName => models.find(model => model.name === modelName)?.displayName ?? modelName}
                 disabled={locked || models.length === 0}
                 triggerClassName="h-9"

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/HardwareSection/HardwareSection.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/HardwareSection/HardwareSection.spec.tsx
@@ -47,8 +47,29 @@ describe(HardwareSection.name, () => {
 
     setup({ dependencies: { PresetsCard, GpuCard, useTrialGate } });
 
-    expect(PresetsCard).toHaveBeenCalledWith(expect.objectContaining({ isBlockedModel: expect.any(Function), onUnlock: expect.any(Function) }), expect.anything());
+    expect(PresetsCard).toHaveBeenCalledWith(
+      expect.objectContaining({ isBlockedModel: expect.any(Function), onUnlock: expect.any(Function) }),
+      expect.anything()
+    );
     expect(GpuCard).toHaveBeenCalledWith(expect.objectContaining({ isBlockedModel: expect.any(Function), onUnlock: expect.any(Function) }), expect.anything());
+  });
+
+  it("passes isGpuBlocked and an unlock handler to the confidential compute card for a trial", () => {
+    const ConfidentialComputeCard = vi.fn(() => null);
+    const useTrialGate = () => ({ isRestricted: true, isWalletReady: true });
+
+    setup({ dependencies: { ConfidentialComputeCard, useTrialGate } });
+
+    expect(ConfidentialComputeCard).toHaveBeenCalledWith(expect.objectContaining({ isGpuBlocked: true, onUnlock: expect.any(Function) }), expect.anything());
+  });
+
+  it("does not block the confidential compute card when the trial restriction is not in force", () => {
+    const ConfidentialComputeCard = vi.fn(() => null);
+    const useTrialGate = () => ({ isRestricted: false, isWalletReady: true });
+
+    setup({ dependencies: { ConfidentialComputeCard, useTrialGate } });
+
+    expect(ConfidentialComputeCard).toHaveBeenCalledWith(expect.objectContaining({ isGpuBlocked: false }), expect.anything());
   });
 
   it("blocks nothing while the pane is locked", () => {

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/HardwareSection/HardwareSection.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/HardwareSection/HardwareSection.spec.tsx
@@ -72,6 +72,15 @@ describe(HardwareSection.name, () => {
     expect(ConfidentialComputeCard).toHaveBeenCalledWith(expect.objectContaining({ isGpuBlocked: false }), expect.anything());
   });
 
+  it("does not block the confidential compute card while the pane is locked so the trial warning never fights the read-only quote view", () => {
+    const ConfidentialComputeCard = vi.fn(() => null);
+    const useTrialGate = () => ({ isRestricted: true, isWalletReady: true });
+
+    setup({ locked: true, dependencies: { ConfidentialComputeCard, useTrialGate } });
+
+    expect(ConfidentialComputeCard).toHaveBeenCalledWith(expect.objectContaining({ isGpuBlocked: false }), expect.anything());
+  });
+
   it("blocks nothing while the pane is locked", () => {
     const GpuCard = vi.fn<typeof DEPENDENCIES.GpuCard>(() => null);
     const useTrialGate = () => ({ isRestricted: true, isWalletReady: true });

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/HardwareSection/HardwareSection.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/HardwareSection/HardwareSection.tsx
@@ -4,8 +4,7 @@ import { CollapsibleCard } from "@akashnetwork/ui/components";
 import { CpuIcon, PackageOpenIcon } from "lucide-react";
 
 import { AddCreditsSheet } from "@src/components/auth/AddCreditsSheet/AddCreditsSheet";
-import { isTrialBlockedGpuSelection } from "@src/utils/deploymentData/v1beta3";
-import { defaultGpuModel } from "@src/utils/sdl/data";
+import { isTrialBlockedGpuSelection, isTrialGpuRestrictionActive } from "@src/utils/deploymentData/v1beta3";
 import { useRevalidateUniqueness } from "../../DeploymentPane/useRevalidateUniqueness/useRevalidateUniqueness";
 import { computeResourcesTooltip, presetsTooltip } from "../cardTooltips";
 import { ComputeResourcesCard } from "../ComputeResourcesCard/ComputeResourcesCard";
@@ -91,7 +90,7 @@ export const HardwareSection: FC<Props> = ({ serviceIndex, locked = false, depen
         <d.ConfidentialComputeCard
           serviceIndex={serviceIndex}
           locked={locked}
-          isGpuBlocked={isBlockedModel(defaultGpuModel.vendor, defaultGpuModel.name)}
+          isGpuBlocked={isRestricted && !locked && isTrialGpuRestrictionActive()}
           onUnlock={openUnlock}
         />
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/HardwareSection/HardwareSection.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/HardwareSection/HardwareSection.tsx
@@ -4,7 +4,8 @@ import { CollapsibleCard } from "@akashnetwork/ui/components";
 import { CpuIcon, PackageOpenIcon } from "lucide-react";
 
 import { AddCreditsSheet } from "@src/components/auth/AddCreditsSheet/AddCreditsSheet";
-import { isTrialBlockedGpuModel } from "@src/utils/deploymentData/v1beta3";
+import { isTrialBlockedGpuSelection } from "@src/utils/deploymentData/v1beta3";
+import { defaultGpuModel } from "@src/utils/sdl/data";
 import { useRevalidateUniqueness } from "../../DeploymentPane/useRevalidateUniqueness/useRevalidateUniqueness";
 import { computeResourcesTooltip, presetsTooltip } from "../cardTooltips";
 import { ComputeResourcesCard } from "../ComputeResourcesCard/ComputeResourcesCard";
@@ -66,8 +67,12 @@ export const HardwareSection: FC<Props> = ({ serviceIndex, locked = false, depen
   const openUnlock = () => setIsUnlockOpen(true);
   const closeUnlock = () => setIsUnlockOpen(false);
 
-  /** True only for models the trial blocks and only while the pane is editable — so the lock never fights the quote-lock read-only state. */
-  const isBlockedModel = (vendor?: string | null, model?: string | null) => isRestricted && !locked && isTrialBlockedGpuModel(vendor, model);
+  /**
+   * True only for GPU selections the trial blocks and only while the pane is editable — so the lock never
+   * fights the quote-lock read-only state. Uses {@link isTrialBlockedGpuSelection}, which also treats an
+   * empty ("any") model as blocked for a vendor with blocked models (UI-only, stricter than the SDL policy).
+   */
+  const isBlockedModel = (vendor?: string | null, model?: string | null) => isRestricted && !locked && isTrialBlockedGpuSelection(vendor, model);
 
   return (
     <div className="flex flex-col gap-2 px-4">
@@ -83,7 +88,12 @@ export const HardwareSection: FC<Props> = ({ serviceIndex, locked = false, depen
           <d.ComputeResourcesCard serviceIndex={serviceIndex} locked={locked} />
         </d.CollapsibleCard>
 
-        <d.ConfidentialComputeCard serviceIndex={serviceIndex} locked={locked} />
+        <d.ConfidentialComputeCard
+          serviceIndex={serviceIndex}
+          locked={locked}
+          isGpuBlocked={isBlockedModel(defaultGpuModel.vendor, defaultGpuModel.name)}
+          onUnlock={openUnlock}
+        />
 
         <d.RamStorageCard serviceIndex={serviceIndex} locked={locked} />
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/UnlockGpusButton/UnlockGpusButton.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/UnlockGpusButton/UnlockGpusButton.tsx
@@ -8,6 +8,11 @@ const UNLOCK_EXPLANATION = "High-end GPUs aren't included in your free trial. Ad
 type Props = {
   /** Opens the add-credits (unlock) sheet owned by the HardwareSection. */
   onUnlock?: () => void;
+  /**
+   * Renders a filled primary button when this is the alert's main call-to-action (the trial confidential-compute
+   * warning), instead of the subtle ghost affordance shown beneath the Presets and GPU cards.
+   */
+  prominent?: boolean;
 };
 
 /**
@@ -15,10 +20,16 @@ type Props = {
  * model: opens the add-credits sheet on click and explains why on hover. Wraps its own
  * `TooltipProvider` so it works wherever it's rendered without the consumer supplying one.
  */
-export const UnlockGpusButton: FC<Props> = ({ onUnlock }) => (
+export const UnlockGpusButton: FC<Props> = ({ onUnlock, prominent = false }) => (
   <TooltipProvider>
     <CustomTooltip title={UNLOCK_EXPLANATION} className="font-sans text-sm normal-case">
-      <Button type="button" variant="ghost" size="sm" className="justify-start px-2 text-muted-foreground" onClick={onUnlock}>
+      <Button
+        type="button"
+        variant={prominent ? "default" : "ghost"}
+        size="sm"
+        className={prominent ? undefined : "justify-start px-2 text-muted-foreground"}
+        onClick={onUnlock}
+      >
         <LockIcon className="mr-2 h-3.5 w-3.5" />
         Unlock high-end GPUs
       </Button>

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentHeader/ConfigureDeploymentHeader.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentHeader/ConfigureDeploymentHeader.spec.tsx
@@ -28,6 +28,52 @@ describe(ConfigureDeploymentHeader.name, () => {
     expect(enqueueSnackbar).not.toHaveBeenCalled();
   });
 
+  it("blocks a trial deployment whose GPU resolves to a blocked selection and surfaces the trial message", async () => {
+    const requestQuotes = vi.fn();
+    const { enqueueSnackbar } = setup({
+      phase: "configuring",
+      requestQuotes,
+      isRestricted: true,
+      services: [{ profile: { hasGpu: true, gpuModels: [{ vendor: "nvidia", name: "" }] } }]
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /request quotes/i }));
+
+    await waitFor(() => expect(enqueueSnackbar).toHaveBeenCalledTimes(1));
+    expect(requestQuotes).not.toHaveBeenCalled();
+
+    render(enqueueSnackbar.mock.calls[0][0] as ReactNode);
+    expect(screen.getByText(/GPU access is not available on a free trial/i)).toBeInTheDocument();
+  });
+
+  it("lets a trial deployment on an allowed specific GPU model request quotes", async () => {
+    const requestQuotes = vi.fn();
+    setup({
+      phase: "configuring",
+      requestQuotes,
+      isRestricted: true,
+      services: [{ profile: { hasGpu: true, gpuModels: [{ vendor: "nvidia", name: "t4" }] } }]
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /request quotes/i }));
+
+    await waitFor(() => expect(requestQuotes).toHaveBeenCalledWith(GENERATED_SDL));
+  });
+
+  it("does not apply the trial GPU guard for a non-trial user", async () => {
+    const requestQuotes = vi.fn();
+    setup({
+      phase: "configuring",
+      requestQuotes,
+      isRestricted: false,
+      services: [{ profile: { hasGpu: true, gpuModels: [{ vendor: "nvidia", name: "" }] } }]
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /request quotes/i }));
+
+    await waitFor(() => expect(requestQuotes).toHaveBeenCalledWith(GENERATED_SDL));
+  });
+
   it("surfaces SDL validation errors and does not request quotes when the spec is invalid", async () => {
     const requestQuotes = vi.fn();
     const { enqueueSnackbar } = setup({
@@ -201,6 +247,8 @@ describe(ConfigureDeploymentHeader.name, () => {
     sdl?: string;
     expiry?: QuoteExpiry | null;
     cancelAndEdit?: () => void;
+    isRestricted?: boolean;
+    services?: Array<{ profile: { hasGpu?: boolean; gpuModels?: Array<{ vendor: string; name?: string }> } }>;
   }) {
     const flow = mock<DeploymentFlow>({
       phase: input.phase,
@@ -225,10 +273,11 @@ describe(ConfigureDeploymentHeader.name, () => {
       useDeploymentCost: useDeploymentCost as typeof DEPENDENCIES.useDeploymentCost,
       PriceValue: ({ value }) => <span data-testid="price">{String(value)}</span>,
       useQuoteExpiry: () => input.expiry ?? null,
-      CustomTooltip: ({ children }) => <>{children}</>
+      CustomTooltip: ({ children }) => <>{children}</>,
+      useTrialGate: () => ({ isRestricted: input.isRestricted ?? false, isWalletReady: true })
     };
     render(
-      <Wrapper placements={input.placements}>
+      <Wrapper placements={input.placements} services={input.services}>
         <ConfigureDeploymentHeader
           flow={flow}
           sdl={input.sdl ?? ""}
@@ -241,8 +290,16 @@ describe(ConfigureDeploymentHeader.name, () => {
     return { enqueueSnackbar, useDeploymentCost };
   }
 
-  function Wrapper({ children, placements }: { children: ReactNode; placements?: { id: string }[] }) {
-    const form = useForm({ defaultValues: { placements: placements ?? [] } });
+  function Wrapper({
+    children,
+    placements,
+    services
+  }: {
+    children: ReactNode;
+    placements?: { id: string }[];
+    services?: Array<{ profile: { hasGpu?: boolean; gpuModels?: Array<{ vendor: string; name?: string }> } }>;
+  }) {
+    const form = useForm({ defaultValues: { placements: placements ?? [], services: services ?? [] } });
     return <FormProvider {...form}>{children}</FormProvider>;
   }
 });

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentHeader/ConfigureDeploymentHeader.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentHeader/ConfigureDeploymentHeader.tsx
@@ -7,9 +7,11 @@ import { useSnackbar } from "notistack";
 
 import { PriceValue } from "@src/components/shared/PriceValue";
 import type { SdlBuilderFormValuesType } from "@src/types";
+import { hasTrialBlockedGpu } from "@src/utils/deploymentData/v1beta3";
 import { getAvgCostPerMonth, perBlockToHourly } from "@src/utils/priceUtils";
 import { generateSdl } from "@src/utils/sdl/sdlGenerator";
 import { validateGeneratedSdl } from "@src/utils/sdl/validateGeneratedSdl";
+import { useTrialGate } from "../ConfigurationPane/HardwareSection/useTrialGate/useTrialGate";
 import { useDeploymentHasGpu, useDeploymentResourceSummary } from "../DeploymentResourceSummary/useDeploymentResourceSummary";
 import type { DeploymentCost } from "../useDeploymentCost/useDeploymentCost";
 import { useDeploymentCost } from "../useDeploymentCost/useDeploymentCost";
@@ -27,7 +29,8 @@ export const DEPENDENCIES = {
   useDeploymentCost,
   PriceValue,
   useQuoteExpiry,
-  CustomTooltip
+  CustomTooltip,
+  useTrialGate
 };
 
 type Props = { flow: DeploymentFlow; sdl: string; onDeploy: () => void; allPlacementsHaveBids: boolean; dependencies?: typeof DEPENDENCIES };
@@ -37,6 +40,7 @@ export const ConfigureDeploymentHeader: FC<Props> = ({ flow, sdl, onDeploy, allP
   const showAsHourly = d.useDeploymentHasGpu();
   const { control, handleSubmit, getValues } = useFormContext<SdlBuilderFormValuesType>();
   const { enqueueSnackbar } = d.useSnackbar();
+  const { isRestricted } = d.useTrialGate();
   const placements = useWatch({ control, name: "placements" });
   const cost = d.useDeploymentCost({ dseq: flow.dseq, sdl, placements, selections: flow.selections });
   const expiry = d.useQuoteExpiry({ dseq: flow.dseq, enabled: flow.phase === "quoting" });
@@ -67,7 +71,13 @@ export const ConfigureDeploymentHeader: FC<Props> = ({ flow, sdl, onDeploy, allP
    */
   const onRequestQuotes = handleSubmit(values => {
     const sdl = d.generateSdl(values);
-    const errors = d.validateGeneratedSdl(sdl);
+    const errors = [...d.validateGeneratedSdl(sdl)];
+    // Load-bearing trial guard: enabling the GPU card leaves the model at the empty default without ever
+    // opening the (locked) picker, so the presentational lock alone can't stop an empty-model submission —
+    // otherwise the deployment would spin on "Requesting…" with no usable bid (CON-660).
+    if (isRestricted && hasTrialBlockedGpu(values)) {
+      errors.push("GPU access is not available on a free trial. Add funds to unlock GPU access.");
+    }
     if (errors.length > 0) {
       enqueueSnackbar(
         <d.Snackbar

--- a/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.spec.tsx
+++ b/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.spec.tsx
@@ -372,6 +372,8 @@ describe("OnboardingContainer", () => {
       appendAuditorRequirement: vi.fn(sdl => sdl),
       applyTrialGpuPolicy: vi.fn((sdl: string) => sdl),
       isTrialBlockedGpuModel: vi.fn(() => false),
+      isTrialBlockedGpuSelection: vi.fn(() => false),
+      hasTrialBlockedGpu: vi.fn(() => false),
       replaceSdlDenom: vi.fn((sdl: string) => sdl),
       ENDPOINT_NAME_VALIDATION_REGEX: /^[a-z]+[-_\da-z]+$/,
       TRIAL_ATTRIBUTE: "console/trials" as const,

--- a/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.spec.tsx
+++ b/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.spec.tsx
@@ -373,6 +373,7 @@ describe("OnboardingContainer", () => {
       applyTrialGpuPolicy: vi.fn((sdl: string) => sdl),
       isTrialBlockedGpuModel: vi.fn(() => false),
       isTrialBlockedGpuSelection: vi.fn(() => false),
+      isTrialGpuRestrictionActive: vi.fn(() => false),
       hasTrialBlockedGpu: vi.fn(() => false),
       replaceSdlDenom: vi.fn((sdl: string) => sdl),
       ENDPOINT_NAME_VALIDATION_REGEX: /^[a-z]+[-_\da-z]+$/,

--- a/apps/deploy-web/src/components/shared/SearchableSelect/SearchableSelect.spec.tsx
+++ b/apps/deploy-web/src/components/shared/SearchableSelect/SearchableSelect.spec.tsx
@@ -103,6 +103,18 @@ describe("SearchableSelect", () => {
     expect(await screen.findByRole("option", { name: "eu-west" })).toHaveAttribute("aria-disabled", "true");
   });
 
+  it("renders a disabled empty option as non-selectable", async () => {
+    const { user, onChange } = setup({ value: "eu-west", emptyOption: { value: "", label: "Any region", disabled: true } });
+
+    await user.click(screen.getByRole("combobox", { name: "Region" }));
+    const emptyOption = await screen.findByRole("option", { name: "Any region" });
+
+    expect(emptyOption).toHaveAttribute("aria-disabled", "true");
+
+    await user.click(emptyOption);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
   it("disables the trigger when disabled", () => {
     setup({ disabled: true });
 
@@ -112,7 +124,7 @@ describe("SearchableSelect", () => {
   function setup(input: {
     value?: string;
     options?: SearchableSelectOption[];
-    emptyOption?: { value: string; label: string };
+    emptyOption?: { value: string; label: string; disabled?: boolean };
     placeholder?: string;
     disabled?: boolean;
     renderValue?: (value: string) => ReactNode;

--- a/apps/deploy-web/src/components/shared/SearchableSelect/SearchableSelect.tsx
+++ b/apps/deploy-web/src/components/shared/SearchableSelect/SearchableSelect.tsx
@@ -15,7 +15,12 @@ export type SearchableSelectOption = {
 };
 
 /** A leading "no selection" row (e.g. "Any region"/"Any model") that is always shown and never filtered out. */
-type EmptyOption = { value: string; label: ReactNode };
+type EmptyOption = {
+  value: string;
+  label: ReactNode;
+  /** Renders the row non-selectable and `aria-disabled` (mirrors {@link SearchableSelectOption.disabled}). */
+  disabled?: boolean;
+};
 
 type Props = {
   value: string;
@@ -104,6 +109,7 @@ export const SearchableSelect: FC<Props> = ({
             {emptyOption && (
               <CommandItem
                 value={EMPTY_OPTION_VALUE}
+                disabled={emptyOption.disabled}
                 onSelect={function selectEmptyOption() {
                   selectValue(emptyOption.value);
                 }}

--- a/apps/deploy-web/src/utils/deploymentData/v1beta3.spec.ts
+++ b/apps/deploy-web/src/utils/deploymentData/v1beta3.spec.ts
@@ -2,7 +2,9 @@ import { DeploymentReclamation } from "@akashnetwork/chain-sdk/private-types/aka
 import yaml from "js-yaml";
 import { describe, expect, it } from "vitest";
 
-import { applyTrialGpuPolicy, isTrialBlockedGpuModel, NewDeploymentData, replaceSdlDenom } from "./v1beta3";
+import type { SdlBuilderFormValuesType } from "@src/types";
+import { defaultService, defaultServiceWithPlacement } from "@src/utils/sdl/data";
+import { applyTrialGpuPolicy, hasTrialBlockedGpu, isTrialBlockedGpuModel, isTrialBlockedGpuSelection, NewDeploymentData, replaceSdlDenom } from "./v1beta3";
 
 describe(replaceSdlDenom.name, () => {
   it("replaces denom in a single placement pricing entry", () => {
@@ -209,6 +211,89 @@ describe(isTrialBlockedGpuModel.name, () => {
   it("never blocks when the blocked list is empty", () => {
     expect(isTrialBlockedGpuModel("nvidia", "h100", [])).toBe(false);
   });
+});
+
+describe(isTrialBlockedGpuSelection.name, () => {
+  const BLOCKED = ["nvidia/h100", "nvidia/a100"];
+
+  it("blocks an empty model when the vendor exposes any blocked model", () => {
+    expect(isTrialBlockedGpuSelection("nvidia", "", BLOCKED)).toBe(true);
+    expect(isTrialBlockedGpuSelection("NVIDIA", undefined, BLOCKED)).toBe(true);
+  });
+
+  it("allows an empty model when the vendor exposes no blocked model", () => {
+    expect(isTrialBlockedGpuSelection("amd", "", BLOCKED)).toBe(false);
+  });
+
+  it("does not treat a prefix-colliding vendor as blocked", () => {
+    expect(isTrialBlockedGpuSelection("nvidiax", "", BLOCKED)).toBe(false);
+  });
+
+  it("defers a specific model to isTrialBlockedGpuModel", () => {
+    expect(isTrialBlockedGpuSelection("nvidia", "h100", BLOCKED)).toBe(true);
+    expect(isTrialBlockedGpuSelection("nvidia", "t4", BLOCKED)).toBe(false);
+  });
+
+  it("never blocks when the vendor is missing", () => {
+    expect(isTrialBlockedGpuSelection(undefined, "", BLOCKED)).toBe(false);
+    expect(isTrialBlockedGpuSelection(null, "h100", BLOCKED)).toBe(false);
+  });
+
+  it("never blocks when the blocked list is empty", () => {
+    expect(isTrialBlockedGpuSelection("nvidia", "", [])).toBe(false);
+    expect(isTrialBlockedGpuSelection("nvidia", "h100", [])).toBe(false);
+  });
+});
+
+describe(hasTrialBlockedGpu.name, () => {
+  const BLOCKED = ["nvidia/h100", "nvidia/a100"];
+
+  it("flags a GPU-enabled service left on the empty (any) model", () => {
+    const values = buildValues([{ hasGpu: true, gpuModels: [{ vendor: "nvidia", name: "" }] }]);
+
+    expect(hasTrialBlockedGpu(values, BLOCKED)).toBe(true);
+  });
+
+  it("flags a GPU-enabled service on a specific blocked model", () => {
+    const values = buildValues([{ hasGpu: true, gpuModels: [{ vendor: "nvidia", name: "h100" }] }]);
+
+    expect(hasTrialBlockedGpu(values, BLOCKED)).toBe(true);
+  });
+
+  it("does not flag a GPU-enabled service on a specific allowed model", () => {
+    const values = buildValues([{ hasGpu: true, gpuModels: [{ vendor: "nvidia", name: "t4" }] }]);
+
+    expect(hasTrialBlockedGpu(values, BLOCKED)).toBe(false);
+  });
+
+  it("ignores services with GPU turned off even if the model is blocked", () => {
+    const values = buildValues([{ hasGpu: false, gpuModels: [{ vendor: "nvidia", name: "" }] }]);
+
+    expect(hasTrialBlockedGpu(values, BLOCKED)).toBe(false);
+  });
+
+  it("flags when any one of multiple services has a blocked GPU selection", () => {
+    const values = buildValues([
+      { hasGpu: true, gpuModels: [{ vendor: "nvidia", name: "t4" }] },
+      { hasGpu: true, gpuModels: [{ vendor: "nvidia", name: "" }] }
+    ]);
+
+    expect(hasTrialBlockedGpu(values, BLOCKED)).toBe(true);
+  });
+
+  function buildValues(services: Array<{ hasGpu: boolean; gpuModels: Array<{ vendor: string; name?: string }> }>): SdlBuilderFormValuesType {
+    const base = defaultServiceWithPlacement();
+    const placementId = base.placements[0].id;
+    return {
+      ...base,
+      services: services.map((service, index) =>
+        defaultService(placementId, {
+          title: `service-${index + 1}`,
+          profile: { ...base.services[0].profile, hasGpu: service.hasGpu, gpuModels: service.gpuModels }
+        })
+      )
+    };
+  }
 });
 
 describe(NewDeploymentData.name, () => {

--- a/apps/deploy-web/src/utils/deploymentData/v1beta3.spec.ts
+++ b/apps/deploy-web/src/utils/deploymentData/v1beta3.spec.ts
@@ -4,7 +4,15 @@ import { describe, expect, it } from "vitest";
 
 import type { SdlBuilderFormValuesType } from "@src/types";
 import { defaultService, defaultServiceWithPlacement } from "@src/utils/sdl/data";
-import { applyTrialGpuPolicy, hasTrialBlockedGpu, isTrialBlockedGpuModel, isTrialBlockedGpuSelection, NewDeploymentData, replaceSdlDenom } from "./v1beta3";
+import {
+  applyTrialGpuPolicy,
+  hasTrialBlockedGpu,
+  isTrialBlockedGpuModel,
+  isTrialBlockedGpuSelection,
+  isTrialGpuRestrictionActive,
+  NewDeploymentData,
+  replaceSdlDenom
+} from "./v1beta3";
 
 describe(replaceSdlDenom.name, () => {
   it("replaces denom in a single placement pricing entry", () => {
@@ -242,6 +250,16 @@ describe(isTrialBlockedGpuSelection.name, () => {
   it("never blocks when the blocked list is empty", () => {
     expect(isTrialBlockedGpuSelection("nvidia", "", [])).toBe(false);
     expect(isTrialBlockedGpuSelection("nvidia", "h100", [])).toBe(false);
+  });
+});
+
+describe(isTrialGpuRestrictionActive.name, () => {
+  it("is active when any model is blocklisted", () => {
+    expect(isTrialGpuRestrictionActive(["nvidia/h100"])).toBe(true);
+  });
+
+  it("is inactive when the blocklist is empty", () => {
+    expect(isTrialGpuRestrictionActive([])).toBe(false);
   });
 });
 

--- a/apps/deploy-web/src/utils/deploymentData/v1beta3.ts
+++ b/apps/deploy-web/src/utils/deploymentData/v1beta3.ts
@@ -144,6 +144,16 @@ export function isTrialBlockedGpuSelection(
 }
 
 /**
+ * Whether the managed-wallet trial GPU restriction is switched on at all (any model is blocklisted). This is the
+ * signal for "trials cannot use high-end GPUs", used to gate confidential-compute GPU (cpu-gpu) on its own merit
+ * rather than deriving it from a specific model or the stricter "any" selection rule. When the blocklist is empty
+ * the whole restriction (SDL stripping + per-bid filtering) is a no-op, so nothing GPU-related is gated.
+ */
+export function isTrialGpuRestrictionActive(blockedModels: readonly string[] = browserEnvConfig.NEXT_PUBLIC_MANAGED_WALLET_TRIAL_BLOCKED_GPU_MODELS): boolean {
+  return blockedModels.length > 0;
+}
+
+/**
  * Whether a form's GPU selection would be blocked for a trial on the configure screen — the submit guard in
  * `ConfigureDeploymentHeader` uses this because enabling the GPU card leaves the model at the empty default
  * *without ever opening the (locked) picker*, so the presentational lock alone cannot stop an empty-model

--- a/apps/deploy-web/src/utils/deploymentData/v1beta3.ts
+++ b/apps/deploy-web/src/utils/deploymentData/v1beta3.ts
@@ -5,6 +5,7 @@ import { generateManifestVersion } from "@akashnetwork/chain-sdk/web";
 import yaml from "js-yaml";
 
 import { browserEnvConfig } from "@src/config/browser-env.config";
+import type { SdlBuilderFormValuesType } from "@src/types";
 import type { DepositParams } from "@src/types/deployment";
 import { buildManifest, CustomValidationError, Manifest, ManifestVersion, parseSdlInput } from "./helpers";
 
@@ -115,6 +116,47 @@ export function isTrialBlockedGpuModel(
 ): boolean {
   if (!vendor || !model) return false;
   return blockedModels.includes(`${vendor.toLowerCase()}/${model.toLowerCase()}`);
+}
+
+/**
+ * UI-only trial GPU predicate for the "Configure your deployment" screen, and **intentionally stricter than
+ * the SDL trial policy** ({@link applyTrialGpuPolicy}) and the backend. A specific model defers to
+ * {@link isTrialBlockedGpuModel}; an **empty** model ("any model from this vendor") is treated as blocked
+ * whenever that vendor exposes **any** blocked model.
+ *
+ * Why stricter: unlike a specific blocked model (always broken for trials), "any nvidia" *can* succeed if an
+ * allowed-model provider happens to bid — but "any" is an unreliable gamble. If no allowed-model provider bids
+ * the deployment just spins with no explanation (CON-660). Forcing a trial to pick a specific *allowed* model
+ * (which stays selectable) or add credits gives a deterministic outcome. This predicate must **not** be reused
+ * by {@link applyTrialGpuPolicy}, which deliberately leaves "any" as `null` and punts enforcement to accept-bid.
+ *
+ * The `/` delimiter on the prefix check avoids vendor prefix collisions (e.g. `nvidia` vs `nvidiax`). A missing
+ * vendor is never blocked.
+ */
+export function isTrialBlockedGpuSelection(
+  vendor: string | null | undefined,
+  model: string | null | undefined,
+  blockedModels: readonly string[] = browserEnvConfig.NEXT_PUBLIC_MANAGED_WALLET_TRIAL_BLOCKED_GPU_MODELS
+): boolean {
+  if (!vendor) return false;
+  if (model) return isTrialBlockedGpuModel(vendor, model, blockedModels);
+  return blockedModels.some(entry => entry.startsWith(`${vendor.toLowerCase()}/`));
+}
+
+/**
+ * Whether a form's GPU selection would be blocked for a trial on the configure screen — the submit guard in
+ * `ConfigureDeploymentHeader` uses this because enabling the GPU card leaves the model at the empty default
+ * *without ever opening the (locked) picker*, so the presentational lock alone cannot stop an empty-model
+ * submission. Scans only GPU-enabled services via {@link isTrialBlockedGpuSelection} (UI-only, stricter than
+ * the SDL policy — see there).
+ */
+export function hasTrialBlockedGpu(
+  values: SdlBuilderFormValuesType,
+  blockedModels: readonly string[] = browserEnvConfig.NEXT_PUBLIC_MANAGED_WALLET_TRIAL_BLOCKED_GPU_MODELS
+): boolean {
+  return values.services.some(
+    service => service.profile?.hasGpu && (service.profile.gpuModels ?? []).some(gpu => isTrialBlockedGpuSelection(gpu.vendor, gpu.name, blockedModels))
+  );
 }
 
 export function applyTrialGpuPolicy(

--- a/packages/ui/components/loading-button.spec.tsx
+++ b/packages/ui/components/loading-button.spec.tsx
@@ -1,0 +1,54 @@
+import type { ReactNode } from "react";
+import { describe, expect, it } from "vitest";
+
+import { LoadingButton } from "./loading-button";
+
+import { render, screen } from "@testing-library/react";
+
+describe(LoadingButton.name, () => {
+  it("renders its label", () => {
+    setup({ children: "Redeem coupon" });
+
+    expect(screen.getByRole("button", { name: /redeem coupon/i })).toBeInTheDocument();
+  });
+
+  it("shows an accessible loading indicator while loading", () => {
+    setup({ loading: true });
+
+    expect(screen.getByRole("status")).toBeInTheDocument();
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+  });
+
+  it("shows no loading indicator when not loading", () => {
+    setup({ loading: false });
+
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  it("renders a provided loadingIndicator instead of the default spinner", () => {
+    setup({ loading: true, loadingIndicator: <span>custom-indicator</span> });
+
+    expect(screen.getByText("custom-indicator")).toBeInTheDocument();
+    expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
+  });
+
+  it("disables the button while loading even without an explicit disabled prop", () => {
+    setup({ loading: true });
+
+    expect(screen.getByRole("button")).toBeDisabled();
+  });
+
+  it("stays disabled while loading even when disabled is explicitly false", () => {
+    // Guards against the spread clobbering the combined disabled: a caller that moves its
+    // in-flight flag into `loading` (leaving disabled false) must still block clicks.
+    setup({ loading: true, disabled: false });
+
+    expect(screen.getByRole("button")).toBeDisabled();
+  });
+
+  function setup(input: { children?: ReactNode; loading?: boolean; loadingIndicator?: ReactNode; disabled?: boolean } = {}) {
+    const { children = "Submit", ...buttonProps } = input;
+    render(<LoadingButton {...buttonProps}>{children}</LoadingButton>);
+    return input;
+  }
+});

--- a/packages/ui/components/loading-button.tsx
+++ b/packages/ui/components/loading-button.tsx
@@ -5,37 +5,54 @@ import { AnimatePresence, motion } from "framer-motion";
 import { cn } from "../utils/cn";
 import type { ButtonProps } from "./button";
 import { Button } from "./button";
-import { Spinner } from "./spinner";
 
 export interface LoadingButtonProps extends ButtonProps {
   loading?: boolean;
   loadingIndicator?: React.ReactNode;
 }
 
-const LoadingButton = React.forwardRef<HTMLButtonElement, LoadingButtonProps>(({ className, children, loading = false, loadingIndicator, ...props }, ref) => {
-  const variant = props.variant === "outline" || props.variant === "text" || props.variant === "link" || props.variant === "ghost" ? "primary" : "dark";
-  return (
-    <Button className={cn(className)} disabled={loading || props.disabled} ref={ref} {...props}>
-      <div className="flex items-center">
-        <AnimatePresence mode="popLayout">
-          {loading && (
-            <motion.div
-              initial={{ width: 0, opacity: 0 }}
-              animate={{ width: "auto", opacity: 1 }}
-              exit={{ width: 0, opacity: 0 }}
-              transition={{ duration: 0.2 }}
-              className="overflow-hidden"
-            >
-              {loadingIndicator || <Spinner size="small" className="mr-2" variant={variant} />}
-            </motion.div>
-          )}
-        </AnimatePresence>
-        {children}
-      </div>
-    </Button>
-  );
-});
+const LoadingButton = React.forwardRef<HTMLButtonElement, LoadingButtonProps>(
+  ({ className, children, loading = false, loadingIndicator, disabled, ...props }, ref) => {
+    // `disabled` is destructured out of `props` so it is NOT re-applied by `{...props}` below, which would
+    // clobber this combined value. A loading button must always block clicks, even when the caller passes
+    // `disabled={false}` (e.g. having moved its in-flight flag into `loading`).
+    return (
+      <Button className={cn(className)} disabled={loading || disabled} ref={ref} {...props}>
+        <div className="flex items-center">
+          <AnimatePresence mode="popLayout">
+            {loading && (
+              <motion.div
+                initial={{ width: 0, opacity: 0 }}
+                animate={{ width: "auto", opacity: 1 }}
+                exit={{ width: 0, opacity: 0 }}
+                transition={{ duration: 0.2 }}
+                className="overflow-hidden"
+              >
+                {loadingIndicator || <ButtonSpinner />}
+              </motion.div>
+            )}
+          </AnimatePresence>
+          {children}
+        </div>
+      </Button>
+    );
+  }
+);
 
 LoadingButton.displayName = "LoadingButton";
+
+/**
+ * Default in-button spinner: a ring tinted with the button's own foreground color via `border-current`, so it
+ * stays visible on every variant. The shared `Spinner`'s arc is `fill-primary`, which equals `bg-primary` and
+ * vanishes on solid buttons; the button's foreground is guaranteed to contrast its background by design.
+ */
+function ButtonSpinner() {
+  return (
+    <span role="status" className="mr-2 flex items-center justify-center">
+      <span className="h-4 w-4 animate-spin rounded-full border-2 border-current border-r-transparent" />
+      <span className="sr-only">Loading...</span>
+    </span>
+  );
+}
 
 export { LoadingButton };


### PR DESCRIPTION
## Why

On the new **Configure your deployment** page (flag `onboarding_redesign_v1`), a free-trial user who enables **Confidential Compute → CPU-GPU** — or leaves a GPU card on the default empty **"Any model"** selection — requests a GPU that trials cannot use. The deployment is created and enters quoting, but no usable bid ever satisfies `allPlacementsHaveBids` (the only TEE-capable GPU, `nvidia/pro6000se`, is on the trial blocklist), so the CTA stays on **"Requesting…"** forever with no explanation. The issue asks that trial users be told upfront, with an **Add Funds** path, instead of hitting an endless spinner.

Fixes CON-660

## What

Lock the unusable GPU options upfront and guard submission, mirroring the existing GPU/Presets trial locks from #3409:

- **`v1beta3`** — new **UI-only** predicates `isTrialBlockedGpuSelection` / `hasTrialBlockedGpu`. They treat an **empty ("any") model** as blocked when the vendor exposes any blocked model.
- **`ConfidentialComputeCard`** — locks the `CPU-GPU` radio (lock icon) with a warning + **Unlock high-end GPUs** CTA; keeps CPU-only TEE selectable (the backend never blocks it); defensively rejects `cpu-gpu` in `setTee`.
- **`GpuCard`** — locks the **"Any model"** empty option; specific allowed models stay selectable.
- **`SearchableSelect`** — supports a `disabled` empty option.
- **`HardwareSection`** — routes the new predicate and passes `isGpuBlocked` / `onUnlock` to the confidential-compute card.
- **`ConfigureDeploymentHeader`** — a **load-bearing** submit guard: enabling the GPU card leaves the model at the empty default *without ever opening the (locked) picker*, so the presentational lock alone can't stop an empty-model submission. On a trial with a blocked GPU selection it appends a clear message to the request-quotes error snackbar and blocks the request.

### Intended behavior change (flag for review)

Locking **"Any model"** makes the **front-end intentionally stricter than the backend**. The backend leaves "any nvidia" to per-bid enforcement (`validateLeaseGpuModels`), and the SDL policy `applyTrialGpuPolicy` deliberately leaves "any" as `null` — both are unchanged. "Any" *can* succeed if an allowed-model provider happens to bid, but it's an unreliable gamble: if none bids, the deployment spins with no explanation. Forcing a trial to pick a specific *allowed* model (which stays selectable) or add credits gives a deterministic outcome. This rationale is documented in code comments (`isTrialBlockedGpuSelection`) so the divergence reads as deliberate.

### Out of scope

- Backend enforcement (accept-bid `402`) is unchanged; this is a proactive front-end gate.
- A trial that picks a specific *allowed* model no provider currently offers still hits the pre-existing generic 60s "No providers available" timeout — a separate UX gap.

### Testing

- New/extended specs across all six files (139 tests in the affected set). Full `deploy-web` suite: **2646 passed**. Lint clean; no new type errors.
- **Manual E2E not run in this session** (needs a dev server + a fresh $1 trial wallet with `NEXT_PUBLIC_UNLEASH_ENABLE_ALL=true`). Recommended before merge: verify CPU-GPU locks with CPU still selectable, "Any model" locks, Request quotes on the empty model is blocked with the trial message, an allowed model proceeds, and a funded wallet is unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trial users now see blocked GPU options clearly marked and disabled, with guidance to unlock access.
  * Added unlock actions for high-end GPUs and prevented quote requests when selected GPUs require credits.
  * “Any model” GPU selections now reflect trial availability and credit requirements.
* **UI Improvements**
  * Added disabled-state support for empty selections.
  * Improved loading buttons with accessible indicators and consistent disabled behavior.
  * Added a prominent style option for GPU unlock actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->