### PR TITLE
feat(dx): support multiple domain event handlers via pg-boss pub/sub

### DIFF
--- a/apps/api/src/app/providers/jobs.provider.ts
+++ b/apps/api/src/app/providers/jobs.provider.ts
@@ -17,12 +17,14 @@ container.register(APP_INITIALIZER, {
       const jobQueueManager = container.resolve(JobQueueService);
       await jobQueueManager.setup();
       await jobQueueManager.registerHandlers([
-        container.resolve(TrialStartedHandler),
         container.resolve(NotificationHandler),
         container.resolve(CloseTrialDeploymentHandler),
+        container.resolve(WalletBalanceReloadCheckHandler)
+      ]);
+      await jobQueueManager.registerEventHandlers([
+        container.resolve(TrialStartedHandler),
         container.resolve(TrialDeploymentLeaseCreatedHandler),
         container.resolve(EnableDeploymentAlertHandler),
-        container.resolve(WalletBalanceReloadCheckHandler),
         container.resolve(FirstPurchaseBonusGrantedHandler)
       ]);
     }

--- a/apps/api/src/app/services/enable-deployment-alert/enable-deployment-alert.handler.ts
+++ b/apps/api/src/app/services/enable-deployment-alert/enable-deployment-alert.handler.ts
@@ -1,12 +1,12 @@
 import { singleton } from "tsyringe";
 
 import { EnableDeploymentAlertCommand } from "@src/billing/commands/enable-deployment-alert.command";
-import type { JobHandler, JobPayload } from "@src/core";
+import type { EventHandler, JobPayload } from "@src/core";
 import { LoggerService } from "@src/core/providers/logging.provider";
 import { NotificationService } from "@src/notifications/services/notification/notification.service";
 
 @singleton()
-export class EnableDeploymentAlertHandler implements JobHandler<EnableDeploymentAlertCommand> {
+export class EnableDeploymentAlertHandler implements EventHandler<EnableDeploymentAlertCommand> {
   public readonly accepts = EnableDeploymentAlertCommand;
 
   public readonly concurrency = 2;

--- a/apps/api/src/app/services/first-purchase-bonus-granted/first-purchase-bonus-granted.handler.ts
+++ b/apps/api/src/app/services/first-purchase-bonus-granted/first-purchase-bonus-granted.handler.ts
@@ -1,13 +1,13 @@
 import { singleton } from "tsyringe";
 
 import { FirstPurchaseBonusGranted } from "@src/billing/events/first-purchase-bonus-granted";
-import { EventPayload, JobHandler, LoggerService } from "@src/core";
+import { EventHandler, EventPayload, LoggerService } from "@src/core";
 import { NotificationService } from "@src/notifications/services/notification/notification.service";
 import { firstPurchaseBonusGrantedNotification } from "@src/notifications/services/notification-templates/first-purchase-bonus-granted-notification";
 import { UserRepository } from "@src/user/repositories";
 
 @singleton()
-export class FirstPurchaseBonusGrantedHandler implements JobHandler<FirstPurchaseBonusGranted> {
+export class FirstPurchaseBonusGrantedHandler implements EventHandler<FirstPurchaseBonusGranted> {
   public readonly accepts = FirstPurchaseBonusGranted;
 
   public readonly concurrency = 2;

--- a/apps/api/src/app/services/trial-deployment-lease-created/trial-deployment-lease-created.handler.ts
+++ b/apps/api/src/app/services/trial-deployment-lease-created/trial-deployment-lease-created.handler.ts
@@ -4,13 +4,13 @@ import { singleton } from "tsyringe";
 import { TrialDeploymentLeaseCreated } from "@src/billing/events/trial-deployment-lease-created";
 import { UserWalletRepository } from "@src/billing/repositories";
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
-import { DOMAIN_EVENT_NAME, EventPayload, JobHandler, JobQueueService, LoggerService } from "@src/core";
+import { DOMAIN_EVENT_NAME, EventHandler, EventPayload, JobQueueService, LoggerService } from "@src/core";
 import { RESOLVED_MARKER } from "@src/notifications/services/notification-data-resolver/notification-data-resolver.service";
 import { NotificationJob } from "@src/notifications/services/notification-handler/notification.handler";
 import { CloseTrialDeployment } from "../close-trial-deployment/close-trial-deployment.handler";
 
 @singleton()
-export class TrialDeploymentLeaseCreatedHandler implements JobHandler<TrialDeploymentLeaseCreated> {
+export class TrialDeploymentLeaseCreatedHandler implements EventHandler<TrialDeploymentLeaseCreated> {
   public readonly accepts = TrialDeploymentLeaseCreated;
 
   public readonly concurrency = 2;

--- a/apps/api/src/app/services/trial-started/trial-started.handler.ts
+++ b/apps/api/src/app/services/trial-started/trial-started.handler.ts
@@ -3,7 +3,7 @@ import { singleton } from "tsyringe";
 
 import { TrialStarted } from "@src/billing/events/trial-started";
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
-import { EventPayload, JobHandler, JobQueueService, LoggerService } from "@src/core";
+import { EventHandler, EventPayload, JobQueueService, LoggerService } from "@src/core";
 import { NotificationService } from "@src/notifications/services/notification/notification.service";
 import { RESOLVED_MARKER } from "@src/notifications/services/notification-data-resolver/notification-data-resolver.service";
 import { NotificationJob } from "@src/notifications/services/notification-handler/notification.handler";
@@ -11,7 +11,7 @@ import { startTrialNotification } from "@src/notifications/services/notification
 import { UserRepository } from "@src/user/repositories";
 
 @singleton()
-export class TrialStartedHandler implements JobHandler<TrialStarted> {
+export class TrialStartedHandler implements EventHandler<TrialStarted> {
   public readonly accepts = TrialStarted;
 
   public readonly concurrency = 2;

--- a/apps/api/src/core/services/domain-events/domain-events.service.spec.ts
+++ b/apps/api/src/core/services/domain-events/domain-events.service.spec.ts
@@ -8,7 +8,7 @@ import { DomainEventsService } from "./domain-events.service";
 
 describe(DomainEventsService.name, () => {
   describe("publish()", () => {
-    it("enqueues the event successfully", async () => {
+    it("publishes the event to the job queue", async () => {
       class TestEvent implements DomainEvent {
         version = 1;
         name = "testEvent";
@@ -17,13 +17,32 @@ describe(DomainEventsService.name, () => {
 
       const { service, jobQueueManager } = setup();
       const event = new TestEvent();
-      const jobId = "12345";
-      jobQueueManager.enqueue.mockResolvedValue(jobId);
+      const options = { singletonKey: "key" };
 
-      const result = await service.publish(event);
+      await service.publish(event, options);
 
-      expect(result).toBe(jobId);
-      expect(jobQueueManager.enqueue).toHaveBeenCalledWith(event, undefined);
+      expect(jobQueueManager.publish).toHaveBeenCalledWith(event, options);
+    });
+
+    it("logs and swallows errors when publishing fails", async () => {
+      class TestEvent implements DomainEvent {
+        version = 1;
+        name = "testEvent";
+        data = { key: "value" };
+      }
+
+      const { service, jobQueueManager, logger } = setup();
+      const event = new TestEvent();
+      const error = new Error("boom");
+      jobQueueManager.publish.mockRejectedValue(error);
+
+      await expect(service.publish(event)).resolves.toBeUndefined();
+
+      expect(logger.error).toHaveBeenCalledWith({
+        event: "DOMAIN_EVENT_PUBLISH_FAILED",
+        domainEvent: event,
+        error
+      });
     });
   });
 

--- a/apps/api/src/core/services/domain-events/domain-events.service.ts
+++ b/apps/api/src/core/services/domain-events/domain-events.service.ts
@@ -15,17 +15,15 @@ export class DomainEventsService {
     private readonly logger: LoggerService
   ) {}
 
-  async publish(event: DomainEvent, options?: EnqueueOptions): Promise<string | null> {
+  async publish(event: DomainEvent, options?: EnqueueOptions): Promise<void> {
     try {
-      return await this.jobQueueManager.enqueue(event, options);
+      await this.jobQueueManager.publish(event, options);
     } catch (error) {
       this.logger.error({
         event: "DOMAIN_EVENT_PUBLISH_FAILED",
         domainEvent: event,
         error
       });
-
-      return null;
     }
   }
 }

--- a/apps/api/src/core/services/job-queue/job-queue.service.spec.ts
+++ b/apps/api/src/core/services/job-queue/job-queue.service.spec.ts
@@ -6,7 +6,7 @@ import { mock, mockDeep } from "vitest-mock-extended";
 import type { LoggerService } from "@src/core/providers/logging.provider";
 import type { CoreConfigService } from "../core-config/core-config.service";
 import type { ExecutionContextService } from "../execution-context/execution-context.service";
-import { type Job, JOB_NAME, type JobHandler, JobQueueService } from "./job-queue.service";
+import { type EventHandler, type Job, JOB_NAME, type JobHandler, JobQueueService } from "./job-queue.service";
 
 describe(JobQueueService.name, () => {
   describe("registerHandlers", () => {
@@ -71,6 +71,66 @@ describe(JobQueueService.name, () => {
       const { service } = setup();
 
       await expect(service.registerHandlers([handler1, handler2])).rejects.toThrow("JobQueue does not support multiple handlers for the same queue: test");
+    });
+  });
+
+  describe("registerEventHandlers", () => {
+    it("creates a queue named after the event and subscribes it when no queue suffix is given", async () => {
+      const { service, pgBoss } = setup();
+
+      await service.registerEventHandlers([new TestEventHandler()]);
+
+      expect(pgBoss.createQueue).toHaveBeenCalledWith("TestEvent", {
+        retryBackoff: true,
+        retryDelayMax: 5 * 60,
+        retryLimit: 5,
+        policy: undefined
+      });
+      expect(pgBoss.subscribe).toHaveBeenCalledWith("TestEvent", "TestEvent");
+    });
+
+    it("suffixes the queue name and subscribes it to the event when a queue is given", async () => {
+      const { service, pgBoss } = setup();
+
+      await service.registerEventHandlers([new TestEventHandler(vi.fn(), "analytics")]);
+
+      expect(pgBoss.createQueue).toHaveBeenCalledWith("TestEvent.analytics", expect.anything());
+      expect(pgBoss.subscribe).toHaveBeenCalledWith("TestEvent", "TestEvent.analytics");
+    });
+
+    it("subscribes multiple handlers of the same event to their own queues", async () => {
+      const { service, pgBoss } = setup();
+
+      await service.registerEventHandlers([new TestEventHandler(vi.fn(), "one"), new TestEventHandler(vi.fn(), "two")]);
+
+      expect(pgBoss.subscribe).toHaveBeenCalledWith("TestEvent", "TestEvent.one");
+      expect(pgBoss.subscribe).toHaveBeenCalledWith("TestEvent", "TestEvent.two");
+      expect(pgBoss.createQueue).toHaveBeenCalledTimes(2);
+    });
+
+    it("throws when two handlers resolve to the same queue", async () => {
+      const { service } = setup();
+
+      await expect(service.registerEventHandlers([new TestEventHandler(), new TestEventHandler()])).rejects.toThrow(
+        "JobQueue does not support multiple handlers for the same queue: TestEvent"
+      );
+    });
+  });
+
+  describe("publish", () => {
+    it("publishes the event with its version merged into the data", async () => {
+      const { service, pgBoss, logger } = setup();
+      const event = new TestEvent({ userId: "user-1" });
+      const options = { singletonKey: "user-1" };
+
+      await service.publish(event, options);
+
+      expect(pgBoss.publish).toHaveBeenCalledWith("TestEvent", { userId: "user-1", version: 1 }, options);
+      expect(logger.info).toHaveBeenCalledWith({
+        event: "EVENT_PUBLISHED",
+        domainEvent: event,
+        options
+      });
     });
   });
 
@@ -275,6 +335,23 @@ describe(JobQueueService.name, () => {
       expect(handleFn).toHaveBeenCalledWith({ message: "Job 1", userId: "user-1" }, { id: job.id });
     });
 
+    it("runs an event handler on its subscriber queue rather than the event name", async () => {
+      const handleFn = vi.fn().mockResolvedValue(undefined);
+      const { service, pgBoss } = setup();
+      const job = { id: "1", data: { userId: "user-1", version: 1 } };
+
+      vi.spyOn(pgBoss, "work").mockImplementation(async (queueName: string, options: unknown, processFn: WorkHandler<unknown>) => {
+        await processFn([job as PgBossJob<unknown>]);
+        return "work-id";
+      });
+
+      await service.registerEventHandlers([new TestEventHandler(handleFn, "analytics")]);
+      await service.startWorkers({ concurrency: 1 });
+
+      expect(pgBoss.work).toHaveBeenCalledWith("TestEvent.analytics", { batchSize: 1 }, expect.any(Function));
+      expect(handleFn).toHaveBeenCalledWith({ userId: "user-1", version: 1 }, { id: job.id });
+    });
+
     it("uses default options when none provided", async () => {
       const handleFn = vi.fn().mockResolvedValue(undefined);
       const handler = new TestHandler(handleFn);
@@ -361,6 +438,8 @@ describe(JobQueueService.name, () => {
         mockDeep<PgBoss>({
           createQueue: vi.fn().mockResolvedValue(undefined),
           send: vi.fn().mockResolvedValue("job-id"),
+          publish: vi.fn().mockResolvedValue(undefined),
+          subscribe: vi.fn().mockResolvedValue(undefined),
           work: vi.fn().mockResolvedValue(undefined),
           start: vi.fn().mockResolvedValue(undefined),
           stop: vi.fn().mockResolvedValue(undefined),
@@ -400,5 +479,21 @@ describe(JobQueueService.name, () => {
   class TestHandler implements JobHandler<TestJob> {
     readonly accepts = TestJob;
     constructor(public readonly handle: JobHandler<TestJob>["handle"]) {}
+  }
+
+  class TestEvent implements Job {
+    static readonly [JOB_NAME] = "TestEvent";
+    readonly name = TestEvent[JOB_NAME];
+    readonly version = 1;
+
+    constructor(public readonly data: { userId: string }) {}
+  }
+
+  class TestEventHandler implements EventHandler<TestEvent> {
+    readonly accepts = TestEvent;
+    constructor(
+      public readonly handle: EventHandler<TestEvent>["handle"] = vi.fn().mockResolvedValue(undefined),
+      public readonly queue?: string
+    ) {}
   }
 });

--- a/apps/api/src/core/services/job-queue/job-queue.service.ts
+++ b/apps/api/src/core/services/job-queue/job-queue.service.ts
@@ -12,7 +12,7 @@ export const PG_BOSS_TOKEN: InjectionToken<PgBoss> = Symbol("pgBoss");
 @singleton()
 export class JobQueueService implements Disposable {
   private readonly pgBoss: PgBoss;
-  private handlers?: JobHandler<Job>[];
+  private handlers?: RegisteredHandler[];
   private readonly tracer = trace.getTracer("job-queue");
 
   constructor(
@@ -32,23 +32,67 @@ export class JobQueueService implements Disposable {
       });
   }
 
+  /**
+   * Registers command handlers. Each command is delivered to a single queue named after
+   * the command and processed by exactly one handler.
+   */
   async registerHandlers(handlers: JobHandler<Job>[]): Promise<void> {
-    const seenJobs = new Set<string>();
-    const promises = handlers.map(async handler => {
-      const queueName = handler.accepts[JOB_NAME];
-      if (seenJobs.has(queueName)) {
+    await this.#registerQueues(
+      handlers.map(handler => ({
+        queueName: handler.accepts[JOB_NAME],
+        policy: handler.policy,
+        concurrency: handler.concurrency,
+        handle: handler.handle.bind(handler)
+      }))
+    );
+  }
+
+  /**
+   * Registers domain event handlers using pg-boss publish/subscribe. A single event can have
+   * multiple handlers, each owning its own queue so it fails, retries, and restarts in isolation.
+   * The queue defaults to the event name and takes a `<eventName>.<queue>` suffix when a handler
+   * declares its own `queue`, allowing several handlers to subscribe to the same event.
+   */
+  async registerEventHandlers(handlers: EventHandler<Job>[]): Promise<void> {
+    await this.#registerQueues(
+      handlers.map(handler => {
+        const eventName = handler.accepts[JOB_NAME];
+        return {
+          queueName: handler.queue ? `${eventName}.${handler.queue}` : eventName,
+          subscribesTo: eventName,
+          policy: handler.policy,
+          concurrency: handler.concurrency,
+          handle: handler.handle.bind(handler)
+        };
+      })
+    );
+  }
+
+  async #registerQueues(registrations: QueueRegistration[]): Promise<void> {
+    this.handlers ??= [];
+    const seenQueues = new Set(this.handlers.map(handler => handler.queueName));
+
+    const promises = registrations.map(async registration => {
+      const { queueName, subscribesTo, policy, concurrency, handle } = registration;
+      if (seenQueues.has(queueName)) {
         throw new Error(`JobQueue does not support multiple handlers for the same queue: ${queueName}`);
       }
-      seenJobs.add(queueName);
+      seenQueues.add(queueName);
+      this.handlers!.push({ queueName, concurrency, handle });
+
       await this.pgBoss.createQueue(queueName, {
         retryLimit: 5,
         retryBackoff: true,
         retryDelayMax: 5 * 60,
-        policy: handler.policy
+        policy
       });
+
+      if (subscribesTo) {
+        await this.pgBoss.subscribe(subscribesTo, queueName);
+      }
     });
+
     await Promise.all(promises);
-    this.handlers = handlers.slice(0);
   }
 
   /**
@@ -97,6 +141,20 @@ export class JobQueueService implements Disposable {
     });
 
     return jobId;
+  }
+
+  /**
+   * Publishes a domain event to every queue subscribed to it via {@link registerEventHandlers}.
+   * Unlike {@link enqueue}, this fans out to all subscribers and therefore returns no single job id.
+   */
+  async publish(event: Job, options?: EnqueueOptions): Promise<void> {
+    await this.pgBoss.publish(event.name, { ...event.data, version: event.version }, options);
+
+    this.logger.info({
+      event: "EVENT_PUBLISHED",
+      domainEvent: event,
+      options
+    });
   }
 
   async cancel(name: string, id: string): Promise<void> {
@@ -195,7 +253,7 @@ export class JobQueueService implements Disposable {
       batchSize: 1
     };
     const jobs = this.handlers.map(async handler => {
-      const queueName = handler.accepts[JOB_NAME];
+      const queueName = handler.queueName;
       const workersPromises = Array.from({ length: handler.concurrency ?? concurrency ?? 2 }).map(() =>
         this.pgBoss.work<JobPayload<Job>>(queueName, workerOptions, async ([job]) => {
           await this.#executeWithOtelContext(queueName, job.id, async () => {
@@ -325,6 +383,29 @@ export interface JobHandler<T extends Job> {
   policy?: PgBossQueue["policy"];
   handle(payload: JobPayload<T>, job?: JobMeta): Promise<void>;
 }
+
+export interface EventHandler<T extends Job> {
+  accepts: JobType<T>;
+  /**
+   * Distinct subscriber queue suffix. Enables multiple independent handlers for one event.
+   * When omitted the queue is named after the event itself, otherwise it becomes `<eventName>.<queue>`.
+   */
+  queue?: string;
+  concurrency?: ProcessOptions["concurrency"];
+  policy?: PgBossQueue["policy"];
+  handle(payload: JobPayload<T>, job?: JobMeta): Promise<void>;
+}
+
+interface QueueRegistration {
+  queueName: string;
+  /** When set, the queue is subscribed to this event so published events fan out to it. */
+  subscribesTo?: string;
+  policy?: PgBossQueue["policy"];
+  concurrency?: ProcessOptions["concurrency"];
+  handle: JobHandler<Job>["handle"];
+}
+
+type RegisteredHandler = Pick<QueueRegistration, "queueName" | "concurrency" | "handle">;
 
 export type EnqueueOptions = PgBossSendOptions;
 export interface ProcessOptions extends Omit<PgBossWorkOptions, "batchSize"> {


### PR DESCRIPTION
## Why

Closes #1846

## What

Domain events previously mapped 1:1 to a single queue and handler, so an event could not be consumed by more than one handler. Switch domain event delivery to pg-boss publish/subscribe: each handler owns its own queue and subscribes to the event, so handlers fail, retry, and restart in isolation and can be made idempotent independently.

- Add JobQueueService.publish() (pgBoss.publish) and registerEventHandlers() which creates a per-handler queue and subscribes it to the event
- Add EventHandler interface with an optional queue suffix; the queue defaults to the event name to preserve in-flight jobs on rollout
- Route DomainEventsService.publish through the new publish path
- Migrate existing event handlers to EventHandler and split job registration into commands (send) vs events (publish/subscribe)
