### PR TITLE
fix(analytics): wire deploy funnel events into the configure flow

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.spec.tsx
@@ -1,6 +1,9 @@
+import type { PropsWithChildren } from "react";
+import { createStore, Provider as JotaiStoreProvider } from "jotai";
 import { describe, expect, it, vi } from "vitest";
-import { mock } from "vitest-mock-extended";
+import { mock, mockDeep } from "vitest-mock-extended";
 
+import { settingsIdAtom } from "@src/context/SettingsProvider/settingsStore";
 import { QueryKeys } from "@src/queries/queryKeys";
 import { UrlService } from "@src/utils/urlUtils";
 import type { DeploymentIntent } from "./deploymentIntent";
@@ -42,9 +45,6 @@ describe(useDeploymentFlow.name, () => {
     });
     const { result } = setup({ replace, createMutate, intent: { sdlStrategy: "default", bidStrategy: "auto" } });
 
-    // The auto autopilot fires the create as "auto"; the user then picks "Choose my provider" (switches to select) while
-    // it's still in flight. When the create finally resolves, the URL must land on select — not bounce back to auto and
-    // remount the auto flow.
     act(() => result.current.actions.requestQuotes("sdl-content"));
     act(() => result.current.actions.setBidStrategy("select"));
     act(() => resolveCreate?.({ data: { dseq: "999", manifest: "m" } }));
@@ -70,9 +70,6 @@ describe(useDeploymentFlow.name, () => {
 
       act(() => vi.advanceTimersByTime(60_000));
 
-      // The auto autopilot re-creates whenever the flow returns to `configuring` and reads its error scene off the
-      // "error" phase, so the flow must halt here — leaving the deployment for the user's "Try again"/"Choose my
-      // provider" rather than closing it and looping.
       expect(result.current.phase).toBe("error");
       expect(result.current.error?.message).toContain("No providers");
       expect(closeMutate).not.toHaveBeenCalled();
@@ -101,7 +98,6 @@ describe(useDeploymentFlow.name, () => {
   it("keeps the no-providers message set while the close is still in flight in the manual flow", () => {
     vi.useFakeTimers();
     try {
-      // Never resolves — proves the message survives `cancelAndEdit`'s own `setError(undefined)` so the error toast fires.
       const closeMutate = vi.fn();
       const { result } = setup({ intent: { sdlStrategy: "edit", bidStrategy: "select", dseq: "777" }, closeMutate });
 
@@ -134,24 +130,20 @@ describe(useDeploymentFlow.name, () => {
     try {
       const openBid = { bid: { state: "open", price: { amount: "1", denom: "uakt" }, id: { provider: "p", dseq: "777", gseq: 1, oseq: 1 } } };
       let bids: Array<typeof openBid> = [openBid];
+      const services = mockServices();
       const dependencies: typeof DEPENDENCIES = {
+        useServices: (() => services) as never,
         useCreateDeployment: (() => mockMutation()) as never,
-        useCloseDeployment: (() => mockMutation()) as never,
-        useCreateLease: (() => mockMutation()) as never,
-        useUpdateDeployment: (() => mockMutation()) as never,
         useListBids: (() => ({ data: { data: bids }, isLoading: false, isError: false })) as never,
         useRouter: (() => mock<ReturnType<typeof DEPENDENCIES.useRouter>>({ replace: vi.fn(), push: vi.fn() })) as never,
         useQueryClient: (() => mock<ReturnType<typeof DEPENDENCIES.useQueryClient>>()) as never,
-        useDeploymentLocalStorage: (() => mock<ReturnType<typeof DEPENDENCIES.useDeploymentLocalStorage>>()) as never,
-        useSettingsId: (() => "akash1owner") as never,
-        manifestFromSdl: () => "M"
+        manifestFromSdl: () => "M",
+        deploymentResourcesFromSdl: () => ({ gpuAmount: 0, cpuAmount: 0, memoryAmount: 0, storageAmount: 0 })
       };
-      const { result, rerender } = renderHook(() =>
-        useDeploymentFlow({ intent: { sdlStrategy: "edit", bidStrategy: "select", dseq: "777", vm: false } }, dependencies)
-      );
+      const { result, rerender } = renderDeploymentFlow({ sdlStrategy: "edit", bidStrategy: "select", dseq: "777", vm: false }, dependencies);
       expect(result.current.phase).toBe("quoting");
 
-      bids = []; // every provider's quote disappears (e.g. expired) after having bid
+      bids = [];
       rerender();
       act(() => vi.advanceTimersByTime(60_000));
 
@@ -174,7 +166,7 @@ describe(useDeploymentFlow.name, () => {
 
   it("clears the dseq from the URL as soon as cancel starts, before the close resolves", () => {
     const replace = vi.fn();
-    const closeMutate = vi.fn(); // never resolves — proves the URL reset is optimistic, not tied to close-success
+    const closeMutate = vi.fn();
     const { result } = setup({ intent: { sdlStrategy: "default", bidStrategy: "auto", dseq: "777", templateId: "tpl" }, replace, closeMutate });
 
     act(() => result.current.actions.cancelAndEdit());
@@ -534,6 +526,101 @@ describe(useDeploymentFlow.name, () => {
     expect(result.current.selections).toEqual({ "placement-1": "akash1a/555/1/3" });
   });
 
+  describe("deploy funnel analytics", () => {
+    it("tracks create_deployment with the new dseq when the deployment is created", () => {
+      const createMutate = vi.fn((_args, { onSuccess }) => onSuccess({ data: { dseq: "999", manifest: "m" } }));
+      const { result, analyticsService } = setup({ createMutate });
+
+      act(() => result.current.actions.requestQuotes("sdl-content"));
+
+      expect(analyticsService.track).toHaveBeenCalledWith("create_deployment", { category: "deployments", label: "Create deployment in wizard", dseq: "999" });
+    });
+
+    it("tracks bids_received with the bid count the first time bids arrive", () => {
+      const openBid = { bid: { state: "open", price: { amount: "1", denom: "uakt" }, id: { provider: "p", dseq: "777", gseq: 1, oseq: 1 } } };
+      const { analyticsService } = renderFlow({ intent: { dseq: "777" }, listBids: [openBid] });
+
+      expect(analyticsService.track).toHaveBeenCalledWith("bids_received", { category: "deployments", numberOfBids: 1, dseq: "777" });
+    });
+
+    it("fires bids_received only once across subsequent bid refetches", () => {
+      const openBid = { bid: { state: "open", price: { amount: "1", denom: "uakt" }, id: { provider: "p", dseq: "777", gseq: 1, oseq: 1 } } };
+      const { rerender, analyticsService } = renderFlow({ intent: { dseq: "777" }, listBids: [openBid] });
+
+      rerender();
+      rerender();
+
+      expect(analyticsService.track.mock.calls.filter(([name]) => name === "bids_received")).toHaveLength(1);
+    });
+
+    it("tracks bid_selected when a provider is selected", () => {
+      const { result, analyticsService } = renderFlow();
+
+      act(() => result.current.actions.selectProvider("placement-1", "akash1a/1/1/1"));
+
+      expect(analyticsService.track).toHaveBeenCalledWith("bid_selected", "Amplitude");
+    });
+
+    it("tracks create_lease and send_manifest with the deployment resources on lease success", () => {
+      const { result, analyticsService } = renderDeployedFlow({ gpuAmount: 0, cpuAmount: 2, memoryAmount: 1024, storageAmount: 2048 });
+
+      act(() => result.current.actions.requestQuotes("sdl"));
+      act(() => result.current.actions.selectProvider("placement-1", "akash1a/555/1/3"));
+      act(() => result.current.actions.deploy("sdl"));
+
+      expect(analyticsService.track).toHaveBeenCalledWith("create_lease", {
+        category: "deployments",
+        label: "Create lease",
+        dseq: "555",
+        gpuAmount: 0,
+        cpuAmount: 2,
+        memoryAmount: 1024,
+        storageAmount: 2048
+      });
+      expect(analyticsService.track).toHaveBeenCalledWith("send_manifest", {
+        category: "deployments",
+        label: "Send manifest after creating lease",
+        dseq: "555"
+      });
+    });
+
+    it("tracks create_gpu_deployment on lease success when the deployment requests a GPU", () => {
+      const { result, analyticsService } = renderDeployedFlow({ gpuAmount: 1, cpuAmount: 4, memoryAmount: 2048, storageAmount: 4096 });
+
+      act(() => result.current.actions.requestQuotes("sdl"));
+      act(() => result.current.actions.selectProvider("placement-1", "akash1a/555/1/3"));
+      act(() => result.current.actions.deploy("sdl"));
+
+      expect(analyticsService.track).toHaveBeenCalledWith("create_gpu_deployment", {
+        category: "deployments",
+        label: "Create lease",
+        dseq: "555",
+        gpuAmount: 1,
+        cpuAmount: 4,
+        memoryAmount: 2048,
+        storageAmount: 4096
+      });
+    });
+
+    it("does not track create_gpu_deployment for a CPU-only deployment", () => {
+      const { result, analyticsService } = renderDeployedFlow({ gpuAmount: 0, cpuAmount: 2, memoryAmount: 1024, storageAmount: 2048 });
+
+      act(() => result.current.actions.requestQuotes("sdl"));
+      act(() => result.current.actions.selectProvider("placement-1", "akash1a/555/1/3"));
+      act(() => result.current.actions.deploy("sdl"));
+
+      expect(analyticsService.track).not.toHaveBeenCalledWith("create_gpu_deployment", expect.anything());
+    });
+
+    function renderDeployedFlow(resources: { gpuAmount: number; cpuAmount: number; memoryAmount: number; storageAmount: number }) {
+      const createDeployment = mockMutation();
+      createDeployment.mutate.mockImplementation((_i, o) => o.onSuccess({ data: { dseq: "555", manifest: "M" } }));
+      const createLease = mockMutation();
+      createLease.mutate.mockImplementation((_i, o) => o.onSuccess(deployedResult("akash1owner")));
+      return renderFlow({ createDeployment, createLease, deploymentResourcesFromSdl: () => resources });
+    }
+  });
+
   function setup(input: {
     intent?: { sdlStrategy: "default" | "edit"; bidStrategy: "auto" | "select"; dseq?: string; templateId?: string; draftId?: string; vm?: boolean };
     replace?: ReturnType<typeof vi.fn>;
@@ -541,19 +628,17 @@ describe(useDeploymentFlow.name, () => {
     closeMutate?: ReturnType<typeof vi.fn>;
   }) {
     const intent = { vm: false, ...(input.intent ?? { sdlStrategy: "edit" as const, bidStrategy: "select" as const, dseq: undefined }) };
+    const services = mockServices({ closeDeployment: mockMutation(input.closeMutate) });
     const dependencies: typeof DEPENDENCIES = {
+      useServices: (() => services) as never,
       useCreateDeployment: (() => mock<ReturnType<typeof DEPENDENCIES.useCreateDeployment>>({ mutate: (input.createMutate ?? vi.fn()) as never })) as never,
-      useCloseDeployment: (() => mock<ReturnType<typeof DEPENDENCIES.useCloseDeployment>>({ mutate: (input.closeMutate ?? vi.fn()) as never })) as never,
-      useCreateLease: (() => mock<ReturnType<typeof DEPENDENCIES.useCreateLease>>({ mutate: vi.fn() as never })) as never,
-      useUpdateDeployment: (() => mock<ReturnType<typeof DEPENDENCIES.useUpdateDeployment>>({ mutate: vi.fn() as never })) as never,
       useListBids: (() => ({ data: { data: [] }, isLoading: false, isError: false })) as never,
       useRouter: (() => mock<ReturnType<typeof DEPENDENCIES.useRouter>>({ replace: (input.replace ?? vi.fn()) as never })) as never,
       useQueryClient: (() => mock<ReturnType<typeof DEPENDENCIES.useQueryClient>>()) as never,
-      useDeploymentLocalStorage: (() => mock<ReturnType<typeof DEPENDENCIES.useDeploymentLocalStorage>>()) as never,
-      useSettingsId: (() => "akash1owner") as never,
-      manifestFromSdl: () => "manifest"
+      manifestFromSdl: () => "manifest",
+      deploymentResourcesFromSdl: () => ({ gpuAmount: 0, cpuAmount: 0, memoryAmount: 0, storageAmount: 0 })
     };
-    return renderHook(() => useDeploymentFlow({ intent }, dependencies));
+    return { ...renderDeploymentFlow(intent, dependencies), analyticsService: services.analyticsService };
   }
 
   function renderFlow(input?: {
@@ -563,30 +648,48 @@ describe(useDeploymentFlow.name, () => {
     closeDeployment?: ReturnType<typeof mockMutation>;
     updateDeployment?: ReturnType<typeof mockMutation>;
     manifestFromSdl?: (sdl: string) => string | null;
+    deploymentResourcesFromSdl?: (sdl: string) => { gpuAmount: number; cpuAmount: number; memoryAmount: number; storageAmount: number };
     listBids?: Array<{ bid: { state: string; price: { amount: string; denom: string }; id: { provider: string; dseq: string; gseq: number; oseq: number } } }>;
   }) {
     const intent: DeploymentIntent = { sdlStrategy: "edit", bidStrategy: "select", dseq: undefined, vm: false, ...input?.intent };
     const router = mock<ReturnType<typeof DEPENDENCIES.useRouter>>({ replace: vi.fn(), push: vi.fn() });
-    const deploymentLocalStorage = mock<ReturnType<typeof DEPENDENCIES.useDeploymentLocalStorage>>();
     const queryClient = mock<ReturnType<typeof DEPENDENCIES.useQueryClient>>();
+    const services = mockServices({ closeDeployment: input?.closeDeployment, createLease: input?.createLease, updateDeployment: input?.updateDeployment });
     const dependencies: typeof DEPENDENCIES = {
+      useServices: (() => services) as never,
       useCreateDeployment: (() => input?.createDeployment ?? mockMutation()) as never,
-      useCloseDeployment: (() => input?.closeDeployment ?? mockMutation()) as never,
-      useCreateLease: (() => input?.createLease ?? mockMutation()) as never,
-      useUpdateDeployment: (() => input?.updateDeployment ?? mockMutation()) as never,
       useListBids: (() => ({ data: { data: input?.listBids ?? [] }, isLoading: false, isError: false })) as never,
       useRouter: () => router,
       useQueryClient: (() => queryClient) as never,
-      useDeploymentLocalStorage: (() => deploymentLocalStorage) as never,
-      useSettingsId: (() => "akash1owner") as never,
-      manifestFromSdl: input?.manifestFromSdl ?? (() => "M")
+      manifestFromSdl: input?.manifestFromSdl ?? (() => "M"),
+      deploymentResourcesFromSdl: input?.deploymentResourcesFromSdl ?? (() => ({ gpuAmount: 0, cpuAmount: 0, memoryAmount: 0, storageAmount: 0 }))
     };
-    const utils = renderHook(() => useDeploymentFlow({ intent }, dependencies));
-    return { ...utils, router, deploymentLocalStorage, queryClient };
+    const utils = renderDeploymentFlow(intent, dependencies);
+    return { ...utils, router, queryClient, deploymentLocalStorage: services.deploymentLocalStorage, analyticsService: services.analyticsService };
   }
 
-  function mockMutation() {
-    return mock<{ mutate: ReturnType<typeof vi.fn> }>({ mutate: vi.fn() });
+  function mockMutation(mutate: ReturnType<typeof vi.fn> = vi.fn()) {
+    return mock<{ mutate: ReturnType<typeof vi.fn> }>({ mutate });
+  }
+
+  function mockServices(mutations?: {
+    closeDeployment?: ReturnType<typeof mockMutation>;
+    createLease?: ReturnType<typeof mockMutation>;
+    updateDeployment?: ReturnType<typeof mockMutation>;
+  }) {
+    const services = mockDeep<ReturnType<typeof DEPENDENCIES.useServices>>();
+    services.api.v1.closeDeployment.useMutation.mockReturnValue((mutations?.closeDeployment ?? mockMutation()) as never);
+    services.api.v1.createLease.useMutation.mockReturnValue((mutations?.createLease ?? mockMutation()) as never);
+    services.api.v1.updateDeployment.useMutation.mockReturnValue((mutations?.updateDeployment ?? mockMutation()) as never);
+    return services;
+  }
+
+  function renderDeploymentFlow(intent: DeploymentIntent, dependencies: typeof DEPENDENCIES) {
+    const store = createStore();
+    store.set(settingsIdAtom, "akash1owner");
+    return renderHook(() => useDeploymentFlow({ intent }, dependencies), {
+      wrapper: ({ children }: PropsWithChildren) => <JotaiStoreProvider store={store}>{children}</JotaiStoreProvider>
+    });
   }
 
   /** The create-lease success payload shape the flow reads the owner from. */

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.ts
@@ -10,7 +10,9 @@ import { QueryKeys } from "@src/queries/queryKeys";
 import { BID_POLL_INTERVAL, useListBids } from "@src/queries/useListBids";
 import { formatBidId, parseBidId } from "@src/utils/bids/bidId";
 import { ManifestYaml } from "@src/utils/deploymentData/helpers";
+import { importSimpleSdl } from "@src/utils/sdl/sdlImport";
 import { UrlService } from "@src/utils/urlUtils";
+import { aggregateDeploymentResources } from "../DeploymentResourceSummary/deploymentResources";
 import { useCreateDeployment } from "../useCreateDeployment/useCreateDeployment";
 import type { BidStrategy, DeploymentIntent } from "./deploymentIntent";
 
@@ -71,48 +73,22 @@ const DEFAULT_DEPOSIT = 0.5;
 const DEPLOY_SUCCESS_DWELL_MS = 1200;
 
 /**
- * How long to wait for a *first* bid before giving up on a freshly quoted deployment. Some specs never draw a
- * single bid (niche resources, tight region filters, or a quiet marketplace); rather than leave the user staring
- * at "Requesting…" for the full ~5-minute bid window that only makes sense once bids exist, fail fast when none
- * arrive at all. Reset the instant any open bid lands — from then on the normal quote-expiry window governs.
+ * Wait this long for a first bid before failing fast — some specs never draw one (niche resources, tight filters, a
+ * quiet marketplace), and the full ~5-minute quote window only makes sense once bids exist. Resets when any bid lands.
  */
 const NO_BIDS_TIMEOUT_MS = 60 * 1000;
 
 /** Error surfaced when a deployment draws no provider bids at all within {@link NO_BIDS_TIMEOUT_MS}. */
 const NO_PROVIDERS_MESSAGE = "No providers are available for this deployment right now. Try adjusting your deployment and requesting quotes again.";
 
-function useCloseDeployment() {
-  return useServices().api.v1.closeDeployment.useMutation();
-}
-
-function useCreateLease() {
-  return useServices().api.v1.createLease.useMutation();
-}
-
-function useUpdateDeployment() {
-  return useServices().api.v1.updateDeployment.useMutation();
-}
-
-function useDeploymentLocalStorage() {
-  return useServices().deploymentLocalStorage;
-}
-
-/** The wallet address that keys deployment-local storage (WalletProvider sets it to the wallet address); same key the detail page reads. */
-function useSettingsId() {
-  return useAtomValue(settingsIdAtom);
-}
-
 export const DEPENDENCIES = {
+  useServices,
   useCreateDeployment,
-  useCloseDeployment,
-  useCreateLease,
-  useUpdateDeployment,
   useListBids,
   useRouter,
   useQueryClient,
-  useDeploymentLocalStorage,
-  useSettingsId,
-  manifestFromSdl
+  manifestFromSdl,
+  deploymentResourcesFromSdl
 };
 
 /**
@@ -125,14 +101,14 @@ export function useDeploymentFlow(
   { intent, isWalletReady = true, trialError }: UseDeploymentFlowInput,
   dependencies: typeof DEPENDENCIES = DEPENDENCIES
 ): DeploymentFlow {
+  const { api, deploymentLocalStorage, analyticsService } = dependencies.useServices();
   const router = dependencies.useRouter();
   const createDeployment = dependencies.useCreateDeployment({ isWalletReady, trialError });
-  const closeDeployment = dependencies.useCloseDeployment();
-  const createLease = dependencies.useCreateLease();
-  const updateDeployment = dependencies.useUpdateDeployment();
+  const closeDeployment = api.v1.closeDeployment.useMutation();
+  const createLease = api.v1.createLease.useMutation();
+  const updateDeployment = api.v1.updateDeployment.useMutation();
   const queryClient = dependencies.useQueryClient();
-  const deploymentLocalStorage = dependencies.useDeploymentLocalStorage();
-  const settingsId = dependencies.useSettingsId();
+  const settingsId = useAtomValue(settingsIdAtom);
 
   const [phase, setPhase] = useState<DeploymentFlowPhase>(intent.dseq ? "quoting" : "configuring");
   const [dseq, setDseq] = useState<string | null>(intent.dseq ?? null);
@@ -146,16 +122,11 @@ export function useDeploymentFlow(
   const intentRef = useRef(intent);
   intentRef.current = intent;
 
-  // Always-current bid strategy for the async create-success callback below. The auto autopilot fires the create as
-  // "auto", but the user can switch to "select" ("Choose my provider") while it's still in flight; reading the ref
-  // keeps the create-success URL on whatever strategy is current, so a late create doesn't bounce the user back to the
-  // auto page after they've moved to the manual one.
+  /** Read in the async create-success callback so a create resolving after a strategy switch uses the current value. */
   const bidStrategyRef = useRef(bidStrategy);
   bidStrategyRef.current = bidStrategy;
 
-  // Latest `cancelAndEdit` for the no-providers timeout to call. It closes over `dseq`/`bidStrategy` and the per-render
-  // close mutation, so it can't be a stable effect dependency — a ref lets the timeout reach the current one without
-  // re-arming (and thus resetting) the timer on every render, which would keep it from ever firing.
+  /** Held in a ref so the no-providers timeout calls the latest `cancelAndEdit` without re-arming the timer each render. */
   const cancelAndEditRef = useRef<() => void>();
 
   const bidsQuery = dependencies.useListBids(dseq, { enabled: phase === "quoting", refetchInterval: BID_POLL_INTERVAL });
@@ -182,30 +153,41 @@ export function useDeploymentFlow(
 
   const hasOpenBids = (bidsQuery.data?.data ?? []).some(entry => entry.bid.state === "open");
 
-  // Latches true once this deployment has drawn any open bid. Makes the no-providers timeout one-shot: after providers
-  // have bid, their later disappearance (e.g. quotes expiring) must not re-arm it — that's the quote-expiry path, not a
-  // "no providers" failure. Reset per deployment when a fresh quote request starts (see `requestQuotes`).
+  /** One-shot latch: once any bid appears the no-providers timeout must not re-arm — a later empty list is quote-expiry, not "no providers". */
   const providersEverBidRef = useRef(false);
+
+  const bidsReceivedTrackedRef = useRef(false);
+
+  useEffect(
+    function trackFirstBidsReceived() {
+      const currentBids = bidsQuery.data?.data;
+      if (!currentBids || currentBids.length === 0 || bidsReceivedTrackedRef.current) return;
+      bidsReceivedTrackedRef.current = true;
+      analyticsService.track("bids_received", { category: "deployments", numberOfBids: currentBids.length, dseq });
+    },
+    [bidsQuery.data, dseq, analyticsService]
+  );
 
   useEffect(
     function failWhenNoProvidersBid() {
       if (hasOpenBids) providersEverBidRef.current = true;
-      // Arm only while quoting with nothing shown and no bid ever seen; once a bid has appeared it never re-arms.
       if (phase !== "quoting" || providersEverBidRef.current) return;
-      const timer = setTimeout(function timeOutWithoutProviders() {
-        // Only the auto-deploy experience autopilots over this shared flow. That autopilot re-fires a create whenever
-        // the flow lands back in `configuring` and reads its error scene off `phase === "error"` (not `error`), so there
-        // we must halt in `error` — its "Try again"/"Choose my provider" drive the next step. The manual flow has no
-        // autopilot: close the now-dangling deployment and drop back to editing. Either way set the message last so it
-        // survives `cancelAndEdit`'s own `setError(undefined)` (same batch, last write wins) and the error toast fires.
-        if (intentRef.current.sdlStrategy === "default" && bidStrategyRef.current === "auto") {
+      const timer = setTimeout(
+        /**
+         * The auto flow autopilots over this shared flow and reads its error scene off `phase === "error"`, so it must
+         * halt there; the manual flow has no autopilot, so close the dangling deployment and drop back to editing.
+         */
+        function timeOutWithoutProviders() {
+          if (intentRef.current.sdlStrategy === "default" && bidStrategyRef.current === "auto") {
+            setError({ message: NO_PROVIDERS_MESSAGE });
+            setPhase("error");
+            return;
+          }
+          cancelAndEditRef.current?.();
           setError({ message: NO_PROVIDERS_MESSAGE });
-          setPhase("error");
-          return;
-        }
-        cancelAndEditRef.current?.();
-        setError({ message: NO_PROVIDERS_MESSAGE });
-      }, NO_BIDS_TIMEOUT_MS);
+        },
+        NO_BIDS_TIMEOUT_MS
+      );
       return function cancelNoProvidersTimeout() {
         clearTimeout(timer);
       };
@@ -213,10 +195,14 @@ export function useDeploymentFlow(
     [phase, hasOpenBids]
   );
 
+  /**
+   * Caches the SDL under the settings id + dseq at create time (the create response omits `owner`) so an in-progress
+   * deployment can resume into the flow after a reload — the same key the detail page reads.
+   */
   const requestQuotes = useCallback(
     function requestQuotes(sdl: string) {
-      // A fresh deployment reopens the no-providers window: re-arm the one-shot timeout for the new quoting session.
       providersEverBidRef.current = false;
+      bidsReceivedTrackedRef.current = false;
       setPhase("creating");
       setError(undefined);
       createDeployment.mutate(
@@ -229,9 +215,7 @@ export function useDeploymentFlow(
             setDeployError(undefined);
             setDeploySucceeded(false);
             setPhase("quoting");
-            // Cache the SDL under the wallet + dseq key the detail page reads, at create time, so an in-progress
-            // deployment (on-chain, no lease yet) can be resumed into the configure flow after a reload, when the
-            // captured SDL is otherwise gone. The create response omits `owner`, so key off the settings id.
+            analyticsService.track("create_deployment", { category: "deployments", label: "Create deployment in wizard", dseq: result.data.dseq });
             cacheDeployedSdl(deploymentLocalStorage, settingsId, result.data.dseq, sdl);
             router.replace(buildConfigureUrl(intentRef.current, result.data.dseq, bidStrategyRef.current), undefined, { shallow: true });
           },
@@ -242,13 +226,12 @@ export function useDeploymentFlow(
         }
       );
     },
-    [createDeployment, router, deploymentLocalStorage, settingsId]
+    [createDeployment, router, deploymentLocalStorage, settingsId, analyticsService]
   );
 
+  /** Drops the dseq from the URL immediately, not on close-success, so a returning user never sees the abandoned deployment while the close is in flight. */
   const cancelAndEdit = useCallback(
     function cancelAndEdit() {
-      // Drop the dseq from the URL immediately — not on close-success — so returning to editing (and the auto flow's
-      // "Try again") never leaves the abandoned deployment in the address bar while the close request is in flight.
       router.replace(buildConfigureUrl(intentRef.current, undefined, bidStrategy), undefined, { shallow: true });
       if (!dseq) {
         setPhase("configuring");
@@ -298,10 +281,14 @@ export function useDeploymentFlow(
     [dseq]
   );
 
-  const selectProvider = useCallback(function selectProvider(placementId: string, bidId: string) {
-    setDeployError(undefined);
-    setSelections(previous => ({ ...previous, [placementId]: bidId }));
-  }, []);
+  const selectProvider = useCallback(
+    function selectProvider(placementId: string, bidId: string) {
+      setDeployError(undefined);
+      setSelections(previous => ({ ...previous, [placementId]: bidId }));
+      analyticsService.track("bid_selected", "Amplitude");
+    },
+    [analyticsService]
+  );
 
   const clearSelection = useCallback(function clearSelection(placementId: string) {
     setSelections(function omitPlacement(previous) {
@@ -312,18 +299,8 @@ export function useDeploymentFlow(
   }, []);
 
   /**
-   * Deploys the current selections. The manifest is always derived from the SDL being deployed, so a
-   * quoting-window edit is what gets leased — never a stale create-time manifest. When that manifest differs
-   * from the one captured at create — or none was captured, e.g. a reload that resumed straight into
-   * `quoting` — the deployment is updated first (MsgUpdateDeployment) so the on-chain manifest hash matches
-   * before the provider is sent the manifest at lease time; an unchanged manifest goes straight to the lease.
-   * On success it persists the SDL under the deployment's dseq keyed by the owner the response carries (so it
-   * needs no wallet) — the same key the detail page reads — then replaces the configure entry with the
-   * deployment's events tab (matching the legacy builder), so Back lands on the new-deployment page rather than
-   * the just-deployed config.
-   * On any failure it drops back to `quoting` (unmounting the overlay) and sets `deployError` to drive the
-   * error toast and the header's Retry CTA; retry re-fires with the current selections. Provider re-selection
-   * after a lease exists is out of scope here.
+   * The manifest is derived from the SDL being deployed (not the create-time one) so a quoting-window edit gets leased;
+   * when it differs from create the deployment is updated first so the on-chain hash matches before the manifest is sent.
    */
   const deploy = useCallback(
     function deploy(sdl: string) {
@@ -333,15 +310,22 @@ export function useDeploymentFlow(
       if (leases.length === 0) return;
       const activeDseq = dseq;
       const activeManifest = nextManifest;
+      const resources = dependencies.deploymentResourcesFromSdl(sdl);
       setDeployError(undefined);
       setDeploySucceeded(false);
       setPhase("deploying");
+      /**
+       * The onboarding gate reads "onboarded" off the leases cache, empty until this first deploy, so refreshing it
+       * keeps a client-side nav to /deployments from bouncing the user back to onboarding until a full reload.
+       */
       function completeDeploy(result: { data: { deployment: { id: { owner: string } } } }) {
         const owner = result.data.deployment.id.owner;
+        analyticsService.track("create_lease", { category: "deployments", label: "Create lease", dseq: activeDseq, ...resources });
+        if (resources.gpuAmount > 0) {
+          analyticsService.track("create_gpu_deployment", { category: "deployments", label: "Create lease", dseq: activeDseq, ...resources });
+        }
+        analyticsService.track("send_manifest", { category: "deployments", label: "Send manifest after creating lease", dseq: activeDseq });
         cacheDeployedSdl(deploymentLocalStorage, owner, activeDseq, sdl);
-        // The onboarding gate decides "onboarded" from the leases cache, which was populated empty before this
-        // first deploy. Refresh it (and the deployment list) so a client-side nav to /deployments doesn't read a
-        // stale empty cache and bounce the user back to onboarding until a full page reload.
         queryClient.invalidateQueries({ queryKey: QueryKeys.getAllLeasesKey(owner) });
         queryClient.invalidateQueries({ queryKey: QueryKeys.getDeploymentListKey(owner) });
         setDeploySucceeded(true);
@@ -365,7 +349,7 @@ export function useDeploymentFlow(
         sendManifestAndLease();
       }
     },
-    [createLease, updateDeployment, dseq, manifest, selections, router, dependencies, deploymentLocalStorage, queryClient]
+    [createLease, updateDeployment, dseq, manifest, selections, router, dependencies, deploymentLocalStorage, queryClient, analyticsService]
   );
 
   return {
@@ -381,12 +365,13 @@ export function useDeploymentFlow(
   };
 }
 
-/**
- * Best-effort cache of the deployed SDL under the deployment's owner + dseq — the key the detail page reads.
- * Storage can be blocked, full, or hold corrupt data, so any failure is swallowed: caching must never keep the
- * deploy-success UI or the redirect from running.
- */
-function cacheDeployedSdl(storage: ReturnType<typeof useDeploymentLocalStorage>, owner: string | null | undefined, dseq: string, sdl: string): void {
+/** Best-effort cache under owner + dseq (the key the detail page reads); failures are swallowed so storage issues never block deploy. */
+function cacheDeployedSdl(
+  storage: ReturnType<typeof useServices>["deploymentLocalStorage"],
+  owner: string | null | undefined,
+  dseq: string,
+  sdl: string
+): void {
   try {
     storage.update(owner, dseq, { manifest: sdl });
   } catch {
@@ -394,16 +379,21 @@ function cacheDeployedSdl(storage: ReturnType<typeof useDeploymentLocalStorage>,
   }
 }
 
-/**
- * The provider manifest for an SDL, or null when the SDL can't be built (e.g. invalid/mid-edit). Matches the
- * server's create-deployment manifest (both are `manifestToSortedJSON` of the SDL's groups), so a session that
- * lost the captured manifest — a reload resumed straight into quoting — can still deploy from the restored SDL.
- */
+/** The provider manifest for an SDL, or null when it can't be built (invalid/mid-edit). Matches the server's create-deployment manifest, so the update-before-lease comparison in `deploy` holds. */
 function manifestFromSdl(sdl: string): string | null {
   try {
     return ManifestYaml(sdl);
   } catch {
     return null;
+  }
+}
+
+function deploymentResourcesFromSdl(sdl: string): { gpuAmount: number; cpuAmount: number; memoryAmount: number; storageAmount: number } {
+  try {
+    const totals = aggregateDeploymentResources(importSimpleSdl(sdl).services);
+    return { gpuAmount: totals.gpu, cpuAmount: totals.cpu, memoryAmount: totals.memoryBytes, storageAmount: totals.ephemeralBytes + totals.persistentBytes };
+  } catch {
+    return { gpuAmount: 0, cpuAmount: 0, memoryAmount: 0, storageAmount: 0 };
   }
 }
 


### PR DESCRIPTION
## Why

The deploy-activation funnel — `create_deployment` → `bids_received` → `bid_selected` →
`create_lease` / `create_gpu_deployment` → `send_manifest` — stopped firing in Prod around
**Jul 17, 2026**, coinciding with the onboarding-redesign rollout.

Root cause is an instrumentation gap, not lost traffic or a live deploy failure: those events were
only ever emitted from the legacy `new-deployment` components (`ManifestEdit`, `BidRow`,
`CreateLease`). The flag-gated configure flow (`onboarding_redesign_v1`) creates deployments and
leases through `useDeploymentFlow` and never emitted any of them, so as traffic shifted onto the new
flow the funnel went dark. Control events and deploy entry-card clicks stayed healthy because those
are wired into the new flow — which is the tell that this is a flow-migration gap.


## What

Analytics-only for the configure flow — no visual changes. All six funnel events now fire from
`useDeploymentFlow` at its lifecycle points, with the same names and category the legacy flow used:

- `create_deployment` — on create success.
- `bids_received` `{ numberOfBids }` — once per quoting session, the first time bids arrive.
- `bid_selected` — on provider selection (covers both the manual pick and the auto flow's autopilot).
- `create_lease` + `create_gpu_deployment` (when a GPU is requested) + `send_manifest` — on lease
  success. Resource amounts (`gpuAmount` / `cpuAmount` / `memoryAmount` / `storageAmount`) are derived
  from the deployed SDL.

**Caveat:** `create_lease` and `send_manifest` now fire together, because `POST /v1/leases` creates
the lease and sends the manifest in a single call. Any funnel step that assumed a gap between them
collapses in the new flow.

### Also in this PR (touched-file cleanup)

- Collapsed the five `useServices()` accessor wrappers in `useDeploymentFlow` into a single injected
  `useServices` DI seam, and inlined the `settingsIdAtom` read (matching the sibling
  `useDeploymentName`). Tests mock services with `mockDeep` + a jotai store `Provider`.
- Trimmed narration comments down to the few genuinely non-obvious notes.

### Verification

- `useDeploymentFlow.spec.tsx`: 48/48 pass (7 new tests covering each funnel event and the
  CPU-only / GPU split).
- ESLint and Prettier clean on the touched files; `tsc --noEmit` adds no errors in the touched files
  (pre-existing unrelated baseline errors elsewhere are untouched).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added enhanced analytics throughout the deployment flow, including deployment creation, bids received (first-arrival counted once across rerenders), bid selection, lease creation, manifest delivery, and conditional GPU deployments.
- Enriched analytics with resource details derived from the deployment definition and highlighted GPU-enabled vs CPU-only paths.

## Bug Fixes
- Improved handling when no providers are available by distinguishing between initial “no providers ever” scenarios (before any bids arrive) and later empty bid lists after quote expiry, with corrected one-time tracking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->