### PR TITLE
fix: makes bid-screening timezone validation accept timezone aliases

### DIFF
--- a/apps/api/src/bid-screening/http-schemas/bid-screening.schema.ts
+++ b/apps/api/src/bid-screening/http-schemas/bid-screening.schema.ts
@@ -89,14 +89,26 @@ const RequirementsSchema = z.object({
   attributes: z.array(AttributeSchema).default([])
 });
 
-const SUPPORTED_TIMEZONES = new Set(Intl.supportedValuesOf("timeZone"));
+/**
+ * Accepts any IANA zone the runtime recognizes, including aliases such as `Asia/Kolkata`, `UTC`, or
+ * `US/Eastern` that browsers report but `Intl.supportedValuesOf("timeZone")` omits (it lists only
+ * canonical names). Mirrors what Postgres `AT TIME ZONE` accepts downstream.
+ */
+function isSupportedTimeZone(timeZone: string): boolean {
+  try {
+    new Intl.DateTimeFormat(undefined, { timeZone });
+    return true;
+  } catch {
+    return false;
+  }
+}
 export const BidScreeningRequestSchema = z.object({
   requirements: RequirementsSchema.default({}),
   resources: z.array(ResourceUnitSchema).openapi({ description: "Resource units with replica counts" }),
   timezone: z
     .string()
-    .refine(val => SUPPORTED_TIMEZONES.has(val), { message: "Timezone is not supported" })
-    .openapi({ description: "Client timezone, validated against supported Node.js Intl timezones", example: "America/Chicago" }),
+    .refine(isSupportedTimeZone, { message: "Timezone is not supported" })
+    .openapi({ description: "Client IANA timezone, validated against zones the runtime recognizes", example: "America/Chicago" }),
   reclamationWindow: z.number().int().positive().optional().openapi({
     description:
       "Optional reclamation window in seconds; if provided, only providers with a reclamationWindow greater than or equal to this value will be considered",

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -3053,7 +3053,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                     "type": "array",
                   },
                   "timezone": {
-                    "description": "Client timezone, validated against supported Node.js Intl timezones",
+                    "description": "Client IANA timezone, validated against zones the runtime recognizes",
                     "example": "America/Chicago",
                     "type": "string",
                   },

--- a/apps/provider-inventory/src/http-schemas/bid-screening.schema.ts
+++ b/apps/provider-inventory/src/http-schemas/bid-screening.schema.ts
@@ -96,14 +96,26 @@ const RequirementsSchema = z.object({
   attributes: z.array(AttributeSchema).default([])
 });
 
-const SUPPORTED_TIMEZONES = new Set(Intl.supportedValuesOf("timeZone"));
+/**
+ * Accepts any IANA zone the runtime recognizes, including aliases such as `Asia/Kolkata`, `UTC`, or
+ * `US/Eastern` that browsers report but `Intl.supportedValuesOf("timeZone")` omits (it lists only
+ * canonical names). Mirrors what Postgres `AT TIME ZONE` accepts downstream.
+ */
+function isSupportedTimeZone(timeZone: string): boolean {
+  try {
+    new Intl.DateTimeFormat(undefined, { timeZone });
+    return true;
+  } catch {
+    return false;
+  }
+}
 export const BidScreeningRequestSchema = z.object({
   requirements: RequirementsSchema.default({}),
   resources: z.array(ResourceUnitSchema).openapi({ description: "Resource units with replica counts" }),
   timezone: z
     .string()
-    .refine(val => SUPPORTED_TIMEZONES.has(val), { message: "Timezone is not supported" })
-    .openapi({ description: "Client timezone, validated against supported Node.js Intl timezones", example: "America/Chicago" }),
+    .refine(isSupportedTimeZone, { message: "Timezone is not supported" })
+    .openapi({ description: "Client IANA timezone, validated against zones the runtime recognizes", example: "America/Chicago" }),
   reclamationWindow: z.number().int().positive().optional().openapi({
     description:
       "Optional reclamation window in seconds; if provided, only providers with a reclamationWindow greater than or equal to this value will be considered",


### PR DESCRIPTION
## Why

sentry alerts with 400 errors on /bid-screening endpoint

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timezone validation to accept runtime-recognized IANA timezone names and common aliases.
  * Continued rejecting unsupported timezones with a clear validation message.
  * Updated API documentation to reflect the broader range of accepted timezone values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->