### PR TITLE
test(deployment): guard the legacy deploy-linux e2e behind the onboarding redesign flag

### DIFF
--- a/apps/deploy-web/tests/ui/deploy-linux.spec.ts
+++ b/apps/deploy-web/tests/ui/deploy-linux.spec.ts
@@ -1,3 +1,4 @@
+import { skipIfOnboardingRedesign } from "./actions/feature-flags";
 import { expect, test } from "./fixture/base-test";
 import { HomePage } from "./pages/HomePage";
 import { Sidebar } from "./pages/Sidebar";
@@ -5,6 +6,10 @@ import { Sidebar } from "./pages/Sidebar";
 import { PlainLinuxPage } from "@tests/ui/pages/PlainLinuxPage";
 
 test.use({ userType: "existing" });
+
+test.beforeEach(async ({ page }) => {
+  await skipIfOnboardingRedesign(page);
+});
 
 test("ssh keys generation", async ({ page, context }) => {
   const homePage = new HomePage(page);


### PR DESCRIPTION
## Why

The `Deploy App` → `Test beta (NA) / Test staging` e2e job started failing on the first run after #3443 merged to `main`. `tests/ui/deploy-linux.spec.ts` drives the legacy `/deploy-linux` builder and clicks the "OS image" combobox (`PlainLinuxPage.tsx:6`). #3443 makes `/deploy-linux` redirect to `/new-deployment/configure?vm=true` when `onboarding_redesign_v1` is on (it is on in beta), where that selector is a "Distribution" combobox instead, so the click times out:

```
[chromium] › tests/ui/deploy-linux.spec.ts:9:5 › ssh keys generation
  TimeoutError: locator.click: Timeout 15000ms exceeded.
  - waiting for getByRole('combobox', { name: /os image/i })
```

`deploy-linux.spec.ts` is the only legacy builder spec that #3443's redirect superseded without adding the `skipIfOnboardingRedesign` guard its siblings already use (`managed-wallet-deployment.spec.ts`, `managed-wallet-onboarding.spec.ts`).

Ref CON-675 (already closed by #3443; this fixes the e2e fallout).

## What

Add a module-level `beforeEach` to `deploy-linux.spec.ts` calling the existing `skipIfOnboardingRedesign` helper, mirroring the sibling legacy specs. No production code changes.

- Flag on (beta): the spec skips, matching every other superseded legacy flow, so the job goes green.
- Flag off: the spec runs the legacy builder unchanged, preserving coverage until the legacy builder is retired.

Porting the VM/SSH e2e to the new configure flow is deferred as a follow-up (tracked in CON-685), as #3443 stated.
