### PR TITLE
fix(styling): unify page-title size, weight and top spacing across pages

### DIFF
--- a/apps/deploy-web/src/components/api-keys/ApiKeyList.tsx
+++ b/apps/deploy-web/src/components/api-keys/ApiKeyList.tsx
@@ -6,6 +6,7 @@ import { Trash } from "iconoir-react";
 
 import { ApiKeyDocsBanner } from "@src/components/api-keys/ApiKeyDocsBanner";
 import { CreateApiKeyModal } from "@src/components/api-keys/CreateApiKeyModal";
+import { Title } from "@src/components/shared/Title";
 import { useWallet } from "@src/context/WalletProvider";
 
 interface Props {
@@ -56,10 +57,10 @@ export function ApiKeyList({ apiKeys, onDeleteApiKey, onDeleteClose, isDeleting,
         </Popup>
       )}
 
-      <div className="py-6">
+      <div className="pb-6">
         <div className="mb-6 flex items-center justify-between">
           <div>
-            <h1 className="text-2xl">API Keys</h1>
+            <Title>API Keys</Title>
           </div>
           <Button size="sm" onClick={() => setIsCreateModalOpen(true)}>
             Create Key

--- a/apps/deploy-web/src/components/deployments/DeploymentList.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentList.tsx
@@ -143,9 +143,7 @@ export const DeploymentList: React.FunctionComponent = () => {
       {deployments && deployments.length > 0 && isWalletConnected && (
         <div className="flex flex-wrap items-center pb-6">
           <>
-            <Title className="font-bold" subTitle>
-              Deployments
-            </Title>
+            <Title>Deployments</Title>
 
             <div className="ml-6">
               <Button aria-label="back" onClick={() => getDeployments()} size="icon" variant="ghost">

--- a/apps/deploy-web/src/components/home/WelcomePanel.tsx
+++ b/apps/deploy-web/src/components/home/WelcomePanel.tsx
@@ -5,6 +5,7 @@ import { cn } from "@akashnetwork/ui/utils";
 import { Learning, NavArrowDown, Rocket, SearchEngine } from "iconoir-react";
 import Link from "next/link";
 
+import { Title } from "@src/components/shared/Title";
 import { useServices } from "@src/context/ServicesProvider";
 
 export const WelcomePanel: React.FC = () => {
@@ -14,7 +15,7 @@ export const WelcomePanel: React.FC = () => {
   return (
     <Collapsible open={expanded} onOpenChange={setExpanded}>
       <div className="mb-4 flex items-center justify-between">
-        <h2 className="text-3xl">Welcome to Akash Console!</h2>
+        <Title>Welcome to Akash Console!</Title>
         <CollapsibleTrigger asChild>
           <Button size="icon" variant="ghost" className="!m-0 rounded-full" onClick={() => setExpanded(prev => !prev)}>
             <NavArrowDown fontSize="1rem" className={cn("transition-all duration-100", { ["rotate-180"]: expanded })} />


### PR DESCRIPTION
## Why

Top-level page titles were rendered three different ways, so they looked inconsistent from page to page:

- Shared `Title` component (`h1`, `text-3xl`, `font-semibold`) — Providers, Templates, Billing
- `Title subTitle` (`h3`, `text-xl sm:text-2xl`, bold) — Deployments (smaller than the rest)
- Raw inline headings — Home (`<h2 text-3xl font-semibold>`) and API Keys (`<h1 text-2xl font-bold>`)

Top spacing was uniform (`pt-6` from `Layout`) everywhere except API Keys, which added an extra `py-6` and sat noticeably lower.

## What

Standardize every page title on the shared `Title` component as `h1 · text-3xl · font-bold`, with top spacing coming solely from `Layout`'s `pt-6`:

- **Title** — default `h1` weight `font-semibold` → `font-bold` (single source of truth; applies to all `Title` h1 usages app-wide)
- **Home** — replace inline `<h2>` with `<Title>`
- **API Keys** — replace inline `<h1 text-2xl>` with `<Title>`; wrapper `py-6` → `pb-6` so it relies on `Layout`'s `pt-6` like every other page
- **Deployments** — drop the `subTitle`/`font-bold` override that rendered a smaller `h3`

Secondary text (Providers "N active providers" line, Templates description) is intentionally left unchanged — those are subtitles, not the page title.

Note: this makes all `Title` `h1` headings `font-bold`, overriding the `font-semibold` shipped in the recent theme PR (#2331).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Standardized page headings across API keys, deployments, and the welcome panel.
  * Improved consistency in title styling and spacing throughout the interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->