### PR TITLE
refactor(billing): make StripeTransactionService the single writer for the webhook path

### DIFF
--- a/apps/api/src/billing/services/stripe-transaction/stripe-transaction.service.spec.ts
+++ b/apps/api/src/billing/services/stripe-transaction/stripe-transaction.service.spec.ts
@@ -5,6 +5,8 @@ import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { StripeTransactionRepository } from "@src/billing/repositories";
+import type { FirstPurchaseBonusService } from "@src/billing/services/first-purchase-bonus/first-purchase-bonus.service";
+import type { RefillService } from "@src/billing/services/refill/refill.service";
 import { IDEMPOTENCY_KEY_MISMATCH_ERROR_MESSAGE, PAYMENT_IN_PROGRESS_ERROR_MESSAGE } from "@src/billing/services/stripe-error/stripe-error.service";
 import type { TimerService } from "@src/core/services/timer/timer.service";
 import { StripeTransactionService } from "./stripe-transaction.service";
@@ -426,7 +428,14 @@ describe(StripeTransactionService.name, () => {
 
     const stripe = new Stripe(`sk_test_${faker.string.alphanumeric(32)}`, { apiVersion: "2025-10-29.clover", httpClient: Stripe.createFetchHttpClient() });
 
-    const service = new StripeTransactionService(stripe, stripeTransactionRepository, timerService, () => mock<LoggerService>());
+    const service = new StripeTransactionService(
+      stripe,
+      stripeTransactionRepository,
+      mock<RefillService>(),
+      mock<FirstPurchaseBonusService>(),
+      timerService,
+      () => mock<LoggerService>()
+    );
 
     stripeTransactionRepository.create.mockImplementation(async input => ({
       id: "test-transaction-id",

--- a/apps/api/src/billing/services/stripe-transaction/stripe-transaction.service.ts
+++ b/apps/api/src/billing/services/stripe-transaction/stripe-transaction.service.ts
@@ -8,9 +8,11 @@ import { inject, singleton } from "tsyringe";
 import { PaymentIntentResult } from "@src/billing/http-schemas/stripe.schema";
 import { STRIPE_CLIENT } from "@src/billing/providers/stripe-client.provider";
 import { SETTLED_TRANSACTION_STATUSES, StripeTransactionInput, StripeTransactionOutput, StripeTransactionRepository } from "@src/billing/repositories";
+import { FirstPurchaseBonusService } from "@src/billing/services/first-purchase-bonus/first-purchase-bonus.service";
+import { RefillService } from "@src/billing/services/refill/refill.service";
 import { STRIPE_CURRENCY } from "@src/billing/services/stripe/stripe.service";
 import { IDEMPOTENCY_KEY_MISMATCH_ERROR_MESSAGE, PAYMENT_IN_PROGRESS_ERROR_MESSAGE } from "@src/billing/services/stripe-error/stripe-error.service";
-import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
+import { type CreateLogger, LOGGER_FACTORY, WithTransaction } from "@src/core";
 import { TimerService } from "@src/core/services/timer/timer.service";
 
 /**
@@ -37,6 +39,8 @@ export class StripeTransactionService {
   constructor(
     @inject(STRIPE_CLIENT) private readonly stripe: Stripe,
     private readonly stripeTransactionRepository: StripeTransactionRepository,
+    private readonly refillService: RefillService,
+    private readonly firstPurchaseBonusService: FirstPurchaseBonusService,
     private readonly timerService: TimerService,
     @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
@@ -377,5 +381,188 @@ export class StripeTransactionService {
     assert(lastTransaction, 404, "Transaction not found");
 
     return lastTransaction;
+  }
+
+  @WithTransaction()
+  async settleSucceededTransaction(params: {
+    transactionId: string;
+    chargeId: string | undefined;
+    paymentMethodType: string | undefined;
+    cardBrand: string | undefined;
+    cardLast4: string | undefined;
+    receiptUrl: string | undefined;
+    stripePaymentIntentId: string | undefined;
+    paymentAmount: number;
+    userId: string;
+    eventDescription: string;
+    endTrial?: boolean;
+  }): Promise<number> {
+    const transaction = await this.stripeTransactionRepository.findOneByAndLock({ id: params.transactionId });
+
+    if (!transaction) {
+      this.loggerService.warn({
+        event: "TRANSACTION_NOT_FOUND_FOR_UPDATE",
+        transactionId: params.transactionId,
+        description: params.eventDescription
+      });
+      return 0;
+    }
+
+    if (transaction.status === "succeeded") {
+      this.loggerService.info({
+        event: "PAYMENT_ALREADY_PROCESSED",
+        transactionId: params.transactionId,
+        description: params.eventDescription
+      });
+      return 0;
+    }
+
+    const bonusAmount = await this.firstPurchaseBonusService.getEligibleBonusAmount(transaction, params.paymentAmount);
+
+    await this.stripeTransactionRepository.updateById(params.transactionId, {
+      status: "succeeded",
+      stripeChargeId: params.chargeId,
+      paymentMethodType: params.paymentMethodType,
+      cardBrand: params.cardBrand,
+      cardLast4: params.cardLast4,
+      receiptUrl: params.receiptUrl,
+      stripePaymentIntentId: params.stripePaymentIntentId,
+      ...(bonusAmount > 0 ? { bonusAmount } : {})
+    });
+
+    // Single combined top-up: two calls would double chain fees and race on retrieveDeploymentLimit.
+    await this.refillService.topUpWallet(params.paymentAmount + bonusAmount, params.userId, {
+      endTrial: params.endTrial,
+      payment: {
+        currency: transaction.currency,
+        cardBrand: params.cardBrand,
+        paymentMethodType: params.paymentMethodType,
+        transactionId: transaction.id,
+        source: transaction.type,
+        ...(bonusAmount > 0 ? { bonusAmountCents: bonusAmount } : {})
+      }
+    });
+
+    if (bonusAmount > 0) {
+      this.firstPurchaseBonusService.trackBonusGranted(params.userId, params.paymentAmount, bonusAmount);
+      this.loggerService.info({
+        event: "FIRST_PURCHASE_BONUS_GRANTED",
+        transactionId: params.transactionId,
+        userId: params.userId,
+        paidAmountCents: params.paymentAmount,
+        bonusAmountCents: bonusAmount
+      });
+    }
+
+    return bonusAmount;
+  }
+
+  @WithTransaction()
+  async markPaymentIntentFailed(paymentIntentId: string, errorMessage: string): Promise<void> {
+    await this.stripeTransactionRepository.updateByPaymentIntentId(paymentIntentId, {
+      status: "failed",
+      errorMessage
+    });
+
+    this.loggerService.warn({
+      event: "PAYMENT_INTENT_FAILED",
+      paymentIntentId,
+      errorMessage
+    });
+  }
+
+  @WithTransaction()
+  async markPaymentIntentCanceled(paymentIntentId: string): Promise<void> {
+    await this.stripeTransactionRepository.updateByPaymentIntentId(paymentIntentId, {
+      status: "canceled"
+    });
+
+    this.loggerService.info({
+      event: "PAYMENT_INTENT_CANCELED",
+      paymentIntentId
+    });
+  }
+
+  @WithTransaction()
+  async applyRefund(params: { chargeId: string; amountRefunded: number; fullyRefunded: boolean; userId: string }): Promise<void> {
+    // Locked read: concurrent charge.refunded deliveries serialize here, so the loser
+    // re-reads the committed amountRefunded/status and bails on the idempotency check
+    // instead of double-debiting the wallet.
+    const transaction = await this.stripeTransactionRepository.findOneByAndLock({ stripeChargeId: params.chargeId });
+
+    if (!transaction) {
+      this.loggerService.warn({ event: "CHARGE_REFUNDED_NO_TRANSACTION", chargeId: params.chargeId });
+      return;
+    }
+
+    // Idempotency check: if we've already processed up to this refund amount, skip
+    if (transaction.amountRefunded >= params.amountRefunded) {
+      this.loggerService.info({
+        event: "CHARGE_REFUND_ALREADY_PROCESSED",
+        chargeId: params.chargeId,
+        transactionId: transaction.id,
+        storedAmountRefunded: transaction.amountRefunded,
+        incomingAmountRefunded: params.amountRefunded
+      });
+      return;
+    }
+
+    // Calculate delta based on what we've already processed, not previous_attributes
+    // This handles both retries and partial refunds correctly
+    const refundedAmount = params.amountRefunded - transaction.amountRefunded;
+    if (refundedAmount <= 0) {
+      this.loggerService.warn({ event: "CHARGE_REFUNDED_NO_DELTA", chargeId: params.chargeId, totalRefunded: params.amountRefunded });
+      return;
+    }
+
+    // Only reduce wallet balance if the transaction was successful (user actually received credits)
+    if (transaction.status !== "succeeded" && transaction.status !== "refunded") {
+      this.loggerService.info({
+        event: "CHARGE_REFUNDED_SKIPPED",
+        chargeId: params.chargeId,
+        transactionId: transaction.id,
+        transactionStatus: transaction.status,
+        reason: "Transaction was not in succeeded state, user never received credits"
+      });
+      return;
+    }
+
+    const isFullyRefunded = params.fullyRefunded;
+
+    // Claw back the first-purchase bonus only on the first transition to fully-refunded
+    // (pre-update status check); partial refunds never touch the bonus. bonusAmount stays
+    // on the row as the audit record of the grant.
+    const bonusClawback = isFullyRefunded && transaction.status !== "refunded" && transaction.bonusAmount > 0 ? transaction.bonusAmount : 0;
+
+    await this.stripeTransactionRepository.updateById(transaction.id, {
+      amountRefunded: params.amountRefunded,
+      ...(isFullyRefunded ? { status: "refunded" } : {})
+    });
+
+    await this.refillService.reduceWalletBalance(refundedAmount + bonusClawback, params.userId, {
+      currency: transaction.currency,
+      transactionId: transaction.id
+    });
+
+    if (bonusClawback > 0) {
+      this.loggerService.info({
+        event: "FIRST_PURCHASE_BONUS_CLAWED_BACK",
+        chargeId: params.chargeId,
+        userId: params.userId,
+        transactionId: transaction.id,
+        bonusAmountCents: bonusClawback
+      });
+    }
+
+    this.loggerService.info({
+      event: "CHARGE_REFUNDED",
+      chargeId: params.chargeId,
+      userId: params.userId,
+      refundedAmount,
+      totalRefunded: params.amountRefunded,
+      previouslyRefunded: transaction.amountRefunded,
+      isFullyRefunded,
+      transactionId: transaction.id
+    });
   }
 }

--- a/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.integration.ts
+++ b/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.integration.ts
@@ -1,3 +1,4 @@
+import type { LoggerService } from "@akashnetwork/logging";
 import type Stripe from "stripe";
 import type { Mock } from "vitest";
 import { describe, expect, it, vi } from "vitest";
@@ -8,8 +9,10 @@ import type { PaymentMethodRepository, StripeTransactionOutput, StripeTransactio
 import type { FirstPurchaseBonusService } from "@src/billing/services/first-purchase-bonus/first-purchase-bonus.service";
 import type { RefillService } from "@src/billing/services/refill/refill.service";
 import type { StripeService } from "@src/billing/services/stripe/stripe.service";
+import { StripeTransactionService } from "@src/billing/services/stripe-transaction/stripe-transaction.service";
 import { StripeWebhookService } from "@src/billing/services/stripe-webhook/stripe-webhook.service";
 import type { DomainEventsService } from "@src/core/services/domain-events/domain-events.service";
+import type { TimerService } from "@src/core/services/timer/timer.service";
 import type { UserRepository } from "@src/user/repositories";
 
 import { createTestUser } from "@test/seeders/user-test.seeder";
@@ -1097,14 +1100,22 @@ describe(StripeWebhookService.name, () => {
     firstPurchaseBonusService.getEligibleBonusAmount.mockResolvedValue(0);
     const domainEventsService = mock<DomainEventsService>();
 
+    const stripeTransaction = new StripeTransactionService(
+      mock<Stripe>(),
+      stripeTransactionRepository,
+      refillService,
+      firstPurchaseBonusService,
+      mock<TimerService>(),
+      () => mock<LoggerService>()
+    );
+
     const service = new StripeWebhookService(
       stripeService,
-      refillService,
       userRepository,
       paymentMethodRepository,
       stripeTransactionRepository,
-      firstPurchaseBonusService,
-      domainEventsService
+      domainEventsService,
+      stripeTransaction
     );
 
     return {

--- a/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.ts
+++ b/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.ts
@@ -10,10 +10,9 @@ import {
   StripeTransactionRepository,
   TRIAL_PRESERVING_TRANSACTION_TYPES
 } from "@src/billing/repositories";
-import { FirstPurchaseBonusService } from "@src/billing/services/first-purchase-bonus/first-purchase-bonus.service";
 import { assertIsPayingUser } from "@src/billing/services/paying-user/paying-user";
-import { RefillService } from "@src/billing/services/refill/refill.service";
 import { StripeService } from "@src/billing/services/stripe/stripe.service";
+import { StripeTransactionService } from "@src/billing/services/stripe-transaction/stripe-transaction.service";
 import { WithTransaction } from "@src/core";
 import { DomainEventsService } from "@src/core/services/domain-events/domain-events.service";
 import { UserRepository } from "@src/user/repositories";
@@ -24,12 +23,11 @@ export class StripeWebhookService {
 
   constructor(
     private readonly stripe: StripeService,
-    private readonly refillService: RefillService,
     private readonly userRepository: UserRepository,
     private readonly paymentMethodRepository: PaymentMethodRepository,
     private readonly stripeTransactionRepository: StripeTransactionRepository,
-    private readonly firstPurchaseBonusService: FirstPurchaseBonusService,
-    private readonly domainEventsService: DomainEventsService
+    private readonly domainEventsService: DomainEventsService,
+    private readonly stripeTransaction: StripeTransactionService
   ) {}
 
   async routeStripeEvent(signature: string, rawEvent: string) {
@@ -205,7 +203,7 @@ export class StripeWebhookService {
       }
     }
 
-    const bonusAmountCents = await this.updateTransactionAndTopUp({
+    const bonusAmountCents = await this.stripeTransaction.settleSucceededTransaction({
       transactionId: params.transaction.id,
       chargeId: params.chargeId,
       paymentMethodType: params.paymentMethodType,
@@ -219,119 +217,22 @@ export class StripeWebhookService {
       endTrial: params.endTrial
     });
 
-    // Published here, not inside updateTransactionAndTopUp: this method is not transactional but that one is,
+    // Published here, not inside settleSucceededTransaction: this method is not transactional but that one is,
     // so the awaited call has committed by now and the bonus-granted email never fires on a rolled-back grant.
     if (bonusAmountCents > 0) {
       await this.domainEventsService.publish(new FirstPurchaseBonusGranted({ userId: user.id, bonusAmountCents, paidAmountCents: params.paymentAmount }));
     }
   }
 
-  @WithTransaction()
-  private async updateTransactionAndTopUp(params: {
-    transactionId: string;
-    chargeId: string | undefined;
-    paymentMethodType: string | undefined;
-    cardBrand: string | undefined;
-    cardLast4: string | undefined;
-    receiptUrl: string | undefined;
-    stripePaymentIntentId: string | undefined;
-    paymentAmount: number;
-    userId: string;
-    eventDescription: string;
-    endTrial?: boolean;
-  }): Promise<number> {
-    const transaction = await this.stripeTransactionRepository.findOneByAndLock({ id: params.transactionId });
-
-    if (!transaction) {
-      this.logger.warn({
-        event: "TRANSACTION_NOT_FOUND_FOR_UPDATE",
-        transactionId: params.transactionId,
-        description: params.eventDescription
-      });
-      return 0;
-    }
-
-    if (transaction.status === "succeeded") {
-      this.logger.info({
-        event: "PAYMENT_ALREADY_PROCESSED",
-        transactionId: params.transactionId,
-        description: params.eventDescription
-      });
-      return 0;
-    }
-
-    const bonusAmount = await this.firstPurchaseBonusService.getEligibleBonusAmount(transaction, params.paymentAmount);
-
-    await this.stripeTransactionRepository.updateById(params.transactionId, {
-      status: "succeeded",
-      stripeChargeId: params.chargeId,
-      paymentMethodType: params.paymentMethodType,
-      cardBrand: params.cardBrand,
-      cardLast4: params.cardLast4,
-      receiptUrl: params.receiptUrl,
-      stripePaymentIntentId: params.stripePaymentIntentId,
-      ...(bonusAmount > 0 ? { bonusAmount } : {})
-    });
-
-    // Single combined top-up: two calls would double chain fees and race on retrieveDeploymentLimit.
-    await this.refillService.topUpWallet(params.paymentAmount + bonusAmount, params.userId, {
-      endTrial: params.endTrial,
-      payment: {
-        currency: transaction.currency,
-        cardBrand: params.cardBrand,
-        paymentMethodType: params.paymentMethodType,
-        transactionId: transaction.id,
-        source: transaction.type,
-        ...(bonusAmount > 0 ? { bonusAmountCents: bonusAmount } : {})
-      }
-    });
-
-    if (bonusAmount > 0) {
-      this.firstPurchaseBonusService.trackBonusGranted(params.userId, params.paymentAmount, bonusAmount);
-      this.logger.info({
-        event: "FIRST_PURCHASE_BONUS_GRANTED",
-        transactionId: params.transactionId,
-        userId: params.userId,
-        paidAmountCents: params.paymentAmount,
-        bonusAmountCents: bonusAmount
-      });
-    }
-
-    return bonusAmount;
-  }
-
-  @WithTransaction()
   async handlePaymentIntentFailed(event: Stripe.PaymentIntentPaymentFailedEvent) {
     const paymentIntent = event.data.object;
-    const errorMessage = paymentIntent.last_payment_error?.message ?? "Payment failed";
-
-    await this.stripeTransactionRepository.updateByPaymentIntentId(paymentIntent.id, {
-      status: "failed",
-      errorMessage
-    });
-
-    this.logger.warn({
-      event: "PAYMENT_INTENT_FAILED",
-      paymentIntentId: paymentIntent.id,
-      errorMessage
-    });
+    await this.stripeTransaction.markPaymentIntentFailed(paymentIntent.id, paymentIntent.last_payment_error?.message ?? "Payment failed");
   }
 
-  @WithTransaction()
   async handlePaymentIntentCanceled(event: Stripe.PaymentIntentCanceledEvent) {
-    const paymentIntent = event.data.object;
-
-    await this.stripeTransactionRepository.updateByPaymentIntentId(paymentIntent.id, {
-      status: "canceled"
-    });
-
-    this.logger.info({
-      event: "PAYMENT_INTENT_CANCELED",
-      paymentIntentId: paymentIntent.id
-    });
+    await this.stripeTransaction.markPaymentIntentCanceled(event.data.object.id);
   }
 
-  @WithTransaction()
   async handleChargeRefunded(event: Stripe.ChargeRefundedEvent) {
     const charge = event.data.object;
     const customerId = charge.customer as string;
@@ -347,85 +248,11 @@ export class StripeWebhookService {
       return;
     }
 
-    // Locked read: concurrent charge.refunded deliveries serialize here, so the loser
-    // re-reads the committed amountRefunded/status and bails on the idempotency check
-    // instead of double-debiting the wallet.
-    const transaction = await this.stripeTransactionRepository.findOneByAndLock({ stripeChargeId: charge.id });
-
-    if (!transaction) {
-      this.logger.warn({ event: "CHARGE_REFUNDED_NO_TRANSACTION", chargeId: charge.id });
-      return;
-    }
-
-    // Idempotency check: if we've already processed up to this refund amount, skip
-    if (transaction.amountRefunded >= charge.amount_refunded) {
-      this.logger.info({
-        event: "CHARGE_REFUND_ALREADY_PROCESSED",
-        chargeId: charge.id,
-        transactionId: transaction.id,
-        storedAmountRefunded: transaction.amountRefunded,
-        incomingAmountRefunded: charge.amount_refunded
-      });
-      return;
-    }
-
-    // Calculate delta based on what we've already processed, not previous_attributes
-    // This handles both retries and partial refunds correctly
-    const refundedAmount = charge.amount_refunded - transaction.amountRefunded;
-    if (refundedAmount <= 0) {
-      this.logger.warn({ event: "CHARGE_REFUNDED_NO_DELTA", chargeId: charge.id, totalRefunded: charge.amount_refunded });
-      return;
-    }
-
-    // Only reduce wallet balance if the transaction was successful (user actually received credits)
-    if (transaction.status !== "succeeded" && transaction.status !== "refunded") {
-      this.logger.info({
-        event: "CHARGE_REFUNDED_SKIPPED",
-        chargeId: charge.id,
-        transactionId: transaction.id,
-        transactionStatus: transaction.status,
-        reason: "Transaction was not in succeeded state, user never received credits"
-      });
-      return;
-    }
-
-    const isFullyRefunded = charge.refunded;
-
-    // Claw back the first-purchase bonus only on the first transition to fully-refunded
-    // (pre-update status check); partial refunds never touch the bonus. bonusAmount stays
-    // on the row as the audit record of the grant.
-    const bonusClawback = isFullyRefunded && transaction.status !== "refunded" && transaction.bonusAmount > 0 ? transaction.bonusAmount : 0;
-
-    // Update transaction with new refund amount and status
-    await this.stripeTransactionRepository.updateById(transaction.id, {
-      amountRefunded: charge.amount_refunded,
-      ...(isFullyRefunded ? { status: "refunded" } : {})
-    });
-
-    await this.refillService.reduceWalletBalance(refundedAmount + bonusClawback, user.id, {
-      currency: transaction.currency,
-      transactionId: transaction.id
-    });
-
-    if (bonusClawback > 0) {
-      this.logger.info({
-        event: "FIRST_PURCHASE_BONUS_CLAWED_BACK",
-        chargeId: charge.id,
-        userId: user.id,
-        transactionId: transaction.id,
-        bonusAmountCents: bonusClawback
-      });
-    }
-
-    this.logger.info({
-      event: "CHARGE_REFUNDED",
+    await this.stripeTransaction.applyRefund({
       chargeId: charge.id,
-      userId: user.id,
-      refundedAmount,
-      totalRefunded: charge.amount_refunded,
-      previouslyRefunded: transaction.amountRefunded,
-      isFullyRefunded,
-      transactionId: transaction.id
+      amountRefunded: charge.amount_refunded,
+      fullyRefunded: charge.refunded,
+      userId: user.id
     });
   }
 


### PR DESCRIPTION
## Why

`stripe_transactions` was written by **two** owners: `StripeTransactionService` on the request path (previous slice) and `StripeWebhookService` on the webhook path — the concurrency class this refactor set out to close. This PR routes the webhook's transaction writes (and the coupled wallet mutation) through `StripeTransactionService`, so the table now has a **single writer** across both paths.

Behavior-preserving: no response, status-mapping, idempotency, or concurrency semantics change. The webhook keeps its role as the Stripe-event dispatcher; only the `stripe_transactions` writes move down into the L2 aggregate. Next step in the layered `StripeService` split (follows the request-path slice).

Part of CON-718, Closes CON-723

## What

`apps/api` — behavior-preserving, no new runtime behavior, no migrations.

- `StripeTransactionService` gains the webhook-settlement methods, each owning the `@WithTransaction` "lock the row → update it → refill/reduce the wallet" atomicity that used to live in the webhook:
  - `settleSucceededTransaction` — the former `updateTransactionAndTopUp` core (locked read, already-succeeded no-op, first-purchase bonus, row update, wallet top-up); returns the bonus so the dispatcher can publish the post-commit event.
  - `markPaymentIntentFailed` / `markPaymentIntentCanceled`.
  - `applyRefund` — the refund core (locked read, refund idempotency + delta, status guard, bonus clawback, row update, wallet reduce).
- It picks up `RefillService` + `FirstPurchaseBonusService` as dependencies (the collaborators that moved with the atomic core).
- `StripeWebhookService` stays the L3 dispatcher: verify signature, route the event, extract Stripe-shape primitives, resolve the user, fetch charge details, and publish the deliberately post-commit `FirstPurchaseBonusGranted` event. It performs **no** direct `stripe_transactions` writes and no longer injects `RefillService` / `FirstPurchaseBonusService`.
- **Stripe API calls stay outside the transaction** — `constructWebhookEvent` and `retrieveCharge` run in the dispatcher, before the L2 transaction opens. Only DB + wallet work happens inside `@WithTransaction`.
- `payment_method.attached` / `detached` are untouched (they belong to the upcoming `PaymentMethodService` slice).

## Verification

- **Billing unit suite green — 357 tests / 28 files.**
- `tsc`: no new errors in the changed files; the reworked `stripe-webhook.service.integration.ts` construction (a real `StripeTransactionService` wired with the same mocks, passed into the webhook) type-checks.
- Prettier clean.
- **Run before merge (need the test DB):** `npm run test:integration` (the `handleChargeRefunded` suite — full/partial/clawback/duplicate-delivery idempotency — plus the settle/failed/canceled paths, all now exercised through the real L2) and `npm run test:functional`. These require `npm run test:ci-setup` and run in CI.
