### PR TITLE
fix: increase unordered tx ttll and reset timeout timestamp after simulate

### DIFF
--- a/apps/tx-signer/src/config/env.config.ts
+++ b/apps/tx-signer/src/config/env.config.ts
@@ -4,15 +4,15 @@ export const envSchema = z.object({
   FUNDING_WALLET_MNEMONIC_V2: z.string(),
   DERIVATION_WALLET_MNEMONIC_V2: z.string(),
   RPC_NODE_ENDPOINT: z.string(),
-  GAS_DEFAULT_MULTIPLIER: z.number({ coerce: true }).gt(1).default(1.4),
+  GAS_DEFAULT_MULTIPLIER: z.number({ coerce: true }).gt(1).default(1.6),
   // When a tx still lands out of gas, it is re-signed with gasLimit = on-chain gasUsed × this multiplier and rebroadcast.
   // gasUsed is the actual consumption measured on-chain, so a modest multiplier covers the extra settlement gas that
   // accrues between the failed attempt and the retry's inclusion height.
-  GAS_RECOVERY_MULTIPLIER: z.number({ coerce: true }).gt(1).default(1.3),
+  GAS_RECOVERY_MULTIPLIER: z.number({ coerce: true }).gt(1).default(1.4),
   AVERAGE_GAS_PRICE: z.number({ coerce: true }).default(0.025),
   // TTL for unordered transactions: the chain keeps the tx hash in memory for this window to reject duplicates,
   // so it must be long enough to guarantee block inclusion but short enough to bound mempool memory.
-  UNORDERED_TX_TTL_MS: z.number({ coerce: true }).optional().default(18_000),
+  UNORDERED_TX_TTL_MS: z.number({ coerce: true }).optional().default(30_000),
   LOG_LEVEL: z.enum(["fatal", "error", "warn", "info", "debug", "trace"]).optional().default("info"),
   STD_OUT_LOG_FORMAT: z.enum(["json", "pretty"]).optional().default("json"),
   NODE_ENV: z.enum(["development", "production", "test"]).optional().default("development"),

--- a/apps/tx-signer/src/lib/signing-stargate-client-factory/signing-stargate-client.factory.spec.ts
+++ b/apps/tx-signer/src/lib/signing-stargate-client-factory/signing-stargate-client.factory.spec.ts
@@ -76,6 +76,24 @@ describe(SigningStargateWithUnorderedSupportClient.name, () => {
     expect(authInfo.signerInfos[0].sequence).toBe(0n);
   });
 
+  it("derives the timeout timestamp after gas simulation so estimation latency does not erode the ttl", async () => {
+    vi.useFakeTimers();
+    try {
+      const ttlMs = 120_000;
+      const simulationLatencyMs = 5_000;
+      const startTime = 1_700_000_000_000;
+      vi.setSystemTime(startTime);
+      const { client } = setup({ ttlMs, onSimulate: () => vi.setSystemTime(startTime + simulationLatencyMs) });
+
+      const txRaw = await client.signUnordered(createMessages());
+
+      const body = TxBody.decode(txRaw.bodyBytes);
+      expect(body.timeoutTimestamp!.getTime()).toBe(startTime + simulationLatencyMs + ttlMs);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("estimates gas by simulating the unordered tx body and applies the safety multiplier", async () => {
     const { client, abciQuery } = setup({ gasUsed: 2000, gasMultiplier: 1.2 });
 
@@ -123,7 +141,7 @@ describe(SigningStargateWithUnorderedSupportClient.name, () => {
     return [{ typeUrl: "/test.MsgTest", value: {} }];
   }
 
-  function setup(input?: { ttlMs?: number; gasUsed?: number; gasMultiplier?: number }) {
+  function setup(input?: { ttlMs?: number; gasUsed?: number; gasMultiplier?: number; onSimulate?: () => void }) {
     const address = createAkashAddress();
     const accountNumber = faker.number.int({ min: 1, max: 1000 });
     const gasUsed = input?.gasUsed ?? 2000;
@@ -153,10 +171,13 @@ describe(SigningStargateWithUnorderedSupportClient.name, () => {
     });
 
     // Gas estimation runs the real #simulateRawTx through the query client, so mock the underlying ABCI query.
-    const abciQuery = vi.fn().mockResolvedValue({
-      code: 0,
-      value: SimulateResponse.encode(SimulateResponse.fromPartial({ gasInfo: { gasUsed: BigInt(gasUsed), gasWanted: BigInt(gasUsed) } })).finish(),
-      height: 1
+    const abciQuery = vi.fn().mockImplementation(async () => {
+      input?.onSimulate?.();
+      return {
+        code: 0,
+        value: SimulateResponse.encode(SimulateResponse.fromPartial({ gasInfo: { gasUsed: BigInt(gasUsed), gasWanted: BigInt(gasUsed) } })).finish(),
+        height: 1
+      };
     });
     const cometClient = mock<Comet38Client>({ abciQuery });
 

--- a/apps/tx-signer/src/lib/signing-stargate-client-factory/signing-stargate-client.factory.ts
+++ b/apps/tx-signer/src/lib/signing-stargate-client-factory/signing-stargate-client.factory.ts
@@ -94,11 +94,14 @@ export class SigningStargateWithUnorderedSupportClient extends SigningStargateCl
   async signUnordered(messages: readonly EncodeObject[], options?: { granter?: string; gas?: number }): Promise<TxRaw> {
     const [address, chainId, accountNumber, pubkey] = await Promise.all([this.#getAddress(), this.#getChainId(), this.#getAccountNumber(), this.#getPubkey()]);
 
-    const bodyBytes = this.#encodeTxBody(messages);
-    const fee = await this.#estimateFee(bodyBytes, pubkey, { granter: options?.granter, gas: options?.gas });
+    const txBody = this.#buildTxBody(messages);
+    const fee = await this.#estimateFee(TxBody.encode(txBody).finish(), pubkey, { granter: options?.granter, gas: options?.gas });
 
     // sequence MUST be 0 for unordered transactions; the chain rejects a non-zero sequence when unordered is set.
     const authInfoBytes = makeAuthInfoBytes([{ pubkey, sequence: 0 }], fee.amount, Number(fee.gas), fee.granter, fee.payer);
+    // update timestampTimeout to compensate time spent in doing stuff above
+    txBody.timeoutTimestamp = new Date(Date.now() + this.#signConfig.ttlMs);
+    const bodyBytes = TxBody.encode(txBody).finish();
     const signDoc = makeSignDoc(bodyBytes, authInfoBytes, chainId, accountNumber);
     const { signature, signed } = await this.#signer.signDirect(address, signDoc);
 
@@ -120,15 +123,13 @@ export class SigningStargateWithUnorderedSupportClient extends SigningStargateCl
     return Number(gasInfo.gasUsed);
   }
 
-  #encodeTxBody(messages: readonly EncodeObject[]): Uint8Array {
-    return TxBody.encode(
-      TxBody.fromPartial({
-        messages: messages.map(message => this.registry.encodeAsAny(message)),
-        memo: MEMO,
-        unordered: true,
-        timeoutTimestamp: new Date(Date.now() + this.#signConfig.ttlMs)
-      })
-    ).finish();
+  #buildTxBody(messages: readonly EncodeObject[]) {
+    return TxBody.fromPartial({
+      messages: messages.map(message => this.registry.encodeAsAny(message)),
+      memo: MEMO,
+      unordered: true,
+      timeoutTimestamp: new Date(Date.now() + this.#signConfig.ttlMs)
+    });
   }
 
   async #estimateFee(bodyBytes: Uint8Array, pubkey: ReturnType<typeof encodePubkey>, options: { granter?: string; gas?: number }) {


### PR DESCRIPTION
## Why

Closes CON-696 

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated default gas settings to provide greater fee coverage.
  * Extended the default validity period for unordered transactions.
  * Unordered transactions now calculate their expiration after transaction preparation, preserving the intended validity window.
* **Reliability**
  * Improved handling of transaction timing during gas estimation and signing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->