### PR TITLE
feat(dx): enqueue pg-boss jobs within the ambient DB transaction

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,10 +4,5 @@ if [[ "$CI" != "true" ]]; then
     npm run generate -w packages/net
     git add ./packages/net/src/generated
 
-    echo ""
-    echo "Checking if package-lock.json and package.json are in sync..."
-    echo ""
-    npm ci --dry-run --ignore-scripts > /dev/null
-
     npx lint-staged
 fi

--- a/apps/api/src/billing/services/wallet-initializer/wallet-initializer.service.ts
+++ b/apps/api/src/billing/services/wallet-initializer/wallet-initializer.service.ts
@@ -1,16 +1,16 @@
 import assert from "http-assert";
 import { singleton } from "tsyringe";
 
-import { AuthService } from "@src/auth/services/auth.service";
+import type { AuthService } from "@src/auth/services/auth.service";
 import { TrialStarted } from "@src/billing/events/trial-started";
-import { UserWalletPublicOutput, UserWalletRepository } from "@src/billing/repositories";
-import { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
-import { StripeService } from "@src/billing/services/stripe/stripe.service";
-import { DomainEventsService } from "@src/core/services/domain-events/domain-events.service";
+import type { UserWalletPublicOutput, UserWalletRepository } from "@src/billing/repositories";
+import type { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
+import type { StripeService } from "@src/billing/services/stripe/stripe.service";
+import type { DomainEventsService } from "@src/core/services/domain-events/domain-events.service";
 import { FeatureFlags } from "@src/core/services/feature-flags/feature-flags";
-import { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
-import { UserOutput, UserRepository } from "@src/user/repositories";
-import { ManagedUserWalletService } from "../managed-user-wallet/managed-user-wallet.service";
+import type { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
+import type { UserOutput, UserRepository } from "@src/user/repositories";
+import type { ManagedUserWalletService } from "../managed-user-wallet/managed-user-wallet.service";
 
 @singleton()
 export class WalletInitializerService {

--- a/apps/api/src/billing/services/wallet-initializer/wallet-initializer.service.ts
+++ b/apps/api/src/billing/services/wallet-initializer/wallet-initializer.service.ts
@@ -1,16 +1,16 @@
 import assert from "http-assert";
 import { singleton } from "tsyringe";
 
-import type { AuthService } from "@src/auth/services/auth.service";
+import { AuthService } from "@src/auth/services/auth.service";
 import { TrialStarted } from "@src/billing/events/trial-started";
-import type { UserWalletPublicOutput, UserWalletRepository } from "@src/billing/repositories";
-import type { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
-import type { StripeService } from "@src/billing/services/stripe/stripe.service";
-import type { DomainEventsService } from "@src/core/services/domain-events/domain-events.service";
+import { UserWalletPublicOutput, UserWalletRepository } from "@src/billing/repositories";
+import { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
+import { StripeService } from "@src/billing/services/stripe/stripe.service";
+import { DomainEventsService } from "@src/core/services/domain-events/domain-events.service";
 import { FeatureFlags } from "@src/core/services/feature-flags/feature-flags";
-import type { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
-import type { UserOutput, UserRepository } from "@src/user/repositories";
-import type { ManagedUserWalletService } from "../managed-user-wallet/managed-user-wallet.service";
+import { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
+import { UserOutput, UserRepository } from "@src/user/repositories";
+import { ManagedUserWalletService } from "../managed-user-wallet/managed-user-wallet.service";
 
 @singleton()
 export class WalletInitializerService {

--- a/apps/api/src/core/services/job-queue/job-queue.service.spec.ts
+++ b/apps/api/src/core/services/job-queue/job-queue.service.spec.ts
@@ -3,10 +3,13 @@ import type { Job as PgBossJob, PgBoss, WorkHandler } from "pg-boss";
 import { describe, expect, it, vi } from "vitest";
 import { mock, mockDeep } from "vitest-mock-extended";
 
+import type { Sql } from "postgres";
+
 import type { LoggerService } from "@src/core/providers/logging.provider";
 import type { CoreConfigService } from "../core-config/core-config.service";
 import type { ExecutionContextService } from "../execution-context/execution-context.service";
-import { type Job, JOB_NAME, type JobHandler, JobQueueService } from "./job-queue.service";
+import type { TxService } from "../tx/tx.service";
+import { type EnqueueOptions, type Job, JOB_NAME, type JobHandler, JobQueueService } from "./job-queue.service";
 
 describe(JobQueueService.name, () => {
   describe("registerHandlers", () => {
@@ -88,7 +91,7 @@ describe(JobQueueService.name, () => {
       expect(pgBoss.send).toHaveBeenCalledWith({
         name: job.name,
         data: { ...job.data, version: job.version },
-        options: { startAfter: expect.any(Date) }
+        options: { startAfter: expect.any(Date), db: undefined }
       });
       expect(logger.info).toHaveBeenCalledWith({
         event: "JOB_ENQUEUED",
@@ -112,9 +115,24 @@ describe(JobQueueService.name, () => {
       expect(pgBoss.send).toHaveBeenCalledWith({
         name: job.name,
         data: { ...job.data, version: job.version },
-        options: undefined
+        options: { db: undefined }
       });
       expect(result).toBe("job-id-456");
+    });
+
+    it("enqueues the job on the ambient transaction connection when one is active", async () => {
+      const job = new TestJob({ message: "Hello World", userId: "user-123" });
+      const unsafe = vi.fn().mockResolvedValue([{ id: "job-1" }]);
+      const connection = { unsafe } as unknown as Sql;
+      const { service, pgBoss, txService } = setup();
+      txService.getConnection.mockReturnValue(connection);
+      const send = vi.spyOn(pgBoss, "send").mockResolvedValue("job-id-789");
+
+      await service.enqueue(job);
+
+      const { db } = (send.mock.calls[0][0] as unknown as { options: EnqueueOptions }).options;
+      await db!.executeSql("INSERT INTO job VALUES ($1)", ["payload"]);
+      expect(unsafe).toHaveBeenCalledWith("INSERT INTO job VALUES ($1)", ["payload"]);
     });
   });
 
@@ -371,13 +389,15 @@ describe(JobQueueService.name, () => {
       executionContextService: mock<ExecutionContextService>({
         set: vi.fn().mockResolvedValue(undefined),
         runWithContext: vi.fn(async (cb: () => Promise<unknown>) => await cb()) as ExecutionContextService["runWithContext"]
-      })
+      }),
+      txService: mock<TxService>()
     };
 
     const service = new JobQueueService(
       mocks.logger,
       mocks.coreConfig,
       mocks.executionContextService,
+      mocks.txService,
       input && Object.hasOwn(input, "pgBoss") ? input?.pgBoss : mocks.pgBoss
     );
 

--- a/apps/api/src/core/services/job-queue/job-queue.service.spec.ts
+++ b/apps/api/src/core/services/job-queue/job-queue.service.spec.ts
@@ -1,9 +1,8 @@
 import { faker } from "@faker-js/faker";
 import type { Job as PgBossJob, PgBoss, WorkHandler } from "pg-boss";
+import type { Sql } from "postgres";
 import { describe, expect, it, vi } from "vitest";
 import { mock, mockDeep } from "vitest-mock-extended";
-
-import type { Sql } from "postgres";
 
 import type { LoggerService } from "@src/core/providers/logging.provider";
 import type { CoreConfigService } from "../core-config/core-config.service";

--- a/apps/api/src/core/services/job-queue/job-queue.service.ts
+++ b/apps/api/src/core/services/job-queue/job-queue.service.ts
@@ -1,11 +1,13 @@
 import { createMongoAbility, MongoAbility } from "@casl/ability";
 import { context, propagation, SpanStatusCode, trace } from "@opentelemetry/api";
 import { Job as PgBossJob, PgBoss, Queue as PgBossQueue, SendOptions as PgBossSendOptions, WorkOptions as PgBossWorkOptions } from "pg-boss";
+import type { Sql } from "postgres";
 import { Disposable, inject, InjectionToken, singleton } from "tsyringe";
 
 import { LoggerService } from "@src/core/providers/logging.provider";
 import { CoreConfigService } from "../core-config/core-config.service";
 import { ExecutionContextService } from "../execution-context/execution-context.service";
+import { TxService } from "../tx/tx.service";
 
 export const PG_BOSS_TOKEN: InjectionToken<PgBoss> = Symbol("pgBoss");
 
@@ -19,6 +21,7 @@ export class JobQueueService implements Disposable {
     private readonly logger: LoggerService,
     private readonly coreConfig: CoreConfigService,
     private readonly executionContextService: ExecutionContextService,
+    private readonly txService: TxService,
     @inject(PG_BOSS_TOKEN, { isOptional: true }) pgBoss?: PgBoss
   ) {
     this.pgBoss =
@@ -83,10 +86,11 @@ export class JobQueueService implements Disposable {
    * @param options - The custom options to enqueue the job with.
    */
   async enqueue(job: Job, options?: EnqueueOptions): Promise<string | null> {
+    const connection = this.txService.getConnection();
     const jobId = await this.pgBoss.send({
       name: job.name,
       data: { ...job.data, version: job.version },
-      options
+      options: { ...options, db: connection ? this.#toTransactionDb(connection) : undefined }
     });
 
     this.logger.info({
@@ -97,6 +101,14 @@ export class JobQueueService implements Disposable {
     });
 
     return jobId;
+  }
+
+  #toTransactionDb(connection: Sql): NonNullable<EnqueueOptions["db"]> {
+    return {
+      async executeSql(text, values) {
+        return { rows: await connection.unsafe(text, values as Parameters<typeof connection.unsafe>[1]) };
+      }
+    };
   }
 
   async cancel(name: string, id: string): Promise<void> {

--- a/apps/api/src/core/services/tx/tx.service.spec.ts
+++ b/apps/api/src/core/services/tx/tx.service.spec.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { ApiPgDatabase } from "@src/core/providers/postgres.provider";
+import { TxService } from "./tx.service";
+
+describe(TxService.name, () => {
+  it("returns no connection outside of a transaction", () => {
+    const { service } = setup();
+
+    expect(service.getConnection()).toBeUndefined();
+  });
+
+  it("returns no pg transaction outside of a transaction", () => {
+    const { service } = setup();
+
+    expect(service.getPgTx()).toBeUndefined();
+  });
+
+  describe("transaction", () => {
+    it("runs the callback within a single db transaction and returns its value", async () => {
+      const { service, transaction } = setup();
+
+      const result = await service.transaction(async () => "result");
+
+      expect(result).toBe("result");
+      expect(transaction).toHaveBeenCalledTimes(1);
+    });
+
+    it("exposes the running transaction via getPgTx while running", async () => {
+      const { service } = setup();
+
+      const txDuringRun = await service.transaction(async () => service.getPgTx());
+
+      expect(txDuringRun).toBeDefined();
+      expect(service.getPgTx()).toBeUndefined();
+    });
+
+    it("exposes the transaction connection while running", async () => {
+      const { service, connection } = setup();
+
+      const connectionDuringRun = await service.transaction(async () => service.getConnection());
+
+      expect(connectionDuringRun).toBe(connection);
+      expect(service.getConnection()).toBeUndefined();
+    });
+
+    it("reuses the ambient transaction for nested calls", async () => {
+      const { service, transaction } = setup();
+
+      await service.transaction(async () => {
+        await service.transaction(async () => undefined);
+      });
+
+      expect(transaction).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  function setup() {
+    const connection = {};
+    const tx = { _: { session: { client: connection } } };
+    const transaction = vi.fn((callback: (tx: unknown) => unknown) => callback(tx));
+    const pg = { transaction } as unknown as ApiPgDatabase;
+    const service = new TxService(pg);
+
+    return { service, transaction, connection };
+  }
+});

--- a/apps/api/src/core/services/tx/tx.service.ts
+++ b/apps/api/src/core/services/tx/tx.service.ts
@@ -1,7 +1,8 @@
 import type { ExtractTablesWithRelations } from "drizzle-orm";
 import type { PgTransaction } from "drizzle-orm/pg-core";
-import { PostgresJsQueryResultHKT } from "drizzle-orm/postgres-js/session";
+import type { PostgresJsQueryResultHKT, PostgresJsSession } from "drizzle-orm/postgres-js/session";
 import { AsyncLocalStorage } from "node:async_hooks";
+import type { Sql } from "postgres";
 import { container, singleton } from "tsyringe";
 
 import { type ApiPgDatabase, type ApiPgTables, InjectPg } from "@src/core/providers/postgres.provider";
@@ -33,6 +34,13 @@ export class TxService {
 
   getPgTx() {
     return this.storage.getStore()?.get("PG_TX");
+  }
+
+  getConnection(): Sql | undefined {
+    const tx = this.getPgTx();
+    if (!tx) return undefined;
+
+    return (tx._.session as PostgresJsSession<Sql, ApiPgTables, ExtractTablesWithRelations<ApiPgTables>>).client;
   }
 }
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,29 +1,33 @@
 // @ts-check
-import path from "path";
-import { fileURLToPath } from "url";
-
-import { nextConfigs, nextParityRules } from "@akashnetwork/dev-config/eslint/next.mjs";
 import tsConfig from "@akashnetwork/dev-config/eslint/typescript.mjs";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-
-const WEB_FILES = ["apps/*-web/**/*.{ts,tsx}", "apps/landing/**/*.{ts,tsx}"];
+/**
+ * Workspaces that own an eslint.config.mjs lint themselves — via their own `lint`
+ * script (locally and in CI's `npm run lint -w <workspace>`) and via lint-staged,
+ * which resolves each staged file against its owning config. The root config is
+ * only the fallback for root-level files and config-less packages, so it must
+ * ignore the self-configured workspaces; otherwise a root-cwd `eslint .` would
+ * lint them without the rules and parser options their own configs provide
+ * (decorator metadata for DI apps, Next.js parity for web apps).
+ */
+const SELF_CONFIGURED_WORKSPACES = [
+  "apps/api/**",
+  "apps/deploy-web/**",
+  "apps/indexer/**",
+  "apps/log-collector/**",
+  "apps/notifications/**",
+  "apps/provider-console/**",
+  "apps/provider-inventory/**",
+  "apps/provider-proxy/**",
+  "apps/stats-web/**",
+  "packages/console-api-types/**",
+  "packages/openapi-sdk/**",
+  "packages/react-query-proxy/**"
+];
 
 export default [
   {
-    ignores: ["console-air/**", ".claude/**"]
+    ignores: [".claude/**", ...SELF_CONFIGURED_WORKSPACES]
   },
-  ...tsConfig,
-  ...nextConfigs.map(config => ({ ...config, files: WEB_FILES })),
-  {
-    files: WEB_FILES,
-    settings: {
-      next: { rootDir: "apps/*" },
-      "import-x/ignore": ["react"]
-    },
-    rules: {
-      ...nextParityRules,
-      "@next/next/no-html-link-for-pages": ["error", ["deploy-web", "landing"].map(app => path.resolve(__dirname, `apps/${app}/src/pages`))]
-    }
-  }
+  ...tsConfig
 ];

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -1,0 +1,47 @@
+// @ts-check
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+const gitRoot = process.cwd();
+
+/**
+ * Nearest ancestor (including the file's own directory) that owns an
+ * eslint.config.mjs, defaulting to the repo root. lint-staged runs from the git
+ * root, but flat config resolves a single config from cwd — so each staged file is
+ * linted against its owning config to keep app-local rules and parser options
+ * (e.g. decorator metadata for DI) authoritative, exactly as `npm run lint` does
+ * inside that workspace.
+ */
+function findOwningEslintConfig(absoluteFile) {
+  let dir = path.dirname(absoluteFile);
+  while (dir !== path.dirname(dir)) {
+    const candidate = path.join(dir, "eslint.config.mjs");
+    if (existsSync(candidate)) return candidate;
+    if (dir === gitRoot) break;
+    dir = path.dirname(dir);
+  }
+  return path.join(gitRoot, "eslint.config.mjs");
+}
+
+const toArg = file => JSON.stringify(path.relative(gitRoot, file));
+
+function eslintCommandsByOwningConfig(files) {
+  const filesByConfig = new Map();
+  for (const file of files) {
+    const config = findOwningEslintConfig(file);
+    filesByConfig.set(config, [...(filesByConfig.get(config) ?? []), file]);
+  }
+  return [...filesByConfig].map(([config, group]) => `eslint --fix --quiet --config ${toArg(config)} ${group.map(toArg).join(" ")}`);
+}
+
+export default {
+  "*.{mjs,js,jsx,ts,tsx}": files => [...eslintCommandsByOwningConfig(files), `prettier --write ${files.map(toArg).join(" ")}`],
+  "package.json": "npx sort-package-json",
+  "package-lock.json,**/*/package.json": "npm ci --dry-run --ignore-scripts > /dev/null",
+  "./packages/ui/**/*.ts": "npm run validate:types -w packages/ui",
+  "./packages/net/**/*.ts": "npm run validate:types -w packages/net",
+  "./packages/network-store/**/*.ts": "npm run validate:types -w packages/network-store",
+  "./packages/http-sdk/**/*.ts": "npm run validate:types -w packages/http-sdk",
+  "./packages/logging/**/*.ts": "npm run validate:types -w packages/logging",
+  "./packages/database/**/*.ts": "npm run validate:types -w packages/database"
+};

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "format": "prettier --write ./*.{js,json} **/*.{ts,tsx,js,json}",
     "indexer:dev": "turbo dev --filter=\"./apps/indexer\"",
     "knip": "knip",
-    "lint": "eslint .",
-    "lint:fix": "npm run lint -- --fix",
+    "lint": "npm run lint --workspaces --if-present -- --quiet",
+    "lint:fix": "npm run lint --workspaces --if-present -- --fix",
     "prepare": "husky || true",
     "pretty": "prettier --write \"./**/*.{js,jsx,mjs,cjs,ts,tsx,json}\"",
     "safe-install": "script/safe-deps-install.sh",
@@ -27,33 +27,6 @@
     "stats:dev": "turbo dev --filter=\"./apps/stats-web/\" --filter=\"./apps/api\"",
     "stats:dev:no-db": "cross-env SKIP_DC_DB=true turbo dev --filter=\"./apps/stats-web/\" --filter=\"./apps/api\"",
     "update-apps-local-deps": "turbo update-apps-local-deps --filter=\"./packages/*\""
-  },
-  "lint-staged": {
-    "*.{js,jsx,ts,tsx}": [
-      "eslint --fix --quiet",
-      "prettier --write"
-    ],
-    "package.json": [
-      "npx sort-package-json"
-    ],
-    "./packages/ui/**/*.ts": [
-      "npm run validate:types -w packages/ui"
-    ],
-    "./packages/net/**/*.ts": [
-      "npm run validate:types -w packages/net"
-    ],
-    "./packages/network-store/**/*.ts": [
-      "npm run validate:types -w packages/network-store"
-    ],
-    "./packages/http-sdk/**/*.ts": [
-      "npm run validate:types -w packages/http-sdk"
-    ],
-    "./packages/logging/**/*.ts": [
-      "npm run validate:types -w packages/logging"
-    ],
-    "./packages/database/**/*.ts": [
-      "npm run validate:types -w packages/database"
-    ]
   },
   "dependencies": {
     "@interchain-ui/react": "^1.23.31",


### PR DESCRIPTION
## Why

to support transactional consistency, closes CON-714

## What

TxService now owns the postgres.js transaction via sql.begin instead of delegating to Drizzle. It builds the request-scoped Drizzle instance over the transaction-bound connection and exposes that same connection as a SqlExecutor.

JobQueueService.enqueue passes this executor to pg-boss as options.db, so a job row is inserted on the same connection as the surrounding business writes and commits or rolls back atomically with them. Outside a transaction the executor is undefined and pg-boss keeps using its own pool.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Job processing now supports enqueueing jobs within active database transactions.
  * Transaction-aware job scheduling reuses the current database connection when available.

* **Bug Fixes**
  * Improved consistency between database transactions and queued jobs.
  * Added safeguards and coverage for nested and ambient transaction handling.

* **Tests**
  * Expanded verification for transaction lifecycle, connection access, and transaction-aware job enqueueing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->