### PR TITLE
fix(billing): source billing history from internal transactions

### DIFF
--- a/apps/api/src/billing/controllers/stripe/stripe.controller.ts
+++ b/apps/api/src/billing/controllers/stripe/stripe.controller.ts
@@ -210,18 +210,13 @@ export class StripeController {
   @Protected([{ action: "read", subject: "StripePayment" }])
   async getCustomerTransactions(options?: {
     limit?: number;
-    startingAfter?: string;
-    endingBefore?: string;
+    offset?: number;
     startDate?: string;
     endDate?: string;
-  }): Promise<{ data: { transactions: Transaction[]; hasMore: boolean; nextPage: string | null; prevPage: string | null } }> {
+  }): Promise<{ data: { transactions: Transaction[]; totalCount: number; hasMore: boolean } }> {
     const { currentUser } = this.authService;
 
-    if (!currentUser.stripeCustomerId) {
-      return { data: { transactions: [], hasMore: false, nextPage: null, prevPage: null } };
-    }
-
-    const response = await this.transactionReporting.getCustomerTransactions(currentUser.stripeCustomerId, options);
+    const response = await this.transactionReporting.getCustomerTransactions(currentUser.id, options);
     return { data: response };
   }
 
@@ -229,9 +224,7 @@ export class StripeController {
   async exportTransactionsCsvStream(options: ZodInfer<typeof CustomerTransactionsCsvExportQuerySchema>): Promise<AsyncIterable<string>> {
     const { currentUser } = this.authService;
 
-    assert(currentUser.stripeCustomerId, 403, "Payments are not configured. Please start with a trial first");
-
-    return this.transactionReporting.exportTransactionsCsvStream(currentUser.stripeCustomerId, options);
+    return this.transactionReporting.exportTransactionsCsvStream(currentUser.id, options);
   }
 
   @Protected([{ action: "create", subject: "StripePayment" }])

--- a/apps/api/src/billing/http-schemas/stripe.schema.ts
+++ b/apps/api/src/billing/http-schemas/stripe.schema.ts
@@ -184,7 +184,7 @@ const dateRangeErrorMessage = "Date range cannot exceed 366 days and startDate m
 
 export const CustomerTransactionsQuerySchema = z
   .object({
-    limit: z.coerce.number().optional().openapi({
+    limit: z.coerce.number().int().min(1).max(100).optional().openapi({
       type: "number",
       minimum: 1,
       maximum: 100,

--- a/apps/api/src/billing/http-schemas/stripe.schema.ts
+++ b/apps/api/src/billing/http-schemas/stripe.schema.ts
@@ -134,23 +134,27 @@ export const ApplyCouponResponseSchema = z.object({
 
 export const TransactionSchema = z.object({
   id: z.string(),
+  type: z.enum(["payment_intent", "coupon_claim", "manual_credit"]),
   amount: z.number(),
+  /** Cumulative amount refunded on this transaction, in cents. */
+  amountRefunded: z.number(),
   /** First-purchase bonus credited with this payment, in cents. */
   bonusAmount: z.number().optional(),
   currency: z.string(),
   status: z.string(),
   created: z.number(),
-  paymentMethod: PaymentMethodDetailsSchema.refine(hasCardOrLink, cardOrLinkError).nullable(),
+  cardBrand: z.string().nullable().optional(),
+  cardLast4: z.string().nullable().optional(),
+  stripeInvoiceId: z.string().nullable().optional(),
   receiptUrl: z.string().nullable().optional(),
-  description: z.string().nullable().optional(),
-  metadata: z.record(z.string()).nullable().optional()
+  description: z.string().nullable().optional()
 });
 
 export const CustomerTransactionsResponseSchema = z.object({
   data: z.object({
     transactions: z.array(TransactionSchema),
-    hasMore: z.boolean(),
-    nextPage: z.string().nullable().optional()
+    totalCount: z.number(),
+    hasMore: z.boolean()
   })
 });
 
@@ -188,13 +192,12 @@ export const CustomerTransactionsQuerySchema = z
       example: 100,
       default: 100
     }),
-    startingAfter: z.string().optional().openapi({
-      description: "ID of the last transaction from the previous page (if paginating forwards)",
-      example: "ch_1234567890"
-    }),
-    endingBefore: z.string().optional().openapi({
-      description: "ID of the first transaction from the previous page (if paginating backwards)",
-      example: "ch_0987654321"
+    offset: z.coerce.number().int().min(0).optional().openapi({
+      type: "number",
+      minimum: 0,
+      description: "Number of transactions to skip for pagination",
+      example: 0,
+      default: 0
     }),
     startDate: dateRangeSchema.startDate.optional(),
     endDate: dateRangeSchema.endDate.optional()

--- a/apps/api/src/billing/repositories/stripe-transaction/stripe-transaction.repository.integration.ts
+++ b/apps/api/src/billing/repositories/stripe-transaction/stripe-transaction.repository.integration.ts
@@ -189,10 +189,86 @@ describe(StripeTransactionRepository.name, () => {
     });
   });
 
+  describe("findByUserId", () => {
+    it("returns the user's transactions newest first", async () => {
+      const { stripeTransactionRepository, createTestUser } = setup();
+      const user = await createTestUser();
+      await stripeTransactionRepository.create({ ...transactionInput(user.id), amount: 1000, createdAt: new Date("2024-01-01T00:00:00Z") });
+      await stripeTransactionRepository.create({ ...transactionInput(user.id), amount: 3000, createdAt: new Date("2024-03-01T00:00:00Z") });
+      await stripeTransactionRepository.create({ ...transactionInput(user.id), amount: 2000, createdAt: new Date("2024-02-01T00:00:00Z") });
+
+      const result = await stripeTransactionRepository.findByUserId({ userId: user.id });
+
+      expect(result.map(transaction => transaction.amount)).toEqual([3000, 2000, 1000]);
+    });
+
+    it("paginates with limit and offset", async () => {
+      const { stripeTransactionRepository, createTestUser } = setup();
+      const user = await createTestUser();
+      await stripeTransactionRepository.create({ ...transactionInput(user.id), amount: 1000, createdAt: new Date("2024-01-01T00:00:00Z") });
+      await stripeTransactionRepository.create({ ...transactionInput(user.id), amount: 3000, createdAt: new Date("2024-03-01T00:00:00Z") });
+      await stripeTransactionRepository.create({ ...transactionInput(user.id), amount: 2000, createdAt: new Date("2024-02-01T00:00:00Z") });
+
+      const firstPage = await stripeTransactionRepository.findByUserId({ userId: user.id, limit: 2, offset: 0 });
+      const secondPage = await stripeTransactionRepository.findByUserId({ userId: user.id, limit: 2, offset: 2 });
+
+      expect(firstPage.map(transaction => transaction.amount)).toEqual([3000, 2000]);
+      expect(secondPage.map(transaction => transaction.amount)).toEqual([1000]);
+    });
+
+    it("returns only the requested user's transactions", async () => {
+      const { stripeTransactionRepository, createTestUser } = setup();
+      const user = await createTestUser();
+      const otherUser = await createTestUser();
+      await stripeTransactionRepository.create({ ...transactionInput(user.id), amount: 1000 });
+      await stripeTransactionRepository.create({ ...transactionInput(otherUser.id), amount: 2000 });
+
+      const result = await stripeTransactionRepository.findByUserId({ userId: user.id });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].userId).toBe(user.id);
+    });
+  });
+
+  describe("countByUserId", () => {
+    it("counts all of the user's transactions when no date range is given", async () => {
+      const { stripeTransactionRepository, createTestUser } = setup();
+      const user = await createTestUser();
+      await stripeTransactionRepository.create({ ...transactionInput(user.id) });
+      await stripeTransactionRepository.create({ ...transactionInput(user.id) });
+
+      expect(await stripeTransactionRepository.countByUserId(user.id)).toBe(2);
+    });
+
+    it("counts transactions on and within the date-range boundaries, excluding those outside", async () => {
+      const { stripeTransactionRepository, createTestUser } = setup();
+      const user = await createTestUser();
+      const startDate = new Date("2024-06-01T00:00:00Z");
+      const endDate = new Date("2024-06-30T23:59:59Z");
+      await stripeTransactionRepository.create({ ...transactionInput(user.id), createdAt: startDate });
+      await stripeTransactionRepository.create({ ...transactionInput(user.id), createdAt: new Date("2024-06-15T12:00:00Z") });
+      await stripeTransactionRepository.create({ ...transactionInput(user.id), createdAt: endDate });
+      await stripeTransactionRepository.create({ ...transactionInput(user.id), createdAt: new Date("2024-05-31T23:59:59Z") });
+      await stripeTransactionRepository.create({ ...transactionInput(user.id), createdAt: new Date("2024-07-01T00:00:00Z") });
+
+      expect(await stripeTransactionRepository.countByUserId(user.id, { startDate, endDate })).toBe(3);
+    });
+  });
+
   let cleanup: () => Promise<void>;
   afterEach(async () => {
     await cleanup?.();
   });
+
+  function transactionInput(userId: string): StripeTransactionInput {
+    return {
+      userId,
+      type: "payment_intent",
+      status: "succeeded",
+      amount: faker.number.int({ min: 1000, max: 100000 }),
+      currency: "usd"
+    };
+  }
 
   function setup() {
     const stripeTransactionRepository = container.resolve(StripeTransactionRepository);

--- a/apps/api/src/billing/repositories/stripe-transaction/stripe-transaction.repository.ts
+++ b/apps/api/src/billing/repositories/stripe-transaction/stripe-transaction.repository.ts
@@ -176,9 +176,19 @@ export class StripeTransactionRepository extends BaseRepository<Table, StripeTra
     return !!item;
   }
 
-  async countByUserId(userId: string): Promise<number> {
+  async countByUserId(userId: string, options?: { startDate?: Date; endDate?: Date }): Promise<number> {
+    const conditions: SQL[] = [eq(this.table.userId, userId)];
+
+    if (options?.startDate) {
+      conditions.push(gte(this.table.createdAt, options.startDate));
+    }
+
+    if (options?.endDate) {
+      conditions.push(lte(this.table.createdAt, options.endDate));
+    }
+
     const items = await this.cursor.query.StripeTransactions.findMany({
-      where: this.whereAccessibleBy(eq(this.table.userId, userId)),
+      where: this.whereAccessibleBy(and(...conditions)),
       columns: { id: true }
     });
 

--- a/apps/api/src/billing/repositories/stripe-transaction/stripe-transaction.repository.ts
+++ b/apps/api/src/billing/repositories/stripe-transaction/stripe-transaction.repository.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, gte, inArray, lte, notInArray, SQL, sql } from "drizzle-orm";
+import { and, count, desc, eq, gte, inArray, lte, notInArray, SQL, sql } from "drizzle-orm";
 import { singleton } from "tsyringe";
 
 import { type ApiPgDatabase, type ApiPgTables, InjectPg, InjectPgTable } from "@src/core/providers";
@@ -187,12 +187,12 @@ export class StripeTransactionRepository extends BaseRepository<Table, StripeTra
       conditions.push(lte(this.table.createdAt, options.endDate));
     }
 
-    const items = await this.cursor.query.StripeTransactions.findMany({
-      where: this.whereAccessibleBy(and(...conditions)),
-      columns: { id: true }
-    });
+    const [{ total }] = await this.cursor
+      .select({ total: count() })
+      .from(this.table)
+      .where(this.whereAccessibleBy(and(...conditions)));
 
-    return items.length;
+    return total;
   }
 
   async sumAmountByUserId(userId: string, options?: { startDate?: Date; endDate?: Date; status?: StripeTransactionStatus }): Promise<number> {

--- a/apps/api/src/billing/routes/stripe-transactions/stripe-transactions.router.ts
+++ b/apps/api/src/billing/routes/stripe-transactions/stripe-transactions.router.ts
@@ -93,11 +93,10 @@ const getCustomerTransactionsRoute = createRoute({
   }
 });
 stripeTransactionsRouter.openapi(getCustomerTransactionsRoute, async function getCustomerTransactions(c) {
-  const { limit, startingAfter, endingBefore, startDate, endDate } = c.req.valid("query");
+  const { limit, offset, startDate, endDate } = c.req.valid("query");
   const response = await container.resolve(StripeController).getCustomerTransactions({
     limit,
-    startingAfter,
-    endingBefore,
+    offset,
     startDate,
     endDate
   });

--- a/apps/api/src/billing/services/transaction-reporting/transaction-reporting.service.spec.ts
+++ b/apps/api/src/billing/services/transaction-reporting/transaction-reporting.service.spec.ts
@@ -1,6 +1,4 @@
 import type { LoggerService } from "@akashnetwork/logging";
-import { faker } from "@faker-js/faker";
-import Stripe from "stripe";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
@@ -8,280 +6,143 @@ import type { StripeTransactionRepository } from "@src/billing/repositories";
 import { TransactionReportingService } from "./transaction-reporting.service";
 
 import { generateDatabaseStripeTransaction } from "@test/seeders/database-stripe-transaction.seeder";
-import { generatePaymentMethod } from "@test/seeders/payment-method.seeder";
-import { createTestCharge, TEST_CONSTANTS } from "@test/seeders/stripe-test-data.seeder";
 import { createTestTransaction } from "@test/seeders/stripe-transaction-test.seeder";
+
+const USER_ID = "user-123";
 
 describe(TransactionReportingService.name, () => {
   describe("getCustomerTransactions", () => {
-    it("returns formatted transactions", async () => {
-      const { service, stripe } = setup();
-      const mockCharge = createTestCharge();
-      const mockCharges = {
-        data: [mockCharge],
-        has_more: false
-      } as unknown as Stripe.Response<Stripe.ApiList<Stripe.Charge>>;
+    it("maps stored transactions of every type to the response DTO", async () => {
+      const { service, stripeTransactionRepository } = setup();
+      const payment = generateDatabaseStripeTransaction({ type: "payment_intent", amount: 5000, cardBrand: "visa", cardLast4: "4242" });
+      const coupon = generateDatabaseStripeTransaction({ type: "coupon_claim", amount: 1000, stripeInvoiceId: "in_1" });
+      const manual = generateDatabaseStripeTransaction({ type: "manual_credit", amount: 2000, stripeInvoiceId: "in_2" });
+      stripeTransactionRepository.findByUserId.mockResolvedValue([payment, coupon, manual]);
+      stripeTransactionRepository.countByUserId.mockResolvedValue(3);
 
-      vi.spyOn(stripe.charges, "list").mockResolvedValue(mockCharges);
+      const result = await service.getCustomerTransactions(USER_ID);
 
-      const result = await service.getCustomerTransactions(TEST_CONSTANTS.CUSTOMER_ID);
-      expect(result).toEqual({
-        transactions: [
-          {
-            id: mockCharge.id,
-            amount: mockCharge.amount,
-            bonusAmount: 0,
-            currency: mockCharge.currency,
-            status: mockCharge.status,
-            created: mockCharge.created,
-            paymentMethod: mockCharge.payment_method_details,
-            receiptUrl: mockCharge.receipt_url,
-            description: mockCharge.description,
-            metadata: mockCharge.metadata
-          }
-        ],
-        hasMore: false,
-        nextPage: null,
-        prevPage: null
+      expect(stripeTransactionRepository.findByUserId).toHaveBeenCalledWith({
+        userId: USER_ID,
+        startDate: undefined,
+        endDate: undefined,
+        limit: 100,
+        offset: 0
+      });
+      expect(result.totalCount).toBe(3);
+      expect(result.hasMore).toBe(false);
+      expect(result.transactions.map(transaction => transaction.type)).toEqual(["payment_intent", "coupon_claim", "manual_credit"]);
+    });
+
+    it("maps a stored row to the flat DTO shape", async () => {
+      const { service, stripeTransactionRepository } = setup();
+      const row = generateDatabaseStripeTransaction({
+        id: "txn-1",
+        type: "payment_intent",
+        status: "succeeded",
+        amount: 5000,
+        amountRefunded: 0,
+        bonusAmount: 250,
+        currency: "usd",
+        cardBrand: "visa",
+        cardLast4: "4242",
+        stripeInvoiceId: null,
+        receiptUrl: "https://receipt",
+        description: "Wallet top-up",
+        createdAt: new Date("2024-01-02T03:04:05Z")
+      });
+      stripeTransactionRepository.findByUserId.mockResolvedValue([row]);
+      stripeTransactionRepository.countByUserId.mockResolvedValue(1);
+
+      const result = await service.getCustomerTransactions(USER_ID);
+
+      expect(result.transactions[0]).toEqual({
+        id: "txn-1",
+        type: "payment_intent",
+        amount: 5000,
+        amountRefunded: 0,
+        bonusAmount: 250,
+        currency: "usd",
+        status: "succeeded",
+        created: Math.floor(new Date("2024-01-02T03:04:05Z").getTime() / 1000),
+        cardBrand: "visa",
+        cardLast4: "4242",
+        stripeInvoiceId: null,
+        receiptUrl: "https://receipt",
+        description: "Wallet top-up"
       });
     });
 
-    it("attaches the recorded first-purchase bonus to matching charges", async () => {
-      const { service, stripe, stripeTransactionRepository } = setup();
-      const bonusCharge = createTestCharge({ id: "ch_bonus" });
-      const plainCharge = createTestCharge({ id: "ch_plain" });
-      const mockCharges = {
-        data: [bonusCharge, plainCharge],
-        has_more: false
-      } as unknown as Stripe.Response<Stripe.ApiList<Stripe.Charge>>;
+    it("surfaces refunded status and the refunded amount", async () => {
+      const { service, stripeTransactionRepository } = setup();
+      const refunded = generateDatabaseStripeTransaction({ type: "payment_intent", status: "refunded", amount: 5000, amountRefunded: 2000 });
+      stripeTransactionRepository.findByUserId.mockResolvedValue([refunded]);
+      stripeTransactionRepository.countByUserId.mockResolvedValue(1);
 
-      vi.spyOn(stripe.charges, "list").mockResolvedValue(mockCharges);
-      stripeTransactionRepository.findByChargeIds.mockResolvedValue([generateDatabaseStripeTransaction({ stripeChargeId: "ch_bonus", bonusAmount: 1000 })]);
+      const result = await service.getCustomerTransactions(USER_ID);
 
-      const result = await service.getCustomerTransactions(TEST_CONSTANTS.CUSTOMER_ID);
-
-      expect(stripeTransactionRepository.findByChargeIds).toHaveBeenCalledWith(["ch_bonus", "ch_plain"]);
-      expect(result.transactions[0].bonusAmount).toBe(1000);
-      expect(result.transactions[1].bonusAmount).toBe(0);
+      expect(result.transactions[0].status).toBe("refunded");
+      expect(result.transactions[0].amountRefunded).toBe(2000);
     });
 
-    it("sanitizes link email from payment method details", async () => {
-      const { service, stripe } = setup();
-      const mockCharge = createTestCharge({
-        id: "ch_link",
-        payment_method_details: { type: "link", link: { email: "user@test.com" } } as unknown as Stripe.Charge.PaymentMethodDetails
-      });
-      const mockCharges = {
-        data: [mockCharge],
-        has_more: false
-      } as unknown as Stripe.Response<Stripe.ApiList<Stripe.Charge>>;
+    it("passes offset and date filters through to the repository and count", async () => {
+      const { service, stripeTransactionRepository } = setup();
+      stripeTransactionRepository.findByUserId.mockResolvedValue([]);
+      stripeTransactionRepository.countByUserId.mockResolvedValue(0);
+      const startDate = "2022-01-01T00:00:00.000Z";
+      const endDate = "2022-12-31T23:59:59.000Z";
 
-      vi.spyOn(stripe.charges, "list").mockResolvedValue(mockCharges);
+      await service.getCustomerTransactions(USER_ID, { limit: 25, offset: 50, startDate, endDate });
 
-      const result = await service.getCustomerTransactions(TEST_CONSTANTS.CUSTOMER_ID);
-      expect(result.transactions[0].paymentMethod).toEqual({
-        type: "link",
-        link: { email: undefined }
-      });
-    });
-
-    it("returns null paymentMethod when payment_method_details is null", async () => {
-      const { service, stripe } = setup();
-      const mockCharge = createTestCharge({
-        id: "ch_null_pm",
-        payment_method_details: null as unknown as Stripe.Charge.PaymentMethodDetails
-      });
-      const mockCharges = {
-        data: [mockCharge],
-        has_more: false
-      } as unknown as Stripe.Response<Stripe.ApiList<Stripe.Charge>>;
-
-      vi.spyOn(stripe.charges, "list").mockResolvedValue(mockCharges);
-
-      const result = await service.getCustomerTransactions(TEST_CONSTANTS.CUSTOMER_ID);
-      expect(result.transactions[0].paymentMethod).toBeNull();
-    });
-
-    it("calls charges.list with endingBefore parameter", async () => {
-      const { service, stripe } = setup();
-      const mockCharge = createTestCharge({ id: "ch_456", amount: 2000 });
-      const mockCharges = {
-        data: [mockCharge],
-        has_more: true
-      } as unknown as Stripe.Response<Stripe.ApiList<Stripe.Charge>>;
-
-      vi.spyOn(stripe.charges, "list").mockResolvedValue(mockCharges);
-
-      await service.getCustomerTransactions(TEST_CONSTANTS.CUSTOMER_ID, {
-        endingBefore: "ch_before_id",
-        limit: 50
-      });
-
-      expect(stripe.charges.list).toHaveBeenCalledWith({
-        customer: TEST_CONSTANTS.CUSTOMER_ID,
-        limit: 50,
-        created: undefined,
-        starting_after: undefined,
-        ending_before: "ch_before_id",
-        expand: ["data.payment_intent"]
-      });
-    });
-
-    it("calls charges.list with created parameter", async () => {
-      const { service, stripe } = setup();
-      const mockCharge = createTestCharge({ id: "ch_789", amount: 3000 });
-      const mockCharges = {
-        data: [mockCharge],
-        has_more: false
-      } as unknown as Stripe.Response<Stripe.ApiList<Stripe.Charge>>;
-
-      vi.spyOn(stripe.charges, "list").mockResolvedValue(mockCharges);
-
-      const startDate = new Date("2022-01-01T00:00:00Z").toISOString();
-      const endDate = new Date("2022-12-31T23:59:59Z").toISOString();
-      await service.getCustomerTransactions(TEST_CONSTANTS.CUSTOMER_ID, {
-        startDate,
-        endDate,
-        limit: 25
-      });
-
-      expect(stripe.charges.list).toHaveBeenCalledWith({
-        customer: TEST_CONSTANTS.CUSTOMER_ID,
+      expect(stripeTransactionRepository.findByUserId).toHaveBeenCalledWith({
+        userId: USER_ID,
+        startDate: new Date(startDate),
+        endDate: new Date(endDate),
         limit: 25,
-        created: {
-          gte: new Date(startDate).getTime() / 1000,
-          lte: new Date(endDate).getTime() / 1000
-        },
-        starting_after: undefined,
-        ending_before: undefined,
-        expand: ["data.payment_intent"]
+        offset: 50
+      });
+      expect(stripeTransactionRepository.countByUserId).toHaveBeenCalledWith(USER_ID, {
+        startDate: new Date(startDate),
+        endDate: new Date(endDate)
       });
     });
 
-    it("returns correct prevPage when startingAfter is provided", async () => {
-      const { service, stripe } = setup();
-      const firstCharge = createTestCharge({
-        id: "ch_first",
-        amount: 1000,
-        description: "First charge"
-      });
-      const secondCharge = createTestCharge({
-        id: "ch_second",
-        amount: 2000,
-        created: 1234567891,
-        description: "Second charge"
-      });
-      const mockCharges = {
-        data: [firstCharge, secondCharge],
-        has_more: true
-      } as unknown as Stripe.Response<Stripe.ApiList<Stripe.Charge>>;
+    it("reports hasMore when the page does not reach the total count", async () => {
+      const { service, stripeTransactionRepository } = setup();
+      stripeTransactionRepository.findByUserId.mockResolvedValue([generateDatabaseStripeTransaction(), generateDatabaseStripeTransaction()]);
+      stripeTransactionRepository.countByUserId.mockResolvedValue(10);
 
-      vi.spyOn(stripe.charges, "list").mockResolvedValue(mockCharges);
+      const result = await service.getCustomerTransactions(USER_ID, { limit: 2, offset: 0 });
 
-      const result = await service.getCustomerTransactions(TEST_CONSTANTS.CUSTOMER_ID, {
-        startingAfter: "ch_previous_id"
-      });
-
-      expect(result).toEqual({
-        transactions: [
-          {
-            id: firstCharge.id,
-            amount: firstCharge.amount,
-            bonusAmount: 0,
-            currency: firstCharge.currency,
-            status: firstCharge.status,
-            created: firstCharge.created,
-            paymentMethod: firstCharge.payment_method_details,
-            receiptUrl: firstCharge.receipt_url,
-            description: firstCharge.description,
-            metadata: firstCharge.metadata
-          },
-          {
-            id: secondCharge.id,
-            amount: secondCharge.amount,
-            bonusAmount: 0,
-            currency: secondCharge.currency,
-            status: secondCharge.status,
-            created: secondCharge.created,
-            paymentMethod: secondCharge.payment_method_details,
-            receiptUrl: secondCharge.receipt_url,
-            description: secondCharge.description,
-            metadata: secondCharge.metadata
-          }
-        ],
-        hasMore: true,
-        nextPage: secondCharge.id,
-        prevPage: firstCharge.id
-      });
+      expect(result.hasMore).toBe(true);
     });
 
-    it("returns null prevPage when startingAfter is not provided", async () => {
-      const { service, stripe } = setup();
-      const mockCharge = createTestCharge({
-        id: "ch_only",
-        description: "Only charge"
-      });
-      const mockCharges = {
-        data: [mockCharge],
-        has_more: false
-      } as unknown as Stripe.Response<Stripe.ApiList<Stripe.Charge>>;
+    it("reports no more results on the last page", async () => {
+      const { service, stripeTransactionRepository } = setup();
+      stripeTransactionRepository.findByUserId.mockResolvedValue([generateDatabaseStripeTransaction(), generateDatabaseStripeTransaction()]);
+      stripeTransactionRepository.countByUserId.mockResolvedValue(10);
 
-      vi.spyOn(stripe.charges, "list").mockResolvedValue(mockCharges);
+      const result = await service.getCustomerTransactions(USER_ID, { limit: 2, offset: 8 });
 
-      const result = await service.getCustomerTransactions(TEST_CONSTANTS.CUSTOMER_ID);
-
-      expect(result.prevPage).toBeNull();
-    });
-
-    it("calls charges.list with all parameters combined", async () => {
-      const { service, stripe } = setup();
-      const mockCharges = {
-        data: [],
-        has_more: false
-      } as unknown as Stripe.Response<Stripe.ApiList<Stripe.Charge>>;
-
-      vi.spyOn(stripe.charges, "list").mockResolvedValue(mockCharges);
-
-      const startDate = new Date("2021-01-01T00:00:00Z").toISOString();
-      const endDate = new Date("2021-12-31T23:59:59Z").toISOString();
-
-      const options = {
-        limit: 10,
-        startingAfter: "ch_start_id",
-        endingBefore: "ch_end_id",
-        startDate,
-        endDate
-      };
-
-      await service.getCustomerTransactions(TEST_CONSTANTS.CUSTOMER_ID, options);
-
-      expect(stripe.charges.list).toHaveBeenCalledWith({
-        customer: TEST_CONSTANTS.CUSTOMER_ID,
-        limit: 10,
-        created: {
-          gte: new Date(startDate).getTime() / 1000,
-          lte: new Date(endDate).getTime() / 1000
-        },
-        starting_after: "ch_start_id",
-        ending_before: "ch_end_id",
-        expand: ["data.payment_intent"]
-      });
+      expect(result.hasMore).toBe(false);
     });
   });
 
   describe("exportTransactionsCsvStream", () => {
+    const CSV_HEADER =
+      "Transaction ID,Date (America/New_York),Type,Amount,Bonus,Refunded,Currency,Status,Card Brand,Card Last 4,Description,Invoice ID,Receipt URL";
+
     it("streams transactions for a single page", async () => {
       const { service } = setup();
       const mockTransaction = createTestTransaction();
 
       vi.spyOn(service, "getCustomerTransactions").mockResolvedValue({
         transactions: [mockTransaction],
-        hasMore: false,
-        nextPage: null,
-        prevPage: null
+        totalCount: 1,
+        hasMore: false
       });
 
-      const csvStream = service.exportTransactionsCsvStream(TEST_CONSTANTS.CUSTOMER_ID, {
+      const csvStream = service.exportTransactionsCsvStream(USER_ID, {
         startDate: "2022-01-01T00:00:00Z",
         endDate: "2022-01-31T23:59:59Z",
         timezone: "America/New_York"
@@ -294,12 +155,10 @@ describe(TransactionReportingService.name, () => {
 
       const fullCsv = chunks.join("");
 
-      expect(fullCsv).toContain(
-        "Transaction ID,Date (America/New_York),Amount,Bonus,Currency,Status,Payment Method,Card Brand,Card Last 4,Description,Receipt URL"
-      );
-
+      expect(fullCsv).toContain(CSV_HEADER);
       expect(fullCsv).toContain(mockTransaction.id);
       expect(fullCsv).toContain("2021-12-31, 7:00:00 p.m.");
+      expect(fullCsv).toContain("payment_intent");
       expect(fullCsv).toContain("10.00");
       expect(fullCsv).toContain("visa");
       expect(fullCsv).toContain("4242");
@@ -311,12 +170,11 @@ describe(TransactionReportingService.name, () => {
 
       vi.spyOn(service, "getCustomerTransactions").mockResolvedValue({
         transactions: [mockTransaction],
-        hasMore: false,
-        nextPage: null,
-        prevPage: null
+        totalCount: 1,
+        hasMore: false
       });
 
-      const csvStream = service.exportTransactionsCsvStream(TEST_CONSTANTS.CUSTOMER_ID, {
+      const csvStream = service.exportTransactionsCsvStream(USER_ID, {
         startDate: "2022-01-01T00:00:00Z",
         endDate: "2022-01-31T23:59:59Z",
         timezone: "America/New_York"
@@ -330,51 +188,52 @@ describe(TransactionReportingService.name, () => {
       expect(chunks.join("")).toContain("150.00,15.00");
     });
 
+    it("writes the refunded amount and invoice id columns", async () => {
+      const { service } = setup();
+      const mockTransaction = createTestTransaction({ type: "coupon_claim", amount: 5000, amountRefunded: 2000, stripeInvoiceId: "in_export" });
+
+      vi.spyOn(service, "getCustomerTransactions").mockResolvedValue({
+        transactions: [mockTransaction],
+        totalCount: 1,
+        hasMore: false
+      });
+
+      const csvStream = service.exportTransactionsCsvStream(USER_ID, {
+        startDate: "2022-01-01T00:00:00Z",
+        endDate: "2022-01-31T23:59:59Z",
+        timezone: "America/New_York"
+      });
+
+      const chunks: string[] = [];
+      for await (const chunk of csvStream) {
+        chunks.push(chunk);
+      }
+
+      const fullCsv = chunks.join("");
+      expect(fullCsv).toContain("coupon_claim");
+      expect(fullCsv).toContain("20.00");
+      expect(fullCsv).toContain("in_export");
+    });
+
     it("streams multiple pages without loading all into memory", async () => {
       const { service } = setup();
 
-      const firstPageTransaction = createTestTransaction({
-        id: "ch_001",
-        amount: 1000,
-        description: "First transaction",
-        paymentMethod: generatePaymentMethod({
-          type: "card",
-          card: {
-            brand: "visa",
-            last4: "1111"
-          }
-        })
-      });
-
-      const secondPageTransaction = createTestTransaction({
-        id: "ch_002",
-        amount: 2000,
-        created: 1641081600,
-        description: "Second transaction",
-        paymentMethod: generatePaymentMethod({
-          type: "card",
-          card: {
-            brand: "mastercard",
-            last4: "2222"
-          }
-        })
-      });
+      const firstPageTransaction = createTestTransaction({ id: "ch_001", amount: 1000, description: "First transaction" });
+      const secondPageTransaction = createTestTransaction({ id: "ch_002", amount: 2000, created: 1641081600, description: "Second transaction" });
 
       vi.spyOn(service, "getCustomerTransactions")
         .mockResolvedValueOnce({
           transactions: [firstPageTransaction],
-          hasMore: true,
-          nextPage: "ch_001",
-          prevPage: null
+          totalCount: 2,
+          hasMore: true
         })
         .mockResolvedValueOnce({
           transactions: [secondPageTransaction],
-          hasMore: false,
-          nextPage: null,
-          prevPage: "ch_002"
+          totalCount: 2,
+          hasMore: false
         });
 
-      const csvStream = service.exportTransactionsCsvStream(TEST_CONSTANTS.CUSTOMER_ID, {
+      const csvStream = service.exportTransactionsCsvStream(USER_ID, {
         startDate: "2022-01-01T00:00:00Z",
         endDate: "2022-01-31T23:59:59Z",
         timezone: "America/New_York"
@@ -388,15 +247,15 @@ describe(TransactionReportingService.name, () => {
       const fullCsv = chunks.join("");
 
       expect(service.getCustomerTransactions).toHaveBeenCalledTimes(2);
-      expect(service.getCustomerTransactions).toHaveBeenNthCalledWith(1, TEST_CONSTANTS.CUSTOMER_ID, {
+      expect(service.getCustomerTransactions).toHaveBeenNthCalledWith(1, USER_ID, {
         limit: 100,
-        startingAfter: undefined,
+        offset: 0,
         startDate: "2022-01-01T00:00:00Z",
         endDate: "2022-01-31T23:59:59Z"
       });
-      expect(service.getCustomerTransactions).toHaveBeenNthCalledWith(2, TEST_CONSTANTS.CUSTOMER_ID, {
+      expect(service.getCustomerTransactions).toHaveBeenNthCalledWith(2, USER_ID, {
         limit: 100,
-        startingAfter: "ch_001",
+        offset: 1,
         startDate: "2022-01-01T00:00:00Z",
         endDate: "2022-01-31T23:59:59Z"
       });
@@ -412,12 +271,11 @@ describe(TransactionReportingService.name, () => {
 
       vi.spyOn(service, "getCustomerTransactions").mockResolvedValue({
         transactions: [],
-        hasMore: false,
-        nextPage: null,
-        prevPage: null
+        totalCount: 0,
+        hasMore: false
       });
 
-      const csvStream = service.exportTransactionsCsvStream(TEST_CONSTANTS.CUSTOMER_ID, {
+      const csvStream = service.exportTransactionsCsvStream(USER_ID, {
         startDate: "2022-01-01T00:00:00Z",
         endDate: "2022-01-31T23:59:59Z",
         timezone: "America/New_York"
@@ -432,7 +290,7 @@ describe(TransactionReportingService.name, () => {
       expect(fullCsv).toContain("No transactions found for the specified date range");
     });
 
-    it("handles transactions with null payment methods", async () => {
+    it("handles transactions with null card details", async () => {
       const { service } = setup();
       const mockTransaction = createTestTransaction({
         id: "ch_123",
@@ -440,19 +298,19 @@ describe(TransactionReportingService.name, () => {
         currency: "usd",
         status: "succeeded",
         created: 1640995200,
-        paymentMethod: null,
+        cardBrand: null,
+        cardLast4: null,
         receiptUrl: null,
-        description: "No payment method"
+        description: "No card details"
       });
 
       vi.spyOn(service, "getCustomerTransactions").mockResolvedValue({
         transactions: [mockTransaction],
-        hasMore: false,
-        nextPage: null,
-        prevPage: null
+        totalCount: 1,
+        hasMore: false
       });
 
-      const csvStream = service.exportTransactionsCsvStream(TEST_CONSTANTS.CUSTOMER_ID, {
+      const csvStream = service.exportTransactionsCsvStream(USER_ID, {
         startDate: "2022-01-01T00:00:00Z",
         endDate: "2022-01-31T23:59:59Z",
         timezone: "America/New_York"
@@ -466,24 +324,23 @@ describe(TransactionReportingService.name, () => {
       const fullCsv = chunks.join("");
 
       expect(fullCsv).toContain("ch_123");
-      expect(fullCsv).toContain("No payment method");
-      expect(fullCsv).toMatch(/ch_123,"[^"]*",[^,]*,[^,]*,[^,]*,[^,]*,,,,No payment method,/);
+      expect(fullCsv).toContain("No card details");
+      expect(fullCsv).toContain(",,No card details,");
     });
 
-    it("handles error during streaming gracefully", async () => {
+    it("yields a generic sanitized placeholder without leaking the raw error message", async () => {
       const { service } = setup();
       const mockTransaction = createTestTransaction();
 
       vi.spyOn(service, "getCustomerTransactions")
         .mockResolvedValueOnce({
           transactions: [mockTransaction],
-          hasMore: true,
-          nextPage: "ch_123",
-          prevPage: null
+          totalCount: 5,
+          hasMore: true
         })
         .mockRejectedValueOnce(new Error("Stripe API error"));
 
-      const csvStream = service.exportTransactionsCsvStream(TEST_CONSTANTS.CUSTOMER_ID, {
+      const csvStream = service.exportTransactionsCsvStream(USER_ID, {
         startDate: "2022-01-01T00:00:00Z",
         endDate: "2022-01-31T23:59:59Z",
         timezone: "America/New_York"
@@ -496,20 +353,16 @@ describe(TransactionReportingService.name, () => {
 
       const fullCsv = chunks.join("");
 
-      expect(fullCsv).toContain(
-        "Transaction ID,Date (America/New_York),Amount,Bonus,Currency,Status,Payment Method,Card Brand,Card Last 4,Description,Receipt URL"
-      );
+      expect(fullCsv).toContain(CSV_HEADER);
       expect(fullCsv).toContain("ch_123");
-      expect(fullCsv).toContain("Error: unable to fetch transactions");
+      expect(fullCsv).toContain("Error retrieving some transactions. Please contact support.");
       expect(fullCsv).not.toContain("Stripe API error");
     });
   });
 
   function setup() {
-    const stripe = new Stripe(`sk_test_${faker.string.alphanumeric(32)}`, { apiVersion: "2025-10-29.clover", httpClient: Stripe.createFetchHttpClient() });
     const stripeTransactionRepository = mock<StripeTransactionRepository>();
-    stripeTransactionRepository.findByChargeIds.mockResolvedValue([]);
-    const service = new TransactionReportingService(stripe, stripeTransactionRepository, () => mock<LoggerService>());
-    return { service, stripe, stripeTransactionRepository };
+    const service = new TransactionReportingService(stripeTransactionRepository, () => mock<LoggerService>());
+    return { service, stripeTransactionRepository };
   }
 });

--- a/apps/api/src/billing/services/transaction-reporting/transaction-reporting.service.ts
+++ b/apps/api/src/billing/services/transaction-reporting/transaction-reporting.service.ts
@@ -1,13 +1,10 @@
 import type { LoggerService } from "@akashnetwork/logging";
 import { stringify } from "csv-stringify";
-import keyBy from "lodash/keyBy";
 import { Readable } from "stream";
-import Stripe from "stripe";
 import { inject, singleton } from "tsyringe";
 
 import { Transaction } from "@src/billing/http-schemas/stripe.schema";
-import { STRIPE_CLIENT } from "@src/billing/providers/stripe-client.provider";
-import { StripeTransactionRepository } from "@src/billing/repositories";
+import { StripeTransactionOutput, StripeTransactionRepository } from "@src/billing/repositories";
 import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
 import type { TransactionCsvRow } from "@src/types/transactions";
 
@@ -16,71 +13,63 @@ export class TransactionReportingService {
   private readonly loggerService: LoggerService;
 
   constructor(
-    @inject(STRIPE_CLIENT) private readonly stripe: Stripe,
     private readonly stripeTransactionRepository: StripeTransactionRepository,
     @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
     this.loggerService = createLogger({ context: TransactionReportingService.name });
   }
 
+  /**
+   * Customer billing history sourced from our own `stripe_transactions` table rather than Stripe
+   * charges, so it surfaces every transaction type (card payments, coupon claims, manual credits)
+   * and refund state (`status: "refunded"`, `amountRefunded`) that a charge-only view cannot see.
+   */
   async getCustomerTransactions(
-    customerId: string,
-    options?: { limit?: number; startingAfter?: string; endingBefore?: string; startDate?: string; endDate?: string }
+    userId: string,
+    options?: { limit?: number; offset?: number; startDate?: string; endDate?: string }
   ): Promise<{
     transactions: Transaction[];
+    totalCount: number;
     hasMore: boolean;
-    nextPage: string | null;
-    prevPage: string | null;
   }> {
-    const created =
-      options?.startDate || options?.endDate
-        ? {
-            gte: options?.startDate ? Math.floor(new Date(options.startDate).getTime() / 1000) : undefined,
-            lte: options?.endDate ? Math.floor(new Date(options.endDate).getTime() / 1000) : undefined
-          }
-        : undefined;
+    const startDate = options?.startDate ? new Date(options.startDate) : undefined;
+    const endDate = options?.endDate ? new Date(options.endDate) : undefined;
+    const limit = options?.limit ?? 100;
+    const offset = options?.offset ?? 0;
 
-    const charges = await this.stripe.charges.list({
-      created,
-      customer: customerId,
-      limit: options?.limit ?? 100,
-      starting_after: options?.startingAfter,
-      ending_before: options?.endingBefore,
-      expand: ["data.payment_intent"]
-    });
-
-    const internalTransactions = await this.stripeTransactionRepository.findByChargeIds(charges.data.map(charge => charge.id));
-    const internalByChargeId = keyBy(internalTransactions, "stripeChargeId");
-
-    const transactions = charges.data.map(charge => ({
-      id: charge.id,
-      amount: charge.amount,
-      bonusAmount: internalByChargeId[charge.id]?.bonusAmount ?? 0,
-      currency: charge.currency,
-      status: charge.status,
-      created: charge.created,
-      paymentMethod: charge.payment_method_details
-        ? {
-            ...charge.payment_method_details,
-            link: charge.payment_method_details.link ? { email: undefined } : undefined
-          }
-        : null,
-      receiptUrl: charge.receipt_url,
-      description: charge.description,
-      metadata: charge.metadata
-    }));
+    const [rows, totalCount] = await Promise.all([
+      this.stripeTransactionRepository.findByUserId({ userId, startDate, endDate, limit, offset }),
+      this.stripeTransactionRepository.countByUserId(userId, { startDate, endDate })
+    ]);
 
     return {
-      transactions,
-      hasMore: charges.has_more,
-      nextPage: charges.has_more ? charges.data[charges.data.length - 1]?.id ?? null : null,
-      prevPage: options?.startingAfter ? charges.data[0]?.id ?? null : null
+      transactions: rows.map(row => this.toTransactionDto(row)),
+      totalCount,
+      hasMore: offset + rows.length < totalCount
     };
   }
 
-  async *exportTransactionsCsvStream(customerId: string, options: { startDate: string; endDate: string; timezone: string }): AsyncIterable<string> {
+  private toTransactionDto(row: StripeTransactionOutput): Transaction {
+    return {
+      id: row.id,
+      type: row.type,
+      amount: row.amount,
+      amountRefunded: row.amountRefunded,
+      bonusAmount: row.bonusAmount,
+      currency: row.currency,
+      status: row.status,
+      created: Math.floor(row.createdAt.getTime() / 1000),
+      cardBrand: row.cardBrand,
+      cardLast4: row.cardLast4,
+      stripeInvoiceId: row.stripeInvoiceId,
+      receiptUrl: row.receiptUrl,
+      description: row.description
+    };
+  }
+
+  async *exportTransactionsCsvStream(userId: string, options: { startDate: string; endDate: string; timezone: string }): AsyncIterable<string> {
     const normalizedTimezone = this.normalizeTimeZone(options.timezone);
-    const transactionGenerator = this.createTransactionGenerator(customerId, {
+    const transactionGenerator = this.createTransactionGenerator(userId, {
       ...options,
       timezone: normalizedTimezone
     });
@@ -91,14 +80,16 @@ export class TransactionReportingService {
       columns: [
         { key: "id", header: "Transaction ID" },
         { key: "date", header: `Date (${normalizedTimezone})` },
+        { key: "type", header: "Type" },
         { key: "amount", header: "Amount" },
         { key: "bonusAmount", header: "Bonus" },
+        { key: "amountRefunded", header: "Refunded" },
         { key: "currency", header: "Currency" },
         { key: "status", header: "Status" },
-        { key: "paymentMethodType", header: "Payment Method" },
         { key: "cardBrand", header: "Card Brand" },
         { key: "cardLast4", header: "Card Last 4" },
         { key: "description", header: "Description" },
+        { key: "invoiceId", header: "Invoice ID" },
         { key: "receiptUrl", header: "Receipt URL" }
       ]
     });
@@ -118,19 +109,19 @@ export class TransactionReportingService {
   }
 
   private async *createTransactionGenerator(
-    customerId: string,
+    userId: string,
     options: { startDate: string; endDate: string; timezone: string }
   ): AsyncGenerator<TransactionCsvRow, void, unknown> {
     let hasMore = true;
-    let startingAfter: string | undefined;
+    let offset = 0;
     const batchSize = 100;
     let hasYieldedAny = false;
 
     while (hasMore) {
       try {
-        const batch = await this.getCustomerTransactions(customerId, {
+        const batch = await this.getCustomerTransactions(userId, {
           limit: batchSize,
-          startingAfter,
+          offset,
           startDate: options.startDate,
           endDate: options.endDate
         });
@@ -141,42 +132,36 @@ export class TransactionReportingService {
           yield this.transformTransactionForCsv(transaction, options.timezone);
         }
 
-        hasMore = batch.hasMore;
-        startingAfter = batch.nextPage || undefined;
+        offset += batch.transactions.length;
+        hasMore = batch.hasMore && batch.transactions.length > 0;
       } catch (error) {
-        this.loggerService.error({ event: "TRANSACTION_FETCH_ERROR", error, customerId, startingAfter });
-        yield {
-          id: this.sanitizeForCsv("Error: unable to fetch transactions"),
-          date: "",
-          amount: "",
-          bonusAmount: "",
-          currency: "",
-          status: "",
-          paymentMethodType: "",
-          cardBrand: "",
-          cardLast4: "",
-          description: "",
-          receiptUrl: ""
-        };
+        this.loggerService.error({ event: "TRANSACTION_FETCH_ERROR", error, userId, offset });
+        yield this.createEmptyCsvRow(this.sanitizeForCsv("Error retrieving some transactions. Please contact support."));
         hasMore = false;
       }
     }
 
     if (!hasYieldedAny) {
-      yield {
-        id: "No transactions found for the specified date range",
-        date: "",
-        amount: "",
-        bonusAmount: "",
-        currency: "",
-        status: "",
-        paymentMethodType: "",
-        cardBrand: "",
-        cardLast4: "",
-        description: "",
-        receiptUrl: ""
-      };
+      yield this.createEmptyCsvRow("No transactions found for the specified date range");
     }
+  }
+
+  private createEmptyCsvRow(id: string): TransactionCsvRow {
+    return {
+      id,
+      date: "",
+      type: "",
+      amount: "",
+      bonusAmount: "",
+      amountRefunded: "",
+      currency: "",
+      status: "",
+      cardBrand: "",
+      cardLast4: "",
+      description: "",
+      invoiceId: "",
+      receiptUrl: ""
+    };
   }
 
   private sanitizeForCsv(value: string): string {
@@ -189,7 +174,7 @@ export class TransactionReportingService {
     return value;
   }
 
-  private transformTransactionForCsv(transaction: Transaction, timeZone: string) {
+  private transformTransactionForCsv(transaction: Transaction, timeZone: string): TransactionCsvRow {
     const amount = (transaction.amount / 100).toFixed(2);
     const date = new Date(transaction.created * 1000).toLocaleString("en-CA", {
       timeZone
@@ -198,14 +183,16 @@ export class TransactionReportingService {
     return {
       id: transaction.id,
       date,
+      type: transaction.type,
       amount,
       bonusAmount: ((transaction.bonusAmount ?? 0) / 100).toFixed(2),
+      amountRefunded: ((transaction.amountRefunded ?? 0) / 100).toFixed(2),
       currency: transaction.currency.toUpperCase(),
       status: transaction.status,
-      paymentMethodType: transaction.paymentMethod?.type || "",
-      cardBrand: transaction.paymentMethod?.card?.brand || "",
-      cardLast4: transaction.paymentMethod?.card?.last4 || "",
+      cardBrand: transaction.cardBrand || "",
+      cardLast4: transaction.cardLast4 || "",
       description: this.sanitizeForCsv(transaction.description || ""),
+      invoiceId: transaction.stripeInvoiceId || "",
       receiptUrl: transaction.receiptUrl || ""
     };
   }

--- a/apps/api/src/types/transactions.ts
+++ b/apps/api/src/types/transactions.ts
@@ -21,13 +21,15 @@ export type ApiTransactionResponse = {
 export type TransactionCsvRow = {
   id: string;
   date: string;
+  type: string;
   amount: string;
   bonusAmount: string;
+  amountRefunded: string;
   currency: string;
   status: string;
-  paymentMethodType: string;
   cardBrand: string;
   cardLast4: string;
   description: string;
+  invoiceId: string;
   receiptUrl: string;
 };

--- a/apps/api/test/seeders/stripe-transaction-test.seeder.ts
+++ b/apps/api/test/seeders/stripe-transaction-test.seeder.ts
@@ -1,18 +1,13 @@
-import { generatePaymentMethod } from "./payment-method.seeder";
 import { createStripeTransaction } from "./stripe-transaction.seeder";
 
 export function createTestTransaction(overrides: Partial<ReturnType<typeof createStripeTransaction>> = {}) {
   return createStripeTransaction({
     id: "ch_123",
+    type: "payment_intent",
     amount: 1000,
     created: 1640995200,
-    paymentMethod: generatePaymentMethod({
-      type: "card",
-      card: {
-        brand: "visa",
-        last4: "4242"
-      }
-    }),
+    cardBrand: "visa",
+    cardLast4: "4242",
     ...overrides
   });
 }

--- a/apps/api/test/seeders/stripe-transaction.seeder.ts
+++ b/apps/api/test/seeders/stripe-transaction.seeder.ts
@@ -2,30 +2,34 @@ import { faker } from "@faker-js/faker";
 
 import type { Transaction } from "@src/billing/http-schemas/stripe.schema";
 
-import { generatePaymentMethod } from "@test/seeders/payment-method.seeder";
-
 export const createStripeTransaction = ({
   id = faker.string.uuid(),
+  type = "payment_intent",
   amount = faker.number.int({ min: 1000, max: 100000 }),
+  amountRefunded = 0,
   bonusAmount,
   currency = "usd",
   status = "succeeded",
   description = faker.lorem.sentence(),
-  created = new Date().getTime(),
-  metadata = {},
-  paymentMethod = generatePaymentMethod(),
+  created = Math.floor(Date.now() / 1000),
+  cardBrand = "visa",
+  cardLast4 = "4242",
+  stripeInvoiceId = null,
   receiptUrl = faker.internet.url()
 }: Partial<Transaction> = {}): Transaction => {
   return {
     id,
+    type,
     amount,
+    amountRefunded,
     bonusAmount,
     currency,
     status,
     description,
     created,
-    paymentMethod,
-    receiptUrl,
-    metadata
+    cardBrand,
+    cardLast4,
+    stripeInvoiceId,
+    receiptUrl
   };
 };

--- a/apps/deploy-web/src/components/billing-usage/BillingContainer/BillingContainer.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/BillingContainer/BillingContainer.spec.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import type { Charge } from "@akashnetwork/http-sdk";
+import type { BillingTransaction } from "@akashnetwork/http-sdk";
 import type { PaginationState } from "@tanstack/react-table";
 import type { AxiosError } from "axios";
 import { describe, expect, it, type MockedFunction, vi } from "vitest";
@@ -66,7 +66,7 @@ describe(BillingContainer.name, () => {
 
   async function setup(
     overrides: Partial<{
-      data: { transactions: Charge[]; hasMore: boolean; nextPage?: string; totalCount: number };
+      data: { transactions: BillingTransaction[]; hasMore: boolean; totalCount: number };
       isFetching: boolean;
       isError: boolean;
       queryError: AxiosError;
@@ -77,7 +77,6 @@ describe(BillingContainer.name, () => {
       ? {
           transactions: [createMockTransaction()],
           hasMore: true,
-          nextPage: "next_cursor",
           totalCount: 1
         }
       : overrides.data;

--- a/apps/deploy-web/src/components/billing-usage/BillingContainer/BillingContainer.tsx
+++ b/apps/deploy-web/src/components/billing-usage/BillingContainer/BillingContainer.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import type { Charge } from "@akashnetwork/http-sdk";
+import type { BillingTransaction } from "@akashnetwork/http-sdk";
 import { useToast } from "@akashnetwork/ui/hooks";
 import type { PaginationState } from "@tanstack/react-table";
 import axios from "axios";
@@ -14,7 +14,7 @@ const DEPENDENCIES = {
 };
 
 export type ChildrenProps = {
-  data: Charge[];
+  data: BillingTransaction[];
   hasMore: boolean;
   hasPrevious: boolean;
   isFetching: boolean;
@@ -33,23 +33,11 @@ type BillingContainerProps = {
   dependencies?: typeof DEPENDENCIES;
 };
 
-type CursorHistoryItem = {
-  startingAfter?: string | null;
-  endingBefore?: string | null;
-  pageIndex: number;
-};
-
 export const BillingContainer: React.FC<BillingContainerProps> = ({ children, dependencies: D = DEPENDENCIES }) => {
   const { toast } = useToast();
   const { stripe } = useServices();
   const [dateRange, setDateRange] = React.useState<{ from: Date; to: Date }>(() => createDateRange());
   const [pagination, setPagination] = useState<PaginationState>({ pageIndex: 0, pageSize: 10 });
-  const [currentCursors, setCurrentCursors] = useState<{
-    startingAfter?: string | null;
-    endingBefore?: string | null;
-  }>({});
-
-  const [cursorHistory, setCursorHistory] = useState<CursorHistoryItem[]>([{ pageIndex: 0 }]);
 
   const [errorMessage, setErrorMessage] = React.useState("");
 
@@ -62,8 +50,7 @@ export const BillingContainer: React.FC<BillingContainerProps> = ({ children, de
     error: queryError
   } = D.usePaymentTransactionsQuery({
     limit: pagination.pageSize,
-    startingAfter: currentCursors.startingAfter,
-    endingBefore: currentCursors.endingBefore,
+    offset: pagination.pageIndex * pagination.pageSize,
     startDate,
     endDate
   });
@@ -75,56 +62,11 @@ export const BillingContainer: React.FC<BillingContainerProps> = ({ children, de
   }, [queryError]);
 
   const handlePaginationChange = (state: PaginationState) => {
-    const isForward = state.pageIndex > pagination.pageIndex;
-    const isBackward = state.pageIndex < pagination.pageIndex;
-
-    if (isForward && data?.nextPage) {
-      const newCursors = {
-        startingAfter: data.nextPage,
-        endingBefore: undefined
-      };
-
-      setCurrentCursors(newCursors);
-
-      setCursorHistory(prev => [
-        ...prev,
-        {
-          startingAfter: data.nextPage,
-          pageIndex: state.pageIndex
-        }
-      ]);
-    } else if (isBackward) {
-      const targetHistoryItem = cursorHistory.find(item => item.pageIndex === state.pageIndex);
-
-      if (targetHistoryItem) {
-        setCurrentCursors({
-          startingAfter: targetHistoryItem.startingAfter,
-          endingBefore: targetHistoryItem.endingBefore
-        });
-
-        setCursorHistory(prev => prev.filter(item => item.pageIndex <= state.pageIndex));
-      } else if (state.pageIndex === 0) {
-        setCurrentCursors({});
-        setCursorHistory([{ pageIndex: 0 }]);
-      }
-    } else if (state.pageSize !== pagination.pageSize) {
-      setCurrentCursors({});
-      setCursorHistory([{ pageIndex: 0 }]);
-      setPagination(prev => ({
-        ...prev,
-        pageIndex: 0,
-        pageSize: state.pageSize
-      }));
-      return;
-    }
-
-    setPagination(state);
+    setPagination(state.pageSize !== pagination.pageSize ? { pageIndex: 0, pageSize: state.pageSize } : state);
   };
 
   const changeDateRange = (range: { from: Date; to: Date }) => {
     setDateRange(createDateRange(range));
-    setCurrentCursors({});
-    setCursorHistory([{ pageIndex: 0 }]);
     setPagination(prev => ({ ...prev, pageIndex: 0 }));
     setErrorMessage("");
   };

--- a/apps/deploy-web/src/components/billing-usage/BillingView/BillingView.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/BillingView/BillingView.spec.tsx
@@ -1,8 +1,7 @@
 import React from "react";
-import type { Charge } from "@akashnetwork/http-sdk";
+import type { BillingTransaction } from "@akashnetwork/http-sdk";
 import { TooltipProvider } from "@akashnetwork/ui/components";
 import { describe, expect, it, vi } from "vitest";
-import { mock } from "vitest-mock-extended";
 
 import type { BillingViewProps } from "./BillingView";
 import { BillingView } from "./BillingView";
@@ -27,33 +26,54 @@ describe(BillingView.name, () => {
     expect(screen.getByText(/No billing history found/i)).toBeInTheDocument();
   });
 
-  it("renders table with billing data", () => {
-    const { data } = setup();
+  it("renders table headers", () => {
+    setup();
     expect(screen.getByText("History")).toBeInTheDocument();
     expect(screen.getByText("Date")).toBeInTheDocument();
+    expect(screen.getByText("Type")).toBeInTheDocument();
+    expect(screen.getByText("Description")).toBeInTheDocument();
     expect(screen.getByText("Amount")).toBeInTheDocument();
-    expect(screen.getByText("Account source")).toBeInTheDocument();
     expect(screen.getByText("Status")).toBeInTheDocument();
     expect(screen.getByText("Receipt")).toBeInTheDocument();
+  });
 
-    expect(screen.getByText(new Date(data[0].created * 1000).toLocaleDateString())).toBeInTheDocument();
+  it("renders the type badge label for each transaction type", () => {
+    setup({
+      data: [
+        createMockTransaction({ type: "payment_intent" }),
+        createMockTransaction({ type: "coupon_claim" }),
+        createMockTransaction({ type: "manual_credit" })
+      ]
+    });
+
+    expect(screen.getByText("Card Payment")).toBeInTheDocument();
+    expect(screen.getByText("Coupon")).toBeInTheDocument();
+    expect(screen.getByText("Manual Credit")).toBeInTheDocument();
+  });
+
+  it("shows the card brand and last4 under a card payment", () => {
+    setup({ data: [createMockTransaction({ type: "payment_intent", cardBrand: "visa", cardLast4: "4242" })] });
+
+    expect(screen.getByText(/Visa/)).toBeInTheDocument();
+    expect(screen.getByText(/4242/)).toBeInTheDocument();
+  });
+
+  it("renders the description, falling back to N/A when missing", () => {
+    setup({
+      data: [createMockTransaction({ description: "Wallet top-up" }), createMockTransaction({ description: null })]
+    });
+
+    expect(screen.getByText("Wallet top-up")).toBeInTheDocument();
+    expect(screen.getByText("N/A")).toBeInTheDocument();
+  });
+
+  it("renders the transaction amount", () => {
+    const { data } = setup({ data: [createMockTransaction({ amount: 25000, status: "succeeded" })] });
     expect(screen.getByText((data[0].amount / 100).toFixed(2))).toBeInTheDocument();
-    expect(screen.getByText(new RegExp(data[0].paymentMethod.card?.last4 || ""))).toBeInTheDocument();
-    expect(screen.getByText(/Succeeded|Pending|Failed/i)).toBeInTheDocument();
   });
 
   it("shows the first-purchase bonus under the amount when present", () => {
-    const transaction = createMockTransaction({ amount: 25000, status: "succeeded" });
-    setup({
-      data: [
-        mock<Charge>({
-          ...transaction,
-          paymentMethod: transaction.payment_method,
-          receiptUrl: "https://example.com/receipt",
-          bonusAmount: 1000
-        })
-      ]
-    });
+    setup({ data: [createMockTransaction({ amount: 25000, bonusAmount: 1000 })] });
 
     expect(screen.getByText("250.00")).toBeInTheDocument();
     expect(screen.getByText("10.00")).toBeInTheDocument();
@@ -61,19 +81,35 @@ describe(BillingView.name, () => {
   });
 
   it("renders no bonus line when the transaction has no bonus", () => {
-    const transaction = createMockTransaction({ amount: 25000, status: "succeeded" });
-    setup({
-      data: [
-        mock<Charge>({
-          ...transaction,
-          paymentMethod: transaction.payment_method,
-          receiptUrl: "https://example.com/receipt",
-          bonusAmount: 0
-        })
-      ]
-    });
+    setup({ data: [createMockTransaction({ amount: 25000, bonusAmount: 0 })] });
 
     expect(screen.queryByText(/bonus/)).not.toBeInTheDocument();
+  });
+
+  it("shows the refunded amount when the transaction has a refund", () => {
+    setup({ data: [createMockTransaction({ amount: 25000, amountRefunded: 5000, status: "refunded" })] });
+
+    expect(screen.getByText("50.00")).toBeInTheDocument();
+    expect(screen.getByText(/refunded/)).toBeInTheDocument();
+    expect(screen.getByText("Refunded")).toBeInTheDocument();
+  });
+
+  it("renders no refunded line when nothing was refunded", () => {
+    setup({ data: [createMockTransaction({ amount: 25000, amountRefunded: 0 })] });
+
+    expect(screen.queryByText(/refunded/i)).not.toBeInTheDocument();
+  });
+
+  it("renders a receipt link when a receipt url is present", () => {
+    setup({ data: [createMockTransaction({ receiptUrl: "https://example.com/receipt" })] });
+    const receiptLink = screen.getAllByRole("link").find(link => link.getAttribute("target") === "_blank");
+    expect(receiptLink).toHaveAttribute("href", "https://example.com/receipt");
+  });
+
+  it("renders no receipt link when the receipt url is missing", () => {
+    setup({ data: [createMockTransaction({ receiptUrl: null })] });
+    const receiptLink = screen.queryAllByRole("link").find(link => link.getAttribute("target") === "_blank");
+    expect(receiptLink).toBeUndefined();
   });
 
   it("calls onPaginationChange when changing page size", () => {
@@ -146,13 +182,7 @@ describe(BillingView.name, () => {
   });
 
   function setup(props: Partial<React.ComponentProps<typeof BillingView>> = {}) {
-    const defaultData = createMockItems(createMockTransaction, 1).map((t: ReturnType<typeof createMockTransaction>) =>
-      mock<Charge>({
-        ...t,
-        paymentMethod: t.payment_method,
-        receiptUrl: "https://example.com/receipt"
-      })
-    );
+    const defaultData: BillingTransaction[] = createMockItems(createMockTransaction, 1);
 
     const defaultComponents: NonNullable<BillingViewProps["components"]> = {
       FormattedNumber: ({ value }) => <span>{value.toFixed(2)}</span>,

--- a/apps/deploy-web/src/components/billing-usage/BillingView/BillingView.tsx
+++ b/apps/deploy-web/src/components/billing-usage/BillingView/BillingView.tsx
@@ -1,12 +1,11 @@
 import React from "react";
 import { FormattedNumber } from "react-intl";
-import type { Charge } from "@akashnetwork/http-sdk";
+import type { BillingTransaction } from "@akashnetwork/http-sdk";
 import {
   Alert,
   AlertDescription,
   AlertTitle,
   Button,
-  CustomTooltip,
   DateRangePicker,
   Label,
   Pagination,
@@ -41,8 +40,32 @@ export const COMPONENTS = {
   PaginationSizeSelector
 };
 
+const TRANSACTION_TYPE_LABELS: Record<BillingTransaction["type"], string> = {
+  payment_intent: "Card Payment",
+  coupon_claim: "Coupon",
+  manual_credit: "Manual Credit"
+};
+
+const TRANSACTION_TYPE_BADGE_CLASSES: Record<BillingTransaction["type"], string> = {
+  coupon_claim: "bg-blue-100 text-blue-800",
+  manual_credit: "bg-gray-100 text-gray-800",
+  payment_intent: "bg-gray-100 text-gray-800"
+};
+
+const STATUS_BADGE_CLASSES: Record<string, string> = {
+  succeeded: "bg-green-100 text-green-800",
+  pending: "bg-yellow-100 text-yellow-800",
+  failed: "bg-red-100 text-red-800",
+  refunded: "bg-blue-100 text-blue-800"
+};
+
+const DEFAULT_STATUS_BADGE_CLASS = "bg-gray-100 text-gray-800";
+
+/** Coupon claims and manual credits top up the wallet, so their amount reads as money in (green +). */
+const isCreditTransaction = (type: BillingTransaction["type"]) => type === "coupon_claim" || type === "manual_credit";
+
 export type BillingViewProps = {
-  data: Charge[];
+  data: BillingTransaction[];
   hasMore: boolean;
   hasPrevious: boolean;
   isFetching: boolean;
@@ -72,36 +95,60 @@ export const BillingView: React.FC<BillingViewProps> = ({
   components: { FormattedNumber, DateRangePicker, PaginationSizeSelector } = COMPONENTS
 }) => {
   const oneYearAgo = startOfDay(subYears(new Date(), 1));
-  const columnHelper = createColumnHelper<Charge>();
+  const columnHelper = createColumnHelper<BillingTransaction>();
 
   const columns = [
     columnHelper.accessor("created", {
       header: "Date",
       cell: info => new Date(info.getValue() * 1000).toLocaleDateString()
     }),
-    columnHelper.accessor("amount", {
-      header: "Amount",
+    columnHelper.accessor("type", {
+      header: "Type",
       cell: info => {
-        const { currency, bonusAmount = 0 } = info.row.original;
+        const { cardBrand, cardLast4 } = info.row.original;
+        const type = info.getValue();
         return (
           <div>
-            <FormattedNumber value={info.getValue() / 100} style="currency" currency={currency} currencyDisplay="narrowSymbol" />
-            {bonusAmount > 0 && (
-              <div className="text-xs font-medium text-primary">
-                +<FormattedNumber value={bonusAmount / 100} style="currency" currency={currency} currencyDisplay="narrowSymbol" /> bonus
+            <span className={cn("inline-flex items-center justify-center rounded-full px-2 py-1 text-xs font-semibold", TRANSACTION_TYPE_BADGE_CLASSES[type])}>
+              {TRANSACTION_TYPE_LABELS[type]}
+            </span>
+            {cardLast4 && (
+              <div className="mt-1 text-xs text-muted-foreground">
+                {cardBrand ? `${capitalizeFirstLetter(cardBrand)} ` : ""}**** {cardLast4}
               </div>
             )}
           </div>
         );
       }
     }),
-    columnHelper.accessor("paymentMethod.card.brand", {
-      header: "Account source",
+    columnHelper.accessor("amount", {
+      header: "Amount",
       cell: info => {
-        const { card } = info.row.original.paymentMethod;
-        if (!card) return "N/A";
-        return `${capitalizeFirstLetter(card.brand)} **** ${card.last4}`;
+        const { currency, bonusAmount = 0, amountRefunded = 0, type } = info.row.original;
+        const isCredit = isCreditTransaction(type);
+        return (
+          <div>
+            <span className={cn(isCredit && "font-medium text-green-600 dark:text-green-500")}>
+              {isCredit && "+"}
+              <FormattedNumber value={info.getValue() / 100} style="currency" currency={currency} currencyDisplay="narrowSymbol" />
+            </span>
+            {bonusAmount > 0 && (
+              <div className="text-xs font-medium text-primary">
+                +<FormattedNumber value={bonusAmount / 100} style="currency" currency={currency} currencyDisplay="narrowSymbol" /> bonus
+              </div>
+            )}
+            {amountRefunded > 0 && (
+              <div className="text-xs font-medium text-muted-foreground">
+                -<FormattedNumber value={amountRefunded / 100} style="currency" currency={currency} currencyDisplay="narrowSymbol" /> refunded
+              </div>
+            )}
+          </div>
+        );
       }
+    }),
+    columnHelper.accessor("description", {
+      header: "Description",
+      cell: info => info.getValue() || "N/A"
     }),
     columnHelper.accessor("status", {
       header: "Status",
@@ -109,13 +156,7 @@ export const BillingView: React.FC<BillingViewProps> = ({
         <div
           className={cn(
             "inline-flex items-center justify-center rounded-full px-2 py-1 text-xs font-semibold",
-            info.getValue() === "succeeded"
-              ? "bg-green-100 text-green-800"
-              : info.getValue() === "pending"
-                ? "bg-yellow-100 text-yellow-800"
-                : info.getValue() === "failed"
-                  ? "bg-red-100 text-red-800"
-                  : "bg-gray-100 text-gray-800"
+            STATUS_BADGE_CLASSES[info.getValue()] ?? DEFAULT_STATUS_BADGE_CLASS
           )}
         >
           {capitalizeFirstLetter(info.getValue())}
@@ -125,15 +166,17 @@ export const BillingView: React.FC<BillingViewProps> = ({
     columnHelper.display({
       id: "receipt",
       header: "Receipt",
-      cell: info => (
-        <CustomTooltip title={<p className="text-sm">View Receipt on Stripe</p>}>
-          <Link href={info.row.original.receiptUrl || "#"} target="_blank" rel="noopener noreferrer">
+      cell: info => {
+        const { receiptUrl } = info.row.original;
+        if (!receiptUrl) return null;
+        return (
+          <Link href={receiptUrl} target="_blank" rel="noopener noreferrer" aria-label="View receipt on Stripe">
             <Button size="icon" variant="ghost" className="text-black hover:bg-primary hover:text-white dark:text-white">
               <Page width={16} />
             </Button>
           </Link>
-        </CustomTooltip>
-      )
+        );
+      }
     })
   ];
 
@@ -171,7 +214,7 @@ export const BillingView: React.FC<BillingViewProps> = ({
     );
   }
 
-  const columnClasses = ["w-32 px-4 py-2", "w-32 px-4 py-2", "w-32 px-4 py-2", "w-32 px-4 py-2", "w-4 px-4 py-2"];
+  const columnClasses = ["w-28 px-4 py-2", "w-40 px-4 py-2", "w-32 px-4 py-2", "w-48 px-4 py-2", "w-28 px-4 py-2", "w-16 px-4 py-2"];
 
   return (
     <div className="space-y-2">

--- a/apps/deploy-web/src/components/billing-usage/BillingView/BillingView.tsx
+++ b/apps/deploy-web/src/components/billing-usage/BillingView/BillingView.tsx
@@ -52,6 +52,8 @@ const TRANSACTION_TYPE_BADGE_CLASSES: Record<BillingTransaction["type"], string>
   payment_intent: "bg-gray-100 text-gray-800"
 };
 
+const DEFAULT_TRANSACTION_TYPE_BADGE_CLASS = "bg-gray-100 text-gray-800";
+
 const STATUS_BADGE_CLASSES: Record<string, string> = {
   succeeded: "bg-green-100 text-green-800",
   pending: "bg-yellow-100 text-yellow-800",
@@ -109,8 +111,13 @@ export const BillingView: React.FC<BillingViewProps> = ({
         const type = info.getValue();
         return (
           <div>
-            <span className={cn("inline-flex items-center justify-center rounded-full px-2 py-1 text-xs font-semibold", TRANSACTION_TYPE_BADGE_CLASSES[type])}>
-              {TRANSACTION_TYPE_LABELS[type]}
+            <span
+              className={cn(
+                "inline-flex items-center justify-center rounded-full px-2 py-1 text-xs font-semibold",
+                TRANSACTION_TYPE_BADGE_CLASSES[type] ?? DEFAULT_TRANSACTION_TYPE_BADGE_CLASS
+              )}
+            >
+              {TRANSACTION_TYPE_LABELS[type] ?? capitalizeFirstLetter(type)}
             </span>
             {cardLast4 && (
               <div className="mt-1 text-xs text-muted-foreground">

--- a/apps/deploy-web/src/components/billing-usage/FirstPurchaseBonusAlert/FirstPurchaseBonusAlert.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/FirstPurchaseBonusAlert/FirstPurchaseBonusAlert.spec.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { IntlProvider } from "react-intl";
-import type { Charge } from "@akashnetwork/http-sdk";
+import type { BillingTransaction } from "@akashnetwork/http-sdk";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
@@ -17,7 +17,7 @@ describe(FirstPurchaseBonusAlert.name, () => {
   });
 
   it("renders nothing when the user already has a succeeded charge", () => {
-    const { container } = setup({ transactions: [mock<Charge>({ status: "succeeded" })] });
+    const { container } = setup({ transactions: [mock<BillingTransaction>({ status: "succeeded" })] });
 
     expect(container).toBeEmptyDOMElement();
   });
@@ -31,7 +31,7 @@ describe(FirstPurchaseBonusAlert.name, () => {
   });
 
   it("shows the offer to users whose only charges failed", () => {
-    setup({ amount: 0, transactions: [mock<Charge>({ status: "failed" })] });
+    setup({ amount: 0, transactions: [mock<BillingTransaction>({ status: "failed" })] });
 
     expect(screen.getByText("First-purchase bonus")).toBeInTheDocument();
   });
@@ -66,7 +66,7 @@ describe(FirstPurchaseBonusAlert.name, () => {
     expect(container).not.toHaveTextContent("more to unlock");
   });
 
-  function setup(input?: { amount?: number; isSuccess?: boolean; transactions?: Charge[] }) {
+  function setup(input?: { amount?: number; isSuccess?: boolean; transactions?: BillingTransaction[] }) {
     // UseQueryResult is a discriminated union that neither mock<T>() nor a partial literal can satisfy
     const usePaymentTransactionsQuery = vi.fn(() => ({
       data: { transactions: input?.transactions ?? [] },

--- a/apps/deploy-web/src/queries/queryKeys.spec.ts
+++ b/apps/deploy-web/src/queries/queryKeys.spec.ts
@@ -13,14 +13,9 @@ describe("QueryKeys", () => {
       expect(QueryKeys.getPaymentTransactionsKey({ limit: 50 })).toEqual(["STRIPE_TRANSACTIONS", "limit", "50"]);
     });
 
-    it("should return payment transactions key with startingAfter", () => {
-      expect(QueryKeys.getPaymentTransactionsKey({ startingAfter: "txn_123" })).toEqual(["STRIPE_TRANSACTIONS", "after", "txn_123"]);
-      expect(QueryKeys.getPaymentTransactionsKey({ startingAfter: "txn_456" })).toEqual(["STRIPE_TRANSACTIONS", "after", "txn_456"]);
-    });
-
-    it("should return payment transactions key with endingBefore", () => {
-      expect(QueryKeys.getPaymentTransactionsKey({ endingBefore: "txn_123" })).toEqual(["STRIPE_TRANSACTIONS", "before", "txn_123"]);
-      expect(QueryKeys.getPaymentTransactionsKey({ endingBefore: "txn_456" })).toEqual(["STRIPE_TRANSACTIONS", "before", "txn_456"]);
+    it("returns payment transactions key with offset", () => {
+      expect(QueryKeys.getPaymentTransactionsKey({ offset: 10 })).toEqual(["STRIPE_TRANSACTIONS", "offset", "10"]);
+      expect(QueryKeys.getPaymentTransactionsKey({ offset: 20 })).toEqual(["STRIPE_TRANSACTIONS", "offset", "20"]);
     });
 
     it("should return payment transactions key with created start_date", () => {
@@ -45,35 +40,22 @@ describe("QueryKeys", () => {
       ]);
     });
 
-    it("should return payment transactions key with multiple options", () => {
+    it("returns payment transactions key with multiple options", () => {
       const startDate = new Date(1234567890);
       const endDate = new Date(1234567900);
       expect(
         QueryKeys.getPaymentTransactionsKey({
           limit: 25,
-          startingAfter: "txn_123",
-          endingBefore: "txn_456",
+          offset: 50,
           startDate,
           endDate
         })
-      ).toEqual([
-        "STRIPE_TRANSACTIONS",
-        "limit",
-        "25",
-        "after",
-        "txn_123",
-        "before",
-        "txn_456",
-        "start_date",
-        startDate.toISOString(),
-        "end_date",
-        endDate.toISOString()
-      ]);
+      ).toEqual(["STRIPE_TRANSACTIONS", "limit", "25", "offset", "50", "start_date", startDate.toISOString(), "end_date", endDate.toISOString()]);
     });
 
-    it("should handle null values for startingAfter and endingBefore", () => {
-      expect(QueryKeys.getPaymentTransactionsKey({ startingAfter: null })).toEqual(["STRIPE_TRANSACTIONS"]);
-      expect(QueryKeys.getPaymentTransactionsKey({ endingBefore: null })).toEqual(["STRIPE_TRANSACTIONS"]);
+    it("omits offset when it is null or zero", () => {
+      expect(QueryKeys.getPaymentTransactionsKey({ offset: null })).toEqual(["STRIPE_TRANSACTIONS"]);
+      expect(QueryKeys.getPaymentTransactionsKey({ offset: 0 })).toEqual(["STRIPE_TRANSACTIONS"]);
     });
 
     it("should handle partial created options", () => {

--- a/apps/deploy-web/src/queries/queryKeys.ts
+++ b/apps/deploy-web/src/queries/queryKeys.ts
@@ -81,25 +81,15 @@ export class QueryKeys {
    */
   static getManagedWalletCreateMutationKey = () => ["MANAGED_WALLET_CREATE"];
 
-  static getPaymentTransactionsKey = (options?: {
-    limit?: number;
-    startingAfter?: string | null;
-    endingBefore?: string | null;
-    startDate?: Date | null;
-    endDate?: Date | null;
-  }) => {
+  static getPaymentTransactionsKey = (options?: { limit?: number; offset?: number | null; startDate?: Date | null; endDate?: Date | null }) => {
     const key = ["STRIPE_TRANSACTIONS"];
 
     if (options?.limit) {
       key.push("limit", options.limit.toString());
     }
 
-    if (options?.startingAfter) {
-      key.push("after", options.startingAfter);
-    }
-
-    if (options?.endingBefore) {
-      key.push("before", options.endingBefore);
+    if (options?.offset) {
+      key.push("offset", options.offset.toString());
     }
 
     if (options?.startDate) {

--- a/apps/deploy-web/src/queries/usePaymentQueries.ts
+++ b/apps/deploy-web/src/queries/usePaymentQueries.ts
@@ -45,8 +45,7 @@ export const useDefaultPaymentMethodQuery = (
 
 export interface UsePaymentTransactionsOptions {
   limit?: number;
-  startingAfter?: string | null;
-  endingBefore?: string | null;
+  offset?: number | null;
   startDate?: Date | null;
   endDate?: Date | null;
 }

--- a/apps/deploy-web/tests/seeders/payment.ts
+++ b/apps/deploy-web/tests/seeders/payment.ts
@@ -59,7 +59,7 @@ export const createMockTransaction = (overrides: Partial<BillingTransaction> = {
   bonusAmount: 0,
   currency: "usd",
   status: faker.helpers.arrayElement(["succeeded", "pending", "failed"]),
-  created: faker.date.past().getTime(),
+  created: Math.floor(faker.date.past().getTime() / 1000),
   cardBrand: "visa",
   cardLast4: faker.string.numeric(4),
   stripeInvoiceId: null,

--- a/apps/deploy-web/tests/seeders/payment.ts
+++ b/apps/deploy-web/tests/seeders/payment.ts
@@ -1,3 +1,4 @@
+import type { BillingTransaction } from "@akashnetwork/http-sdk";
 import { faker } from "@faker-js/faker";
 
 export const createMockPaymentMethod = (overrides = {}) => ({
@@ -50,13 +51,19 @@ export const createMockDiscount = (overrides = {}) => ({
   ...overrides
 });
 
-export const createMockTransaction = (overrides = {}) => ({
+export const createMockTransaction = (overrides: Partial<BillingTransaction> = {}): BillingTransaction => ({
   id: `pi_${faker.string.alphanumeric(24)}`,
+  type: "payment_intent",
   amount: faker.number.int({ min: 1000, max: 10000 }),
+  amountRefunded: 0,
+  bonusAmount: 0,
   currency: "usd",
   status: faker.helpers.arrayElement(["succeeded", "pending", "failed"]),
-  payment_method: createMockPaymentMethod(),
   created: faker.date.past().getTime(),
+  cardBrand: "visa",
+  cardLast4: faker.string.numeric(4),
+  stripeInvoiceId: null,
+  receiptUrl: faker.internet.url(),
   description: faker.helpers.arrayElement(["Monthly subscription", "One-time purchase", "Annual plan"]),
   ...overrides
 });

--- a/packages/http-sdk/src/stripe/stripe.service.spec.ts
+++ b/packages/http-sdk/src/stripe/stripe.service.spec.ts
@@ -7,10 +7,9 @@ describe(StripeService.name, () => {
   describe("getCustomerTransactions", () => {
     it("unwraps the API data envelope so transactions reach the caller", async () => {
       const payload = {
-        transactions: [{ id: "ch_123", amount: 2000 }],
-        hasMore: false,
-        nextPage: null,
-        prevPage: null
+        transactions: [{ id: "txn_123", type: "payment_intent", amount: 2000, amountRefunded: 0 }],
+        totalCount: 1,
+        hasMore: false
       };
       const { service } = setup({ payload });
 
@@ -18,6 +17,14 @@ describe(StripeService.name, () => {
 
       expect(result).toEqual(payload);
       expect(result.transactions).toHaveLength(1);
+    });
+
+    it("forwards limit and offset as query params", async () => {
+      const { service, httpClient } = setup();
+
+      await service.getCustomerTransactions({ limit: 10, offset: 20 });
+
+      expect(httpClient.get).toHaveBeenCalledWith("/v1/stripe/transactions?limit=10&offset=20");
     });
 
     it("throws when startDate is after endDate", async () => {
@@ -37,7 +44,7 @@ describe(StripeService.name, () => {
   });
 
   function setup(input?: { payload?: unknown }) {
-    const payload = input?.payload ?? { transactions: [], hasMore: false, nextPage: null, prevPage: null };
+    const payload = input?.payload ?? { transactions: [], totalCount: 0, hasMore: false };
     const httpClient = {
       get: vi.fn().mockResolvedValue({ data: { data: payload } })
     } as unknown as HttpClient & { get: ReturnType<typeof vi.fn> };

--- a/packages/http-sdk/src/stripe/stripe.service.ts
+++ b/packages/http-sdk/src/stripe/stripe.service.ts
@@ -60,7 +60,7 @@ export class StripeService {
   }
 
   async getCustomerTransactions(options?: CustomerTransactionsParams): Promise<CustomerTransactionsResponse> {
-    const { limit, startingAfter, endingBefore, startDate, endDate } = options || {};
+    const { limit, offset, startDate, endDate } = options || {};
 
     if (startDate && endDate && startDate >= endDate) {
       throw new Error("startDate must be less than endDate");
@@ -68,8 +68,7 @@ export class StripeService {
 
     const params = new URLSearchParams({
       ...(limit && { limit: limit.toString() }),
-      ...(startingAfter && { startingAfter }),
-      ...(endingBefore && { endingBefore }),
+      ...(offset && { offset: offset.toString() }),
       ...(startDate && { startDate: startDate.toISOString() }),
       ...(endDate && { endDate: endDate.toISOString() })
     });

--- a/packages/http-sdk/src/stripe/stripe.types.ts
+++ b/packages/http-sdk/src/stripe/stripe.types.ts
@@ -45,18 +45,24 @@ export interface PaymentMethod {
   } | null;
 }
 
-export interface Charge {
+export type BillingTransactionType = "payment_intent" | "coupon_claim" | "manual_credit";
+
+export interface BillingTransaction {
   id: string;
+  type: BillingTransactionType;
   amount: number;
+  /** Cumulative amount refunded on this transaction, in cents. */
+  amountRefunded: number;
   /** First-purchase bonus credited with this payment, in cents. */
   bonusAmount?: number;
   currency: string;
   status: string;
   created: number;
-  paymentMethod: PaymentMethod;
-  receiptUrl?: string;
-  description?: string;
-  metadata?: Record<string, string>;
+  cardBrand?: string | null;
+  cardLast4?: string | null;
+  stripeInvoiceId?: string | null;
+  receiptUrl?: string | null;
+  description?: string | null;
 }
 
 export interface Discount {
@@ -89,18 +95,15 @@ export interface ApplyCouponParams {
 
 export interface CustomerTransactionsParams {
   limit?: number;
-  startingAfter?: string | null;
-  endingBefore?: string | null;
+  offset?: number | null;
   startDate?: Date | null;
   endDate?: Date | null;
 }
 
 export interface CustomerTransactionsResponse {
-  transactions: Charge[];
-  hasMore: boolean;
-  nextPage: string | null;
-  prevPage: string | null;
+  transactions: BillingTransaction[];
   totalCount: number;
+  hasMore: boolean;
 }
 
 export interface ExportTransactionsCsvParams {


### PR DESCRIPTION
## Why

Part of CON-674 (backend half; the UI change is in the stacked follow-up PR).

The customer-facing **Billing → History** table only showed credit-card purchases. It was built from Stripe **charges**, so:

- **Coupon claims** and **manual credits** never appeared (they are Stripe invoices, not charges).
- **Refunds** never appeared (a refund reduces `amount_refunded` but leaves the charge `succeeded`).

Our internal `stripe_transactions` table already records every type and all refund state, so this sources the history from it instead, matching what the internal admin console shows.

This PR is the API/data half of what used to be #3500, rebased onto Yaro's `TransactionReportingService` extraction (#3499). It splits the old oversized PR in two; the deploy-web UI + http-sdk contract land in the stacked PR on top of this branch.

## What

`apps/api` only. No migrations.

- `TransactionReportingService.getCustomerTransactions` now reads `StripeTransactionRepository.findByUserId` + `countByUserId` (keyed on `userId`) instead of `stripe.charges.list`. Returns `{ transactions, totalCount, hasMore }` with offset pagination. The service no longer depends on the injected Stripe client.
- Flat transaction DTO: adds `type`, `amountRefunded`, `cardBrand`, `cardLast4`, `stripeInvoiceId`; drops the nested `paymentMethod`/`metadata`.
- `countByUserId` gains an optional `{ startDate, endDate }` filter.
- Controller retrieves by `currentUser.id` and drops the obsolete `stripeCustomerId` prerequisite, so coupon/manual-credit-only users are no longer excluded.
- Query param `startingAfter`/`endingBefore` -> `offset`, validated as a non-negative integer at parse time.
- CSV export gains `Type`, `Refunded`, and `Invoice ID` columns and yields a generic sanitized placeholder on a fetch error instead of the raw exception message.

### Needs verification before merge

**Historical completeness.** The old endpoint listed every Stripe charge; this DB-sourced list shows only rows in `stripe_transactions`. Any card payment predating that table (or never backfilled) would drop out of history. Please confirm against prod that historical `payment_intent` rows exist for older customers; if there is a gap, a one-time backfill of legacy charges is needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Switched billing transaction pagination to offset-based paging across API, client, and UI, including `totalCount` and date-range filtering.
  * Updated transaction details everywhere (new type badges, refunded amounts, card brand/last4, and invoice ID).
  * Refreshed transaction CSV export schema with new columns and streaming improvements.

* **Bug Fixes**
  * Standardized API response and query shapes so listing and exporting stay consistent.
  * Improved CSV output robustness (sanitized descriptions, safer handling of missing card details, and cleaned-up error messaging).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->