### PR TITLE
refactor(billing): expose named Stripe primitives and route callers off the raw SDK

### DIFF
--- a/apps/api/src/billing/controllers/stripe/stripe.controller.spec.ts
+++ b/apps/api/src/billing/controllers/stripe/stripe.controller.spec.ts
@@ -220,7 +220,7 @@ describe(StripeController.name, () => {
 
       userWalletRepository.findOneByUserId.mockResolvedValue(mock<UserWalletOutput>({ isTrialing: true }));
       stripe.getStripeCustomerId.mockResolvedValue(user.stripeCustomerId!);
-      stripe.createSetupIntent.mockResolvedValue(mock<Stripe.SetupIntent>({ client_secret: clientSecret }));
+      stripe.createSetupIntent.mockResolvedValue(mock<Stripe.Response<Stripe.SetupIntent>>({ client_secret: clientSecret }));
 
       const result = await controller.createSetupIntent();
 
@@ -234,7 +234,7 @@ describe(StripeController.name, () => {
 
       userWalletRepository.findOneByUserId.mockResolvedValue(mock<UserWalletOutput>({ isTrialing: false }));
       stripe.getStripeCustomerId.mockResolvedValue(user.stripeCustomerId!);
-      stripe.createSetupIntent.mockResolvedValue(mock<Stripe.SetupIntent>({ client_secret: clientSecret }));
+      stripe.createSetupIntent.mockResolvedValue(mock<Stripe.Response<Stripe.SetupIntent>>({ client_secret: clientSecret }));
 
       const result = await controller.createSetupIntent();
 
@@ -248,7 +248,7 @@ describe(StripeController.name, () => {
 
       userWalletRepository.findOneByUserId.mockResolvedValue(undefined);
       stripe.getStripeCustomerId.mockResolvedValue(user.stripeCustomerId!);
-      stripe.createSetupIntent.mockResolvedValue(mock<Stripe.SetupIntent>({ client_secret: clientSecret }));
+      stripe.createSetupIntent.mockResolvedValue(mock<Stripe.Response<Stripe.SetupIntent>>({ client_secret: clientSecret }));
 
       const result = await controller.createSetupIntent();
 
@@ -321,21 +321,21 @@ describe(StripeController.name, () => {
     it("detaches the payment method without checking trial status", async () => {
       const { controller, stripe, userWalletRepository, user } = setup();
       const paymentMethodId = faker.string.uuid();
-      stripe.paymentMethods.retrieve.mockResolvedValue(mock<Stripe.Response<Stripe.PaymentMethod>>({ customer: user.stripeCustomerId }));
+      stripe.retrievePaymentMethod.mockResolvedValue(mock<Stripe.Response<Stripe.PaymentMethod>>({ customer: user.stripeCustomerId }));
 
       await controller.removePaymentMethod(paymentMethodId);
 
-      expect(stripe.paymentMethods.detach).toHaveBeenCalledWith(paymentMethodId);
+      expect(stripe.detachPaymentMethod).toHaveBeenCalledWith(paymentMethodId);
       expect(userWalletRepository.findOneByUserId).not.toHaveBeenCalled();
     });
 
     it("rejects when the payment method does not belong to the user", async () => {
       const { controller, stripe } = setup();
       const paymentMethodId = faker.string.uuid();
-      stripe.paymentMethods.retrieve.mockResolvedValue(mock<Stripe.Response<Stripe.PaymentMethod>>({ customer: "cus_someoneelse" }));
+      stripe.retrievePaymentMethod.mockResolvedValue(mock<Stripe.Response<Stripe.PaymentMethod>>({ customer: "cus_someoneelse" }));
 
       await expect(controller.removePaymentMethod(paymentMethodId)).rejects.toMatchObject({ status: 403 });
-      expect(stripe.paymentMethods.detach).not.toHaveBeenCalled();
+      expect(stripe.detachPaymentMethod).not.toHaveBeenCalled();
     });
   });
 
@@ -366,11 +366,34 @@ describe(StripeController.name, () => {
     });
   });
 
+  describe("validatePaymentMethodAfter3DS", () => {
+    it("validates the payment method after confirming ownership", async () => {
+      const { controller, stripe, user } = setup();
+      stripe.retrievePaymentMethod.mockResolvedValue(mock<Stripe.Response<Stripe.PaymentMethod>>({ customer: user.stripeCustomerId }));
+      stripe.validatePaymentMethodAfter3DS.mockResolvedValue({ success: true });
+
+      const result = await controller.validatePaymentMethodAfter3DS({ data: { paymentMethodId: "pm_1", paymentIntentId: "pi_1" } });
+
+      expect(stripe.retrievePaymentMethod).toHaveBeenCalledWith("pm_1");
+      expect(stripe.validatePaymentMethodAfter3DS).toHaveBeenCalledWith(user.stripeCustomerId, "pm_1", "pi_1");
+      expect(result).toEqual({ success: true });
+    });
+
+    it("rejects when the payment method belongs to another customer", async () => {
+      const { controller, stripe } = setup();
+      stripe.retrievePaymentMethod.mockResolvedValue(mock<Stripe.Response<Stripe.PaymentMethod>>({ customer: "cus_someoneelse" }));
+
+      await expect(controller.validatePaymentMethodAfter3DS({ data: { paymentMethodId: "pm_1", paymentIntentId: "pi_1" } })).rejects.toMatchObject({
+        status: 403
+      });
+      expect(stripe.validatePaymentMethodAfter3DS).not.toHaveBeenCalled();
+    });
+  });
+
   function setup() {
     const user = createUser();
     const payingUser: PayingUser = { ...user, stripeCustomerId: user.stripeCustomerId! };
     const stripe = mock<StripeService>();
-    stripe.paymentMethods = mock<Stripe.PaymentMethodsResource>();
     const authService = mock<AuthService>({
       currentUser: user
     });

--- a/apps/api/src/billing/controllers/stripe/stripe.controller.ts
+++ b/apps/api/src/billing/controllers/stripe/stripe.controller.ts
@@ -188,11 +188,11 @@ export class StripeController {
 
     try {
       // Verify payment method ownership
-      const paymentMethod = await this.stripe.paymentMethods.retrieve(paymentMethodId);
+      const paymentMethod = await this.stripe.retrievePaymentMethod(paymentMethodId);
       const customerId = typeof paymentMethod.customer === "string" ? paymentMethod.customer : paymentMethod.customer?.id;
       assert(customerId === currentUser.stripeCustomerId, 403, "Payment method does not belong to the user");
 
-      await this.stripe.paymentMethods.detach(paymentMethodId);
+      await this.stripe.detachPaymentMethod(paymentMethodId);
     } catch (error: unknown) {
       if (this.stripeErrorService.isKnownError(error, "payment")) {
         throw this.stripeErrorService.toAppError(error, "payment");
@@ -241,7 +241,7 @@ export class StripeController {
 
     try {
       // Verify payment method ownership
-      const paymentMethod = await this.stripe.paymentMethods.retrieve(paymentMethodId);
+      const paymentMethod = await this.stripe.retrievePaymentMethod(paymentMethodId);
       const customerId = typeof paymentMethod.customer === "string" ? paymentMethod.customer : paymentMethod.customer?.id;
       assert(customerId === currentUser.stripeCustomerId, 403, "Payment method does not belong to the user");
 

--- a/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.integration.ts
+++ b/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.integration.ts
@@ -5,7 +5,6 @@ import { mock } from "vitest-mock-extended";
 
 import { FirstPurchaseBonusGranted } from "@src/billing/events/first-purchase-bonus-granted";
 import type { PaymentMethodRepository, StripeTransactionOutput, StripeTransactionRepository } from "@src/billing/repositories";
-import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import type { FirstPurchaseBonusService } from "@src/billing/services/first-purchase-bonus/first-purchase-bonus.service";
 import type { RefillService } from "@src/billing/services/refill/refill.service";
 import type { StripeService } from "@src/billing/services/stripe/stripe.service";
@@ -30,7 +29,7 @@ describe(StripeWebhookService.name, () => {
       stripeTransactionRepository.findOneByAndLock.mockResolvedValue(internalTransaction);
       stripeTransactionRepository.updateById.mockResolvedValue(undefined);
       refillService.topUpWallet.mockResolvedValue();
-      (stripeService.charges.retrieve as Mock).mockResolvedValue({
+      (stripeService.retrieveCharge as Mock).mockResolvedValue({
         id: chargeId,
         payment_method_details: { card: { brand: "visa", last4: "4242" } },
         receipt_url: "https://receipt.url"
@@ -51,7 +50,7 @@ describe(StripeWebhookService.name, () => {
       await service.tryToTopUpWalletFromPaymentIntent(event);
 
       expect(userRepository.findOneBy).toHaveBeenCalledWith({ stripeCustomerId: mockUser.stripeCustomerId });
-      expect(stripeService.charges.retrieve).toHaveBeenCalledWith(chargeId);
+      expect(stripeService.retrieveCharge).toHaveBeenCalledWith(chargeId);
       expect(stripeTransactionRepository.updateById).toHaveBeenCalledWith(internalTransaction.id, {
         status: "succeeded",
         stripeChargeId: chargeId,
@@ -304,7 +303,7 @@ describe(StripeWebhookService.name, () => {
       stripeTransactionRepository.findOneByAndLock.mockResolvedValue(internalTransaction);
       stripeTransactionRepository.updateById.mockResolvedValue(undefined);
       refillService.topUpWallet.mockResolvedValue();
-      (stripeService.charges.retrieve as Mock).mockResolvedValue({
+      (stripeService.retrieveCharge as Mock).mockResolvedValue({
         id: chargeId,
         payment_method_details: { card: { brand: "mastercard", last4: "5555" } },
         receipt_url: "https://receipt.stripe.com/inv"
@@ -334,7 +333,7 @@ describe(StripeWebhookService.name, () => {
 
       expect(userRepository.findOneBy).toHaveBeenCalledWith({ stripeCustomerId: mockUser.stripeCustomerId });
       expect(stripeTransactionRepository.findByInvoiceId).toHaveBeenCalledWith(invoiceId);
-      expect(stripeService.charges.retrieve).toHaveBeenCalledWith(chargeId);
+      expect(stripeService.retrieveCharge).toHaveBeenCalledWith(chargeId);
       expect(stripeTransactionRepository.updateById).toHaveBeenCalledWith(internalTransaction.id, {
         status: "succeeded",
         stripeChargeId: chargeId,
@@ -565,7 +564,7 @@ describe(StripeWebhookService.name, () => {
       createInvoicePaymentSucceededEvent({ id: "in_route", customer: "cus_route", amount_paid: 1000 })
     ])("routes $type events to the invoice top-up handler", async event => {
       const { service, stripeService } = setup();
-      stripeService.webhooks = { constructEvent: vi.fn().mockReturnValue(event) } as unknown as Stripe.Webhooks;
+      (stripeService.constructWebhookEvent as Mock).mockReturnValue(event);
       const handler = vi.spyOn(service, "tryToTopUpWalletFromInvoice").mockResolvedValue();
 
       await service.routeStripeEvent("signature", "raw-body");
@@ -1091,7 +1090,6 @@ describe(StripeWebhookService.name, () => {
   function setup() {
     const stripeService = mock<StripeService>();
     const refillService = mock<RefillService>();
-    const billingConfig = mock<BillingConfigService>();
     const userRepository = mock<UserRepository>();
     const paymentMethodRepository = mock<PaymentMethodRepository>();
     const stripeTransactionRepository = mock<StripeTransactionRepository>();
@@ -1099,15 +1097,9 @@ describe(StripeWebhookService.name, () => {
     firstPurchaseBonusService.getEligibleBonusAmount.mockResolvedValue(0);
     const domainEventsService = mock<DomainEventsService>();
 
-    // Mock Stripe charges API
-    stripeService.charges = {
-      retrieve: vi.fn()
-    } as unknown as Stripe.ChargesResource;
-
     const service = new StripeWebhookService(
       stripeService,
       refillService,
-      billingConfig,
       userRepository,
       paymentMethodRepository,
       stripeTransactionRepository,
@@ -1119,7 +1111,6 @@ describe(StripeWebhookService.name, () => {
       service,
       stripeService,
       refillService,
-      billingConfig,
       userRepository,
       paymentMethodRepository,
       stripeTransactionRepository,

--- a/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.ts
+++ b/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.ts
@@ -17,7 +17,6 @@ import { StripeService } from "@src/billing/services/stripe/stripe.service";
 import { WithTransaction } from "@src/core";
 import { DomainEventsService } from "@src/core/services/domain-events/domain-events.service";
 import { UserRepository } from "@src/user/repositories";
-import { BillingConfigService } from "../billing-config/billing-config.service";
 
 @singleton()
 export class StripeWebhookService {
@@ -26,7 +25,6 @@ export class StripeWebhookService {
   constructor(
     private readonly stripe: StripeService,
     private readonly refillService: RefillService,
-    private readonly billingConfig: BillingConfigService,
     private readonly userRepository: UserRepository,
     private readonly paymentMethodRepository: PaymentMethodRepository,
     private readonly stripeTransactionRepository: StripeTransactionRepository,
@@ -35,7 +33,7 @@ export class StripeWebhookService {
   ) {}
 
   async routeStripeEvent(signature: string, rawEvent: string) {
-    const event = this.stripe.webhooks.constructEvent(rawEvent, signature, this.billingConfig.get("STRIPE_WEBHOOK_SECRET"));
+    const event = this.stripe.constructWebhookEvent(rawEvent, signature);
     this.logger.info({
       event: "STRIPE_EVENT_RECEIVED",
       type: event.type,
@@ -194,7 +192,7 @@ export class StripeWebhookService {
 
     if (params.chargeId) {
       try {
-        const charge = await this.stripe.charges.retrieve(params.chargeId);
+        const charge = await this.stripe.retrieveCharge(params.chargeId);
         cardBrand = charge.payment_method_details?.card?.brand ?? undefined;
         cardLast4 = charge.payment_method_details?.card?.last4 ?? undefined;
         receiptUrl = charge.receipt_url ?? undefined;

--- a/apps/api/src/billing/services/stripe/stripe.service.spec.ts
+++ b/apps/api/src/billing/services/stripe/stripe.service.spec.ts
@@ -1,5 +1,6 @@
 import type { LoggerService } from "@akashnetwork/logging";
 import { createMongoAbility } from "@casl/ability";
+import { faker } from "@faker-js/faker";
 import crypto from "crypto";
 import Stripe from "stripe";
 import { describe, expect, it, vi } from "vitest";
@@ -1942,6 +1943,55 @@ describe(StripeService.name, () => {
 
       expect(result).toEqual(failedTransaction);
     }, 10_000);
+  });
+
+  describe("Stripe SDK primitive wrappers", () => {
+    it("retrievePaymentMethod delegates to the Stripe payment-methods API", async () => {
+      const { service } = setup();
+      const paymentMethod = mock<Stripe.Response<Stripe.PaymentMethod>>({ id: "pm_1" });
+      vi.spyOn(service.paymentMethods, "retrieve").mockResolvedValue(paymentMethod);
+
+      const result = await service.retrievePaymentMethod("pm_1");
+
+      expect(service.paymentMethods.retrieve).toHaveBeenCalledWith("pm_1");
+      expect(result).toBe(paymentMethod);
+    });
+
+    it("detachPaymentMethod delegates to the Stripe payment-methods API", async () => {
+      const { service } = setup();
+      const paymentMethod = mock<Stripe.Response<Stripe.PaymentMethod>>({ id: "pm_1" });
+      vi.spyOn(service.paymentMethods, "detach").mockResolvedValue(paymentMethod);
+
+      const result = await service.detachPaymentMethod("pm_1");
+
+      expect(service.paymentMethods.detach).toHaveBeenCalledWith("pm_1");
+      expect(result).toBe(paymentMethod);
+    });
+
+    it("retrieveCharge delegates to the Stripe charges API", async () => {
+      const { service } = setup();
+      const charge = mock<Stripe.Response<Stripe.Charge>>({ id: "ch_1" });
+      vi.spyOn(service.charges, "retrieve").mockResolvedValue(charge);
+
+      const result = await service.retrieveCharge("ch_1");
+
+      expect(service.charges.retrieve).toHaveBeenCalledWith("ch_1");
+      expect(result).toBe(charge);
+    });
+
+    it("constructWebhookEvent verifies the signature with the configured webhook secret", () => {
+      const { service, billingConfig } = setup();
+      const webhookSecret = `whsec_${faker.string.alphanumeric(32)}`;
+      billingConfig.get.mockReturnValue(webhookSecret);
+      const event = mock<Stripe.Event>({ id: "evt_1" });
+      vi.spyOn(service.webhooks, "constructEvent").mockReturnValue(event);
+
+      const result = service.constructWebhookEvent("raw-body", "sig-header");
+
+      expect(billingConfig.get).toHaveBeenCalledWith("STRIPE_WEBHOOK_SECRET");
+      expect(service.webhooks.constructEvent).toHaveBeenCalledWith("raw-body", "sig-header", webhookSecret);
+      expect(result).toBe(event);
+    });
   });
 });
 

--- a/apps/api/src/billing/services/stripe/stripe.service.ts
+++ b/apps/api/src/billing/services/stripe/stripe.service.ts
@@ -88,6 +88,22 @@ export class StripeService extends Stripe {
     });
   }
 
+  retrievePaymentMethod(paymentMethodId: string): Promise<Stripe.PaymentMethod> {
+    return this.paymentMethods.retrieve(paymentMethodId);
+  }
+
+  detachPaymentMethod(paymentMethodId: string): Promise<Stripe.PaymentMethod> {
+    return this.paymentMethods.detach(paymentMethodId);
+  }
+
+  retrieveCharge(chargeId: string): Promise<Stripe.Charge> {
+    return this.charges.retrieve(chargeId);
+  }
+
+  constructWebhookEvent(payload: string | Buffer, signature: string): Stripe.Event {
+    return this.webhooks.constructEvent(payload, signature, this.billingConfig.get("STRIPE_WEBHOOK_SECRET"));
+  }
+
   async findPrices(): Promise<StripePrices[]> {
     const { data: prices } = await this.prices.list({ active: true, product: this.billingConfig.get("STRIPE_PRODUCT_ID") });
     const responsePrices = prices.map(price => ({


### PR DESCRIPTION

## Why

`StripeService` **extends** the Stripe SDK, so its entire SDK surface leaks through the service to every caller — the Stripe controller and the webhook service reach straight into `this.stripe.paymentMethods` / `.charges` / `.webhooks`. There is no boundary around Stripe access, and no abstraction can hold while callers bypass the service into the raw SDK.

This is the first, safe step of the StripeService layering: expose the operations callers actually need as named methods and route everyone through them, so the raw SDK is reachable in exactly **one** place. That's the prerequisite for the next step — flipping `extends Stripe` to composition — which can't land while external code still reaches the SDK.

Closes CON-719 · Part of CON-718.

## What

`apps/api` — behavior-preserving, no new dependencies, no migrations.

- Adds `retrievePaymentMethod`, `detachPaymentMethod`, `retrieveCharge`, and `constructWebhookEvent` to `StripeService` (thin wrappers over the SDK it already holds).
- Routes the 5 external raw-SDK call sites — 3 in the Stripe controller, 2 in the webhook service — through those named methods. Verified by grep: no code outside `StripeService` touches the raw Stripe SDK anymore.
- `constructWebhookEvent` owns the webhook-secret lookup, so the webhook service no longer depends on `BillingConfigService` (removed the now-dead dependency).
- Also fixes 3 pre-existing `SetupIntent` mock type errors in the touched controller spec (`createSetupIntent` returns a `Stripe.Response`, so the mock must be typed as one).

## Verification

- `apps/api` unit specs green — Stripe controller + `stripe.service` (108 tests).
- `tsc`: no new errors; the baseline drops (−5) since this also clears the SetupIntent mismatches.
- Webhook integration test compiles (tsc); it runs in CI, which needs the DB.
- Lint runs under the repo's ESLint v9 flat config in CI (not runnable in this sandbox — stale local toolchain).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened payment method removal and post-3DS validation by consistently enforcing ownership checks before proceeding.
  * Improved Stripe webhook event construction/verification and wallet top-up flows by standardizing how charges and webhook events are retrieved.
* **Tests**
  * Updated Stripe controller and StripeService unit tests to reflect the newer helper-based Stripe interactions.
  * Refactored Stripe webhook integration tests to mock higher-level StripeService methods and validate the same top-up and routing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->