### PR TITLE
fix(auth): passwordless login back navigation and disabled-looking email input

### DIFF
--- a/.claude/instructions/clean-code-over-comments.md
+++ b/.claude/instructions/clean-code-over-comments.md
@@ -4,6 +4,7 @@
 - **Clarity is the default; a comment is the last resort.** Before writing any comment, make the code say it — rename to reveal intent, or extract a named function. A comment you *had* to write is a signal the code failed to be clear: fix the code, don't annotate it.
 - **No inline comments.** Never write `//` or `/* */` comments inside function bodies, JSX, or tests — not even to label a section or restate a line. The only allowed comment is a `/** ... */` JSDoc block on a declaration, and only for the *why* (a non-obvious constraint, gotcha, or tradeoff) — never the *what*.
 - **Names replace comments.** Prefer a verbose, intention-revealing name over a short name plus a comment: `secondsUntilBidExpiry`, not `t` with a `// seconds until bid expires`. Name functions by behavior, not by trigger: `redirectToSocialLogin`, not `onOAuthClick`. A name that needs a comment to be understood is the wrong name.
+- **One name per callback.** When a callback is bound to a named `const` (a `useCallback`, `useMemo`, event handler, or any assignment), the `const` carries the behavior name and the body stays an anonymous arrow — don't *also* name the function expression, and don't name the `const` after its trigger or the prop it feeds. One name is enough, and it names the *behavior*. Keep a named function expression only for a callback that has no binding name of its own: `useEffect(function redirectWhenSignedOut() {…})`, a `return function teardown() {…}` cleanup, or an inline `items.map(function renderRow() {…})`.
 - **Structure replaces comments.** A function that needs internal section-comments to navigate wants to be several named functions. Separate concerns at every level — orchestration vs. detail, one reason to change per unit — so each piece is small enough to need no narration. Don't over-fragment though: single-statement operations stay inline; extract only multi-line sequences that earn a name.
 - **JSDoc the non-obvious.** Module-level helper functions and "magic" constants (colors, fallbacks, multipliers, timeouts) get a 1–2 line JSDoc stating what/why. Skip it when the name is already fully self-describing.
 
@@ -25,6 +26,16 @@ async function activateDeployment(deploymentId: string) {
   const cheapest = selectCheapestBid(bids);
   await createLease(deploymentId, cheapest);
 }
+```
+
+```typescript
+const clearPersistedFlow = useCallback(() => {
+  sessionStorage.removeItem(FLOW_KEY);
+}, []);
+
+useEffect(function redirectWhenSignedOut() {
+  if (!user) redirectToLogin();
+}, [user]);
 ```
 
 ### Bad
@@ -53,4 +64,10 @@ async function activateDeployment(deploymentId: string) {
   // 3. create the lease
   await createLease(deploymentId, cheapest);
 }
+```
+
+```typescript
+const onReset = useCallback(function clearPersistedFlow() {
+  sessionStorage.removeItem(FLOW_KEY);
+}, []);
 ```

--- a/apps/deploy-web/src/components/auth/EmailCodeStart/EmailCodeStart.tsx
+++ b/apps/deploy-web/src/components/auth/EmailCodeStart/EmailCodeStart.tsx
@@ -67,7 +67,7 @@ export function EmailCodeStart({ dependencies: d = DEPENDENCIES, ...props }: Pro
             render={({ field }) => (
               <d.FormInput
                 className="w-full"
-                inputClassName="bg-background dark:bg-input/30"
+                inputClassName="dark:bg-input/30"
                 type="email"
                 label="Email"
                 placeholder="you@company.com"

--- a/apps/deploy-web/src/components/auth/PasswordlessAuth/PasswordlessAuth.spec.tsx
+++ b/apps/deploy-web/src/components/auth/PasswordlessAuth/PasswordlessAuth.spec.tsx
@@ -12,58 +12,60 @@ import { ComponentMock, MockComponents } from "@tests/unit/mocks";
 import { TestContainerProvider } from "@tests/unit/TestContainerProvider";
 
 describe(PasswordlessAuth.name, () => {
-  it("flips to the verify screen when EmailCodeStart calls onStarted", () => {
+  it("renders the entry screen when the URL has no step", () => {
     const EmailCodeStartMock = vi.fn(ComponentMock);
     const EmailCodeVerifyMock = vi.fn(ComponentMock);
-    setup({
-      dependencies: { EmailCodeStart: EmailCodeStartMock as never, EmailCodeVerify: EmailCodeVerifyMock as never }
-    });
+    setup({ dependencies: { EmailCodeStart: EmailCodeStartMock as never, EmailCodeVerify: EmailCodeVerifyMock as never } });
+
+    expect(EmailCodeStartMock).toHaveBeenCalled();
+    expect(EmailCodeVerifyMock).not.toHaveBeenCalled();
+  });
+
+  it("renders the verify screen prefilled with the known email when the URL step is verify", () => {
+    const EmailCodeVerifyMock = vi.fn(ComponentMock);
+    setup({ step: "verify", initialEmail: "alice@example.com", dependencies: { EmailCodeVerify: EmailCodeVerifyMock as never } });
+
+    expect(EmailCodeVerifyMock).toHaveBeenLastCalledWith(expect.objectContaining({ email: "alice@example.com" }), expect.anything());
+  });
+
+  it("pushes step=verify to the URL when EmailCodeStart calls onStarted", () => {
+    const EmailCodeStartMock = vi.fn(ComponentMock);
+    const { push } = setup({ dependencies: { EmailCodeStart: EmailCodeStartMock as never } });
 
     act(() => EmailCodeStartMock.mock.lastCall![0].onStarted("alice@example.com"));
 
-    expect(EmailCodeVerifyMock).toHaveBeenLastCalledWith(expect.objectContaining({ email: "alice@example.com" }), expect.anything());
+    expect(push).toHaveBeenCalledWith(expect.stringContaining("step=verify"), undefined, { shallow: true });
   });
 
-  it("starts on the verify screen and prefills email from initialEmail/initialScreen", () => {
+  it("persists the email when EmailCodeStart calls onStarted", () => {
     const EmailCodeStartMock = vi.fn(ComponentMock);
-    const EmailCodeVerifyMock = vi.fn(ComponentMock);
-    setup({
-      initialEmail: "alice@example.com",
-      initialScreen: "verify",
-      dependencies: { EmailCodeStart: EmailCodeStartMock as never, EmailCodeVerify: EmailCodeVerifyMock as never }
-    });
+    const { onEmailChange } = setup({ dependencies: { EmailCodeStart: EmailCodeStartMock as never } });
 
-    expect(EmailCodeVerifyMock).toHaveBeenLastCalledWith(expect.objectContaining({ email: "alice@example.com" }), expect.anything());
+    act(() => EmailCodeStartMock.mock.lastCall![0].onStarted("alice@example.com"));
+
+    expect(onEmailChange).toHaveBeenCalledWith("alice@example.com");
   });
 
-  it("returns to the entry screen when EmailCodeVerify calls onEditEmail", () => {
-    const EmailCodeStartMock = vi.fn(ComponentMock);
+  it("removes the step param from the URL when EmailCodeVerify calls onEditEmail", () => {
     const EmailCodeVerifyMock = vi.fn(ComponentMock);
-    setup({
-      initialEmail: "alice@example.com",
-      initialScreen: "verify",
-      dependencies: { EmailCodeStart: EmailCodeStartMock as never, EmailCodeVerify: EmailCodeVerifyMock as never }
-    });
+    const { replace } = setup({ step: "verify", initialEmail: "alice@example.com", dependencies: { EmailCodeVerify: EmailCodeVerifyMock as never } });
 
     act(() => EmailCodeVerifyMock.mock.lastCall![0].onEditEmail());
 
-    expect(EmailCodeStartMock).toHaveBeenLastCalledWith(expect.objectContaining({ defaultEmail: "alice@example.com" }), expect.anything());
+    expect(replace).toHaveBeenCalledWith(expect.not.stringContaining("step"), undefined, { shallow: true });
   });
 
-  it("notifies the persistence layer when EmailCodeStart succeeds", () => {
-    const EmailCodeStartMock = vi.fn(ComponentMock);
-    const { onFlowChange } = setup({ dependencies: { EmailCodeStart: EmailCodeStartMock as never } });
+  it("redirects to the entry screen when the URL step is verify but no email is known", () => {
+    const { replace } = setup({ step: "verify", initialEmail: "" });
 
-    act(() => EmailCodeStartMock.mock.lastCall![0].onStarted("alice@example.com"));
-
-    expect(onFlowChange).toHaveBeenLastCalledWith({ email: "alice@example.com", screen: "verify" });
+    expect(replace).toHaveBeenCalledWith(expect.not.stringContaining("step"), undefined, { shallow: true });
   });
 
   it("resets the persisted flow, refreshes the session, and navigates back when EmailCodeVerify calls onVerified", async () => {
     const EmailCodeVerifyMock = vi.fn(ComponentMock);
     const { onFlowReset, checkSession, navigateBack } = setup({
+      step: "verify",
       initialEmail: "alice@example.com",
-      initialScreen: "verify",
       dependencies: { EmailCodeVerify: EmailCodeVerifyMock as never }
     });
 
@@ -115,16 +117,20 @@ describe(PasswordlessAuth.name, () => {
   function setup(
     input: {
       initialEmail?: string;
-      initialScreen?: "entry" | "verify";
+      step?: string;
       isOnboardingRedesignEnabled?: boolean;
       dependencies?: Partial<typeof DEPENDENCIES>;
     } = {}
   ) {
     const analyticsService = mock<AnalyticsService>();
-    const onFlowChange = vi.fn();
+    const onEmailChange = vi.fn();
     const onFlowReset = vi.fn();
     const checkSession = vi.fn(async () => undefined);
     const navigateBack = vi.fn();
+    const push = vi.fn();
+    const replace = vi.fn();
+    const params = new URLSearchParams();
+    if (input.step) params.set("step", input.step);
     const useUser: typeof DEPENDENCIES.useUser = () =>
       mock<ReturnType<typeof DEPENDENCIES.useUser>>({
         checkSession,
@@ -140,6 +146,8 @@ describe(PasswordlessAuth.name, () => {
         isDeploymentReturnTo: false
       });
     const useFlag: typeof DEPENDENCIES.useFlag = (() => Boolean(input.isOnboardingRedesignEnabled)) as never;
+    const useRouter: typeof DEPENDENCIES.useRouter = (() => ({ push, replace, pathname: "/login" })) as never;
+    const useSearchParams: typeof DEPENDENCIES.useSearchParams = (() => params) as never;
 
     const Turnstile = vi.fn(({ turnstileRef }: { turnstileRef?: RefObject<TurnstileRef> }) => {
       if (turnstileRef) {
@@ -154,14 +162,15 @@ describe(PasswordlessAuth.name, () => {
       <TestContainerProvider services={{ analyticsService: () => analyticsService }}>
         <PasswordlessAuth
           initialEmail={input.initialEmail ?? ""}
-          initialScreen={input.initialScreen ?? "entry"}
-          onFlowChange={onFlowChange}
+          onEmailChange={onEmailChange}
           onFlowReset={onFlowReset}
           dependencies={{
             ...MockComponents(DEPENDENCIES),
             useUser,
             useReturnTo,
             useFlag,
+            useRouter,
+            useSearchParams,
             Turnstile,
             ...input.dependencies
           }}
@@ -169,7 +178,7 @@ describe(PasswordlessAuth.name, () => {
       </TestContainerProvider>
     );
 
-    return { analyticsService, onFlowChange, onFlowReset, checkSession, navigateBack };
+    return { analyticsService, onEmailChange, onFlowReset, checkSession, navigateBack, push, replace };
   }
 });
 

--- a/apps/deploy-web/src/components/auth/PasswordlessAuth/PasswordlessAuth.tsx
+++ b/apps/deploy-web/src/components/auth/PasswordlessAuth/PasswordlessAuth.tsx
@@ -3,6 +3,8 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import dynamic from "next/dynamic";
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { useRouter } from "next/router";
 
 import type { TurnstileRef } from "@src/components/turnstile/Turnstile";
 import { ClientOnlyTurnstile } from "@src/components/turnstile/Turnstile";
@@ -24,6 +26,8 @@ export const DEPENDENCIES = {
   Turnstile: ClientOnlyTurnstile,
   useFlag,
   useReturnTo,
+  useRouter,
+  useSearchParams,
   useUser
 };
 
@@ -35,13 +39,18 @@ export function PasswordlessAuth({ dependencies: d = DEPENDENCIES, ...props }: P
   const { publicConfig, analyticsService } = useServices();
   const { navigateBack } = d.useReturnTo({ defaultReturnTo: "/" });
   const { checkSession } = d.useUser();
+  const router = d.useRouter();
+  const searchParams = d.useSearchParams();
   const isOnboardingRedesignEnabled = d.useFlag("onboarding_redesign_v1");
   const [email, setEmail] = useState(props.initialEmail);
-  const [screen, setScreen] = useState<"entry" | "verify">(props.initialScreen);
   const [screenKey, setScreenKey] = useState(0);
   const turnstileRef = useRef<TurnstileRef>(null);
 
-  const getCaptchaToken = useCallback(async function getCaptchaToken() {
+  const screen: "entry" | "verify" = searchParams.get("step") === "verify" ? "verify" : "entry";
+
+  const { onEmailChange, onFlowReset } = props;
+
+  const getCaptchaToken = useCallback(async () => {
     if (!turnstileRef.current) {
       throw new Error("Captcha has not been rendered");
     }
@@ -49,41 +58,42 @@ export function PasswordlessAuth({ dependencies: d = DEPENDENCIES, ...props }: P
     return token;
   }, []);
 
-  const goToVerify = useCallback(function goToVerify(verifiedEmail: string) {
-    setEmail(verifiedEmail);
-    setScreen("verify");
-  }, []);
-
-  const goBackToEntry = useCallback(function goBackToEntry() {
-    setScreen("entry");
-  }, []);
-
-  const { onFlowChange, onFlowReset } = props;
-
-  const handleVerified = useCallback(
-    async function handleVerified() {
-      onFlowReset();
-      await checkSession();
-      navigateBack();
+  const goToVerify = useCallback(
+    (verifiedEmail: string) => {
+      setEmail(verifiedEmail);
+      onEmailChange(verifiedEmail);
+      const params = new URLSearchParams(searchParams);
+      params.set("step", "verify");
+      router.push(`?${params.toString()}`, undefined, { shallow: true });
     },
-    [checkSession, navigateBack, onFlowReset]
+    [router, searchParams, onEmailChange]
   );
 
-  const remountActiveScreen = useCallback(function remountActiveScreen() {
+  const goBackToEntry = useCallback(() => {
+    const params = new URLSearchParams(searchParams);
+    params.delete("step");
+    const query = params.toString();
+    router.replace(query ? `?${query}` : router.pathname, undefined, { shallow: true });
+  }, [router, searchParams]);
+
+  useEffect(
+    function redirectToEntryWhenEmailMissing() {
+      if (screen === "verify" && !email) {
+        goBackToEntry();
+      }
+    },
+    [screen, email, goBackToEntry]
+  );
+
+  const handleVerified = useCallback(async () => {
+    onFlowReset();
+    await checkSession();
+    navigateBack();
+  }, [checkSession, navigateBack, onFlowReset]);
+
+  const remountActiveScreen = useCallback(() => {
     setScreenKey(value => value + 1);
   }, []);
-
-  const isFirstFlowChangeRef = useRef(true);
-  useEffect(
-    function notifyFlowChange() {
-      if (isFirstFlowChangeRef.current) {
-        isFirstFlowChangeRef.current = false;
-        return;
-      }
-      onFlowChange({ email, screen });
-    },
-    [email, screen, onFlowChange]
-  );
 
   return (
     <>
@@ -132,7 +142,7 @@ export function PasswordlessAuth({ dependencies: d = DEPENDENCIES, ...props }: P
           </div>
         </>
       )}
-      {screen === "verify" && (
+      {screen === "verify" && email && (
         <d.EmailCodeVerify
           key={`verify-${screenKey}`}
           email={email}

--- a/apps/deploy-web/src/components/auth/PasswordlessAuth/withPersistedPasswordlessFlow.spec.tsx
+++ b/apps/deploy-web/src/components/auth/PasswordlessAuth/withPersistedPasswordlessFlow.spec.tsx
@@ -5,49 +5,46 @@ import { EMAIL_CODE_FLOW_STORAGE_KEY, type PassedFlowProps, withPersistedPasswor
 import { act, render } from "@testing-library/react";
 
 describe(withPersistedPasswordlessFlow.name, () => {
-  it("provides initialEmail and initialScreen from sessionStorage", () => {
-    const { lastProps } = setup({ persistedFlow: { email: "alice@example.com", screen: "verify" } });
+  it("provides initialEmail from sessionStorage", () => {
+    const { lastProps } = setup({ persistedEmail: "alice@example.com" });
 
     expect(lastProps().initialEmail).toBe("alice@example.com");
-    expect(lastProps().initialScreen).toBe("verify");
   });
 
-  it("defaults to empty entry when sessionStorage is empty", () => {
+  it("defaults to an empty email when sessionStorage is empty", () => {
     const { lastProps } = setup();
 
     expect(lastProps().initialEmail).toBe("");
-    expect(lastProps().initialScreen).toBe("entry");
   });
 
-  it("defaults to empty entry when sessionStorage is corrupted", () => {
+  it("defaults to an empty email when sessionStorage is corrupted", () => {
     const { lastProps } = setup({ persistedRaw: "{not json" });
 
     expect(lastProps().initialEmail).toBe("");
-    expect(lastProps().initialScreen).toBe("entry");
   });
 
-  it("persists flow state to sessionStorage on onFlowChange", () => {
+  it("persists the email to sessionStorage on onEmailChange", () => {
     const { lastProps } = setup();
 
     act(() => {
-      lastProps().onFlowChange({ email: "bob@example.com", screen: "verify" });
+      lastProps().onEmailChange("bob@example.com");
     });
 
-    expect(window.sessionStorage.getItem(EMAIL_CODE_FLOW_STORAGE_KEY)).toBe(JSON.stringify({ email: "bob@example.com", screen: "verify" }));
+    expect(window.sessionStorage.getItem(EMAIL_CODE_FLOW_STORAGE_KEY)).toBe(JSON.stringify({ email: "bob@example.com" }));
   });
 
-  it("clears sessionStorage when onFlowChange is called with entry state", () => {
-    const { lastProps } = setup({ persistedFlow: { email: "alice@example.com", screen: "verify" } });
+  it("clears sessionStorage when onEmailChange is called with an empty email", () => {
+    const { lastProps } = setup({ persistedEmail: "alice@example.com" });
 
     act(() => {
-      lastProps().onFlowChange({ email: "alice@example.com", screen: "entry" });
+      lastProps().onEmailChange("");
     });
 
     expect(window.sessionStorage.getItem(EMAIL_CODE_FLOW_STORAGE_KEY)).toBeNull();
   });
 
   it("clears sessionStorage on onFlowReset", () => {
-    const { lastProps } = setup({ persistedFlow: { email: "alice@example.com", screen: "verify" } });
+    const { lastProps } = setup({ persistedEmail: "alice@example.com" });
 
     act(() => {
       lastProps().onFlowReset();
@@ -56,10 +53,10 @@ describe(withPersistedPasswordlessFlow.name, () => {
     expect(window.sessionStorage.getItem(EMAIL_CODE_FLOW_STORAGE_KEY)).toBeNull();
   });
 
-  function setup(input: { persistedFlow?: { email: string; screen: "entry" | "verify" }; persistedRaw?: string } = {}) {
+  function setup(input: { persistedEmail?: string; persistedRaw?: string } = {}) {
     window.sessionStorage.clear();
-    if (input.persistedFlow) {
-      window.sessionStorage.setItem(EMAIL_CODE_FLOW_STORAGE_KEY, JSON.stringify(input.persistedFlow));
+    if (input.persistedEmail !== undefined) {
+      window.sessionStorage.setItem(EMAIL_CODE_FLOW_STORAGE_KEY, JSON.stringify({ email: input.persistedEmail }));
     } else if (input.persistedRaw !== undefined) {
       window.sessionStorage.setItem(EMAIL_CODE_FLOW_STORAGE_KEY, input.persistedRaw);
     }

--- a/apps/deploy-web/src/components/auth/PasswordlessAuth/withPersistedPasswordlessFlow.tsx
+++ b/apps/deploy-web/src/components/auth/PasswordlessAuth/withPersistedPasswordlessFlow.tsx
@@ -3,7 +3,7 @@
 import type { ComponentType } from "react";
 import { useCallback, useState } from "react";
 
-/** sessionStorage key for the in-flight passwordless screen + email. Per-tab; cleared on successful verify. */
+/** sessionStorage key for the in-flight passwordless email. Per-tab; cleared on successful verify. The screen itself lives in the URL. */
 export const EMAIL_CODE_FLOW_STORAGE_KEY = "console_email_code_flow_v1";
 
 /** sessionStorage key for the last code-send time (ms), so the resend cooldown survives a reload. Per-tab. */
@@ -18,7 +18,7 @@ export function markCodeSent(): void {
   }
 }
 
-/** Read the last code-send time (ms); null when missing, corrupted, or server-side. */
+/** Epoch ms of the last code send; null when unknown (missing, corrupted, or server-side). */
 export function readCodeSentAt(): number | null {
   if (typeof window === "undefined") return null;
   try {
@@ -32,33 +32,32 @@ export function readCodeSentAt(): number | null {
 
 export interface PassedFlowProps {
   initialEmail: string;
-  initialScreen: "entry" | "verify";
-  onFlowChange: (state: { email: string; screen: "entry" | "verify" }) => void;
+  onEmailChange: (email: string) => void;
   onFlowReset: () => void;
 }
 
 /**
- * Lifts sessionStorage hydration and persistence out of the wrapped component.
- * Read happens in a lazy useState initializer so the first paint already reflects the persisted flow.
+ * Lifts sessionStorage hydration and persistence of the in-flight email out of the wrapped component.
+ * Read happens in a lazy useState initializer so the first paint already reflects the persisted email.
  * Intended to be combined with `dynamic({ ssr: false })` at the route entry to avoid SSR hydration mismatch.
  */
 export function withPersistedPasswordlessFlow<P extends PassedFlowProps>(Component: ComponentType<P>): ComponentType<Omit<P, keyof PassedFlowProps>> {
   function WithPersistedPasswordlessFlow(outerProps: Omit<P, keyof PassedFlowProps>) {
-    const [initial] = useState(readPersistedFlow);
+    const [initialEmail] = useState(readPersistedEmail);
 
-    const onFlowChange = useCallback(function persistPasswordlessFlow(state: { email: string; screen: "entry" | "verify" }) {
+    const persistPasswordlessEmail = useCallback((email: string) => {
       try {
-        if (state.screen !== "verify") {
+        if (!email) {
           window.sessionStorage.removeItem(EMAIL_CODE_FLOW_STORAGE_KEY);
           return;
         }
-        window.sessionStorage.setItem(EMAIL_CODE_FLOW_STORAGE_KEY, JSON.stringify(state));
+        window.sessionStorage.setItem(EMAIL_CODE_FLOW_STORAGE_KEY, JSON.stringify({ email }));
       } catch {
         return;
       }
     }, []);
 
-    const onFlowReset = useCallback(function clearPersistedPasswordlessFlow() {
+    const clearPersistedPasswordlessFlow = useCallback(() => {
       try {
         window.sessionStorage.removeItem(EMAIL_CODE_FLOW_STORAGE_KEY);
         window.sessionStorage.removeItem(CODE_SENT_AT_STORAGE_KEY);
@@ -68,25 +67,22 @@ export function withPersistedPasswordlessFlow<P extends PassedFlowProps>(Compone
     }, []);
 
     return (
-      <Component {...(outerProps as P)} initialEmail={initial.email} initialScreen={initial.screen} onFlowChange={onFlowChange} onFlowReset={onFlowReset} />
+      <Component {...(outerProps as P)} initialEmail={initialEmail} onEmailChange={persistPasswordlessEmail} onFlowReset={clearPersistedPasswordlessFlow} />
     );
   }
   WithPersistedPasswordlessFlow.displayName = `withPersistedPasswordlessFlow(${Component.displayName ?? Component.name ?? "Component"})`;
   return WithPersistedPasswordlessFlow;
 }
 
-/** Read `{ email, screen }` from sessionStorage; defaults to empty entry when missing, corrupted, or server-side. */
-function readPersistedFlow(): { email: string; screen: "entry" | "verify" } {
-  if (typeof window === "undefined") return { email: "", screen: "entry" };
+/** The persisted email; "" when unknown (missing, corrupted, or server-side). */
+function readPersistedEmail(): string {
+  if (typeof window === "undefined") return "";
   try {
     const raw = window.sessionStorage.getItem(EMAIL_CODE_FLOW_STORAGE_KEY);
-    if (!raw) return { email: "", screen: "entry" };
-    const parsed = JSON.parse(raw) as { email?: unknown; screen?: unknown };
-    return {
-      email: typeof parsed.email === "string" ? parsed.email : "",
-      screen: parsed.screen === "verify" ? "verify" : "entry"
-    };
+    if (!raw) return "";
+    const parsed = JSON.parse(raw) as { email?: unknown };
+    return typeof parsed.email === "string" ? parsed.email : "";
   } catch {
-    return { email: "", screen: "entry" };
+    return "";
   }
 }

--- a/apps/deploy-web/tests/ui/pages/AuthPagePasswordless.ts
+++ b/apps/deploy-web/tests/ui/pages/AuthPagePasswordless.ts
@@ -5,12 +5,16 @@ import { testEnvConfig } from "../fixture/test-env.config";
 export class AuthPagePasswordless {
   constructor(readonly page: Page) {}
 
+  get emailInput() {
+    return this.page.getByLabel("Email", { exact: true });
+  }
+
   async goto() {
     await this.page.goto(`${testEnvConfig.BASE_URL}/login`);
   }
 
   async startWithEmail(email: string) {
-    await this.page.getByLabel("Email", { exact: true }).fill(email);
+    await this.emailInput.fill(email);
     await this.page.getByRole("button", { name: /continue with email/i }).click();
   }
 
@@ -20,5 +24,9 @@ export class AuthPagePasswordless {
 
   async waitForRedirectAwayFromLogin() {
     await this.page.waitForURL(url => !/^\/login(\/|$)/.test(url.pathname));
+  }
+
+  async goBack() {
+    await this.page.goBack();
   }
 }

--- a/apps/deploy-web/tests/ui/pages/OnboardingPage.ts
+++ b/apps/deploy-web/tests/ui/pages/OnboardingPage.ts
@@ -3,25 +3,17 @@ import type { Page } from "@playwright/test";
 export class OnboardingPage {
   constructor(readonly page: Page) {}
 
-  async waitForPage() {
-    await this.page.waitForURL(/\/signup/);
-  }
-
   /**
-   * Resolves true once the app has settled on the onboarding flow (signup or the
-   * redesigned onboarding picker) — i.e. the current user is new and not yet onboarded.
+   * Resolves true once the app has settled on the onboarding flow
+   * i.e. the current user is new and not yet onboarded.
    */
   async isCurrentPage(): Promise<boolean> {
-    await this.page.waitForURL(/\/(signup|onboarding)/, { timeout: 30_000 });
-    return /\/(signup|onboarding)/.test(new URL(this.page.url()).pathname);
+    await this.page.waitForURL(/\/onboarding/, { timeout: 30_000, waitUntil: "commit" });
+    return /\/onboarding/.test(new URL(this.page.url()).pathname);
   }
 
   async startFreeTrial() {
     await this.page.getByRole("button", { name: /start free trial/i }).click();
-  }
-
-  getFirstVerificationCodeDigit() {
-    return this.page.getByLabel("Verification code digit 1");
   }
 
   async fillStripeAddress(input: { name: string; line1: string; city: string; state: string; zip: string }) {

--- a/apps/deploy-web/tests/ui/passwordless-login.spec.ts
+++ b/apps/deploy-web/tests/ui/passwordless-login.spec.ts
@@ -3,6 +3,7 @@ import { ManagementApiError } from "auth0";
 import { signInPasswordless } from "./actions/auth";
 import { expect, test } from "./fixture/base-test";
 import { testEnvConfig } from "./fixture/test-env.config";
+import { AuthPagePasswordless } from "./pages/AuthPagePasswordless";
 import { HomePage } from "./pages/HomePage";
 import { OnboardingPage } from "./pages/OnboardingPage";
 import { MailsacCodeVerificationStrategy } from "./services/email-verification/mailsac-code.strategy";
@@ -46,5 +47,19 @@ test.describe("Passwordless auth", () => {
     await signInPasswordless(page, testEnvConfig.TEST_USER_EMAIL!);
 
     expect(await new HomePage(page).isCurrentPage()).toBe(true);
+  });
+
+  test("returns to the email step when the browser back button is pressed on the verify screen", async ({ page }) => {
+    test.setTimeout(60 * 1000);
+
+    const auth = new AuthPagePasswordless(page);
+    await auth.goto();
+    await auth.startWithEmail(testEnvConfig.TEST_USER_EMAIL!);
+    await auth.waitForVerifyScreen();
+
+    await auth.goBack();
+
+    await expect(auth.emailInput).toBeVisible();
+    await expect(page).not.toHaveURL(/step=verify/);
   });
 });

--- a/apps/deploy-web/tests/ui/services/email-verification/mailsac-code.strategy.ts
+++ b/apps/deploy-web/tests/ui/services/email-verification/mailsac-code.strategy.ts
@@ -24,6 +24,13 @@ const SUBMIT_TIMEOUT_MS = 10_000;
 /** How long we tolerate the digit inputs not being ready (just mounted, or being reset after a prior failure). */
 const INPUT_READY_TIMEOUT_MS = 5_000;
 
+/**
+ * Next.js renders an off-screen `role="alert"` route announcer (`#__next-route-announcer__`) and fills it with
+ * `document.title` on every client-side navigation — an accessibility aid, not an error. Excluded from error-alert
+ * detection so a normal SPA route change (e.g. entering the OTP step) is not misread as a rejected code.
+ */
+const NEXT_ROUTE_ANNOUNCER_SELECTOR = "#__next-route-announcer__";
+
 interface MailsacMessage {
   _id: string;
   subject?: string;
@@ -150,7 +157,7 @@ export class MailsacCodeVerificationStrategy implements EmailVerificationStrateg
   }
 
   async #awaitSubmitOutcome(page: Page): Promise<SubmitOutcome> {
-    const errorAlert = page.locator('[role="alert"]').filter({ hasText: /\S/ }).first();
+    const errorAlert = page.locator(`[role="alert"]:not(${NEXT_ROUTE_ANNOUNCER_SELECTOR})`).filter({ hasText: /\S/ }).first();
 
     const whenNavigatedAway = page
       .waitForURL(url => !url.pathname.includes("/login"), { timeout: SUBMIT_TIMEOUT_MS })


### PR DESCRIPTION
## Why

Two passwordless-login UX defects surfaced from user feedback:

- The email input on the login page looked **disabled** — it rendered with a grey fill
  (`bg-background`, `#f5f5f5`) on the white auth panel, which reads as a disabled field.
- On the email-verification step, the **browser back button** did not return to the email-entry
  step. The step was internal React state with no history entry, so back left the login flow
  entirely; only the in-app "Wrong email? Edit" CTA moved back — which users don't necessarily
  map to "go back".

## What

Passwordless auth (`deploy-web`) — frontend, no new dependencies.

**Email input no longer looks disabled**
`EmailCodeStart` drops the light-mode `bg-background` override; the input falls back to the white
`bg-popover` used by every other auth field. The dark-mode subtle fill (`dark:bg-input/30`) is
unchanged.

**Browser back returns to the email step**
The verify screen is now modeled as a `?step=verify` query param instead of internal state:

- Entering verify does `router.push` (creates a history entry), so browser-back pops to the
  email-entry step.
- The "Wrong email? Edit" CTA does `router.replace` to strip the param.
- `withPersistedPasswordlessFlow` now persists **only the email** in sessionStorage; the screen
  derives from the URL.
- A guard redirects to entry when `?step=verify` is opened without a known email (refresh with
  cleared storage / deep link).

This follows the existing `?tab=` pattern already used by the sibling `PasswordAuth`.

_Screenshots: TBD — light-mode login input before/after._

### Also in this PR

- Applied `clean-code-over-comments` to the touched files: callbacks named by behavior (no
  `const onX = useCallback(function doY() {})` double-naming), JSDoc trimmed to the non-obvious *why*.
- Documented the "one name per callback" rule in `.claude/instructions/clean-code-over-comments.md`.

### Verification

- Unit tests: `PasswordlessAuth` + `withPersistedPasswordlessFlow` specs — 18/18 pass (URL-driven
  rendering, `push`/`replace` intent, missing-email guard, verify → session refresh → navigate back).
- `tsc --noEmit`: no new errors in the touched files (pre-existing unrelated baseline errors
  elsewhere are untouched).
- Prettier clean on the touched files.
- E2E: `passwordless-login.spec.ts` › "returns to the email step when the browser back button is
  pressed on the verify screen" — drives entry → verify, presses browser back, and asserts the email
  step is shown with `?step=verify` gone. Run in the deploy-web e2e env
  (`npm run test:e2e -- passwordless-login`, `console_auth_passwordless` enabled). Not executed in
  this sandbox (no browser / auth0 / env); it compiles and registers via `playwright test --list`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Passwordless authentication step is now driven by the URL, so browser back navigation moves between the email and verification screens.
  - Resend behavior now persists the in-progress email and resend cooldown state across navigation.

- **Bug Fixes**
  - Updated dark-mode styling for the passwordless email input.
  - Improved recovery when the verification step is requested without a known email.
  - Prevented route announcements from being misidentified as verification-code errors.

- **Tests**
  - Extended Playwright coverage for URL-based step transitions, persisted state, and browser back behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->