### PR TITLE
refactor(dx): inject chain api http client into balance and provider http services

### DIFF
--- a/apps/api/src/core/providers/http-sdk.provider.ts
+++ b/apps/api/src/core/providers/http-sdk.provider.ts
@@ -28,13 +28,6 @@ container.register(CHAIN_API_HTTP_CLIENT, {
   )
 });
 
-const SERVICES = [BalanceHttpService, ProviderHttpService];
-SERVICES.forEach(Service =>
-  container.register(Service as InjectionToken<unknown>, {
-    useFactory: instancePerContainerCachingFactory(c => new Service({ baseURL: c.resolve(CoreConfigService).get("REST_API_NODE_URL") }))
-  })
-);
-
 const NON_AXIOS_SERVICES: Array<new (httpClient: HttpClient) => unknown> = [
   DeploymentHttpService,
   LeaseHttpService,
@@ -42,7 +35,9 @@ const NON_AXIOS_SERVICES: Array<new (httpClient: HttpClient) => unknown> = [
   AuthzHttpService,
   BlockHttpService,
   BmeHttpService,
-  BidHttpService
+  BidHttpService,
+  BalanceHttpService,
+  ProviderHttpService
 ];
 NON_AXIOS_SERVICES.forEach(Service =>
   container.register(Service, { useFactory: instancePerContainerCachingFactory(c => new Service(c.resolve(CHAIN_API_HTTP_CLIENT))) })

--- a/apps/notifications/src/modules/alert/providers/http-sdk.provider.ts
+++ b/apps/notifications/src/modules/alert/providers/http-sdk.provider.ts
@@ -29,7 +29,7 @@ export const HTTP_SDK_PROVIDERS: Provider[] = [
   },
   {
     provide: BalanceHttpService,
-    inject: [ConfigService],
-    useFactory: (configService: ConfigService<AlertConfig>) => new BalanceHttpService({ baseURL: configService.getOrThrow("alert.API_NODE_ENDPOINT") })
+    inject: [CHAIN_API_HTTP_CLIENT_TOKEN],
+    useFactory: (httpClient: HttpClient) => new BalanceHttpService(httpClient)
   }
 ];

--- a/packages/http-sdk/src/balance/balance-http.service.ts
+++ b/packages/http-sdk/src/balance/balance-http.service.ts
@@ -1,7 +1,6 @@
-import type { AxiosRequestConfig } from "axios";
-
-import { HttpService } from "../http/http.service";
+import { extractData } from "../http/http.service";
 import type { Denom } from "../types/denom.type";
+import type { HttpClient } from "../utils/httpClient";
 
 export interface RawBalance {
   amount: string;
@@ -17,13 +16,11 @@ interface BalanceResponse {
   balance: RawBalance;
 }
 
-export class BalanceHttpService extends HttpService {
-  constructor(config?: Pick<AxiosRequestConfig, "baseURL">) {
-    super(config);
-  }
+export class BalanceHttpService {
+  constructor(private readonly httpClient: HttpClient) {}
 
   async getBalance(address: string, denom: string): Promise<Balance | undefined> {
-    const response = this.extractData(await this.get<BalanceResponse>(`cosmos/bank/v1beta1/balances/${address}/by_denom?denom=${denom}`));
+    const response = extractData(await this.httpClient.get<BalanceResponse>(`cosmos/bank/v1beta1/balances/${address}/by_denom?denom=${denom}`));
     return response.balance ? { amount: parseFloat(response.balance.amount), denom: response.balance.denom } : undefined;
   }
 }

--- a/packages/http-sdk/src/provider/provider-http.service.ts
+++ b/packages/http-sdk/src/provider/provider-http.service.ts
@@ -1,20 +1,17 @@
-import type { AxiosRequestConfig } from "axios";
-
-import { HttpService } from "../http/http.service";
+import { extractData } from "../http/http.service";
+import type { HttpClient } from "../utils/httpClient";
 import type { GetProviderResponse } from "./types";
 
-export class ProviderHttpService extends HttpService {
-  constructor(config?: Pick<AxiosRequestConfig, "baseURL">) {
-    super(config);
-  }
+export class ProviderHttpService {
+  constructor(private readonly httpClient: HttpClient) {}
 
   async getProvider(address: string): Promise<GetProviderResponse> {
-    return this.extractData(await this.get<GetProviderResponse>(`/akash/provider/v1beta4/providers/${address}`));
+    return extractData(await this.httpClient.get<GetProviderResponse>(`/akash/provider/v1beta4/providers/${address}`));
   }
 
   async sendManifest({ hostUri, dseq, manifest, jwtToken }: { hostUri: string; dseq: string; manifest: string; jwtToken: string }): Promise<void> {
-    return this.extractData(
-      await this.put(`/deployment/${dseq}/manifest`, {
+    return extractData(
+      await this.httpClient.put(`/deployment/${dseq}/manifest`, {
         baseURL: hostUri,
         body: manifest,
         headers: this.getJwtTokenHeaders(jwtToken),
@@ -24,8 +21,8 @@ export class ProviderHttpService extends HttpService {
   }
 
   async getLeaseStatus({ hostUri, dseq, gseq, oseq, jwtToken }: { hostUri: string; dseq: string; gseq: number; oseq: number; jwtToken: string }) {
-    return this.extractData(
-      await this.get(`/lease/${dseq}/${gseq}/${oseq}/status`, {
+    return extractData(
+      await this.httpClient.get(`/lease/${dseq}/${gseq}/${oseq}/status`, {
         baseURL: hostUri,
         headers: this.getJwtTokenHeaders(jwtToken),
         timeout: 30000

--- a/packages/http-sdk/src/provider/provider-http.service.ts
+++ b/packages/http-sdk/src/provider/provider-http.service.ts
@@ -11,9 +11,8 @@ export class ProviderHttpService {
 
   async sendManifest({ hostUri, dseq, manifest, jwtToken }: { hostUri: string; dseq: string; manifest: string; jwtToken: string }): Promise<void> {
     return extractData(
-      await this.httpClient.put(`/deployment/${dseq}/manifest`, {
+      await this.httpClient.put(`/deployment/${dseq}/manifest`, manifest, {
         baseURL: hostUri,
-        body: manifest,
         headers: this.getJwtTokenHeaders(jwtToken),
         timeout: 60000
       })


### PR DESCRIPTION
## Why

To enable retry mechanism for `BalanceHttpService` and `ProviderHttpService` and improve cross-service resilience.

## What

Refactor BalanceHttpService and ProviderHttpService to accept an injected HttpClient (CHAIN_API_HTTP_CLIENT) instead of extending HttpService with an axios config, matching the LeaseHttpService pattern. Register both via the shared chain-api http client in apps/api and apps/notifications DI providers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved balance and provider service connectivity by routing requests through the shared HTTP client across core API and alerting.
  * Enhanced reliability for provider lookups, manifest uploads, lease status checks, and balance retrieval.
* **Refactor**
  * Standardized HTTP service setup and response extraction for balance and provider HTTP services, using the same injected client and consistent handling paths across features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->