### PR TITLE
fix(managed-wallet): skip storage sync while wallet has no address

### DIFF
--- a/apps/deploy-web/src/hooks/useManagedWallet.spec.tsx
+++ b/apps/deploy-web/src/hooks/useManagedWallet.spec.tsx
@@ -1,10 +1,11 @@
-import type { ManagedWalletHttpService } from "@akashnetwork/http-sdk";
+import type { ApiManagedWalletOutput, ManagedWalletHttpService } from "@akashnetwork/http-sdk";
 import type { UserProfile } from "@auth0/nextjs-auth0/client";
 import { UserProvider } from "@auth0/nextjs-auth0/client";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import { useCreateManagedWalletMutation } from "@src/queries/useManagedWalletQuery";
+import { getStorageManagedWallet, updateStorageManagedWallet } from "@src/utils/walletUtils";
 import { useManagedWallet } from "./useManagedWallet";
 
 import { act } from "@testing-library/react";
@@ -33,11 +34,73 @@ describe(useManagedWallet.name, () => {
     });
   });
 
-  function setup() {
-    const managedWalletService = mock<ManagedWalletHttpService>({
-      // A never-settling create keeps the mutation pending for the duration of the assertion.
-      createWallet: vi.fn().mockReturnValue(new Promise<never>(() => {}))
+  it("keeps the stored wallet untouched when the API returns a wallet without an address", async () => {
+    const userId = "user-guard-merge";
+    updateStorageManagedWallet({ userId, address: "akash1existing", creditAmount: 100, isTrialing: true, selected: true });
+
+    const { result } = setup({ userId, apiWallet: buildApiWallet({ userId, address: null, creditAmount: 0 }) });
+
+    await vi.waitFor(() => {
+      expect(result.current.managed.wallet).toBeDefined();
     });
+    expect(getStorageManagedWallet(userId)).toMatchObject({ address: "akash1existing", creditAmount: 100, isTrialing: true });
+  });
+
+  it("does not persist a wallet without an address to storage", async () => {
+    const userId = "user-guard-empty";
+
+    const { result } = setup({ userId, apiWallet: buildApiWallet({ userId, address: null }) });
+
+    await vi.waitFor(() => {
+      expect(result.current.managed.wallet).toBeDefined();
+    });
+    expect(getStorageManagedWallet(userId)).toBeUndefined();
+  });
+
+  it("persists the queried wallet to storage once it has an address", async () => {
+    const userId = "user-sync";
+
+    setup({ userId, apiWallet: buildApiWallet({ userId, address: "akash1queried", creditAmount: 25 }) });
+
+    await vi.waitFor(() => {
+      expect(getStorageManagedWallet(userId)).toMatchObject({ address: "akash1queried", creditAmount: 25, isTrialing: true });
+    });
+  });
+
+  it("persists the created wallet as selected after a successful create", async () => {
+    const userId = "user-create";
+    const createdWallet = buildApiWallet({ userId, address: "akash1created", creditAmount: 50 });
+
+    const { result } = setup({ userId, createdWallet });
+
+    act(() => {
+      result.current.managed.create();
+    });
+
+    await vi.waitFor(() => {
+      expect(getStorageManagedWallet(userId)).toMatchObject({ address: "akash1created", creditAmount: 50, selected: true });
+    });
+  });
+
+  /** Mirrors the real API contract: `address` is nullable while a wallet is mid-provisioning, even though the SDK type claims `string`. */
+  function buildApiWallet(overrides: { userId: string; address: string | null; creditAmount?: number }) {
+    return {
+      ...mock<ApiManagedWalletOutput>(),
+      isTrialing: true,
+      creditAmount: overrides.creditAmount ?? 0,
+      userId: overrides.userId,
+      address: overrides.address
+    } as ApiManagedWalletOutput;
+  }
+
+  function setup(input?: { userId?: string; apiWallet?: ApiManagedWalletOutput; createdWallet?: ApiManagedWalletOutput }) {
+    const managedWalletService = mock<ManagedWalletHttpService>({
+      getWallet: vi.fn().mockResolvedValue(input?.apiWallet ?? null),
+      // A never-settling create keeps the mutation pending for the duration of the assertion.
+      createWallet: input?.createdWallet ? vi.fn().mockResolvedValue(input.createdWallet) : vi.fn().mockReturnValue(new Promise<never>(() => {}))
+    });
+
+    const user = { email: "test@akash.network", id: input?.userId, userId: input?.userId } as UserProfile;
 
     return setupQuery(
       () => {
@@ -47,7 +110,7 @@ describe(useManagedWallet.name, () => {
       },
       {
         services: { managedWalletService: () => managedWalletService },
-        wrapper: ({ children }) => <UserProvider user={{ email: "test@akash.network" } as UserProfile}>{children}</UserProvider>
+        wrapper: ({ children }) => <UserProvider user={user}>{children}</UserProvider>
       }
     );
   }

--- a/apps/deploy-web/src/hooks/useManagedWallet.ts
+++ b/apps/deploy-web/src/hooks/useManagedWallet.ts
@@ -39,9 +39,13 @@ export const useManagedWallet = () => {
   }, [signedInUser?.id, queried, created, setIsSignedInWithTrial]);
 
   useEffect(() => {
-    if (wallet && isCreated) {
+    if (!wallet?.address) {
+      return;
+    }
+
+    if (isCreated) {
       updateStorageManagedWallet({ ...wallet, selected: true });
-    } else if (wallet) {
+    } else {
       updateStorageManagedWallet(wallet);
     }
   }, [isCreated, wallet]);


### PR DESCRIPTION
## Why

New trial users intermittently hit the Sentry warning `Cannot create managed wallet entry without address, creditAmount and isTrialing` ([Sentry 7542732522](https://cloudmos.sentry.io/issues/7542732522/)). The API legitimately returns a wallet with a `null` address while trial provisioning is in flight (or after an interrupted provision), and the storage-sync effect in `useManagedWallet` tried to persist that address-less wallet on every render.

Fixes CON-743
Related to CON-744 (backend redesign that makes address-less wallets unobservable in API responses)

## What

- Skip the browser-storage sync in `useManagedWallet` while the wallet has no address — an address-less wallet can neither create a valid storage entry nor safely merge into an existing one.
- Specs covering: address-less wallet is not persisted and does not clobber an existing entry; wallet with address is persisted; created wallet is persisted as `selected`.

Verified end-to-end against a local deploy-web with a mocked `v1/wallets` response: pre-fix the warning fires 4x on page load, post-fix zero, and with-address sync still writes the storage entry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved managed wallet persistence by ignoring wallets without an address.
  * Preserved existing stored wallets when API responses lack an address.
  * Ensured wallets are saved with their latest balance and trial details once ready.
  * Newly created wallets are now correctly saved as the selected wallet.

* **Tests**
  * Added coverage for wallet storage and persistence scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->