### PR TITLE
refactor(dx): adopt preserve-caught-error and preserve error causes

### DIFF
--- a/apps/api/src/app/console.ts
+++ b/apps/api/src/app/console.ts
@@ -96,7 +96,7 @@ async function executeCliHandler(name: string, handler: () => Promise<unknown>, 
   await context.with(trace.setSpan(context.active(), tracer.startSpan(name)), async () => {
     logger.info({ event: "COMMAND_START", name });
 
-    const { migratePG } = require("../core/providers/postgres.provider");
+    const { migratePG } = await import("../core/providers/postgres.provider.ts");
 
     try {
       await Promise.all([migratePG(), ...container.resolveAll(APP_INITIALIZER).map(initializer => initializer[ON_APP_START]())]);

--- a/apps/api/src/billing/services/stripe/stripe.service.ts
+++ b/apps/api/src/billing/services/stripe/stripe.service.ts
@@ -851,7 +851,7 @@ export class StripeService extends Stripe {
           }
         }
 
-        throw new Error("Duplicate card validation request detected. Please wait before retrying.");
+        throw new Error("Duplicate card validation request detected. Please wait before retrying.", { cause: error });
       }
       throw error;
     }

--- a/apps/api/src/billing/services/wallet-initializer/wallet-initializer.service.ts
+++ b/apps/api/src/billing/services/wallet-initializer/wallet-initializer.service.ts
@@ -112,7 +112,6 @@ export class WalletInitializerService {
     let userWallet = wallet;
     if (!isNew) return this.userWalletRepository.toPublic(userWallet);
 
-    let isTrialSpendingAuthorized = false;
     try {
       const wallet = await this.walletManager.createAndAuthorizeTrialSpending(this.managedSignerService, { addressIndex: userWallet.id });
       userWallet = await this.userWalletRepository.updateById(
@@ -124,17 +123,13 @@ export class WalletInitializerService {
         },
         { returning: true }
       );
-      isTrialSpendingAuthorized = true;
     } catch (error) {
       await this.userWalletRepository.deleteById(userWallet.id);
       throw error;
     }
 
     const walletOutput = this.userWalletRepository.toPublic(userWallet);
-
-    if (isTrialSpendingAuthorized) {
-      await this.domainEvents.publish(new TrialStarted({ userId }));
-    }
+    await this.domainEvents.publish(new TrialStarted({ userId }));
 
     return walletOutput;
   }

--- a/apps/api/src/gpu/services/gpu-price/gpu-price.service.ts
+++ b/apps/api/src/gpu/services/gpu-price/gpu-price.service.ts
@@ -167,12 +167,10 @@ export class GpuPriceService {
         const providerBidsLast14d = providerBids.filter(b => b.datetime > lastBidsForPeriod);
         const bidsFromPricingBot = providerBids.filter(b => b.deployment.owner === pricingBotAddress && b.deployment.cpuUnits === 100);
 
-        let bestBid = null;
-        if (bidsFromPricingBot.length > 0) {
-          bestBid = bidsFromPricingBot.reduce((best, bid) => (bid.height > best.height ? bid : best));
-        } else {
-          bestBid = this.findBestProviderBid(providerBidsLast14d, x) ?? this.findBestProviderBid(providerBids, x);
-        }
+        const bestBid =
+          bidsFromPricingBot.length > 0
+            ? bidsFromPricingBot.reduce((best, bid) => (bid.height > best.height ? bid : best))
+            : this.findBestProviderBid(providerBidsLast14d, x) ?? this.findBestProviderBid(providerBids, x);
 
         if (bestBid) {
           providersWithBestBid.push({

--- a/apps/api/src/template/services/template-processor/template-processor.service.ts
+++ b/apps/api/src/template/services/template-processor/template-processor.service.ts
@@ -9,12 +9,11 @@ export class TemplateProcessorService {
   mergeTemplateCategories(...categories: Category[][]): MergedCategory[] {
     const mergedCategories: MergedCategory[] = [];
     for (const category of categories.flat()) {
-      let categoryIndex = mergedCategories.findIndex(c => c.title.toLowerCase() === category.title.toLowerCase());
+      const categoryIndex = mergedCategories.findIndex(c => c.title.toLowerCase() === category.title.toLowerCase());
       if (categoryIndex !== -1) {
         const existingCategory = mergedCategories[categoryIndex];
         existingCategory.templates = (existingCategory.templates || []).concat(category.templates || []);
       } else {
-        categoryIndex = mergedCategories.length;
         const categoryClone = JSON.parse(JSON.stringify(category));
         categoryClone.templates ??= [];
         mergedCategories.push(categoryClone);

--- a/apps/api/src/utils/json.ts
+++ b/apps/api/src/utils/json.ts
@@ -1,7 +1,7 @@
 export const safeParseJson = <T>(json: string, defaultValue?: T): T | null => {
   try {
     return JSON.parse(json) as T;
-  } catch (error) {
+  } catch {
     return (defaultValue as T) ?? null;
   }
 };

--- a/apps/api/src/utils/map/provider.ts
+++ b/apps/api/src/utils/map/provider.ts
@@ -186,7 +186,6 @@ export const getProviderAttributeValue = <TKey extends keyof ProviderAttributesS
 ): string | string[] | boolean | number | null => {
   const _key = providerAttributeSchema[key].key;
   const possibleValues = providerAttributeSchema[key].values;
-  let values = null;
 
   switch (providerAttributeSchema[key].type) {
     case "string":
@@ -196,20 +195,22 @@ export const getProviderAttributeValue = <TKey extends keyof ProviderAttributesS
           .map(x => x.value)
           .join(",") || null
       );
-    case "number":
-      values =
+    case "number": {
+      const numberValue =
         provider.providerAttributes
           .filter(x => x.key === _key)
           .map(x => x.value)
           .join(",") || "0";
-      return parseFloat(values);
-    case "boolean":
-      values =
+      return parseFloat(numberValue);
+    }
+    case "boolean": {
+      const booleanValue =
         provider.providerAttributes
           .filter(x => x.key === _key)
           .map(x => x.value)
           .join(",") || null;
-      return values ? values === "true" : false;
+      return booleanValue ? booleanValue === "true" : false;
+    }
     case "option":
       return provider.providerAttributes
         .filter(x => x.key === _key)

--- a/apps/api/src/verify-rsa-jwt-cloudflare-worker-main/get-jwks.ts
+++ b/apps/api/src/verify-rsa-jwt-cloudflare-worker-main/get-jwks.ts
@@ -10,7 +10,7 @@ export async function getJwks(jwksUri: string, kvStore: KVStore, jwkCacheKey?: s
   try {
     new URL(jwksUri);
   } catch (error) {
-    throw new Error("Invalid JWKS URI");
+    throw new Error("Invalid JWKS URI", { cause: error });
   }
   // Fetch the JWKs from KV or the JWKS URI
   const jwks = await kvStore.get<Jwks>(jwkCacheKey && jwkCacheKey.length > 0 ? jwkCacheKey : DEFAULT_JWK_CACHE_KEY, () => fetchJwks(jwksUri), validateJwks);
@@ -22,7 +22,7 @@ async function fetchJwks(jwksUri: string): Promise<Jwks> {
   try {
     response = await fetch(jwksUri);
   } catch (e) {
-    throw new Error("Failed to request on fetching JWKs: " + (e as Error).message);
+    throw new Error("Failed to request on fetching JWKs: " + (e as Error).message, { cause: e });
   }
   if (!response.ok || !response.status.toString().startsWith("2")) {
     throw new Error("Failed to fetch JWKs: " + response.statusText);

--- a/apps/api/src/verify-rsa-jwt-cloudflare-worker-main/verify.ts
+++ b/apps/api/src/verify-rsa-jwt-cloudflare-worker-main/verify.ts
@@ -37,7 +37,7 @@ function parseToken(token: string): {
   try {
     // kid = JSON.parse(atob(tokenParts[0])).kid; - kid is optional. Cannot always expect.
     payload = JSON.parse(atob(tokenParts[1]));
-  } catch (error) {
+  } catch {
     throw new BadRequest("Invalid token format");
   }
   const headerPayload = new TextEncoder().encode(`${tokenParts[0]}.${tokenParts[1]}`);

--- a/apps/api/test/setup-functional-tests.ts
+++ b/apps/api/test/setup-functional-tests.ts
@@ -67,7 +67,7 @@ expect.extend({
         message: () => `Ok`,
         pass: true
       };
-    } catch (error) {
+    } catch {
       return received === null
         ? {
             message: () => `Ok`,

--- a/apps/deploy-web/src/components/alerts/AlertsListContainer/AlertsListContainer.tsx
+++ b/apps/deploy-web/src/components/alerts/AlertsListContainer/AlertsListContainer.tsx
@@ -59,7 +59,7 @@ export const AlertsListContainer: FC<AlertsListContainerProps> = ({ children }) 
         } else {
           refetch();
         }
-      } catch (error) {
+      } catch {
         notificator.error("Failed to remove alert", {
           dataTestId: "alert-remove-error-notification"
         });
@@ -85,7 +85,7 @@ export const AlertsListContainer: FC<AlertsListContainerProps> = ({ children }) 
         await queryClient.invalidateQueries({
           queryKey: QueryKeys.getDeploymentDetailKey(address, dseq)
         });
-      } catch (error) {
+      } catch {
         notificator.error("Failed to update alert");
       } finally {
         setLoadingIds(prev => {

--- a/apps/deploy-web/src/components/alerts/DeploymentAlertsContainer/DeploymentAlertsContainer.tsx
+++ b/apps/deploy-web/src/components/alerts/DeploymentAlertsContainer/DeploymentAlertsContainer.tsx
@@ -94,7 +94,7 @@ export const DeploymentAlertsContainer: FC<Props> = ({ children, deployment }) =
         });
 
         return toOutput(result);
-      } catch (e) {
+      } catch {
         notificator.error("Alert configuration failed...", { dataTestId: "alert-config-error-notification" });
       }
     },

--- a/apps/deploy-web/src/components/alerts/NotificationChannelForm/NotificationChannelForm.tsx
+++ b/apps/deploy-web/src/components/alerts/NotificationChannelForm/NotificationChannelForm.tsx
@@ -67,7 +67,7 @@ export const NotificationChannelForm: FC<NotificationChannelFormProps> = ({ onCa
           ...values,
           emails: Array.from(new Set(emails))
         });
-      } catch (err) {
+      } catch {
         setError("Failed to save notification channel. Please try again.");
       }
     },

--- a/apps/deploy-web/src/components/deployments/DeploymentLeaseShell.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentLeaseShell.tsx
@@ -127,7 +127,7 @@ export const DeploymentLeaseShell: React.FunctionComponent<Props> = ({ leases })
       try {
         const jsonData = JSON.parse(parsedData);
         exitCode = jsonData["exit_code"];
-      } catch (error) {
+      } catch {
         /* empty */
       }
       if (exitCode === undefined) {

--- a/apps/deploy-web/src/components/new-deployment/CreateLease/CreateLease.tsx
+++ b/apps/deploy-web/src/components/new-deployment/CreateLease/CreateLease.tsx
@@ -137,7 +137,7 @@ export const CreateLease: React.FunctionComponent<Props> = ({ dseq, dependencies
   const bidsReceivedTracked = useRef(false);
 
   useEffect(() => {
-    setNumberOfRequests(prev => ++prev);
+    setNumberOfRequests(prev => prev + 1);
   }, [bidsUpdatedAt]);
 
   useEffect(() => {
@@ -220,15 +220,14 @@ export const CreateLease: React.FunctionComponent<Props> = ({ dseq, dependencies
         await providerProxy.sendManifest(provider, mani, options);
       }
 
-      // Ad tracking script
-      publicConfig.NEXT_PUBLIC_TRACKING_ENABLED &&
-        publicConfig.NEXT_PUBLIC_GROWTH_CHANNEL_TRACKING_ENABLED &&
+      if (publicConfig.NEXT_PUBLIC_TRACKING_ENABLED && publicConfig.NEXT_PUBLIC_GROWTH_CHANNEL_TRACKING_ENABLED) {
         addScriptToHead({
           src: "https://pxl.growth-channel.net/s/76250b26-c260-4776-874b-471ed290230d",
           async: true,
           defer: true,
           id: "growth-channel-script-lease"
         });
+      }
 
       router.replace(UrlService.deploymentDetails(dseq, "EVENTS", "events"));
     } catch (error) {

--- a/apps/deploy-web/src/components/new-deployment/SdlBuilder.tsx
+++ b/apps/deploy-web/src/components/new-deployment/SdlBuilder.tsx
@@ -113,7 +113,7 @@ export const SdlBuilder = React.forwardRef<SdlBuilderRefType, Props>(
             lastSyncedSdlRef.current = sdlString;
             form.reset({ ...form.getValues(), placements: imported.placements, services: imported.services });
           }
-        } catch (error) {
+        } catch {
           setError("Error importing SDL");
         }
       }

--- a/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.tsx
+++ b/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.tsx
@@ -304,23 +304,11 @@ export const OnboardingContainer: React.FunctionComponent<OnboardingContainerPro
           wallet.connectManagedWallet();
           router.replace(urlService.newDeployment({ step: RouteStep.createLeases, dseq: dd.deploymentId.dseq }));
         }
-      } catch (error) {
+      } catch {
         notificator.error("Failed to deploy template. Please try again.");
       }
     },
-    [
-      d,
-      router,
-      urlService,
-      wallet,
-      templateService,
-      minDeposit,
-      deploymentLocalStorage,
-      analyticsService,
-      notificator,
-      errorHandler,
-      navigateBack
-    ]
+    [d, router, urlService, wallet, templateService, minDeposit, deploymentLocalStorage, analyticsService, notificator, errorHandler, navigateBack]
   );
 
   const steps: OnboardingStep[] = [

--- a/apps/deploy-web/src/components/remote-deploy/update/RemoteDeployUpdate.tsx
+++ b/apps/deploy-web/src/components/remote-deploy/update/RemoteDeployUpdate.tsx
@@ -45,7 +45,7 @@ const RemoteDeployUpdate = ({ sdlString, onManifestChange }: { sdlString: string
           setValue("services", imported.services);
         }
       }
-    } catch (error) {
+    } catch {
       enqueueSnackbar(<Snackbar title="Error while parsing SDL file" />, { variant: "error" });
     }
 

--- a/apps/deploy-web/src/components/sdl/SDLEditor/SDLEditor.tsx
+++ b/apps/deploy-web/src/components/sdl/SDLEditor/SDLEditor.tsx
@@ -48,7 +48,7 @@ export const SDLEditor = forwardRef<SdlEditorRefType, Props>(({ onChange, onVali
       try {
         const { parseDocument } = await import("yaml");
         doc = parseDocument(value, { keepSourceTokens: true });
-      } catch (error) {
+      } catch {
         onValidate?.({ isValid: false });
         return false;
       }

--- a/apps/deploy-web/src/components/sdl/SimpleSdlBuilderForm.tsx
+++ b/apps/deploy-web/src/components/sdl/SimpleSdlBuilderForm.tsx
@@ -109,7 +109,7 @@ export const SimpleSDLBuilderForm: React.FunctionComponent = () => {
       setValue("services", imported.services);
       setServiceCollapsed(imported.services.map((x, i) => i));
       setTemplateMetadata(template);
-    } catch (error) {
+    } catch {
       enqueueSnackbar(<Snackbar title="Error fetching template." iconVariant="error" />, {
         variant: "error"
       });

--- a/apps/deploy-web/src/components/shared/PaymentMethodForm/PaymentMethodForm.tsx
+++ b/apps/deploy-web/src/components/shared/PaymentMethodForm/PaymentMethodForm.tsx
@@ -49,7 +49,7 @@ export const PaymentMethodForm: React.FC<PaymentMethodFormProps> = ({
       if (result.setupIntent?.status === "succeeded") {
         onSuccess(organization.trim() || undefined);
       }
-    } catch (err) {
+    } catch {
       setError("An unexpected error occurred.");
     } finally {
       setIsProcessing(false);

--- a/apps/deploy-web/src/components/shared/UserFavoriteButton.tsx
+++ b/apps/deploy-web/src/components/shared/UserFavoriteButton.tsx
@@ -37,10 +37,10 @@ export const UserFavoriteButton: React.FunctionComponent<Props> = ({ id, isFavor
 
       if (isFavorite) {
         await removeFavorite();
-        onRemoveFavorite && onRemoveFavorite();
+        if (onRemoveFavorite) onRemoveFavorite();
       } else {
         await addFavorite();
-        onAddFavorite && onAddFavorite();
+        if (onAddFavorite) onAddFavorite();
       }
 
       setIsFavorite(prev => !prev);

--- a/apps/deploy-web/src/components/shared/ViewPanel.tsx
+++ b/apps/deploy-web/src/components/shared/ViewPanel.tsx
@@ -58,7 +58,7 @@ export const ViewPanel: React.FunctionComponent<Props> = ({
         }
 
         setHeight(height);
-      } catch (error) {
+      } catch {
         setHeight("auto");
       }
     }

--- a/apps/deploy-web/src/components/templates/TemplateGallery.tsx
+++ b/apps/deploy-web/src/components/templates/TemplateGallery.tsx
@@ -60,7 +60,7 @@ export const TemplateGallery: React.FunctionComponent<{ dependencies?: typeof DE
   useEffect(() => {
     const queryCategory = searchParams?.get("category");
     const querySearch = searchParams?.get("search");
-    let _templates: TemplateOutputSummaryWithCategory[] = [];
+    let _templates: TemplateOutputSummaryWithCategory[];
 
     if (queryCategory) {
       const selectedCategory = categories.find(x => x.title === queryCategory);

--- a/apps/deploy-web/src/components/user/UserSettingsForm.tsx
+++ b/apps/deploy-web/src/components/user/UserSettingsForm.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { MdHighlightOff } from "react-icons/md";
 import { Alert, Button, Card, CardContent, Form, FormField, FormInput, Spinner, Switch, Textarea } from "@akashnetwork/ui/components";
+import { zodResolver } from "@hookform/resolvers/zod";
 import { CheckCircle } from "iconoir-react";
 import { NextSeo } from "next-seo";
 import { z } from "zod";
@@ -15,7 +16,6 @@ import { useSaveSettings } from "@src/queries/useSaveSettings";
 import type { CustomUserProfile, UserSettings } from "@src/types/user";
 import Layout from "../layout/Layout";
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const formSchema = z.object({
   username: z
     .string()
@@ -35,6 +35,7 @@ export const UserSettingsForm: FC<{ user: CustomUserProfile }> = ({ user }) => {
   const [isAvailable, setIsAvailable] = useState<boolean | null>(null);
   const { isLoading } = useCustomUser();
   const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
     defaultValues: {
       username: "",
       subscribedToNewsletter: false,

--- a/apps/deploy-web/src/context/SdlBuilderProvider/SdlBuilderProvider.tsx
+++ b/apps/deploy-web/src/context/SdlBuilderProvider/SdlBuilderProvider.tsx
@@ -41,7 +41,11 @@ export const SdlBuilderProvider: FCWithChildren<SdlBuilderProviderProps> = ({ ch
     (component: ComponentNames) => {
       setHiddenComponents(prev => {
         const next = new Set(prev);
-        next.has(component) ? next.delete(component) : next.add(component);
+        if (next.has(component)) {
+          next.delete(component);
+        } else {
+          next.add(component);
+        }
         return next;
       });
     },

--- a/apps/deploy-web/src/hooks/useFormPersist.tsx
+++ b/apps/deploy-web/src/hooks/useFormPersist.tsx
@@ -62,7 +62,7 @@ const useFormPersist = (
       const currTimestamp = Date.now();
 
       if (timeout && currTimestamp - _timestamp > timeout) {
-        onTimeout && onTimeout();
+        if (onTimeout) onTimeout();
         clearStorage();
         return;
       }

--- a/apps/deploy-web/src/hooks/useTailwind.ts
+++ b/apps/deploy-web/src/hooks/useTailwind.ts
@@ -3,8 +3,16 @@ import resolveConfig from "tailwindcss/resolveConfig";
 
 import tailwindConfig from "../../tailwind.config";
 
-export default function useTailwind() {
-  const tailwind = useMemo(() => resolveConfig(tailwindConfig), [tailwindConfig]);
+/** Semantic colors declared in the shared UI tailwind preset that Tailwind's built-in DefaultColors type does not describe. */
+type CustomThemeColors = {
+  primary: { DEFAULT: string; foreground: string; visited: string };
+};
 
-  return tailwind;
+export default function useTailwind() {
+  return useMemo(() => {
+    const resolvedConfig = resolveConfig(tailwindConfig);
+    const colors = resolvedConfig.theme.colors as typeof resolvedConfig.theme.colors & CustomThemeColors;
+
+    return { ...resolvedConfig, theme: { ...resolvedConfig.theme, colors } };
+  }, []);
 }

--- a/apps/deploy-web/src/lib/nextjs/defineServerSideProps/defineServerSideProps.spec.ts
+++ b/apps/deploy-web/src/lib/nextjs/defineServerSideProps/defineServerSideProps.spec.ts
@@ -210,7 +210,7 @@ describe(defineServerSideProps, () => {
   it("handles if condition that returns undefined and null", async () => {
     const mockHandler = vi.fn().mockResolvedValue({ props: { handled: true } });
 
-    let result = await setup({
+    const result = await setup({
       route: "/test",
       if: vi.fn().mockReturnValue(undefined),
       handler: mockHandler
@@ -219,7 +219,7 @@ describe(defineServerSideProps, () => {
     expect(mockHandler).toHaveBeenCalled();
     expect(result).toEqual({ props: { handled: true } });
 
-    result = await setup({
+    await setup({
       route: "/test",
       if: vi.fn().mockReturnValue(null),
       handler: mockHandler

--- a/apps/deploy-web/src/pages/api/blockchain-config.ts
+++ b/apps/deploy-web/src/pages/api/blockchain-config.ts
@@ -17,7 +17,7 @@ export default defineApiHandler({
     let networkConfig: Array<ReturnType<typeof nodeWithId>>;
     try {
       networkConfig = allNetworksConfig[query.network];
-    } catch (error) {
+    } catch {
       res.status(422).json({ error: `Unable to fetch ${query.network} blockchain network config. Does this network exist?` });
       return;
     }

--- a/apps/deploy-web/src/utils/deploymentData/helpers.ts
+++ b/apps/deploy-web/src/utils/deploymentData/helpers.ts
@@ -42,7 +42,7 @@ export function parseSizeStr(str: string) {
     }
   } catch (err) {
     console.error(err);
-    throw new Error("Error while parsing size: " + str);
+    throw new Error("Error while parsing size: " + str, { cause: err });
   }
 }
 

--- a/apps/deploy-web/src/utils/priceUtils.ts
+++ b/apps/deploy-web/src/utils/priceUtils.ts
@@ -29,7 +29,7 @@ export function aktToUakt(amount: number | string) {
 }
 
 export function coinToUDenom(coin: Coin) {
-  let value: number | null = null;
+  let value: number | null;
   const usdcDenom = getUsdcDenom();
 
   if (coin.denom === "akt" || coin.denom === "act") {
@@ -44,7 +44,7 @@ export function coinToUDenom(coin: Coin) {
 }
 
 export function coinToDenom(coin: Coin) {
-  let value: number | null = null;
+  let value: number | null;
   const usdcDenom = getUsdcDenom();
 
   if (coin.denom === "akt" || coin.denom === "act") {

--- a/apps/deploy-web/src/utils/stringUtils.ts
+++ b/apps/deploy-web/src/utils/stringUtils.ts
@@ -18,7 +18,7 @@ export function isUrl(val: string) {
   try {
     const url = new URL(val);
     return url.protocol === "http:" || url.protocol === "https:";
-  } catch (_) {
+  } catch {
     return false;
   }
 }

--- a/apps/deploy-web/tailwind.config.ts
+++ b/apps/deploy-web/tailwind.config.ts
@@ -1,3 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-declare const require: any;
-export default require("@akashnetwork/ui/tailwind")("deploy-web");
+import createTailwindConfig from "@akashnetwork/ui/tailwind";
+
+export default createTailwindConfig("deploy-web");

--- a/apps/indexer/src/chain/chainSync.ts
+++ b/apps/indexer/src/chain/chainSync.ts
@@ -196,10 +196,9 @@ async function insertBlocks(startHeight: number, endHeight: number) {
     const blockDatetime = new Date(blockData.block.header.time);
 
     const txs = blockData.block.data.txs;
-    let blockResults: BlockResultType | null = null;
 
     // Always fetch block results — BME epoch events fire in EndBlocker regardless of transactions
-    blockResults = await getCachedBlockResultsByHeight(i);
+    let blockResults: BlockResultType | null = await getCachedBlockResultsByHeight(i);
     if (blockResults == null) {
       // Block results may be missing from old cache that only fetched results for blocks with txs.
       // Fetch from node and cache for future use.

--- a/apps/indexer/src/chain/nodeAccessor.ts
+++ b/apps/indexer/src/chain/nodeAccessor.ts
@@ -25,9 +25,16 @@ class NodeAccessor {
     console.log("Saving node status...");
     const statuses = this.nodes.map(x => x.getSavedNodeInfo());
 
-    await fs.promises.writeFile(savedNodeInfoPath, JSON.stringify(statuses, (k, value) => {
-      return typeof value === "number" && Number.isNaN(value) ? null : value;
-    }, 2));
+    await fs.promises.writeFile(
+      savedNodeInfoPath,
+      JSON.stringify(
+        statuses,
+        (k, value) => {
+          return typeof value === "number" && Number.isNaN(value) ? null : value;
+        },
+        2
+      )
+    );
   }
 
   private async refetchNodeStatus() {
@@ -93,7 +100,7 @@ class NodeAccessor {
   }
 
   public async waitForAvailableNode(height?: number): Promise<NodeInfo> {
-    let node: NodeInfo | null = null;
+    let node: NodeInfo | null;
     do {
       node = this.getAvailableNode(height);
       if (node) return node;

--- a/apps/indexer/src/shared/utils/files.ts
+++ b/apps/indexer/src/shared/utils/files.ts
@@ -49,7 +49,7 @@ export function parseSizeStr(str: string | undefined): number {
     }
   } catch (err) {
     console.error(err);
-    throw new Error("Error while parsing size: " + str);
+    throw new Error("Error while parsing size: " + str, { cause: err });
   }
 }
 
@@ -77,6 +77,6 @@ export function parseDecimalKubernetesString(str: string | undefined): number {
     }
   } catch (err) {
     console.error(err);
-    throw new Error("Error while parsing size: " + str);
+    throw new Error("Error while parsing size: " + str, { cause: err });
   }
 }

--- a/apps/log-collector/src/services/file-destination/file-destination.service.ts
+++ b/apps/log-collector/src/services/file-destination/file-destination.service.ts
@@ -101,7 +101,7 @@ export class FileDestinationService {
     try {
       const filePath = await this.getLogPath();
       return await this.readLastLinesFromFile(filePath);
-    } catch (error) {
+    } catch {
       return [];
     }
   }
@@ -150,12 +150,12 @@ export class FileDestinationService {
   private async ensureFileExists(filePath: string): Promise<void> {
     try {
       await this.fs.promises.access(filePath);
-    } catch (error) {
+    } catch {
       const logDir = this.configService.get("LOG_DIR");
 
       try {
         await this.fs.promises.access(logDir);
-      } catch (dirError) {
+      } catch {
         await this.fs.promises.mkdir(logDir, { recursive: true });
         this.loggerService.info({
           event: "LOG_DIR_CREATED",

--- a/apps/log-collector/src/services/pod-discovery/pod-discovery.service.ts
+++ b/apps/log-collector/src/services/pod-discovery/pod-discovery.service.ts
@@ -157,7 +157,7 @@ export class PodDiscoveryService {
           resourceVersion = yield* this.pollEvents(AbortSignal.timeout(this.WATCH_RETRY_INTERVAL_MS));
         } catch (pollError) {
           if (pollError instanceof AggregateError && watchErrors.length > 0) {
-            throw new AggregateError([...watchErrors, ...pollError.errors], pollError.message);
+            throw new AggregateError([...watchErrors, ...pollError.errors], pollError.message, { cause: pollError });
           }
           throw pollError;
         }
@@ -257,7 +257,7 @@ export class PodDiscoveryService {
           this.loggerService.error({ event: "POD_POLL_ERROR", error, consecutiveFailures: consecutiveErrors.length });
 
           if (consecutiveErrors.length >= this.MAX_POLL_FAILURES) {
-            throw new AggregateError(consecutiveErrors, `Pod polling failed ${consecutiveErrors.length} times consecutively`);
+            throw new AggregateError(consecutiveErrors, `Pod polling failed ${consecutiveErrors.length} times consecutively`, { cause: error });
           }
         }
 

--- a/apps/notifications/src/lib/value-backoff/value-backoff.ts
+++ b/apps/notifications/src/lib/value-backoff/value-backoff.ts
@@ -40,7 +40,7 @@ export function valueBackoff<T>(request: () => Promise<T | EmptyResult>, options
         const customError = options.createError();
         customError.cause = error;
         return Promise.reject(customError);
-      } catch (createErrorException) {
+      } catch {
         return Promise.reject(error);
       }
     }

--- a/apps/notifications/src/main.ts
+++ b/apps/notifications/src/main.ts
@@ -6,7 +6,7 @@ async function bootstrap() {
   const interfaceModuleName = process.env.INTERFACE || "all";
   const logger = new Logger({ context: "BOOTSTRAP" });
 
-  const interfaceModule = load(interfaceModuleName);
+  const interfaceModule = await load(interfaceModuleName);
 
   if (!interfaceModule) {
     logger.error(`Unsupported interface "${interfaceModuleName}"`);
@@ -17,29 +17,29 @@ async function bootstrap() {
   logger.info(`Successfully started with interface "${interfaceModuleName}" with NODE_OPTIONS=${process.env.NODE_OPTIONS}.`);
 }
 
-function load(interfaceModule: string): { bootstrap: () => Promise<void> } | undefined {
+async function load(interfaceModule: string): Promise<{ bootstrap: () => Promise<void> } | undefined> {
   if (interfaceModule === "alert-events") {
-    return require("./interfaces/alert-events");
+    return import("./interfaces/alert-events/index.ts");
   }
 
   if (interfaceModule === "all") {
-    return require("./interfaces/all");
+    return import("./interfaces/all/index.ts");
   }
 
   if (interfaceModule === "chain-events") {
-    return require("./interfaces/chain-events");
+    return import("./interfaces/chain-events/index.ts");
   }
 
   if (interfaceModule === "notifications-events") {
-    return require("./interfaces/notifications-events");
+    return import("./interfaces/notifications-events/index.ts");
   }
 
   if (interfaceModule === "rest") {
-    return require("./interfaces/rest");
+    return import("./interfaces/rest/index.ts");
   }
 
   if (interfaceModule === "swagger-gen") {
-    return require("./interfaces/swagger-gen");
+    return import("./interfaces/swagger-gen/index.ts");
   }
 
   return undefined;

--- a/apps/notifications/src/modules/alert/repositories/alert/alert.repository.ts
+++ b/apps/notifications/src/modules/alert/repositories/alert/alert.repository.ts
@@ -319,7 +319,6 @@ export class AlertRepository {
       const batch = await cursor;
 
       if (batch.length === 0) {
-        hasMore = false;
         break;
       }
 

--- a/apps/notifications/src/modules/chain/services/tx-events-service/tx-events.service.ts
+++ b/apps/notifications/src/modules/chain/services/tx-events-service/tx-events.service.ts
@@ -124,7 +124,7 @@ export class TxEventsService {
   private extractFilteredEventsFromBlockResults(blockResults: BlockResultsResponse, filter?: EventFilter): ProcessedEvent[] {
     return blockResults.results
       .map(result => {
-        let events: Event[] = [];
+        let events: Event[];
 
         if (filter) {
           const regexp = this.toFilterRegexp(filter);

--- a/apps/notifications/test/functional/account-purge.spec.ts
+++ b/apps/notifications/test/functional/account-purge.spec.ts
@@ -11,7 +11,7 @@ import { LoggerService } from "@src/common/services/logger/logger.service";
 import { DRIZZLE_PROVIDER_TOKEN } from "@src/infrastructure/db/config/db.config";
 import { HttpExceptionFilter } from "@src/interfaces/rest/filters/http-exception/http-exception.filter";
 import RestModule from "@src/interfaces/rest/rest.module";
-import * as alertSchema from "@src/modules/alert/model-schemas";
+import type * as alertSchema from "@src/modules/alert/model-schemas";
 import { Alert } from "@src/modules/alert/model-schemas";
 import { NotificationChannel } from "@src/modules/notifications/model-schemas";
 
@@ -61,9 +61,7 @@ describe("Account Purge (internal)", () => {
     const userId = faker.string.uuid();
 
     if (input.withSeed) {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const schema = { ...alertSchema, NotificationChannel };
-      const db = module.get<NodePgDatabase<typeof schema>>(DRIZZLE_PROVIDER_TOKEN);
+      const db = module.get<NodePgDatabase<typeof alertSchema & { NotificationChannel: typeof NotificationChannel }>>(DRIZZLE_PROVIDER_TOKEN);
       const [channel] = await db
         .insert(NotificationChannel)
         .values([generateNotificationChannel({ userId })])

--- a/apps/notifications/test/functional/alert-crud.spec.ts
+++ b/apps/notifications/test/functional/alert-crud.spec.ts
@@ -14,7 +14,7 @@ import { HttpExceptionFilter } from "@src/interfaces/rest/filters/http-exception
 import { chainMessageCreateInputSchema } from "@src/interfaces/rest/http-schemas/alert.http-schema";
 import { HttpResultInterceptor } from "@src/interfaces/rest/interceptors/http-result/http-result.interceptor";
 import RestModule from "@src/interfaces/rest/rest.module";
-import * as alertSchema from "@src/modules/alert/model-schemas";
+import type * as alertSchema from "@src/modules/alert/model-schemas";
 import type { AlertOutput } from "@src/modules/alert/repositories/alert/alert.repository";
 import { AlertRepository } from "@src/modules/alert/repositories/alert/alert.repository";
 import { NotificationChannel } from "@src/modules/notifications/model-schemas";
@@ -128,12 +128,7 @@ describe("Alerts CRUD", () => {
     await app.init();
 
     const userId = faker.string.uuid();
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const schema = {
-      ...alertSchema,
-      NotificationChannel
-    };
-    const db = module.get<NodePgDatabase<typeof schema>>(DRIZZLE_PROVIDER_TOKEN);
+    const db = module.get<NodePgDatabase<typeof alertSchema & { NotificationChannel: typeof NotificationChannel }>>(DRIZZLE_PROVIDER_TOKEN);
     const [notificationChannel] = await db
       .insert(NotificationChannel)
       .values([generateNotificationChannel({ userId })])

--- a/apps/notifications/test/functional/deployment-alert-crud.spec.ts
+++ b/apps/notifications/test/functional/deployment-alert-crud.spec.ts
@@ -15,7 +15,7 @@ import { DeploymentAlertCreateInput } from "@src/interfaces/rest/controllers/dep
 import { HttpExceptionFilter } from "@src/interfaces/rest/filters/http-exception/http-exception.filter";
 import { HttpResultInterceptor } from "@src/interfaces/rest/interceptors/http-result/http-result.interceptor";
 import RestModule from "@src/interfaces/rest/rest.module";
-import * as alertSchema from "@src/modules/alert/model-schemas";
+import type * as alertSchema from "@src/modules/alert/model-schemas";
 import { NotificationChannel } from "@src/modules/notifications/model-schemas";
 
 import { mockAkashAddress } from "@test/seeders/akash-address.seeder";
@@ -135,12 +135,7 @@ describe("Deployment Alerts CRUD", () => {
     await app.init();
 
     const userId = faker.string.uuid();
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const schema = {
-      ...alertSchema,
-      NotificationChannel
-    };
-    const db = module.get<NodePgDatabase<typeof schema>>(DRIZZLE_PROVIDER_TOKEN);
+    const db = module.get<NodePgDatabase<typeof alertSchema & { NotificationChannel: typeof NotificationChannel }>>(DRIZZLE_PROVIDER_TOKEN);
     const [notificationChannel] = await db
       .insert(NotificationChannel)
       .values([generateNotificationChannel({ userId })])

--- a/apps/provider-console/src/components/become-provider/ProviderAttributes.tsx
+++ b/apps/provider-console/src/components/become-provider/ProviderAttributes.tsx
@@ -168,7 +168,7 @@ export const ProviderAttributes: React.FunctionComponent<ProviderAttributesProps
         }))
       };
       setProviderProcess(updatedProviderProcess);
-      onComplete && onComplete();
+      if (onComplete) onComplete();
     } else {
       const attributes = data.attributes.map(attr => ({
         key: attr.key === "unknown-attributes" ? attr.customKey || "" : attr.key || "",

--- a/apps/provider-console/src/components/nodes/NodeListTable.tsx
+++ b/apps/provider-console/src/components/nodes/NodeListTable.tsx
@@ -63,7 +63,7 @@ export const NodeListTable = ({ nodes, onRemoveNode, activeControlMachine, isNod
       } else {
         return date.toLocaleDateString();
       }
-    } catch (e) {
+    } catch {
       return "Invalid Date";
     }
   };

--- a/apps/provider-console/src/components/shared/ActivityLogDetails.tsx
+++ b/apps/provider-console/src/components/shared/ActivityLogDetails.tsx
@@ -212,7 +212,7 @@ export const ActivityLogDetails: React.FC<{ actionId: string | null }> = ({ acti
           />
         </div>
       );
-    } catch (error) {
+    } catch {
       return (
         <div className="mt-4 rounded-md bg-gray-100 p-4 dark:bg-gray-800" style={{ height: 200, overflowY: "auto" }}>
           <pre className="whitespace-pre-wrap break-words text-sm">{logs}</pre>

--- a/apps/provider-console/src/context/WalletProvider/WalletProvider.tsx
+++ b/apps/provider-console/src/context/WalletProvider/WalletProvider.tsx
@@ -92,7 +92,7 @@ export const WalletProvider = ({ children }) => {
     } catch (error) {
       console.warn(`Failed to connect to RPC endpoint: ${rpc}`, error);
       // If the selected network's RPC fails, we could add fallback logic here if needed
-      throw new Error(`Unable to connect to ${selectedNetwork.title} RPC endpoint: ${rpc}`);
+      throw new Error(`Unable to connect to ${selectedNetwork.title} RPC endpoint: ${rpc}`, { cause: error });
     }
 
     const client = await SigningStargateClient.connectWithSigner(rpc, offlineSigner);

--- a/apps/provider-console/src/context/WalletProvider/WalletProvider.tsx
+++ b/apps/provider-console/src/context/WalletProvider/WalletProvider.tsx
@@ -156,7 +156,7 @@ export const WalletProvider = ({ children }) => {
             throw new Error("Invalid nonce response");
           }
         }
-      } catch (error) {
+      } catch {
         logout();
       }
     }

--- a/apps/provider-console/src/hooks/useLocalStorage.ts
+++ b/apps/provider-console/src/hooks/useLocalStorage.ts
@@ -82,7 +82,7 @@ export function useCustomLocalStorage<T>(key: string, initialValue: T) {
 function parseJSON(value: string) {
   try {
     return value === "undefined" ? undefined : JSON.parse(value ?? "");
-  } catch (error) {
+  } catch {
     return value === "undefined" ? undefined : value;
   }
 }

--- a/apps/provider-console/src/pages/nodes/index.tsx
+++ b/apps/provider-console/src/pages/nodes/index.tsx
@@ -43,7 +43,7 @@ const NodesPage: React.FunctionComponent = () => {
 
       // If we have an action_id, the mutation will handle the redirect in onSuccess
       // This toast is still useful for users to see even if they'll be redirected
-    } catch (error) {
+    } catch {
       toast({
         variant: "destructive",
         title: "Failed to remove node",

--- a/apps/provider-console/src/pages/settings/index.tsx
+++ b/apps/provider-console/src/pages/settings/index.tsx
@@ -158,7 +158,7 @@ const SettingsPage: React.FC = () => {
         setTimeout(() => setRestartSuccess(false), 20000);
       }
       setUrlError("");
-    } catch (error) {
+    } catch {
       setUrlError("Please enter a valid domain name");
     }
   };

--- a/apps/provider-console/src/utils/authClient.ts
+++ b/apps/provider-console/src/utils/authClient.ts
@@ -17,7 +17,7 @@ authClient.interceptors.response.use(
     return response.data;
   },
   error => {
-    let errorMessage = "An unexpected error occurred";
+    let errorMessage: string;
 
     if (typeof error.response === "undefined") {
       errorMessage = "Server is not reachable or CORS is not enabled on the server!";

--- a/apps/provider-console/src/utils/consoleClient.ts
+++ b/apps/provider-console/src/utils/consoleClient.ts
@@ -17,7 +17,7 @@ consoleClient.interceptors.response.use(
     return response.data;
   },
   async error => {
-    let errorMessage = "An unexpected error occurred";
+    let errorMessage: string;
     if (typeof error.response === "undefined") {
       errorMessage = "Server is not reachable or CORS is not enable on the server!";
       errorNotification("Server is not reachable or CORS is not enable on the server!");

--- a/apps/provider-console/src/utils/nodeDistribution.ts
+++ b/apps/provider-console/src/utils/nodeDistribution.ts
@@ -9,7 +9,7 @@
  */
 export const calculateNodeDistribution = (totalNewNodes: number, existingControlPlane: number = 0, existingWorkers: number = 0) => {
   const totalNodes = totalNewNodes + existingControlPlane + existingWorkers;
-  let targetControlPlane = 0;
+  let targetControlPlane: number;
 
   // Calculate target number of control plane nodes for the entire cluster
   // Following Kubernetes best practices:

--- a/apps/provider-console/src/utils/nodeVerification.ts
+++ b/apps/provider-console/src/utils/nodeVerification.ts
@@ -41,7 +41,7 @@ export const processKeyfile = (keyfile?: string): string | null => {
     }
   } catch (error) {
     console.error("Error encoding keyfile:", error);
-    throw new Error("Failed to process keyfile. The keyfile content could not be encoded properly.");
+    throw new Error("Failed to process keyfile. The keyfile content could not be encoded properly.", { cause: error });
   }
 };
 
@@ -76,7 +76,7 @@ export const verifyControlMachine = async (access: MachineAccess): Promise<Syste
     return response.data.system_info;
   } catch (error: any) {
     console.error("Control machine verification error:", error);
-    throw new Error(error.response?.data?.detail?.error?.message || error.message || "Failed to verify server access");
+    throw new Error(error.response?.data?.detail?.error?.message || error.message || "Failed to verify server access", { cause: error });
   }
 };
 
@@ -119,6 +119,6 @@ export const verifyWorkerNode = async (controlMachine: MachineAccess, workerNode
     return response.data.system_info;
   } catch (error: any) {
     console.error("Worker node verification error:", error);
-    throw new Error(error.response?.data?.detail?.error?.message || error.message || "Failed to verify server access");
+    throw new Error(error.response?.data?.detail?.error?.message || error.message || "Failed to verify server access", { cause: error });
   }
 };

--- a/apps/provider-console/src/utils/priceUtils.ts
+++ b/apps/provider-console/src/utils/priceUtils.ts
@@ -18,7 +18,7 @@ export function aktToUakt(amount: number | string) {
 }
 
 export function coinToUDenom(coin: Coin) {
-  let value: number | null = null;
+  let value: number | null;
   const usdcDenom = getUsdcDenom();
 
   if (coin.denom === "akt") {
@@ -33,7 +33,7 @@ export function coinToUDenom(coin: Coin) {
 }
 
 export function coinToDenom(coin: Coin) {
-  let value: number | null = null;
+  let value: number | null;
   const usdcDenom = getUsdcDenom();
 
   if (coin.denom === "akt") {

--- a/apps/provider-console/src/utils/walletScopedStorage.ts
+++ b/apps/provider-console/src/utils/walletScopedStorage.ts
@@ -35,7 +35,7 @@ export function createWalletScopedStorage<T>(baseKey: string): AsyncStorage<T> {
 
     try {
       return JSON.parse(value) as T;
-    } catch (error) {
+    } catch {
       return undefined;
     }
   };

--- a/apps/provider-console/tailwind.config.ts
+++ b/apps/provider-console/tailwind.config.ts
@@ -1,1 +1,3 @@
-export default require("@akashnetwork/ui/tailwind")("provider-console");
+import createTailwindConfig from "@akashnetwork/ui/tailwind";
+
+export default createTailwindConfig("provider-console");

--- a/apps/provider-inventory/src/lib/generators/chunkify.ts
+++ b/apps/provider-inventory/src/lib/generators/chunkify.ts
@@ -16,7 +16,5 @@ export function* chunkify<T>(iter: Iterable<T>, size: number): Generator<readonl
 
   if (i !== 0) {
     yield buf.slice(0, i);
-    i = 0;
-    buf.length = 0;
   }
 }

--- a/apps/provider-proxy/src/services/WebsocketServer.ts
+++ b/apps/provider-proxy/src/services/WebsocketServer.ts
@@ -87,7 +87,7 @@ export class WebsocketServer {
             let newOrLegacyMessage: Record<string, unknown> | undefined;
             try {
               newOrLegacyMessage = typeof messageStr === "string" ? JSON.parse(messageStr) : undefined;
-            } catch (error) {
+            } catch {
               this.logger?.error({
                 event: "CLIENT_MESSAGE_INVALID_JSON",
                 message: "Received message is not a JSON string",

--- a/apps/provider-proxy/src/utils/schema.ts
+++ b/apps/provider-proxy/src/utils/schema.ts
@@ -84,7 +84,7 @@ const jwtTokenManager = new JwtTokenManager({
 function validateJwtPayload(token: string): { isValid: boolean; errors?: string[] } {
   try {
     return jwtTokenManager.validatePayload(jwtTokenManager.decodeToken(token));
-  } catch (error) {
+  } catch {
     return { isValid: false, errors: ["Invalid token"] };
   }
 }

--- a/apps/provider-proxy/test/functional/provider-proxy-http.spec.ts
+++ b/apps/provider-proxy/test/functional/provider-proxy-http.spec.ts
@@ -97,7 +97,7 @@ describe("Provider HTTP proxy", () => {
     const { providerUrl } = await startProviderServer({ certPair: validCertPair });
     await startServer({ REST_API_NODE_URL: chainServer.url });
 
-    let response = await request("/", {
+    await request("/", {
       method: "POST",
       body: JSON.stringify({
         method: "GET",
@@ -107,7 +107,7 @@ describe("Provider HTTP proxy", () => {
     });
     await chainServer.close();
 
-    response = await request("/", {
+    const response = await request("/", {
       method: "POST",
       body: JSON.stringify({
         method: "GET",

--- a/apps/provider-proxy/test/functional/provider-proxy-ws.spec.ts
+++ b/apps/provider-proxy/test/functional/provider-proxy-ws.spec.ts
@@ -170,7 +170,8 @@ describe("Provider proxy ws", () => {
     const proxyServerUrl = await startServer({ REST_API_NODE_URL: chainServer.url });
     const ws = new WebSocket(`${proxyServerUrl}/ws`);
 
-    await new Promise(resolve => ws.once("open", resolve)), ws.send(JSON.stringify(ourMessage("please_close", providerUrl, { providerAddress })));
+    await new Promise(resolve => ws.once("open", resolve));
+    ws.send(JSON.stringify(ourMessage("please_close", providerUrl, { providerAddress })));
     expect(await waitForMessage(ws)).toEqual(
       providerMessage("", {
         closed: true,

--- a/apps/stats-web/src/hooks/useTopBanner.tsx
+++ b/apps/stats-web/src/hooks/useTopBanner.tsx
@@ -93,7 +93,7 @@ export function useGenericBannerDetails(): GenericBannerDetails {
   try {
     const details = genericBannerFlag?.enabled ? (JSON.parse(genericBannerFlag.payload?.value as string) as GenericBannerDetails) : { message: "" };
     return details;
-  } catch (error) {
+  } catch {
     return { message: "" };
   }
 }

--- a/apps/stats-web/src/lib/urlUtils.ts
+++ b/apps/stats-web/src/lib/urlUtils.ts
@@ -50,7 +50,7 @@ export function isValidHttpUrl(str: string): boolean {
 
   try {
     url = new URL(str);
-  } catch (_) {
+  } catch {
     return false;
   }
 

--- a/apps/stats-web/tailwind.config.ts
+++ b/apps/stats-web/tailwind.config.ts
@@ -1,1 +1,3 @@
-export default require("@akashnetwork/ui/tailwind")("stats-web");
+import createTailwindConfig from "@akashnetwork/ui/tailwind";
+
+export default createTailwindConfig("stats-web");

--- a/apps/tx-signer/src/services/config/config.service.spec.ts
+++ b/apps/tx-signer/src/services/config/config.service.spec.ts
@@ -5,9 +5,8 @@ import { ConfigService } from "./config.service";
 
 describe(ConfigService.name, () => {
   it("returns stored config values", () => {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const schema = z.object({ FOO: z.string() });
-    const service = new ConfigService({ config: { FOO: "bar" } as z.infer<typeof schema> });
+    const service = new ConfigService({ config: schema.parse({ FOO: "bar" }) });
 
     expect(service.get("FOO")).toBe("bar");
   });

--- a/packages/dev-config/eslint/base.mjs
+++ b/packages/dev-config/eslint/base.mjs
@@ -50,7 +50,7 @@ export default [
       "import-x/external-module-folders": ["node_modules", "dist", "build", "public"]
     },
     rules: {
-      "no-useless-assignment": "off",
+      "no-useless-assignment": "error",
       "preserve-caught-error": "error",
       "simple-import-sort/imports": [
         "error",

--- a/packages/dev-config/eslint/base.mjs
+++ b/packages/dev-config/eslint/base.mjs
@@ -51,7 +51,7 @@ export default [
     },
     rules: {
       "no-useless-assignment": "off",
-      "preserve-caught-error": "off",
+      "preserve-caught-error": "error",
       "simple-import-sort/imports": [
         "error",
         {

--- a/packages/dev-config/eslint/typescript.mjs
+++ b/packages/dev-config/eslint/typescript.mjs
@@ -15,9 +15,9 @@ export default tseslint.config(...base, {
   rules: {
     "@typescript-eslint/no-explicit-any": ["warn"],
     "@typescript-eslint/no-require-imports": ["error"],
-    "@typescript-eslint/no-unused-expressions": ["off"],
+    "@typescript-eslint/no-unused-expressions": ["error"],
     "@typescript-eslint/no-empty-object-type": ["error", { allowInterfaces: "with-single-extends" }],
     "@typescript-eslint/consistent-type-imports": ["error", { prefer: "type-imports", fixStyle: "separate-type-imports" }],
-    "@typescript-eslint/no-unused-vars": ["error", { ignoreRestSiblings: true, argsIgnorePattern: "^_", caughtErrors: "none" }]
+    "@typescript-eslint/no-unused-vars": ["error", { ignoreRestSiblings: true, argsIgnorePattern: "^_", caughtErrors: "all" }]
   }
 });

--- a/packages/dev-config/eslint/typescript.mjs
+++ b/packages/dev-config/eslint/typescript.mjs
@@ -14,7 +14,7 @@ export default tseslint.config(...base, {
   },
   rules: {
     "@typescript-eslint/no-explicit-any": ["warn"],
-    "@typescript-eslint/no-require-imports": ["off"],
+    "@typescript-eslint/no-require-imports": ["error"],
     "@typescript-eslint/no-unused-expressions": ["off"],
     "@typescript-eslint/no-empty-object-type": ["error", { allowInterfaces: "with-single-extends" }],
     "@typescript-eslint/consistent-type-imports": ["error", { prefer: "type-imports", fixStyle: "separate-type-imports" }],

--- a/packages/logging/src/services/logger/logger.service.ts
+++ b/packages/logging/src/services/logger/logger.service.ts
@@ -1,4 +1,5 @@
 import { isHttpError } from "http-errors";
+import { createRequire } from "node:module";
 import type { DestinationStream } from "pino";
 import pino from "pino";
 
@@ -102,10 +103,11 @@ export class LoggerService implements Logger {
   private getPrettyIfPresent() {
     if (typeof window === "undefined" && LoggerService.config.STD_OUT_LOG_FORMAT === "pretty") {
       try {
+        const requireModule = createRequire(__filename);
         return {
           ok: true,
 
-          value: require("pino-pretty")({ colorize: true, sync: true })
+          value: requireModule("pino-pretty")({ colorize: true, sync: true })
         } as const;
       } catch (error) {
         return {

--- a/packages/react-query-proxy/src/createProxy/createProxy.spec.ts
+++ b/packages/react-query-proxy/src/createProxy/createProxy.spec.ts
@@ -151,68 +151,66 @@ describe(createProxy.name, () => {
     it("reflects the select return type in the query data", () => {
       const { proxy } = setup();
 
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const result = proxy.users.getById.useQuery({ id: 1 }, { select: user => user.name });
-
-      expectTypeOf<(typeof result)["data"]>().toEqualTypeOf<string | undefined>();
+      expectTypeOf(proxy.users.getById.useQuery({ id: 1 }, { select: user => user.name }))
+        .toHaveProperty("data")
+        .toEqualTypeOf<string | undefined>();
     });
 
     it("defaults the data type to the SDK return type when no select is given", () => {
       const { proxy } = setup();
 
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const result = proxy.users.getById.useQuery({ id: 1 });
-
-      expectTypeOf<(typeof result)["data"]>().toEqualTypeOf<User | undefined>();
+      expectTypeOf(proxy.users.getById.useQuery({ id: 1 }))
+        .toHaveProperty("data")
+        .toEqualTypeOf<User | undefined>();
     });
 
     it("widens the data type by the catchError return type", () => {
       const { proxy } = setup();
 
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const result = proxy.users.getById.useQuery({ id: 1 }, { catchError: () => null });
-
-      expectTypeOf<(typeof result)["data"]>().toEqualTypeOf<User | null | undefined>();
+      expectTypeOf(proxy.users.getById.useQuery({ id: 1 }, { catchError: () => null }))
+        .toHaveProperty("data")
+        .toEqualTypeOf<User | null | undefined>();
     });
 
     it("applies select on top of the catchError-widened type", () => {
       const { proxy } = setup();
 
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const result = proxy.users.getById.useQuery(
-        { id: 1 },
-        {
-          select: user => user?.id ?? null,
-          catchError: () => null
-        }
-      );
-
-      expectTypeOf<(typeof result)["data"]>().toEqualTypeOf<number | null | undefined>();
+      expectTypeOf(
+        proxy.users.getById.useQuery(
+          { id: 1 },
+          {
+            select: user => user?.id ?? null,
+            catchError: () => null
+          }
+        )
+      )
+        .toHaveProperty("data")
+        .toEqualTypeOf<number | null | undefined>();
     });
 
     it("keeps the data type as the SDK return type when placeholderData is keepPreviousData", () => {
       const { proxy } = setup();
 
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const result = proxy.users.getById.useQuery({ id: 1 }, { placeholderData: keepPreviousData });
-
-      expectTypeOf<(typeof result)["data"]>().toEqualTypeOf<User | undefined>();
+      expectTypeOf(proxy.users.getById.useQuery({ id: 1 }, { placeholderData: keepPreviousData }))
+        .toHaveProperty("data")
+        .toEqualTypeOf<User | undefined>();
     });
 
     it("keeps select and catchError intact when combined with keepPreviousData", () => {
       const { proxy } = setup();
 
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const result = proxy.users.getById.useQuery(
-        { id: 1 },
-        {
-          placeholderData: keepPreviousData,
-          catchError: () => null,
-          select: user => user?.id ?? null
-        }
-      );
-
-      expectTypeOf<(typeof result)["data"]>().toEqualTypeOf<number | null | undefined>();
+      expectTypeOf(
+        proxy.users.getById.useQuery(
+          { id: 1 },
+          {
+            placeholderData: keepPreviousData,
+            catchError: () => null,
+            select: user => user?.id ?? null
+          }
+        )
+      )
+        .toHaveProperty("data")
+        .toEqualTypeOf<number | null | undefined>();
     });
 
     it("can proxy class instance", () => {

--- a/packages/ui/components/custom/popup.tsx
+++ b/packages/ui/components/custom/popup.tsx
@@ -256,13 +256,14 @@ export function Popup(props: React.PropsWithChildren<PopupProps>) {
       );
       break;
     case "custom": {
-      props.actions?.length > 0 &&
+      if ((props.actions?.length ?? 0) > 0) {
         component.push(
           <DialogFooter className="flex flex-row justify-between space-x-2 sm:justify-between" key="DialogCustomActions">
             <div className="space-x-2">{buttonsForSide("left")}</div>
             <div className="space-x-2">{buttonsForSide("right")}</div>
           </DialogFooter>
         );
+      }
       break;
     }
     case "select": {

--- a/packages/ui/components/data-table/data-table.tsx
+++ b/packages/ui/components/data-table/data-table.tsx
@@ -97,8 +97,8 @@ export function DataTable<TData, TValue>({
     // TODO fix typing
     const nextState = (updater as any)(pagination);
 
-    setPageIndex && setPageIndex(nextState.pageIndex);
-    setPageSize && setPageSize(nextState.pageSize);
+    if (setPageIndex) setPageIndex(nextState.pageIndex);
+    if (setPageSize) setPageSize(nextState.pageSize);
 
     setPagination(nextState);
   }

--- a/packages/ui/components/input.tsx
+++ b/packages/ui/components/input.tsx
@@ -113,7 +113,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ classNa
 
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setValue(e.target.value);
-    onChange && onChange(e);
+    if (onChange) onChange(e);
   };
 
   return (

--- a/packages/ui/components/multiple-selector.tsx
+++ b/packages/ui/components/multiple-selector.tsx
@@ -366,7 +366,7 @@ export const MultipleSelector = React.forwardRef<MultipleSelectorRef, MultipleSe
               }}
               onFocus={event => {
                 setOpen(true);
-                triggerSearchOnFocus && onSearch?.(debouncedSearchTerm);
+                if (triggerSearchOnFocus) onSearch?.(debouncedSearchTerm);
                 inputProps?.onFocus?.(event);
               }}
               placeholder={hidePlaceholderWhenSelected && selected.length !== 0 ? "" : placeholder}

--- a/packages/ui/hooks/use-toast.tsx
+++ b/packages/ui/hooks/use-toast.tsx
@@ -15,13 +15,6 @@ export type ToasterToast = ToastProps & {
   action?: ToastActionElement;
 };
 
-const actionTypes = {
-  ADD_TOAST: "ADD_TOAST",
-  UPDATE_TOAST: "UPDATE_TOAST",
-  DISMISS_TOAST: "DISMISS_TOAST",
-  REMOVE_TOAST: "REMOVE_TOAST"
-} as const;
-
 let count = 0;
 
 function genId() {
@@ -29,7 +22,12 @@ function genId() {
   return count.toString();
 }
 
-type ActionType = typeof actionTypes;
+type ActionType = {
+  ADD_TOAST: "ADD_TOAST";
+  UPDATE_TOAST: "UPDATE_TOAST";
+  DISMISS_TOAST: "DISMISS_TOAST";
+  REMOVE_TOAST: "REMOVE_TOAST";
+};
 
 type Action =
   | {

--- a/packages/ui/tailwind.config.ts
+++ b/packages/ui/tailwind.config.ts
@@ -1,6 +1,9 @@
+import typography from "@tailwindcss/typography";
+import tailwindScrollbar from "tailwind-scrollbar";
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
-module.exports = function (app: string) {
+export default function createTailwindConfig(app: string): Config {
   const config: Config = {
     darkMode: "selector",
     content: [
@@ -95,8 +98,8 @@ module.exports = function (app: string) {
       }
     },
 
-    plugins: [require("tailwindcss-animate"), require("tailwind-scrollbar")({ nocompatible: true }), require("@tailwindcss/typography")]
+    plugins: [tailwindcssAnimate, tailwindScrollbar({ nocompatible: true }), typography]
   };
 
   return config;
-};
+}


### PR DESCRIPTION
## Why

Closes CON-707

The core ESLint rule `preserve-caught-error` was set to `"off"` in `packages/dev-config/eslint/base.mjs` for parity while migrating the flat config. This rule guards against silently dropping the original error when a `catch` block throws a new error, which loses the root-cause stack/context and makes production debugging harder. Enabling it (`"error"`) and preserving causes improves observability with zero runtime behavior change.

Stacked on #3480; part of CON-705 parity re-adoption. Verified on a delta basis against CON-704's pre-existing lint backlog.

## What

- Enable `preserve-caught-error` (`"off"` → `"error"`) in `packages/dev-config/eslint/base.mjs`.
- Fix the 12 resulting violations across 7 files by forwarding the caught error via the `cause` option (`new Error(msg, { cause: err })`, `new AggregateError(errors, msg, { cause: err })`) in apps/api, apps/deploy-web, apps/indexer, apps/log-collector, and apps/provider-console.
- No `eslint-disable` and no re-disabling of the rule; every throw honestly preserves its cause.

Verified on a delta basis: target rule ends at 0 violations and every other ESLint rule count (notably `@typescript-eslint/consistent-type-imports` at 716) is unchanged before→after. Per-workspace `tsc` and unit tests show no regressions relative to the pre-existing backlog.