### PR TITLE
fix: makes bid screening endpoints schema more strict

### DIFF
--- a/apps/provider-inventory/src/controllers/bid-screening/bid-screening.controller.ts
+++ b/apps/provider-inventory/src/controllers/bid-screening/bid-screening.controller.ts
@@ -13,7 +13,7 @@ export class BidScreeningController {
   }
 
   async screenProviders(request: BidScreeningRequest, options?: Abortable): Promise<BidScreeningResponse> {
-    const results = await this.#bidScreeningService.findMatchingProviders(request as BidScreeningInput, options);
+    const results = await this.#bidScreeningService.findMatchingProviders(request as unknown as BidScreeningInput, options);
     return { providers: results };
   }
 }

--- a/apps/provider-inventory/src/http-schemas/bid-screening.schema.ts
+++ b/apps/provider-inventory/src/http-schemas/bid-screening.schema.ts
@@ -65,7 +65,14 @@ const ResourceSchema = z.object({
     attributes: z.array(AttributeSchema).optional()
   }),
   storage: z.array(StorageResourceSchema),
-  endpoints: z.array(z.unknown()).optional().optional()
+  endpoints: z
+    .array(
+      z.object({
+        kind: z.enum(["SHARED_HTTP", "RANDOM_PORT", "LEASED_IP", "UNRECOGNIZED"]).optional(),
+        sequenceNumber: z.number({ coerce: true }).int().nonnegative().optional()
+      })
+    )
+    .optional()
 });
 
 const PriceSchema = z.object({


### PR DESCRIPTION
## Why

alert with 500 because of accessing property on null when checking endpoints

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for resource endpoint information.
  * Endpoint `kind` values are now restricted to supported options.
  * Endpoint `sequenceNumber` is now coerced to a number and must be a non-negative integer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->