### PR TITLE
fix: height of name and reclamation inputs on deployment page

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/DeploymentNameField/DeploymentNameField.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/DeploymentNameField/DeploymentNameField.tsx
@@ -11,6 +11,13 @@ type Props = {
 export const DeploymentNameField: FC<Props> = ({ value, onChange, disabled }) => (
   <div className="space-y-2">
     <div className="px-1 font-mono text-xs uppercase text-muted-foreground">Name</div>
-    <Input aria-label="Deployment name" placeholder="Name your deployment" value={value} disabled={disabled} onChange={event => onChange(event.target.value)} />
+    <Input
+      inputClassName="h-9"
+      aria-label="Deployment name"
+      placeholder="Name your deployment"
+      value={value}
+      disabled={disabled}
+      onChange={event => onChange(event.target.value)}
+    />
   </div>
 );

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/ReclamationSection/ReclamationSection.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/ReclamationSection/ReclamationSection.tsx
@@ -68,7 +68,7 @@ export const ReclamationSection: FC<Props> = ({ locked = false }) => {
             value={field.value ?? ""}
             onValueChange={value => field.onChange(value === RECLAMATION_ANY_VALUE ? undefined : (value as ReclamationMinWindow))}
           >
-            <SelectTrigger aria-label="Reclamation" className="h-8 w-full text-xs">
+            <SelectTrigger aria-label="Reclamation" className="h-9 w-full text-xs">
               <SelectValue placeholder="Any" />
             </SelectTrigger>
             <SelectContent>


### PR DESCRIPTION
## Why

Closes CON-671

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved visual consistency in deployment configuration fields by standardizing input and selection control heights.
  * Preserved existing labels, placeholders, values, and interaction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->