### PR TITLE
test(styling): pin onboarding-gate Deploy-link to page CTA under top nav

### DIFF
--- a/apps/deploy-web/tests/ui/onboarding-gate.spec.ts
+++ b/apps/deploy-web/tests/ui/onboarding-gate.spec.ts
@@ -84,7 +84,9 @@ test.describe("Onboarding gate — onboarded user", () => {
       await page.setViewportSize({ width: 1440, height: 900 });
       await visit(page, "/deployments");
       await expect(page).toHaveURL(/\/deployments(\?|$)/, { timeout: 30_000 });
-      await expect(page.getByRole("link", { name: "Deploy" }).first()).toHaveAttribute("href", /\/new-deployment(\?|$)/, { timeout: 30_000 });
+      await expect(page.getByRole("link", { name: /^(deploy|create deployment)$/i }).first()).toHaveAttribute("href", /\/new-deployment(\?|$)/, {
+        timeout: 30_000
+      });
     });
 
     await test.step("the classic deployment-type/template picker is reachable and renders", async () => {


### PR DESCRIPTION
## Why

The Deploy App beta e2e job started failing on release `console-web/v3.146.3` ([run 29610910631](https://github.com/akash-network/console/actions/runs/29610910631)) in the `onboarding-gate` spec, which gates prod promotion.

Root cause is a latent test-locator bug exposed once `ui_top_nav` was enabled on beta. `page.getByRole("link", { name: "Deploy" })` uses a case-insensitive **substring** match, so it also matched the new top-nav **"Deployments"** link (`href="/deployments"`). The header renders before the page content, so `.first()` resolved to that nav link and the `/new-deployment` href assertion failed. Releases v3.146.0/.1/.2 passed with the same nav code already merged; only the runtime flag flip on beta triggered it. The Slack notification blamed #3457 (page-title styling), but that PR is unrelated.

This is a test-only issue: the real Deploy CTA still points at `/new-deployment`.

## What

Anchor the matcher to the page's Deploy CTA, matching the pattern already used by `AppNav.openDeploy()`:

- change `{ name: "Deploy" }` to `{ name: /^(deploy|create deployment)$/i }`

The anchored regex excludes "Deployments" while still matching the deployments-page header CTA ("Deploy") and the empty-state CTA ("Create Deployment"), so it works whether or not the test account has deployments, and stays correct under the legacy sidebar. A sweep of the whole `apps/deploy-web/tests/ui/` suite confirmed this was the only remaining at-risk nav locator.

Note: this is a `test:` (non-releasable) change, so it reaches the beta e2e job via the next releasable console-web release.
