### PR TITLE
feat(styling): add flag-gated top navigation replacing sidebar

### DIFF
--- a/apps/deploy-web/src/components/layout/Layout.tsx
+++ b/apps/deploy-web/src/components/layout/Layout.tsx
@@ -10,9 +10,11 @@ import { useMediaQuery, useTheme as useMuiTheme } from "@mui/material";
 import { ACCOUNT_BAR_HEIGHT } from "@src/config/ui.config";
 import { useSettings } from "@src/context/SettingsProvider";
 import { useWallet } from "@src/context/WalletProvider";
+import { useFlag } from "@src/hooks/useFlag";
 import { useOnboardingChrome } from "@src/hooks/useOnboardingChrome";
 import { useTopBanner } from "@src/hooks/useTopBanner";
 import { LinearLoadingSkeleton } from "../shared/LinearLoadingSkeleton";
+import { TopNav } from "./TopNav/TopNav";
 import { Nav } from "./Nav";
 import { Sidebar } from "./Sidebar";
 import { TrackingScripts } from "./TrackingScripts";
@@ -88,6 +90,8 @@ const LayoutApp: React.FunctionComponent<Props> = ({
   const { isWalletLoaded } = useWallet();
   const { hasBanner } = useTopBanner();
   const { isStripped } = useOnboardingChrome();
+  const isTopNavEnabled = useFlag("ui_top_nav");
+  const hasSidebar = !isTopNavEnabled && !isStripped;
 
   const onOpenMenuClick = () => {
     setIsNavOpen(prev => {
@@ -107,10 +111,10 @@ const LayoutApp: React.FunctionComponent<Props> = ({
     <div className={cn("flex h-full flex-col", { "min-h-screen bg-white text-foreground": background === "white" })}>
       <div className="w-full flex-1" style={{ marginTop: `var(--app-header-height, ${ACCOUNT_BAR_HEIGHT + (hasBanner ? 40 : 0)}px)` }}>
         <div className="h-full overflow-x-auto">
-          <Nav isMobileOpen={isMobileOpen} handleDrawerToggle={handleDrawerToggle} minimal={isStripped} />
+          {isTopNavEnabled ? <TopNav minimal={isStripped} /> : <Nav isMobileOpen={isMobileOpen} handleDrawerToggle={handleDrawerToggle} minimal={isStripped} />}
 
           <div className="block h-full w-full flex-grow rounded-none md:flex">
-            {!isStripped && (
+            {hasSidebar && (
               <Sidebar
                 onOpenMenuClick={onOpenMenuClick}
                 isNavOpen={isNavOpen}
@@ -122,8 +126,8 @@ const LayoutApp: React.FunctionComponent<Props> = ({
 
             <div
               className={cn("ease ml-0 h-full flex-grow overflow-x-auto transition-[margin-left] duration-300", {
-                ["md:ml-[240px]"]: !isStripped && isNavOpen,
-                ["md:ml-[57px]"]: !isStripped && !isNavOpen
+                ["md:ml-[240px]"]: hasSidebar && isNavOpen,
+                ["md:ml-[57px]"]: hasSidebar && !isNavOpen
               })}
             >
               {isLoading !== undefined && <LinearLoadingSkeleton isLoading={isLoading} />}

--- a/apps/deploy-web/src/components/layout/Nav.tsx
+++ b/apps/deploy-web/src/components/layout/Nav.tsx
@@ -1,6 +1,5 @@
 "use client";
-import type { RefObject } from "react";
-import { useEffect, useRef } from "react";
+import { useRef } from "react";
 import { Button } from "@akashnetwork/ui/components";
 import { cn, REMOVE_SCROLL_CLASS_NAMES } from "@akashnetwork/ui/utils";
 import type { ClassValue } from "clsx";
@@ -13,13 +12,8 @@ import { HackathonCouponNavEntry } from "./HackathonCouponNavEntry/HackathonCoup
 import { AccountMenu } from "./AccountMenu";
 import { AkashLogo } from "./AkashLogo";
 import { TopBanner } from "./TopBanner";
+import { usePublishHeaderHeight } from "./usePublishHeaderHeight";
 import { WalletStatus } from "./WalletStatus";
-
-/**
- * Published to `:root` so the layout can offset content by the header's *actual* height. The header grows
- * when the top banner wraps to multiple lines on small screens; a fixed guess would hide content behind it.
- */
-const APP_HEADER_HEIGHT_VAR = "--app-header-height";
 
 export const Nav = ({
   isMobileOpen,
@@ -77,26 +71,3 @@ export const Nav = ({
     </header>
   );
 };
-
-/** Keeps {@link APP_HEADER_HEIGHT_VAR} in sync with the header's rendered height as the banner appears, wraps, or clears. */
-function usePublishHeaderHeight(ref: RefObject<HTMLElement>) {
-  useEffect(
-    function publishHeaderHeightAsCssVar() {
-      const header = ref.current;
-      if (!header) return;
-
-      const root = document.documentElement;
-      function syncHeight() {
-        root.style.setProperty(APP_HEADER_HEIGHT_VAR, `${header!.offsetHeight}px`);
-      }
-
-      syncHeight();
-      const observer = new ResizeObserver(syncHeight);
-      observer.observe(header);
-      return function stopPublishingHeaderHeight() {
-        observer.disconnect();
-      };
-    },
-    [ref]
-  );
-}

--- a/apps/deploy-web/src/components/layout/TopNav/ThemeToggle.spec.tsx
+++ b/apps/deploy-web/src/components/layout/TopNav/ThemeToggle.spec.tsx
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { DEPENDENCIES } from "./ThemeToggle";
+import { ThemeToggle } from "./ThemeToggle";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+describe(ThemeToggle.name, () => {
+  it("sets the light theme and persists it in a cookie", async () => {
+    const { setTheme } = setup({ theme: "dark" });
+
+    await userEvent.click(screen.getByRole("button", { name: "Light" }));
+
+    expect(setTheme).toHaveBeenCalledWith("light");
+    expect(document.cookie).toContain("theme=light");
+  });
+
+  it("sets the dark theme and persists it in a cookie", async () => {
+    const { setTheme } = setup({ theme: "light" });
+
+    await userEvent.click(screen.getByRole("button", { name: "Dark" }));
+
+    expect(setTheme).toHaveBeenCalledWith("dark");
+    expect(document.cookie).toContain("theme=dark");
+  });
+
+  function setup(input: { theme?: string }) {
+    const setTheme = vi.fn();
+    const dependencies: typeof DEPENDENCIES = {
+      useTheme: () => mock<ReturnType<typeof DEPENDENCIES.useTheme>>({ setTheme, theme: input.theme })
+    };
+
+    render(<ThemeToggle dependencies={dependencies} />);
+
+    return { setTheme };
+  }
+});

--- a/apps/deploy-web/src/components/layout/TopNav/ThemeToggle.tsx
+++ b/apps/deploy-web/src/components/layout/TopNav/ThemeToggle.tsx
@@ -1,0 +1,50 @@
+"use client";
+import { useEffect, useState } from "react";
+import { Button } from "@akashnetwork/ui/components";
+import { cn } from "@akashnetwork/ui/utils";
+import { useTheme } from "next-themes";
+
+export const DEPENDENCIES = { useTheme };
+
+interface Props {
+  dependencies?: typeof DEPENDENCIES;
+}
+
+export function ThemeToggle({ dependencies: d = DEPENDENCIES }: Props = {}) {
+  const { setTheme, theme } = d.useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return null;
+  }
+
+  const onThemeClick = (nextTheme: string) => {
+    setTheme(nextTheme);
+    document.cookie = `theme=${nextTheme}; path=/`;
+  };
+
+  return (
+    <div className="flex items-center rounded-md border p-0.5">
+      <Button
+        variant="ghost"
+        size="sm"
+        className={cn("h-6 rounded-sm px-2 text-xs", { "bg-accent font-medium": theme === "light" })}
+        onClick={() => onThemeClick("light")}
+      >
+        Light
+      </Button>
+      <Button
+        variant="ghost"
+        size="sm"
+        className={cn("h-6 rounded-sm px-2 text-xs", { "bg-accent font-medium": theme === "dark" })}
+        onClick={() => onThemeClick("dark")}
+      >
+        Dark
+      </Button>
+    </div>
+  );
+}

--- a/apps/deploy-web/src/components/layout/TopNav/ThemeToggle.tsx
+++ b/apps/deploy-web/src/components/layout/TopNav/ThemeToggle.tsx
@@ -24,7 +24,7 @@ export function ThemeToggle({ dependencies: d = DEPENDENCIES }: Props = {}) {
 
   const onThemeClick = (nextTheme: string) => {
     setTheme(nextTheme);
-    document.cookie = `theme=${nextTheme}; path=/`;
+    document.cookie = `theme=${nextTheme}; path=/; Max-Age=31536000; SameSite=Lax`;
   };
 
   return (

--- a/apps/deploy-web/src/components/layout/TopNav/TopNav.spec.tsx
+++ b/apps/deploy-web/src/components/layout/TopNav/TopNav.spec.tsx
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { FeatureFlag } from "@src/types/feature-flags";
+import { DEPENDENCIES, TopNav } from "./TopNav";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MockComponents } from "@tests/unit/mocks";
+
+describe(TopNav.name, () => {
+  it("renders primary nav links for an authenticated user", () => {
+    setup({ isAuthenticated: true });
+
+    expect(screen.getByRole("link", { name: "Deployments" })).toHaveAttribute("href", "/deployments");
+    expect(screen.getByRole("link", { name: "Providers" })).toHaveAttribute("href", "/providers");
+    expect(screen.getByRole("link", { name: "Templates" })).toHaveAttribute("href", "/templates");
+    expect(screen.getByRole("button", { name: /settings/i })).toBeInTheDocument();
+  });
+
+  it("hides nav links when signed out", () => {
+    setup({ isAuthenticated: false });
+
+    expect(screen.queryByRole("link", { name: "Deployments" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /settings/i })).not.toBeInTheDocument();
+  });
+
+  it("hides nav links in minimal mode and reduces the account menu", () => {
+    const { accountMenu } = setup({ isAuthenticated: true, minimal: true });
+
+    expect(screen.queryByRole("link", { name: "Deployments" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /settings/i })).not.toBeInTheDocument();
+    expect(accountMenu.mock.calls[0][0]).toMatchObject({ minimal: true });
+  });
+
+  it("marks the link matching the current route as active", () => {
+    setup({ isAuthenticated: true, pathname: "/providers" });
+
+    expect(screen.getByRole("link", { name: "Providers" })).toHaveAttribute("aria-current", "page");
+    expect(screen.getByRole("link", { name: "Deployments" })).not.toHaveAttribute("aria-current");
+  });
+
+  it("marks Deployments active on the new deployment flow", () => {
+    setup({ isAuthenticated: true, pathname: "/new-deployment/configure" });
+
+    expect(screen.getByRole("link", { name: "Deployments" })).toHaveAttribute("aria-current", "page");
+  });
+
+  it("shows all settings items when billing and alerts flags are on", async () => {
+    setup({ isAuthenticated: true, flags: { billing_usage: true, alerts: true } });
+
+    await userEvent.click(screen.getByRole("button", { name: /settings/i }));
+
+    expect(await screen.findByRole("menuitem", { name: "Billing" })).toHaveAttribute("href", "/billing");
+    expect(screen.getByRole("menuitem", { name: "API Keys" })).toHaveAttribute("href", "/user/api-keys");
+    expect(screen.getByRole("menuitem", { name: "Usage" })).toHaveAttribute("href", "/usage");
+    expect(screen.getByRole("menuitem", { name: "Alerts" })).toHaveAttribute("href", "/alerts");
+  });
+
+  it("hides flag-gated settings items when flags are off", async () => {
+    setup({ isAuthenticated: true, flags: {} });
+
+    await userEvent.click(screen.getByRole("button", { name: /settings/i }));
+
+    expect(await screen.findByRole("menuitem", { name: "API Keys" })).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: "Billing" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: "Usage" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: "Alerts" })).not.toBeInTheDocument();
+  });
+
+  function setup(input: { isAuthenticated?: boolean; minimal?: boolean; pathname?: string; flags?: Partial<Record<FeatureFlag, boolean>> }) {
+    const accountMenu = vi.fn<typeof DEPENDENCIES.TopNavAccountMenu>(() => <></>);
+
+    const dependencies = MockComponents(DEPENDENCIES, {
+      useUser: () =>
+        mock<ReturnType<typeof DEPENDENCIES.useUser>>({
+          user: input.isAuthenticated ? { userId: "user-1" } : undefined
+        }),
+      useFlag: (flag: FeatureFlag) => input.flags?.[flag] ?? false,
+      usePathname: () => input.pathname ?? "/",
+      useCookieTheme: () => "light",
+      TopNavAccountMenu: accountMenu
+    });
+
+    render(<TopNav dependencies={dependencies} minimal={input.minimal} />);
+
+    return { accountMenu };
+  }
+});

--- a/apps/deploy-web/src/components/layout/TopNav/TopNav.spec.tsx
+++ b/apps/deploy-web/src/components/layout/TopNav/TopNav.spec.tsx
@@ -46,6 +46,12 @@ describe(TopNav.name, () => {
     expect(screen.getByRole("link", { name: "Deployments" })).toHaveAttribute("aria-current", "page");
   });
 
+  it("does not mark a link active for a route that only shares its prefix", () => {
+    setup({ isAuthenticated: true, pathname: "/providers-old" });
+
+    expect(screen.getByRole("link", { name: "Providers" })).not.toHaveAttribute("aria-current");
+  });
+
   it("shows all settings items when billing and alerts flags are on", async () => {
     setup({ isAuthenticated: true, flags: { billing_usage: true, alerts: true } });
 

--- a/apps/deploy-web/src/components/layout/TopNav/TopNav.tsx
+++ b/apps/deploy-web/src/components/layout/TopNav/TopNav.tsx
@@ -13,7 +13,7 @@ import {
   SheetTrigger
 } from "@akashnetwork/ui/components";
 import { cn, REMOVE_SCROLL_CLASS_NAMES } from "@akashnetwork/ui/utils";
-import { Menu, NavArrowDown } from "iconoir-react";
+import { Cloud, CreditCard, Key, Menu, MessageAlert, MultiplePages, NavArrowDown, Server, StatsUpSquare } from "iconoir-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
@@ -39,6 +39,7 @@ type TopNavLink = {
   title: string;
   url: string;
   isActive: boolean;
+  icon: React.ComponentType<{ className?: string }>;
 };
 
 export function TopNav({ dependencies: d = DEPENDENCIES, minimal = false }: Props = {}) {
@@ -55,16 +56,16 @@ export function TopNav({ dependencies: d = DEPENDENCIES, minimal = false }: Prop
   const isRouteActive = (...routePrefixes: string[]) => !!pathname && routePrefixes.some(prefix => pathname === prefix || pathname.startsWith(`${prefix}/`));
 
   const navLinks: TopNavLink[] = [
-    { title: "Deployments", url: UrlService.deploymentList(), isActive: isRouteActive("/deployments", "/new-deployment") },
-    { title: "Providers", url: UrlService.providers(), isActive: isRouteActive("/providers") },
-    { title: "Templates", url: UrlService.templates(), isActive: isRouteActive("/templates") }
+    { title: "Deployments", url: UrlService.deploymentList(), isActive: isRouteActive("/deployments", "/new-deployment"), icon: Cloud },
+    { title: "Providers", url: UrlService.providers(), isActive: isRouteActive("/providers"), icon: Server },
+    { title: "Templates", url: UrlService.templates(), isActive: isRouteActive("/templates"), icon: MultiplePages }
   ];
 
   const settingsLinks: TopNavLink[] = [
-    ...(isBillingUsageEnabled ? [{ title: "Billing", url: UrlService.billing(), isActive: isRouteActive("/billing") }] : []),
-    { title: "API Keys", url: UrlService.userApiKeys(), isActive: isRouteActive("/user/api-keys") },
-    ...(isBillingUsageEnabled ? [{ title: "Usage", url: UrlService.usage(), isActive: isRouteActive("/usage") }] : []),
-    ...(isAlertsEnabled ? [{ title: "Alerts", url: UrlService.alerts(), isActive: isRouteActive("/alerts") }] : [])
+    ...(isBillingUsageEnabled ? [{ title: "Billing", url: UrlService.billing(), isActive: isRouteActive("/billing"), icon: CreditCard }] : []),
+    { title: "API Keys", url: UrlService.userApiKeys(), isActive: isRouteActive("/user/api-keys"), icon: Key },
+    ...(isBillingUsageEnabled ? [{ title: "Usage", url: UrlService.usage(), isActive: isRouteActive("/usage"), icon: StatsUpSquare }] : []),
+    ...(isAlertsEnabled ? [{ title: "Alerts", url: UrlService.alerts(), isActive: isRouteActive("/alerts"), icon: MessageAlert }] : [])
   ];
   const isSettingsActive = settingsLinks.some(link => link.isActive);
   const showNavLinks = isAuthenticated && !minimal;
@@ -73,7 +74,7 @@ export function TopNav({ dependencies: d = DEPENDENCIES, minimal = false }: Prop
     <header ref={headerRef} className={cn("fixed left-0 right-0 top-0 z-50 border-b border-border bg-header", REMOVE_SCROLL_CLASS_NAMES.zeroRight)}>
       <d.TopBanner />
 
-      <div className="flex h-14 items-center justify-between pl-4 pr-4">
+      <div className="flex h-14 items-center justify-between px-4 md:px-8">
         <div className="flex items-center gap-8">
           {!!theme && (
             <Link className="flex items-center" href="/">
@@ -113,7 +114,9 @@ export function TopNav({ dependencies: d = DEPENDENCIES, minimal = false }: Prop
             </div>
           )}
 
-          <d.TopNavAccountMenu minimal={minimal} />
+          <div className={cn({ "hidden md:block": showNavLinks })}>
+            <d.TopNavAccountMenu minimal={minimal} />
+          </div>
 
           {showNavLinks && (
             <Sheet open={isMobileNavOpen} onOpenChange={setIsMobileNavOpen}>
@@ -122,11 +125,15 @@ export function TopNav({ dependencies: d = DEPENDENCIES, minimal = false }: Prop
                   <Menu />
                 </Button>
               </SheetTrigger>
-              <SheetContent side="left" className="w-[280px]">
-                <SheetTitle>
-                  <AkashLogo />
-                </SheetTitle>
-                <nav aria-label="Primary mobile" className="mt-6 flex flex-col gap-1">
+              <SheetContent side="left" className="w-[280px] p-0">
+                <div className="flex h-14 items-center border-b border-border px-4">
+                  <SheetTitle asChild>
+                    <Link href="/" className="flex items-center" onClick={() => setIsMobileNavOpen(false)}>
+                      <AkashLogo />
+                    </Link>
+                  </SheetTitle>
+                </div>
+                <nav aria-label="Primary mobile" className="flex flex-col gap-1 p-3">
                   {navLinks.map(link => (
                     <Link
                       key={link.title}
@@ -135,6 +142,7 @@ export function TopNav({ dependencies: d = DEPENDENCIES, minimal = false }: Prop
                       className={mobileNavLinkClasses(link.isActive)}
                       onClick={() => setIsMobileNavOpen(false)}
                     >
+                      <link.icon className="h-5 w-5 shrink-0" />
                       {link.title}
                     </Link>
                   ))}
@@ -150,9 +158,14 @@ export function TopNav({ dependencies: d = DEPENDENCIES, minimal = false }: Prop
                       className={mobileNavLinkClasses(link.isActive)}
                       onClick={() => setIsMobileNavOpen(false)}
                     >
+                      <link.icon className="h-5 w-5 shrink-0" />
                       {link.title}
                     </Link>
                   ))}
+
+                  <Separator className="my-2" />
+
+                  <d.TopNavAccountMenu variant="inline" onNavigate={() => setIsMobileNavOpen(false)} />
                 </nav>
               </SheetContent>
             </Sheet>
@@ -171,7 +184,7 @@ function desktopNavLinkClasses(isActive: boolean) {
 }
 
 function mobileNavLinkClasses(isActive: boolean) {
-  return cn("rounded-md px-3 py-2 text-sm hover:bg-accent", {
+  return cn("flex items-center gap-3 rounded-md px-3 py-2 text-sm hover:bg-accent", {
     "bg-accent font-medium text-foreground": isActive,
     "text-muted-foreground": !isActive
   });

--- a/apps/deploy-web/src/components/layout/TopNav/TopNav.tsx
+++ b/apps/deploy-web/src/components/layout/TopNav/TopNav.tsx
@@ -1,0 +1,178 @@
+"use client";
+import { useRef, useState } from "react";
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  Separator,
+  Sheet,
+  SheetContent,
+  SheetTitle,
+  SheetTrigger
+} from "@akashnetwork/ui/components";
+import { cn, REMOVE_SCROLL_CLASS_NAMES } from "@akashnetwork/ui/utils";
+import { Menu, NavArrowDown } from "iconoir-react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+import { useFlag } from "@src/hooks/useFlag";
+import useCookieTheme from "@src/hooks/useTheme";
+import { useUser } from "@src/hooks/useUser";
+import { UrlService } from "@src/utils/urlUtils";
+import { AkashLogo } from "../AkashLogo";
+import { HackathonCouponNavEntry } from "../HackathonCouponNavEntry/HackathonCouponNavEntry";
+import { TopBanner } from "../TopBanner";
+import { usePublishHeaderHeight } from "../usePublishHeaderHeight";
+import { TopNavAccountMenu } from "./TopNavAccountMenu";
+
+export const DEPENDENCIES = { useUser, useFlag, usePathname, useCookieTheme, TopBanner, HackathonCouponNavEntry, TopNavAccountMenu };
+
+interface Props {
+  dependencies?: typeof DEPENDENCIES;
+  /** During onboarding, reduce the chrome to the logo and a logout-only account menu. */
+  minimal?: boolean;
+}
+
+type TopNavLink = {
+  title: string;
+  url: string;
+  isActive: boolean;
+};
+
+export function TopNav({ dependencies: d = DEPENDENCIES, minimal = false }: Props = {}) {
+  const theme = d.useCookieTheme();
+  const headerRef = useRef<HTMLElement>(null);
+  usePublishHeaderHeight(headerRef);
+  const { user } = d.useUser();
+  const isAuthenticated = !!user?.userId;
+  const pathname = d.usePathname();
+  const isBillingUsageEnabled = d.useFlag("billing_usage");
+  const isAlertsEnabled = d.useFlag("alerts");
+  const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
+
+  const isRouteActive = (...routePrefixes: string[]) => !!pathname && routePrefixes.some(prefix => pathname.startsWith(prefix));
+
+  const navLinks: TopNavLink[] = [
+    { title: "Deployments", url: UrlService.deploymentList(), isActive: isRouteActive("/deployments", "/new-deployment") },
+    { title: "Providers", url: UrlService.providers(), isActive: isRouteActive("/providers") },
+    { title: "Templates", url: UrlService.templates(), isActive: isRouteActive("/templates") }
+  ];
+
+  const settingsLinks: TopNavLink[] = [
+    ...(isBillingUsageEnabled ? [{ title: "Billing", url: UrlService.billing(), isActive: isRouteActive("/billing") }] : []),
+    { title: "API Keys", url: UrlService.userApiKeys(), isActive: isRouteActive("/user/api-keys") },
+    ...(isBillingUsageEnabled ? [{ title: "Usage", url: UrlService.usage(), isActive: isRouteActive("/usage") }] : []),
+    ...(isAlertsEnabled ? [{ title: "Alerts", url: UrlService.alerts(), isActive: isRouteActive("/alerts") }] : [])
+  ];
+  const isSettingsActive = settingsLinks.some(link => link.isActive);
+  const showNavLinks = isAuthenticated && !minimal;
+
+  return (
+    <header ref={headerRef} className={cn("fixed left-0 right-0 top-0 z-50 border-b border-border bg-header", REMOVE_SCROLL_CLASS_NAMES.zeroRight)}>
+      <d.TopBanner />
+
+      <div className="flex h-14 items-center justify-between pl-4 pr-4">
+        <div className="flex items-center gap-8">
+          {!!theme && (
+            <Link className="flex items-center" href="/">
+              <AkashLogo />
+            </Link>
+          )}
+
+          {showNavLinks && (
+            <nav aria-label="Primary" className="hidden items-center gap-1 md:flex">
+              {navLinks.map(link => (
+                <Link key={link.title} href={link.url} aria-current={link.isActive ? "page" : undefined} className={desktopNavLinkClasses(link.isActive)}>
+                  {link.title}
+                </Link>
+              ))}
+
+              <DropdownMenu modal={false}>
+                <DropdownMenuTrigger className={cn(desktopNavLinkClasses(isSettingsActive), "flex items-center gap-1")}>
+                  Settings
+                  <NavArrowDown className="h-4 w-4" />
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="start" className="w-[160px]">
+                  {settingsLinks.map(link => (
+                    <DropdownMenuItem key={link.title} asChild className="cursor-pointer">
+                      <Link href={link.url}>{link.title}</Link>
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </nav>
+          )}
+        </div>
+
+        <div className="flex items-center gap-2">
+          {!minimal && (
+            <div className="hidden md:block">
+              <d.HackathonCouponNavEntry />
+            </div>
+          )}
+
+          <d.TopNavAccountMenu minimal={minimal} />
+
+          {showNavLinks && (
+            <Sheet open={isMobileNavOpen} onOpenChange={setIsMobileNavOpen}>
+              <SheetTrigger asChild>
+                <Button size="icon" variant="ghost" className="rounded-full md:hidden" aria-label="Open navigation menu">
+                  <Menu />
+                </Button>
+              </SheetTrigger>
+              <SheetContent side="left" className="w-[280px]">
+                <SheetTitle>
+                  <AkashLogo />
+                </SheetTitle>
+                <nav aria-label="Primary mobile" className="mt-6 flex flex-col gap-1">
+                  {navLinks.map(link => (
+                    <Link
+                      key={link.title}
+                      href={link.url}
+                      aria-current={link.isActive ? "page" : undefined}
+                      className={mobileNavLinkClasses(link.isActive)}
+                      onClick={() => setIsMobileNavOpen(false)}
+                    >
+                      {link.title}
+                    </Link>
+                  ))}
+
+                  <Separator className="my-2" />
+
+                  <div className="px-3 py-1 text-xs font-medium uppercase text-muted-foreground">Settings</div>
+                  {settingsLinks.map(link => (
+                    <Link
+                      key={link.title}
+                      href={link.url}
+                      aria-current={link.isActive ? "page" : undefined}
+                      className={mobileNavLinkClasses(link.isActive)}
+                      onClick={() => setIsMobileNavOpen(false)}
+                    >
+                      {link.title}
+                    </Link>
+                  ))}
+                </nav>
+              </SheetContent>
+            </Sheet>
+          )}
+        </div>
+      </div>
+    </header>
+  );
+}
+
+function desktopNavLinkClasses(isActive: boolean) {
+  return cn("rounded-md px-3 py-2 text-sm transition-colors hover:text-foreground", {
+    "font-medium text-foreground": isActive,
+    "text-muted-foreground": !isActive
+  });
+}
+
+function mobileNavLinkClasses(isActive: boolean) {
+  return cn("rounded-md px-3 py-2 text-sm hover:bg-accent", {
+    "bg-accent font-medium text-foreground": isActive,
+    "text-muted-foreground": !isActive
+  });
+}

--- a/apps/deploy-web/src/components/layout/TopNav/TopNav.tsx
+++ b/apps/deploy-web/src/components/layout/TopNav/TopNav.tsx
@@ -52,7 +52,7 @@ export function TopNav({ dependencies: d = DEPENDENCIES, minimal = false }: Prop
   const isAlertsEnabled = d.useFlag("alerts");
   const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
 
-  const isRouteActive = (...routePrefixes: string[]) => !!pathname && routePrefixes.some(prefix => pathname.startsWith(prefix));
+  const isRouteActive = (...routePrefixes: string[]) => !!pathname && routePrefixes.some(prefix => pathname === prefix || pathname.startsWith(`${prefix}/`));
 
   const navLinks: TopNavLink[] = [
     { title: "Deployments", url: UrlService.deploymentList(), isActive: isRouteActive("/deployments", "/new-deployment") },

--- a/apps/deploy-web/src/components/layout/TopNav/TopNavAccountMenu.spec.tsx
+++ b/apps/deploy-web/src/components/layout/TopNav/TopNavAccountMenu.spec.tsx
@@ -87,8 +87,48 @@ describe(TopNavAccountMenu.name, () => {
     expect(screen.queryByText("Contact us")).not.toBeInTheDocument();
   });
 
-  function setup(input: { isLoading?: boolean; username?: string; minimal?: boolean }) {
+  describe("inline variant", () => {
+    it("renders the account items without an account menu trigger", () => {
+      setup({ username: "alice", variant: "inline" });
+
+      expect(screen.queryByRole("button", { name: /account menu/i })).not.toBeInTheDocument();
+      expect(screen.getByText("Profile")).toBeInTheDocument();
+      expect(screen.getByText("Theme")).toBeInTheDocument();
+      expect(screen.getByText("Docs")).toBeInTheDocument();
+      expect(screen.getByText("Privacy Policy")).toBeInTheDocument();
+      expect(screen.getByText("Terms of Service")).toBeInTheDocument();
+      expect(screen.getByText("Contact us")).toBeInTheDocument();
+      expect(screen.getByText("Log out")).toBeInTheDocument();
+    });
+
+    it("renders nothing when signed out", () => {
+      const { container } = setup({ variant: "inline" });
+
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it("navigates and closes the sheet when an item is selected", async () => {
+      const { push, onNavigate } = setup({ username: "alice", variant: "inline" });
+
+      await userEvent.click(screen.getByText("Profile"));
+
+      expect(push).toHaveBeenCalledWith("/user/settings");
+      expect(onNavigate).toHaveBeenCalledTimes(1);
+    });
+
+    it("logs out and closes the sheet when Log out is selected", async () => {
+      const { authService, onNavigate } = setup({ username: "bob", variant: "inline" });
+
+      await userEvent.click(screen.getByText("Log out"));
+
+      expect(authService.logout).toHaveBeenCalledTimes(1);
+      expect(onNavigate).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  function setup(input: { isLoading?: boolean; username?: string; minimal?: boolean; variant?: "dropdown" | "inline" }) {
     const push = vi.fn();
+    const onNavigate = vi.fn();
     const authService = mock<AuthService>();
     const windowOpen = vi.spyOn(window, "open").mockImplementation(() => null);
 
@@ -101,12 +141,12 @@ describe(TopNavAccountMenu.name, () => {
       useRouter: () => mock<ReturnType<typeof DEPENDENCIES.useRouter>>({ push })
     });
 
-    render(
+    const { container } = render(
       <TestContainerProvider services={{ authService: () => authService }}>
-        <TopNavAccountMenu dependencies={dependencies} minimal={input.minimal} />
+        <TopNavAccountMenu dependencies={dependencies} minimal={input.minimal} variant={input.variant} onNavigate={onNavigate} />
       </TestContainerProvider>
     );
 
-    return { authService, push, windowOpen };
+    return { authService, push, windowOpen, onNavigate, container };
   }
 });

--- a/apps/deploy-web/src/components/layout/TopNav/TopNavAccountMenu.spec.tsx
+++ b/apps/deploy-web/src/components/layout/TopNav/TopNavAccountMenu.spec.tsx
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { AuthService } from "@src/services/auth/auth/auth.service";
+import { DEPENDENCIES, TopNavAccountMenu } from "./TopNavAccountMenu";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MockComponents } from "@tests/unit/mocks";
+import { TestContainerProvider } from "@tests/unit/TestContainerProvider";
+
+describe(TopNavAccountMenu.name, () => {
+  it("renders the spinner while loading", () => {
+    setup({ isLoading: true });
+
+    expect(screen.getByRole("status")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /account menu/i })).not.toBeInTheDocument();
+  });
+
+  it("renders the user's initial when signed in", () => {
+    setup({ username: "alice" });
+
+    expect(screen.getByRole("button", { name: /account menu/i })).toHaveTextContent("A");
+  });
+
+  it("shows the signed-in items when opened", async () => {
+    setup({ username: "alice" });
+
+    await userEvent.click(screen.getByRole("button", { name: /account menu/i }));
+
+    expect(await screen.findByText("Profile")).toBeInTheDocument();
+    expect(screen.getByText("Theme")).toBeInTheDocument();
+    expect(screen.getByText("Docs")).toBeInTheDocument();
+    expect(screen.getByText("Privacy Policy")).toBeInTheDocument();
+    expect(screen.getByText("Terms of Service")).toBeInTheDocument();
+    expect(screen.getByText("Contact us")).toBeInTheDocument();
+    expect(screen.getByText("Log out")).toBeInTheDocument();
+    expect(screen.queryByText("Sign in")).not.toBeInTheDocument();
+  });
+
+  it("navigates to profile settings when Profile is selected", async () => {
+    const { push } = setup({ username: "alice" });
+
+    await userEvent.click(screen.getByRole("button", { name: /account menu/i }));
+    await userEvent.click(await screen.findByText("Profile"));
+
+    expect(push).toHaveBeenCalledWith("/user/settings");
+  });
+
+  it("opens the docs in a new tab when Docs is selected", async () => {
+    const { windowOpen } = setup({ username: "alice" });
+
+    await userEvent.click(screen.getByRole("button", { name: /account menu/i }));
+    await userEvent.click(await screen.findByText("Docs"));
+
+    expect(windowOpen).toHaveBeenCalledWith("https://akash.network/docs", "_blank", "noreferrer noopener");
+  });
+
+  it("calls authService.logout when Log out is selected", async () => {
+    const { authService } = setup({ username: "bob" });
+
+    await userEvent.click(screen.getByRole("button", { name: /account menu/i }));
+    await userEvent.click(await screen.findByText("Log out"));
+
+    expect(authService.logout).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows sign up and sign in when signed out", async () => {
+    setup({});
+
+    await userEvent.click(screen.getByRole("button", { name: /account menu/i }));
+
+    expect(await screen.findByText("Sign up")).toBeInTheDocument();
+    expect(screen.getByText("Sign in")).toBeInTheDocument();
+    expect(screen.queryByText("Profile")).not.toBeInTheDocument();
+  });
+
+  it("shows only Log out in the minimal variant when signed in", async () => {
+    setup({ username: "erin", minimal: true });
+
+    await userEvent.click(screen.getByRole("button", { name: /account menu/i }));
+
+    expect(await screen.findByText("Log out")).toBeInTheDocument();
+    expect(screen.queryByText("Profile")).not.toBeInTheDocument();
+    expect(screen.queryByText("Theme")).not.toBeInTheDocument();
+    expect(screen.queryByText("Docs")).not.toBeInTheDocument();
+    expect(screen.queryByText("Contact us")).not.toBeInTheDocument();
+  });
+
+  function setup(input: { isLoading?: boolean; username?: string; minimal?: boolean }) {
+    const push = vi.fn();
+    const authService = mock<AuthService>();
+    const windowOpen = vi.spyOn(window, "open").mockImplementation(() => null);
+
+    const dependencies = MockComponents(DEPENDENCIES, {
+      useCustomUser: () =>
+        mock<ReturnType<typeof DEPENDENCIES.useCustomUser>>({
+          user: input.username ? { username: input.username, userId: "user-1" } : undefined,
+          isLoading: input.isLoading ?? false
+        }),
+      useRouter: () => mock<ReturnType<typeof DEPENDENCIES.useRouter>>({ push })
+    });
+
+    render(
+      <TestContainerProvider services={{ authService: () => authService }}>
+        <TopNavAccountMenu dependencies={dependencies} minimal={input.minimal} />
+      </TestContainerProvider>
+    );
+
+    return { authService, push, windowOpen };
+  }
+});

--- a/apps/deploy-web/src/components/layout/TopNav/TopNavAccountMenu.tsx
+++ b/apps/deploy-web/src/components/layout/TopNav/TopNavAccountMenu.tsx
@@ -10,7 +10,7 @@ import {
   DropdownMenuTrigger,
   Spinner
 } from "@akashnetwork/ui/components";
-import { Book, LogOut, Page, PrivacyPolicy, Send, SunLight, User } from "iconoir-react";
+import { Book, CloudSunny, LogOut, Page, Send, ShieldCheck, User } from "iconoir-react";
 import { useRouter } from "next/navigation";
 
 import { useServices } from "@src/context/ServicesProvider";
@@ -61,7 +61,7 @@ export function TopNavAccountMenu({ dependencies: d = DEPENDENCIES, minimal = fa
                 </CustomDropdownLinkItem>
                 <div className="relative flex items-center justify-between py-1 pl-8 pr-2 text-sm">
                   <span className="absolute left-2 flex h-4 w-4 items-center justify-center">
-                    <SunLight />
+                    <CloudSunny />
                   </span>
                   <span>Theme</span>
                   <d.ThemeToggle />
@@ -69,13 +69,13 @@ export function TopNavAccountMenu({ dependencies: d = DEPENDENCIES, minimal = fa
                 <CustomDropdownLinkItem onClick={() => window.open(DOCS_URL, "_blank", "noreferrer noopener")} icon={<Book />}>
                   Docs
                 </CustomDropdownLinkItem>
-                <CustomDropdownLinkItem onClick={() => router.push(urlService.privacyPolicy())} icon={<PrivacyPolicy />}>
+                <CustomDropdownLinkItem onClick={() => router.push(urlService.privacyPolicy())} icon={<ShieldCheck />}>
                   Privacy Policy
                 </CustomDropdownLinkItem>
                 <CustomDropdownLinkItem onClick={() => router.push(urlService.termsOfService())} icon={<Page />}>
                   Terms of Service
                 </CustomDropdownLinkItem>
-                <CustomDropdownLinkItem onClick={() => router.push(urlService.contact())} icon={<Send />}>
+                <CustomDropdownLinkItem onClick={() => router.push(urlService.contact())} icon={<Send className="-rotate-45" />}>
                   Contact us
                 </CustomDropdownLinkItem>
                 <DropdownMenuSeparator />

--- a/apps/deploy-web/src/components/layout/TopNav/TopNavAccountMenu.tsx
+++ b/apps/deploy-web/src/components/layout/TopNav/TopNavAccountMenu.tsx
@@ -10,6 +10,7 @@ import {
   DropdownMenuTrigger,
   Spinner
 } from "@akashnetwork/ui/components";
+import { cn } from "@akashnetwork/ui/utils";
 import { Book, CloudSunny, LogOut, Page, Send, ShieldCheck, User } from "iconoir-react";
 import { useRouter } from "next/navigation";
 
@@ -24,15 +25,80 @@ interface Props {
   dependencies?: typeof DEPENDENCIES;
   /** During onboarding, reduce the signed-in menu to the Log out action only. */
   minimal?: boolean;
+  /** "dropdown" renders the avatar trigger + popover; "inline" renders a flat list for the mobile nav sheet. */
+  variant?: "dropdown" | "inline";
+  /** Called after an inline item is selected so the surrounding sheet can close. */
+  onNavigate?: () => void;
 }
+
+type AccountAction = {
+  title: string;
+  icon: React.ComponentType<{ className?: string }>;
+  iconClassName?: string;
+  onClick: () => void;
+};
 
 const DOCS_URL = "https://akash.network/docs";
 
-export function TopNavAccountMenu({ dependencies: d = DEPENDENCIES, minimal = false }: Props = {}) {
+export function TopNavAccountMenu({ dependencies: d = DEPENDENCIES, minimal = false, variant = "dropdown", onNavigate }: Props = {}) {
   const { user, isLoading } = d.useCustomUser();
   const username = user?.username;
   const router = d.useRouter();
   const { authService, urlService } = useServices();
+
+  const links: AccountAction[] = [
+    { title: "Profile", icon: User, onClick: () => router.push(urlService.userSettings()) },
+    { title: "Docs", icon: Book, onClick: () => window.open(DOCS_URL, "_blank", "noreferrer noopener") },
+    { title: "Privacy Policy", icon: ShieldCheck, onClick: () => router.push(urlService.privacyPolicy()) },
+    { title: "Terms of Service", icon: Page, onClick: () => router.push(urlService.termsOfService()) },
+    { title: "Contact us", icon: Send, iconClassName: "-rotate-45", onClick: () => router.push(urlService.contact()) }
+  ];
+  const [profileLink, ...secondaryLinks] = links;
+
+  if (variant === "inline") {
+    if (!user) return null;
+
+    const handle = (action: AccountAction) => () => {
+      action.onClick();
+      onNavigate?.();
+    };
+
+    return (
+      <div className="flex flex-col gap-1">
+        <button type="button" className={inlineItemClasses()} onClick={handle(profileLink)}>
+          <profileLink.icon className="h-5 w-5 shrink-0" />
+          {profileLink.title}
+        </button>
+
+        <div className="flex items-center justify-between rounded-md px-3 py-2 text-sm text-muted-foreground">
+          <span className="flex items-center gap-3">
+            <CloudSunny className="h-5 w-5 shrink-0" />
+            Theme
+          </span>
+          <d.ThemeToggle />
+        </div>
+
+        {secondaryLinks.map(link => (
+          <button type="button" key={link.title} className={inlineItemClasses()} onClick={handle(link)}>
+            <link.icon className={cn("h-5 w-5 shrink-0", link.iconClassName)} />
+            {link.title}
+          </button>
+        ))}
+
+        <button
+          type="button"
+          className={inlineItemClasses("text-destructive hover:text-destructive")}
+          onClick={() => {
+            authService.logout();
+            onNavigate?.();
+          }}
+        >
+          <LogOut className="h-5 w-5 shrink-0" />
+          Log out
+        </button>
+      </div>
+    );
+  }
 
   if (isLoading) {
     return (
@@ -56,8 +122,8 @@ export function TopNavAccountMenu({ dependencies: d = DEPENDENCIES, minimal = fa
           <div className="w-full">
             {!minimal && (
               <>
-                <CustomDropdownLinkItem onClick={() => router.push(urlService.userSettings())} icon={<User />}>
-                  Profile
+                <CustomDropdownLinkItem onClick={profileLink.onClick} icon={<profileLink.icon />}>
+                  {profileLink.title}
                 </CustomDropdownLinkItem>
                 <div className="relative flex items-center justify-between py-1 pl-8 pr-2 text-sm">
                   <span className="absolute left-2 flex h-4 w-4 items-center justify-center">
@@ -66,18 +132,11 @@ export function TopNavAccountMenu({ dependencies: d = DEPENDENCIES, minimal = fa
                   <span>Theme</span>
                   <d.ThemeToggle />
                 </div>
-                <CustomDropdownLinkItem onClick={() => window.open(DOCS_URL, "_blank", "noreferrer noopener")} icon={<Book />}>
-                  Docs
-                </CustomDropdownLinkItem>
-                <CustomDropdownLinkItem onClick={() => router.push(urlService.privacyPolicy())} icon={<ShieldCheck />}>
-                  Privacy Policy
-                </CustomDropdownLinkItem>
-                <CustomDropdownLinkItem onClick={() => router.push(urlService.termsOfService())} icon={<Page />}>
-                  Terms of Service
-                </CustomDropdownLinkItem>
-                <CustomDropdownLinkItem onClick={() => router.push(urlService.contact())} icon={<Send className="-rotate-45" />}>
-                  Contact us
-                </CustomDropdownLinkItem>
+                {secondaryLinks.map(link => (
+                  <CustomDropdownLinkItem key={link.title} onClick={link.onClick} icon={<link.icon className={link.iconClassName} />}>
+                    {link.title}
+                  </CustomDropdownLinkItem>
+                ))}
                 <DropdownMenuSeparator />
               </>
             )}
@@ -105,4 +164,8 @@ export function TopNavAccountMenu({ dependencies: d = DEPENDENCIES, minimal = fa
       </DropdownMenuContent>
     </DropdownMenu>
   );
+}
+
+function inlineItemClasses(className?: string) {
+  return cn("flex w-full items-center gap-3 rounded-md px-3 py-2 text-left text-sm text-muted-foreground hover:bg-accent hover:text-foreground", className);
 }

--- a/apps/deploy-web/src/components/layout/TopNav/TopNavAccountMenu.tsx
+++ b/apps/deploy-web/src/components/layout/TopNav/TopNavAccountMenu.tsx
@@ -59,11 +59,11 @@ export function TopNavAccountMenu({ dependencies: d = DEPENDENCIES, minimal = fa
                 <CustomDropdownLinkItem onClick={() => router.push(urlService.userSettings())} icon={<User />}>
                   Profile
                 </CustomDropdownLinkItem>
-                <div className="flex items-center justify-between px-4 py-1 text-sm">
-                  <span className="flex items-center gap-2">
-                    <SunLight className="text-xs" />
-                    Theme
+                <div className="relative flex items-center justify-between py-1 pl-8 pr-2 text-sm">
+                  <span className="absolute left-2 flex h-4 w-4 items-center justify-center">
+                    <SunLight />
                   </span>
+                  <span>Theme</span>
                   <d.ThemeToggle />
                 </div>
                 <CustomDropdownLinkItem onClick={() => window.open(DOCS_URL, "_blank", "noreferrer noopener")} icon={<Book />}>

--- a/apps/deploy-web/src/components/layout/TopNav/TopNavAccountMenu.tsx
+++ b/apps/deploy-web/src/components/layout/TopNav/TopNavAccountMenu.tsx
@@ -1,0 +1,108 @@
+"use client";
+import React from "react";
+import {
+  Avatar,
+  AvatarFallback,
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  Spinner
+} from "@akashnetwork/ui/components";
+import { Book, LogOut, Page, PrivacyPolicy, Send, SunLight, User } from "iconoir-react";
+import { useRouter } from "next/navigation";
+
+import { useServices } from "@src/context/ServicesProvider";
+import { useCustomUser } from "@src/hooks/useCustomUser";
+import { CustomDropdownLinkItem } from "../../shared/CustomDropdownLinkItem";
+import { ThemeToggle } from "./ThemeToggle";
+
+export const DEPENDENCIES = { useCustomUser, useRouter, ThemeToggle };
+
+interface Props {
+  dependencies?: typeof DEPENDENCIES;
+  /** During onboarding, reduce the signed-in menu to the Log out action only. */
+  minimal?: boolean;
+}
+
+const DOCS_URL = "https://akash.network/docs";
+
+export function TopNavAccountMenu({ dependencies: d = DEPENDENCIES, minimal = false }: Props = {}) {
+  const { user, isLoading } = d.useCustomUser();
+  const username = user?.username;
+  const router = d.useRouter();
+  const { authService, urlService } = useServices();
+
+  if (isLoading) {
+    return (
+      <div className="px-2">
+        <Spinner size="small" />
+      </div>
+    );
+  }
+
+  return (
+    <DropdownMenu modal={false}>
+      <DropdownMenuTrigger asChild>
+        <Button size="icon" variant="outline" className="h-9 w-9 cursor-pointer rounded-full bg-accent" aria-label="Account menu">
+          <Avatar className="h-9 w-9">
+            <AvatarFallback className="bg-transparent">{username ? username[0].toUpperCase() : <User />}</AvatarFallback>
+          </Avatar>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-[240px]">
+        {user ? (
+          <div className="w-full">
+            {!minimal && (
+              <>
+                <CustomDropdownLinkItem onClick={() => router.push(urlService.userSettings())} icon={<User />}>
+                  Profile
+                </CustomDropdownLinkItem>
+                <div className="flex items-center justify-between px-4 py-1 text-sm">
+                  <span className="flex items-center gap-2">
+                    <SunLight className="text-xs" />
+                    Theme
+                  </span>
+                  <d.ThemeToggle />
+                </div>
+                <CustomDropdownLinkItem onClick={() => window.open(DOCS_URL, "_blank", "noreferrer noopener")} icon={<Book />}>
+                  Docs
+                </CustomDropdownLinkItem>
+                <CustomDropdownLinkItem onClick={() => router.push(urlService.privacyPolicy())} icon={<PrivacyPolicy />}>
+                  Privacy Policy
+                </CustomDropdownLinkItem>
+                <CustomDropdownLinkItem onClick={() => router.push(urlService.termsOfService())} icon={<Page />}>
+                  Terms of Service
+                </CustomDropdownLinkItem>
+                <CustomDropdownLinkItem onClick={() => router.push(urlService.contact())} icon={<Send />}>
+                  Contact us
+                </CustomDropdownLinkItem>
+                <DropdownMenuSeparator />
+              </>
+            )}
+            <CustomDropdownLinkItem
+              className="text-destructive hover:text-destructive focus:text-destructive"
+              onClick={() => authService.logout()}
+              icon={<LogOut />}
+            >
+              Log out
+            </CustomDropdownLinkItem>
+          </div>
+        ) : (
+          <div className="w-full space-y-1">
+            <CustomDropdownLinkItem
+              className="justify-center bg-primary p-2 text-primary-foreground hover:bg-primary/80 hover:text-primary-foreground focus:bg-primary/80 focus:text-primary-foreground"
+              onClick={() => router.push(urlService.newSignup())}
+            >
+              Sign up
+            </CustomDropdownLinkItem>
+            <CustomDropdownLinkItem onClick={() => router.push(urlService.newLogin())} className="justify-center p-2">
+              Sign in
+            </CustomDropdownLinkItem>
+          </div>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/deploy-web/src/components/layout/usePublishHeaderHeight.ts
+++ b/apps/deploy-web/src/components/layout/usePublishHeaderHeight.ts
@@ -1,0 +1,32 @@
+"use client";
+import type { RefObject } from "react";
+import { useEffect } from "react";
+
+/**
+ * Published to `:root` so the layout can offset content by the header's *actual* height. The header grows
+ * when the top banner wraps to multiple lines on small screens; a fixed guess would hide content behind it.
+ */
+export const APP_HEADER_HEIGHT_VAR = "--app-header-height";
+
+/** Keeps {@link APP_HEADER_HEIGHT_VAR} in sync with the header's rendered height as the banner appears, wraps, or clears. */
+export function usePublishHeaderHeight(ref: RefObject<HTMLElement>) {
+  useEffect(
+    function publishHeaderHeightAsCssVar() {
+      const header = ref.current;
+      if (!header) return;
+
+      const root = document.documentElement;
+      function syncHeight() {
+        root.style.setProperty(APP_HEADER_HEIGHT_VAR, `${header!.offsetHeight}px`);
+      }
+
+      syncHeight();
+      const observer = new ResizeObserver(syncHeight);
+      observer.observe(header);
+      return function stopPublishingHeaderHeight() {
+        observer.disconnect();
+      };
+    },
+    [ref]
+  );
+}

--- a/apps/deploy-web/src/types/feature-flags.ts
+++ b/apps/deploy-web/src/types/feature-flags.ts
@@ -13,4 +13,5 @@ export type FeatureFlag =
   | "ui_sdl_preview_panel"
   | "ui_build_and_deploy"
   | "hackathons"
-  | "first_purchase_bonus";
+  | "first_purchase_bonus"
+  | "ui_top_nav";


### PR DESCRIPTION
## Why

Closes CON-298

Console Redesign v2 moves primary navigation from the left sidebar to a single top nav bar: it frees horizontal space for content-heavy pages (configure deployment, deployment details), reduces cognitive load for the most-visited pages, and aligns with AkashML's nav structure. Design approved in Figma (see issue).

## What

<img width="1725" height="879" alt="image" src="https://github.com/user-attachments/assets/943666f4-ebed-4853-a2d0-a055365d6d74" />
<img width="501" height="202" alt="image" src="https://github.com/user-attachments/assets/316f5827-079a-4c30-9b11-3004ce05500f" />
<img width="291" height="344" alt="image" src="https://github.com/user-attachments/assets/925a9d02-27d4-4a9b-8a59-a625626369a2" />
<img width="1728" height="879" alt="image" src="https://github.com/user-attachments/assets/537e5480-1b51-4f98-9e94-61a57c437974" />
<img width="422" height="819" alt="image" src="https://github.com/user-attachments/assets/a84c2c63-c43c-4f89-a5bd-65cc97dc4027" />




Everything ships behind a new `ui_top_nav` Unleash flag (off by default) — flag-off keeps the current sidebar chrome byte-for-byte; old components are removed in a post-rollout cleanup ticket.

- **`TopNav`**: logo · Deployments / Providers / Templates (active state via `aria-current`) · Settings dropdown (Billing + Usage behind `billing_usage`, API Keys, Alerts behind `alerts`) · hackathon coupon entry · avatar menu. No wallet balance pill per product decision. Renders `TopBanner` and publishes `--app-header-height` like the old `Nav` (hook extracted to `usePublishHeaderHeight` and shared). Mobile: hamburger → `Sheet` with the same links. `minimal` mode preserves the stripped onboarding chrome.
- **`TopNavAccountMenu`**: Profile → `/user/settings`, inline Theme (Light|Dark segmented control, keeps the SSR `theme` cookie), Docs (new tab), Privacy Policy, Terms of Service, Contact us, Log out; Sign up/Sign in when signed out.
- **`Layout`** branches on the flag: TopNav-only chrome with full-width content when on, unchanged sidebar layout when off.
- 17 new unit tests (flag gating, auth states, active links, minimal mode, logout, theme cookie).

Runtime-verified locally (Playwright against `npm run dev`):
- flag **on** — nav links + active states, settings dropdown routes, avatar menu items, Light/Dark toggle (cookie persists, works with menu open), mobile sheet navigation, signed-out Sign up/Sign in on public pages, light + dark themes
- flag **off** — sidebar chrome untouched (collapse button, deploy CTA, wallet pill, no top-nav DOM)

**Rollout notes**
- `ui_top_nav` must be created in Unleash (off); local dev sees it ON via `NEXT_PUBLIC_UNLEASH_ENABLE_ALL`.
- E2E page objects (`tests/ui/pages/Sidebar.ts`) navigate via the sidebar — update them before enabling the flag in test environments.
- Trial banner is tracked separately in CON-321; old sidebar/nav component removal is a follow-up cleanup ticket.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional top navigation bar behind a feature flag, with primary links, settings dropdown, account menu, mobile side navigation, and active-page highlighting.
  - Added a Light/Dark theme toggle that saves the selected theme via cookies.
  - Settings dropdown items are now shown/hidden based on feature flags (e.g., billing/usage/alerts).
- **Bug Fixes**
  - Improved responsive layout spacing by publishing header height and adjusting sidebar/mobile offsets when the top navigation is enabled.
- **Tests**
  - Added UI tests for the theme toggle, top navigation, and account menu across signed-in/signed-out and feature-flag states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->