### PR TITLE
refactor(billing): extract top-up idempotency key into useTopUpAttemptKey hook

### DIFF
--- a/apps/deploy-web/src/components/billing-usage/AddCreditsForm/AddCreditsForm.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AddCreditsForm/AddCreditsForm.spec.tsx
@@ -10,6 +10,7 @@ import type { AnalyticsService } from "@src/services/analytics/analytics.service
 import { handleStripeError } from "@src/utils/stripeErrorHandler";
 import { AddCreditsAmountFields } from "../AddCreditsAmountFields/AddCreditsAmountFields";
 import type { PaymentMethodSourceHandle } from "../AddCreditsNewPaymentMethodFields/AddCreditsNewPaymentMethodFields";
+import { useTopUpAttemptKey } from "./useTopUpAttemptKey/useTopUpAttemptKey";
 import type { DEPENDENCIES } from "./AddCreditsForm";
 import { AddCreditsForm } from "./AddCreditsForm";
 
@@ -712,25 +713,6 @@ describe(AddCreditsForm.name, () => {
     expect(keys[1]).not.toBe(keys[0]);
   });
 
-  it("rotates the key when the amount changes between attempts", async () => {
-    const confirmPayment = vi.fn().mockRejectedValue({ response: { status: 500 } });
-    setup({ status: "idle", confirmPayment, paymentMethods: [paymentMethod({ id: "pm_saved", isDefault: true })] });
-
-    fireEvent.change(screen.getByLabelText(/custom-amount/i), { target: { value: "100" } });
-    await act(async () => {
-      fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
-    });
-
-    fireEvent.change(screen.getByLabelText(/custom-amount/i), { target: { value: "200" } });
-    await act(async () => {
-      fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
-    });
-
-    expect(confirmPayment).toHaveBeenLastCalledWith(expect.objectContaining({ amount: 200 }));
-    const keys = confirmPayment.mock.calls.map(call => call[0].idempotencyKey);
-    expect(keys[1]).not.toBe(keys[0]);
-  });
-
   it("retries the polling-timeout attempt with the same key", async () => {
     const confirmPayment = vi.fn().mockResolvedValue({ success: true });
     const methods = [paymentMethod({ id: "pm_saved", isDefault: true })];
@@ -780,60 +762,6 @@ describe(AddCreditsForm.name, () => {
     expect(keys[1]).toBe(keys[0]);
   });
 
-  it("does not reuse a stored attempt key older than the 24h replay window", async () => {
-    const confirmPayment = vi.fn().mockResolvedValue({ success: true });
-    const staleKey = "11111111-2222-4333-8444-555555555555";
-    window.sessionStorage.setItem(
-      "add-credits-attempt",
-      JSON.stringify({ key: staleKey, amountCents: 10000, paymentMethodId: "pm_saved", userId: "user_1", createdAt: Date.now() - 25 * 60 * 60 * 1000 })
-    );
-    setup({ status: "idle", confirmPayment, paymentMethods: [paymentMethod({ id: "pm_saved", isDefault: true })] });
-
-    fireEvent.click(screen.getByRole("radio", { name: "100" }));
-    await act(async () => {
-      fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
-    });
-
-    expect(confirmPayment.mock.calls[0][0].idempotencyKey).not.toBe(staleKey);
-  });
-
-  it("reuses a stored attempt key that is still inside the 24h replay window", async () => {
-    const confirmPayment = vi.fn().mockResolvedValue({ success: true });
-    const recentKey = "11111111-2222-4333-8444-555555555555";
-    window.sessionStorage.setItem(
-      "add-credits-attempt",
-      JSON.stringify({ key: recentKey, amountCents: 10000, paymentMethodId: "pm_saved", userId: "user_1", createdAt: Date.now() - 23 * 60 * 60 * 1000 })
-    );
-    setup({ status: "idle", confirmPayment, paymentMethods: [paymentMethod({ id: "pm_saved", isDefault: true })] });
-
-    fireEvent.click(screen.getByRole("radio", { name: "100" }));
-    await act(async () => {
-      fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
-    });
-
-    expect(confirmPayment.mock.calls[0][0].idempotencyKey).toBe(recentKey);
-  });
-
-  it("rotates the key after a definitive 409 idempotency-key mismatch", async () => {
-    const confirmPayment = vi
-      .fn()
-      .mockRejectedValueOnce({ response: { status: 409, data: { code: "idempotency_key_mismatch", message: "mismatch" } } })
-      .mockResolvedValue({ success: true });
-    setup({ status: "idle", confirmPayment, paymentMethods: [paymentMethod({ id: "pm_saved", isDefault: true })] });
-
-    fireEvent.click(screen.getByRole("radio", { name: "100" }));
-
-    await act(async () => {
-      fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
-    });
-    await act(async () => {
-      fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
-    });
-
-    const keys = confirmPayment.mock.calls.map(call => call[0].idempotencyKey);
-    expect(keys[1]).not.toBe(keys[0]);
-  });
-
   it("mints a fresh key for the next purchase after the flow completes", async () => {
     const confirmPayment = vi.fn().mockResolvedValue({ success: true });
     const onDone = vi.fn();
@@ -880,28 +808,6 @@ describe(AddCreditsForm.name, () => {
     expect(confirmPayment).toHaveBeenCalledTimes(2);
     const keys = confirmPayment.mock.calls.map(call => call[0].idempotencyKey);
     expect(keys[1]).toBe(keys[0]);
-  });
-
-  it("does not reuse the persisted key when the amount differs after a remount", async () => {
-    const confirmPayment = vi.fn().mockRejectedValue({ response: { status: 500 } });
-    const methods = [paymentMethod({ id: "pm_saved", isDefault: true })];
-    const first = setup({ status: "idle", confirmPayment, paymentMethods: methods });
-
-    fireEvent.click(screen.getByRole("radio", { name: "100" }));
-    await act(async () => {
-      fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
-    });
-    first.unmount();
-
-    setup({ status: "idle", confirmPayment, paymentMethods: methods });
-    fireEvent.change(screen.getByLabelText(/custom-amount/i), { target: { value: "200" } });
-    await act(async () => {
-      fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
-    });
-
-    expect(confirmPayment).toHaveBeenCalledTimes(2);
-    const keys = confirmPayment.mock.calls.map(call => call[0].idempotencyKey);
-    expect(keys[1]).not.toBe(keys[0]);
   });
 
   it("starts polling from the pre-charge baseline when the server replays an already-credited attempt", async () => {
@@ -1186,6 +1092,7 @@ describe(AddCreditsForm.name, () => {
           useWallet,
           useWalletBalance,
           use3DSecure,
+          useTopUpAttemptKey,
           getPaymentMethodDisplay,
           handleStripeError: input.handleStripeError ?? (() => ({ message: "fallback", userAction: undefined })),
           ...input.dependencies

--- a/apps/deploy-web/src/components/billing-usage/AddCreditsForm/AddCreditsForm.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AddCreditsForm/AddCreditsForm.tsx
@@ -31,6 +31,7 @@ import { useUser } from "@src/hooks/useUser";
 import { useWalletBalance } from "@src/hooks/useWalletBalance";
 import { QueryKeys, usePaymentMethodsQuery, usePaymentMutations, useSetupIntentMutation } from "@src/queries";
 import { handleStripeError } from "@src/utils/stripeErrorHandler";
+import { useTopUpAttemptKey } from "./useTopUpAttemptKey/useTopUpAttemptKey";
 
 /** Sentinel Select value for entering a new card instead of charging a saved method. */
 const NEW_CARD = "new";
@@ -57,6 +58,7 @@ export const DEPENDENCIES = {
   useWalletBalance,
   use3DSecure,
   useUser,
+  useTopUpAttemptKey,
   getPaymentMethodDisplay,
   handleStripeError
 };
@@ -77,62 +79,6 @@ interface PendingCharge {
   idempotencyKey: string;
 }
 
-interface StoredAttempt {
-  key: string;
-  amountCents: number;
-  paymentMethodId: string;
-  userId: string;
-  createdAt: number;
-}
-
-/** Attempt keys persist per tab so closing and reopening the errored sheet (which unmounts the form) retries the same attempt instead of minting a fresh charge. */
-const ATTEMPT_STORAGE_KEY = "add-credits-attempt";
-
-/** A stored attempt older than this is treated as a new purchase, not a retry. It matches Stripe's 24h replay window: expiring sooner would mint a fresh key (and possibly a duplicate charge) while the original attempt could still settle. */
-const ATTEMPT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
-
-/** sessionStorage access throws in some privacy modes; attempt-key persistence is best-effort and must never break the purchase flow. */
-function safeSessionStorage<T>(operation: () => T): T | undefined {
-  try {
-    return operation();
-  } catch {
-    return undefined;
-  }
-}
-
-function readStoredAttemptKey(input: { userId: string; amountCents: number; paymentMethodId: string }): string | null {
-  const raw = safeSessionStorage(() => window.sessionStorage.getItem(ATTEMPT_STORAGE_KEY));
-  if (!raw) return null;
-
-  const stored = safeSessionStorage(() => JSON.parse(raw) as StoredAttempt);
-  if (!stored) return null;
-
-  const isCurrentAttempt =
-    stored.userId === input.userId &&
-    stored.amountCents === input.amountCents &&
-    stored.paymentMethodId === input.paymentMethodId &&
-    Date.now() - stored.createdAt < ATTEMPT_MAX_AGE_MS;
-
-  return isCurrentAttempt ? stored.key : null;
-}
-
-function writeStoredAttempt(attempt: StoredAttempt): void {
-  safeSessionStorage(() => window.sessionStorage.setItem(ATTEMPT_STORAGE_KEY, JSON.stringify(attempt)));
-}
-
-function clearStoredAttempt(): void {
-  safeSessionStorage(() => window.sessionStorage.removeItem(ATTEMPT_STORAGE_KEY));
-}
-
-/** Two responses prove the attempt is dead: a 402 (the bank definitively declined, and Stripe replays that decline for the key's lifetime) and a 409 idempotency_key_mismatch (the key is permanently bound to different parameters). Retrying either with the same key could never succeed. Every other failure (timeout, 4xx/5xx, no response) leaves the outcome unknown and the key must survive. */
-function isAttemptConcluded(error: unknown): boolean {
-  if (!error || typeof error !== "object" || !("response" in error)) return false;
-
-  const response = (error as { response?: { status?: number; data?: { code?: string } } }).response;
-
-  return response?.status === 402 || (response?.status === 409 && response.data?.code === "idempotency_key_mismatch");
-}
-
 /**
  * Orchestrates the Add Credits flow: collecting a payment method is always
  * allowed, but the charge waits until the managed wallet is ready. Saved
@@ -146,12 +92,8 @@ function isAttemptConcluded(error: unknown): boolean {
  * the charge may still settle, so the form releases its in-flight state
  * without onDone and the attempt stays replayable. A new card is confirmed
  * against its SetupIntent only once: retries after a failed charge reuse the
- * saved payment method instead of re-confirming a consumed intent. Every
- * attempt carries an idempotency key that survives unknown-outcome failures
- * (and remounts, via sessionStorage) and rotates only when the attempt
- * concludes (polling confirmed settlement, a definitive 402 decline, or a 409
- * key mismatch) or its params change, so a retried slow charge replays the
- * original attempt instead of charging again.
+ * saved payment method instead of re-confirming a consumed intent. Each charge
+ * carries a replay-safe idempotency key managed by useTopUpAttemptKey.
  */
 export function AddCreditsForm({ onDone, isWalletReady = true, onProcessingChange, dependencies: d = DEPENDENCIES }: AddCreditsFormProps) {
   const { data: setupIntent, mutate: createSetupIntent, status: setupIntentStatus, reset: resetSetupIntent } = d.useSetupIntentMutation();
@@ -165,6 +107,7 @@ export function AddCreditsForm({ onDone, isWalletReady = true, onProcessingChang
   const {
     confirmPayment: { mutateAsync: confirmPayment }
   } = d.usePaymentMutations();
+  const attempt = d.useTopUpAttemptKey();
 
   const [amountInput, setAmountInput] = useState<AddCreditsAmountValue>({ predefinedAmount: undefined, customAmount: "" });
   const [selectedMethodId, setSelectedMethodId] = useState<string | undefined>(undefined);
@@ -176,8 +119,6 @@ export function AddCreditsForm({ onDone, isWalletReady = true, onProcessingChang
   const paymentMethodRef = useRef<PaymentMethodSourceHandle>(null);
   /** Payment method already confirmed against the current SetupIntent; reused on retry because a SetupIntent can only be confirmed once. */
   const confirmedNewCardRef = useRef<{ paymentMethodId: string; organization?: string } | null>(null);
-  /** Attempt key outlives PendingCharge: finalizeFailure clears the charge while the key must survive unknown-outcome failures, so a retry replays the same attempt instead of charging again. */
-  const attemptRef = useRef<{ key: string; amount: number; paymentMethodId: string } | null>(null);
   const wasPollingRef = useRef<boolean>(false);
   /** Last payment-method type reported to analytics, so the payment element's frequent change events don't re-fire the same type. */
   const lastPaymentTypeRef = useRef<string | null>(null);
@@ -243,40 +184,9 @@ export function AddCreditsForm({ onDone, isWalletReady = true, onProcessingChang
       amount,
       wasTrialing: isTrialing,
       status: "pending",
-      idempotencyKey: resolveAttemptKey(paymentMethodId, user.id)
+      idempotencyKey: attempt.resolve({ userId: user.id, amount, paymentMethodId })
     });
   };
-
-  /**
-   * Reuses the in-memory key while the purchase params are unchanged (a retry of the same attempt),
-   * rehydrates a matching persisted key after a remount, and only otherwise mints a fresh one.
-   */
-  function resolveAttemptKey(paymentMethodId: string, userId: string): string {
-    const amountCents = Math.round(amount * 100);
-    const current = attemptRef.current;
-
-    if (current && current.amount === amount && current.paymentMethodId === paymentMethodId) {
-      return current.key;
-    }
-
-    const rehydratedKey = readStoredAttemptKey({ userId, amountCents, paymentMethodId });
-
-    if (rehydratedKey) {
-      attemptRef.current = { key: rehydratedKey, amount, paymentMethodId };
-      return rehydratedKey;
-    }
-
-    const key = crypto.randomUUID();
-    attemptRef.current = { key, amount, paymentMethodId };
-    writeStoredAttempt({ key, amountCents, paymentMethodId, userId, createdAt: Date.now() });
-
-    return key;
-  }
-
-  const clearAttempt = useCallback(() => {
-    attemptRef.current = null;
-    clearStoredAttempt();
-  }, []);
 
   /** An exhausted poll leaves the charge outcome unknown: it may still settle, so the attempt key and confirmed card survive for a replay-safe retry while the in-flight form state is released. */
   const releaseChargeKeepingAttempt = useCallback(() => {
@@ -349,15 +259,13 @@ export function AddCreditsForm({ onDone, isWalletReady = true, onProcessingChang
 
         finalizeFailure("Payment failed. Please try again.");
       } catch (err) {
-        if (isAttemptConcluded(err)) {
-          clearAttempt();
-        }
+        attempt.clearIfConcluded(err);
 
         const stripeError = d.handleStripeError(err);
         finalizeFailure(stripeError.message, stripeError.userAction);
       }
     },
-    [user?.id, confirmPayment, threeDSecure, pollForPayment, pollForAlreadyCreditedPayment, finalizeFailure, clearAttempt, d]
+    [user?.id, confirmPayment, threeDSecure, pollForPayment, pollForAlreadyCreditedPayment, finalizeFailure, attempt, d]
   );
 
   useEffect(
@@ -388,7 +296,7 @@ export function AddCreditsForm({ onDone, isWalletReady = true, onProcessingChang
       }
 
       confirmedNewCardRef.current = null;
-      clearAttempt();
+      attempt.clear();
       setCharge(null);
       setIsProcessing(false);
 
@@ -409,7 +317,7 @@ export function AddCreditsForm({ onDone, isWalletReady = true, onProcessingChang
         onDone(amount, organization, bonusAmount);
       })();
     },
-    [isPolling, lastOutcome, isTrialing, charge, releaseChargeKeepingAttempt, finalizeFailure, clearAttempt, onDone, stripe]
+    [isPolling, lastOutcome, isTrialing, charge, releaseChargeKeepingAttempt, finalizeFailure, attempt, onDone, stripe]
   );
 
   useEffect(

--- a/apps/deploy-web/src/components/billing-usage/AddCreditsForm/useTopUpAttemptKey/useTopUpAttemptKey.spec.ts
+++ b/apps/deploy-web/src/components/billing-usage/AddCreditsForm/useTopUpAttemptKey/useTopUpAttemptKey.spec.ts
@@ -1,0 +1,156 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useTopUpAttemptKey } from "./useTopUpAttemptKey";
+
+import { renderHook } from "@testing-library/react";
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const STORAGE_KEY = "add-credits-attempt";
+const INPUT = { userId: "user_1", amount: 100, paymentMethodId: "pm_1" };
+
+describe(useTopUpAttemptKey.name, () => {
+  afterEach(() => {
+    window.sessionStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("resolves a uuid attempt key", () => {
+    const { result } = setup();
+
+    expect(result.current.resolve(INPUT)).toMatch(UUID_PATTERN);
+  });
+
+  it("reuses the key while the purchase params are unchanged", () => {
+    const { result } = setup();
+
+    const first = result.current.resolve(INPUT);
+
+    expect(result.current.resolve(INPUT)).toBe(first);
+  });
+
+  it("rotates the key when the amount changes", () => {
+    const { result } = setup();
+
+    const first = result.current.resolve(INPUT);
+
+    expect(result.current.resolve({ ...INPUT, amount: 200 })).not.toBe(first);
+  });
+
+  it("rotates the key when the payment method changes", () => {
+    const { result } = setup();
+
+    const first = result.current.resolve(INPUT);
+
+    expect(result.current.resolve({ ...INPUT, paymentMethodId: "pm_2" })).not.toBe(first);
+  });
+
+  it("rotates the key when the user changes", () => {
+    const { result } = setup();
+
+    const first = result.current.resolve(INPUT);
+
+    expect(result.current.resolve({ ...INPUT, userId: "user_2" })).not.toBe(first);
+  });
+
+  it("mints a fresh key after the attempt is cleared", () => {
+    const { result } = setup();
+
+    const first = result.current.resolve(INPUT);
+    result.current.clear();
+
+    expect(result.current.resolve(INPUT)).not.toBe(first);
+  });
+
+  it("rotates the key after a definitive 402 decline", () => {
+    const { result } = setup();
+
+    const first = result.current.resolve(INPUT);
+    result.current.clearIfConcluded({ response: { status: 402, data: { code: "card_declined" } } });
+
+    expect(result.current.resolve(INPUT)).not.toBe(first);
+  });
+
+  it("rotates the key after a 409 idempotency-key mismatch", () => {
+    const { result } = setup();
+
+    const first = result.current.resolve(INPUT);
+    result.current.clearIfConcluded({ response: { status: 409, data: { code: "idempotency_key_mismatch" } } });
+
+    expect(result.current.resolve(INPUT)).not.toBe(first);
+  });
+
+  it("keeps the key after a 409 conflict that is not a key mismatch", () => {
+    const { result } = setup();
+
+    const first = result.current.resolve(INPUT);
+    result.current.clearIfConcluded({ response: { status: 409, data: { code: "conflict" } } });
+
+    expect(result.current.resolve(INPUT)).toBe(first);
+  });
+
+  it("keeps the key after an unknown-outcome failure", () => {
+    const { result } = setup();
+
+    const first = result.current.resolve(INPUT);
+    result.current.clearIfConcluded({ response: { status: 500 } });
+    result.current.clearIfConcluded(new Error("network down"));
+
+    expect(result.current.resolve(INPUT)).toBe(first);
+  });
+
+  it("reuses a stored key that is still inside the 24h replay window", () => {
+    const storedKey = "11111111-2222-4333-8444-555555555555";
+    seedStoredAttempt({ key: storedKey, ageMs: 23 * 60 * 60 * 1000 });
+    const { result } = setup();
+
+    expect(result.current.resolve(INPUT)).toBe(storedKey);
+  });
+
+  it("ignores a stored key older than the 24h replay window", () => {
+    const staleKey = "11111111-2222-4333-8444-555555555555";
+    seedStoredAttempt({ key: staleKey, ageMs: 25 * 60 * 60 * 1000 });
+    const { result } = setup();
+
+    expect(result.current.resolve(INPUT)).not.toBe(staleKey);
+  });
+
+  it("replays the same key after a remount with identical params", () => {
+    const first = setup();
+    const key = first.result.current.resolve(INPUT);
+    first.unmount();
+
+    const second = setup();
+
+    expect(second.result.current.resolve(INPUT)).toBe(key);
+  });
+
+  it("mints a fresh key when params differ after a remount", () => {
+    const first = setup();
+    const key = first.result.current.resolve(INPUT);
+    first.unmount();
+
+    const second = setup();
+
+    expect(second.result.current.resolve({ ...INPUT, amount: 200 })).not.toBe(key);
+  });
+
+  it("returns a key even when sessionStorage writes throw", () => {
+    vi.spyOn(window.sessionStorage, "setItem").mockImplementation(() => {
+      throw new Error("storage blocked");
+    });
+    const { result } = setup();
+
+    expect(result.current.resolve(INPUT)).toMatch(UUID_PATTERN);
+  });
+
+  function seedStoredAttempt(input: { key: string; ageMs: number }) {
+    window.sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ key: input.key, amountCents: 10000, paymentMethodId: INPUT.paymentMethodId, userId: INPUT.userId, createdAt: Date.now() - input.ageMs })
+    );
+  }
+
+  function setup() {
+    return renderHook(() => useTopUpAttemptKey());
+  }
+});

--- a/apps/deploy-web/src/components/billing-usage/AddCreditsForm/useTopUpAttemptKey/useTopUpAttemptKey.ts
+++ b/apps/deploy-web/src/components/billing-usage/AddCreditsForm/useTopUpAttemptKey/useTopUpAttemptKey.ts
@@ -1,0 +1,123 @@
+import { useCallback, useMemo, useRef } from "react";
+
+interface StoredAttempt {
+  key: string;
+  amountCents: number;
+  paymentMethodId: string;
+  userId: string;
+  createdAt: number;
+}
+
+export interface ResolveAttemptInput {
+  userId: string;
+  amount: number;
+  paymentMethodId: string;
+}
+
+export interface TopUpAttemptKey {
+  /**
+   * Reuses the in-memory key while the purchase params are unchanged (a retry of the same attempt),
+   * rehydrates a matching persisted key after a remount, and only otherwise mints a fresh one.
+   */
+  resolve(input: ResolveAttemptInput): string;
+  /** Forgets the current attempt once it has concluded (polling confirmed settlement) so the next purchase mints a fresh key. */
+  clear(): void;
+  /** Forgets the attempt only when the error proves it is dead, so a retry after an unknown-outcome failure replays the same key. */
+  clearIfConcluded(error: unknown): void;
+}
+
+/** Attempt keys persist per tab so closing and reopening the errored sheet (which unmounts the form) retries the same attempt instead of minting a fresh charge. */
+const ATTEMPT_STORAGE_KEY = "add-credits-attempt";
+
+/** A stored attempt older than this is treated as a new purchase, not a retry. It matches Stripe's 24h replay window: expiring sooner would mint a fresh key (and possibly a duplicate charge) while the original attempt could still settle. */
+const ATTEMPT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Owns the replay-safe idempotency key for a single top-up charge attempt. The key survives
+ * unknown-outcome failures (and remounts, via sessionStorage) and rotates only when the attempt
+ * concludes (polling confirmed settlement, a definitive 402 decline, or a 409 key mismatch) or its
+ * params change, so a retried slow charge replays the original attempt instead of charging again.
+ */
+export function useTopUpAttemptKey(): TopUpAttemptKey {
+  const attemptRef = useRef<{ key: string; userId: string; amount: number; paymentMethodId: string } | null>(null);
+
+  const resolve = useCallback(({ userId, amount, paymentMethodId }: ResolveAttemptInput): string => {
+    const amountCents = Math.round(amount * 100);
+    const current = attemptRef.current;
+
+    if (current && current.userId === userId && current.amount === amount && current.paymentMethodId === paymentMethodId) {
+      return current.key;
+    }
+
+    const rehydratedKey = readStoredAttemptKey({ userId, amountCents, paymentMethodId });
+
+    if (rehydratedKey) {
+      attemptRef.current = { key: rehydratedKey, userId, amount, paymentMethodId };
+      return rehydratedKey;
+    }
+
+    const key = crypto.randomUUID();
+    attemptRef.current = { key, userId, amount, paymentMethodId };
+    writeStoredAttempt({ key, amountCents, paymentMethodId, userId, createdAt: Date.now() });
+
+    return key;
+  }, []);
+
+  const clear = useCallback(() => {
+    attemptRef.current = null;
+    clearStoredAttempt();
+  }, []);
+
+  const clearIfConcluded = useCallback(
+    (error: unknown) => {
+      if (isConcludedError(error)) {
+        clear();
+      }
+    },
+    [clear]
+  );
+
+  return useMemo(() => ({ resolve, clear, clearIfConcluded }), [resolve, clear, clearIfConcluded]);
+}
+
+/** sessionStorage access throws in some privacy modes; attempt-key persistence is best-effort and must never break the purchase flow. */
+function safeSessionStorage<T>(operation: () => T): T | undefined {
+  try {
+    return operation();
+  } catch {
+    return undefined;
+  }
+}
+
+function readStoredAttemptKey(input: { userId: string; amountCents: number; paymentMethodId: string }): string | null {
+  const raw = safeSessionStorage(() => window.sessionStorage.getItem(ATTEMPT_STORAGE_KEY));
+  if (!raw) return null;
+
+  const stored = safeSessionStorage(() => JSON.parse(raw) as StoredAttempt);
+  if (!stored) return null;
+
+  const isCurrentAttempt =
+    stored.userId === input.userId &&
+    stored.amountCents === input.amountCents &&
+    stored.paymentMethodId === input.paymentMethodId &&
+    Date.now() - stored.createdAt < ATTEMPT_MAX_AGE_MS;
+
+  return isCurrentAttempt ? stored.key : null;
+}
+
+function writeStoredAttempt(attempt: StoredAttempt): void {
+  safeSessionStorage(() => window.sessionStorage.setItem(ATTEMPT_STORAGE_KEY, JSON.stringify(attempt)));
+}
+
+function clearStoredAttempt(): void {
+  safeSessionStorage(() => window.sessionStorage.removeItem(ATTEMPT_STORAGE_KEY));
+}
+
+/** Two responses prove the attempt is dead: a 402 (the bank definitively declined, and Stripe replays that decline for the key's lifetime) and a 409 idempotency_key_mismatch (the key is permanently bound to different parameters). Retrying either with the same key could never succeed. Every other failure (timeout, 4xx/5xx, no response) leaves the outcome unknown and the key must survive. */
+function isConcludedError(error: unknown): boolean {
+  if (!error || typeof error !== "object" || !("response" in error)) return false;
+
+  const response = (error as { response?: { status?: number; data?: { code?: string } } }).response;
+
+  return response?.status === 402 || (response?.status === 409 && response.data?.code === "idempotency_key_mismatch");
+}


### PR DESCRIPTION
## Why

Billing top-up charges were made idempotent in #3449, but that landed as ~70 lines of replay-safe
attempt-key machinery inlined directly into `AddCreditsForm` — sessionStorage persistence, a 24h
replay window, key reuse/rehydrate/mint, and the 402/409 conclusion rules — all tangled into the
form's charge orchestration. It carried the densest "why" comments in the file and made both the
form and its spec hard to review.

This follow-up extracts that one distinct concern into a dedicated, independently-tested hook, so
the form reads as pure charge orchestration again. No behavior change.

Ref #3449.
<!-- add the Linear issue here if one tracks this, e.g. Part of CON-xxxx -->

## What

`deploy-web` frontend only — no behavior change, no new dependencies, no migrations, no visual change.

Extracts the top-up idempotency-key lifecycle out of `AddCreditsForm` into a colocated
`useTopUpAttemptKey` hook.

**The hook** (`AddCreditsForm/useTopUpAttemptKey/`) owns the whole concern; the storage constants,
`safeSessionStorage`, the persisted-attempt shape, and the 402/409 classifier are all private to its
module. Public API:

- `resolve({ userId, amount, paymentMethodId })` — reuses the in-memory key, rehydrates a matching
  persisted key after a remount (within the 24h replay window), or mints a fresh one.
- `clear()` — on poll-confirmed settlement.
- `clearIfConcluded(error)` — drops the key only on a definitive 402 decline or a 409
  `idempotency_key_mismatch`, so a retry after an unknown-outcome failure replays the same attempt.

**The form** sheds ~112 lines: the `catch` becomes `attempt.clearIfConcluded(err)`, the poll-success
path calls `attempt.clear()`, and submit resolves the key via `attempt.resolve(...)`. The Stripe
replay semantics (why 402/409 conclude an attempt, why the key survives remounts) now live with the
key lifecycle instead of scattered through the form; the form's class-JSDoc drops the idempotency
paragraph for a one-line pointer to the hook. The analytics instrumentation added to the form in
#3449 is untouched — this change is orthogonal to it.

**Tests** — the exhaustive lifecycle moves to a focused `useTopUpAttemptKey.spec.ts` (`renderHook`:
reuse/rehydrate/mint, 24h window, amount/payment-method rotation, `clearIfConcluded` for 402 /
409-mismatch / non-conclusive errors, remount replay, storage-throw safety). The form spec keeps the
orchestration cases (poll timeout, poll exhaust, complete-then-mint-fresh, 409-conflict copy,
3DS-failure) plus one 402 case as the end-to-end proof that the form's
`catch → clearIfConcluded → rotation` wiring works. Same coverage, most of it now at a faster,
clearer level.

### Verification

- Unit: `AddCreditsForm` + `useTopUpAttemptKey` specs green (56 tests); the hook spec runs the full
  lifecycle in ~20ms instead of driving it through the form.
- `tsc --noEmit`: no new errors in the changed files (pre-existing baseline elsewhere untouched).
- Prettier clean; lint runs under `main`'s ESLint v9 flat config in CI.
- Behavior-preserving: rebased onto the merged #3449 with zero conflicts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a replay-safe idempotency/attempt key mechanism for “add credits” top-ups that reuses keys across remounts within 24 hours when details match.
- **Bug Fixes**
  - Keys now rotate reliably when key-relevant purchase details change.
  - Failed/terminal payment outcomes now clear or preserve keys appropriately to prevent incorrect reuse.
- **Tests**
  - Added a dedicated test suite for the new key lifecycle, including storage-reliability and failure-case handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->