### PR TITLE
fix(billing): run the 3DS confirm exactly once per payment intent

### DIFF
--- a/apps/deploy-web/src/components/shared/PaymentMethodForm/ThreeDSecureModal.spec.tsx
+++ b/apps/deploy-web/src/components/shared/PaymentMethodForm/ThreeDSecureModal.spec.tsx
@@ -1,0 +1,199 @@
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { DEPENDENCIES } from "./ThreeDSecureModal";
+import { ThreeDSecureModal } from "./ThreeDSecureModal";
+
+import { act, render, screen } from "@testing-library/react";
+
+interface AuthenticationResult {
+  error?: { message?: string };
+  paymentIntent?: { status: string; id: string };
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe(ThreeDSecureModal.name, () => {
+  it("runs the Stripe confirmation exactly once despite parent re-renders with fresh callback identities", () => {
+    const confirmPayment = vi.fn(() => new Promise<AuthenticationResult>(() => {}));
+    const { rerenderWithCallbacks } = setup({ confirmPayment });
+
+    rerenderWithCallbacks({ onSuccess: vi.fn(), onError: vi.fn() });
+    rerenderWithCallbacks({ onSuccess: vi.fn(), onError: vi.fn() });
+
+    expect(confirmPayment).toHaveBeenCalledTimes(1);
+  });
+
+  it("confirms the payment intent with the client secret and selected payment method", () => {
+    const confirmPayment = vi.fn(() => new Promise<AuthenticationResult>(() => {}));
+    setup({ confirmPayment, clientSecret: "pi_secret_abc", paymentMethodId: "pm_abc" });
+
+    expect(confirmPayment).toHaveBeenCalledWith({
+      clientSecret: "pi_secret_abc",
+      confirmParams: { payment_method: "pm_abc", return_url: window.location.href },
+      redirect: "if_required"
+    });
+  });
+
+  it("routes a successful confirmation to the latest onSuccess after the success delay", async () => {
+    vi.useFakeTimers();
+    try {
+      const deferred = createDeferred<AuthenticationResult>();
+      const confirmPayment = vi.fn(() => deferred.promise);
+      const staleOnSuccess = vi.fn();
+      const latestOnSuccess = vi.fn();
+      const { rerenderWithCallbacks } = setup({ confirmPayment, onSuccess: staleOnSuccess });
+
+      rerenderWithCallbacks({ onSuccess: latestOnSuccess, onError: vi.fn() });
+
+      await act(async () => {
+        deferred.resolve({ paymentIntent: { status: "succeeded", id: "pi_1" } });
+        await deferred.promise;
+      });
+
+      expect(screen.getByText("Authentication Successful!")).toBeInTheDocument();
+      expect(latestOnSuccess).not.toHaveBeenCalled();
+
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+
+      expect(latestOnSuccess).toHaveBeenCalledTimes(1);
+      expect(staleOnSuccess).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("surfaces the Stripe error message and reports it through onError", async () => {
+    const confirmPayment = vi.fn().mockResolvedValue({ error: { message: "Your card was declined." } });
+    const { onError } = setup({ confirmPayment });
+
+    expect(await screen.findByText("Your card was declined.")).toBeInTheDocument();
+    expect(screen.getByText("Authentication Failed")).toBeInTheDocument();
+    expect(onError).toHaveBeenCalledWith("Your card was declined.");
+  });
+
+  it("shows a declined message when the intent still requires a payment method", async () => {
+    const confirmPayment = vi.fn().mockResolvedValue({ paymentIntent: { status: "requires_payment_method", id: "pi_1" } });
+    const { onError } = setup({ confirmPayment });
+
+    expect(await screen.findByText("Your payment method was declined. Please try a different card.")).toBeInTheDocument();
+    expect(onError).toHaveBeenCalledWith("Your payment method was declined. Please try a different card.");
+  });
+
+  it("reports an unexpected payment intent status", async () => {
+    const confirmPayment = vi.fn().mockResolvedValue({ paymentIntent: { status: "requires_action", id: "pi_1" } });
+    const { onError } = setup({ confirmPayment });
+
+    expect(await screen.findByText("Authentication failed. Status: requires_action")).toBeInTheDocument();
+    expect(onError).toHaveBeenCalledWith("Authentication failed. Status: requires_action");
+  });
+
+  it("fails with a retry message when no payment intent is returned", async () => {
+    const confirmPayment = vi.fn().mockResolvedValue({});
+    const { onError } = setup({ confirmPayment });
+
+    expect(await screen.findByText("Authentication failed. Please try again.")).toBeInTheDocument();
+    expect(onError).toHaveBeenCalledWith("Authentication failed. Please try again.");
+  });
+
+  it("reports the thrown message when the confirmation rejects", async () => {
+    const confirmPayment = vi.fn().mockRejectedValue(new Error("Network down"));
+    const { onError } = setup({ confirmPayment });
+
+    expect(await screen.findByText("Network down")).toBeInTheDocument();
+    expect(onError).toHaveBeenCalledWith("Network down");
+  });
+
+  it("does not start a second confirmation when unmounted mid-challenge", () => {
+    const confirmPayment = vi.fn(() => new Promise<AuthenticationResult>(() => {}));
+    const { unmount } = setup({ confirmPayment });
+
+    unmount();
+
+    expect(confirmPayment).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows an unavailable message and never confirms when Stripe cannot be loaded", () => {
+    const confirmPayment = vi.fn(() => new Promise<AuthenticationResult>(() => {}));
+    setup({ confirmPayment, stripeUnavailable: true });
+
+    expect(screen.getByText(/Payment processing is not available at this time/i)).toBeInTheDocument();
+    expect(confirmPayment).not.toHaveBeenCalled();
+  });
+
+  it("shows a missing-data message and never confirms when the client secret is empty", () => {
+    const confirmPayment = vi.fn(() => new Promise<AuthenticationResult>(() => {}));
+    setup({ confirmPayment, clientSecret: "" });
+
+    expect(screen.getByText(/Authentication data is missing/i)).toBeInTheDocument();
+    expect(confirmPayment).not.toHaveBeenCalled();
+  });
+
+  function setup(input: {
+    clientSecret?: string;
+    paymentMethodId?: string;
+    onSuccess?: () => void;
+    onError?: (error: string) => void;
+    confirmPayment?: (...args: unknown[]) => Promise<unknown>;
+    stripeUnavailable?: boolean;
+    dependencies?: Partial<typeof DEPENDENCIES>;
+  }) {
+    const clientSecret = input.clientSecret ?? "pi_secret_123";
+    const paymentMethodId = input.paymentMethodId ?? "pm_123";
+    const onSuccess = input.onSuccess ?? vi.fn();
+    const onError = input.onError ?? vi.fn();
+    const confirmPayment = input.confirmPayment ?? vi.fn(() => new Promise(() => {}));
+
+    const Elements = (({ children }: { children?: React.ReactNode }) => (
+      <div data-testid="stripe-elements">{children}</div>
+    )) as unknown as typeof DEPENDENCIES.Elements;
+
+    const useServices: typeof DEPENDENCIES.useServices = () =>
+      mock<ReturnType<typeof DEPENDENCIES.useServices>>({
+        stripeService: mock<ReturnType<typeof DEPENDENCIES.useServices>["stripeService"]>({
+          getStripe: () =>
+            input.stripeUnavailable
+              ? (null as unknown as ReturnType<ReturnType<typeof DEPENDENCIES.useServices>["stripeService"]["getStripe"]>)
+              : Promise.resolve(mock<Awaited<ReturnType<ReturnType<typeof DEPENDENCIES.useServices>["stripeService"]["getStripe"]>>>())
+        })
+      });
+
+    const useTheme: typeof DEPENDENCIES.useTheme = () => mock<ReturnType<typeof DEPENDENCIES.useTheme>>({ resolvedTheme: "light" });
+
+    const stripe = { confirmPayment } as unknown as NonNullable<ReturnType<typeof DEPENDENCIES.useStripe>>;
+    const useStripe: typeof DEPENDENCIES.useStripe = () => stripe;
+
+    const elements = mock<NonNullable<ReturnType<typeof DEPENDENCIES.useElements>>>();
+    const useElements: typeof DEPENDENCIES.useElements = () => elements;
+
+    const dependencies: typeof DEPENDENCIES = { Elements, useServices, useTheme, useStripe, useElements, ...input.dependencies };
+
+    const view = render(
+      <ThreeDSecureModal clientSecret={clientSecret} paymentMethodId={paymentMethodId} onSuccess={onSuccess} onError={onError} dependencies={dependencies} />
+    );
+
+    const rerenderWithCallbacks = (callbacks: { onSuccess: () => void; onError: (error: string) => void }) =>
+      view.rerender(
+        <ThreeDSecureModal
+          clientSecret={clientSecret}
+          paymentMethodId={paymentMethodId}
+          onSuccess={callbacks.onSuccess}
+          onError={callbacks.onError}
+          dependencies={dependencies}
+        />
+      );
+
+    return { ...view, rerenderWithCallbacks, confirmPayment, onSuccess, onError };
+  }
+});

--- a/apps/deploy-web/src/components/shared/PaymentMethodForm/ThreeDSecureModal.spec.tsx
+++ b/apps/deploy-web/src/components/shared/PaymentMethodForm/ThreeDSecureModal.spec.tsx
@@ -83,6 +83,14 @@ describe(ThreeDSecureModal.name, () => {
     expect(onError).toHaveBeenCalledWith("Your card was declined.");
   });
 
+  it("falls back to a generic message when the Stripe error has no message", async () => {
+    const confirmPayment = vi.fn().mockResolvedValue({ error: {} });
+    const { onError } = setup({ confirmPayment });
+
+    expect(await screen.findByText("Authentication failed")).toBeInTheDocument();
+    expect(onError).toHaveBeenCalledWith("Authentication failed");
+  });
+
   it("shows a declined message when the intent still requires a payment method", async () => {
     const confirmPayment = vi.fn().mockResolvedValue({ paymentIntent: { status: "requires_payment_method", id: "pi_1" } });
     const { onError } = setup({ confirmPayment });
@@ -99,6 +107,14 @@ describe(ThreeDSecureModal.name, () => {
     expect(onError).toHaveBeenCalledWith("Authentication failed. Status: requires_action");
   });
 
+  it("labels the status as unknown when the payment intent status is empty", async () => {
+    const confirmPayment = vi.fn().mockResolvedValue({ paymentIntent: { status: "", id: "pi_1" } });
+    const { onError } = setup({ confirmPayment });
+
+    expect(await screen.findByText("Authentication failed. Status: unknown")).toBeInTheDocument();
+    expect(onError).toHaveBeenCalledWith("Authentication failed. Status: unknown");
+  });
+
   it("fails with a retry message when no payment intent is returned", async () => {
     const confirmPayment = vi.fn().mockResolvedValue({});
     const { onError } = setup({ confirmPayment });
@@ -113,6 +129,14 @@ describe(ThreeDSecureModal.name, () => {
 
     expect(await screen.findByText("Network down")).toBeInTheDocument();
     expect(onError).toHaveBeenCalledWith("Network down");
+  });
+
+  it("reports a generic message when the confirmation rejects with a non-error value", async () => {
+    const confirmPayment = vi.fn().mockRejectedValue("stripe exploded");
+    const { onError } = setup({ confirmPayment });
+
+    expect(await screen.findByText("Authentication failed due to an unexpected error")).toBeInTheDocument();
+    expect(onError).toHaveBeenCalledWith("Authentication failed due to an unexpected error");
   });
 
   it("does not start a second confirmation when unmounted mid-challenge", () => {
@@ -137,6 +161,15 @@ describe(ThreeDSecureModal.name, () => {
     setup({ confirmPayment, clientSecret: "" });
 
     expect(screen.getByText(/Authentication data is missing/i)).toBeInTheDocument();
+    expect(confirmPayment).not.toHaveBeenCalled();
+  });
+
+  it("keeps processing without confirming while Stripe.js is still loading inside Elements", () => {
+    const confirmPayment = vi.fn(() => new Promise<AuthenticationResult>(() => {}));
+    const useStripe: typeof DEPENDENCIES.useStripe = () => null;
+    setup({ confirmPayment, dependencies: { useStripe } });
+
+    expect(screen.getByText("Processing Authentication")).toBeInTheDocument();
     expect(confirmPayment).not.toHaveBeenCalled();
   });
 

--- a/apps/deploy-web/src/components/shared/PaymentMethodForm/ThreeDSecureModal.spec.tsx
+++ b/apps/deploy-web/src/components/shared/PaymentMethodForm/ThreeDSecureModal.spec.tsx
@@ -139,6 +139,31 @@ describe(ThreeDSecureModal.name, () => {
     expect(onError).toHaveBeenCalledWith("Authentication failed due to an unexpected error");
   });
 
+  it("does not invoke onSuccess when unmounted during the success delay window", async () => {
+    vi.useFakeTimers();
+    try {
+      const deferred = createDeferred<AuthenticationResult>();
+      const confirmPayment = vi.fn(() => deferred.promise);
+      const onSuccess = vi.fn();
+      const { unmount } = setup({ confirmPayment, onSuccess });
+
+      await act(async () => {
+        deferred.resolve({ paymentIntent: { status: "succeeded", id: "pi_1" } });
+        await deferred.promise;
+      });
+
+      unmount();
+
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+
+      expect(onSuccess).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not start a second confirmation when unmounted mid-challenge", () => {
     const confirmPayment = vi.fn(() => new Promise<AuthenticationResult>(() => {}));
     const { unmount } = setup({ confirmPayment });

--- a/apps/deploy-web/src/components/shared/PaymentMethodForm/ThreeDSecureModal.tsx
+++ b/apps/deploy-web/src/components/shared/PaymentMethodForm/ThreeDSecureModal.tsx
@@ -69,10 +69,19 @@ const ThreeDSecureForm: React.FC<Omit<ThreeDSecureModalProps, "isOpen" | "onClos
   const [errorMsg, setErrorMsg] = useState<string>("");
   const hasStartedAuthenticationRef = useRef(false);
   const callbacksRef = useRef({ onSuccess, onError });
+  const successTimerRef = useRef<ReturnType<typeof setTimeout>>();
 
   useEffect(function trackLatestCallbacks() {
     callbacksRef.current = { onSuccess, onError };
   });
+
+  useEffect(function clearSuccessTimerOnUnmount() {
+    return () => {
+      if (successTimerRef.current) {
+        clearTimeout(successTimerRef.current);
+      }
+    };
+  }, []);
 
   useEffect(
     function authenticateOnce() {
@@ -89,7 +98,7 @@ const ThreeDSecureForm: React.FC<Omit<ThreeDSecureModalProps, "isOpen" | "onClos
 
       function succeed() {
         setStatus("succeeded");
-        setTimeout(() => callbacksRef.current.onSuccess(), SUCCESS_DELAY);
+        successTimerRef.current = setTimeout(() => callbacksRef.current.onSuccess(), SUCCESS_DELAY);
       }
 
       function routeResult({ error, paymentIntent }: AuthenticationResult) {

--- a/apps/deploy-web/src/components/shared/PaymentMethodForm/ThreeDSecureModal.tsx
+++ b/apps/deploy-web/src/components/shared/PaymentMethodForm/ThreeDSecureModal.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Spinner } from "@akashnetwork/ui/components";
 import { Elements, useElements, useStripe } from "@stripe/react-stripe-js";
 import { CheckCircle, Shield, WarningTriangle } from "iconoir-react";
@@ -9,6 +9,14 @@ import { useServices } from "@src/context/ServicesProvider/ServicesProvider";
 
 const SUCCESS_DELAY = 1_500;
 const SUCCESSFUL_STATUSES = ["succeeded", "requires_capture", "processing"] as const;
+
+export const DEPENDENCIES = {
+  Elements,
+  useServices,
+  useTheme,
+  useStripe,
+  useElements
+};
 
 interface ThreeDSecureModalProps {
   clientSecret: string;
@@ -21,6 +29,7 @@ interface ThreeDSecureModalProps {
   successMessage?: string;
   errorMessage?: string;
   hideTitle?: boolean;
+  dependencies?: typeof DEPENDENCIES;
 }
 
 type AuthenticationStatus = "processing" | "succeeded" | "failed";
@@ -51,107 +60,70 @@ const ThreeDSecureForm: React.FC<Omit<ThreeDSecureModalProps, "isOpen" | "onClos
   description = "Your bank requires additional verification for this transaction.",
   successMessage = "Your card has been verified successfully.",
   errorMessage = "Please try again or use a different payment method.",
-  hideTitle = false
+  hideTitle = false,
+  dependencies: d = DEPENDENCIES
 }) => {
-  const stripe = useStripe();
-  const elements = useElements();
+  const stripe = d.useStripe();
+  const elements = d.useElements();
   const [status, setStatus] = useState<AuthenticationStatus>("processing");
   const [errorMsg, setErrorMsg] = useState<string>("");
-  const authenticationInProgress = useRef(false);
+  const hasStartedAuthenticationRef = useRef(false);
+  const callbacksRef = useRef({ onSuccess, onError });
 
-  const handleAuthenticationFailure = useCallback(
-    (message: string) => {
-      setStatus("failed");
-      setErrorMsg(message);
-      onError(message);
-    },
-    [onError]
-  );
+  useEffect(function trackLatestCallbacks() {
+    callbacksRef.current = { onSuccess, onError };
+  });
 
-  const handleAuthenticationSuccess = useCallback(
-    (paymentIntentStatus: string) => {
-      console.log("3D Secure authentication successful, status:", paymentIntentStatus);
-      setStatus("succeeded");
-      setTimeout(() => {
-        onSuccess();
-      }, SUCCESS_DELAY);
-    },
-    [onSuccess]
-  );
-
-  const processAuthenticationResult = useCallback(
-    (result: AuthenticationResult) => {
-      const { error, paymentIntent } = result;
-
-      if (error) {
-        console.error("3D Secure authentication error:", error);
-        const errorMessage = error.message || "Authentication failed";
-        handleAuthenticationFailure(errorMessage);
+  useEffect(
+    function authenticateOnce() {
+      if (!stripe || !elements || hasStartedAuthenticationRef.current) {
         return;
       }
+      hasStartedAuthenticationRef.current = true;
 
-      if (!paymentIntent) {
-        console.error("3D Secure authentication failed - no payment intent");
-        handleAuthenticationFailure("Authentication failed. Please try again.");
-        return;
+      function fail(message: string) {
+        setStatus("failed");
+        setErrorMsg(message);
+        callbacksRef.current.onError(message);
       }
 
-      if (SUCCESSFUL_STATUSES.includes(paymentIntent.status as (typeof SUCCESSFUL_STATUSES)[number])) {
-        handleAuthenticationSuccess(paymentIntent.status);
-      } else if (paymentIntent.status === "requires_payment_method") {
-        console.error("3D Secure authentication failed - payment method declined");
-        const errorMessage = "Your payment method was declined. Please try a different card.";
-        handleAuthenticationFailure(errorMessage);
-      } else {
-        console.error("3D Secure authentication failed, unexpected status:", paymentIntent.status);
-        const errorText = `Authentication failed. Status: ${paymentIntent.status || "unknown"}`;
-        handleAuthenticationFailure(errorText);
+      function succeed() {
+        setStatus("succeeded");
+        setTimeout(() => callbacksRef.current.onSuccess(), SUCCESS_DELAY);
       }
+
+      function routeResult({ error, paymentIntent }: AuthenticationResult) {
+        if (error) {
+          fail(error.message || "Authentication failed");
+        } else if (!paymentIntent) {
+          fail("Authentication failed. Please try again.");
+        } else if (SUCCESSFUL_STATUSES.includes(paymentIntent.status as (typeof SUCCESSFUL_STATUSES)[number])) {
+          succeed();
+        } else if (paymentIntent.status === "requires_payment_method") {
+          fail("Your payment method was declined. Please try a different card.");
+        } else {
+          fail(`Authentication failed. Status: ${paymentIntent.status || "unknown"}`);
+        }
+      }
+
+      function failWithThrownError(err: unknown) {
+        fail(err instanceof Error ? err.message : "Authentication failed due to an unexpected error");
+      }
+
+      stripe
+        .confirmPayment({
+          clientSecret,
+          confirmParams: {
+            payment_method: paymentMethodId,
+            return_url: window.location.href
+          },
+          redirect: "if_required"
+        })
+        .then(routeResult)
+        .catch(failWithThrownError);
     },
-    [handleAuthenticationFailure, handleAuthenticationSuccess]
+    [stripe, elements, clientSecret, paymentMethodId]
   );
-
-  const performAuthentication = useCallback(async () => {
-    if (!stripe || authenticationInProgress.current) {
-      if (authenticationInProgress.current) {
-        console.log("Authentication already in progress, skipping...");
-      }
-      return;
-    }
-
-    authenticationInProgress.current = true;
-
-    try {
-      const result = await stripe.confirmPayment({
-        clientSecret,
-        confirmParams: {
-          payment_method: paymentMethodId,
-          return_url: window.location.href
-        },
-        redirect: "if_required"
-      });
-      console.log("3D Secure authentication result:", result);
-      processAuthenticationResult(result);
-    } catch (err) {
-      console.error("3D Secure authentication exception:", err);
-      const errorText = err instanceof Error ? err.message : "Authentication failed due to an unexpected error";
-      handleAuthenticationFailure(errorText);
-    } finally {
-      authenticationInProgress.current = false;
-    }
-  }, [stripe, clientSecret, paymentMethodId, processAuthenticationResult, handleAuthenticationFailure]);
-
-  useEffect(() => {
-    if (!stripe || !elements || status !== "processing") {
-      return;
-    }
-
-    performAuthentication();
-
-    return () => {
-      authenticationInProgress.current = false;
-    };
-  }, [stripe, elements, status, performAuthentication, handleAuthenticationFailure]);
 
   if (status === "succeeded") {
     return (
@@ -211,10 +183,11 @@ export const ThreeDSecureModal: React.FC<ThreeDSecureModalProps> = ({
   description = "Your bank requires additional verification for this transaction.",
   successMessage = "Your card has been verified successfully.",
   errorMessage = "Please try again or use a different payment method.",
-  hideTitle = false
+  hideTitle = false,
+  dependencies: d = DEPENDENCIES
 }) => {
-  const { stripeService } = useServices();
-  const { resolvedTheme } = useTheme();
+  const { stripeService } = d.useServices();
+  const { resolvedTheme } = d.useTheme();
   const isDarkMode = resolvedTheme === "dark";
   const stripePromise = stripeService.getStripe();
 
@@ -235,7 +208,7 @@ export const ThreeDSecureModal: React.FC<ThreeDSecureModalProps> = ({
   }
 
   return (
-    <Elements
+    <d.Elements
       key={clientSecret}
       stripe={stripePromise}
       options={{
@@ -260,7 +233,8 @@ export const ThreeDSecureModal: React.FC<ThreeDSecureModalProps> = ({
         successMessage={successMessage}
         errorMessage={errorMessage}
         hideTitle={hideTitle}
+        dependencies={d}
       />
-    </Elements>
+    </d.Elements>
   );
 };

--- a/apps/deploy-web/src/queries/usePaymentQueries.spec.tsx
+++ b/apps/deploy-web/src/queries/usePaymentQueries.spec.tsx
@@ -5,6 +5,7 @@ import { QueryClient } from "@tanstack/react-query";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
+import { QueryKeys } from "./queryKeys";
 import {
   useDefaultPaymentMethodQuery,
   usePaymentMethodsQuery,
@@ -136,14 +137,16 @@ describe("usePaymentQueries", () => {
   });
 
   describe("usePaymentMutations", () => {
-    it("confirms payment and invalidate queries", async () => {
-      const mockPaymentResponse = createMockPaymentResponse();
+    it("invalidates both payment methods and transactions after a settled payment", async () => {
+      const mockPaymentResponse = createMockPaymentResponse({ requiresAction: false });
       const stripeService = mock<StripeService>({
         confirmPayment: vi.fn().mockResolvedValue(mockPaymentResponse)
       });
-      const { result } = setupQuery(() => usePaymentMutations(), {
+      const { result, queryClient } = setupQueryWithClient(() => usePaymentMutations(), {
         services: { stripe: () => stripeService }
       });
+
+      const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries");
 
       await act(async () => {
         await result.current.confirmPayment.mutateAsync({
@@ -155,7 +158,35 @@ describe("usePaymentQueries", () => {
 
       await vi.waitFor(() => {
         expect(stripeService.confirmPayment).toHaveBeenCalled();
+        expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: QueryKeys.getPaymentMethodsKey() });
+        expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: QueryKeys.getPaymentTransactionsKey() });
       });
+    });
+
+    it("skips payment-method invalidation while a payment still requires 3DS action", async () => {
+      const mockPaymentResponse = createMockPaymentResponse({ requiresAction: true });
+      const stripeService = mock<StripeService>({
+        confirmPayment: vi.fn().mockResolvedValue(mockPaymentResponse)
+      });
+      const { result, queryClient } = setupQueryWithClient(() => usePaymentMutations(), {
+        services: { stripe: () => stripeService }
+      });
+
+      const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+      await act(async () => {
+        await result.current.confirmPayment.mutateAsync({
+          userId: "u1",
+          paymentMethodId: mockPaymentResponse.id,
+          amount: mockPaymentResponse.amount
+        });
+      });
+
+      await vi.waitFor(() => {
+        expect(stripeService.confirmPayment).toHaveBeenCalled();
+        expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: QueryKeys.getPaymentTransactionsKey() });
+      });
+      expect(invalidateQueriesSpy).not.toHaveBeenCalledWith({ queryKey: QueryKeys.getPaymentMethodsKey() });
     });
 
     it("applies coupon and invalidate discounts", async () => {

--- a/apps/deploy-web/src/queries/usePaymentQueries.ts
+++ b/apps/deploy-web/src/queries/usePaymentQueries.ts
@@ -92,10 +92,12 @@ export const usePaymentMutations = () => {
         idempotencyKey
       });
     },
-    onSuccess: () => {
-      // Invalidate relevant queries after successful payment
-      queryClient.invalidateQueries({ queryKey: QueryKeys.getPaymentMethodsKey() });
+    onSuccess: response => {
       queryClient.invalidateQueries({ queryKey: QueryKeys.getPaymentTransactionsKey() });
+
+      if (!response.requiresAction) {
+        queryClient.invalidateQueries({ queryKey: QueryKeys.getPaymentMethodsKey() });
+      }
     }
   });
 


### PR DESCRIPTION
## Why

Adding credits with a **new** card that requires 3D Secure was glitchy: the challenge opened, closed itself, an error toast ("We are unable to authenticate your payment method…") appeared, and then a **second** challenge opened. If the user completed that second challenge, Stripe charged the card and the webhook credited the wallet — while the UI showed a failure. Already-saved 3DS cards were unaffected (exactly one challenge).

Root cause (two parts):

- **Re-entrant confirm** — `ThreeDSecureForm` fired `stripe.confirmPayment` inside an effect whose deps included callbacks chained to unstable parent props, and the effect **cleanup reset the in-progress guard**. So any mid-challenge parent re-render re-ran the effect and fired a second `confirmPayment` on the same PaymentIntent: Stripe cancelled the first challenge (popup closes), its promise resolved with an auth error (toast + failure), and the second confirm opened a fresh challenge.
- **The new-card-only trigger** — `confirmPayment.onSuccess` invalidated the payment-methods query even on the `202 { requiresAction: true }` response. For a new card the refetched list changed (the card was just saved via `confirmSetup`), producing a new reference that re-rendered the form mid-challenge. For a saved card the list was deep-equal → structural sharing kept the same reference → no re-render → single clean challenge.

Backend is sound and untouched (202 with clientSecret, attempt-key idempotency resumes the same PaymentIntent, crediting is webhook-only).

No linked Linear issue.

## What

- **`ThreeDSecureModal`** — the 3DS confirmation now runs **exactly once per PaymentIntent**: a run-once latch that no cleanup resets (safe because `<Elements key={clientSecret}>` plus conditional mounting remount the form for every genuinely new challenge), and a latest-callbacks ref so parent re-renders can neither re-fire nor abort the in-flight confirm while the freshest `onSuccess`/`onError` still run on resolution. Result routing (success / declined / unexpected status / missing intent / thrown error) is unchanged. Added a `DEPENDENCIES` export for DI-based testing and dropped stray `console.*` calls.
- **`usePaymentQueries`** — `confirmPayment.onSuccess` no longer invalidates the payment-methods query while a payment still `requiresAction` (a 202 settles nothing; the 3DS-success path invalidates via `validatePaymentMethodAfter3DS.onSuccess` and the failure path via the form's own handler). The transactions invalidation stays unconditional.

Note: a brand-new 3DS card still sees **two sequential, clean** challenges (one saving the card, one for the charge) — inherent to the current save-then-charge design and accepted here; this PR only removes the glitch (self-closing challenge + false error + duplicate popup).

### Tests

- New `ThreeDSecureModal.spec.tsx` (TDD): the key regression asserts `confirmPayment` fires **exactly once** across parent re-renders with fresh callback identities (failed with 3 calls before the fix), plus success routes to the latest `onSuccess` after the delay, all failure routings, unmount safety, and the stripe-unavailable / empty-client-secret guards.
- Extended `usePaymentQueries.spec.tsx`: `requiresAction` response → payment methods **not** invalidated (transactions still are); settled response → both invalidated (asserted via `QueryKeys.*` helpers).

### Manual QA (Stripe test mode, card `4000 0027 6000 3184`)

- New-card top-up → one setup challenge + one payment challenge, no error toast, no form reshuffle behind the popup, credits arrive.
- Same flow, click FAIL → single error surfaced, no second popup, retry works.
- Saved-card top-up → exactly one challenge.
- Onboarding trial start with a 3DS card → one challenge, wallet created.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced 3D Secure payment authentication with clearer handling for success, failures, declines, unknown states, and user-facing retry messaging.
* **Bug Fixes**
  * Prevented duplicate Stripe confirmations and ensured only the latest success/error callbacks are invoked, including during unmounts mid-challenge.
  * Improved resilience when Stripe/auth data is unavailable, and improved error messages for unexpected or malformed responses.
  * Refined data refresh after confirmation: payment methods are invalidated only when no additional 3DS action is required.
* **Tests**
  * Added/updated coverage for confirmation logic, callback timing, unmount safety, error edge cases, and query invalidation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->