### PR TITLE
fix(stats): prevent gpu-prices debug requests from poisoning the shared cache

### DIFF
--- a/apps/api/src/caching/helpers.spec.ts
+++ b/apps/api/src/caching/helpers.spec.ts
@@ -227,6 +227,26 @@ describe("Memoize Function", () => {
       expect(cacheKeys).toContain("TestClass#testMethod#test#456");
     });
 
+    it("includes boolean arguments in cache key", async () => {
+      setup();
+
+      class TestClass {
+        @Memoize()
+        async testMethod(_arg1: string, _arg2: boolean) {
+          return "test";
+        }
+      }
+
+      const instance = new TestClass();
+      await instance.testMethod("test", true);
+      await instance.testMethod("test", false);
+
+      const cacheKeys = cacheEngine.getKeys();
+      expect(cacheKeys).toHaveLength(2);
+      expect(cacheKeys).toContain("TestClass#testMethod#test#true");
+      expect(cacheKeys).toContain("TestClass#testMethod#test#false");
+    });
+
     it("should filter out other types of arguments from cache key", async () => {
       setup();
 

--- a/apps/api/src/caching/helpers.ts
+++ b/apps/api/src/caching/helpers.ts
@@ -28,7 +28,7 @@ export const Memoize = (options?: MemoizeOptions) => (target: object, propertyNa
     const argsKey =
       args.length > 0
         ? `${cacheKey}#${args
-            .map(arg => (["string", "number"].includes(typeof arg) ? String(arg) : null))
+            .map(arg => (["string", "number", "boolean"].includes(typeof arg) ? String(arg) : null))
             .filter(Boolean)
             .join("#")}`
         : cacheKey;

--- a/apps/api/src/gpu/services/gpu-price/gpu-price.service.spec.ts
+++ b/apps/api/src/gpu/services/gpu-price/gpu-price.service.spec.ts
@@ -385,6 +385,75 @@ describe(GpuPriceService.name, () => {
       expect(result.models[0].providerAvailability.providers).toBeUndefined();
     });
 
+    it("returns a JSON-serializable debug payload for v1beta5 bids", async () => {
+      const provider = createProvider();
+      const gpu = createGpuType({
+        vendor: "nvidia",
+        model: "a100",
+        providers: [provider]
+      });
+
+      const bidData = createMsgCreateBidV5({
+        provider: provider.owner,
+        gpuVendor: "nvidia",
+        gpuModel: "a100"
+      });
+
+      const days = [createDay({ aktPrice: 3.0 })];
+      const deployment = createDeploymentWithBid({
+        dayId: days[0].id,
+        bidData: bidData.encoded,
+        bidType: `/akash.market.v1beta5.MsgCreateBid`
+      });
+
+      const { service } = setup({
+        gpusForPricing: [gpu],
+        deploymentsWithGpu: [deployment],
+        days
+      });
+
+      const result = await service.getGpuPrices(true);
+
+      expect(result.models[0].providersWithBestBid).toHaveLength(1);
+      expect(() => JSON.stringify(result)).not.toThrow();
+    });
+
+    it("does not serve the debug payload to non-debug requests from the shared cache", async () => {
+      const provider = createProvider();
+      const gpu = createGpuType({
+        vendor: "nvidia",
+        model: "a100",
+        providers: [provider]
+      });
+
+      const bidData = createMsgCreateBidV5({
+        provider: provider.owner,
+        gpuVendor: "nvidia",
+        gpuModel: "a100"
+      });
+
+      const days = [createDay({ aktPrice: 3.0 })];
+      const deployment = createDeploymentWithBid({
+        dayId: days[0].id,
+        bidData: bidData.encoded,
+        bidType: `/akash.market.v1beta5.MsgCreateBid`
+      });
+
+      const { service } = setup({
+        gpusForPricing: [gpu],
+        deploymentsWithGpu: [deployment],
+        days
+      });
+
+      const debugResult = await service.getGpuPrices(true);
+      const publicResult = await service.getGpuPrices(false);
+
+      expect(debugResult.models[0].providersWithBestBid).toBeDefined();
+      expect(publicResult.models[0].providersWithBestBid).toBeUndefined();
+      expect(publicResult.models[0].bidCount).toBeUndefined();
+      expect(() => JSON.stringify(publicResult)).not.toThrow();
+    });
+
     it("sorts GPU models by vendor, model, ram, interface", async () => {
       const gpus = [
         createGpuType({ vendor: "nvidia", model: "h100", ram: "80Gi", interface: "sxm" }),

--- a/apps/api/src/gpu/services/gpu-price/gpu-price.service.ts
+++ b/apps/api/src/gpu/services/gpu-price/gpu-price.service.ts
@@ -72,13 +72,16 @@ export class GpuPriceService {
 
         // Determine the message version and decode accordingly
         let decodedBid: MsgCreateBidV4 | MsgCreateBidV5;
+        let decodedBidJson: unknown;
         let provider: string;
 
         if (x.type.includes("v1beta5")) {
           decodedBid = this.#typeRegistry.decode({ typeUrl: `/${MsgCreateBidV5.$type}`, value: x.data }) as MsgCreateBidV5;
+          decodedBidJson = MsgCreateBidV5.toJSON(decodedBid);
           provider = decodedBid.id?.provider || "";
         } else {
           decodedBid = this.#typeRegistry.decode({ typeUrl: `/${MsgCreateBidV4.$type}`, value: x.data }) as MsgCreateBidV4;
+          decodedBidJson = MsgCreateBidV4.toJSON(decodedBid);
           provider = decodedBid.provider || "";
         }
 
@@ -123,7 +126,7 @@ export class GpuPriceService {
               .reduce((a: number, b: number) => a + b, 0),
             gpus: bidGpus
           },
-          data: decodedBid
+          data: decodedBidJson
         } as GpuBidType;
 
         const gpu = bid.deployment.gpus[0];

--- a/apps/api/src/gpu/types/gpu.type.ts
+++ b/apps/api/src/gpu/types/gpu.type.ts
@@ -1,5 +1,3 @@
-import type { MsgCreateBid } from "@akashnetwork/chain-sdk/private-types/akash.v1beta5";
-
 export type GpuProviderType = {
   owner: string;
   hostUri: string;
@@ -40,7 +38,8 @@ export type GpuBidType = {
       interface: string;
     }[];
   };
-  data: MsgCreateBid;
+  /** JSON-encoded MsgCreateBid (v1beta4 or v1beta5), exposed only on debug requests; must stay JSON.stringify-safe. */
+  data: unknown;
 };
 
 export type GpuWithPricesType = GpuType & {


### PR DESCRIPTION
## Why

Grafana alerted on 500s from `GET /v1/gpu-prices` (`TypeError: Do not know how to serialize a BigInt` at response serialization). Production logs show all 38 errors in the past 7 days happened in a single 15-minute window (2026-07-24 12:03-12:18 UTC) on one pod, starting ~1 minute after a `/v1/gpu-prices?debug=true` request hit that pod.

Root cause is a two-part failure:

1. The `@Memoize` cache key only incorporates `string`/`number` arguments, so the boolean `debug` argument was silently dropped and `debug=true` shared the same per-pod cache entry as normal requests. A debug request that happened to trigger the stale-while-revalidate background refresh stored the debug payload in the shared entry, serving it to every user on that pod for the full 15-minute TTL.
2. The debug payload embeds raw decoded `MsgCreateBid` messages. v1beta5 messages decode with native `bigint` fields (`dseq`, etc.), which `JSON.stringify` cannot serialize, turning every poisoned cache hit into a 500. (v1beta4 used protobufjs `Long`, which serializes fine, so debug mode was harmless before v1beta5 bids appeared on chain.)

Related to CON-757

## What

- Include boolean arguments in the `Memoize` cache key so debug and non-debug results cache separately.
- Store the ts-proto `toJSON` encoding of decoded bids in the debug payload instead of the raw message, making it JSON-serializable (bigint/Long become strings) for both v1beta4 and v1beta5.
- Regression tests: boolean cache-key separation, debug payload serializability with a v1beta5 bid, and non-debug requests not receiving the debug payload. All three fail against the previous code.

Note: `/v1/gpu-breakdown` has a sibling cache-key issue with object arguments (all filter variants share one cache slot), tracked separately in CON-757.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Memoization cache keys now correctly include boolean arguments.
  - GPU pricing results are now consistently JSON-serializable across supported bid message versions.
  - Debug-only GPU pricing details no longer appear in non-debug cached responses.

- **Tests**
  - Added coverage to ensure boolean-aware memoization key generation.
  - Added tests confirming JSON serialization and proper separation of debug vs non-debug GPU pricing output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->