### PR TITLE
fix(styling): remove render-blocking external Google Fonts link

### DIFF
--- a/apps/deploy-web/src/pages/_document.tsx
+++ b/apps/deploy-web/src/pages/_document.tsx
@@ -25,7 +25,6 @@ export default function MyDocument(props: DocumentHeadTagsProps) {
         <meta name="theme-color" content={customColors.dark} />
         <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
         <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-        <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100;300;500;700;900&display=swap" rel="stylesheet" />
       </Head>
       <body>
         <Main />


### PR DESCRIPTION
## Why

Closes #1744, CON-715
 
## What

The Inter stylesheet loaded via <link> to fonts.googleapis.com in deploy-web's _document.tsx was render-blocking in <head> and depended on an external service that could become unavailable and stall page load. Inter was never actually applied anywhere — all apps render the self-hosted Geist font (bundled at build time via the geist package), so the link was dead code. Removing it eliminates the external dependency with no visual change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Removed the external Inter font stylesheet, reducing reliance on third-party font loading.
  * Pages may now load with the system’s default font instead of Inter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->