### PR TITLE
feat(config): add content security policy to stats-web and deploy-web

### DIFF
--- a/apps/deploy-web/src/config/env-config.schema.ts
+++ b/apps/deploy-web/src/config/env-config.schema.ts
@@ -58,7 +58,7 @@ export const browserEnvSchema = z.object({
 
 export const serverEnvSchema = browserEnvSchema.extend({
   MAINTENANCE_MODE: coercedBoolean().optional().default("false"),
-  CSP_MODE: z.enum(["enforce", "report-only"]).optional(),
+  CSP_MODE: z.enum(["enforce", "report-only"]).default("report-only"),
   AUTH0_SECRET: z.string(),
   AUTH0_BASE_URL: z.string().url(),
   AUTH0_ISSUER_BASE_URL: z.string().url(),

--- a/apps/deploy-web/src/config/env-config.schema.ts
+++ b/apps/deploy-web/src/config/env-config.schema.ts
@@ -58,6 +58,7 @@ export const browserEnvSchema = z.object({
 
 export const serverEnvSchema = browserEnvSchema.extend({
   MAINTENANCE_MODE: coercedBoolean().optional().default("false"),
+  CSP_MODE: z.enum(["enforce", "report-only"]).optional(),
   AUTH0_SECRET: z.string(),
   AUTH0_BASE_URL: z.string().url(),
   AUTH0_ISSUER_BASE_URL: z.string().url(),

--- a/apps/deploy-web/src/lib/csp/csp.spec.ts
+++ b/apps/deploy-web/src/lib/csp/csp.spec.ts
@@ -1,6 +1,13 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { buildContentSecurityPolicy, type ContentSecurityPolicyInput, getContentSecurityPolicyHeaderName, toOrigin } from "./csp";
+import {
+  buildContentSecurityPolicy,
+  type ContentSecurityPolicyInput,
+  getContentSecurityPolicyHeaderName,
+  getContentSecurityPolicyReportHeaders,
+  toOrigin,
+  toSentrySecurityReportUri
+} from "./csp";
 
 describe("csp", () => {
   afterEach(() => {
@@ -18,6 +25,27 @@ describe("csp", () => {
       expect(toOrigin("")).toBeUndefined();
       expect(toOrigin(undefined)).toBeUndefined();
       expect(toOrigin("not a url")).toBeUndefined();
+    });
+  });
+
+  describe("toSentrySecurityReportUri", () => {
+    it("builds a Sentry security report URI from the browser DSN", () => {
+      expect(toSentrySecurityReportUri("https://publicKey@o877251.ingest.sentry.io/4504")).toBe(
+        "https://o877251.ingest.sentry.io/api/4504/security/?sentry_key=publicKey"
+      );
+    });
+
+    it("preserves a self-hosted Sentry base path", () => {
+      expect(toSentrySecurityReportUri("https://publicKey@sentry.example.com/sentry/4504")).toBe(
+        "https://sentry.example.com/sentry/api/4504/security/?sentry_key=publicKey"
+      );
+    });
+
+    it("returns undefined for relative, empty, or invalid values", () => {
+      expect(toSentrySecurityReportUri("/sentry-dsn")).toBeUndefined();
+      expect(toSentrySecurityReportUri("")).toBeUndefined();
+      expect(toSentrySecurityReportUri(undefined)).toBeUndefined();
+      expect(toSentrySecurityReportUri("not a url")).toBeUndefined();
     });
   });
 
@@ -73,6 +101,20 @@ describe("csp", () => {
 
       expect(connectSrc).toContain("https://*.amplitude.com");
     });
+
+    it("adds Sentry CSP reporting directives when a Sentry DSN is configured", () => {
+      const { reportUri, reportTo } = setup({ sentryDsn: "https://publicKey@o877251.ingest.sentry.io/4504" });
+
+      expect(reportUri).toBe("report-uri https://o877251.ingest.sentry.io/api/4504/security/?sentry_key=publicKey");
+      expect(reportTo).toBe("report-to csp-endpoint");
+    });
+
+    it("omits Sentry CSP reporting directives when no Sentry DSN is configured", () => {
+      const { reportUri, reportTo } = setup({});
+
+      expect(reportUri).toBeUndefined();
+      expect(reportTo).toBeUndefined();
+    });
   });
 
   describe("getContentSecurityPolicyHeaderName", () => {
@@ -87,9 +129,41 @@ describe("csp", () => {
     });
   });
 
+  describe("getContentSecurityPolicyReportHeaders", () => {
+    it("returns Report-To and Reporting-Endpoints headers for the Sentry CSP endpoint", () => {
+      const headers = getContentSecurityPolicyReportHeaders({ sentryDsn: "https://publicKey@o877251.ingest.sentry.io/4504" });
+
+      expect(headers).toEqual([
+        {
+          name: "Report-To",
+          value: JSON.stringify({
+            group: "csp-endpoint",
+            max_age: 10886400,
+            endpoints: [{ url: "https://o877251.ingest.sentry.io/api/4504/security/?sentry_key=publicKey" }],
+            include_subdomains: true
+          })
+        },
+        {
+          name: "Reporting-Endpoints",
+          value: 'csp-endpoint="https://o877251.ingest.sentry.io/api/4504/security/?sentry_key=publicKey"'
+        }
+      ]);
+    });
+
+    it("returns no reporting headers when no Sentry DSN is configured", () => {
+      expect(getContentSecurityPolicyReportHeaders({})).toEqual([]);
+    });
+  });
+
   function setup(input: ContentSecurityPolicyInput) {
     const policy = buildContentSecurityPolicy("test-nonce", input);
     const directives = Object.fromEntries(policy.split("; ").map(directive => [directive.split(" ")[0], directive]));
-    return { policy, connectSrc: directives["connect-src"], imgSrc: directives["img-src"] };
+    return {
+      policy,
+      connectSrc: directives["connect-src"],
+      imgSrc: directives["img-src"],
+      reportUri: directives["report-uri"],
+      reportTo: directives["report-to"]
+    };
   }
 });

--- a/apps/deploy-web/src/lib/csp/csp.spec.ts
+++ b/apps/deploy-web/src/lib/csp/csp.spec.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { buildContentSecurityPolicy, type ContentSecurityPolicyInput, getContentSecurityPolicyHeaderName, toOrigin } from "./csp";
+
+describe("csp", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe("toOrigin", () => {
+    it("reduces a URL with a path to a bare origin", () => {
+      expect(toOrigin("https://features-edge.akash.network/api/frontend")).toBe("https://features-edge.akash.network");
+      expect(toOrigin("https://console-proxy.akash.network/collect")).toBe("https://console-proxy.akash.network");
+    });
+
+    it("returns undefined for relative, empty, or invalid values", () => {
+      expect(toOrigin("/provider-proxy-mainnet")).toBeUndefined();
+      expect(toOrigin("")).toBeUndefined();
+      expect(toOrigin(undefined)).toBeUndefined();
+      expect(toOrigin("not a url")).toBeUndefined();
+    });
+  });
+
+  describe("buildContentSecurityPolicy", () => {
+    it("includes origins derived from the provided env values", () => {
+      const { connectSrc } = setup({
+        amplitudeProxyUrl: "https://console-proxy.akash.network/collect",
+        unleashFrontendApiUrl: "https://features-edge.akash.network/api/frontend",
+        sentryDsn: "https://key@o877251.ingest.sentry.io/4504",
+        networkRpcAndApiUrls: ["https://rpc.akt.dev/rpc", "https://api.akashnet.net:443"]
+      });
+
+      expect(connectSrc).toContain("https://console-proxy.akash.network");
+      expect(connectSrc).toContain("https://features-edge.akash.network");
+      expect(connectSrc).toContain("https://o877251.ingest.sentry.io");
+      expect(connectSrc).toContain("https://rpc.akt.dev");
+      expect(connectSrc).toContain("https://api.akashnet.net");
+    });
+
+    it("adds a websocket origin for the provider proxy", () => {
+      const { connectSrc } = setup({ providerProxyUrl: "https://console-proxy.akash.network" });
+
+      expect(connectSrc).toContain("https://console-proxy.akash.network");
+      expect(connectSrc).toContain("wss://console-proxy.akash.network");
+    });
+
+    it("excludes origins that were not provided", () => {
+      const { connectSrc } = setup({ amplitudeProxyUrl: "https://console-proxy.akash.network/collect" });
+
+      expect(connectSrc).not.toContain("https://features-edge.akash.network");
+    });
+
+    it("does not leak relative api or proxy urls into connect-src", () => {
+      const { connectSrc } = setup({
+        mainnetApiUrl: "/api-mainnet",
+        sandboxApiUrl: "/api-sandbox",
+        providerProxyUrl: "/provider-proxy-mainnet"
+      });
+
+      expect(connectSrc).not.toContain("/api-mainnet");
+      expect(connectSrc).not.toContain("/provider-proxy-mainnet");
+      expect(connectSrc).toContain("'self'");
+    });
+
+    it("derives the templates img-src origin from the provided value", () => {
+      const { imgSrc } = setup({ templatesUrl: "https://akash-templates.pages.dev" });
+
+      expect(imgSrc).toContain("https://akash-templates.pages.dev");
+    });
+
+    it("always allows Amplitude endpoints since Session Replay is not routed through the proxy", () => {
+      const { connectSrc } = setup({});
+
+      expect(connectSrc).toContain("https://*.amplitude.com");
+    });
+  });
+
+  describe("getContentSecurityPolicyHeaderName", () => {
+    it("returns the enforce header when CSP_MODE is enforce", () => {
+      vi.stubEnv("CSP_MODE", "enforce");
+      expect(getContentSecurityPolicyHeaderName()).toBe("Content-Security-Policy");
+    });
+
+    it("returns the report-only header by default", () => {
+      vi.stubEnv("CSP_MODE", "");
+      expect(getContentSecurityPolicyHeaderName()).toBe("Content-Security-Policy-Report-Only");
+    });
+  });
+
+  function setup(input: ContentSecurityPolicyInput) {
+    const policy = buildContentSecurityPolicy("test-nonce", input);
+    const directives = Object.fromEntries(policy.split("; ").map(directive => [directive.split(" ")[0], directive]));
+    return { policy, connectSrc: directives["connect-src"], imgSrc: directives["img-src"] };
+  }
+});

--- a/apps/deploy-web/src/lib/csp/csp.ts
+++ b/apps/deploy-web/src/lib/csp/csp.ts
@@ -1,5 +1,7 @@
 const CSP_HEADER_ENFORCE = "Content-Security-Policy";
 const CSP_HEADER_REPORT_ONLY = "Content-Security-Policy-Report-Only";
+const CSP_REPORT_ENDPOINT_NAME = "csp-endpoint";
+const CSP_REPORT_MAX_AGE_SECONDS = 10886400;
 
 const NONCE_BYTE_LENGTH = 16;
 
@@ -22,7 +24,14 @@ const FIXED_VENDOR_CONNECT_ORIGINS = [
 ];
 
 /** Image hosts that never vary by environment (inline data/blob URIs, GitHub avatars/raw content, Google). */
-const FIXED_IMG_SRC = ["data:", "blob:", "https://raw.githubusercontent.com", "https://avatars.githubusercontent.com", "https://www.googletagmanager.com", "https://*.google-analytics.com"];
+const FIXED_IMG_SRC = [
+  "data:",
+  "blob:",
+  "https://raw.githubusercontent.com",
+  "https://avatars.githubusercontent.com",
+  "https://www.googletagmanager.com",
+  "https://*.google-analytics.com"
+];
 
 export interface ContentSecurityPolicyInput {
   mainnetApiUrl?: string;
@@ -46,6 +55,27 @@ export function toOrigin(value?: string): string | undefined {
 
   try {
     return new URL(value).origin;
+  } catch {
+    return undefined;
+  }
+}
+
+export function toSentrySecurityReportUri(dsn?: string): string | undefined {
+  if (!dsn || dsn.startsWith("/")) return undefined;
+
+  try {
+    const dsnUrl = new URL(dsn);
+    const pathSegments = dsnUrl.pathname.split("/").filter(Boolean);
+    const projectId = pathSegments[pathSegments.length - 1];
+
+    if (!dsnUrl.username || !projectId) return undefined;
+
+    const basePath = pathSegments.slice(0, -1).join("/");
+    const reportUrl = new URL(dsnUrl.origin);
+    reportUrl.pathname = `${basePath ? `/${basePath}` : ""}/api/${projectId}/security/`;
+    reportUrl.searchParams.set("sentry_key", dsnUrl.username);
+
+    return reportUrl.toString();
   } catch {
     return undefined;
   }
@@ -89,6 +119,7 @@ export function buildContentSecurityPolicy(nonce: string, input: ContentSecurity
 
   const connectSrc = dedupeOrigins(["'self'", ...envConnectOrigins, ...FIXED_VENDOR_CONNECT_ORIGINS]);
   const imgSrc = dedupeOrigins(["'self'", ...FIXED_IMG_SRC, toOrigin(input.templatesUrl)]);
+  const sentrySecurityReportUri = toSentrySecurityReportUri(input.sentryDsn);
 
   if (isDevelopment) {
     scriptSrc.push("'unsafe-eval'");
@@ -110,12 +141,35 @@ export function buildContentSecurityPolicy(nonce: string, input: ContentSecurity
     "frame-src 'self' https://js.stripe.com https://hooks.stripe.com https://challenges.cloudflare.com https://www.googletagmanager.com",
     "worker-src 'self' blob:",
     "manifest-src 'self'",
-    ...(isDevelopment ? [] : ["upgrade-insecure-requests"])
+    ...(isDevelopment ? [] : ["upgrade-insecure-requests"]),
+    ...(sentrySecurityReportUri ? [`report-uri ${sentrySecurityReportUri}`, `report-to ${CSP_REPORT_ENDPOINT_NAME}`] : [])
   ].join("; ");
 }
 
 export function getContentSecurityPolicyHeaderName() {
   return process.env.CSP_MODE === "enforce" ? CSP_HEADER_ENFORCE : CSP_HEADER_REPORT_ONLY;
+}
+
+export function getContentSecurityPolicyReportHeaders(input: ContentSecurityPolicyInput) {
+  const sentrySecurityReportUri = toSentrySecurityReportUri(input.sentryDsn);
+
+  if (!sentrySecurityReportUri) return [];
+
+  return [
+    {
+      name: "Report-To",
+      value: JSON.stringify({
+        group: CSP_REPORT_ENDPOINT_NAME,
+        max_age: CSP_REPORT_MAX_AGE_SECONDS,
+        endpoints: [{ url: sentrySecurityReportUri }],
+        include_subdomains: true
+      })
+    },
+    {
+      name: "Reporting-Endpoints",
+      value: `${CSP_REPORT_ENDPOINT_NAME}="${sentrySecurityReportUri}"`
+    }
+  ];
 }
 
 function dedupeOrigins(origins: Array<string | undefined>) {

--- a/apps/deploy-web/src/lib/csp/csp.ts
+++ b/apps/deploy-web/src/lib/csp/csp.ts
@@ -1,0 +1,123 @@
+const CSP_HEADER_ENFORCE = "Content-Security-Policy";
+const CSP_HEADER_REPORT_ONLY = "Content-Security-Policy-Report-Only";
+
+const NONCE_BYTE_LENGTH = 16;
+
+const isDevelopment = process.env.NODE_ENV !== "production";
+
+/**
+ * Third-party endpoints the app connects to directly (Stripe, Cloudflare, Google, Growth Channel, Amplitude); these never vary by environment.
+ * Amplitude core events are proxied via NEXT_PUBLIC_AMPLITUDE_PROXY_URL, but Session Replay (config + ingest) and the no-proxy fallback hit
+ * `*.amplitude.com` subdomains directly, so the wildcard is required regardless of the proxy setting.
+ */
+const FIXED_VENDOR_CONNECT_ORIGINS = [
+  "https://api.stripe.com",
+  "https://m.stripe.network",
+  "https://challenges.cloudflare.com",
+  "https://www.googletagmanager.com",
+  "https://*.google-analytics.com",
+  "https://*.analytics.google.com",
+  "https://pxl.growth-channel.net",
+  "https://*.amplitude.com"
+];
+
+/** Image hosts that never vary by environment (inline data/blob URIs, GitHub avatars/raw content, Google). */
+const FIXED_IMG_SRC = ["data:", "blob:", "https://raw.githubusercontent.com", "https://avatars.githubusercontent.com", "https://www.googletagmanager.com", "https://*.google-analytics.com"];
+
+export interface ContentSecurityPolicyInput {
+  mainnetApiUrl?: string;
+  testnetApiUrl?: string;
+  sandboxApiUrl?: string;
+  providerProxyUrl?: string;
+  amplitudeProxyUrl?: string;
+  unleashFrontendApiUrl?: string;
+  sentryDsn?: string;
+  templatesUrl?: string;
+  networkRpcAndApiUrls?: string[];
+}
+
+/**
+ * Reduces a configured URL (which may carry a path, e.g. an Unleash frontend endpoint or a Sentry DSN) to a bare origin.
+ * Returns undefined for empty, relative (`/...`), or unparseable values: relative endpoints are same-origin and already
+ * covered by `'self'`.
+ */
+export function toOrigin(value?: string): string | undefined {
+  if (!value || value.startsWith("/")) return undefined;
+
+  try {
+    return new URL(value).origin;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Uses Web Crypto (available on the Edge/standard middleware runtime) since Node's
+ * `crypto` module is not guaranteed to be available where the middleware executes.
+ */
+export function generateNonce() {
+  const bytes = new Uint8Array(NONCE_BYTE_LENGTH);
+  crypto.getRandomValues(bytes);
+  return btoa(String.fromCharCode(...bytes));
+}
+
+export function buildContentSecurityPolicy(nonce: string, input: ContentSecurityPolicyInput) {
+  const scriptSrc = [
+    "'self'",
+    `'nonce-${nonce}'`,
+    "'strict-dynamic'",
+    "https://www.googletagmanager.com",
+    "https://pxl.growth-channel.net",
+    "https://challenges.cloudflare.com",
+    "https://js.stripe.com"
+  ];
+
+  const providerProxyOrigin = toOrigin(input.providerProxyUrl);
+  const providerProxyWebSocketOrigin = providerProxyOrigin?.replace(/^http/, "ws");
+
+  const envConnectOrigins = [
+    toOrigin(input.mainnetApiUrl),
+    toOrigin(input.testnetApiUrl),
+    toOrigin(input.sandboxApiUrl),
+    providerProxyOrigin,
+    providerProxyWebSocketOrigin,
+    toOrigin(input.amplitudeProxyUrl),
+    toOrigin(input.unleashFrontendApiUrl),
+    toOrigin(input.sentryDsn),
+    ...(input.networkRpcAndApiUrls ?? []).map(toOrigin)
+  ];
+
+  const connectSrc = dedupeOrigins(["'self'", ...envConnectOrigins, ...FIXED_VENDOR_CONNECT_ORIGINS]);
+  const imgSrc = dedupeOrigins(["'self'", ...FIXED_IMG_SRC, toOrigin(input.templatesUrl)]);
+
+  if (isDevelopment) {
+    scriptSrc.push("'unsafe-eval'");
+    connectSrc.push("http://localhost:3080", "ws:");
+  }
+
+  return [
+    "default-src 'self'",
+    "base-uri 'self'",
+    "object-src 'none'",
+    "frame-ancestors 'none'",
+    "form-action 'self'",
+    `script-src ${scriptSrc.join(" ")}`,
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+    "style-src-attr 'unsafe-inline'",
+    `img-src ${imgSrc.join(" ")}`,
+    "font-src 'self' data: https://fonts.gstatic.com",
+    `connect-src ${connectSrc.join(" ")}`,
+    "frame-src 'self' https://js.stripe.com https://hooks.stripe.com https://challenges.cloudflare.com https://www.googletagmanager.com",
+    "worker-src 'self' blob:",
+    "manifest-src 'self'",
+    ...(isDevelopment ? [] : ["upgrade-insecure-requests"])
+  ].join("; ");
+}
+
+export function getContentSecurityPolicyHeaderName() {
+  return process.env.CSP_MODE === "enforce" ? CSP_HEADER_ENFORCE : CSP_HEADER_REPORT_ONLY;
+}
+
+function dedupeOrigins(origins: Array<string | undefined>) {
+  return Array.from(new Set(origins.filter((origin): origin is string => Boolean(origin))));
+}

--- a/apps/deploy-web/src/middleware.ts
+++ b/apps/deploy-web/src/middleware.ts
@@ -1,26 +1,54 @@
 import { LoggerService } from "@akashnetwork/logging";
+import { netConfig } from "@akashnetwork/net";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
+
+import { buildContentSecurityPolicy, generateNonce, getContentSecurityPolicyHeaderName } from "./lib/csp/csp";
 
 const { MAINTENANCE_MODE } = process.env;
 const logger = new LoggerService({ name: "middleware" });
 
+const networkRpcAndApiUrls = netConfig.getSupportedNetworks().flatMap(network => [netConfig.getBaseRpcUrl(network), netConfig.getBaseAPIUrl(network)]);
+
 export function middleware(request: NextRequest) {
+  const nonce = generateNonce();
+  const contentSecurityPolicy = buildContentSecurityPolicy(nonce, {
+    mainnetApiUrl: process.env.NEXT_PUBLIC_BASE_API_MAINNET_URL,
+    testnetApiUrl: process.env.NEXT_PUBLIC_BASE_API_TESTNET_URL,
+    sandboxApiUrl: process.env.NEXT_PUBLIC_BASE_API_SANDBOX_URL,
+    providerProxyUrl: process.env.NEXT_PUBLIC_PROVIDER_PROXY_URL,
+    amplitudeProxyUrl: process.env.NEXT_PUBLIC_AMPLITUDE_PROXY_URL,
+    unleashFrontendApiUrl: process.env.NEXT_PUBLIC_UNLEASH_FRONTEND_API_URL,
+    sentryDsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+    templatesUrl: process.env.NEXT_PUBLIC_BASE_TEMPLATES_URL,
+    networkRpcAndApiUrls
+  });
+  const contentSecurityPolicyHeaderName = getContentSecurityPolicyHeaderName();
+
   const maintenancePage = "/maintenance";
   const isMaintenanceMode = MAINTENANCE_MODE === "true";
   if (isMaintenanceMode && !request.nextUrl.pathname.startsWith(maintenancePage)) {
     const fromPath = request.nextUrl.pathname + request.nextUrl.search;
     logger.info({ message: `Redirecting to maintenance page from ${fromPath}` });
 
-    return NextResponse.redirect(new URL(`${maintenancePage}?return=${encodeURIComponent(fromPath)}`, request.url), 307); // 307 - temporary redirect
+    const redirectResponse = NextResponse.redirect(new URL(`${maintenancePage}?return=${encodeURIComponent(fromPath)}`, request.url), 307); // 307 - temporary redirect
+    redirectResponse.headers.set(contentSecurityPolicyHeaderName, contentSecurityPolicy);
+    return redirectResponse;
   } else if (!isMaintenanceMode && request.nextUrl.pathname.startsWith(maintenancePage)) {
     const returnPath = getReturnPath(request);
     logger.info({ message: `Redirecting from maintenance page to ${returnPath}` });
 
-    return NextResponse.redirect(new URL(returnPath, request.url), 307); // 307 - temporary redirect
+    const redirectResponse = NextResponse.redirect(new URL(returnPath, request.url), 307); // 307 - temporary redirect
+    redirectResponse.headers.set(contentSecurityPolicyHeaderName, contentSecurityPolicy);
+    return redirectResponse;
   }
 
-  const res = NextResponse.next();
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-nonce", nonce);
+  requestHeaders.set(contentSecurityPolicyHeaderName, contentSecurityPolicy);
+
+  const res = NextResponse.next({ request: { headers: requestHeaders } });
+  res.headers.set(contentSecurityPolicyHeaderName, contentSecurityPolicy);
 
   const cookieName = "unleash-session-id";
   let sessionId = request.cookies.get(cookieName)?.value;

--- a/apps/deploy-web/src/middleware.ts
+++ b/apps/deploy-web/src/middleware.ts
@@ -3,7 +3,7 @@ import { netConfig } from "@akashnetwork/net";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 
-import { buildContentSecurityPolicy, generateNonce, getContentSecurityPolicyHeaderName } from "./lib/csp/csp";
+import { buildContentSecurityPolicy, generateNonce, getContentSecurityPolicyHeaderName, getContentSecurityPolicyReportHeaders } from "./lib/csp/csp";
 
 const { MAINTENANCE_MODE } = process.env;
 const logger = new LoggerService({ name: "middleware" });
@@ -12,7 +12,7 @@ const networkRpcAndApiUrls = netConfig.getSupportedNetworks().flatMap(network =>
 
 export function middleware(request: NextRequest) {
   const nonce = generateNonce();
-  const contentSecurityPolicy = buildContentSecurityPolicy(nonce, {
+  const contentSecurityPolicyInput = {
     mainnetApiUrl: process.env.NEXT_PUBLIC_BASE_API_MAINNET_URL,
     testnetApiUrl: process.env.NEXT_PUBLIC_BASE_API_TESTNET_URL,
     sandboxApiUrl: process.env.NEXT_PUBLIC_BASE_API_SANDBOX_URL,
@@ -22,8 +22,10 @@ export function middleware(request: NextRequest) {
     sentryDsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
     templatesUrl: process.env.NEXT_PUBLIC_BASE_TEMPLATES_URL,
     networkRpcAndApiUrls
-  });
+  };
+  const contentSecurityPolicy = buildContentSecurityPolicy(nonce, contentSecurityPolicyInput);
   const contentSecurityPolicyHeaderName = getContentSecurityPolicyHeaderName();
+  const contentSecurityPolicyReportHeaders = getContentSecurityPolicyReportHeaders(contentSecurityPolicyInput);
 
   const maintenancePage = "/maintenance";
   const isMaintenanceMode = MAINTENANCE_MODE === "true";
@@ -32,14 +34,14 @@ export function middleware(request: NextRequest) {
     logger.info({ message: `Redirecting to maintenance page from ${fromPath}` });
 
     const redirectResponse = NextResponse.redirect(new URL(`${maintenancePage}?return=${encodeURIComponent(fromPath)}`, request.url), 307); // 307 - temporary redirect
-    redirectResponse.headers.set(contentSecurityPolicyHeaderName, contentSecurityPolicy);
+    setContentSecurityPolicyHeaders(redirectResponse, contentSecurityPolicyHeaderName, contentSecurityPolicy, contentSecurityPolicyReportHeaders);
     return redirectResponse;
   } else if (!isMaintenanceMode && request.nextUrl.pathname.startsWith(maintenancePage)) {
     const returnPath = getReturnPath(request);
     logger.info({ message: `Redirecting from maintenance page to ${returnPath}` });
 
     const redirectResponse = NextResponse.redirect(new URL(returnPath, request.url), 307); // 307 - temporary redirect
-    redirectResponse.headers.set(contentSecurityPolicyHeaderName, contentSecurityPolicy);
+    setContentSecurityPolicyHeaders(redirectResponse, contentSecurityPolicyHeaderName, contentSecurityPolicy, contentSecurityPolicyReportHeaders);
     return redirectResponse;
   }
 
@@ -48,7 +50,7 @@ export function middleware(request: NextRequest) {
   requestHeaders.set(contentSecurityPolicyHeaderName, contentSecurityPolicy);
 
   const res = NextResponse.next({ request: { headers: requestHeaders } });
-  res.headers.set(contentSecurityPolicyHeaderName, contentSecurityPolicy);
+  setContentSecurityPolicyHeaders(res, contentSecurityPolicyHeaderName, contentSecurityPolicy, contentSecurityPolicyReportHeaders);
 
   const cookieName = "unleash-session-id";
   let sessionId = request.cookies.get(cookieName)?.value;
@@ -65,6 +67,18 @@ export function middleware(request: NextRequest) {
   }
 
   return res;
+}
+
+function setContentSecurityPolicyHeaders(
+  response: NextResponse,
+  contentSecurityPolicyHeaderName: string,
+  contentSecurityPolicy: string,
+  reportHeaders: Array<{ name: string; value: string }>
+) {
+  response.headers.set(contentSecurityPolicyHeaderName, contentSecurityPolicy);
+  reportHeaders.forEach(header => {
+    response.headers.set(header.name, header.value);
+  });
 }
 
 function getReturnPath(request: NextRequest) {

--- a/apps/deploy-web/src/utils/domUtils.ts
+++ b/apps/deploy-web/src/utils/domUtils.ts
@@ -21,9 +21,23 @@ function scriptExists(id: string): boolean {
   return !!document.getElementById(id);
 }
 
+/**
+ * Reads the active CSP nonce from an already-nonced script via the `.nonce` IDL property,
+ * since browsers clear the `nonce` content attribute after parsing.
+ */
+export function getCspNonce(): string | undefined {
+  return document.querySelector<HTMLScriptElement>("script[nonce]")?.nonce || undefined;
+}
+
 function createScriptElement(options: ScriptOptions): HTMLScriptElement {
   const script = document.createElement("script");
   Object.assign(script, options);
+
+  const nonce = getCspNonce();
+  if (nonce) {
+    script.nonce = nonce;
+  }
+
   return script;
 }
 

--- a/apps/stats-web/src/config/env-config.schema.ts
+++ b/apps/stats-web/src/config/env-config.schema.ts
@@ -22,6 +22,7 @@ export const browserEnvSchema = z.object({
 
 export const serverEnvSchema = browserEnvSchema.extend({
   MAINTENANCE_MODE: coercedBoolean().optional().default("false"),
+  CSP_MODE: z.enum(["enforce", "report-only"]).optional(),
   BASE_API_MAINNET_URL: z.string().url(),
   BASE_API_TESTNET_URL: z.string().url(),
   BASE_API_SANDBOX_URL: z.string().url()

--- a/apps/stats-web/src/config/env-config.schema.ts
+++ b/apps/stats-web/src/config/env-config.schema.ts
@@ -22,7 +22,7 @@ export const browserEnvSchema = z.object({
 
 export const serverEnvSchema = browserEnvSchema.extend({
   MAINTENANCE_MODE: coercedBoolean().optional().default("false"),
-  CSP_MODE: z.enum(["enforce", "report-only"]).optional(),
+  CSP_MODE: z.enum(["enforce", "report-only"]).default("report-only"),
   BASE_API_MAINNET_URL: z.string().url(),
   BASE_API_TESTNET_URL: z.string().url(),
   BASE_API_SANDBOX_URL: z.string().url()

--- a/apps/stats-web/src/lib/csp/csp.spec.ts
+++ b/apps/stats-web/src/lib/csp/csp.spec.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { buildContentSecurityPolicy, type ContentSecurityPolicyInput, getContentSecurityPolicyHeaderName, toOrigin } from "./csp";
+
+describe("csp", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe("toOrigin", () => {
+    it("reduces a URL with a path to a bare origin", () => {
+      expect(toOrigin("https://features-edge.akash.network/api/frontend")).toBe("https://features-edge.akash.network");
+      expect(toOrigin("https://2d6f725d@o877251.ingest.sentry.io/4504")).toBe("https://o877251.ingest.sentry.io");
+    });
+
+    it("returns undefined for relative, empty, or invalid values", () => {
+      expect(toOrigin("/api-mainnet")).toBeUndefined();
+      expect(toOrigin("")).toBeUndefined();
+      expect(toOrigin(undefined)).toBeUndefined();
+      expect(toOrigin("not a url")).toBeUndefined();
+    });
+  });
+
+  describe("buildContentSecurityPolicy", () => {
+    it("includes origins derived from the provided env values", () => {
+      const { connectSrc } = setup({
+        mainnetApiUrl: "https://console-api.akash.network",
+        unleashFrontendApiUrl: "https://features-edge.akash.network/api/frontend",
+        sentryDsn: "https://key@o877251.ingest.sentry.io/4504"
+      });
+
+      expect(connectSrc).toContain("https://console-api.akash.network");
+      expect(connectSrc).toContain("https://features-edge.akash.network");
+      expect(connectSrc).toContain("https://o877251.ingest.sentry.io");
+    });
+
+    it("excludes origins that were not provided", () => {
+      const { connectSrc } = setup({ mainnetApiUrl: "https://console-api.akash.network" });
+
+      expect(connectSrc).not.toContain("https://console-api-sandbox.akash.network");
+      expect(connectSrc).not.toContain("https://features-edge.akash.network");
+    });
+
+    it("does not leak relative api urls into connect-src", () => {
+      const { connectSrc } = setup({ mainnetApiUrl: "/api-mainnet", sandboxApiUrl: "/api-sandbox" });
+
+      expect(connectSrc).not.toContain("/api-mainnet");
+      expect(connectSrc).not.toContain("/api-sandbox");
+      expect(connectSrc).toContain("'self'");
+    });
+
+    it("always includes fixed vendor connect origins", () => {
+      const { connectSrc } = setup({});
+
+      expect(connectSrc).toContain("https://www.google-analytics.com");
+      expect(connectSrc).toContain("https://www.googletagmanager.com");
+    });
+  });
+
+  describe("getContentSecurityPolicyHeaderName", () => {
+    it("returns the enforce header when CSP_MODE is enforce", () => {
+      vi.stubEnv("CSP_MODE", "enforce");
+      expect(getContentSecurityPolicyHeaderName()).toBe("Content-Security-Policy");
+    });
+
+    it("returns the report-only header by default", () => {
+      vi.stubEnv("CSP_MODE", "");
+      expect(getContentSecurityPolicyHeaderName()).toBe("Content-Security-Policy-Report-Only");
+    });
+  });
+
+  function setup(input: ContentSecurityPolicyInput) {
+    const policy = buildContentSecurityPolicy("test-nonce", input);
+    const directives = Object.fromEntries(policy.split("; ").map(directive => [directive.split(" ")[0], directive]));
+    return { policy, connectSrc: directives["connect-src"] };
+  }
+});

--- a/apps/stats-web/src/lib/csp/csp.spec.ts
+++ b/apps/stats-web/src/lib/csp/csp.spec.ts
@@ -1,6 +1,13 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { buildContentSecurityPolicy, type ContentSecurityPolicyInput, getContentSecurityPolicyHeaderName, toOrigin } from "./csp";
+import {
+  buildContentSecurityPolicy,
+  type ContentSecurityPolicyInput,
+  getContentSecurityPolicyHeaderName,
+  getContentSecurityPolicyReportHeaders,
+  toOrigin,
+  toSentrySecurityReportUri
+} from "./csp";
 
 describe("csp", () => {
   afterEach(() => {
@@ -18,6 +25,27 @@ describe("csp", () => {
       expect(toOrigin("")).toBeUndefined();
       expect(toOrigin(undefined)).toBeUndefined();
       expect(toOrigin("not a url")).toBeUndefined();
+    });
+  });
+
+  describe("toSentrySecurityReportUri", () => {
+    it("builds a Sentry security report URI from the browser DSN", () => {
+      expect(toSentrySecurityReportUri("https://publicKey@o877251.ingest.sentry.io/4504")).toBe(
+        "https://o877251.ingest.sentry.io/api/4504/security/?sentry_key=publicKey"
+      );
+    });
+
+    it("preserves a self-hosted Sentry base path", () => {
+      expect(toSentrySecurityReportUri("https://publicKey@sentry.example.com/sentry/4504")).toBe(
+        "https://sentry.example.com/sentry/api/4504/security/?sentry_key=publicKey"
+      );
+    });
+
+    it("returns undefined for relative, empty, or invalid values", () => {
+      expect(toSentrySecurityReportUri("/sentry-dsn")).toBeUndefined();
+      expect(toSentrySecurityReportUri("")).toBeUndefined();
+      expect(toSentrySecurityReportUri(undefined)).toBeUndefined();
+      expect(toSentrySecurityReportUri("not a url")).toBeUndefined();
     });
   });
 
@@ -55,6 +83,20 @@ describe("csp", () => {
       expect(connectSrc).toContain("https://www.google-analytics.com");
       expect(connectSrc).toContain("https://www.googletagmanager.com");
     });
+
+    it("adds Sentry CSP reporting directives when a Sentry DSN is configured", () => {
+      const { reportUri, reportTo } = setup({ sentryDsn: "https://publicKey@o877251.ingest.sentry.io/4504" });
+
+      expect(reportUri).toBe("report-uri https://o877251.ingest.sentry.io/api/4504/security/?sentry_key=publicKey");
+      expect(reportTo).toBe("report-to csp-endpoint");
+    });
+
+    it("omits Sentry CSP reporting directives when no Sentry DSN is configured", () => {
+      const { reportUri, reportTo } = setup({});
+
+      expect(reportUri).toBeUndefined();
+      expect(reportTo).toBeUndefined();
+    });
   });
 
   describe("getContentSecurityPolicyHeaderName", () => {
@@ -69,9 +111,35 @@ describe("csp", () => {
     });
   });
 
+  describe("getContentSecurityPolicyReportHeaders", () => {
+    it("returns Report-To and Reporting-Endpoints headers for the Sentry CSP endpoint", () => {
+      const headers = getContentSecurityPolicyReportHeaders({ sentryDsn: "https://publicKey@o877251.ingest.sentry.io/4504" });
+
+      expect(headers).toEqual([
+        {
+          name: "Report-To",
+          value: JSON.stringify({
+            group: "csp-endpoint",
+            max_age: 10886400,
+            endpoints: [{ url: "https://o877251.ingest.sentry.io/api/4504/security/?sentry_key=publicKey" }],
+            include_subdomains: true
+          })
+        },
+        {
+          name: "Reporting-Endpoints",
+          value: 'csp-endpoint="https://o877251.ingest.sentry.io/api/4504/security/?sentry_key=publicKey"'
+        }
+      ]);
+    });
+
+    it("returns no reporting headers when no Sentry DSN is configured", () => {
+      expect(getContentSecurityPolicyReportHeaders({})).toEqual([]);
+    });
+  });
+
   function setup(input: ContentSecurityPolicyInput) {
     const policy = buildContentSecurityPolicy("test-nonce", input);
     const directives = Object.fromEntries(policy.split("; ").map(directive => [directive.split(" ")[0], directive]));
-    return { policy, connectSrc: directives["connect-src"] };
+    return { policy, connectSrc: directives["connect-src"], reportUri: directives["report-uri"], reportTo: directives["report-to"] };
   }
 });

--- a/apps/stats-web/src/lib/csp/csp.ts
+++ b/apps/stats-web/src/lib/csp/csp.ts
@@ -1,0 +1,93 @@
+const CSP_HEADER_ENFORCE = "Content-Security-Policy";
+const CSP_HEADER_REPORT_ONLY = "Content-Security-Policy-Report-Only";
+
+const NONCE_BYTE_LENGTH = 16;
+
+const isDevelopment = process.env.NODE_ENV !== "production";
+
+/** Google Analytics / Tag Manager endpoints the app connects to directly; these never vary by environment. */
+const FIXED_VENDOR_CONNECT_ORIGINS = [
+  "https://www.google-analytics.com",
+  "https://region1.google-analytics.com",
+  "https://analytics.google.com",
+  "https://www.googletagmanager.com"
+];
+
+export interface ContentSecurityPolicyInput {
+  apiBaseUrl?: string;
+  mainnetApiUrl?: string;
+  testnetApiUrl?: string;
+  sandboxApiUrl?: string;
+  unleashFrontendApiUrl?: string;
+  sentryDsn?: string;
+}
+
+/**
+ * Reduces a configured URL (which may carry a path, e.g. an Unleash frontend endpoint or a Sentry DSN) to a bare origin.
+ * Returns undefined for empty, relative (`/...`), or unparseable values: relative endpoints are same-origin and already
+ * covered by `'self'`.
+ */
+export function toOrigin(value?: string): string | undefined {
+  if (!value || value.startsWith("/")) return undefined;
+
+  try {
+    return new URL(value).origin;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Uses Web Crypto (available on the Edge/standard middleware runtime) since Node's
+ * `crypto` module is not guaranteed to be available where the middleware executes.
+ */
+export function generateNonce() {
+  const bytes = new Uint8Array(NONCE_BYTE_LENGTH);
+  crypto.getRandomValues(bytes);
+  return btoa(String.fromCharCode(...bytes));
+}
+
+export function buildContentSecurityPolicy(nonce: string, input: ContentSecurityPolicyInput) {
+  const scriptSrc = ["'self'", `'nonce-${nonce}'`, "'strict-dynamic'", "https://www.googletagmanager.com", "https://www.google-analytics.com"];
+
+  const envConnectOrigins = [
+    toOrigin(input.apiBaseUrl),
+    toOrigin(input.mainnetApiUrl),
+    toOrigin(input.testnetApiUrl),
+    toOrigin(input.sandboxApiUrl),
+    toOrigin(input.unleashFrontendApiUrl),
+    toOrigin(input.sentryDsn)
+  ];
+
+  const connectSrc = dedupeOrigins(["'self'", ...envConnectOrigins, ...FIXED_VENDOR_CONNECT_ORIGINS]);
+
+  if (isDevelopment) {
+    scriptSrc.push("'unsafe-eval'");
+    connectSrc.push("http://localhost:3080", "ws:");
+  }
+
+  return [
+    "default-src 'self'",
+    "base-uri 'self'",
+    "object-src 'none'",
+    "frame-ancestors 'none'",
+    "frame-src 'none'",
+    "form-action 'self'",
+    `script-src ${scriptSrc.join(" ")}`,
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data: blob: https://www.google-analytics.com https://www.googletagmanager.com",
+    "font-src 'self' data:",
+    `connect-src ${connectSrc.join(" ")}`,
+    "worker-src 'self' blob:",
+    "manifest-src 'self'",
+    ...(isDevelopment ? [] : ["upgrade-insecure-requests"])
+  ].join("; ");
+}
+
+export function getContentSecurityPolicyHeaderName() {
+  return process.env.CSP_MODE === "enforce" ? CSP_HEADER_ENFORCE : CSP_HEADER_REPORT_ONLY;
+}
+
+function dedupeOrigins(origins: Array<string | undefined>) {
+  return Array.from(new Set(origins.filter((origin): origin is string => Boolean(origin))));
+}

--- a/apps/stats-web/src/lib/csp/csp.ts
+++ b/apps/stats-web/src/lib/csp/csp.ts
@@ -1,5 +1,7 @@
 const CSP_HEADER_ENFORCE = "Content-Security-Policy";
 const CSP_HEADER_REPORT_ONLY = "Content-Security-Policy-Report-Only";
+const CSP_REPORT_ENDPOINT_NAME = "csp-endpoint";
+const CSP_REPORT_MAX_AGE_SECONDS = 10886400;
 
 const NONCE_BYTE_LENGTH = 16;
 
@@ -37,6 +39,27 @@ export function toOrigin(value?: string): string | undefined {
   }
 }
 
+export function toSentrySecurityReportUri(dsn?: string): string | undefined {
+  if (!dsn || dsn.startsWith("/")) return undefined;
+
+  try {
+    const dsnUrl = new URL(dsn);
+    const pathSegments = dsnUrl.pathname.split("/").filter(Boolean);
+    const projectId = pathSegments[pathSegments.length - 1];
+
+    if (!dsnUrl.username || !projectId) return undefined;
+
+    const basePath = pathSegments.slice(0, -1).join("/");
+    const reportUrl = new URL(dsnUrl.origin);
+    reportUrl.pathname = `${basePath ? `/${basePath}` : ""}/api/${projectId}/security/`;
+    reportUrl.searchParams.set("sentry_key", dsnUrl.username);
+
+    return reportUrl.toString();
+  } catch {
+    return undefined;
+  }
+}
+
 /**
  * Uses Web Crypto (available on the Edge/standard middleware runtime) since Node's
  * `crypto` module is not guaranteed to be available where the middleware executes.
@@ -60,6 +83,7 @@ export function buildContentSecurityPolicy(nonce: string, input: ContentSecurity
   ];
 
   const connectSrc = dedupeOrigins(["'self'", ...envConnectOrigins, ...FIXED_VENDOR_CONNECT_ORIGINS]);
+  const sentrySecurityReportUri = toSentrySecurityReportUri(input.sentryDsn);
 
   if (isDevelopment) {
     scriptSrc.push("'unsafe-eval'");
@@ -80,12 +104,35 @@ export function buildContentSecurityPolicy(nonce: string, input: ContentSecurity
     `connect-src ${connectSrc.join(" ")}`,
     "worker-src 'self' blob:",
     "manifest-src 'self'",
-    ...(isDevelopment ? [] : ["upgrade-insecure-requests"])
+    ...(isDevelopment ? [] : ["upgrade-insecure-requests"]),
+    ...(sentrySecurityReportUri ? [`report-uri ${sentrySecurityReportUri}`, `report-to ${CSP_REPORT_ENDPOINT_NAME}`] : [])
   ].join("; ");
 }
 
 export function getContentSecurityPolicyHeaderName() {
   return process.env.CSP_MODE === "enforce" ? CSP_HEADER_ENFORCE : CSP_HEADER_REPORT_ONLY;
+}
+
+export function getContentSecurityPolicyReportHeaders(input: ContentSecurityPolicyInput) {
+  const sentrySecurityReportUri = toSentrySecurityReportUri(input.sentryDsn);
+
+  if (!sentrySecurityReportUri) return [];
+
+  return [
+    {
+      name: "Report-To",
+      value: JSON.stringify({
+        group: CSP_REPORT_ENDPOINT_NAME,
+        max_age: CSP_REPORT_MAX_AGE_SECONDS,
+        endpoints: [{ url: sentrySecurityReportUri }],
+        include_subdomains: true
+      })
+    },
+    {
+      name: "Reporting-Endpoints",
+      value: `${CSP_REPORT_ENDPOINT_NAME}="${sentrySecurityReportUri}"`
+    }
+  ];
 }
 
 function dedupeOrigins(origins: Array<string | undefined>) {

--- a/apps/stats-web/src/middleware.ts
+++ b/apps/stats-web/src/middleware.ts
@@ -2,26 +2,48 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 
 import { createLogger } from "./lib/createLogger/createLogger";
+import { buildContentSecurityPolicy, generateNonce, getContentSecurityPolicyHeaderName } from "./lib/csp/csp";
 
 const { MAINTENANCE_MODE } = process.env;
 const logger = createLogger({ name: "middleware" });
 
 export function middleware(request: NextRequest) {
+  const nonce = generateNonce();
+  const contentSecurityPolicy = buildContentSecurityPolicy(nonce, {
+    apiBaseUrl: process.env.NEXT_PUBLIC_API_BASE_URL,
+    mainnetApiUrl: process.env.NEXT_PUBLIC_BASE_API_MAINNET_URL,
+    testnetApiUrl: process.env.NEXT_PUBLIC_BASE_API_TESTNET_URL,
+    sandboxApiUrl: process.env.NEXT_PUBLIC_BASE_API_SANDBOX_URL,
+    unleashFrontendApiUrl: process.env.NEXT_PUBLIC_UNLEASH_FRONTEND_API_URL,
+    sentryDsn: process.env.NEXT_PUBLIC_SENTRY_DSN
+  });
+  const contentSecurityPolicyHeaderName = getContentSecurityPolicyHeaderName();
+
   const maintenancePage = "/maintenance";
   const isMaintenanceMode = MAINTENANCE_MODE === "true";
   if (isMaintenanceMode && !request.nextUrl.pathname.startsWith(maintenancePage)) {
     const fromPath = request.nextUrl.pathname + request.nextUrl.search;
     logger.info({ message: `Redirecting to maintenance page from ${fromPath}` });
 
-    return NextResponse.redirect(new URL(`${maintenancePage}?return=${encodeURIComponent(fromPath)}`, request.url), 307); // 307 - temporary redirect
+    const redirectResponse = NextResponse.redirect(new URL(`${maintenancePage}?return=${encodeURIComponent(fromPath)}`, request.url), 307); // 307 - temporary redirect
+    redirectResponse.headers.set(contentSecurityPolicyHeaderName, contentSecurityPolicy);
+    return redirectResponse;
   } else if (!isMaintenanceMode && request.nextUrl.pathname.startsWith(maintenancePage)) {
     const returnPath = getReturnPath(request);
     logger.info({ message: `Redirecting from maintenance page to ${returnPath}` });
 
-    return NextResponse.redirect(new URL(returnPath, request.url), 307); // 307 - temporary redirect
+    const redirectResponse = NextResponse.redirect(new URL(returnPath, request.url), 307); // 307 - temporary redirect
+    redirectResponse.headers.set(contentSecurityPolicyHeaderName, contentSecurityPolicy);
+    return redirectResponse;
   }
 
-  return NextResponse.next();
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-nonce", nonce);
+  requestHeaders.set(contentSecurityPolicyHeaderName, contentSecurityPolicy);
+
+  const response = NextResponse.next({ request: { headers: requestHeaders } });
+  response.headers.set(contentSecurityPolicyHeaderName, contentSecurityPolicy);
+  return response;
 }
 
 function getReturnPath(request: NextRequest) {

--- a/apps/stats-web/src/middleware.ts
+++ b/apps/stats-web/src/middleware.ts
@@ -2,22 +2,24 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 
 import { createLogger } from "./lib/createLogger/createLogger";
-import { buildContentSecurityPolicy, generateNonce, getContentSecurityPolicyHeaderName } from "./lib/csp/csp";
+import { buildContentSecurityPolicy, generateNonce, getContentSecurityPolicyHeaderName, getContentSecurityPolicyReportHeaders } from "./lib/csp/csp";
 
 const { MAINTENANCE_MODE } = process.env;
 const logger = createLogger({ name: "middleware" });
 
 export function middleware(request: NextRequest) {
   const nonce = generateNonce();
-  const contentSecurityPolicy = buildContentSecurityPolicy(nonce, {
+  const contentSecurityPolicyInput = {
     apiBaseUrl: process.env.NEXT_PUBLIC_API_BASE_URL,
     mainnetApiUrl: process.env.NEXT_PUBLIC_BASE_API_MAINNET_URL,
     testnetApiUrl: process.env.NEXT_PUBLIC_BASE_API_TESTNET_URL,
     sandboxApiUrl: process.env.NEXT_PUBLIC_BASE_API_SANDBOX_URL,
     unleashFrontendApiUrl: process.env.NEXT_PUBLIC_UNLEASH_FRONTEND_API_URL,
     sentryDsn: process.env.NEXT_PUBLIC_SENTRY_DSN
-  });
+  };
+  const contentSecurityPolicy = buildContentSecurityPolicy(nonce, contentSecurityPolicyInput);
   const contentSecurityPolicyHeaderName = getContentSecurityPolicyHeaderName();
+  const contentSecurityPolicyReportHeaders = getContentSecurityPolicyReportHeaders(contentSecurityPolicyInput);
 
   const maintenancePage = "/maintenance";
   const isMaintenanceMode = MAINTENANCE_MODE === "true";
@@ -26,14 +28,14 @@ export function middleware(request: NextRequest) {
     logger.info({ message: `Redirecting to maintenance page from ${fromPath}` });
 
     const redirectResponse = NextResponse.redirect(new URL(`${maintenancePage}?return=${encodeURIComponent(fromPath)}`, request.url), 307); // 307 - temporary redirect
-    redirectResponse.headers.set(contentSecurityPolicyHeaderName, contentSecurityPolicy);
+    setContentSecurityPolicyHeaders(redirectResponse, contentSecurityPolicyHeaderName, contentSecurityPolicy, contentSecurityPolicyReportHeaders);
     return redirectResponse;
   } else if (!isMaintenanceMode && request.nextUrl.pathname.startsWith(maintenancePage)) {
     const returnPath = getReturnPath(request);
     logger.info({ message: `Redirecting from maintenance page to ${returnPath}` });
 
     const redirectResponse = NextResponse.redirect(new URL(returnPath, request.url), 307); // 307 - temporary redirect
-    redirectResponse.headers.set(contentSecurityPolicyHeaderName, contentSecurityPolicy);
+    setContentSecurityPolicyHeaders(redirectResponse, contentSecurityPolicyHeaderName, contentSecurityPolicy, contentSecurityPolicyReportHeaders);
     return redirectResponse;
   }
 
@@ -42,8 +44,20 @@ export function middleware(request: NextRequest) {
   requestHeaders.set(contentSecurityPolicyHeaderName, contentSecurityPolicy);
 
   const response = NextResponse.next({ request: { headers: requestHeaders } });
-  response.headers.set(contentSecurityPolicyHeaderName, contentSecurityPolicy);
+  setContentSecurityPolicyHeaders(response, contentSecurityPolicyHeaderName, contentSecurityPolicy, contentSecurityPolicyReportHeaders);
   return response;
+}
+
+function setContentSecurityPolicyHeaders(
+  response: NextResponse,
+  contentSecurityPolicyHeaderName: string,
+  contentSecurityPolicy: string,
+  reportHeaders: Array<{ name: string; value: string }>
+) {
+  response.headers.set(contentSecurityPolicyHeaderName, contentSecurityPolicy);
+  reportHeaders.forEach(header => {
+    response.headers.set(header.name, header.value);
+  });
 }
 
 function getReturnPath(request: NextRequest) {


### PR DESCRIPTION
## Why

Closes CON-335

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Rolled out enhanced Content Security Policy support with per-request script nonces, tightened script/connect/image source construction, and Sentry CSP reporting headers.
  - Added configurable `CSP_MODE` to switch between `enforce` and `report-only` (defaulting to `report-only`).
  - Implemented shared CSP utilities and nonce reuse when an existing nonce is present.
- **Bug Fixes**
  - Fixed CSP header/nonce injection to consistently apply to both normal responses and maintenance-mode (307) redirects.
- **Tests**
  - Added/expanded CSP utility unit tests covering nonce handling, origin derivation, and header naming/reporting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->