### PR TITLE
fix(billing): unwrap transactions envelope so billing history renders

### DIFF
--- a/packages/http-sdk/src/stripe/stripe.service.spec.ts
+++ b/packages/http-sdk/src/stripe/stripe.service.spec.ts
@@ -20,12 +20,19 @@ describe(StripeService.name, () => {
       expect(result.transactions).toHaveLength(1);
     });
 
-    it("throws when startDate is not before endDate", async () => {
+    it("throws when startDate is after endDate", async () => {
       const { service } = setup();
 
       await expect(service.getCustomerTransactions({ startDate: new Date("2026-07-21T00:00:00Z"), endDate: new Date("2026-06-21T00:00:00Z") })).rejects.toThrow(
         "startDate must be less than endDate"
       );
+    });
+
+    it("throws when startDate equals endDate", async () => {
+      const { service } = setup();
+      const sameInstant = new Date("2026-07-21T00:00:00Z");
+
+      await expect(service.getCustomerTransactions({ startDate: sameInstant, endDate: sameInstant })).rejects.toThrow("startDate must be less than endDate");
     });
   });
 

--- a/packages/http-sdk/src/stripe/stripe.service.spec.ts
+++ b/packages/http-sdk/src/stripe/stripe.service.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { HttpClient } from "../utils/httpClient";
+import { StripeService } from "./stripe.service";
+
+describe(StripeService.name, () => {
+  describe("getCustomerTransactions", () => {
+    it("unwraps the API data envelope so transactions reach the caller", async () => {
+      const payload = {
+        transactions: [{ id: "ch_123", amount: 2000 }],
+        hasMore: false,
+        nextPage: null,
+        prevPage: null
+      };
+      const { service } = setup({ payload });
+
+      const result = await service.getCustomerTransactions();
+
+      expect(result).toEqual(payload);
+      expect(result.transactions).toHaveLength(1);
+    });
+
+    it("throws when startDate is not before endDate", async () => {
+      const { service } = setup();
+
+      await expect(service.getCustomerTransactions({ startDate: new Date("2026-07-21T00:00:00Z"), endDate: new Date("2026-06-21T00:00:00Z") })).rejects.toThrow(
+        "startDate must be less than endDate"
+      );
+    });
+  });
+
+  function setup(input?: { payload?: unknown }) {
+    const payload = input?.payload ?? { transactions: [], hasMore: false, nextPage: null, prevPage: null };
+    const httpClient = {
+      get: vi.fn().mockResolvedValue({ data: { data: payload } })
+    } as unknown as HttpClient & { get: ReturnType<typeof vi.fn> };
+    const service = new StripeService(httpClient);
+    return { service, httpClient };
+  }
+});

--- a/packages/http-sdk/src/stripe/stripe.service.ts
+++ b/packages/http-sdk/src/stripe/stripe.service.ts
@@ -76,7 +76,7 @@ export class StripeService {
 
     const url = `/v1/stripe/transactions${params.toString() ? `?${params}` : ""}`;
 
-    return extractData(await this.#httpClient.get(url));
+    return extractData(await this.#httpClient.get(url)).data;
   }
 
   async exportTransactionsCsv(params: ExportTransactionsCsvParams): Promise<Blob> {


### PR DESCRIPTION
## Why

Billing history renders **"No billing history found for the selected date range"** even when the customer has transactions and the `GET /v1/stripe/transactions` endpoint returns them. This is a regression on `main` introduced by #3462 (merged 2026-07-20), so it currently affects everyone with billing history, not just a local setup.

Discovered while manually verifying #3449.

## What

#3462 refactored `StripeService` from `extractApiData(...)` — which unwrapped **two** levels (the axios `data` plus the API's `data` envelope) — to the standalone `extractData(...)`, which unwraps **one** level. It added a compensating `.data` to every method (`getPaymentMethods`, `confirmPayment`, `getCustomerDiscounts`, `getPrices`, …) **except** `getCustomerTransactions`:

```
getPaymentMethods       extractData(...).data   ✓
getCustomerDiscounts    extractData(...).data   ✓
getCustomerTransactions extractData(...)        ✗  ← .data dropped
```

So `getCustomerTransactions` returned the still-wrapped `{ data: { transactions: [...] } }`. The billing container reads `data.transactions` / `data.nextPage` — one level too high — so the table always rendered empty even though the rows were in the response.

- Restore the `.data` unwrap on `getCustomerTransactions` (one line), bringing it in line with every sibling method.
- Add a `stripe.service.spec.ts` regression test that asserts the unwrapped shape reaches the caller (verified red on the wrapped shape, green after the fix).

No API/behavioral changes; `exportTransactionsCsv` correctly stays without `.data` since it returns a raw `Blob`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Stripe transaction retrieval so responses return the expected transaction data directly.
  - Added validation to reject requests when the start date is not earlier than the end date, with a clear error message.

- **Tests**
  - Added coverage for response handling and invalid date ranges to help ensure reliable transaction queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->