### PR TITLE
refactor(billing): move Stripe customer provisioning into a dedicated service

### DIFF
--- a/apps/api/src/billing/controllers/stripe/stripe.controller.spec.ts
+++ b/apps/api/src/billing/controllers/stripe/stripe.controller.spec.ts
@@ -7,6 +7,7 @@ import { mock } from "vitest-mock-extended";
 import { AuthService } from "@src/auth/services/auth.service";
 import type { UserWalletOutput, UserWalletRepository } from "@src/billing/repositories";
 import type { CouponRedemptionService } from "@src/billing/services/coupon-redemption/coupon-redemption.service";
+import type { CustomerService } from "@src/billing/services/customer/customer.service";
 import type { PayingUser } from "@src/billing/services/paying-user/paying-user";
 import type { PaymentMethodService } from "@src/billing/services/payment-method/payment-method.service";
 import { type PaymentMethod } from "@src/billing/services/payment-method/payment-method.service";
@@ -220,11 +221,11 @@ describe(StripeController.name, () => {
 
   describe("createSetupIntent", () => {
     it("passes isFreeTrial true when user wallet is trialing", async () => {
-      const { controller, stripe, userWalletRepository, user } = setup();
+      const { controller, stripe, customerService, userWalletRepository, user } = setup();
       const clientSecret = faker.string.alphanumeric(32);
 
       userWalletRepository.findOneByUserId.mockResolvedValue(mock<UserWalletOutput>({ isTrialing: true }));
-      stripe.getStripeCustomerId.mockResolvedValue(user.stripeCustomerId!);
+      customerService.getStripeCustomerId.mockResolvedValue(user.stripeCustomerId!);
       stripe.createSetupIntent.mockResolvedValue(mock<Stripe.Response<Stripe.SetupIntent>>({ client_secret: clientSecret }));
 
       const result = await controller.createSetupIntent();
@@ -234,11 +235,11 @@ describe(StripeController.name, () => {
     });
 
     it("passes isFreeTrial false when user wallet is not trialing", async () => {
-      const { controller, stripe, userWalletRepository, user } = setup();
+      const { controller, stripe, customerService, userWalletRepository, user } = setup();
       const clientSecret = faker.string.alphanumeric(32);
 
       userWalletRepository.findOneByUserId.mockResolvedValue(mock<UserWalletOutput>({ isTrialing: false }));
-      stripe.getStripeCustomerId.mockResolvedValue(user.stripeCustomerId!);
+      customerService.getStripeCustomerId.mockResolvedValue(user.stripeCustomerId!);
       stripe.createSetupIntent.mockResolvedValue(mock<Stripe.Response<Stripe.SetupIntent>>({ client_secret: clientSecret }));
 
       const result = await controller.createSetupIntent();
@@ -248,11 +249,11 @@ describe(StripeController.name, () => {
     });
 
     it("defaults isFreeTrial to true when no wallet exists", async () => {
-      const { controller, stripe, userWalletRepository, user } = setup();
+      const { controller, stripe, customerService, userWalletRepository, user } = setup();
       const clientSecret = faker.string.alphanumeric(32);
 
       userWalletRepository.findOneByUserId.mockResolvedValue(undefined);
-      stripe.getStripeCustomerId.mockResolvedValue(user.stripeCustomerId!);
+      customerService.getStripeCustomerId.mockResolvedValue(user.stripeCustomerId!);
       stripe.createSetupIntent.mockResolvedValue(mock<Stripe.Response<Stripe.SetupIntent>>({ client_secret: clientSecret }));
 
       const result = await controller.createSetupIntent();
@@ -433,6 +434,7 @@ describe(StripeController.name, () => {
     const stripe = mock<StripeService>();
     const paymentMethodService = mock<PaymentMethodService>();
     const couponRedemptionService = mock<CouponRedemptionService>();
+    const customerService = mock<CustomerService>();
     const stripeTransaction = mock<StripeTransactionService>();
     const authService = mock<AuthService>({
       currentUser: user
@@ -451,7 +453,8 @@ describe(StripeController.name, () => {
       trialValidationService,
       transactionReporting,
       paymentMethodService,
-      couponRedemptionService
+      couponRedemptionService,
+      customerService
     );
     container.register(AuthService, { useValue: authService });
 
@@ -460,6 +463,7 @@ describe(StripeController.name, () => {
       stripe,
       paymentMethodService,
       couponRedemptionService,
+      customerService,
       stripeTransaction,
       authService,
       stripeErrorService,

--- a/apps/api/src/billing/controllers/stripe/stripe.controller.ts
+++ b/apps/api/src/billing/controllers/stripe/stripe.controller.ts
@@ -22,6 +22,7 @@ import {
 import type { StripeTransactionOutput } from "@src/billing/repositories";
 import { UserWalletRepository } from "@src/billing/repositories";
 import { CouponRedemptionService } from "@src/billing/services/coupon-redemption/coupon-redemption.service";
+import { CustomerService } from "@src/billing/services/customer/customer.service";
 import { PaymentMethodService } from "@src/billing/services/payment-method/payment-method.service";
 import { StripeService, TOP_UP_IDEMPOTENCY_KEY_PREFIX } from "@src/billing/services/stripe/stripe.service";
 import { StripeErrorService } from "@src/billing/services/stripe-error/stripe-error.service";
@@ -39,7 +40,8 @@ export class StripeController {
     private readonly trialValidationService: TrialValidationService,
     private readonly transactionReporting: TransactionReportingService,
     private readonly paymentMethodService: PaymentMethodService,
-    private readonly couponRedemptionService: CouponRedemptionService
+    private readonly couponRedemptionService: CouponRedemptionService,
+    private readonly customerService: CustomerService
   ) {}
 
   @Protected([{ action: "read", subject: "StripePayment" }])
@@ -51,7 +53,7 @@ export class StripeController {
   async createSetupIntent(): Promise<{ data: { clientSecret: string | null } }> {
     const { currentUser } = this.authService;
 
-    const stripeCustomerId = await this.stripe.getStripeCustomerId(currentUser);
+    const stripeCustomerId = await this.customerService.getStripeCustomerId(currentUser);
     const userWallet = await this.userWalletRepository.findOneByUserId(currentUser.id);
     const isFreeTrial = userWallet?.isTrialing ?? true;
 
@@ -263,6 +265,6 @@ export class StripeController {
 
     assert(currentUser.stripeCustomerId, 400, "Payment method is not configured for this user");
 
-    await this.stripe.updateCustomerOrganization(currentUser.stripeCustomerId, input.organization);
+    await this.customerService.updateCustomerOrganization(currentUser.stripeCustomerId, input.organization);
   }
 }

--- a/apps/api/src/billing/services/coupon-redemption/coupon-redemption.service.spec.ts
+++ b/apps/api/src/billing/services/coupon-redemption/coupon-redemption.service.spec.ts
@@ -5,7 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { StripeTransactionOutput } from "@src/billing/repositories";
-import type { StripeService } from "@src/billing/services/stripe/stripe.service";
+import type { CustomerService } from "@src/billing/services/customer/customer.service";
 import type { StripeTransactionService } from "@src/billing/services/stripe-transaction/stripe-transaction.service";
 import { CouponRedemptionService } from "./coupon-redemption.service";
 
@@ -71,9 +71,9 @@ describe(CouponRedemptionService.name, () => {
     });
 
     it("provisions a Stripe customer via getStripeCustomerId before redeeming when the account has none", async () => {
-      const { service, stripe, stripeService, stripeTransactionService } = setup();
+      const { service, stripe, customerService, stripeTransactionService } = setup();
       const mockUser = createTestUser({ stripeCustomerId: null });
-      stripeService.getStripeCustomerId.mockResolvedValue("cus_new_456");
+      customerService.getStripeCustomerId.mockResolvedValue("cus_new_456");
       const mockCoupon = createTestCoupon({ id: "coupon_new", amount_off: 1000, percent_off: null, valid: true, currency: "usd", name: "New User Coupon" });
       const mockPromotionCode = createTestPromotionCode({ id: "promo_new", promotion: { type: "coupon", coupon: mockCoupon } });
       const mockInvoice = createTestInvoice({ id: "in_new", status: "draft" });
@@ -85,7 +85,7 @@ describe(CouponRedemptionService.name, () => {
 
       await service.redeemCoupon(mockUser, mockPromotionCode.code);
 
-      expect(stripeService.getStripeCustomerId).toHaveBeenCalledWith(mockUser);
+      expect(customerService.getStripeCustomerId).toHaveBeenCalledWith(mockUser);
       expect(stripe.invoices.create).toHaveBeenCalledWith({
         customer: "cus_new_456",
         auto_advance: false,
@@ -179,18 +179,18 @@ describe(CouponRedemptionService.name, () => {
     });
 
     it("does not provision a Stripe customer when no matching code is found", async () => {
-      const { service, stripe, stripeService } = setup();
+      const { service, stripe, customerService } = setup();
       const mockUser = createTestUser({ stripeCustomerId: null });
       vi.spyOn(stripe.promotionCodes, "list").mockResolvedValue({ data: [] } as unknown as Stripe.Response<Stripe.ApiList<Stripe.PromotionCode>>);
       vi.spyOn(stripe.coupons, "list").mockResolvedValue({ data: [] } as unknown as Stripe.Response<Stripe.ApiList<Stripe.Coupon>>);
 
       await expect(service.redeemCoupon(mockUser, "INVALID_CODE")).rejects.toThrow("No valid promotion code or coupon found with the provided code");
 
-      expect(stripeService.getStripeCustomerId).not.toHaveBeenCalled();
+      expect(customerService.getStripeCustomerId).not.toHaveBeenCalled();
     });
 
     it("does not provision a Stripe customer when the coupon is unsupported", async () => {
-      const { service, stripeService } = setup();
+      const { service, customerService } = setup();
       const mockUser = createTestUser({ stripeCustomerId: null });
       const mockCoupon = createTestCoupon({ percent_off: 20, amount_off: null, valid: true });
       vi.spyOn(service, "findPromotionCodeByCode").mockResolvedValue(undefined);
@@ -200,7 +200,7 @@ describe(CouponRedemptionService.name, () => {
         "Percentage-based coupons are not supported. Only fixed amount coupons are allowed."
       );
 
-      expect(stripeService.getStripeCustomerId).not.toHaveBeenCalled();
+      expect(customerService.getStripeCustomerId).not.toHaveBeenCalled();
     });
 
     it("voids the invoice and does not record a transaction when the invoice flow fails", async () => {
@@ -224,16 +224,16 @@ describe(CouponRedemptionService.name, () => {
 
   function setup() {
     const stripe = new Stripe(`sk_test_${faker.string.alphanumeric(32)}`, { apiVersion: "2025-10-29.clover", httpClient: Stripe.createFetchHttpClient() });
-    const stripeService = mock<StripeService>();
+    const customerService = mock<CustomerService>();
     const stripeTransactionService = mock<StripeTransactionService>();
 
-    stripeService.getStripeCustomerId.mockImplementation(async user => user.stripeCustomerId ?? "cus_provisioned");
+    customerService.getStripeCustomerId.mockImplementation(async user => user.stripeCustomerId ?? "cus_provisioned");
     stripeTransactionService.recordCouponClaim.mockResolvedValue(
       mock<StripeTransactionOutput>({ id: "test-transaction-id", status: "pending", type: "coupon_claim" })
     );
 
-    const service = new CouponRedemptionService(stripe, stripeService, stripeTransactionService, () => mock<LoggerService>());
+    const service = new CouponRedemptionService(stripe, customerService, stripeTransactionService, () => mock<LoggerService>());
 
-    return { service, stripe, stripeService, stripeTransactionService };
+    return { service, stripe, customerService, stripeTransactionService };
   }
 });

--- a/apps/api/src/billing/services/coupon-redemption/coupon-redemption.service.ts
+++ b/apps/api/src/billing/services/coupon-redemption/coupon-redemption.service.ts
@@ -4,7 +4,7 @@ import { inject, singleton } from "tsyringe";
 
 import { STRIPE_CLIENT } from "@src/billing/providers/stripe-client.provider";
 import { StripeTransactionOutput } from "@src/billing/repositories";
-import { StripeService } from "@src/billing/services/stripe/stripe.service";
+import { CustomerService } from "@src/billing/services/customer/customer.service";
 import { StripeTransactionService } from "@src/billing/services/stripe-transaction/stripe-transaction.service";
 import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
 import type { UserOutput } from "@src/user/repositories/user/user.repository";
@@ -15,7 +15,7 @@ export class CouponRedemptionService {
 
   constructor(
     @inject(STRIPE_CLIENT) private readonly stripe: Stripe,
-    private readonly stripeService: StripeService,
+    private readonly customerService: CustomerService,
     private readonly stripeTransactionService: StripeTransactionService,
     @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
@@ -128,7 +128,7 @@ export class CouponRedemptionService {
     // Ensure the user has a Stripe customer only once the coupon is known to be redeemable. Brand-new
     // accounts may not have one yet since it is created lazily by the add-payment-method flow (see
     // getStripeCustomerId); provisioning it earlier would create customers for invalid/unsupported coupons.
-    const stripeCustomerId = await this.stripeService.getStripeCustomerId(currentUser);
+    const stripeCustomerId = await this.customerService.getStripeCustomerId(currentUser);
 
     let invoice: Stripe.Invoice | undefined;
 

--- a/apps/api/src/billing/services/customer/customer.service.spec.ts
+++ b/apps/api/src/billing/services/customer/customer.service.spec.ts
@@ -1,0 +1,87 @@
+import { faker } from "@faker-js/faker";
+import Stripe from "stripe";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { UserOutput, UserRepository } from "@src/user/repositories/user/user.repository";
+import { CustomerService } from "./customer.service";
+
+describe(CustomerService.name, () => {
+  describe("getStripeCustomerId", () => {
+    it("returns the existing customer id without creating one", async () => {
+      const { service, stripe } = setup();
+      const create = vi.spyOn(stripe.customers, "create");
+      const user = mock<UserOutput>({ id: "user_1", stripeCustomerId: "cus_existing" });
+
+      const result = await service.getStripeCustomerId(user);
+
+      expect(result).toBe("cus_existing");
+      expect(create).not.toHaveBeenCalled();
+    });
+
+    it("creates and persists a Stripe customer when the user has none", async () => {
+      const { service, stripe, userRepository } = setup();
+      const user = mock<UserOutput>({ id: "user_1", stripeCustomerId: null, email: "alice@example.com", username: "alice" });
+      vi.spyOn(stripe.customers, "create").mockResolvedValue(mock<Stripe.Response<Stripe.Customer>>({ id: "cus_new" }));
+      userRepository.updateBy.mockResolvedValue(mock<UserOutput>({ stripeCustomerId: "cus_new" }) as never);
+
+      const result = await service.getStripeCustomerId(user);
+
+      expect(stripe.customers.create).toHaveBeenCalledWith(
+        { email: "alice@example.com", name: "alice", metadata: { userId: "user_1" } },
+        { idempotencyKey: "create-customer:user_1" }
+      );
+      expect(userRepository.updateBy).toHaveBeenCalledWith({ id: "user_1", stripeCustomerId: null }, { stripeCustomerId: "cus_new" }, { returning: true });
+      expect(result).toBe("cus_new");
+    });
+
+    it("returns the concurrently-persisted id when the update is a no-op", async () => {
+      const { service, stripe, userRepository } = setup();
+      const user = mock<UserOutput>({ id: "user_1", stripeCustomerId: null });
+      vi.spyOn(stripe.customers, "create").mockResolvedValue(mock<Stripe.Response<Stripe.Customer>>({ id: "cus_new" }));
+      userRepository.updateBy.mockResolvedValue(undefined);
+      userRepository.findOneBy.mockResolvedValue(mock<UserOutput>({ id: "user_1", stripeCustomerId: "cus_concurrent" }));
+
+      const result = await service.getStripeCustomerId(user);
+
+      expect(userRepository.findOneBy).toHaveBeenCalledWith({ id: "user_1" });
+      expect(result).toBe("cus_concurrent");
+    });
+
+    it("throws when the concurrently-created customer id cannot be reloaded", async () => {
+      const { service, stripe, userRepository } = setup();
+      const user = mock<UserOutput>({ id: "user_1", stripeCustomerId: null });
+      vi.spyOn(stripe.customers, "create").mockResolvedValue(mock<Stripe.Response<Stripe.Customer>>({ id: "cus_new" }));
+      userRepository.updateBy.mockResolvedValue(undefined);
+      userRepository.findOneBy.mockResolvedValue(mock<UserOutput>({ id: "user_1", stripeCustomerId: null }));
+
+      await expect(service.getStripeCustomerId(user)).rejects.toMatchObject({ status: 500 });
+    });
+  });
+
+  describe("updateCustomerOrganization", () => {
+    it("sets the customer business name", async () => {
+      const { service, stripe } = setup();
+      vi.spyOn(stripe.customers, "retrieve").mockResolvedValue(mock<Stripe.Response<Stripe.Customer>>({ id: "cus_1" }));
+      const update = vi.spyOn(stripe.customers, "update").mockResolvedValue(mock<Stripe.Response<Stripe.Customer>>({ id: "cus_1" }));
+
+      await service.updateCustomerOrganization("cus_1", "Acme Inc");
+
+      expect(update).toHaveBeenCalledWith("cus_1", { business_name: "Acme Inc" });
+    });
+
+    it("rejects when the customer is deleted", async () => {
+      const { service, stripe } = setup();
+      vi.spyOn(stripe.customers, "retrieve").mockResolvedValue(mock<Stripe.Response<Stripe.DeletedCustomer>>({ id: "cus_1", deleted: true }));
+
+      await expect(service.updateCustomerOrganization("cus_1", "Acme Inc")).rejects.toMatchObject({ status: 404 });
+    });
+  });
+
+  function setup() {
+    const userRepository = mock<UserRepository>();
+    const stripe = new Stripe(`sk_test_${faker.string.alphanumeric(32)}`, { apiVersion: "2025-10-29.clover", httpClient: Stripe.createFetchHttpClient() });
+    const service = new CustomerService(stripe, userRepository);
+    return { service, stripe, userRepository };
+  }
+});

--- a/apps/api/src/billing/services/customer/customer.service.ts
+++ b/apps/api/src/billing/services/customer/customer.service.ts
@@ -1,0 +1,54 @@
+import assert from "http-assert";
+import Stripe from "stripe";
+import { inject, singleton } from "tsyringe";
+
+import { STRIPE_CLIENT } from "@src/billing/providers/stripe-client.provider";
+import { type UserOutput, UserRepository } from "@src/user/repositories/user/user.repository";
+
+@singleton()
+export class CustomerService {
+  constructor(
+    @inject(STRIPE_CLIENT) private readonly stripe: Stripe,
+    private readonly userRepository: UserRepository
+  ) {}
+
+  async getStripeCustomerId(user: UserOutput): Promise<string> {
+    if (user.stripeCustomerId) {
+      return user.stripeCustomerId;
+    }
+
+    // Stripe idempotency keyed on the user id so concurrent provisioning (eager registration +
+    // lazy billing paths) can never create duplicate/orphaned customers before the DB update wins.
+    const customer = await this.stripe.customers.create(
+      {
+        email: user.email ?? undefined,
+        name: user.username ?? undefined,
+        metadata: {
+          userId: user.id
+        }
+      },
+      { idempotencyKey: `create-customer:${user.id}` }
+    );
+
+    const updated = await this.userRepository.updateBy({ id: user.id, stripeCustomerId: null }, { stripeCustomerId: customer.id }, { returning: true });
+
+    if (updated) {
+      return updated.stripeCustomerId!;
+    }
+
+    // Concurrent creation detected: fetch and return the persisted customer ID
+    const reloaded = await this.userRepository.findOneBy({ id: user.id });
+    assert(reloaded?.stripeCustomerId, 500, "Failed to retrieve stripeCustomerId");
+    return reloaded.stripeCustomerId;
+  }
+
+  async updateCustomerOrganization(customerId: string, organization: string): Promise<void> {
+    const customer = await this.stripe.customers.retrieve(customerId);
+
+    assert(!("deleted" in customer), 404, "Customer is deleted");
+
+    await this.stripe.customers.update(customerId, {
+      business_name: organization
+    });
+  }
+}

--- a/apps/api/src/billing/services/stripe/stripe.service.spec.ts
+++ b/apps/api/src/billing/services/stripe/stripe.service.spec.ts
@@ -1,48 +1,15 @@
-import type { LoggerService } from "@akashnetwork/logging";
 import { faker } from "@faker-js/faker";
 import Stripe from "stripe";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
-import type { UserRepository } from "@src/user/repositories";
 import { StripeService } from "./stripe.service";
 
 import { create as StripeSeederCreate } from "@test/seeders/stripe.seeder";
-import { createTestInvoice, TEST_CONSTANTS } from "@test/seeders/stripe-test-data.seeder";
-import { createTestUser } from "@test/seeders/user-test.seeder";
+import { TEST_CONSTANTS } from "@test/seeders/stripe-test-data.seeder";
 
 describe(StripeService.name, () => {
-  describe("getStripeCustomerId", () => {
-    it("returns existing user when stripeCustomerId exists", async () => {
-      const { service, stripe } = setup();
-      const userWithStripeId = createTestUser();
-      const result = await service.getStripeCustomerId(userWithStripeId);
-      expect(result).toEqual(userWithStripeId.stripeCustomerId);
-      expect(stripe.customers.create).not.toHaveBeenCalled();
-    });
-
-    it("creates new Stripe customer and updates user when no stripeCustomerId", async () => {
-      const { service, stripe, userRepository } = setup();
-      const user = createTestUser({ stripeCustomerId: null });
-      const result = await service.getStripeCustomerId(user);
-      expect(stripe.customers.create).toHaveBeenCalledWith(
-        {
-          email: user.email,
-          name: user.username,
-          metadata: { userId: user.id }
-        },
-        { idempotencyKey: `create-customer:${user.id}` }
-      );
-      expect(userRepository.updateBy).toHaveBeenCalledWith(
-        { id: user.id, stripeCustomerId: null },
-        { stripeCustomerId: StripeSeederCreate().customer.id },
-        { returning: true }
-      );
-      expect(result).toEqual(StripeSeederCreate().customer.id);
-    });
-  });
-
   describe("createSetupIntent", () => {
     it("creates setup intent with correct parameters when not a free trial", async () => {
       const { service, stripe } = setup();
@@ -172,82 +139,10 @@ describe(StripeService.name, () => {
   });
 });
 
-function setup(
-  params: {
-    user?: ReturnType<typeof createTestUser> | null;
-    paymentIntent?: Stripe.Response<Stripe.PaymentIntent>;
-  } = {}
-) {
+function setup() {
   const billingConfig = mock<BillingConfigService>({ get: vi.fn().mockReturnValue("sk_live_key") });
-  const userRepository = mock<UserRepository>();
-
   const stripe = new Stripe(`sk_test_${faker.string.alphanumeric(32)}`, { apiVersion: "2025-10-29.clover", httpClient: Stripe.createFetchHttpClient() });
+  const service = new StripeService(billingConfig, stripe);
 
-  const service = new StripeService(billingConfig, userRepository, stripe, () => mock<LoggerService>());
-
-  const stripeData = StripeSeederCreate();
-
-  // Store the last user for correct mocking
-  let lastUser: any = null;
-  userRepository.findOneBy.mockImplementation(async query => {
-    if (query?.stripeCustomerId && lastUser && lastUser.stripeCustomerId === query.stripeCustomerId) {
-      return lastUser;
-    }
-    if (query?.id && lastUser && lastUser.id === query.id) {
-      return lastUser;
-    }
-    // fallback for tests that don't use createUser
-    if (query?.stripeCustomerId) {
-      return { id: query.stripeCustomerId, stripeCustomerId: query.stripeCustomerId };
-    }
-    if (query?.id) {
-      return { id: query.id, stripeCustomerId: null };
-    }
-    return null;
-  });
-  userRepository.updateBy.mockImplementation(async (query, update) => {
-    if (lastUser && lastUser.id === query.id) {
-      lastUser = { ...lastUser, ...update };
-      return lastUser;
-    }
-    // If no lastUser, create a new one with the update
-    if (query.id) {
-      lastUser = { id: query.id, ...update };
-      return lastUser;
-    }
-    return null;
-  });
-
-  // Setup user repository mock based on parameters
-  const userToReturn = "user" in params ? params.user : createTestUser();
-  vi.spyOn(userRepository, "findOneBy").mockResolvedValue(userToReturn ?? undefined);
-
-  // Mock Stripe methods
-  vi.spyOn(stripe.customers, "create").mockResolvedValue(stripeData.customer);
-  vi.spyOn(stripe.customers, "update").mockResolvedValue({} as unknown as Stripe.Response<Stripe.Customer>);
-  vi.spyOn(stripe.customers, "retrieve").mockResolvedValue({} as unknown as Stripe.Response<Stripe.Customer>);
-  // Setup payment intent mock based on parameters
-  const paymentIntentToReturn = params.paymentIntent || stripeData.paymentIntent;
-  vi.spyOn(stripe.paymentIntents, "create").mockResolvedValue(paymentIntentToReturn);
-  vi.spyOn(stripe.paymentIntents, "retrieve").mockResolvedValue(paymentIntentToReturn);
-  vi.spyOn(stripe.prices, "list").mockResolvedValue({ data: [] } as unknown as Stripe.Response<Stripe.ApiList<Stripe.Price>>);
-  vi.spyOn(stripe.promotionCodes, "list").mockResolvedValue({ data: [] } as unknown as Stripe.Response<Stripe.ApiList<Stripe.PromotionCode>>);
-  vi.spyOn(stripe.coupons, "list").mockResolvedValue({ data: [] } as unknown as Stripe.Response<Stripe.ApiList<Stripe.Coupon>>);
-  vi.spyOn(stripe.coupons, "retrieve").mockResolvedValue({} as unknown as Stripe.Response<Stripe.Coupon>);
-  vi.spyOn(stripe.charges, "list").mockResolvedValue({ data: [], has_more: false } as unknown as Stripe.Response<Stripe.ApiList<Stripe.Charge>>);
-  vi.spyOn(stripe.refunds, "create").mockResolvedValue({} as unknown as Stripe.Response<Stripe.Refund>);
-  vi.spyOn(stripe.refunds, "list").mockResolvedValue({ data: [] } as unknown as Stripe.Response<Stripe.ApiList<Stripe.Refund>>);
-  vi.spyOn(stripe.setupIntents, "create").mockResolvedValue(stripeData.setupIntent);
-  vi.spyOn(stripe.paymentMethods, "list").mockResolvedValue({ data: [] } as unknown as Stripe.Response<Stripe.ApiList<Stripe.PaymentMethod>>);
-  vi.spyOn(stripe.invoices, "create").mockResolvedValue(createTestInvoice());
-  vi.spyOn(stripe.invoices, "finalizeInvoice").mockResolvedValue(createTestInvoice({ status: "paid" }));
-  vi.spyOn(stripe.invoices, "voidInvoice").mockResolvedValue({} as unknown as Stripe.Response<Stripe.Invoice>);
-  vi.spyOn(stripe.invoiceItems, "create").mockResolvedValue({} as unknown as Stripe.Response<Stripe.InvoiceItem>);
-
-  return {
-    service,
-    stripe,
-    userRepository,
-    billingConfig
-  };
+  return { service, stripe, billingConfig };
 }

--- a/apps/api/src/billing/services/stripe/stripe.service.ts
+++ b/apps/api/src/billing/services/stripe/stripe.service.ts
@@ -1,13 +1,9 @@
-import type { LoggerService } from "@akashnetwork/logging";
-import assert from "http-assert";
 import orderBy from "lodash/orderBy";
 import Stripe from "stripe";
 import { inject, singleton } from "tsyringe";
 
 import { STRIPE_CLIENT } from "@src/billing/providers/stripe-client.provider";
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
-import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
-import { type UserOutput, UserRepository } from "@src/user/repositories/user/user.repository";
 
 interface StripePrices {
   unitAmount: number;
@@ -33,16 +29,10 @@ export const TOP_UP_IDEMPOTENCY_KEY_PREFIX = "topup_";
 export class StripeService {
   readonly isProduction = this.billingConfig.get("STRIPE_SECRET_KEY").startsWith("sk_live");
 
-  private readonly loggerService: LoggerService;
-
   constructor(
     private readonly billingConfig: BillingConfigService,
-    private readonly userRepository: UserRepository,
-    @inject(STRIPE_CLIENT) private readonly stripe: Stripe,
-    @inject(LOGGER_FACTORY) createLogger: CreateLogger
-  ) {
-    this.loggerService = createLogger({ context: StripeService.name });
-  }
+    @inject(STRIPE_CLIENT) private readonly stripe: Stripe
+  ) {}
 
   async createSetupIntent(customerId: string, { isFreeTrial }: { isFreeTrial: boolean }) {
     return await this.stripe.setupIntents.create({
@@ -89,45 +79,5 @@ export class StripeService {
 
   async getCoupon(couponId: string) {
     return await this.stripe.coupons.retrieve(couponId);
-  }
-
-  async getStripeCustomerId(user: UserOutput): Promise<string> {
-    if (user.stripeCustomerId) {
-      return user.stripeCustomerId;
-    }
-
-    // Stripe idempotency keyed on the user id so concurrent provisioning (eager registration +
-    // lazy billing paths) can never create duplicate/orphaned customers before the DB update wins.
-    const customer = await this.stripe.customers.create(
-      {
-        email: user.email ?? undefined,
-        name: user.username ?? undefined,
-        metadata: {
-          userId: user.id
-        }
-      },
-      { idempotencyKey: `create-customer:${user.id}` }
-    );
-
-    const updated = await this.userRepository.updateBy({ id: user.id, stripeCustomerId: null }, { stripeCustomerId: customer.id }, { returning: true });
-
-    if (updated) {
-      return updated.stripeCustomerId!;
-    }
-
-    // Concurrent creation detected: fetch and return the persisted customer ID
-    const reloaded = await this.userRepository.findOneBy({ id: user.id });
-    assert(reloaded?.stripeCustomerId, 500, "Failed to retrieve stripeCustomerId");
-    return reloaded.stripeCustomerId;
-  }
-
-  async updateCustomerOrganization(customerId: string, organization: string): Promise<void> {
-    const customer = await this.stripe.customers.retrieve(customerId);
-
-    assert(!("deleted" in customer), 404, "Customer is deleted");
-
-    await this.stripe.customers.update(customerId, {
-      business_name: organization
-    });
   }
 }


### PR DESCRIPTION
## Why

Lazily provisioning and updating the Stripe customer record is a distinct concern that was embedded in the `StripeService` god object. Extracting it is also what lets `StripeService` finally become a pure Stripe-SDK client with no repositories or business rules.

## What

`apps/api` — behavior-preserving, no new runtime behavior, no migrations.

- Adds `@singleton CustomerService` owning `getStripeCustomerId` (lazy provision + the concurrent-provisioning race handling, moved intact) and `updateCustomerOrganization`. It depends on the raw Stripe client and `UserRepository`.
- `StripeService` sheds both methods and, with them, its `UserRepository` dependency **and** its now-dead `LoggerService` (nothing in it logs once the trial methods left). It is now a pure L1 client — ctor is just the billing config and the Stripe client, exposing only named SDK primitives plus `findPrices` / `listPromotionCodes` / `getCoupon`.
- Consumers rerouted to `CustomerService`: `StripeController` (`createSetupIntent`, the org-update endpoint) and `CouponRedemptionService` — which **drops its transitional `StripeService` dependency entirely** (customer provisioning was the only reason it held one).

## Verification

- **Billing unit suite green — 356 tests / 32 files.** New `customer.service` spec covers both methods, including the concurrent-provisioning no-op and reload-failure branches (previously untested). The `getStripeCustomerId` tests moved out of the `stripe.service` spec, whose setup collapses to a two-line construction now that the service is a pure client.
- `tsc`: zero errors in the changed set. `eslint` clean. Prettier clean.

Closes CON-727 · Part of CON-718.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added centralized Stripe customer management, including customer creation, lookup, and organization updates.
  * Added post-3DS payment-method validation with payment intent and ownership checks.
  * Coupon redemption and billing flows now use the updated customer and payment-method handling.

* **Bug Fixes**
  * Improved handling of concurrent Stripe customer creation and deleted customer records.

* **Tests**
  * Expanded coverage for customer provisioning, payment validation, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->