### PR TITLE
fix: optional chaining for transaction status check

### DIFF
--- a/apps/deploy-web/src/components/billing-usage/FirstPurchaseBonusAlert/FirstPurchaseBonusAlert.tsx
+++ b/apps/deploy-web/src/components/billing-usage/FirstPurchaseBonusAlert/FirstPurchaseBonusAlert.tsx
@@ -35,7 +35,7 @@ export function FirstPurchaseBonusAlert({ amount, dependencies: d = DEPENDENCIES
   const isEnabled = d.useFlag("first_purchase_bonus");
   const { data, isSuccess } = d.usePaymentTransactionsQuery(undefined, { enabled: isEnabled });
 
-  const hasPaidBefore = !!data?.transactions.some(transaction => transaction.status === "succeeded");
+  const hasPaidBefore = !!data?.transactions?.some(transaction => transaction.status === "succeeded");
 
   // Gate on isSuccess (not isFetched): a failed transactions fetch also sets isFetched, leaving `data`
   // empty and hasPaidBefore false, which would wrongly show the offer to users with unknown history.


### PR DESCRIPTION
## Why

Right now, when AddCredits modal is open on UI it fails and causes page reload in console-beta. Locally it shows an error:
```
TypeError: Cannot read properties of undefined (reading 'some')
```

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved billing alert stability when transaction data is unavailable.
  - Prevented potential runtime errors while checking for previously completed purchases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->