### PR TITLE
fix(billing): show all transaction types and refunds in history UI

### DIFF
--- a/apps/deploy-web/src/components/billing-usage/BillingContainer/BillingContainer.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/BillingContainer/BillingContainer.spec.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import type { Charge } from "@akashnetwork/http-sdk";
+import type { BillingTransaction } from "@akashnetwork/http-sdk";
 import type { PaginationState } from "@tanstack/react-table";
 import type { AxiosError } from "axios";
 import { describe, expect, it, type MockedFunction, vi } from "vitest";
@@ -66,7 +66,7 @@ describe(BillingContainer.name, () => {
 
   async function setup(
     overrides: Partial<{
-      data: { transactions: Charge[]; hasMore: boolean; nextPage?: string; totalCount: number };
+      data: { transactions: BillingTransaction[]; hasMore: boolean; totalCount: number };
       isFetching: boolean;
       isError: boolean;
       queryError: AxiosError;
@@ -77,7 +77,6 @@ describe(BillingContainer.name, () => {
       ? {
           transactions: [createMockTransaction()],
           hasMore: true,
-          nextPage: "next_cursor",
           totalCount: 1
         }
       : overrides.data;

--- a/apps/deploy-web/src/components/billing-usage/BillingContainer/BillingContainer.tsx
+++ b/apps/deploy-web/src/components/billing-usage/BillingContainer/BillingContainer.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import type { Charge } from "@akashnetwork/http-sdk";
+import type { BillingTransaction } from "@akashnetwork/http-sdk";
 import { useToast } from "@akashnetwork/ui/hooks";
 import type { PaginationState } from "@tanstack/react-table";
 import axios from "axios";
@@ -14,7 +14,7 @@ const DEPENDENCIES = {
 };
 
 export type ChildrenProps = {
-  data: Charge[];
+  data: BillingTransaction[];
   hasMore: boolean;
   hasPrevious: boolean;
   isFetching: boolean;
@@ -33,23 +33,11 @@ type BillingContainerProps = {
   dependencies?: typeof DEPENDENCIES;
 };
 
-type CursorHistoryItem = {
-  startingAfter?: string | null;
-  endingBefore?: string | null;
-  pageIndex: number;
-};
-
 export const BillingContainer: React.FC<BillingContainerProps> = ({ children, dependencies: D = DEPENDENCIES }) => {
   const { toast } = useToast();
   const { stripe } = useServices();
   const [dateRange, setDateRange] = React.useState<{ from: Date; to: Date }>(() => createDateRange());
   const [pagination, setPagination] = useState<PaginationState>({ pageIndex: 0, pageSize: 10 });
-  const [currentCursors, setCurrentCursors] = useState<{
-    startingAfter?: string | null;
-    endingBefore?: string | null;
-  }>({});
-
-  const [cursorHistory, setCursorHistory] = useState<CursorHistoryItem[]>([{ pageIndex: 0 }]);
 
   const [errorMessage, setErrorMessage] = React.useState("");
 
@@ -62,8 +50,7 @@ export const BillingContainer: React.FC<BillingContainerProps> = ({ children, de
     error: queryError
   } = D.usePaymentTransactionsQuery({
     limit: pagination.pageSize,
-    startingAfter: currentCursors.startingAfter,
-    endingBefore: currentCursors.endingBefore,
+    offset: pagination.pageIndex * pagination.pageSize,
     startDate,
     endDate
   });
@@ -75,56 +62,11 @@ export const BillingContainer: React.FC<BillingContainerProps> = ({ children, de
   }, [queryError]);
 
   const handlePaginationChange = (state: PaginationState) => {
-    const isForward = state.pageIndex > pagination.pageIndex;
-    const isBackward = state.pageIndex < pagination.pageIndex;
-
-    if (isForward && data?.nextPage) {
-      const newCursors = {
-        startingAfter: data.nextPage,
-        endingBefore: undefined
-      };
-
-      setCurrentCursors(newCursors);
-
-      setCursorHistory(prev => [
-        ...prev,
-        {
-          startingAfter: data.nextPage,
-          pageIndex: state.pageIndex
-        }
-      ]);
-    } else if (isBackward) {
-      const targetHistoryItem = cursorHistory.find(item => item.pageIndex === state.pageIndex);
-
-      if (targetHistoryItem) {
-        setCurrentCursors({
-          startingAfter: targetHistoryItem.startingAfter,
-          endingBefore: targetHistoryItem.endingBefore
-        });
-
-        setCursorHistory(prev => prev.filter(item => item.pageIndex <= state.pageIndex));
-      } else if (state.pageIndex === 0) {
-        setCurrentCursors({});
-        setCursorHistory([{ pageIndex: 0 }]);
-      }
-    } else if (state.pageSize !== pagination.pageSize) {
-      setCurrentCursors({});
-      setCursorHistory([{ pageIndex: 0 }]);
-      setPagination(prev => ({
-        ...prev,
-        pageIndex: 0,
-        pageSize: state.pageSize
-      }));
-      return;
-    }
-
-    setPagination(state);
+    setPagination(state.pageSize !== pagination.pageSize ? { pageIndex: 0, pageSize: state.pageSize } : state);
   };
 
   const changeDateRange = (range: { from: Date; to: Date }) => {
     setDateRange(createDateRange(range));
-    setCurrentCursors({});
-    setCursorHistory([{ pageIndex: 0 }]);
     setPagination(prev => ({ ...prev, pageIndex: 0 }));
     setErrorMessage("");
   };

--- a/apps/deploy-web/src/components/billing-usage/BillingView/BillingView.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/BillingView/BillingView.spec.tsx
@@ -1,8 +1,7 @@
 import React from "react";
-import type { Charge } from "@akashnetwork/http-sdk";
+import type { BillingTransaction } from "@akashnetwork/http-sdk";
 import { TooltipProvider } from "@akashnetwork/ui/components";
 import { describe, expect, it, vi } from "vitest";
-import { mock } from "vitest-mock-extended";
 
 import type { BillingViewProps } from "./BillingView";
 import { BillingView } from "./BillingView";
@@ -27,33 +26,54 @@ describe(BillingView.name, () => {
     expect(screen.getByText(/No billing history found/i)).toBeInTheDocument();
   });
 
-  it("renders table with billing data", () => {
-    const { data } = setup();
+  it("renders table headers", () => {
+    setup();
     expect(screen.getByText("History")).toBeInTheDocument();
     expect(screen.getByText("Date")).toBeInTheDocument();
+    expect(screen.getByText("Type")).toBeInTheDocument();
+    expect(screen.getByText("Description")).toBeInTheDocument();
     expect(screen.getByText("Amount")).toBeInTheDocument();
-    expect(screen.getByText("Account source")).toBeInTheDocument();
     expect(screen.getByText("Status")).toBeInTheDocument();
     expect(screen.getByText("Receipt")).toBeInTheDocument();
+  });
 
-    expect(screen.getByText(new Date(data[0].created * 1000).toLocaleDateString())).toBeInTheDocument();
+  it("renders the type badge label for each transaction type", () => {
+    setup({
+      data: [
+        createMockTransaction({ type: "payment_intent" }),
+        createMockTransaction({ type: "coupon_claim" }),
+        createMockTransaction({ type: "manual_credit" })
+      ]
+    });
+
+    expect(screen.getByText("Card Payment")).toBeInTheDocument();
+    expect(screen.getByText("Coupon")).toBeInTheDocument();
+    expect(screen.getByText("Manual Credit")).toBeInTheDocument();
+  });
+
+  it("shows the card brand and last4 under a card payment", () => {
+    setup({ data: [createMockTransaction({ type: "payment_intent", cardBrand: "visa", cardLast4: "4242" })] });
+
+    expect(screen.getByText(/Visa/)).toBeInTheDocument();
+    expect(screen.getByText(/4242/)).toBeInTheDocument();
+  });
+
+  it("renders the description, falling back to N/A when missing", () => {
+    setup({
+      data: [createMockTransaction({ description: "Wallet top-up" }), createMockTransaction({ description: null })]
+    });
+
+    expect(screen.getByText("Wallet top-up")).toBeInTheDocument();
+    expect(screen.getByText("N/A")).toBeInTheDocument();
+  });
+
+  it("renders the transaction amount", () => {
+    const { data } = setup({ data: [createMockTransaction({ amount: 25000, status: "succeeded" })] });
     expect(screen.getByText((data[0].amount / 100).toFixed(2))).toBeInTheDocument();
-    expect(screen.getByText(new RegExp(data[0].paymentMethod.card?.last4 || ""))).toBeInTheDocument();
-    expect(screen.getByText(/Succeeded|Pending|Failed/i)).toBeInTheDocument();
   });
 
   it("shows the first-purchase bonus under the amount when present", () => {
-    const transaction = createMockTransaction({ amount: 25000, status: "succeeded" });
-    setup({
-      data: [
-        mock<Charge>({
-          ...transaction,
-          paymentMethod: transaction.payment_method,
-          receiptUrl: "https://example.com/receipt",
-          bonusAmount: 1000
-        })
-      ]
-    });
+    setup({ data: [createMockTransaction({ amount: 25000, bonusAmount: 1000 })] });
 
     expect(screen.getByText("250.00")).toBeInTheDocument();
     expect(screen.getByText("10.00")).toBeInTheDocument();
@@ -61,19 +81,35 @@ describe(BillingView.name, () => {
   });
 
   it("renders no bonus line when the transaction has no bonus", () => {
-    const transaction = createMockTransaction({ amount: 25000, status: "succeeded" });
-    setup({
-      data: [
-        mock<Charge>({
-          ...transaction,
-          paymentMethod: transaction.payment_method,
-          receiptUrl: "https://example.com/receipt",
-          bonusAmount: 0
-        })
-      ]
-    });
+    setup({ data: [createMockTransaction({ amount: 25000, bonusAmount: 0 })] });
 
     expect(screen.queryByText(/bonus/)).not.toBeInTheDocument();
+  });
+
+  it("shows the refunded amount when the transaction has a refund", () => {
+    setup({ data: [createMockTransaction({ amount: 25000, amountRefunded: 5000, status: "refunded" })] });
+
+    expect(screen.getByText("50.00")).toBeInTheDocument();
+    expect(screen.getByText(/refunded/)).toBeInTheDocument();
+    expect(screen.getByText("Refunded")).toBeInTheDocument();
+  });
+
+  it("renders no refunded line when nothing was refunded", () => {
+    setup({ data: [createMockTransaction({ amount: 25000, amountRefunded: 0 })] });
+
+    expect(screen.queryByText(/refunded/i)).not.toBeInTheDocument();
+  });
+
+  it("renders a receipt link when a receipt url is present", () => {
+    setup({ data: [createMockTransaction({ receiptUrl: "https://example.com/receipt" })] });
+    const receiptLink = screen.getAllByRole("link").find(link => link.getAttribute("target") === "_blank");
+    expect(receiptLink).toHaveAttribute("href", "https://example.com/receipt");
+  });
+
+  it("renders no receipt link when the receipt url is missing", () => {
+    setup({ data: [createMockTransaction({ receiptUrl: null })] });
+    const receiptLink = screen.queryAllByRole("link").find(link => link.getAttribute("target") === "_blank");
+    expect(receiptLink).toBeUndefined();
   });
 
   it("calls onPaginationChange when changing page size", () => {
@@ -146,13 +182,7 @@ describe(BillingView.name, () => {
   });
 
   function setup(props: Partial<React.ComponentProps<typeof BillingView>> = {}) {
-    const defaultData = createMockItems(createMockTransaction, 1).map((t: ReturnType<typeof createMockTransaction>) =>
-      mock<Charge>({
-        ...t,
-        paymentMethod: t.payment_method,
-        receiptUrl: "https://example.com/receipt"
-      })
-    );
+    const defaultData: BillingTransaction[] = createMockItems(createMockTransaction, 1);
 
     const defaultComponents: NonNullable<BillingViewProps["components"]> = {
       FormattedNumber: ({ value }) => <span>{value.toFixed(2)}</span>,

--- a/apps/deploy-web/src/components/billing-usage/BillingView/BillingView.tsx
+++ b/apps/deploy-web/src/components/billing-usage/BillingView/BillingView.tsx
@@ -121,10 +121,6 @@ export const BillingView: React.FC<BillingViewProps> = ({
         );
       }
     }),
-    columnHelper.accessor("description", {
-      header: "Description",
-      cell: info => info.getValue() || "N/A"
-    }),
     columnHelper.accessor("amount", {
       header: "Amount",
       cell: info => {
@@ -149,6 +145,10 @@ export const BillingView: React.FC<BillingViewProps> = ({
           </div>
         );
       }
+    }),
+    columnHelper.accessor("description", {
+      header: "Description",
+      cell: info => info.getValue() || "N/A"
     }),
     columnHelper.accessor("status", {
       header: "Status",
@@ -214,7 +214,7 @@ export const BillingView: React.FC<BillingViewProps> = ({
     );
   }
 
-  const columnClasses = ["w-28 px-4 py-2", "w-40 px-4 py-2", "w-48 px-4 py-2", "w-32 px-4 py-2", "w-28 px-4 py-2", "w-16 px-4 py-2"];
+  const columnClasses = ["w-28 px-4 py-2", "w-40 px-4 py-2", "w-32 px-4 py-2", "w-48 px-4 py-2", "w-28 px-4 py-2", "w-16 px-4 py-2"];
 
   return (
     <div className="space-y-2">

--- a/apps/deploy-web/src/components/billing-usage/BillingView/BillingView.tsx
+++ b/apps/deploy-web/src/components/billing-usage/BillingView/BillingView.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { FormattedNumber } from "react-intl";
-import type { Charge } from "@akashnetwork/http-sdk";
+import type { BillingTransaction } from "@akashnetwork/http-sdk";
 import {
   Alert,
   AlertDescription,
@@ -41,8 +41,32 @@ export const COMPONENTS = {
   PaginationSizeSelector
 };
 
+const TRANSACTION_TYPE_LABELS: Record<BillingTransaction["type"], string> = {
+  payment_intent: "Card Payment",
+  coupon_claim: "Coupon",
+  manual_credit: "Manual Credit"
+};
+
+const TRANSACTION_TYPE_BADGE_CLASSES: Record<BillingTransaction["type"], string> = {
+  coupon_claim: "bg-blue-100 text-blue-800",
+  manual_credit: "bg-gray-100 text-gray-800",
+  payment_intent: "bg-gray-100 text-gray-800"
+};
+
+const STATUS_BADGE_CLASSES: Record<string, string> = {
+  succeeded: "bg-green-100 text-green-800",
+  pending: "bg-yellow-100 text-yellow-800",
+  failed: "bg-red-100 text-red-800",
+  refunded: "bg-blue-100 text-blue-800"
+};
+
+const DEFAULT_STATUS_BADGE_CLASS = "bg-gray-100 text-gray-800";
+
+/** Coupon claims and manual credits top up the wallet, so their amount reads as money in (green +). */
+const isCreditTransaction = (type: BillingTransaction["type"]) => type === "coupon_claim" || type === "manual_credit";
+
 export type BillingViewProps = {
-  data: Charge[];
+  data: BillingTransaction[];
   hasMore: boolean;
   hasPrevious: boolean;
   isFetching: boolean;
@@ -72,35 +96,59 @@ export const BillingView: React.FC<BillingViewProps> = ({
   components: { FormattedNumber, DateRangePicker, PaginationSizeSelector } = COMPONENTS
 }) => {
   const oneYearAgo = startOfDay(subYears(new Date(), 1));
-  const columnHelper = createColumnHelper<Charge>();
+  const columnHelper = createColumnHelper<BillingTransaction>();
 
   const columns = [
     columnHelper.accessor("created", {
       header: "Date",
       cell: info => new Date(info.getValue() * 1000).toLocaleDateString()
     }),
-    columnHelper.accessor("amount", {
-      header: "Amount",
+    columnHelper.accessor("type", {
+      header: "Type",
       cell: info => {
-        const { currency, bonusAmount = 0 } = info.row.original;
+        const { cardBrand, cardLast4 } = info.row.original;
+        const type = info.getValue();
         return (
           <div>
-            <FormattedNumber value={info.getValue() / 100} style="currency" currency={currency} currencyDisplay="narrowSymbol" />
-            {bonusAmount > 0 && (
-              <div className="text-xs font-medium text-primary">
-                +<FormattedNumber value={bonusAmount / 100} style="currency" currency={currency} currencyDisplay="narrowSymbol" /> bonus
+            <span className={cn("inline-flex items-center justify-center rounded-full px-2 py-1 text-xs font-semibold", TRANSACTION_TYPE_BADGE_CLASSES[type])}>
+              {TRANSACTION_TYPE_LABELS[type]}
+            </span>
+            {cardLast4 && (
+              <div className="mt-1 text-xs text-muted-foreground">
+                {cardBrand ? `${capitalizeFirstLetter(cardBrand)} ` : ""}**** {cardLast4}
               </div>
             )}
           </div>
         );
       }
     }),
-    columnHelper.accessor("paymentMethod.card.brand", {
-      header: "Account source",
+    columnHelper.accessor("description", {
+      header: "Description",
+      cell: info => info.getValue() || "N/A"
+    }),
+    columnHelper.accessor("amount", {
+      header: "Amount",
       cell: info => {
-        const { card } = info.row.original.paymentMethod;
-        if (!card) return "N/A";
-        return `${capitalizeFirstLetter(card.brand)} **** ${card.last4}`;
+        const { currency, bonusAmount = 0, amountRefunded = 0, type } = info.row.original;
+        const isCredit = isCreditTransaction(type);
+        return (
+          <div>
+            <span className={cn(isCredit && "font-medium text-green-600 dark:text-green-500")}>
+              {isCredit && "+"}
+              <FormattedNumber value={info.getValue() / 100} style="currency" currency={currency} currencyDisplay="narrowSymbol" />
+            </span>
+            {bonusAmount > 0 && (
+              <div className="text-xs font-medium text-primary">
+                +<FormattedNumber value={bonusAmount / 100} style="currency" currency={currency} currencyDisplay="narrowSymbol" /> bonus
+              </div>
+            )}
+            {amountRefunded > 0 && (
+              <div className="text-xs font-medium text-muted-foreground">
+                -<FormattedNumber value={amountRefunded / 100} style="currency" currency={currency} currencyDisplay="narrowSymbol" /> refunded
+              </div>
+            )}
+          </div>
+        );
       }
     }),
     columnHelper.accessor("status", {
@@ -109,13 +157,7 @@ export const BillingView: React.FC<BillingViewProps> = ({
         <div
           className={cn(
             "inline-flex items-center justify-center rounded-full px-2 py-1 text-xs font-semibold",
-            info.getValue() === "succeeded"
-              ? "bg-green-100 text-green-800"
-              : info.getValue() === "pending"
-                ? "bg-yellow-100 text-yellow-800"
-                : info.getValue() === "failed"
-                  ? "bg-red-100 text-red-800"
-                  : "bg-gray-100 text-gray-800"
+            STATUS_BADGE_CLASSES[info.getValue()] ?? DEFAULT_STATUS_BADGE_CLASS
           )}
         >
           {capitalizeFirstLetter(info.getValue())}
@@ -125,15 +167,19 @@ export const BillingView: React.FC<BillingViewProps> = ({
     columnHelper.display({
       id: "receipt",
       header: "Receipt",
-      cell: info => (
-        <CustomTooltip title={<p className="text-sm">View Receipt on Stripe</p>}>
-          <Link href={info.row.original.receiptUrl || "#"} target="_blank" rel="noopener noreferrer">
-            <Button size="icon" variant="ghost" className="text-black hover:bg-primary hover:text-white dark:text-white">
-              <Page width={16} />
-            </Button>
-          </Link>
-        </CustomTooltip>
-      )
+      cell: info => {
+        const { receiptUrl } = info.row.original;
+        if (!receiptUrl) return null;
+        return (
+          <CustomTooltip title={<p className="text-sm">View Receipt on Stripe</p>}>
+            <Link href={receiptUrl} target="_blank" rel="noopener noreferrer">
+              <Button size="icon" variant="ghost" className="text-black hover:bg-primary hover:text-white dark:text-white">
+                <Page width={16} />
+              </Button>
+            </Link>
+          </CustomTooltip>
+        );
+      }
     })
   ];
 
@@ -171,7 +217,7 @@ export const BillingView: React.FC<BillingViewProps> = ({
     );
   }
 
-  const columnClasses = ["w-32 px-4 py-2", "w-32 px-4 py-2", "w-32 px-4 py-2", "w-32 px-4 py-2", "w-4 px-4 py-2"];
+  const columnClasses = ["w-28 px-4 py-2", "w-40 px-4 py-2", "px-4 py-2", "w-32 px-4 py-2", "w-28 px-4 py-2", "w-16 px-4 py-2"];
 
   return (
     <div className="space-y-2">

--- a/apps/deploy-web/src/components/billing-usage/BillingView/BillingView.tsx
+++ b/apps/deploy-web/src/components/billing-usage/BillingView/BillingView.tsx
@@ -6,7 +6,6 @@ import {
   AlertDescription,
   AlertTitle,
   Button,
-  CustomTooltip,
   DateRangePicker,
   Label,
   Pagination,
@@ -171,13 +170,11 @@ export const BillingView: React.FC<BillingViewProps> = ({
         const { receiptUrl } = info.row.original;
         if (!receiptUrl) return null;
         return (
-          <CustomTooltip title={<p className="text-sm">View Receipt on Stripe</p>}>
-            <Link href={receiptUrl} target="_blank" rel="noopener noreferrer">
-              <Button size="icon" variant="ghost" className="text-black hover:bg-primary hover:text-white dark:text-white">
-                <Page width={16} />
-              </Button>
-            </Link>
-          </CustomTooltip>
+          <Link href={receiptUrl} target="_blank" rel="noopener noreferrer" aria-label="View receipt on Stripe">
+            <Button size="icon" variant="ghost" className="text-black hover:bg-primary hover:text-white dark:text-white">
+              <Page width={16} />
+            </Button>
+          </Link>
         );
       }
     })
@@ -217,7 +214,7 @@ export const BillingView: React.FC<BillingViewProps> = ({
     );
   }
 
-  const columnClasses = ["w-28 px-4 py-2", "w-40 px-4 py-2", "px-4 py-2", "w-32 px-4 py-2", "w-28 px-4 py-2", "w-16 px-4 py-2"];
+  const columnClasses = ["w-28 px-4 py-2", "w-40 px-4 py-2", "w-48 px-4 py-2", "w-32 px-4 py-2", "w-28 px-4 py-2", "w-16 px-4 py-2"];
 
   return (
     <div className="space-y-2">

--- a/apps/deploy-web/src/components/billing-usage/FirstPurchaseBonusAlert/FirstPurchaseBonusAlert.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/FirstPurchaseBonusAlert/FirstPurchaseBonusAlert.spec.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { IntlProvider } from "react-intl";
-import type { Charge } from "@akashnetwork/http-sdk";
+import type { BillingTransaction } from "@akashnetwork/http-sdk";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
@@ -17,7 +17,7 @@ describe(FirstPurchaseBonusAlert.name, () => {
   });
 
   it("renders nothing when the user already has a succeeded charge", () => {
-    const { container } = setup({ transactions: [mock<Charge>({ status: "succeeded" })] });
+    const { container } = setup({ transactions: [mock<BillingTransaction>({ status: "succeeded" })] });
 
     expect(container).toBeEmptyDOMElement();
   });
@@ -31,7 +31,7 @@ describe(FirstPurchaseBonusAlert.name, () => {
   });
 
   it("shows the offer to users whose only charges failed", () => {
-    setup({ amount: 0, transactions: [mock<Charge>({ status: "failed" })] });
+    setup({ amount: 0, transactions: [mock<BillingTransaction>({ status: "failed" })] });
 
     expect(screen.getByText("First-purchase bonus")).toBeInTheDocument();
   });
@@ -66,7 +66,7 @@ describe(FirstPurchaseBonusAlert.name, () => {
     expect(container).not.toHaveTextContent("more to unlock");
   });
 
-  function setup(input?: { amount?: number; isSuccess?: boolean; transactions?: Charge[] }) {
+  function setup(input?: { amount?: number; isSuccess?: boolean; transactions?: BillingTransaction[] }) {
     // UseQueryResult is a discriminated union that neither mock<T>() nor a partial literal can satisfy
     const usePaymentTransactionsQuery = vi.fn(() => ({
       data: { transactions: input?.transactions ?? [] },

--- a/apps/deploy-web/src/queries/queryKeys.spec.ts
+++ b/apps/deploy-web/src/queries/queryKeys.spec.ts
@@ -13,14 +13,9 @@ describe("QueryKeys", () => {
       expect(QueryKeys.getPaymentTransactionsKey({ limit: 50 })).toEqual(["STRIPE_TRANSACTIONS", "limit", "50"]);
     });
 
-    it("should return payment transactions key with startingAfter", () => {
-      expect(QueryKeys.getPaymentTransactionsKey({ startingAfter: "txn_123" })).toEqual(["STRIPE_TRANSACTIONS", "after", "txn_123"]);
-      expect(QueryKeys.getPaymentTransactionsKey({ startingAfter: "txn_456" })).toEqual(["STRIPE_TRANSACTIONS", "after", "txn_456"]);
-    });
-
-    it("should return payment transactions key with endingBefore", () => {
-      expect(QueryKeys.getPaymentTransactionsKey({ endingBefore: "txn_123" })).toEqual(["STRIPE_TRANSACTIONS", "before", "txn_123"]);
-      expect(QueryKeys.getPaymentTransactionsKey({ endingBefore: "txn_456" })).toEqual(["STRIPE_TRANSACTIONS", "before", "txn_456"]);
+    it("returns payment transactions key with offset", () => {
+      expect(QueryKeys.getPaymentTransactionsKey({ offset: 10 })).toEqual(["STRIPE_TRANSACTIONS", "offset", "10"]);
+      expect(QueryKeys.getPaymentTransactionsKey({ offset: 20 })).toEqual(["STRIPE_TRANSACTIONS", "offset", "20"]);
     });
 
     it("should return payment transactions key with created start_date", () => {
@@ -45,35 +40,22 @@ describe("QueryKeys", () => {
       ]);
     });
 
-    it("should return payment transactions key with multiple options", () => {
+    it("returns payment transactions key with multiple options", () => {
       const startDate = new Date(1234567890);
       const endDate = new Date(1234567900);
       expect(
         QueryKeys.getPaymentTransactionsKey({
           limit: 25,
-          startingAfter: "txn_123",
-          endingBefore: "txn_456",
+          offset: 50,
           startDate,
           endDate
         })
-      ).toEqual([
-        "STRIPE_TRANSACTIONS",
-        "limit",
-        "25",
-        "after",
-        "txn_123",
-        "before",
-        "txn_456",
-        "start_date",
-        startDate.toISOString(),
-        "end_date",
-        endDate.toISOString()
-      ]);
+      ).toEqual(["STRIPE_TRANSACTIONS", "limit", "25", "offset", "50", "start_date", startDate.toISOString(), "end_date", endDate.toISOString()]);
     });
 
-    it("should handle null values for startingAfter and endingBefore", () => {
-      expect(QueryKeys.getPaymentTransactionsKey({ startingAfter: null })).toEqual(["STRIPE_TRANSACTIONS"]);
-      expect(QueryKeys.getPaymentTransactionsKey({ endingBefore: null })).toEqual(["STRIPE_TRANSACTIONS"]);
+    it("omits offset when it is null or zero", () => {
+      expect(QueryKeys.getPaymentTransactionsKey({ offset: null })).toEqual(["STRIPE_TRANSACTIONS"]);
+      expect(QueryKeys.getPaymentTransactionsKey({ offset: 0 })).toEqual(["STRIPE_TRANSACTIONS"]);
     });
 
     it("should handle partial created options", () => {

--- a/apps/deploy-web/src/queries/queryKeys.ts
+++ b/apps/deploy-web/src/queries/queryKeys.ts
@@ -81,25 +81,15 @@ export class QueryKeys {
    */
   static getManagedWalletCreateMutationKey = () => ["MANAGED_WALLET_CREATE"];
 
-  static getPaymentTransactionsKey = (options?: {
-    limit?: number;
-    startingAfter?: string | null;
-    endingBefore?: string | null;
-    startDate?: Date | null;
-    endDate?: Date | null;
-  }) => {
+  static getPaymentTransactionsKey = (options?: { limit?: number; offset?: number | null; startDate?: Date | null; endDate?: Date | null }) => {
     const key = ["STRIPE_TRANSACTIONS"];
 
     if (options?.limit) {
       key.push("limit", options.limit.toString());
     }
 
-    if (options?.startingAfter) {
-      key.push("after", options.startingAfter);
-    }
-
-    if (options?.endingBefore) {
-      key.push("before", options.endingBefore);
+    if (options?.offset) {
+      key.push("offset", options.offset.toString());
     }
 
     if (options?.startDate) {

--- a/apps/deploy-web/src/queries/usePaymentQueries.ts
+++ b/apps/deploy-web/src/queries/usePaymentQueries.ts
@@ -45,8 +45,7 @@ export const useDefaultPaymentMethodQuery = (
 
 export interface UsePaymentTransactionsOptions {
   limit?: number;
-  startingAfter?: string | null;
-  endingBefore?: string | null;
+  offset?: number | null;
   startDate?: Date | null;
   endDate?: Date | null;
 }

--- a/apps/deploy-web/tests/seeders/payment.ts
+++ b/apps/deploy-web/tests/seeders/payment.ts
@@ -1,3 +1,4 @@
+import type { BillingTransaction } from "@akashnetwork/http-sdk";
 import { faker } from "@faker-js/faker";
 
 export const createMockPaymentMethod = (overrides = {}) => ({
@@ -50,13 +51,19 @@ export const createMockDiscount = (overrides = {}) => ({
   ...overrides
 });
 
-export const createMockTransaction = (overrides = {}) => ({
+export const createMockTransaction = (overrides: Partial<BillingTransaction> = {}): BillingTransaction => ({
   id: `pi_${faker.string.alphanumeric(24)}`,
+  type: "payment_intent",
   amount: faker.number.int({ min: 1000, max: 10000 }),
+  amountRefunded: 0,
+  bonusAmount: 0,
   currency: "usd",
   status: faker.helpers.arrayElement(["succeeded", "pending", "failed"]),
-  payment_method: createMockPaymentMethod(),
   created: faker.date.past().getTime(),
+  cardBrand: "visa",
+  cardLast4: faker.string.numeric(4),
+  stripeInvoiceId: null,
+  receiptUrl: faker.internet.url(),
   description: faker.helpers.arrayElement(["Monthly subscription", "One-time purchase", "Annual plan"]),
   ...overrides
 });

--- a/packages/http-sdk/src/stripe/stripe.service.spec.ts
+++ b/packages/http-sdk/src/stripe/stripe.service.spec.ts
@@ -7,10 +7,9 @@ describe(StripeService.name, () => {
   describe("getCustomerTransactions", () => {
     it("unwraps the API data envelope so transactions reach the caller", async () => {
       const payload = {
-        transactions: [{ id: "ch_123", amount: 2000 }],
-        hasMore: false,
-        nextPage: null,
-        prevPage: null
+        transactions: [{ id: "txn_123", type: "payment_intent", amount: 2000, amountRefunded: 0 }],
+        totalCount: 1,
+        hasMore: false
       };
       const { service } = setup({ payload });
 
@@ -18,6 +17,14 @@ describe(StripeService.name, () => {
 
       expect(result).toEqual(payload);
       expect(result.transactions).toHaveLength(1);
+    });
+
+    it("forwards limit and offset as query params", async () => {
+      const { service, httpClient } = setup();
+
+      await service.getCustomerTransactions({ limit: 10, offset: 20 });
+
+      expect(httpClient.get).toHaveBeenCalledWith("/v1/stripe/transactions?limit=10&offset=20");
     });
 
     it("throws when startDate is after endDate", async () => {
@@ -37,7 +44,7 @@ describe(StripeService.name, () => {
   });
 
   function setup(input?: { payload?: unknown }) {
-    const payload = input?.payload ?? { transactions: [], hasMore: false, nextPage: null, prevPage: null };
+    const payload = input?.payload ?? { transactions: [], totalCount: 0, hasMore: false };
     const httpClient = {
       get: vi.fn().mockResolvedValue({ data: { data: payload } })
     } as unknown as HttpClient & { get: ReturnType<typeof vi.fn> };

--- a/packages/http-sdk/src/stripe/stripe.service.ts
+++ b/packages/http-sdk/src/stripe/stripe.service.ts
@@ -60,7 +60,7 @@ export class StripeService {
   }
 
   async getCustomerTransactions(options?: CustomerTransactionsParams): Promise<CustomerTransactionsResponse> {
-    const { limit, startingAfter, endingBefore, startDate, endDate } = options || {};
+    const { limit, offset, startDate, endDate } = options || {};
 
     if (startDate && endDate && startDate >= endDate) {
       throw new Error("startDate must be less than endDate");
@@ -68,8 +68,7 @@ export class StripeService {
 
     const params = new URLSearchParams({
       ...(limit && { limit: limit.toString() }),
-      ...(startingAfter && { startingAfter }),
-      ...(endingBefore && { endingBefore }),
+      ...(offset && { offset: offset.toString() }),
       ...(startDate && { startDate: startDate.toISOString() }),
       ...(endDate && { endDate: endDate.toISOString() })
     });

--- a/packages/http-sdk/src/stripe/stripe.types.ts
+++ b/packages/http-sdk/src/stripe/stripe.types.ts
@@ -45,18 +45,24 @@ export interface PaymentMethod {
   } | null;
 }
 
-export interface Charge {
+export type BillingTransactionType = "payment_intent" | "coupon_claim" | "manual_credit";
+
+export interface BillingTransaction {
   id: string;
+  type: BillingTransactionType;
   amount: number;
+  /** Cumulative amount refunded on this transaction, in cents. */
+  amountRefunded: number;
   /** First-purchase bonus credited with this payment, in cents. */
   bonusAmount?: number;
   currency: string;
   status: string;
   created: number;
-  paymentMethod: PaymentMethod;
-  receiptUrl?: string;
-  description?: string;
-  metadata?: Record<string, string>;
+  cardBrand?: string | null;
+  cardLast4?: string | null;
+  stripeInvoiceId?: string | null;
+  receiptUrl?: string | null;
+  description?: string | null;
 }
 
 export interface Discount {
@@ -89,18 +95,15 @@ export interface ApplyCouponParams {
 
 export interface CustomerTransactionsParams {
   limit?: number;
-  startingAfter?: string | null;
-  endingBefore?: string | null;
+  offset?: number | null;
   startDate?: Date | null;
   endDate?: Date | null;
 }
 
 export interface CustomerTransactionsResponse {
-  transactions: Charge[];
-  hasMore: boolean;
-  nextPage: string | null;
-  prevPage: string | null;
+  transactions: BillingTransaction[];
   totalCount: number;
+  hasMore: boolean;
 }
 
 export interface ExportTransactionsCsvParams {


### PR DESCRIPTION
## Why

Closes CON-674. This is the UI half; **stacked on #3508** (the API/data half) — review and merge that first. Base branch is `fix/billing-history-all-transaction-types`, so this PR's diff should be read on top of it.

The customer-facing **Billing → History** table only showed credit-card purchases (it was built from Stripe charges). #3508 makes the API source history from the internal `stripe_transactions` table; this PR renders that richer data so coupon claims, manual credits, and refunds all appear.

## What

<img width="1414" height="445" alt="image" src="https://github.com/user-attachments/assets/0763c62b-f694-4969-a42e-e10df4da6a4b" />


`packages/http-sdk` + `apps/deploy-web`.

- **http-sdk**: replace `Charge` with `BillingTransaction` (adds `type`, `amountRefunded`, `cardBrand`, `cardLast4`, `stripeInvoiceId`); response becomes `{ transactions, totalCount, hasMore }`; params switch cursor -> `offset`.
- **BillingView** columns: **Date**, **Type** (badge with `Visa **** 4242` subtext for card payments), **Description**, **Amount** (credits show green `+`, keeps the bonus subtext, adds a `refunded` subtext when `amountRefunded > 0`), **Status** (adds a `Refunded` badge), **Receipt**.
- **BillingContainer** drops the cursor bookkeeping in favor of `offset = pageIndex * pageSize` (net simplification).

## Note

This replaces the oversized #3500, which is now closed. That PR was split in two and rebased onto Yaro's `TransactionReportingService` extraction (CON-718): #3508 (API) + this PR (UI). CodeRabbit's actionable comments from #3500 were folded into #3508.
