### PR TITLE
fix(deployment): raise configure-page cards and fix agent skill-install commands

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/PlacementCard/PlacementCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/PlacementCard/PlacementCard.tsx
@@ -71,7 +71,7 @@ export const PlacementCard: FC<Props> = ({
   return (
     <div
       onClick={selectPlacement}
-      className={cn("cursor-pointer rounded-lg border p-2", {
+      className={cn("cursor-pointer rounded-lg border bg-card p-2", {
         "border-green-500/60 bg-green-50 dark:border-green-500/40 dark:bg-green-950/30": selectionState === "done",
         "ring-[3px] ring-blue-500/20": selectionState === "done" && isSelected,
         "border-blue-500 ring-[3px] ring-blue-500/20": selectionState === "selecting",

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.tsx
@@ -107,11 +107,11 @@ export const MarketplaceProvidersTable: FC<Props> = ({
   const columnCount = table.getVisibleFlatColumns().length;
 
   return (
-    <div className="overflow-hidden rounded-[14px] border shadow-sm">
+    <div className="overflow-hidden rounded-lg border border-zinc-300 bg-card shadow-sm dark:border-zinc-700">
       <Table className="table-fixed">
         <TableHeader>
           {table.getHeaderGroups().map(headerGroup => (
-            <TableRow key={headerGroup.id} className="hover:bg-transparent">
+            <TableRow key={headerGroup.id} className="bg-muted/40 hover:bg-muted/40">
               {headerGroup.headers.map(header => (
                 <TableHead key={header.id} className={cn("h-10 pl-4 pr-2", COLUMN_WIDTH_CLASS[header.column.id])}>
                   {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
@@ -153,10 +153,10 @@ const SKELETON_COLUMNS = [
 /** Loading placeholder mirroring the real table shell — same container, header labels and row height — so the pane doesn't shift when providers arrive. */
 function ProvidersTableSkeleton() {
   return (
-    <div className="overflow-hidden rounded-[14px] border shadow-sm">
+    <div className="overflow-hidden rounded-lg border border-zinc-300 bg-card shadow-sm dark:border-zinc-700">
       <Table className="table-fixed">
         <TableHeader>
-          <TableRow className="hover:bg-transparent">
+          <TableRow className="bg-muted/40 hover:bg-muted/40">
             {SKELETON_COLUMNS.map(column => (
               <TableHead key={column.id} className={cn("h-10 pl-4 pr-2", COLUMN_WIDTH_CLASS[column.id])}>
                 <span className="whitespace-nowrap font-mono text-sm font-normal uppercase text-muted-foreground">{column.header}</span>

--- a/apps/deploy-web/src/components/new-deployment/AgentModePanel/AgentModePanel.spec.tsx
+++ b/apps/deploy-web/src/components/new-deployment/AgentModePanel/AgentModePanel.spec.tsx
@@ -24,14 +24,15 @@ describe(AgentModePanel.name, () => {
     expect(analyticsService.track).toHaveBeenCalledWith("deploy_with_agent_btn_clk", "Amplitude");
     expect(screen.getByText("Install the Akash skill")).toBeInTheDocument();
     expect(screen.getByText("/plugin marketplace add akash-network/akash-skill")).toBeInTheDocument();
+    expect(screen.getByText("/plugin install akash-network@akash-network")).toBeInTheDocument();
   });
 
-  it("offers a copy button for the install command", async () => {
+  it("offers a copy button for each install command", async () => {
     setup();
 
     await userEvent.click(screen.getByRole("button", { name: /Set up with your agent/ }));
 
-    expect(screen.getByRole("button", { name: "copy" })).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "copy" })).toHaveLength(2);
   });
 
   it("links Create an API key to the in-app API keys page", async () => {

--- a/apps/deploy-web/src/components/new-deployment/AgentModePanel/AgentModePanel.tsx
+++ b/apps/deploy-web/src/components/new-deployment/AgentModePanel/AgentModePanel.tsx
@@ -11,7 +11,7 @@ import { useServices } from "@src/context/ServicesProvider";
 import { copyTextToClipboard } from "@src/utils/copyClipboard";
 import { UrlService } from "@src/utils/urlUtils";
 
-const SKILL_INSTALL_COMMAND = "/plugin marketplace add akash-network/akash-skill";
+const SKILL_INSTALL_COMMANDS = ["/plugin marketplace add akash-network/akash-skill", "/plugin install akash-network@akash-network"];
 const AI_AGENTS_DOCS_URL = "https://akash.network/docs/getting-started/ai-agents/";
 
 export const AgentModePanel: React.FunctionComponent = () => {
@@ -52,7 +52,13 @@ export const AgentModePanel: React.FunctionComponent = () => {
               index={1}
               title="Install the Akash skill"
               description="In Claude Code, Codex, or OpenCode:"
-              action={<CommandLine command={SKILL_INSTALL_COMMAND} />}
+              action={
+                <div className="space-y-2">
+                  {SKILL_INSTALL_COMMANDS.map(command => (
+                    <CommandLine key={command} command={command} />
+                  ))}
+                </div>
+              }
             />
 
             <AgentModeStep


### PR DESCRIPTION
## Why

Follow-up polish to the "Configure your deployment" page after the near-black theme PR (#3505), plus a correctness fix on the agent setup panel (#3447):

- After #3505, raised surfaces read via `bg-card`. The **compute-marketplace provider list** and the **placement cards** had a border and rounding but no `bg-card`, so they rendered flat against the page background instead of as raised cards like the configuration cards.
- The **"Deploy with your agent"** panel listed only `/plugin marketplace add akash-network/akash-skill`, which merely *registers* the marketplace and does **not** install the skill — a user following step 1 ended up without the skill installed. The official setup guide (akash.network/docs/getting-started/ai-agents) correctly shows both commands.

## What

- **Marketplace provider list → raised card** — add `bg-card`, align the border/radius to the shared card tokens (`rounded-lg`, `border-zinc-300 dark:border-zinc-700`), and give the table header a subtle `bg-muted/40` strip. Applied to both the live table and the loading skeleton.
- **Placement cards → raised card** — add `bg-card` to the base container; the selection states (green "done" fill, blue "selecting" border, selected ring) still override correctly via tailwind-merge.
- **Agent setup panel** — render both install commands as two stacked, independently-copyable rows (`/plugin marketplace add …` then `/plugin install akash-network@akash-network`), since Claude Code runs each slash command separately. Spec updated to assert both commands and the second copy button.

Frontend-only styling/UI change; matches the provided design mockup (Audit Tier column/filter and "Best Match" badge from the mockup are intentionally out of scope — separate future work).

### Verification
- `npm run test:unit` (affected components): 70 passed / 0 failed — the two-command fix is directly asserted.
- ESLint clean on all changed files; no new type errors introduced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent setup now displays multiple Akash skill installation commands, each with its own copy button.

* **Style**
  * Updated deployment and marketplace layouts with refreshed card backgrounds, borders, rounding, and muted table headers.

* **Tests**
  * Expanded coverage to verify all required installation commands and copy buttons are displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->