### PR TITLE
feat(analytics): track onboarding, add-credits, and configure events

### DIFF
--- a/apps/deploy-web/src/components/auth/AddCreditsSheet/AddCreditsSheet.spec.tsx
+++ b/apps/deploy-web/src/components/auth/AddCreditsSheet/AddCreditsSheet.spec.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect } from "react";
 import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
 
+import type { AnalyticsService } from "@src/services/analytics/analytics.service";
 import { AddCreditsSheet, DEPENDENCIES } from "./AddCreditsSheet";
 
 import { act, render, screen } from "@testing-library/react";
@@ -32,18 +34,59 @@ describe(AddCreditsSheet.name, () => {
     expect(dependencies.AddCreditsTabs).not.toHaveBeenCalled();
   });
 
-  it("forwards onDone to the tabs", () => {
+  it("forwards a completed purchase to onDone", () => {
     const onDone = vi.fn();
     const { dependencies } = setup({ open: true, onDone });
+    const tabsProps = dependencies.AddCreditsTabs.mock.calls.at(-1)![0] as Parameters<typeof DEPENDENCIES.AddCreditsTabs>[0];
 
-    expect(dependencies.AddCreditsTabs).toHaveBeenCalledWith(expect.objectContaining({ onDone }), expect.anything());
+    act(() => tabsProps.onDone(100, "Acme", 5));
+
+    expect(onDone).toHaveBeenCalledWith(100, "Acme", 5);
   });
 
-  it("forwards onRedeemed to the tabs", () => {
+  it("forwards a redemption to onRedeemed", () => {
     const onRedeemed = vi.fn();
     const { dependencies } = setup({ open: true, onRedeemed });
+    const tabsProps = dependencies.AddCreditsTabs.mock.calls.at(-1)![0] as Parameters<typeof DEPENDENCIES.AddCreditsTabs>[0];
 
-    expect(dependencies.AddCreditsTabs).toHaveBeenCalledWith(expect.objectContaining({ onRedeemed }), expect.anything());
+    act(() => tabsProps.onRedeemed!());
+
+    expect(onRedeemed).toHaveBeenCalled();
+  });
+
+  it("tracks opening the sheet with the provided context", () => {
+    const { analyticsService } = setup({ open: true, context: "skip-trial" });
+
+    expect(analyticsService.track).toHaveBeenCalledWith("add_credits_opened", { category: "billing", context: "skip-trial" });
+  });
+
+  it("tracks a purchase when the tabs report completion", () => {
+    const { analyticsService, dependencies } = setup({ open: true });
+    const tabsProps = dependencies.AddCreditsTabs.mock.calls.at(-1)![0] as Parameters<typeof DEPENDENCIES.AddCreditsTabs>[0];
+
+    act(() => tabsProps.onDone(250, "Acme", 10));
+
+    expect(analyticsService.track).toHaveBeenCalledWith("add_credits_purchased", { category: "billing", amount: 250, context: undefined });
+  });
+
+  it("tracks a cancellation when the sheet is closed without a purchase", () => {
+    const onOpenChange = vi.fn();
+    const { analyticsService, dependencies } = setup({ open: true, onOpenChange, dependencies: { AddCreditsTabs: reportingTabs(false) } });
+
+    act(() => dependencies.Sheet.mock.calls.at(-1)![0].onOpenChange?.(false));
+
+    expect(analyticsService.track).toHaveBeenCalledWith("add_credits_cancelled", { category: "billing", context: undefined });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("does not track a cancellation after a purchase completes", () => {
+    const { analyticsService, dependencies } = setup({ open: true });
+    const tabsProps = dependencies.AddCreditsTabs.mock.calls.at(-1)![0] as Parameters<typeof DEPENDENCIES.AddCreditsTabs>[0];
+
+    act(() => tabsProps.onDone(100));
+    act(() => dependencies.Sheet.mock.calls.at(-1)![0].onOpenChange?.(false));
+
+    expect(analyticsService.track).not.toHaveBeenCalledWith("add_credits_cancelled", expect.anything());
   });
 
   it("forwards isWalletReady to the tabs", () => {
@@ -97,9 +140,12 @@ describe(AddCreditsSheet.name, () => {
     isWalletReady?: boolean;
     initialTab?: "purchase" | "coupon";
     description?: React.ReactNode;
+    context?: string;
     dependencies?: Partial<typeof DEPENDENCIES>;
   }) {
-    const dependencies = MockComponents(DEPENDENCIES, input.dependencies);
+    const analyticsService = mock<AnalyticsService>();
+    const useServices = (() => mock<ReturnType<typeof DEPENDENCIES.useServices>>({ analyticsService })) as typeof DEPENDENCIES.useServices;
+    const dependencies = MockComponents(DEPENDENCIES, { useServices, ...input.dependencies });
 
     render(
       <AddCreditsSheet
@@ -110,10 +156,11 @@ describe(AddCreditsSheet.name, () => {
         isWalletReady={input.isWalletReady}
         initialTab={input.initialTab}
         description={input.description}
+        context={input.context}
         dependencies={dependencies}
       />
     );
 
-    return { dependencies };
+    return { dependencies, analyticsService };
   }
 });

--- a/apps/deploy-web/src/components/auth/AddCreditsSheet/AddCreditsSheet.tsx
+++ b/apps/deploy-web/src/components/auth/AddCreditsSheet/AddCreditsSheet.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@akashnetwork/ui/components";
 
 import { type AddCreditsTab, AddCreditsTabs } from "@src/components/billing-usage/AddCreditsTabs/AddCreditsTabs";
+import { useServices } from "@src/context/ServicesProvider";
 
 export const DEPENDENCIES = {
   Sheet,
@@ -11,7 +12,8 @@ export const DEPENDENCIES = {
   SheetHeader,
   SheetTitle,
   SheetDescription,
-  AddCreditsTabs
+  AddCreditsTabs,
+  useServices
 };
 
 const DEFAULT_DESCRIPTION =
@@ -25,6 +27,8 @@ interface AddCreditsSheetProps {
   isWalletReady?: boolean;
   initialTab?: AddCreditsTab;
   description?: React.ReactNode;
+  /** Where the sheet was opened from (e.g. the onboarding reason); sent with the lifecycle events for funnel segmentation. */
+  context?: string;
   dependencies?: typeof DEPENDENCIES;
 }
 
@@ -36,13 +40,43 @@ export function AddCreditsSheet({
   isWalletReady,
   initialTab,
   description = DEFAULT_DESCRIPTION,
+  context,
   dependencies: d = DEPENDENCIES
 }: AddCreditsSheetProps) {
+  const { analyticsService } = d.useServices();
   const [isProcessing, setIsProcessing] = useState(false);
+  const wasOpenRef = useRef(false);
+  /** Set once a purchase or coupon redemption completes, so closing afterward isn't reported as a cancellation. */
+  const completedRef = useRef(false);
+
+  useEffect(
+    function trackOpened() {
+      if (open && !wasOpenRef.current) {
+        completedRef.current = false;
+        analyticsService.track("add_credits_opened", { category: "billing", context });
+      }
+      wasOpenRef.current = open;
+    },
+    [open, context, analyticsService]
+  );
 
   const requestOpenChange = (next: boolean) => {
     if (!next && isProcessing) return;
+    if (!next && !completedRef.current) {
+      analyticsService.track("add_credits_cancelled", { category: "billing", context });
+    }
     onOpenChange(next);
+  };
+
+  const completePurchase = (amount: number, organization?: string, bonusAmount?: number) => {
+    completedRef.current = true;
+    analyticsService.track("add_credits_purchased", { category: "billing", amount, context });
+    onDone(amount, organization, bonusAmount);
+  };
+
+  const completeRedemption = () => {
+    completedRef.current = true;
+    onRedeemed?.();
   };
 
   return (
@@ -56,8 +90,8 @@ export function AddCreditsSheet({
         {open && (
           <d.AddCreditsTabs
             initialTab={initialTab}
-            onDone={onDone}
-            onRedeemed={onRedeemed}
+            onDone={completePurchase}
+            onRedeemed={completeRedemption}
             isWalletReady={isWalletReady}
             onProcessingChange={setIsProcessing}
           />

--- a/apps/deploy-web/src/components/billing-usage/AddCreditsAmountFields/AddCreditsAmountFields.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AddCreditsAmountFields/AddCreditsAmountFields.spec.tsx
@@ -42,9 +42,36 @@ describe(AddCreditsAmountFields.name, () => {
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 
-  function setup(input: { value: AddCreditsAmountValue; minAmount?: number; error?: string }) {
+  it("reports a committed predefined amount", () => {
+    const { onAmountCommit } = setup({ value: { predefinedAmount: "", customAmount: "" } });
+
+    fireEvent.click(screen.getByRole("radio", { name: "100" }));
+
+    expect(onAmountCommit).toHaveBeenCalledWith(100, false);
+  });
+
+  it("reports a committed custom amount on blur", () => {
+    const { onAmountCommit } = setup({ value: { predefinedAmount: "", customAmount: "250" } });
+
+    fireEvent.blur(screen.getByLabelText("custom-amount"));
+
+    expect(onAmountCommit).toHaveBeenCalledWith(250, true);
+  });
+
+  it("does not report an empty custom amount on blur", () => {
+    const { onAmountCommit } = setup({ value: { predefinedAmount: "", customAmount: "" } });
+
+    fireEvent.blur(screen.getByLabelText("custom-amount"));
+
+    expect(onAmountCommit).not.toHaveBeenCalled();
+  });
+
+  function setup(input: { value: AddCreditsAmountValue; minAmount?: number; error?: string; onAmountCommit?: (amount: number, isCustom: boolean) => void }) {
     const onChange = vi.fn();
-    render(<AddCreditsAmountFields value={input.value} onChange={onChange} minAmount={input.minAmount ?? 20} error={input.error} />);
-    return { onChange };
+    const onAmountCommit = input.onAmountCommit ?? vi.fn();
+    render(
+      <AddCreditsAmountFields value={input.value} onChange={onChange} minAmount={input.minAmount ?? 20} error={input.error} onAmountCommit={onAmountCommit} />
+    );
+    return { onChange, onAmountCommit };
   }
 });

--- a/apps/deploy-web/src/components/billing-usage/AddCreditsAmountFields/AddCreditsAmountFields.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AddCreditsAmountFields/AddCreditsAmountFields.tsx
@@ -14,14 +14,17 @@ interface AddCreditsAmountFieldsProps {
   onChange: (value: AddCreditsAmountValue) => void;
   minAmount: number;
   error?: string;
+  /** Fired when the user commits an amount — a preset pick or a blurred custom amount — for analytics. */
+  onAmountCommit?: (amount: number, isCustom: boolean) => void;
 }
 
-export function AddCreditsAmountFields({ value, onChange, minAmount, error }: AddCreditsAmountFieldsProps) {
+export function AddCreditsAmountFields({ value, onChange, minAmount, error, onAmountCommit }: AddCreditsAmountFieldsProps) {
   const changePredefinedAmount = useCallback(
     (predefinedAmount: string) => {
       onChange({ predefinedAmount, customAmount: "" });
+      onAmountCommit?.(Number(predefinedAmount), false);
     },
-    [onChange]
+    [onChange, onAmountCommit]
   );
 
   const changeCustomAmount: ChangeEventHandler<HTMLInputElement> = useCallback(
@@ -30,6 +33,13 @@ export function AddCreditsAmountFields({ value, onChange, minAmount, error }: Ad
     },
     [onChange]
   );
+
+  const commitCustomAmount = useCallback(() => {
+    const amount = Number(value.customAmount);
+    if (amount > 0) {
+      onAmountCommit?.(amount, true);
+    }
+  }, [value.customAmount, onAmountCommit]);
 
   return (
     <div className="space-y-3">
@@ -76,6 +86,7 @@ export function AddCreditsAmountFields({ value, onChange, minAmount, error }: Ad
           type="number"
           value={value.customAmount}
           onChange={changeCustomAmount}
+          onBlur={commitCustomAmount}
           min={minAmount}
           step="0.01"
         />

--- a/apps/deploy-web/src/components/billing-usage/AddCreditsForm/AddCreditsForm.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AddCreditsForm/AddCreditsForm.spec.tsx
@@ -5,6 +5,7 @@ import { mock } from "vitest-mock-extended";
 
 import { getPaymentMethodDisplay } from "@src/components/shared/PaymentMethodCard/PaymentMethodCard";
 import { QueryKeys } from "@src/queries";
+import type { AnalyticsService } from "@src/services/analytics/analytics.service";
 import { AddCreditsAmountFields } from "../AddCreditsAmountFields/AddCreditsAmountFields";
 import type { PaymentMethodSourceHandle } from "../AddCreditsNewPaymentMethodFields/AddCreditsNewPaymentMethodFields";
 import type { DEPENDENCIES } from "./AddCreditsForm";
@@ -590,6 +591,61 @@ describe(AddCreditsForm.name, () => {
     expect(onProcessingChange).toHaveBeenCalledWith(true);
   });
 
+  it("tracks the selected amount when a predefined amount is chosen", () => {
+    const analyticsService = mock<AnalyticsService>();
+    setup({ status: "idle", analyticsService, paymentMethods: [paymentMethod({ id: "pm_saved", isDefault: true })] });
+
+    fireEvent.click(screen.getByRole("radio", { name: "100" }));
+
+    expect(analyticsService.track).toHaveBeenCalledWith("add_credits_amount_selected", { category: "billing", amount: 100, isCustom: false });
+  });
+
+  it("tracks the payment method type when a saved bank method is selected", () => {
+    const analyticsService = mock<AnalyticsService>();
+    setup({
+      status: "idle",
+      analyticsService,
+      paymentMethods: [paymentMethod({ id: "pm_default", isDefault: true }), paymentMethod({ id: "pm_bank", type: "us_bank_account", card: undefined })]
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /us_bank_account/i }));
+
+    expect(analyticsService.track).toHaveBeenCalledWith("add_credits_payment_method_selected", { category: "billing", type: "bank" });
+  });
+
+  it("re-reports a new-card payment type after switching to a saved method and back", () => {
+    const analyticsService = mock<AnalyticsService>();
+    const NewCardFields: typeof DEPENDENCIES.AddCreditsNewPaymentMethodFields = React.forwardRef<
+      PaymentMethodSourceHandle,
+      { clientSecret?: string; isLoading: boolean; onPaymentTypeChange?: (type: string) => void }
+    >(function NewCardFields({ onPaymentTypeChange }) {
+      return (
+        <button type="button" onClick={() => onPaymentTypeChange?.("card")}>
+          emit card
+        </button>
+      );
+    });
+
+    setup({
+      status: "idle",
+      analyticsService,
+      paymentMethods: [paymentMethod({ id: "pm_bank", type: "us_bank_account", card: undefined })],
+      dependencies: { AddCreditsNewPaymentMethodFields: NewCardFields }
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /add new payment method/i }));
+    fireEvent.click(screen.getByRole("button", { name: /emit card/i }));
+    fireEvent.click(screen.getByRole("button", { name: /emit card/i }));
+    fireEvent.click(screen.getByRole("button", { name: /us_bank_account/i }));
+    fireEvent.click(screen.getByRole("button", { name: /add new payment method/i }));
+    fireEvent.click(screen.getByRole("button", { name: /emit card/i }));
+
+    const cardEvents = analyticsService.track.mock.calls.filter(
+      ([event, props]) => event === "add_credits_payment_method_selected" && (props as { type?: string })?.type === "card"
+    );
+    expect(cardEvents).toHaveLength(2);
+  });
+
   function makePaymentMethodFieldsMock(addPaymentMethod: PaymentMethodSourceHandle["addPaymentMethod"] = vi.fn().mockResolvedValue(null)) {
     const propsLog: Array<{ clientSecret?: string; isLoading: boolean }> = [];
     const Mock: typeof DEPENDENCIES.AddCreditsNewPaymentMethodFields = React.forwardRef<
@@ -675,6 +731,7 @@ describe(AddCreditsForm.name, () => {
     paymentMethods?: PaymentMethod[];
     isLoadingMethods?: boolean;
     isMethodsError?: boolean;
+    analyticsService?: AnalyticsService;
     dependencies?: Partial<typeof DEPENDENCIES>;
   };
 
@@ -718,7 +775,8 @@ describe(AddCreditsForm.name, () => {
       mock<ReturnType<typeof DEPENDENCIES.useServices>>({
         stripe: mock<ReturnType<typeof DEPENDENCIES.useServices>["stripe"]>({
           getCustomerTransactions: input.getCustomerTransactions ?? vi.fn().mockResolvedValue({ transactions: [] })
-        })
+        }),
+        analyticsService: input.analyticsService ?? mock<AnalyticsService>()
       });
 
     // UseQueryResult is a discriminated union that neither mock<T>() nor a partial literal can satisfy

--- a/apps/deploy-web/src/components/billing-usage/AddCreditsForm/AddCreditsForm.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AddCreditsForm/AddCreditsForm.tsx
@@ -91,7 +91,7 @@ export function AddCreditsForm({ onDone, isWalletReady = true, onProcessingChang
   const { data: setupIntent, mutate: createSetupIntent, status: setupIntentStatus, reset: resetSetupIntent } = d.useSetupIntentMutation();
   const { user } = d.useUser();
   const { pollForPayment, isPolling } = d.usePaymentPolling();
-  const { stripe } = d.useServices();
+  const { stripe, analyticsService } = d.useServices();
   const { isTrialing, topUpMinAmountUsd } = d.useWallet();
   const queryClient = d.useQueryClient();
   const { data: paymentMethods, isLoading: isLoadingMethods, isError: isMethodsError } = d.usePaymentMethodsQuery();
@@ -110,6 +110,8 @@ export function AddCreditsForm({ onDone, isWalletReady = true, onProcessingChang
   /** Payment method already confirmed against the current SetupIntent; reused on retry because a SetupIntent can only be confirmed once. */
   const confirmedNewCardRef = useRef<{ paymentMethodId: string; organization?: string } | null>(null);
   const wasPollingRef = useRef<boolean>(false);
+  /** Last payment-method type reported to analytics, so the payment element's frequent change events don't re-fire the same type. */
+  const lastPaymentTypeRef = useRef<string | null>(null);
 
   const amount = useMemo(() => Number(amountInput.predefinedAmount || amountInput.customAmount) || 0, [amountInput.predefinedAmount, amountInput.customAmount]);
   const amountError = amount > 0 && amount < topUpMinAmountUsd ? `Minimum amount is $${topUpMinAmountUsd}` : undefined;
@@ -289,14 +291,41 @@ export function AddCreditsForm({ onDone, isWalletReady = true, onProcessingChang
 
   const changeSelectedMethod = useCallback(
     (methodId: string) => {
-      if (methodId === NEW_CARD && confirmedNewCardRef.current) {
-        // The previous SetupIntent was consumed by confirmSetup; a fresh one is required to collect a different card.
-        confirmedNewCardRef.current = null;
-        resetSetupIntent();
+      if (methodId === NEW_CARD) {
+        lastPaymentTypeRef.current = null;
+        if (confirmedNewCardRef.current) {
+          confirmedNewCardRef.current = null;
+          resetSetupIntent();
+        }
       }
       setSelectedMethodId(methodId);
+      const method = methodId === NEW_CARD ? undefined : paymentMethods?.find(candidate => candidate.id === methodId);
+      if (method) {
+        analyticsService.track("add_credits_payment_method_selected", { category: "billing", type: toPaymentMethodType(method.type) });
+      }
     },
-    [resetSetupIntent]
+    [resetSetupIntent, paymentMethods, analyticsService]
+  );
+
+  const trackAmountSelected = useCallback(
+    (amount: number, isCustom: boolean) => {
+      if (amount > 0) {
+        analyticsService.track("add_credits_amount_selected", { category: "billing", amount, isCustom });
+      }
+    },
+    [analyticsService]
+  );
+
+  const trackPaymentTypeSelected = useCallback(
+    (type: string) => {
+      const normalizedType = toPaymentMethodType(type);
+      if (lastPaymentTypeRef.current === normalizedType) {
+        return;
+      }
+      lastPaymentTypeRef.current = normalizedType;
+      analyticsService.track("add_credits_payment_method_selected", { category: "billing", type: normalizedType });
+    },
+    [analyticsService]
   );
 
   return (
@@ -304,7 +333,13 @@ export function AddCreditsForm({ onDone, isWalletReady = true, onProcessingChang
       <d.FirstPurchaseBonusAlert amount={amount} />
 
       <form className="space-y-6" onSubmit={submit}>
-        <d.AddCreditsAmountFields value={amountInput} onChange={setAmountInput} minAmount={topUpMinAmountUsd} error={amountError} />
+        <d.AddCreditsAmountFields
+          value={amountInput}
+          onChange={setAmountInput}
+          minAmount={topUpMinAmountUsd}
+          error={amountError}
+          onAmountCommit={trackAmountSelected}
+        />
 
         {isMethodsError && (
           <Alert variant="destructive">
@@ -335,7 +370,14 @@ export function AddCreditsForm({ onDone, isWalletReady = true, onProcessingChang
           )
         )}
 
-        {isNewCard && <d.AddCreditsNewPaymentMethodFields ref={paymentMethodRef} clientSecret={setupIntent?.clientSecret} isLoading={isSetupLoading} />}
+        {isNewCard && (
+          <d.AddCreditsNewPaymentMethodFields
+            ref={paymentMethodRef}
+            clientSecret={setupIntent?.clientSecret}
+            isLoading={isSetupLoading}
+            onPaymentTypeChange={trackPaymentTypeSelected}
+          />
+        )}
 
         {error && (
           <Alert variant="destructive">
@@ -372,4 +414,11 @@ export function AddCreditsForm({ onDone, isWalletReady = true, onProcessingChang
       )}
     </>
   );
+}
+
+/** Maps a Stripe payment-method type (`card`, `us_bank_account`, …) to the coarse label reported to analytics. */
+function toPaymentMethodType(rawType: string): string {
+  if (rawType === "card") return "card";
+  if (rawType.includes("bank")) return "bank";
+  return rawType;
 }

--- a/apps/deploy-web/src/components/billing-usage/AddCreditsNewPaymentMethodFields/AddCreditsNewPaymentMethodFields.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AddCreditsNewPaymentMethodFields/AddCreditsNewPaymentMethodFields.spec.tsx
@@ -101,7 +101,27 @@ describe(AddCreditsNewPaymentMethodFields.name, () => {
     expect(await screen.findByText(/couldn't save your card/i)).toBeInTheDocument();
   });
 
-  function setup(input: { isLoading: boolean; clientSecret?: string; dependencies?: Partial<typeof DEPENDENCIES> }) {
+  it("reports the selected payment method type from the payment element", () => {
+    const onPaymentTypeChange = vi.fn();
+    const PaymentElement = ((props: { onChange?: (event: { value: { type: string } }) => void }) => (
+      <button type="button" onClick={() => props.onChange?.({ value: { type: "us_bank_account" } })}>
+        choose bank
+      </button>
+    )) as unknown as typeof DEPENDENCIES.PaymentElement;
+
+    setup({ isLoading: false, clientSecret: "seti_secret", onPaymentTypeChange, dependencies: { PaymentElement } });
+
+    fireEvent.click(screen.getByRole("button", { name: /choose bank/i }));
+
+    expect(onPaymentTypeChange).toHaveBeenCalledWith("us_bank_account");
+  });
+
+  function setup(input: {
+    isLoading: boolean;
+    clientSecret?: string;
+    onPaymentTypeChange?: (type: string) => void;
+    dependencies?: Partial<typeof DEPENDENCIES>;
+  }) {
     const Elements = (({ children }: { children?: React.ReactNode }) => (
       <div data-testid="stripe-elements">{children}</div>
     )) as unknown as typeof DEPENDENCIES.Elements;
@@ -125,6 +145,7 @@ describe(AddCreditsNewPaymentMethodFields.name, () => {
         ref={ref}
         clientSecret={input.clientSecret}
         isLoading={input.isLoading}
+        onPaymentTypeChange={input.onPaymentTypeChange}
         dependencies={{
           Elements,
           useServices,

--- a/apps/deploy-web/src/components/billing-usage/AddCreditsNewPaymentMethodFields/AddCreditsNewPaymentMethodFields.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AddCreditsNewPaymentMethodFields/AddCreditsNewPaymentMethodFields.tsx
@@ -36,11 +36,13 @@ export const DEPENDENCIES = {
 interface AddCreditsNewPaymentMethodFieldsProps {
   clientSecret?: string;
   isLoading: boolean;
+  /** Reports the payment-method type (card, bank, …) the user selects in the Stripe payment element, for analytics. */
+  onPaymentTypeChange?: (type: string) => void;
   dependencies?: typeof DEPENDENCIES;
 }
 
 export const AddCreditsNewPaymentMethodFields = forwardRef<PaymentMethodSourceHandle, AddCreditsNewPaymentMethodFieldsProps>(
-  function AddCreditsNewPaymentMethodFields({ clientSecret, isLoading, dependencies: d = DEPENDENCIES }, ref) {
+  function AddCreditsNewPaymentMethodFields({ clientSecret, isLoading, onPaymentTypeChange, dependencies: d = DEPENDENCIES }, ref) {
     const { stripeService } = d.useServices();
     const { resolvedTheme } = d.useTheme();
 
@@ -64,7 +66,7 @@ export const AddCreditsNewPaymentMethodFields = forwardRef<PaymentMethodSourceHa
       <ErrorBoundary fallback={<div>Failed to load payment form</div>}>
         {stripePromise ? (
           <d.Elements key={clientSecret} stripe={stripePromise} options={{ clientSecret, appearance: stripeAppearance }}>
-            <StripePaymentMethodFields ref={ref} dependencies={d} />
+            <StripePaymentMethodFields ref={ref} dependencies={d} onPaymentTypeChange={onPaymentTypeChange} />
           </d.Elements>
         ) : (
           <div className="p-4 text-center text-muted-foreground">
@@ -78,10 +80,11 @@ export const AddCreditsNewPaymentMethodFields = forwardRef<PaymentMethodSourceHa
 
 interface StripePaymentMethodFieldsProps {
   dependencies: typeof DEPENDENCIES;
+  onPaymentTypeChange?: (type: string) => void;
 }
 
 const StripePaymentMethodFields = forwardRef<PaymentMethodSourceHandle, StripePaymentMethodFieldsProps>(function StripePaymentMethodFields(
-  { dependencies: d },
+  { dependencies: d, onPaymentTypeChange },
   ref
 ) {
   const stripe = d.useStripe();
@@ -131,7 +134,7 @@ const StripePaymentMethodFields = forwardRef<PaymentMethodSourceHandle, StripePa
 
       <div className="space-y-2">
         <h3 className="text-left text-sm font-medium text-muted-foreground">CHOOSE A PAYMENT METHOD</h3>
-        <d.PaymentElement options={{ layout: "tabs" }} />
+        <d.PaymentElement options={{ layout: "tabs" }} onChange={event => onPaymentTypeChange?.(event.value.type)} />
       </div>
 
       <Field className="gap-1">

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ComputeResourcesCard/ComputeResourcesCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ComputeResourcesCard/ComputeResourcesCard.spec.tsx
@@ -4,13 +4,15 @@ import type { Resolver } from "react-hook-form";
 import { FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
 
+import type { AnalyticsService } from "@src/services/analytics/analytics.service";
 import type { SdlBuilderFormValuesType } from "@src/types";
 import { SdlBuilderFormValuesSchema } from "@src/types";
 import { defaultServiceWithPlacement } from "@src/utils/sdl/data";
 import { ComputeResourcesCard, DEPENDENCIES } from "./ComputeResourcesCard";
 
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 describe(ComputeResourcesCard.name, () => {
@@ -123,6 +125,37 @@ describe(ComputeResourcesCard.name, () => {
     expect(await screen.findByText("RAM is required.")).toBeInTheDocument();
   });
 
+  it("tracks the CPU count on blur", async () => {
+    const { analyticsService } = setup({});
+
+    const cpuInput = screen.getByLabelText("CPU Count");
+    await userEvent.clear(cpuInput);
+    await userEvent.type(cpuInput, "2");
+    fireEvent.blur(cpuInput);
+
+    expect(analyticsService.track).toHaveBeenCalledWith("configure_cpu_count_changed", { category: "deployments", count: 2 });
+  });
+
+  it("does not track the CPU count when it is unchanged on blur", () => {
+    const { analyticsService } = setup({});
+
+    const cpuInput = screen.getByLabelText("CPU Count");
+    fireEvent.focus(cpuInput);
+    fireEvent.blur(cpuInput);
+
+    expect(analyticsService.track).not.toHaveBeenCalledWith("configure_cpu_count_changed", expect.anything());
+  });
+
+  it("does not track the CPU count when the field is cleared to an empty value", async () => {
+    const { analyticsService } = setup({});
+
+    const cpuInput = screen.getByLabelText("CPU Count");
+    await userEvent.clear(cpuInput);
+    fireEvent.blur(cpuInput);
+
+    expect(analyticsService.track).not.toHaveBeenCalledWith("configure_cpu_count_changed", expect.anything());
+  });
+
   function setup(input: {
     ram?: number;
     ramUnit?: string;
@@ -158,12 +191,15 @@ describe(ComputeResourcesCard.name, () => {
       return <FormProvider {...form}>{children}</FormProvider>;
     };
 
+    const analyticsService = mock<AnalyticsService>();
+    const useServices: typeof DEPENDENCIES.useServices = () => mock<ReturnType<typeof DEPENDENCIES.useServices>>({ analyticsService });
+
     render(
       <Wrapper>
-        <ComputeResourcesCard serviceIndex={0} locked={input.locked} dependencies={{ ...DEPENDENCIES, ...input.dependencies }} />
+        <ComputeResourcesCard serviceIndex={0} locked={input.locked} dependencies={{ ...DEPENDENCIES, useServices, ...input.dependencies }} />
       </Wrapper>
     );
 
-    return { getValues: () => getValues() };
+    return { getValues: () => getValues(), analyticsService };
   }
 });

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ComputeResourcesCard/ComputeResourcesCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ComputeResourcesCard/ComputeResourcesCard.tsx
@@ -1,4 +1,5 @@
 import type { FC } from "react";
+import { useRef } from "react";
 import { useController, useFormContext } from "react-hook-form";
 import {
   Field,
@@ -13,10 +14,11 @@ import {
   useFieldError
 } from "@akashnetwork/ui/components";
 
+import { useServices } from "@src/context/ServicesProvider";
 import type { SdlBuilderFormValuesType } from "@src/types";
 import { memoryUnits, storageUnits, validationConfig } from "@src/utils/akash/units";
 
-export const DEPENDENCIES = { NumberUnitInput, useFieldError };
+export const DEPENDENCIES = { NumberUnitInput, useFieldError, useServices };
 
 type Props = {
   serviceIndex: number;
@@ -33,6 +35,8 @@ type Props = {
  */
 export const ComputeResourcesCard: FC<Props> = ({ serviceIndex, locked = false, dependencies: d = DEPENDENCIES }) => {
   const { control } = useFormContext<SdlBuilderFormValuesType>();
+  const { analyticsService } = d.useServices();
+  const cpuFocusValueRef = useRef<number | null>(null);
 
   const ram = useController({ control, name: `services.${serviceIndex}.profile.ram` });
   const ramUnit = useController({ control, name: `services.${serviceIndex}.profile.ramUnit` });
@@ -47,31 +51,43 @@ export const ComputeResourcesCard: FC<Props> = ({ serviceIndex, locked = false, 
       <FormField
         control={control}
         name={`services.${serviceIndex}.profile.cpu`}
-        render={({ field, fieldState }) => (
-          <FormItem>
-            <FormLabel className="text-sm" htmlFor="cpu-count-input">
-              CPU Count
-            </FormLabel>
-            <Input
-              type="number"
-              id="cpu-count"
-              aria-label="CPU Count"
-              error={!!fieldState.error}
-              value={Number.isFinite(field.value) ? field.value : ""}
-              min={0.1}
-              step={0.1}
-              max={validationConfig.maxCpuAmount}
-              disabled={locked}
-              onChange={event => {
-                const next = parseFloat(event.target.value);
-                field.onChange(Number.isFinite(next) ? next : null);
-              }}
-              onBlur={field.onBlur}
-              inputClassName="h-9"
-            />
-            <FormMessage className="text-muted-foreground" />
-          </FormItem>
-        )}
+        render={({ field, fieldState }) => {
+          const captureCpuCount = () => {
+            cpuFocusValueRef.current = field.value;
+          };
+          const commitCpuCount = () => {
+            if (field.value !== cpuFocusValueRef.current && Number.isFinite(field.value)) {
+              analyticsService.track("configure_cpu_count_changed", { category: "deployments", count: field.value });
+            }
+            field.onBlur();
+          };
+          return (
+            <FormItem>
+              <FormLabel className="text-sm" htmlFor="cpu-count-input">
+                CPU Count
+              </FormLabel>
+              <Input
+                type="number"
+                id="cpu-count"
+                aria-label="CPU Count"
+                error={!!fieldState.error}
+                value={Number.isFinite(field.value) ? field.value : ""}
+                min={0.1}
+                step={0.1}
+                max={validationConfig.maxCpuAmount}
+                disabled={locked}
+                onFocus={captureCpuCount}
+                onChange={event => {
+                  const next = parseFloat(event.target.value);
+                  field.onChange(Number.isFinite(next) ? next : null);
+                }}
+                onBlur={commitCpuCount}
+                inputClassName="h-9"
+              />
+              <FormMessage className="text-muted-foreground" />
+            </FormItem>
+          );
+        }}
       />
 
       <div className="grid grid-cols-2 gap-2">

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/GpuCard/GpuCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/GpuCard/GpuCard.spec.tsx
@@ -3,6 +3,7 @@ import { FormProvider, useForm } from "react-hook-form";
 import { describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
 
+import type { AnalyticsService } from "@src/services/analytics/analytics.service";
 import type { SdlBuilderFormValuesType } from "@src/types";
 import type { GpuVendor } from "@src/types/gpu";
 import { validationConfig } from "@src/utils/akash/units";
@@ -305,6 +306,23 @@ describe(GpuCard.name, () => {
     expect(screen.getByRole("combobox", { name: "GPU interface" })).toBeDisabled();
   }, 15_000);
 
+  it("tracks the selected GPU model with its vendor", async () => {
+    const { analyticsService, user } = setup({ hasGpu: true, gpuModels: [{ vendor: "nvidia", name: "", memory: "", interface: "" }] });
+
+    await user.click(screen.getByRole("combobox", { name: "GPU model" }));
+    await user.click(await screen.findByRole("option", { name: "t4" }));
+
+    expect(analyticsService.track).toHaveBeenCalledWith("configure_gpu_type_selected", { category: "deployments", model: "t4", vendor: "nvidia" });
+  });
+
+  it("tracks a GPU count change", async () => {
+    const { analyticsService, user } = setup({ hasGpu: true, gpu: 1 });
+
+    await user.click(screen.getByRole("button", { name: "Increase GPU count" }));
+
+    expect(analyticsService.track).toHaveBeenCalledWith("configure_gpu_count_changed", { category: "deployments", count: 2 });
+  });
+
   const StubGpuModelFields: typeof DEPENDENCIES.GpuModelFields = ({ gpuIndex }) => <div role="group" aria-label={`GPU ${gpuIndex + 1}`} />;
 
   function makeGpuModels(count: number): SdlBuilderFormValuesType["services"][number]["profile"]["gpuModels"] {
@@ -341,6 +359,8 @@ describe(GpuCard.name, () => {
     gpuModelsResult.data = input.isLoading || input.isError ? undefined : input.vendors ?? GPU_VENDORS;
     const useGpuModels: typeof DEPENDENCIES.useGpuModels = () => gpuModelsResult;
     const useFieldError: typeof DEPENDENCIES.useFieldError = () => ({ error: input.gpuError });
+    const analyticsService = mock<AnalyticsService>();
+    const useServices: typeof DEPENDENCIES.useServices = () => mock<ReturnType<typeof DEPENDENCIES.useServices>>({ analyticsService });
 
     let getValues: () => SdlBuilderFormValuesType = () => values;
     const Wrapper = ({ children }: PropsWithChildren) => {
@@ -351,12 +371,12 @@ describe(GpuCard.name, () => {
 
     render(
       <Wrapper>
-        <GpuCard serviceIndex={0} locked={input.locked} dependencies={{ ...DEPENDENCIES, useGpuModels, useFieldError, ...input.dependencies }} />
+        <GpuCard serviceIndex={0} locked={input.locked} dependencies={{ ...DEPENDENCIES, useGpuModels, useFieldError, useServices, ...input.dependencies }} />
       </Wrapper>
     );
 
     const user = userEvent.setup();
 
-    return { user, getValues: () => getValues() };
+    return { user, getValues: () => getValues(), analyticsService };
   }
 });

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/GpuCard/GpuCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/GpuCard/GpuCard.tsx
@@ -20,6 +20,7 @@ import {
 import { GpuIcon, LockIcon, PlusIcon, TrashIcon, XIcon } from "lucide-react";
 
 import { SearchableSelect } from "@src/components/shared/SearchableSelect/SearchableSelect";
+import { useServices } from "@src/context/ServicesProvider";
 import { useGpuModels } from "@src/queries/useGpuQuery";
 import type { SdlBuilderFormValuesType } from "@src/types";
 import type { GpuVendor } from "@src/types/gpu";
@@ -30,7 +31,7 @@ import { gpuTooltip } from "../cardTooltips";
 import { SELECT_TRUNCATE_VALUE } from "../selectStyles";
 import { UnlockGpusButton } from "../UnlockGpusButton/UnlockGpusButton";
 
-export const DEPENDENCIES = { CollapsibleCard, useGpuModels, useFieldError, GpuModelFields };
+export const DEPENDENCIES = { CollapsibleCard, useGpuModels, useFieldError, useServices, GpuModelFields };
 
 type Props = {
   serviceIndex: number;
@@ -113,6 +114,7 @@ export const GpuCard: FC<Props> = ({ serviceIndex, locked = false, isBlockedMode
               onUnlock={onUnlock}
               locked={locked}
               onRemove={index === 0 ? undefined : () => remove(index)}
+              dependencies={d}
             />
           ))}
 
@@ -143,9 +145,15 @@ const GpuCountField: FC<{ serviceIndex: number; locked?: boolean; dependencies: 
   dependencies: d
 }) => {
   const { control } = useFormContext<SdlBuilderFormValuesType>();
+  const { analyticsService } = d.useServices();
   const { error: gpuError } = d.useFieldError(`services.${serviceIndex}.profile.gpu`);
   const errorId = useId();
   const gpu = useController({ control, name: `services.${serviceIndex}.profile.gpu` });
+
+  function changeGpuCount(count: number) {
+    analyticsService.track("configure_gpu_count_changed", { category: "deployments", count });
+    gpu.field.onChange(count);
+  }
 
   return (
     <Field className="gap-2">
@@ -159,7 +167,7 @@ const GpuCountField: FC<{ serviceIndex: number; locked?: boolean; dependencies: 
           max={validationConfig.maxGpuAmount}
           aria-describedby={gpuError ? errorId : undefined}
           disabled={locked}
-          onChange={gpu.field.onChange}
+          onChange={changeGpuCount}
         />
         <FieldError id={errorId}>{gpuError}</FieldError>
       </FieldContent>
@@ -180,6 +188,7 @@ type GpuModelFieldsProps = {
   /** While the pane is locked every input is disabled so the configured GPU stays viewable but read-only. */
   locked?: boolean;
   onRemove?: () => void;
+  dependencies?: typeof DEPENDENCIES;
 };
 
 /**
@@ -193,8 +202,20 @@ type GpuModelFieldsProps = {
  * selects never sit permanently dead with no explanation (matching the legacy
  * GPU control's "Loading GPU models…" affordance).
  */
-function GpuModelFields({ serviceIndex, gpuIndex, gpuVendors, isLoading, isError, isBlockedModel, onUnlock, locked = false, onRemove }: GpuModelFieldsProps) {
+function GpuModelFields({
+  serviceIndex,
+  gpuIndex,
+  gpuVendors,
+  isLoading,
+  isError,
+  isBlockedModel,
+  onUnlock,
+  locked = false,
+  onRemove,
+  dependencies: d = DEPENDENCIES
+}: GpuModelFieldsProps) {
   const { control, setValue } = useFormContext<SdlBuilderFormValuesType>();
+  const { analyticsService } = d.useServices();
   const basePath = `services.${serviceIndex}.profile.gpuModels.${gpuIndex}` as const;
 
   const vendor = useController({ control, name: `${basePath}.vendor` });
@@ -228,8 +249,9 @@ function GpuModelFields({ serviceIndex, gpuIndex, gpuVendors, isLoading, isError
       name.field.onChange(value);
       setValue(`${basePath}.memory`, onlyOption(picked?.memory), { shouldValidate: true, shouldDirty: true });
       setValue(`${basePath}.interface`, onlyOption(picked?.interface), { shouldValidate: true, shouldDirty: true });
+      analyticsService.track("configure_gpu_type_selected", { category: "deployments", model: value, vendor: vendor.field.value });
     },
-    [models, name.field, setValue, basePath]
+    [models, name.field, setValue, basePath, analyticsService, vendor.field.value]
   );
 
   const clearModel = useCallback(() => {

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/PresetsCard/PresetsCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/PresetsCard/PresetsCard.spec.tsx
@@ -1,7 +1,9 @@
 import type { PropsWithChildren } from "react";
 import { FormProvider, useForm, type UseFormSetValue } from "react-hook-form";
 import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
 
+import type { AnalyticsService } from "@src/services/analytics/analytics.service";
 import type { SdlBuilderFormValuesType } from "@src/types";
 import { defaultServiceWithPlacement } from "@src/utils/sdl/data";
 import type { HardwarePreset } from "./hardwarePresets";
@@ -12,8 +14,32 @@ import userEvent from "@testing-library/user-event";
 
 const PRESETS: HardwarePreset[] = [
   { id: "small", label: "Small preset", group: "compute", cpu: 2, ram: 4, ramUnit: "Gi", storage: 20, storageUnit: "Gi" },
-  { id: "gpu", label: "GPU preset", group: "gpu", cpu: 4, ram: 16, ramUnit: "Gi", storage: 100, storageUnit: "Gi", gpu: 2, gpuVendor: "nvidia", gpuModel: "t4" },
-  { id: "gpu-h100", label: "H100 preset", group: "gpu", cpu: 8, ram: 32, ramUnit: "Gi", storage: 100, storageUnit: "Gi", gpu: 1, gpuVendor: "nvidia", gpuModel: "h100" }
+  {
+    id: "gpu",
+    label: "GPU preset",
+    group: "gpu",
+    cpu: 4,
+    ram: 16,
+    ramUnit: "Gi",
+    storage: 100,
+    storageUnit: "Gi",
+    gpu: 2,
+    gpuVendor: "nvidia",
+    gpuModel: "t4"
+  },
+  {
+    id: "gpu-h100",
+    label: "H100 preset",
+    group: "gpu",
+    cpu: 8,
+    ram: 32,
+    ramUnit: "Gi",
+    storage: 100,
+    storageUnit: "Gi",
+    gpu: 1,
+    gpuVendor: "nvidia",
+    gpuModel: "h100"
+  }
 ];
 
 describe(PresetsCard.name, () => {
@@ -135,6 +161,14 @@ describe(PresetsCard.name, () => {
     expect(screen.queryByRole("button", { name: /unlock/i })).not.toBeInTheDocument();
   });
 
+  it("tracks the selected preset", async () => {
+    const { analyticsService } = setup({});
+
+    await pickPreset("Small preset");
+
+    expect(analyticsService.track).toHaveBeenCalledWith("configure_preset_selected", { category: "deployments", preset: "small" });
+  });
+
   async function pickPreset(name: string) {
     await userEvent.click(screen.getByRole("combobox", { name: "Preset" }));
     await userEvent.click(await screen.findByRole("option", { name: new RegExp(name) }));
@@ -160,6 +194,9 @@ describe(PresetsCard.name, () => {
       return <FormProvider {...form}>{children}</FormProvider>;
     };
 
+    const analyticsService = mock<AnalyticsService>();
+    const useServices: typeof DEPENDENCIES.useServices = () => mock<ReturnType<typeof DEPENDENCIES.useServices>>({ analyticsService });
+
     render(
       <Wrapper>
         <PresetsCard
@@ -167,11 +204,11 @@ describe(PresetsCard.name, () => {
           locked={input.locked}
           isBlockedModel={input.isBlockedModel}
           onUnlock={input.onUnlock}
-          dependencies={{ ...DEPENDENCIES, hardwarePresets: PRESETS }}
+          dependencies={{ ...DEPENDENCIES, hardwarePresets: PRESETS, useServices }}
         />
       </Wrapper>
     );
 
-    return { getValues: () => getValues(), setValue };
+    return { getValues: () => getValues(), setValue, analyticsService };
   }
 });

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/PresetsCard/PresetsCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/PresetsCard/PresetsCard.tsx
@@ -4,13 +4,14 @@ import { useFormContext, useWatch } from "react-hook-form";
 import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectSeparator, SelectTrigger, SelectValue } from "@akashnetwork/ui/components";
 import { LockIcon } from "lucide-react";
 
+import { useServices } from "@src/context/ServicesProvider";
 import type { SdlBuilderFormValuesType } from "@src/types";
 import { SELECT_TRUNCATE_VALUE } from "../selectStyles";
 import { UnlockGpusButton } from "../UnlockGpusButton/UnlockGpusButton";
 import type { HardwarePreset, HardwarePresetGroup } from "./hardwarePresets";
 import { applyPreset, detectPreset, formatPresetSpecs, HARDWARE_PRESET_GROUP_LABELS, HARDWARE_PRESET_GROUP_ORDER, hardwarePresets } from "./hardwarePresets";
 
-export const DEPENDENCIES = { hardwarePresets };
+export const DEPENDENCIES = { hardwarePresets, useServices };
 
 type Props = {
   serviceIndex: number;
@@ -37,6 +38,7 @@ type Props = {
  */
 export const PresetsCard: FC<Props> = ({ serviceIndex, locked = false, isBlockedModel = () => false, onUnlock, dependencies: d = DEPENDENCIES }) => {
   const { control, setValue } = useFormContext<SdlBuilderFormValuesType>();
+  const { analyticsService } = d.useServices();
   const profile = useWatch({ control, name: `services.${serviceIndex}.profile` });
   const selectedPresetId = useMemo(() => detectPreset(d.hardwarePresets, profile ?? {})?.id ?? "", [d.hardwarePresets, profile]);
 
@@ -47,8 +49,9 @@ export const PresetsCard: FC<Props> = ({ serviceIndex, locked = false, isBlocked
         return;
       }
       applyPreset(setValue, serviceIndex, preset);
+      analyticsService.track("configure_preset_selected", { category: "deployments", preset: id });
     },
-    [d.hardwarePresets, setValue, serviceIndex]
+    [d.hardwarePresets, setValue, serviceIndex, analyticsService]
   );
 
   const groups = HARDWARE_PRESET_GROUP_ORDER.map(group => ({

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.spec.tsx
@@ -2,6 +2,7 @@ import { useController, useFormContext, useWatch } from "react-hook-form";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
+import type { AnalyticsService } from "@src/services/analytics/analytics.service";
 import type { PlacementType, SdlBuilderFormValuesType, ServiceType } from "@src/types";
 import { defaultService } from "@src/utils/sdl/data";
 import { ConfigurationPane } from "../ConfigurationPane/ConfigurationPane";
@@ -369,6 +370,12 @@ describe(ConfigureDeploymentForm.name, () => {
     expect(screen.getByTestId("has-ssh-key").textContent).toBe("false");
   });
 
+  it("tracks the configure page view on mount", () => {
+    const { analyticsService } = setup({ initialSdl: undefined });
+
+    expect(analyticsService.track).toHaveBeenCalledWith("configure_page_viewed", { category: "deployments" });
+  });
+
   function setup(input: {
     initialSdl: string | undefined;
     initialName?: string;
@@ -409,6 +416,7 @@ describe(ConfigureDeploymentForm.name, () => {
       error: input.flowError,
       actions: mock<DeploymentFlow["actions"]>({ requestQuotes })
     });
+    const analyticsService = mock<AnalyticsService>();
     const dependencies: typeof DEPENDENCIES = {
       Layout: vi.fn(({ children }) => <div data-testid="layout-mock">{children}</div>) as never,
       NextSeo: vi.fn(() => null) as never,
@@ -418,6 +426,7 @@ describe(ConfigureDeploymentForm.name, () => {
       useConfigureDraft: useConfigureDraft as never,
       useDeploymentName,
       useSnackbar: () => mock<ReturnType<typeof DEPENDENCIES.useSnackbar>>({ enqueueSnackbar }),
+      useServices: () => mock<ReturnType<typeof DEPENDENCIES.useServices>>({ analyticsService }),
       Snackbar: Snackbar as never,
       ReviewAndDeployModal: ReviewAndDeployModal as never,
       DeployProgressOverlay: () => null,
@@ -436,7 +445,18 @@ describe(ConfigureDeploymentForm.name, () => {
       />
     );
 
-    return { ConfigureDeploymentPanes, ConfigureDeploymentHeader, ReviewAndDeployModal, flow, enqueueSnackbar, save, clear, requestQuotes, retryTrial };
+    return {
+      ConfigureDeploymentPanes,
+      ConfigureDeploymentHeader,
+      ReviewAndDeployModal,
+      flow,
+      enqueueSnackbar,
+      save,
+      clear,
+      requestQuotes,
+      retryTrial,
+      analyticsService
+    };
   }
 });
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
@@ -9,6 +9,7 @@ import { useSnackbar } from "notistack";
 
 import Layout from "@src/components/layout/Layout";
 import { isLogCollectorService } from "@src/components/sdl/LogCollectorControl/LogCollectorControl";
+import { useServices } from "@src/context/ServicesProvider";
 import { usePlacementsWithBids } from "@src/queries/usePlacementsWithBids";
 import type { SdlBuilderFormValuesType, ServiceType } from "@src/types";
 import { SdlBuilderFormValuesSchema } from "@src/types";
@@ -40,6 +41,7 @@ export const DEPENDENCIES = {
   useConfigureDraft,
   useDeploymentName,
   usePlacementsWithBids,
+  useServices,
   useSnackbar,
   Snackbar
 };
@@ -72,6 +74,7 @@ export const ConfigureDeploymentForm: FC<Props> = ({ initialSdl, initialName, in
    */
   const lastSelectedServiceId = useRef(selectedServiceId);
   const { enqueueSnackbar } = d.useSnackbar();
+  const { analyticsService } = d.useServices();
   const draft = d.useConfigureDraft(intent);
   const { name: deploymentName, setName: setDeploymentName } = d.useDeploymentName({ initialName, dseq: flow.dseq });
   const form = useForm<SdlBuilderFormValuesType>({
@@ -83,6 +86,13 @@ export const ConfigureDeploymentForm: FC<Props> = ({ initialSdl, initialName, in
   const services = useWatch({ control: form.control, name: "services" });
   const placements = useWatch({ control: form.control, name: "placements" });
   const selectedPlacement = resolveSelectedPlacement(services, placements, selectedServiceId);
+
+  useEffect(
+    function trackConfigurePageViewed() {
+      analyticsService.track("configure_page_viewed", { category: "deployments" });
+    },
+    [analyticsService]
+  );
 
   useEffect(
     function notifyOnImportError() {

--- a/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.spec.tsx
+++ b/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.spec.tsx
@@ -5,10 +5,11 @@ import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { EnsureTrialStartedResult } from "@src/hooks/useEnsureTrialStarted";
+import type { AnalyticsService } from "@src/services/analytics/analytics.service";
 import { UrlService } from "@src/utils/urlUtils";
 import { DEPENDENCIES, OnboardingPickerPage } from "./OnboardingPickerPage";
 
-import { act, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { ComponentMock, MockComponents } from "@tests/unit/mocks";
 
 const HELLO_WORLD_ID = "hello-world";
@@ -315,6 +316,71 @@ describe(OnboardingPickerPage.name, () => {
     expect(replace).not.toHaveBeenCalled();
   });
 
+  it("tracks a deploy click for the hello-world template", () => {
+    const DeploymentTemplatePickerCard = vi.fn(ComponentMock);
+    const { analyticsService } = setup({ dependencies: { DeploymentTemplatePickerCard } });
+
+    act(() => getCard(DeploymentTemplatePickerCard, "Hello world").onDeploy!());
+
+    expect(analyticsService.track).toHaveBeenCalledWith("onboarding_deploy_click", { category: "onboarding", option: HELLO_WORLD_ID });
+  });
+
+  it("tracks a deploy click for the space-agent template", () => {
+    const DeploymentTemplatePickerCard = vi.fn(ComponentMock);
+    const { analyticsService } = setup({ dependencies: { DeploymentTemplatePickerCard } });
+
+    act(() => getCard(DeploymentTemplatePickerCard, "Space Agent").onDeploy!());
+
+    expect(analyticsService.track).toHaveBeenCalledWith("onboarding_deploy_click", { category: "onboarding", option: SPACE_AGENT_ID });
+  });
+
+  it("tracks a deploy click for the llm template once the user is no longer trialing", () => {
+    const DeploymentTemplatePickerCard = vi.fn(ComponentMock);
+    const { analyticsService } = setup({ isTrialing: false, dependencies: { DeploymentTemplatePickerCard } });
+
+    act(() => getCard(DeploymentTemplatePickerCard, "LLM Chatbot").onDeploy!());
+
+    expect(analyticsService.track).toHaveBeenCalledWith("onboarding_deploy_click", { category: "onboarding", option: LLM_ID });
+  });
+
+  it("tracks a deploy click with the custom-image option from the Deploy image link", () => {
+    const { analyticsService } = setup({});
+
+    act(() => fireEvent.click(screen.getByRole("link", { name: /deploy image/i })));
+
+    expect(analyticsService.track).toHaveBeenCalledWith("onboarding_deploy_click", { category: "onboarding", option: "custom-image" });
+  });
+
+  it("tracks skipping the trial as an add-credits click", () => {
+    const Button = vi.fn(ComponentMock);
+    const { analyticsService } = setup({ isTrialing: true, dependencies: { Button: Button as unknown as typeof DEPENDENCIES.Button } });
+
+    const skipButton = Button.mock.calls.at(-1)![0] as ButtonProps;
+    act(() => (skipButton.onClick as () => void)());
+
+    expect(analyticsService.track).toHaveBeenCalledWith("onboarding_add_credits_click", { category: "onboarding", reason: "skip-trial" });
+  });
+
+  it("tracks the add-credits-to-unlock click on the gated LLM card", () => {
+    const DeploymentTemplatePickerCard = vi.fn(ComponentMock);
+    const { analyticsService } = setup({ isTrialing: true, dependencies: { DeploymentTemplatePickerCard } });
+
+    act(() => getCard(DeploymentTemplatePickerCard, "LLM Chatbot").onDeploy!());
+
+    expect(analyticsService.track).toHaveBeenCalledWith("onboarding_add_credits_click", { category: "onboarding", reason: "unlock-gpu" });
+  });
+
+  it("does not track a deploy click when the llm auto-deploys after adding credits", () => {
+    const DeploymentTemplatePickerCard = vi.fn(ComponentMock);
+    const AddCreditsSheet = vi.fn(ComponentMock);
+    const { analyticsService } = setup({ isTrialing: true, dependencies: { DeploymentTemplatePickerCard, AddCreditsSheet } });
+
+    act(() => getCard(DeploymentTemplatePickerCard, "LLM Chatbot").onDeploy!());
+    act(() => (AddCreditsSheet.mock.calls.at(-1)![0] as SheetProps).onDone(100, "Acme"));
+
+    expect(analyticsService.track).not.toHaveBeenCalledWith("onboarding_deploy_click", expect.anything());
+  });
+
   function getCard(DeploymentTemplatePickerCard: ReturnType<typeof vi.fn>, title: string) {
     return DeploymentTemplatePickerCard.mock.calls.find(call => (call[0] as PickerCardProps).title === title)![0] as PickerCardProps;
   }
@@ -361,10 +427,15 @@ describe(OnboardingPickerPage.name, () => {
     );
     const useWallet: typeof DEPENDENCIES.useWallet = () => mock<ReturnType<typeof DEPENDENCIES.useWallet>>({ isTrialing });
     const useFlag: typeof DEPENDENCIES.useFlag = flag => (flag === "first_purchase_bonus" ? isFirstPurchaseBonusEnabled : isHackathonsEnabled);
+    const analyticsService = mock<AnalyticsService>();
     const useServices: typeof DEPENDENCIES.useServices = () =>
-      mock<ReturnType<typeof DEPENDENCIES.useServices>>({ publicConfig: { NEXT_PUBLIC_TRIAL_CREDITS_AMOUNT: trialCreditsAmount }, urlService: UrlService });
+      mock<ReturnType<typeof DEPENDENCIES.useServices>>({
+        publicConfig: { NEXT_PUBLIC_TRIAL_CREDITS_AMOUNT: trialCreditsAmount },
+        urlService: UrlService,
+        analyticsService
+      });
 
-    return render(
+    const result = render(
       <OnboardingPickerPage
         dependencies={MockComponents(DEPENDENCIES, {
           useRouter,
@@ -377,5 +448,7 @@ describe(OnboardingPickerPage.name, () => {
         })}
       />
     );
+
+    return { ...result, analyticsService };
   }
 });

--- a/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.tsx
+++ b/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.tsx
@@ -50,7 +50,7 @@ type OnboardingPickerPageProps = {
 export function OnboardingPickerPage({ dependencies: d = DEPENDENCIES }: OnboardingPickerPageProps) {
   const router = d.useRouter();
   const { isTrialing } = d.useWallet();
-  const { publicConfig, urlService } = d.useServices();
+  const { publicConfig, urlService, analyticsService } = d.useServices();
   const trialCreditsAmount = publicConfig.NEXT_PUBLIC_TRIAL_CREDITS_AMOUNT;
   const [addCreditsSheetReason, setAddCreditsSheetReason] = useState<"unlock-gpu" | "skip-trial" | "hackathon-coupon" | null>(null);
   const { isWalletReady, error: trialError, wallet } = d.useEnsureTrialStarted();
@@ -72,8 +72,27 @@ export function OnboardingPickerPage({ dependencies: d = DEPENDENCIES }: Onboard
   }, [showHackathonEntry, searchParams, router, urlService]);
 
   /** Redirects to the bid-screening view, which auto-starts the deployment from the intent params. */
-  function deployTemplate(templateId: string) {
+  function redirectToConfigure(templateId: string) {
     router.push(urlService.configureDeployment({ templateId, sdlStrategy: "default", bidStrategy: "auto" }));
+  }
+
+  function deployTemplate(templateId: string) {
+    analyticsService.track("onboarding_deploy_click", { category: "onboarding", option: templateId });
+    redirectToConfigure(templateId);
+  }
+
+  function trackCustomImageDeploy() {
+    analyticsService.track("onboarding_deploy_click", { category: "onboarding", option: "custom-image" });
+  }
+
+  function openSkipTrialCredits() {
+    analyticsService.track("onboarding_add_credits_click", { category: "onboarding", reason: "skip-trial" });
+    setAddCreditsSheetReason("skip-trial");
+  }
+
+  function openGpuUnlockCredits() {
+    analyticsService.track("onboarding_add_credits_click", { category: "onboarding", reason: "unlock-gpu" });
+    setAddCreditsSheetReason("unlock-gpu");
   }
 
   return (
@@ -163,7 +182,7 @@ export function OnboardingPickerPage({ dependencies: d = DEPENDENCIES }: Onboard
                 ctaVariant="outline"
                 heroImageSrc="/images/onboarding/llm-chatbot.png"
                 heroImageAlt="LLM chatbot template"
-                onDeploy={() => (isLlmAvailable ? deployTemplate(TEMPLATE_IDS.llmChatbot) : setAddCreditsSheetReason("unlock-gpu"))}
+                onDeploy={() => (isLlmAvailable ? deployTemplate(TEMPLATE_IDS.llmChatbot) : openGpuUnlockCredits())}
               />
             </div>
 
@@ -175,7 +194,7 @@ export function OnboardingPickerPage({ dependencies: d = DEPENDENCIES }: Onboard
                 </div>
 
                 <Button variant="outline" className="w-full gap-2 no-underline hover:no-underline sm:w-auto" asChild>
-                  <Link href={urlService.configureDeployment()}>
+                  <Link href={urlService.configureDeployment()} onClick={trackCustomImageDeploy}>
                     <span>Deploy image</span>
                     <ArrowRight className="h-4 w-4" />
                   </Link>
@@ -184,7 +203,7 @@ export function OnboardingPickerPage({ dependencies: d = DEPENDENCIES }: Onboard
 
               {(isTrialing || !wallet?.creditAmount) && (
                 <div className="text-center">
-                  <d.Button onClick={() => setAddCreditsSheetReason("skip-trial")} variant="ghost">
+                  <d.Button onClick={openSkipTrialCredits} variant="ghost">
                     Skip the trial - unlock Console
                     <ArrowRight className="ml-2 h-4 w-4" />
                   </d.Button>
@@ -196,13 +215,14 @@ export function OnboardingPickerPage({ dependencies: d = DEPENDENCIES }: Onboard
 
         <d.AddCreditsSheet
           open={addCreditsSheetReason !== null}
+          context={addCreditsSheetReason ?? undefined}
           onOpenChange={open => setAddCreditsSheetReason(open ? "unlock-gpu" : null)}
           isWalletReady={isWalletReady}
           onRedeemed={() => setAddCreditsSheetReason(null)}
           initialTab={addCreditsSheetReason === "hackathon-coupon" ? "coupon" : "purchase"}
           onDone={() => {
             if (addCreditsSheetReason === "unlock-gpu") {
-              deployTemplate(TEMPLATE_IDS.llmChatbot);
+              redirectToConfigure(TEMPLATE_IDS.llmChatbot);
             } else if (addCreditsSheetReason === "skip-trial") {
               router.push(urlService.configureDeployment());
             } else {

--- a/apps/deploy-web/src/services/analytics/analytics.service.ts
+++ b/apps/deploy-web/src/services/analytics/analytics.service.ts
@@ -109,7 +109,19 @@ export type AnalyticsEvent =
   | "onboarding_logout"
   | "log_collector_enabled"
   | "log_collector_disabled"
-  | "log_collector_deployed";
+  | "log_collector_deployed"
+  | "onboarding_deploy_click"
+  | "onboarding_add_credits_click"
+  | "add_credits_opened"
+  | "add_credits_amount_selected"
+  | "add_credits_payment_method_selected"
+  | "add_credits_purchased"
+  | "add_credits_cancelled"
+  | "configure_page_viewed"
+  | "configure_preset_selected"
+  | "configure_gpu_type_selected"
+  | "configure_gpu_count_changed"
+  | "configure_cpu_count_changed";
 
 export type AnalyticsCategory = "user" | "billing" | "deployments" | "wallet" | "sdl_builder" | "transactions" | "profile" | "settings" | "onboarding";
 


### PR DESCRIPTION
## Why

Onboarding, Add Credits, and the new-deployment Configure screen are among Console's most important
activation and conversion surfaces, but the specific user actions on them weren't reported to
Amplitude. We couldn't answer product questions like which starter template people deploy, how the
add-credits funnel converts (and where it's abandoned), or what hardware people pick while
configuring.

This instruments those actions so the funnel — land on onboarding → deploy a template / add credits
/ configure → deploy — can be measured in Amplitude.

## What

No visual changes — analytics-only. All events go through the existing
`useServices().analyticsService.track(...)` and are added to the `AnalyticsEvent` union.

**`/onboarding` picker** (`category: "onboarding"`)

- `onboarding_deploy_click` `{ option }` — the three template cards report their template id; the
  "Deploy image" link reports `"custom-image"`. The post-credit LLM auto-deploy deliberately does
  **not** fire this (deploy-click tracking is split from navigation).
- `onboarding_add_credits_click` `{ reason: "skip-trial" | "unlock-gpu" }` — both add-credits entry
  points (skip the trial, unlock the gated GPU template), distinguished by reason.

**Add Credits sheet/form** (`category: "billing"`)

- `add_credits_opened`, `add_credits_amount_selected` `{ amount, isCustom }`,
  `add_credits_payment_method_selected` `{ type }` (saved method type, or the Stripe payment-element
  selection, mapped to `card`/`bank`), `add_credits_purchased` `{ amount }`, `add_credits_cancelled`.
- Fired from the shared `AddCreditsSheet`, so they cover every surface that opens it. The sheet gains
  an optional `context` prop (onboarding passes its reason) to segment the funnel by surface.

**`/new-deployment/configure`** (`category: "deployments"`)

- `configure_page_viewed` (on mount), `configure_preset_selected` `{ preset }`,
  `configure_gpu_type_selected` `{ model, vendor }`, `configure_gpu_count_changed` `{ count }`,
  `configure_cpu_count_changed` `{ count }` (on blur, not per keystroke).

**Duration is derived in Amplitude, not computed client-side.** For "time spent" / "time to convert"
we emit clean start and end events (e.g. `add_credits_opened → add_credits_purchased`,
`configure_page_viewed → create_lease`) and let Amplitude's Funnel "time to convert" report the
elapsed time — no `durationMs` prop or unmount timers.

### Notes

- One event per interaction with the varying dimension as a property (matches the existing catalog,
  e.g. `create_lease` + `{ gpuAmount }`), rather than a combinatorial set of event names.
- The configure leaf cards (`PresetsCard`, `GpuCard`, `ComputeResourcesCard`) expose `useServices`
  via their `DEPENDENCIES` so they stay unit-testable with an injected `mock<AnalyticsService>()`.

### Verification

- Behavioral specs added/updated for every touched component (onboarding picker, the four Add
  Credits components, the four configure components). All touched specs pass.
- ESLint and Prettier clean on all changed files; `tsc` adds no new errors over the pre-existing
  baseline. The full deploy-web unit suite is green except 3 pre-existing env failures unrelated to
  this change (`validateGeneratedSdl` ×2, `useProviderJwt` ×1, all confirmed failing on `main`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added context-aware analytics for the onboarding deploy/credits flows, credits sheet lifecycle (opened, purchased, cancelled), and credits selection steps (amount commitments, payment method/type, payment method selection).
  * Added configuration analytics for page views and hardware choices, including preset selection and GPU/CPU changes.
* **Bug Fixes**
  * Prevented duplicate “payment type selected” analytics events.
  * Avoided emitting cancellation analytics after a successful credits completion.
* **Tests**
  * Expanded analytics verification across onboarding, billing/credits, and deployment configuration using mocked analytics tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->