### PR TITLE
fix(billing): make the active add-credits tab visible with a muted track

### DIFF
--- a/apps/deploy-web/src/components/billing-usage/AddCreditsTabs/AddCreditsTabs.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AddCreditsTabs/AddCreditsTabs.tsx
@@ -64,7 +64,7 @@ export function AddCreditsTabs({
 
   return (
     <d.Tabs value={activeTab} onValueChange={handleTabChange} className="space-y-6">
-      <d.TabsList className="grid w-full grid-cols-2">
+      <d.TabsList className="grid w-full grid-cols-2 border-0 bg-muted">
         <d.TabsTrigger value="purchase" disabled={isProcessing && activeTab !== "purchase"}>
           Purchase credits
         </d.TabsTrigger>


### PR DESCRIPTION
The tab bar had no background, so the white active tab blended into the white sheet and it was hard to tell which tab was active. Give the track a muted background and drop the border to match the design.

closes CON-667

<img width="536" height="243" alt="image" src="https://github.com/user-attachments/assets/cbac72bb-9c0a-4e96-afc8-51bfa1083535" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the add-credits tab navigation styling with a muted background and no border.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->