### PR TITLE
fix(deployment): route redeploy and in-progress deployments to the configure flow

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useConfigureDraft/useConfigureDraft.spec.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useConfigureDraft/useConfigureDraft.spec.ts
@@ -205,9 +205,21 @@ describe(createConfigureDraft.name, () => {
     expect(create("version: '2.0'")).toBe("fresh-1");
   });
 
+  it("persists the deployment name alongside the sdl when one is given", () => {
+    const { create } = setup({ mintedDraftId: "fresh-1" });
+
+    create("version: '2.0'", "my-app");
+
+    expect(readEntry("fresh-1")).toEqual(expect.objectContaining({ sdl: "version: '2.0'", name: "my-app" }));
+  });
+
   function readSdl(draftId: string) {
+    return readEntry(draftId)?.sdl;
+  }
+
+  function readEntry(draftId: string) {
     const raw = window.localStorage.getItem(`${DRAFT_KEY_PREFIX}${draftId}`);
-    return raw ? (JSON.parse(raw) as { sdl: string }).sdl : undefined;
+    return raw ? (JSON.parse(raw) as { sdl: string; name?: string }) : undefined;
   }
 
   function setup(input: { mintedDraftId?: string; getStorage?: typeof DEPENDENCIES.getStorage }) {
@@ -217,6 +229,6 @@ describe(createConfigureDraft.name, () => {
       useRouter: () => mock<ReturnType<typeof DEPENDENCIES.useRouter>>({}),
       mintDraftId: vi.fn(() => input.mintedDraftId ?? "minted-id")
     };
-    return { create: (sdl: string) => createConfigureDraft(sdl, dependencies) };
+    return { create: (sdl: string, name?: string) => createConfigureDraft(sdl, name, dependencies) };
   }
 });

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useConfigureDraft/useConfigureDraft.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useConfigureDraft/useConfigureDraft.ts
@@ -89,15 +89,15 @@ export function useConfigureDraft(intent: DeploymentIntent, dependencies: typeof
 }
 
 /**
- * Starts a configure session from an SDL produced outside the screen (e.g. an uploaded file): mints a draft id,
- * persists the SDL under it, and returns the id so the caller can route to `configure?draftId=<id>`. Uses the same
- * storage format as in-screen saves, so the configure screen restores it via `persistedSdl` on arrival. Storage-safe:
- * if storage is blocked or full the write no-ops and the id is still returned (configure then seeds from its other
- * sources), matching how `saveDraft` already swallows failures.
+ * Starts a configure session from an SDL produced outside the screen (e.g. an uploaded file or a redeploy): mints a
+ * draft id, persists the SDL (and optional deployment `name`) under it, and returns the id so the caller can route to
+ * `configure?draftId=<id>`. Uses the same storage format as in-screen saves, so the configure screen restores it via
+ * `persistedSdl`/`persistedName` on arrival. Storage-safe: if storage is blocked or full the write no-ops and the id
+ * is still returned (configure then seeds from its other sources), matching how `saveDraft` already swallows failures.
  */
-export function createConfigureDraft(sdl: string, dependencies: typeof DEPENDENCIES = DEPENDENCIES): string {
+export function createConfigureDraft(sdl: string, name?: string, dependencies: typeof DEPENDENCIES = DEPENDENCIES): string {
   const draftId = dependencies.mintDraftId();
-  saveDraft(dependencies.getStorage(), draftId, sdl);
+  saveDraft(dependencies.getStorage(), draftId, sdl, name);
   return draftId;
 }
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.spec.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.spec.ts
@@ -143,6 +143,7 @@ describe(useDeploymentFlow.name, () => {
         useRouter: (() => mock<ReturnType<typeof DEPENDENCIES.useRouter>>({ replace: vi.fn(), push: vi.fn() })) as never,
         useQueryClient: (() => mock<ReturnType<typeof DEPENDENCIES.useQueryClient>>()) as never,
         useDeploymentLocalStorage: (() => mock<ReturnType<typeof DEPENDENCIES.useDeploymentLocalStorage>>()) as never,
+        useSettingsId: (() => "akash1owner") as never,
         manifestFromSdl: () => "M"
       };
       const { result, rerender } = renderHook(() => useDeploymentFlow({ intent: { sdlStrategy: "edit", bidStrategy: "select", dseq: "777" } }, dependencies));
@@ -303,6 +304,16 @@ describe(useDeploymentFlow.name, () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("caches the created SDL by the settings id and dseq at create time so an in-progress deployment can be resumed after a reload", () => {
+    const createDeployment = mockMutation();
+    createDeployment.mutate.mockImplementation((_i, o) => o.onSuccess({ data: { dseq: "555", manifest: "M" } }));
+    const { result, deploymentLocalStorage } = renderFlow({ createDeployment });
+
+    act(() => result.current.actions.requestQuotes("SDL_AT_CREATE"));
+
+    expect(deploymentLocalStorage.update).toHaveBeenCalledWith("akash1owner", "555", { manifest: "SDL_AT_CREATE" });
   });
 
   it("still marks the deploy succeeded and redirects when caching the SDL throws", () => {
@@ -537,6 +548,7 @@ describe(useDeploymentFlow.name, () => {
       useRouter: (() => mock<ReturnType<typeof DEPENDENCIES.useRouter>>({ replace: (input.replace ?? vi.fn()) as never })) as never,
       useQueryClient: (() => mock<ReturnType<typeof DEPENDENCIES.useQueryClient>>()) as never,
       useDeploymentLocalStorage: (() => mock<ReturnType<typeof DEPENDENCIES.useDeploymentLocalStorage>>()) as never,
+      useSettingsId: (() => "akash1owner") as never,
       manifestFromSdl: () => "manifest"
     };
     return renderHook(() => useDeploymentFlow({ intent }, dependencies));
@@ -564,6 +576,7 @@ describe(useDeploymentFlow.name, () => {
       useRouter: () => router,
       useQueryClient: (() => queryClient) as never,
       useDeploymentLocalStorage: (() => deploymentLocalStorage) as never,
+      useSettingsId: (() => "akash1owner") as never,
       manifestFromSdl: input?.manifestFromSdl ?? (() => "M")
     };
     const utils = renderHook(() => useDeploymentFlow({ intent }, dependencies));

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.ts
@@ -1,9 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { extractApiErrorMessage } from "@akashnetwork/openapi-sdk";
 import { useQueryClient } from "@tanstack/react-query";
+import { useAtomValue } from "jotai";
 import { useRouter } from "next/router";
 
 import { useServices } from "@src/context/ServicesProvider";
+import { settingsIdAtom } from "@src/context/SettingsProvider/settingsStore";
 import { QueryKeys } from "@src/queries/queryKeys";
 import { BID_POLL_INTERVAL, useListBids } from "@src/queries/useListBids";
 import { formatBidId, parseBidId } from "@src/utils/bids/bidId";
@@ -95,6 +97,11 @@ function useDeploymentLocalStorage() {
   return useServices().deploymentLocalStorage;
 }
 
+/** The wallet address that keys deployment-local storage (WalletProvider sets it to the wallet address); same key the detail page reads. */
+function useSettingsId() {
+  return useAtomValue(settingsIdAtom);
+}
+
 export const DEPENDENCIES = {
   useCreateDeployment,
   useCloseDeployment,
@@ -104,6 +111,7 @@ export const DEPENDENCIES = {
   useRouter,
   useQueryClient,
   useDeploymentLocalStorage,
+  useSettingsId,
   manifestFromSdl
 };
 
@@ -124,6 +132,7 @@ export function useDeploymentFlow(
   const updateDeployment = dependencies.useUpdateDeployment();
   const queryClient = dependencies.useQueryClient();
   const deploymentLocalStorage = dependencies.useDeploymentLocalStorage();
+  const settingsId = dependencies.useSettingsId();
 
   const [phase, setPhase] = useState<DeploymentFlowPhase>(intent.dseq ? "quoting" : "configuring");
   const [dseq, setDseq] = useState<string | null>(intent.dseq ?? null);
@@ -220,6 +229,10 @@ export function useDeploymentFlow(
             setDeployError(undefined);
             setDeploySucceeded(false);
             setPhase("quoting");
+            // Cache the SDL under the wallet + dseq key the detail page reads, at create time, so an in-progress
+            // deployment (on-chain, no lease yet) can be resumed into the configure flow after a reload, when the
+            // captured SDL is otherwise gone. The create response omits `owner`, so key off the settings id.
+            cacheDeployedSdl(deploymentLocalStorage, settingsId, result.data.dseq, sdl);
             router.replace(buildConfigureUrl(intentRef.current, result.data.dseq, bidStrategyRef.current), undefined, { shallow: true });
           },
           onError: function onCreateFailed(cause: unknown) {
@@ -229,7 +242,7 @@ export function useDeploymentFlow(
         }
       );
     },
-    [createDeployment, router]
+    [createDeployment, router, deploymentLocalStorage, settingsId]
   );
 
   const cancelAndEdit = useCallback(
@@ -373,7 +386,7 @@ export function useDeploymentFlow(
  * Storage can be blocked, full, or hold corrupt data, so any failure is swallowed: caching must never keep the
  * deploy-success UI or the redirect from running.
  */
-function cacheDeployedSdl(storage: ReturnType<typeof useDeploymentLocalStorage>, owner: string, dseq: string, sdl: string): void {
+function cacheDeployedSdl(storage: ReturnType<typeof useDeploymentLocalStorage>, owner: string | null | undefined, dseq: string, sdl: string): void {
   try {
     storage.update(owner, dseq, { manifest: sdl });
   } catch {

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail.tsx
@@ -11,6 +11,7 @@ import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { NextSeo } from "next-seo";
 
+import { createConfigureDraft } from "@src/components/deployments/ConfigureDeployment/useConfigureDraft/useConfigureDraft";
 import { DeploymentAlerts } from "@src/components/deployments/DeploymentAlerts/DeploymentAlerts";
 import { useServices } from "@src/context/ServicesProvider";
 import { useSettings } from "@src/context/SettingsProvider";
@@ -24,7 +25,6 @@ import { useDeploymentDetail } from "@src/queries/useDeploymentQuery";
 import { useDeploymentLeaseList } from "@src/queries/useLeaseQuery";
 import { useProviderList } from "@src/queries/useProvidersQuery";
 import { extractRepositoryUrl } from "@src/services/remote-deploy/env-var-manager.service";
-import { RouteStep } from "@src/types/route-steps.type";
 import { isLeaseLive } from "@src/utils/reclamationUtils";
 import { UrlService } from "@src/utils/urlUtils";
 import Layout from "../layout/Layout";
@@ -76,7 +76,13 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = ({ dseq }) => {
       // Redirect to select bids if has no lease — but not when a group is paused (reclaimed): the
       // deployment is still active with no live lease, and must remain viewable, not bounce to bid selection.
       if (deployment?.state === "active" && leases.length === 0 && !deployment.groups?.some(g => g.state === "paused")) {
-        router.replace(UrlService.newDeployment({ dseq, step: RouteStep.createLeases }));
+        // Resume the in-progress (on-chain, no lease yet) deployment in the configure flow. Seed the editor from the
+        // locally cached SDL (kept at create time) so quoting bids against the real spec; passing dseq resumes the
+        // existing deployment rather than creating a new one. With no local SDL (e.g. opened on another device) fall
+        // back to a bare resume.
+        const localData = deploymentLocalStorage.get(address, dseq);
+        const draftId = localData?.manifest ? createConfigureDraft(localData.manifest, localData.name) : undefined;
+        router.replace(UrlService.configureDeployment({ dseq, draftId }));
       }
 
       // Set the array of refs for lease rows
@@ -89,7 +95,7 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = ({ dseq }) => {
         );
       }
     }
-  }, [deployment?.state, dseq, leaseRefs.length, leases, router]);
+  }, [deployment?.state, dseq, leaseRefs.length, leases, router, address, deploymentLocalStorage]);
 
   const isDeploymentNotFound = deploymentError && (deploymentError as any).response?.data?.message?.includes("Deployment not found") && !isLoadingDeployment;
   const hasLeases = leases && leases.length > 0;

--- a/apps/deploy-web/src/components/deployments/DeploymentDetailTopBar/DeploymentDetailTopBar.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetailTopBar/DeploymentDetailTopBar.spec.tsx
@@ -98,6 +98,24 @@ describe(DeploymentDetailTopBar.name, () => {
       expect(deps.CustomDropdownLinkItem).toHaveBeenCalledWith(expect.objectContaining({ children: "Redeploy" }), {});
     });
 
+    it("redeploys with the stored sdl and name and tracks the click when Redeploy is clicked", () => {
+      const redeploy = vi.fn();
+      const track = vi.fn();
+      const deps = setup({
+        deployment: createDeployment({ state: "active" }),
+        analyticsTrack: track,
+        redeploy,
+        localNotes: {
+          getDeploymentData: () => ({ manifest: "some-manifest", name: "my-app" })
+        }
+      });
+
+      clickMockComponent(deps.CustomDropdownLinkItem, ([props]) => props.children === "Redeploy");
+
+      expect(redeploy).toHaveBeenCalledWith({ sdl: "some-manifest", name: "my-app" });
+      expect(track).toHaveBeenCalledWith("redeploy_btn_clk", "Amplitude");
+    });
+
     it("does not render Redeploy option when manifest is missing", () => {
       setup({
         deployment: createDeployment({ state: "active" }),
@@ -212,9 +230,10 @@ describe(DeploymentDetailTopBar.name, () => {
     router?: { back?: () => void; push?: () => void };
     wallet?: { isManaged?: boolean; denom?: string; signAndBroadcastTx?: () => Promise<boolean> };
     analyticsTrack?: ReturnType<typeof vi.fn>;
+    redeploy?: ReturnType<typeof vi.fn>;
     localNotes?: {
       getDeploymentName?: (dseq: string | number) => string | null | undefined;
-      getDeploymentData?: (dseq: string | number) => { manifest?: string } | null;
+      getDeploymentData?: (dseq: string | number) => { manifest?: string; name?: string } | null;
       changeDeploymentName?: (dseq: string | number) => void;
     };
   }) {
@@ -264,6 +283,7 @@ describe(DeploymentDetailTopBar.name, () => {
       useManagedDeploymentConfirm: vi.fn(() => ({
         closeDeploymentConfirm: vi.fn(() => Promise.resolve(true))
       })) as typeof DEPENDENCIES.useManagedDeploymentConfirm,
+      useRedeploy: vi.fn(() => input?.redeploy ?? vi.fn()) as unknown as typeof DEPENDENCIES.useRedeploy,
       useDeploymentSettingQuery: vi.fn(() => ({
         data: { autoTopUpEnabled: false, estimatedTopUpAmount: 0, topUpFrequencyMs: 0 },
         setAutoTopUpEnabled: vi.fn(),

--- a/apps/deploy-web/src/components/deployments/DeploymentDetailTopBar/DeploymentDetailTopBar.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetailTopBar/DeploymentDetailTopBar.tsx
@@ -22,6 +22,7 @@ import { useDepositDeployment } from "@src/hooks/useDepositDeployment/useDeposit
 import { useManagedDeploymentConfirm } from "@src/hooks/useManagedDeploymentConfirm";
 import { usePreviousRoute } from "@src/hooks/usePreviousRoute";
 import { usePricing } from "@src/hooks/usePricing/usePricing";
+import { useRedeploy } from "@src/hooks/useRedeploy/useRedeploy";
 import { useDeploymentSettingQuery } from "@src/queries/deploymentSettingsQuery";
 import type { DeploymentDto, LeaseDto } from "@src/types/deployment";
 import { averageBlockTime } from "@src/utils/priceUtils";
@@ -50,7 +51,8 @@ export const DEPENDENCIES = {
   usePricing,
   useDeploymentSettingQuery,
   usePopup,
-  useRouter
+  useRouter,
+  useRedeploy
 };
 
 type Props = {
@@ -120,10 +122,7 @@ export const DeploymentDetailTopBar: React.FunctionComponent<Props> = ({
     changeDeploymentName(deployment.dseq);
   }
 
-  const redeploy = () => {
-    const url = UrlService.newDeployment({ redeploy: deployment.dseq });
-    router.push(url);
-  };
+  const redeploy = d.useRedeploy();
 
   const { deposit: depositDeployment } = d.useDepositDeployment({
     dseq: deployment.dseq,
@@ -212,7 +211,7 @@ export const DeploymentDetailTopBar: React.FunctionComponent<Props> = ({
                 {storageDeploymentData?.manifest && (
                   <d.CustomDropdownLinkItem
                     onClick={() => {
-                      redeploy();
+                      redeploy({ sdl: storageDeploymentData?.manifest, name: storageDeploymentData?.name });
                       analyticsService.track("redeploy_btn_clk", "Amplitude");
                     }}
                     icon={<Upload fontSize="small" />}
@@ -286,7 +285,7 @@ export const DeploymentDetailTopBar: React.FunctionComponent<Props> = ({
             {storageDeploymentData?.manifest && (
               <d.Button
                 onClick={() => {
-                  redeploy();
+                  redeploy({ sdl: storageDeploymentData?.manifest, name: storageDeploymentData?.name });
                   analyticsService.track("redeploy_btn_clk", "Amplitude");
                 }}
                 variant="default"

--- a/apps/deploy-web/src/components/deployments/DeploymentListRow.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentListRow.tsx
@@ -29,6 +29,7 @@ import { useDepositDeployment } from "@src/hooks/useDepositDeployment/useDeposit
 import { useManagedDeploymentConfirm } from "@src/hooks/useManagedDeploymentConfirm";
 import { useProviderCredentials } from "@src/hooks/useProviderCredentials/useProviderCredentials";
 import { useRealTimeLeft } from "@src/hooks/useRealTimeLeft";
+import { useRedeploy } from "@src/hooks/useRedeploy/useRedeploy";
 import { useDenomData } from "@src/hooks/useWalletBalance";
 import { useAllLeases, useLeaseStatus } from "@src/queries/useLeaseQuery";
 import type { LeaseDto, NamedDeploymentDto } from "@src/types/deployment";
@@ -156,10 +157,7 @@ export const DeploymentListRow: React.FunctionComponent<Props> = ({ deployment, 
     }
   };
 
-  const redeploy = () => {
-    const url = UrlService.newDeployment({ redeploy: deployment.dseq });
-    router.push(url);
-  };
+  const redeploy = useRedeploy();
 
   function showDepositModal(e?: React.MouseEvent) {
     e?.preventDefault();
@@ -350,7 +348,10 @@ export const DeploymentListRow: React.FunctionComponent<Props> = ({ deployment, 
                         Edit name
                       </CustomDropdownLinkItem>
                       {storageDeploymentData?.manifest && (
-                        <CustomDropdownLinkItem onClick={() => redeploy()} icon={<Upload fontSize="small" />}>
+                        <CustomDropdownLinkItem
+                          onClick={() => redeploy({ sdl: storageDeploymentData?.manifest, name: storageDeploymentData?.name })}
+                          icon={<Upload fontSize="small" />}
+                        >
                           Redeploy
                         </CustomDropdownLinkItem>
                       )}

--- a/apps/deploy-web/src/components/deployments/ReclamationBanner/ReclamationBanner.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ReclamationBanner/ReclamationBanner.spec.tsx
@@ -1,9 +1,14 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
 
 import type { LeaseDto } from "@src/types/deployment";
-import { ReclamationBanner } from "./ReclamationBanner";
+import { DEPENDENCIES, ReclamationBanner } from "./ReclamationBanner";
 
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MockComponents } from "@tests/unit/mocks";
+
+type DeploymentData = NonNullable<ReturnType<ReturnType<typeof DEPENDENCIES.useLocalNotes>["getDeploymentData"]>>;
 
 describe("ReclamationBanner", () => {
   afterEach(() => {
@@ -50,11 +55,31 @@ describe("ReclamationBanner", () => {
 
   it("offers a redeploy action", () => {
     setup({ leases: [createLease({ state: "reclaiming" })] });
-    expect(screen.getByRole("link", { name: "Redeploy" })).toHaveAttribute("href", expect.stringContaining("redeploy=123"));
+    expect(screen.getByRole("button", { name: "Redeploy" })).toBeInTheDocument();
   });
 
-  function setup(input: { leases: LeaseDto[] | null }) {
-    return render(<ReclamationBanner leases={input.leases} dseq="123" />);
+  it("redeploys with the stored sdl and name when Redeploy is clicked", async () => {
+    const { redeploy } = setup({
+      leases: [createLease({ state: "reclaiming" })],
+      deploymentData: { manifest: "version: 2.0", name: "my-app" }
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "Redeploy" }));
+
+    expect(redeploy).toHaveBeenCalledWith({ sdl: "version: 2.0", name: "my-app" });
+  });
+
+  function setup(input: { leases: LeaseDto[] | null; deploymentData?: { manifest?: string; name?: string } | null }) {
+    const localNotes = mock<ReturnType<typeof DEPENDENCIES.useLocalNotes>>();
+    localNotes.getDeploymentData.mockReturnValue(input.deploymentData ? mock<DeploymentData>(input.deploymentData) : null);
+    const redeploy = vi.fn();
+
+    const useLocalNotes: typeof DEPENDENCIES.useLocalNotes = () => localNotes;
+    const useRedeploy: typeof DEPENDENCIES.useRedeploy = () => redeploy;
+
+    const utils = render(<ReclamationBanner leases={input.leases} dseq="123" dependencies={MockComponents(DEPENDENCIES, { useLocalNotes, useRedeploy })} />);
+
+    return { ...utils, redeploy };
   }
 
   function createLease(overrides: { state?: string; reclamation?: LeaseDto["reclamation"] } = {}): LeaseDto {

--- a/apps/deploy-web/src/components/deployments/ReclamationBanner/ReclamationBanner.tsx
+++ b/apps/deploy-web/src/components/deployments/ReclamationBanner/ReclamationBanner.tsx
@@ -1,18 +1,20 @@
 "use client";
 import { useMemo } from "react";
-import { Alert, AlertDescription, AlertTitle, buttonVariants } from "@akashnetwork/ui/components";
-import { cn } from "@akashnetwork/ui/utils";
+import { Alert, AlertDescription, AlertTitle, Button } from "@akashnetwork/ui/components";
 import { WarningTriangle } from "iconoir-react";
-import Link from "next/link";
 
+import { useLocalNotes } from "@src/components/LocalNoteManager";
+import { useRedeploy } from "@src/hooks/useRedeploy/useRedeploy";
 import type { LeaseDto } from "@src/types/deployment";
 import { getLeaseCloseReasonLabel, getReclamationDeadline, isReclaiming } from "@src/utils/reclamationUtils";
-import { UrlService } from "@src/utils/urlUtils";
 import { useCountdown } from "./useCountdown";
+
+export const DEPENDENCIES = { useLocalNotes, useRedeploy };
 
 type Props = {
   leases: LeaseDto[] | undefined | null;
   dseq: string;
+  dependencies?: typeof DEPENDENCIES;
 };
 
 /**
@@ -20,7 +22,10 @@ type Props = {
  * Reclamation is terminal — it can't be cancelled — so the call to action is to redeploy elsewhere
  * before the grace-period deadline. The terminal (already-closed) case is handled by ReclamationCard.
  */
-export const ReclamationBanner: React.FunctionComponent<Props> = ({ leases, dseq }) => {
+export const ReclamationBanner: React.FunctionComponent<Props> = ({ leases, dseq, dependencies = DEPENDENCIES }) => {
+  const { getDeploymentData } = dependencies.useLocalNotes();
+  const redeploy = dependencies.useRedeploy();
+  const deploymentData = getDeploymentData(dseq);
   const reclaimingLeases = useMemo(() => (leases ?? []).filter(isReclaiming), [leases]);
 
   const nearestDeadline = useMemo(() => {
@@ -47,9 +52,9 @@ export const ReclamationBanner: React.FunctionComponent<Props> = ({ leases, dseq
         </p>
         <p className="mt-1 text-xs text-muted-foreground">Reason: {reasonLabel}</p>
         <p className="mt-2">Reclamation can&apos;t be cancelled. Redeploy to another provider before the deadline to avoid downtime.</p>
-        <Link href={UrlService.newDeployment({ redeploy: dseq })} className={cn(buttonVariants({ variant: "default", size: "sm" }), "mt-3")}>
+        <Button variant="default" size="sm" className="mt-3" onClick={() => redeploy({ sdl: deploymentData?.manifest, name: deploymentData?.name })}>
           Redeploy
-        </Link>
+        </Button>
       </AlertDescription>
     </Alert>
   );

--- a/apps/deploy-web/src/components/deployments/ReclamationCard/ReclamationCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ReclamationCard/ReclamationCard.spec.tsx
@@ -25,6 +25,14 @@ describe("ReclamationCard", () => {
     expect(screen.queryByRole("button", { name: /resume/i })).not.toBeInTheDocument();
   });
 
+  it("redeploys with the stored sdl and name when Redeploy is clicked", async () => {
+    const { redeploy } = setup({ hasLocalManifest: true, manifest: "version: 2.0", name: "my-app" });
+
+    await userEvent.click(screen.getByRole("button", { name: "Redeploy" }));
+
+    expect(redeploy).toHaveBeenCalledWith({ sdl: "version: 2.0", name: "my-app" });
+  });
+
   it("falls back to a 'new SDL' link when there is no local manifest", () => {
     setup({ hasLocalManifest: false });
 
@@ -52,7 +60,7 @@ describe("ReclamationCard", () => {
     expect(wallet.signAndBroadcastTx).not.toHaveBeenCalled();
   });
 
-  function setup(input: { reason?: string; hasLocalManifest?: boolean; isConfirmed?: boolean; onClosed?: () => void } = {}) {
+  function setup(input: { reason?: string; hasLocalManifest?: boolean; manifest?: string; name?: string; isConfirmed?: boolean; onClosed?: () => void } = {}) {
     const wallet = mock<ReturnType<typeof DEPENDENCIES.useWallet>>({ address: "akash1owner" });
     wallet.signAndBroadcastTx.mockResolvedValue(true);
 
@@ -60,14 +68,16 @@ describe("ReclamationCard", () => {
     confirm.closeDeploymentConfirm.mockResolvedValue(input.isConfirmed ?? true);
 
     const localNotes = mock<ReturnType<typeof DEPENDENCIES.useLocalNotes>>();
-    localNotes.getDeploymentData.mockReturnValue(input.hasLocalManifest ? mock<DeploymentData>({ manifest: "version: 2.0" }) : null);
+    localNotes.getDeploymentData.mockReturnValue(
+      input.hasLocalManifest ? mock<DeploymentData>({ manifest: input.manifest ?? "version: 2.0", name: input.name }) : null
+    );
 
-    const router = mock<ReturnType<typeof DEPENDENCIES.useRouter>>();
+    const redeploy = vi.fn();
 
     const useWallet: typeof DEPENDENCIES.useWallet = () => wallet;
     const useManagedDeploymentConfirm: typeof DEPENDENCIES.useManagedDeploymentConfirm = () => confirm;
     const useLocalNotes: typeof DEPENDENCIES.useLocalNotes = () => localNotes;
-    const useRouter: typeof DEPENDENCIES.useRouter = () => router;
+    const useRedeploy: typeof DEPENDENCIES.useRedeploy = () => redeploy;
     const useNewDeploymentUrl: typeof DEPENDENCIES.useNewDeploymentUrl = () => () => "/new-deployment";
 
     const lease = mock<LeaseDto>({
@@ -87,10 +97,10 @@ describe("ReclamationCard", () => {
         lease={lease}
         dseq="123"
         onClosed={input.onClosed}
-        dependencies={MockComponents(DEPENDENCIES, { useWallet, useManagedDeploymentConfirm, useLocalNotes, useRouter, useNewDeploymentUrl })}
+        dependencies={MockComponents(DEPENDENCIES, { useWallet, useManagedDeploymentConfirm, useLocalNotes, useRedeploy, useNewDeploymentUrl })}
       />
     );
 
-    return { wallet, confirm, router };
+    return { wallet, confirm, redeploy };
   }
 });

--- a/apps/deploy-web/src/components/deployments/ReclamationCard/ReclamationCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ReclamationCard/ReclamationCard.tsx
@@ -4,18 +4,17 @@ import { Alert, AlertDescription, AlertTitle, Button, buttonVariants, Spinner } 
 import { cn } from "@akashnetwork/ui/utils";
 import { WarningTriangle } from "iconoir-react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 
 import { useLocalNotes } from "@src/components/LocalNoteManager";
 import { useWallet } from "@src/context/WalletProvider";
 import { useManagedDeploymentConfirm } from "@src/hooks/useManagedDeploymentConfirm";
 import { useNewDeploymentUrl } from "@src/hooks/useNewDeploymentUrl/useNewDeploymentUrl";
+import { useRedeploy } from "@src/hooks/useRedeploy/useRedeploy";
 import type { LeaseDto } from "@src/types/deployment";
 import { getLeaseCloseReasonLabel } from "@src/utils/reclamationUtils";
 import { TransactionMessageData } from "@src/utils/TransactionMessageData";
-import { UrlService } from "@src/utils/urlUtils";
 
-export const DEPENDENCIES = { useWallet, useManagedDeploymentConfirm, useLocalNotes, useRouter, useNewDeploymentUrl };
+export const DEPENDENCIES = { useWallet, useManagedDeploymentConfirm, useLocalNotes, useNewDeploymentUrl, useRedeploy };
 
 type Props = {
   lease: LeaseDto;
@@ -30,16 +29,17 @@ type Props = {
  * deployment) + Redeploy. The live, still-running case is handled by ReclamationBanner.
  */
 export const ReclamationCard: React.FunctionComponent<Props> = ({ lease, dseq, onClosed, dependencies = DEPENDENCIES }) => {
-  const { useWallet, useManagedDeploymentConfirm, useLocalNotes, useRouter, useNewDeploymentUrl } = dependencies;
+  const { useWallet, useManagedDeploymentConfirm, useLocalNotes, useNewDeploymentUrl, useRedeploy } = dependencies;
   const { address, signAndBroadcastTx } = useWallet();
   const { closeDeploymentConfirm } = useManagedDeploymentConfirm();
   const { getDeploymentData } = useLocalNotes();
-  const router = useRouter();
   const newDeploymentUrl = useNewDeploymentUrl();
+  const redeploy = useRedeploy();
   const [isClosing, setIsClosing] = useState(false);
 
   const reasonLabel = getLeaseCloseReasonLabel(lease.reclamation?.reason ?? lease.reason);
-  const hasLocalManifest = !!getDeploymentData(dseq)?.manifest;
+  const deploymentData = getDeploymentData(dseq);
+  const hasLocalManifest = !!deploymentData?.manifest;
 
   const confirmAndClose = async () => {
     const isConfirmed = await closeDeploymentConfirm([dseq]);
@@ -55,8 +55,6 @@ export const ReclamationCard: React.FunctionComponent<Props> = ({ lease, dseq, o
     }
   };
 
-  const redeploy = () => router.push(UrlService.newDeployment({ redeploy: dseq }));
-
   return (
     <Alert variant="warning" className="p-4">
       <WarningTriangle className="h-4 w-4" />
@@ -70,7 +68,12 @@ export const ReclamationCard: React.FunctionComponent<Props> = ({ lease, dseq, o
             {isClosing ? <Spinner size="small" /> : "Close & refund"}
           </Button>
           {hasLocalManifest ? (
-            <Button variant="outline" size="sm" className="text-foreground" onClick={redeploy}>
+            <Button
+              variant="outline"
+              size="sm"
+              className="text-foreground"
+              onClick={() => redeploy({ sdl: deploymentData?.manifest, name: deploymentData?.name })}
+            >
               Redeploy
             </Button>
           ) : (

--- a/apps/deploy-web/src/hooks/useRedeploy/useRedeploy.spec.ts
+++ b/apps/deploy-web/src/hooks/useRedeploy/useRedeploy.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import { UrlService } from "@src/utils/urlUtils";
+import { type DEPENDENCIES, useRedeploy } from "./useRedeploy";
+
+import { renderHook } from "@testing-library/react";
+
+describe(useRedeploy.name, () => {
+  it("mints a draft from the sdl and opens it in the configure flow, carrying the name", () => {
+    const { redeploy, push, createConfigureDraft } = setup({ draftId: "draft-1" });
+
+    redeploy({ sdl: "version: '2.0'", name: "my-app" });
+
+    expect(createConfigureDraft).toHaveBeenCalledWith("version: '2.0'", "my-app");
+    expect(push).toHaveBeenCalledWith("/new-deployment/configure?draftId=draft-1");
+  });
+
+  it("opens a blank configure screen and mints no draft when no sdl is available", () => {
+    const { redeploy, push, createConfigureDraft } = setup();
+
+    redeploy({});
+
+    expect(createConfigureDraft).not.toHaveBeenCalled();
+    expect(push).toHaveBeenCalledWith("/new-deployment/configure");
+  });
+
+  function setup(input: { draftId?: string } = {}) {
+    const push = vi.fn();
+    const router = mock<ReturnType<typeof DEPENDENCIES.useRouter>>({ push });
+    const createConfigureDraft = vi.fn(() => input.draftId ?? "draft-id") as unknown as typeof DEPENDENCIES.createConfigureDraft;
+    const dependencies: typeof DEPENDENCIES = {
+      useRouter: () => router,
+      UrlService,
+      createConfigureDraft
+    };
+    const redeploy = renderHook(() => useRedeploy(dependencies)).result.current;
+    return { redeploy, push, createConfigureDraft };
+  }
+});

--- a/apps/deploy-web/src/hooks/useRedeploy/useRedeploy.spec.ts
+++ b/apps/deploy-web/src/hooks/useRedeploy/useRedeploy.spec.ts
@@ -28,7 +28,7 @@ describe(useRedeploy.name, () => {
   function setup(input: { draftId?: string } = {}) {
     const push = vi.fn();
     const router = mock<ReturnType<typeof DEPENDENCIES.useRouter>>({ push });
-    const createConfigureDraft = vi.fn(() => input.draftId ?? "draft-id") as unknown as typeof DEPENDENCIES.createConfigureDraft;
+    const createConfigureDraft = vi.fn<typeof DEPENDENCIES.createConfigureDraft>(() => input.draftId ?? "draft-id");
     const dependencies: typeof DEPENDENCIES = {
       useRouter: () => router,
       UrlService,

--- a/apps/deploy-web/src/hooks/useRedeploy/useRedeploy.ts
+++ b/apps/deploy-web/src/hooks/useRedeploy/useRedeploy.ts
@@ -1,0 +1,32 @@
+import { useRouter } from "next/navigation";
+
+import { createConfigureDraft } from "@src/components/deployments/ConfigureDeployment/useConfigureDraft/useConfigureDraft";
+import { UrlService } from "@src/utils/urlUtils";
+
+export const DEPENDENCIES = { useRouter, UrlService, createConfigureDraft };
+
+export interface RedeployInput {
+  /** The previous deployment's SDL, recovered from local storage. Seeds the editor when present. */
+  sdl?: string;
+  /** The previous deployment's name, carried through so it prefills on the new flow. */
+  name?: string;
+}
+
+/**
+ * Navigates to the configure flow to redeploy a deployment. A recovered SDL is minted into a draft and opened at
+ * `configure?draftId=<id>` (name carried through) so the previous spec prefills; with no SDL it opens a blank
+ * configure screen. Redeploy always starts a fresh deployment, so the original dseq is not part of the destination.
+ */
+export function useRedeploy(dependencies = DEPENDENCIES) {
+  const d = dependencies;
+  const router = d.useRouter();
+
+  return function redeploy({ sdl, name }: RedeployInput) {
+    if (sdl) {
+      const draftId = d.createConfigureDraft(sdl, name);
+      router.push(d.UrlService.configureDeployment({ draftId }));
+      return;
+    }
+    router.push(d.UrlService.configureDeployment({}));
+  };
+}


### PR DESCRIPTION
## Why

With `onboarding_redesign_v1` on for all users (and being removed shortly), two entry points still hard-coded the old `/new-deployment` flow, so redeploy and resuming an in-progress deployment dropped users out of the new configure experience.

Resolves CON-661

## What

Routes both the in-progress-deployment resume and all 4 Redeploy entry points into the new `/new-deployment/configure` flow. The flag gate is dropped (on for everyone), so these paths always use the new flow.

- **New `useRedeploy` hook** mints a configure draft from the previous SDL (carrying the deployment name) and navigates to `configure?draftId=…`; with no local SDL it opens a blank configure screen.
- **Wired 4 redeploy sites** through the hook: deployment list row, detail top bar (both buttons; `redeploy_btn_clk` analytics preserved), reclamation card, and reclamation banner (its render-time `<Link>` became a `<Button onClick>`).
- **`createConfigureDraft(sdl, name?)`** now carries the deployment name into the draft so it prefills.
- **Create-time SDL cache**: `useDeploymentFlow` caches the SDL by wallet + dseq at create time (not just after a successful lease), so an in-progress deployment (on-chain, no lease yet) can be resumed into configure after a reload.
- **In-progress redirect** in `DeploymentDetail` now resumes into configure seeded from that cached SDL, instead of bouncing to the classic bid step.

### Tests
- New `useRedeploy.spec.ts`.
- Extended specs: `useConfigureDraft`, `useDeploymentFlow` (create-time cache), `DeploymentDetailTopBar` (navigate + analytics), `ReclamationCard`, `ReclamationBanner`.
- Full deploy-web unit suite green; `tsc --noEmit` no new errors; lint clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified redeploy flow via a dedicated redeploy hook, carrying over the deployment manifest (SDL) and optional name when available.
  * Active deployments with zero leases can resume the configure flow after reload.
  * Configure drafts can now persist and restore an optional deployment name.
* **Bug Fixes**
  * Improved recovery/resume for in-progress deployments, including better SDL caching tied to settings and dseq.
* **Tests**
  * Expanded coverage for redeploy and configure-draft persistence, including updated mocks and assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->