### PR TITLE
feat(deployment): add "Deploy with Agent mode" panel to new deployment page

### DIFF
--- a/apps/deploy-web/src/components/new-deployment/AgentModePanel/AgentModePanel.spec.tsx
+++ b/apps/deploy-web/src/components/new-deployment/AgentModePanel/AgentModePanel.spec.tsx
@@ -12,14 +12,14 @@ describe(AgentModePanel.name, () => {
   it("renders the header but keeps the setup steps collapsed by default", () => {
     setup();
 
-    expect(screen.getByText("Deploy with Agent mode")).toBeInTheDocument();
+    expect(screen.getByText("Deploy with your agent")).toBeInTheDocument();
     expect(screen.queryByText("Install the Akash skill")).not.toBeInTheDocument();
   });
 
-  it("reveals the setup steps and tracks the click when Set up Agent mode is clicked", async () => {
+  it("reveals the setup steps and tracks the click when Set up with your agent is clicked", async () => {
     const { analyticsService } = setup();
 
-    await userEvent.click(screen.getByRole("button", { name: /Set up Agent mode/ }));
+    await userEvent.click(screen.getByRole("button", { name: /Set up with your agent/ }));
 
     expect(analyticsService.track).toHaveBeenCalledWith("deploy_with_agent_btn_clk", "Amplitude");
     expect(screen.getByText("Install the Akash skill")).toBeInTheDocument();
@@ -29,7 +29,7 @@ describe(AgentModePanel.name, () => {
   it("offers a copy button for the install command", async () => {
     setup();
 
-    await userEvent.click(screen.getByRole("button", { name: /Set up Agent mode/ }));
+    await userEvent.click(screen.getByRole("button", { name: /Set up with your agent/ }));
 
     expect(screen.getByRole("button", { name: "copy" })).toBeInTheDocument();
   });
@@ -37,7 +37,7 @@ describe(AgentModePanel.name, () => {
   it("links Create an API key to the in-app API keys page", async () => {
     setup();
 
-    await userEvent.click(screen.getByRole("button", { name: /Set up Agent mode/ }));
+    await userEvent.click(screen.getByRole("button", { name: /Set up with your agent/ }));
 
     expect(screen.getByRole("link", { name: /Go to API keys/ })).toHaveAttribute("href", "/user/api-keys");
   });
@@ -45,7 +45,7 @@ describe(AgentModePanel.name, () => {
   it("opens the setup guide docs in a new tab", async () => {
     setup();
 
-    await userEvent.click(screen.getByRole("button", { name: /Set up Agent mode/ }));
+    await userEvent.click(screen.getByRole("button", { name: /Set up with your agent/ }));
 
     const setupGuide = screen.getByRole("link", { name: /Setup guide/ });
     expect(setupGuide).toHaveAttribute("href", "https://akash.network/docs/getting-started/ai-agents/");

--- a/apps/deploy-web/src/components/new-deployment/AgentModePanel/AgentModePanel.spec.tsx
+++ b/apps/deploy-web/src/components/new-deployment/AgentModePanel/AgentModePanel.spec.tsx
@@ -26,6 +26,14 @@ describe(AgentModePanel.name, () => {
     expect(screen.getByText("/plugin marketplace add akash-network/akash-skill")).toBeInTheDocument();
   });
 
+  it("offers a copy button for the install command", async () => {
+    setup();
+
+    await userEvent.click(screen.getByRole("button", { name: /Set up Agent mode/ }));
+
+    expect(screen.getByRole("button", { name: "copy" })).toBeInTheDocument();
+  });
+
   it("links Create an API key to the in-app API keys page", async () => {
     setup();
 

--- a/apps/deploy-web/src/components/new-deployment/AgentModePanel/AgentModePanel.spec.tsx
+++ b/apps/deploy-web/src/components/new-deployment/AgentModePanel/AgentModePanel.spec.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { AnalyticsService } from "@src/services/analytics/analytics.service";
+import { AgentModePanel } from "./AgentModePanel";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { TestContainerProvider } from "@tests/unit/TestContainerProvider";
+
+describe(AgentModePanel.name, () => {
+  it("renders the header but keeps the setup steps collapsed by default", () => {
+    setup();
+
+    expect(screen.getByText("Deploy with Agent mode")).toBeInTheDocument();
+    expect(screen.queryByText("Install the Akash skill")).not.toBeInTheDocument();
+  });
+
+  it("reveals the setup steps and tracks the click when Set up Agent mode is clicked", async () => {
+    const { analyticsService } = setup();
+
+    await userEvent.click(screen.getByRole("button", { name: /Set up Agent mode/ }));
+
+    expect(analyticsService.track).toHaveBeenCalledWith("deploy_with_agent_btn_clk", "Amplitude");
+    expect(screen.getByText("Install the Akash skill")).toBeInTheDocument();
+    expect(screen.getByText("/plugin marketplace add akash-network/akash-skill")).toBeInTheDocument();
+  });
+
+  it("links Create an API key to the in-app API keys page", async () => {
+    setup();
+
+    await userEvent.click(screen.getByRole("button", { name: /Set up Agent mode/ }));
+
+    expect(screen.getByRole("link", { name: /Go to API keys/ })).toHaveAttribute("href", "/user/api-keys");
+  });
+
+  it("opens the setup guide docs in a new tab", async () => {
+    setup();
+
+    await userEvent.click(screen.getByRole("button", { name: /Set up Agent mode/ }));
+
+    const setupGuide = screen.getByRole("link", { name: /Setup guide/ });
+    expect(setupGuide).toHaveAttribute("href", "https://akash.network/docs/getting-started/ai-agents/");
+    expect(setupGuide).toHaveAttribute("target", "_blank");
+  });
+
+  function setup() {
+    const analyticsService = mock<AnalyticsService>();
+
+    render(
+      <TestContainerProvider services={{ analyticsService: () => analyticsService }}>
+        <AgentModePanel />
+      </TestContainerProvider>
+    );
+
+    return { analyticsService };
+  }
+});

--- a/apps/deploy-web/src/components/new-deployment/AgentModePanel/AgentModePanel.tsx
+++ b/apps/deploy-web/src/components/new-deployment/AgentModePanel/AgentModePanel.tsx
@@ -5,6 +5,7 @@ import { cn } from "@akashnetwork/ui/utils";
 import { NavArrowDown, Sparks } from "iconoir-react";
 import Link from "next/link";
 
+import { CodeSnippet } from "@src/components/shared/CodeSnippet";
 import { ExternalLink } from "@src/components/shared/ExternalLink";
 import { useServices } from "@src/context/ServicesProvider";
 import { UrlService } from "@src/utils/urlUtils";
@@ -48,7 +49,9 @@ export const AgentModePanel: React.FunctionComponent = () => {
           <div className="mt-6 grid grid-cols-1 gap-6 border-t pt-6 md:grid-cols-3">
             <AgentModeStep index={1} title="Install the Akash skill">
               <p className="text-sm text-muted-foreground">In Claude Code, Codex, or OpenCode:</p>
-              <code className="mt-2 block overflow-x-auto rounded-md bg-secondary px-3 py-2 text-sm">{SKILL_INSTALL_COMMAND}</code>
+              <div className="mt-2">
+                <CodeSnippet code={SKILL_INSTALL_COMMAND} />
+              </div>
             </AgentModeStep>
 
             <AgentModeStep index={2} title="Create an API key">

--- a/apps/deploy-web/src/components/new-deployment/AgentModePanel/AgentModePanel.tsx
+++ b/apps/deploy-web/src/components/new-deployment/AgentModePanel/AgentModePanel.tsx
@@ -48,24 +48,34 @@ export const AgentModePanel: React.FunctionComponent = () => {
 
         <CollapsibleContent>
           <div className="mt-5 grid grid-cols-1 gap-x-8 gap-y-6 border-t pt-5 md:grid-cols-3">
-            <AgentModeStep index={1} title="Install the Akash skill">
-              <p>In Claude Code, Codex, or OpenCode:</p>
-              <CommandLine command={SKILL_INSTALL_COMMAND} />
-            </AgentModeStep>
+            <AgentModeStep
+              index={1}
+              title="Install the Akash skill"
+              description="In Claude Code, Codex, or OpenCode:"
+              action={<CommandLine command={SKILL_INSTALL_COMMAND} />}
+            />
 
-            <AgentModeStep index={2} title="Create an API key">
-              <p>The agent deploys on your behalf using a Console API key.</p>
-              <Link href={UrlService.userApiKeys()} className="inline-flex font-medium text-primary hover:underline">
-                Go to API keys →
-              </Link>
-            </AgentModeStep>
+            <AgentModeStep
+              index={2}
+              title="Create an API key"
+              description="The agent deploys on your behalf using a Console API key."
+              action={
+                <Link href={UrlService.userApiKeys()} className="inline-flex font-medium text-primary hover:underline">
+                  Go to API keys →
+                </Link>
+              }
+            />
 
-            <AgentModeStep index={3} title="Read the setup guide">
-              <p>Full walkthrough for connecting your agent and deploying.</p>
-              <span className="font-medium text-primary hover:underline">
-                <ExternalLink href={AI_AGENTS_DOCS_URL} text="Setup guide" />
-              </span>
-            </AgentModeStep>
+            <AgentModeStep
+              index={3}
+              title="Read the setup guide"
+              description="Full walkthrough for connecting your agent and deploying."
+              action={
+                <span className="font-medium text-primary hover:underline">
+                  <ExternalLink href={AI_AGENTS_DOCS_URL} text="Setup guide" />
+                </span>
+              }
+            />
           </div>
         </CollapsibleContent>
       </Collapsible>
@@ -76,16 +86,18 @@ export const AgentModePanel: React.FunctionComponent = () => {
 type AgentModeStepProps = {
   index: number;
   title: string;
-  children: React.ReactNode;
+  description: React.ReactNode;
+  action: React.ReactNode;
 };
 
-const AgentModeStep: React.FunctionComponent<AgentModeStepProps> = ({ index, title, children }) => (
-  <div>
+const AgentModeStep: React.FunctionComponent<AgentModeStepProps> = ({ index, title, description, action }) => (
+  <div className="flex h-full flex-col">
     <div className="flex items-center gap-2.5">
       <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-secondary text-xs font-semibold text-muted-foreground">{index}</span>
       <h4 className="text-sm font-semibold">{title}</h4>
     </div>
-    <div className="mt-3 space-y-3 text-sm text-muted-foreground">{children}</div>
+    <p className="mt-3 text-sm text-muted-foreground">{description}</p>
+    <div className="mt-auto pt-4">{action}</div>
   </div>
 );
 

--- a/apps/deploy-web/src/components/new-deployment/AgentModePanel/AgentModePanel.tsx
+++ b/apps/deploy-web/src/components/new-deployment/AgentModePanel/AgentModePanel.tsx
@@ -1,13 +1,14 @@
 "use client";
 import { useState } from "react";
-import { Button, Card, Collapsible, CollapsibleContent, CollapsibleTrigger } from "@akashnetwork/ui/components";
+import { Button, Card, Collapsible, CollapsibleContent, CollapsibleTrigger, Snackbar } from "@akashnetwork/ui/components";
 import { cn } from "@akashnetwork/ui/utils";
-import { NavArrowDown, Sparks } from "iconoir-react";
+import { Copy, NavArrowDown, Sparks } from "iconoir-react";
 import Link from "next/link";
+import { useSnackbar } from "notistack";
 
-import { CodeSnippet } from "@src/components/shared/CodeSnippet";
 import { ExternalLink } from "@src/components/shared/ExternalLink";
 import { useServices } from "@src/context/ServicesProvider";
+import { copyTextToClipboard } from "@src/utils/copyClipboard";
 import { UrlService } from "@src/utils/urlUtils";
 
 const SKILL_INSTALL_COMMAND = "/plugin marketplace add akash-network/akash-skill";
@@ -23,51 +24,47 @@ export const AgentModePanel: React.FunctionComponent = () => {
   };
 
   return (
-    <Card className="mb-6 p-6">
+    <Card className="mb-6 p-5 sm:p-6">
       <Collapsible open={isOpen} onOpenChange={handleOpenChange}>
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-          <div className="flex items-start gap-3">
-            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-secondary">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-3">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-secondary text-foreground">
               <Sparks className="h-5 w-5" />
             </div>
-            <div>
+            <div className="space-y-0.5">
               <h3 className="text-base font-bold tracking-tight">Deploy with Agent mode</h3>
-              <p className="text-sm text-muted-foreground">
+              <p className="max-w-2xl text-sm text-muted-foreground">
                 Describe your deployment in plain language. The Akash skill drafts the SDL and deploys it from your coding agent.
               </p>
             </div>
           </div>
           <CollapsibleTrigger asChild>
-            <Button variant="outline" size="sm" className="shrink-0 space-x-2 self-start">
+            <Button variant="outline" size="sm" className="shrink-0 gap-2 self-start sm:self-center">
               <span>Set up Agent mode</span>
-              <NavArrowDown className={cn("text-xs transition-transform", isOpen && "rotate-180")} />
+              <NavArrowDown className={cn("h-4 w-4 transition-transform duration-200", isOpen && "rotate-180")} />
             </Button>
           </CollapsibleTrigger>
         </div>
 
         <CollapsibleContent>
-          <div className="mt-6 grid grid-cols-1 gap-6 border-t pt-6 md:grid-cols-3">
+          <div className="mt-5 grid grid-cols-1 gap-x-8 gap-y-6 border-t pt-5 md:grid-cols-3">
             <AgentModeStep index={1} title="Install the Akash skill">
-              <p className="text-sm text-muted-foreground">In Claude Code, Codex, or OpenCode:</p>
-              <div className="mt-2">
-                <CodeSnippet code={SKILL_INSTALL_COMMAND} />
-              </div>
+              <p>In Claude Code, Codex, or OpenCode:</p>
+              <CommandLine command={SKILL_INSTALL_COMMAND} />
             </AgentModeStep>
 
             <AgentModeStep index={2} title="Create an API key">
-              <p className="text-sm text-muted-foreground">
-                The agent deploys on your behalf using a Console API key.{" "}
-                <Link href={UrlService.userApiKeys()} className="whitespace-nowrap text-primary underline">
-                  Go to API keys →
-                </Link>
-              </p>
+              <p>The agent deploys on your behalf using a Console API key.</p>
+              <Link href={UrlService.userApiKeys()} className="inline-flex font-medium text-primary hover:underline">
+                Go to API keys →
+              </Link>
             </AgentModeStep>
 
             <AgentModeStep index={3} title="Read the setup guide">
-              <p className="text-sm text-muted-foreground">Full walkthrough for connecting your agent and deploying.</p>
-              <div className="mt-2 text-sm text-primary">
+              <p>Full walkthrough for connecting your agent and deploying.</p>
+              <span className="font-medium text-primary hover:underline">
                 <ExternalLink href={AI_AGENTS_DOCS_URL} text="Setup guide" />
-              </div>
+              </span>
             </AgentModeStep>
           </div>
         </CollapsibleContent>
@@ -84,10 +81,28 @@ type AgentModeStepProps = {
 
 const AgentModeStep: React.FunctionComponent<AgentModeStepProps> = ({ index, title, children }) => (
   <div>
-    <div className="flex items-center gap-2">
-      <span className="flex h-5 w-5 items-center justify-center rounded bg-secondary text-xs font-medium">{index}</span>
+    <div className="flex items-center gap-2.5">
+      <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-secondary text-xs font-semibold text-muted-foreground">{index}</span>
       <h4 className="text-sm font-semibold">{title}</h4>
     </div>
-    <div className="mt-2">{children}</div>
+    <div className="mt-3 space-y-3 text-sm text-muted-foreground">{children}</div>
   </div>
 );
+
+const CommandLine: React.FunctionComponent<{ command: string }> = ({ command }) => {
+  const { enqueueSnackbar } = useSnackbar();
+
+  const onCopy = () => {
+    copyTextToClipboard(command);
+    enqueueSnackbar(<Snackbar title="Copied to clipboard!" iconVariant="success" />, { variant: "success", autoHideDuration: 1500 });
+  };
+
+  return (
+    <div className="flex items-center gap-2 rounded-md border bg-muted/40 py-1 pl-3 pr-1">
+      <code className="flex-1 overflow-x-auto whitespace-nowrap text-xs text-foreground">{command}</code>
+      <Button aria-label="copy" onClick={onCopy} size="icon" variant="ghost" type="button" className="h-7 w-7 shrink-0 text-muted-foreground">
+        <Copy className="h-3.5 w-3.5" />
+      </Button>
+    </div>
+  );
+};

--- a/apps/deploy-web/src/components/new-deployment/AgentModePanel/AgentModePanel.tsx
+++ b/apps/deploy-web/src/components/new-deployment/AgentModePanel/AgentModePanel.tsx
@@ -32,7 +32,7 @@ export const AgentModePanel: React.FunctionComponent = () => {
               <Sparks className="h-5 w-5" />
             </div>
             <div className="space-y-0.5">
-              <h3 className="text-base font-bold tracking-tight">Deploy with Agent mode</h3>
+              <h3 className="text-base font-bold tracking-tight">Deploy with your agent</h3>
               <p className="max-w-2xl text-sm text-muted-foreground">
                 Describe your deployment in plain language. The Akash skill drafts the SDL and deploys it from your coding agent.
               </p>
@@ -40,7 +40,7 @@ export const AgentModePanel: React.FunctionComponent = () => {
           </div>
           <CollapsibleTrigger asChild>
             <Button variant="outline" size="sm" className="shrink-0 gap-2 self-start sm:self-center">
-              <span>Set up Agent mode</span>
+              <span>Set up with your agent</span>
               <NavArrowDown className={cn("h-4 w-4 transition-transform duration-200", isOpen && "rotate-180")} />
             </Button>
           </CollapsibleTrigger>

--- a/apps/deploy-web/src/components/new-deployment/AgentModePanel/AgentModePanel.tsx
+++ b/apps/deploy-web/src/components/new-deployment/AgentModePanel/AgentModePanel.tsx
@@ -60,7 +60,7 @@ export const AgentModePanel: React.FunctionComponent = () => {
               title="Create an API key"
               description="The agent deploys on your behalf using a Console API key."
               action={
-                <Link href={UrlService.userApiKeys()} className="inline-flex font-medium text-primary hover:underline">
+                <Link href={UrlService.userApiKeys()} className="inline-flex text-sm font-medium text-primary hover:underline">
                   Go to API keys →
                 </Link>
               }
@@ -71,7 +71,7 @@ export const AgentModePanel: React.FunctionComponent = () => {
               title="Read the setup guide"
               description="Full walkthrough for connecting your agent and deploying."
               action={
-                <span className="font-medium text-primary hover:underline">
+                <span className="text-sm font-medium text-primary hover:underline">
                   <ExternalLink href={AI_AGENTS_DOCS_URL} text="Setup guide" />
                 </span>
               }

--- a/apps/deploy-web/src/components/new-deployment/AgentModePanel/AgentModePanel.tsx
+++ b/apps/deploy-web/src/components/new-deployment/AgentModePanel/AgentModePanel.tsx
@@ -1,0 +1,90 @@
+"use client";
+import { useState } from "react";
+import { Button, Card, Collapsible, CollapsibleContent, CollapsibleTrigger } from "@akashnetwork/ui/components";
+import { cn } from "@akashnetwork/ui/utils";
+import { NavArrowDown, Sparks } from "iconoir-react";
+import Link from "next/link";
+
+import { ExternalLink } from "@src/components/shared/ExternalLink";
+import { useServices } from "@src/context/ServicesProvider";
+import { UrlService } from "@src/utils/urlUtils";
+
+const SKILL_INSTALL_COMMAND = "/plugin marketplace add akash-network/akash-skill";
+const AI_AGENTS_DOCS_URL = "https://akash.network/docs/getting-started/ai-agents/";
+
+export const AgentModePanel: React.FunctionComponent = () => {
+  const { analyticsService } = useServices();
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleOpenChange = (open: boolean) => {
+    if (open) analyticsService.track("deploy_with_agent_btn_clk", "Amplitude");
+    setIsOpen(open);
+  };
+
+  return (
+    <Card className="mb-6 p-6">
+      <Collapsible open={isOpen} onOpenChange={handleOpenChange}>
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div className="flex items-start gap-3">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-secondary">
+              <Sparks className="h-5 w-5" />
+            </div>
+            <div>
+              <h3 className="text-base font-bold tracking-tight">Deploy with Agent mode</h3>
+              <p className="text-sm text-muted-foreground">
+                Describe your deployment in plain language. The Akash skill drafts the SDL and deploys it from your coding agent.
+              </p>
+            </div>
+          </div>
+          <CollapsibleTrigger asChild>
+            <Button variant="outline" size="sm" className="shrink-0 space-x-2 self-start">
+              <span>Set up Agent mode</span>
+              <NavArrowDown className={cn("text-xs transition-transform", isOpen && "rotate-180")} />
+            </Button>
+          </CollapsibleTrigger>
+        </div>
+
+        <CollapsibleContent>
+          <div className="mt-6 grid grid-cols-1 gap-6 border-t pt-6 md:grid-cols-3">
+            <AgentModeStep index={1} title="Install the Akash skill">
+              <p className="text-sm text-muted-foreground">In Claude Code, Codex, or OpenCode:</p>
+              <code className="mt-2 block overflow-x-auto rounded-md bg-secondary px-3 py-2 text-sm">{SKILL_INSTALL_COMMAND}</code>
+            </AgentModeStep>
+
+            <AgentModeStep index={2} title="Create an API key">
+              <p className="text-sm text-muted-foreground">
+                The agent deploys on your behalf using a Console API key.{" "}
+                <Link href={UrlService.userApiKeys()} className="whitespace-nowrap text-primary underline">
+                  Go to API keys →
+                </Link>
+              </p>
+            </AgentModeStep>
+
+            <AgentModeStep index={3} title="Read the setup guide">
+              <p className="text-sm text-muted-foreground">Full walkthrough for connecting your agent and deploying.</p>
+              <div className="mt-2 text-sm text-primary">
+                <ExternalLink href={AI_AGENTS_DOCS_URL} text="Setup guide" />
+              </div>
+            </AgentModeStep>
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
+    </Card>
+  );
+};
+
+type AgentModeStepProps = {
+  index: number;
+  title: string;
+  children: React.ReactNode;
+};
+
+const AgentModeStep: React.FunctionComponent<AgentModeStepProps> = ({ index, title, children }) => (
+  <div>
+    <div className="flex items-center gap-2">
+      <span className="flex h-5 w-5 items-center justify-center rounded bg-secondary text-xs font-medium">{index}</span>
+      <h4 className="text-sm font-semibold">{title}</h4>
+    </div>
+    <div className="mt-2">{children}</div>
+  </div>
+);

--- a/apps/deploy-web/src/components/new-deployment/TemplateList.spec.tsx
+++ b/apps/deploy-web/src/components/new-deployment/TemplateList.spec.tsx
@@ -28,6 +28,16 @@ describe(TemplateList.name, () => {
     expect(screen.getByText("Run Custom Container")).toBeInTheDocument();
   });
 
+  it("hides the Agent mode panel when the flag is disabled", () => {
+    setup({ isAgentModeEnabled: false });
+    expect(screen.queryByText("Deploy with Agent mode")).not.toBeInTheDocument();
+  });
+
+  it("shows the Agent mode panel when the flag is enabled", () => {
+    setup({ isAgentModeEnabled: true });
+    expect(screen.getByText("Deploy with Agent mode")).toBeInTheDocument();
+  });
+
   it("uploads a valid SDL into a configure draft and routes to configure when the redesign flag is on", async () => {
     const { push, createConfigureDraft, onTemplateSelected, enqueueSnackbar } = setup({ isRedesignEnabled: true });
 
@@ -65,7 +75,7 @@ describe(TemplateList.name, () => {
     return new File([content], "deploy.yaml", { type: "application/x-yaml" });
   }
 
-  function setup(input: { isBuildAndDeployEnabled?: boolean; isRedesignEnabled?: boolean; importSdlThrows?: boolean }) {
+  function setup(input: { isBuildAndDeployEnabled?: boolean; isRedesignEnabled?: boolean; isAgentModeEnabled?: boolean; importSdlThrows?: boolean }) {
     const push = vi.fn();
     const onTemplateSelected = vi.fn();
     const setEditedManifest = vi.fn();
@@ -95,6 +105,7 @@ describe(TemplateList.name, () => {
       useFlag: flagName => {
         if (flagName === "ui_build_and_deploy") return input.isBuildAndDeployEnabled ?? false;
         if (flagName === "onboarding_redesign_v1") return input.isRedesignEnabled ?? false;
+        if (flagName === "ui_agent_mode_deploy") return input.isAgentModeEnabled ?? false;
         return false;
       },
       useNewDeploymentUrl: () => params => UrlService.newDeployment(params),

--- a/apps/deploy-web/src/components/new-deployment/TemplateList.spec.tsx
+++ b/apps/deploy-web/src/components/new-deployment/TemplateList.spec.tsx
@@ -30,12 +30,12 @@ describe(TemplateList.name, () => {
 
   it("hides the Agent mode panel when the flag is disabled", () => {
     setup({ isAgentModeEnabled: false });
-    expect(screen.queryByText("Deploy with Agent mode")).not.toBeInTheDocument();
+    expect(screen.queryByText("Deploy with your agent")).not.toBeInTheDocument();
   });
 
   it("shows the Agent mode panel when the flag is enabled", () => {
     setup({ isAgentModeEnabled: true });
-    expect(screen.getByText("Deploy with Agent mode")).toBeInTheDocument();
+    expect(screen.getByText("Deploy with your agent")).toBeInTheDocument();
   });
 
   it("uploads a valid SDL into a configure draft and routes to configure when the redesign flag is on", async () => {

--- a/apps/deploy-web/src/components/new-deployment/TemplateList.tsx
+++ b/apps/deploy-web/src/components/new-deployment/TemplateList.tsx
@@ -24,6 +24,7 @@ import type { NewDeploymentParams } from "@src/utils/urlUtils";
 import { domainName, UrlService } from "@src/utils/urlUtils";
 import { CustomNextSeo } from "../shared/CustomNextSeo";
 import { TemplateBox } from "../templates/TemplateBox";
+import { AgentModePanel } from "./AgentModePanel/AgentModePanel";
 import { DeployOptionBox } from "./DeployOptionBox";
 
 const previewTemplateIds = [
@@ -68,6 +69,7 @@ export const TemplateList: React.FunctionComponent<Props> = ({
   const [, setSdlEditMode] = useAtom(sdlStore.selectedSdlEditMode);
   const isBuildAndDeployEnabled = d.useFlag("ui_build_and_deploy");
   const isRedesignEnabled = d.useFlag("onboarding_redesign_v1");
+  const isAgentModeEnabled = d.useFlag("ui_agent_mode_deploy");
 
   const handleGithubTemplate = async () => {
     analyticsService.track("build_n_deploy_btn_clk", "Amplitude");
@@ -131,6 +133,8 @@ export const TemplateList: React.FunctionComponent<Props> = ({
   return (
     <div className="my-0 pb-8">
       <CustomNextSeo title="Create Deployment - Template List" url={`${domainName}${UrlService.newDeployment({ step: RouteStep.chooseTemplate })}`} />
+
+      {isAgentModeEnabled && <AgentModePanel />}
 
       {/* Build Your Own Section */}
       <Card className="mb-6">
@@ -201,11 +205,7 @@ export const TemplateList: React.FunctionComponent<Props> = ({
         </CardHeader>
         <CardContent className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3" aria-label="Template list">
           {previewTemplates.map(template => (
-            <TemplateBox
-              key={template.id}
-              template={template}
-              linkHref={newDeploymentUrl({ step: RouteStep.editDeployment, templateId: template?.id })}
-            />
+            <TemplateBox key={template.id} template={template} linkHref={newDeploymentUrl({ step: RouteStep.editDeployment, templateId: template?.id })} />
           ))}
         </CardContent>
       </Card>

--- a/apps/deploy-web/src/services/analytics/analytics.service.ts
+++ b/apps/deploy-web/src/services/analytics/analytics.service.ts
@@ -90,6 +90,7 @@ export type AnalyticsEvent =
   | "build_n_deploy_btn_clk"
   | "launch_container_vm_btn_clk"
   | "run_custom_container_btn_clk"
+  | "deploy_with_agent_btn_clk"
   | "sdl_uploaded"
   | "deposit_deployment_btn_clk"
   | "add_funds_btn_clk"

--- a/apps/deploy-web/src/types/feature-flags.ts
+++ b/apps/deploy-web/src/types/feature-flags.ts
@@ -12,5 +12,6 @@ export type FeatureFlag =
   | "onboarding_redesign_v1"
   | "ui_sdl_preview_panel"
   | "ui_build_and_deploy"
+  | "ui_agent_mode_deploy"
   | "hackathons"
   | "first_purchase_bonus";


### PR DESCRIPTION
## Why

Users can already deploy on Akash through AI coding agents (via the Akash skill), but Console never surfaced this path. The new deployment page is exactly where users decide *how* to deploy, so we surface an agent-based option there.

Closes CON-683

## What

<img width="1722" height="880" alt="image" src="https://github.com/user-attachments/assets/025b537b-51bf-499e-9abe-9f4fbd27b39d" />


Adds a flag-gated, expandable **"Deploy with Agent mode"** panel to the new deployment page (`chooseTemplate` step), rendered above the "Build Your Own" cards.

- **Gating:** new `ui_agent_mode_deploy` feature flag; the panel renders only when enabled.
- **Collapsed:** ✨ Sparks icon, title, one-line description, and a "Set up Agent mode" expand toggle.
- **Expanded (self-guided instructions, no persisted state):** three steps
  1. **Install the Akash skill** — `/plugin marketplace add akash-network/akash-skill`
  2. **Create an API key** — links in-app to `/user/api-keys`
  3. **Read the setup guide** — opens the [AI agents docs](https://akash.network/docs/getting-started/ai-agents/) in a new tab
- **Analytics:** expanding the panel fires `deploy_with_agent_btn_clk`.
- New component `AgentModePanel` (built on the `Collapsible` primitive) with unit tests; the existing "Launch Container-VM" / "Run Custom Container" cards are unchanged.

### Verification
- `vitest run` on the new-deployment components — 11/11 pass
- `npm run lint -- --quiet` and `npx tsc --noEmit` — no new errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional “Deploy with Agent mode” panel to the deployment experience, including guided setup steps with a copyable install command, an API keys link, and an external setup guide.
  * The panel appears only when the corresponding feature flag is enabled.

* **Analytics**
  * Added analytics tracking for when users open the Agent mode setup.

* **Tests**
  * Added coverage for panel visibility, expand/collapse behavior, links, setup content, and analytics tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->