### PR TITLE
refactor(billing): move coupon redemption into its own service

### DIFF
--- a/apps/api/src/billing/controllers/stripe/stripe.controller.spec.ts
+++ b/apps/api/src/billing/controllers/stripe/stripe.controller.spec.ts
@@ -6,6 +6,7 @@ import { mock } from "vitest-mock-extended";
 
 import { AuthService } from "@src/auth/services/auth.service";
 import type { UserWalletOutput, UserWalletRepository } from "@src/billing/repositories";
+import type { CouponRedemptionService } from "@src/billing/services/coupon-redemption/coupon-redemption.service";
 import type { PayingUser } from "@src/billing/services/paying-user/paying-user";
 import type { PaymentMethodService } from "@src/billing/services/payment-method/payment-method.service";
 import { type PaymentMethod } from "@src/billing/services/payment-method/payment-method.service";
@@ -263,11 +264,11 @@ describe(StripeController.name, () => {
 
   describe("applyCoupon", () => {
     it("returns transactionId and transactionStatus on successful coupon", async () => {
-      const { controller, stripe, user } = setup();
+      const { controller, couponRedemptionService, user } = setup();
       const transactionId = faker.string.uuid();
       const mockCoupon = mock<Stripe.Coupon>({ id: faker.string.uuid() });
 
-      stripe.applyCoupon.mockResolvedValue({
+      couponRedemptionService.redeemCoupon.mockResolvedValue({
         coupon: mockCoupon,
         amountAdded: 10,
         transactionId,
@@ -290,12 +291,12 @@ describe(StripeController.name, () => {
     });
 
     it("resolves transaction when awaitResolved is true", async () => {
-      const { controller, stripe, stripeTransaction, user } = setup();
+      const { controller, couponRedemptionService, stripeTransaction, user } = setup();
       const transactionId = faker.string.uuid();
       const mockCoupon = mock<Stripe.Coupon>({ id: faker.string.uuid() });
       const resolvedTransaction = generateDatabaseStripeTransaction({ id: transactionId, status: "succeeded" });
 
-      stripe.applyCoupon.mockResolvedValue({
+      couponRedemptionService.redeemCoupon.mockResolvedValue({
         coupon: mockCoupon,
         amountAdded: 10,
         transactionId,
@@ -431,6 +432,7 @@ describe(StripeController.name, () => {
     const payingUser: PayingUser = { ...user, stripeCustomerId: user.stripeCustomerId! };
     const stripe = mock<StripeService>();
     const paymentMethodService = mock<PaymentMethodService>();
+    const couponRedemptionService = mock<CouponRedemptionService>();
     const stripeTransaction = mock<StripeTransactionService>();
     const authService = mock<AuthService>({
       currentUser: user
@@ -448,7 +450,8 @@ describe(StripeController.name, () => {
       userWalletRepository,
       trialValidationService,
       transactionReporting,
-      paymentMethodService
+      paymentMethodService,
+      couponRedemptionService
     );
     container.register(AuthService, { useValue: authService });
 
@@ -456,6 +459,7 @@ describe(StripeController.name, () => {
       controller,
       stripe,
       paymentMethodService,
+      couponRedemptionService,
       stripeTransaction,
       authService,
       stripeErrorService,

--- a/apps/api/src/billing/controllers/stripe/stripe.controller.ts
+++ b/apps/api/src/billing/controllers/stripe/stripe.controller.ts
@@ -21,6 +21,7 @@ import {
 } from "@src/billing/http-schemas/stripe.schema";
 import type { StripeTransactionOutput } from "@src/billing/repositories";
 import { UserWalletRepository } from "@src/billing/repositories";
+import { CouponRedemptionService } from "@src/billing/services/coupon-redemption/coupon-redemption.service";
 import { PaymentMethodService } from "@src/billing/services/payment-method/payment-method.service";
 import { StripeService, TOP_UP_IDEMPOTENCY_KEY_PREFIX } from "@src/billing/services/stripe/stripe.service";
 import { StripeErrorService } from "@src/billing/services/stripe-error/stripe-error.service";
@@ -37,7 +38,8 @@ export class StripeController {
     private readonly userWalletRepository: UserWalletRepository,
     private readonly trialValidationService: TrialValidationService,
     private readonly transactionReporting: TransactionReportingService,
-    private readonly paymentMethodService: PaymentMethodService
+    private readonly paymentMethodService: PaymentMethodService,
+    private readonly couponRedemptionService: CouponRedemptionService
   ) {}
 
   @Protected([{ action: "read", subject: "StripePayment" }])
@@ -168,7 +170,7 @@ export class StripeController {
     assert(params.userId, 400, "User ID is required");
 
     try {
-      const result = await this.stripe.applyCoupon(currentUser, params.couponId);
+      const result = await this.couponRedemptionService.redeemCoupon(currentUser, params.couponId);
 
       if (params.awaitResolved) {
         const transaction = await this.stripeTransaction.resolveTransaction(result.transactionId);

--- a/apps/api/src/billing/services/coupon-redemption/coupon-redemption.service.spec.ts
+++ b/apps/api/src/billing/services/coupon-redemption/coupon-redemption.service.spec.ts
@@ -1,0 +1,239 @@
+import type { LoggerService } from "@akashnetwork/logging";
+import { faker } from "@faker-js/faker";
+import Stripe from "stripe";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { StripeTransactionOutput } from "@src/billing/repositories";
+import type { StripeService } from "@src/billing/services/stripe/stripe.service";
+import type { StripeTransactionService } from "@src/billing/services/stripe-transaction/stripe-transaction.service";
+import { CouponRedemptionService } from "./coupon-redemption.service";
+
+import { createTestCoupon, createTestInvoice, createTestPromotionCode } from "@test/seeders/stripe-test-data.seeder";
+import { createTestUser } from "@test/seeders/user-test.seeder";
+
+describe(CouponRedemptionService.name, () => {
+  describe("redeemCoupon", () => {
+    it("applies a promotion code, creates the discounted invoice, and records a pending coupon_claim", async () => {
+      const { service, stripe, stripeTransactionService } = setup();
+      const mockUser = createTestUser();
+      const mockCoupon = createTestCoupon({ id: "coupon_123", amount_off: 1000, percent_off: null, valid: true, currency: "usd", name: "Test Coupon" });
+      const mockPromotionCode = createTestPromotionCode({ id: "promo_123", promotion: { type: "coupon", coupon: mockCoupon } });
+      const mockInvoice = createTestInvoice({ id: "in_123", status: "draft" });
+
+      vi.spyOn(service, "findPromotionCodeByCode").mockResolvedValue(mockPromotionCode);
+      vi.spyOn(stripe.invoices, "create").mockResolvedValue(mockInvoice);
+      vi.spyOn(stripe.invoiceItems, "create").mockResolvedValue(mock<Stripe.Response<Stripe.InvoiceItem>>());
+      vi.spyOn(stripe.invoices, "finalizeInvoice").mockResolvedValue(createTestInvoice({ id: "in_123", status: "paid" }));
+
+      const result = await service.redeemCoupon(mockUser, mockPromotionCode.code);
+
+      expect(stripe.invoices.create).toHaveBeenCalledWith({
+        customer: mockUser.stripeCustomerId,
+        auto_advance: false,
+        discounts: [{ promotion_code: mockPromotionCode.id }]
+      });
+      expect(stripe.invoiceItems.create).toHaveBeenCalledWith({
+        amount: 1000,
+        customer: mockUser.stripeCustomerId,
+        invoice: mockInvoice.id,
+        currency: "usd",
+        description: "Akash Network Console"
+      });
+      expect(stripe.invoices.finalizeInvoice).toHaveBeenCalledWith(mockInvoice.id);
+      expect(stripeTransactionService.recordCouponClaim).toHaveBeenCalledWith({
+        userId: mockUser.id,
+        amount: 1000,
+        currency: "usd",
+        couponId: mockCoupon.id,
+        promotionCodeId: mockPromotionCode.id,
+        invoiceId: mockInvoice.id,
+        description: `Coupon: ${mockCoupon.name}`
+      });
+      expect(result).toEqual({ coupon: mockPromotionCode, amountAdded: 10, transactionId: "test-transaction-id", transactionStatus: "pending" });
+    });
+
+    it("records the pending coupon_claim before finalizing the invoice so the invoice.paid webhook can find it", async () => {
+      const { service, stripe, stripeTransactionService } = setup();
+      const mockUser = createTestUser();
+      const mockCoupon = createTestCoupon({ id: "coupon_order", amount_off: 1000, percent_off: null, valid: true, currency: "usd", name: "Order Coupon" });
+      const mockPromotionCode = createTestPromotionCode({ id: "promo_order", promotion: { type: "coupon", coupon: mockCoupon } });
+      const mockInvoice = createTestInvoice({ id: "in_order", status: "draft" });
+
+      vi.spyOn(service, "findPromotionCodeByCode").mockResolvedValue(mockPromotionCode);
+      vi.spyOn(stripe.invoices, "create").mockResolvedValue(mockInvoice);
+      vi.spyOn(stripe.invoiceItems, "create").mockResolvedValue(mock<Stripe.Response<Stripe.InvoiceItem>>());
+      const finalizeInvoice = vi.spyOn(stripe.invoices, "finalizeInvoice").mockResolvedValue(createTestInvoice({ id: "in_order", status: "paid" }));
+
+      await service.redeemCoupon(mockUser, mockPromotionCode.code);
+
+      expect(stripeTransactionService.recordCouponClaim.mock.invocationCallOrder[0]).toBeLessThan(finalizeInvoice.mock.invocationCallOrder[0]);
+    });
+
+    it("provisions a Stripe customer via getStripeCustomerId before redeeming when the account has none", async () => {
+      const { service, stripe, stripeService, stripeTransactionService } = setup();
+      const mockUser = createTestUser({ stripeCustomerId: null });
+      stripeService.getStripeCustomerId.mockResolvedValue("cus_new_456");
+      const mockCoupon = createTestCoupon({ id: "coupon_new", amount_off: 1000, percent_off: null, valid: true, currency: "usd", name: "New User Coupon" });
+      const mockPromotionCode = createTestPromotionCode({ id: "promo_new", promotion: { type: "coupon", coupon: mockCoupon } });
+      const mockInvoice = createTestInvoice({ id: "in_new", status: "draft" });
+
+      vi.spyOn(service, "findPromotionCodeByCode").mockResolvedValue(mockPromotionCode);
+      vi.spyOn(stripe.invoices, "create").mockResolvedValue(mockInvoice);
+      vi.spyOn(stripe.invoiceItems, "create").mockResolvedValue(mock<Stripe.Response<Stripe.InvoiceItem>>());
+      vi.spyOn(stripe.invoices, "finalizeInvoice").mockResolvedValue(createTestInvoice({ id: "in_new", status: "paid" }));
+
+      await service.redeemCoupon(mockUser, mockPromotionCode.code);
+
+      expect(stripeService.getStripeCustomerId).toHaveBeenCalledWith(mockUser);
+      expect(stripe.invoices.create).toHaveBeenCalledWith({
+        customer: "cus_new_456",
+        auto_advance: false,
+        discounts: [{ promotion_code: mockPromotionCode.id }]
+      });
+      expect(stripeTransactionService.recordCouponClaim).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: mockUser.id, couponId: mockCoupon.id, invoiceId: mockInvoice.id })
+      );
+    });
+
+    it("falls back to a matching coupon when no promotion code is found", async () => {
+      const { service, stripe, stripeTransactionService } = setup();
+      const mockUser = createTestUser();
+      const mockCoupon = createTestCoupon({ id: "coupon_direct", amount_off: 500, percent_off: null, valid: true, currency: "usd", name: "Direct Coupon" });
+      const mockInvoice = createTestInvoice({ id: "in_456", status: "draft" });
+
+      vi.spyOn(service, "findPromotionCodeByCode").mockResolvedValue(undefined);
+      vi.spyOn(service, "listCoupons").mockResolvedValue({ coupons: [mockCoupon] });
+      vi.spyOn(stripe.invoices, "create").mockResolvedValue(mockInvoice);
+      vi.spyOn(stripe.invoiceItems, "create").mockResolvedValue(mock<Stripe.Response<Stripe.InvoiceItem>>());
+      vi.spyOn(stripe.invoices, "finalizeInvoice").mockResolvedValue(createTestInvoice({ id: "in_456", status: "paid" }));
+
+      const result = await service.redeemCoupon(mockUser, mockCoupon.id);
+
+      expect(stripe.invoices.create).toHaveBeenCalledWith({ customer: mockUser.stripeCustomerId, auto_advance: false, discounts: [{ coupon: mockCoupon.id }] });
+      expect(stripeTransactionService.recordCouponClaim).toHaveBeenCalledWith({
+        userId: mockUser.id,
+        amount: 500,
+        currency: "usd",
+        couponId: mockCoupon.id,
+        promotionCodeId: undefined,
+        invoiceId: mockInvoice.id,
+        description: `Coupon: ${mockCoupon.name}`
+      });
+      expect(result).toEqual({ coupon: mockCoupon, amountAdded: 5, transactionId: "test-transaction-id", transactionStatus: "pending" });
+    });
+
+    it("rejects percentage-based promotion codes", async () => {
+      const { service } = setup();
+      const mockUser = createTestUser();
+      const mockPromotionCode = createTestPromotionCode({
+        promotion: { type: "coupon", coupon: { ...createTestCoupon(), percent_off: 20, amount_off: null, valid: true } }
+      });
+      vi.spyOn(service, "findPromotionCodeByCode").mockResolvedValue(mockPromotionCode);
+
+      await expect(service.redeemCoupon(mockUser, mockPromotionCode.code)).rejects.toThrow(
+        "Percentage-based coupons are not supported. Only fixed amount coupons are allowed."
+      );
+    });
+
+    it("rejects promotion codes without amount_off", async () => {
+      const { service } = setup();
+      const mockUser = createTestUser();
+      const mockPromotionCode = createTestPromotionCode({
+        promotion: { type: "coupon", coupon: { ...createTestCoupon(), percent_off: null, amount_off: null, valid: true } }
+      });
+      vi.spyOn(service, "findPromotionCodeByCode").mockResolvedValue(mockPromotionCode);
+
+      await expect(service.redeemCoupon(mockUser, mockPromotionCode.code)).rejects.toThrow("Invalid coupon type. Only fixed amount coupons are supported.");
+    });
+
+    it("rejects percentage-based coupons", async () => {
+      const { service } = setup();
+      const mockUser = createTestUser();
+      const mockCoupon = createTestCoupon({ percent_off: 20, amount_off: null, valid: true });
+      vi.spyOn(service, "findPromotionCodeByCode").mockResolvedValue(undefined);
+      vi.spyOn(service, "listCoupons").mockResolvedValue({ coupons: [mockCoupon] });
+
+      await expect(service.redeemCoupon(mockUser, mockCoupon.id)).rejects.toThrow(
+        "Percentage-based coupons are not supported. Only fixed amount coupons are allowed."
+      );
+    });
+
+    it("rejects coupons without amount_off", async () => {
+      const { service } = setup();
+      const mockUser = createTestUser();
+      const mockCoupon = createTestCoupon({ percent_off: null, amount_off: null, valid: true });
+      vi.spyOn(service, "findPromotionCodeByCode").mockResolvedValue(undefined);
+      vi.spyOn(service, "listCoupons").mockResolvedValue({ coupons: [mockCoupon] });
+
+      await expect(service.redeemCoupon(mockUser, mockCoupon.id)).rejects.toThrow("Invalid coupon type. Only fixed amount coupons are supported.");
+    });
+
+    it("throws when no promotion code or coupon matches the code", async () => {
+      const { service, stripe } = setup();
+      const mockUser = createTestUser();
+      vi.spyOn(stripe.promotionCodes, "list").mockResolvedValue({ data: [] } as unknown as Stripe.Response<Stripe.ApiList<Stripe.PromotionCode>>);
+      vi.spyOn(stripe.coupons, "list").mockResolvedValue({ data: [] } as unknown as Stripe.Response<Stripe.ApiList<Stripe.Coupon>>);
+
+      await expect(service.redeemCoupon(mockUser, "INVALID_CODE")).rejects.toThrow("No valid promotion code or coupon found with the provided code");
+    });
+
+    it("does not provision a Stripe customer when no matching code is found", async () => {
+      const { service, stripe, stripeService } = setup();
+      const mockUser = createTestUser({ stripeCustomerId: null });
+      vi.spyOn(stripe.promotionCodes, "list").mockResolvedValue({ data: [] } as unknown as Stripe.Response<Stripe.ApiList<Stripe.PromotionCode>>);
+      vi.spyOn(stripe.coupons, "list").mockResolvedValue({ data: [] } as unknown as Stripe.Response<Stripe.ApiList<Stripe.Coupon>>);
+
+      await expect(service.redeemCoupon(mockUser, "INVALID_CODE")).rejects.toThrow("No valid promotion code or coupon found with the provided code");
+
+      expect(stripeService.getStripeCustomerId).not.toHaveBeenCalled();
+    });
+
+    it("does not provision a Stripe customer when the coupon is unsupported", async () => {
+      const { service, stripeService } = setup();
+      const mockUser = createTestUser({ stripeCustomerId: null });
+      const mockCoupon = createTestCoupon({ percent_off: 20, amount_off: null, valid: true });
+      vi.spyOn(service, "findPromotionCodeByCode").mockResolvedValue(undefined);
+      vi.spyOn(service, "listCoupons").mockResolvedValue({ coupons: [mockCoupon] });
+
+      await expect(service.redeemCoupon(mockUser, mockCoupon.id)).rejects.toThrow(
+        "Percentage-based coupons are not supported. Only fixed amount coupons are allowed."
+      );
+
+      expect(stripeService.getStripeCustomerId).not.toHaveBeenCalled();
+    });
+
+    it("voids the invoice and does not record a transaction when the invoice flow fails", async () => {
+      const { service, stripe, stripeTransactionService } = setup();
+      const mockUser = createTestUser();
+      const mockCoupon = createTestCoupon({ id: "coupon_123", amount_off: 1000, percent_off: null, valid: true, currency: "usd", name: "Test Coupon" });
+      const mockPromotionCode = createTestPromotionCode({ id: "promo_123", promotion: { type: "coupon", coupon: mockCoupon } });
+      const mockInvoice = createTestInvoice({ id: "in_123", status: "draft" });
+
+      vi.spyOn(service, "findPromotionCodeByCode").mockResolvedValue(mockPromotionCode);
+      vi.spyOn(stripe.invoices, "create").mockResolvedValue(mockInvoice);
+      vi.spyOn(stripe.invoiceItems, "create").mockRejectedValue(new Error("Invoice item creation failed"));
+      vi.spyOn(stripe.invoices, "voidInvoice").mockResolvedValue(mock<Stripe.Response<Stripe.Invoice>>());
+
+      await expect(service.redeemCoupon(mockUser, mockPromotionCode.code)).rejects.toThrow("Invoice item creation failed");
+
+      expect(stripe.invoices.voidInvoice).toHaveBeenCalledWith(mockInvoice.id);
+      expect(stripeTransactionService.recordCouponClaim).not.toHaveBeenCalled();
+    });
+  });
+
+  function setup() {
+    const stripe = new Stripe(`sk_test_${faker.string.alphanumeric(32)}`, { apiVersion: "2025-10-29.clover", httpClient: Stripe.createFetchHttpClient() });
+    const stripeService = mock<StripeService>();
+    const stripeTransactionService = mock<StripeTransactionService>();
+
+    stripeService.getStripeCustomerId.mockImplementation(async user => user.stripeCustomerId ?? "cus_provisioned");
+    stripeTransactionService.recordCouponClaim.mockResolvedValue(
+      mock<StripeTransactionOutput>({ id: "test-transaction-id", status: "pending", type: "coupon_claim" })
+    );
+
+    const service = new CouponRedemptionService(stripe, stripeService, stripeTransactionService, () => mock<LoggerService>());
+
+    return { service, stripe, stripeService, stripeTransactionService };
+  }
+});

--- a/apps/api/src/billing/services/coupon-redemption/coupon-redemption.service.ts
+++ b/apps/api/src/billing/services/coupon-redemption/coupon-redemption.service.ts
@@ -1,0 +1,200 @@
+import type { LoggerService } from "@akashnetwork/logging";
+import Stripe from "stripe";
+import { inject, singleton } from "tsyringe";
+
+import { STRIPE_CLIENT } from "@src/billing/providers/stripe-client.provider";
+import { StripeTransactionOutput } from "@src/billing/repositories";
+import { StripeService } from "@src/billing/services/stripe/stripe.service";
+import { StripeTransactionService } from "@src/billing/services/stripe-transaction/stripe-transaction.service";
+import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
+import type { UserOutput } from "@src/user/repositories/user/user.repository";
+
+@singleton()
+export class CouponRedemptionService {
+  private readonly loggerService: LoggerService;
+
+  constructor(
+    @inject(STRIPE_CLIENT) private readonly stripe: Stripe,
+    private readonly stripeService: StripeService,
+    private readonly stripeTransactionService: StripeTransactionService,
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
+  ) {
+    this.loggerService = createLogger({ context: CouponRedemptionService.name });
+  }
+
+  async findPromotionCodeByCode(code: string): Promise<Stripe.PromotionCode | undefined> {
+    const { data: promotionCodes } = await this.stripe.promotionCodes.list({
+      code,
+      expand: ["data.promotion.coupon"]
+    });
+
+    return promotionCodes[0];
+  }
+
+  async listCoupons() {
+    const coupons = await this.stripe.coupons.list({
+      limit: 100
+    });
+    return { coupons: coupons.data };
+  }
+
+  async redeemCoupon(
+    currentUser: UserOutput,
+    couponCode: string
+  ): Promise<{
+    coupon: Stripe.Coupon | Stripe.PromotionCode;
+    amountAdded: number;
+    transactionId: string;
+    transactionStatus: StripeTransactionOutput["status"];
+  }> {
+    const promotionCode = await this.findPromotionCodeByCode(couponCode);
+
+    if (promotionCode) {
+      const coupon = promotionCode.promotion.coupon;
+
+      if (typeof coupon === "string" || !coupon) {
+        throw new Error("Promotion code coupon was not expanded");
+      }
+
+      return this.redeemCouponOrPromotionCode({
+        currentUser,
+        couponOrPromotion: promotionCode,
+        coupon,
+        updateField: "promotion_code",
+        updateId: promotionCode.id
+      });
+    }
+
+    // If no promotion code found, try to find a matching coupon
+    const { coupons } = await this.listCoupons();
+    const matchingCoupon = coupons.find(coupon => coupon.id === couponCode);
+
+    if (matchingCoupon) {
+      return this.redeemCouponOrPromotionCode({
+        currentUser,
+        couponOrPromotion: matchingCoupon,
+        coupon: matchingCoupon,
+        updateField: "coupon",
+        updateId: matchingCoupon.id
+      });
+    }
+
+    throw new Error("No valid promotion code or coupon found with the provided code");
+  }
+
+  private async redeemCouponOrPromotionCode({
+    currentUser,
+    couponOrPromotion,
+    coupon,
+    updateField,
+    updateId
+  }: {
+    currentUser: UserOutput;
+    couponOrPromotion: Stripe.Coupon | Stripe.PromotionCode;
+    coupon: Stripe.Coupon;
+    updateField: "promotion_code" | "coupon";
+    updateId: string;
+  }): Promise<{
+    coupon: Stripe.Coupon | Stripe.PromotionCode;
+    amountAdded: number;
+    transactionId: string;
+    transactionStatus: StripeTransactionOutput["status"];
+  }> {
+    this.loggerService.info({
+      event: "APPLYING_COUPON",
+      couponId: coupon.id,
+      valid: coupon.valid,
+      redeem_by: coupon.redeem_by,
+      max_redemptions: coupon.max_redemptions,
+      times_redeemed: coupon.times_redeemed,
+      updateField,
+      updateId
+    });
+
+    if (!coupon.valid) {
+      throw new Error(updateField === "promotion_code" ? "Promotion code is invalid or expired" : "Coupon is invalid or expired");
+    }
+
+    if (coupon.percent_off) {
+      throw new Error("Percentage-based coupons are not supported. Only fixed amount coupons are allowed.");
+    }
+
+    if (!coupon.amount_off) {
+      throw new Error("Invalid coupon type. Only fixed amount coupons are supported.");
+    }
+
+    const amountToAdd = coupon.amount_off; // amount_off is already in cents
+
+    // Ensure the user has a Stripe customer only once the coupon is known to be redeemable. Brand-new
+    // accounts may not have one yet since it is created lazily by the add-payment-method flow (see
+    // getStripeCustomerId); provisioning it earlier would create customers for invalid/unsupported coupons.
+    const stripeCustomerId = await this.stripeService.getStripeCustomerId(currentUser);
+
+    let invoice: Stripe.Invoice | undefined;
+
+    try {
+      invoice = await this.stripe.invoices.create({
+        customer: stripeCustomerId,
+        auto_advance: false,
+        ...(updateField === "promotion_code" ? { discounts: [{ promotion_code: updateId }] } : { discounts: [{ coupon: updateId }] })
+      });
+
+      this.loggerService.info({
+        event: "INVOICE_CREATED_WITH_DISCOUNT",
+        userId: currentUser.id,
+        invoiceId: invoice.id,
+        discountType: updateField
+      });
+
+      await this.stripe.invoiceItems.create({
+        amount: amountToAdd,
+        customer: stripeCustomerId,
+        invoice: invoice.id,
+        currency: "usd",
+        description: "Akash Network Console"
+      });
+
+      const transaction = await this.stripeTransactionService.recordCouponClaim({
+        userId: currentUser.id,
+        amount: amountToAdd,
+        currency: coupon.currency ?? "usd",
+        couponId: coupon.id,
+        promotionCodeId: updateField === "promotion_code" ? updateId : undefined,
+        invoiceId: invoice.id,
+        description: `Coupon: ${coupon.name || coupon.id}`
+      });
+
+      invoice = await this.stripe.invoices.finalizeInvoice(invoice.id);
+
+      this.loggerService.info({
+        event: "INVOICE_FINALIZED_AND_PAID",
+        userId: currentUser.id,
+        invoiceId: invoice.id,
+        status: invoice.status,
+        amountDue: invoice.amount_due,
+        amountPaid: invoice.amount_paid
+      });
+
+      return { coupon: couponOrPromotion, amountAdded: amountToAdd / 100, transactionId: transaction.id, transactionStatus: transaction.status };
+    } catch (error) {
+      let isInvoiceRolledBack: boolean | undefined;
+
+      if (invoice?.id) {
+        isInvoiceRolledBack = await this.stripe.invoices
+          .voidInvoice(invoice.id)
+          .then(() => true)
+          .catch(() => false);
+      }
+
+      this.loggerService.error({
+        event: "COUPON_APPLICATION_FAILED",
+        userId: currentUser.id,
+        couponId: updateId,
+        error,
+        isInvoiceRolledBack
+      });
+
+      throw error;
+    }
+  }
+}

--- a/apps/api/src/billing/services/stripe-transaction/stripe-transaction.service.spec.ts
+++ b/apps/api/src/billing/services/stripe-transaction/stripe-transaction.service.spec.ts
@@ -422,6 +422,35 @@ describe(StripeTransactionService.name, () => {
     }, 10_000);
   });
 
+  describe("recordCouponClaim", () => {
+    it("creates a pending coupon_claim transaction with the coupon metadata", async () => {
+      const { service, stripeTransactionRepository } = setup();
+
+      const result = await service.recordCouponClaim({
+        userId: "user_1",
+        amount: 1000,
+        currency: "usd",
+        couponId: "coupon_1",
+        promotionCodeId: "promo_1",
+        invoiceId: "in_1",
+        description: "Coupon: Test"
+      });
+
+      expect(stripeTransactionRepository.create).toHaveBeenCalledWith({
+        userId: "user_1",
+        type: "coupon_claim",
+        status: "pending",
+        amount: 1000,
+        currency: "usd",
+        stripeCouponId: "coupon_1",
+        stripePromotionCodeId: "promo_1",
+        stripeInvoiceId: "in_1",
+        description: "Coupon: Test"
+      });
+      expect(result).toEqual(expect.objectContaining({ type: "coupon_claim" }));
+    });
+  });
+
   function setup(params: { paymentIntent?: Stripe.Response<Stripe.PaymentIntent> } = {}) {
     const stripeTransactionRepository = mock<StripeTransactionRepository>();
     const timerService = mock<TimerService>();

--- a/apps/api/src/billing/services/stripe-transaction/stripe-transaction.service.ts
+++ b/apps/api/src/billing/services/stripe-transaction/stripe-transaction.service.ts
@@ -565,4 +565,26 @@ export class StripeTransactionService {
       transactionId: transaction.id
     });
   }
+
+  async recordCouponClaim(params: {
+    userId: string;
+    amount: number;
+    currency: string;
+    couponId: string;
+    promotionCodeId?: string;
+    invoiceId: string;
+    description: string;
+  }): Promise<StripeTransactionOutput> {
+    return this.stripeTransactionRepository.create({
+      userId: params.userId,
+      type: "coupon_claim",
+      status: "pending",
+      amount: params.amount,
+      currency: params.currency,
+      stripeCouponId: params.couponId,
+      stripePromotionCodeId: params.promotionCodeId,
+      stripeInvoiceId: params.invoiceId,
+      description: params.description
+    });
+  }
 }

--- a/apps/api/src/billing/services/stripe/stripe.service.spec.ts
+++ b/apps/api/src/billing/services/stripe/stripe.service.spec.ts
@@ -5,7 +5,7 @@ import Stripe from "stripe";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
-import type { PaymentMethodRepository, StripeTransactionRepository } from "@src/billing/repositories";
+import type { PaymentMethodRepository } from "@src/billing/repositories";
 import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import type { UserRepository } from "@src/user/repositories";
 import { StripeService } from "./stripe.service";
@@ -13,7 +13,7 @@ import { StripeService } from "./stripe.service";
 import { generateDatabasePaymentMethod } from "@test/seeders/database-payment-method.seeder";
 import { generatePaymentMethod } from "@test/seeders/payment-method.seeder";
 import { create as StripeSeederCreate } from "@test/seeders/stripe.seeder";
-import { createTestCoupon, createTestInvoice, createTestPaymentIntent, createTestPromotionCode, TEST_CONSTANTS } from "@test/seeders/stripe-test-data.seeder";
+import { createTestInvoice, createTestPaymentIntent, TEST_CONSTANTS } from "@test/seeders/stripe-test-data.seeder";
 import { createUser } from "@test/seeders/user.seeder";
 import { createTestUser } from "@test/seeders/user-test.seeder";
 
@@ -45,339 +45,6 @@ describe(StripeService.name, () => {
         { returning: true }
       );
       expect(result).toEqual(StripeSeederCreate().customer.id);
-    });
-  });
-
-  describe("applyCoupon", () => {
-    it("applies promotion code successfully, creates invoice with item, and leaves transaction pending for webhook", async () => {
-      const { service, stripe, stripeTransactionRepository } = setup();
-      const mockUser = createTestUser();
-      const mockCoupon = createTestCoupon({
-        id: "coupon_123",
-        amount_off: 1000,
-        percent_off: null,
-        valid: true,
-        currency: "usd",
-        name: "Test Coupon"
-      });
-      const mockPromotionCode = createTestPromotionCode({
-        id: "promo_123",
-        promotion: {
-          type: "coupon",
-          coupon: mockCoupon
-        }
-      });
-      const mockInvoice = createTestInvoice({ id: "in_123", status: "draft" });
-      const mockFinalizedInvoice = createTestInvoice({ id: "in_123", status: "paid" });
-
-      vi.spyOn(service, "findPromotionCodeByCode").mockResolvedValue(mockPromotionCode);
-      vi.spyOn(stripe.invoices, "create").mockResolvedValue(mockInvoice);
-      vi.spyOn(stripe.invoiceItems, "create").mockResolvedValue(mock<Stripe.Response<Stripe.InvoiceItem>>());
-      vi.spyOn(stripe.invoices, "finalizeInvoice").mockResolvedValue(mockFinalizedInvoice);
-
-      const result = await service.applyCoupon(mockUser, mockPromotionCode.code);
-
-      expect(stripe.invoices.create).toHaveBeenCalledWith({
-        customer: mockUser.stripeCustomerId,
-        auto_advance: false,
-        discounts: [{ promotion_code: mockPromotionCode.id }]
-      });
-      expect(stripe.invoiceItems.create).toHaveBeenCalledWith({
-        amount: 1000,
-        customer: mockUser.stripeCustomerId,
-        invoice: mockInvoice.id,
-        currency: "usd",
-        description: "Akash Network Console"
-      });
-      expect(stripe.invoices.finalizeInvoice).toHaveBeenCalledWith(mockInvoice.id);
-
-      expect(stripeTransactionRepository.create).toHaveBeenCalledWith({
-        userId: mockUser.id,
-        type: "coupon_claim",
-        status: "pending",
-        amount: 1000,
-        currency: "usd",
-        stripeCouponId: mockCoupon.id,
-        stripePromotionCodeId: mockPromotionCode.id,
-        stripeInvoiceId: mockInvoice.id,
-        description: `Coupon: ${mockCoupon.name}`
-      });
-
-      expect(stripeTransactionRepository.updateById).not.toHaveBeenCalled();
-
-      expect(result).toEqual({
-        coupon: mockPromotionCode,
-        amountAdded: 10, // 1000 cents = $10
-        transactionId: "test-transaction-id",
-        transactionStatus: "pending"
-      });
-    });
-
-    it("creates a Stripe customer before redeeming when the account has none, then applies the coupon", async () => {
-      const { service, stripe, userRepository, stripeTransactionRepository } = setup();
-      const mockUser = createTestUser({ stripeCustomerId: null });
-      const createdCustomer = mock<Stripe.Response<Stripe.Customer>>({ id: "cus_new_456" });
-      const mockCoupon = createTestCoupon({
-        id: "coupon_new",
-        amount_off: 1000,
-        percent_off: null,
-        valid: true,
-        currency: "usd",
-        name: "New User Coupon"
-      });
-      const mockPromotionCode = createTestPromotionCode({
-        id: "promo_new",
-        promotion: {
-          type: "coupon",
-          coupon: mockCoupon
-        }
-      });
-      const mockInvoice = createTestInvoice({ id: "in_new", status: "draft" });
-
-      vi.spyOn(stripe.customers, "create").mockResolvedValue(createdCustomer);
-      vi.spyOn(service, "findPromotionCodeByCode").mockResolvedValue(mockPromotionCode);
-      vi.spyOn(stripe.invoices, "create").mockResolvedValue(mockInvoice);
-      vi.spyOn(stripe.invoiceItems, "create").mockResolvedValue(mock<Stripe.Response<Stripe.InvoiceItem>>());
-      vi.spyOn(stripe.invoices, "finalizeInvoice").mockResolvedValue(createTestInvoice({ id: "in_new", status: "paid" }));
-
-      const result = await service.applyCoupon(mockUser, mockPromotionCode.code);
-
-      expect(stripe.customers.create).toHaveBeenCalledWith(
-        {
-          email: mockUser.email,
-          name: mockUser.username,
-          metadata: { userId: mockUser.id }
-        },
-        { idempotencyKey: `create-customer:${mockUser.id}` }
-      );
-      expect(userRepository.updateBy).toHaveBeenCalledWith(
-        { id: mockUser.id, stripeCustomerId: null },
-        { stripeCustomerId: "cus_new_456" },
-        { returning: true }
-      );
-      expect(stripe.invoices.create).toHaveBeenCalledWith({
-        customer: "cus_new_456",
-        auto_advance: false,
-        discounts: [{ promotion_code: mockPromotionCode.id }]
-      });
-      expect(stripe.invoiceItems.create).toHaveBeenCalledWith({
-        amount: 1000,
-        customer: "cus_new_456",
-        invoice: mockInvoice.id,
-        currency: "usd",
-        description: "Akash Network Console"
-      });
-      expect(stripeTransactionRepository.create).toHaveBeenCalledWith({
-        userId: mockUser.id,
-        type: "coupon_claim",
-        status: "pending",
-        amount: 1000,
-        currency: "usd",
-        stripeCouponId: mockCoupon.id,
-        stripePromotionCodeId: mockPromotionCode.id,
-        stripeInvoiceId: mockInvoice.id,
-        description: `Coupon: ${mockCoupon.name}`
-      });
-
-      expect(result).toEqual({
-        coupon: mockPromotionCode,
-        amountAdded: 10,
-        transactionId: "test-transaction-id",
-        transactionStatus: "pending"
-      });
-    });
-
-    it("applies coupon successfully when no promotion code found", async () => {
-      const { service, stripe, stripeTransactionRepository } = setup();
-      const mockUser = createTestUser();
-      const mockCoupon = createTestCoupon({
-        id: "coupon_direct",
-        amount_off: 500,
-        percent_off: null,
-        valid: true,
-        currency: "usd",
-        name: "Direct Coupon"
-      });
-      const mockInvoice = createTestInvoice({ id: "in_456", status: "draft" });
-      const mockFinalizedInvoice = createTestInvoice({ id: "in_456", status: "paid" });
-
-      vi.spyOn(service, "findPromotionCodeByCode").mockResolvedValue(undefined);
-      vi.spyOn(service, "listCoupons").mockResolvedValue({ coupons: [mockCoupon] });
-      vi.spyOn(stripe.invoices, "create").mockResolvedValue(mockInvoice);
-      vi.spyOn(stripe.invoiceItems, "create").mockResolvedValue(mock<Stripe.Response<Stripe.InvoiceItem>>());
-      vi.spyOn(stripe.invoices, "finalizeInvoice").mockResolvedValue(mockFinalizedInvoice);
-
-      const result = await service.applyCoupon(mockUser, mockCoupon.id);
-
-      expect(stripe.invoices.create).toHaveBeenCalledWith({
-        customer: mockUser.stripeCustomerId,
-        auto_advance: false,
-        discounts: [{ coupon: mockCoupon.id }]
-      });
-      expect(stripe.invoiceItems.create).toHaveBeenCalledWith({
-        amount: 500,
-        customer: mockUser.stripeCustomerId,
-        invoice: mockInvoice.id,
-        currency: "usd",
-        description: "Akash Network Console"
-      });
-      expect(stripe.invoices.finalizeInvoice).toHaveBeenCalledWith(mockInvoice.id);
-
-      expect(stripeTransactionRepository.create).toHaveBeenCalledWith({
-        userId: mockUser.id,
-        type: "coupon_claim",
-        status: "pending",
-        amount: 500,
-        currency: "usd",
-        stripeCouponId: mockCoupon.id,
-        stripePromotionCodeId: undefined,
-        stripeInvoiceId: mockInvoice.id,
-        description: `Coupon: ${mockCoupon.name}`
-      });
-
-      expect(stripeTransactionRepository.updateById).not.toHaveBeenCalled();
-
-      expect(result).toEqual({
-        coupon: mockCoupon,
-        amountAdded: 5, // 500 cents = $5
-        transactionId: "test-transaction-id",
-        transactionStatus: "pending"
-      });
-    });
-
-    it("rejects percentage-based promotion codes", async () => {
-      const { service } = setup();
-      const mockUser = createTestUser();
-      const mockPromotionCode = createTestPromotionCode({
-        promotion: {
-          type: "coupon",
-          coupon: {
-            ...createTestCoupon(),
-            percent_off: 20,
-            amount_off: null,
-            valid: true
-          }
-        }
-      });
-      vi.spyOn(service, "findPromotionCodeByCode").mockResolvedValue(mockPromotionCode);
-
-      await expect(service.applyCoupon(mockUser, mockPromotionCode.code)).rejects.toThrow(
-        "Percentage-based coupons are not supported. Only fixed amount coupons are allowed."
-      );
-    });
-
-    it("rejects promotion codes without amount_off", async () => {
-      const { service } = setup();
-      const mockUser = createTestUser();
-      const mockPromotionCode = createTestPromotionCode({
-        promotion: {
-          type: "coupon",
-          coupon: {
-            ...createTestCoupon(),
-            percent_off: null,
-            amount_off: null,
-            valid: true
-          }
-        }
-      });
-      vi.spyOn(service, "findPromotionCodeByCode").mockResolvedValue(mockPromotionCode);
-
-      await expect(service.applyCoupon(mockUser, mockPromotionCode.code)).rejects.toThrow("Invalid coupon type. Only fixed amount coupons are supported.");
-    });
-
-    it("rejects percentage-based coupons", async () => {
-      const { service } = setup();
-      const mockUser = createTestUser();
-      const mockCoupon = createTestCoupon({
-        percent_off: 20,
-        amount_off: null,
-        valid: true
-      });
-      vi.spyOn(service, "findPromotionCodeByCode").mockResolvedValue(undefined);
-      vi.spyOn(service, "listCoupons").mockResolvedValue({ coupons: [mockCoupon] });
-
-      await expect(service.applyCoupon(mockUser, mockCoupon.id)).rejects.toThrow(
-        "Percentage-based coupons are not supported. Only fixed amount coupons are allowed."
-      );
-    });
-
-    it("rejects coupons without amount_off", async () => {
-      const { service } = setup();
-      const mockUser = createTestUser();
-      const mockCoupon = createTestCoupon({
-        percent_off: null,
-        amount_off: null,
-        valid: true
-      });
-      vi.spyOn(service, "findPromotionCodeByCode").mockResolvedValue(undefined);
-      vi.spyOn(service, "listCoupons").mockResolvedValue({ coupons: [mockCoupon] });
-
-      await expect(service.applyCoupon(mockUser, mockCoupon.id)).rejects.toThrow("Invalid coupon type. Only fixed amount coupons are supported.");
-    });
-
-    it("throws error for invalid promotion code", async () => {
-      const { service, stripe } = setup();
-      const mockUser = createTestUser();
-      vi.spyOn(stripe.promotionCodes, "list").mockResolvedValue({ data: [] } as unknown as Stripe.Response<Stripe.ApiList<Stripe.PromotionCode>>);
-      vi.spyOn(stripe.coupons, "list").mockResolvedValue({ data: [] } as unknown as Stripe.Response<Stripe.ApiList<Stripe.Coupon>>);
-
-      await expect(service.applyCoupon(mockUser, "INVALID_CODE")).rejects.toThrow("No valid promotion code or coupon found with the provided code");
-    });
-
-    it("does not provision a Stripe customer for a brand-new account when no matching code is found", async () => {
-      const { service, stripe } = setup();
-      const mockUser = createTestUser({ stripeCustomerId: null });
-      vi.spyOn(stripe.promotionCodes, "list").mockResolvedValue({ data: [] } as unknown as Stripe.Response<Stripe.ApiList<Stripe.PromotionCode>>);
-      vi.spyOn(stripe.coupons, "list").mockResolvedValue({ data: [] } as unknown as Stripe.Response<Stripe.ApiList<Stripe.Coupon>>);
-
-      await expect(service.applyCoupon(mockUser, "INVALID_CODE")).rejects.toThrow("No valid promotion code or coupon found with the provided code");
-
-      expect(stripe.customers.create).not.toHaveBeenCalled();
-    });
-
-    it("does not provision a Stripe customer for a brand-new account when the coupon is unsupported", async () => {
-      const { service, stripe } = setup();
-      const mockUser = createTestUser({ stripeCustomerId: null });
-      const mockCoupon = createTestCoupon({ percent_off: 20, amount_off: null, valid: true });
-      vi.spyOn(service, "findPromotionCodeByCode").mockResolvedValue(undefined);
-      vi.spyOn(service, "listCoupons").mockResolvedValue({ coupons: [mockCoupon] });
-
-      await expect(service.applyCoupon(mockUser, mockCoupon.id)).rejects.toThrow(
-        "Percentage-based coupons are not supported. Only fixed amount coupons are allowed."
-      );
-
-      expect(stripe.customers.create).not.toHaveBeenCalled();
-    });
-
-    it("voids invoice on error after invoice is created", async () => {
-      const { service, stripe, stripeTransactionRepository } = setup();
-      const mockUser = createTestUser();
-      const mockCoupon = createTestCoupon({
-        id: "coupon_123",
-        amount_off: 1000,
-        percent_off: null,
-        valid: true,
-        currency: "usd",
-        name: "Test Coupon"
-      });
-      const mockPromotionCode = createTestPromotionCode({
-        id: "promo_123",
-        promotion: {
-          type: "coupon",
-          coupon: mockCoupon
-        }
-      });
-      const mockInvoice = createTestInvoice({ id: "in_123", status: "draft" });
-
-      vi.spyOn(service, "findPromotionCodeByCode").mockResolvedValue(mockPromotionCode);
-      vi.spyOn(stripe.invoices, "create").mockResolvedValue(mockInvoice);
-      vi.spyOn(stripe.invoiceItems, "create").mockRejectedValue(new Error("Invoice item creation failed"));
-      vi.spyOn(stripe.invoices, "voidInvoice").mockResolvedValue(mock<Stripe.Response<Stripe.Invoice>>());
-
-      await expect(service.applyCoupon(mockUser, mockPromotionCode.code)).rejects.toThrow("Invoice item creation failed");
-
-      expect(stripe.invoices.voidInvoice).toHaveBeenCalledWith(mockInvoice.id);
-      expect(stripeTransactionRepository.create).not.toHaveBeenCalled();
     });
   });
 
@@ -445,23 +112,6 @@ describe(StripeService.name, () => {
         expand: ["data.promotion.coupon"]
       });
       expect(result).toEqual({ promotionCodes: mockPromotionCodes });
-    });
-  });
-
-  describe("listCoupons", () => {
-    it("returns coupons", async () => {
-      const { service, stripe } = setup();
-      const mockCoupons = [
-        { id: TEST_CONSTANTS.COUPON_ID, percent_off: 50 },
-        { id: "coupon_456", amount_off: 1000 }
-      ];
-      vi.spyOn(stripe.coupons, "list").mockResolvedValue({ data: mockCoupons } as unknown as Stripe.Response<Stripe.ApiList<Stripe.Coupon>>);
-
-      const result = await service.listCoupons();
-      expect(stripe.coupons.list).toHaveBeenCalledWith({
-        limit: 100
-      });
-      expect(result).toEqual({ coupons: mockCoupons });
     });
   });
 
@@ -1016,39 +666,11 @@ function setup(
   const billingConfig = mock<BillingConfigService>({ get: vi.fn().mockReturnValue("sk_live_key") });
   const userRepository = mock<UserRepository>();
   const paymentMethodRepository = mock<PaymentMethodRepository>();
-  const stripeTransactionRepository = mock<StripeTransactionRepository>();
 
   const stripe = new Stripe(`sk_test_${faker.string.alphanumeric(32)}`, { apiVersion: "2025-10-29.clover", httpClient: Stripe.createFetchHttpClient() });
 
-  const service = new StripeService(billingConfig, userRepository, paymentMethodRepository, stripeTransactionRepository, stripe, () => mock<LoggerService>());
+  const service = new StripeService(billingConfig, userRepository, paymentMethodRepository, stripe, () => mock<LoggerService>());
 
-  // Setup stripe transaction repository mocks
-  stripeTransactionRepository.create.mockImplementation(async input => ({
-    id: "test-transaction-id",
-    userId: input.userId,
-    type: input.type,
-    status: input.status ?? "created",
-    amount: input.amount,
-    amountRefunded: input.amountRefunded ?? 0,
-    bonusAmount: input.bonusAmount ?? 0,
-    currency: input.currency ?? "usd",
-    stripePaymentIntentId: input.stripePaymentIntentId ?? null,
-    stripeChargeId: input.stripeChargeId ?? null,
-    stripeCouponId: input.stripeCouponId ?? null,
-    stripePromotionCodeId: input.stripePromotionCodeId ?? null,
-    stripeInvoiceId: input.stripeInvoiceId ?? null,
-    stripeIdempotencyKey: input.stripeIdempotencyKey ?? null,
-    paymentMethodType: input.paymentMethodType ?? null,
-    cardBrand: input.cardBrand ?? null,
-    cardLast4: input.cardLast4 ?? null,
-    receiptUrl: input.receiptUrl ?? null,
-    description: input.description ?? null,
-    errorMessage: input.errorMessage ?? null,
-    createdAt: new Date(),
-    updatedAt: new Date()
-  }));
-  stripeTransactionRepository.updateById.mockResolvedValue(undefined);
-  stripeTransactionRepository.findByChargeIds.mockResolvedValue([]);
   const stripeData = StripeSeederCreate();
 
   // Store the last user for correct mocking
@@ -1122,7 +744,6 @@ function setup(
     stripe,
     userRepository,
     billingConfig,
-    paymentMethodRepository,
-    stripeTransactionRepository
+    paymentMethodRepository
   };
 }

--- a/apps/api/src/billing/services/stripe/stripe.service.ts
+++ b/apps/api/src/billing/services/stripe/stripe.service.ts
@@ -6,7 +6,7 @@ import { inject, singleton } from "tsyringe";
 
 import { extractFingerprint } from "@src/billing/lib/payment-method/extract-fingerprint";
 import { STRIPE_CLIENT } from "@src/billing/providers/stripe-client.provider";
-import { PaymentMethodRepository, StripeTransactionOutput, StripeTransactionRepository } from "@src/billing/repositories";
+import { PaymentMethodRepository } from "@src/billing/repositories";
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
 import { type UserOutput, UserRepository } from "@src/user/repositories/user/user.repository";
@@ -41,7 +41,6 @@ export class StripeService {
     private readonly billingConfig: BillingConfigService,
     private readonly userRepository: UserRepository,
     private readonly paymentMethodRepository: PaymentMethodRepository,
-    private readonly stripeTransactionRepository: StripeTransactionRepository,
     @inject(STRIPE_CLIENT) private readonly stripe: Stripe,
     @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
@@ -89,184 +88,6 @@ export class StripeService {
       expand: ["data.promotion.coupon"]
     });
     return { promotionCodes: promotionCodes.data };
-  }
-
-  async findPromotionCodeByCode(code: string): Promise<Stripe.PromotionCode | undefined> {
-    const { data: promotionCodes } = await this.stripe.promotionCodes.list({
-      code,
-      expand: ["data.promotion.coupon"]
-    });
-
-    return promotionCodes[0];
-  }
-
-  async applyCoupon(
-    currentUser: UserOutput,
-    couponCode: string
-  ): Promise<{
-    coupon: Stripe.Coupon | Stripe.PromotionCode;
-    amountAdded: number;
-    transactionId: string;
-    transactionStatus: StripeTransactionOutput["status"];
-  }> {
-    const promotionCode = await this.findPromotionCodeByCode(couponCode);
-
-    if (promotionCode) {
-      const coupon = promotionCode.promotion.coupon;
-
-      if (typeof coupon === "string" || !coupon) {
-        throw new Error("Promotion code coupon was not expanded");
-      }
-
-      return this.applyCouponOrPromotionCode({
-        currentUser,
-        couponOrPromotion: promotionCode,
-        coupon,
-        updateField: "promotion_code",
-        updateId: promotionCode.id
-      });
-    }
-
-    // If no promotion code found, try to find a matching coupon
-    const { coupons } = await this.listCoupons();
-    const matchingCoupon = coupons.find(coupon => coupon.id === couponCode);
-
-    if (matchingCoupon) {
-      return this.applyCouponOrPromotionCode({
-        currentUser,
-        couponOrPromotion: matchingCoupon,
-        coupon: matchingCoupon,
-        updateField: "coupon",
-        updateId: matchingCoupon.id
-      });
-    }
-
-    throw new Error("No valid promotion code or coupon found with the provided code");
-  }
-
-  private async applyCouponOrPromotionCode({
-    currentUser,
-    couponOrPromotion,
-    coupon,
-    updateField,
-    updateId
-  }: {
-    currentUser: UserOutput;
-    couponOrPromotion: Stripe.Coupon | Stripe.PromotionCode;
-    coupon: Stripe.Coupon;
-    updateField: "promotion_code" | "coupon";
-    updateId: string;
-  }): Promise<{
-    coupon: Stripe.Coupon | Stripe.PromotionCode;
-    amountAdded: number;
-    transactionId: string;
-    transactionStatus: StripeTransactionOutput["status"];
-  }> {
-    this.loggerService.info({
-      event: "APPLYING_COUPON",
-      couponId: coupon.id,
-      valid: coupon.valid,
-      redeem_by: coupon.redeem_by,
-      max_redemptions: coupon.max_redemptions,
-      times_redeemed: coupon.times_redeemed,
-      updateField,
-      updateId
-    });
-
-    if (!coupon.valid) {
-      throw new Error(updateField === "promotion_code" ? "Promotion code is invalid or expired" : "Coupon is invalid or expired");
-    }
-
-    if (coupon.percent_off) {
-      throw new Error("Percentage-based coupons are not supported. Only fixed amount coupons are allowed.");
-    }
-
-    if (!coupon.amount_off) {
-      throw new Error("Invalid coupon type. Only fixed amount coupons are supported.");
-    }
-
-    const amountToAdd = coupon.amount_off; // amount_off is already in cents
-
-    // Ensure the user has a Stripe customer only once the coupon is known to be redeemable. Brand-new
-    // accounts may not have one yet since it is created lazily by the add-payment-method flow (see
-    // getStripeCustomerId); provisioning it earlier would create customers for invalid/unsupported coupons.
-    const stripeCustomerId = await this.getStripeCustomerId(currentUser);
-
-    let invoice: Stripe.Invoice | undefined;
-
-    try {
-      invoice = await this.stripe.invoices.create({
-        customer: stripeCustomerId,
-        auto_advance: false,
-        ...(updateField === "promotion_code" ? { discounts: [{ promotion_code: updateId }] } : { discounts: [{ coupon: updateId }] })
-      });
-
-      this.loggerService.info({
-        event: "INVOICE_CREATED_WITH_DISCOUNT",
-        userId: currentUser.id,
-        invoiceId: invoice.id,
-        discountType: updateField
-      });
-
-      await this.stripe.invoiceItems.create({
-        amount: amountToAdd,
-        customer: stripeCustomerId,
-        invoice: invoice.id,
-        currency: "usd",
-        description: "Akash Network Console"
-      });
-
-      invoice = await this.stripe.invoices.finalizeInvoice(invoice.id);
-
-      this.loggerService.info({
-        event: "INVOICE_FINALIZED_AND_PAID",
-        userId: currentUser.id,
-        invoiceId: invoice.id,
-        status: invoice.status,
-        amountDue: invoice.amount_due,
-        amountPaid: invoice.amount_paid
-      });
-
-      const transaction = await this.stripeTransactionRepository.create({
-        userId: currentUser.id,
-        type: "coupon_claim",
-        status: "pending",
-        amount: amountToAdd,
-        currency: coupon.currency ?? "usd",
-        stripeCouponId: coupon.id,
-        stripePromotionCodeId: updateField === "promotion_code" ? updateId : undefined,
-        stripeInvoiceId: invoice.id,
-        description: `Coupon: ${coupon.name || coupon.id}`
-      });
-
-      return { coupon: couponOrPromotion, amountAdded: amountToAdd / 100, transactionId: transaction.id, transactionStatus: transaction.status };
-    } catch (error) {
-      let isInvoiceRolledBack: boolean | undefined;
-
-      if (invoice?.id) {
-        isInvoiceRolledBack = await this.stripe.invoices
-          .voidInvoice(invoice.id)
-          .then(() => true)
-          .catch(() => false);
-      }
-
-      this.loggerService.error({
-        event: "COUPON_APPLICATION_FAILED",
-        userId: currentUser.id,
-        couponId: updateId,
-        error,
-        isInvoiceRolledBack
-      });
-
-      throw error;
-    }
-  }
-
-  async listCoupons() {
-    const coupons = await this.stripe.coupons.list({
-      limit: 100
-    });
-    return { coupons: coupons.data };
   }
 
   async getCoupon(couponId: string) {


### PR DESCRIPTION
## Why

Coupon/promotion redemption — including its Stripe invoice flow — is billing business logic embedded in the `StripeService` god object. It's a self-contained concern (invoice orchestration + transaction recording) unrelated to charging, customers, or payment methods.

This PR extracts it into a dedicated `CouponRedemptionService` that uses the shared Stripe client and records the coupon-claim transaction through the payment-transaction owner. Behavior-preserving — no change to redemption or crediting.

Closes CON-725 · Part of CON-718.

## What

`apps/api` — behavior-preserving, no new runtime behavior, no migrations.

- Adds `@singleton CouponRedemptionService`: `redeemCoupon` + the invoice flow (`redeemCouponOrPromotionCode`) + the redemption-only lookups (`findPromotionCodeByCode`, `listCoupons`), moved from `StripeService`. Injects the raw Stripe client (invoice/promotion/coupon calls), `StripeService` (only `getStripeCustomerId` — lazy customer provisioning, transitional until the customer service is extracted), and `StripeTransactionService`.
- The coupon-claim transaction is created via new `StripeTransactionService.recordCouponClaim` instead of a direct repository write, so the transactions table stays written in one place.
- **Naming reflects the domain:** this is a *redemption* coupon (redeemed for credits), distinct from discount coupons that would be *applied* — hence `CouponRedemptionService.redeemCoupon`. The public endpoint/operationId (`applyStripeCoupon`) is left unchanged (API contract).
- `StripeController` delegates to `couponRedemptionService.redeemCoupon`. `StripeService` sheds the four redemption methods and its now-unused `StripeTransactionRepository` dependency; `getCoupon` / `listPromotionCodes` stay (unrelated to redemption).

## Verification

- **Billing unit suite green — 368 tests / 31 files** (new `coupon-redemption.service` spec; the redemption tests moved out of the `stripe.service` spec).
- `tsc`: zero errors in the changed set. `eslint` clean. Prettier clean.
- No `@WithTransaction` in the redemption flow, so everything is unit-tested — no integration spec needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added coupon redemption support for fixed-amount Stripe coupons and promotion codes.
  * Redemption is validated, credited via an invoice, and recorded as a pending coupon-claim transaction.
  * Improved handling for unmatched/unsupported codes with clear error messages.
* **Bug Fixes**
  * Failed redemptions now void the created invoice when possible.
  * Stripe customer provisioning happens only after coupon validation succeeds.
* **Tests**
  * Added and updated coverage for coupon redemption and coupon-claim transaction recording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->