### PR TITLE
fix(styling): reserve page loading-bar height on all pages

### DIFF
--- a/apps/deploy-web/src/components/layout/Layout.spec.tsx
+++ b/apps/deploy-web/src/components/layout/Layout.spec.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from "react";
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import Layout, { DEPENDENCIES } from "./Layout";
+
+import { render, screen } from "@testing-library/react";
+import { MockComponents } from "@tests/unit/mocks";
+
+describe("Layout", () => {
+  it("reserves the loading indicator space when no isLoading prop is provided", () => {
+    const { dependencies } = setup({});
+
+    expect(dependencies.LinearLoadingSkeleton).toHaveBeenCalledWith(expect.objectContaining({ isLoading: false }), expect.anything());
+  });
+
+  it("shows the loading indicator when isLoading is true", () => {
+    const { dependencies } = setup({ isLoading: true });
+
+    expect(dependencies.LinearLoadingSkeleton).toHaveBeenCalledWith(expect.objectContaining({ isLoading: true }), expect.anything());
+  });
+
+  it("renders children", () => {
+    setup({ children: <div>page content</div> });
+
+    expect(screen.getByText("page content")).toBeInTheDocument();
+  });
+
+  function setup(input: { isLoading?: boolean; children?: ReactNode }) {
+    const dependencies = MockComponents(DEPENDENCIES, {
+      useFlag: () => false,
+      useOnboardingChrome: () => mock<ReturnType<typeof DEPENDENCIES.useOnboardingChrome>>({ isStripped: false }),
+      useSettings: () => mock<ReturnType<typeof DEPENDENCIES.useSettings>>({ isSettingsInit: true }),
+      useTopBanner: () => mock<ReturnType<typeof DEPENDENCIES.useTopBanner>>({ hasBanner: false }),
+      useWallet: () => mock<ReturnType<typeof DEPENDENCIES.useWallet>>({ isWalletLoaded: true })
+    });
+
+    render(
+      <Layout isLoading={input.isLoading} dependencies={dependencies}>
+        {input.children}
+      </Layout>
+    );
+
+    return { dependencies };
+  }
+});

--- a/apps/deploy-web/src/components/layout/Layout.tsx
+++ b/apps/deploy-web/src/components/layout/Layout.tsx
@@ -67,7 +67,7 @@ const Layout: React.FunctionComponent<Props> = ({ children, isLoading, isUsingSe
 
 const LayoutApp: React.FunctionComponent<Props> = ({
   children,
-  isLoading,
+  isLoading = false,
   isUsingSettings,
   isUsingWallet,
   disableContainer,
@@ -130,7 +130,7 @@ const LayoutApp: React.FunctionComponent<Props> = ({
                 ["md:ml-[57px]"]: hasSidebar && !isNavOpen
               })}
             >
-              {isLoading !== undefined && <LinearLoadingSkeleton isLoading={isLoading} />}
+              <LinearLoadingSkeleton isLoading={isLoading} />
 
               <ErrorBoundary FallbackComponent={ErrorFallback}>
                 {!isUsingSettings || isSettingsInit ? (

--- a/apps/deploy-web/src/components/layout/Layout.tsx
+++ b/apps/deploy-web/src/components/layout/Layout.tsx
@@ -30,6 +30,19 @@ const SIDEBAR_BELOW_BANNER_STYLE: CSSProperties = {
   height: `calc(100% - ${APP_HEADER_HEIGHT_CSS} + ${ACCOUNT_BAR_HEIGHT}px)`
 };
 
+export const DEPENDENCIES = {
+  LinearLoadingSkeleton,
+  Nav,
+  Sidebar,
+  TopNav,
+  TrackingScripts,
+  useFlag,
+  useOnboardingChrome,
+  useSettings,
+  useTopBanner,
+  useWallet
+};
+
 type Props = {
   isLoading?: boolean;
   isUsingSettings?: boolean;
@@ -38,9 +51,19 @@ type Props = {
   containerClassName?: string;
   background?: "default" | "white";
   children?: ReactNode;
+  dependencies?: typeof DEPENDENCIES;
 };
 
-const Layout: React.FunctionComponent<Props> = ({ children, isLoading, isUsingSettings, isUsingWallet, disableContainer, containerClassName, background }) => {
+const Layout: React.FunctionComponent<Props> = ({
+  children,
+  isLoading,
+  isUsingSettings,
+  isUsingWallet,
+  disableContainer,
+  containerClassName,
+  background,
+  dependencies
+}) => {
   const [locale, setLocale] = useState("en-US");
 
   useEffect(() => {
@@ -58,6 +81,7 @@ const Layout: React.FunctionComponent<Props> = ({ children, isLoading, isUsingSe
         disableContainer={disableContainer}
         containerClassName={containerClassName}
         background={background}
+        dependencies={dependencies}
       >
         {children}
       </LayoutApp>
@@ -72,8 +96,10 @@ const LayoutApp: React.FunctionComponent<Props> = ({
   isUsingWallet,
   disableContainer,
   containerClassName = "",
-  background = "default"
+  background = "default",
+  dependencies: d = DEPENDENCIES
 }) => {
+  const { LinearLoadingSkeleton, Nav, Sidebar, TopNav, TrackingScripts, useFlag, useOnboardingChrome, useSettings, useTopBanner, useWallet } = d;
   const muiTheme = useMuiTheme();
   const smallScreen = useMediaQuery(muiTheme.breakpoints.down("md"));
   const [isNavOpen, setIsNavOpen] = useState(() => {


### PR DESCRIPTION
## Why

Navigating between pages shifts all page content vertically by 4px. The layout only rendered the top loading bar when a page passed the `isLoading` prop: the ~9 pages that pass it (deployments, providers, home, etc.) always reserve a 4px strip, while the ~18 pages that omit it (alerts, billing, sdl-builder, faq, etc.) reserve 0px, so the content top jumps depending on which page you land on.

## What

Always render `LinearLoadingSkeleton` in the deploy-web `Layout`, defaulting `isLoading` to `false`. The skeleton is already shift-free on its own (4px `LinearProgress` when loading, 4px placeholder when idle), so every page now reserves the same 4px strip whether or not it has a loading state. No page call-site changes needed.

Verified against a local dev server on `/faq` (a page that does not pass `isLoading`):

| | first child of content wrapper | content top |
|---|---|---|
| before | page container directly (no strip) | 57px |
| after | 4px skeleton placeholder | 61px (matches pages that pass `isLoading`) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading-state handling so the loading indicator behaves consistently when no loading status is provided.
  * Ensured the loading indicator correctly reflects whether content is loading.
* **Tests**
  * Added coverage to verify loading-state behavior and that provided page content renders correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->