### PR TITLE
refactor: makes bid-http-service to retry on network errors

### DIFF
--- a/apps/api/src/core/providers/http-sdk.provider.ts
+++ b/apps/api/src/core/providers/http-sdk.provider.ts
@@ -29,7 +29,7 @@ container.register(CHAIN_API_HTTP_CLIENT, {
   )
 });
 
-const SERVICES = [BalanceHttpService, BidHttpService, ProviderHttpService];
+const SERVICES = [BalanceHttpService, ProviderHttpService];
 SERVICES.forEach(Service =>
   container.register(Service as InjectionToken<unknown>, {
     useFactory: instancePerContainerCachingFactory(c => new Service({ baseURL: c.resolve(CoreConfigService).get("REST_API_NODE_URL") }))
@@ -42,7 +42,8 @@ const NON_AXIOS_SERVICES: Array<new (httpClient: HttpClient) => unknown> = [
   CosmosHttpService,
   AuthzHttpService,
   BlockHttpService,
-  BmeHttpService
+  BmeHttpService,
+  BidHttpService
 ];
 NON_AXIOS_SERVICES.forEach(Service =>
   container.register(Service, { useFactory: instancePerContainerCachingFactory(c => new Service(c.resolve(CHAIN_API_HTTP_CLIENT))) })

--- a/apps/api/src/deployment/services/gpu-bids-creator/gpu-bids-creator.service.spec.ts
+++ b/apps/api/src/deployment/services/gpu-bids-creator/gpu-bids-creator.service.spec.ts
@@ -1,13 +1,15 @@
 import "@test/mocks/logger-service.mock";
 
-import type { BidHttpService, BlockHttpService } from "@akashnetwork/http-sdk";
+import type { QueryBidsResponse } from "@akashnetwork/chain-sdk/private-types/akash.v1beta5";
+import type { BlockHttpService } from "@akashnetwork/http-sdk";
 import type { Registry } from "@cosmjs/proto-signing";
 import type { SigningStargateClient } from "@cosmjs/stargate";
 import { describe, expect, it, vi } from "vitest";
-import { mock } from "vitest-mock-extended";
+import { mock, mockDeep } from "vitest-mock-extended";
 
 import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
-import type { LoggerService } from "@src/core";
+import type { ChainSDK } from "@src/chain/providers/chain-sdk.provider";
+import type { CreateLogger } from "@src/core/providers/logging.provider";
 import type { DeploymentConfig } from "@src/deployment/config/config.provider";
 import type { GpuService } from "@src/gpu/services/gpu.service";
 import { GpuBidsCreatorService } from "./gpu-bids-creator.service";
@@ -136,7 +138,7 @@ describe(GpuBidsCreatorService.name, () => {
 
   describe("createBidsForAllModels", () => {
     it("creates deployments for each GPU model, waits for bids, and closes", async () => {
-      const { service, signingClient, bidHttpService, blockHttpService } = setup();
+      const { service, signingClient, chainSdk, blockHttpService } = setup();
       const gpuModels = {
         gpus: {
           total: { allocatable: 10, allocated: 5 },
@@ -146,17 +148,15 @@ describe(GpuBidsCreatorService.name, () => {
         }
       };
 
-      bidHttpService.list.mockResolvedValue([]);
-
       await service["createBidsForAllModels"](gpuModels as any, signingClient, "akash1owner", false);
 
       expect(blockHttpService.getCurrentHeight).toHaveBeenCalled();
       expect(signingClient.simulate).toHaveBeenCalledTimes(2);
-      expect(bidHttpService.list).toHaveBeenCalledWith("akash1owner", "100000");
+      expect(chainSdk.akash.market.v1beta5.getBids).toHaveBeenCalledWith({ filters: { owner: "akash1owner", dseq: "100000" } });
     });
 
     it("skips duplicate model+ram combos when includeInterface is false", async () => {
-      const { service, signingClient, bidHttpService } = setup();
+      const { service, signingClient } = setup();
       const gpuModels = {
         gpus: {
           total: { allocatable: 10, allocated: 5 },
@@ -168,8 +168,6 @@ describe(GpuBidsCreatorService.name, () => {
           }
         }
       };
-
-      bidHttpService.list.mockResolvedValue([]);
 
       await service["createBidsForAllModels"](gpuModels as any, signingClient, "akash1owner", false);
 
@@ -177,7 +175,7 @@ describe(GpuBidsCreatorService.name, () => {
     });
 
     it("does not skip duplicate model+ram combos when includeInterface is true", async () => {
-      const { service, signingClient, bidHttpService } = setup();
+      const { service, signingClient } = setup();
       const gpuModels = {
         gpus: {
           total: { allocatable: 10, allocated: 5 },
@@ -190,15 +188,13 @@ describe(GpuBidsCreatorService.name, () => {
         }
       };
 
-      bidHttpService.list.mockResolvedValue([]);
-
       await service["createBidsForAllModels"](gpuModels as any, signingClient, "akash1owner", true);
 
       expect(signingClient.simulate).toHaveBeenCalledTimes(4);
     });
 
     it("filters out UNKNOWN vendor", async () => {
-      const { service, signingClient, bidHttpService } = setup();
+      const { service, signingClient } = setup();
       const gpuModels = {
         gpus: {
           total: { allocatable: 10, allocated: 5 },
@@ -208,8 +204,6 @@ describe(GpuBidsCreatorService.name, () => {
           }
         }
       };
-
-      bidHttpService.list.mockResolvedValue([]);
 
       await service["createBidsForAllModels"](gpuModels as any, signingClient, "akash1owner", false);
 
@@ -255,33 +249,11 @@ describe(GpuBidsCreatorService.name, () => {
     const config = mockConfigService<BillingConfigService>({
       NETWORK: "mainnet",
       AVERAGE_GAS_PRICE: 0.025,
-      ...(input.rpcNodeEndpoint !== undefined ? {} : { RPC_NODE_ENDPOINT: "https://rpc.example.com" })
+      RPC_NODE_ENDPOINT: "rpcNodeEndpoint" in input ? input.rpcNodeEndpoint : "https://rpc.example.com"
     });
 
-    if (input.rpcNodeEndpoint === undefined && !("rpcNodeEndpoint" in input)) {
-      config.get.mockImplementation((key: string) => {
-        const values: Record<string, any> = {
-          NETWORK: "mainnet",
-          AVERAGE_GAS_PRICE: 0.025,
-          RPC_NODE_ENDPOINT: "https://rpc.example.com"
-        };
-        if (key in values) return values[key];
-        throw new Error(`Missing mock for config key "${key}"`);
-      });
-    } else if (input.rpcNodeEndpoint === undefined) {
-      config.get.mockImplementation((key: string) => {
-        if (key === "RPC_NODE_ENDPOINT") return "";
-        const values: Record<string, any> = {
-          NETWORK: "mainnet",
-          AVERAGE_GAS_PRICE: 0.025
-        };
-        if (key in values) return values[key];
-        throw new Error(`Missing mock for config key "${key}"`);
-      });
-    }
-
-    const bidHttpService = mock<BidHttpService>();
-    bidHttpService.list.mockResolvedValue([]);
+    const chainSdk = mockDeep<ChainSDK>();
+    chainSdk.akash.market.v1beta5.getBids.mockResolvedValue(mock<QueryBidsResponse>({ bids: [] }));
 
     const gpuService = mock<GpuService>();
     gpuService.getGpuList.mockResolvedValue({
@@ -304,17 +276,21 @@ describe(GpuBidsCreatorService.name, () => {
     signingClient.broadcastTx.mockResolvedValue({ code: 0, rawLog: "" } as any);
     signingClient.getBalance.mockResolvedValue({ amount: "1000000", denom: "uakt" });
 
-    const service = new GpuBidsCreatorService(config, bidHttpService, gpuService, blockHttpService, typeRegistry, deploymentConfig, mock<LoggerService>());
+    const logger = mock<ReturnType<CreateLogger>>();
+    const createLogger: CreateLogger = () => logger;
+
+    const service = new GpuBidsCreatorService(config, chainSdk, gpuService, blockHttpService, typeRegistry, deploymentConfig, createLogger);
 
     return {
       service,
       config,
-      bidHttpService,
+      chainSdk,
       gpuService,
       blockHttpService,
       typeRegistry,
       deploymentConfig,
-      signingClient
+      signingClient,
+      logger
     };
   }
 });

--- a/apps/api/src/deployment/services/gpu-bids-creator/gpu-bids-creator.service.ts
+++ b/apps/api/src/deployment/services/gpu-bids-creator/gpu-bids-creator.service.ts
@@ -3,7 +3,7 @@ import { generateManifest, generateManifestVersion, yaml as sdlYaml } from "@aka
 import { Source } from "@akashnetwork/chain-sdk/private-types/akash.v1";
 import { MsgCloseDeployment, MsgCreateDeployment } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
 import { TxRaw } from "@akashnetwork/chain-sdk/private-types/cosmos.v1beta1";
-import { BidHttpService, BlockHttpService } from "@akashnetwork/http-sdk";
+import { BlockHttpService } from "@akashnetwork/http-sdk";
 import { DirectSecp256k1HdWallet, EncodeObject, Registry } from "@cosmjs/proto-signing";
 import { calculateFee, SigningStargateClient } from "@cosmjs/stargate";
 import assert from "http-assert";
@@ -13,7 +13,8 @@ import { inject, singleton } from "tsyringe";
 
 import { InjectTypeRegistry } from "@src/billing/providers/type-registry.provider";
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
-import { LoggerService } from "@src/core";
+import { CHAIN_SDK, type ChainSDK } from "@src/chain/providers/chain-sdk.provider";
+import { type CreateLogger, LOGGER_FACTORY } from "@src/core/providers/logging.provider";
 import { DEPLOYMENT_CONFIG, type DeploymentConfig } from "@src/deployment/config/config.provider";
 import { GpuService } from "@src/gpu/services/gpu.service";
 import { sdlTemplateWithRam, sdlTemplateWithRamAndInterface } from "./sdl-templates";
@@ -21,18 +22,21 @@ import { sdlTemplateWithRam, sdlTemplateWithRamAndInterface } from "./sdl-templa
 @singleton()
 export class GpuBidsCreatorService {
   readonly #deploymentConfig: DeploymentConfig;
+  readonly #chainSdk: ChainSDK;
+  readonly #logger: ReturnType<CreateLogger>;
 
   constructor(
     private readonly config: BillingConfigService,
-    private readonly bidHttpService: BidHttpService,
+    @inject(CHAIN_SDK) chainSdk: ChainSDK,
     private readonly gpuService: GpuService,
     private readonly blockHttpService: BlockHttpService,
     @InjectTypeRegistry() private readonly typeRegistry: Registry,
     @inject(DEPLOYMENT_CONFIG) deploymentConfig: DeploymentConfig,
-    private readonly logger: LoggerService
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
     this.#deploymentConfig = deploymentConfig;
-    this.logger.setContext(GpuBidsCreatorService.name);
+    this.#chainSdk = chainSdk;
+    this.#logger = createLogger({ context: GpuBidsCreatorService.name });
   }
 
   async createGpuBids() {
@@ -42,7 +46,7 @@ export class GpuBidsCreatorService {
     const wallet = await DirectSecp256k1HdWallet.fromMnemonic(this.#deploymentConfig.GPU_BOT_WALLET_MNEMONIC, { prefix: "akash" });
     const [account] = await wallet.getAccounts();
 
-    this.logger.info({ event: "CREATING_GPU_BIDS", address: account.address });
+    this.#logger.info({ event: "CREATING_GPU_BIDS", address: account.address });
 
     const client = await SigningStargateClient.connectWithSigner(this.config.get("RPC_NODE_ENDPOINT"), wallet, {
       registry: this.typeRegistry,
@@ -51,7 +55,7 @@ export class GpuBidsCreatorService {
     const balanceBefore = await client.getBalance(account.address, "uact");
     const balanceBeforeUAct = parseFloat(balanceBefore.amount);
     const act = Math.round((balanceBeforeUAct / 1_000_000) * 100) / 100;
-    this.logger.info({ event: "CLIENT_CONNECTED", balance: act });
+    this.#logger.info({ event: "CLIENT_CONNECTED", balance: act });
 
     const gpuModels = await this.gpuService.getGpuList();
 
@@ -62,7 +66,7 @@ export class GpuBidsCreatorService {
     const balanceAfterUAct = parseFloat(balanceAfter.amount);
     const diff = balanceBeforeUAct - balanceAfterUAct;
 
-    this.logger.info({ event: "GPU_BIDS_CREATED", cost: diff / 1_000_000 });
+    this.#logger.info({ event: "GPU_BIDS_CREATED", cost: diff / 1_000_000 });
   }
 
   private async signAndBroadcast(address: string, client: SigningStargateClient, messages: readonly EncodeObject[]) {
@@ -76,7 +80,7 @@ export class GpuBidsCreatorService {
     const txResult = await client.broadcastTx(txRawBytes);
 
     if (txResult.code !== 0) {
-      this.logger.error(txResult);
+      this.#logger.error(txResult);
       throw new Error(`Error broadcasting transaction: ${txResult.rawLog}`);
     }
 
@@ -97,30 +101,35 @@ export class GpuBidsCreatorService {
       (a, b) => a.vendor.localeCompare(b.vendor) || a.model.localeCompare(b.model) || a.ram.localeCompare(b.ram) || a.interface.localeCompare(b.interface)
     );
 
-    this.logger.info({ event: "CREATING_BIDS", includeInterface });
+    this.#logger.info({ event: "CREATING_BIDS", includeInterface });
 
     const doneModels: string[] = [];
     for (const model of models) {
       const dseq = (await this.getCurrentHeight()).toString();
-      this.logger.info({ event: "CREATING_DEPLOYMENT", ...pick(model, ["vendor", "model", "ram", "interface"]) });
+      this.#logger.info({ event: "CREATING_DEPLOYMENT", ...pick(model, ["vendor", "model", "ram", "interface"]) });
 
       if (doneModels.includes(model.model + "-" + model.ram)) {
-        this.logger.info({ event: "SKIPPING_DEPLOYMENT", ...pick(model, ["model", "ram"]) });
+        this.#logger.info({ event: "SKIPPING_DEPLOYMENT", ...pick(model, ["model", "ram"]) });
         continue;
       }
 
       const gpuSdl = this.getModelSdl(model.vendor, model.model, model.ram, includeInterface ? model.interface : undefined);
 
       await this.createDeployment(client, gpuSdl, walletAddress, dseq);
-      this.logger.info({ event: "DEPLOYMENT_CREATED" });
+      this.#logger.info({ event: "DEPLOYMENT_CREATED" });
 
       await sleep(30_000);
 
-      const bids = await this.bidHttpService.list(walletAddress, dseq);
+      const bids = await this.#chainSdk.akash.market.v1beta5.getBids({
+        filters: {
+          owner: walletAddress,
+          dseq
+        }
+      });
 
-      this.logger.info({ event: "DEPLOYMENT_CLOSING", bidsCount: bids.length });
+      this.#logger.info({ event: "DEPLOYMENT_CLOSING", bidsCount: bids?.bids.length });
       await this.closeDeployment(client, walletAddress, dseq);
-      this.logger.info({ event: "DEPLOYMENT_CLOSED" });
+      this.#logger.info({ event: "DEPLOYMENT_CLOSED" });
 
       if (!includeInterface) {
         doneModels.push(model.model + "-" + model.ram);
@@ -129,7 +138,7 @@ export class GpuBidsCreatorService {
       await sleep(10_000);
     }
 
-    this.logger.info({ event: "BIDS_CREATED" });
+    this.#logger.info({ event: "BIDS_CREATED" });
   }
 
   private async createDeployment(client: SigningStargateClient, sdlStr: string, owner: string, dseq: string) {

--- a/packages/http-sdk/src/bid/bid-http.service.ts
+++ b/packages/http-sdk/src/bid/bid-http.service.ts
@@ -1,6 +1,4 @@
-import type { AxiosRequestConfig } from "axios";
-
-import { HttpService } from "../http/http.service";
+import type { HttpClient } from "../utils/httpClient";
 
 type Attribute = {
   key: string;
@@ -102,14 +100,16 @@ type RestAkashBidListResponse = {
   };
 };
 
-export class BidHttpService extends HttpService {
-  constructor(config?: Pick<AxiosRequestConfig, "baseURL">) {
-    super(config);
+export class BidHttpService {
+  readonly #httpClient: HttpClient;
+
+  constructor(httpClient: HttpClient) {
+    this.#httpClient = httpClient;
   }
 
   public async list(owner: string, dseq: string): Promise<Bid[]> {
-    const response = this.extractData(await this.get<RestAkashBidListResponse>(`/akash/market/v1beta5/bids/list?filters.owner=${owner}&filters.dseq=${dseq}`));
+    const response = await this.#httpClient.get<RestAkashBidListResponse>(`/akash/market/v1beta5/bids/list?filters.owner=${owner}&filters.dseq=${dseq}`);
 
-    return response.bids;
+    return response.data.bids;
   }
 }


### PR DESCRIPTION
## Why

Closes CON-680

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - GPU bid creation now retrieves existing bids directly from the chain, improving consistency with on-chain data.
  - Bid HTTP services use dedicated HTTP clients for more reliable service communication.
  - Logging and error reporting were updated across GPU bid creation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->