### PR TITLE
fix(sdl): heal pre-uact sdl-builder drafts and remove sidebar entry

### DIFF
--- a/apps/deploy-web/src/components/layout/Sidebar.tsx
+++ b/apps/deploy-web/src/components/layout/Sidebar.tsx
@@ -27,7 +27,6 @@ import {
   SidebarCollapse,
   SidebarExpand,
   StatsUpSquare,
-  Tools,
   X as TwitterX,
   Youtube
 } from "iconoir-react";
@@ -88,13 +87,6 @@ export const Sidebar: React.FunctionComponent<Props> = ({ isMobileOpen, handleDr
             icon: props => <MultiplePages {...props} />,
             url: UrlService.templates(),
             activeRoutes: [UrlService.templates()]
-          },
-          {
-            title: "SDL Builder",
-            icon: props => <Tools {...props} />,
-            url: UrlService.sdlBuilder(),
-            activeRoutes: [UrlService.sdlBuilder()],
-            testId: "sidebar-sdl-builder-link"
           },
           {
             title: "Providers",

--- a/apps/deploy-web/src/components/sdl/SimpleSdlBuilderForm.tsx
+++ b/apps/deploy-web/src/components/sdl/SimpleSdlBuilderForm.tsx
@@ -20,7 +20,7 @@ import type { ITemplate, SdlBuilderFormValuesType, ServiceType } from "@src/type
 import { SdlBuilderFormValuesSchema } from "@src/types";
 import { RouteStep } from "@src/types/route-steps.type";
 import { memoryUnits, storageUnits } from "@src/utils/akash/units";
-import { defaultServiceWithPlacement } from "@src/utils/sdl/data";
+import { defaultServiceWithPlacement, healSdlBuilderDraft } from "@src/utils/sdl/data";
 import { generateSdl } from "@src/utils/sdl/sdlGenerator";
 import { importSimpleSdl } from "@src/utils/sdl/sdlImport";
 import { UrlService } from "@src/utils/urlUtils";
@@ -53,7 +53,8 @@ export const SimpleSDLBuilderForm: React.FunctionComponent = () => {
     watch,
     setValue,
     defaultValues: initialValues,
-    storage: typeof window === "undefined" ? undefined : window.localStorage
+    storage: typeof window === "undefined" ? undefined : window.localStorage,
+    transform: healSdlBuilderDraft
   });
   const { services: _services } = watch();
   const serviceManager = useSdlServiceManager({ control });

--- a/apps/deploy-web/src/hooks/useFormPersist.spec.ts
+++ b/apps/deploy-web/src/hooks/useFormPersist.spec.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { UACT_DENOM } from "@src/config/denom.config";
+import { defaultPricing, healSdlBuilderDraft } from "@src/utils/sdl/data";
+import useFormPersist from "./useFormPersist";
+
+import { renderHook } from "@testing-library/react";
+
+describe(useFormPersist.name, () => {
+  it("applies transform to restored values before setting them on the form", () => {
+    const transform = vi.fn((values: Record<string, any>) => ({ ...values, services: "transformed" }));
+    const { setValue } = setup({
+      stored: JSON.stringify({ _timestamp: 123, services: "stale" }),
+      transform
+    });
+
+    expect(transform).toHaveBeenCalledWith({ services: "stale" });
+    expect(setValue).toHaveBeenCalledWith("services", "transformed", expect.any(Object));
+  });
+
+  it("restores values unchanged when no transform is given", () => {
+    const { setValue } = setup({ stored: JSON.stringify({ services: "stale" }) });
+
+    expect(setValue).toHaveBeenCalledWith("services", "stale", expect.any(Object));
+  });
+
+  it("recovers from corrupted storage by clearing it and applying the default values", () => {
+    const { setValue } = setup({
+      stored: "{not-json",
+      defaultValues: { services: "defaults" }
+    });
+
+    expect(window.localStorage.getItem(STORAGE_KEY)).not.toBe("{not-json");
+    expect(setValue).toHaveBeenCalledWith("services", "defaults", expect.any(Object));
+  });
+
+  it("heals a pre-uact draft missing service pricing when given the sdl-builder transform", () => {
+    const preUactDraft = {
+      placements: [{ id: "p1", name: "dcloud" }],
+      services: [{ id: "s1", title: "web", image: "nginx", profile: { cpu: 0.1 }, expose: [], placementId: "p1" }],
+      endpoints: []
+    };
+    const { setValue } = setup({
+      stored: JSON.stringify(preUactDraft),
+      transform: healSdlBuilderDraft
+    });
+
+    expect(setValue).toHaveBeenCalledWith(
+      "services",
+      [expect.objectContaining({ image: "nginx", pricing: { amount: defaultPricing().amount, denom: UACT_DENOM } })],
+      expect.any(Object)
+    );
+  });
+
+  const STORAGE_KEY = "test-form";
+
+  function setup(input?: { stored?: string; transform?: (values: Record<string, any>) => Record<string, any>; defaultValues?: Record<string, any> }) {
+    window.localStorage.clear();
+
+    if (input?.stored !== undefined) {
+      window.localStorage.setItem(STORAGE_KEY, input.stored);
+    }
+
+    const watch = vi.fn();
+    const setValue = vi.fn();
+
+    const rendered = renderHook(() =>
+      useFormPersist(STORAGE_KEY, {
+        watch,
+        setValue,
+        storage: window.localStorage,
+        defaultValues: input?.defaultValues,
+        transform: input?.transform
+      })
+    );
+
+    return { watch, setValue, rendered };
+  }
+});

--- a/apps/deploy-web/src/hooks/useFormPersist.tsx
+++ b/apps/deploy-web/src/hooks/useFormPersist.tsx
@@ -13,6 +13,11 @@ export interface FormPersistConfig {
   onTimeout?: () => void;
   timeout?: number;
   defaultValues?: any;
+  /**
+   * Maps restored values before they are applied to the form — e.g. to migrate
+   * drafts persisted with an older shape. Must be an idempotent, stable reference.
+   */
+  transform?: (values: Record<string, any>) => Record<string, any>;
 }
 
 const useFormPersist = (
@@ -28,7 +33,8 @@ const useFormPersist = (
     touch = false,
     onTimeout,
     timeout,
-    defaultValues
+    defaultValues,
+    transform
   }: FormPersistConfig
 ) => {
   const watchedValues = watch();
@@ -39,10 +45,19 @@ const useFormPersist = (
 
   useEffect(() => {
     const str = getStorage().getItem(name);
-    const parsed = str ? JSON.parse(str) : defaultValues;
+    let parsed = defaultValues;
+
+    if (str) {
+      try {
+        parsed = JSON.parse(str);
+      } catch {
+        clearStorage();
+        parsed = defaultValues;
+      }
+    }
 
     if (parsed) {
-      const { _timestamp = null, ...values } = parsed;
+      const { _timestamp = null, ...restored } = parsed;
       const dataRestored: { [key: string]: any } = {};
       const currTimestamp = Date.now();
 
@@ -51,6 +66,8 @@ const useFormPersist = (
         clearStorage();
         return;
       }
+
+      const values = transform ? transform(restored) : restored;
 
       Object.keys(values).forEach(key => {
         const shouldSet = !exclude.includes(key);
@@ -68,7 +85,7 @@ const useFormPersist = (
         onDataRestored(dataRestored);
       }
     }
-  }, [storage, name, onDataRestored, setValue, defaultValues]);
+  }, [storage, name, onDataRestored, setValue, defaultValues, transform]);
 
   useEffect(() => {
     const values = exclude.length

--- a/apps/deploy-web/src/utils/sdl/data.spec.ts
+++ b/apps/deploy-web/src/utils/sdl/data.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { defaultPlacement, defaultService } from "./data";
+import { UACT_DENOM } from "@src/config/denom.config";
+import { defaultPlacement, defaultPricing, defaultService, healSdlBuilderDraft } from "./data";
 
 describe("default factories", () => {
   it("defaultPlacement returns an object with a stable id and a default name", () => {
@@ -23,5 +24,58 @@ describe("default factories", () => {
     const b = defaultService(placement.id);
     a.title = "modified";
     expect(b.title).not.toBe("modified");
+  });
+});
+
+describe(healSdlBuilderDraft.name, () => {
+  it("fills default pricing for services missing it and preserves the other fields", () => {
+    const draft = {
+      placements: [{ id: "p1", name: "dcloud" }],
+      services: [{ id: "s1", title: "web", image: "nginx", placementId: "p1" }],
+      endpoints: []
+    };
+
+    const healed = healSdlBuilderDraft(draft);
+
+    expect(healed.services[0]).toEqual({
+      id: "s1",
+      title: "web",
+      image: "nginx",
+      placementId: "p1",
+      pricing: defaultPricing()
+    });
+    expect(healed.placements).toEqual(draft.placements);
+  });
+
+  it("leaves services with valid pricing untouched", () => {
+    const valid = { id: "s1", title: "web", pricing: { amount: 42, denom: UACT_DENOM } };
+    const stale = { id: "s2", title: "api" };
+
+    const healed = healSdlBuilderDraft({ services: [valid, stale] });
+
+    expect(healed.services[0]).toBe(valid);
+    expect(healed.services[1].pricing).toEqual(defaultPricing());
+  });
+
+  it("replaces malformed pricing", () => {
+    const healed = healSdlBuilderDraft({ services: [{ id: "s1", pricing: { amount: "1" } }] });
+
+    expect(healed.services[0].pricing).toEqual(defaultPricing());
+  });
+
+  it("returns values unchanged when services is absent or not an array", () => {
+    const withoutServices = { placements: [] };
+    const corrupted = { services: "corrupt" };
+
+    expect(healSdlBuilderDraft(withoutServices)).toBe(withoutServices);
+    expect(healSdlBuilderDraft(corrupted)).toBe(corrupted);
+  });
+
+  it("gives healed services independent pricing objects", () => {
+    const healed = healSdlBuilderDraft({ services: [{ id: "s1" }, { id: "s2" }] });
+
+    healed.services[0].pricing.amount = 1;
+
+    expect(healed.services[1].pricing.amount).toBe(defaultPricing().amount);
   });
 });

--- a/apps/deploy-web/src/utils/sdl/data.ts
+++ b/apps/deploy-web/src/utils/sdl/data.ts
@@ -40,6 +40,14 @@ export const defaultEndpoint = (overrides?: Partial<EndpointType>): EndpointType
 });
 
 /**
+ * Builds a fresh per-service pricing object with the default max price.
+ */
+export const defaultPricing = (): ServiceType["pricing"] => ({
+  amount: 100000,
+  denom: UACT_DENOM
+});
+
+/**
  * Builds a fresh service bound to the given placement id and seeded with the
  * standard single-port HTTP expose / compute / pricing defaults.
  */
@@ -87,10 +95,7 @@ export const defaultService = (placementId: string, overrides?: Partial<ServiceT
   command: { command: "", arg: "" },
   env: [],
   placementId,
-  pricing: {
-    amount: 100000,
-    denom: UACT_DENOM
-  },
+  pricing: defaultPricing(),
   count: 1,
   ...overrides
 });
@@ -106,6 +111,25 @@ export const defaultServiceWithPlacement = (serviceOverrides?: Partial<ServiceTy
     placements: [placement],
     services: [defaultService(placement.id, serviceOverrides)],
     endpoints: []
+  };
+};
+
+const hasValidPricing = (service: Record<string, any>): boolean => typeof service.pricing?.amount === "number" && typeof service.pricing?.denom === "string";
+
+/**
+ * Heals sdl-builder drafts persisted to storage before the uact pricing model
+ * (or corrupted in storage): fills each service's missing/malformed pricing with
+ * the current default, leaving the rest of the draft untouched. Idempotent and
+ * safe on malformed input.
+ */
+export const healSdlBuilderDraft = (values: Record<string, any>): Record<string, any> => {
+  if (!values || !Array.isArray(values.services)) return values;
+
+  return {
+    ...values,
+    services: values.services.map(service =>
+      service && typeof service === "object" && !hasValidPricing(service) ? { ...service, pricing: defaultPricing() } : service
+    )
   };
 };
 

--- a/apps/deploy-web/tests/ui/pages/BuildTemplatePage.tsx
+++ b/apps/deploy-web/tests/ui/pages/BuildTemplatePage.tsx
@@ -3,11 +3,7 @@ import { DeployPage } from "./DeployPage";
 
 export class BuildTemplatePage extends DeployPage {
   async gotoInteractive() {
-    await this.page.goto(testEnvConfig.BASE_URL);
-    await this.page
-      .getByRole("link", { name: /sdl builder/i })
-      .first()
-      .click();
+    await this.page.goto(`${testEnvConfig.BASE_URL}/sdl-builder`);
   }
 
   async addService() {


### PR DESCRIPTION
## Why

Returning users with `/sdl-builder` drafts saved before the ACT (`uact`) pricing model crash on load with `TypeError: Cannot read properties of undefined (reading 'amount')`: the draft restored from `localStorage` has no per-service `pricing`, and both the pricing summary and SDL generation (Deploy / Preview / Save) read it unguarded. Retiring the page (the eventual fix) is blocked until Configure gains template management and Container-VM support, so this fixes the crash in place and removes the sidebar entry point now.

Fixes CON-681
Related to CON-672

## What

- `useFormPersist` gains a `transform` option applied to restored values, and recovers from corrupted stored JSON (clears the entry, falls back to defaults) instead of throwing.
- New `healSdlBuilderDraft` fills missing/malformed service pricing with the default (`defaultPricing()`), leaving the rest of the draft untouched; the persist effect writes the healed draft back, so storage self-migrates.
- Removes the "SDL Builder" sidebar nav entry. The page itself stays reachable via direct URL and saved-template edit links until the retirement lands (CON-673/CON-675 prerequisites).
- E2E page object navigates to `/sdl-builder` directly instead of clicking the removed nav link.
- New specs for `useFormPersist` (transform, corrupted storage, pre-uact regression fixture) and `healSdlBuilderDraft`.

Verified on a local run by driving the real page with Playwright: a seeded pre-uact draft that reproduces the exact TypeError on `main` renders fine with this fix — pricing shows "Max 0.1 ACT per block", the draft's image/env survive, and storage ends up migrated; corrupted storage loads defaults instead of a white screen.
