### PR TITLE
fix(styling): adopt near-black dark theme and white light background

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/AutoDeployFlow/AutoDeployFlow.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/AutoDeployFlow/AutoDeployFlow.tsx
@@ -67,7 +67,7 @@ export const AutoDeployFlow: FC<Props> = ({ templateName, sdl, resume, flow, isW
   }, [trialError, retryTrial, tryAgain]);
 
   return (
-    <d.Layout background="white" disableContainer containerClassName="flex h-[calc(100vh-57px)] flex-col dark:bg-card">
+    <d.Layout background="white" disableContainer containerClassName="flex h-[calc(100vh-57px)] flex-col">
       <d.PhasedDeployProgressScene
         templateName={templateName}
         state={state}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
@@ -269,7 +269,7 @@ export const ConfigureDeploymentForm: FC<Props> = ({ initialSdl, initialName, in
   );
 
   return (
-    <d.Layout background="white" disableContainer containerClassName="flex h-[calc(100vh-57px)] flex-col dark:bg-card">
+    <d.Layout background="white" disableContainer containerClassName="flex h-[calc(100vh-57px)] flex-col">
       <d.NextSeo title="Configure your deployment" />
       <FormProvider {...form}>
         <div className="relative flex min-h-0 flex-1 flex-col">

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeployProgressOverlay/ProvidersGlobe.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeployProgressOverlay/ProvidersGlobe.spec.tsx
@@ -88,11 +88,11 @@ describe(ProvidersGlobe.name, () => {
   });
 
   describe("cobe options", () => {
-    it("brightens the map and darkens the glow under the dark theme", () => {
+    it("brightens the map and holds the glow at the card level under the dark theme", () => {
       const Globe = vi.fn(ComponentMock);
       setup({ theme: "dark", dependencies: { Globe } });
 
-      expect(Globe.mock.calls[0][0].cobeOptions).toMatchObject({ mapBrightness: 3, glowColor: [0.05, 0.05, 0.05] });
+      expect(Globe.mock.calls[0][0].cobeOptions).toMatchObject({ mapBrightness: 8, glowColor: [0.09, 0.09, 0.09] });
     });
 
     it("uses the light map brightness and glow under the light theme", () => {

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeployProgressOverlay/ProvidersGlobe.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeployProgressOverlay/ProvidersGlobe.tsx
@@ -35,8 +35,9 @@ export const ProvidersGlobe: FC<Props> = ({ focusedProviderAddress, dependencies
   const { data: providers } = d.useProviderList();
 
   const cobeOptions = useMemo(() => {
-    const glowColor: [number, number, number] = documentTheme === "dark" ? [0.05, 0.05, 0.05] : [1, 1, 1];
-    return { mapSamples: 32000, dark: 1, diffuse: 0, mapBrightness: documentTheme === "dark" ? 3 : 1, glowColor };
+    // Dark: lift the glow to the --card level (#171717) and brighten the map so the dotted continents read against the near-black (#0a0a0a) app background; white glow in light.
+    const glowColor: [number, number, number] = documentTheme === "dark" ? [0.09, 0.09, 0.09] : [1, 1, 1];
+    return { mapSamples: 32000, dark: 1, diffuse: 0, mapBrightness: documentTheme === "dark" ? 8 : 1, glowColor };
   }, [documentTheme]);
 
   const focused = useMemo(

--- a/apps/deploy-web/src/components/layout/Layout.tsx
+++ b/apps/deploy-web/src/components/layout/Layout.tsx
@@ -134,7 +134,7 @@ const LayoutApp: React.FunctionComponent<Props> = ({
   };
 
   return (
-    <div className={cn("flex h-full flex-col", { "min-h-screen bg-white text-foreground": background === "white" })}>
+    <div className={cn("flex h-full flex-col", { "min-h-screen bg-white text-foreground dark:bg-background": background === "white" })}>
       <div className="w-full flex-1" style={{ marginTop: `var(--app-header-height, ${ACCOUNT_BAR_HEIGHT + (hasBanner ? 40 : 0)}px)` }}>
         <div className="h-full overflow-x-auto">
           {isTopNavEnabled ? <TopNav minimal={isStripped} /> : <Nav isMobileOpen={isMobileOpen} handleDrawerToggle={handleDrawerToggle} minimal={isStripped} />}

--- a/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.tsx
+++ b/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.tsx
@@ -100,7 +100,7 @@ export function OnboardingPickerPage({ dependencies: d = DEPENDENCIES }: Onboard
         <title>Onboarding | Akash Console</title>
         <meta name="description" content="Deploy your first app on Akash Network with our onboarding flow. Get a live URL in about 30 seconds." />
       </Head>
-      <div className="flex min-h-screen flex-col bg-white dark:bg-black">
+      <div className="flex min-h-screen flex-col bg-background">
         <header className="relative flex items-center justify-between border-b border-border">
           <div className="flex h-14 w-full items-center justify-between pl-4 pr-4">
             <AkashConsoleLogo />

--- a/packages/ui/components/spinner.tsx
+++ b/packages/ui/components/spinner.tsx
@@ -13,7 +13,7 @@ export function Spinner({ className, size = "medium", variant = "primary" }: Spi
       <svg
         aria-hidden="true"
         className={cn("animate-spin", {
-          "fill-primary text-muted-foreground/20 dark:fill-primary dark:text-transparent/20": variant === "primary",
+          "fill-primary text-muted-foreground/20": variant === "primary",
           "fill-primary text-transparent/20 dark:text-white": variant === "dark",
           "h-2 w-2": size === "xSmall",
           "h-4 w-4": size === "small",

--- a/packages/ui/styles/global.css
+++ b/packages/ui/styles/global.css
@@ -4,7 +4,7 @@
 
 @layer base {
   :root, .light {
-    --background: 0 0% 96%;
+    --background: 0 0% 100%;
     --header: 120 33% 100%;
     --foreground: 0 0% 4%;
     --card: 120 33% 100%;
@@ -38,30 +38,30 @@
   }
 
   .dark {
-    --background: 0 0% 15%;
+    --background: 0 0% 4%;
     --header: 0 0% 4%;
-    --foreground: 0 0% 96%;
+    --foreground: 0 0% 98%;
     --card: 0 0% 9%;
-    --card-foreground: 0 0% 96%;
-    --popover: 0 0% 15%;
-    --popover-foreground: 0 0% 96%;
+    --card-foreground: 0 0% 98%;
+    --popover: 0 0% 9%;
+    --popover-foreground: 0 0% 98%;
     --primary: 0 0% 90%;
-    --primary-foreground: 0 0% 4%;
+    --primary-foreground: 0 0% 9%;
     --primary-visited: 0 0% 30%;
-    --secondary: 0 0% 16%;
-    --secondary-foreground: 0 0% 47%;
+    --secondary: 0 0% 15%;
+    --secondary-foreground: 0 0% 98%;
     --success: 142 76% 36%;
-    --muted: 0 0% 16%;
-    --muted-foreground: 0 0% 56%;
-    --accent: 0 0% 9%;
-    --accent-foreground: 0 0% 96%;
+    --muted: 0 0% 15%;
+    --muted-foreground: 0 0% 64%;
+    --accent: 0 0% 15%;
+    --accent-foreground: 0 0% 98%;
     --warning: 27 98% 47%;
     --warning-foreground: 0 0% 98%;
     --destructive: 0 84% 51%;
     --destructive-foreground: 0 0% 96%;
     --akash: 355 100% 62%;
     --border: 0 0% 100% / 10%;
-    --input: 0 0% 25%;
+    --input: 0 0% 100% / 15%;
     --ring: 0 0% 56%;
     --chart-1: 220 70% 50%;
     --chart-2: 160 60% 45%;


### PR DESCRIPTION
## Why

The dark theme used a medium-gray background (`0 0% 15%`) that clashed with the new near-black design, and the newly always-on top loading bar exposed the mismatch on the configure/deploy flow. This aligns the shared theme to the Figma design: near-black in dark mode, white in light mode.

## What

- **Dark palette** (`packages/ui/styles/global.css`): set to the Figma dark tokens. `--background` → `#0a0a0a`; harmonized `--popover`, `--secondary`, `--muted`, `--accent`, `--input` and the near-white foreground tokens. `--card`, `--border`, `--primary` already matched the design.
- **Light palette**: `--background` → white (`0 0% 100%`); cards stay white, separated by their existing borders.
- **Configure + deploy surfaces**: `Layout`'s `background="white"` variant now carries `dark:bg-background`, and the redundant per-container `dark:bg-card` is dropped. This also fixes the top loading-bar strip that showed the wrong color on the configure page.
- **Deploy-progress globe** (`ProvidersGlobe`): glow held at the card level and `mapBrightness` raised from `3` to `8` so the dotted continents read against the near-black background.
- **Spinner** (`packages/ui`): the dark track is no longer transparent, so the ring is visible in dark mode.
- **Onboarding picker**: uses the `bg-background` token instead of hardcoded `bg-white dark:bg-black`.

These are shared `packages/ui` tokens, so the change affects **deploy-web, stats-web, and provider-console**. Theme/CSS only, no behavior or contract changes. Screenshots of the affected dark/light screens to be attached.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated light and dark theme colors for improved visual consistency.
  * Refined backgrounds across onboarding and deployment configuration screens.
  * Improved dark-mode visibility for the provider globe.
  * Updated primary spinner styling across themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->