### PR TITLE
feat(deployment): add SDL import/export to the configure page

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ConfigurationPane.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ConfigurationPane.spec.tsx
@@ -1,4 +1,4 @@
-import type { PropsWithChildren } from "react";
+import type { PropsWithChildren, ReactNode } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { describe, expect, it, vi } from "vitest";
 
@@ -143,11 +143,19 @@ describe(ConfigurationPane.name, () => {
     expect(ImageSection).toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
   });
 
+  it("renders the actions slot in the pane header", () => {
+    const values = defaultServiceWithPlacement({ title: "api" });
+    setup({ values, selectedServiceId: values.services[0].id, actions: <button type="button">Import / export</button> });
+
+    expect(screen.getByRole("button", { name: "Import / export" })).toBeInTheDocument();
+  });
+
   function setup(input: {
     values: SdlBuilderFormValuesType;
     selectedServiceId: string;
     locked?: ConfigurationLock;
     onCancelAndEdit?: () => void;
+    actions?: ReactNode;
     dependencies?: Partial<typeof DEPENDENCIES>;
   }) {
     const Wrapper = ({ children }: PropsWithChildren) => {
@@ -160,6 +168,7 @@ describe(ConfigurationPane.name, () => {
           selectedServiceId={input.selectedServiceId}
           locked={input.locked}
           onCancelAndEdit={input.onCancelAndEdit}
+          actions={input.actions}
           dependencies={MockComponents(DEPENDENCIES, input.dependencies)}
         />
       </Wrapper>

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ConfigurationPane.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ConfigurationPane.tsx
@@ -1,4 +1,4 @@
-import type { FC } from "react";
+import type { FC, ReactNode } from "react";
 import { useFormContext, useWatch } from "react-hook-form";
 
 import type { SdlBuilderFormValuesType } from "@src/types";
@@ -20,6 +20,8 @@ type Props = {
   locked?: ConfigurationLock;
   isClosing?: boolean;
   onCancelAndEdit?: () => void;
+  /** Rendered at the trailing edge of the pane header, e.g. the SDL import/export menu. */
+  actions?: ReactNode;
   dependencies?: typeof DEPENDENCIES;
 };
 
@@ -30,7 +32,7 @@ type Props = {
  * index per mount rather than reacting to a changing one, which would otherwise
  * leave the previous service's values and errors on screen.
  */
-export const ConfigurationPane: FC<Props> = ({ selectedServiceId, locked, isClosing = false, onCancelAndEdit, dependencies: d = DEPENDENCIES }) => {
+export const ConfigurationPane: FC<Props> = ({ selectedServiceId, locked, isClosing = false, onCancelAndEdit, actions, dependencies: d = DEPENDENCIES }) => {
   const { control } = useFormContext<SdlBuilderFormValuesType>();
   const watchedServices = useWatch<SdlBuilderFormValuesType>({ control, name: "services" });
   const services = Array.isArray(watchedServices) ? (watchedServices as SdlBuilderFormValuesType["services"]) : [];
@@ -44,6 +46,7 @@ export const ConfigurationPane: FC<Props> = ({ selectedServiceId, locked, isClos
           2. Configuration
         </h2>
         {selectedService && <span className="min-w-0 truncate font-mono text-sm font-semibold text-blue-500">• {selectedService.title}</span>}
+        {actions ? <div className="ml-auto shrink-0">{actions}</div> : null}
       </header>
       {locked ? <PaneLockBanner onCancelAndEdit={onCancelAndEdit ?? noop} isClosing={isClosing} /> : null}
       <div className="flex-1 overflow-y-auto py-4">

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.spec.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { useController, useFormContext, useWatch } from "react-hook-form";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
@@ -426,7 +427,9 @@ describe(ConfigureDeploymentForm.name, () => {
     vm?: boolean;
     phase?: DeploymentFlow["phase"];
   }) {
-    const ConfigureDeploymentPanes = vi.fn(input.Panes ?? (() => <div data-testid="panes-mock" />));
+    const ConfigureDeploymentPanes = vi.fn(
+      input.Panes ?? (({ configurationActions }: ProbePanesProps) => <div data-testid="panes-mock">{configurationActions}</div>)
+    );
     const ConfigureDeploymentHeader = vi.fn(() => <div data-testid="header-mock" />);
     const SdlImportExport = vi.fn(() => null);
     const enqueueSnackbar = vi.fn();
@@ -557,6 +560,7 @@ interface ProbePanesProps {
   onSelectService: (serviceId: string) => void;
   selectedPlacementId: string;
   onSelectProvider: (placementId: string, bidId: string) => void;
+  configurationActions?: ReactNode;
 }
 
 /**
@@ -668,7 +672,7 @@ function AddRemoveProbePanes({ sdl, selectedServiceId, onSelectService }: ProbeP
 }
 
 /** Panes stand-in that reports the imported services, live sdl, and selection so an import can be asserted end to end. */
-function ImportProbePanes({ sdl, selectedServiceId }: ProbePanesProps) {
+function ImportProbePanes({ sdl, selectedServiceId, configurationActions }: ProbePanesProps) {
   const services = useWatch<SdlBuilderFormValuesType>({ name: "services" });
   const titles = Array.isArray(services) ? (services as SdlBuilderFormValuesType["services"]).map(service => service.title) : [];
   return (
@@ -676,6 +680,7 @@ function ImportProbePanes({ sdl, selectedServiceId }: ProbePanesProps) {
       <div data-testid="service-titles">{titles.join(",")}</div>
       <div data-testid="sdl">{sdl}</div>
       <div data-testid="selected">{selectedServiceId}</div>
+      {configurationActions}
     </div>
   );
 }

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.spec.tsx
@@ -7,11 +7,12 @@ import type { PlacementType, SdlBuilderFormValuesType, ServiceType } from "@src/
 import { defaultService } from "@src/utils/sdl/data";
 import { ConfigurationPane } from "../ConfigurationPane/ConfigurationPane";
 import { usePlacementManager } from "../DeploymentPane/usePlacementManager/usePlacementManager";
+import { importDeploymentState } from "../importDeploymentState/importDeploymentState";
 import type { DeploymentFlow } from "../useDeploymentFlow/useDeploymentFlow";
 import type { DEPENDENCIES } from "./ConfigureDeploymentForm";
 import { ConfigureDeploymentForm, firstBidReadyServiceId, nextUndoneServiceId } from "./ConfigureDeploymentForm";
 
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 const VALID_SDL = [
@@ -376,6 +377,44 @@ describe(ConfigureDeploymentForm.name, () => {
     expect(analyticsService.track).toHaveBeenCalledWith("configure_page_viewed", { category: "deployments" });
   });
 
+  it("threads the live sdl, deployment name, and editability into the import/export control", () => {
+    const { SdlImportExport } = setup({ initialSdl: VALID_SDL, initialName: "my-app" });
+
+    expect(SdlImportExport).toHaveBeenCalledWith(expect.objectContaining({ sdl: VALID_SDL, deploymentName: "my-app", canImport: true }), expect.anything());
+  });
+
+  it("disables import while the flow is quoting", () => {
+    const { SdlImportExport } = setup({ initialSdl: VALID_SDL, phase: "quoting" });
+
+    expect(SdlImportExport).toHaveBeenCalledWith(expect.objectContaining({ canImport: false }), expect.anything());
+  });
+
+  it("replaces the whole configuration when an sdl is imported", async () => {
+    const { SdlImportExport } = setup({ initialSdl: undefined, Panes: ImportProbePanes });
+    const state = importDeploymentState(TWO_SERVICE_SDL);
+
+    await act(async () => {
+      (SdlImportExport as ReturnType<typeof vi.fn>).mock.calls[0][0].onImport(state);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("service-titles").textContent).toBe("web,api");
+      expect(screen.getByTestId("sdl").textContent).toContain("version: '2.0'");
+      expect(screen.getByTestId("selected").textContent).toBe(state.selectedServiceId);
+    });
+  });
+
+  it("persists the imported sdl to the draft under the existing deployment name", async () => {
+    const { SdlImportExport, save } = setup({ initialSdl: undefined, initialName: "my-app", Panes: ImportProbePanes });
+    const state = importDeploymentState(TWO_SERVICE_SDL);
+
+    await act(async () => {
+      (SdlImportExport as ReturnType<typeof vi.fn>).mock.calls[0][0].onImport(state);
+    });
+
+    await waitFor(() => expect(save).toHaveBeenCalledWith(expect.stringContaining("node:18"), "my-app"));
+  });
+
   function setup(input: {
     initialSdl: string | undefined;
     initialName?: string;
@@ -385,9 +424,11 @@ describe(ConfigureDeploymentForm.name, () => {
     flowError?: { message?: string };
     trialError?: unknown;
     vm?: boolean;
+    phase?: DeploymentFlow["phase"];
   }) {
     const ConfigureDeploymentPanes = vi.fn(input.Panes ?? (() => <div data-testid="panes-mock" />));
     const ConfigureDeploymentHeader = vi.fn(() => <div data-testid="header-mock" />);
+    const SdlImportExport = vi.fn(() => null);
     const enqueueSnackbar = vi.fn();
     const Snackbar = vi.fn(() => null);
     const save = vi.fn<(sdl: string, name?: string) => void>();
@@ -408,7 +449,7 @@ describe(ConfigureDeploymentForm.name, () => {
     const useDeploymentName = ((args: { initialName?: string }) => ({ name: args.initialName ?? "", setName: setDeploymentName })) as never;
     // The base flow is created upstream by the DeploymentFlowProvider now, so it arrives as a prop rather than a hook.
     const flow = mock<DeploymentFlow>({
-      phase: "configuring",
+      phase: input.phase ?? "configuring",
       dseq: null,
       bidStrategy: "select",
       selections: {},
@@ -430,6 +471,7 @@ describe(ConfigureDeploymentForm.name, () => {
       Snackbar: Snackbar as never,
       ReviewAndDeployModal: ReviewAndDeployModal as never,
       DeployProgressOverlay: () => null,
+      SdlImportExport: SdlImportExport as never,
       usePlacementsWithBids: () => new Set<string>()
     };
 
@@ -449,6 +491,7 @@ describe(ConfigureDeploymentForm.name, () => {
       ConfigureDeploymentPanes,
       ConfigureDeploymentHeader,
       ReviewAndDeployModal,
+      SdlImportExport,
       flow,
       enqueueSnackbar,
       save,
@@ -620,6 +663,19 @@ function AddRemoveProbePanes({ sdl, selectedServiceId, onSelectService }: ProbeP
           AdditionalSection: FieldRegisteringSection as never
         }}
       />
+    </div>
+  );
+}
+
+/** Panes stand-in that reports the imported services, live sdl, and selection so an import can be asserted end to end. */
+function ImportProbePanes({ sdl, selectedServiceId }: ProbePanesProps) {
+  const services = useWatch<SdlBuilderFormValuesType>({ name: "services" });
+  const titles = Array.isArray(services) ? (services as SdlBuilderFormValuesType["services"]).map(service => service.title) : [];
+  return (
+    <div>
+      <div data-testid="service-titles">{titles.join(",")}</div>
+      <div data-testid="sdl">{sdl}</div>
+      <div data-testid="selected">{selectedServiceId}</div>
     </div>
   );
 }

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
@@ -274,10 +274,7 @@ export const ConfigureDeploymentForm: FC<Props> = ({ initialSdl, initialName, in
       <FormProvider {...form}>
         <div className="relative flex min-h-0 flex-1 flex-col">
           <div className="px-6 pt-6">
-            <div className="flex items-center justify-between">
-              <d.ConfigureDeploymentBackButton />
-              <d.SdlImportExport sdl={liveSdl} deploymentName={deploymentName} canImport={isEditable} onImport={applyImportedState} />
-            </div>
+            <d.ConfigureDeploymentBackButton />
             <div className="mt-2">
               <d.ConfigureDeploymentHeader flow={headerFlow} sdl={liveSdl} onDeploy={() => setReviewOpen(true)} allPlacementsHaveBids={allPlacementsHaveBids} />
             </div>
@@ -298,6 +295,7 @@ export const ConfigureDeploymentForm: FC<Props> = ({ initialSdl, initialName, in
               onCancelAndEdit={flow.actions.cancelAndEdit}
               deploymentName={deploymentName}
               onDeploymentNameChange={setDeploymentName}
+              configurationActions={<d.SdlImportExport sdl={liveSdl} deploymentName={deploymentName} canImport={isEditable} onImport={applyImportedState} />}
             />
           </div>
           {flow.phase === "deploying" && (

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
@@ -339,18 +339,14 @@ interface InitialState {
  * A Container-VM entry (`isVm`) seeds an SSH-ready VM service instead of the blank default.
  */
 function getInitialState(carriedInSdl: string | undefined, isVm: boolean): InitialState {
-  if (carriedInSdl) {
-    try {
-      return importDeploymentState(carriedInSdl);
-    } catch (error) {
-      // A service-less SDL falls back silently to a default deployment (unchanged behavior); any other
-      // failure means the carried-in SDL was genuinely unusable, so it falls back with a surfaced error.
-      if (!(error instanceof NoVisibleServiceError)) {
-        return defaultInitialState(isVm, getImportErrorMessage(error));
-      }
-    }
+  if (!carriedInSdl) return defaultInitialState(isVm);
+
+  try {
+    return importDeploymentState(carriedInSdl);
+  } catch (error) {
+    if (error instanceof NoVisibleServiceError) return defaultInitialState(isVm);
+    return defaultInitialState(isVm, getImportErrorMessage(error));
   }
-  return defaultInitialState(isVm);
 }
 
 /** A fresh default deployment (or SSH-ready VM deployment), optionally annotated with the error that made an import unusable. */

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
@@ -22,7 +22,7 @@ import { ConfigureDeploymentHeader } from "../ConfigureDeploymentHeader/Configur
 import { ConfigureDeploymentPanes } from "../ConfigureDeploymentPanes/ConfigureDeploymentPanes";
 import { DeployProgressOverlay } from "../DeployProgressOverlay/DeployProgressOverlay";
 import type { ImportedDeploymentState } from "../importDeploymentState/importDeploymentState";
-import { importDeploymentState, NoVisibleServiceError, seedSelectedServiceId } from "../importDeploymentState/importDeploymentState";
+import { importDeploymentState, isKnownSdlParserError, NoVisibleServiceError, seedSelectedServiceId } from "../importDeploymentState/importDeploymentState";
 import { ReviewAndDeployModal } from "../ReviewAndDeployModal/ReviewAndDeployModal";
 import { SdlImportExport } from "../SdlImportExport/SdlImportExport";
 import { useConfigureDraft } from "../useConfigureDraft/useConfigureDraft";
@@ -373,7 +373,7 @@ function withDefaultPreset(values: SdlBuilderFormValuesType): SdlBuilderFormValu
  * keeping it out of the rendered DOM avoids any injection surface.
  */
 function getImportErrorMessage(error: unknown): string {
-  if (error instanceof Error && (error.name === "YAMLException" || error.name === "CustomValidationError" || error.name === "TemplateValidation")) {
+  if (isKnownSdlParserError(error)) {
     return "The deployment couldn't be loaded because its SDL is invalid.";
   }
   return "The deployment couldn't be loaded.";

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
@@ -16,15 +16,15 @@ import { SdlBuilderFormValuesSchema } from "@src/types";
 import { parseBidId } from "@src/utils/bids/bidId";
 import { defaultServiceWithPlacement, vmServiceOverrides } from "@src/utils/sdl/data";
 import { generateSdl } from "@src/utils/sdl/sdlGenerator";
-import { importSimpleSdl } from "@src/utils/sdl/sdlImport";
-import { applyImportedSshState } from "@src/utils/sdl/sshKey";
-import { isVmImage } from "@src/utils/sdl/vmImages";
 import { applyPresetToProfile, DEFAULT_HARDWARE_PRESET } from "../ConfigurationPane/PresetsCard/hardwarePresets";
 import { ConfigureDeploymentBackButton } from "../ConfigureDeploymentBackButton/ConfigureDeploymentBackButton";
 import { ConfigureDeploymentHeader } from "../ConfigureDeploymentHeader/ConfigureDeploymentHeader";
 import { ConfigureDeploymentPanes } from "../ConfigureDeploymentPanes/ConfigureDeploymentPanes";
 import { DeployProgressOverlay } from "../DeployProgressOverlay/DeployProgressOverlay";
+import type { ImportedDeploymentState } from "../importDeploymentState/importDeploymentState";
+import { importDeploymentState, NoVisibleServiceError, seedSelectedServiceId } from "../importDeploymentState/importDeploymentState";
 import { ReviewAndDeployModal } from "../ReviewAndDeployModal/ReviewAndDeployModal";
+import { SdlImportExport } from "../SdlImportExport/SdlImportExport";
 import { useConfigureDraft } from "../useConfigureDraft/useConfigureDraft";
 import type { DeploymentIntent } from "../useDeploymentFlow/deploymentIntent";
 import type { DeploymentFlow } from "../useDeploymentFlow/useDeploymentFlow";
@@ -38,6 +38,7 @@ export const DEPENDENCIES = {
   ConfigureDeploymentPanes,
   ReviewAndDeployModal,
   DeployProgressOverlay,
+  SdlImportExport,
   useConfigureDraft,
   useDeploymentName,
   usePlacementsWithBids,
@@ -233,6 +234,22 @@ export const ConfigureDeploymentForm: FC<Props> = ({ initialSdl, initialName, in
     setReviewOpen(false);
   }
 
+  /**
+   * Replaces the whole configuration with an imported SDL. Resets the form first (clearing dirty/touched/errors
+   * so stale validation can't leak), then explicitly syncs the live SDL and selection; both setters are batched
+   * with the reset, so they win over what the watch subscriptions would recompute mid-reset.
+   */
+  const applyImportedState = useCallback(
+    (state: ImportedDeploymentState) => {
+      form.reset(state.values);
+      setLiveSdl(state.sdl);
+      setSelectedServiceId(state.selectedServiceId);
+    },
+    [form]
+  );
+  /** Import is only meaningful while the deployment is still editable; export stays available in every phase. */
+  const isEditable = flow.phase === "configuring" || flow.phase === "error";
+
   const requestQuotes = flow.actions.requestQuotes;
   /**
    * A terminal start-trial error is sticky, so requesting quotes again after one would otherwise fail straight
@@ -257,7 +274,10 @@ export const ConfigureDeploymentForm: FC<Props> = ({ initialSdl, initialName, in
       <FormProvider {...form}>
         <div className="relative flex min-h-0 flex-1 flex-col">
           <div className="px-6 pt-6">
-            <d.ConfigureDeploymentBackButton />
+            <div className="flex items-center justify-between">
+              <d.ConfigureDeploymentBackButton />
+              <d.SdlImportExport sdl={liveSdl} deploymentName={deploymentName} canImport={isEditable} onImport={applyImportedState} />
+            </div>
             <div className="mt-2">
               <d.ConfigureDeploymentHeader flow={headerFlow} sdl={liveSdl} onDeploy={() => setReviewOpen(true)} allPlacementsHaveBids={allPlacementsHaveBids} />
             </div>
@@ -321,12 +341,13 @@ interface InitialState {
 function getInitialState(carriedInSdl: string | undefined, isVm: boolean): InitialState {
   if (carriedInSdl) {
     try {
-      const values = withVmSshBackfill(applyImportedSshState(importSimpleSdl(carriedInSdl)));
-      if (hasVisibleService(values)) {
-        return { values, sdl: carriedInSdl, selectedServiceId: seedSelectedServiceId(values) };
-      }
+      return importDeploymentState(carriedInSdl);
     } catch (error) {
-      return defaultInitialState(isVm, getImportErrorMessage(error));
+      // A service-less SDL falls back silently to a default deployment (unchanged behavior); any other
+      // failure means the carried-in SDL was genuinely unusable, so it falls back with a surfaced error.
+      if (!(error instanceof NoVisibleServiceError)) {
+        return defaultInitialState(isVm, getImportErrorMessage(error));
+      }
     }
   }
   return defaultInitialState(isVm);
@@ -340,27 +361,10 @@ function defaultInitialState(isVm: boolean, importError?: string): InitialState 
   return { values, sdl: regenerateSdl(values, ""), selectedServiceId: seedSelectedServiceId(values), importError };
 }
 
-/**
- * Restores the deployment-wide "Expose SSH" flag for a carried-in deployment holding a VM service, covering
- * a VM draft saved before a key was entered (`applyImportedSshState` only flips it once a key exists). The
- * SDL itself is taken literally: no expose or key is backfilled.
- */
-function withVmSshBackfill(values: SdlBuilderFormValuesType): SdlBuilderFormValuesType {
-  if (values.hasSSHKey || !values.services.some(service => isVmImage(service.image))) {
-    return values;
-  }
-  return { ...values, hasSSHKey: true };
-}
-
 /** Seeds the fresh deployment's service on the default (small) hardware preset so the screen opens deployable. */
 function withDefaultPreset(values: SdlBuilderFormValuesType): SdlBuilderFormValuesType {
   const [service, ...rest] = values.services;
   return { ...values, services: [{ ...service, profile: applyPresetToProfile(service.profile, DEFAULT_HARDWARE_PRESET) }, ...rest] };
-}
-
-/** A usable deployment has at least one service the user can configure (log collectors don't count). */
-function hasVisibleService(values: SdlBuilderFormValuesType): boolean {
-  return values.services.some(service => !isLogCollectorService(service));
 }
 
 /**
@@ -373,12 +377,6 @@ function getImportErrorMessage(error: unknown): string {
     return "The deployment couldn't be loaded because its SDL is invalid.";
   }
   return "The deployment couldn't be loaded.";
-}
-
-/** Picks the first user-visible service to focus when the screen first mounts. `getInitialState` guarantees one exists. */
-function seedSelectedServiceId(values: SdlBuilderFormValuesType): string {
-  const visible = values.services.find(candidate => !isLogCollectorService(candidate)) ?? values.services[0];
-  return visible.id;
 }
 
 /** Regenerates the preview SDL, keeping the last good output while the form is mid-edit. */

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentPanes/ConfigureDeploymentPanes.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentPanes/ConfigureDeploymentPanes.spec.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { createStore, Provider as JotaiStoreProvider } from "jotai";
 import { describe, expect, it, vi } from "vitest";
 
@@ -103,6 +104,13 @@ describe("ConfigureDeploymentPanes", () => {
     expect(ConfigurationPane).toHaveBeenCalledWith(expect.objectContaining({ locked: "all" }), expect.anything());
   });
 
+  it("forwards the configuration actions slot into the configuration pane header", () => {
+    const actions = <div data-testid="config-actions" />;
+    const { ConfigurationPane } = setup({ configurationActions: actions });
+
+    expect(ConfigurationPane).toHaveBeenCalledWith(expect.objectContaining({ actions }), expect.anything());
+  });
+
   function setup(
     input: {
       isSdlPreviewEnabled?: boolean;
@@ -119,6 +127,7 @@ describe("ConfigureDeploymentPanes", () => {
       selections?: Record<string, string>;
       onSelectProvider?: (placementId: string, bidId: string) => void;
       onCancelAndEdit?: () => void;
+      configurationActions?: ReactNode;
     } = {}
   ) {
     const SdlPreviewPane = vi.fn(({ isOpen, onOpen, onClose }: { isOpen: boolean; onOpen: () => void; onClose: () => void }) => (
@@ -159,6 +168,7 @@ describe("ConfigureDeploymentPanes", () => {
           onCancelAndEdit={input.onCancelAndEdit ?? vi.fn()}
           deploymentName=""
           onDeploymentNameChange={vi.fn()}
+          configurationActions={input.configurationActions}
           dependencies={dependencies}
         />
       </JotaiStoreProvider>

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentPanes/ConfigureDeploymentPanes.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentPanes/ConfigureDeploymentPanes.tsx
@@ -1,4 +1,4 @@
-import type { FC } from "react";
+import type { FC, ReactNode } from "react";
 import { useAtom } from "jotai";
 
 import { useFlag } from "@src/hooks/useFlag";
@@ -27,6 +27,8 @@ type Props = {
   onCancelAndEdit: () => void;
   deploymentName: string;
   onDeploymentNameChange: (value: string) => void;
+  /** Rendered in the Configuration column header, e.g. the SDL import/export menu. */
+  configurationActions?: ReactNode;
   dependencies?: typeof DEPENDENCIES;
 };
 
@@ -50,6 +52,7 @@ export const ConfigureDeploymentPanes: FC<Props> = ({
   onCancelAndEdit,
   deploymentName,
   onDeploymentNameChange,
+  configurationActions,
   dependencies: d = DEPENDENCIES
 }) => {
   const [isSdlPreviewOpen, setIsSdlPreviewOpen] = useAtom(sdlStore.sdlPreviewOpen);
@@ -78,7 +81,13 @@ export const ConfigureDeploymentPanes: FC<Props> = ({
           />
         </div>
         <div className="min-h-0">
-          <d.ConfigurationPane selectedServiceId={selectedServiceId} locked={configurationLock} isClosing={isClosing} onCancelAndEdit={onCancelAndEdit} />
+          <d.ConfigurationPane
+            selectedServiceId={selectedServiceId}
+            locked={configurationLock}
+            isClosing={isClosing}
+            onCancelAndEdit={onCancelAndEdit}
+            actions={configurationActions}
+          />
         </div>
       </div>
       <div className="min-h-0 border-l border-zinc-300 dark:border-zinc-700">

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/SdlImportExport/ImportSdlDialog.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/SdlImportExport/ImportSdlDialog.spec.tsx
@@ -91,7 +91,7 @@ describe(ImportSdlDialog.name, () => {
     await userEvent.type(screen.getByLabelText("SDL editor"), "1");
     await userEvent.click(screen.getByRole("button", { name: "Import" }));
 
-    expect(screen.getByText("This SDL couldn't be parsed. Check the file and try again.")).toBeInTheDocument();
+    expect(screen.getByText("This config couldn't be parsed. Check the file and try again.")).toBeInTheDocument();
   });
 
   it("clears the error message when the editor is edited again", async () => {
@@ -103,11 +103,11 @@ describe(ImportSdlDialog.name, () => {
 
     await userEvent.type(screen.getByLabelText("SDL editor"), "1");
     await userEvent.click(screen.getByRole("button", { name: "Import" }));
-    expect(screen.getByText("This SDL couldn't be parsed. Check the file and try again.")).toBeInTheDocument();
+    expect(screen.getByText("This config couldn't be parsed. Check the file and try again.")).toBeInTheDocument();
 
     await userEvent.type(screen.getByLabelText("SDL editor"), "2");
 
-    expect(screen.queryByText("This SDL couldn't be parsed. Check the file and try again.")).not.toBeInTheDocument();
+    expect(screen.queryByText("This config couldn't be parsed. Check the file and try again.")).not.toBeInTheDocument();
   });
 
   it("populates the editor from an uploaded file", async () => {
@@ -166,7 +166,7 @@ describe(ImportSdlDialog.name, () => {
 
     await userEvent.upload(screen.getByLabelText("Upload file"), oversizedFile());
 
-    expect(screen.getByText("This file is too large to be an SDL. Choose a file under 512 KB.")).toBeInTheDocument();
+    expect(screen.getByText("This file is too large to be a config. Choose a file under 512 KB.")).toBeInTheDocument();
     expect(screen.getByLabelText("SDL editor")).toHaveValue("");
     expect(importDeploymentState).not.toHaveBeenCalled();
   });

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/SdlImportExport/ImportSdlDialog.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/SdlImportExport/ImportSdlDialog.spec.tsx
@@ -1,0 +1,165 @@
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { SdlBuilderFormValuesType } from "@src/types";
+import type { ImportedDeploymentState } from "../importDeploymentState/importDeploymentState";
+import { NoVisibleServiceError } from "../importDeploymentState/importDeploymentState";
+import type { DEPENDENCIES } from "./ImportSdlDialog";
+import { ImportSdlDialog } from "./ImportSdlDialog";
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const IMPORTED_STATE: ImportedDeploymentState = { values: mock<SdlBuilderFormValuesType>(), sdl: "imported-sdl", selectedServiceId: "svc-1" };
+
+describe(ImportSdlDialog.name, () => {
+  it("disables Import while the editor is empty", () => {
+    setup({});
+
+    expect(screen.getByRole("button", { name: "Import" })).toBeDisabled();
+  });
+
+  it("imports pasted text and reports the paste method", async () => {
+    const { onImport, importDeploymentState } = setup({});
+
+    await userEvent.type(screen.getByLabelText("SDL editor"), "some: sdl");
+    await userEvent.click(screen.getByRole("button", { name: "Import" }));
+
+    expect(importDeploymentState).toHaveBeenCalledWith("some: sdl");
+    expect(onImport).toHaveBeenCalledWith(IMPORTED_STATE, { method: "paste" });
+  });
+
+  it("shows a known parser error inline, keeps the dialog open, and does not import", async () => {
+    const error = Object.assign(new Error("bad indentation at line 3"), { name: "YAMLException" });
+    const { onImport } = setup({
+      importResult: () => {
+        throw error;
+      }
+    });
+
+    await userEvent.type(screen.getByLabelText("SDL editor"), "bad: sdl");
+    await userEvent.click(screen.getByRole("button", { name: "Import" }));
+
+    expect(screen.getByText("bad indentation at line 3")).toBeInTheDocument();
+    expect(onImport).not.toHaveBeenCalled();
+  });
+
+  it("shows the no-services message when the SDL defines nothing to configure", async () => {
+    const error = new NoVisibleServiceError("This SDL doesn't define any services to configure.");
+    setup({
+      importResult: () => {
+        throw error;
+      }
+    });
+
+    await userEvent.type(screen.getByLabelText("SDL editor"), "version: '2.0'");
+    await userEvent.click(screen.getByRole("button", { name: "Import" }));
+
+    expect(screen.getByText("This SDL doesn't define any services to configure.")).toBeInTheDocument();
+  });
+
+  it("shows a generic fallback for an unrecognized error", async () => {
+    setup({
+      importResult: () => {
+        throw new TypeError("cannot read properties of undefined");
+      }
+    });
+
+    await userEvent.type(screen.getByLabelText("SDL editor"), "1");
+    await userEvent.click(screen.getByRole("button", { name: "Import" }));
+
+    expect(screen.getByText("This SDL couldn't be parsed. Check the file and try again.")).toBeInTheDocument();
+  });
+
+  it("clears the error message when the editor is edited again", async () => {
+    setup({
+      importResult: () => {
+        throw new TypeError("boom");
+      }
+    });
+
+    await userEvent.type(screen.getByLabelText("SDL editor"), "1");
+    await userEvent.click(screen.getByRole("button", { name: "Import" }));
+    expect(screen.getByText("This SDL couldn't be parsed. Check the file and try again.")).toBeInTheDocument();
+
+    await userEvent.type(screen.getByLabelText("SDL editor"), "2");
+
+    expect(screen.queryByText("This SDL couldn't be parsed. Check the file and try again.")).not.toBeInTheDocument();
+  });
+
+  it("populates the editor from an uploaded file", async () => {
+    setup({});
+
+    await userEvent.upload(screen.getByLabelText("Upload file"), sdlFile("uploaded: sdl"));
+
+    await waitFor(() => expect(screen.getByLabelText("SDL editor")).toHaveValue("uploaded: sdl"));
+  });
+
+  it("reports the file method for an unedited upload", async () => {
+    const { onImport } = setup({});
+
+    await userEvent.upload(screen.getByLabelText("Upload file"), sdlFile("uploaded: sdl"));
+    await waitFor(() => expect(screen.getByLabelText("SDL editor")).toHaveValue("uploaded: sdl"));
+    await userEvent.click(screen.getByRole("button", { name: "Import" }));
+
+    expect(onImport).toHaveBeenCalledWith(IMPORTED_STATE, { method: "file" });
+  });
+
+  it("reports the paste method when an uploaded file is then edited", async () => {
+    const { onImport } = setup({});
+
+    await userEvent.upload(screen.getByLabelText("Upload file"), sdlFile("uploaded: sdl"));
+    await waitFor(() => expect(screen.getByLabelText("SDL editor")).toHaveValue("uploaded: sdl"));
+    await userEvent.type(screen.getByLabelText("SDL editor"), " edited");
+    await userEvent.click(screen.getByRole("button", { name: "Import" }));
+
+    expect(onImport).toHaveBeenCalledWith(IMPORTED_STATE, { method: "paste" });
+  });
+
+  it("rejects an oversized file without reading it", async () => {
+    const { importDeploymentState } = setup({});
+
+    await userEvent.upload(screen.getByLabelText("Upload file"), oversizedFile());
+
+    expect(screen.getByText("This file is too large to be an SDL. Choose a file under 512 KB.")).toBeInTheDocument();
+    expect(screen.getByLabelText("SDL editor")).toHaveValue("");
+    expect(importDeploymentState).not.toHaveBeenCalled();
+  });
+
+  it("closes without importing when Cancel is clicked", async () => {
+    const { onClose, onImport } = setup({});
+
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(onClose).toHaveBeenCalled();
+    expect(onImport).not.toHaveBeenCalled();
+  });
+
+  function sdlFile(content: string) {
+    return new File([content], "deploy.yaml", { type: "application/x-yaml" });
+  }
+
+  function oversizedFile() {
+    return new File(["a".repeat(512 * 1024 + 1)], "huge.yaml", { type: "application/x-yaml" });
+  }
+
+  function setup(input: { importResult?: () => ImportedDeploymentState }) {
+    const onClose = vi.fn();
+    const onImport = vi.fn();
+    const importDeploymentState = vi.fn(input.importResult ?? (() => IMPORTED_STATE));
+
+    const SDLEditor = (({ value, onChange }: { value?: string; onChange?: (value: string) => void }) => (
+      <textarea aria-label="SDL editor" value={value ?? ""} onChange={event => onChange?.(event.target.value)} />
+    )) as never;
+    const FileButton: typeof DEPENDENCIES.FileButton = ({ onFileSelect, children }) => (
+      <label>
+        {children}
+        <input type="file" onChange={event => onFileSelect?.(event.currentTarget.files?.[0] ?? null)} />
+      </label>
+    );
+
+    render(<ImportSdlDialog onClose={onClose} onImport={onImport} dependencies={{ SDLEditor, FileButton, importDeploymentState }} />);
+
+    return { onClose, onImport, importDeploymentState };
+  }
+});

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/SdlImportExport/ImportSdlDialog.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/SdlImportExport/ImportSdlDialog.spec.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { SdlBuilderFormValuesType } from "@src/types";
@@ -7,12 +7,14 @@ import { NoVisibleServiceError } from "../importDeploymentState/importDeployment
 import type { DEPENDENCIES } from "./ImportSdlDialog";
 import { ImportSdlDialog } from "./ImportSdlDialog";
 
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 const IMPORTED_STATE: ImportedDeploymentState = { values: mock<SdlBuilderFormValuesType>(), sdl: "imported-sdl", selectedServiceId: "svc-1" };
 
 describe(ImportSdlDialog.name, () => {
+  afterEach(() => vi.unstubAllGlobals());
+
   it("disables Import while the editor is empty", () => {
     setup({});
 
@@ -137,6 +139,28 @@ describe(ImportSdlDialog.name, () => {
     expect(onImport).toHaveBeenCalledWith(IMPORTED_STATE, { method: "paste" });
   });
 
+  it("ignores a slow file read once the editor has been edited", async () => {
+    const reads = captureFileReads();
+    setup({});
+
+    await userEvent.upload(screen.getByLabelText("Upload file"), sdlFile("stale: sdl"));
+    await userEvent.type(screen.getByLabelText("SDL editor"), "fresh");
+    act(() => reads[0].emitLoad("stale: sdl"));
+
+    expect(screen.getByLabelText("SDL editor")).toHaveValue("fresh");
+  });
+
+  it("suppresses a read error for a file superseded by a newer edit", async () => {
+    const reads = captureFileReads();
+    setup({});
+
+    await userEvent.upload(screen.getByLabelText("Upload file"), sdlFile("stale: sdl"));
+    await userEvent.type(screen.getByLabelText("SDL editor"), "fresh");
+    act(() => reads[0].emitError());
+
+    expect(screen.queryByText("Couldn't read the file. Please try again.")).not.toBeInTheDocument();
+  });
+
   it("rejects an oversized file without reading it", async () => {
     const { importDeploymentState } = setup({});
 
@@ -155,6 +179,24 @@ describe(ImportSdlDialog.name, () => {
     expect(onClose).toHaveBeenCalled();
     expect(onImport).not.toHaveBeenCalled();
   });
+
+  function captureFileReads() {
+    const reads: Array<{ emitLoad: (content: string) => void; emitError: () => void }> = [];
+    vi.stubGlobal(
+      "FileReader",
+      class {
+        onload: ((event: { target: { result: string } }) => void) | null = null;
+        onerror: (() => void) | null = null;
+        readAsText() {
+          reads.push({
+            emitLoad: content => this.onload?.({ target: { result: content } }),
+            emitError: () => this.onerror?.()
+          });
+        }
+      }
+    );
+    return reads;
+  }
 
   function sdlFile(content: string) {
     return new File([content], "deploy.yaml", { type: "application/x-yaml" });

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/SdlImportExport/ImportSdlDialog.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/SdlImportExport/ImportSdlDialog.spec.tsx
@@ -29,6 +29,27 @@ describe(ImportSdlDialog.name, () => {
     expect(onImport).toHaveBeenCalledWith(IMPORTED_STATE, { method: "paste" });
   });
 
+  it("disables Import while the editor reports validation errors", async () => {
+    setup({});
+
+    await userEvent.type(screen.getByLabelText("SDL editor"), "invalid: sdl");
+    await userEvent.click(screen.getByRole("button", { name: "mark invalid" }));
+
+    expect(screen.getByRole("button", { name: "Import" })).toBeDisabled();
+  });
+
+  it("re-enables Import once the editor reports the sdl is valid", async () => {
+    setup({});
+
+    await userEvent.type(screen.getByLabelText("SDL editor"), "some: sdl");
+    await userEvent.click(screen.getByRole("button", { name: "mark invalid" }));
+    expect(screen.getByRole("button", { name: "Import" })).toBeDisabled();
+
+    await userEvent.click(screen.getByRole("button", { name: "mark valid" }));
+
+    expect(screen.getByRole("button", { name: "Import" })).toBeEnabled();
+  });
+
   it("shows a known parser error inline, keeps the dialog open, and does not import", async () => {
     const error = Object.assign(new Error("bad indentation at line 3"), { name: "YAMLException" });
     const { onImport } = setup({
@@ -148,8 +169,24 @@ describe(ImportSdlDialog.name, () => {
     const onImport = vi.fn();
     const importDeploymentState = vi.fn(input.importResult ?? (() => IMPORTED_STATE));
 
-    const SDLEditor = (({ value, onChange }: { value?: string; onChange?: (value: string) => void }) => (
-      <textarea aria-label="SDL editor" value={value ?? ""} onChange={event => onChange?.(event.target.value)} />
+    const SDLEditor = (({
+      value,
+      onChange,
+      onValidate
+    }: {
+      value?: string;
+      onChange?: (value: string) => void;
+      onValidate?: (event: { isValid: boolean }) => void;
+    }) => (
+      <div>
+        <textarea aria-label="SDL editor" value={value ?? ""} onChange={event => onChange?.(event.target.value)} />
+        <button type="button" onClick={() => onValidate?.({ isValid: false })}>
+          mark invalid
+        </button>
+        <button type="button" onClick={() => onValidate?.({ isValid: true })}>
+          mark valid
+        </button>
+      </div>
     )) as never;
     const FileButton: typeof DEPENDENCIES.FileButton = ({ onFileSelect, children }) => (
       <label>

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/SdlImportExport/ImportSdlDialog.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/SdlImportExport/ImportSdlDialog.tsx
@@ -18,7 +18,7 @@ import { useTheme } from "next-themes";
 
 import { SDLEditor } from "@src/components/sdl/SDLEditor/SDLEditor";
 import type { ImportedDeploymentState } from "../importDeploymentState/importDeploymentState";
-import { importDeploymentState } from "../importDeploymentState/importDeploymentState";
+import { importDeploymentState, isKnownSdlParserError, NoVisibleServiceError } from "../importDeploymentState/importDeploymentState";
 
 /** An SDL well over any real deployment is almost certainly the wrong file; reject before reading it into memory. */
 const MAX_SDL_FILE_BYTES = 512 * 1024;
@@ -40,10 +40,10 @@ export const ImportSdlDialog: FC<Props> = ({ onClose, onImport, dependencies: d 
   const { resolvedTheme } = useTheme();
   const [text, setText] = useState("");
   const [error, setError] = useState<string | null>(null);
-  /** The editor's SDL-validation verdict (null until the editor has validated once); a false verdict blocks import. */
-  const [isValid, setIsValid] = useState<boolean | null>(null);
-  /** The exact text of the last uploaded file, so an unedited upload is reported as `method: "file"`. */
-  const uploadedContentRef = useRef<string | null>(null);
+  /** The editor's SDL-validation verdict; assumed valid until the editor reports otherwise, so a false verdict blocks import. */
+  const [isValid, setIsValid] = useState(true);
+  /** True while the editor still holds an untouched uploaded file, so an unedited upload is reported as `method: "file"`. */
+  const fromFileRef = useRef(false);
 
   const focusOnMount = useCallback((editorInstance: editor.IStandaloneCodeEditor) => {
     editorInstance.focus();
@@ -52,6 +52,7 @@ export const ImportSdlDialog: FC<Props> = ({ onClose, onImport, dependencies: d 
   function handleEditorChange(value?: string) {
     setText(value ?? "");
     setError(null);
+    fromFileRef.current = false;
   }
 
   function handleValidate(event: { isValid: boolean }) {
@@ -67,7 +68,7 @@ export const ImportSdlDialog: FC<Props> = ({ onClose, onImport, dependencies: d 
     const reader = new FileReader();
     reader.onload = function populateEditor(event) {
       const content = (event.target?.result as string) ?? "";
-      uploadedContentRef.current = content;
+      fromFileRef.current = true;
       setText(content);
       setError(null);
     };
@@ -80,7 +81,7 @@ export const ImportSdlDialog: FC<Props> = ({ onClose, onImport, dependencies: d 
   function handleImport() {
     try {
       const state = d.importDeploymentState(text);
-      onImport(state, { method: text === uploadedContentRef.current ? "file" : "paste" });
+      onImport(state, { method: fromFileRef.current ? "file" : "paste" });
     } catch (err) {
       setError(describeImportError(err));
     }
@@ -121,7 +122,7 @@ export const ImportSdlDialog: FC<Props> = ({ onClose, onImport, dependencies: d 
           <Button variant="ghost" onClick={onClose}>
             Cancel
           </Button>
-          <Button onClick={handleImport} disabled={!text.trim() || isValid === false}>
+          <Button onClick={handleImport} disabled={!text.trim() || !isValid}>
             Import
           </Button>
         </DialogV2Footer>
@@ -131,18 +132,15 @@ export const ImportSdlDialog: FC<Props> = ({ onClose, onImport, dependencies: d 
 };
 
 /**
- * Turns an import failure into a user-facing message. Parser errors (`YAMLException` with line/col,
- * validation errors, the no-service case) carry a helpful message, so it is surfaced directly; anything
- * else is parser-internal noise and gets a fixed fallback. Name-based checks match the legacy importer.
+ * Turns an import failure into a user-facing message. Recognized parser/validation errors and the
+ * no-service case carry a helpful message, so it is surfaced directly; anything else is parser-internal
+ * noise and gets a fixed fallback.
  * Note: this consciously diverges from the mount path's fixed-message policy — showing `err.message` here
  * gives the "clear validation error" the feature requires, and React escapes text nodes so it is not an
  * injection vector. This function is the single swap point if that policy call is revisited.
  */
 function describeImportError(err: unknown): string {
-  if (
-    err instanceof Error &&
-    (err.name === "NoVisibleServiceError" || err.name === "YAMLException" || err.name === "CustomValidationError" || err.name === "TemplateValidation")
-  ) {
+  if (err instanceof NoVisibleServiceError || isKnownSdlParserError(err)) {
     return err.message;
   }
   return "This SDL couldn't be parsed. Check the file and try again.";

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/SdlImportExport/ImportSdlDialog.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/SdlImportExport/ImportSdlDialog.tsx
@@ -1,0 +1,136 @@
+"use client";
+import type { FC } from "react";
+import { useCallback, useRef, useState } from "react";
+import {
+  Alert,
+  Button,
+  DialogV2,
+  DialogV2Body,
+  DialogV2Content,
+  DialogV2Description,
+  DialogV2Footer,
+  DialogV2Header,
+  DialogV2Title,
+  FileButton
+} from "@akashnetwork/ui/components";
+import type { editor } from "monaco-editor";
+import { useTheme } from "next-themes";
+
+import { SDLEditor } from "@src/components/sdl/SDLEditor/SDLEditor";
+import type { ImportedDeploymentState } from "../importDeploymentState/importDeploymentState";
+import { importDeploymentState } from "../importDeploymentState/importDeploymentState";
+
+/** An SDL well over any real deployment is almost certainly the wrong file; reject before reading it into memory. */
+const MAX_SDL_FILE_BYTES = 512 * 1024;
+
+export const DEPENDENCIES = { SDLEditor, FileButton, importDeploymentState };
+
+type Props = {
+  onClose: () => void;
+  onImport: (state: ImportedDeploymentState, meta: { method: "paste" | "file" }) => void;
+  dependencies?: typeof DEPENDENCIES;
+};
+
+/**
+ * The import dialog for the configure screen: an SDL editor to paste into plus an upload button that
+ * populates the same editor. The single "Import" action is the only validate/apply path — uploading a file
+ * never bypasses it. A failed import shows an inline message and leaves the parent form untouched.
+ */
+export const ImportSdlDialog: FC<Props> = ({ onClose, onImport, dependencies: d = DEPENDENCIES }) => {
+  const { resolvedTheme } = useTheme();
+  const [text, setText] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  /** The exact text of the last uploaded file, so an unedited upload is reported as `method: "file"`. */
+  const uploadedContentRef = useRef<string | null>(null);
+
+  const focusOnMount = useCallback((editorInstance: editor.IStandaloneCodeEditor) => {
+    editorInstance.focus();
+  }, []);
+
+  function handleEditorChange(value?: string) {
+    setText(value ?? "");
+    setError(null);
+  }
+
+  function handleFileSelect(file: File | null) {
+    if (!file) return;
+    if (file.size > MAX_SDL_FILE_BYTES) {
+      setError("This file is too large to be an SDL. Choose a file under 512 KB.");
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = function populateEditor(event) {
+      const content = (event.target?.result as string) ?? "";
+      uploadedContentRef.current = content;
+      setText(content);
+      setError(null);
+    };
+    reader.onerror = function reportReadFailure() {
+      setError("Couldn't read the file. Please try again.");
+    };
+    reader.readAsText(file);
+  }
+
+  function handleImport() {
+    try {
+      const state = d.importDeploymentState(text);
+      onImport(state, { method: text === uploadedContentRef.current ? "file" : "paste" });
+    } catch (err) {
+      setError(describeImportError(err));
+    }
+  }
+
+  return (
+    <DialogV2 open onOpenChange={isOpen => (!isOpen ? onClose() : undefined)}>
+      <DialogV2Content className="max-w-3xl">
+        <DialogV2Header>
+          <DialogV2Title>Import SDL</DialogV2Title>
+          <DialogV2Description>Paste your SDL below or upload a file. Importing replaces your current configuration.</DialogV2Description>
+        </DialogV2Header>
+
+        <DialogV2Body className="space-y-4">
+          <div className="flex justify-end">
+            <d.FileButton onFileSelect={handleFileSelect} accept=".yml,.yaml,.txt" size="sm" variant="outline">
+              Upload file
+            </d.FileButton>
+          </div>
+          <d.SDLEditor
+            height="440px"
+            value={text}
+            onChange={handleEditorChange}
+            theme={resolvedTheme === "dark" ? "vs-dark" : "light"}
+            onMount={focusOnMount}
+          />
+          {error && <Alert variant="destructive">{error}</Alert>}
+        </DialogV2Body>
+
+        <DialogV2Footer>
+          <Button variant="ghost" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button onClick={handleImport} disabled={!text.trim()}>
+            Import
+          </Button>
+        </DialogV2Footer>
+      </DialogV2Content>
+    </DialogV2>
+  );
+};
+
+/**
+ * Turns an import failure into a user-facing message. Parser errors (`YAMLException` with line/col,
+ * validation errors, the no-service case) carry a helpful message, so it is surfaced directly; anything
+ * else is parser-internal noise and gets a fixed fallback. Name-based checks match the legacy importer.
+ * Note: this consciously diverges from the mount path's fixed-message policy — showing `err.message` here
+ * gives the "clear validation error" the feature requires, and React escapes text nodes so it is not an
+ * injection vector. This function is the single swap point if that policy call is revisited.
+ */
+function describeImportError(err: unknown): string {
+  if (
+    err instanceof Error &&
+    (err.name === "NoVisibleServiceError" || err.name === "YAMLException" || err.name === "CustomValidationError" || err.name === "TemplateValidation")
+  ) {
+    return err.message;
+  }
+  return "This SDL couldn't be parsed. Check the file and try again.";
+}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/SdlImportExport/ImportSdlDialog.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/SdlImportExport/ImportSdlDialog.tsx
@@ -40,10 +40,8 @@ export const ImportSdlDialog: FC<Props> = ({ onClose, onImport, dependencies: d 
   const { resolvedTheme } = useTheme();
   const [text, setText] = useState("");
   const [error, setError] = useState<string | null>(null);
-  /** The editor's SDL-validation verdict; assumed valid until the editor reports otherwise, so a false verdict blocks import. */
   const [isValid, setIsValid] = useState(true);
-  /** True while the editor still holds an untouched uploaded file, so an unedited upload is reported as `method: "file"`. */
-  const fromFileRef = useRef(false);
+  const untouchedUploadedFileRef = useRef(false);
 
   const focusOnMount = useCallback((editorInstance: editor.IStandaloneCodeEditor) => {
     editorInstance.focus();
@@ -52,7 +50,7 @@ export const ImportSdlDialog: FC<Props> = ({ onClose, onImport, dependencies: d 
   function handleEditorChange(value?: string) {
     setText(value ?? "");
     setError(null);
-    fromFileRef.current = false;
+    untouchedUploadedFileRef.current = false;
   }
 
   function handleValidate(event: { isValid: boolean }) {
@@ -68,7 +66,7 @@ export const ImportSdlDialog: FC<Props> = ({ onClose, onImport, dependencies: d 
     const reader = new FileReader();
     reader.onload = function populateEditor(event) {
       const content = (event.target?.result as string) ?? "";
-      fromFileRef.current = true;
+      untouchedUploadedFileRef.current = true;
       setText(content);
       setError(null);
     };
@@ -81,7 +79,7 @@ export const ImportSdlDialog: FC<Props> = ({ onClose, onImport, dependencies: d 
   function handleImport() {
     try {
       const state = d.importDeploymentState(text);
-      onImport(state, { method: fromFileRef.current ? "file" : "paste" });
+      onImport(state, { method: untouchedUploadedFileRef.current ? "file" : "paste" });
     } catch (err) {
       setError(describeImportError(err));
     }

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/SdlImportExport/ImportSdlDialog.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/SdlImportExport/ImportSdlDialog.tsx
@@ -40,6 +40,8 @@ export const ImportSdlDialog: FC<Props> = ({ onClose, onImport, dependencies: d 
   const { resolvedTheme } = useTheme();
   const [text, setText] = useState("");
   const [error, setError] = useState<string | null>(null);
+  /** The editor's SDL-validation verdict (null until the editor has validated once); a false verdict blocks import. */
+  const [isValid, setIsValid] = useState<boolean | null>(null);
   /** The exact text of the last uploaded file, so an unedited upload is reported as `method: "file"`. */
   const uploadedContentRef = useRef<string | null>(null);
 
@@ -50,6 +52,10 @@ export const ImportSdlDialog: FC<Props> = ({ onClose, onImport, dependencies: d 
   function handleEditorChange(value?: string) {
     setText(value ?? "");
     setError(null);
+  }
+
+  function handleValidate(event: { isValid: boolean }) {
+    setIsValid(event.isValid);
   }
 
   function handleFileSelect(file: File | null) {
@@ -82,33 +88,40 @@ export const ImportSdlDialog: FC<Props> = ({ onClose, onImport, dependencies: d 
 
   return (
     <DialogV2 open onOpenChange={isOpen => (!isOpen ? onClose() : undefined)}>
-      <DialogV2Content className="max-w-3xl">
+      <DialogV2Content className="flex h-[600px] max-h-[85vh] max-w-3xl flex-col">
         <DialogV2Header>
           <DialogV2Title>Import SDL</DialogV2Title>
           <DialogV2Description>Paste your SDL below or upload a file. Importing replaces your current configuration.</DialogV2Description>
         </DialogV2Header>
 
-        <DialogV2Body className="space-y-4">
-          <div className="flex justify-end">
+        <DialogV2Body className="flex min-h-0 flex-1 flex-col gap-4">
+          <div className="flex shrink-0 justify-end">
             <d.FileButton onFileSelect={handleFileSelect} accept=".yml,.yaml,.txt" size="sm" variant="outline">
               Upload file
             </d.FileButton>
           </div>
-          <d.SDLEditor
-            height="440px"
-            value={text}
-            onChange={handleEditorChange}
-            theme={resolvedTheme === "dark" ? "vs-dark" : "light"}
-            onMount={focusOnMount}
-          />
-          {error && <Alert variant="destructive">{error}</Alert>}
+          <div className="min-h-0 flex-1 overflow-hidden rounded-md border">
+            <d.SDLEditor
+              height="100%"
+              value={text}
+              onChange={handleEditorChange}
+              onValidate={handleValidate}
+              theme={resolvedTheme === "dark" ? "vs-dark" : "light"}
+              onMount={focusOnMount}
+            />
+          </div>
+          {error && (
+            <Alert variant="destructive" className="shrink-0">
+              {error}
+            </Alert>
+          )}
         </DialogV2Body>
 
         <DialogV2Footer>
           <Button variant="ghost" onClick={onClose}>
             Cancel
           </Button>
-          <Button onClick={handleImport} disabled={!text.trim()}>
+          <Button onClick={handleImport} disabled={!text.trim() || isValid === false}>
             Import
           </Button>
         </DialogV2Footer>

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/SdlImportExport/ImportSdlDialog.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/SdlImportExport/ImportSdlDialog.tsx
@@ -65,7 +65,7 @@ export const ImportSdlDialog: FC<Props> = ({ onClose, onImport, dependencies: d 
     fileReadGenerationRef.current += 1;
     const generation = fileReadGenerationRef.current;
     if (file.size > MAX_SDL_FILE_BYTES) {
-      setError("This file is too large to be an SDL. Choose a file under 512 KB.");
+      setError("This file is too large to be a config. Choose a file under 512 KB.");
       return;
     }
     const reader = new FileReader();
@@ -96,8 +96,13 @@ export const ImportSdlDialog: FC<Props> = ({ onClose, onImport, dependencies: d 
     <DialogV2 open onOpenChange={isOpen => (!isOpen ? onClose() : undefined)}>
       <DialogV2Content className="flex h-[600px] max-h-[85vh] max-w-3xl flex-col">
         <DialogV2Header>
-          <DialogV2Title>Import SDL</DialogV2Title>
-          <DialogV2Description>Paste your SDL below or upload a file. Importing replaces your current configuration.</DialogV2Description>
+          <DialogV2Title>Import Config</DialogV2Title>
+          <DialogV2Description>
+            Paste your config below or upload a file. Importing replaces your current configuration.{" "}
+            <a href="https://akash.network/docs/developers/deployment/akash-sdl/" target="_blank" rel="noopener" className="text-primary underline">
+              View the SDL reference
+            </a>
+          </DialogV2Description>
         </DialogV2Header>
 
         <DialogV2Body className="flex min-h-0 flex-1 flex-col gap-4">
@@ -148,5 +153,5 @@ function describeImportError(err: unknown): string {
   if (err instanceof NoVisibleServiceError || isKnownSdlParserError(err)) {
     return err.message;
   }
-  return "This SDL couldn't be parsed. Check the file and try again.";
+  return "This config couldn't be parsed. Check the file and try again.";
 }

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/SdlImportExport/ImportSdlDialog.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/SdlImportExport/ImportSdlDialog.tsx
@@ -42,12 +42,15 @@ export const ImportSdlDialog: FC<Props> = ({ onClose, onImport, dependencies: d 
   const [error, setError] = useState<string | null>(null);
   const [isValid, setIsValid] = useState(true);
   const untouchedUploadedFileRef = useRef(false);
+  /** Guards against a slow FileReader overwriting newer text: a read applies only while it is still the latest. */
+  const fileReadGenerationRef = useRef(0);
 
   const focusOnMount = useCallback((editorInstance: editor.IStandaloneCodeEditor) => {
     editorInstance.focus();
   }, []);
 
   function handleEditorChange(value?: string) {
+    fileReadGenerationRef.current += 1;
     setText(value ?? "");
     setError(null);
     untouchedUploadedFileRef.current = false;
@@ -59,18 +62,22 @@ export const ImportSdlDialog: FC<Props> = ({ onClose, onImport, dependencies: d 
 
   function handleFileSelect(file: File | null) {
     if (!file) return;
+    fileReadGenerationRef.current += 1;
+    const generation = fileReadGenerationRef.current;
     if (file.size > MAX_SDL_FILE_BYTES) {
       setError("This file is too large to be an SDL. Choose a file under 512 KB.");
       return;
     }
     const reader = new FileReader();
     reader.onload = function populateEditor(event) {
+      if (generation !== fileReadGenerationRef.current) return;
       const content = (event.target?.result as string) ?? "";
       untouchedUploadedFileRef.current = true;
       setText(content);
       setError(null);
     };
     reader.onerror = function reportReadFailure() {
+      if (generation !== fileReadGenerationRef.current) return;
       setError("Couldn't read the file. Please try again.");
     };
     reader.readAsText(file);

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/SdlImportExport/SdlImportExport.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/SdlImportExport/SdlImportExport.spec.tsx
@@ -16,21 +16,25 @@ describe(SdlImportExport.name, () => {
   it("opens the import dialog when Import is clicked", async () => {
     setup({});
 
-    await userEvent.click(screen.getByRole("button", { name: "Import" }));
+    await openMenu();
+    await userEvent.click(screen.getByRole("menuitem", { name: /Import Config/ }));
 
     expect(screen.getByRole("button", { name: "trigger import" })).toBeInTheDocument();
   });
 
-  it("disables Import while the flow is locked", () => {
+  it("disables Import while the flow is locked", async () => {
     setup({ canImport: false });
 
-    expect(screen.getByRole("button", { name: "Import" })).toBeDisabled();
+    await openMenu();
+
+    expect(screen.getByRole("menuitem", { name: /Import Config/ })).toHaveAttribute("aria-disabled", "true");
   });
 
   it("applies the import, shows a snackbar, tracks the method, and closes the dialog", async () => {
     const { onImport, analyticsService, enqueueSnackbar } = setup({});
 
-    await userEvent.click(screen.getByRole("button", { name: "Import" }));
+    await openMenu();
+    await userEvent.click(screen.getByRole("menuitem", { name: /Import Config/ }));
     await userEvent.click(screen.getByRole("button", { name: "trigger import" }));
 
     expect(onImport).toHaveBeenCalledWith(IMPORTED_STATE);
@@ -42,7 +46,7 @@ describe(SdlImportExport.name, () => {
   it("downloads the sdl as a yaml file named after the deployment", async () => {
     const { saveAs } = setup({ sdl: "some: sdl", deploymentName: "My App 2!" });
 
-    await userEvent.click(screen.getByRole("button", { name: "Export" }));
+    await openMenu();
     await userEvent.click(screen.getByRole("menuitem", { name: "Download .yaml" }));
 
     const [blob, filename] = saveAs.mock.calls[0];
@@ -54,7 +58,7 @@ describe(SdlImportExport.name, () => {
   it("falls back to a generic filename when the deployment name has no usable characters", async () => {
     const { saveAs } = setup({ sdl: "some: sdl", deploymentName: "!!!" });
 
-    await userEvent.click(screen.getByRole("button", { name: "Export" }));
+    await openMenu();
     await userEvent.click(screen.getByRole("menuitem", { name: "Download .yaml" }));
 
     expect(saveAs.mock.calls[0][1]).toBe("deployment.yaml");
@@ -63,7 +67,7 @@ describe(SdlImportExport.name, () => {
   it("tracks the download", async () => {
     const { analyticsService } = setup({ sdl: "some: sdl" });
 
-    await userEvent.click(screen.getByRole("button", { name: "Export" }));
+    await openMenu();
     await userEvent.click(screen.getByRole("menuitem", { name: "Download .yaml" }));
 
     expect(analyticsService.track).toHaveBeenCalledWith("configure_sdl_downloaded", { category: "deployments" });
@@ -72,7 +76,7 @@ describe(SdlImportExport.name, () => {
   it("copies the sdl to the clipboard, shows a snackbar, and tracks the copy", async () => {
     const { copyTextToClipboard, enqueueSnackbar, analyticsService } = setup({ sdl: "some: sdl" });
 
-    await userEvent.click(screen.getByRole("button", { name: "Export" }));
+    await openMenu();
     await userEvent.click(screen.getByRole("menuitem", { name: "Copy to clipboard" }));
 
     expect(copyTextToClipboard).toHaveBeenCalledWith("some: sdl");
@@ -83,7 +87,7 @@ describe(SdlImportExport.name, () => {
   it("shows an error and does not track the copy when the clipboard write fails", async () => {
     const { enqueueSnackbar, analyticsService } = setup({ sdl: "some: sdl", canCopy: false });
 
-    await userEvent.click(screen.getByRole("button", { name: "Export" }));
+    await openMenu();
     await userEvent.click(screen.getByRole("menuitem", { name: "Copy to clipboard" }));
 
     await waitFor(() => expect(enqueueSnackbar).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ variant: "error" })));
@@ -93,11 +97,15 @@ describe(SdlImportExport.name, () => {
   it("disables the export actions when there is no sdl to export", async () => {
     setup({ sdl: "" });
 
-    await userEvent.click(screen.getByRole("button", { name: "Export" }));
+    await openMenu();
 
     expect(screen.getByRole("menuitem", { name: "Download .yaml" })).toHaveAttribute("aria-disabled", "true");
     expect(screen.getByRole("menuitem", { name: "Copy to clipboard" })).toHaveAttribute("aria-disabled", "true");
   });
+
+  function openMenu() {
+    return userEvent.click(screen.getByRole("button", { name: "SDL import and export" }));
+  }
 
   function setup(input: { sdl?: string; deploymentName?: string; canImport?: boolean; canCopy?: boolean }) {
     const onImport = vi.fn();

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/SdlImportExport/SdlImportExport.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/SdlImportExport/SdlImportExport.spec.tsx
@@ -7,7 +7,7 @@ import type { ImportedDeploymentState } from "../importDeploymentState/importDep
 import type { DEPENDENCIES } from "./SdlImportExport";
 import { SdlImportExport } from "./SdlImportExport";
 
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 const IMPORTED_STATE: ImportedDeploymentState = { values: mock<SdlBuilderFormValuesType>(), sdl: "imported-sdl", selectedServiceId: "svc-1" };
@@ -76,8 +76,18 @@ describe(SdlImportExport.name, () => {
     await userEvent.click(screen.getByRole("menuitem", { name: "Copy to clipboard" }));
 
     expect(copyTextToClipboard).toHaveBeenCalledWith("some: sdl");
+    await waitFor(() => expect(analyticsService.track).toHaveBeenCalledWith("configure_sdl_copied", { category: "deployments" }));
     expect(enqueueSnackbar).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ variant: "success" }));
-    expect(analyticsService.track).toHaveBeenCalledWith("configure_sdl_copied", { category: "deployments" });
+  });
+
+  it("shows an error and does not track the copy when the clipboard write fails", async () => {
+    const { enqueueSnackbar, analyticsService } = setup({ sdl: "some: sdl", canCopy: false });
+
+    await userEvent.click(screen.getByRole("button", { name: "Export" }));
+    await userEvent.click(screen.getByRole("menuitem", { name: "Copy to clipboard" }));
+
+    await waitFor(() => expect(enqueueSnackbar).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ variant: "error" })));
+    expect(analyticsService.track).not.toHaveBeenCalledWith("configure_sdl_copied", { category: "deployments" });
   });
 
   it("disables the export actions when there is no sdl to export", async () => {
@@ -89,12 +99,12 @@ describe(SdlImportExport.name, () => {
     expect(screen.getByRole("menuitem", { name: "Copy to clipboard" })).toHaveAttribute("aria-disabled", "true");
   });
 
-  function setup(input: { sdl?: string; deploymentName?: string; canImport?: boolean }) {
+  function setup(input: { sdl?: string; deploymentName?: string; canImport?: boolean; canCopy?: boolean }) {
     const onImport = vi.fn();
     const analyticsService = mock<AnalyticsService>();
     const enqueueSnackbar = vi.fn();
     const saveAs = vi.fn<(data: Blob, filename: string) => void>();
-    const copyTextToClipboard = vi.fn();
+    const copyTextToClipboard = vi.fn<(text: string) => Promise<boolean>>().mockResolvedValue(input.canCopy ?? true);
 
     const ImportSdlDialog: typeof DEPENDENCIES.ImportSdlDialog = ({ onImport: onDialogImport }) => (
       <button type="button" onClick={() => onDialogImport(IMPORTED_STATE, { method: "file" })}>

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/SdlImportExport/SdlImportExport.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/SdlImportExport/SdlImportExport.spec.tsx
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { AnalyticsService } from "@src/services/analytics/analytics.service";
+import type { SdlBuilderFormValuesType } from "@src/types";
+import type { ImportedDeploymentState } from "../importDeploymentState/importDeploymentState";
+import type { DEPENDENCIES } from "./SdlImportExport";
+import { SdlImportExport } from "./SdlImportExport";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const IMPORTED_STATE: ImportedDeploymentState = { values: mock<SdlBuilderFormValuesType>(), sdl: "imported-sdl", selectedServiceId: "svc-1" };
+
+describe(SdlImportExport.name, () => {
+  it("opens the import dialog when Import is clicked", async () => {
+    setup({});
+
+    await userEvent.click(screen.getByRole("button", { name: "Import" }));
+
+    expect(screen.getByRole("button", { name: "trigger import" })).toBeInTheDocument();
+  });
+
+  it("disables Import while the flow is locked", () => {
+    setup({ canImport: false });
+
+    expect(screen.getByRole("button", { name: "Import" })).toBeDisabled();
+  });
+
+  it("applies the import, shows a snackbar, tracks the method, and closes the dialog", async () => {
+    const { onImport, analyticsService, enqueueSnackbar } = setup({});
+
+    await userEvent.click(screen.getByRole("button", { name: "Import" }));
+    await userEvent.click(screen.getByRole("button", { name: "trigger import" }));
+
+    expect(onImport).toHaveBeenCalledWith(IMPORTED_STATE);
+    expect(analyticsService.track).toHaveBeenCalledWith("configure_sdl_imported", { category: "deployments", method: "file" });
+    expect(enqueueSnackbar).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ variant: "success" }));
+    expect(screen.queryByRole("button", { name: "trigger import" })).not.toBeInTheDocument();
+  });
+
+  it("downloads the sdl as a yaml file named after the deployment", async () => {
+    const { saveAs } = setup({ sdl: "some: sdl", deploymentName: "My App 2!" });
+
+    await userEvent.click(screen.getByRole("button", { name: "Export" }));
+    await userEvent.click(screen.getByRole("menuitem", { name: "Download .yaml" }));
+
+    const [blob, filename] = saveAs.mock.calls[0];
+    expect(filename).toBe("my-app-2.yaml");
+    expect(blob.type).toBe("text/yaml;charset=utf-8");
+    expect(await blob.text()).toBe("some: sdl");
+  });
+
+  it("falls back to a generic filename when the deployment name has no usable characters", async () => {
+    const { saveAs } = setup({ sdl: "some: sdl", deploymentName: "!!!" });
+
+    await userEvent.click(screen.getByRole("button", { name: "Export" }));
+    await userEvent.click(screen.getByRole("menuitem", { name: "Download .yaml" }));
+
+    expect(saveAs.mock.calls[0][1]).toBe("deployment.yaml");
+  });
+
+  it("tracks the download", async () => {
+    const { analyticsService } = setup({ sdl: "some: sdl" });
+
+    await userEvent.click(screen.getByRole("button", { name: "Export" }));
+    await userEvent.click(screen.getByRole("menuitem", { name: "Download .yaml" }));
+
+    expect(analyticsService.track).toHaveBeenCalledWith("configure_sdl_downloaded", { category: "deployments" });
+  });
+
+  it("copies the sdl to the clipboard, shows a snackbar, and tracks the copy", async () => {
+    const { copyTextToClipboard, enqueueSnackbar, analyticsService } = setup({ sdl: "some: sdl" });
+
+    await userEvent.click(screen.getByRole("button", { name: "Export" }));
+    await userEvent.click(screen.getByRole("menuitem", { name: "Copy to clipboard" }));
+
+    expect(copyTextToClipboard).toHaveBeenCalledWith("some: sdl");
+    expect(enqueueSnackbar).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ variant: "success" }));
+    expect(analyticsService.track).toHaveBeenCalledWith("configure_sdl_copied", { category: "deployments" });
+  });
+
+  it("disables the export actions when there is no sdl to export", async () => {
+    setup({ sdl: "" });
+
+    await userEvent.click(screen.getByRole("button", { name: "Export" }));
+
+    expect(screen.getByRole("menuitem", { name: "Download .yaml" })).toHaveAttribute("aria-disabled", "true");
+    expect(screen.getByRole("menuitem", { name: "Copy to clipboard" })).toHaveAttribute("aria-disabled", "true");
+  });
+
+  function setup(input: { sdl?: string; deploymentName?: string; canImport?: boolean }) {
+    const onImport = vi.fn();
+    const analyticsService = mock<AnalyticsService>();
+    const enqueueSnackbar = vi.fn();
+    const saveAs = vi.fn<(data: Blob, filename: string) => void>();
+    const copyTextToClipboard = vi.fn();
+
+    const ImportSdlDialog: typeof DEPENDENCIES.ImportSdlDialog = ({ onImport: onDialogImport }) => (
+      <button type="button" onClick={() => onDialogImport(IMPORTED_STATE, { method: "file" })}>
+        trigger import
+      </button>
+    );
+
+    render(
+      <SdlImportExport
+        sdl={input.sdl ?? "default-sdl"}
+        deploymentName={input.deploymentName ?? "my-app"}
+        canImport={input.canImport ?? true}
+        onImport={onImport}
+        dependencies={{
+          ImportSdlDialog,
+          useServices: () => mock<ReturnType<typeof DEPENDENCIES.useServices>>({ analyticsService }),
+          useSnackbar: () => mock<ReturnType<typeof DEPENDENCIES.useSnackbar>>({ enqueueSnackbar }),
+          Snackbar: () => null,
+          saveAs,
+          copyTextToClipboard
+        }}
+      />
+    );
+
+    return { onImport, analyticsService, enqueueSnackbar, saveAs, copyTextToClipboard };
+  }
+});

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/SdlImportExport/SdlImportExport.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/SdlImportExport/SdlImportExport.tsx
@@ -1,10 +1,10 @@
 "use client";
 import type { FC } from "react";
 import { useState } from "react";
-import { Button, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger, Snackbar } from "@akashnetwork/ui/components";
+import { Button, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger, Snackbar } from "@akashnetwork/ui/components";
 import { copyTextToClipboard } from "@akashnetwork/ui/utils";
 import { saveAs } from "file-saver";
-import { Download, Import, NavArrowDown } from "iconoir-react";
+import { MoreHoriz } from "iconoir-react";
 import { useSnackbar } from "notistack";
 
 import { useServices } from "@src/context/ServicesProvider";
@@ -27,7 +27,7 @@ type Props = {
   dependencies?: typeof DEPENDENCIES;
 };
 
-/** Import/export controls for the configure toolbar: an Import button and an Export dropdown. */
+/** SDL import/export actions for the configure toolbar, collapsed into a single overflow menu. */
 export const SdlImportExport: FC<Props> = ({ sdl, deploymentName, canImport, onImport, dependencies: d = DEPENDENCIES }) => {
   const { analyticsService } = d.useServices();
   const { enqueueSnackbar } = d.useSnackbar();
@@ -56,21 +56,18 @@ export const SdlImportExport: FC<Props> = ({ sdl, deploymentName, canImport, onI
   }
 
   return (
-    <div className="flex items-center gap-2">
-      <Button variant="outline" size="sm" disabled={!canImport} onClick={() => setImportOpen(true)} className="gap-2">
-        <Import className="h-4 w-4" />
-        Import
-      </Button>
-
-      <DropdownMenu>
+    <>
+      <DropdownMenu modal={false}>
         <DropdownMenuTrigger asChild>
-          <Button variant="outline" size="sm" className="gap-2">
-            <Download className="h-4 w-4" />
-            Export
-            <NavArrowDown className="h-4 w-4" />
+          <Button variant="ghost" size="icon" className="rounded-full" aria-label="SDL import and export">
+            <MoreHoriz />
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
+          <DropdownMenuItem disabled={!canImport} onClick={() => setImportOpen(true)}>
+            Import Config
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
           <DropdownMenuItem disabled={!sdl} onClick={handleDownload}>
             Download .yaml
           </DropdownMenuItem>
@@ -81,7 +78,7 @@ export const SdlImportExport: FC<Props> = ({ sdl, deploymentName, canImport, onI
       </DropdownMenu>
 
       {isImportOpen && <d.ImportSdlDialog onClose={() => setImportOpen(false)} onImport={handleImported} />}
-    </div>
+    </>
   );
 };
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/SdlImportExport/SdlImportExport.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/SdlImportExport/SdlImportExport.tsx
@@ -45,8 +45,12 @@ export const SdlImportExport: FC<Props> = ({ sdl, deploymentName, canImport, onI
     analyticsService.track("configure_sdl_downloaded", { category: "deployments" });
   }
 
-  function handleCopy() {
-    d.copyTextToClipboard(sdl);
+  async function handleCopy() {
+    const copied = await d.copyTextToClipboard(sdl);
+    if (!copied) {
+      enqueueSnackbar(<d.Snackbar title="Couldn't copy the SDL to your clipboard" iconVariant="error" />, { variant: "error" });
+      return;
+    }
     enqueueSnackbar(<d.Snackbar title="SDL copied to clipboard!" iconVariant="success" />, { variant: "success" });
     analyticsService.track("configure_sdl_copied", { category: "deployments" });
   }

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/SdlImportExport/SdlImportExport.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/SdlImportExport/SdlImportExport.tsx
@@ -1,0 +1,96 @@
+"use client";
+import type { FC } from "react";
+import { useState } from "react";
+import { Button, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger, Snackbar } from "@akashnetwork/ui/components";
+import { copyTextToClipboard } from "@akashnetwork/ui/utils";
+import { saveAs } from "file-saver";
+import { Download, Import, NavArrowDown } from "iconoir-react";
+import { useSnackbar } from "notistack";
+
+import { useServices } from "@src/context/ServicesProvider";
+import type { ImportedDeploymentState } from "../importDeploymentState/importDeploymentState";
+import { ImportSdlDialog } from "./ImportSdlDialog";
+
+/** Narrowed to the single call signature used here so tests can supply a plain stub. */
+const saveBlobAs: (data: Blob, filename: string) => void = saveAs;
+
+export const DEPENDENCIES = { ImportSdlDialog, useServices, useSnackbar, Snackbar, saveAs: saveBlobAs, copyTextToClipboard };
+
+type Props = {
+  /** The live SDL — exactly what Deploy would submit — used as the export source. */
+  sdl: string;
+  /** Names the exported file. */
+  deploymentName: string;
+  /** False while the flow is locked (quoting/deploying); disables Import only, Export stays available. */
+  canImport: boolean;
+  onImport: (state: ImportedDeploymentState) => void;
+  dependencies?: typeof DEPENDENCIES;
+};
+
+/** Import/export controls for the configure toolbar: an Import button and an Export dropdown. */
+export const SdlImportExport: FC<Props> = ({ sdl, deploymentName, canImport, onImport, dependencies: d = DEPENDENCIES }) => {
+  const { analyticsService } = d.useServices();
+  const { enqueueSnackbar } = d.useSnackbar();
+  const [isImportOpen, setImportOpen] = useState(false);
+
+  function handleImported(state: ImportedDeploymentState, meta: { method: "paste" | "file" }) {
+    onImport(state);
+    analyticsService.track("configure_sdl_imported", { category: "deployments", method: meta.method });
+    enqueueSnackbar(<d.Snackbar title="SDL imported" iconVariant="success" />, { variant: "success" });
+    setImportOpen(false);
+  }
+
+  function handleDownload() {
+    d.saveAs(new Blob([sdl], { type: "text/yaml;charset=utf-8" }), sdlFileName(deploymentName));
+    analyticsService.track("configure_sdl_downloaded", { category: "deployments" });
+  }
+
+  function handleCopy() {
+    d.copyTextToClipboard(sdl);
+    enqueueSnackbar(<d.Snackbar title="SDL copied to clipboard!" iconVariant="success" />, { variant: "success" });
+    analyticsService.track("configure_sdl_copied", { category: "deployments" });
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <Button variant="outline" size="sm" disabled={!canImport} onClick={() => setImportOpen(true)} className="gap-2">
+        <Import className="h-4 w-4" />
+        Import
+      </Button>
+
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline" size="sm" className="gap-2">
+            <Download className="h-4 w-4" />
+            Export
+            <NavArrowDown className="h-4 w-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem disabled={!sdl} onClick={handleDownload}>
+            Download .yaml
+          </DropdownMenuItem>
+          <DropdownMenuItem disabled={!sdl} onClick={handleCopy}>
+            Copy to clipboard
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      {isImportOpen && <d.ImportSdlDialog onClose={() => setImportOpen(false)} onImport={handleImported} />}
+    </div>
+  );
+};
+
+/**
+ * Turns a deployment name into a safe `.yaml` filename: lowercased, non-alphanumeric runs collapsed to single
+ * hyphens, edge hyphens trimmed, capped at 64 chars. An empty or symbol-only name falls back to `deployment`.
+ */
+function sdlFileName(deploymentName: string): string {
+  const slug = deploymentName
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64)
+    .replace(/-+$/g, "");
+  return `${slug || "deployment"}.yaml`;
+}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/importDeploymentState/importDeploymentState.spec.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/importDeploymentState/importDeploymentState.spec.ts
@@ -1,0 +1,252 @@
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import { LOG_COLLECTOR_IMAGE } from "@src/config/log-collector.config";
+import type { SdlBuilderFormValuesType, ServiceType } from "@src/types";
+import { importDeploymentState, NoVisibleServiceError, seedSelectedServiceId } from "./importDeploymentState";
+
+const VALID_SDL = [
+  "version: '2.0'",
+  "services:",
+  "  web:",
+  "    image: nginx:1.0",
+  "    expose:",
+  "      - port: 80",
+  "        as: 80",
+  "        to:",
+  "          - global: true",
+  "profiles:",
+  "  compute:",
+  "    web:",
+  "      resources:",
+  "        cpu:",
+  "          units: 0.5",
+  "        memory:",
+  "          size: 512Mi",
+  "        storage:",
+  "          - size: 512Mi",
+  "  placement:",
+  "    dcloud:",
+  "      pricing:",
+  "        web:",
+  "          denom: uact",
+  "          amount: 1000",
+  "deployment:",
+  "  web:",
+  "    dcloud:",
+  "      profile: web",
+  "      count: 1"
+].join("\n");
+
+/** Two services sharing the `dcloud` placement name — the default (non-legacy) import dedupes them to one placement record. */
+const TWO_SERVICE_SHARED_PLACEMENT_SDL = [
+  "version: '2.0'",
+  "services:",
+  "  web:",
+  "    image: nginx:1.0",
+  "  api:",
+  "    image: node:18",
+  "profiles:",
+  "  compute:",
+  "    web:",
+  "      resources:",
+  "        cpu:",
+  "          units: 0.5",
+  "        memory:",
+  "          size: 512Mi",
+  "        storage:",
+  "          - size: 512Mi",
+  "    api:",
+  "      resources:",
+  "        cpu:",
+  "          units: 0.5",
+  "        memory:",
+  "          size: 512Mi",
+  "        storage:",
+  "          - size: 512Mi",
+  "  placement:",
+  "    dcloud:",
+  "      pricing:",
+  "        web:",
+  "          denom: uact",
+  "          amount: 1000",
+  "        api:",
+  "          denom: uact",
+  "          amount: 1000",
+  "deployment:",
+  "  web:",
+  "    dcloud:",
+  "      profile: web",
+  "      count: 1",
+  "  api:",
+  "    dcloud:",
+  "      profile: api",
+  "      count: 1"
+].join("\n");
+
+/** A deployment carrying an SSH public key in the managed `SSH_PUBKEY` env var. */
+const SSH_SDL = [
+  "version: '2.0'",
+  "services:",
+  "  web:",
+  "    image: nginx:1.0",
+  "    env:",
+  "      - SSH_PUBKEY=ssh-rsa AAAAKEY",
+  "profiles:",
+  "  compute:",
+  "    web:",
+  "      resources:",
+  "        cpu:",
+  "          units: 0.5",
+  "        memory:",
+  "          size: 512Mi",
+  "        storage:",
+  "          - size: 512Mi",
+  "  placement:",
+  "    dcloud:",
+  "      pricing:",
+  "        web:",
+  "          denom: uact",
+  "          amount: 1000",
+  "deployment:",
+  "  web:",
+  "    dcloud:",
+  "      profile: web",
+  "      count: 1"
+].join("\n");
+
+/** A VM image with no SSH key entered yet — the expose-ssh flag must still be backfilled on. */
+const VM_SDL_WITHOUT_KEY = [
+  "version: '2.0'",
+  "services:",
+  "  vm:",
+  "    image: ghcr.io/akash-network/ubuntu-2404-ssh:2",
+  "profiles:",
+  "  compute:",
+  "    vm:",
+  "      resources:",
+  "        cpu:",
+  "          units: 0.5",
+  "        memory:",
+  "          size: 512Mi",
+  "        storage:",
+  "          - size: 512Mi",
+  "  placement:",
+  "    dcloud:",
+  "      pricing:",
+  "        vm:",
+  "          denom: uact",
+  "          amount: 1000",
+  "deployment:",
+  "  vm:",
+  "    dcloud:",
+  "      profile: vm",
+  "      count: 1"
+].join("\n");
+
+/** A deployment whose only service is a log collector — the configure screen has nothing to focus. */
+const LOG_COLLECTOR_ONLY_SDL = [
+  "version: '2.0'",
+  "services:",
+  "  web-log-collector:",
+  `    image: ${LOG_COLLECTOR_IMAGE}`,
+  "profiles:",
+  "  compute:",
+  "    web-log-collector:",
+  "      resources:",
+  "        cpu:",
+  "          units: 0.5",
+  "        memory:",
+  "          size: 512Mi",
+  "        storage:",
+  "          - size: 512Mi",
+  "  placement:",
+  "    dcloud:",
+  "      pricing:",
+  "        web-log-collector:",
+  "          denom: uact",
+  "          amount: 1000",
+  "deployment:",
+  "  web-log-collector:",
+  "    dcloud:",
+  "      profile: web-log-collector",
+  "      count: 1"
+].join("\n");
+
+describe(importDeploymentState.name, () => {
+  it("imports a valid SDL into form values, keeps the SDL verbatim, and selects the first service", () => {
+    const state = importDeploymentState(VALID_SDL);
+
+    expect(state.sdl).toBe(VALID_SDL);
+    expect(state.values.services.map(service => service.title)).toEqual(["web"]);
+    expect(state.selectedServiceId).toBe(state.values.services[0].id);
+  });
+
+  it("dedupes placements that share a name into a single record", () => {
+    const state = importDeploymentState(TWO_SERVICE_SHARED_PLACEMENT_SDL);
+
+    expect(state.values.placements).toHaveLength(1);
+    expect(state.values.services.map(service => service.title)).toEqual(["web", "api"]);
+  });
+
+  it("restores an imported SSH key into the service and turns on the expose-ssh flag", () => {
+    const state = importDeploymentState(SSH_SDL);
+
+    expect(state.values.hasSSHKey).toBe(true);
+    expect(state.values.services[0].sshPubKey).toBe("ssh-rsa AAAAKEY");
+  });
+
+  it("backfills the expose-ssh flag for a VM service saved without a key", () => {
+    const state = importDeploymentState(VM_SDL_WITHOUT_KEY);
+
+    expect(state.values.hasSSHKey).toBe(true);
+  });
+
+  it("leaves the expose-ssh flag off for a non-VM deployment without a key", () => {
+    const state = importDeploymentState(VALID_SDL);
+
+    expect(state.values.hasSSHKey).toBeFalsy();
+  });
+
+  it("throws NoVisibleServiceError for a service-less SDL", () => {
+    expect(() => importDeploymentState('version: "2.0"')).toThrow(NoVisibleServiceError);
+  });
+
+  it("throws NoVisibleServiceError when the only service is a log collector", () => {
+    expect(() => importDeploymentState(LOG_COLLECTOR_ONLY_SDL)).toThrow(NoVisibleServiceError);
+  });
+
+  it("propagates a YAML parse failure as a YAMLException", () => {
+    expect(() => importDeploymentState("services: [unclosed")).toThrow(expect.objectContaining({ name: "YAMLException" }));
+  });
+
+  it("propagates a structural validation failure as a CustomValidationError", () => {
+    expect(() => importDeploymentState("- not\n- an\n- object")).toThrow(expect.objectContaining({ name: "CustomValidationError" }));
+  });
+});
+
+describe(seedSelectedServiceId.name, () => {
+  it("returns the first non-log-collector service id", () => {
+    const values = valuesWithServices([logCollectorService("collector"), visibleService("web"), visibleService("api")]);
+
+    expect(seedSelectedServiceId(values)).toBe("web");
+  });
+
+  it("falls back to the first service when every service is a log collector", () => {
+    const values = valuesWithServices([logCollectorService("only-collector")]);
+
+    expect(seedSelectedServiceId(values)).toBe("only-collector");
+  });
+
+  function valuesWithServices(services: ServiceType[]): SdlBuilderFormValuesType {
+    return mock<SdlBuilderFormValuesType>({ services });
+  }
+
+  function visibleService(id: string): ServiceType {
+    return mock<ServiceType>({ id, title: id, image: "nginx:1.0" });
+  }
+
+  function logCollectorService(id: string): ServiceType {
+    return mock<ServiceType>({ id, title: `${id}-log-collector`, image: LOG_COLLECTOR_IMAGE });
+  }
+});

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/importDeploymentState/importDeploymentState.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/importDeploymentState/importDeploymentState.ts
@@ -1,0 +1,57 @@
+import { isLogCollectorService } from "@src/components/sdl/LogCollectorControl/LogCollectorControl";
+import type { SdlBuilderFormValuesType } from "@src/types";
+import { importSimpleSdl } from "@src/utils/sdl/sdlImport";
+import { applyImportedSshState } from "@src/utils/sdl/sshKey";
+import { isVmImage } from "@src/utils/sdl/vmImages";
+
+export interface ImportedDeploymentState {
+  values: SdlBuilderFormValuesType;
+  /** The imported SDL verbatim, mirroring how a carried-in SDL is used at mount. */
+  sdl: string;
+  selectedServiceId: string;
+}
+
+/**
+ * Thrown when an SDL parses but defines no service the configure screen can work with (empty or
+ * log-collector-only). Its own name lets the mount path fall back silently while the import dialog
+ * shows a message.
+ */
+export class NoVisibleServiceError extends Error {
+  override name = "NoVisibleServiceError";
+}
+
+/**
+ * The single import pipeline for the configure screen: parses an SDL, lifts its SSH state into the
+ * form model, backfills the VM expose-ssh flag, and seeds the selection. Throws `NoVisibleServiceError`
+ * for a service-less SDL and rethrows parser errors (`YAMLException`, `CustomValidationError`, …) verbatim.
+ */
+export function importDeploymentState(sdl: string): ImportedDeploymentState {
+  const values = withVmSshBackfill(applyImportedSshState(importSimpleSdl(sdl)));
+  if (!hasVisibleService(values)) {
+    throw new NoVisibleServiceError("This SDL doesn't define any services to configure.");
+  }
+  return { values, sdl, selectedServiceId: seedSelectedServiceId(values) };
+}
+
+/** Picks the first user-visible service to focus. Callers guarantee at least one service exists. */
+export function seedSelectedServiceId(values: SdlBuilderFormValuesType): string {
+  const visible = values.services.find(candidate => !isLogCollectorService(candidate)) ?? values.services[0];
+  return visible.id;
+}
+
+/**
+ * Restores the deployment-wide "Expose SSH" flag for a carried-in deployment holding a VM service, covering
+ * a VM draft saved before a key was entered (`applyImportedSshState` only flips it once a key exists). The
+ * SDL itself is taken literally: no expose or key is backfilled.
+ */
+function withVmSshBackfill(values: SdlBuilderFormValuesType): SdlBuilderFormValuesType {
+  if (values.hasSSHKey || !values.services.some(service => isVmImage(service.image))) {
+    return values;
+  }
+  return { ...values, hasSSHKey: true };
+}
+
+/** A usable deployment has at least one service the user can configure (log collectors don't count). */
+function hasVisibleService(values: SdlBuilderFormValuesType): boolean {
+  return values.services.some(service => !isLogCollectorService(service));
+}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/importDeploymentState/importDeploymentState.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/importDeploymentState/importDeploymentState.ts
@@ -20,6 +20,14 @@ export class NoVisibleServiceError extends Error {
   override name = "NoVisibleServiceError";
 }
 
+/** Error names `importSimpleSdl` throws that carry a meaningful, user-safe message (line/col, validation detail). */
+const KNOWN_SDL_PARSER_ERROR_NAMES = ["YAMLException", "CustomValidationError", "TemplateValidation"];
+
+/** True for a recognized parser/validation failure from the import pipeline, as opposed to unexpected internal noise. */
+export function isKnownSdlParserError(err: unknown): err is Error {
+  return err instanceof Error && KNOWN_SDL_PARSER_ERROR_NAMES.includes(err.name);
+}
+
 /**
  * The single import pipeline for the configure screen: parses an SDL, lifts its SSH state into the
  * form model, backfills the VM expose-ssh flag, and seeds the selection. Throws `NoVisibleServiceError`

--- a/apps/deploy-web/src/services/analytics/analytics.service.ts
+++ b/apps/deploy-web/src/services/analytics/analytics.service.ts
@@ -121,7 +121,10 @@ export type AnalyticsEvent =
   | "configure_preset_selected"
   | "configure_gpu_type_selected"
   | "configure_gpu_count_changed"
-  | "configure_cpu_count_changed";
+  | "configure_cpu_count_changed"
+  | "configure_sdl_imported"
+  | "configure_sdl_downloaded"
+  | "configure_sdl_copied";
 
 export type AnalyticsCategory = "user" | "billing" | "deployments" | "wallet" | "sdl_builder" | "transactions" | "profile" | "settings" | "onboarding";
 

--- a/packages/ui/utils/copyClipboard.ts
+++ b/packages/ui/utils/copyClipboard.ts
@@ -1,4 +1,4 @@
-function fallbackCopyTextToClipboard(text: string) {
+function fallbackCopyTextToClipboard(text: string): boolean {
   const textArea = document.createElement("textarea");
   textArea.value = text;
 
@@ -12,26 +12,24 @@ function fallbackCopyTextToClipboard(text: string) {
   textArea.select();
 
   try {
-    const successful = document.execCommand("copy");
-    const msg = successful ? "successful" : "unsuccessful";
-    console.log("Fallback: Copying text command was " + msg);
-  } catch (err) {
-    console.error("Fallback: Oops, unable to copy", err);
+    return document.execCommand("copy");
+  } catch {
+    return false;
+  } finally {
+    document.body.removeChild(textArea);
+  }
+}
+
+/** Copies text to the clipboard, resolving to whether the write actually succeeded (including the legacy fallback path). */
+export const copyTextToClipboard = async (text: string): Promise<boolean> => {
+  if (!navigator.clipboard) {
+    return fallbackCopyTextToClipboard(text);
   }
 
-  document.body.removeChild(textArea);
-}
-export const copyTextToClipboard = (text: string) => {
-  if (!navigator.clipboard) {
-    fallbackCopyTextToClipboard(text);
-    return;
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    return false;
   }
-  navigator.clipboard.writeText(text).then(
-    () => {
-      console.log("Async: Copying to clipboard was successful!");
-    },
-    err => {
-      console.error("Async: Could not copy text: ", err);
-    }
-  );
 };


### PR DESCRIPTION
## Why

Closes CON-701.

The redesigned deployment configure page (`/new-deployment/configure`, gated by `onboarding_redesign_v1`) generates SDL from form state, so an SDL could only enter the page at mount (template upload, drafts, redeploy) and could never leave it. Users need to move SDLs in and out of the flow to version-control, share, or reuse them (e.g. via the CLI). This adds in-page import (paste + file upload) and export (download `.yaml` + copy to clipboard).

## What

Toolbar controls (top-right, opposite the Back button): an **Import** button and an **Export** dropdown (**Download .yaml** / **Copy to clipboard**). Import opens a `DialogV2` with a Monaco editor to paste into plus an **Upload file** button that populates the same editor; a single **Import** action validates and applies. Import is gated on the editable phases; Export stays available in every phase.

- **`importDeploymentState/`** — the single import pipeline for the configure screen, extracted from `ConfigureDeploymentForm`'s module-private helpers. `getInitialState` (mount path) now delegates to it. A dedicated `NoVisibleServiceError` lets the mount path keep its **silent** fallback for a valid-but-serviceless SDL, while the import dialog surfaces a message.
- **`SdlImportExport/`** — the control cluster and its `ImportSdlDialog`. `saveAs` (file-saver) and `copyTextToClipboard` are injected via `DEPENDENCIES` (RuntimeCard precedent). Export source is `liveSdl` — exactly what Deploy submits — so export mirrors deploy semantics.
- **Analytics** — three new events (`configure_sdl_imported` / `_downloaded` / `_copied`) under `category: "deployments"`, matching the redesigned page's `configure_*` funnel (the legacy `import_sdl` under `sdl_builder` is left untouched).

**One flagged policy call for reviewers:** the import dialog shows the parser's `err.message` for known error names (YAML line/col, validation, no-service), whereas the mount path (`getImportErrorMessage`) keeps fixed messages. Surfacing the parser message gives the "clear validation error" the AC asks for; React escapes text nodes so it is not an injection vector. `describeImportError` in `ImportSdlDialog.tsx` is the single swap point if you'd rather keep fixed messages here too.

### Testing
- New specs: `importDeploymentState.spec.ts` (11), `ImportSdlDialog.spec.tsx` (11), `SdlImportExport.spec.tsx` (8); `ConfigureDeploymentForm.spec.tsx` extended (+4, existing mount-path tests are the regression net for the `getInitialState` refactor).
- Full deploy-web suite: 2812 passed / 5 skipped. `tsc --noEmit`: 0 new errors vs. baseline. Lint clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SDL import to the configure form via paste or file upload, updating services, selected service, generated SDL, and draft persistence.
  * Added SDL export actions: “Download .yaml” (sanitized filename with safe fallback) and “Copy to clipboard”.
  * Import is now enabled only in editable phases, and disabled for empty/invalid SDL; uploads are rejected above 512 KB with inline errors.
* **Analytics**
  * Track SDL imported, downloaded, and copied.
* **Tests**
  * Expanded coverage for import/export flows, parser/error handling, filename generation, and clipboard success/failure (including async upload race conditions).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->