### PR TITLE
refactor(dx): adopt no-unused-expressions and make statement intent explicit

### DIFF
--- a/apps/api/src/utils/json.ts
+++ b/apps/api/src/utils/json.ts
@@ -1,7 +1,7 @@
 export const safeParseJson = <T>(json: string, defaultValue?: T): T | null => {
   try {
     return JSON.parse(json) as T;
-  } catch (error) {
+  } catch {
     return (defaultValue as T) ?? null;
   }
 };

--- a/apps/api/src/verify-rsa-jwt-cloudflare-worker-main/verify.ts
+++ b/apps/api/src/verify-rsa-jwt-cloudflare-worker-main/verify.ts
@@ -37,7 +37,7 @@ function parseToken(token: string): {
   try {
     // kid = JSON.parse(atob(tokenParts[0])).kid; - kid is optional. Cannot always expect.
     payload = JSON.parse(atob(tokenParts[1]));
-  } catch (error) {
+  } catch {
     throw new BadRequest("Invalid token format");
   }
   const headerPayload = new TextEncoder().encode(`${tokenParts[0]}.${tokenParts[1]}`);

--- a/apps/api/test/setup-functional-tests.ts
+++ b/apps/api/test/setup-functional-tests.ts
@@ -67,7 +67,7 @@ expect.extend({
         message: () => `Ok`,
         pass: true
       };
-    } catch (error) {
+    } catch {
       return received === null
         ? {
             message: () => `Ok`,

--- a/apps/deploy-web/src/components/alerts/AlertsListContainer/AlertsListContainer.tsx
+++ b/apps/deploy-web/src/components/alerts/AlertsListContainer/AlertsListContainer.tsx
@@ -59,7 +59,7 @@ export const AlertsListContainer: FC<AlertsListContainerProps> = ({ children }) 
         } else {
           refetch();
         }
-      } catch (error) {
+      } catch {
         notificator.error("Failed to remove alert", {
           dataTestId: "alert-remove-error-notification"
         });
@@ -85,7 +85,7 @@ export const AlertsListContainer: FC<AlertsListContainerProps> = ({ children }) 
         await queryClient.invalidateQueries({
           queryKey: QueryKeys.getDeploymentDetailKey(address, dseq)
         });
-      } catch (error) {
+      } catch {
         notificator.error("Failed to update alert");
       } finally {
         setLoadingIds(prev => {

--- a/apps/deploy-web/src/components/alerts/DeploymentAlertsContainer/DeploymentAlertsContainer.tsx
+++ b/apps/deploy-web/src/components/alerts/DeploymentAlertsContainer/DeploymentAlertsContainer.tsx
@@ -94,7 +94,7 @@ export const DeploymentAlertsContainer: FC<Props> = ({ children, deployment }) =
         });
 
         return toOutput(result);
-      } catch (e) {
+      } catch {
         notificator.error("Alert configuration failed...", { dataTestId: "alert-config-error-notification" });
       }
     },

--- a/apps/deploy-web/src/components/alerts/NotificationChannelForm/NotificationChannelForm.tsx
+++ b/apps/deploy-web/src/components/alerts/NotificationChannelForm/NotificationChannelForm.tsx
@@ -67,7 +67,7 @@ export const NotificationChannelForm: FC<NotificationChannelFormProps> = ({ onCa
           ...values,
           emails: Array.from(new Set(emails))
         });
-      } catch (err) {
+      } catch {
         setError("Failed to save notification channel. Please try again.");
       }
     },

--- a/apps/deploy-web/src/components/deployments/DeploymentLeaseShell.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentLeaseShell.tsx
@@ -127,7 +127,7 @@ export const DeploymentLeaseShell: React.FunctionComponent<Props> = ({ leases })
       try {
         const jsonData = JSON.parse(parsedData);
         exitCode = jsonData["exit_code"];
-      } catch (error) {
+      } catch {
         /* empty */
       }
       if (exitCode === undefined) {

--- a/apps/deploy-web/src/components/new-deployment/CreateLease/CreateLease.tsx
+++ b/apps/deploy-web/src/components/new-deployment/CreateLease/CreateLease.tsx
@@ -220,15 +220,14 @@ export const CreateLease: React.FunctionComponent<Props> = ({ dseq, dependencies
         await providerProxy.sendManifest(provider, mani, options);
       }
 
-      // Ad tracking script
-      publicConfig.NEXT_PUBLIC_TRACKING_ENABLED &&
-        publicConfig.NEXT_PUBLIC_GROWTH_CHANNEL_TRACKING_ENABLED &&
+      if (publicConfig.NEXT_PUBLIC_TRACKING_ENABLED && publicConfig.NEXT_PUBLIC_GROWTH_CHANNEL_TRACKING_ENABLED) {
         addScriptToHead({
           src: "https://pxl.growth-channel.net/s/76250b26-c260-4776-874b-471ed290230d",
           async: true,
           defer: true,
           id: "growth-channel-script-lease"
         });
+      }
 
       router.replace(UrlService.deploymentDetails(dseq, "EVENTS", "events"));
     } catch (error) {

--- a/apps/deploy-web/src/components/new-deployment/SdlBuilder.tsx
+++ b/apps/deploy-web/src/components/new-deployment/SdlBuilder.tsx
@@ -113,7 +113,7 @@ export const SdlBuilder = React.forwardRef<SdlBuilderRefType, Props>(
             lastSyncedSdlRef.current = sdlString;
             form.reset({ ...form.getValues(), placements: imported.placements, services: imported.services });
           }
-        } catch (error) {
+        } catch {
           setError("Error importing SDL");
         }
       }

--- a/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.tsx
+++ b/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.tsx
@@ -304,23 +304,11 @@ export const OnboardingContainer: React.FunctionComponent<OnboardingContainerPro
           wallet.connectManagedWallet();
           router.replace(urlService.newDeployment({ step: RouteStep.createLeases, dseq: dd.deploymentId.dseq }));
         }
-      } catch (error) {
+      } catch {
         notificator.error("Failed to deploy template. Please try again.");
       }
     },
-    [
-      d,
-      router,
-      urlService,
-      wallet,
-      templateService,
-      minDeposit,
-      deploymentLocalStorage,
-      analyticsService,
-      notificator,
-      errorHandler,
-      navigateBack
-    ]
+    [d, router, urlService, wallet, templateService, minDeposit, deploymentLocalStorage, analyticsService, notificator, errorHandler, navigateBack]
   );
 
   const steps: OnboardingStep[] = [

--- a/apps/deploy-web/src/components/remote-deploy/update/RemoteDeployUpdate.tsx
+++ b/apps/deploy-web/src/components/remote-deploy/update/RemoteDeployUpdate.tsx
@@ -45,7 +45,7 @@ const RemoteDeployUpdate = ({ sdlString, onManifestChange }: { sdlString: string
           setValue("services", imported.services);
         }
       }
-    } catch (error) {
+    } catch {
       enqueueSnackbar(<Snackbar title="Error while parsing SDL file" />, { variant: "error" });
     }
 

--- a/apps/deploy-web/src/components/sdl/SDLEditor/SDLEditor.tsx
+++ b/apps/deploy-web/src/components/sdl/SDLEditor/SDLEditor.tsx
@@ -48,7 +48,7 @@ export const SDLEditor = forwardRef<SdlEditorRefType, Props>(({ onChange, onVali
       try {
         const { parseDocument } = await import("yaml");
         doc = parseDocument(value, { keepSourceTokens: true });
-      } catch (error) {
+      } catch {
         onValidate?.({ isValid: false });
         return false;
       }

--- a/apps/deploy-web/src/components/sdl/SimpleSdlBuilderForm.tsx
+++ b/apps/deploy-web/src/components/sdl/SimpleSdlBuilderForm.tsx
@@ -109,7 +109,7 @@ export const SimpleSDLBuilderForm: React.FunctionComponent = () => {
       setValue("services", imported.services);
       setServiceCollapsed(imported.services.map((x, i) => i));
       setTemplateMetadata(template);
-    } catch (error) {
+    } catch {
       enqueueSnackbar(<Snackbar title="Error fetching template." iconVariant="error" />, {
         variant: "error"
       });

--- a/apps/deploy-web/src/components/shared/PaymentMethodForm/PaymentMethodForm.tsx
+++ b/apps/deploy-web/src/components/shared/PaymentMethodForm/PaymentMethodForm.tsx
@@ -49,7 +49,7 @@ export const PaymentMethodForm: React.FC<PaymentMethodFormProps> = ({
       if (result.setupIntent?.status === "succeeded") {
         onSuccess(organization.trim() || undefined);
       }
-    } catch (err) {
+    } catch {
       setError("An unexpected error occurred.");
     } finally {
       setIsProcessing(false);

--- a/apps/deploy-web/src/components/shared/UserFavoriteButton.tsx
+++ b/apps/deploy-web/src/components/shared/UserFavoriteButton.tsx
@@ -37,10 +37,10 @@ export const UserFavoriteButton: React.FunctionComponent<Props> = ({ id, isFavor
 
       if (isFavorite) {
         await removeFavorite();
-        onRemoveFavorite && onRemoveFavorite();
+        if (onRemoveFavorite) onRemoveFavorite();
       } else {
         await addFavorite();
-        onAddFavorite && onAddFavorite();
+        if (onAddFavorite) onAddFavorite();
       }
 
       setIsFavorite(prev => !prev);

--- a/apps/deploy-web/src/components/shared/ViewPanel.tsx
+++ b/apps/deploy-web/src/components/shared/ViewPanel.tsx
@@ -58,7 +58,7 @@ export const ViewPanel: React.FunctionComponent<Props> = ({
         }
 
         setHeight(height);
-      } catch (error) {
+      } catch {
         setHeight("auto");
       }
     }

--- a/apps/deploy-web/src/components/user/UserSettingsForm.tsx
+++ b/apps/deploy-web/src/components/user/UserSettingsForm.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { MdHighlightOff } from "react-icons/md";
 import { Alert, Button, Card, CardContent, Form, FormField, FormInput, Spinner, Switch, Textarea } from "@akashnetwork/ui/components";
+import { zodResolver } from "@hookform/resolvers/zod";
 import { CheckCircle } from "iconoir-react";
 import { NextSeo } from "next-seo";
 import { z } from "zod";
@@ -15,7 +16,6 @@ import { useSaveSettings } from "@src/queries/useSaveSettings";
 import type { CustomUserProfile, UserSettings } from "@src/types/user";
 import Layout from "../layout/Layout";
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const formSchema = z.object({
   username: z
     .string()
@@ -35,6 +35,7 @@ export const UserSettingsForm: FC<{ user: CustomUserProfile }> = ({ user }) => {
   const [isAvailable, setIsAvailable] = useState<boolean | null>(null);
   const { isLoading } = useCustomUser();
   const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
     defaultValues: {
       username: "",
       subscribedToNewsletter: false,

--- a/apps/deploy-web/src/context/SdlBuilderProvider/SdlBuilderProvider.tsx
+++ b/apps/deploy-web/src/context/SdlBuilderProvider/SdlBuilderProvider.tsx
@@ -41,7 +41,11 @@ export const SdlBuilderProvider: FCWithChildren<SdlBuilderProviderProps> = ({ ch
     (component: ComponentNames) => {
       setHiddenComponents(prev => {
         const next = new Set(prev);
-        next.has(component) ? next.delete(component) : next.add(component);
+        if (next.has(component)) {
+          next.delete(component);
+        } else {
+          next.add(component);
+        }
         return next;
       });
     },

--- a/apps/deploy-web/src/hooks/useFormPersist.tsx
+++ b/apps/deploy-web/src/hooks/useFormPersist.tsx
@@ -62,7 +62,7 @@ const useFormPersist = (
       const currTimestamp = Date.now();
 
       if (timeout && currTimestamp - _timestamp > timeout) {
-        onTimeout && onTimeout();
+        if (onTimeout) onTimeout();
         clearStorage();
         return;
       }

--- a/apps/deploy-web/src/pages/api/blockchain-config.ts
+++ b/apps/deploy-web/src/pages/api/blockchain-config.ts
@@ -17,7 +17,7 @@ export default defineApiHandler({
     let networkConfig: Array<ReturnType<typeof nodeWithId>>;
     try {
       networkConfig = allNetworksConfig[query.network];
-    } catch (error) {
+    } catch {
       res.status(422).json({ error: `Unable to fetch ${query.network} blockchain network config. Does this network exist?` });
       return;
     }

--- a/apps/deploy-web/src/utils/stringUtils.ts
+++ b/apps/deploy-web/src/utils/stringUtils.ts
@@ -18,7 +18,7 @@ export function isUrl(val: string) {
   try {
     const url = new URL(val);
     return url.protocol === "http:" || url.protocol === "https:";
-  } catch (_) {
+  } catch {
     return false;
   }
 }

--- a/apps/log-collector/src/services/file-destination/file-destination.service.ts
+++ b/apps/log-collector/src/services/file-destination/file-destination.service.ts
@@ -101,7 +101,7 @@ export class FileDestinationService {
     try {
       const filePath = await this.getLogPath();
       return await this.readLastLinesFromFile(filePath);
-    } catch (error) {
+    } catch {
       return [];
     }
   }
@@ -150,12 +150,12 @@ export class FileDestinationService {
   private async ensureFileExists(filePath: string): Promise<void> {
     try {
       await this.fs.promises.access(filePath);
-    } catch (error) {
+    } catch {
       const logDir = this.configService.get("LOG_DIR");
 
       try {
         await this.fs.promises.access(logDir);
-      } catch (dirError) {
+      } catch {
         await this.fs.promises.mkdir(logDir, { recursive: true });
         this.loggerService.info({
           event: "LOG_DIR_CREATED",

--- a/apps/notifications/src/lib/value-backoff/value-backoff.ts
+++ b/apps/notifications/src/lib/value-backoff/value-backoff.ts
@@ -40,7 +40,7 @@ export function valueBackoff<T>(request: () => Promise<T | EmptyResult>, options
         const customError = options.createError();
         customError.cause = error;
         return Promise.reject(customError);
-      } catch (createErrorException) {
+      } catch {
         return Promise.reject(error);
       }
     }

--- a/apps/notifications/test/functional/account-purge.spec.ts
+++ b/apps/notifications/test/functional/account-purge.spec.ts
@@ -11,7 +11,7 @@ import { LoggerService } from "@src/common/services/logger/logger.service";
 import { DRIZZLE_PROVIDER_TOKEN } from "@src/infrastructure/db/config/db.config";
 import { HttpExceptionFilter } from "@src/interfaces/rest/filters/http-exception/http-exception.filter";
 import RestModule from "@src/interfaces/rest/rest.module";
-import * as alertSchema from "@src/modules/alert/model-schemas";
+import type * as alertSchema from "@src/modules/alert/model-schemas";
 import { Alert } from "@src/modules/alert/model-schemas";
 import { NotificationChannel } from "@src/modules/notifications/model-schemas";
 
@@ -61,9 +61,7 @@ describe("Account Purge (internal)", () => {
     const userId = faker.string.uuid();
 
     if (input.withSeed) {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const schema = { ...alertSchema, NotificationChannel };
-      const db = module.get<NodePgDatabase<typeof schema>>(DRIZZLE_PROVIDER_TOKEN);
+      const db = module.get<NodePgDatabase<typeof alertSchema & { NotificationChannel: typeof NotificationChannel }>>(DRIZZLE_PROVIDER_TOKEN);
       const [channel] = await db
         .insert(NotificationChannel)
         .values([generateNotificationChannel({ userId })])

--- a/apps/notifications/test/functional/alert-crud.spec.ts
+++ b/apps/notifications/test/functional/alert-crud.spec.ts
@@ -14,7 +14,7 @@ import { HttpExceptionFilter } from "@src/interfaces/rest/filters/http-exception
 import { chainMessageCreateInputSchema } from "@src/interfaces/rest/http-schemas/alert.http-schema";
 import { HttpResultInterceptor } from "@src/interfaces/rest/interceptors/http-result/http-result.interceptor";
 import RestModule from "@src/interfaces/rest/rest.module";
-import * as alertSchema from "@src/modules/alert/model-schemas";
+import type * as alertSchema from "@src/modules/alert/model-schemas";
 import type { AlertOutput } from "@src/modules/alert/repositories/alert/alert.repository";
 import { AlertRepository } from "@src/modules/alert/repositories/alert/alert.repository";
 import { NotificationChannel } from "@src/modules/notifications/model-schemas";
@@ -128,12 +128,7 @@ describe("Alerts CRUD", () => {
     await app.init();
 
     const userId = faker.string.uuid();
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const schema = {
-      ...alertSchema,
-      NotificationChannel
-    };
-    const db = module.get<NodePgDatabase<typeof schema>>(DRIZZLE_PROVIDER_TOKEN);
+    const db = module.get<NodePgDatabase<typeof alertSchema & { NotificationChannel: typeof NotificationChannel }>>(DRIZZLE_PROVIDER_TOKEN);
     const [notificationChannel] = await db
       .insert(NotificationChannel)
       .values([generateNotificationChannel({ userId })])

--- a/apps/notifications/test/functional/deployment-alert-crud.spec.ts
+++ b/apps/notifications/test/functional/deployment-alert-crud.spec.ts
@@ -15,7 +15,7 @@ import { DeploymentAlertCreateInput } from "@src/interfaces/rest/controllers/dep
 import { HttpExceptionFilter } from "@src/interfaces/rest/filters/http-exception/http-exception.filter";
 import { HttpResultInterceptor } from "@src/interfaces/rest/interceptors/http-result/http-result.interceptor";
 import RestModule from "@src/interfaces/rest/rest.module";
-import * as alertSchema from "@src/modules/alert/model-schemas";
+import type * as alertSchema from "@src/modules/alert/model-schemas";
 import { NotificationChannel } from "@src/modules/notifications/model-schemas";
 
 import { mockAkashAddress } from "@test/seeders/akash-address.seeder";
@@ -135,12 +135,7 @@ describe("Deployment Alerts CRUD", () => {
     await app.init();
 
     const userId = faker.string.uuid();
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const schema = {
-      ...alertSchema,
-      NotificationChannel
-    };
-    const db = module.get<NodePgDatabase<typeof schema>>(DRIZZLE_PROVIDER_TOKEN);
+    const db = module.get<NodePgDatabase<typeof alertSchema & { NotificationChannel: typeof NotificationChannel }>>(DRIZZLE_PROVIDER_TOKEN);
     const [notificationChannel] = await db
       .insert(NotificationChannel)
       .values([generateNotificationChannel({ userId })])

--- a/apps/provider-console/src/components/become-provider/ProviderAttributes.tsx
+++ b/apps/provider-console/src/components/become-provider/ProviderAttributes.tsx
@@ -168,7 +168,7 @@ export const ProviderAttributes: React.FunctionComponent<ProviderAttributesProps
         }))
       };
       setProviderProcess(updatedProviderProcess);
-      onComplete && onComplete();
+      if (onComplete) onComplete();
     } else {
       const attributes = data.attributes.map(attr => ({
         key: attr.key === "unknown-attributes" ? attr.customKey || "" : attr.key || "",

--- a/apps/provider-console/src/components/nodes/NodeListTable.tsx
+++ b/apps/provider-console/src/components/nodes/NodeListTable.tsx
@@ -63,7 +63,7 @@ export const NodeListTable = ({ nodes, onRemoveNode, activeControlMachine, isNod
       } else {
         return date.toLocaleDateString();
       }
-    } catch (e) {
+    } catch {
       return "Invalid Date";
     }
   };

--- a/apps/provider-console/src/components/shared/ActivityLogDetails.tsx
+++ b/apps/provider-console/src/components/shared/ActivityLogDetails.tsx
@@ -212,7 +212,7 @@ export const ActivityLogDetails: React.FC<{ actionId: string | null }> = ({ acti
           />
         </div>
       );
-    } catch (error) {
+    } catch {
       return (
         <div className="mt-4 rounded-md bg-gray-100 p-4 dark:bg-gray-800" style={{ height: 200, overflowY: "auto" }}>
           <pre className="whitespace-pre-wrap break-words text-sm">{logs}</pre>

--- a/apps/provider-console/src/context/WalletProvider/WalletProvider.tsx
+++ b/apps/provider-console/src/context/WalletProvider/WalletProvider.tsx
@@ -156,7 +156,7 @@ export const WalletProvider = ({ children }) => {
             throw new Error("Invalid nonce response");
           }
         }
-      } catch (error) {
+      } catch {
         logout();
       }
     }

--- a/apps/provider-console/src/hooks/useLocalStorage.ts
+++ b/apps/provider-console/src/hooks/useLocalStorage.ts
@@ -82,7 +82,7 @@ export function useCustomLocalStorage<T>(key: string, initialValue: T) {
 function parseJSON(value: string) {
   try {
     return value === "undefined" ? undefined : JSON.parse(value ?? "");
-  } catch (error) {
+  } catch {
     return value === "undefined" ? undefined : value;
   }
 }

--- a/apps/provider-console/src/pages/nodes/index.tsx
+++ b/apps/provider-console/src/pages/nodes/index.tsx
@@ -43,7 +43,7 @@ const NodesPage: React.FunctionComponent = () => {
 
       // If we have an action_id, the mutation will handle the redirect in onSuccess
       // This toast is still useful for users to see even if they'll be redirected
-    } catch (error) {
+    } catch {
       toast({
         variant: "destructive",
         title: "Failed to remove node",

--- a/apps/provider-console/src/pages/settings/index.tsx
+++ b/apps/provider-console/src/pages/settings/index.tsx
@@ -158,7 +158,7 @@ const SettingsPage: React.FC = () => {
         setTimeout(() => setRestartSuccess(false), 20000);
       }
       setUrlError("");
-    } catch (error) {
+    } catch {
       setUrlError("Please enter a valid domain name");
     }
   };

--- a/apps/provider-console/src/utils/walletScopedStorage.ts
+++ b/apps/provider-console/src/utils/walletScopedStorage.ts
@@ -35,7 +35,7 @@ export function createWalletScopedStorage<T>(baseKey: string): AsyncStorage<T> {
 
     try {
       return JSON.parse(value) as T;
-    } catch (error) {
+    } catch {
       return undefined;
     }
   };

--- a/apps/provider-proxy/src/services/WebsocketServer.ts
+++ b/apps/provider-proxy/src/services/WebsocketServer.ts
@@ -87,7 +87,7 @@ export class WebsocketServer {
             let newOrLegacyMessage: Record<string, unknown> | undefined;
             try {
               newOrLegacyMessage = typeof messageStr === "string" ? JSON.parse(messageStr) : undefined;
-            } catch (error) {
+            } catch {
               this.logger?.error({
                 event: "CLIENT_MESSAGE_INVALID_JSON",
                 message: "Received message is not a JSON string",

--- a/apps/provider-proxy/src/utils/schema.ts
+++ b/apps/provider-proxy/src/utils/schema.ts
@@ -84,7 +84,7 @@ const jwtTokenManager = new JwtTokenManager({
 function validateJwtPayload(token: string): { isValid: boolean; errors?: string[] } {
   try {
     return jwtTokenManager.validatePayload(jwtTokenManager.decodeToken(token));
-  } catch (error) {
+  } catch {
     return { isValid: false, errors: ["Invalid token"] };
   }
 }

--- a/apps/provider-proxy/test/functional/provider-proxy-ws.spec.ts
+++ b/apps/provider-proxy/test/functional/provider-proxy-ws.spec.ts
@@ -170,7 +170,8 @@ describe("Provider proxy ws", () => {
     const proxyServerUrl = await startServer({ REST_API_NODE_URL: chainServer.url });
     const ws = new WebSocket(`${proxyServerUrl}/ws`);
 
-    await new Promise(resolve => ws.once("open", resolve)), ws.send(JSON.stringify(ourMessage("please_close", providerUrl, { providerAddress })));
+    await new Promise(resolve => ws.once("open", resolve));
+    ws.send(JSON.stringify(ourMessage("please_close", providerUrl, { providerAddress })));
     expect(await waitForMessage(ws)).toEqual(
       providerMessage("", {
         closed: true,

--- a/apps/stats-web/src/hooks/useTopBanner.tsx
+++ b/apps/stats-web/src/hooks/useTopBanner.tsx
@@ -93,7 +93,7 @@ export function useGenericBannerDetails(): GenericBannerDetails {
   try {
     const details = genericBannerFlag?.enabled ? (JSON.parse(genericBannerFlag.payload?.value as string) as GenericBannerDetails) : { message: "" };
     return details;
-  } catch (error) {
+  } catch {
     return { message: "" };
   }
 }

--- a/apps/stats-web/src/lib/urlUtils.ts
+++ b/apps/stats-web/src/lib/urlUtils.ts
@@ -50,7 +50,7 @@ export function isValidHttpUrl(str: string): boolean {
 
   try {
     url = new URL(str);
-  } catch (_) {
+  } catch {
     return false;
   }
 

--- a/apps/tx-signer/src/services/config/config.service.spec.ts
+++ b/apps/tx-signer/src/services/config/config.service.spec.ts
@@ -5,9 +5,8 @@ import { ConfigService } from "./config.service";
 
 describe(ConfigService.name, () => {
   it("returns stored config values", () => {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const schema = z.object({ FOO: z.string() });
-    const service = new ConfigService({ config: { FOO: "bar" } as z.infer<typeof schema> });
+    const service = new ConfigService({ config: schema.parse({ FOO: "bar" }) });
 
     expect(service.get("FOO")).toBe("bar");
   });

--- a/packages/dev-config/eslint/typescript.mjs
+++ b/packages/dev-config/eslint/typescript.mjs
@@ -15,7 +15,7 @@ export default tseslint.config(...base, {
   rules: {
     "@typescript-eslint/no-explicit-any": ["warn"],
     "@typescript-eslint/no-require-imports": ["error"],
-    "@typescript-eslint/no-unused-expressions": ["off"],
+    "@typescript-eslint/no-unused-expressions": ["error"],
     "@typescript-eslint/no-empty-object-type": ["error", { allowInterfaces: "with-single-extends" }],
     "@typescript-eslint/consistent-type-imports": ["error", { prefer: "type-imports", fixStyle: "separate-type-imports" }],
     "@typescript-eslint/no-unused-vars": ["error", { ignoreRestSiblings: true, argsIgnorePattern: "^_", caughtErrors: "none" }]

--- a/packages/dev-config/eslint/typescript.mjs
+++ b/packages/dev-config/eslint/typescript.mjs
@@ -18,6 +18,6 @@ export default tseslint.config(...base, {
     "@typescript-eslint/no-unused-expressions": ["error"],
     "@typescript-eslint/no-empty-object-type": ["error", { allowInterfaces: "with-single-extends" }],
     "@typescript-eslint/consistent-type-imports": ["error", { prefer: "type-imports", fixStyle: "separate-type-imports" }],
-    "@typescript-eslint/no-unused-vars": ["error", { ignoreRestSiblings: true, argsIgnorePattern: "^_", caughtErrors: "none" }]
+    "@typescript-eslint/no-unused-vars": ["error", { ignoreRestSiblings: true, argsIgnorePattern: "^_", caughtErrors: "all" }]
   }
 });

--- a/packages/react-query-proxy/src/createProxy/createProxy.spec.ts
+++ b/packages/react-query-proxy/src/createProxy/createProxy.spec.ts
@@ -151,68 +151,66 @@ describe(createProxy.name, () => {
     it("reflects the select return type in the query data", () => {
       const { proxy } = setup();
 
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const result = proxy.users.getById.useQuery({ id: 1 }, { select: user => user.name });
-
-      expectTypeOf<(typeof result)["data"]>().toEqualTypeOf<string | undefined>();
+      expectTypeOf(proxy.users.getById.useQuery({ id: 1 }, { select: user => user.name }))
+        .toHaveProperty("data")
+        .toEqualTypeOf<string | undefined>();
     });
 
     it("defaults the data type to the SDK return type when no select is given", () => {
       const { proxy } = setup();
 
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const result = proxy.users.getById.useQuery({ id: 1 });
-
-      expectTypeOf<(typeof result)["data"]>().toEqualTypeOf<User | undefined>();
+      expectTypeOf(proxy.users.getById.useQuery({ id: 1 }))
+        .toHaveProperty("data")
+        .toEqualTypeOf<User | undefined>();
     });
 
     it("widens the data type by the catchError return type", () => {
       const { proxy } = setup();
 
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const result = proxy.users.getById.useQuery({ id: 1 }, { catchError: () => null });
-
-      expectTypeOf<(typeof result)["data"]>().toEqualTypeOf<User | null | undefined>();
+      expectTypeOf(proxy.users.getById.useQuery({ id: 1 }, { catchError: () => null }))
+        .toHaveProperty("data")
+        .toEqualTypeOf<User | null | undefined>();
     });
 
     it("applies select on top of the catchError-widened type", () => {
       const { proxy } = setup();
 
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const result = proxy.users.getById.useQuery(
-        { id: 1 },
-        {
-          select: user => user?.id ?? null,
-          catchError: () => null
-        }
-      );
-
-      expectTypeOf<(typeof result)["data"]>().toEqualTypeOf<number | null | undefined>();
+      expectTypeOf(
+        proxy.users.getById.useQuery(
+          { id: 1 },
+          {
+            select: user => user?.id ?? null,
+            catchError: () => null
+          }
+        )
+      )
+        .toHaveProperty("data")
+        .toEqualTypeOf<number | null | undefined>();
     });
 
     it("keeps the data type as the SDK return type when placeholderData is keepPreviousData", () => {
       const { proxy } = setup();
 
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const result = proxy.users.getById.useQuery({ id: 1 }, { placeholderData: keepPreviousData });
-
-      expectTypeOf<(typeof result)["data"]>().toEqualTypeOf<User | undefined>();
+      expectTypeOf(proxy.users.getById.useQuery({ id: 1 }, { placeholderData: keepPreviousData }))
+        .toHaveProperty("data")
+        .toEqualTypeOf<User | undefined>();
     });
 
     it("keeps select and catchError intact when combined with keepPreviousData", () => {
       const { proxy } = setup();
 
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const result = proxy.users.getById.useQuery(
-        { id: 1 },
-        {
-          placeholderData: keepPreviousData,
-          catchError: () => null,
-          select: user => user?.id ?? null
-        }
-      );
-
-      expectTypeOf<(typeof result)["data"]>().toEqualTypeOf<number | null | undefined>();
+      expectTypeOf(
+        proxy.users.getById.useQuery(
+          { id: 1 },
+          {
+            placeholderData: keepPreviousData,
+            catchError: () => null,
+            select: user => user?.id ?? null
+          }
+        )
+      )
+        .toHaveProperty("data")
+        .toEqualTypeOf<number | null | undefined>();
     });
 
     it("can proxy class instance", () => {

--- a/packages/ui/components/custom/popup.tsx
+++ b/packages/ui/components/custom/popup.tsx
@@ -256,13 +256,14 @@ export function Popup(props: React.PropsWithChildren<PopupProps>) {
       );
       break;
     case "custom": {
-      props.actions?.length > 0 &&
+      if ((props.actions?.length ?? 0) > 0) {
         component.push(
           <DialogFooter className="flex flex-row justify-between space-x-2 sm:justify-between" key="DialogCustomActions">
             <div className="space-x-2">{buttonsForSide("left")}</div>
             <div className="space-x-2">{buttonsForSide("right")}</div>
           </DialogFooter>
         );
+      }
       break;
     }
     case "select": {

--- a/packages/ui/components/data-table/data-table.tsx
+++ b/packages/ui/components/data-table/data-table.tsx
@@ -97,8 +97,8 @@ export function DataTable<TData, TValue>({
     // TODO fix typing
     const nextState = (updater as any)(pagination);
 
-    setPageIndex && setPageIndex(nextState.pageIndex);
-    setPageSize && setPageSize(nextState.pageSize);
+    if (setPageIndex) setPageIndex(nextState.pageIndex);
+    if (setPageSize) setPageSize(nextState.pageSize);
 
     setPagination(nextState);
   }

--- a/packages/ui/components/input.tsx
+++ b/packages/ui/components/input.tsx
@@ -113,7 +113,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ classNa
 
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setValue(e.target.value);
-    onChange && onChange(e);
+    if (onChange) onChange(e);
   };
 
   return (

--- a/packages/ui/components/multiple-selector.tsx
+++ b/packages/ui/components/multiple-selector.tsx
@@ -366,7 +366,7 @@ export const MultipleSelector = React.forwardRef<MultipleSelectorRef, MultipleSe
               }}
               onFocus={event => {
                 setOpen(true);
-                triggerSearchOnFocus && onSearch?.(debouncedSearchTerm);
+                if (triggerSearchOnFocus) onSearch?.(debouncedSearchTerm);
                 inputProps?.onFocus?.(event);
               }}
               placeholder={hidePlaceholderWhenSelected && selected.length !== 0 ? "" : placeholder}

--- a/packages/ui/hooks/use-toast.tsx
+++ b/packages/ui/hooks/use-toast.tsx
@@ -15,13 +15,6 @@ export type ToasterToast = ToastProps & {
   action?: ToastActionElement;
 };
 
-const actionTypes = {
-  ADD_TOAST: "ADD_TOAST",
-  UPDATE_TOAST: "UPDATE_TOAST",
-  DISMISS_TOAST: "DISMISS_TOAST",
-  REMOVE_TOAST: "REMOVE_TOAST"
-} as const;
-
 let count = 0;
 
 function genId() {
@@ -29,7 +22,12 @@ function genId() {
   return count.toString();
 }
 
-type ActionType = typeof actionTypes;
+type ActionType = {
+  ADD_TOAST: "ADD_TOAST";
+  UPDATE_TOAST: "UPDATE_TOAST";
+  DISMISS_TOAST: "DISMISS_TOAST";
+  REMOVE_TOAST: "REMOVE_TOAST";
+};
 
 type Action =
   | {


### PR DESCRIPTION
## Why

Closes CON-710

`@typescript-eslint/no-unused-expressions` was disabled in the shared config (`packages/dev-config/eslint/typescript.mjs`). This rule flags expression statements whose computed value is discarded, which usually hides either dead code or a side-effecting expression that would read more clearly as a real statement. Enabling it keeps intent explicit and prevents accidental no-op statements.

Stacked on #3483; part of CON-705 parity re-adoption. Verified on a delta basis against CON-704's pre-existing lint backlog (hundreds of `consistent-type-imports`, some `react-hooks/*`, etc. — unchanged by this PR).

## What

- Enabled `@typescript-eslint/no-unused-expressions` (`off` → `error`).
- Rewrote the 12 flagged sites as explicit statements (no escape-hatch options, no inline disables):
  - `apps/deploy-web/.../CreateLease.tsx` — `flagA && flagB && addScriptToHead(...)` → `if (flagA && flagB) { addScriptToHead(...) }` (dropped a redundant leading comment).
  - `apps/deploy-web/.../UserFavoriteButton.tsx` — `onRemoveFavorite && onRemoveFavorite()` / `onAddFavorite && onAddFavorite()` → `if (...) ...()`.
  - `apps/deploy-web/.../SdlBuilderProvider.tsx` — `next.has(c) ? next.delete(c) : next.add(c)` → `if/else`.
  - `apps/deploy-web/.../useFormPersist.tsx` — `onTimeout && onTimeout()` → `if (onTimeout) onTimeout()`.
  - `apps/provider-console/.../ProviderAttributes.tsx` — `onComplete && onComplete()` → `if (onComplete) onComplete()`.
  - `apps/provider-proxy/test/functional/provider-proxy-ws.spec.ts` — comma sequence `await new Promise(...), ws.send(...)` split into two statements.
  - `packages/ui/components/custom/popup.tsx` — `props.actions?.length > 0 && component.push(...)` → `if ((props.actions?.length ?? 0) > 0) { component.push(...) }`.
  - `packages/ui/components/data-table/data-table.tsx` — `setPageIndex && setPageIndex(...)` / `setPageSize && setPageSize(...)` → `if (...) ...()`.
  - `packages/ui/components/input.tsx` — `onChange && onChange(e)` → `if (onChange) onChange(e)`.
  - `packages/ui/components/multiple-selector.tsx` — `triggerSearchOnFocus && onSearch?.(...)` → `if (triggerSearchOnFocus) onSearch?.(...)`.

All rewrites preserve the original conditional behavior (the side effect still runs under exactly the same conditions). The one behavior-adjacent site to note is the provider-proxy functional test: the comma-sequence previously awaited the socket `open` promise and then sent the message; the split keeps that exact ordering (`await` open, then `send`), just as two clear statements instead of a discarded sequence expression.