### PR TITLE
fix(billing): make top-up charges idempotent across client retries

### DIFF
--- a/apps/api/drizzle/0032_massive_wolverine.sql
+++ b/apps/api/drizzle/0032_massive_wolverine.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "stripe_transactions" ADD COLUMN "stripe_idempotency_key" varchar(255);--> statement-breakpoint
+CREATE UNIQUE INDEX "stripe_transactions_stripe_idempotency_key_unique" ON "stripe_transactions" USING btree ("stripe_idempotency_key") WHERE "stripe_transactions"."stripe_idempotency_key" IS NOT NULL;

--- a/apps/api/drizzle/meta/0032_snapshot.json
+++ b/apps/api/drizzle/meta/0032_snapshot.json
@@ -1,0 +1,1355 @@
+{
+  "id": "c149bb61-3fb8-43b7-9eef-1ee778d722c5",
+  "prevId": "4655dea1-63ec-468b-b060-502553acd772",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.user_wallets": {
+      "name": "user_wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_allowance": {
+          "name": "deployment_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "fee_allowance": {
+          "name": "fee_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "trial": {
+          "name": "trial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_wallets_user_id_userSetting_id_fk": {
+          "name": "user_wallets_user_id_userSetting_id_fk",
+          "tableFrom": "user_wallets",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_wallets_user_id_unique": {
+          "name": "user_wallets_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "user_wallets_address_unique": {
+          "name": "user_wallets_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_methods": {
+      "name": "payment_methods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_method_id": {
+          "name": "payment_method_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_validated": {
+          "name": "is_validated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payment_methods_fingerprint_payment_method_id_unique": {
+          "name": "payment_methods_fingerprint_payment_method_id_unique",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_default_unique": {
+          "name": "payment_methods_user_id_is_default_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"payment_methods\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_fingerprint_idx": {
+          "name": "payment_methods_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_idx": {
+          "name": "payment_methods_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_validated_idx": {
+          "name": "payment_methods_user_id_is_validated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_validated",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_fingerprint_payment_method_id_idx": {
+          "name": "payment_methods_user_id_fingerprint_payment_method_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_methods_user_id_userSetting_id_fk": {
+          "name": "payment_methods_user_id_userSetting_id_fk",
+          "tableFrom": "payment_methods",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_transactions": {
+      "name": "stripe_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "stripe_transaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "stripe_transaction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created'"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_refunded": {
+          "name": "amount_refunded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bonus_amount": {
+          "name": "bonus_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_charge_id": {
+          "name": "stripe_charge_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_coupon_id": {
+          "name": "stripe_coupon_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_promotion_code_id": {
+          "name": "stripe_promotion_code_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_idempotency_key": {
+          "name": "stripe_idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method_type": {
+          "name": "payment_method_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_brand": {
+          "name": "card_brand",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_last4": {
+          "name": "card_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_url": {
+          "name": "receipt_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_transactions_stripe_invoice_id_unique": {
+          "name": "stripe_transactions_stripe_invoice_id_unique",
+          "columns": [
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stripe_transactions\".\"stripe_invoice_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_idempotency_key_unique": {
+          "name": "stripe_transactions_stripe_idempotency_key_unique",
+          "columns": [
+            {
+              "expression": "stripe_idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stripe_transactions\".\"stripe_idempotency_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_user_id_idx": {
+          "name": "stripe_transactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_payment_intent_id_idx": {
+          "name": "stripe_transactions_stripe_payment_intent_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_payment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_charge_id_idx": {
+          "name": "stripe_transactions_stripe_charge_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_coupon_id_idx": {
+          "name": "stripe_transactions_stripe_coupon_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_coupon_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_promotion_code_id_idx": {
+          "name": "stripe_transactions_stripe_promotion_code_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_promotion_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_status_idx": {
+          "name": "stripe_transactions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_created_at_idx": {
+          "name": "stripe_transactions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_user_id_created_at_idx": {
+          "name": "stripe_transactions_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_transactions_user_id_userSetting_id_fk": {
+          "name": "stripe_transactions_user_id_userSetting_id_fk",
+          "tableFrom": "stripe_transactions",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_settings": {
+      "name": "wallet_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_reload_enabled": {
+          "name": "auto_reload_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_settings_user_id_idx": {
+          "name": "wallet_settings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_settings_wallet_id_user_wallets_id_fk": {
+          "name": "wallet_settings_wallet_id_user_wallets_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "user_wallets",
+          "columnsFrom": [
+            "wallet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wallet_settings_user_id_userSetting_id_fk": {
+          "name": "wallet_settings_user_id_userSetting_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallet_settings_wallet_id_unique": {
+          "name": "wallet_settings_wallet_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wallet_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.userSetting": {
+      "name": "userSetting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscribedToNewsletter": {
+          "name": "subscribedToNewsletter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "youtubeUsername": {
+          "name": "youtubeUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitterUsername": {
+          "name": "twitterUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "githubUsername": {
+          "name": "githubUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_ip": {
+          "name": "last_ip",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_user_agent": {
+          "name": "last_user_agent",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fingerprint": {
+          "name": "last_fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "userSetting_userId_unique": {
+          "name": "userSetting_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        },
+        "userSetting_username_unique": {
+          "name": "userSetting_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.template": {
+      "name": "template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "copiedFromId": {
+          "name": "copiedFromId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cpu": {
+          "name": "cpu",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ram": {
+          "name": "ram",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage": {
+          "name": "storage",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sdl": {
+          "name": "sdl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "template_userId_idx": {
+          "name": "template_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.templateFavorite": {
+      "name": "templateFavorite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "templateId": {
+          "name": "templateId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addedDate": {
+          "name": "addedDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "templateFavorite_userId_templateId_unique": {
+          "name": "templateFavorite_userId_templateId_unique",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "templateId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "templateFavorite_templateId_template_id_fk": {
+          "name": "templateFavorite_templateId_template_id_fk",
+          "tableFrom": "templateFavorite",
+          "tableTo": "template",
+          "columnsFrom": [
+            "templateId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_settings": {
+      "name": "deployment_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dseq": {
+          "name": "dseq",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_top_up_enabled": {
+          "name": "auto_top_up_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "closed": {
+          "name": "closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "id_auto_top_up_enabled_closed_idx": {
+          "name": "id_auto_top_up_enabled_closed_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auto_top_up_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "closed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_settings_user_id_userSetting_id_fk": {
+          "name": "deployment_settings_user_id_userSetting_id_fk",
+          "tableFrom": "deployment_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dseq_user_id_idx": {
+          "name": "dseq_user_id_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "dseq",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_key": {
+          "name": "hashed_key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_format": {
+          "name": "key_format",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_user_id_userSetting_id_fk": {
+          "name": "api_keys_user_id_userSetting_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_hashed_key_unique": {
+          "name": "api_keys_hashed_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hashed_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_verification_codes": {
+      "name": "email_verification_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_verification_codes_user_id_idx": {
+          "name": "email_verification_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_verification_codes_user_id_userSetting_id_fk": {
+          "name": "email_verification_codes_user_id_userSetting_id_fk",
+          "tableFrom": "email_verification_codes",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.stripe_transaction_status": {
+      "name": "stripe_transaction_status",
+      "schema": "public",
+      "values": [
+        "created",
+        "pending",
+        "requires_action",
+        "succeeded",
+        "failed",
+        "refunded",
+        "canceled"
+      ]
+    },
+    "public.stripe_transaction_type": {
+      "name": "stripe_transaction_type",
+      "schema": "public",
+      "values": [
+        "payment_intent",
+        "coupon_claim",
+        "manual_credit"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -225,6 +225,13 @@
       "when": 1784062230879,
       "tag": "0031_lively_gwen_stacy",
       "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "7",
+      "when": 1784238593894,
+      "tag": "0032_massive_wolverine",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/billing/controllers/stripe/stripe.controller.spec.ts
+++ b/apps/api/src/billing/controllers/stripe/stripe.controller.spec.ts
@@ -169,6 +169,48 @@ describe(StripeController.name, () => {
         }
       });
     });
+
+    it("namespaces the client attempt key with the user id before calling Stripe", async () => {
+      const { controller, stripe, user } = setup();
+      const clientKey = faker.string.uuid();
+
+      stripe.hasPaymentMethod.mockResolvedValue(true);
+      stripe.createPaymentIntent.mockResolvedValue({
+        success: true,
+        paymentIntentId: faker.string.uuid(),
+        transactionId: faker.string.uuid(),
+        transactionStatus: "pending"
+      });
+
+      await controller.confirmPayment({
+        userId: user.id,
+        paymentMethodId: faker.string.uuid(),
+        amount: 100,
+        idempotencyKey: clientKey
+      });
+
+      expect(stripe.createPaymentIntent).toHaveBeenCalledWith(expect.objectContaining({ idempotencyKey: `topup_${user.id}_${clientKey}` }));
+    });
+
+    it("passes no idempotency key to Stripe when the client sends none", async () => {
+      const { controller, stripe, user } = setup();
+
+      stripe.hasPaymentMethod.mockResolvedValue(true);
+      stripe.createPaymentIntent.mockResolvedValue({
+        success: true,
+        paymentIntentId: faker.string.uuid(),
+        transactionId: faker.string.uuid(),
+        transactionStatus: "pending"
+      });
+
+      await controller.confirmPayment({
+        userId: user.id,
+        paymentMethodId: faker.string.uuid(),
+        amount: 100
+      });
+
+      expect(stripe.createPaymentIntent).toHaveBeenCalledWith(expect.objectContaining({ idempotencyKey: undefined }));
+    });
   });
 
   describe("createSetupIntent", () => {

--- a/apps/api/src/billing/controllers/stripe/stripe.controller.ts
+++ b/apps/api/src/billing/controllers/stripe/stripe.controller.ts
@@ -21,7 +21,7 @@ import {
 } from "@src/billing/http-schemas/stripe.schema";
 import type { StripeTransactionOutput } from "@src/billing/repositories";
 import { UserWalletRepository } from "@src/billing/repositories";
-import { StripeService } from "@src/billing/services/stripe/stripe.service";
+import { StripeService, TOP_UP_IDEMPOTENCY_KEY_PREFIX } from "@src/billing/services/stripe/stripe.service";
 import { StripeErrorService } from "@src/billing/services/stripe-error/stripe-error.service";
 import { TrialValidationService } from "@src/billing/services/trial-validation/trial-validation.service";
 @singleton()
@@ -107,7 +107,8 @@ export class StripeController {
         customer: currentUser.stripeCustomerId,
         payment_method: params.paymentMethodId,
         amount: params.amount,
-        confirm: true
+        confirm: true,
+        idempotencyKey: params.idempotencyKey ? `${TOP_UP_IDEMPOTENCY_KEY_PREFIX}${currentUser.id}_${params.idempotencyKey}` : undefined
       });
 
       // Handle 3D Secure authentication requirement

--- a/apps/api/src/billing/http-schemas/stripe.schema.ts
+++ b/apps/api/src/billing/http-schemas/stripe.schema.ts
@@ -79,7 +79,8 @@ export const ConfirmPaymentRequestSchema = z.object({
     userId: z.string(),
     paymentMethodId: z.string(),
     amount: z.number().gte(20, "Amount must be greater or equal to $20"),
-    awaitResolved: z.boolean().optional()
+    awaitResolved: z.boolean().optional(),
+    idempotencyKey: z.string().uuid().optional()
   })
 });
 

--- a/apps/api/src/billing/model-schemas/stripe-transaction/stripe-transaction.schema.ts
+++ b/apps/api/src/billing/model-schemas/stripe-transaction/stripe-transaction.schema.ts
@@ -36,6 +36,7 @@ export const StripeTransactions = pgTable(
     stripeCouponId: varchar("stripe_coupon_id", { length: 255 }),
     stripePromotionCodeId: varchar("stripe_promotion_code_id", { length: 255 }),
     stripeInvoiceId: varchar("stripe_invoice_id", { length: 255 }),
+    stripeIdempotencyKey: varchar("stripe_idempotency_key", { length: 255 }),
     paymentMethodType: varchar("payment_method_type", { length: 50 }),
     cardBrand: varchar("card_brand", { length: 50 }),
     cardLast4: varchar("card_last4", { length: 4 }),
@@ -52,6 +53,13 @@ export const StripeTransactions = pgTable(
     stripeInvoiceIdUnique: uniqueIndex("stripe_transactions_stripe_invoice_id_unique")
       .on(table.stripeInvoiceId)
       .where(sql`${table.stripeInvoiceId} IS NOT NULL`),
+    // Partial unique index: enforces one transaction row per Stripe idempotency key so retried
+    // deliveries of the same attempt find-or-create the same row (the PaymentIntent metadata embeds
+    // the row id, so a fresh row per delivery would break Stripe's byte-identical replay contract).
+    // Keyless payment_intent rows and legacy rows leave it null.
+    stripeIdempotencyKeyUnique: uniqueIndex("stripe_transactions_stripe_idempotency_key_unique")
+      .on(table.stripeIdempotencyKey)
+      .where(sql`${table.stripeIdempotencyKey} IS NOT NULL`),
     userIdIdx: index("stripe_transactions_user_id_idx").on(table.userId),
     stripePaymentIntentIdIdx: index("stripe_transactions_stripe_payment_intent_id_idx").on(table.stripePaymentIntentId),
     stripeChargeIdIdx: index("stripe_transactions_stripe_charge_id_idx").on(table.stripeChargeId),

--- a/apps/api/src/billing/repositories/stripe-transaction/stripe-transaction.repository.integration.ts
+++ b/apps/api/src/billing/repositories/stripe-transaction/stripe-transaction.repository.integration.ts
@@ -97,6 +97,98 @@ describe(StripeTransactionRepository.name, () => {
     });
   });
 
+  describe("findOrCreateByIdempotencyKey", () => {
+    it("creates the row on first use of a key", async () => {
+      const { stripeTransactionRepository, createTestUser } = setup();
+      const user = await createTestUser();
+      const key = `topup_${user.id}_${faker.string.uuid()}`;
+
+      const result = await stripeTransactionRepository.findOrCreateByIdempotencyKey(keyedTransactionInput(user.id, key));
+
+      expect(result.isNew).toBe(true);
+      expect(result.transaction.stripeIdempotencyKey).toBe(key);
+      expect(await stripeTransactionRepository.findById(result.transaction.id)).toMatchObject({ stripeIdempotencyKey: key, amount: 10000 });
+    });
+
+    it("returns the existing row without creating another on a reused key", async () => {
+      const { stripeTransactionRepository, createTestUser } = setup();
+      const user = await createTestUser();
+      const key = `topup_${user.id}_${faker.string.uuid()}`;
+
+      const first = await stripeTransactionRepository.findOrCreateByIdempotencyKey(keyedTransactionInput(user.id, key));
+      const second = await stripeTransactionRepository.findOrCreateByIdempotencyKey(keyedTransactionInput(user.id, key));
+
+      expect(second.isNew).toBe(false);
+      expect(second.transaction.id).toBe(first.transaction.id);
+      expect(await stripeTransactionRepository.find({ userId: user.id })).toHaveLength(1);
+    });
+
+    it("resolves a concurrent insert race to a single row", async () => {
+      const { stripeTransactionRepository, createTestUser } = setup();
+      const user = await createTestUser();
+      const key = `topup_${user.id}_${faker.string.uuid()}`;
+
+      const [first, second] = await Promise.all([
+        stripeTransactionRepository.findOrCreateByIdempotencyKey(keyedTransactionInput(user.id, key)),
+        stripeTransactionRepository.findOrCreateByIdempotencyKey(keyedTransactionInput(user.id, key))
+      ]);
+
+      expect(first.transaction.id).toBe(second.transaction.id);
+      expect([first.isNew, second.isNew].filter(Boolean)).toHaveLength(1);
+      expect(await stripeTransactionRepository.find({ userId: user.id })).toHaveLength(1);
+    });
+
+    it("allows multiple rows with a null idempotency key", async () => {
+      const { createTestTransaction } = setup();
+
+      const first = await createTestTransaction({ stripeIdempotencyKey: null });
+      const second = await createTestTransaction({ stripeIdempotencyKey: null });
+
+      expect(first.id).not.toBe(second.id);
+    });
+
+    function keyedTransactionInput(userId: string, stripeIdempotencyKey: string): StripeTransactionInput & { stripeIdempotencyKey: string } {
+      return {
+        userId,
+        type: "payment_intent",
+        status: "created",
+        amount: 10000,
+        currency: "usd",
+        stripeIdempotencyKey
+      };
+    }
+  });
+
+  describe("updateByIdUnlessSettled", () => {
+    it("updates an unsettled row and returns it", async () => {
+      const { stripeTransactionRepository, createTestTransaction } = setup();
+      const transaction = await createTestTransaction({ status: "created" });
+
+      const updated = await stripeTransactionRepository.updateByIdUnlessSettled(transaction.id, { status: "pending", stripePaymentIntentId: "pi_1" });
+
+      expect(updated).toMatchObject({ id: transaction.id, status: "pending", stripePaymentIntentId: "pi_1" });
+    });
+
+    it("updates a failed row so a retried attempt can resume it", async () => {
+      const { stripeTransactionRepository, createTestTransaction } = setup();
+      const transaction = await createTestTransaction({ status: "failed" });
+
+      const updated = await stripeTransactionRepository.updateByIdUnlessSettled(transaction.id, { status: "requires_action" });
+
+      expect(updated).toMatchObject({ id: transaction.id, status: "requires_action" });
+    });
+
+    it.each(["succeeded", "refunded"] as const)("suppresses writes to a %s row", async status => {
+      const { stripeTransactionRepository, createTestTransaction } = setup();
+      const transaction = await createTestTransaction({ status });
+
+      const updated = await stripeTransactionRepository.updateByIdUnlessSettled(transaction.id, { status: "failed", errorMessage: "stale replay" });
+
+      expect(updated).toBeUndefined();
+      expect(await stripeTransactionRepository.findById(transaction.id)).toMatchObject({ status, errorMessage: null });
+    });
+  });
+
   let cleanup: () => Promise<void>;
   afterEach(async () => {
     await cleanup?.();

--- a/apps/api/src/billing/repositories/stripe-transaction/stripe-transaction.repository.ts
+++ b/apps/api/src/billing/repositories/stripe-transaction/stripe-transaction.repository.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, gte, inArray, lte, SQL } from "drizzle-orm";
+import { and, desc, eq, gte, inArray, lte, notInArray, SQL, sql } from "drizzle-orm";
 import { singleton } from "tsyringe";
 
 import { type ApiPgDatabase, type ApiPgTables, InjectPg, InjectPgTable } from "@src/core/providers";
@@ -18,6 +18,14 @@ export type StripeTransactionType = StripeTransactionOutput["type"];
  * Add new trial-preserving credit-grant types here.
  */
 export const TRIAL_PRESERVING_TRANSACTION_TYPES: Set<StripeTransactionType> = new Set(["manual_credit"]);
+
+/**
+ * Statuses written by Stripe webhooks once money has actually moved (wallet credited, then possibly
+ * clawed back). Rows in these statuses must never be rewritten by the payment-intent request path:
+ * the webhook's `status !== "succeeded"` guard is what makes crediting exactly-once. `failed` and
+ * `canceled` intentionally stay updatable so a retried attempt can resume them.
+ */
+export const SETTLED_TRANSACTION_STATUSES: Set<StripeTransactionStatus> = new Set(["succeeded", "refunded"]);
 
 export interface FindTransactionsOptions {
   userId: string;
@@ -108,6 +116,49 @@ export class StripeTransactionRepository extends BaseRepository<Table, StripeTra
     if (!existing) return undefined;
 
     return this.updateById(existing.id, update, { returning: true });
+  }
+
+  /**
+   * Finds the transaction recorded for a Stripe idempotency key or creates it, resolving concurrent
+   * inserts through the partial unique index (conflict-do-nothing, then re-fetch the winner).
+   */
+  async findOrCreateByIdempotencyKey(
+    input: StripeTransactionInput & { stripeIdempotencyKey: string }
+  ): Promise<{ transaction: StripeTransactionOutput; isNew: boolean }> {
+    const existing = await this.findOneBy({ stripeIdempotencyKey: input.stripeIdempotencyKey, userId: input.userId });
+
+    if (existing) {
+      return { transaction: existing, isNew: false };
+    }
+
+    const [created] = await this.cursor.insert(this.table).values(input).onConflictDoNothing().returning();
+
+    if (created) {
+      return { transaction: this.toOutput(created), isNew: true };
+    }
+
+    const winner = await this.findOneBy({ stripeIdempotencyKey: input.stripeIdempotencyKey, userId: input.userId });
+
+    if (!winner) {
+      throw new Error(`Stripe transaction not found after idempotency key conflict resolution. userId: ${input.userId}`);
+    }
+
+    return { transaction: winner, isNew: false };
+  }
+
+  /**
+   * Atomically updates a row unless a webhook already settled it (see SETTLED_TRANSACTION_STATUSES),
+   * so a slow request path can never downgrade a status the webhook wrote first. Returns the updated
+   * row, or undefined when the guard suppressed the write.
+   */
+  async updateByIdUnlessSettled(id: StripeTransactionOutput["id"], update: Partial<StripeTransactionInput>): Promise<StripeTransactionOutput | undefined> {
+    const [item] = await this.cursor
+      .update(this.table)
+      .set({ ...update, updatedAt: sql`now()` })
+      .where(and(eq(this.table.id, id), notInArray(this.table.status, [...SETTLED_TRANSACTION_STATUSES])))
+      .returning();
+
+    return item ? this.toOutput(item) : undefined;
   }
 
   /**

--- a/apps/api/src/billing/routes/stripe-transactions/stripe-transactions.router.ts
+++ b/apps/api/src/billing/routes/stripe-transactions/stripe-transactions.router.ts
@@ -58,7 +58,8 @@ stripeTransactionsRouter.openapi(confirmPaymentRoute, async function confirmPaym
   const result = await container.resolve(StripeController).confirmPayment({
     userId: data.userId,
     paymentMethodId: data.paymentMethodId,
-    amount: data.amount
+    amount: data.amount,
+    idempotencyKey: data.idempotencyKey
   });
 
   // Check if 3D Secure is required

--- a/apps/api/src/billing/services/stripe-error/stripe-error.service.spec.ts
+++ b/apps/api/src/billing/services/stripe-error/stripe-error.service.spec.ts
@@ -1,7 +1,7 @@
 import type Stripe from "stripe";
 import { describe, expect, it } from "vitest";
 
-import { StripeErrorService } from "./stripe-error.service";
+import { PAYMENT_IN_PROGRESS_ERROR_MESSAGE, StripeErrorService } from "./stripe-error.service";
 
 // Helper function to create proper Stripe error objects
 function createStripeError(type: string, props: any = {}): Stripe.errors.StripeError {
@@ -131,6 +131,29 @@ describe(StripeErrorService.name, () => {
 
         expect(result).toHaveProperty("status", 400);
         expect(result).toHaveProperty("message", "Coupon ID is required");
+      });
+
+      it("maps the payment-in-progress message to a 409 with the payment_in_progress code", () => {
+        const { service } = setup();
+        const error = new Error(PAYMENT_IN_PROGRESS_ERROR_MESSAGE);
+        const result = service.toAppError(error, "payment");
+
+        expect(result).toHaveProperty("status", 409);
+        expect(result).toHaveProperty("message", PAYMENT_IN_PROGRESS_ERROR_MESSAGE);
+        expect(result).toHaveProperty("errorCode", "payment_in_progress");
+        expect(result).toHaveProperty("errorType", "payment_error");
+      });
+
+      it("returns the payment_in_progress code from getPaymentErrorCode", () => {
+        const { service } = setup();
+
+        const result = service.getPaymentErrorCode(new Error(PAYMENT_IN_PROGRESS_ERROR_MESSAGE));
+
+        expect(result).toEqual({
+          message: PAYMENT_IN_PROGRESS_ERROR_MESSAGE,
+          code: "payment_in_progress",
+          type: "payment_error"
+        });
       });
     });
 

--- a/apps/api/src/billing/services/stripe-error/stripe-error.service.spec.ts
+++ b/apps/api/src/billing/services/stripe-error/stripe-error.service.spec.ts
@@ -1,7 +1,7 @@
 import type Stripe from "stripe";
 import { describe, expect, it } from "vitest";
 
-import { PAYMENT_IN_PROGRESS_ERROR_MESSAGE, StripeErrorService } from "./stripe-error.service";
+import { IDEMPOTENCY_KEY_MISMATCH_ERROR_MESSAGE, PAYMENT_IN_PROGRESS_ERROR_MESSAGE, StripeErrorService } from "./stripe-error.service";
 
 // Helper function to create proper Stripe error objects
 function createStripeError(type: string, props: any = {}): Stripe.errors.StripeError {
@@ -152,6 +152,29 @@ describe(StripeErrorService.name, () => {
         expect(result).toEqual({
           message: PAYMENT_IN_PROGRESS_ERROR_MESSAGE,
           code: "payment_in_progress",
+          type: "payment_error"
+        });
+      });
+
+      it("maps the idempotency-key-mismatch message to a 409 with the idempotency_key_mismatch code", () => {
+        const { service } = setup();
+        const error = new Error(IDEMPOTENCY_KEY_MISMATCH_ERROR_MESSAGE);
+        const result = service.toAppError(error, "payment");
+
+        expect(result).toHaveProperty("status", 409);
+        expect(result).toHaveProperty("message", IDEMPOTENCY_KEY_MISMATCH_ERROR_MESSAGE);
+        expect(result).toHaveProperty("errorCode", "idempotency_key_mismatch");
+        expect(result).toHaveProperty("errorType", "payment_error");
+      });
+
+      it("returns the idempotency_key_mismatch code from getPaymentErrorCode", () => {
+        const { service } = setup();
+
+        const result = service.getPaymentErrorCode(new Error(IDEMPOTENCY_KEY_MISMATCH_ERROR_MESSAGE));
+
+        expect(result).toEqual({
+          message: IDEMPOTENCY_KEY_MISMATCH_ERROR_MESSAGE,
+          code: "idempotency_key_mismatch",
           type: "payment_error"
         });
       });
@@ -323,6 +346,7 @@ describe(StripeErrorService.name, () => {
 
         expect(result).toHaveProperty("status", 409);
         expect(result).toHaveProperty("message", "This request conflicts with a previous request. Please try again with different parameters.");
+        expect(result).toHaveProperty("errorCode", "idempotency_key_mismatch");
       });
 
       it("should handle StripePermissionError", () => {

--- a/apps/api/src/billing/services/stripe-error/stripe-error.service.ts
+++ b/apps/api/src/billing/services/stripe-error/stripe-error.service.ts
@@ -3,11 +3,18 @@ import Stripe from "stripe";
 import { singleton } from "tsyringe";
 
 /**
- * Thrown when a retried attempt reuses an idempotency key whose first delivery is still executing
- * (or recorded a different amount). Maps to 409 so the client keeps its attempt key and retries the
- * same attempt instead of minting a new charge.
+ * Thrown when a retried attempt reuses an idempotency key whose first delivery is still executing.
+ * Maps to 409 so the client keeps its attempt key and retries the same attempt instead of minting a
+ * new charge.
  */
 export const PAYMENT_IN_PROGRESS_ERROR_MESSAGE = "A payment for this request is already in progress. Please wait a moment and try again.";
+
+/**
+ * Thrown when a reused idempotency key carries different parameters (e.g. a changed amount) than
+ * the attempt it recorded. Unlike an in-progress conflict this can never resolve by retrying, so it
+ * maps to a 409 with a distinct code telling the client to rotate its attempt key.
+ */
+export const IDEMPOTENCY_KEY_MISMATCH_ERROR_MESSAGE = "This payment was already requested with different parameters. Please start a new payment attempt.";
 
 @singleton()
 export class StripeErrorService {
@@ -82,6 +89,10 @@ export class StripeErrorService {
     [PAYMENT_IN_PROGRESS_ERROR_MESSAGE]: {
       code: 409,
       message: PAYMENT_IN_PROGRESS_ERROR_MESSAGE
+    },
+    [IDEMPOTENCY_KEY_MISMATCH_ERROR_MESSAGE]: {
+      code: 409,
+      message: IDEMPOTENCY_KEY_MISMATCH_ERROR_MESSAGE
     }
   };
 
@@ -214,6 +225,8 @@ export class StripeErrorService {
       return "card_validation_failed";
     } else if (messageLower.includes("already in progress")) {
       return "payment_in_progress";
+    } else if (messageLower.includes("different parameters")) {
+      return "idempotency_key_mismatch";
     }
 
     return "unknown_payment_error";
@@ -393,7 +406,7 @@ export class StripeErrorService {
   private handleIdempotencyError(error: Stripe.errors.StripeIdempotencyError): HttpError {
     return createError(409, "This request conflicts with a previous request. Please try again with different parameters.", {
       originalError: error,
-      errorCode: "conflict",
+      errorCode: "idempotency_key_mismatch",
       errorType: "client_error"
     });
   }

--- a/apps/api/src/billing/services/stripe-error/stripe-error.service.ts
+++ b/apps/api/src/billing/services/stripe-error/stripe-error.service.ts
@@ -2,6 +2,13 @@ import createError, { HttpError } from "http-errors";
 import Stripe from "stripe";
 import { singleton } from "tsyringe";
 
+/**
+ * Thrown when a retried attempt reuses an idempotency key whose first delivery is still executing
+ * (or recorded a different amount). Maps to 409 so the client keeps its attempt key and retries the
+ * same attempt instead of minting a new charge.
+ */
+export const PAYMENT_IN_PROGRESS_ERROR_MESSAGE = "A payment for this request is already in progress. Please wait a moment and try again.";
+
 @singleton()
 export class StripeErrorService {
   private readonly COUPON_ERRORS = {
@@ -71,6 +78,10 @@ export class StripeErrorService {
     "Payment method was declined. Please try a different card.": {
       code: 402,
       message: "Payment method was declined. Please try a different card."
+    },
+    [PAYMENT_IN_PROGRESS_ERROR_MESSAGE]: {
+      code: 409,
+      message: PAYMENT_IN_PROGRESS_ERROR_MESSAGE
     }
   };
 
@@ -201,6 +212,8 @@ export class StripeErrorService {
       return "duplicate_validation_request";
     } else if (messageLower.includes("card validation failed")) {
       return "card_validation_failed";
+    } else if (messageLower.includes("already in progress")) {
+      return "payment_in_progress";
     }
 
     return "unknown_payment_error";

--- a/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.integration.ts
+++ b/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.integration.ts
@@ -1143,6 +1143,7 @@ describe(StripeWebhookService.name, () => {
       stripeCouponId: null,
       stripePromotionCodeId: null,
       stripeInvoiceId: null,
+      stripeIdempotencyKey: null,
       paymentMethodType: "card",
       cardBrand: "visa",
       cardLast4: "4242",

--- a/apps/api/src/billing/services/stripe/stripe.service.spec.ts
+++ b/apps/api/src/billing/services/stripe/stripe.service.spec.ts
@@ -1,12 +1,13 @@
 import type { LoggerService } from "@akashnetwork/logging";
 import { createMongoAbility } from "@casl/ability";
 import crypto from "crypto";
-import type Stripe from "stripe";
+import Stripe from "stripe";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { PaymentMethodRepository, StripeTransactionRepository } from "@src/billing/repositories";
 import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
+import { PAYMENT_IN_PROGRESS_ERROR_MESSAGE } from "@src/billing/services/stripe-error/stripe-error.service";
 import type { TimerService } from "@src/core/services/timer/timer.service";
 import type { UserRepository } from "@src/user/repositories";
 import { StripeService } from "./stripe.service";
@@ -93,6 +94,226 @@ describe(StripeService.name, () => {
         paymentIntentId: StripeSeederCreate().paymentIntent.id,
         transactionId: "test-transaction-id",
         transactionStatus: "created"
+      });
+    });
+
+    it("does not consult the idempotency-key row lookup on keyless calls", async () => {
+      const { service, stripeTransactionRepository } = setup();
+
+      await service.createPaymentIntent(mockPaymentParams);
+
+      expect(stripeTransactionRepository.findOrCreateByIdempotencyKey).not.toHaveBeenCalled();
+      expect(vi.mocked(service.paymentIntents.create).mock.calls[0]).toHaveLength(1);
+    });
+
+    describe("when an idempotency key is provided", () => {
+      const idempotencyKey = `topup_${TEST_CONSTANTS.USER_ID}_11111111-2222-4333-8444-555555555555`;
+      const keyedParams = { ...mockPaymentParams, idempotencyKey };
+
+      it("finds or creates the row by key and forwards the key to Stripe", async () => {
+        const { service, stripeTransactionRepository } = setup();
+        const transaction = generateDatabaseStripeTransaction({ amount: 10000, status: "created", stripeIdempotencyKey: idempotencyKey });
+        stripeTransactionRepository.findOrCreateByIdempotencyKey.mockResolvedValue({ transaction, isNew: true });
+
+        const result = await service.createPaymentIntent(keyedParams);
+
+        expect(stripeTransactionRepository.findOrCreateByIdempotencyKey).toHaveBeenCalledWith({
+          userId: keyedParams.userId,
+          type: "payment_intent",
+          status: "created",
+          amount: 10000,
+          currency: "usd",
+          stripeIdempotencyKey: idempotencyKey
+        });
+        expect(stripeTransactionRepository.create).not.toHaveBeenCalled();
+        expect(service.paymentIntents.create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            amount: 10000,
+            metadata: { internal_transaction_id: transaction.id }
+          }),
+          { idempotencyKey }
+        );
+        expect(result).toEqual(expect.objectContaining({ success: true, transactionId: transaction.id }));
+      });
+
+      it.each(["succeeded", "refunded"] as const)("short-circuits a replay of a %s row without contacting Stripe", async status => {
+        const { service, stripeTransactionRepository } = setup();
+        const transaction = generateDatabaseStripeTransaction({ amount: 10000, status, stripePaymentIntentId: "pi_replayed" });
+        stripeTransactionRepository.findOrCreateByIdempotencyKey.mockResolvedValue({ transaction, isNew: false });
+
+        const result = await service.createPaymentIntent(keyedParams);
+
+        expect(service.paymentIntents.create).not.toHaveBeenCalled();
+        expect(service.paymentIntents.retrieve).not.toHaveBeenCalled();
+        expect(result).toEqual({
+          success: true,
+          paymentIntentId: "pi_replayed",
+          transactionId: transaction.id,
+          transactionStatus: status
+        });
+      });
+
+      it.each(["succeeded", "requires_capture"] as const)(
+        "retrieves the live intent instead of creating one and defers the %s status to the webhook",
+        async liveStatus => {
+          const { service, stripeTransactionRepository } = setup();
+          const transaction = generateDatabaseStripeTransaction({ amount: 10000, status: "pending", stripePaymentIntentId: "pi_live" });
+          stripeTransactionRepository.findOrCreateByIdempotencyKey.mockResolvedValue({ transaction, isNew: false });
+          vi.mocked(service.paymentIntents.retrieve).mockResolvedValue(createTestPaymentIntent({ id: "pi_live", status: liveStatus }));
+
+          const result = await service.createPaymentIntent(keyedParams);
+
+          expect(service.paymentIntents.retrieve).toHaveBeenCalledWith("pi_live");
+          expect(service.paymentIntents.create).not.toHaveBeenCalled();
+          expect(stripeTransactionRepository.updateByIdUnlessSettled).not.toHaveBeenCalled();
+          expect(result).toEqual({
+            success: true,
+            paymentIntentId: "pi_live",
+            transactionId: transaction.id,
+            transactionStatus: "pending"
+          });
+        }
+      );
+
+      it("records the mapped status when the live intent is processing", async () => {
+        const { service, stripeTransactionRepository } = setup();
+        const transaction = generateDatabaseStripeTransaction({ amount: 10000, status: "requires_action", stripePaymentIntentId: "pi_live" });
+        stripeTransactionRepository.findOrCreateByIdempotencyKey.mockResolvedValue({ transaction, isNew: false });
+        vi.mocked(service.paymentIntents.retrieve).mockResolvedValue(createTestPaymentIntent({ id: "pi_live", status: "processing" }));
+
+        const result = await service.createPaymentIntent(keyedParams);
+
+        expect(stripeTransactionRepository.updateByIdUnlessSettled).toHaveBeenCalledWith(transaction.id, { status: "pending" });
+        expect(result).toEqual(expect.objectContaining({ success: true, transactionStatus: "pending" }));
+      });
+
+      it.each(["requires_action", "requires_confirmation"] as const)("resumes 3DS with the live client secret when the intent is in %s", async liveStatus => {
+        const { service, stripeTransactionRepository } = setup();
+        const transaction = generateDatabaseStripeTransaction({ amount: 10000, status: "requires_action", stripePaymentIntentId: "pi_live" });
+        stripeTransactionRepository.findOrCreateByIdempotencyKey.mockResolvedValue({ transaction, isNew: false });
+        vi.mocked(service.paymentIntents.retrieve).mockResolvedValue(
+          createTestPaymentIntent({ id: "pi_live", status: liveStatus, client_secret: "pi_live_secret" })
+        );
+
+        const result = await service.createPaymentIntent(keyedParams);
+
+        expect(service.paymentIntents.create).not.toHaveBeenCalled();
+        expect(result).toEqual({
+          success: false,
+          paymentIntentId: "pi_live",
+          requiresAction: true,
+          clientSecret: "pi_live_secret",
+          transactionId: transaction.id,
+          transactionStatus: "requires_action"
+        });
+      });
+
+      it("defers the succeeded status to the webhook when a fresh keyed charge requires capture", async () => {
+        const { service, stripeTransactionRepository } = setup({ paymentIntent: createTestPaymentIntent({ status: "requires_capture" }) });
+        const transaction = generateDatabaseStripeTransaction({ amount: 10000, status: "created", stripeIdempotencyKey: idempotencyKey });
+        stripeTransactionRepository.findOrCreateByIdempotencyKey.mockResolvedValue({ transaction, isNew: true });
+
+        const result = await service.createPaymentIntent(keyedParams);
+
+        expect(stripeTransactionRepository.updateByIdUnlessSettled).toHaveBeenCalledWith(transaction.id, {
+          stripePaymentIntentId: createTestPaymentIntent().id
+        });
+        expect(result).toEqual(expect.objectContaining({ success: true, transactionStatus: "created" }));
+      });
+
+      it("synthesizes a 402 with the live decline reason when the intent requires a new payment method", async () => {
+        const { service, stripeTransactionRepository } = setup();
+        const transaction = generateDatabaseStripeTransaction({ amount: 10000, status: "pending", stripePaymentIntentId: "pi_live" });
+        stripeTransactionRepository.findOrCreateByIdempotencyKey.mockResolvedValue({ transaction, isNew: false });
+        vi.mocked(service.paymentIntents.retrieve).mockResolvedValue(
+          createTestPaymentIntent({
+            id: "pi_live",
+            status: "requires_payment_method",
+            last_payment_error: { message: "Your card was declined." } as Stripe.PaymentIntent.LastPaymentError
+          })
+        );
+
+        await expect(service.createPaymentIntent(keyedParams)).rejects.toMatchObject({
+          status: 402,
+          message: "Your card was declined.",
+          errorCode: "card_declined"
+        });
+        expect(service.paymentIntents.create).not.toHaveBeenCalled();
+        expect(stripeTransactionRepository.updateByIdUnlessSettled).toHaveBeenCalledWith(transaction.id, {
+          status: "failed",
+          errorMessage: "Your card was declined."
+        });
+      });
+
+      it("rejects a reused top-up key whose amount changed without touching the row or Stripe", async () => {
+        const { service, stripeTransactionRepository } = setup();
+        const transaction = generateDatabaseStripeTransaction({ amount: 5000, status: "created", stripePaymentIntentId: null });
+        stripeTransactionRepository.findOrCreateByIdempotencyKey.mockResolvedValue({ transaction, isNew: false });
+
+        await expect(service.createPaymentIntent(keyedParams)).rejects.toThrow(PAYMENT_IN_PROGRESS_ERROR_MESSAGE);
+        expect(service.paymentIntents.create).not.toHaveBeenCalled();
+        expect(stripeTransactionRepository.updateByIdUnlessSettled).not.toHaveBeenCalled();
+      });
+
+      it("charges the recorded amount when a reused wallet-reload key recomputes a different amount", async () => {
+        const { service, stripeTransactionRepository } = setup();
+        const reloadKey = "WalletBalanceReloadCheck.job_1";
+        const transaction = generateDatabaseStripeTransaction({
+          amount: 5000,
+          status: "created",
+          stripePaymentIntentId: null,
+          stripeIdempotencyKey: reloadKey
+        });
+        stripeTransactionRepository.findOrCreateByIdempotencyKey.mockResolvedValue({ transaction, isNew: false });
+
+        const result = await service.createPaymentIntent({ ...mockPaymentParams, idempotencyKey: reloadKey });
+
+        expect(service.paymentIntents.create).toHaveBeenCalledWith(expect.objectContaining({ amount: 5000 }), { idempotencyKey: reloadKey });
+        expect(result).toEqual(expect.objectContaining({ success: true, transactionId: transaction.id }));
+      });
+
+      it("maps a concurrent key-in-use rejection to the in-progress error without touching the row", async () => {
+        const { service, stripeTransactionRepository } = setup();
+        const transaction = generateDatabaseStripeTransaction({ amount: 10000, status: "created", stripePaymentIntentId: null });
+        stripeTransactionRepository.findOrCreateByIdempotencyKey.mockResolvedValue({ transaction, isNew: false });
+        vi.mocked(service.paymentIntents.create).mockRejectedValue(
+          new Stripe.errors.StripeInvalidRequestError({
+            type: "invalid_request_error",
+            code: "idempotency_key_in_use",
+            message: "There is currently another in-progress request using this Idempotent Key"
+          } as Stripe.StripeRawError)
+        );
+
+        await expect(service.createPaymentIntent(keyedParams)).rejects.toThrow(PAYMENT_IN_PROGRESS_ERROR_MESSAGE);
+        expect(stripeTransactionRepository.updateByIdUnlessSettled).not.toHaveBeenCalled();
+      });
+
+      it("rethrows a params-mismatch idempotency error without recording a failure", async () => {
+        const { service, stripeTransactionRepository } = setup();
+        const transaction = generateDatabaseStripeTransaction({ amount: 10000, status: "created", stripePaymentIntentId: null });
+        stripeTransactionRepository.findOrCreateByIdempotencyKey.mockResolvedValue({ transaction, isNew: true });
+        const idempotencyError = new Stripe.errors.StripeIdempotencyError({
+          type: "idempotency_error",
+          message: "Keys for idempotent requests can only be used with the same parameters they were first used with."
+        } as Stripe.StripeRawError);
+        vi.mocked(service.paymentIntents.create).mockRejectedValue(idempotencyError);
+
+        await expect(service.createPaymentIntent(keyedParams)).rejects.toBe(idempotencyError);
+        expect(stripeTransactionRepository.updateByIdUnlessSettled).not.toHaveBeenCalled();
+      });
+
+      it("records failures through the settled-status guard", async () => {
+        const { service, stripeTransactionRepository } = setup();
+        const transaction = generateDatabaseStripeTransaction({ amount: 10000, status: "created", stripePaymentIntentId: null });
+        stripeTransactionRepository.findOrCreateByIdempotencyKey.mockResolvedValue({ transaction, isNew: true });
+        vi.mocked(service.paymentIntents.create).mockRejectedValue(new Error("socket hang up"));
+
+        await expect(service.createPaymentIntent(keyedParams)).rejects.toThrow("socket hang up");
+        expect(stripeTransactionRepository.updateByIdUnlessSettled).toHaveBeenCalledWith(
+          transaction.id,
+          expect.objectContaining({ status: "failed", errorMessage: "socket hang up" })
+        );
+        expect(stripeTransactionRepository.updateById).not.toHaveBeenCalled();
       });
     });
   });
@@ -1740,6 +1961,7 @@ function setup(
     stripeCouponId: input.stripeCouponId ?? null,
     stripePromotionCodeId: input.stripePromotionCodeId ?? null,
     stripeInvoiceId: input.stripeInvoiceId ?? null,
+    stripeIdempotencyKey: input.stripeIdempotencyKey ?? null,
     paymentMethodType: input.paymentMethodType ?? null,
     cardBrand: input.cardBrand ?? null,
     cardLast4: input.cardLast4 ?? null,

--- a/apps/api/src/billing/services/stripe/stripe.service.spec.ts
+++ b/apps/api/src/billing/services/stripe/stripe.service.spec.ts
@@ -7,7 +7,7 @@ import { mock } from "vitest-mock-extended";
 
 import type { PaymentMethodRepository, StripeTransactionRepository } from "@src/billing/repositories";
 import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
-import { PAYMENT_IN_PROGRESS_ERROR_MESSAGE } from "@src/billing/services/stripe-error/stripe-error.service";
+import { IDEMPOTENCY_KEY_MISMATCH_ERROR_MESSAGE, PAYMENT_IN_PROGRESS_ERROR_MESSAGE } from "@src/billing/services/stripe-error/stripe-error.service";
 import type { TimerService } from "@src/core/services/timer/timer.service";
 import type { UserRepository } from "@src/user/repositories";
 import { StripeService } from "./stripe.service";
@@ -250,8 +250,28 @@ describe(StripeService.name, () => {
         const transaction = generateDatabaseStripeTransaction({ amount: 5000, status: "created", stripePaymentIntentId: null });
         stripeTransactionRepository.findOrCreateByIdempotencyKey.mockResolvedValue({ transaction, isNew: false });
 
-        await expect(service.createPaymentIntent(keyedParams)).rejects.toThrow(PAYMENT_IN_PROGRESS_ERROR_MESSAGE);
+        await expect(service.createPaymentIntent(keyedParams)).rejects.toThrow(IDEMPOTENCY_KEY_MISMATCH_ERROR_MESSAGE);
         expect(service.paymentIntents.create).not.toHaveBeenCalled();
+        expect(stripeTransactionRepository.updateByIdUnlessSettled).not.toHaveBeenCalled();
+      });
+
+      it.each(["succeeded", "refunded"] as const)("rejects a reused top-up key whose amount changed instead of replaying the %s row", async status => {
+        const { service, stripeTransactionRepository } = setup();
+        const transaction = generateDatabaseStripeTransaction({ amount: 5000, status, stripePaymentIntentId: "pi_replayed" });
+        stripeTransactionRepository.findOrCreateByIdempotencyKey.mockResolvedValue({ transaction, isNew: false });
+
+        await expect(service.createPaymentIntent(keyedParams)).rejects.toThrow(IDEMPOTENCY_KEY_MISMATCH_ERROR_MESSAGE);
+        expect(service.paymentIntents.create).not.toHaveBeenCalled();
+        expect(service.paymentIntents.retrieve).not.toHaveBeenCalled();
+      });
+
+      it("rejects a reused top-up key whose amount changed before resuming the recorded intent", async () => {
+        const { service, stripeTransactionRepository } = setup();
+        const transaction = generateDatabaseStripeTransaction({ amount: 5000, status: "pending", stripePaymentIntentId: "pi_live" });
+        stripeTransactionRepository.findOrCreateByIdempotencyKey.mockResolvedValue({ transaction, isNew: false });
+
+        await expect(service.createPaymentIntent(keyedParams)).rejects.toThrow(IDEMPOTENCY_KEY_MISMATCH_ERROR_MESSAGE);
+        expect(service.paymentIntents.retrieve).not.toHaveBeenCalled();
         expect(stripeTransactionRepository.updateByIdUnlessSettled).not.toHaveBeenCalled();
       });
 
@@ -314,6 +334,80 @@ describe(StripeService.name, () => {
           expect.objectContaining({ status: "failed", errorMessage: "socket hang up" })
         );
         expect(stripeTransactionRepository.updateById).not.toHaveBeenCalled();
+      });
+
+      describe("when a webhook settles the row mid-request", () => {
+        it("responds with the settled outcome when the guard suppresses the fresh-charge update", async () => {
+          const { service, stripeTransactionRepository } = setup();
+          const transaction = generateDatabaseStripeTransaction({ amount: 10000, status: "created", stripeIdempotencyKey: idempotencyKey });
+          stripeTransactionRepository.findOrCreateByIdempotencyKey.mockResolvedValue({ transaction, isNew: true });
+          stripeTransactionRepository.updateByIdUnlessSettled.mockResolvedValue(undefined);
+          stripeTransactionRepository.findById.mockResolvedValue({ ...transaction, status: "succeeded", stripePaymentIntentId: "pi_settled" });
+
+          const result = await service.createPaymentIntent(keyedParams);
+
+          expect(result).toEqual({
+            success: true,
+            paymentIntentId: "pi_settled",
+            transactionId: transaction.id,
+            transactionStatus: "succeeded"
+          });
+        });
+
+        it("responds with the settled outcome when the guard suppresses the resumed-intent update", async () => {
+          const { service, stripeTransactionRepository } = setup();
+          const transaction = generateDatabaseStripeTransaction({ amount: 10000, status: "pending", stripePaymentIntentId: "pi_live" });
+          stripeTransactionRepository.findOrCreateByIdempotencyKey.mockResolvedValue({ transaction, isNew: false });
+          vi.mocked(service.paymentIntents.retrieve).mockResolvedValue(createTestPaymentIntent({ id: "pi_live", status: "processing" }));
+          stripeTransactionRepository.updateByIdUnlessSettled.mockResolvedValue(undefined);
+          stripeTransactionRepository.findById.mockResolvedValue({ ...transaction, status: "succeeded" });
+
+          const result = await service.createPaymentIntent(keyedParams);
+
+          expect(result).toEqual({
+            success: true,
+            paymentIntentId: "pi_live",
+            transactionId: transaction.id,
+            transactionStatus: "succeeded"
+          });
+        });
+
+        it("responds with the settled outcome instead of throwing the stale decline", async () => {
+          const { service, stripeTransactionRepository } = setup();
+          const transaction = generateDatabaseStripeTransaction({ amount: 10000, status: "pending", stripePaymentIntentId: "pi_live" });
+          stripeTransactionRepository.findOrCreateByIdempotencyKey.mockResolvedValue({ transaction, isNew: false });
+          vi.mocked(service.paymentIntents.retrieve).mockResolvedValue(createTestPaymentIntent({ id: "pi_live", status: "requires_payment_method" }));
+          stripeTransactionRepository.updateByIdUnlessSettled.mockResolvedValue(undefined);
+          stripeTransactionRepository.findById.mockResolvedValue({ ...transaction, status: "succeeded" });
+
+          const result = await service.createPaymentIntent(keyedParams);
+
+          expect(result).toEqual(expect.objectContaining({ success: true, transactionStatus: "succeeded" }));
+        });
+
+        it("responds with the settled outcome instead of rethrowing a stale charge error", async () => {
+          const { service, stripeTransactionRepository } = setup();
+          const transaction = generateDatabaseStripeTransaction({ amount: 10000, status: "created", stripeIdempotencyKey: idempotencyKey });
+          stripeTransactionRepository.findOrCreateByIdempotencyKey.mockResolvedValue({ transaction, isNew: true });
+          vi.mocked(service.paymentIntents.create).mockRejectedValue(new Error("socket hang up"));
+          stripeTransactionRepository.updateByIdUnlessSettled.mockResolvedValue(undefined);
+          stripeTransactionRepository.findById.mockResolvedValue({ ...transaction, status: "succeeded", stripePaymentIntentId: "pi_settled" });
+
+          const result = await service.createPaymentIntent(keyedParams);
+
+          expect(result).toEqual(expect.objectContaining({ success: true, paymentIntentId: "pi_settled", transactionStatus: "succeeded" }));
+        });
+
+        it("rethrows the original error when the suppressed row is not actually settled", async () => {
+          const { service, stripeTransactionRepository } = setup();
+          const transaction = generateDatabaseStripeTransaction({ amount: 10000, status: "created", stripeIdempotencyKey: idempotencyKey });
+          stripeTransactionRepository.findOrCreateByIdempotencyKey.mockResolvedValue({ transaction, isNew: true });
+          vi.mocked(service.paymentIntents.create).mockRejectedValue(new Error("socket hang up"));
+          stripeTransactionRepository.updateByIdUnlessSettled.mockResolvedValue(undefined);
+          stripeTransactionRepository.findById.mockResolvedValue({ ...transaction, status: "failed" });
+
+          await expect(service.createPaymentIntent(keyedParams)).rejects.toThrow("socket hang up");
+        });
       });
     });
   });

--- a/apps/api/src/billing/services/stripe/stripe.service.ts
+++ b/apps/api/src/billing/services/stripe/stripe.service.ts
@@ -21,7 +21,7 @@ import {
   StripeTransactionRepository
 } from "@src/billing/repositories";
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
-import { PAYMENT_IN_PROGRESS_ERROR_MESSAGE } from "@src/billing/services/stripe-error/stripe-error.service";
+import { IDEMPOTENCY_KEY_MISMATCH_ERROR_MESSAGE, PAYMENT_IN_PROGRESS_ERROR_MESSAGE } from "@src/billing/services/stripe-error/stripe-error.service";
 import { type CreateLogger, LOGGER_FACTORY, WithTransaction } from "@src/core";
 import { TimerService } from "@src/core/services/timer/timer.service";
 import type { TransactionCsvRow } from "@src/types/transactions";
@@ -253,6 +253,8 @@ export class StripeService extends Stripe {
       hasPaymentIntent: !!transaction.stripePaymentIntentId
     });
 
+    this.#ensureReusedKeyAmountConsistency(transaction, params.idempotencyKey, amountInCents);
+
     if (SETTLED_TRANSACTION_STATUSES.has(transaction.status)) {
       this.loggerService.info({
         event: "PAYMENT_INTENT_REPLAY_SHORT_CIRCUIT",
@@ -271,8 +273,6 @@ export class StripeService extends Stripe {
     if (transaction.stripePaymentIntentId) {
       return await this.#resumeFromRecordedPaymentIntent(transaction, transaction.stripePaymentIntentId);
     }
-
-    this.#ensureReusedKeyAmountConsistency(transaction, params.idempotencyKey, amountInCents);
 
     return await this.#chargePaymentIntent(transaction, params);
   }
@@ -297,7 +297,12 @@ export class StripeService extends Stripe {
         }
 
         if (update.status) {
-          await this.stripeTransactionRepository.updateByIdUnlessSettled(transaction.id, update);
+          const updated = await this.stripeTransactionRepository.updateByIdUnlessSettled(transaction.id, update);
+
+          if (!updated) {
+            const settled = await this.#resultFromSettledWinner(transaction.id, paymentIntent.id);
+            if (settled) return settled;
+          }
         }
 
         return {
@@ -322,10 +327,15 @@ export class StripeService extends Stripe {
       default: {
         const message = paymentIntent.last_payment_error?.message ?? transaction.errorMessage ?? "Payment method was declined. Please try a different card.";
 
-        await this.stripeTransactionRepository.updateByIdUnlessSettled(transaction.id, {
+        const updated = await this.stripeTransactionRepository.updateByIdUnlessSettled(transaction.id, {
           status: this.mapPaymentIntentStatusToTransactionStatus(paymentIntent.status),
           errorMessage: message
         });
+
+        if (!updated) {
+          const settled = await this.#resultFromSettledWinner(transaction.id, paymentIntent.id);
+          if (settled) return settled;
+        }
 
         throw createError(402, message, { errorCode: "card_declined", errorType: "payment_error" });
       }
@@ -333,11 +343,11 @@ export class StripeService extends Stripe {
   }
 
   /**
-   * A reused key must charge the amount recorded on its row so Stripe's byte-identical replay
-   * contract holds. Top-up keys reject a changed amount because the client rotates its key whenever
-   * the amount changes, so a mismatch means a stale or misbehaving client. Wallet-reload keys
-   * tolerate it (the reload job recomputes a live amount on every redelivery of the same job id)
-   * and the charge proceeds with the recorded amount.
+   * A reused key must request the amount recorded on its row so a replay can never report success
+   * for a different amount than was charged. Top-up keys reject a changed amount as a definitive
+   * mismatch (the client rotates its key whenever the amount changes, so this only means a stale or
+   * misbehaving client). Wallet-reload keys tolerate it (the reload job recomputes a live amount on
+   * every redelivery of the same job id) and the flow proceeds with the recorded amount.
    */
   #ensureReusedKeyAmountConsistency(transaction: StripeTransactionOutput, idempotencyKey: string, requestedAmountInCents: number): void {
     if (transaction.amount === requestedAmountInCents) {
@@ -355,8 +365,34 @@ export class StripeService extends Stripe {
     });
 
     if (isTopUpKey) {
-      throw new Error(PAYMENT_IN_PROGRESS_ERROR_MESSAGE);
+      throw new Error(IDEMPOTENCY_KEY_MISMATCH_ERROR_MESSAGE);
     }
+  }
+
+  /**
+   * When updateByIdUnlessSettled() suppresses a write, a webhook settled the row mid-request and its
+   * outcome is authoritative. Responding from the request's now-stale view would report a credited
+   * payment as still pending (or as a failure), so the settled row drives the response instead.
+   */
+  async #resultFromSettledWinner(transactionId: string, fallbackPaymentIntentId?: string): Promise<PaymentIntentResult | undefined> {
+    const winner = await this.stripeTransactionRepository.findById(transactionId);
+
+    if (!winner || !SETTLED_TRANSACTION_STATUSES.has(winner.status)) {
+      return undefined;
+    }
+
+    this.loggerService.info({
+      event: "PAYMENT_INTENT_SETTLED_MID_REQUEST",
+      transactionId,
+      status: winner.status
+    });
+
+    return {
+      success: true,
+      paymentIntentId: winner.stripePaymentIntentId ?? fallbackPaymentIntentId,
+      transactionId: winner.id,
+      transactionStatus: winner.status
+    };
   }
 
   async #chargePaymentIntent(
@@ -390,7 +426,12 @@ export class StripeService extends Stripe {
         update.status = this.mapPaymentIntentStatusToTransactionStatus(paymentIntent.status);
       }
 
-      await this.stripeTransactionRepository.updateByIdUnlessSettled(transaction.id, update);
+      const updated = await this.stripeTransactionRepository.updateByIdUnlessSettled(transaction.id, update);
+
+      if (!updated) {
+        const settled = await this.#resultFromSettledWinner(transaction.id, paymentIntent.id);
+        if (settled) return settled;
+      }
 
       const transactionStatus = update.status ?? transaction.status;
 
@@ -431,11 +472,17 @@ export class StripeService extends Stripe {
         paymentIntentId = rawError.payment_intent?.id;
       }
 
-      await this.stripeTransactionRepository.updateByIdUnlessSettled(transaction.id, {
+      const updated = await this.stripeTransactionRepository.updateByIdUnlessSettled(transaction.id, {
         status: "failed",
         errorMessage: error instanceof Error ? error.message : "Unknown error",
         stripePaymentIntentId: paymentIntentId
       });
+
+      if (!updated) {
+        const settled = await this.#resultFromSettledWinner(transaction.id, paymentIntentId);
+        if (settled) return settled;
+      }
+
       throw error;
     }
   }

--- a/apps/api/src/billing/services/stripe/stripe.service.ts
+++ b/apps/api/src/billing/services/stripe/stripe.service.ts
@@ -4,6 +4,7 @@ import { ConstantBackoff, handleWhenResult, retry, TaskCancelledError, timeout, 
 import crypto from "crypto";
 import { stringify } from "csv-stringify";
 import assert from "http-assert";
+import createError from "http-errors";
 import difference from "lodash/difference";
 import keyBy from "lodash/keyBy";
 import orderBy from "lodash/orderBy";
@@ -12,8 +13,15 @@ import Stripe from "stripe";
 import { inject, singleton } from "tsyringe";
 
 import { PaymentIntentResult, PaymentMethodValidationResult, Transaction } from "@src/billing/http-schemas/stripe.schema";
-import { PaymentMethodRepository, StripeTransactionInput, StripeTransactionOutput, StripeTransactionRepository } from "@src/billing/repositories";
+import {
+  PaymentMethodRepository,
+  SETTLED_TRANSACTION_STATUSES,
+  StripeTransactionInput,
+  StripeTransactionOutput,
+  StripeTransactionRepository
+} from "@src/billing/repositories";
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
+import { PAYMENT_IN_PROGRESS_ERROR_MESSAGE } from "@src/billing/services/stripe-error/stripe-error.service";
 import { type CreateLogger, LOGGER_FACTORY, WithTransaction } from "@src/core";
 import { TimerService } from "@src/core/services/timer/timer.service";
 import type { TransactionCsvRow } from "@src/types/transactions";
@@ -32,6 +40,14 @@ interface StripePrices {
  */
 const STRIPE_CURRENCY = "usd";
 
+/**
+ * Prefix of the idempotency keys the confirm-payment controller builds from client attempt keys.
+ * The service uses it to tell strict top-up attempts (reject on amount change; the client rotates
+ * its key whenever the amount changes) from wallet auto-reload keys (tolerate a recomputed amount
+ * and charge the recorded one, since the reload job re-derives live amounts on every redelivery).
+ */
+export const TOP_UP_IDEMPOTENCY_KEY_PREFIX = "topup_";
+
 export type PaymentMethod = Stripe.PaymentMethod & { validated: boolean; isDefault: boolean };
 
 @singleton()
@@ -39,9 +55,12 @@ export class StripeService extends Stripe {
   readonly isProduction = this.billingConfig.get("STRIPE_SECRET_KEY").startsWith("sk_live");
 
   /**
-   * Statuses that should be applied later via Stripe webhooks.
+   * Statuses that should be applied later via Stripe webhooks. Both map to transaction status
+   * "succeeded", and writing that from the request path would make the webhook's
+   * `status !== "succeeded"` guard skip crediting the wallet: the customer would be charged
+   * without ever receiving credits.
    */
-  readonly #DEFERRED_STATUSES = new Set<Stripe.PaymentIntent.Status>(["succeeded"]);
+  readonly #DEFERRED_STATUSES = new Set<Stripe.PaymentIntent.Status>(["succeeded", "requires_capture"]);
   private readonly loggerService: LoggerService;
 
   constructor(
@@ -202,19 +221,153 @@ export class StripeService extends Stripe {
   }): Promise<PaymentIntentResult> {
     const amountInCents = Math.round(params.amount * 100);
 
-    const transaction = await this.stripeTransactionRepository.create({
+    if (!params.idempotencyKey) {
+      const transaction = await this.stripeTransactionRepository.create({
+        userId: params.userId,
+        type: "payment_intent",
+        status: "created",
+        amount: amountInCents,
+        currency: STRIPE_CURRENCY
+      });
+
+      return await this.#chargePaymentIntent(transaction, params);
+    }
+
+    const { transaction, isNew } = await this.stripeTransactionRepository.findOrCreateByIdempotencyKey({
       userId: params.userId,
       type: "payment_intent",
       status: "created",
       amount: amountInCents,
-      currency: STRIPE_CURRENCY
+      currency: STRIPE_CURRENCY,
+      stripeIdempotencyKey: params.idempotencyKey
     });
 
+    if (isNew) {
+      return await this.#chargePaymentIntent(transaction, params);
+    }
+
+    this.loggerService.info({
+      event: "PAYMENT_INTENT_KEY_REUSED",
+      transactionId: transaction.id,
+      status: transaction.status,
+      hasPaymentIntent: !!transaction.stripePaymentIntentId
+    });
+
+    if (SETTLED_TRANSACTION_STATUSES.has(transaction.status)) {
+      this.loggerService.info({
+        event: "PAYMENT_INTENT_REPLAY_SHORT_CIRCUIT",
+        transactionId: transaction.id,
+        status: transaction.status
+      });
+
+      return {
+        success: true,
+        paymentIntentId: transaction.stripePaymentIntentId ?? undefined,
+        transactionId: transaction.id,
+        transactionStatus: transaction.status
+      };
+    }
+
+    if (transaction.stripePaymentIntentId) {
+      return await this.#resumeFromRecordedPaymentIntent(transaction, transaction.stripePaymentIntentId);
+    }
+
+    this.#ensureReusedKeyAmountConsistency(transaction, params.idempotencyKey, amountInCents);
+
+    return await this.#chargePaymentIntent(transaction, params);
+  }
+
+  /**
+   * A row that already records a PaymentIntent must never create a second one: the live intent is
+   * retrieved and its current status drives the outcome. This keeps a replayed delivery from
+   * downgrading row state with a stale response, re-opening 3DS on a dead intent, or creating an
+   * extra charge after Stripe prunes the key (replays are only guaranteed for 24 hours).
+   */
+  async #resumeFromRecordedPaymentIntent(transaction: StripeTransactionOutput, stripePaymentIntentId: string): Promise<PaymentIntentResult> {
+    const paymentIntent = await this.paymentIntents.retrieve(stripePaymentIntentId);
+
+    switch (paymentIntent.status) {
+      case "succeeded":
+      case "requires_capture":
+      case "processing": {
+        const update: Partial<Pick<StripeTransactionInput, "status">> = {};
+
+        if (!this.#DEFERRED_STATUSES.has(paymentIntent.status)) {
+          update.status = this.mapPaymentIntentStatusToTransactionStatus(paymentIntent.status);
+        }
+
+        if (update.status) {
+          await this.stripeTransactionRepository.updateByIdUnlessSettled(transaction.id, update);
+        }
+
+        return {
+          success: true,
+          paymentIntentId: paymentIntent.id,
+          transactionId: transaction.id,
+          transactionStatus: update.status ?? transaction.status
+        };
+      }
+
+      case "requires_action":
+      case "requires_confirmation":
+        return {
+          success: false,
+          paymentIntentId: paymentIntent.id,
+          requiresAction: true,
+          clientSecret: paymentIntent.client_secret || undefined,
+          transactionId: transaction.id,
+          transactionStatus: transaction.status
+        };
+
+      default: {
+        const message = paymentIntent.last_payment_error?.message ?? transaction.errorMessage ?? "Payment method was declined. Please try a different card.";
+
+        await this.stripeTransactionRepository.updateByIdUnlessSettled(transaction.id, {
+          status: this.mapPaymentIntentStatusToTransactionStatus(paymentIntent.status),
+          errorMessage: message
+        });
+
+        throw createError(402, message, { errorCode: "card_declined", errorType: "payment_error" });
+      }
+    }
+  }
+
+  /**
+   * A reused key must charge the amount recorded on its row so Stripe's byte-identical replay
+   * contract holds. Top-up keys reject a changed amount because the client rotates its key whenever
+   * the amount changes, so a mismatch means a stale or misbehaving client. Wallet-reload keys
+   * tolerate it (the reload job recomputes a live amount on every redelivery of the same job id)
+   * and the charge proceeds with the recorded amount.
+   */
+  #ensureReusedKeyAmountConsistency(transaction: StripeTransactionOutput, idempotencyKey: string, requestedAmountInCents: number): void {
+    if (transaction.amount === requestedAmountInCents) {
+      return;
+    }
+
+    const isTopUpKey = idempotencyKey.startsWith(TOP_UP_IDEMPOTENCY_KEY_PREFIX);
+
+    this.loggerService.warn({
+      event: "PAYMENT_INTENT_KEY_AMOUNT_MISMATCH",
+      transactionId: transaction.id,
+      recordedAmount: transaction.amount,
+      requestedAmount: requestedAmountInCents,
+      isTopUpKey
+    });
+
+    if (isTopUpKey) {
+      throw new Error(PAYMENT_IN_PROGRESS_ERROR_MESSAGE);
+    }
+  }
+
+  async #chargePaymentIntent(
+    transaction: StripeTransactionOutput,
+    params: { customer: string; payment_method: string; confirm: boolean; metadata?: Record<string, string>; idempotencyKey?: string }
+  ): Promise<PaymentIntentResult> {
     const createOptions: Parameters<Stripe["paymentIntents"]["create"]> = [
       {
         customer: params.customer,
         payment_method: params.payment_method,
-        amount: amountInCents,
+        amount: transaction.amount,
         currency: STRIPE_CURRENCY,
         confirm: params.confirm,
         metadata: {
@@ -237,7 +390,7 @@ export class StripeService extends Stripe {
         update.status = this.mapPaymentIntentStatusToTransactionStatus(paymentIntent.status);
       }
 
-      await this.stripeTransactionRepository.updateById(transaction.id, update);
+      await this.stripeTransactionRepository.updateByIdUnlessSettled(transaction.id, update);
 
       const transactionStatus = update.status ?? transaction.status;
 
@@ -247,7 +400,6 @@ export class StripeService extends Stripe {
           return { success: true, paymentIntentId: paymentIntent.id, transactionId: transaction.id, transactionStatus };
 
         case "requires_action":
-          // Card requires 3D Secure authentication
           return {
             success: false,
             paymentIntentId: paymentIntent.id,
@@ -258,22 +410,28 @@ export class StripeService extends Stripe {
           };
 
         case "requires_payment_method":
-          // Card was declined
           throw new Error("Payment method was declined. Please try a different card.");
 
         default:
           throw new Error(`Payment failed with status: ${paymentIntent.status}`);
       }
     } catch (error) {
-      // Extract payment intent ID from Stripe error if available (e.g., card declined still creates a payment intent)
+      if (error instanceof Stripe.errors.StripeError && error.code === "idempotency_key_in_use") {
+        this.loggerService.warn({ event: "PAYMENT_INTENT_KEY_IN_USE", transactionId: transaction.id });
+        throw new Error(PAYMENT_IN_PROGRESS_ERROR_MESSAGE);
+      }
+
+      if (error instanceof Stripe.errors.StripeIdempotencyError) {
+        throw error;
+      }
+
       let paymentIntentId: string | undefined;
       if (error instanceof Stripe.errors.StripeError && error.raw) {
         const rawError = error.raw as { payment_intent?: Stripe.PaymentIntent };
         paymentIntentId = rawError.payment_intent?.id;
       }
 
-      // Update transaction with error status and payment intent ID if available
-      await this.stripeTransactionRepository.updateById(transaction.id, {
+      await this.stripeTransactionRepository.updateByIdUnlessSettled(transaction.id, {
         status: "failed",
         errorMessage: error instanceof Error ? error.message : "Unknown error",
         stripePaymentIntentId: paymentIntentId

--- a/apps/api/src/core/services/hono-error-handler/hono-error-handler.service.spec.ts
+++ b/apps/api/src/core/services/hono-error-handler/hono-error-handler.service.spec.ts
@@ -74,6 +74,21 @@ describe(HonoErrorHandlerService.name, () => {
     });
   });
 
+  describe("when an HttpError carries errorCode/errorType properties", () => {
+    it("serializes them instead of the status-derived fallbacks", async () => {
+      const { service, mockContext } = setup();
+      const error = createHttpError(409, "This payment was already requested with different parameters.", {
+        errorCode: "idempotency_key_mismatch",
+        errorType: "payment_error"
+      });
+
+      await service.handle(error, mockContext);
+
+      expect(mockContext.body).toHaveBeenCalledWith(expect.stringContaining('"code":"idempotency_key_mismatch"'), expect.objectContaining({ status: 409 }));
+      expect(mockContext.body).toHaveBeenCalledWith(expect.stringContaining('"type":"payment_error"'), expect.anything());
+    });
+  });
+
   describe("when error contains non-JSON values", () => {
     it("handles bigint values in http errors", async () => {
       const { service, mockContext } = setup();

--- a/apps/api/src/core/services/hono-error-handler/hono-error-handler.service.ts
+++ b/apps/api/src/core/services/hono-error-handler/hono-error-handler.service.ts
@@ -37,8 +37,8 @@ export class HonoErrorHandlerService {
 
     if (isHttpError(error)) {
       const { name } = error.constructor;
-      const errorCode = error.data?.errorCode || this.getErrorCode(error);
-      const errorType = error.data?.errorType || this.getErrorType(error);
+      const errorCode = error.data?.errorCode || error.errorCode || this.getErrorCode(error);
+      const errorType = error.data?.errorType || error.errorType || this.getErrorType(error);
 
       return this.unsafeJson(
         c,

--- a/apps/api/test/functional/stripe-transactions-confirm.spec.ts
+++ b/apps/api/test/functional/stripe-transactions-confirm.spec.ts
@@ -1,0 +1,104 @@
+import { faker } from "@faker-js/faker";
+import nock from "nock";
+import { container } from "tsyringe";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { UserAuthTokenService } from "@src/auth/services/user-auth-token/user-auth-token.service";
+import { StripeTransactionRepository } from "@src/billing/repositories";
+import { app } from "@src/rest-app";
+import { UserRepository } from "@src/user/repositories/user/user.repository";
+
+describe("Stripe transactions confirm", () => {
+  const userRepository = container.resolve(UserRepository);
+  const stripeTransactionRepository = container.resolve(StripeTransactionRepository);
+  const userAuthTokenService = container.resolve(UserAuthTokenService);
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    nock.cleanAll();
+  });
+
+  describe("POST /v1/stripe/transactions/confirm", () => {
+    it("threads the namespaced idempotency key through to Stripe and records it on the transaction row", async () => {
+      const { user, token, stripeCustomerId, paymentMethodId } = await setup();
+      const clientKey = faker.string.uuid();
+      const namespacedKey = `topup_${user.id}_${clientKey}`;
+      const paymentIntentId = `pi_${faker.string.alphanumeric(24)}`;
+
+      nock("https://api.stripe.com")
+        .get(`/v1/payment_methods/${paymentMethodId}`)
+        .reply(200, { id: paymentMethodId, object: "payment_method", customer: stripeCustomerId });
+      nock("https://api.stripe.com")
+        .post("/v1/payment_intents")
+        .matchHeader("idempotency-key", namespacedKey)
+        .reply(200, { id: paymentIntentId, object: "payment_intent", status: "succeeded", amount: 2000, currency: "usd" });
+
+      const response = await confirmPayment(token, { userId: user.userId!, paymentMethodId, amount: 20, idempotencyKey: clientKey });
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.data).toEqual(expect.objectContaining({ success: true }));
+      expect(await stripeTransactionRepository.findById(body.data.transactionId)).toMatchObject({
+        userId: user.id,
+        stripeIdempotencyKey: namespacedKey,
+        stripePaymentIntentId: paymentIntentId,
+        amount: 2000
+      });
+      expect(nock.isDone()).toBe(true);
+    });
+
+    it("replays an already-credited attempt without creating another payment intent", async () => {
+      const { user, token, stripeCustomerId, paymentMethodId } = await setup();
+      const clientKey = faker.string.uuid();
+      const namespacedKey = `topup_${user.id}_${clientKey}`;
+
+      const creditedTransaction = await stripeTransactionRepository.create({
+        userId: user.id,
+        type: "payment_intent",
+        status: "succeeded",
+        amount: 2000,
+        currency: "usd",
+        stripePaymentIntentId: `pi_${faker.string.alphanumeric(24)}`,
+        stripeIdempotencyKey: namespacedKey
+      });
+
+      nock("https://api.stripe.com")
+        .get(`/v1/payment_methods/${paymentMethodId}`)
+        .reply(200, { id: paymentMethodId, object: "payment_method", customer: stripeCustomerId });
+
+      const response = await confirmPayment(token, { userId: user.userId!, paymentMethodId, amount: 20, idempotencyKey: clientKey });
+
+      expect(response.status).toBe(200);
+      expect((await response.json()).data).toEqual(
+        expect.objectContaining({
+          success: true,
+          transactionId: creditedTransaction.id,
+          transactionStatus: "succeeded"
+        })
+      );
+      expect(await stripeTransactionRepository.find({ userId: user.id })).toHaveLength(1);
+    });
+  });
+
+  async function confirmPayment(token: string, data: { userId: string; paymentMethodId: string; amount: number; idempotencyKey?: string }) {
+    return await app.request("/v1/stripe/transactions/confirm", {
+      method: "POST",
+      body: JSON.stringify({ data }),
+      headers: new Headers({
+        "Content-Type": "application/json",
+        authorization: `Bearer ${token}`
+      })
+    });
+  }
+
+  async function setup() {
+    const stripeCustomerId = `cus_${faker.string.alphanumeric(14)}`;
+    const user = await userRepository.create({ userId: faker.string.uuid(), stripeCustomerId });
+    const token = faker.string.alphanumeric(40);
+    const paymentMethodId = `pm_${faker.string.alphanumeric(24)}`;
+
+    vi.spyOn(userAuthTokenService, "getValidUserId").mockImplementation(async received => (received.replace(/^Bearer +/i, "") === token ? user.userId! : null));
+
+    return { user, token, stripeCustomerId, paymentMethodId };
+  }
+});

--- a/apps/api/test/functional/stripe-transactions-confirm.spec.ts
+++ b/apps/api/test/functional/stripe-transactions-confirm.spec.ts
@@ -65,6 +65,7 @@ describe("Stripe transactions confirm", () => {
       nock("https://api.stripe.com")
         .get(`/v1/payment_methods/${paymentMethodId}`)
         .reply(200, { id: paymentMethodId, object: "payment_method", customer: stripeCustomerId });
+      const paymentIntentCreateScope = nock("https://api.stripe.com").post("/v1/payment_intents").reply(500);
 
       const response = await confirmPayment(token, { userId: user.userId!, paymentMethodId, amount: 20, idempotencyKey: clientKey });
 
@@ -77,6 +78,7 @@ describe("Stripe transactions confirm", () => {
         })
       );
       expect(await stripeTransactionRepository.find({ userId: user.id })).toHaveLength(1);
+      expect(paymentIntentCreateScope.isDone()).toBe(false);
     });
   });
 

--- a/apps/api/test/functional/stripe-transactions-confirm.spec.ts
+++ b/apps/api/test/functional/stripe-transactions-confirm.spec.ts
@@ -80,6 +80,29 @@ describe("Stripe transactions confirm", () => {
       expect(await stripeTransactionRepository.find({ userId: user.id })).toHaveLength(1);
       expect(paymentIntentCreateScope.isDone()).toBe(false);
     });
+
+    it("rejects a replayed key whose amount changed with a definitive idempotency_key_mismatch code", async () => {
+      const { user, token, stripeCustomerId, paymentMethodId } = await setup();
+      const clientKey = faker.string.uuid();
+
+      await stripeTransactionRepository.create({
+        userId: user.id,
+        type: "payment_intent",
+        status: "created",
+        amount: 2000,
+        currency: "usd",
+        stripeIdempotencyKey: `topup_${user.id}_${clientKey}`
+      });
+
+      nock("https://api.stripe.com")
+        .get(`/v1/payment_methods/${paymentMethodId}`)
+        .reply(200, { id: paymentMethodId, object: "payment_method", customer: stripeCustomerId });
+
+      const response = await confirmPayment(token, { userId: user.userId!, paymentMethodId, amount: 25, idempotencyKey: clientKey });
+
+      expect(response.status).toBe(409);
+      expect(await response.json()).toEqual(expect.objectContaining({ code: "idempotency_key_mismatch" }));
+    });
   });
 
   async function confirmPayment(token: string, data: { userId: string; paymentMethodId: string; amount: number; idempotencyKey?: string }) {

--- a/apps/api/test/seeders/database-stripe-transaction.seeder.ts
+++ b/apps/api/test/seeders/database-stripe-transaction.seeder.ts
@@ -17,6 +17,7 @@ export function generateDatabaseStripeTransaction(overrides: Partial<StripeTrans
     stripeCouponId: null,
     stripePromotionCodeId: null,
     stripeInvoiceId: null,
+    stripeIdempotencyKey: null,
     paymentMethodType: null,
     cardBrand: null,
     cardLast4: null,

--- a/apps/deploy-web/src/components/billing-usage/AddCreditsForm/AddCreditsForm.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AddCreditsForm/AddCreditsForm.spec.tsx
@@ -1,11 +1,13 @@
 import React, { useContext, useImperativeHandle } from "react";
 import type { PaymentMethod } from "@akashnetwork/http-sdk";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import { getPaymentMethodDisplay } from "@src/components/shared/PaymentMethodCard/PaymentMethodCard";
+import type { WalletBalance } from "@src/hooks/useWalletBalance";
 import { QueryKeys } from "@src/queries";
 import type { AnalyticsService } from "@src/services/analytics/analytics.service";
+import { handleStripeError } from "@src/utils/stripeErrorHandler";
 import { AddCreditsAmountFields } from "../AddCreditsAmountFields/AddCreditsAmountFields";
 import type { PaymentMethodSourceHandle } from "../AddCreditsNewPaymentMethodFields/AddCreditsNewPaymentMethodFields";
 import type { DEPENDENCIES } from "./AddCreditsForm";
@@ -13,7 +15,13 @@ import { AddCreditsForm } from "./AddCreditsForm";
 
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 describe(AddCreditsForm.name, () => {
+  afterEach(() => {
+    window.sessionStorage.clear();
+  });
+
   it("creates a setup intent on mount when the user has no saved payment methods", () => {
     const mutate = vi.fn();
     setup({ status: "idle", mutate });
@@ -88,7 +96,7 @@ describe(AddCreditsForm.name, () => {
     });
 
     expect(addPaymentMethod).not.toHaveBeenCalled();
-    expect(confirmPayment).toHaveBeenCalledWith({ userId: "user_1", paymentMethodId: "pm_saved", amount: 100 });
+    expect(confirmPayment).toHaveBeenCalledWith({ userId: "user_1", paymentMethodId: "pm_saved", amount: 100, idempotencyKey: expect.any(String) });
   });
 
   it("passes a loading flag to the payment-method fields while the setup intent is being prepared", () => {
@@ -127,7 +135,7 @@ describe(AddCreditsForm.name, () => {
     });
 
     expect(addPaymentMethod).toHaveBeenCalledTimes(1);
-    expect(confirmPayment).toHaveBeenCalledWith({ userId: "user_1", paymentMethodId: "pm_1", amount: 100 });
+    expect(confirmPayment).toHaveBeenCalledWith({ userId: "user_1", paymentMethodId: "pm_1", amount: 100, idempotencyKey: expect.any(String) });
     expect(pollForPayment).toHaveBeenCalledTimes(1);
     expect(onDone).not.toHaveBeenCalled();
   });
@@ -308,7 +316,9 @@ describe(AddCreditsForm.name, () => {
       rerender({ status: "success", clientSecret: "seti_secret", confirmPayment, isWalletReady: true });
     });
 
-    await waitFor(() => expect(confirmPayment).toHaveBeenCalledWith({ userId: "user_1", paymentMethodId: "pm_1", amount: 100 }));
+    await waitFor(() =>
+      expect(confirmPayment).toHaveBeenCalledWith({ userId: "user_1", paymentMethodId: "pm_1", amount: 100, idempotencyKey: expect.any(String) })
+    );
   });
 
   it("does not call the API when addPaymentMethod resolves null", async () => {
@@ -464,7 +474,7 @@ describe(AddCreditsForm.name, () => {
       fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
     });
 
-    expect(confirmPayment).toHaveBeenCalledWith({ userId: "user_1", paymentMethodId: "pm_saved", amount: 50 });
+    expect(confirmPayment).toHaveBeenCalledWith({ userId: "user_1", paymentMethodId: "pm_saved", amount: 50, idempotencyKey: expect.any(String) });
   });
 
   it("shows a notice and falls back to new-card entry when saved payment methods fail to load", () => {
@@ -506,7 +516,7 @@ describe(AddCreditsForm.name, () => {
 
     expect(addPaymentMethod).toHaveBeenCalledTimes(1);
     expect(confirmPayment).toHaveBeenCalledTimes(2);
-    expect(confirmPayment).toHaveBeenLastCalledWith({ userId: "user_1", paymentMethodId: "pm_new", amount: 100 });
+    expect(confirmPayment).toHaveBeenLastCalledWith({ userId: "user_1", paymentMethodId: "pm_new", amount: 100, idempotencyKey: expect.any(String) });
   });
 
   it("invalidates the payment methods query when a new-card charge fails", async () => {
@@ -646,6 +656,272 @@ describe(AddCreditsForm.name, () => {
     expect(cardEvents).toHaveLength(2);
   });
 
+  it("sends a uuid attempt key with the charge", async () => {
+    const confirmPayment = vi.fn().mockResolvedValue({ success: true });
+    setup({ status: "idle", confirmPayment, paymentMethods: [paymentMethod({ id: "pm_saved", isDefault: true })] });
+
+    fireEvent.click(screen.getByRole("radio", { name: "100" }));
+
+    await act(async () => {
+      fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
+    });
+
+    expect(confirmPayment.mock.calls[0][0].idempotencyKey).toMatch(UUID_PATTERN);
+  });
+
+  it("reuses the same key when retrying after unknown-outcome failures", async () => {
+    const confirmPayment = vi
+      .fn()
+      .mockRejectedValueOnce({ response: { status: 500 } })
+      .mockRejectedValueOnce(new Error("network down"))
+      .mockResolvedValue({ success: true });
+    setup({ status: "idle", confirmPayment, paymentMethods: [paymentMethod({ id: "pm_saved", isDefault: true })] });
+
+    fireEvent.click(screen.getByRole("radio", { name: "100" }));
+
+    for (let attempt = 0; attempt < 3; attempt++) {
+      await act(async () => {
+        fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
+      });
+    }
+
+    expect(confirmPayment).toHaveBeenCalledTimes(3);
+    const keys = confirmPayment.mock.calls.map(call => call[0].idempotencyKey);
+    expect(new Set(keys).size).toBe(1);
+  });
+
+  it("rotates the key after a definitive 402 decline", async () => {
+    const confirmPayment = vi
+      .fn()
+      .mockRejectedValueOnce({ response: { status: 402, data: { code: "card_declined" } } })
+      .mockResolvedValue({ success: true });
+    setup({ status: "idle", confirmPayment, paymentMethods: [paymentMethod({ id: "pm_saved", isDefault: true })] });
+
+    fireEvent.click(screen.getByRole("radio", { name: "100" }));
+
+    await act(async () => {
+      fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
+    });
+    await act(async () => {
+      fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
+    });
+
+    const keys = confirmPayment.mock.calls.map(call => call[0].idempotencyKey);
+    expect(keys[0]).toMatch(UUID_PATTERN);
+    expect(keys[1]).toMatch(UUID_PATTERN);
+    expect(keys[1]).not.toBe(keys[0]);
+  });
+
+  it("rotates the key when the amount changes between attempts", async () => {
+    const confirmPayment = vi.fn().mockRejectedValue({ response: { status: 500 } });
+    setup({ status: "idle", confirmPayment, paymentMethods: [paymentMethod({ id: "pm_saved", isDefault: true })] });
+
+    fireEvent.change(screen.getByLabelText(/custom-amount/i), { target: { value: "100" } });
+    await act(async () => {
+      fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
+    });
+
+    fireEvent.change(screen.getByLabelText(/custom-amount/i), { target: { value: "200" } });
+    await act(async () => {
+      fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
+    });
+
+    expect(confirmPayment).toHaveBeenLastCalledWith(expect.objectContaining({ amount: 200 }));
+    const keys = confirmPayment.mock.calls.map(call => call[0].idempotencyKey);
+    expect(keys[1]).not.toBe(keys[0]);
+  });
+
+  it("retries the polling-timeout attempt with the same key", async () => {
+    const confirmPayment = vi.fn().mockResolvedValue({ success: true });
+    const methods = [paymentMethod({ id: "pm_saved", isDefault: true })];
+    const { rerender } = setup({ status: "idle", confirmPayment, isTrialing: true, isPolling: false, paymentMethods: methods });
+
+    fireEvent.click(screen.getByRole("radio", { name: "100" }));
+
+    await act(async () => {
+      fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
+    });
+
+    rerender({ status: "idle", confirmPayment, isTrialing: true, isPolling: true, paymentMethods: methods });
+    rerender({ status: "idle", confirmPayment, isTrialing: true, isPolling: false, paymentMethods: methods });
+
+    expect(await screen.findByText(/payment did not complete in time/i)).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
+    });
+
+    expect(confirmPayment).toHaveBeenCalledTimes(2);
+    const keys = confirmPayment.mock.calls.map(call => call[0].idempotencyKey);
+    expect(keys[1]).toBe(keys[0]);
+  });
+
+  it("mints a fresh key for the next purchase after the flow completes", async () => {
+    const confirmPayment = vi.fn().mockResolvedValue({ success: true });
+    const onDone = vi.fn();
+    const methods = [paymentMethod({ id: "pm_saved", isDefault: true })];
+    const { rerender } = setup({ status: "idle", confirmPayment, onDone, isTrialing: true, isPolling: false, paymentMethods: methods });
+
+    fireEvent.click(screen.getByRole("radio", { name: "100" }));
+
+    await act(async () => {
+      fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
+    });
+
+    rerender({ status: "idle", confirmPayment, onDone, isTrialing: true, isPolling: true, paymentMethods: methods });
+    rerender({ status: "idle", confirmPayment, onDone, isTrialing: false, isPolling: false, paymentMethods: methods });
+
+    await waitFor(() => expect(onDone).toHaveBeenCalled());
+
+    await act(async () => {
+      fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
+    });
+
+    expect(confirmPayment).toHaveBeenCalledTimes(2);
+    const keys = confirmPayment.mock.calls.map(call => call[0].idempotencyKey);
+    expect(keys[1]).not.toBe(keys[0]);
+  });
+
+  it("replays the same key after a remount with identical purchase params", async () => {
+    const confirmPayment = vi.fn().mockRejectedValue({ response: { status: 500 } });
+    const methods = [paymentMethod({ id: "pm_saved", isDefault: true })];
+    const first = setup({ status: "idle", confirmPayment, paymentMethods: methods });
+
+    fireEvent.click(screen.getByRole("radio", { name: "100" }));
+    await act(async () => {
+      fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
+    });
+    first.unmount();
+
+    setup({ status: "idle", confirmPayment, paymentMethods: methods });
+    fireEvent.click(screen.getByRole("radio", { name: "100" }));
+    await act(async () => {
+      fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
+    });
+
+    expect(confirmPayment).toHaveBeenCalledTimes(2);
+    const keys = confirmPayment.mock.calls.map(call => call[0].idempotencyKey);
+    expect(keys[1]).toBe(keys[0]);
+  });
+
+  it("does not reuse the persisted key when the amount differs after a remount", async () => {
+    const confirmPayment = vi.fn().mockRejectedValue({ response: { status: 500 } });
+    const methods = [paymentMethod({ id: "pm_saved", isDefault: true })];
+    const first = setup({ status: "idle", confirmPayment, paymentMethods: methods });
+
+    fireEvent.click(screen.getByRole("radio", { name: "100" }));
+    await act(async () => {
+      fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
+    });
+    first.unmount();
+
+    setup({ status: "idle", confirmPayment, paymentMethods: methods });
+    fireEvent.change(screen.getByLabelText(/custom-amount/i), { target: { value: "200" } });
+    await act(async () => {
+      fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
+    });
+
+    expect(confirmPayment).toHaveBeenCalledTimes(2);
+    const keys = confirmPayment.mock.calls.map(call => call[0].idempotencyKey);
+    expect(keys[1]).not.toBe(keys[0]);
+  });
+
+  it("starts polling from the pre-charge baseline when the server replays an already-credited attempt", async () => {
+    const confirmPayment = vi.fn().mockResolvedValue({ success: true, transactionStatus: "succeeded" });
+    const pollForPayment = vi.fn();
+    setup({ status: "idle", confirmPayment, pollForPayment, walletBalanceUsd: 500, paymentMethods: [paymentMethod({ id: "pm_saved", isDefault: true })] });
+
+    fireEvent.click(screen.getByRole("radio", { name: "100" }));
+
+    await act(async () => {
+      fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
+    });
+
+    expect(pollForPayment).toHaveBeenCalledWith({ initialBalance: 400 });
+  });
+
+  it("polls with the default baseline on a fresh successful charge", async () => {
+    const confirmPayment = vi.fn().mockResolvedValue({ success: true, transactionStatus: "pending" });
+    const pollForPayment = vi.fn();
+    setup({ status: "idle", confirmPayment, pollForPayment, walletBalanceUsd: 500, paymentMethods: [paymentMethod({ id: "pm_saved", isDefault: true })] });
+
+    fireEvent.click(screen.getByRole("radio", { name: "100" }));
+
+    await act(async () => {
+      fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
+    });
+
+    expect(pollForPayment).toHaveBeenCalledWith();
+  });
+
+  it("keeps the key and shows the still-processing copy on a 409 conflict", async () => {
+    const confirmPayment = vi
+      .fn()
+      .mockRejectedValueOnce({ response: { status: 409, data: { code: "conflict", message: "A payment for this request is already in progress." } } })
+      .mockResolvedValue({ success: true });
+    setup({ status: "idle", confirmPayment, handleStripeError, paymentMethods: [paymentMethod({ id: "pm_saved", isDefault: true })] });
+
+    fireEvent.click(screen.getByRole("radio", { name: "100" }));
+
+    await act(async () => {
+      fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
+    });
+
+    expect(await screen.findByText("Your payment is still being processed.")).toBeInTheDocument();
+    expect(screen.getByText("Wait a moment, then check your balance before retrying.")).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
+    });
+
+    const keys = confirmPayment.mock.calls.map(call => call[0].idempotencyKey);
+    expect(keys[1]).toBe(keys[0]);
+  });
+
+  it("keeps the key when 3D Secure fails so the retry resumes the same attempt", async () => {
+    const confirmPayment = vi.fn().mockResolvedValue({ requiresAction: true, clientSecret: "pi_secret", paymentIntentId: "pi_1" });
+    let threeDSecureOptions: Parameters<typeof DEPENDENCIES.use3DSecure>[0] | undefined;
+    const use3DSecure: typeof DEPENDENCIES.use3DSecure = options => {
+      threeDSecureOptions = options;
+      return mock<ReturnType<typeof DEPENDENCIES.use3DSecure>>({
+        isOpen: false,
+        threeDSData: null,
+        isLoading: false,
+        start3DSecure: vi.fn(),
+        close3DSecure: vi.fn(),
+        handle3DSSuccess: vi.fn(),
+        handle3DSError: vi.fn()
+      });
+    };
+
+    setup({
+      status: "idle",
+      confirmPayment,
+      paymentMethods: [paymentMethod({ id: "pm_saved", isDefault: true })],
+      dependencies: { use3DSecure }
+    });
+
+    fireEvent.click(screen.getByRole("radio", { name: "100" }));
+
+    await act(async () => {
+      fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
+    });
+
+    await act(async () => {
+      threeDSecureOptions?.onError?.("Authentication failed");
+    });
+
+    expect(await screen.findByText("Authentication failed")).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
+    });
+
+    expect(confirmPayment).toHaveBeenCalledTimes(2);
+    const keys = confirmPayment.mock.calls.map(call => call[0].idempotencyKey);
+    expect(keys[1]).toBe(keys[0]);
+  });
+
   function makePaymentMethodFieldsMock(addPaymentMethod: PaymentMethodSourceHandle["addPaymentMethod"] = vi.fn().mockResolvedValue(null)) {
     const propsLog: Array<{ clientSecret?: string; isLoading: boolean }> = [];
     const Mock: typeof DEPENDENCIES.AddCreditsNewPaymentMethodFields = React.forwardRef<
@@ -728,6 +1004,7 @@ describe(AddCreditsForm.name, () => {
     isTrialing?: boolean;
     isPolling?: boolean;
     isWalletReady?: boolean;
+    walletBalanceUsd?: number;
     paymentMethods?: PaymentMethod[];
     isLoadingMethods?: boolean;
     isMethodsError?: boolean;
@@ -765,6 +1042,11 @@ describe(AddCreditsForm.name, () => {
 
     const useWallet: typeof DEPENDENCIES.useWallet = () =>
       mock<ReturnType<typeof DEPENDENCIES.useWallet>>({ isTrialing: input.isTrialing ?? false, topUpMinAmountUsd: input.topUpMinAmountUsd ?? 20 });
+
+    const useWalletBalance: typeof DEPENDENCIES.useWalletBalance = () =>
+      mock<ReturnType<typeof DEPENDENCIES.useWalletBalance>>({
+        balance: input.walletBalanceUsd != null ? mock<WalletBalance>({ totalUsd: input.walletBalanceUsd }) : null
+      });
 
     const useQueryClient: typeof DEPENDENCIES.useQueryClient = () =>
       mock<ReturnType<typeof DEPENDENCIES.useQueryClient>>({
@@ -822,6 +1104,7 @@ describe(AddCreditsForm.name, () => {
           useQueryClient,
           useServices,
           useWallet,
+          useWalletBalance,
           use3DSecure,
           getPaymentMethodDisplay,
           handleStripeError: input.handleStripeError ?? (() => ({ message: "fallback", userAction: undefined })),

--- a/apps/deploy-web/src/components/billing-usage/AddCreditsForm/AddCreditsForm.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AddCreditsForm/AddCreditsForm.spec.tsx
@@ -261,7 +261,7 @@ describe(AddCreditsForm.name, () => {
     await waitFor(() => expect(onDone).toHaveBeenCalledWith(100, "Acme", 0));
   });
 
-  it("shows an error when polling stops without the trial flipping", async () => {
+  it("shows an error when polling confirms payment but the trial does not flip", async () => {
     const confirmPayment = vi.fn().mockResolvedValue({ success: true });
     const onDone = vi.fn();
     const addPaymentMethod = vi.fn().mockResolvedValue({ paymentMethodId: "pm_1", organization: "Acme" });
@@ -742,10 +742,8 @@ describe(AddCreditsForm.name, () => {
       fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
     });
 
-    rerender({ status: "idle", confirmPayment, isTrialing: true, isPolling: true, paymentMethods: methods });
-    rerender({ status: "idle", confirmPayment, isTrialing: true, isPolling: false, paymentMethods: methods });
-
-    expect(await screen.findByText(/payment did not complete in time/i)).toBeInTheDocument();
+    rerender({ status: "idle", confirmPayment, isTrialing: true, isPolling: true, lastOutcome: null, paymentMethods: methods });
+    rerender({ status: "idle", confirmPayment, isTrialing: true, isPolling: false, lastOutcome: "timeout", paymentMethods: methods });
 
     await act(async () => {
       fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
@@ -754,6 +752,86 @@ describe(AddCreditsForm.name, () => {
     expect(confirmPayment).toHaveBeenCalledTimes(2);
     const keys = confirmPayment.mock.calls.map(call => call[0].idempotencyKey);
     expect(keys[1]).toBe(keys[0]);
+  });
+
+  it("does not complete or rotate the key when polling exhausts without confirming the payment", async () => {
+    const confirmPayment = vi.fn().mockResolvedValue({ success: true });
+    const onDone = vi.fn();
+    const methods = [paymentMethod({ id: "pm_saved", isDefault: true })];
+    const { rerender } = setup({ status: "idle", confirmPayment, onDone, isTrialing: false, isPolling: false, paymentMethods: methods });
+
+    fireEvent.click(screen.getByRole("radio", { name: "100" }));
+
+    await act(async () => {
+      fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
+    });
+
+    rerender({ status: "idle", confirmPayment, onDone, isTrialing: false, isPolling: true, lastOutcome: null, paymentMethods: methods });
+    rerender({ status: "idle", confirmPayment, onDone, isTrialing: false, isPolling: false, lastOutcome: "timeout", paymentMethods: methods });
+
+    expect(onDone).not.toHaveBeenCalled();
+    expect(screen.queryByText(/payment did not complete in time/i)).not.toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
+    });
+
+    const keys = confirmPayment.mock.calls.map(call => call[0].idempotencyKey);
+    expect(keys[1]).toBe(keys[0]);
+  });
+
+  it("does not reuse a stored attempt key older than the 24h replay window", async () => {
+    const confirmPayment = vi.fn().mockResolvedValue({ success: true });
+    const staleKey = "11111111-2222-4333-8444-555555555555";
+    window.sessionStorage.setItem(
+      "add-credits-attempt",
+      JSON.stringify({ key: staleKey, amountCents: 10000, paymentMethodId: "pm_saved", userId: "user_1", createdAt: Date.now() - 25 * 60 * 60 * 1000 })
+    );
+    setup({ status: "idle", confirmPayment, paymentMethods: [paymentMethod({ id: "pm_saved", isDefault: true })] });
+
+    fireEvent.click(screen.getByRole("radio", { name: "100" }));
+    await act(async () => {
+      fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
+    });
+
+    expect(confirmPayment.mock.calls[0][0].idempotencyKey).not.toBe(staleKey);
+  });
+
+  it("reuses a stored attempt key that is still inside the 24h replay window", async () => {
+    const confirmPayment = vi.fn().mockResolvedValue({ success: true });
+    const recentKey = "11111111-2222-4333-8444-555555555555";
+    window.sessionStorage.setItem(
+      "add-credits-attempt",
+      JSON.stringify({ key: recentKey, amountCents: 10000, paymentMethodId: "pm_saved", userId: "user_1", createdAt: Date.now() - 23 * 60 * 60 * 1000 })
+    );
+    setup({ status: "idle", confirmPayment, paymentMethods: [paymentMethod({ id: "pm_saved", isDefault: true })] });
+
+    fireEvent.click(screen.getByRole("radio", { name: "100" }));
+    await act(async () => {
+      fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
+    });
+
+    expect(confirmPayment.mock.calls[0][0].idempotencyKey).toBe(recentKey);
+  });
+
+  it("rotates the key after a definitive 409 idempotency-key mismatch", async () => {
+    const confirmPayment = vi
+      .fn()
+      .mockRejectedValueOnce({ response: { status: 409, data: { code: "idempotency_key_mismatch", message: "mismatch" } } })
+      .mockResolvedValue({ success: true });
+    setup({ status: "idle", confirmPayment, paymentMethods: [paymentMethod({ id: "pm_saved", isDefault: true })] });
+
+    fireEvent.click(screen.getByRole("radio", { name: "100" }));
+
+    await act(async () => {
+      fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
+    });
+    await act(async () => {
+      fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
+    });
+
+    const keys = confirmPayment.mock.calls.map(call => call[0].idempotencyKey);
+    expect(keys[1]).not.toBe(keys[0]);
   });
 
   it("mints a fresh key for the next purchase after the flow completes", async () => {
@@ -1003,6 +1081,7 @@ describe(AddCreditsForm.name, () => {
     onProcessingChange?: (isProcessing: boolean) => void;
     isTrialing?: boolean;
     isPolling?: boolean;
+    lastOutcome?: ReturnType<typeof DEPENDENCIES.usePaymentPolling>["lastOutcome"];
     isWalletReady?: boolean;
     walletBalanceUsd?: number;
     paymentMethods?: PaymentMethod[];
@@ -1037,7 +1116,8 @@ describe(AddCreditsForm.name, () => {
       mock<ReturnType<typeof DEPENDENCIES.usePaymentPolling>>({
         pollForPayment: input.pollForPayment ?? vi.fn(),
         stopPolling: vi.fn(),
-        isPolling: input.isPolling ?? false
+        isPolling: input.isPolling ?? false,
+        lastOutcome: input.lastOutcome === undefined ? "success" : input.lastOutcome
       });
 
     const useWallet: typeof DEPENDENCIES.useWallet = () =>

--- a/apps/deploy-web/src/components/billing-usage/AddCreditsForm/AddCreditsForm.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AddCreditsForm/AddCreditsForm.tsx
@@ -28,6 +28,7 @@ import { useServices } from "@src/context/ServicesProvider";
 import { useWallet } from "@src/context/WalletProvider";
 import { use3DSecure } from "@src/hooks/use3DSecure";
 import { useUser } from "@src/hooks/useUser";
+import { useWalletBalance } from "@src/hooks/useWalletBalance";
 import { QueryKeys, usePaymentMethodsQuery, usePaymentMutations, useSetupIntentMutation } from "@src/queries";
 import { handleStripeError } from "@src/utils/stripeErrorHandler";
 
@@ -53,6 +54,7 @@ export const DEPENDENCIES = {
   useQueryClient,
   useServices,
   useWallet,
+  useWalletBalance,
   use3DSecure,
   useUser,
   getPaymentMethodDisplay,
@@ -72,6 +74,59 @@ interface PendingCharge {
   amount: number;
   wasTrialing: boolean;
   status: "pending" | "charging";
+  idempotencyKey: string;
+}
+
+interface StoredAttempt {
+  key: string;
+  amountCents: number;
+  paymentMethodId: string;
+  userId: string;
+  createdAt: number;
+}
+
+/** Attempt keys persist per tab so closing and reopening the errored sheet (which unmounts the form) retries the same attempt instead of minting a fresh charge. */
+const ATTEMPT_STORAGE_KEY = "add-credits-attempt";
+
+/** A stored attempt older than this is treated as a new purchase, not a retry; Stripe only replays a key for 24h anyway. */
+const ATTEMPT_MAX_AGE_MS = 60 * 60 * 1000;
+
+/** sessionStorage access throws in some privacy modes; attempt-key persistence is best-effort and must never break the purchase flow. */
+function safeSessionStorage<T>(operation: () => T): T | undefined {
+  try {
+    return operation();
+  } catch {
+    return undefined;
+  }
+}
+
+function readStoredAttemptKey(input: { userId: string; amountCents: number; paymentMethodId: string }): string | null {
+  const raw = safeSessionStorage(() => window.sessionStorage.getItem(ATTEMPT_STORAGE_KEY));
+  if (!raw) return null;
+
+  const stored = safeSessionStorage(() => JSON.parse(raw) as StoredAttempt);
+  if (!stored) return null;
+
+  const isCurrentAttempt =
+    stored.userId === input.userId &&
+    stored.amountCents === input.amountCents &&
+    stored.paymentMethodId === input.paymentMethodId &&
+    Date.now() - stored.createdAt < ATTEMPT_MAX_AGE_MS;
+
+  return isCurrentAttempt ? stored.key : null;
+}
+
+function writeStoredAttempt(attempt: StoredAttempt): void {
+  safeSessionStorage(() => window.sessionStorage.setItem(ATTEMPT_STORAGE_KEY, JSON.stringify(attempt)));
+}
+
+function clearStoredAttempt(): void {
+  safeSessionStorage(() => window.sessionStorage.removeItem(ATTEMPT_STORAGE_KEY));
+}
+
+/** A 402 is the only response that proves the attempt is dead: the bank definitively declined and Stripe replays that decline for the key's lifetime, so retrying the same key could never succeed. Every other failure (timeout, 4xx/5xx, no response) leaves the outcome unknown and the key must survive. */
+function isAttemptConcluded(error: unknown): boolean {
+  return !!error && typeof error === "object" && "response" in error && (error as { response?: { status?: number } }).response?.status === 402;
 }
 
 /**
@@ -85,7 +140,11 @@ interface PendingCharge {
  * waits for payment polling to settle before notifying the caller through
  * onDone. A new card is confirmed against its SetupIntent only once: retries
  * after a failed charge reuse the saved payment method instead of
- * re-confirming a consumed intent.
+ * re-confirming a consumed intent. Every attempt carries an idempotency key
+ * that survives unknown-outcome failures (and remounts, via sessionStorage)
+ * and rotates only when the attempt concludes (polling settled, or a
+ * definitive 402 decline) or its params change, so a retried slow charge
+ * replays the original attempt instead of charging again.
  */
 export function AddCreditsForm({ onDone, isWalletReady = true, onProcessingChange, dependencies: d = DEPENDENCIES }: AddCreditsFormProps) {
   const { data: setupIntent, mutate: createSetupIntent, status: setupIntentStatus, reset: resetSetupIntent } = d.useSetupIntentMutation();
@@ -93,6 +152,7 @@ export function AddCreditsForm({ onDone, isWalletReady = true, onProcessingChang
   const { pollForPayment, isPolling } = d.usePaymentPolling();
   const { stripe, analyticsService } = d.useServices();
   const { isTrialing, topUpMinAmountUsd } = d.useWallet();
+  const { balance } = d.useWalletBalance();
   const queryClient = d.useQueryClient();
   const { data: paymentMethods, isLoading: isLoadingMethods, isError: isMethodsError } = d.usePaymentMethodsQuery();
   const {
@@ -109,6 +169,8 @@ export function AddCreditsForm({ onDone, isWalletReady = true, onProcessingChang
   const paymentMethodRef = useRef<PaymentMethodSourceHandle>(null);
   /** Payment method already confirmed against the current SetupIntent; reused on retry because a SetupIntent can only be confirmed once. */
   const confirmedNewCardRef = useRef<{ paymentMethodId: string; organization?: string } | null>(null);
+  /** Attempt key outlives PendingCharge: finalizeFailure clears the charge while the key must survive unknown-outcome failures, so a retry replays the same attempt instead of charging again. */
+  const attemptRef = useRef<{ key: string; amount: number; paymentMethodId: string } | null>(null);
   const wasPollingRef = useRef<boolean>(false);
   /** Last payment-method type reported to analytics, so the payment element's frequent change events don't re-fire the same type. */
   const lastPaymentTypeRef = useRef<string | null>(null);
@@ -173,9 +235,41 @@ export function AddCreditsForm({ onDone, isWalletReady = true, onProcessingChang
       organization,
       amount,
       wasTrialing: isTrialing,
-      status: "pending"
+      status: "pending",
+      idempotencyKey: resolveAttemptKey(paymentMethodId, user.id)
     });
   };
+
+  /**
+   * Reuses the in-memory key while the purchase params are unchanged (a retry of the same attempt),
+   * rehydrates a matching persisted key after a remount, and only otherwise mints a fresh one.
+   */
+  function resolveAttemptKey(paymentMethodId: string, userId: string): string {
+    const amountCents = Math.round(amount * 100);
+    const current = attemptRef.current;
+
+    if (current && current.amount === amount && current.paymentMethodId === paymentMethodId) {
+      return current.key;
+    }
+
+    const rehydratedKey = readStoredAttemptKey({ userId, amountCents, paymentMethodId });
+
+    if (rehydratedKey) {
+      attemptRef.current = { key: rehydratedKey, amount, paymentMethodId };
+      return rehydratedKey;
+    }
+
+    const key = crypto.randomUUID();
+    attemptRef.current = { key, amount, paymentMethodId };
+    writeStoredAttempt({ key, amountCents, paymentMethodId, userId, createdAt: Date.now() });
+
+    return key;
+  }
+
+  const clearAttempt = useCallback(() => {
+    attemptRef.current = null;
+    clearStoredAttempt();
+  }, []);
 
   const finalizeFailure = useCallback(
     (message: string, userAction?: string | null) => {
@@ -202,6 +296,14 @@ export function AddCreditsForm({ onDone, isWalletReady = true, onProcessingChang
     showSuccessMessage: false
   });
 
+  /** A replayed attempt the webhook already credited settles polling against the pre-charge baseline: the balance rose before polling started, so the default start-of-poll snapshot would never register an increase and the flow would time out. */
+  const pollForAlreadyCreditedPayment = useCallback(
+    (chargedAmount: number) => {
+      pollForPayment({ initialBalance: balance ? balance.totalUsd - chargedAmount : null });
+    },
+    [pollForPayment, balance]
+  );
+
   const performCharge = useCallback(
     async function performCharge(pending: PendingCharge) {
       if (!user?.id) return;
@@ -210,7 +312,8 @@ export function AddCreditsForm({ onDone, isWalletReady = true, onProcessingChang
         const chargeResult = await confirmPayment({
           userId: user.id,
           paymentMethodId: pending.paymentMethodId,
-          amount: pending.amount
+          amount: pending.amount,
+          idempotencyKey: pending.idempotencyKey
         });
 
         if (chargeResult.requiresAction && chargeResult.clientSecret && chargeResult.paymentIntentId) {
@@ -223,17 +326,25 @@ export function AddCreditsForm({ onDone, isWalletReady = true, onProcessingChang
         }
 
         if (chargeResult.success) {
-          pollForPayment();
+          if (chargeResult.transactionStatus === "succeeded") {
+            pollForAlreadyCreditedPayment(pending.amount);
+          } else {
+            pollForPayment();
+          }
           return;
         }
 
         finalizeFailure("Payment failed. Please try again.");
       } catch (err) {
+        if (isAttemptConcluded(err)) {
+          clearAttempt();
+        }
+
         const stripeError = d.handleStripeError(err);
         finalizeFailure(stripeError.message, stripeError.userAction);
       }
     },
-    [user?.id, confirmPayment, threeDSecure, pollForPayment, finalizeFailure, d]
+    [user?.id, confirmPayment, threeDSecure, pollForPayment, pollForAlreadyCreditedPayment, finalizeFailure, clearAttempt, d]
   );
 
   useEffect(
@@ -259,6 +370,7 @@ export function AddCreditsForm({ onDone, isWalletReady = true, onProcessingChang
       }
 
       confirmedNewCardRef.current = null;
+      clearAttempt();
       setCharge(null);
       setIsProcessing(false);
 
@@ -279,7 +391,7 @@ export function AddCreditsForm({ onDone, isWalletReady = true, onProcessingChang
         onDone(amount, organization, bonusAmount);
       })();
     },
-    [isPolling, isTrialing, charge, finalizeFailure, onDone, stripe]
+    [isPolling, isTrialing, charge, finalizeFailure, clearAttempt, onDone, stripe]
   );
 
   useEffect(

--- a/apps/deploy-web/src/components/billing-usage/AddCreditsForm/AddCreditsForm.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AddCreditsForm/AddCreditsForm.tsx
@@ -88,8 +88,8 @@ interface StoredAttempt {
 /** Attempt keys persist per tab so closing and reopening the errored sheet (which unmounts the form) retries the same attempt instead of minting a fresh charge. */
 const ATTEMPT_STORAGE_KEY = "add-credits-attempt";
 
-/** A stored attempt older than this is treated as a new purchase, not a retry; Stripe only replays a key for 24h anyway. */
-const ATTEMPT_MAX_AGE_MS = 60 * 60 * 1000;
+/** A stored attempt older than this is treated as a new purchase, not a retry. It matches Stripe's 24h replay window: expiring sooner would mint a fresh key (and possibly a duplicate charge) while the original attempt could still settle. */
+const ATTEMPT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 
 /** sessionStorage access throws in some privacy modes; attempt-key persistence is best-effort and must never break the purchase flow. */
 function safeSessionStorage<T>(operation: () => T): T | undefined {
@@ -124,9 +124,13 @@ function clearStoredAttempt(): void {
   safeSessionStorage(() => window.sessionStorage.removeItem(ATTEMPT_STORAGE_KEY));
 }
 
-/** A 402 is the only response that proves the attempt is dead: the bank definitively declined and Stripe replays that decline for the key's lifetime, so retrying the same key could never succeed. Every other failure (timeout, 4xx/5xx, no response) leaves the outcome unknown and the key must survive. */
+/** Two responses prove the attempt is dead: a 402 (the bank definitively declined, and Stripe replays that decline for the key's lifetime) and a 409 idempotency_key_mismatch (the key is permanently bound to different parameters). Retrying either with the same key could never succeed. Every other failure (timeout, 4xx/5xx, no response) leaves the outcome unknown and the key must survive. */
 function isAttemptConcluded(error: unknown): boolean {
-  return !!error && typeof error === "object" && "response" in error && (error as { response?: { status?: number } }).response?.status === 402;
+  if (!error || typeof error !== "object" || !("response" in error)) return false;
+
+  const response = (error as { response?: { status?: number; data?: { code?: string } } }).response;
+
+  return response?.status === 402 || (response?.status === 409 && response.data?.code === "idempotency_key_mismatch");
 }
 
 /**
@@ -137,19 +141,22 @@ function isAttemptConcluded(error: unknown): boolean {
  * the payment method (saved id, or the swappable child for a new card) and
  * stores it as a pending charge; a reactive effect fires confirmPayment once
  * the wallet is ready, hands off to the 3D Secure popup when required, then
- * waits for payment polling to settle before notifying the caller through
- * onDone. A new card is confirmed against its SetupIntent only once: retries
- * after a failed charge reuse the saved payment method instead of
- * re-confirming a consumed intent. Every attempt carries an idempotency key
- * that survives unknown-outcome failures (and remounts, via sessionStorage)
- * and rotates only when the attempt concludes (polling settled, or a
- * definitive 402 decline) or its params change, so a retried slow charge
- * replays the original attempt instead of charging again.
+ * waits for payment polling to confirm settlement before notifying the caller
+ * through onDone. A poll that exhausts without confirmation is NOT completion:
+ * the charge may still settle, so the form releases its in-flight state
+ * without onDone and the attempt stays replayable. A new card is confirmed
+ * against its SetupIntent only once: retries after a failed charge reuse the
+ * saved payment method instead of re-confirming a consumed intent. Every
+ * attempt carries an idempotency key that survives unknown-outcome failures
+ * (and remounts, via sessionStorage) and rotates only when the attempt
+ * concludes (polling confirmed settlement, a definitive 402 decline, or a 409
+ * key mismatch) or its params change, so a retried slow charge replays the
+ * original attempt instead of charging again.
  */
 export function AddCreditsForm({ onDone, isWalletReady = true, onProcessingChange, dependencies: d = DEPENDENCIES }: AddCreditsFormProps) {
   const { data: setupIntent, mutate: createSetupIntent, status: setupIntentStatus, reset: resetSetupIntent } = d.useSetupIntentMutation();
   const { user } = d.useUser();
-  const { pollForPayment, isPolling } = d.usePaymentPolling();
+  const { pollForPayment, isPolling, lastOutcome } = d.usePaymentPolling();
   const { stripe, analyticsService } = d.useServices();
   const { isTrialing, topUpMinAmountUsd } = d.useWallet();
   const { balance } = d.useWalletBalance();
@@ -271,6 +278,12 @@ export function AddCreditsForm({ onDone, isWalletReady = true, onProcessingChang
     clearStoredAttempt();
   }, []);
 
+  /** An exhausted poll leaves the charge outcome unknown: it may still settle, so the attempt key and confirmed card survive for a replay-safe retry while the in-flight form state is released. */
+  const releaseChargeKeepingAttempt = useCallback(() => {
+    setCharge(null);
+    setIsProcessing(false);
+  }, []);
+
   const finalizeFailure = useCallback(
     (message: string, userAction?: string | null) => {
       setCharge(null);
@@ -364,6 +377,11 @@ export function AddCreditsForm({ onDone, isWalletReady = true, onProcessingChang
 
       if (!wasPolling || isPolling || !charge) return;
 
+      if (lastOutcome !== "success") {
+        releaseChargeKeepingAttempt();
+        return;
+      }
+
       if (charge.wasTrialing && isTrialing) {
         finalizeFailure("Payment did not complete in time. Please try again.");
         return;
@@ -391,7 +409,7 @@ export function AddCreditsForm({ onDone, isWalletReady = true, onProcessingChang
         onDone(amount, organization, bonusAmount);
       })();
     },
-    [isPolling, isTrialing, charge, finalizeFailure, clearAttempt, onDone, stripe]
+    [isPolling, lastOutcome, isTrialing, charge, releaseChargeKeepingAttempt, finalizeFailure, clearAttempt, onDone, stripe]
   );
 
   useEffect(

--- a/apps/deploy-web/src/context/PaymentPollingProvider/PaymentPollingProvider.spec.tsx
+++ b/apps/deploy-web/src/context/PaymentPollingProvider/PaymentPollingProvider.spec.tsx
@@ -267,6 +267,90 @@ describe(PaymentPollingProvider.name, () => {
     cleanup();
   });
 
+  it("reports a timeout outcome when polling exhausts without confirming the payment", async () => {
+    const { pumpPollCycles, cleanup } = setup({
+      isTrialing: false,
+      balance: { totalUsd: 100 },
+      isWalletBalanceLoading: false
+    });
+
+    await act(async () => {
+      screen.getByTestId("start-polling").click();
+    });
+
+    expect(screen.queryByTestId("last-outcome")).toHaveTextContent("null");
+
+    await pumpPollCycles(16);
+
+    expect(screen.queryByTestId("is-polling")).toHaveTextContent("false");
+    expect(screen.queryByTestId("last-outcome")).toHaveTextContent("timeout");
+
+    cleanup();
+  });
+
+  it("reports a success outcome when the balance increase is confirmed", async () => {
+    const { setBalance, cleanup } = setup({
+      isTrialing: false,
+      balance: { totalUsd: 100 },
+      isWalletBalanceLoading: false
+    });
+
+    await act(async () => {
+      screen.getByTestId("start-polling").click();
+    });
+
+    await setBalance({ totalUsd: 200 });
+
+    expect(screen.queryByTestId("is-polling")).toHaveTextContent("false");
+    expect(screen.queryByTestId("last-outcome")).toHaveTextContent("success");
+
+    cleanup();
+  });
+
+  it("reports a success outcome when the trial flips", async () => {
+    const { setIsTrialing, advancePollCycle, cleanup } = setup({
+      isTrialing: true,
+      balance: { totalUsd: 100 },
+      isWalletBalanceLoading: false
+    });
+
+    await act(async () => {
+      screen.getByTestId("start-polling").click();
+    });
+
+    await setIsTrialing(false);
+    await advancePollCycle();
+
+    expect(screen.queryByTestId("is-polling")).toHaveTextContent("false");
+    expect(screen.queryByTestId("last-outcome")).toHaveTextContent("success");
+
+    cleanup();
+  });
+
+  it("resets the outcome when a new poll starts", async () => {
+    const { pumpPollCycles, cleanup } = setup({
+      isTrialing: false,
+      balance: { totalUsd: 100 },
+      isWalletBalanceLoading: false
+    });
+
+    await act(async () => {
+      screen.getByTestId("start-polling").click();
+    });
+
+    await pumpPollCycles(16);
+
+    expect(screen.queryByTestId("last-outcome")).toHaveTextContent("timeout");
+
+    await act(async () => {
+      screen.getByTestId("start-polling").click();
+    });
+
+    expect(screen.queryByTestId("last-outcome")).toHaveTextContent("null");
+
+    cleanup();
+  });
+
   it("shows coupon copy instead of payment copy for a coupon redemption", async () => {
     const { enqueueSnackbar, setIsTrialing, advancePollCycle, cleanup } = setup({
       isTrialing: true,
@@ -346,10 +430,11 @@ describe(PaymentPollingProvider.name, () => {
     } as unknown as typeof DEPENDENCIES;
 
     const TestComponent = () => {
-      const { pollForPayment, stopPolling, isPolling } = usePaymentPolling();
+      const { pollForPayment, stopPolling, isPolling, lastOutcome } = usePaymentPolling();
       return (
         <div>
           <div data-testid="is-polling">{isPolling.toString()}</div>
+          <div data-testid="last-outcome">{String(lastOutcome)}</div>
           <button data-testid="start-polling" onClick={() => pollForPayment()}>
             Start Polling
           </button>
@@ -380,6 +465,12 @@ describe(PaymentPollingProvider.name, () => {
       unmount,
       setIsTrialing: async (isTrialing: boolean) => {
         state.isTrialing = isTrialing;
+        await act(async () => {
+          rerender(buildUi());
+        });
+      },
+      setBalance: async (balance: { totalUsd: number } | null) => {
+        state.balance = balance;
         await act(async () => {
           rerender(buildUi());
         });

--- a/apps/deploy-web/src/context/PaymentPollingProvider/PaymentPollingProvider.spec.tsx
+++ b/apps/deploy-web/src/context/PaymentPollingProvider/PaymentPollingProvider.spec.tsx
@@ -206,7 +206,7 @@ describe(PaymentPollingProvider.name, () => {
     consoleSpy.mockRestore();
   });
 
-  it("signals 'Payment successful!' on trial flip and suppresses the later timeout warning", async () => {
+  it("signals 'Payment successful!' on trial flip and suppresses the later timeout notice", async () => {
     const { enqueueSnackbar, setIsTrialing, advancePollCycle, cleanup } = setup({
       isTrialing: true,
       balance: { totalUsd: 100 },
@@ -226,7 +226,43 @@ describe(PaymentPollingProvider.name, () => {
 
     await advancePollCycle(30000);
 
-    expect(enqueueSnackbar).not.toHaveBeenCalledWith(snackbarWithTitle("Payment processing timeout"), expect.anything());
+    expect(enqueueSnackbar).not.toHaveBeenCalledWith(snackbarWithTitle("Your payment is still processing"), expect.anything());
+
+    cleanup();
+  });
+
+  it("frames an exhausted poll as still processing, not a failure, so the user is not nudged to pay again", async () => {
+    const { enqueueSnackbar, pumpPollCycles, cleanup } = setup({
+      isTrialing: false,
+      balance: { totalUsd: 100 },
+      isWalletBalanceLoading: false
+    });
+
+    await act(async () => {
+      screen.getByTestId("start-polling").click();
+    });
+
+    await pumpPollCycles(16);
+
+    expect(enqueueSnackbar).toHaveBeenCalledWith(snackbarWithTitle("Your payment is still processing"), expect.objectContaining({ variant: "info" }));
+
+    cleanup();
+  });
+
+  it("frames an exhausted coupon poll as still processing rather than failed", async () => {
+    const { enqueueSnackbar, pumpPollCycles, cleanup } = setup({
+      isTrialing: false,
+      balance: { totalUsd: 100 },
+      isWalletBalanceLoading: false
+    });
+
+    await act(async () => {
+      screen.getByTestId("start-polling-coupon").click();
+    });
+
+    await pumpPollCycles(16);
+
+    expect(enqueueSnackbar).toHaveBeenCalledWith(snackbarWithTitle("Your coupon is still processing"), expect.objectContaining({ variant: "info" }));
 
     cleanup();
   });
@@ -268,7 +304,8 @@ describe(PaymentPollingProvider.name, () => {
 
     const state = {
       isTrialing: input.isTrialing,
-      balance: input.balance
+      balance: input.balance,
+      balanceLoading: input.isWalletBalanceLoading
     };
 
     const mockSnackbar = ({ title, subTitle, iconVariant, showLoading }: { title: string; subTitle: string; iconVariant?: string; showLoading?: boolean }) => (
@@ -281,7 +318,7 @@ describe(PaymentPollingProvider.name, () => {
       useWalletBalance: vi.fn(() => ({
         balance: state.balance ? buildWalletBalance(state.balance) : null,
         refetch: refetchBalance,
-        isLoading: input.isWalletBalanceLoading
+        isLoading: state.balanceLoading
       })),
       useManagedWallet: vi.fn(() => ({
         wallet: {
@@ -351,6 +388,27 @@ describe(PaymentPollingProvider.name, () => {
         await act(async () => {
           vi.advanceTimersByTime(time);
         });
+      },
+      /**
+       * Drives `cycles` poll iterations to exhaustion. The provider reschedules the next poll off a
+       * balance-query loading transition; the mocked `refetch` never toggles `isLoading`, so a plain
+       * timer advance stalls after one tick. Each cycle emulates that transition (true → false) then
+       * advances one interval so the scheduled poll fires, letting a test reach the timeout branch.
+       */
+      pumpPollCycles: async (cycles: number) => {
+        for (let i = 0; i < cycles; i++) {
+          state.balanceLoading = true;
+          await act(async () => {
+            rerender(buildUi());
+          });
+          state.balanceLoading = false;
+          await act(async () => {
+            rerender(buildUi());
+          });
+          await act(async () => {
+            vi.advanceTimersByTime(2000);
+          });
+        }
       },
       cleanup: () => {
         vi.useRealTimers();

--- a/apps/deploy-web/src/context/PaymentPollingProvider/PaymentPollingProvider.tsx
+++ b/apps/deploy-web/src/context/PaymentPollingProvider/PaymentPollingProvider.tsx
@@ -14,6 +14,8 @@ const MAX_ATTEMPTS = MAX_POLLING_DURATION_MS / POLLING_INTERVAL_MS;
 
 export type PaymentPollingVariant = "payment" | "coupon";
 
+export type PaymentPollingOutcome = "success" | "timeout";
+
 /**
  * Snackbar copy per flow. The coupon flow avoids "payment" wording since redeeming a coupon is not a charge.
  * The `timeout` copy deliberately frames an exhausted poll as still-pending, not failed: the charge usually
@@ -65,6 +67,14 @@ export interface PaymentPollingContextType {
    * Whether currently polling
    */
   isPolling: boolean;
+  /**
+   * Terminal outcome of the most recent poll: "success" once settlement was
+   * confirmed (balance rose or the trial flipped), "timeout" when polling
+   * exhausted without confirmation — the payment may still settle later, so
+   * exhaustion must not be treated as completion. Null while polling or
+   * before the first poll.
+   */
+  lastOutcome: PaymentPollingOutcome | null;
 }
 
 const PaymentPollingContext = createContext<PaymentPollingContextType | null>(null);
@@ -82,6 +92,7 @@ export const PaymentPollingProvider: React.FC<PaymentPollingProviderProps> = ({ 
   const { analyticsService } = d.useServices();
 
   const [isPolling, setIsPolling] = React.useState(false);
+  const [lastOutcome, setLastOutcome] = React.useState<PaymentPollingOutcome | null>(null);
   const pollingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isPollingRef = useRef<boolean>(false);
   const attemptCountRef = useRef<number>(0);
@@ -118,6 +129,7 @@ export const PaymentPollingProvider: React.FC<PaymentPollingProviderProps> = ({ 
 
     if (attemptCountRef.current > MAX_ATTEMPTS) {
       stopPolling();
+      setLastOutcome(hasSignaledSuccessRef.current ? "success" : "timeout");
       if (!hasSignaledSuccessRef.current) {
         const { title, subTitle } = POLLING_COPY[variantRef.current].timeout;
         enqueueSnackbar(<d.Snackbar title={title} subTitle={subTitle} iconVariant="info" />, {
@@ -144,6 +156,7 @@ export const PaymentPollingProvider: React.FC<PaymentPollingProviderProps> = ({ 
       hasSignaledSuccessRef.current = false;
       isPollingRef.current = true;
       attemptCountRef.current = 0;
+      setLastOutcome(null);
       setIsPolling(true);
 
       const { title, subTitle } = POLLING_COPY[variantRef.current].loading;
@@ -218,6 +231,7 @@ export const PaymentPollingProvider: React.FC<PaymentPollingProviderProps> = ({ 
         });
       } else {
         stopPolling();
+        setLastOutcome("success");
       }
     },
     [isPolling, currentBalance, wasTrialing, stopPolling, enqueueSnackbar, analyticsService, d, closeLoadingSnackbar]
@@ -231,6 +245,7 @@ export const PaymentPollingProvider: React.FC<PaymentPollingProviderProps> = ({ 
 
       if (initialTrialingRef.current && !wasTrialing) {
         stopPolling();
+        setLastOutcome("success");
 
         enqueueSnackbar(
           <d.Snackbar title="Welcome to Akash!" subTitle="Your trial has been completed. You now have full access to the platform." iconVariant="success" />,
@@ -253,7 +268,8 @@ export const PaymentPollingProvider: React.FC<PaymentPollingProviderProps> = ({ 
   const contextValue: PaymentPollingContextType = {
     pollForPayment,
     stopPolling,
-    isPolling
+    isPolling,
+    lastOutcome
   };
 
   return <PaymentPollingContext.Provider value={contextValue}>{children}</PaymentPollingContext.Provider>;

--- a/apps/deploy-web/src/context/PaymentPollingProvider/PaymentPollingProvider.tsx
+++ b/apps/deploy-web/src/context/PaymentPollingProvider/PaymentPollingProvider.tsx
@@ -14,15 +14,31 @@ const MAX_ATTEMPTS = MAX_POLLING_DURATION_MS / POLLING_INTERVAL_MS;
 
 export type PaymentPollingVariant = "payment" | "coupon";
 
-/** Snackbar copy per flow. The coupon flow avoids "payment" wording since redeeming a coupon is not a charge. */
-const POLLING_COPY: Record<PaymentPollingVariant, { loading: { title: string; subTitle: string }; success: { title: string; subTitle: string } }> = {
+/**
+ * Snackbar copy per flow. The coupon flow avoids "payment" wording since redeeming a coupon is not a charge.
+ * The `timeout` copy deliberately frames an exhausted poll as still-pending, not failed: the charge usually
+ * succeeded and is just settling slower than the poll window, so the message reassures instead of nudging a
+ * retry (a retried slow-but-successful charge is what produced the duplicate top-ups in CON-684).
+ */
+const POLLING_COPY: Record<
+  PaymentPollingVariant,
+  { loading: { title: string; subTitle: string }; success: { title: string; subTitle: string }; timeout: { title: string; subTitle: string } }
+> = {
   payment: {
     loading: { title: "Processing payment...", subTitle: "Please wait while we update your balance" },
-    success: { title: "Payment successful!", subTitle: "Your balance has been updated" }
+    success: { title: "Payment successful!", subTitle: "Your balance has been updated" },
+    timeout: {
+      title: "Your payment is still processing",
+      subTitle: "This is taking longer than usual — no need to pay again. Your balance will update shortly once it completes."
+    }
   },
   coupon: {
     loading: { title: "Applying coupon...", subTitle: "Please wait while we add your credits" },
-    success: { title: "Coupon applied!", subTitle: "Your balance has been updated" }
+    success: { title: "Coupon applied!", subTitle: "Your balance has been updated" },
+    timeout: {
+      title: "Your coupon is still processing",
+      subTitle: "This is taking longer than usual. Your balance will update shortly once it completes."
+    }
   }
 };
 
@@ -103,8 +119,9 @@ export const PaymentPollingProvider: React.FC<PaymentPollingProviderProps> = ({ 
     if (attemptCountRef.current > MAX_ATTEMPTS) {
       stopPolling();
       if (!hasSignaledSuccessRef.current) {
-        enqueueSnackbar(<d.Snackbar title="Payment processing timeout" subTitle="Please refresh the page to check your balance" iconVariant="warning" />, {
-          variant: "warning"
+        const { title, subTitle } = POLLING_COPY[variantRef.current].timeout;
+        enqueueSnackbar(<d.Snackbar title={title} subTitle={subTitle} iconVariant="info" />, {
+          variant: "info"
         });
       }
       return;

--- a/apps/deploy-web/src/queries/usePaymentQueries.ts
+++ b/apps/deploy-web/src/queries/usePaymentQueries.ts
@@ -80,11 +80,12 @@ export const usePaymentMutations = () => {
   const queryClient = useQueryClient();
 
   const confirmPayment = useMutation({
-    mutationFn: async ({ userId, paymentMethodId, amount }: ConfirmPaymentParams): Promise<ConfirmPaymentResponse> => {
+    mutationFn: async ({ userId, paymentMethodId, amount, idempotencyKey }: ConfirmPaymentParams): Promise<ConfirmPaymentResponse> => {
       return await stripe.confirmPayment({
         userId,
         paymentMethodId,
-        amount
+        amount,
+        idempotencyKey
       });
     },
     onSuccess: () => {

--- a/apps/deploy-web/src/utils/stripeErrorHandler.spec.ts
+++ b/apps/deploy-web/src/utils/stripeErrorHandler.spec.ts
@@ -78,8 +78,46 @@ describe("StripeErrorHandler", () => {
 
       const result = handleStripeError(error);
 
-      expect(result.message).toBe("This payment request conflicts with a previous one. Please try again.");
-      expect(result.userAction).toBe("Try the payment again.");
+      expect(result.message).toBe("Your payment is still being processed.");
+      expect(result.userAction).toBe("Wait a moment, then check your balance before retrying.");
+    });
+
+    it("shows the still-processing copy for a 409 carrying the status-derived conflict code", () => {
+      const error = {
+        response: {
+          status: 409,
+          data: {
+            error: "ConflictError",
+            message: "A payment for this request is already in progress. Please wait a moment and try again.",
+            code: "conflict",
+            type: "client_error"
+          }
+        }
+      };
+
+      const result = handleStripeError(error);
+
+      expect(result.message).toBe("Your payment is still being processed.");
+      expect(result.userAction).toBe("Wait a moment, then check your balance before retrying.");
+    });
+
+    it("shows the still-processing copy for the payment_in_progress code", () => {
+      const error = {
+        response: {
+          status: 409,
+          data: {
+            error: "ConflictError",
+            message: "A payment for this request is already in progress. Please wait a moment and try again.",
+            code: "payment_in_progress",
+            type: "payment_error"
+          }
+        }
+      };
+
+      const result = handleStripeError(error);
+
+      expect(result.message).toBe("Your payment is still being processed.");
+      expect(result.userAction).toBe("Wait a moment, then check your balance before retrying.");
     });
 
     it("should handle insufficient funds error codes", () => {

--- a/apps/deploy-web/src/utils/stripeErrorHandler.spec.ts
+++ b/apps/deploy-web/src/utils/stripeErrorHandler.spec.ts
@@ -120,6 +120,25 @@ describe("StripeErrorHandler", () => {
       expect(result.userAction).toBe("Wait a moment, then check your balance before retrying.");
     });
 
+    it("tells the user to start over for the idempotency_key_mismatch code", () => {
+      const error = {
+        response: {
+          status: 409,
+          data: {
+            error: "ConflictError",
+            message: "This payment was already requested with different parameters. Please start a new payment attempt.",
+            code: "idempotency_key_mismatch",
+            type: "payment_error"
+          }
+        }
+      };
+
+      const result = handleStripeError(error);
+
+      expect(result.message).toBe("This payment request conflicts with a previous attempt.");
+      expect(result.userAction).toBe("Check your balance, then start a new payment.");
+    });
+
     it("should handle insufficient funds error codes", () => {
       const error = {
         response: {

--- a/apps/deploy-web/src/utils/stripeErrorHandler.ts
+++ b/apps/deploy-web/src/utils/stripeErrorHandler.ts
@@ -125,6 +125,10 @@ function handleErrorByCode(errorCode: string, originalMessage?: string): StripeE
       message: "Your payment is still being processed.",
       userAction: "Wait a moment, then check your balance before retrying."
     },
+    idempotency_key_mismatch: {
+      message: "This payment request conflicts with a previous attempt.",
+      userAction: "Check your balance, then start a new payment."
+    },
     rate_limited: {
       message: "Too many payment attempts. Please wait a moment and try again.",
       userAction: "Wait a moment and try again."

--- a/apps/deploy-web/src/utils/stripeErrorHandler.ts
+++ b/apps/deploy-web/src/utils/stripeErrorHandler.ts
@@ -118,8 +118,12 @@ function handleErrorByCode(errorCode: string, originalMessage?: string): StripeE
       userAction: "Refresh the page and try again."
     },
     conflict: {
-      message: "This payment request conflicts with a previous one. Please try again.",
-      userAction: "Try the payment again."
+      message: "Your payment is still being processed.",
+      userAction: "Wait a moment, then check your balance before retrying."
+    },
+    payment_in_progress: {
+      message: "Your payment is still being processed.",
+      userAction: "Wait a moment, then check your balance before retrying."
     },
     rate_limited: {
       message: "Too many payment attempts. Please wait a moment and try again.",
@@ -181,8 +185,8 @@ function handleErrorByStatus(status: number, originalMessage?: string): StripeEr
       };
     case 409:
       return {
-        message: "This payment request conflicts with a previous one. Please try again.",
-        userAction: "Try the payment again."
+        message: "Your payment is still being processed.",
+        userAction: "Wait a moment, then check your balance before retrying."
       };
     case 404:
       return {

--- a/apps/deploy-web/tests/unit/setup.ts
+++ b/apps/deploy-web/tests/unit/setup.ts
@@ -1,6 +1,7 @@
 import "@testing-library/jest-dom/vitest";
 
 import { Blob } from "node:buffer";
+import { randomUUID } from "node:crypto";
 import { afterEach, beforeAll, vi } from "vitest";
 
 import { cleanup } from "@testing-library/react";
@@ -13,6 +14,11 @@ Object.assign(globalThis, {
     disconnect() {}
   }
 });
+
+// jsdom 20 ships crypto.getRandomValues but not crypto.randomUUID
+if (typeof globalThis.crypto.randomUUID !== "function") {
+  Object.defineProperty(globalThis.crypto, "randomUUID", { value: randomUUID, writable: true, configurable: true });
+}
 
 // Mock hasPointerCapture and scrollIntoView for jsdom compatibility with Radix UI
 Object.defineProperty(HTMLElement.prototype, "hasPointerCapture", {

--- a/packages/http-sdk/src/stripe/stripe.types.ts
+++ b/packages/http-sdk/src/stripe/stripe.types.ts
@@ -78,6 +78,8 @@ export interface ConfirmPaymentParams {
   userId: string;
   paymentMethodId: string;
   amount: number;
+  /** Client attempt key (uuid): retries of the same attempt reuse it so the API charges at most once. */
+  idempotencyKey?: string;
 }
 
 export interface ApplyCouponParams {
@@ -112,6 +114,9 @@ export interface ConfirmPaymentResponse {
   requiresAction?: boolean;
   clientSecret?: string;
   paymentIntentId?: string;
+  transactionId?: string;
+  /** "succeeded" on a replayed attempt means the wallet was already credited by the first delivery. */
+  transactionStatus?: string;
 }
 
 export interface ThreeDSecureAuthParams {


### PR DESCRIPTION
## Why

Customers were charged 2-3x for a single credit purchase (Jul 15-16 clusters: same customer, same amount, distinct successful PaymentIntents minutes apart). `POST /v1/stripe/transactions/confirm` created a fresh `stripe_transactions` row and a fresh PaymentIntent (`confirm: true`) on every delivery with no idempotency key, so a user retrying a slow-but-actually-successful charge fired a second independent charge, and each PaymentIntent's webhook credited the wallet again.

Fixes CON-684

## What

**Client (deploy-web)**
- `AddCreditsForm` mints a `crypto.randomUUID()` attempt key per purchase attempt and sends it as `idempotencyKey`. The key survives unknown-outcome failures (network errors, 4xx/5xx, the polling-timeout path from the incident, 3DS failures) and remounts (sessionStorage, matched on user + amount + payment method, 24h max age to match Stripe's replay window). It rotates only when polling confirms settlement, a definitive 402 decline or 409 `idempotency_key_mismatch` arrives, or the purchase params change.
- A replayed already-credited attempt (`transactionStatus === "succeeded"`) polls from the pre-charge baseline so it settles against the already-credited balance instead of timing out.
- `PaymentPollingProvider` exposes the terminal poll outcome; a poll that exhausts without confirming settlement is treated as unknown, not complete: the form releases its in-flight state but keeps the attempt key and skips `onDone`, so the parent success screen never shows for an unconfirmed charge and a retry replays the same attempt.
- 409s show "Your payment is still being processed." copy.

**API**
- New nullable `stripe_idempotency_key` column + partial unique index (migration 0032, auto-applies at boot; verified on a live boot against a fresh database).
- Controller namespaces the client key as `topup_<userId>_<clientKey>` (uuid-validated, cross-user collision-proof, disjoint from `WalletBalanceReloadCheck.*` and `card_validation_*`).
- `StripeService.createPaymentIntent` keyed path: find-or-create the row by key (insert race resolved via conflict-do-nothing + winner re-fetch), short-circuit rows the webhook already settled (succeeded/refunded), and when the row already records a PaymentIntent, retrieve it and act on its live status instead of ever creating a second one (succeeded/processing/requires_capture resume, requires_action returns the live client_secret, declined synthesizes a 402 with the real decline reason).
- All row status writes on this path go through `updateByIdUnlessSettled` (atomic `UPDATE ... WHERE status NOT IN ('succeeded','refunded')`), so a slow request can never downgrade a status the webhook wrote first. `succeeded` and now `requires_capture` are deferred to the webhook, protecting the exactly-once crediting guard.
- Reused key with a changed amount: validated before every replay branch (settled short-circuit and recorded-intent resume included) and rejected for `topup_` keys with a definitive 409 `idempotency_key_mismatch` — distinct from the retryable in-progress 409 — so a replay can never report success for a different amount than was charged; wallet auto-reload keys charge the recorded amount instead, because pg-boss redeliveries reuse the job id but recompute live amounts. Stripe's own params-mismatch (`StripeIdempotencyError`) maps to the same code.
- When the settled-status guard suppresses a request-path write (`updateByIdUnlessSettled` returns undefined because a webhook settled the row mid-request), the response is derived from the settled row instead of the request's stale view, so an already-credited charge is reported as succeeded rather than pending/failed.
- Stripe's `idempotency_key_in_use` (concurrency loser; arrives as `invalid_request_error` in stripe-node 19, detected via `error.code`) maps to 409 `payment_in_progress` without touching the row.
- Keyless callers keep today's behavior byte-identically (old bundles keep working; `idempotencyKey` is optional).
- Observability: `PAYMENT_INTENT_KEY_REUSED`, `PAYMENT_INTENT_REPLAY_SHORT_CIRCUIT`, `PAYMENT_INTENT_KEY_IN_USE`, `PAYMENT_INTENT_KEY_AMOUNT_MISMATCH`.

**Migration note:** additive nullable column + partial unique index on a NULL-heavy column; no table rewrite, safe to apply on production without blocking.

**Quirk fixed along the way:** `createError(status, msg, { errorCode })` puts props on the error object while the hono handler only serialized `error.data?.errorCode`, so every billing error collapsed to a status-derived code (`conflict`, `unknown_error`). The handler now falls back to the `errorCode`/`errorType` properties, so the curated billing codes (`card_declined`, `payment_in_progress`, `idempotency_key_mismatch`, …) actually reach clients; the client still handles `conflict` and the bare 409 status as fallbacks.

**Accepted residuals (documented in the plan):**
- A polling timeout no longer completes the flow nor rotates the key: the outcome is treated as unknown, the attempt stays replayable, and the provider snackbar frames it as still-processing.
- If the create call dies before the PI id is recorded, the webhook never lands, and the key is only reused after Stripe prunes it (>24h), one extra PI is possible.
- Multi-tab purchases are intentionally two attempts.

**Tests:** service keyed-path specs (replay, retrieve-guard per live status, amount-mismatch policy, key-in-use, guarded failed writes), repository integration specs against real Postgres (find-or-create race via `Promise.all`, settled-guard no-ops), controller namespacing specs, error-mapping specs, a functional test that nock-matches the `Idempotency-Key` header Stripe receives end-to-end over HTTP plus a replay short-circuit functional test, and 12 `AddCreditsForm` scenarios capturing actual keys across retries, remounts, 3DS failure, and rotations.

**Ops follow-up (not in this PR):** identify and refund the Jul 15-16 duplicates (read-only SQL in the plan doc); refunding the duplicate PI reconciles the double credit via the existing `handleChargeRefunded` clawback. Follow-up once old bundles turn over: consider making `idempotencyKey` required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added idempotency-key support for credit purchases to prevent duplicate charges across retries and remounts.
  * Reused prior payment attempts when matching; included payment status details in confirmation responses.
* **Bug Fixes**
  * Improved handling of “still processing” outcomes for HTTP 409, including updated user guidance.
  * Added clear messaging for idempotency-key mismatches and prevented already-settled transactions from being overwritten.
  * Enhanced payment polling results and snackbars for success vs timeout scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
