### PR TITLE
fix: prevent payment intent creation for unauthenticated user

### DIFF
--- a/apps/deploy-web/src/components/onboarding/steps/PaymentMethodContainer/PaymentMethodContainer.spec.tsx
+++ b/apps/deploy-web/src/components/onboarding/steps/PaymentMethodContainer/PaymentMethodContainer.spec.tsx
@@ -37,6 +37,12 @@ describe("PaymentMethodContainer", () => {
     expect(mockCreateSetupIntent).toHaveBeenCalled();
   });
 
+  it("should not create setup intent until the user is authenticated", () => {
+    const { mockCreateSetupIntent } = setup({ user: null });
+
+    expect(mockCreateSetupIntent).not.toHaveBeenCalled();
+  });
+
   it("should handle payment method removal", async () => {
     const { child, mockRemovePaymentMethod } = setup();
     mockRemovePaymentMethod.mockResolvedValue(undefined);

--- a/apps/deploy-web/src/components/onboarding/steps/PaymentMethodContainer/PaymentMethodContainer.tsx
+++ b/apps/deploy-web/src/components/onboarding/steps/PaymentMethodContainer/PaymentMethodContainer.tsx
@@ -140,10 +140,10 @@ export const PaymentMethodContainer: FC<PaymentMethodContainerProps> = ({ childr
   );
 
   useEffect(() => {
-    if (!setupIntent) {
+    if (user && !setupIntent) {
       createSetupIntent();
     }
-  }, [setupIntent, createSetupIntent]);
+  }, [user, setupIntent, createSetupIntent]);
 
   useEffect(() => {
     if (isConnectingWallet && hasManagedWallet && !isWalletLoading) {

--- a/apps/deploy-web/src/services/app-di-container/app-di-container.ts
+++ b/apps/deploy-web/src/services/app-di-container/app-di-container.ts
@@ -55,9 +55,11 @@ export const createAppRootContainer = (config: ServicesConfig) => {
         });
     },
     stripe: () =>
-      container.applyAxiosInterceptors(new HttpStripeService(apiConfig), {
-        request: [withUserToken]
-      }),
+      new HttpStripeService(
+        container.applyAxiosInterceptors(createHttpClient(apiConfig), {
+          request: [withUserToken]
+        })
+      ),
     stripeService: () =>
       new StripeService({
         config: {

--- a/packages/http-sdk/src/stripe/stripe.service.ts
+++ b/packages/http-sdk/src/stripe/stripe.service.ts
@@ -1,6 +1,7 @@
 import type { AxiosRequestConfig } from "axios";
 
-import { ApiHttpService } from "../api-http/api-http.service";
+import { extractData } from "../http/http.service";
+import type { HttpClient } from "../utils/httpClient";
 import type {
   ConfirmPaymentParams,
   ConfirmPaymentResponse,
@@ -16,49 +17,50 @@ import type {
   ThreeDSecureAuthParams
 } from "./stripe.types";
 
-export class StripeService extends ApiHttpService {
-  constructor(config?: AxiosRequestConfig) {
-    super(config);
+export class StripeService {
+  readonly #httpClient: HttpClient;
+  constructor(httpClient: HttpClient) {
+    this.#httpClient = httpClient;
   }
 
   async createSetupIntent(config?: AxiosRequestConfig): Promise<SetupIntentResponse> {
-    return this.extractApiData(await this.post("/v1/stripe/payment-methods/setup", {}, config));
+    return extractData(await this.#httpClient.post("/v1/stripe/payment-methods/setup", {}, config)).data;
   }
 
   async getPaymentMethods(): Promise<PaymentMethod[]> {
-    return this.extractApiData(await this.get("/v1/stripe/payment-methods"));
+    return extractData(await this.#httpClient.get("/v1/stripe/payment-methods")).data;
   }
 
   async getDefaultPaymentMethod(): Promise<PaymentMethod> {
-    return this.extractApiData(await this.get("/v1/stripe/payment-methods/default"));
+    return extractData(await this.#httpClient.get("/v1/stripe/payment-methods/default")).data;
   }
 
   async removePaymentMethod(paymentMethodId: string): Promise<void> {
-    return this.extractApiData(await this.delete(`/v1/stripe/payment-methods/${paymentMethodId}`));
+    return extractData(await this.#httpClient.delete(`/v1/stripe/payment-methods/${paymentMethodId}`)).data;
   }
 
   async updateCustomerOrganization(organization: string): Promise<void> {
-    await this.put("/v1/stripe/customers/organization", { organization });
+    await this.#httpClient.put("/v1/stripe/customers/organization", { organization });
   }
 
   async applyCoupon(couponId: string, userId: string): Promise<CouponResponse> {
-    return this.extractApiData(await this.post("/v1/stripe/coupons/apply", { data: { couponId, userId } }));
+    return extractData(await this.#httpClient.post("/v1/stripe/coupons/apply", { data: { couponId, userId } })).data;
   }
 
   async getCustomerDiscounts(): Promise<CustomerDiscountsResponse> {
-    return this.extractApiData(await this.get("/v1/stripe/coupons/customer-discounts"));
+    return extractData(await this.#httpClient.get("/v1/stripe/coupons/customer-discounts")).data;
   }
 
   async confirmPayment(params: ConfirmPaymentParams): Promise<ConfirmPaymentResponse> {
-    return this.extractApiData(await this.post("/v1/stripe/transactions/confirm", { data: params }));
+    return extractData(await this.#httpClient.post("/v1/stripe/transactions/confirm", { data: params })).data;
   }
 
   async validatePaymentMethodAfter3DS(params: ThreeDSecureAuthParams): Promise<{ success: boolean }> {
-    return this.extractApiData(await this.post("/v1/stripe/payment-methods/validate", { data: params }));
+    return extractData(await this.#httpClient.post("/v1/stripe/payment-methods/validate", { data: params })).data;
   }
 
   async setPaymentMethodAsDefault(params: SetPaymentMethodAsDefaultParams): Promise<PaymentMethod[]> {
-    return this.extractApiData(await this.post("/v1/stripe/payment-methods/default", { data: params }));
+    return extractData(await this.#httpClient.post("/v1/stripe/payment-methods/default", { data: params })).data;
   }
 
   async getCustomerTransactions(options?: CustomerTransactionsParams): Promise<CustomerTransactionsResponse> {
@@ -78,7 +80,7 @@ export class StripeService extends ApiHttpService {
 
     const url = `/v1/stripe/transactions${params.toString() ? `?${params}` : ""}`;
 
-    return this.extractApiData(await this.get(url));
+    return extractData(await this.#httpClient.get(url));
   }
 
   async exportTransactionsCsv(params: ExportTransactionsCsvParams): Promise<Blob> {
@@ -90,14 +92,14 @@ export class StripeService extends ApiHttpService {
 
     const url = `/v1/stripe/transactions/export?${queryParams}`;
 
-    return this.extractData(
-      await this.get(url, {
+    return extractData(
+      await this.#httpClient.get(url, {
         responseType: "blob"
       })
     );
   }
 
   async findPrices(config?: AxiosRequestConfig): Promise<StripePrice[]> {
-    return this.extractApiData(await this.get("/v1/stripe/prices", config));
+    return extractData(await this.#httpClient.get("/v1/stripe/prices", config)).data;
   }
 }


### PR DESCRIPTION
## Why

Closes CON-697

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Payment setup intents are now created only after authentication is confirmed, preventing premature payment setup attempts.
  - Stripe payment and billing requests now use consistent authenticated request handling, improving reliability across payment methods, discounts, transactions, and payment confirmation.
- **Tests**
  - Added coverage to verify that unauthenticated visitors do not trigger payment setup requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->