### PR TITLE
refactor(billing): give payment-method sync a single owner across user actions and webhooks

### DIFF
--- a/apps/api/src/billing/controllers/stripe/stripe.controller.spec.ts
+++ b/apps/api/src/billing/controllers/stripe/stripe.controller.spec.ts
@@ -7,7 +7,9 @@ import { mock } from "vitest-mock-extended";
 import { AuthService } from "@src/auth/services/auth.service";
 import type { UserWalletOutput, UserWalletRepository } from "@src/billing/repositories";
 import type { PayingUser } from "@src/billing/services/paying-user/paying-user";
-import type { PaymentMethod, StripeService } from "@src/billing/services/stripe/stripe.service";
+import type { PaymentMethodService } from "@src/billing/services/payment-method/payment-method.service";
+import { type PaymentMethod } from "@src/billing/services/payment-method/payment-method.service";
+import type { StripeService } from "@src/billing/services/stripe/stripe.service";
 import type { StripeErrorService } from "@src/billing/services/stripe-error/stripe-error.service";
 import type { StripeTransactionService } from "@src/billing/services/stripe-transaction/stripe-transaction.service";
 import type { TransactionReportingService } from "@src/billing/services/transaction-reporting/transaction-reporting.service";
@@ -20,10 +22,10 @@ import { createUser } from "@test/seeders/user.seeder";
 describe(StripeController.name, () => {
   describe("confirmPayment", () => {
     it("returns transactionId and transactionStatus on successful payment", async () => {
-      const { controller, stripe, stripeTransaction, user } = setup();
+      const { controller, stripeTransaction, paymentMethodService, user } = setup();
       const transactionId = faker.string.uuid();
 
-      stripe.hasPaymentMethod.mockResolvedValue(true);
+      paymentMethodService.hasPaymentMethod.mockResolvedValue(true);
       stripeTransaction.createPaymentIntent.mockResolvedValue({
         success: true,
         paymentIntentId: faker.string.uuid(),
@@ -47,11 +49,11 @@ describe(StripeController.name, () => {
     });
 
     it("resolves transaction when awaitResolved is true", async () => {
-      const { controller, stripe, stripeTransaction, user } = setup();
+      const { controller, stripeTransaction, paymentMethodService, user } = setup();
       const transactionId = faker.string.uuid();
       const resolvedTransaction = generateDatabaseStripeTransaction({ id: transactionId, status: "succeeded" });
 
-      stripe.hasPaymentMethod.mockResolvedValue(true);
+      paymentMethodService.hasPaymentMethod.mockResolvedValue(true);
       stripeTransaction.createPaymentIntent.mockResolvedValue({
         success: true,
         paymentIntentId: faker.string.uuid(),
@@ -78,10 +80,10 @@ describe(StripeController.name, () => {
     });
 
     it("invokes trial-min validation before contacting Stripe", async () => {
-      const { controller, stripe, stripeTransaction, userWalletRepository, trialValidationService, user } = setup();
+      const { controller, stripeTransaction, userWalletRepository, trialValidationService, paymentMethodService, user } = setup();
       const wallet = mock<UserWalletOutput>({ isTrialing: true });
       userWalletRepository.findOneByUserId.mockResolvedValue(wallet);
-      stripe.hasPaymentMethod.mockResolvedValue(true);
+      paymentMethodService.hasPaymentMethod.mockResolvedValue(true);
       stripeTransaction.createPaymentIntent.mockResolvedValue({
         success: true,
         paymentIntentId: faker.string.uuid(),
@@ -99,7 +101,7 @@ describe(StripeController.name, () => {
     });
 
     it("propagates the trial-min rejection without ever calling Stripe", async () => {
-      const { controller, stripe, stripeTransaction, userWalletRepository, trialValidationService, user } = setup();
+      const { controller, stripeTransaction, userWalletRepository, trialValidationService, paymentMethodService, user } = setup();
       const wallet = mock<UserWalletOutput>({ isTrialing: true });
       userWalletRepository.findOneByUserId.mockResolvedValue(wallet);
       const trialError = Object.assign(new Error("First top-up must be at least $100 while on the free trial."), { status: 402 });
@@ -114,14 +116,14 @@ describe(StripeController.name, () => {
           amount: 50
         })
       ).rejects.toBe(trialError);
-      expect(stripe.hasPaymentMethod).not.toHaveBeenCalled();
+      expect(paymentMethodService.hasPaymentMethod).not.toHaveBeenCalled();
       expect(stripeTransaction.createPaymentIntent).not.toHaveBeenCalled();
     });
 
     it("forwards an undefined wallet to trial-min validation when no wallet exists", async () => {
-      const { controller, stripe, stripeTransaction, userWalletRepository, trialValidationService, user } = setup();
+      const { controller, stripeTransaction, userWalletRepository, trialValidationService, paymentMethodService, user } = setup();
       userWalletRepository.findOneByUserId.mockResolvedValue(undefined);
-      stripe.hasPaymentMethod.mockResolvedValue(true);
+      paymentMethodService.hasPaymentMethod.mockResolvedValue(true);
       stripeTransaction.createPaymentIntent.mockResolvedValue({
         success: true,
         paymentIntentId: faker.string.uuid(),
@@ -139,12 +141,12 @@ describe(StripeController.name, () => {
     });
 
     it("returns 3DS data with transactionId and transactionStatus", async () => {
-      const { controller, stripe, stripeTransaction, user } = setup();
+      const { controller, stripeTransaction, paymentMethodService, user } = setup();
       const transactionId = faker.string.uuid();
       const paymentIntentId = faker.string.uuid();
       const clientSecret = faker.string.alphanumeric(32);
 
-      stripe.hasPaymentMethod.mockResolvedValue(true);
+      paymentMethodService.hasPaymentMethod.mockResolvedValue(true);
       stripeTransaction.createPaymentIntent.mockResolvedValue({
         success: false,
         requiresAction: true,
@@ -173,10 +175,10 @@ describe(StripeController.name, () => {
     });
 
     it("namespaces the client attempt key with the user id before calling Stripe", async () => {
-      const { controller, stripe, stripeTransaction, user } = setup();
+      const { controller, stripeTransaction, paymentMethodService, user } = setup();
       const clientKey = faker.string.uuid();
 
-      stripe.hasPaymentMethod.mockResolvedValue(true);
+      paymentMethodService.hasPaymentMethod.mockResolvedValue(true);
       stripeTransaction.createPaymentIntent.mockResolvedValue({
         success: true,
         paymentIntentId: faker.string.uuid(),
@@ -195,9 +197,9 @@ describe(StripeController.name, () => {
     });
 
     it("passes no idempotency key to Stripe when the client sends none", async () => {
-      const { controller, stripe, stripeTransaction, user } = setup();
+      const { controller, stripeTransaction, paymentMethodService, user } = setup();
 
-      stripe.hasPaymentMethod.mockResolvedValue(true);
+      paymentMethodService.hasPaymentMethod.mockResolvedValue(true);
       stripeTransaction.createPaymentIntent.mockResolvedValue({
         success: true,
         paymentIntentId: faker.string.uuid(),
@@ -343,9 +345,9 @@ describe(StripeController.name, () => {
 
   describe("getDefaultPaymentMethod", () => {
     it("returns the default payment method for the current paying user", async () => {
-      const { controller, stripe } = setup();
+      const { controller, paymentMethodService } = setup();
       const paymentMethod = mock<PaymentMethod>({ id: faker.string.uuid(), isDefault: true });
-      stripe.getDefaultPaymentMethod.mockResolvedValue(paymentMethod);
+      paymentMethodService.getDefaultPaymentMethod.mockResolvedValue(paymentMethod);
 
       const result = await controller.getDefaultPaymentMethod();
 
@@ -353,16 +355,16 @@ describe(StripeController.name, () => {
     });
 
     it("throws 404 when the current user has no Stripe customer", async () => {
-      const { controller, authService, stripe } = setup();
+      const { controller, authService, paymentMethodService } = setup();
       authService.getCurrentPayingUser.mockReturnValue(undefined as unknown as PayingUser);
 
       await expect(controller.getDefaultPaymentMethod()).rejects.toMatchObject({ status: 404 });
-      expect(stripe.getDefaultPaymentMethod).not.toHaveBeenCalled();
+      expect(paymentMethodService.getDefaultPaymentMethod).not.toHaveBeenCalled();
     });
 
     it("throws 404 when no default payment method exists", async () => {
-      const { controller, stripe } = setup();
-      stripe.getDefaultPaymentMethod.mockResolvedValue(undefined);
+      const { controller, paymentMethodService } = setup();
+      paymentMethodService.getDefaultPaymentMethod.mockResolvedValue(undefined);
 
       await expect(controller.getDefaultPaymentMethod()).rejects.toMatchObject({ status: 404 });
     });
@@ -392,10 +394,43 @@ describe(StripeController.name, () => {
     });
   });
 
+  describe("markAsDefault", () => {
+    it("delegates to PaymentMethodService with the current paying user and ability", async () => {
+      const { controller, paymentMethodService, authService } = setup();
+
+      await controller.markAsDefault({ data: { id: "pm_1" } });
+
+      expect(paymentMethodService.markPaymentMethodAsDefault).toHaveBeenCalledWith("pm_1", authService.getCurrentPayingUser(), authService.ability);
+    });
+  });
+
+  describe("getPaymentMethods", () => {
+    it("returns the current user's payment methods", async () => {
+      const { controller, paymentMethodService } = setup();
+      const methods = [mock<PaymentMethod>({ id: "pm_1", isDefault: true })];
+      paymentMethodService.getPaymentMethods.mockResolvedValue(methods);
+
+      const result = await controller.getPaymentMethods();
+
+      expect(result).toEqual({ data: methods });
+    });
+
+    it("returns an empty list when there is no current paying user", async () => {
+      const { controller, authService, paymentMethodService } = setup();
+      authService.getCurrentPayingUser.mockReturnValue(undefined as unknown as PayingUser);
+
+      const result = await controller.getPaymentMethods();
+
+      expect(result).toEqual({ data: [] });
+      expect(paymentMethodService.getPaymentMethods).not.toHaveBeenCalled();
+    });
+  });
+
   function setup() {
     const user = createUser();
     const payingUser: PayingUser = { ...user, stripeCustomerId: user.stripeCustomerId! };
     const stripe = mock<StripeService>();
+    const paymentMethodService = mock<PaymentMethodService>();
     const stripeTransaction = mock<StripeTransactionService>();
     const authService = mock<AuthService>({
       currentUser: user
@@ -412,13 +447,15 @@ describe(StripeController.name, () => {
       stripeErrorService,
       userWalletRepository,
       trialValidationService,
-      transactionReporting
+      transactionReporting,
+      paymentMethodService
     );
     container.register(AuthService, { useValue: authService });
 
     return {
       controller,
       stripe,
+      paymentMethodService,
       stripeTransaction,
       authService,
       stripeErrorService,

--- a/apps/api/src/billing/controllers/stripe/stripe.controller.ts
+++ b/apps/api/src/billing/controllers/stripe/stripe.controller.ts
@@ -21,6 +21,7 @@ import {
 } from "@src/billing/http-schemas/stripe.schema";
 import type { StripeTransactionOutput } from "@src/billing/repositories";
 import { UserWalletRepository } from "@src/billing/repositories";
+import { PaymentMethodService } from "@src/billing/services/payment-method/payment-method.service";
 import { StripeService, TOP_UP_IDEMPOTENCY_KEY_PREFIX } from "@src/billing/services/stripe/stripe.service";
 import { StripeErrorService } from "@src/billing/services/stripe-error/stripe-error.service";
 import { StripeTransactionService } from "@src/billing/services/stripe-transaction/stripe-transaction.service";
@@ -35,7 +36,8 @@ export class StripeController {
     private readonly stripeErrorService: StripeErrorService,
     private readonly userWalletRepository: UserWalletRepository,
     private readonly trialValidationService: TrialValidationService,
-    private readonly transactionReporting: TransactionReportingService
+    private readonly transactionReporting: TransactionReportingService,
+    private readonly paymentMethodService: PaymentMethodService
   ) {}
 
   @Protected([{ action: "read", subject: "StripePayment" }])
@@ -60,7 +62,7 @@ export class StripeController {
     const { ability } = this.authService;
     const currentUser = this.authService.getCurrentPayingUser();
 
-    await this.stripe.markPaymentMethodAsDefault(input.data.id, currentUser, ability);
+    await this.paymentMethodService.markPaymentMethodAsDefault(input.data.id, currentUser, ability);
   }
 
   @Protected([{ action: "read", subject: "PaymentMethod" }])
@@ -75,7 +77,7 @@ export class StripeController {
       });
     }
 
-    const paymentMethod = await this.stripe.getDefaultPaymentMethod(currentUser, ability);
+    const paymentMethod = await this.paymentMethodService.getDefaultPaymentMethod(currentUser, ability);
 
     assert(paymentMethod, 404, "PaymentMethod not found");
 
@@ -87,7 +89,7 @@ export class StripeController {
     const currentUser = this.authService.getCurrentPayingUser({ strict: false });
 
     if (currentUser) {
-      const paymentMethods = await this.stripe.getPaymentMethods(currentUser.id, currentUser.stripeCustomerId, this.authService.ability);
+      const paymentMethods = await this.paymentMethodService.getPaymentMethods(currentUser.id, currentUser.stripeCustomerId, this.authService.ability);
       return { data: paymentMethods };
     }
 
@@ -104,7 +106,7 @@ export class StripeController {
     this.trialValidationService.validateTopUpAmount(userWallet, params.amount);
 
     try {
-      assert(await this.stripe.hasPaymentMethod(params.paymentMethodId, currentUser), 403, "Payment method does not belong to the user");
+      assert(await this.paymentMethodService.hasPaymentMethod(params.paymentMethodId, currentUser), 403, "Payment method does not belong to the user");
 
       const result = await this.stripeTransaction.createPaymentIntent({
         userId: currentUser.id,

--- a/apps/api/src/billing/lib/payment-method/extract-fingerprint.spec.ts
+++ b/apps/api/src/billing/lib/payment-method/extract-fingerprint.spec.ts
@@ -1,0 +1,35 @@
+import crypto from "crypto";
+import type Stripe from "stripe";
+import { describe, expect, it } from "vitest";
+
+import { extractFingerprint } from "./extract-fingerprint";
+
+import { generatePaymentMethod } from "@test/seeders/payment-method.seeder";
+
+describe("extractFingerprint", () => {
+  it("returns the card fingerprint when present", () => {
+    const paymentMethod = generatePaymentMethod({ card: { fingerprint: "fp_card_1" } });
+
+    expect(extractFingerprint(paymentMethod)).toBe("fp_card_1");
+  });
+
+  it("hashes the lowercased Link email when there is no card fingerprint", () => {
+    const paymentMethod = generatePaymentMethod({
+      type: "link",
+      card: null,
+      link: { email: "User@Test.com" }
+    } as unknown as Parameters<typeof generatePaymentMethod>[0]);
+    const expected = `link_${crypto.createHash("sha256").update("user@test.com").digest("hex")}`;
+
+    expect(extractFingerprint(paymentMethod)).toBe(expected);
+  });
+
+  it("returns undefined when neither a card fingerprint nor a Link email identifies the method", () => {
+    const paymentMethod = generatePaymentMethod({
+      type: "us_bank_account",
+      card: null
+    } as unknown as Parameters<typeof generatePaymentMethod>[0]);
+
+    expect(extractFingerprint(paymentMethod as Stripe.PaymentMethod)).toBeUndefined();
+  });
+});

--- a/apps/api/src/billing/lib/payment-method/extract-fingerprint.ts
+++ b/apps/api/src/billing/lib/payment-method/extract-fingerprint.ts
@@ -1,0 +1,17 @@
+import crypto from "crypto";
+import type Stripe from "stripe";
+
+/**
+ * Stable identity used to dedupe a payment method across Stripe objects: the card fingerprint when
+ * present, otherwise a hash of the lowercased Link email. Returns undefined when neither identifies
+ * the method (e.g. a bank account), in which case the caller must not try to sync it locally.
+ */
+export function extractFingerprint(paymentMethod: Stripe.PaymentMethod): string | undefined {
+  if (paymentMethod.card?.fingerprint) {
+    return paymentMethod.card.fingerprint;
+  }
+
+  if (paymentMethod.type === "link" && paymentMethod.link?.email) {
+    return `link_${crypto.createHash("sha256").update(paymentMethod.link.email.toLowerCase()).digest("hex")}`;
+  }
+}

--- a/apps/api/src/billing/services/payment-method/payment-method.service.integration.ts
+++ b/apps/api/src/billing/services/payment-method/payment-method.service.integration.ts
@@ -1,0 +1,144 @@
+import type { LoggerService } from "@akashnetwork/logging";
+import { createMongoAbility } from "@casl/ability";
+import { faker } from "@faker-js/faker";
+import Stripe from "stripe";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { PaymentMethodRepository } from "@src/billing/repositories";
+import type { PayingUser } from "@src/billing/services/paying-user/paying-user";
+import { PaymentMethodService } from "./payment-method.service";
+
+import { generateDatabasePaymentMethod } from "@test/seeders/database-payment-method.seeder";
+import { generatePaymentMethod } from "@test/seeders/payment-method.seeder";
+
+/**
+ * These cover the `@WithTransaction` methods, which open a real DB transaction and so can't run as
+ * unit specs — they live here (DB-backed `integration` project). The repository is still mocked;
+ * only the transaction wrapper needs the database.
+ */
+const ability = createMongoAbility([{ action: "manage", subject: "all" }]);
+const asPaymentMethodResponse = (paymentMethod: Stripe.PaymentMethod) => paymentMethod as unknown as Stripe.Response<Stripe.PaymentMethod>;
+
+describe(PaymentMethodService.name, () => {
+  describe("markPaymentMethodAsDefault", () => {
+    it("sets an already-synced method as default locally and on Stripe", async () => {
+      const { service, stripe, paymentMethodRepository } = setup();
+      const user = mock<PayingUser>({ id: "user_1", stripeCustomerId: "cus_1" });
+      const local = generateDatabasePaymentMethod({ paymentMethodId: "pm_1" });
+      const remote = generatePaymentMethod({ id: "pm_1" });
+      paymentMethodRepository.markAsDefault.mockResolvedValue(local);
+      vi.spyOn(stripe.paymentMethods, "retrieve").mockResolvedValue(asPaymentMethodResponse(remote));
+      const update = vi.spyOn(stripe.customers, "update").mockResolvedValue(mock<Stripe.Response<Stripe.Customer>>());
+
+      const result = await service.markPaymentMethodAsDefault("pm_1", user, ability);
+
+      expect(update).toHaveBeenCalledWith("cus_1", { invoice_settings: { default_payment_method: "pm_1" } }, { timeout: 3_000 });
+      expect(paymentMethodRepository.createAsDefault).not.toHaveBeenCalled();
+      expect(result).toEqual({ ...remote, validated: local.isValidated, isDefault: local.isDefault });
+    });
+
+    it("creates a local record for an unsynced method, then sets it as default", async () => {
+      const { service, stripe, paymentMethodRepository } = setup();
+      const user = mock<PayingUser>({ id: "user_1", stripeCustomerId: "cus_1" });
+      const remote = generatePaymentMethod({ id: "pm_1", card: { fingerprint: "fp_1" } });
+      const created = generateDatabasePaymentMethod({ paymentMethodId: "pm_1", fingerprint: "fp_1" });
+      paymentMethodRepository.markAsDefault.mockResolvedValue(undefined);
+      paymentMethodRepository.createAsDefault.mockResolvedValue(created);
+      vi.spyOn(stripe.paymentMethods, "retrieve").mockResolvedValue(asPaymentMethodResponse(remote));
+      vi.spyOn(stripe.customers, "update").mockResolvedValue(mock<Stripe.Response<Stripe.Customer>>());
+
+      const result = await service.markPaymentMethodAsDefault("pm_1", user, ability);
+
+      expect(paymentMethodRepository.createAsDefault).toHaveBeenCalledWith({ userId: "user_1", fingerprint: "fp_1", paymentMethodId: "pm_1" });
+      expect(result).toEqual({ ...remote, validated: created.isValidated, isDefault: created.isDefault });
+    });
+
+    it("rejects with 403 when an unsynced method has no identifiable fingerprint", async () => {
+      const { service, stripe, paymentMethodRepository } = setup();
+      const user = mock<PayingUser>({ id: "user_1", stripeCustomerId: "cus_1" });
+      paymentMethodRepository.markAsDefault.mockResolvedValue(undefined);
+      const remote = generatePaymentMethod({ type: "us_bank_account", card: null } as unknown as Parameters<typeof generatePaymentMethod>[0]);
+      vi.spyOn(stripe.paymentMethods, "retrieve").mockResolvedValue(asPaymentMethodResponse(remote));
+
+      await expect(service.markPaymentMethodAsDefault("pm_1", user, ability)).rejects.toMatchObject({ status: 403 });
+      expect(paymentMethodRepository.createAsDefault).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("syncAttached", () => {
+    it("upserts and marks a newly created default method as default on Stripe", async () => {
+      const { service, stripe, paymentMethodRepository } = setup();
+      const user = mock<PayingUser>({ id: "user_1", stripeCustomerId: "cus_1" });
+      const paymentMethod = generatePaymentMethod({ id: "pm_1", card: { fingerprint: "fp_1" } });
+      const local = { ...generateDatabasePaymentMethod({ paymentMethodId: "pm_1" }), isDefault: true };
+      paymentMethodRepository.upsert.mockResolvedValue({ paymentMethod: local, isNew: true });
+      const update = vi.spyOn(stripe.customers, "update").mockResolvedValue(mock<Stripe.Response<Stripe.Customer>>());
+
+      const result = await service.syncAttached({ user, paymentMethod });
+
+      expect(paymentMethodRepository.upsert).toHaveBeenCalledWith({ userId: "user_1", fingerprint: "fp_1", paymentMethodId: "pm_1" });
+      expect(update).toHaveBeenCalledWith("cus_1", { invoice_settings: { default_payment_method: "pm_1" } }, { timeout: 3_000 });
+      expect(result).toEqual({ isNew: true, isDefault: true });
+    });
+
+    it("upserts without a remote default sync for an already-synced method", async () => {
+      const { service, stripe, paymentMethodRepository } = setup();
+      const user = mock<PayingUser>({ id: "user_1", stripeCustomerId: "cus_1" });
+      const paymentMethod = generatePaymentMethod({ id: "pm_1", card: { fingerprint: "fp_1" } });
+      const local = { ...generateDatabasePaymentMethod({ paymentMethodId: "pm_1" }), isDefault: true };
+      paymentMethodRepository.upsert.mockResolvedValue({ paymentMethod: local, isNew: false });
+      const update = vi.spyOn(stripe.customers, "update").mockResolvedValue(mock<Stripe.Response<Stripe.Customer>>());
+
+      const result = await service.syncAttached({ user, paymentMethod });
+
+      expect(update).not.toHaveBeenCalled();
+      expect(result).toEqual({ isNew: false, isDefault: true });
+    });
+
+    it("skips the upsert when the payment method has no fingerprint", async () => {
+      const { service, paymentMethodRepository } = setup();
+      const user = mock<PayingUser>({ id: "user_1", stripeCustomerId: "cus_1" });
+      const paymentMethod = generatePaymentMethod({ type: "us_bank_account", card: null } as unknown as Parameters<typeof generatePaymentMethod>[0]);
+
+      const result = await service.syncAttached({ user, paymentMethod });
+
+      expect(paymentMethodRepository.upsert).not.toHaveBeenCalled();
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("removeDetached", () => {
+    it("deletes the local record by fingerprint", async () => {
+      const { service, paymentMethodRepository } = setup();
+      const paymentMethod = generatePaymentMethod({ id: "pm_1", card: { fingerprint: "fp_1" } });
+      paymentMethodRepository.deleteByFingerprint.mockResolvedValue(generateDatabasePaymentMethod({ paymentMethodId: "pm_1" }));
+
+      const result = await service.removeDetached({ userId: "user_1", paymentMethod });
+
+      expect(paymentMethodRepository.deleteByFingerprint).toHaveBeenCalledWith("fp_1", "pm_1", "user_1");
+      expect(result).toBe(true);
+    });
+
+    it("skips the delete when the payment method has no fingerprint", async () => {
+      const { service, paymentMethodRepository } = setup();
+      const paymentMethod = generatePaymentMethod({ type: "us_bank_account", card: null } as unknown as Parameters<typeof generatePaymentMethod>[0]);
+
+      const result = await service.removeDetached({ userId: "user_1", paymentMethod });
+
+      expect(paymentMethodRepository.deleteByFingerprint).not.toHaveBeenCalled();
+      expect(result).toBe(false);
+    });
+  });
+
+  function setup() {
+    const paymentMethodRepository = mock<PaymentMethodRepository>();
+    paymentMethodRepository.accessibleBy.mockReturnValue(paymentMethodRepository);
+
+    const stripe = new Stripe(`sk_test_${faker.string.alphanumeric(32)}`, { apiVersion: "2025-10-29.clover", httpClient: Stripe.createFetchHttpClient() });
+
+    const service = new PaymentMethodService(stripe, paymentMethodRepository, () => mock<LoggerService>());
+
+    return { service, stripe, paymentMethodRepository };
+  }
+});

--- a/apps/api/src/billing/services/payment-method/payment-method.service.spec.ts
+++ b/apps/api/src/billing/services/payment-method/payment-method.service.spec.ts
@@ -1,0 +1,104 @@
+import type { LoggerService } from "@akashnetwork/logging";
+import { createMongoAbility } from "@casl/ability";
+import { faker } from "@faker-js/faker";
+import Stripe from "stripe";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { PaymentMethodRepository } from "@src/billing/repositories";
+import type { PayingUser } from "@src/billing/services/paying-user/paying-user";
+import type { UserOutput } from "@src/user/repositories/user/user.repository";
+import { PaymentMethodService } from "./payment-method.service";
+
+import { generateDatabasePaymentMethod } from "@test/seeders/database-payment-method.seeder";
+import { generatePaymentMethod } from "@test/seeders/payment-method.seeder";
+import { TEST_CONSTANTS } from "@test/seeders/stripe-test-data.seeder";
+
+const ability = createMongoAbility([{ action: "manage", subject: "all" }]);
+const asResponse = <T>(value: T) => value as unknown as Stripe.Response<T>;
+
+describe(PaymentMethodService.name, () => {
+  describe("getPaymentMethods", () => {
+    it("returns remote methods merged with local validated/default flags, newest first", async () => {
+      const { service, stripe, paymentMethodRepository } = setup();
+      const newer = generatePaymentMethod({ id: TEST_CONSTANTS.PAYMENT_METHOD_ID, created: 1757992768, card: { fingerprint: "fp_a" } });
+      const older = generatePaymentMethod({ id: "pm_456", created: 1757991776, card: { fingerprint: "fp_b" } });
+      vi.spyOn(stripe.paymentMethods, "list").mockResolvedValue({ data: [older, newer] } as unknown as Stripe.Response<Stripe.ApiList<Stripe.PaymentMethod>>);
+      paymentMethodRepository.findByUserId.mockResolvedValue([]);
+
+      const result = await service.getPaymentMethods(TEST_CONSTANTS.USER_ID, TEST_CONSTANTS.CUSTOMER_ID, ability);
+
+      expect(stripe.paymentMethods.list).toHaveBeenCalledWith({ customer: TEST_CONSTANTS.CUSTOMER_ID });
+      expect(result).toEqual([
+        { ...newer, validated: false, isDefault: false },
+        { ...older, validated: false, isDefault: false }
+      ]);
+    });
+  });
+
+  describe("getDefaultPaymentMethod", () => {
+    it("merges the remote default with the local record", async () => {
+      const { service, stripe, paymentMethodRepository } = setup();
+      const remote = generatePaymentMethod({ id: "pm_default" });
+      const local = generateDatabasePaymentMethod({ paymentMethodId: "pm_default" });
+      vi.spyOn(stripe.customers, "retrieve").mockResolvedValue({
+        invoice_settings: { default_payment_method: remote }
+      } as unknown as Stripe.Response<Stripe.Customer>);
+      paymentMethodRepository.findDefaultByUserId.mockResolvedValue(local);
+
+      const result = await service.getDefaultPaymentMethod(mock<PayingUser>({ id: "user_1", stripeCustomerId: "cus_1" }), ability);
+
+      expect(result).toEqual({ ...remote, validated: local.isValidated, isDefault: local.isDefault });
+    });
+
+    it("returns undefined when there is no local record for the remote default", async () => {
+      const { service, stripe, paymentMethodRepository } = setup();
+      vi.spyOn(stripe.customers, "retrieve").mockResolvedValue({
+        invoice_settings: { default_payment_method: generatePaymentMethod() }
+      } as unknown as Stripe.Response<Stripe.Customer>);
+      paymentMethodRepository.findDefaultByUserId.mockResolvedValue(undefined);
+
+      expect(await service.getDefaultPaymentMethod(mock<PayingUser>({ id: "user_1", stripeCustomerId: "cus_1" }), ability)).toBeUndefined();
+    });
+  });
+
+  describe("hasPaymentMethod", () => {
+    it("returns true when the method belongs to the user's customer", async () => {
+      const { service, stripe } = setup();
+      vi.spyOn(stripe.paymentMethods, "retrieve").mockResolvedValue(asResponse(generatePaymentMethod({ customer: "cus_1" })));
+
+      expect(await service.hasPaymentMethod("pm_1", mock<UserOutput>({ stripeCustomerId: "cus_1" }))).toBe(true);
+    });
+
+    it("returns false when the method belongs to a different customer", async () => {
+      const { service, stripe } = setup();
+      vi.spyOn(stripe.paymentMethods, "retrieve").mockResolvedValue(asResponse(generatePaymentMethod({ customer: "cus_other" })));
+
+      expect(await service.hasPaymentMethod("pm_1", mock<UserOutput>({ stripeCustomerId: "cus_1" }))).toBe(false);
+    });
+
+    it("returns false when Stripe reports the method is missing", async () => {
+      const { service, stripe } = setup();
+      vi.spyOn(stripe.paymentMethods, "retrieve").mockRejectedValue(
+        new Stripe.errors.StripeInvalidRequestError({
+          type: "invalid_request_error",
+          code: "resource_missing",
+          message: "No such PaymentMethod"
+        } as Stripe.StripeRawError)
+      );
+
+      expect(await service.hasPaymentMethod("pm_missing", mock<UserOutput>({ stripeCustomerId: "cus_1" }))).toBe(false);
+    });
+  });
+
+  function setup() {
+    const paymentMethodRepository = mock<PaymentMethodRepository>();
+    paymentMethodRepository.accessibleBy.mockReturnValue(paymentMethodRepository);
+
+    const stripe = new Stripe(`sk_test_${faker.string.alphanumeric(32)}`, { apiVersion: "2025-10-29.clover", httpClient: Stripe.createFetchHttpClient() });
+
+    const service = new PaymentMethodService(stripe, paymentMethodRepository, () => mock<LoggerService>());
+
+    return { service, stripe, paymentMethodRepository };
+  }
+});

--- a/apps/api/src/billing/services/payment-method/payment-method.service.ts
+++ b/apps/api/src/billing/services/payment-method/payment-method.service.ts
@@ -1,0 +1,198 @@
+import type { LoggerService } from "@akashnetwork/logging";
+import type { AnyAbility } from "@casl/ability";
+import assert from "http-assert";
+import difference from "lodash/difference";
+import keyBy from "lodash/keyBy";
+import Stripe from "stripe";
+import { inject, singleton } from "tsyringe";
+
+import { extractFingerprint } from "@src/billing/lib/payment-method/extract-fingerprint";
+import { STRIPE_CLIENT } from "@src/billing/providers/stripe-client.provider";
+import { PaymentMethodRepository } from "@src/billing/repositories";
+import { type CreateLogger, LOGGER_FACTORY, WithTransaction } from "@src/core";
+import type { UserOutput } from "@src/user/repositories/user/user.repository";
+import type { PayingUser } from "../paying-user/paying-user";
+
+export type PaymentMethod = Stripe.PaymentMethod & { validated: boolean; isDefault: boolean };
+
+@singleton()
+export class PaymentMethodService {
+  private readonly loggerService: LoggerService;
+
+  constructor(
+    @inject(STRIPE_CLIENT) private readonly stripe: Stripe,
+    private readonly paymentMethodRepository: PaymentMethodRepository,
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
+  ) {
+    this.loggerService = createLogger({ context: PaymentMethodService.name });
+  }
+
+  async getPaymentMethods(userId: string, customerId: string, ability: AnyAbility): Promise<PaymentMethod[]> {
+    const [remotes, locals] = await Promise.all([
+      this.stripe.paymentMethods.list({ customer: customerId }),
+      this.paymentMethodRepository.accessibleBy(ability, "read").findByUserId(userId)
+    ]);
+
+    const localById = keyBy(locals, "paymentMethodId");
+    const remoteIds: string[] = [];
+
+    const merged = remotes.data
+      .map(remote => {
+        remoteIds.push(remote.id);
+        return {
+          ...remote,
+          validated: !!localById[remote.id]?.isValidated,
+          isDefault: !!localById[remote.id]?.isDefault
+        };
+      })
+      .sort((a, b) => b.created - a.created);
+
+    const outOfSyncIds = difference(remoteIds, Object.keys(localById));
+
+    if (outOfSyncIds.length) {
+      this.loggerService.warn({
+        event: "STRIPE_PAYMENT_METHOD_OUT_OF_SYNC",
+        userId,
+        outOfSyncIds
+      });
+    }
+
+    return merged;
+  }
+
+  async getDefaultPaymentMethod(user: PayingUser, ability: AnyAbility): Promise<PaymentMethod | undefined> {
+    const [customer, local] = await Promise.all([
+      this.stripe.customers.retrieve(user.stripeCustomerId, {
+        expand: ["invoice_settings.default_payment_method"]
+      }),
+      this.paymentMethodRepository.accessibleBy(ability, "read").findDefaultByUserId(user.id)
+    ]);
+
+    assert(!customer.deleted, 402, "Payment account has been deleted");
+
+    const remote = customer.invoice_settings.default_payment_method;
+
+    if (typeof remote === "object" && remote && local) {
+      return { ...remote, validated: local.isValidated, isDefault: local.isDefault };
+    } else {
+      this.loggerService.warn({
+        event: "STRIPE_PAYMENT_METHOD_OUT_OF_SYNC",
+        userId: user.id,
+        remoteId: typeof remote === "string" ? remote : remote?.id,
+        localId: local?.paymentMethodId
+      });
+    }
+  }
+
+  async hasPaymentMethod(paymentMethodId: string, user: UserOutput): Promise<boolean> {
+    try {
+      const paymentMethod = await this.stripe.paymentMethods.retrieve(paymentMethodId);
+      const customerId = typeof paymentMethod.customer === "string" ? paymentMethod.customer : paymentMethod.customer?.id;
+
+      return customerId === user.stripeCustomerId;
+    } catch (error: unknown) {
+      if (error instanceof Stripe.errors.StripeInvalidRequestError && error.code === "resource_missing") {
+        return false;
+      }
+
+      throw error;
+    }
+  }
+
+  @WithTransaction()
+  async markPaymentMethodAsDefault(paymentMethodId: string, user: PayingUser, ability: AnyAbility): Promise<PaymentMethod> {
+    const [local, remote] = await Promise.all([
+      this.paymentMethodRepository.accessibleBy(ability, "update").markAsDefault(paymentMethodId),
+      this.stripe.paymentMethods.retrieve(paymentMethodId, undefined, { timeout: 3_000 })
+    ]);
+
+    assert(remote, 404, "Payment method not found", { source: "stripe" });
+
+    if (local) {
+      await this.markRemotePaymentMethodAsDefault(paymentMethodId, user);
+      return { ...remote, validated: local.isValidated, isDefault: local.isDefault };
+    }
+
+    const fingerprint = extractFingerprint(remote);
+
+    assert(fingerprint, 403, "Payment method cannot be set as default. No identifiable fingerprint found.");
+
+    const newLocal = await this.paymentMethodRepository.accessibleBy(ability, "create").createAsDefault({
+      userId: user.id,
+      fingerprint,
+      paymentMethodId
+    });
+
+    await this.markRemotePaymentMethodAsDefault(paymentMethodId, user);
+
+    return { ...remote, validated: newLocal.isValidated, isDefault: newLocal.isDefault };
+  }
+
+  async markRemotePaymentMethodAsDefault(paymentMethodId: string, user: PayingUser): Promise<void> {
+    await this.stripe.customers.update(
+      user.stripeCustomerId,
+      {
+        invoice_settings: { default_payment_method: paymentMethodId }
+      },
+      { timeout: 3_000 }
+    );
+  }
+
+  @WithTransaction()
+  async syncAttached(params: { user: PayingUser; paymentMethod: Stripe.PaymentMethod }): Promise<{ isNew: boolean; isDefault: boolean } | undefined> {
+    const { user, paymentMethod } = params;
+
+    const fingerprint = extractFingerprint(paymentMethod);
+    if (!fingerprint) {
+      this.loggerService.error({
+        event: "PAYMENT_METHOD_MISSING_FINGERPRINT",
+        paymentMethodId: paymentMethod.id,
+        type: paymentMethod.type
+      });
+      return;
+    }
+
+    // Use upsert for idempotency - handles Stripe webhook retries gracefully
+    const { paymentMethod: localPaymentMethod, isNew } = await this.paymentMethodRepository.upsert({
+      userId: user.id,
+      fingerprint,
+      paymentMethodId: paymentMethod.id
+    });
+
+    // Only set as default on Stripe if newly created AND is the first payment method (default)
+    if (isNew && localPaymentMethod.isDefault) {
+      try {
+        await this.markRemotePaymentMethodAsDefault(paymentMethod.id, user);
+      } catch (error) {
+        // Log but don't fail - local record exists, Stripe sync can be retried manually if needed
+        this.loggerService.warn({
+          event: "STRIPE_DEFAULT_PAYMENT_METHOD_SYNC_FAILED",
+          paymentMethodId: paymentMethod.id,
+          userId: user.id,
+          error
+        });
+      }
+    }
+
+    return { isNew, isDefault: localPaymentMethod.isDefault };
+  }
+
+  @WithTransaction()
+  async removeDetached(params: { userId: string; paymentMethod: Stripe.PaymentMethod }): Promise<boolean> {
+    const { userId, paymentMethod } = params;
+
+    const fingerprint = extractFingerprint(paymentMethod);
+    if (!fingerprint) {
+      this.loggerService.warn({
+        event: "PAYMENT_METHOD_DETACHED_NO_FINGERPRINT",
+        paymentMethodId: paymentMethod.id,
+        type: paymentMethod.type
+      });
+      return false;
+    }
+
+    const deletedPaymentMethod = await this.paymentMethodRepository.deleteByFingerprint(fingerprint, paymentMethod.id, userId);
+
+    return !!deletedPaymentMethod;
+  }
+}

--- a/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.integration.ts
+++ b/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.integration.ts
@@ -7,6 +7,7 @@ import { mock } from "vitest-mock-extended";
 import { FirstPurchaseBonusGranted } from "@src/billing/events/first-purchase-bonus-granted";
 import type { PaymentMethodRepository, StripeTransactionOutput, StripeTransactionRepository } from "@src/billing/repositories";
 import type { FirstPurchaseBonusService } from "@src/billing/services/first-purchase-bonus/first-purchase-bonus.service";
+import type { PaymentMethodService } from "@src/billing/services/payment-method/payment-method.service";
 import type { RefillService } from "@src/billing/services/refill/refill.service";
 import type { StripeService } from "@src/billing/services/stripe/stripe.service";
 import { StripeTransactionService } from "@src/billing/services/stripe-transaction/stripe-transaction.service";
@@ -858,235 +859,69 @@ describe(StripeWebhookService.name, () => {
   });
 
   describe("handlePaymentMethodAttached", () => {
-    it("creates payment method for new card", async () => {
-      const { service, userRepository, paymentMethodRepository, stripeService } = setup();
+    it("delegates to PaymentMethodService for a paying user", async () => {
+      const { service, userRepository, paymentMethodService } = setup();
       const mockUser = createTestUser({ stripeCustomerId: "cus_123" });
-      const paymentMethodId = "pm_123";
-      const fingerprint = "fp_abc123";
-
       userRepository.findOneBy.mockResolvedValue(mockUser);
-      stripeService.extractFingerprint.mockReturnValue(fingerprint);
-      paymentMethodRepository.upsert.mockResolvedValue({
-        paymentMethod: {
-          id: "local-pm-123",
-          userId: mockUser.id,
-          fingerprint,
-          paymentMethodId,
-          isDefault: true,
-          isValidated: false,
-          createdAt: new Date(),
-          updatedAt: new Date()
-        },
-        isNew: true
-      });
-      stripeService.markRemotePaymentMethodAsDefault.mockResolvedValue(undefined);
-
-      const event = createPaymentMethodAttachedEvent({
-        id: paymentMethodId,
-        customer: mockUser.stripeCustomerId!,
-        card: { fingerprint }
-      });
+      paymentMethodService.syncAttached.mockResolvedValue({ isNew: true, isDefault: true });
+      const event = createPaymentMethodAttachedEvent({ id: "pm_123", customer: mockUser.stripeCustomerId!, card: { fingerprint: "fp_abc123" } });
 
       await service.handlePaymentMethodAttached(event);
 
-      expect(paymentMethodRepository.upsert).toHaveBeenCalledWith({
-        userId: mockUser.id,
-        fingerprint,
-        paymentMethodId
-      });
-      expect(stripeService.markRemotePaymentMethodAsDefault).toHaveBeenCalledWith(paymentMethodId, mockUser);
+      expect(paymentMethodService.syncAttached).toHaveBeenCalledWith({ user: mockUser, paymentMethod: event.data.object });
     });
 
-    it("creates payment method for link type", async () => {
-      const { service, userRepository, paymentMethodRepository, stripeService } = setup();
-      const mockUser = createTestUser({ stripeCustomerId: "cus_123" });
-      const paymentMethodId = "pm_link_123";
-      const linkFingerprint = "link_abc123hash";
-
-      userRepository.findOneBy.mockResolvedValue(mockUser);
-      stripeService.extractFingerprint.mockReturnValue(linkFingerprint);
-      paymentMethodRepository.upsert.mockResolvedValue({
-        paymentMethod: {
-          id: "local-pm-link-123",
-          userId: mockUser.id,
-          fingerprint: linkFingerprint,
-          paymentMethodId,
-          isDefault: true,
-          isValidated: false,
-          createdAt: new Date(),
-          updatedAt: new Date()
-        },
-        isNew: true
-      });
-      stripeService.markRemotePaymentMethodAsDefault.mockResolvedValue(undefined);
-
-      const event = createPaymentMethodAttachedEvent({
-        id: paymentMethodId,
-        customer: mockUser.stripeCustomerId!,
-        type: "link",
-        link: { email: "user@test.com" }
-      });
-
-      await service.handlePaymentMethodAttached(event);
-
-      expect(stripeService.extractFingerprint).toHaveBeenCalled();
-      expect(paymentMethodRepository.upsert).toHaveBeenCalledWith({
-        userId: mockUser.id,
-        fingerprint: linkFingerprint,
-        paymentMethodId
-      });
-      expect(stripeService.markRemotePaymentMethodAsDefault).toHaveBeenCalledWith(paymentMethodId, mockUser);
-    });
-
-    it("handles duplicate webhook delivery gracefully (idempotency)", async () => {
-      const { service, userRepository, paymentMethodRepository, stripeService } = setup();
-      const mockUser = createTestUser({ stripeCustomerId: "cus_123" });
-      const paymentMethodId = "pm_123";
-      const fingerprint = "fp_abc123";
-
-      userRepository.findOneBy.mockResolvedValue(mockUser);
-      stripeService.extractFingerprint.mockReturnValue(fingerprint);
-      paymentMethodRepository.upsert.mockResolvedValue({
-        paymentMethod: {
-          id: "local-pm-123",
-          userId: mockUser.id,
-          fingerprint,
-          paymentMethodId,
-          isDefault: true,
-          isValidated: false,
-          createdAt: new Date(),
-          updatedAt: new Date()
-        },
-        isNew: false // Already existed
-      });
-
-      const event = createPaymentMethodAttachedEvent({
-        id: paymentMethodId,
-        customer: mockUser.stripeCustomerId!,
-        card: { fingerprint }
-      });
-
-      await service.handlePaymentMethodAttached(event);
-
-      expect(paymentMethodRepository.upsert).toHaveBeenCalled();
-      // Should NOT call Stripe API when payment method already exists
-      expect(stripeService.markRemotePaymentMethodAsDefault).not.toHaveBeenCalled();
-    });
-
-    it("does not set as default on Stripe when not the first payment method", async () => {
-      const { service, userRepository, paymentMethodRepository, stripeService } = setup();
-      const mockUser = createTestUser({ stripeCustomerId: "cus_123" });
-      const paymentMethodId = "pm_456";
-      const fingerprint = "fp_def456";
-
-      userRepository.findOneBy.mockResolvedValue(mockUser);
-      stripeService.extractFingerprint.mockReturnValue(fingerprint);
-      paymentMethodRepository.upsert.mockResolvedValue({
-        paymentMethod: {
-          id: "local-pm-456",
-          userId: mockUser.id,
-          fingerprint,
-          paymentMethodId,
-          isDefault: false, // Not the default (not first payment method)
-          isValidated: false,
-          createdAt: new Date(),
-          updatedAt: new Date()
-        },
-        isNew: true
-      });
-
-      const event = createPaymentMethodAttachedEvent({
-        id: paymentMethodId,
-        customer: mockUser.stripeCustomerId!,
-        card: { fingerprint }
-      });
-
-      await service.handlePaymentMethodAttached(event);
-
-      expect(stripeService.markRemotePaymentMethodAsDefault).not.toHaveBeenCalled();
-    });
-
-    it("logs warning but does not fail when Stripe default sync fails", async () => {
-      const { service, userRepository, paymentMethodRepository, stripeService } = setup();
-      const mockUser = createTestUser({ stripeCustomerId: "cus_123" });
-      const paymentMethodId = "pm_123";
-      const fingerprint = "fp_abc123";
-
-      userRepository.findOneBy.mockResolvedValue(mockUser);
-      stripeService.extractFingerprint.mockReturnValue(fingerprint);
-      paymentMethodRepository.upsert.mockResolvedValue({
-        paymentMethod: {
-          id: "local-pm-123",
-          userId: mockUser.id,
-          fingerprint,
-          paymentMethodId,
-          isDefault: true,
-          isValidated: false,
-          createdAt: new Date(),
-          updatedAt: new Date()
-        },
-        isNew: true
-      });
-      stripeService.markRemotePaymentMethodAsDefault.mockRejectedValue(new Error("Stripe API error"));
-
-      const event = createPaymentMethodAttachedEvent({
-        id: paymentMethodId,
-        customer: mockUser.stripeCustomerId!,
-        card: { fingerprint }
-      });
-
-      // Should not throw
-      await expect(service.handlePaymentMethodAttached(event)).resolves.not.toThrow();
-    });
-
-    it("returns early when customer ID is missing", async () => {
-      const { service, userRepository, paymentMethodRepository } = setup();
-
-      const event = createPaymentMethodAttachedEvent({
-        id: "pm_123",
-        customer: null,
-        card: { fingerprint: "fp_abc123" }
-      });
+    it("returns early without delegating when the customer id is missing", async () => {
+      const { service, userRepository, paymentMethodService } = setup();
+      const event = createPaymentMethodAttachedEvent({ id: "pm_123", customer: null, card: { fingerprint: "fp_abc123" } });
 
       await service.handlePaymentMethodAttached(event);
 
       expect(userRepository.findOneBy).not.toHaveBeenCalled();
-      expect(paymentMethodRepository.upsert).not.toHaveBeenCalled();
+      expect(paymentMethodService.syncAttached).not.toHaveBeenCalled();
     });
 
-    it("returns early when user is not found", async () => {
-      const { service, userRepository, paymentMethodRepository } = setup();
-
+    it("returns early without delegating when the user is not found", async () => {
+      const { service, userRepository, paymentMethodService } = setup();
       userRepository.findOneBy.mockResolvedValue(undefined);
-
-      const event = createPaymentMethodAttachedEvent({
-        id: "pm_123",
-        customer: "cus_unknown",
-        card: { fingerprint: "fp_abc123" }
-      });
+      const event = createPaymentMethodAttachedEvent({ id: "pm_123", customer: "cus_unknown", card: { fingerprint: "fp_abc123" } });
 
       await service.handlePaymentMethodAttached(event);
 
       expect(userRepository.findOneBy).toHaveBeenCalledWith({ stripeCustomerId: "cus_unknown" });
-      expect(paymentMethodRepository.upsert).not.toHaveBeenCalled();
+      expect(paymentMethodService.syncAttached).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("handlePaymentMethodDetached", () => {
+    it("delegates removal to PaymentMethodService for a known customer", async () => {
+      const { service, userRepository, paymentMethodService } = setup();
+      const mockUser = createTestUser({ stripeCustomerId: "cus_123" });
+      userRepository.findOneBy.mockResolvedValue(mockUser);
+      paymentMethodService.removeDetached.mockResolvedValue(true);
+      const event = {
+        id: "evt_1",
+        type: "payment_method.detached",
+        data: { object: { id: "pm_1", customer: "cus_123" } }
+      } as unknown as Stripe.PaymentMethodDetachedEvent;
+
+      await service.handlePaymentMethodDetached(event);
+
+      expect(paymentMethodService.removeDetached).toHaveBeenCalledWith({ userId: mockUser.id, paymentMethod: event.data.object });
     });
 
-    it("returns early when fingerprint is missing", async () => {
-      const { service, userRepository, paymentMethodRepository, stripeService } = setup();
-      const mockUser = createTestUser({ stripeCustomerId: "cus_123" });
+    it("returns early without delegating when the user is not found", async () => {
+      const { service, userRepository, paymentMethodService } = setup();
+      userRepository.findOneBy.mockResolvedValue(undefined);
+      const event = {
+        id: "evt_1",
+        type: "payment_method.detached",
+        data: { object: { id: "pm_1", customer: "cus_unknown" } }
+      } as unknown as Stripe.PaymentMethodDetachedEvent;
 
-      userRepository.findOneBy.mockResolvedValue(mockUser);
-      stripeService.extractFingerprint.mockReturnValue(undefined);
+      await service.handlePaymentMethodDetached(event);
 
-      const event = createPaymentMethodAttachedEvent({
-        id: "pm_123",
-        customer: mockUser.stripeCustomerId!,
-        card: { fingerprint: null }
-      });
-
-      await service.handlePaymentMethodAttached(event);
-
-      expect(paymentMethodRepository.upsert).not.toHaveBeenCalled();
+      expect(paymentMethodService.removeDetached).not.toHaveBeenCalled();
     });
   });
 
@@ -1100,6 +935,8 @@ describe(StripeWebhookService.name, () => {
     firstPurchaseBonusService.getEligibleBonusAmount.mockResolvedValue(0);
     const domainEventsService = mock<DomainEventsService>();
 
+    const paymentMethodService = mock<PaymentMethodService>();
+
     const stripeTransaction = new StripeTransactionService(
       mock<Stripe>(),
       stripeTransactionRepository,
@@ -1112,10 +949,10 @@ describe(StripeWebhookService.name, () => {
     const service = new StripeWebhookService(
       stripeService,
       userRepository,
-      paymentMethodRepository,
       stripeTransactionRepository,
       domainEventsService,
-      stripeTransaction
+      stripeTransaction,
+      paymentMethodService
     );
 
     return {
@@ -1126,7 +963,8 @@ describe(StripeWebhookService.name, () => {
       paymentMethodRepository,
       stripeTransactionRepository,
       firstPurchaseBonusService,
-      domainEventsService
+      domainEventsService,
+      paymentMethodService
     };
   }
 

--- a/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.ts
+++ b/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.ts
@@ -4,16 +4,11 @@ import Stripe from "stripe";
 import { singleton } from "tsyringe";
 
 import { FirstPurchaseBonusGranted } from "@src/billing/events/first-purchase-bonus-granted";
-import {
-  PaymentMethodRepository,
-  type StripeTransactionOutput,
-  StripeTransactionRepository,
-  TRIAL_PRESERVING_TRANSACTION_TYPES
-} from "@src/billing/repositories";
+import { type StripeTransactionOutput, StripeTransactionRepository, TRIAL_PRESERVING_TRANSACTION_TYPES } from "@src/billing/repositories";
 import { assertIsPayingUser } from "@src/billing/services/paying-user/paying-user";
+import { PaymentMethodService } from "@src/billing/services/payment-method/payment-method.service";
 import { StripeService } from "@src/billing/services/stripe/stripe.service";
 import { StripeTransactionService } from "@src/billing/services/stripe-transaction/stripe-transaction.service";
-import { WithTransaction } from "@src/core";
 import { DomainEventsService } from "@src/core/services/domain-events/domain-events.service";
 import { UserRepository } from "@src/user/repositories";
 
@@ -24,10 +19,10 @@ export class StripeWebhookService {
   constructor(
     private readonly stripe: StripeService,
     private readonly userRepository: UserRepository,
-    private readonly paymentMethodRepository: PaymentMethodRepository,
     private readonly stripeTransactionRepository: StripeTransactionRepository,
     private readonly domainEventsService: DomainEventsService,
-    private readonly stripeTransaction: StripeTransactionService
+    private readonly stripeTransaction: StripeTransactionService,
+    private readonly paymentMethodService: PaymentMethodService
   ) {}
 
   async routeStripeEvent(signature: string, rawEvent: string) {
@@ -256,7 +251,6 @@ export class StripeWebhookService {
     });
   }
 
-  @WithTransaction()
   async handlePaymentMethodAttached(event: Stripe.PaymentMethodAttachedEvent) {
     const paymentMethod = event.data.object;
     const customerId = paymentMethod.customer as string;
@@ -281,68 +275,23 @@ export class StripeWebhookService {
 
     assertIsPayingUser(user);
 
-    const fingerprint = this.stripe.extractFingerprint(paymentMethod);
-    if (!fingerprint) {
-      this.logger.error({
-        event: "PAYMENT_METHOD_MISSING_FINGERPRINT",
-        paymentMethodId: paymentMethod.id,
-        type: paymentMethod.type
-      });
+    const result = await this.paymentMethodService.syncAttached({ user, paymentMethod });
+    if (!result) {
       return;
-    }
-
-    // Use upsert for idempotency - handles Stripe webhook retries gracefully
-    const { paymentMethod: localPaymentMethod, isNew } = await this.paymentMethodRepository.upsert({
-      userId: user.id,
-      fingerprint,
-      paymentMethodId: paymentMethod.id
-    });
-
-    // Only set as default on Stripe if newly created AND is the first payment method (default)
-    if (isNew && localPaymentMethod.isDefault) {
-      try {
-        await this.stripe.markRemotePaymentMethodAsDefault(paymentMethod.id, user);
-      } catch (error) {
-        // Log but don't fail - local record exists, Stripe sync can be retried manually if needed
-        this.logger.warn({
-          event: "STRIPE_DEFAULT_PAYMENT_METHOD_SYNC_FAILED",
-          paymentMethodId: paymentMethod.id,
-          userId: user.id,
-          error
-        });
-      }
     }
 
     this.logger.info({
       event: "PAYMENT_METHOD_ATTACHED",
       paymentMethodId: paymentMethod.id,
       userId: user.id,
-      isDefault: localPaymentMethod.isDefault,
-      wasAlreadyProcessed: !isNew
+      isDefault: result.isDefault,
+      wasAlreadyProcessed: !result.isNew
     });
   }
 
-  @WithTransaction()
   async handlePaymentMethodDetached(event: Stripe.PaymentMethodDetachedEvent) {
     const paymentMethod = event.data.object;
     const customerId = paymentMethod.customer || event.data.previous_attributes?.customer;
-    const fingerprint = this.stripe.extractFingerprint(paymentMethod);
-
-    this.logger.info({
-      event: "PAYMENT_METHOD_DETACHED",
-      paymentMethodId: paymentMethod.id,
-      customerId,
-      fingerprint
-    });
-
-    if (!fingerprint) {
-      this.logger.warn({
-        event: "PAYMENT_METHOD_DETACHED_NO_FINGERPRINT",
-        paymentMethodId: paymentMethod.id,
-        type: paymentMethod.type
-      });
-      return;
-    }
 
     if (!customerId) {
       this.logger.warn({
@@ -361,13 +310,12 @@ export class StripeWebhookService {
       return;
     }
 
-    const deletedPaymentMethod = await this.paymentMethodRepository.deleteByFingerprint(fingerprint, paymentMethod.id, currentUser.id);
+    const deleted = await this.paymentMethodService.removeDetached({ userId: currentUser.id, paymentMethod });
 
     this.logger.info({
       event: "PAYMENT_METHOD_DETACHED",
       paymentMethodId: paymentMethod.id,
-      fingerprint,
-      deleted: !!deletedPaymentMethod
+      deleted
     });
   }
 }

--- a/apps/api/src/billing/services/stripe/stripe.service.spec.ts
+++ b/apps/api/src/billing/services/stripe/stripe.service.spec.ts
@@ -1,5 +1,4 @@
 import type { LoggerService } from "@akashnetwork/logging";
-import { createMongoAbility } from "@casl/ability";
 import { faker } from "@faker-js/faker";
 import crypto from "crypto";
 import Stripe from "stripe";
@@ -428,90 +427,6 @@ describe(StripeService.name, () => {
         { unitAmount: 10, isCustom: false, currency: "usd" },
         { unitAmount: 20, isCustom: false, currency: "usd" },
         { unitAmount: undefined, isCustom: true, currency: "usd" }
-      ]);
-    });
-  });
-
-  describe("getPaymentMethods", () => {
-    it("returns customer payment methods", async () => {
-      const { service, stripe, paymentMethodRepository } = setup();
-      const mockPaymentMethods = [
-        generatePaymentMethod({
-          id: TEST_CONSTANTS.PAYMENT_METHOD_ID,
-          created: 1757992768,
-          card: {
-            brand: "visa",
-            last4: "8732",
-            exp_month: 8,
-            exp_year: 2027,
-            fingerprint: "6a91270a-2f4a-481a-9b03-40b62efb6aff"
-          },
-          billing_details: {
-            address: {
-              city: "Pembroke Pines",
-              country: "US",
-              line1: "81275 Cambridge Street",
-              line2: null,
-              postal_code: "04285-3982",
-              state: "New Hampshire"
-            },
-            email: "Claudie27@yahoo.com",
-            name: "Winifred Wiegand",
-            phone: "1-233-340-5835 x45200",
-            tax_id: null
-          }
-        }),
-        generatePaymentMethod({
-          id: "pm_456",
-          created: 1757991776,
-          card: {
-            brand: "mastercard",
-            last4: "0777",
-            exp_month: 4,
-            exp_year: 2030,
-            fingerprint: "a7c2eb4c-e81e-48cd-9515-71089d4bd0ce"
-          },
-          billing_details: {
-            address: {
-              city: "West Estellaburgh",
-              country: "US",
-              line1: "842 Molly Circles",
-              line2: null,
-              postal_code: "51261-2993",
-              state: "North Carolina"
-            },
-            email: "Golda_Rodriguez95@yahoo.com",
-            name: "Robin Nader V",
-            phone: "336.613.4413 x6559",
-            tax_id: null
-          }
-        })
-      ];
-      vi.spyOn(stripe.paymentMethods, "list").mockResolvedValue({ data: mockPaymentMethods } as unknown as Stripe.Response<
-        Stripe.ApiList<Stripe.PaymentMethod>
-      >);
-      paymentMethodRepository.findByUserId.mockResolvedValue([]);
-
-      const result = await service.getPaymentMethods(
-        TEST_CONSTANTS.USER_ID,
-        TEST_CONSTANTS.CUSTOMER_ID,
-        createMongoAbility([{ action: "read", subject: "PaymentMethod" }])
-      );
-      expect(stripe.paymentMethods.list).toHaveBeenCalledWith({
-        customer: TEST_CONSTANTS.CUSTOMER_ID
-      });
-      // The method sorts by created timestamp in descending order, so pm_123 (higher timestamp) comes first
-      expect(result).toEqual([
-        {
-          ...mockPaymentMethods[0],
-          validated: false,
-          isDefault: false
-        },
-        {
-          ...mockPaymentMethods[1],
-          validated: false,
-          isDefault: false
-        }
       ]);
     });
   });

--- a/apps/api/src/billing/services/stripe/stripe.service.ts
+++ b/apps/api/src/billing/services/stripe/stripe.service.ts
@@ -1,19 +1,15 @@
 import type { LoggerService } from "@akashnetwork/logging";
-import type { AnyAbility } from "@casl/ability";
-import crypto from "crypto";
 import assert from "http-assert";
-import difference from "lodash/difference";
-import keyBy from "lodash/keyBy";
 import orderBy from "lodash/orderBy";
 import Stripe from "stripe";
 import { inject, singleton } from "tsyringe";
 
+import { extractFingerprint } from "@src/billing/lib/payment-method/extract-fingerprint";
 import { STRIPE_CLIENT } from "@src/billing/providers/stripe-client.provider";
 import { PaymentMethodRepository, StripeTransactionOutput, StripeTransactionRepository } from "@src/billing/repositories";
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
-import { type CreateLogger, LOGGER_FACTORY, WithTransaction } from "@src/core";
+import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
 import { type UserOutput, UserRepository } from "@src/user/repositories/user/user.repository";
-import type { PayingUser } from "../paying-user/paying-user";
 
 interface StripePrices {
   unitAmount: number;
@@ -34,8 +30,6 @@ export const STRIPE_CURRENCY = "usd";
  * inferred from this prefix.
  */
 export const TOP_UP_IDEMPOTENCY_KEY_PREFIX = "topup_";
-
-export type PaymentMethod = Stripe.PaymentMethod & { validated: boolean; isDefault: boolean };
 
 @singleton()
 export class StripeService {
@@ -88,117 +82,6 @@ export class StripeService {
     }));
 
     return orderBy(responsePrices, ["isCustom", "unitAmount"], ["asc", "asc"]) as StripePrices[];
-  }
-
-  async getPaymentMethods(userId: string, customerId: string, ability: AnyAbility): Promise<PaymentMethod[]> {
-    const [remotes, locals] = await Promise.all([
-      this.stripe.paymentMethods.list({ customer: customerId }),
-      this.paymentMethodRepository.accessibleBy(ability, "read").findByUserId(userId)
-    ]);
-
-    const localById = keyBy(locals, "paymentMethodId");
-    const remoteIds: string[] = [];
-
-    const merged = remotes.data
-      .map(remote => {
-        remoteIds.push(remote.id);
-        return {
-          ...remote,
-          validated: !!localById[remote.id]?.isValidated,
-          isDefault: !!localById[remote.id]?.isDefault
-        };
-      })
-      .sort((a, b) => b.created - a.created);
-
-    const outOfSyncIds = difference(remoteIds, Object.keys(localById));
-
-    if (outOfSyncIds.length) {
-      this.loggerService.warn({
-        event: "STRIPE_PAYMENT_METHOD_OUT_OF_SYNC",
-        userId,
-        outOfSyncIds
-      });
-    }
-
-    return merged;
-  }
-
-  async getDefaultPaymentMethod(user: PayingUser, ability: AnyAbility): Promise<PaymentMethod | undefined> {
-    const [customer, local] = await Promise.all([
-      this.stripe.customers.retrieve(user.stripeCustomerId, {
-        expand: ["invoice_settings.default_payment_method"]
-      }),
-      this.paymentMethodRepository.accessibleBy(ability, "read").findDefaultByUserId(user.id)
-    ]);
-
-    assert(!customer.deleted, 402, "Payment account has been deleted");
-
-    const remote = customer.invoice_settings.default_payment_method;
-
-    if (typeof remote === "object" && remote && local) {
-      return { ...remote, validated: local.isValidated, isDefault: local.isDefault };
-    } else {
-      this.loggerService.warn({
-        event: "STRIPE_PAYMENT_METHOD_OUT_OF_SYNC",
-        userId: user.id,
-        remoteId: typeof remote === "string" ? remote : remote?.id,
-        localId: local?.paymentMethodId
-      });
-    }
-  }
-
-  async hasPaymentMethod(paymentMethodId: string, user: UserOutput): Promise<boolean> {
-    try {
-      const paymentMethod = await this.stripe.paymentMethods.retrieve(paymentMethodId);
-      const customerId = typeof paymentMethod.customer === "string" ? paymentMethod.customer : paymentMethod.customer?.id;
-
-      return customerId === user.stripeCustomerId;
-    } catch (error: unknown) {
-      if (error instanceof Stripe.errors.StripeInvalidRequestError && error.code === "resource_missing") {
-        return false;
-      }
-
-      throw error;
-    }
-  }
-
-  @WithTransaction()
-  async markPaymentMethodAsDefault(paymentMethodId: string, user: PayingUser, ability: AnyAbility): Promise<PaymentMethod> {
-    const [local, remote] = await Promise.all([
-      this.paymentMethodRepository.accessibleBy(ability, "update").markAsDefault(paymentMethodId),
-      this.stripe.paymentMethods.retrieve(paymentMethodId, undefined, { timeout: 3_000 })
-    ]);
-
-    assert(remote, 404, "Payment method not found", { source: "stripe" });
-
-    if (local) {
-      await this.markRemotePaymentMethodAsDefault(paymentMethodId, user);
-      return { ...remote, validated: local.isValidated, isDefault: local.isDefault };
-    }
-
-    const fingerprint = this.extractFingerprint(remote);
-
-    assert(fingerprint, 403, "Payment method cannot be set as default. No identifiable fingerprint found.");
-
-    const newLocal = await this.paymentMethodRepository.accessibleBy(ability, "create").createAsDefault({
-      userId: user.id,
-      fingerprint,
-      paymentMethodId
-    });
-
-    await this.markRemotePaymentMethodAsDefault(paymentMethodId, user);
-
-    return { ...remote, validated: newLocal.isValidated, isDefault: newLocal.isDefault };
-  }
-
-  async markRemotePaymentMethodAsDefault(paymentMethodId: string, user: PayingUser): Promise<void> {
-    await this.stripe.customers.update(
-      user.stripeCustomerId,
-      {
-        invoice_settings: { default_payment_method: paymentMethodId }
-      },
-      { timeout: 3_000 }
-    );
   }
 
   async listPromotionCodes() {
@@ -438,7 +321,7 @@ export class StripeService {
       currentUserId
     });
 
-    const fingerprints = paymentMethods.map(paymentMethod => this.extractFingerprint(paymentMethod)).filter(Boolean) as string[];
+    const fingerprints = paymentMethods.map(paymentMethod => extractFingerprint(paymentMethod)).filter(Boolean) as string[];
 
     if (!fingerprints.length) {
       return false;
@@ -648,16 +531,6 @@ export class StripeService {
         error: validationError
       });
       // Don't fail the test charge if validation update fails - the card is still valid
-    }
-  }
-
-  extractFingerprint(paymentMethod: Stripe.PaymentMethod): string | undefined {
-    if (paymentMethod.card?.fingerprint) {
-      return paymentMethod.card.fingerprint;
-    }
-
-    if (paymentMethod.type === "link" && paymentMethod.link?.email) {
-      return `link_${crypto.createHash("sha256").update(paymentMethod.link.email.toLowerCase()).digest("hex")}`;
     }
   }
 }

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.spec.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.spec.ts
@@ -6,7 +6,7 @@ import { mock } from "vitest-mock-extended";
 import { WalletBalanceReloadCheck } from "@src/billing/events/wallet-balance-reload-check";
 import type { WalletSettingRepository } from "@src/billing/repositories";
 import type { BalancesService } from "@src/billing/services/balances/balances.service";
-import type { StripeService } from "@src/billing/services/stripe/stripe.service";
+import type { PaymentMethodService } from "@src/billing/services/payment-method/payment-method.service";
 import type { StripeTransactionService } from "@src/billing/services/stripe-transaction/stripe-transaction.service";
 import type { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
 import type { JobMeta } from "@src/core";
@@ -317,10 +317,10 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
     it("logs validation error when default payment method cannot be retrieved", async () => {
       const balance = 15.0;
 
-      const { handler, instrumentationService, stripeService, job, jobMeta } = setup({
+      const { handler, instrumentationService, paymentMethodService, job, jobMeta } = setup({
         balance
       });
-      stripeService.getDefaultPaymentMethod.mockResolvedValue(undefined);
+      paymentMethodService.getDefaultPaymentMethod.mockResolvedValue(undefined);
 
       await handler.handle(job, jobMeta);
 
@@ -381,7 +381,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
     });
     const walletReloadJobService = mock<WalletReloadJobService>();
     const drainingDeploymentService = mock<DrainingDeploymentService>();
-    const stripeService = mock<StripeService>();
+    const paymentMethodService = mock<PaymentMethodService>();
     const stripeTransactionService = mock<StripeTransactionService>();
     const instrumentationService = mock<WalletBalanceReloadCheckInstrumentationService>({
       recordJobExecution: vi.fn(),
@@ -407,7 +407,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       balancesService.getDeploymentBalanceInFiat.mockResolvedValue(balance);
       balancesService.toFiatAmount.mockResolvedValue(weeklyCostInFiat);
       drainingDeploymentService.calculateAllDeploymentCostUntilDate.mockResolvedValue(weeklyCostInDenom);
-      stripeService.getDefaultPaymentMethod.mockResolvedValue(generatePaymentMethod());
+      paymentMethodService.getDefaultPaymentMethod.mockResolvedValue(generatePaymentMethod());
     }
 
     walletReloadJobService.scheduleForWalletSetting.mockResolvedValue(jobId);
@@ -416,7 +416,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       walletSettingRepository,
       balancesService,
       walletReloadJobService,
-      stripeService,
+      paymentMethodService,
       stripeTransactionService,
       drainingDeploymentService,
       instrumentationService
@@ -428,7 +428,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       balancesService,
       walletReloadJobService,
       drainingDeploymentService,
-      stripeService,
+      paymentMethodService,
       stripeTransactionService,
       instrumentationService,
       walletSetting,

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.ts
@@ -7,7 +7,7 @@ import { WalletBalanceReloadCheck } from "@src/billing/events/wallet-balance-rel
 import type { GetBalancesResponseOutput } from "@src/billing/http-schemas/balance.schema";
 import { UserWalletOutput, WalletSettingOutput, WalletSettingRepository } from "@src/billing/repositories";
 import { BalancesService } from "@src/billing/services/balances/balances.service";
-import { PaymentMethod, StripeService } from "@src/billing/services/stripe/stripe.service";
+import { type PaymentMethod, PaymentMethodService } from "@src/billing/services/payment-method/payment-method.service";
 import { StripeTransactionService } from "@src/billing/services/stripe-transaction/stripe-transaction.service";
 import { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
 import { JobHandler, JobMeta, JobPayload } from "@src/core";
@@ -53,7 +53,7 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
     private readonly walletSettingRepository: WalletSettingRepository,
     private readonly balancesService: BalancesService,
     private readonly walletReloadJobService: WalletReloadJobService,
-    private readonly stripeService: StripeService,
+    private readonly paymentMethodService: PaymentMethodService,
     private readonly stripeTransactionService: StripeTransactionService,
     private readonly drainingDeploymentService: DrainingDeploymentService,
     private readonly instrumentationService: WalletBalanceReloadCheckInstrumentationService
@@ -146,7 +146,7 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
   }
 
   async #getDefaultPaymentMethod(user: PayingUser): Promise<Result<PaymentMethod, ValidationError>> {
-    const paymentMethod = await this.stripeService.getDefaultPaymentMethod(
+    const paymentMethod = await this.paymentMethodService.getDefaultPaymentMethod(
       user,
       createMongoAbility([
         {

--- a/apps/api/src/billing/services/wallet-initializer/wallet-initializer.service.spec.ts
+++ b/apps/api/src/billing/services/wallet-initializer/wallet-initializer.service.spec.ts
@@ -52,7 +52,6 @@ describe(WalletInitializerService.name, () => {
 
       await di.resolve(WalletInitializerService).startTrial(user.id);
 
-      expect(di.resolve(StripeService).getPaymentMethods).not.toHaveBeenCalled();
       expect(managedUserWalletService.createAndAuthorizeTrialSpending).toHaveBeenCalled();
     });
 
@@ -210,8 +209,7 @@ describe(WalletInitializerService.name, () => {
     di.registerInstance(
       StripeService,
       mock<StripeService>({
-        isProduction: input?.isProduction ?? false,
-        getPaymentMethods: vi.fn(async () => [])
+        isProduction: input?.isProduction ?? false
       })
     );
     di.registerInstance(

--- a/apps/api/src/billing/services/wallet-settings/wallet-settings.service.integration.ts
+++ b/apps/api/src/billing/services/wallet-settings/wallet-settings.service.integration.ts
@@ -6,7 +6,8 @@ import { mock } from "vitest-mock-extended";
 
 import type { AuthService } from "@src/auth/services/auth.service";
 import type { UserWalletRepository, WalletSettingRepository } from "@src/billing/repositories";
-import type { PaymentMethod, StripeService } from "@src/billing/services/stripe/stripe.service";
+import type { PaymentMethodService } from "@src/billing/services/payment-method/payment-method.service";
+import { type PaymentMethod } from "@src/billing/services/payment-method/payment-method.service";
 import type { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
 import type { UserRepository } from "@src/user/repositories";
 import { WalletSettingService } from "./wallet-settings.service";
@@ -181,7 +182,7 @@ describe(WalletSettingService.name, () => {
     const userRepository = mock<UserRepository>();
     userRepository.findById.mockResolvedValue(userWithStripe);
     const paymentMethod = { ...generatePaymentMethod(), validated: true };
-    const stripeService = mock<StripeService>({
+    const paymentMethodService = mock<PaymentMethodService>({
       getDefaultPaymentMethod: vi.fn().mockResolvedValue(paymentMethod as PaymentMethod)
     });
     const walletSetting = generateWalletSetting({ userId: user.id });
@@ -195,7 +196,14 @@ describe(WalletSettingService.name, () => {
     const walletReloadJobService = mock<WalletReloadJobService>({
       scheduleForWalletSetting: vi.fn().mockResolvedValue(jobId)
     });
-    const service = new WalletSettingService(walletSettingRepository, userWalletRepository, userRepository, stripeService, authService, walletReloadJobService);
+    const service = new WalletSettingService(
+      walletSettingRepository,
+      userWalletRepository,
+      userRepository,
+      paymentMethodService,
+      authService,
+      walletReloadJobService
+    );
 
     return {
       user: userWithStripe,
@@ -205,7 +213,7 @@ describe(WalletSettingService.name, () => {
       walletSettingRepository,
       userWalletRepository,
       userRepository,
-      stripeService,
+      paymentMethodService,
       authService,
       walletReloadJobService,
       jobId,

--- a/apps/api/src/billing/services/wallet-settings/wallet-settings.service.ts
+++ b/apps/api/src/billing/services/wallet-settings/wallet-settings.service.ts
@@ -3,7 +3,7 @@ import { singleton } from "tsyringe";
 
 import { AuthService } from "@src/auth/services/auth.service";
 import { UserWalletRepository, type WalletSettingOutput, WalletSettingRepository } from "@src/billing/repositories";
-import { StripeService } from "@src/billing/services/stripe/stripe.service";
+import { PaymentMethodService } from "@src/billing/services/payment-method/payment-method.service";
 import { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
 import { WithTransaction } from "@src/core";
 import { isUniqueViolation } from "@src/core/repositories/base.repository";
@@ -21,7 +21,7 @@ export class WalletSettingService {
     private readonly walletSettingRepository: WalletSettingRepository,
     private readonly userWalletRepository: UserWalletRepository,
     private readonly userRepository: UserRepository,
-    private readonly stripeService: StripeService,
+    private readonly paymentMethodService: PaymentMethodService,
     private readonly authService: AuthService,
     private readonly walletReloadJobService: WalletReloadJobService
   ) {}
@@ -104,7 +104,7 @@ export class WalletSettingService {
 
       const { ability } = this.authService;
       assert(
-        await this.stripeService.getDefaultPaymentMethod({ ...user, stripeCustomerId }, ability),
+        await this.paymentMethodService.getDefaultPaymentMethod({ ...user, stripeCustomerId }, ability),
         403,
         "Default payment method is required to enable automatic wallet balance reload"
       );

--- a/apps/api/test/seeders/payment-method.seeder.ts
+++ b/apps/api/test/seeders/payment-method.seeder.ts
@@ -2,7 +2,7 @@ import { faker } from "@faker-js/faker";
 import { merge } from "lodash";
 import type Stripe from "stripe";
 
-import type { PaymentMethod } from "@src/billing/services/stripe/stripe.service";
+import type { PaymentMethod } from "@src/billing/services/payment-method/payment-method.service";
 
 type PaymentMethodOverrides = Omit<Partial<Stripe.PaymentMethod>, "card"> & {
   card?: Partial<Stripe.PaymentMethod.Card> | null;


### PR DESCRIPTION
## Why

The local `payment_methods` records are written by **two** owners: user actions (list/default/ownership via the controller) and Stripe webhook sync (`payment_method.attached` / `detached`) — the same dual-writer risk we just closed for `stripe_transactions`. This PR introduces a single owner, `PaymentMethodService`, that both paths use, so the table is written in one place.

Behavior-preserving: no change to how payment methods are listed, defaulted, or validated. Next step in the layered `StripeService` split.

Closes CON-724 · Part of CON-718 · unblocks CON-729 (thin webhook dispatcher).

## What

`apps/api` — behavior-preserving, no new runtime behavior, no migrations.

- Adds `@singleton PaymentMethodService` (injected `STRIPE_CLIENT` + `PaymentMethodRepository` + logger — no `StripeService` dependency, so no cycle). It owns:
  - reads/default/ownership: `getPaymentMethods`, `getDefaultPaymentMethod`, `hasPaymentMethod`, `markPaymentMethodAsDefault`, `markRemotePaymentMethodAsDefault` — moved verbatim from `StripeService`;
  - webhook sync: `syncAttached` (upsert + first-card default sync) and `removeDetached` (delete by fingerprint), lifted out of the webhook handlers.
- `extractFingerprint` becomes a standalone pure helper (`lib/payment-method/extract-fingerprint.ts`), shared by the service and the trial code that still lives in `StripeService`. This is what lets `PaymentMethodService` avoid depending on `StripeService`.
- Rerouted consumers: `StripeController`, `WalletSettingsService`, `WalletBalanceReloadCheckHandler`, and `StripeWebhookService` (attach/detach now delegate to `PaymentMethodService`). `StripeService` sheds the moved methods, the `PaymentMethod` type, and the now-dead `AnyAbility` / `lodash` / `PayingUser` / `WithTransaction` imports.
- **Out of scope (documented):** the trial `markPaymentMethodAsValidated` write stays in `StripeService` — it's a trial-validation concern (its only callers are `createTestCharge` / `validatePaymentMethodAfter3DS`) and moves with them in CON-726 (L-8), not folded in here. It is *not* part of the dual-writer sync risk this PR targets. HTTP-in-transaction boundaries are left as-is (verbatim moves).

## Verification

- **Billing unit suite green — 365 tests / 30 files** (new `payment-method.service` + `extract-fingerprint` specs; the reporting/charge tests unchanged).
- `tsc`: every remaining error is in a pre-existing, unrelated file — zero in the changed set.
- Prettier clean.
- **Run before merge (need the test DB / CI):** `npm run lint`, and `npm run test:integration` + `npm run test:functional` (require `npm run test:ci-setup`). Note: `markPaymentMethodAsDefault`, `syncAttached`, and `removeDetached` are `@WithTransaction` (DB-bound, not unit-testable); their logic is exercised via the functional webhook path — confirm codecov patch coverage on those, and add a `payment-method.service.integration.ts` if it's short.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved payment method synchronization using a stable identity for Link-based methods, improving deduplication during syncing.
  * Payment method views now consistently combine remote status with locally stored validation and default state.
* **Bug Fixes**
  * Strengthened payment confirmation checks to ensure the payment method belongs to the current user, with safer handling when methods are missing or detached.
  * Improved default payment method resolution for wallet settings and automatic reload checks.
* **Refactor**
  * Centralized payment-method handling so payments, wallets, and webhook flows share consistent logic.
* **Tests**
  * Expanded controller, service, and webhook coverage to validate delegation and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->