### PR TITLE
fix(billing): stop setup-intent request storm on signup

### DIFF
--- a/apps/deploy-web/src/components/onboarding/steps/PaymentMethodContainer/PaymentMethodContainer.spec.tsx
+++ b/apps/deploy-web/src/components/onboarding/steps/PaymentMethodContainer/PaymentMethodContainer.spec.tsx
@@ -43,6 +43,18 @@ describe("PaymentMethodContainer", () => {
     expect(mockCreateSetupIntent).not.toHaveBeenCalled();
   });
 
+  it("does not create another setup intent while a request is already in flight", () => {
+    const { mockCreateSetupIntent } = setup({ setupIntentStatus: "pending" });
+
+    expect(mockCreateSetupIntent).not.toHaveBeenCalled();
+  });
+
+  it("does not recreate a setup intent after a failed request", () => {
+    const { mockCreateSetupIntent } = setup({ setupIntentStatus: "error" });
+
+    expect(mockCreateSetupIntent).not.toHaveBeenCalled();
+  });
+
   it("should handle payment method removal", async () => {
     const { child, mockRemovePaymentMethod } = setup();
     mockRemovePaymentMethod.mockResolvedValue(undefined);
@@ -357,6 +369,7 @@ describe("PaymentMethodContainer", () => {
     input: {
       paymentMethods?: any[];
       setupIntent?: any;
+      setupIntentStatus?: "idle" | "pending" | "success" | "error";
       hasManagedWallet?: boolean;
       isWalletLoading?: boolean;
       isConnectingWallet?: boolean;
@@ -376,6 +389,7 @@ describe("PaymentMethodContainer", () => {
     const mockUseSetupIntentMutation = vi.fn().mockReturnValue({
       data: input.setupIntent,
       mutate: mockCreateSetupIntent,
+      status: input.setupIntentStatus ?? (input.setupIntent ? "success" : "idle"),
       reset: vi.fn()
     });
 

--- a/apps/deploy-web/src/components/onboarding/steps/PaymentMethodContainer/PaymentMethodContainer.tsx
+++ b/apps/deploy-web/src/components/onboarding/steps/PaymentMethodContainer/PaymentMethodContainer.tsx
@@ -56,7 +56,7 @@ export type PaymentMethodContainerProps = {
 };
 
 export const PaymentMethodContainer: FC<PaymentMethodContainerProps> = ({ children, onComplete, dependencies: d = DEPENDENCIES }) => {
-  const { data: setupIntent, mutate: createSetupIntent, reset: resetSetupIntent } = d.useSetupIntentMutation();
+  const { data: setupIntent, mutate: createSetupIntent, status: setupIntentStatus, reset: resetSetupIntent } = d.useSetupIntentMutation();
   const { data: paymentMethods = [], refetch: refetchPaymentMethods } = d.usePaymentMethodsQuery();
   const { removePaymentMethod } = d.usePaymentMutations();
   const { isWalletLoading, hasManagedWallet, managedWalletError } = d.useWallet();
@@ -140,10 +140,10 @@ export const PaymentMethodContainer: FC<PaymentMethodContainerProps> = ({ childr
   );
 
   useEffect(() => {
-    if (user && !setupIntent) {
+    if (user && setupIntentStatus === "idle") {
       createSetupIntent();
     }
-  }, [user, setupIntent, createSetupIntent]);
+  }, [user, setupIntentStatus, createSetupIntent]);
 
   useEffect(() => {
     if (isConnectingWallet && hasManagedWallet && !isWalletLoading) {

--- a/apps/deploy-web/src/hooks/useCustomUser.ts
+++ b/apps/deploy-web/src/hooks/useCustomUser.ts
@@ -1,4 +1,5 @@
 import { useUser } from "@auth0/nextjs-auth0/client";
+import { useMemo } from "react";
 
 import type { CustomUserProfile } from "@src/types/user";
 import { plans } from "@src/utils/plans";
@@ -15,7 +16,7 @@ type UseCustomUser = {
  */
 export const useCustomUser = (): UseCustomUser => {
   const { user, isLoading, error, checkSession } = useUser();
-  const completeUser = user ? { ...user, plan: plans.find(x => x.code === user.planCode) } : user;
+  const completeUser = useMemo(() => (user ? { ...user, plan: plans.find(x => x.code === user.planCode) } : user), [user]);
 
   return {
     user: completeUser,

--- a/apps/deploy-web/src/hooks/useCustomUser.ts
+++ b/apps/deploy-web/src/hooks/useCustomUser.ts
@@ -1,5 +1,5 @@
-import { useUser } from "@auth0/nextjs-auth0/client";
 import { useMemo } from "react";
+import { useUser } from "@auth0/nextjs-auth0/client";
 
 import type { CustomUserProfile } from "@src/types/user";
 import { plans } from "@src/utils/plans";

--- a/apps/deploy-web/src/queries/usePaymentQueries.ts
+++ b/apps/deploy-web/src/queries/usePaymentQueries.ts
@@ -66,11 +66,15 @@ export const usePaymentTransactionsQuery = (
 };
 
 export const useSetupIntentMutation = () => {
-  const { stripe } = useServices();
+  const { stripe, errorHandler } = useServices();
   return useMutation<SetupIntentResponse, Error>({
+    retry: false,
     mutationFn: async () => {
       const response = await stripe.createSetupIntent();
       return response;
+    },
+    onError: error => {
+      errorHandler.reportError({ error, tags: { category: "billing" } });
     }
   });
 };


### PR DESCRIPTION
## Why

Closes CON-716

## What

An unstable `user` reference from useCustomUser changed identity on every render, retriggering the PaymentMethodContainer effect that creates a Stripe setup intent. Because the effect guarded on `!setupIntent` (which stays undefined on failure), a failed request re-fired in a tight loop, hammering POST /v1/stripe/payment-methods/setup until Cloudflare returned a 429 challenge and the signup payment step could never render the card form.

- Memoize completeUser in useCustomUser so its identity is stable across renders, breaking the effect loop at its source.
- Guard the setup-intent effect on mutation status === "idle" instead of !setupIntent, so it never re-fires while pending or after an error.
- Disable retries and report failures via errorHandler in useSetupIntentMutation so errors are observable, not silently re-looped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate setup intent creation while a setup request is pending.
  * Avoided recreating a setup intent after a failed request when the setup status is in an error state.
  * Improved billing-related error reporting and disabled automatic retries for setup requests.
* **Performance**
  * Reduced unnecessary user data recomputation by memoizing derived user information.
* **Tests**
  * Added/expanded coverage for pending and failed setup intent scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->