### PR TITLE
fix(billing): attach caught error as cause in payment-in-progress throw

### DIFF
--- a/apps/api/src/billing/services/stripe/stripe.service.ts
+++ b/apps/api/src/billing/services/stripe/stripe.service.ts
@@ -459,7 +459,7 @@ export class StripeService extends Stripe {
     } catch (error) {
       if (error instanceof Stripe.errors.StripeError && error.code === "idempotency_key_in_use") {
         this.loggerService.warn({ event: "PAYMENT_INTENT_KEY_IN_USE", transactionId: transaction.id });
-        throw new Error(PAYMENT_IN_PROGRESS_ERROR_MESSAGE);
+        throw new Error(PAYMENT_IN_PROGRESS_ERROR_MESSAGE, { cause: error });
       }
 
       if (error instanceof Stripe.errors.StripeIdempotencyError) {


### PR DESCRIPTION
## Why

The `preserve-caught-error` ESLint rule flags `stripe.service.ts:462`: the `payment_in_progress` branch rethrows a fresh `Error` inside a `catch` without attaching the original Stripe error as `cause`, dropping the underlying error context and (under the current CI dependency resolution) failing `validate (api) / validate`.

## What

Attach the caught `error` as `cause` when rethrowing `PAYMENT_IN_PROGRESS_ERROR_MESSAGE`, preserving the original error chain and satisfying the lint rule. One-line change, no behavior change to the happy path.