### PR TITLE
fix(styling): make switch off-state track visible in dark mode

### DIFF
--- a/packages/ui/components/switch.tsx
+++ b/packages/ui/components/switch.tsx
@@ -14,7 +14,7 @@ const Switch = React.forwardRef<
   <SwitchPrimitives.Root
     data-size={size}
     className={cn(
-      "group/switch aria-[checked=false]:bg-input aria-[checked=false]:dark:bg-input/80 aria-[checked=true]:bg-primary focus-visible:ring-ring focus-visible:ring-offset-background peer inline-flex shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-6 data-[size=sm]:h-4 data-[size=default]:w-11 data-[size=sm]:w-7",
+      "group/switch aria-[checked=false]:bg-input aria-[checked=true]:bg-primary focus-visible:ring-ring focus-visible:ring-offset-background peer inline-flex shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-6 data-[size=sm]:h-4 data-[size=default]:w-11 data-[size=sm]:w-7",
       className
     )}
     {...props}


### PR DESCRIPTION
## Why

The `Switch` off-state track was invisible on dark cards (e.g. the **Auto Recharge** toggle in the billing account overview) — only the thumb showed, as a dark blob.

Root cause: in dark mode the theme defines `--input: 0 0% 100% / 15%` (alpha baked into the variable). The switch off-state used `dark:bg-input/80`, and Tailwind's `/80` opacity modifier expands to `hsl(var(--input) / 0.8)` → `hsl(0 0% 100% / 15% / 0.8)`, which is invalid CSS. The browser drops the declaration, so the track renders transparent and blends into the card.

## What

`packages/ui` — remove the `dark:bg-input/80` modifier from `Switch`, so both themes use `bg-input`. That composites to a visible pill (white @ 15% over the dark card), with no change to the light theme or the checked/`bg-primary` state.

Found while working on the billing history UI; fixed separately since it is a shared component and unrelated to that change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the switch’s unchecked-state styling to use consistent background colors across light and dark modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->