### PR TITLE
feat(deployment): bring container-vm ssh deployments to the configure page

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/AdditionalSection/AdditionalSection.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/AdditionalSection/AdditionalSection.spec.tsx
@@ -1,5 +1,9 @@
+import type { PropsWithChildren } from "react";
+import { FormProvider, useForm } from "react-hook-form";
 import { describe, expect, it, vi } from "vitest";
 
+import type { SdlBuilderFormValuesType } from "@src/types";
+import { defaultService, defaultServiceWithPlacement } from "@src/utils/sdl/data";
 import type { ConfigurationLock } from "../configurationLock";
 import { AdditionalSection, DEPENDENCIES } from "./AdditionalSection";
 
@@ -49,7 +53,41 @@ describe(AdditionalSection.name, () => {
     expect(CommandsCard).toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
   });
 
-  function setup(input: { serviceIndex?: number; locked?: ConfigurationLock; dependencies?: Partial<typeof DEPENDENCIES> }) {
-    render(<AdditionalSection serviceIndex={input.serviceIndex ?? 0} locked={input.locked} dependencies={MockComponents(DEPENDENCIES, input.dependencies)} />);
+  it("omits the commands card for a vm service", () => {
+    const CommandsCard = vi.fn(() => null);
+    const RuntimeCard = vi.fn(() => null);
+
+    setup({ image: "ghcr.io/akash-network/ubuntu-2404-ssh:2", dependencies: { CommandsCard, RuntimeCard } });
+
+    expect(CommandsCard).not.toHaveBeenCalled();
+    expect(RuntimeCard).toHaveBeenCalled();
+  });
+
+  it("renders the commands card for a custom service", () => {
+    const CommandsCard = vi.fn(() => null);
+
+    setup({ image: "nginx:latest", dependencies: { CommandsCard } });
+
+    expect(CommandsCard).toHaveBeenCalled();
+  });
+
+  function setup(input: { serviceIndex?: number; locked?: ConfigurationLock; image?: string; dependencies?: Partial<typeof DEPENDENCIES> }) {
+    const serviceIndex = input.serviceIndex ?? 0;
+    const base = defaultServiceWithPlacement();
+    const placementId = base.placements[0].id;
+    const services = Array.from({ length: serviceIndex + 1 }, (_, index) => defaultService(placementId, { title: `service-${index + 1}` }));
+    services[serviceIndex] = { ...services[serviceIndex], image: input.image ?? "" };
+    const values: SdlBuilderFormValuesType = { ...base, services };
+
+    const Wrapper = ({ children }: PropsWithChildren) => {
+      const form = useForm<SdlBuilderFormValuesType>({ defaultValues: values });
+      return <FormProvider {...form}>{children}</FormProvider>;
+    };
+
+    render(
+      <Wrapper>
+        <AdditionalSection serviceIndex={serviceIndex} locked={input.locked} dependencies={MockComponents(DEPENDENCIES, input.dependencies)} />
+      </Wrapper>
+    );
   }
 });

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/AdditionalSection/AdditionalSection.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/AdditionalSection/AdditionalSection.tsx
@@ -1,5 +1,8 @@
 import type { FC } from "react";
+import { useFormContext, useWatch } from "react-hook-form";
 
+import type { SdlBuilderFormValuesType } from "@src/types";
+import { isVmImage } from "@src/utils/sdl/vmImages";
 import { CommandsCard } from "../CommandsCard/CommandsCard";
 import type { ConfigurationLock } from "../configurationLock";
 import { EnvironmentVariablesCard } from "../EnvironmentVariablesCard/EnvironmentVariablesCard";
@@ -23,10 +26,16 @@ type Props = {
  * The "ADDITIONAL" section of the Configuration pane for the selected service:
  * the runtime-facing cards that aren't hardware sizing. Each card edits the
  * shared deployment model for `services.${serviceIndex}` directly.
+ *
+ * A managed SSH-VM service gets no Commands card: overriding the entrypoint would break the SSH
+ * bootstrap that installs the public key and starts sshd (the legacy builder hid it the same way).
  */
 export const AdditionalSection: FC<Props> = ({ serviceIndex, locked, dependencies: d = DEPENDENCIES }) => {
   const structuralLocked = !!locked;
   const manifestLocked = locked === "all";
+  const { control } = useFormContext<SdlBuilderFormValuesType>();
+  const image = useWatch({ control, name: `services.${serviceIndex}.image` });
+  const isVm = isVmImage(image ?? "");
 
   return (
     <div className="flex flex-col gap-2 px-4">
@@ -36,7 +45,7 @@ export const AdditionalSection: FC<Props> = ({ serviceIndex, locked, dependencie
 
         <d.EnvironmentVariablesCard serviceIndex={serviceIndex} locked={manifestLocked} />
 
-        <d.CommandsCard serviceIndex={serviceIndex} locked={manifestLocked} />
+        {!isVm && <d.CommandsCard serviceIndex={serviceIndex} locked={manifestLocked} />}
 
         <d.ExposePortsCard serviceIndex={serviceIndex} locked={structuralLocked} />
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ExposePortsCard/ExposePortsCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ExposePortsCard/ExposePortsCard.spec.tsx
@@ -448,6 +448,60 @@ describe(ExposePortsCard.name, () => {
     });
   });
 
+  describe("when the service runs a vm image", () => {
+    const VM_IMAGE = "ghcr.io/akash-network/ubuntu-2404-ssh:2";
+
+    it("shows the port-22 row read-only with the SSH caption and no remove control", async () => {
+      const { openCard } = setup({
+        image: VM_IMAGE,
+        expose: [
+          { port: 22, as: 22, proto: "tcp" },
+          { port: 80, as: 80 }
+        ]
+      });
+
+      await openCard();
+
+      expect(screen.getByText("Reserved for SSH access")).toBeInTheDocument();
+      expect(screen.getByLabelText("Port 1 container port")).toBeDisabled();
+      expect(screen.getByLabelText("Port 1 exposed as")).toBeDisabled();
+      expect(screen.queryByRole("button", { name: "Remove port 1" })).not.toBeInTheDocument();
+    });
+
+    it("keeps the other rows editable and removable", async () => {
+      const { openCard } = setup({
+        image: VM_IMAGE,
+        expose: [
+          { port: 22, as: 22, proto: "tcp" },
+          { port: 80, as: 80 }
+        ]
+      });
+
+      await openCard();
+
+      expect(screen.getByLabelText("Port 2 container port")).not.toBeDisabled();
+      expect(screen.getByRole("button", { name: "Remove port 2" })).toBeInTheDocument();
+    });
+
+    it("protects nothing when no row is exposed as port 22", async () => {
+      const { openCard } = setup({ image: VM_IMAGE, expose: [{ port: 80, as: 80 }] });
+
+      await openCard();
+
+      expect(screen.queryByText("Reserved for SSH access")).not.toBeInTheDocument();
+      expect(screen.getByLabelText("Port 1 container port")).not.toBeDisabled();
+    });
+  });
+
+  it("does not protect a port-22 row on a non-vm service", async () => {
+    const { openCard } = setup({ image: "nginx:latest", expose: [{ port: 22, as: 22, proto: "tcp" }] });
+
+    await openCard();
+
+    expect(screen.queryByText("Reserved for SSH access")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Port 1 container port")).not.toBeDisabled();
+  });
+
   function setup(
     input: {
       expose?: Array<Partial<ExposeType>>;

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ExposePortsCard/ExposePortsCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ExposePortsCard/ExposePortsCard.tsx
@@ -237,12 +237,14 @@ const ExposePortsList: FC<ExposePortsListProps> = ({ serviceIndex, commitsRef })
   const { fields, append, remove } = useFieldArray({ control, name: `services.${serviceIndex}.expose`, keyName: "fieldId" });
   const image = useWatch({ control, name: `services.${serviceIndex}.image` });
   /**
-   * On a VM service the row exposed as port 22 is the managed SSH row: read-only and non-removable.
-   * `fields` is the field-array snapshot (updated on append/remove/reset, not on typing), so the managed
-   * row can't hop to another row mid-session while the user edits port numbers. When no such row exists
-   * (a carried-in SDL without one is taken literally) there is nothing to protect.
+   * On a VM service the exact 22-to-22 row is the managed SSH row: read-only and non-removable. The
+   * exact-pair predicate matches the seeded shape and the schema's reservation, so a row merely squatting
+   * on one side of port 22 stays editable and gets the validation error instead of a lock. `fields` is the
+   * field-array snapshot (updated on append/remove/reset, not on typing), so the managed row can't hop to
+   * another row mid-session while the user edits port numbers. When no such row exists (a carried-in SDL
+   * without one is taken literally) there is nothing to protect.
    */
-  const managedSshIndex = isVmImage(image ?? "") ? fields.findIndex(field => field.as === 22) : -1;
+  const managedSshIndex = isVmImage(image ?? "") ? fields.findIndex(field => field.port === 22 && field.as === 22) : -1;
 
   const add = useCallback(() => {
     append(newExpose() as ExposeType);

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ExposePortsCard/ExposePortsCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ExposePortsCard/ExposePortsCard.tsx
@@ -32,6 +32,7 @@ import { nanoid } from "nanoid";
 import type { ExposeType, SdlBuilderFormValuesType } from "@src/types";
 import { EndpointSchema } from "@src/types/sdlBuilder/sdlBuilder";
 import { defaultEndpoint, defaultHttpOptions, nextCases as nextCaseOptions, protoTypes } from "@src/utils/sdl/data";
+import { isVmImage } from "@src/utils/sdl/vmImages";
 import { exposePortsTooltip } from "../cardTooltips";
 
 export const DEPENDENCIES = { CollapsibleCard, DialogV2, DialogV2Content, DialogV2Header, DialogV2Title, DialogV2Description, DialogV2Body, DialogV2Footer };
@@ -234,6 +235,14 @@ type ExposePortsListProps = {
 const ExposePortsList: FC<ExposePortsListProps> = ({ serviceIndex, commitsRef }) => {
   const { control } = useFormContext<SdlBuilderFormValuesType>();
   const { fields, append, remove } = useFieldArray({ control, name: `services.${serviceIndex}.expose`, keyName: "fieldId" });
+  const image = useWatch({ control, name: `services.${serviceIndex}.image` });
+  /**
+   * On a VM service the row exposed as port 22 is the managed SSH row: read-only and non-removable.
+   * `fields` is the field-array snapshot (updated on append/remove/reset, not on typing), so the managed
+   * row can't hop to another row mid-session while the user edits port numbers. When no such row exists
+   * (a carried-in SDL without one is taken literally) there is nothing to protect.
+   */
+  const managedSshIndex = isVmImage(image ?? "") ? fields.findIndex(field => field.as === 22) : -1;
 
   const add = useCallback(() => {
     append(newExpose() as ExposeType);
@@ -247,7 +256,8 @@ const ExposePortsList: FC<ExposePortsListProps> = ({ serviceIndex, commitsRef })
           serviceIndex={serviceIndex}
           exposeIndex={exposeIndex}
           commitsRef={commitsRef}
-          onRemove={fields.length > 1 ? () => remove(exposeIndex) : undefined}
+          isManagedSsh={exposeIndex === managedSshIndex}
+          onRemove={fields.length > 1 && exposeIndex !== managedSshIndex ? () => remove(exposeIndex) : undefined}
         />
       ))}
 
@@ -263,10 +273,12 @@ type ExposePortFieldsProps = {
   serviceIndex: number;
   exposeIndex: number;
   commitsRef: EndpointCommitRegistry;
+  /** Marks the VM service's managed SSH row: its inputs are disabled and it carries the "Reserved for SSH access" caption. */
+  isManagedSsh?: boolean;
   onRemove?: () => void;
 };
 
-const ExposePortFields: FC<ExposePortFieldsProps> = ({ serviceIndex, exposeIndex, commitsRef, onRemove }) => {
+const ExposePortFields: FC<ExposePortFieldsProps> = ({ serviceIndex, exposeIndex, commitsRef, isManagedSsh = false, onRemove }) => {
   const { control, getValues, setValue } = useFormContext<SdlBuilderFormValuesType>();
   const basePath = `services.${serviceIndex}.expose.${exposeIndex}` as const;
   const endpoints = useWatch({ control, name: "endpoints" }) ?? [];
@@ -397,162 +409,172 @@ const ExposePortFields: FC<ExposePortFieldsProps> = ({ serviceIndex, exposeIndex
 
   return (
     <div role="group" aria-label={`Port ${exposeIndex + 1}`} className="flex flex-col gap-3 rounded-md border border-zinc-200 p-3 dark:border-zinc-800">
-      <div className="flex items-start gap-2">
-        <Field className="flex-1 gap-2">
-          <FieldLabel htmlFor={`${fieldId}-port`}>Container port</FieldLabel>
-          <FieldContent>
-            <Input
-              id={`${fieldId}-port`}
-              aria-label={`Port ${exposeIndex + 1} container port`}
-              type="number"
-              min={1}
-              max={65535}
-              value={port.field.value ?? ""}
-              onChange={event => port.field.onChange(parsePort(event.target.value))}
-              onBlur={port.field.onBlur}
-              error={!!port.fieldState.error}
-              inputClassName="h-9"
-            />
-            <FieldError>{port.fieldState.error?.message}</FieldError>
-          </FieldContent>
-        </Field>
+      {isManagedSsh && <p className="text-sm text-muted-foreground">Reserved for SSH access</p>}
+      <fieldset disabled={isManagedSsh} className="contents">
+        <div className="flex items-start gap-2">
+          <Field className="flex-1 gap-2">
+            <FieldLabel htmlFor={`${fieldId}-port`}>Container port</FieldLabel>
+            <FieldContent>
+              <Input
+                id={`${fieldId}-port`}
+                aria-label={`Port ${exposeIndex + 1} container port`}
+                type="number"
+                min={1}
+                max={65535}
+                value={port.field.value ?? ""}
+                onChange={event => port.field.onChange(parsePort(event.target.value))}
+                onBlur={port.field.onBlur}
+                error={!!port.fieldState.error}
+                inputClassName="h-9"
+              />
+              <FieldError>{port.fieldState.error?.message}</FieldError>
+            </FieldContent>
+          </Field>
 
-        <Field className="flex-1 gap-2">
-          <FieldLabel htmlFor={`${fieldId}-as`}>Exposed as</FieldLabel>
-          <FieldContent>
-            <Input
-              id={`${fieldId}-as`}
-              aria-label={`Port ${exposeIndex + 1} exposed as`}
-              type="number"
-              min={1}
-              max={65535}
-              value={as.field.value ?? ""}
-              onChange={event => as.field.onChange(parsePort(event.target.value))}
-              onBlur={as.field.onBlur}
-              error={!!as.fieldState.error}
-              inputClassName="h-9"
-            />
-            <FieldError>{as.fieldState.error?.message}</FieldError>
-          </FieldContent>
-        </Field>
+          <Field className="flex-1 gap-2">
+            <FieldLabel htmlFor={`${fieldId}-as`}>Exposed as</FieldLabel>
+            <FieldContent>
+              <Input
+                id={`${fieldId}-as`}
+                aria-label={`Port ${exposeIndex + 1} exposed as`}
+                type="number"
+                min={1}
+                max={65535}
+                value={as.field.value ?? ""}
+                onChange={event => as.field.onChange(parsePort(event.target.value))}
+                onBlur={as.field.onBlur}
+                error={!!as.fieldState.error}
+                inputClassName="h-9"
+              />
+              <FieldError>{as.fieldState.error?.message}</FieldError>
+            </FieldContent>
+          </Field>
 
-        {onRemove && (
-          <Button size="icon" type="button" variant="ghost" className="mt-6 h-9 w-9 shrink-0" aria-label={`Remove port ${exposeIndex + 1}`} onClick={onRemove}>
-            <XIcon className="h-4 w-4" />
-          </Button>
-        )}
-      </div>
-
-      <div className="flex items-start gap-2">
-        <Field className="flex-1 gap-2">
-          <FieldLabel>Protocol</FieldLabel>
-          <FieldContent>
-            <ToggleGroup
-              type="single"
-              variant="outline"
-              value={proto.field.value ?? "http"}
-              onValueChange={changeProto}
-              className="h-9 justify-start gap-0 rounded-md border"
-              aria-label={`Port ${exposeIndex + 1} protocol`}
+          {onRemove && (
+            <Button
+              size="icon"
+              type="button"
+              variant="ghost"
+              className="mt-6 h-9 w-9 shrink-0"
+              aria-label={`Remove port ${exposeIndex + 1}`}
+              onClick={onRemove}
             >
-              {protoTypes.map(option => (
-                <ToggleGroupItem
-                  key={option.id}
-                  value={option.name}
-                  aria-label={option.name}
-                  className="h-full flex-1 rounded-none border-0 uppercase first:rounded-l-md last:rounded-r-md"
-                >
-                  {option.name}
-                </ToggleGroupItem>
-              ))}
-            </ToggleGroup>
-          </FieldContent>
-        </Field>
+              <XIcon className="h-4 w-4" />
+            </Button>
+          )}
+        </div>
 
-        <Field className="flex-1 gap-2">
-          <FieldLabel>Routing</FieldLabel>
-          <FieldContent>
-            <Select value={routingValue} onValueChange={changeRouting}>
-              <SelectTrigger aria-label={`Port ${exposeIndex + 1} routing`} className="h-9">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent onCloseAutoFocus={keepFocusInDialog}>
-                <SelectItem value={PUBLIC_ROUTING}>Public (any IP)</SelectItem>
-                <SelectItem value={INTERNAL_ROUTING}>Internal</SelectItem>
-                {endpoints.map(endpoint => (
-                  <SelectItem key={endpoint.id} value={endpoint.name}>
-                    IP endpoint: {endpoint.name}
-                  </SelectItem>
+        <div className="flex items-start gap-2">
+          <Field className="flex-1 gap-2">
+            <FieldLabel>Protocol</FieldLabel>
+            <FieldContent>
+              <ToggleGroup
+                type="single"
+                variant="outline"
+                value={proto.field.value ?? "http"}
+                onValueChange={changeProto}
+                className="h-9 justify-start gap-0 rounded-md border"
+                aria-label={`Port ${exposeIndex + 1} protocol`}
+              >
+                {protoTypes.map(option => (
+                  <ToggleGroupItem
+                    key={option.id}
+                    value={option.name}
+                    aria-label={option.name}
+                    className="h-full flex-1 rounded-none border-0 uppercase first:rounded-l-md last:rounded-r-md"
+                  >
+                    {option.name}
+                  </ToggleGroupItem>
                 ))}
-                <SelectItem value={NEW_IP_ENDPOINT}>+ New IP endpoint</SelectItem>
-              </SelectContent>
-            </Select>
-          </FieldContent>
-        </Field>
-      </div>
+              </ToggleGroup>
+            </FieldContent>
+          </Field>
 
-      {isAddingEndpoint && (
-        <Field className="gap-2">
-          <FieldLabel htmlFor={`${fieldId}-new-endpoint`}>New IP endpoint name</FieldLabel>
-          <FieldContent>
-            <Input
-              id={`${fieldId}-new-endpoint`}
-              aria-label="New IP endpoint name"
-              placeholder="e.g. web-ip"
-              value={newEndpointName}
-              onChange={event => {
-                setNewEndpointName(event.target.value);
-                setAddEndpointError(null);
-              }}
-              error={!!addEndpointError}
-              inputClassName="h-9"
-            />
-            <FieldError>{addEndpointError}</FieldError>
-          </FieldContent>
-        </Field>
-      )}
+          <Field className="flex-1 gap-2">
+            <FieldLabel>Routing</FieldLabel>
+            <FieldContent>
+              <Select value={routingValue} onValueChange={changeRouting}>
+                <SelectTrigger aria-label={`Port ${exposeIndex + 1} routing`} className="h-9">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent onCloseAutoFocus={keepFocusInDialog}>
+                  <SelectItem value={PUBLIC_ROUTING}>Public (any IP)</SelectItem>
+                  <SelectItem value={INTERNAL_ROUTING}>Internal</SelectItem>
+                  {endpoints.map(endpoint => (
+                    <SelectItem key={endpoint.id} value={endpoint.name}>
+                      IP endpoint: {endpoint.name}
+                    </SelectItem>
+                  ))}
+                  <SelectItem value={NEW_IP_ENDPOINT}>+ New IP endpoint</SelectItem>
+                </SelectContent>
+              </Select>
+            </FieldContent>
+          </Field>
+        </div>
 
-      {isHttp && !isInternal && (
-        <Field className="gap-2">
-          <FieldLabel htmlFor={`${fieldId}-hostnames`}>Accept hostnames</FieldLabel>
-          <FieldContent>
-            <Input
-              id={`${fieldId}-hostnames`}
-              aria-label={`Port ${exposeIndex + 1} accept hostnames`}
-              placeholder="example.com, api.example.com"
-              defaultValue={hostnamesValue}
-              onChange={event => changeHostnames(event.target.value)}
-              inputClassName="h-9"
-            />
-          </FieldContent>
-        </Field>
-      )}
+        {isAddingEndpoint && (
+          <Field className="gap-2">
+            <FieldLabel htmlFor={`${fieldId}-new-endpoint`}>New IP endpoint name</FieldLabel>
+            <FieldContent>
+              <Input
+                id={`${fieldId}-new-endpoint`}
+                aria-label="New IP endpoint name"
+                placeholder="e.g. web-ip"
+                value={newEndpointName}
+                onChange={event => {
+                  setNewEndpointName(event.target.value);
+                  setAddEndpointError(null);
+                }}
+                error={!!addEndpointError}
+                inputClassName="h-9"
+              />
+              <FieldError>{addEndpointError}</FieldError>
+            </FieldContent>
+          </Field>
+        )}
 
-      {otherServices.length > 0 && (
-        <Field className="gap-2">
-          <FieldLabel>To</FieldLabel>
-          <FieldContent>
-            <div role="group" aria-label={`Port ${exposeIndex + 1} to targets`} className="flex flex-col gap-2">
-              {otherServices.map(service => (
-                <CheckboxWithLabel
-                  key={service.id}
-                  checked={selectedTargets.has(service.title)}
-                  onCheckedChange={state => toggleTarget(service.title, state === "indeterminate" ? false : state)}
-                  label={service.title}
-                />
-              ))}
-            </div>
-          </FieldContent>
-        </Field>
-      )}
+        {isHttp && !isInternal && (
+          <Field className="gap-2">
+            <FieldLabel htmlFor={`${fieldId}-hostnames`}>Accept hostnames</FieldLabel>
+            <FieldContent>
+              <Input
+                id={`${fieldId}-hostnames`}
+                aria-label={`Port ${exposeIndex + 1} accept hostnames`}
+                placeholder="example.com, api.example.com"
+                defaultValue={hostnamesValue}
+                onChange={event => changeHostnames(event.target.value)}
+                inputClassName="h-9"
+              />
+            </FieldContent>
+          </Field>
+        )}
 
-      {isHttp && (
-        <>
-          <Separator className="my-2" />
+        {otherServices.length > 0 && (
+          <Field className="gap-2">
+            <FieldLabel>To</FieldLabel>
+            <FieldContent>
+              <div role="group" aria-label={`Port ${exposeIndex + 1} to targets`} className="flex flex-col gap-2">
+                {otherServices.map(service => (
+                  <CheckboxWithLabel
+                    key={service.id}
+                    checked={selectedTargets.has(service.title)}
+                    onCheckedChange={state => toggleTarget(service.title, state === "indeterminate" ? false : state)}
+                    label={service.title}
+                  />
+                ))}
+              </div>
+            </FieldContent>
+          </Field>
+        )}
 
-          <HttpOptionsFields serviceIndex={serviceIndex} exposeIndex={exposeIndex} />
-        </>
-      )}
+        {isHttp && (
+          <>
+            <Separator className="my-2" />
+
+            <HttpOptionsFields serviceIndex={serviceIndex} exposeIndex={exposeIndex} />
+          </>
+        )}
+      </fieldset>
     </div>
   );
 };

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ImageCard/ImageCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ImageCard/ImageCard.spec.tsx
@@ -129,9 +129,44 @@ describe(ImageCard.name, () => {
     });
   });
 
-  function setup(input: { hasCredentials?: boolean; resolver?: Resolver<SdlBuilderFormValuesType>; locked?: boolean }) {
+  it("renders as an Operating System card with a Distribution select for a vm image", () => {
+    setup({ image: "ghcr.io/akash-network/ubuntu-2404-ssh:2" });
+
+    expect(screen.getByText("Operating System")).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "Distribution" })).toBeInTheDocument();
+    expect(screen.queryByLabelText("Docker image")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Private registry")).not.toBeInTheDocument();
+  });
+
+  it("stores the real image ref when a distro is picked", async () => {
+    const { getValues } = setup({ image: "ghcr.io/akash-network/ubuntu-2404-ssh:2" });
+
+    await userEvent.click(screen.getByRole("combobox", { name: "Distribution" }));
+    await userEvent.click(screen.getByRole("option", { name: "Debian 11" }));
+
+    expect(getValues().services[0].image).toBe("ghcr.io/akash-network/debian-11-ssh:2");
+  });
+
+  it("clears private-registry credentials when the service runs a vm image", async () => {
+    const { getValues } = setup({ image: "ghcr.io/akash-network/ubuntu-2404-ssh:2", hasCredentials: true });
+
+    await waitFor(() => {
+      expect(getValues().services[0].hasCredentials).toBe(false);
+      expect(getValues().services[0].credentials).toBeUndefined();
+    });
+  });
+
+  it("keeps the Docker card for a non-vm image", () => {
+    setup({ image: "nginx:latest" });
+
+    expect(screen.getByText("Docker")).toBeInTheDocument();
+    expect(screen.getByLabelText("Docker image")).toBeInTheDocument();
+    expect(screen.queryByText("Operating System")).not.toBeInTheDocument();
+  });
+
+  function setup(input: { image?: string; hasCredentials?: boolean; resolver?: Resolver<SdlBuilderFormValuesType>; locked?: boolean }) {
     const values = defaultServiceWithPlacement({
-      image: "",
+      image: input.image ?? "",
       hasCredentials: input.hasCredentials ?? false,
       credentials: input.hasCredentials ? { host: "docker.io", username: "", password: "" } : undefined
     });

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ImageCard/ImageCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ImageCard/ImageCard.tsx
@@ -1,6 +1,6 @@
 import type { FC } from "react";
-import { useCallback, useState } from "react";
-import { useController, useFormContext } from "react-hook-form";
+import { useCallback, useEffect, useState } from "react";
+import { useController, useFormContext, useWatch } from "react-hook-form";
 import {
   Checkbox,
   CollapsibleCard,
@@ -16,12 +16,13 @@ import {
   SelectTrigger,
   SelectValue
 } from "@akashnetwork/ui/components";
-import { BoxIcon, EyeClosedIcon, EyeIcon } from "lucide-react";
+import { BoxIcon, EyeClosedIcon, EyeIcon, MonitorIcon } from "lucide-react";
 
 import type { SdlBuilderFormValuesType } from "@src/types";
 import { CUSTOM_HOST_ID } from "@src/types";
 import { normalizeDockerImage } from "@src/utils/sdl/normalizeDockerImage";
-import { dockerImageTooltip } from "../cardTooltips";
+import { isVmImage, SSH_VM_IMAGES } from "@src/utils/sdl/vmImages";
+import { dockerImageTooltip, operatingSystemTooltip } from "../cardTooltips";
 import { SELECT_TRUNCATE_VALUE } from "../selectStyles";
 
 export const DEPENDENCIES = { CollapsibleCard };
@@ -52,19 +53,74 @@ const defaultCredentials = { host: "docker.io", username: "", password: "" };
  * behind the "Private registry" toggle, the host/username/password credentials
  * (`hasCredentials`/`credentials`). Checking "Private registry" reveals the credentials fields and
  * seeds defaults; unchecking clears them.
+ *
+ * A service running a managed SSH-VM image presents as an "Operating System" card instead: the image
+ * becomes a distro Select over the managed catalog (the form always stores the real image ref), and
+ * the private-registry controls are hidden (the VM images are public) with any credentials cleared.
  */
 export const ImageCard: FC<Props> = ({ serviceIndex, locked = false, dependencies: d = DEPENDENCIES }) => {
-  const { control } = useFormContext<SdlBuilderFormValuesType>();
+  const { control, setValue } = useFormContext<SdlBuilderFormValuesType>();
   const hasCredentials = useController({ control, name: `services.${serviceIndex}.hasCredentials` });
+  const image = useWatch({ control, name: `services.${serviceIndex}.image` });
+  const isVm = isVmImage(image ?? "");
+
+  useEffect(
+    function clearCredentialsOnVmImage() {
+      if (isVm && hasCredentials.field.value) {
+        hasCredentials.field.onChange(false);
+        setValue(`services.${serviceIndex}.credentials`, undefined, { shouldValidate: true, shouldDirty: true });
+      }
+    },
+    [isVm, hasCredentials.field, setValue, serviceIndex]
+  );
 
   return (
-    <d.CollapsibleCard locked={locked} title="Docker" icon={<BoxIcon className="h-4 w-4" />} infoTooltip={dockerImageTooltip}>
+    <d.CollapsibleCard
+      locked={locked}
+      title={isVm ? "Operating System" : "Docker"}
+      icon={isVm ? <MonitorIcon className="h-4 w-4" /> : <BoxIcon className="h-4 w-4" />}
+      infoTooltip={isVm ? operatingSystemTooltip : dockerImageTooltip}
+    >
       <fieldset disabled={locked} className="flex min-w-0 flex-col gap-4 border-0 p-0">
-        <ImageField serviceIndex={serviceIndex} hasCredentials={!!hasCredentials.field.value} onToggleCredentials={hasCredentials.field.onChange} />
+        {isVm ? (
+          <DistributionField serviceIndex={serviceIndex} />
+        ) : (
+          <>
+            <ImageField serviceIndex={serviceIndex} hasCredentials={!!hasCredentials.field.value} onToggleCredentials={hasCredentials.field.onChange} />
 
-        {hasCredentials.field.value && <CredentialsFields serviceIndex={serviceIndex} />}
+            {hasCredentials.field.value && <CredentialsFields serviceIndex={serviceIndex} />}
+          </>
+        )}
       </fieldset>
     </d.CollapsibleCard>
+  );
+};
+
+const DistributionField: FC<{ serviceIndex: number }> = ({ serviceIndex }) => {
+  const { control } = useFormContext<SdlBuilderFormValuesType>();
+  const image = useController({ control, name: `services.${serviceIndex}.image` });
+
+  return (
+    <Field className="gap-2">
+      <FieldLabel htmlFor={`image-${serviceIndex}`}>
+        Distribution <span className="text-destructive">*</span>
+      </FieldLabel>
+      <FieldContent>
+        <Select value={image.field.value} onValueChange={image.field.onChange}>
+          <SelectTrigger id={`image-${serviceIndex}`} aria-label="Distribution" className={`h-9 ${SELECT_TRUNCATE_VALUE}`}>
+            <SelectValue placeholder="Select" />
+          </SelectTrigger>
+          <SelectContent>
+            {Object.entries(SSH_VM_IMAGES).map(([distro, imageRef]) => (
+              <SelectItem key={imageRef} value={imageRef}>
+                {distro}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <FieldError className="text-muted-foreground">{image.fieldState.error?.message}</FieldError>
+      </FieldContent>
+    </Field>
   );
 };
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/RuntimeCard/RuntimeCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/RuntimeCard/RuntimeCard.spec.tsx
@@ -191,6 +191,30 @@ describe(RuntimeCard.name, () => {
     expect(screen.queryByText("VMs run as a single instance.")).not.toBeInTheDocument();
   });
 
+  it("opens expanded for a vm service so the required key field is visible on entry", () => {
+    setup({ image: "ghcr.io/akash-network/ubuntu-2404-ssh:2", expanded: false });
+
+    expect(screen.getByLabelText("SSH public key")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Expand Runtime" })).not.toBeInTheDocument();
+  });
+
+  it("shows the missing-key error inline when a vm submit is rejected", async () => {
+    setup({ image: "ghcr.io/akash-network/ubuntu-2404-ssh:2", resolver: zodResolver(SdlBuilderFormValuesSchema), expanded: false });
+
+    await userEvent.click(screen.getByRole("button", { name: "Request quotes" }));
+
+    await waitFor(() => expect(screen.getByText("SSH Public key is required.")).toBeInTheDocument());
+  });
+
+  it("marks the collapsed card when a submit is rejected on its hidden ssh key field", async () => {
+    setup({ image: "ghcr.io/akash-network/ubuntu-2404-ssh:2", resolver: zodResolver(SdlBuilderFormValuesSchema), expanded: false });
+
+    await userEvent.click(screen.getByRole("button", { name: "Collapse Runtime" }));
+    await userEvent.click(screen.getByRole("button", { name: "Request quotes" }));
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Expand Runtime" }).closest(".border-destructive")).not.toBeNull());
+  });
+
   it("re-validates the CPU group limit when the replica count changes", async () => {
     const resolver: Resolver<SdlBuilderFormValuesType> = async values => {
       const errors = values.services[0].count > 1 ? { services: { 0: { profile: { cpu: { type: "max", message: "CPU group limit exceeded" } } } } } : {};
@@ -297,7 +321,10 @@ describe(RuntimeCard.name, () => {
     );
 
     if (input.expanded ?? true) {
-      fireEvent.click(screen.getByRole("button", { name: "Expand Runtime" }));
+      const expandTrigger = screen.queryByRole("button", { name: "Expand Runtime" });
+      if (expandTrigger) {
+        fireEvent.click(expandTrigger);
+      }
     }
 
     return { getValues: () => getValues() };

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/RuntimeCard/RuntimeCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/RuntimeCard/RuntimeCard.spec.tsx
@@ -156,6 +156,41 @@ describe(RuntimeCard.name, () => {
     expect(screen.getByRole("button", { name: "How to use the SSH key" })).toBeInTheDocument();
   });
 
+  it("pins the replica stepper at a single disabled instance for a vm service", () => {
+    setup({ image: "ghcr.io/akash-network/ubuntu-2404-ssh:2" });
+
+    expect(screen.getByRole("spinbutton", { name: "Replicas" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Increase Replicas" })).toBeDisabled();
+    expect(screen.getByRole("spinbutton", { name: "Replicas" })).toHaveValue(1);
+    expect(screen.getByText("VMs run as a single instance.")).toBeInTheDocument();
+  });
+
+  it("forces Expose SSH on, disabled, with the key field visible for a vm service", async () => {
+    const { getValues } = setup({ image: "ghcr.io/akash-network/ubuntu-2404-ssh:2" });
+
+    expect(screen.getByRole("checkbox", { name: "Expose SSH" })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "Expose SSH" })).toBeDisabled();
+    expect(screen.getByLabelText("SSH public key")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Generate new key" })).toBeInTheDocument();
+    await waitFor(() => expect(getValues().hasSSHKey).toBe(true));
+  });
+
+  it("keeps Expose SSH forced on a sibling non-vm service's card while the deployment holds a vm", () => {
+    setup({ image: "", siblingVmService: true });
+
+    expect(screen.getByRole("checkbox", { name: "Expose SSH" })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "Expose SSH" })).toBeDisabled();
+    expect(screen.getByRole("spinbutton", { name: "Replicas" })).not.toBeDisabled();
+  });
+
+  it("leaves the replica stepper editable for a non-vm service without vm siblings", () => {
+    setup({ image: "nginx:latest" });
+
+    expect(screen.getByRole("spinbutton", { name: "Replicas" })).not.toBeDisabled();
+    expect(screen.getByRole("checkbox", { name: "Expose SSH" })).not.toBeDisabled();
+    expect(screen.queryByText("VMs run as a single instance.")).not.toBeInTheDocument();
+  });
+
   it("re-validates the CPU group limit when the replica count changes", async () => {
     const resolver: Resolver<SdlBuilderFormValuesType> = async values => {
       const errors = values.services[0].count > 1 ? { services: { 0: { profile: { cpu: { type: "max", message: "CPU group limit exceeded" } } } } } : {};
@@ -194,13 +229,15 @@ describe(RuntimeCard.name, () => {
     sshPubKey?: string;
     env?: Array<{ key: string; value?: string }>;
     extraServices?: number;
+    image?: string;
+    siblingVmService?: boolean;
     locked?: boolean;
     expanded?: boolean;
     resolver?: Resolver<SdlBuilderFormValuesType>;
     dependencies?: Partial<typeof DEPENDENCIES>;
   }) {
     const base = defaultServiceWithPlacement({
-      image: "",
+      image: input.image ?? "",
       count: input.count ?? 1,
       sshPubKey: input.sshPubKey ?? "",
       env: input.env?.map(e => ({ value: "", isSecret: false, ...e })) ?? []
@@ -208,6 +245,9 @@ describe(RuntimeCard.name, () => {
 
     const placementId = base.placements[0].id;
     const extraServices = Array.from({ length: input.extraServices ?? 0 }, (_, i) => defaultService(placementId, { title: `service-${i + 2}`, image: "" }));
+    if (input.siblingVmService) {
+      extraServices.push(defaultService(placementId, { title: "vm-service", image: "ghcr.io/akash-network/ubuntu-2404-ssh:2" }));
+    }
 
     const values: SdlBuilderFormValuesType = {
       ...base,

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/RuntimeCard/RuntimeCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/RuntimeCard/RuntimeCard.tsx
@@ -60,11 +60,39 @@ type Props = {
  * Container-VM constraints: a service running a managed SSH-VM image has its replica stepper pinned
  * at a single instance, and while ANY service in the deployment is a VM, "Expose SSH" is forced on
  * (checked and disabled, key field always shown). The force keys off any-service because `hasSSHKey`
- * is deployment-wide: unchecking it from a sibling service's card would strip the VM's key too.
+ * is deployment-wide: unchecking it from a sibling service's card would strip the VM's key too. The
+ * force lives on the card (not the collapsible body, which unmounts while collapsed), a VM service's
+ * card opens expanded so the required key field is visible on entry, and a submit rejected on this
+ * card's fields (missing key, replica limit) marks the collapsed header, mirroring ExposePortsCard.
  */
 export const RuntimeCard: FC<Props> = ({ serviceIndex, locked = false, dependencies: d = DEPENDENCIES }) => {
+  const { control, formState } = useFormContext<SdlBuilderFormValuesType>();
+  const hasSSHKey = useController({ control, name: "hasSSHKey" });
+  const services = useWatch({ control, name: "services" });
+  const isVm = isVmImage(services?.[serviceIndex]?.image ?? "");
+  const hasVmService = (services ?? []).some(service => isVmImage(service?.image ?? ""));
+  const { isSubmitted } = formState;
+  const serviceErrors = formState.errors.services?.[serviceIndex];
+  const hasErrors = isSubmitted && !!(serviceErrors?.sshPubKey || serviceErrors?.count);
+
+  useEffect(
+    function forceSshWhileVmServiceExists() {
+      if (hasVmService && !hasSSHKey.field.value) {
+        hasSSHKey.field.onChange(true);
+      }
+    },
+    [hasVmService, hasSSHKey.field]
+  );
+
   return (
-    <d.CollapsibleCard defaultOpen={false} locked={locked} title="Runtime" icon={<SettingsIcon className="h-4 w-4" />} infoTooltip={runtimeTooltip}>
+    <d.CollapsibleCard
+      defaultOpen={isVm}
+      locked={locked}
+      title="Runtime"
+      icon={<SettingsIcon className="h-4 w-4" />}
+      infoTooltip={runtimeTooltip}
+      className={hasErrors ? "border-destructive dark:border-destructive" : undefined}
+    >
       <fieldset disabled={locked} className="flex min-w-0 flex-col gap-4 border-0 p-0">
         <ReplicasField serviceIndex={serviceIndex} dependencies={d} />
 
@@ -123,15 +151,6 @@ const SshKeyField: FC<Required<Omit<Props, "locked">>> = ({ serviceIndex, depend
   const sshPubKey = useController({ control, name: `services.${serviceIndex}.sshPubKey` });
   const services = useWatch({ control, name: "services" });
   const hasVmService = (services ?? []).some(service => isVmImage(service?.image ?? ""));
-
-  useEffect(
-    function forceSshWhileVmServiceExists() {
-      if (hasVmService && !hasSSHKey.field.value) {
-        hasSSHKey.field.onChange(true);
-      }
-    },
-    [hasVmService, hasSSHKey.field]
-  );
 
   const applyKeyToAllServices = useCallback(
     (publicKey: string) => {

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/RuntimeCard/RuntimeCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/RuntimeCard/RuntimeCard.tsx
@@ -1,6 +1,6 @@
 import type { FC } from "react";
-import { useCallback } from "react";
-import { useController, useFormContext } from "react-hook-form";
+import { useCallback, useEffect } from "react";
+import { useController, useFormContext, useWatch } from "react-hook-form";
 import {
   Button,
   Checkbox,
@@ -23,6 +23,7 @@ import { useSnackbar } from "notistack";
 import { CodeSnippet } from "@src/components/shared/CodeSnippet";
 import type { SdlBuilderFormValuesType } from "@src/types";
 import { withServiceSshKey } from "@src/utils/sdl/sshKey";
+import { isVmImage } from "@src/utils/sdl/vmImages";
 import { generateSSHKeyPair } from "@src/utils/sshKeyUtils";
 import { runtimeTooltip } from "../cardTooltips";
 
@@ -55,6 +56,11 @@ type Props = {
  * it is on, the key is applied to all services (not just the selected one) and mirrored into a
  * managed `SSH_PUBKEY` env var on each (so it appears in the Environment Variables card and the
  * generated SDL); unchecking "Expose SSH" clears both the key and that env var from every service.
+ *
+ * Container-VM constraints: a service running a managed SSH-VM image has its replica stepper pinned
+ * at a single instance, and while ANY service in the deployment is a VM, "Expose SSH" is forced on
+ * (checked and disabled, key field always shown). The force keys off any-service because `hasSSHKey`
+ * is deployment-wide: unchecking it from a sibling service's card would strip the VM's key too.
  */
 export const RuntimeCard: FC<Props> = ({ serviceIndex, locked = false, dependencies: d = DEPENDENCIES }) => {
   return (
@@ -71,6 +77,8 @@ export const RuntimeCard: FC<Props> = ({ serviceIndex, locked = false, dependenc
 const ReplicasField: FC<Required<Omit<Props, "locked">>> = ({ serviceIndex, dependencies: d }) => {
   const { control, trigger } = useFormContext<SdlBuilderFormValuesType>();
   const count = useController({ control, name: `services.${serviceIndex}.count` });
+  const image = useWatch({ control, name: `services.${serviceIndex}.image` });
+  const isVm = isVmImage(image ?? "");
 
   /**
    * The replica count feeds the per-group CPU/RAM/GPU totals, so re-validate those limits when the user
@@ -95,9 +103,11 @@ const ReplicasField: FC<Required<Omit<Props, "locked">>> = ({ serviceIndex, depe
           value={count.field.value ?? 1}
           min={1}
           max={20}
+          disabled={isVm}
           aria-describedby={count.fieldState.error ? `replicas-error-${serviceIndex}` : undefined}
           onChange={changeCount}
         />
+        {isVm && <p className="text-sm text-muted-foreground">VMs run as a single instance.</p>}
         <FieldError id={`replicas-error-${serviceIndex}`} className="text-muted-foreground">
           {count.fieldState.error?.message}
         </FieldError>
@@ -111,6 +121,17 @@ const SshKeyField: FC<Required<Omit<Props, "locked">>> = ({ serviceIndex, depend
   const { enqueueSnackbar } = d.useSnackbar();
   const hasSSHKey = useController({ control, name: "hasSSHKey" });
   const sshPubKey = useController({ control, name: `services.${serviceIndex}.sshPubKey` });
+  const services = useWatch({ control, name: "services" });
+  const hasVmService = (services ?? []).some(service => isVmImage(service?.image ?? ""));
+
+  useEffect(
+    function forceSshWhileVmServiceExists() {
+      if (hasVmService && !hasSSHKey.field.value) {
+        hasSSHKey.field.onChange(true);
+      }
+    },
+    [hasVmService, hasSSHKey.field]
+  );
 
   const applyKeyToAllServices = useCallback(
     (publicKey: string) => {
@@ -168,11 +189,16 @@ const SshKeyField: FC<Required<Omit<Props, "locked">>> = ({ serviceIndex, depend
   return (
     <Field className="gap-2">
       <div className="flex items-center gap-2">
-        <Checkbox id={`expose-ssh-${serviceIndex}`} checked={!!hasSSHKey.field.value} onCheckedChange={checked => toggleExposeSsh(!!checked)} />
+        <Checkbox
+          id={`expose-ssh-${serviceIndex}`}
+          checked={hasVmService || !!hasSSHKey.field.value}
+          disabled={hasVmService}
+          onCheckedChange={checked => toggleExposeSsh(!!checked)}
+        />
         <Label htmlFor={`expose-ssh-${serviceIndex}`}>Expose SSH</Label>
       </div>
 
-      {hasSSHKey.field.value && (
+      {(hasVmService || hasSSHKey.field.value) && (
         <>
           <FieldLabel htmlFor={`ssh-pub-key-${serviceIndex}`}>SSH public key</FieldLabel>
           <FieldContent>

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/cardTooltips.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/cardTooltips.tsx
@@ -100,12 +100,16 @@ export const dockerImageTooltip = (
   </>
 );
 
-export const runtimeTooltip = (
+export const operatingSystemTooltip = (
   <>
-    Runtime options for the service: how many replicas to run and an optional SSH public key for shell access to the
-    container.
+    The Linux distribution this VM-like container runs.
+    <br />
+    <br />
+    Every option is a public, SSH-enabled image maintained by the Akash team.
   </>
 );
+
+export const runtimeTooltip = <>Runtime options for the service: how many replicas to run and an optional SSH public key for shell access to the container.</>;
 
 export const commandsTooltip = (
   <>

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/cardTooltips.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/cardTooltips.tsx
@@ -102,7 +102,7 @@ export const dockerImageTooltip = (
 
 export const operatingSystemTooltip = (
   <>
-    The Linux distribution this VM-like container runs.
+    The Linux distribution this VM-like container runs on.
     <br />
     <br />
     Every option is a public, SSH-enabled image maintained by the Akash team.

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeployment/ConfigureDeployment.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeployment/ConfigureDeployment.spec.tsx
@@ -119,6 +119,13 @@ describe(ConfigureDeployment.name, () => {
     expect(ConfigureDeploymentForm).toHaveBeenCalledWith(expect.objectContaining({ initialSdl: "restored: sdl" }), expect.anything());
   });
 
+  it("ignores a templateId carried alongside vm=true", () => {
+    const { ConfigureDeploymentForm, usePublicTemplate } = setup({ templateId: helloWorldTemplate.code, vm: true });
+
+    expect(usePublicTemplate).toHaveBeenCalledWith(undefined);
+    expect(ConfigureDeploymentForm).toHaveBeenCalledWith(expect.objectContaining({ initialSdl: undefined }), expect.anything());
+  });
+
   it("routes an auto-deploy intent to the auto flow with the shared flow, not the manual form", () => {
     const { AutoDeployFlow, ConfigureDeploymentForm, DeploymentFlowProvider } = setup({
       templateId: helloWorldTemplate.code,

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeployment/ConfigureDeployment.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeployment/ConfigureDeployment.spec.tsx
@@ -104,6 +104,21 @@ describe(ConfigureDeployment.name, () => {
     expect(ConfigureDeploymentForm).toHaveBeenCalledWith(expect.objectContaining({ initialName: "resumed-name" }), expect.anything());
   });
 
+  it("ignores the carried-in deploySdl on a vm entry and forwards the vm intent", () => {
+    const { ConfigureDeploymentForm } = setup({ templateId: null, vm: true, deploySdl: mock<TemplateCreation>({ content: "carried: sdl" }) });
+
+    expect(ConfigureDeploymentForm).toHaveBeenCalledWith(
+      expect.objectContaining({ initialSdl: undefined, intent: expect.objectContaining({ vm: true }) }),
+      expect.anything()
+    );
+  });
+
+  it("still restores the draft's persisted SDL on a vm entry", () => {
+    const { ConfigureDeploymentForm } = setup({ templateId: null, vm: true, persistedSdl: "restored: sdl" });
+
+    expect(ConfigureDeploymentForm).toHaveBeenCalledWith(expect.objectContaining({ initialSdl: "restored: sdl" }), expect.anything());
+  });
+
   it("routes an auto-deploy intent to the auto flow with the shared flow, not the manual form", () => {
     const { AutoDeployFlow, ConfigureDeploymentForm, DeploymentFlowProvider } = setup({
       templateId: helloWorldTemplate.code,
@@ -128,6 +143,7 @@ describe(ConfigureDeployment.name, () => {
     persistedName?: string;
     template?: { isLoading?: boolean; isError?: boolean; data?: TemplateOutput };
     deploySdl?: TemplateCreation | null;
+    vm?: boolean;
   }) {
     const ConfigureDeploymentForm = vi.fn(() => <div data-testid="form-mock" />);
     const AutoDeployFlow = vi.fn(() => <div data-testid="auto-mock" />);
@@ -152,6 +168,7 @@ describe(ConfigureDeployment.name, () => {
     if (input.templateId) query.templateId = input.templateId;
     if (input.sdlStrategy) query["sdl-strategy"] = input.sdlStrategy;
     if (input.bidStrategy) query["bid-strategy"] = input.bidStrategy;
+    if (input.vm) query.vm = "true";
     const params = new URLSearchParams(query);
 
     const dependencies: typeof DEPENDENCIES = {

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeployment/ConfigureDeployment.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeployment/ConfigureDeployment.tsx
@@ -67,7 +67,7 @@ export const ConfigureDeployment: FC<Props> = ({ dependencies: d = DEPENDENCIES 
     [intent.templateId, intent.sdlStrategy, intent.bidStrategy, intent.dseq, draft.draftId, intent.vm]
   );
 
-  const templateId = searchParams?.get("templateId") ?? undefined;
+  const templateId = intent.templateId;
   const deploySdl = useAtomValue(sdlStore.deploySdl);
   const hardcodedTemplate: TemplateCreation | undefined = templateId ? hardcodedTemplates.find(template => template.code === templateId) : undefined;
   const fetchedTemplateId = draft.persistedSdl === undefined && !hardcodedTemplate ? templateId : undefined;

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeployment/ConfigureDeployment.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeployment/ConfigureDeployment.tsx
@@ -45,8 +45,9 @@ type Props = {
  * and the template is ignored; when absent an id is minted and written into the URL so a reload resumes the same draft.
  * Without a draft, a `templateId` is resolved the same way the legacy flow does: hardcoded templates (e.g. hello-world)
  * carry their SDL inline and are matched by code, while everything else is fetched as a public gallery template; with
- * neither, the carried-in `deploySdl` atom is used. Keeping resolution here lets the form initialize synchronously from
- * a single source — and lets a resume skip the template fetch.
+ * neither, the carried-in `deploySdl` atom is used, except on a `vm=true` entry, which ignores the atom so a fresh
+ * Container-VM session always seeds deterministically. Keeping resolution here lets the form initialize synchronously
+ * from a single source — and lets a resume skip the template fetch.
  */
 export const ConfigureDeployment: FC<Props> = ({ dependencies: d = DEPENDENCIES }) => {
   const searchParams = d.useSearchParams();
@@ -55,8 +56,15 @@ export const ConfigureDeployment: FC<Props> = ({ dependencies: d = DEPENDENCIES 
   const intent = parseDeploymentIntent({ dseqSegment, searchParams: new URLSearchParams(searchParams?.toString() ?? "") });
   const draft = d.useConfigureDraft(intent);
   const resolvedIntent = useMemo<DeploymentIntent>(
-    () => ({ templateId: intent.templateId, sdlStrategy: intent.sdlStrategy, bidStrategy: intent.bidStrategy, dseq: intent.dseq, draftId: draft.draftId }),
-    [intent.templateId, intent.sdlStrategy, intent.bidStrategy, intent.dseq, draft.draftId]
+    () => ({
+      templateId: intent.templateId,
+      sdlStrategy: intent.sdlStrategy,
+      bidStrategy: intent.bidStrategy,
+      dseq: intent.dseq,
+      draftId: draft.draftId,
+      vm: intent.vm
+    }),
+    [intent.templateId, intent.sdlStrategy, intent.bidStrategy, intent.dseq, draft.draftId, intent.vm]
   );
 
   const templateId = searchParams?.get("templateId") ?? undefined;
@@ -78,7 +86,8 @@ export const ConfigureDeployment: FC<Props> = ({ dependencies: d = DEPENDENCIES 
     [fetchedTemplateId, templateQuery.isError, enqueueSnackbar, d]
   );
 
-  const initialSdl = draft.persistedSdl ?? hardcodedTemplate?.content ?? (fetchedTemplateId ? templateQuery.data?.deploy : deploySdl?.content);
+  const carriedInSdl = intent.vm ? undefined : deploySdl?.content;
+  const initialSdl = draft.persistedSdl ?? hardcodedTemplate?.content ?? (fetchedTemplateId ? templateQuery.data?.deploy : carriedInSdl);
   const initialName = draft.persistedName ?? hardcodedTemplate?.name ?? (fetchedTemplateId ? templateQuery.data?.name : undefined);
 
   const isAutoDeploy = resolvedIntent.sdlStrategy === "default" && resolvedIntent.bidStrategy === "auto";

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.spec.tsx
@@ -101,6 +101,41 @@ const TWO_SERVICE_SDL = [
   "      count: 1"
 ].join("\n");
 
+/** A VM deployment saved before any SSH key was entered: the VM image is present but no SSH_PUBKEY env exists. */
+const VM_SDL_WITHOUT_KEY = [
+  "version: '2.0'",
+  "services:",
+  "  vm:",
+  "    image: ghcr.io/akash-network/ubuntu-2404-ssh:2",
+  "    expose:",
+  "      - port: 22",
+  "        as: 22",
+  "        proto: tcp",
+  "        to:",
+  "          - global: true",
+  "profiles:",
+  "  compute:",
+  "    vm:",
+  "      resources:",
+  "        cpu:",
+  "          units: 0.5",
+  "        memory:",
+  "          size: 512Mi",
+  "        storage:",
+  "          - size: 512Mi",
+  "  placement:",
+  "    dcloud:",
+  "      pricing:",
+  "        vm:",
+  "          denom: uact",
+  "          amount: 1000",
+  "deployment:",
+  "  vm:",
+  "    dcloud:",
+  "      profile: vm",
+  "      count: 1"
+].join("\n");
+
 describe(ConfigureDeploymentForm.name, () => {
   it("seeds the panes with the carried-in template SDL", () => {
     const { ConfigureDeploymentPanes } = setup({ initialSdl: VALID_SDL });
@@ -298,6 +333,42 @@ describe(ConfigureDeploymentForm.name, () => {
     expect(screen.queryByRole("button", { name: "back to marketplace" })).not.toBeInTheDocument();
   });
 
+  it("seeds an ssh-ready vm service on a vm entry with no carried-in SDL", () => {
+    setup({ initialSdl: undefined, vm: true, Panes: VmStateProbePanes });
+
+    expect(screen.getByTestId("image").textContent).toBe("ghcr.io/akash-network/ubuntu-2404-ssh:2");
+    expect(screen.getByTestId("count").textContent).toBe("1");
+    expect(screen.getByTestId("has-ssh-key").textContent).toBe("true");
+    expect(JSON.parse(screen.getByTestId("expose").textContent ?? "[]")).toEqual([{ port: 22, as: 22, proto: "tcp", global: true }]);
+  });
+
+  it("previews the vm seed's real image and ssh port in the generated SDL", () => {
+    setup({ initialSdl: undefined, vm: true, Panes: VmStateProbePanes });
+
+    const sdl = screen.getByTestId("sdl").textContent ?? "";
+    expect(sdl).toContain("ghcr.io/akash-network/ubuntu-2404-ssh:2");
+    expect(sdl).toContain("port: 22");
+  });
+
+  it("keeps the vm seed's ssh key empty so the schema demands one before quotes", () => {
+    setup({ initialSdl: undefined, vm: true, Panes: VmStateProbePanes });
+
+    expect(screen.getByTestId("ssh-pub-key").textContent).toBe("");
+  });
+
+  it("restores the expose-ssh flag for a carried-in deployment holding a vm service", () => {
+    setup({ initialSdl: VM_SDL_WITHOUT_KEY, Panes: VmStateProbePanes });
+
+    expect(screen.getByTestId("image").textContent).toBe("ghcr.io/akash-network/ubuntu-2404-ssh:2");
+    expect(screen.getByTestId("has-ssh-key").textContent).toBe("true");
+  });
+
+  it("does not turn on the expose-ssh flag for a carried-in deployment without vm services", () => {
+    setup({ initialSdl: VALID_SDL, Panes: VmStateProbePanes });
+
+    expect(screen.getByTestId("has-ssh-key").textContent).toBe("false");
+  });
+
   function setup(input: {
     initialSdl: string | undefined;
     initialName?: string;
@@ -306,6 +377,7 @@ describe(ConfigureDeploymentForm.name, () => {
     deploySucceeded?: boolean;
     flowError?: { message?: string };
     trialError?: unknown;
+    vm?: boolean;
   }) {
     const ConfigureDeploymentPanes = vi.fn(input.Panes ?? (() => <div data-testid="panes-mock" />));
     const ConfigureDeploymentHeader = vi.fn(() => <div data-testid="header-mock" />);
@@ -356,7 +428,7 @@ describe(ConfigureDeploymentForm.name, () => {
       <ConfigureDeploymentForm
         initialSdl={input.initialSdl}
         initialName={input.initialName}
-        intent={{ sdlStrategy: "edit", bidStrategy: "select", dseq: undefined, draftId: input.draftId }}
+        intent={{ sdlStrategy: "edit", bidStrategy: "select", dseq: undefined, draftId: input.draftId, vm: input.vm ?? false }}
         flow={flow}
         trialError={input.trialError}
         retryTrial={retryTrial}
@@ -460,6 +532,24 @@ function SdlProbePanes({ sdl }: ProbePanesProps) {
       <button type="button" onClick={() => setValue("services.0.image", "nginx:latest")}>
         change image
       </button>
+    </div>
+  );
+}
+
+/** Panes stand-in that reports the first service's VM-relevant state and the deployment-wide SSH flag. */
+function VmStateProbePanes({ sdl }: ProbePanesProps) {
+  const { getValues } = useFormContext<SdlBuilderFormValuesType>();
+  const service = getValues("services")[0];
+  return (
+    <div>
+      <div data-testid="sdl">{sdl}</div>
+      <div data-testid="image">{service.image}</div>
+      <div data-testid="count">{String(service.count)}</div>
+      <div data-testid="has-ssh-key">{String(!!getValues("hasSSHKey"))}</div>
+      <div data-testid="ssh-pub-key">{service.sshPubKey ?? ""}</div>
+      <div data-testid="expose">
+        {JSON.stringify(service.expose.map(entry => ({ port: entry.port, as: entry.as, proto: entry.proto, global: entry.global })))}
+      </div>
     </div>
   );
 }

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
@@ -13,10 +13,11 @@ import { usePlacementsWithBids } from "@src/queries/usePlacementsWithBids";
 import type { SdlBuilderFormValuesType, ServiceType } from "@src/types";
 import { SdlBuilderFormValuesSchema } from "@src/types";
 import { parseBidId } from "@src/utils/bids/bidId";
-import { defaultServiceWithPlacement } from "@src/utils/sdl/data";
+import { defaultServiceWithPlacement, vmServiceOverrides } from "@src/utils/sdl/data";
 import { generateSdl } from "@src/utils/sdl/sdlGenerator";
 import { importSimpleSdl } from "@src/utils/sdl/sdlImport";
 import { applyImportedSshState } from "@src/utils/sdl/sshKey";
+import { isVmImage } from "@src/utils/sdl/vmImages";
 import { applyPresetToProfile, DEFAULT_HARDWARE_PRESET } from "../ConfigurationPane/PresetsCard/hardwarePresets";
 import { ConfigureDeploymentBackButton } from "../ConfigureDeploymentBackButton/ConfigureDeploymentBackButton";
 import { ConfigureDeploymentHeader } from "../ConfigureDeploymentHeader/ConfigureDeploymentHeader";
@@ -60,7 +61,7 @@ type Props = {
 };
 
 export const ConfigureDeploymentForm: FC<Props> = ({ initialSdl, initialName, intent, flow, trialError, retryTrial, dependencies: d = DEPENDENCIES }) => {
-  const [initialState] = useState(() => getInitialState(initialSdl));
+  const [initialState] = useState(() => getInitialState(initialSdl, intent.vm));
   const [liveSdl, setLiveSdl] = useState(initialState.sdl);
   const [previewSdl, setPreviewSdl] = useState(initialState.sdl);
   const [selectedServiceId, setSelectedServiceId] = useState<string>(initialState.selectedServiceId);
@@ -305,25 +306,40 @@ interface InitialState {
  * A carried-in SDL is used only when it imports to a usable deployment (at least one visible service);
  * otherwise — invalid YAML, or a service-less SDL the configure screen can't work with — the screen falls
  * back to a default deployment. This guarantees there is always a service (and placement) to select.
+ * A Container-VM entry (`isVm`) seeds an SSH-ready VM service instead of the blank default.
  */
-function getInitialState(carriedInSdl: string | undefined): InitialState {
+function getInitialState(carriedInSdl: string | undefined, isVm: boolean): InitialState {
   if (carriedInSdl) {
     try {
-      const values = applyImportedSshState(importSimpleSdl(carriedInSdl));
+      const values = withVmSshBackfill(applyImportedSshState(importSimpleSdl(carriedInSdl)));
       if (hasVisibleService(values)) {
         return { values, sdl: carriedInSdl, selectedServiceId: seedSelectedServiceId(values) };
       }
     } catch (error) {
-      return defaultInitialState(getImportErrorMessage(error));
+      return defaultInitialState(isVm, getImportErrorMessage(error));
     }
   }
-  return defaultInitialState();
+  return defaultInitialState(isVm);
 }
 
-/** A fresh default deployment, optionally annotated with the error that made an import unusable. */
-function defaultInitialState(importError?: string): InitialState {
-  const values = withDefaultPreset(defaultServiceWithPlacement());
+/** A fresh default deployment (or SSH-ready VM deployment), optionally annotated with the error that made an import unusable. */
+function defaultInitialState(isVm: boolean, importError?: string): InitialState {
+  const values = isVm
+    ? { ...withDefaultPreset(defaultServiceWithPlacement(vmServiceOverrides())), hasSSHKey: true }
+    : withDefaultPreset(defaultServiceWithPlacement());
   return { values, sdl: regenerateSdl(values, ""), selectedServiceId: seedSelectedServiceId(values), importError };
+}
+
+/**
+ * Restores the deployment-wide "Expose SSH" flag for a carried-in deployment holding a VM service, covering
+ * a VM draft saved before a key was entered (`applyImportedSshState` only flips it once a key exists). The
+ * SDL itself is taken literally: no expose or key is backfilled.
+ */
+function withVmSshBackfill(values: SdlBuilderFormValuesType): SdlBuilderFormValuesType {
+  if (values.hasSSHKey || !values.services.some(service => isVmImage(service.image))) {
+    return values;
+  }
+  return { ...values, hasSSHKey: true };
 }
 
 /** Seeds the fresh deployment's service on the default (small) hardware preset so the screen opens deployable. */

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentFlowProvider/DeploymentFlowProvider.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentFlowProvider/DeploymentFlowProvider.spec.tsx
@@ -37,7 +37,7 @@ describe(DeploymentFlowProvider.name, () => {
   });
 
   function intentFor(dseq: string | undefined): DeploymentIntent {
-    return { sdlStrategy: "default", bidStrategy: "auto", dseq };
+    return { sdlStrategy: "default", bidStrategy: "auto", dseq, vm: false };
   }
 
   function setup(input: {

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ResumeDeploymentGuard/ResumeDeploymentGuard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ResumeDeploymentGuard/ResumeDeploymentGuard.spec.tsx
@@ -114,7 +114,7 @@ describe(ResumeDeploymentGuard.name, () => {
   });
 
   function intentFor(dseq: string | undefined): DeploymentIntent {
-    return { sdlStrategy: "edit", bidStrategy: "select", dseq };
+    return { sdlStrategy: "edit", bidStrategy: "select", dseq, vm: false };
   }
 
   function deployment(input: { state: string; leases?: unknown[] }) {

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useConfigureDraft/useConfigureDraft.spec.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useConfigureDraft/useConfigureDraft.spec.ts
@@ -91,7 +91,7 @@ describe(useConfigureDraft.name, () => {
     });
     expect(result.current.persistedSdl).toBe("sdl: a");
 
-    rerender({ sdlStrategy: "edit", bidStrategy: "select", draftId: "draft-b" });
+    rerender({ sdlStrategy: "edit", bidStrategy: "select", draftId: "draft-b", vm: false });
 
     expect(result.current.draftId).toBe("draft-b");
     expect(result.current.persistedSdl).toBe("sdl: b");
@@ -131,7 +131,7 @@ describe(useConfigureDraft.name, () => {
     const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => clock++);
 
     for (let index = 0; index < 25; index++) {
-      rerender({ sdlStrategy: "edit", bidStrategy: "select", draftId: `draft-${index}` });
+      rerender({ sdlStrategy: "edit", bidStrategy: "select", draftId: `draft-${index}`, vm: false });
       result.current.save(`sdl-${index}`);
     }
     nowSpy.mockRestore();
@@ -179,7 +179,7 @@ describe(useConfigureDraft.name, () => {
       useRouter: () => mock<ReturnType<typeof DEPENDENCIES.useRouter>>({ replace }),
       mintDraftId
     };
-    const initialProps: DeploymentIntent = { sdlStrategy: "edit", bidStrategy: "select", ...input.intent };
+    const initialProps: DeploymentIntent = { sdlStrategy: "edit", bidStrategy: "select", vm: false, ...input.intent };
 
     return {
       ...renderHook((intent: DeploymentIntent) => useConfigureDraft(intent, dependencies), { initialProps }),

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/deploymentIntent.spec.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/deploymentIntent.spec.ts
@@ -5,7 +5,7 @@ import { parseDeploymentIntent } from "./deploymentIntent";
 describe(parseDeploymentIntent.name, () => {
   it("defaults strategies when params are absent", () => {
     const intent = parseDeploymentIntent({ dseqSegment: undefined, searchParams: new URLSearchParams() });
-    expect(intent).toEqual({ templateId: undefined, sdlStrategy: "edit", bidStrategy: "select", dseq: undefined });
+    expect(intent).toEqual({ templateId: undefined, sdlStrategy: "edit", bidStrategy: "select", dseq: undefined, vm: false });
   });
 
   it("reads templateId and both strategies", () => {
@@ -13,7 +13,7 @@ describe(parseDeploymentIntent.name, () => {
       dseqSegment: undefined,
       searchParams: new URLSearchParams("templateId=abc&sdl-strategy=default&bid-strategy=auto")
     });
-    expect(intent).toEqual({ templateId: "abc", sdlStrategy: "default", bidStrategy: "auto", dseq: undefined, draftId: undefined });
+    expect(intent).toEqual({ templateId: "abc", sdlStrategy: "default", bidStrategy: "auto", dseq: undefined, draftId: undefined, vm: false });
   });
 
   it("reads the draft id alongside the other params", () => {
@@ -21,7 +21,7 @@ describe(parseDeploymentIntent.name, () => {
       dseqSegment: "12345",
       searchParams: new URLSearchParams("templateId=abc&draftId=draft-1")
     });
-    expect(intent).toEqual({ templateId: "abc", sdlStrategy: "edit", bidStrategy: "select", dseq: "12345", draftId: "draft-1" });
+    expect(intent).toEqual({ templateId: "abc", sdlStrategy: "edit", bidStrategy: "select", dseq: "12345", draftId: "draft-1", vm: false });
   });
 
   it("leaves the draft id undefined when absent", () => {
@@ -51,5 +51,25 @@ describe(parseDeploymentIntent.name, () => {
     });
     expect(intent.sdlStrategy).toBe("edit");
     expect(intent.bidStrategy).toBe("select");
+  });
+
+  it("parses vm=true as a container-vm entry", () => {
+    const intent = parseDeploymentIntent({ dseqSegment: undefined, searchParams: new URLSearchParams("vm=true") });
+    expect(intent.vm).toBe(true);
+  });
+
+  it("treats anything but vm=true as a non-vm entry", () => {
+    const intent = parseDeploymentIntent({ dseqSegment: undefined, searchParams: new URLSearchParams("vm=1") });
+    expect(intent.vm).toBe(false);
+  });
+
+  it("drops templateId and forces the edit strategy on a vm entry", () => {
+    const intent = parseDeploymentIntent({
+      dseqSegment: undefined,
+      searchParams: new URLSearchParams("vm=true&templateId=abc&sdl-strategy=default")
+    });
+    expect(intent.templateId).toBeUndefined();
+    expect(intent.sdlStrategy).toBe("edit");
+    expect(intent.vm).toBe(true);
   });
 });

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/deploymentIntent.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/deploymentIntent.ts
@@ -8,6 +8,8 @@ export interface DeploymentIntent {
   dseq?: string;
   /** Identifies the persisted working draft. Present once a configure session has started; absent on a fresh entry. */
   draftId?: string;
+  /** Container-VM entry (`?vm=true`): the form seeds an SSH-ready VM service instead of the blank default. */
+  vm: boolean;
 }
 
 interface ParseInput {
@@ -19,14 +21,17 @@ interface ParseInput {
 /**
  * Maps the declarative configure URL to a normalized intent. Strategy values fall back to the
  * safe manual defaults (`edit`/`select`) on anything unrecognized, and `sdl-strategy` is only
- * honored alongside a `templateId` (it governs creating *from a template*).
+ * honored alongside a `templateId` (it governs creating *from a template*). A `vm=true` entry
+ * is a Container-VM seed, not a template build: it drops any `templateId` (and with it the
+ * `default` strategy), so the manual form always opens.
  */
 export function parseDeploymentIntent({ dseqSegment, searchParams }: ParseInput): DeploymentIntent {
-  const templateId = searchParams.get("templateId") ?? undefined;
+  const vm = searchParams.get("vm") === "true";
+  const templateId = vm ? undefined : searchParams.get("templateId") ?? undefined;
   const sdlStrategy = templateId ? toSdlStrategy(searchParams.get("sdl-strategy")) : "edit";
   const bidStrategy = toBidStrategy(searchParams.get("bid-strategy"));
   const draftId = searchParams.get("draftId") || undefined;
-  return { templateId, sdlStrategy, bidStrategy, dseq: dseqSegment || undefined, draftId };
+  return { templateId, sdlStrategy, bidStrategy, dseq: dseqSegment || undefined, draftId, vm };
 }
 
 /** Narrows the raw `sdl-strategy` param to the union, defaulting to `edit`. */

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.spec.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.spec.ts
@@ -146,7 +146,9 @@ describe(useDeploymentFlow.name, () => {
         useSettingsId: (() => "akash1owner") as never,
         manifestFromSdl: () => "M"
       };
-      const { result, rerender } = renderHook(() => useDeploymentFlow({ intent: { sdlStrategy: "edit", bidStrategy: "select", dseq: "777" } }, dependencies));
+      const { result, rerender } = renderHook(() =>
+        useDeploymentFlow({ intent: { sdlStrategy: "edit", bidStrategy: "select", dseq: "777", vm: false } }, dependencies)
+      );
       expect(result.current.phase).toBe("quoting");
 
       bids = []; // every provider's quote disappears (e.g. expired) after having bid
@@ -533,12 +535,12 @@ describe(useDeploymentFlow.name, () => {
   });
 
   function setup(input: {
-    intent?: { sdlStrategy: "default" | "edit"; bidStrategy: "auto" | "select"; dseq?: string; templateId?: string; draftId?: string };
+    intent?: { sdlStrategy: "default" | "edit"; bidStrategy: "auto" | "select"; dseq?: string; templateId?: string; draftId?: string; vm?: boolean };
     replace?: ReturnType<typeof vi.fn>;
     createMutate?: ReturnType<typeof vi.fn>;
     closeMutate?: ReturnType<typeof vi.fn>;
   }) {
-    const intent = input.intent ?? { sdlStrategy: "edit" as const, bidStrategy: "select" as const, dseq: undefined };
+    const intent = { vm: false, ...(input.intent ?? { sdlStrategy: "edit" as const, bidStrategy: "select" as const, dseq: undefined }) };
     const dependencies: typeof DEPENDENCIES = {
       useCreateDeployment: (() => mock<ReturnType<typeof DEPENDENCIES.useCreateDeployment>>({ mutate: (input.createMutate ?? vi.fn()) as never })) as never,
       useCloseDeployment: (() => mock<ReturnType<typeof DEPENDENCIES.useCloseDeployment>>({ mutate: (input.closeMutate ?? vi.fn()) as never })) as never,
@@ -563,7 +565,7 @@ describe(useDeploymentFlow.name, () => {
     manifestFromSdl?: (sdl: string) => string | null;
     listBids?: Array<{ bid: { state: string; price: { amount: string; denom: string }; id: { provider: string; dseq: string; gseq: number; oseq: number } } }>;
   }) {
-    const intent: DeploymentIntent = { sdlStrategy: "edit", bidStrategy: "select", dseq: undefined, ...input?.intent };
+    const intent: DeploymentIntent = { sdlStrategy: "edit", bidStrategy: "select", dseq: undefined, vm: false, ...input?.intent };
     const router = mock<ReturnType<typeof DEPENDENCIES.useRouter>>({ replace: vi.fn(), push: vi.fn() });
     const deploymentLocalStorage = mock<ReturnType<typeof DEPENDENCIES.useDeploymentLocalStorage>>();
     const queryClient = mock<ReturnType<typeof DEPENDENCIES.useQueryClient>>();
@@ -595,7 +597,7 @@ describe(useDeploymentFlow.name, () => {
 
 describe(buildConfigureUrl.name, () => {
   it("preserves the draft id alongside the dseq and bid strategy", () => {
-    const url = buildConfigureUrl({ sdlStrategy: "edit", bidStrategy: "select", templateId: "tpl", draftId: "draft-1" }, "999", "auto");
+    const url = buildConfigureUrl({ sdlStrategy: "edit", bidStrategy: "select", templateId: "tpl", draftId: "draft-1", vm: false }, "999", "auto");
 
     expect(url).toContain("/new-deployment/configure/999");
     expect(url).toContain("bid-strategy=auto");
@@ -603,8 +605,21 @@ describe(buildConfigureUrl.name, () => {
   });
 
   it("omits the draft id when the intent carries none", () => {
-    const url = buildConfigureUrl({ sdlStrategy: "edit", bidStrategy: "select" }, undefined, "select");
+    const url = buildConfigureUrl({ sdlStrategy: "edit", bidStrategy: "select", vm: false }, undefined, "select");
 
     expect(url).not.toContain("draftId");
+  });
+
+  it("preserves the vm flag across rewrites", () => {
+    const url = buildConfigureUrl({ sdlStrategy: "edit", bidStrategy: "select", draftId: "draft-1", vm: true }, "999", "select");
+
+    expect(url).toContain("/new-deployment/configure/999");
+    expect(url).toContain("vm=true");
+  });
+
+  it("omits the vm flag for non-vm intents", () => {
+    const url = buildConfigureUrl({ sdlStrategy: "edit", bidStrategy: "select", vm: false }, undefined, "select");
+
+    expect(url).not.toContain("vm=");
   });
 });

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.ts
@@ -407,13 +407,14 @@ function manifestFromSdl(sdl: string): string | null {
   }
 }
 
-/** Builds the canonical configure URL preserving templateId/sdl-strategy/draftId and the current dseq + bid-strategy. */
+/** Builds the canonical configure URL preserving templateId/sdl-strategy/draftId/vm and the current dseq + bid-strategy. */
 export function buildConfigureUrl(intent: DeploymentIntent, dseq: string | undefined, bidStrategy: BidStrategy): string {
   return UrlService.configureDeployment({
     dseq,
     templateId: intent.templateId,
     sdlStrategy: intent.templateId ? intent.sdlStrategy : undefined,
     bidStrategy,
-    draftId: intent.draftId
+    draftId: intent.draftId,
+    vm: intent.vm
   });
 }

--- a/apps/deploy-web/src/components/new-deployment/RedirectDeployLinuxToConfigure/RedirectDeployLinuxToConfigure.spec.tsx
+++ b/apps/deploy-web/src/components/new-deployment/RedirectDeployLinuxToConfigure/RedirectDeployLinuxToConfigure.spec.tsx
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import { DEPENDENCIES, RedirectDeployLinuxToConfigure } from "./RedirectDeployLinuxToConfigure";
+
+import { render, screen } from "@testing-library/react";
+
+describe(RedirectDeployLinuxToConfigure.name, () => {
+  it("redirects to the configure vm seed when the flag is on", () => {
+    const { replace } = setup({ flag: true });
+    expect(replace).toHaveBeenCalledWith("/new-deployment/configure?vm=true");
+    expect(screen.queryByText("classic")).not.toBeInTheDocument();
+  });
+
+  it("renders the classic builder when the flag is off", () => {
+    const { replace } = setup({ flag: false });
+    expect(replace).not.toHaveBeenCalled();
+    expect(screen.getByText("classic")).toBeInTheDocument();
+  });
+
+  function setup(input: { flag: boolean }) {
+    const replace = vi.fn();
+    const d: typeof DEPENDENCIES = {
+      ...DEPENDENCIES,
+      useFlag: (() => input.flag) as typeof DEPENDENCIES.useFlag,
+      useRouter: (() => mock<ReturnType<typeof DEPENDENCIES.useRouter>>({ replace })) as typeof DEPENDENCIES.useRouter
+    };
+    render(
+      <RedirectDeployLinuxToConfigure dependencies={d}>
+        <div>classic</div>
+      </RedirectDeployLinuxToConfigure>
+    );
+    return { replace };
+  }
+});

--- a/apps/deploy-web/src/components/new-deployment/RedirectDeployLinuxToConfigure/RedirectDeployLinuxToConfigure.tsx
+++ b/apps/deploy-web/src/components/new-deployment/RedirectDeployLinuxToConfigure/RedirectDeployLinuxToConfigure.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useEffect } from "react";
+import { useRouter } from "next/router";
+
+import { Loading } from "@src/components/layout/Layout";
+import { useFlag } from "@src/hooks/useFlag";
+import { UrlService } from "@src/utils/urlUtils";
+
+export const DEPENDENCIES = { useFlag, useRouter, UrlService };
+
+type Props = { children: ReactNode; dependencies?: typeof DEPENDENCIES };
+
+/**
+ * Client-side redirect for the classic `/deploy-linux` SSH-VM builder. With the redesign flag on, the
+ * Container-VM experience lives on the configure screen as a `vm=true` seed, so every visit is replaced
+ * there; flag off renders the classic builder untouched. Intentionally client-only, matching
+ * {@link RedirectMappableBuilderToConfigure} (the team is phasing getServerSideProps out).
+ */
+export function RedirectDeployLinuxToConfigure({ children, dependencies: d = DEPENDENCIES }: Props) {
+  const isRedesignEnabled = d.useFlag("onboarding_redesign_v1");
+  const router = d.useRouter();
+
+  useEffect(
+    function redirectDeployLinuxToConfigure() {
+      if (isRedesignEnabled) router.replace(d.UrlService.configureDeployment({ vm: true }));
+    },
+    [isRedesignEnabled, router, d.UrlService]
+  );
+
+  if (isRedesignEnabled) return <Loading text="" />;
+  return <>{children}</>;
+}

--- a/apps/deploy-web/src/hooks/useNewDeploymentUrl/useNewDeploymentUrl.spec.ts
+++ b/apps/deploy-web/src/hooks/useNewDeploymentUrl/useNewDeploymentUrl.spec.ts
@@ -26,11 +26,20 @@ describe(useNewDeploymentUrl.name, () => {
     expect(make({ step: RouteStep.editDeployment, templateId: "tpl-1" })).toBe("/new-deployment?step=edit-deployment&templateId=tpl-1");
   });
 
-  it("keeps the classic URL for git/redeploy/vm intents even when the flag is on", () => {
+  it("keeps the classic URL for git/redeploy intents even when the flag is on", () => {
     const make = build({ flag: true });
     expect(make({ step: RouteStep.editDeployment, gitProvider: "github", templateId: "x" })).toContain("/new-deployment?");
     expect(make({ redeploy: "42" })).toContain("/new-deployment?");
-    expect(make({ step: RouteStep.editDeployment, page: "deploy-linux" })).toContain("/deploy-linux");
+  });
+
+  it("maps the container-vm intent to the configure vm seed when the flag is on", () => {
+    const make = build({ flag: true });
+    expect(make({ step: RouteStep.editDeployment, page: "deploy-linux" })).toBe("/new-deployment/configure?vm=true");
+  });
+
+  it("keeps the container-vm intent on the classic builder when the flag is off", () => {
+    const make = build({ flag: false });
+    expect(make({ step: RouteStep.editDeployment, page: "deploy-linux" })).toBe("/deploy-linux?step=edit-deployment");
   });
 
   function build(input: { flag: boolean }) {

--- a/apps/deploy-web/src/hooks/useNewDeploymentUrl/useNewDeploymentUrl.ts
+++ b/apps/deploy-web/src/hooks/useNewDeploymentUrl/useNewDeploymentUrl.ts
@@ -6,18 +6,22 @@ export const DEPENDENCIES = { useFlag, UrlService };
 
 /**
  * Resolves the "open the deployment editor" destination. With `onboarding_redesign_v1` on, a concrete build
- * intent — a chosen template or the `edit-deployment` step — opens the new `/new-deployment/configure` screen.
- * A bare "new deployment" keeps the classic `/new-deployment` deployment-type/template picker so it stays the
- * reachable entry point (its own template picks then route on to configure); git, redeploy, and VM
- * (`deploy-linux`) intents are not representable on configure and always keep the classic URL.
+ * intent — a chosen template or the `edit-deployment` step — opens the new `/new-deployment/configure` screen,
+ * and a Container-VM intent (`deploy-linux`) opens it as a VM seed (`vm=true`). A bare "new deployment" keeps
+ * the classic `/new-deployment` deployment-type/template picker so it stays the reachable entry point (its own
+ * template picks then route on to configure); git and redeploy intents are not representable on configure and
+ * always keep the classic URL.
  */
 export function useNewDeploymentUrl(dependencies = DEPENDENCIES) {
   const d = dependencies;
   const isRedesignEnabled = d.useFlag("onboarding_redesign_v1");
 
   return function newDeploymentUrl(params: NewDeploymentParams = {}) {
-    const isClassicOnly = !!params.redeploy || !!params.gitProvider || !!params.repoUrl || params.page === "deploy-linux";
+    const isClassicOnly = !!params.redeploy || !!params.gitProvider || !!params.repoUrl;
     const opensBuilder = params.step === "edit-deployment" || !!params.templateId;
+    if (isRedesignEnabled && !isClassicOnly && params.page === "deploy-linux") {
+      return d.UrlService.configureDeployment({ vm: true });
+    }
     if (isRedesignEnabled && !isClassicOnly && opensBuilder) {
       return d.UrlService.configureDeployment({ templateId: params.templateId });
     }

--- a/apps/deploy-web/src/pages/deploy-linux/index.tsx
+++ b/apps/deploy-web/src/pages/deploy-linux/index.tsx
@@ -1,10 +1,23 @@
+import type { ComponentProps } from "react";
+
 import { NewDeploymentContainer } from "@src/components/new-deployment/NewDeploymentContainer/NewDeploymentContainer";
 import { createServerSideProps } from "@src/components/new-deployment/NewDeploymentPage/createServerSideProps";
+import { RedirectDeployLinuxToConfigure } from "@src/components/new-deployment/RedirectDeployLinuxToConfigure/RedirectDeployLinuxToConfigure";
 import { withSdlBuilder } from "@src/context/SdlBuilderProvider/SdlBuilderProvider";
 
-export default withSdlBuilder({
+const DeployLinuxWithSdl = withSdlBuilder({
   componentsSet: "ssh",
   imageSource: "ssh-vms"
 })(NewDeploymentContainer);
+
+function DeployLinuxPage(props: ComponentProps<typeof NewDeploymentContainer>) {
+  return (
+    <RedirectDeployLinuxToConfigure>
+      <DeployLinuxWithSdl {...props} />
+    </RedirectDeployLinuxToConfigure>
+  );
+}
+
+export default DeployLinuxPage;
 
 export const getServerSideProps = createServerSideProps("/deploy-linux");

--- a/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.spec.ts
+++ b/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.spec.ts
@@ -178,6 +178,83 @@ describe("SdlBuilderFormValuesSchema", () => {
     expect(result.error.issues).toContainEqual(expect.objectContaining({ path: ["endpoints", 1, "name"], message: "Endpoint name must be unique." }));
   });
 
+  it("accepts a vm service with its single managed SSH expose", () => {
+    const result = SdlBuilderFormValuesSchema.safeParse({
+      placements: [{ id: "p-1", name: "dcloud" }],
+      services: [
+        {
+          ...vmService(),
+          expose: [
+            { port: 22, as: 22, proto: "tcp", global: true },
+            { port: 80, as: 80, global: true }
+          ]
+        }
+      ]
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a second row exposed as port 22 on a vm service", () => {
+    const result = SdlBuilderFormValuesSchema.safeParse({
+      placements: [{ id: "p-1", name: "dcloud" }],
+      services: [
+        {
+          ...vmService(),
+          expose: [
+            { port: 22, as: 22, proto: "tcp", global: true },
+            { port: 8080, as: 22, global: true }
+          ]
+        }
+      ]
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues).toContainEqual(
+      expect.objectContaining({ path: ["services", 0, "expose", 1, "port"], message: "Port 22 is reserved for SSH." })
+    );
+  });
+
+  it("rejects a second row using container port 22 on a vm service", () => {
+    const result = SdlBuilderFormValuesSchema.safeParse({
+      placements: [{ id: "p-1", name: "dcloud" }],
+      services: [
+        {
+          ...vmService(),
+          expose: [
+            { port: 22, as: 22, proto: "tcp", global: true },
+            { port: 22, as: 2222, global: true }
+          ]
+        }
+      ]
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues).toContainEqual(
+      expect.objectContaining({ path: ["services", 0, "expose", 1, "port"], message: "Port 22 is reserved for SSH." })
+    );
+  });
+
+  it("does not reserve port 22 on non-vm services", () => {
+    const result = SdlBuilderFormValuesSchema.safeParse({
+      placements: [{ id: "p-1", name: "dcloud" }],
+      services: [
+        {
+          ...vmService(),
+          image: "nginx:latest",
+          expose: [
+            { port: 22, as: 22, proto: "tcp", global: true },
+            { port: 8080, as: 22, global: true }
+          ]
+        }
+      ]
+    });
+
+    expect(result.success).toBe(true);
+  });
+
   it("flags every storage entry that shares a name, including the first occurrence", () => {
     const result = SdlBuilderFormValuesSchema.safeParse({
       placements: [{ id: "p-1", name: "dcloud" }],
@@ -304,6 +381,19 @@ describe("SdlBuilderFormValuesSchema", () => {
     if (result.success) return;
     expect(result.error.issues).toContainEqual(expect.objectContaining({ path: ["endpoints", 1, "name"], message: "Endpoint name must be unique." }));
   });
+
+  function vmService() {
+    return {
+      id: "svc-1",
+      title: "vm",
+      image: "ghcr.io/akash-network/ubuntu-2404-ssh:2",
+      profile: { cpu: 0.1, ram: 256, ramUnit: "Mi", storage: [{ size: 512, unit: "Mi" }] },
+      expose: [{ port: 22, as: 22, proto: "tcp", global: true }],
+      placementId: "p-1",
+      pricing: { amount: 1000, denom: "uakt" },
+      count: 1
+    };
+  }
 });
 
 describe("CredentialsSchema", () => {

--- a/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.spec.ts
+++ b/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.spec.ts
@@ -255,6 +255,38 @@ describe("SdlBuilderFormValuesSchema", () => {
     expect(result.success).toBe(true);
   });
 
+  it("exempts only the exact 22-to-22 row: a squatter exposed as 22 gets the error", () => {
+    const result = SdlBuilderFormValuesSchema.safeParse({
+      placements: [{ id: "p-1", name: "dcloud" }],
+      services: [
+        {
+          ...vmService(),
+          expose: [
+            { port: 8080, as: 22, global: true },
+            { port: 22, as: 22, proto: "tcp", global: true }
+          ]
+        }
+      ]
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues).toContainEqual(
+      expect.objectContaining({ path: ["services", 0, "expose", 0, "port"], message: "Port 22 is reserved for SSH." })
+    );
+  });
+
+  it("requires an ssh key on a vm service even when the deployment-wide flag is off", () => {
+    const result = SdlBuilderFormValuesSchema.safeParse({
+      placements: [{ id: "p-1", name: "dcloud" }],
+      services: [{ ...vmService(), sshPubKey: "" }]
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues).toContainEqual(expect.objectContaining({ path: ["services", 0, "sshPubKey"], message: "SSH Public key is required." }));
+  });
+
   it("flags every storage entry that shares a name, including the first occurrence", () => {
     const result = SdlBuilderFormValuesSchema.safeParse({
       placements: [{ id: "p-1", name: "dcloud" }],
@@ -391,7 +423,8 @@ describe("SdlBuilderFormValuesSchema", () => {
       expose: [{ port: 22, as: 22, proto: "tcp", global: true }],
       placementId: "p-1",
       pricing: { amount: 1000, denom: "uakt" },
-      count: 1
+      count: 1,
+      sshPubKey: "ssh-ed25519 AAAATESTKEY user@host"
     };
   }
 });

--- a/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.spec.ts
+++ b/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.spec.ts
@@ -287,6 +287,17 @@ describe("SdlBuilderFormValuesSchema", () => {
     expect(result.error.issues).toContainEqual(expect.objectContaining({ path: ["services", 0, "sshPubKey"], message: "SSH Public key is required." }));
   });
 
+  it("rejects a whitespace-only ssh key on a vm service", () => {
+    const result = SdlBuilderFormValuesSchema.safeParse({
+      placements: [{ id: "p-1", name: "dcloud" }],
+      services: [{ ...vmService(), sshPubKey: "   " }]
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues).toContainEqual(expect.objectContaining({ path: ["services", 0, "sshPubKey"], message: "SSH Public key is required." }));
+  });
+
   it("flags every storage entry that shares a name, including the first occurrence", () => {
     const result = SdlBuilderFormValuesSchema.safeParse({
       placements: [{ id: "p-1", name: "dcloud" }],

--- a/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.ts
+++ b/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.ts
@@ -556,7 +556,7 @@ export const SdlBuilderFormValuesSchema = z
         continue;
       }
       const expose = data.services[i].expose;
-      const managedSshIndex = expose.findIndex(entry => entry.as === 22);
+      const managedSshIndex = expose.findIndex(entry => entry.port === 22 && entry.as === 22);
       for (let j = 0; j < expose.length; j++) {
         if (j === managedSshIndex) {
           continue;
@@ -571,17 +571,15 @@ export const SdlBuilderFormValuesSchema = z
       }
     }
 
-    if (data.hasSSHKey) {
-      for (let i = 0; i < data.services.length; i++) {
-        if (!data.services[i].sshPubKey) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            message: "SSH Public key is required.",
-            path: ["services", i, "sshPubKey"],
-            fatal: true
-          });
-          return z.NEVER;
-        }
+    for (let i = 0; i < data.services.length; i++) {
+      if ((data.hasSSHKey || isVmImage(data.services[i].image)) && !data.services[i].sshPubKey) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "SSH Public key is required.",
+          path: ["services", i, "sshPubKey"],
+          fatal: true
+        });
+        return z.NEVER;
       }
     }
 

--- a/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.ts
+++ b/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.ts
@@ -572,7 +572,7 @@ export const SdlBuilderFormValuesSchema = z
     }
 
     for (let i = 0; i < data.services.length; i++) {
-      if ((data.hasSSHKey || isVmImage(data.services[i].image)) && !data.services[i].sshPubKey) {
+      if ((data.hasSSHKey || isVmImage(data.services[i].image)) && !data.services[i].sshPubKey?.trim()) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: "SSH Public key is required.",

--- a/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.ts
+++ b/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.ts
@@ -7,6 +7,7 @@ import { memoryUnits, storageUnits, validationConfig } from "@src/utils/akash/un
 import { ENDPOINT_NAME_VALIDATION_REGEX } from "@src/utils/deploymentData/v1beta3";
 import { kvArrayToObject } from "@src/utils/keyValue/keyValue";
 import { roundDecimal } from "@src/utils/mathHelpers";
+import { isVmImage } from "@src/utils/sdl/vmImages";
 import { bytesToShrink } from "@src/utils/unitUtils";
 
 const VALID_IMAGE_NAME =
@@ -546,6 +547,26 @@ export const SdlBuilderFormValuesSchema = z
             fatal: true
           });
           return z.NEVER;
+        }
+      }
+    }
+
+    for (let i = 0; i < data.services.length; i++) {
+      if (!isVmImage(data.services[i].image)) {
+        continue;
+      }
+      const expose = data.services[i].expose;
+      const managedSshIndex = expose.findIndex(entry => entry.as === 22);
+      for (let j = 0; j < expose.length; j++) {
+        if (j === managedSshIndex) {
+          continue;
+        }
+        if (expose[j].port === 22 || expose[j].as === 22) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: "Port 22 is reserved for SSH.",
+            path: ["services", i, "expose", j, "port"]
+          });
         }
       }
     }

--- a/apps/deploy-web/src/utils/sdl/data.ts
+++ b/apps/deploy-web/src/utils/sdl/data.ts
@@ -1,7 +1,10 @@
 import { nanoid } from "nanoid";
 
 import { UACT_DENOM } from "@src/config/denom.config";
-import type { EndpointType, PlacementType, SdlBuilderFormValuesType, ServiceType } from "@src/types";
+import type { EndpointType, ExposeType, PlacementType, SdlBuilderFormValuesType, ServiceType } from "@src/types";
+import { SSH_VM_IMAGES, sshVmDistros, sshVmImages } from "./vmImages";
+
+export { SSH_VM_IMAGES, sshVmDistros, sshVmImages };
 
 export const protoTypes = [
   { id: 1, name: "http" },
@@ -132,14 +135,6 @@ export const defaultRamStorage = {
 /** The defaults applied to a freshly added GPU collection (vendor preset, model left for the user to pick). */
 export const defaultGpuModel = { vendor: "nvidia", name: "", memory: "", interface: "" };
 
-export const SSH_VM_IMAGES = {
-  "Ubuntu 24.04": "ghcr.io/akash-network/ubuntu-2404-ssh:2",
-  "CentOS Stream 9": "ghcr.io/akash-network/centos-stream9-ssh:2",
-  "Debian 11": "ghcr.io/akash-network/debian-11-ssh:2",
-  "SuSE Leap 15.5": "ghcr.io/akash-network/opensuse-leap-155-ssh:2"
-};
-export const sshVmDistros: string[] = Object.keys(SSH_VM_IMAGES);
-export const sshVmImages: Set<string> = new Set(Object.values(SSH_VM_IMAGES));
 export const SSH_EXPOSE = {
   port: 22,
   as: 22,
@@ -155,6 +150,33 @@ export const sshServiceOverrides: Partial<ServiceType> = {
   image: sshVmDistros[0],
   expose: []
 };
+
+/**
+ * The managed SSH expose row a fresh Container-VM service is seeded with: container port 22 published
+ * globally as 22 over tcp. The configure flow generates the SDL straight from form state (no
+ * `transformCustomSdlFields` pass), so the row must exist on the model itself.
+ */
+export const vmSshExpose = (): ExposeType => ({
+  id: nanoid(),
+  port: 22,
+  as: 22,
+  proto: "tcp",
+  global: true,
+  to: [],
+  accept: [],
+  ipName: ""
+});
+
+/**
+ * Overrides for a fresh Container-VM service on the configure screen: the real distro image ref
+ * (unlike the legacy `sshServiceOverrides`, which stores a display label mapped at generation time),
+ * the managed SSH expose, and the single instance VMs run as.
+ */
+export const vmServiceOverrides = (): Partial<ServiceType> => ({
+  image: SSH_VM_IMAGES["Ubuntu 24.04"],
+  expose: [vmSshExpose()],
+  count: 1
+});
 
 export const nextCases = [
   { value: "error", label: "error" },

--- a/apps/deploy-web/src/utils/sdl/vmImages.ts
+++ b/apps/deploy-web/src/utils/sdl/vmImages.ts
@@ -1,0 +1,20 @@
+/**
+ * The managed Container-VM (SSH VM) distro catalog, keyed by display label. Kept free of imports so
+ * the form schema (`types/sdlBuilder`) can consume it without creating a cycle through `utils/sdl/data.ts`,
+ * which itself imports the schema's types.
+ */
+export const SSH_VM_IMAGES = {
+  "Ubuntu 24.04": "ghcr.io/akash-network/ubuntu-2404-ssh:2",
+  "CentOS Stream 9": "ghcr.io/akash-network/centos-stream9-ssh:2",
+  "Debian 11": "ghcr.io/akash-network/debian-11-ssh:2",
+  "SuSE Leap 15.5": "ghcr.io/akash-network/opensuse-leap-155-ssh:2"
+};
+
+export const sshVmDistros: string[] = Object.keys(SSH_VM_IMAGES);
+
+export const sshVmImages: Set<string> = new Set(Object.values(SSH_VM_IMAGES));
+
+/** Whether the image is one of the managed SSH-VM distro images; drives the VM behavior of the configure cards. */
+export function isVmImage(image: string): boolean {
+  return sshVmImages.has(image);
+}

--- a/apps/deploy-web/src/utils/urlUtils.ts
+++ b/apps/deploy-web/src/utils/urlUtils.ts
@@ -25,6 +25,7 @@ export type ConfigureDeploymentParams = {
   sdlStrategy?: "default" | "edit";
   bidStrategy?: "auto" | "select";
   draftId?: string;
+  vm?: boolean;
 };
 
 export const domainName = "https://console.akash.network";
@@ -124,9 +125,9 @@ export const UrlService = {
   },
 
   configureDeployment: (params: ConfigureDeploymentParams = {}) => {
-    const { dseq, templateId, sdlStrategy, bidStrategy, draftId } = params;
+    const { dseq, templateId, sdlStrategy, bidStrategy, draftId, vm } = params;
     const base = dseq ? `/new-deployment/configure/${dseq}` : "/new-deployment/configure";
-    return `${base}${appendSearchParams({ templateId, "sdl-strategy": sdlStrategy, "bid-strategy": bidStrategy, draftId })}`;
+    return `${base}${appendSearchParams({ templateId, "sdl-strategy": sdlStrategy, "bid-strategy": bidStrategy, draftId, vm })}`;
   }
 };
 


### PR DESCRIPTION
## Why

Closes CON-675

When the legacy SDL Builder flow is retired (CON-672), "Launch Container-VM" must survive. Today an SSH-accessible plain-linux VM can only be launched through the legacy `/deploy-linux` builder; the new Configure page cannot represent it. This PR makes the Container-VM experience first-class on Configure, gated on the existing `onboarding_redesign_v1` flag. With the flag off, the classic `/deploy-linux` builder is untouched.

## What


https://github.com/user-attachments/assets/72aaf8e9-6549-40af-9405-b53effa670f7



Entry and routing (flag-gated):

- New `vm=true` intent param on `/new-deployment/configure`. It survives every URL rewrite (draft-id write-back, dseq mirroring, cancel-and-edit, bid-strategy switches) via `buildConfigureUrl`, and a `templateId` carried alongside it is ignored (the intent parser drops it and the screen resolves templates from the parsed intent).
- The TemplateList "Launch Container-VM" card and direct `/deploy-linux` visits route to `/new-deployment/configure?vm=true` when the flag is on (`useNewDeploymentUrl` + new `RedirectDeployLinuxToConfigure`). Analytics event is unchanged.

Seeding and form behavior:

- A fresh `vm=true` entry seeds a service with the real Ubuntu 24.04 image ref, a managed `port 22/tcp/global` expose, `count: 1`, and `hasSSHKey: true` (key required before quotes). The legacy flow injected all this at SDL-generation time via `transformCustomSdlFields`; Configure generates SDL straight from form state, so it lives in the state itself.
- Per-service VM behavior keys off image detection (`isVmImage`), not the URL param, so draft resume and imported VM SDLs restore VM mode for free: the Docker card becomes an "Operating System" card with a Distribution select over the 4 managed distros (private registry hidden, credentials cleared), replicas pin to 1, "Expose SSH" is forced on while any VM service exists, and the Commands card is hidden (overriding the entrypoint would break the SSH bootstrap).
- The Runtime card opens expanded for a VM service so the required key field is visible on entry, and its header is marked after a submit rejected on its hidden fields (same treatment as Expose Ports). The schema also requires an SSH key on any VM service even if the deployment-wide flag is somehow off, so an unreachable VM cannot be submitted.
- The exact 22-to-22 expose row renders read-only ("Reserved for SSH access") and non-removable; the schema rejects any other row touching port 22 on a VM service, mirroring the legacy reservation. Carried-in SDLs are taken literally: no expose backfill.
- `SSH_VM_IMAGES` moved to a dependency-free `utils/sdl/vmImages.ts` so the form schema can consume it without an import cycle; `utils/sdl/data.ts` re-exports for existing consumers.

Known accepted tradeoffs (by design, from CON-675 planning): pasting a VM image ref into a normal service flips it into VM mode with no UI path back except deleting the service; a carried-in VM SDL that already has a `command` keeps emitting it (just not editable); credentials on a carried-in VM service clear when that service is first selected.

Out of scope (per CON-675 planning): a Playwright VM e2e ships as a follow-up under the E2E initiative.

Verification: full deploy-web unit suite (2672 passed), `lint --quiet`, `tsc --noEmit` (0 new errors), plus a manifest smoke check confirming the seeded VM deployment produces a chain-valid manifest and round-trips through SDL import. The manual flag-on pass from the plan (deploy end-to-end, SSH instructions on the Lease tab) still needs a run in a flag-enabled environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for managed SSH virtual-machine deployments in the redesigned flow, including VM image distribution selection.
  * VM services now run as a single instance and automatically enable SSH.
  * Commands are hidden for VM services, while a managed “Reserved for SSH access” Port 22 row is shown and protected from edits/removal.
  * Feature-flagged redirect sends classic Linux entry into the VM-capable configure flow.
* **Bug Fixes**
  * Improved VM-specific configuration initialization, credential clearing, and deterministic SDL seeding for VM entries.
* **Tests**
  * Expanded VM coverage across deployment configuration, runtime, ports, image selection, and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->