### PR TITLE
refactor(dx): enable explicit-module-boundary-types for indexer

### DIFF
--- a/apps/indexer/eslint.config.mjs
+++ b/apps/indexer/eslint.config.mjs
@@ -1,3 +1,11 @@
 import tsConfig from "@akashnetwork/dev-config/eslint/typescript.mjs";
 
-export default tsConfig;
+export default [
+  ...tsConfig,
+  {
+    files: ["**/*.ts", "**/*.tsx"],
+    rules: {
+      "@typescript-eslint/explicit-module-boundary-types": ["error"]
+    }
+  }
+];

--- a/apps/indexer/src/chain/chainSync.ts
+++ b/apps/indexer/src/chain/chainSync.ts
@@ -37,10 +37,21 @@ function parseEventAttrs(event: { attributes: Array<{ key: string; value: string
   return attrs;
 }
 
-export const setMissingBlock = (height: number) => (missingBlock = height);
+export const setMissingBlock = (height: number): number => (missingBlock = height);
 let missingBlock: number | null = null;
 
-export async function getSyncStatus() {
+export async function getSyncStatus(): Promise<{
+  latestHeightInCache: number;
+  latestHeightInDb: number;
+  latestDateInDb: Date | null;
+  isInsertLate: boolean | null;
+  latestProcessedHeight: number;
+  latestProcessedDateInDb: Date | null;
+  isProcessingLate: boolean | null;
+  latestNotificationProcessedHeight: number;
+  latestNotificationProcessedDateInDb: Date | null;
+  isNotificationProcessingLate: boolean | null;
+}> {
   const latestHeightInCacheRequest = getLatestHeightInCache();
   const latestHeightInDbRequest = Block.max("height") as Promise<number>;
   const latestProcessedHeightRequest = Block.max("height", { where: { isProcessed: true } }) as Promise<number>;
@@ -88,7 +99,7 @@ export async function getSyncStatus() {
   };
 }
 
-export async function syncBlocks() {
+export async function syncBlocks(): Promise<void> {
   const latestAvailableHeight = await nodeAccessor.getLatestBlockHeight();
   let latestBlockToDownload = Math.min(lastBlockToSync, latestAvailableHeight);
   const latestInsertedHeight = ((await Block.max("height")) as number) || 0;

--- a/apps/indexer/src/chain/dataStore.ts
+++ b/apps/indexer/src/chain/dataStore.ts
@@ -12,12 +12,12 @@ if (!fs.existsSync(dataFolderPath)) {
   fs.mkdirSync(dataFolderPath, { recursive: true });
 }
 
-export const blockHeightToKey = (height: number) => height.toString().padStart(10, "0");
+export const blockHeightToKey = (height: number): string => height.toString().padStart(10, "0");
 
 export const blocksDb = new Level(dataFolderPath + "/blocks.db");
 export const blockResultsDb = new Level(dataFolderPath + "/blockResults.db");
 
-export async function getLatestHeightInCache() {
+export async function getLatestHeightInCache(): Promise<number> {
   const reverseKeyIterator = blocksDb.keys({ reverse: true });
   const keyStr = await reverseKeyIterator.next();
   await reverseKeyIterator.close();
@@ -29,7 +29,7 @@ export async function getLatestHeightInCache() {
   }
 }
 
-export const getCacheSize = async function () {
+export const getCacheSize = async function (): Promise<{ blocksSize: string; blockResultsSize: string }> {
   console.time("size");
   const blocksSize = await getTotalSize(dataFolderPath + "/blocks.db");
   const blockResultsSize = await getTotalSize(dataFolderPath + "/blockResults.db");
@@ -37,14 +37,14 @@ export const getCacheSize = async function () {
   return { blocksSize: blocksSize, blockResultsSize: blockResultsSize };
 };
 
-export const deleteCache = async function () {
+export const deleteCache = async function (): Promise<void> {
   console.log("Deleting cache...");
   await blocksDb.clear();
   await blockResultsDb.clear();
   console.log("Deleted");
 };
 
-export async function getCachedBlockByHeight(height: number) {
+export async function getCachedBlockByHeight(height: number): Promise<BlockType | null> {
   try {
     const content = await blocksDb.get(blockHeightToKey(height));
     return JSON.parse(content) as BlockType;
@@ -55,7 +55,7 @@ export async function getCachedBlockByHeight(height: number) {
   }
 }
 
-export async function getCachedBlockResultsByHeight(height: number) {
+export async function getCachedBlockResultsByHeight(height: number): Promise<BlockResultType | null> {
   try {
     const content = await blockResultsDb.get(blockHeightToKey(height));
     return JSON.parse(content) as BlockResultType;

--- a/apps/indexer/src/chain/nodeInfo.ts
+++ b/apps/indexer/src/chain/nodeInfo.ts
@@ -62,7 +62,7 @@ export class NodeInfo {
     };
   }
 
-  public loadFromSavedNodeInfo(savedNodeInfo: SavedNodeInfo) {
+  public loadFromSavedNodeInfo(savedNodeInfo: SavedNodeInfo): void {
     this.status = savedNodeInfo.status === NodeStatus.OK && !Number.isFinite(savedNodeInfo.earliestBlockHeight) ? NodeStatus.UNKNOWN : savedNodeInfo.status;
     this.maxConcurrentQuery = savedNodeInfo.maxConcurrentQuery;
     this.delayBetweenRequests = savedNodeInfo.delayBetweenRequests;
@@ -152,7 +152,7 @@ export class NodeInfo {
     }
   }
 
-  public async query(path: string, height?: number) {
+  public async query(path: string, height?: number): Promise<any> {
     this.activeQueries.push(path);
 
     if (this.delayBetweenRequests && this.lastQueryDate) {

--- a/apps/indexer/src/db/buildDatabase.ts
+++ b/apps/indexer/src/db/buildDatabase.ts
@@ -10,7 +10,7 @@ import { sequelize } from "./dbConnection";
 /**
  * Initiate database schema
  */
-export const initDatabase = async () => {
+export const initDatabase = async (): Promise<void> => {
   console.log(`Connecting to db (${sequelize.config.host}/${sequelize.config.database})...`);
   await sequelize.authenticate();
   console.log("Connection has been established successfully.");

--- a/apps/indexer/src/db/keybaseProvider.ts
+++ b/apps/indexer/src/db/keybaseProvider.ts
@@ -2,7 +2,7 @@ import { Validator } from "@akashnetwork/database/dbSchemas/base";
 import fetch from "node-fetch";
 import { Op } from "sequelize";
 
-export async function fetchValidatorKeybaseInfos() {
+export async function fetchValidatorKeybaseInfos(): Promise<void> {
   const validators = await Validator.findAll({
     where: {
       identity: { [Op.notIn]: [null, ""] }

--- a/apps/indexer/src/db/priceHistoryProvider.ts
+++ b/apps/indexer/src/db/priceHistoryProvider.ts
@@ -9,7 +9,7 @@ interface PriceHistoryResponse {
   total_volumes: Array<Array<number>>;
 }
 
-export const syncPriceHistory = async () => {
+export const syncPriceHistory = async (): Promise<void> => {
   if (!activeChain.coinGeckoId) {
     console.log("No coin gecko id defined for this chain. Skipping price history sync.");
     return;

--- a/apps/indexer/src/indexers/akashStatsIndexer.ts
+++ b/apps/indexer/src/indexers/akashStatsIndexer.ts
@@ -166,7 +166,7 @@ export class AkashStatsIndexer extends Indexer {
     await Bid.sync({ force: false });
   }
 
-  async initCache(firstBlockHeight: number) {
+  async initCache(firstBlockHeight: number): Promise<void> {
     this.activeLeases = await this.getActiveLeases(null, firstBlockHeight);
 
     this.totalLeaseCount = await Lease.count();
@@ -185,7 +185,7 @@ export class AkashStatsIndexer extends Indexer {
   }
 
   @benchmark.measureMethodAsync
-  async afterEveryBlock(currentBlock: Block, previousBlock: Block | null, dbTransaction: DbTransaction) {
+  async afterEveryBlock(currentBlock: Block, previousBlock: Block | null, dbTransaction: DbTransaction): Promise<void> {
     const shouldRefreshPredictedHeights = currentBlock.transactions.some(tx => tx.messages?.some(msg => this.shouldRefreshForMessage(msg)));
 
     if (shouldRefreshPredictedHeights || this.activeLeases?.predictedClosedHeights.includes(currentBlock.height)) {

--- a/apps/indexer/src/indexers/indexer.ts
+++ b/apps/indexer/src/indexers/indexer.ts
@@ -15,7 +15,7 @@ export abstract class Indexer {
     return Object.keys(this.msgHandlers).includes(type);
   }
 
-  async processMessage(decodedMessage: any, height: number, blockGroupTransaction: DbTransaction, msg: Message): Promise<void> {
+  async processMessage(decodedMessage: unknown, height: number, blockGroupTransaction: DbTransaction, msg: Message): Promise<void> {
     if (!(msg.type in this.msgHandlers)) {
       throw new Error(`No handler for message type ${msg.type} in ${this.name}`);
     }

--- a/apps/indexer/src/indexers/validatorIndexer.ts
+++ b/apps/indexer/src/indexers/validatorIndexer.ts
@@ -33,7 +33,7 @@ export class ValidatorIndexer extends Indexer {
   }
 
   @benchmark.measureMethodAsync
-  async seed(genesis: IGenesis) {
+  async seed(genesis: IGenesis): Promise<void> {
     const validators = genesis.app_state.staking.validators;
 
     await sequelize.transaction(async dbTransaction => {

--- a/apps/indexer/src/providers/ipLocationProvider.ts
+++ b/apps/indexer/src/providers/ipLocationProvider.ts
@@ -23,7 +23,7 @@ async function getIpLocation(ip: string) {
   };
 }
 
-export async function updateProvidersLocation() {
+export async function updateProvidersLocation(): Promise<void> {
   const providers = await Provider.findAll({
     where: {
       isOnline: true

--- a/apps/indexer/src/providers/providerStatusProvider.ts
+++ b/apps/indexer/src/providers/providerStatusProvider.ts
@@ -24,7 +24,7 @@ const ConcurrentStatusCall = 10;
 const StatusCallTimeout = 10_000; // 10 seconds
 const UptimeCheckIntervalSeconds = 15 * 60; // 15 minutes
 
-export async function syncProvidersInfo() {
+export async function syncProvidersInfo(): Promise<void> {
   const providers = await Provider.findAll({
     where: {
       deletedHeight: null,

--- a/apps/indexer/src/scheduler.ts
+++ b/apps/indexer/src/scheduler.ts
@@ -152,7 +152,17 @@ export class Scheduler {
     }
   }
 
-  public getTasksStatus() {
+  public getTasksStatus(): Array<{
+    name: string;
+    isRunning: boolean;
+    function: () => Promise<void>;
+    interval: string;
+    runCount: number;
+    successfulRunCount: number;
+    failedRunCount: number;
+    latestError: string | Error | null;
+    healthchecksConfig: boolean;
+  }> {
     return Array.from(this.tasks.values()).map(task => ({
       name: task.name,
       isRunning: !!task.runningPromise,

--- a/apps/indexer/src/shared/utils/addresses.ts
+++ b/apps/indexer/src/shared/utils/addresses.ts
@@ -1,13 +1,13 @@
 import { ripemd160, sha256 } from "@cosmjs/crypto";
 import { fromBech32 } from "@cosmjs/encoding";
 
-export function isValidBech32Address(address: string, prefix?: string) {
+export function isValidBech32Address(address: string, prefix?: string): boolean | null {
   const bech32 = parseBech32(address);
 
   return bech32 && (!prefix || bech32.prefix === prefix);
 }
 
-export function parseBech32(str: string) {
+export function parseBech32(str: string): ReturnType<typeof fromBech32> | null {
   try {
     return fromBech32(str);
   } catch {

--- a/apps/indexer/src/shared/utils/benchmark.ts
+++ b/apps/indexer/src/shared/utils/benchmark.ts
@@ -17,7 +17,7 @@ let firstTime: number | null = null;
 let lastTime: number | null = null;
 let activeTimer: string | null = null;
 
-export function measureMethod(target: any, propertyKey: string, descriptor: PropertyDescriptor) {
+export function measureMethod(target: { constructor: { name: string } }, propertyKey: string, descriptor: PropertyDescriptor): void {
   const originalMethod = descriptor.value;
 
   descriptor.value = function (...args: any[]) {
@@ -29,7 +29,7 @@ export function measureMethod(target: any, propertyKey: string, descriptor: Prop
   };
 }
 
-export function measureMethodAsync(target: any, propertyKey: string, descriptor: PropertyDescriptor) {
+export function measureMethodAsync(target: { constructor: { name: string } }, propertyKey: string, descriptor: PropertyDescriptor): void {
   const originalMethod = descriptor.value;
 
   descriptor.value = async function (...args: any[]) {
@@ -56,7 +56,7 @@ export async function measureAsync<T>(name: string, fn: () => Promise<T>): Promi
   return await fn().finally(() => timer.end());
 }
 
-export function startTimer(name: string) {
+export function startTimer(name: string): { end: () => void } {
   const startTime = performance.now();
 
   const parent = activeTimer;
@@ -106,7 +106,7 @@ export function displayTimes(): void {
   }
 }
 
-export function displayTimesForGroup(group: string) {
+export function displayTimesForGroup(group: string): void {
   console.log("Group: " + (group || "ROOT"));
 
   const fullTime = group

--- a/apps/indexer/src/shared/utils/date.ts
+++ b/apps/indexer/src/shared/utils/date.ts
@@ -1,31 +1,31 @@
 import { round } from "./math";
 
-export const getDayStr = (date?: Date) => {
+export const getDayStr = (date?: Date): string => {
   return date ? toUTC(date).toISOString().split("T")[0] : getTodayUTC().toISOString().split("T")[0];
 };
 
-export function getTodayUTC() {
+export function getTodayUTC(): Date {
   const currentDate = toUTC(new Date());
   currentDate.setUTCHours(0, 0, 0, 0);
 
   return currentDate;
 }
 
-export function startOfDay(date: Date) {
+export function startOfDay(date: Date): Date {
   const currentDate = toUTC(date);
   currentDate.setUTCHours(0, 0, 0, 0);
 
   return currentDate;
 }
 
-export function endOfDay(date: Date) {
+export function endOfDay(date: Date): Date {
   const currentDate = toUTC(date);
   currentDate.setUTCHours(23, 59, 59, 999);
 
   return currentDate;
 }
 
-export function toUTC(date: Date) {
+export function toUTC(date: Date): Date {
   const now_utc = Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), date.getUTCHours(), date.getUTCMinutes(), date.getUTCSeconds());
 
   return new Date(now_utc);

--- a/apps/indexer/src/shared/utils/download.ts
+++ b/apps/indexer/src/shared/utils/download.ts
@@ -6,7 +6,7 @@ import { bytesToHumanReadableSize } from "./files";
 
 const progressLogThrottle = 1000;
 
-export async function download(url: string, path: string) {
+export async function download(url: string, path: string): Promise<void> {
   const uri = new URL(url);
   if (!path) {
     path = basename(uri.pathname);

--- a/apps/indexer/src/shared/utils/files.ts
+++ b/apps/indexer/src/shared/utils/files.ts
@@ -1,4 +1,4 @@
-export const bytesToHumanReadableSize = function (bytes: number) {
+export const bytesToHumanReadableSize = function (bytes: number): string {
   const sizes = ["Bytes", "KB", "MB", "GB", "TB"];
 
   if (bytes == 0) {

--- a/apps/indexer/src/shared/utils/math.ts
+++ b/apps/indexer/src/shared/utils/math.ts
@@ -1,11 +1,11 @@
-export function pickRandomElement<T>(arr: T[]) {
+export function pickRandomElement<T>(arr: T[]): T {
   return arr[Math.floor(Math.random() * arr.length)];
 }
 
-export function round(amount: number, precision: number = 2) {
+export function round(amount: number, precision: number = 2): number {
   return Math.round((amount + Number.EPSILON) * Math.pow(10, precision)) / Math.pow(10, precision);
 }
 
-export function uaktToAKT(amount: number, precision = 2) {
+export function uaktToAKT(amount: number, precision = 2): number {
   return round(amount / 1_000_000, precision);
 }

--- a/apps/indexer/src/shared/utils/protobuf.ts
+++ b/apps/indexer/src/shared/utils/protobuf.ts
@@ -29,7 +29,7 @@ const newAkashTypes: ReadonlyArray<[string, GeneratedType]> = [...Object.values(
   .filter(x => "$type" in x)
   .map(x => ["/" + x.$type, x as unknown as GeneratedType]);
 
-export function decodeMsg(type: string, msg: Uint8Array) {
+export function decodeMsg(type: string, msg: Uint8Array): unknown {
   const myRegistry = new Registry([...defaultRegistryTypes, ...akashTypes, ...newAkashTypes]);
 
   const msgType = myRegistry.lookupType(type);
@@ -45,7 +45,7 @@ export function decodeMsg(type: string, msg: Uint8Array) {
   return msgType.decode(msg);
 }
 
-export function uint8arrayToString(arr: Uint8Array | undefined) {
+export function uint8arrayToString(arr: Uint8Array | undefined): string {
   if (!arr) return "";
   return new TextDecoder().decode(arr);
 }

--- a/apps/indexer/src/tasks/providerUptimeTracker.ts
+++ b/apps/indexer/src/tasks/providerUptimeTracker.ts
@@ -4,7 +4,7 @@ import { QueryTypes } from "sequelize";
 
 import { sequelize } from "@src/db/dbConnection";
 
-export async function updateProviderUptime() {
+export async function updateProviderUptime(): Promise<void> {
   console.log("Updating provider uptimes.");
   console.time("updateProviderUptimes");
 

--- a/apps/indexer/src/tasks/usdSpendingTracker.ts
+++ b/apps/indexer/src/tasks/usdSpendingTracker.ts
@@ -4,7 +4,7 @@ import { Op } from "sequelize";
 
 import { sequelize } from "@src/db/dbConnection";
 
-export async function updateUsdSpending() {
+export async function updateUsdSpending(): Promise<void> {
   // Check if there is a day flagged for update (akt price changed)
   let firstDayToRefresh = await Day.findOne({
     where: {


### PR DESCRIPTION
## Why

Part of #958

Enabling `@typescript-eslint/explicit-module-boundary-types` makes the public surface of the indexer explicit and self-documenting, catching accidental `any` leaks and inferred return-type drift at the module boundary.

## What

- Enabled `@typescript-eslint/explicit-module-boundary-types` (error) for `**/*.ts`/`**/*.tsx` in `apps/indexer/eslint.config.mjs`.
- Fixed all 46 resulting violations by adding explicit return types to exported/public functions and explicit (non-`any`) parameter types. Annotation-only changes, no runtime logic changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)