### PR TITLE
refactor(dx): enable explicit-module-boundary-types for core packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44425,6 +44425,7 @@
         "zod": "3.*"
       },
       "devDependencies": {
+        "@akashnetwork/dev-config": "*",
         "vitest": "^4.1.5"
       },
       "peerDependencies": {
@@ -45101,6 +45102,7 @@
         "zod": "^3.23.8"
       },
       "devDependencies": {
+        "@akashnetwork/dev-config": "*",
         "@types/http-errors": "^2.0.4",
         "@types/node": "^22.8.6",
         "pino-pretty": "^11.3.0",
@@ -45210,6 +45212,9 @@
         "@akashnetwork/chain-sdk": "1.0.0-alpha.39",
         "@akashnetwork/net": "*",
         "jotai": "^2.9.2"
+      },
+      "devDependencies": {
+        "@akashnetwork/dev-config": "*"
       }
     },
     "packages/openapi-sdk": {

--- a/packages/http-sdk/eslint.config.mjs
+++ b/packages/http-sdk/eslint.config.mjs
@@ -1,0 +1,11 @@
+import tsConfig from "@akashnetwork/dev-config/eslint/typescript.mjs";
+
+export default [
+  ...tsConfig,
+  {
+    files: ["**/*.ts", "**/*.tsx"],
+    rules: {
+      "@typescript-eslint/explicit-module-boundary-types": ["error"]
+    }
+  }
+];

--- a/packages/http-sdk/package.json
+++ b/packages/http-sdk/package.json
@@ -25,6 +25,7 @@
     "zod": "3.*"
   },
   "devDependencies": {
+    "@akashnetwork/dev-config": "*",
     "vitest": "^4.1.5"
   },
   "peerDependencies": {

--- a/packages/http-sdk/src/api-key/api-key-http.service.ts
+++ b/packages/http-sdk/src/api-key/api-key-http.service.ts
@@ -1,16 +1,18 @@
+import type { AxiosResponse } from "axios";
+
 import { ApiHttpService } from "../api-http/api-http.service";
 import type { ApiKeyResponse, CreateApiKeyRequest, ListApiKeys } from "./api-key-http.types";
 
 export class ApiKeyHttpService extends ApiHttpService {
-  async createApiKey(data: CreateApiKeyRequest) {
+  async createApiKey(data: CreateApiKeyRequest): Promise<ApiKeyResponse> {
     return this.extractApiData(await this.post<ApiKeyResponse>("/v1/api-keys", data, { withCredentials: true }));
   }
 
-  async getApiKeys() {
+  async getApiKeys(): Promise<ListApiKeys> {
     return this.extractApiData(await this.get<ListApiKeys>("/v1/api-keys"));
   }
 
-  async deleteApiKey(id: string) {
+  async deleteApiKey(id: string): Promise<AxiosResponse> {
     return await this.delete(`/v1/api-keys/${id}`, { withCredentials: true });
   }
 }

--- a/packages/http-sdk/src/auth/auth-http.service.ts
+++ b/packages/http-sdk/src/auth/auth-http.service.ts
@@ -1,4 +1,4 @@
-import type { AxiosRequestConfig } from "axios";
+import type { AxiosRequestConfig, AxiosResponse } from "axios";
 
 import { HttpService } from "../http/http.service";
 import type { SendVerificationCodeResponse, VerifyEmailResponse } from "./auth-http.types";
@@ -9,19 +9,19 @@ export class AuthHttpService extends HttpService {
   }
 
   /** @deprecated Use {@link sendVerificationCode} instead. This targets the legacy link-based verification endpoint. */
-  async sendVerificationEmail(userId: string) {
+  async sendVerificationEmail(userId: string): Promise<AxiosResponse> {
     return this.post("/v1/send-verification-email", { data: { userId } });
   }
 
-  async sendVerificationCode() {
+  async sendVerificationCode(): Promise<SendVerificationCodeResponse> {
     return this.extractData(await this.post<SendVerificationCodeResponse>("/v1/send-verification-code"));
   }
 
-  async verifyEmailCode(code: string) {
+  async verifyEmailCode(code: string): Promise<void> {
     await this.post("/v1/verify-email-code", { data: { code } });
   }
 
-  async verifyEmail(email: string) {
+  async verifyEmail(email: string): Promise<VerifyEmailResponse> {
     return this.extractData(await this.post<VerifyEmailResponse>("/v1/verify-email", { data: { email } }, { withCredentials: true }));
   }
 }

--- a/packages/http-sdk/src/authz/authz-http.service.ts
+++ b/packages/http-sdk/src/authz/authz-http.service.ts
@@ -72,17 +72,21 @@ export class AuthzHttpService {
 
   constructor(private readonly httpClient: HttpClient) {}
 
-  async getFeeAllowancesForGrantee(address: string) {
+  async getFeeAllowancesForGrantee(address: string): Promise<FeeAllowance[]> {
     const allowances = extractData(await this.httpClient.get<FeeAllowanceListResponse>(`cosmos/feegrant/v1beta1/allowances/${address}`));
     return allowances.allowances;
   }
 
-  async getValidFeeAllowancesForGrantee(address: string) {
+  async getValidFeeAllowancesForGrantee(address: string): Promise<FeeAllowance[]> {
     const allowances = await this.getFeeAllowancesForGrantee(address);
     return allowances.filter(allowance => this.isValidFeeAllowance(allowance));
   }
 
-  async getPaginatedFeeAllowancesForGranter(address: string, limit: number, offset: number) {
+  async getPaginatedFeeAllowancesForGranter(
+    address: string,
+    limit: number,
+    offset: number
+  ): Promise<{ allowances: FeeAllowance[]; pagination: { next_key: string | null; total: number } }> {
     const allowances = extractData(
       await this.httpClient.get<FeeAllowanceListResponse>(`cosmos/feegrant/v1beta1/issued/${address}`, {
         params: {
@@ -140,21 +144,21 @@ export class AuthzHttpService {
     return migrateLegacyDepositDeploymentGrant(response.grants.find(grant => this.isValidDepositDeploymentGrant(grant)));
   }
 
-  async hasFeeAllowance(granter: string, grantee: string) {
+  async hasFeeAllowance(granter: string, grantee: string): Promise<boolean> {
     const feeAllowances = await this.getFeeAllowancesForGrantee(grantee);
     return feeAllowances.some(allowance => allowance.granter === granter);
   }
 
-  async hasValidFeeAllowance(granter: string, grantee: string) {
+  async hasValidFeeAllowance(granter: string, grantee: string): Promise<boolean> {
     const feeAllowances = await this.getValidFeeAllowancesForGrantee(grantee);
     return feeAllowances.some(allowance => allowance.granter === granter);
   }
 
-  async hasDepositDeploymentGrant(granter: string, grantee: string) {
+  async hasDepositDeploymentGrant(granter: string, grantee: string): Promise<boolean> {
     return !!(await this.getDepositDeploymentGrantsForGranterAndGrantee(granter, grantee));
   }
 
-  async hasValidDepositDeploymentGrant(granter: string, grantee: string) {
+  async hasValidDepositDeploymentGrant(granter: string, grantee: string): Promise<boolean> {
     return !!(await this.getValidDepositDeploymentGrantsForGranterAndGrantee(granter, grantee));
   }
 
@@ -188,7 +192,9 @@ export class AuthzHttpService {
     return result;
   }
 
-  async getPaginatedDepositDeploymentGrants(options: ({ granter: string } | { grantee: string }) & { limit: number; offset: number }) {
+  async getPaginatedDepositDeploymentGrants(
+    options: ({ granter: string } | { grantee: string }) & { limit: number; offset: number }
+  ): Promise<{ grants: DepositDeploymentGrant[]; pagination: { next_key: string | null; total: number } }> {
     const side = "granter" in options ? "granter" : "grantee";
     const address = "granter" in options ? options.granter : options.grantee;
     const limit = options.limit;

--- a/packages/http-sdk/src/git-hub/git-hub-http.service.ts
+++ b/packages/http-sdk/src/git-hub/git-hub-http.service.ts
@@ -51,7 +51,7 @@ export class GitHubHttpService extends HttpService {
     super(config);
   }
 
-  async getProviderAttributesSchema() {
+  async getProviderAttributesSchema(): Promise<ProviderAttributesSchema> {
     return this.extractData(await this.get<ProviderAttributesSchema>(this.getFullPath("/config/provider-attributes.json")));
   }
 

--- a/packages/http-sdk/src/provider/provider-http.service.ts
+++ b/packages/http-sdk/src/provider/provider-http.service.ts
@@ -19,7 +19,19 @@ export class ProviderHttpService {
     );
   }
 
-  async getLeaseStatus({ hostUri, dseq, gseq, oseq, jwtToken }: { hostUri: string; dseq: string; gseq: number; oseq: number; jwtToken: string }) {
+  async getLeaseStatus({
+    hostUri,
+    dseq,
+    gseq,
+    oseq,
+    jwtToken
+  }: {
+    hostUri: string;
+    dseq: string;
+    gseq: number;
+    oseq: number;
+    jwtToken: string;
+  }): Promise<unknown> {
     return extractData(
       await this.httpClient.get(`/lease/${dseq}/${gseq}/${oseq}/status`, {
         baseURL: hostUri,

--- a/packages/http-sdk/src/tx-http/tx-http.service.ts
+++ b/packages/http-sdk/src/tx-http/tx-http.service.ts
@@ -18,7 +18,7 @@ export class TxHttpService extends ApiHttpService {
   ) {
     super(config);
   }
-  async signAndBroadcastTx(input: TxInput) {
+  async signAndBroadcastTx(input: TxInput): Promise<TxOutput> {
     const messages = input.messages.map(m => ({ ...m, value: Buffer.from(this.registry.encode(m)).toString("base64") }));
 
     return this.extractApiData(

--- a/packages/instrumentation/eslint.config.mjs
+++ b/packages/instrumentation/eslint.config.mjs
@@ -1,0 +1,11 @@
+import tsConfig from "@akashnetwork/dev-config/eslint/typescript.mjs";
+
+export default [
+  ...tsConfig,
+  {
+    files: ["**/*.ts", "**/*.tsx"],
+    rules: {
+      "@typescript-eslint/explicit-module-boundary-types": ["error"]
+    }
+  }
+];

--- a/packages/instrumentation/src/util/tracing/tracing.util.ts
+++ b/packages/instrumentation/src/util/tracing/tracing.util.ts
@@ -33,7 +33,7 @@ import { context, SpanStatusCode, trace } from "@opentelemetry/api";
  * @returns Method decorator
  */
 export function Trace(spanName?: string) {
-  return function (target: any, propertyKey: string, descriptor: PropertyDescriptor) {
+  return function (target: { constructor: { name: string } }, propertyKey: string, descriptor: PropertyDescriptor): PropertyDescriptor {
     const originalMethod = descriptor.value;
     const methodName = propertyKey;
 
@@ -122,7 +122,7 @@ export function Trace(spanName?: string) {
  * @param name - Name of the span
  * @returns OpenTelemetry Span object
  */
-export function createSpan(name: string) {
+export function createSpan(name: string): Span {
   return trace.getTracer("default").startSpan(name);
 }
 

--- a/packages/logging/eslint.config.mjs
+++ b/packages/logging/eslint.config.mjs
@@ -1,0 +1,11 @@
+import tsConfig from "@akashnetwork/dev-config/eslint/typescript.mjs";
+
+export default [
+  ...tsConfig,
+  {
+    files: ["**/*.ts", "**/*.tsx"],
+    rules: {
+      "@typescript-eslint/explicit-module-boundary-types": ["error"]
+    }
+  }
+];

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -29,6 +29,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@akashnetwork/dev-config": "*",
     "@types/http-errors": "^2.0.4",
     "@types/node": "^22.8.6",
     "pino-pretty": "^11.3.0",

--- a/packages/logging/src/services/logger/logger.service.ts
+++ b/packages/logging/src/services/logger/logger.service.ts
@@ -39,14 +39,14 @@ export const CUSTOM_LEVELS: Record<string, string> = {
 export class LoggerService implements Logger {
   static config: Config = envConfig;
 
-  static configure(config: Partial<Config>) {
+  static configure(config: Partial<Config>): void {
     this.config = {
       ...this.config,
       ...config
     };
   }
 
-  static forContext(context: string) {
+  static forContext(context: string): LoggerService {
     const logger = new LoggerService();
     logger.setContext(context);
 
@@ -116,7 +116,7 @@ export class LoggerService implements Logger {
     }
   }
 
-  setContext(context: string) {
+  setContext(context: string): void {
     this.bind({ context });
   }
 

--- a/packages/logging/src/utils/create-otel-logger/create-otel-logger.ts
+++ b/packages/logging/src/utils/create-otel-logger/create-otel-logger.ts
@@ -1,3 +1,4 @@
+import type { SpanContext } from "@opentelemetry/api";
 import { context, propagation, trace } from "@opentelemetry/api";
 
 import { LoggerService } from "../../services/logger/logger.service";
@@ -8,7 +9,7 @@ import type { CreateLogger } from "../../types";
  * This mixin adds trace information to log entries
  * @deprecated Use `createOtelLogger` instead of setting `LoggerService.mixin` directly
  */
-export function collectOtel() {
+export function collectOtel(): Partial<SpanContext> & { jobId?: string; userId?: string } {
   const currentSpan = trace.getSpan(context.active());
   const spanContext = currentSpan?.spanContext();
   const currentBaggage = propagation.getBaggage(context.active());

--- a/packages/network-store/eslint.config.mjs
+++ b/packages/network-store/eslint.config.mjs
@@ -1,0 +1,11 @@
+import tsConfig from "@akashnetwork/dev-config/eslint/typescript.mjs";
+
+export default [
+  ...tsConfig,
+  {
+    files: ["**/*.ts", "**/*.tsx"],
+    rules: {
+      "@typescript-eslint/explicit-module-boundary-types": ["error"]
+    }
+  }
+];

--- a/packages/network-store/package.json
+++ b/packages/network-store/package.json
@@ -21,5 +21,8 @@
     "@akashnetwork/chain-sdk": "1.0.0-alpha.39",
     "@akashnetwork/net": "*",
     "jotai": "^2.9.2"
+  },
+  "devDependencies": {
+    "@akashnetwork/dev-config": "*"
   }
 }

--- a/packages/network-store/src/network.store.ts
+++ b/packages/network-store/src/network.store.ts
@@ -1,3 +1,4 @@
+import type { SetStateAction } from "jotai";
 import { atom } from "jotai";
 import { getDefaultStore, useAtom } from "jotai";
 import { atomWithStorage } from "jotai/utils";
@@ -18,7 +19,7 @@ interface NetworksStore {
 }
 
 export class NetworkStore {
-  static create(options: NetworkStoreOptions) {
+  static create(options: NetworkStoreOptions): NetworkStore {
     return new NetworkStore(options);
   }
 
@@ -45,11 +46,11 @@ export class NetworkStore {
 
   private readonly store: ReturnType<typeof getDefaultStore>;
 
-  get networks() {
+  get networks(): Network[] {
     return this.store.get(this.networksStore).data;
   }
 
-  get selectedNetwork() {
+  get selectedNetwork(): Network {
     return this.store.get(this.selectedNetworkStore);
   }
 
@@ -57,23 +58,23 @@ export class NetworkStore {
     return this.store.get(this.selectedNetworkIdStore) as Network["id"];
   }
 
-  get deploymentVersion() {
+  get deploymentVersion(): Network["deploymentVersion"] {
     return this.selectedNetwork.deploymentVersion;
   }
 
-  get marketVersion() {
+  get marketVersion(): Network["marketVersion"] {
     return this.selectedNetwork.marketVersion;
   }
 
-  get escrowVersion() {
+  get escrowVersion(): Network["escrowVersion"] {
     return this.selectedNetwork.escrowVersion;
   }
 
-  get certVersion() {
+  get certVersion(): Network["certVersion"] {
     return this.selectedNetwork.certVersion;
   }
 
-  get providerVersion() {
+  get providerVersion(): Network["providerVersion"] {
     return this.selectedNetwork.providerVersion;
   }
 
@@ -98,19 +99,19 @@ export class NetworkStore {
     }
   }
 
-  useNetworksStore() {
+  useNetworksStore(): [NetworksStore, (update: SetStateAction<NetworksStore>) => void] {
     return useAtom(this.networksStore);
   }
 
-  useNetworks() {
+  useNetworks(): Network[] {
     return this.useNetworksStore()[0].data;
   }
 
-  useSelectedNetworkStore() {
+  useSelectedNetworkStore(): [Network, (network: Network) => void] {
     return useAtom(this.selectedNetworkStore);
   }
 
-  useSelectedNetwork() {
+  useSelectedNetwork(): Network {
     return this.useSelectedNetworkStore()[0];
   }
 
@@ -131,7 +132,7 @@ export class NetworkStore {
     }
   }
 
-  useSelectedNetworkId() {
+  useSelectedNetworkId(): Network["id"] {
     return this.useSelectedNetworkIdStore()[0];
   }
 }


### PR DESCRIPTION
## Why

Part of #958 — incrementally enabling `@typescript-eslint/explicit-module-boundary-types` (EMB) across the codebase. This PR covers four shared packages that previously had no local ESLint config.

## What

- Add a local `eslint.config.mjs` to each of the four packages, re-spreading the shared `@akashnetwork/dev-config` TypeScript config and enabling `@typescript-eslint/explicit-module-boundary-types: ["error"]`.
- Add `@akashnetwork/dev-config` to `devDependencies` of `http-sdk`, `network-store`, and `logging` (required so the local config file passes `import-x/no-extraneous-dependencies`; `instrumentation` already had it).
- Fix all EMB violations by adding explicit return/parameter type annotations (real inferred types, no `any`; async → `Promise<T>`; `import type` where applicable). Annotations only — no logic changes.

Per-package violation counts:
- `packages/http-sdk` — 18
- `packages/network-store` — 13
- `packages/logging` — 4
- `packages/instrumentation` — 3

Verification per package: `npm run lint -- --quiet` (0 errors), `validate:types` (pass), and unit tests where present (http-sdk 22 passed, logging 46 passed; network-store and instrumentation have no test suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improved Type Safety**
  * Added explicit return types across HTTP, networking, logging, and instrumentation APIs.
  * Improved type definitions for network stores, tracing utilities, telemetry data, and service methods.
  * Clarified return values for pagination, status checks, authentication, and transaction operations.

* **Developer Experience**
  * Added consistent linting configuration to enforce explicit module boundary types across packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->