### PR TITLE
fix(billing): stamp wallet activation only after trial provisioning succeeds

### DIFF
--- a/apps/api/drizzle/0034_natural_piledriver.sql
+++ b/apps/api/drizzle/0034_natural_piledriver.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "user_wallets" ADD COLUMN "activation_claimed_at" timestamp with time zone;

--- a/apps/api/drizzle/meta/0034_snapshot.json
+++ b/apps/api/drizzle/meta/0034_snapshot.json
@@ -1,0 +1,1367 @@
+{
+  "id": "ac14bdd7-96b1-4a0e-9244-688b051999de",
+  "prevId": "0e3866c6-bb02-4bb0-8241-6e6ac040f4f7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.user_wallets": {
+      "name": "user_wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_allowance": {
+          "name": "deployment_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "fee_allowance": {
+          "name": "fee_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "trial": {
+          "name": "trial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activation_claimed_at": {
+          "name": "activation_claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_wallets_user_id_userSetting_id_fk": {
+          "name": "user_wallets_user_id_userSetting_id_fk",
+          "tableFrom": "user_wallets",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_wallets_user_id_unique": {
+          "name": "user_wallets_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "user_wallets_address_unique": {
+          "name": "user_wallets_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_methods": {
+      "name": "payment_methods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_method_id": {
+          "name": "payment_method_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_validated": {
+          "name": "is_validated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payment_methods_fingerprint_payment_method_id_unique": {
+          "name": "payment_methods_fingerprint_payment_method_id_unique",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_default_unique": {
+          "name": "payment_methods_user_id_is_default_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"payment_methods\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_fingerprint_idx": {
+          "name": "payment_methods_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_idx": {
+          "name": "payment_methods_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_validated_idx": {
+          "name": "payment_methods_user_id_is_validated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_validated",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_fingerprint_payment_method_id_idx": {
+          "name": "payment_methods_user_id_fingerprint_payment_method_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_methods_user_id_userSetting_id_fk": {
+          "name": "payment_methods_user_id_userSetting_id_fk",
+          "tableFrom": "payment_methods",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_transactions": {
+      "name": "stripe_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "stripe_transaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "stripe_transaction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created'"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_refunded": {
+          "name": "amount_refunded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bonus_amount": {
+          "name": "bonus_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_charge_id": {
+          "name": "stripe_charge_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_coupon_id": {
+          "name": "stripe_coupon_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_promotion_code_id": {
+          "name": "stripe_promotion_code_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_idempotency_key": {
+          "name": "stripe_idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method_type": {
+          "name": "payment_method_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_brand": {
+          "name": "card_brand",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_last4": {
+          "name": "card_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_url": {
+          "name": "receipt_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_transactions_stripe_invoice_id_unique": {
+          "name": "stripe_transactions_stripe_invoice_id_unique",
+          "columns": [
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stripe_transactions\".\"stripe_invoice_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_idempotency_key_unique": {
+          "name": "stripe_transactions_stripe_idempotency_key_unique",
+          "columns": [
+            {
+              "expression": "stripe_idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stripe_transactions\".\"stripe_idempotency_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_user_id_idx": {
+          "name": "stripe_transactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_payment_intent_id_idx": {
+          "name": "stripe_transactions_stripe_payment_intent_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_payment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_charge_id_idx": {
+          "name": "stripe_transactions_stripe_charge_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_coupon_id_idx": {
+          "name": "stripe_transactions_stripe_coupon_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_coupon_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_promotion_code_id_idx": {
+          "name": "stripe_transactions_stripe_promotion_code_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_promotion_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_status_idx": {
+          "name": "stripe_transactions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_created_at_idx": {
+          "name": "stripe_transactions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_user_id_created_at_idx": {
+          "name": "stripe_transactions_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_transactions_user_id_userSetting_id_fk": {
+          "name": "stripe_transactions_user_id_userSetting_id_fk",
+          "tableFrom": "stripe_transactions",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_settings": {
+      "name": "wallet_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_reload_enabled": {
+          "name": "auto_reload_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_settings_user_id_idx": {
+          "name": "wallet_settings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_settings_wallet_id_user_wallets_id_fk": {
+          "name": "wallet_settings_wallet_id_user_wallets_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "user_wallets",
+          "columnsFrom": [
+            "wallet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wallet_settings_user_id_userSetting_id_fk": {
+          "name": "wallet_settings_user_id_userSetting_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallet_settings_wallet_id_unique": {
+          "name": "wallet_settings_wallet_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wallet_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.userSetting": {
+      "name": "userSetting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscribedToNewsletter": {
+          "name": "subscribedToNewsletter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "youtubeUsername": {
+          "name": "youtubeUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitterUsername": {
+          "name": "twitterUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "githubUsername": {
+          "name": "githubUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_ip": {
+          "name": "last_ip",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_user_agent": {
+          "name": "last_user_agent",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fingerprint": {
+          "name": "last_fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "userSetting_userId_unique": {
+          "name": "userSetting_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        },
+        "userSetting_username_unique": {
+          "name": "userSetting_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.template": {
+      "name": "template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "copiedFromId": {
+          "name": "copiedFromId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cpu": {
+          "name": "cpu",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ram": {
+          "name": "ram",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage": {
+          "name": "storage",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sdl": {
+          "name": "sdl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "template_userId_idx": {
+          "name": "template_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.templateFavorite": {
+      "name": "templateFavorite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "templateId": {
+          "name": "templateId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addedDate": {
+          "name": "addedDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "templateFavorite_userId_templateId_unique": {
+          "name": "templateFavorite_userId_templateId_unique",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "templateId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "templateFavorite_templateId_template_id_fk": {
+          "name": "templateFavorite_templateId_template_id_fk",
+          "tableFrom": "templateFavorite",
+          "tableTo": "template",
+          "columnsFrom": [
+            "templateId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_settings": {
+      "name": "deployment_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dseq": {
+          "name": "dseq",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_top_up_enabled": {
+          "name": "auto_top_up_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "closed": {
+          "name": "closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "id_auto_top_up_enabled_closed_idx": {
+          "name": "id_auto_top_up_enabled_closed_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auto_top_up_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "closed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_settings_user_id_userSetting_id_fk": {
+          "name": "deployment_settings_user_id_userSetting_id_fk",
+          "tableFrom": "deployment_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dseq_user_id_idx": {
+          "name": "dseq_user_id_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "dseq",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_key": {
+          "name": "hashed_key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_format": {
+          "name": "key_format",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_user_id_userSetting_id_fk": {
+          "name": "api_keys_user_id_userSetting_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_hashed_key_unique": {
+          "name": "api_keys_hashed_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hashed_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_verification_codes": {
+      "name": "email_verification_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_verification_codes_user_id_idx": {
+          "name": "email_verification_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_verification_codes_user_id_userSetting_id_fk": {
+          "name": "email_verification_codes_user_id_userSetting_id_fk",
+          "tableFrom": "email_verification_codes",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.stripe_transaction_status": {
+      "name": "stripe_transaction_status",
+      "schema": "public",
+      "values": [
+        "created",
+        "pending",
+        "requires_action",
+        "succeeded",
+        "failed",
+        "refunded",
+        "canceled"
+      ]
+    },
+    "public.stripe_transaction_type": {
+      "name": "stripe_transaction_type",
+      "schema": "public",
+      "values": [
+        "payment_intent",
+        "coupon_claim",
+        "manual_credit"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -239,6 +239,13 @@
       "when": 1784819171143,
       "tag": "0033_long_solo",
       "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "7",
+      "when": 1784922168738,
+      "tag": "0034_natural_piledriver",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/billing/model-schemas/user-wallet/user-wallet.schema.ts
+++ b/apps/api/src/billing/model-schemas/user-wallet/user-wallet.schema.ts
@@ -14,6 +14,7 @@ export const UserWallets = pgTable("user_wallets", {
   feeAllowance: allowance("fee_allowance"),
   isTrialing: boolean("trial").default(true),
   activatedAt: timestamp("activated_at", { withTimezone: true }),
+  activationClaimedAt: timestamp("activation_claimed_at", { withTimezone: true }),
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at").defaultNow().notNull()
 });

--- a/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.integration.ts
+++ b/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.integration.ts
@@ -1,4 +1,5 @@
 import { faker } from "@faker-js/faker";
+import subMinutes from "date-fns/subMinutes";
 import { container } from "tsyringe";
 import { describe, expect, it } from "vitest";
 
@@ -9,35 +10,89 @@ import { createAkashAddress } from "@test/seeders/akash-address.seeder";
 
 describe(UserWalletRepository.name, () => {
   describe("claimActivation", () => {
-    it("claims activation exactly once across concurrent attempts", async () => {
+    it("claims exactly once across concurrent attempts without stamping activation", async () => {
       const { userWalletRepository, wallet } = await setup();
 
       const results = await Promise.all(Array.from({ length: 5 }, () => userWalletRepository.claimActivation(wallet.id)));
 
       const claimed = results.filter(Boolean);
       expect(claimed).toHaveLength(1);
-      expect(claimed[0]?.activatedAt).toBeInstanceOf(Date);
+      expect(claimed[0]?.activationClaimedAt).toBeInstanceOf(Date);
+      expect(claimed[0]?.activatedAt).toBeNull();
+    });
+
+    it("returns undefined while another claim is live", async () => {
+      const { userWalletRepository, wallet } = await setup();
+
+      const first = await userWalletRepository.claimActivation(wallet.id);
+      const second = await userWalletRepository.claimActivation(wallet.id);
+
+      expect(first?.activationClaimedAt).toBeInstanceOf(Date);
+      expect(second).toBeUndefined();
     });
 
     it("returns undefined when the wallet is already activated", async () => {
       const { userWalletRepository, wallet } = await setup();
 
-      const first = await userWalletRepository.claimActivation(wallet.id);
-      const second = await userWalletRepository.claimActivation(wallet.id);
+      await userWalletRepository.markActivated(wallet.id);
+      const claimed = await userWalletRepository.claimActivation(wallet.id);
 
-      expect(first?.activatedAt).toBeInstanceOf(Date);
-      expect(second).toBeUndefined();
+      expect(claimed).toBeUndefined();
     });
 
-    it("claims again after activation is unset", async () => {
+    it("claims again after the previous claim is released", async () => {
       const { userWalletRepository, wallet } = await setup();
 
       const first = await userWalletRepository.claimActivation(wallet.id);
-      await userWalletRepository.updateById(wallet.id, { activatedAt: null });
+      await userWalletRepository.releaseActivationClaim(wallet.id, first!.activationClaimedAt!);
       const second = await userWalletRepository.claimActivation(wallet.id);
 
+      expect(second?.activationClaimedAt).toBeInstanceOf(Date);
+    });
+
+    it("takes over a claim older than the stale cutoff", async () => {
+      const { userWalletRepository, wallet } = await setup();
+
+      const staleClaimedAt = subMinutes(new Date(), UserWalletRepository.ACTIVATION_CLAIM_STALE_AFTER_MINUTES + 1);
+      await userWalletRepository.updateById(wallet.id, { activationClaimedAt: staleClaimedAt });
+      const claimed = await userWalletRepository.claimActivation(wallet.id);
+
+      expect(claimed?.activationClaimedAt).toBeInstanceOf(Date);
+      expect(claimed?.activationClaimedAt?.getTime()).toBeGreaterThan(staleClaimedAt.getTime());
+    });
+  });
+
+  describe("releaseActivationClaim", () => {
+    it("keeps a claim intact when released with another attempt's claim timestamp", async () => {
+      const { userWalletRepository, wallet } = await setup();
+
+      await userWalletRepository.claimActivation(wallet.id);
+      await userWalletRepository.releaseActivationClaim(wallet.id, faker.date.past());
+      const concurrentClaim = await userWalletRepository.claimActivation(wallet.id);
+
+      expect(concurrentClaim).toBeUndefined();
+    });
+  });
+
+  describe("markActivated", () => {
+    it("stamps activation and clears any live claim", async () => {
+      const { userWalletRepository, wallet } = await setup();
+
+      await userWalletRepository.claimActivation(wallet.id);
+      const activated = await userWalletRepository.markActivated(wallet.id);
+
+      expect(activated?.activatedAt).toBeInstanceOf(Date);
+      expect(activated?.activationClaimedAt).toBeNull();
+    });
+
+    it("no-ops for an already-activated wallet", async () => {
+      const { userWalletRepository, wallet } = await setup();
+
+      const first = await userWalletRepository.markActivated(wallet.id);
+      const second = await userWalletRepository.markActivated(wallet.id);
+
       expect(first?.activatedAt).toBeInstanceOf(Date);
-      expect(second?.activatedAt).toBeInstanceOf(Date);
+      expect(second).toBeUndefined();
     });
   });
 

--- a/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.ts
+++ b/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.ts
@@ -1,6 +1,7 @@
 import { Trace } from "@akashnetwork/instrumentation";
 import subDays from "date-fns/subDays";
-import { and, count, eq, gt, inArray, isNotNull, isNull, lte, or } from "drizzle-orm";
+import subMinutes from "date-fns/subMinutes";
+import { and, count, eq, gt, inArray, isNotNull, isNull, lt, lte, or } from "drizzle-orm";
 import { singleton } from "tsyringe";
 
 import { type ApiPgDatabase, type ApiPgTables, InjectPg, InjectPgTable } from "@src/core/providers";
@@ -33,6 +34,9 @@ export interface UserWalletPublicOutput {
 
 @singleton()
 export class UserWalletRepository extends BaseRepository<ApiPgTables["UserWallets"], UserWalletInput, UserWalletOutput> {
+  /** Comfortably above the worst observed trial provisioning time (two funding txs behind a load balancer). */
+  static readonly ACTIVATION_CLAIM_STALE_AFTER_MINUTES = 5;
+
   constructor(
     @InjectPg() protected readonly pg: ApiPgDatabase,
     @InjectPgTable("UserWallets") protected readonly table: ApiPgTables["UserWallets"],
@@ -82,14 +86,50 @@ export class UserWalletRepository extends BaseRepository<ApiPgTables["UserWallet
     return this.toOutput(item);
   }
 
+  /**
+   * Grants the caller an exclusive right to provision a not-yet-activated wallet. Returns undefined when the wallet
+   * is already activated or another attempt holds a live claim. A claim older than the stale cutoff is considered
+   * abandoned (crashed or hung attempt) and can be taken over.
+   */
   async claimActivation(id: UserWalletOutput["id"]): Promise<UserWalletOutput | undefined> {
+    const staleClaimCutoff = subMinutes(new Date(), UserWalletRepository.ACTIVATION_CLAIM_STALE_AFTER_MINUTES);
     const [claimed] = await this.cursor
       .update(this.table)
-      .set({ activatedAt: new Date() })
-      .where(this.whereAccessibleBy(and(eq(this.table.id, id), isNull(this.table.activatedAt))))
+      .set({ activationClaimedAt: new Date() })
+      .where(
+        this.whereAccessibleBy(
+          and(
+            eq(this.table.id, id),
+            isNull(this.table.activatedAt),
+            or(isNull(this.table.activationClaimedAt), lt(this.table.activationClaimedAt, staleClaimCutoff))
+          )
+        )
+      )
       .returning();
 
     return claimed ? this.toOutput(claimed) : undefined;
+  }
+
+  /**
+   * Releases only the claim identified by `claimedAt`, so a slow failed attempt cannot clobber
+   * a claim taken over by a newer attempt in the meantime.
+   */
+  async releaseActivationClaim(id: UserWalletOutput["id"], claimedAt: Date): Promise<void> {
+    await this.cursor
+      .update(this.table)
+      .set({ activationClaimedAt: null })
+      .where(this.whereAccessibleBy(and(eq(this.table.id, id), eq(this.table.activationClaimedAt, claimedAt))));
+  }
+
+  /** Stamps activation directly, without the claim/provision cycle. No-ops for already-activated wallets. */
+  async markActivated(id: UserWalletOutput["id"]): Promise<UserWalletOutput | undefined> {
+    const [activated] = await this.cursor
+      .update(this.table)
+      .set({ activatedAt: new Date(), activationClaimedAt: null })
+      .where(this.whereAccessibleBy(and(eq(this.table.id, id), isNull(this.table.activatedAt))))
+      .returning();
+
+    return activated ? this.toOutput(activated) : undefined;
   }
 
   async findDrainingWallets(thresholds: { fee: number; trialExpirationDays: number }) {

--- a/apps/api/src/billing/services/refill/refill.service.spec.ts
+++ b/apps/api/src/billing/services/refill/refill.service.spec.ts
@@ -21,7 +21,7 @@ describe(RefillService.name, () => {
         setup();
       const existingWallet = createUserWallet({ userId });
       walletInitializerService.ensureWallet.mockResolvedValue(existingWallet);
-      userWalletRepository.claimActivation.mockResolvedValue(undefined);
+      userWalletRepository.markActivated.mockResolvedValue(undefined);
       managedUserWalletService.authorizeSpending.mockResolvedValue();
       balancesService.retrieveDeploymentLimit.mockResolvedValue(5000);
       balancesService.refreshUserWalletLimits.mockResolvedValue();
@@ -42,7 +42,7 @@ describe(RefillService.name, () => {
       const { service, userWalletRepository, managedUserWalletService, balancesService, analyticsService, walletInitializerService } = setup();
       const existingWallet = createUserWallet({ userId });
       walletInitializerService.ensureWallet.mockResolvedValue(existingWallet);
-      userWalletRepository.claimActivation.mockResolvedValue(undefined);
+      userWalletRepository.markActivated.mockResolvedValue(undefined);
       managedUserWalletService.authorizeSpending.mockResolvedValue();
       balancesService.retrieveDeploymentLimit.mockResolvedValue(5000);
       balancesService.refreshUserWalletLimits.mockResolvedValue();
@@ -74,7 +74,7 @@ describe(RefillService.name, () => {
       const { service, userWalletRepository, managedUserWalletService, balancesService, walletInitializerService } = setup();
       const existingWallet = createUserWallet({ userId });
       walletInitializerService.ensureWallet.mockResolvedValue(existingWallet);
-      userWalletRepository.claimActivation.mockResolvedValue(undefined);
+      userWalletRepository.markActivated.mockResolvedValue(undefined);
       managedUserWalletService.authorizeSpending.mockResolvedValue();
       balancesService.retrieveDeploymentLimit.mockResolvedValue(5000);
       balancesService.refreshUserWalletLimits.mockResolvedValue();
@@ -90,7 +90,7 @@ describe(RefillService.name, () => {
       const wallet = createUserWallet({ userId, activatedAt: null });
       const activatedWallet = { ...wallet, activatedAt: new Date() };
       walletInitializerService.ensureWallet.mockResolvedValue(wallet);
-      userWalletRepository.claimActivation.mockResolvedValue(activatedWallet);
+      userWalletRepository.markActivated.mockResolvedValue(activatedWallet);
       managedUserWalletService.authorizeSpending.mockResolvedValue();
       balancesService.retrieveDeploymentLimit.mockResolvedValue(0);
       balancesService.refreshUserWalletLimits.mockResolvedValue();
@@ -98,7 +98,7 @@ describe(RefillService.name, () => {
       await service.topUpWallet(amountUsd, userId);
 
       expect(walletInitializerService.ensureWallet).toHaveBeenCalledWith(userId);
-      expect(userWalletRepository.claimActivation).toHaveBeenCalledWith(wallet.id);
+      expect(userWalletRepository.markActivated).toHaveBeenCalledWith(wallet.id);
       expect(managedUserWalletService.authorizeSpending).toHaveBeenCalledWith(managedSignerService, {
         address: wallet.address,
         limits: { deployment: 1000000, fees: 1000 }

--- a/apps/api/src/billing/services/refill/refill.service.ts
+++ b/apps/api/src/billing/services/refill/refill.service.ts
@@ -126,11 +126,11 @@ export class RefillService {
   /**
    * Returns the user's wallet, creating and activating it as needed —
    * funding with real money must activate a wallet even when the user never started a trial.
-   * The activation claim no-ops for already-activated wallets.
+   * The activation stamp no-ops for already-activated wallets.
    */
   private async ensureActivatedWallet(userId: UserWalletOutput["userId"]) {
     const userWallet = await this.walletInitializerService.ensureWallet(userId);
 
-    return (await this.userWalletRepository.claimActivation(userWallet.id)) ?? userWallet;
+    return (await this.userWalletRepository.markActivated(userWallet.id)) ?? userWallet;
   }
 }

--- a/apps/api/src/billing/services/wallet-initializer/wallet-initializer.service.spec.ts
+++ b/apps/api/src/billing/services/wallet-initializer/wallet-initializer.service.spec.ts
@@ -156,7 +156,7 @@ describe(WalletInitializerService.name, () => {
       const claimedAt = new Date();
       const getOrCreateWallet = vi.fn().mockResolvedValue({ wallet, isNew: false });
       const claimActivation = vi.fn().mockResolvedValue({ ...wallet, activationClaimedAt: claimedAt });
-      const releaseActivationClaim = vi.fn();
+      const releaseActivationClaim = vi.fn().mockResolvedValue(undefined);
       const updateWalletById = vi.fn().mockImplementation(async (id, patch) => ({ ...wallet, ...patch }));
       const deleteWalletById = vi.fn();
 
@@ -167,8 +167,26 @@ describe(WalletInitializerService.name, () => {
       await expect(di.resolve(WalletInitializerService).initializeAndGrantTrialLimits(userId)).rejects.toThrow("Failed to authorize trial");
 
       expect(releaseActivationClaim).toHaveBeenCalledWith(wallet.id, claimedAt);
-      expect(updateWalletById).not.toHaveBeenCalledWith(wallet.id, { activatedAt: null });
+      expect(updateWalletById).not.toHaveBeenCalled();
       expect(deleteWalletById).not.toHaveBeenCalled();
+      expect(di.resolve(DomainEventsService).publish).not.toHaveBeenCalled();
+    });
+
+    it("surfaces the original provisioning error even when releasing the claim fails", async () => {
+      const userId = "test-user-id";
+      const wallet = createUserWallet({ userId, activatedAt: null });
+      const claimedAt = new Date();
+      const getOrCreateWallet = vi.fn().mockResolvedValue({ wallet, isNew: false });
+      const claimActivation = vi.fn().mockResolvedValue({ ...wallet, activationClaimedAt: claimedAt });
+      const releaseActivationClaim = vi.fn().mockRejectedValue(new Error("Failed to release claim"));
+
+      const di = setup({ getOrCreateWallet, claimActivation, releaseActivationClaim });
+      const managedUserWalletService = di.resolve(ManagedUserWalletService) as MockProxy<ManagedUserWalletService>;
+      managedUserWalletService.createAndAuthorizeTrialSpending.mockRejectedValue(new Error("Failed to authorize trial"));
+
+      await expect(di.resolve(WalletInitializerService).initializeAndGrantTrialLimits(userId)).rejects.toThrow("Failed to authorize trial");
+
+      expect(releaseActivationClaim).toHaveBeenCalledWith(wallet.id, claimedAt);
       expect(di.resolve(DomainEventsService).publish).not.toHaveBeenCalled();
     });
 
@@ -248,7 +266,7 @@ describe(WalletInitializerService.name, () => {
         updateById: input?.updateWalletById,
         deleteById: input?.deleteWalletById ?? vi.fn(),
         claimActivation: input?.claimActivation,
-        releaseActivationClaim: input?.releaseActivationClaim ?? vi.fn(),
+        releaseActivationClaim: input?.releaseActivationClaim ?? vi.fn().mockResolvedValue(undefined),
         accessibleBy() {
           return this as unknown as UserWalletRepository;
         },

--- a/apps/api/src/billing/services/wallet-initializer/wallet-initializer.service.spec.ts
+++ b/apps/api/src/billing/services/wallet-initializer/wallet-initializer.service.spec.ts
@@ -45,7 +45,7 @@ describe(WalletInitializerService.name, () => {
       const di = setup({
         user,
         getOrCreateWallet: vi.fn().mockResolvedValue({ wallet: newWallet, isNew: true }),
-        claimActivation: vi.fn().mockResolvedValue({ ...newWallet, activatedAt: new Date() }),
+        claimActivation: vi.fn().mockResolvedValue({ ...newWallet, activationClaimedAt: new Date() }),
         updateWalletById: vi.fn().mockResolvedValue(newWallet)
       });
       const managedUserWalletService = di.resolve(ManagedUserWalletService) as MockProxy<ManagedUserWalletService>;
@@ -62,7 +62,7 @@ describe(WalletInitializerService.name, () => {
       const di = setup({
         user,
         getOrCreateWallet: vi.fn().mockResolvedValue({ wallet: newWallet, isNew: true }),
-        claimActivation: vi.fn().mockResolvedValue({ ...newWallet, activatedAt: new Date() }),
+        claimActivation: vi.fn().mockResolvedValue({ ...newWallet, activationClaimedAt: new Date() }),
         updateWalletById: vi.fn().mockResolvedValue(newWallet)
       });
       const managedUserWalletService = di.resolve(ManagedUserWalletService) as MockProxy<ManagedUserWalletService>;
@@ -80,7 +80,7 @@ describe(WalletInitializerService.name, () => {
       const derivedAddress = "akash1derived";
       const getOrCreateWallet = vi.fn().mockResolvedValue({ wallet: orphanWallet, isNew: true });
       const updateWalletById = vi.fn().mockImplementation(async (id, patch) => ({ ...orphanWallet, ...patch }));
-      const claimActivation = vi.fn().mockResolvedValue({ ...orphanWallet, address: derivedAddress, activatedAt: new Date() });
+      const claimActivation = vi.fn().mockResolvedValue({ ...orphanWallet, address: derivedAddress, activationClaimedAt: new Date() });
 
       const di = setup({ getOrCreateWallet, updateWalletById, claimActivation });
       const managedUserWalletService = di.resolve(ManagedUserWalletService) as MockProxy<ManagedUserWalletService>;
@@ -108,12 +108,12 @@ describe(WalletInitializerService.name, () => {
       expect(di.resolve(DomainEventsService).publish).not.toHaveBeenCalled();
     });
 
-    it("claims activation, authorizes trial spending and saves the granted allowances", async () => {
+    it("claims activation, authorizes trial spending and stamps activation together with the granted allowances", async () => {
       const userId = "test-user-id";
       const wallet = createUserWallet({ userId, activatedAt: null });
       const chainWallet = createChainWallet();
       const getOrCreateWallet = vi.fn().mockResolvedValue({ wallet, isNew: false });
-      const claimActivation = vi.fn().mockResolvedValue({ ...wallet, activatedAt: new Date() });
+      const claimActivation = vi.fn().mockResolvedValue({ ...wallet, activationClaimedAt: new Date() });
       const updateWalletById = vi.fn().mockImplementation(async (id, patch) => ({ ...wallet, ...patch }));
 
       const di = setup({ getOrCreateWallet, claimActivation, updateWalletById });
@@ -128,7 +128,9 @@ describe(WalletInitializerService.name, () => {
         wallet.id,
         {
           deploymentAllowance: chainWallet.limits.deployment,
-          feeAllowance: chainWallet.limits.fees
+          feeAllowance: chainWallet.limits.fees,
+          activatedAt: expect.any(Date),
+          activationClaimedAt: null
         },
         { returning: true }
       );
@@ -148,21 +150,24 @@ describe(WalletInitializerService.name, () => {
       expect(di.resolve(DomainEventsService).publish).not.toHaveBeenCalled();
     });
 
-    it("unsets activation and keeps the wallet when authorization fails", async () => {
+    it("releases only its own claim and keeps the wallet when authorization fails", async () => {
       const userId = "test-user-id";
       const wallet = createUserWallet({ userId, activatedAt: null });
+      const claimedAt = new Date();
       const getOrCreateWallet = vi.fn().mockResolvedValue({ wallet, isNew: false });
-      const claimActivation = vi.fn().mockResolvedValue({ ...wallet, activatedAt: new Date() });
+      const claimActivation = vi.fn().mockResolvedValue({ ...wallet, activationClaimedAt: claimedAt });
+      const releaseActivationClaim = vi.fn();
       const updateWalletById = vi.fn().mockImplementation(async (id, patch) => ({ ...wallet, ...patch }));
       const deleteWalletById = vi.fn();
 
-      const di = setup({ getOrCreateWallet, claimActivation, updateWalletById, deleteWalletById });
+      const di = setup({ getOrCreateWallet, claimActivation, releaseActivationClaim, updateWalletById, deleteWalletById });
       const managedUserWalletService = di.resolve(ManagedUserWalletService) as MockProxy<ManagedUserWalletService>;
       managedUserWalletService.createAndAuthorizeTrialSpending.mockRejectedValue(new Error("Failed to authorize trial"));
 
       await expect(di.resolve(WalletInitializerService).initializeAndGrantTrialLimits(userId)).rejects.toThrow("Failed to authorize trial");
 
-      expect(updateWalletById).toHaveBeenCalledWith(wallet.id, { activatedAt: null });
+      expect(releaseActivationClaim).toHaveBeenCalledWith(wallet.id, claimedAt);
+      expect(updateWalletById).not.toHaveBeenCalledWith(wallet.id, { activatedAt: null });
       expect(deleteWalletById).not.toHaveBeenCalled();
       expect(di.resolve(DomainEventsService).publish).not.toHaveBeenCalled();
     });
@@ -172,7 +177,7 @@ describe(WalletInitializerService.name, () => {
       const wallet = createUserWallet({ userId, activatedAt: null });
       const chainWallet = createChainWallet();
       const getOrCreateWallet = vi.fn().mockResolvedValue({ wallet, isNew: false });
-      const claimActivation = vi.fn().mockResolvedValue({ ...wallet, activatedAt: new Date() });
+      const claimActivation = vi.fn().mockResolvedValue({ ...wallet, activationClaimedAt: new Date() });
       const updateWalletById = vi.fn().mockImplementation(async (id, patch) => ({ ...wallet, ...patch }));
 
       const di = setup({ userId, getOrCreateWallet, claimActivation, updateWalletById });
@@ -227,6 +232,7 @@ describe(WalletInitializerService.name, () => {
     updateWalletById?: UserWalletRepository["updateById"];
     deleteWalletById?: UserWalletRepository["deleteById"];
     claimActivation?: UserWalletRepository["claimActivation"];
+    releaseActivationClaim?: UserWalletRepository["releaseActivationClaim"];
     userId?: string;
     user?: UserOutput;
     isProduction?: boolean;
@@ -242,6 +248,7 @@ describe(WalletInitializerService.name, () => {
         updateById: input?.updateWalletById,
         deleteById: input?.deleteWalletById ?? vi.fn(),
         claimActivation: input?.claimActivation,
+        releaseActivationClaim: input?.releaseActivationClaim ?? vi.fn(),
         accessibleBy() {
           return this as unknown as UserWalletRepository;
         },

--- a/apps/api/src/billing/services/wallet-initializer/wallet-initializer.service.ts
+++ b/apps/api/src/billing/services/wallet-initializer/wallet-initializer.service.ts
@@ -1,3 +1,4 @@
+import { createOtelLogger } from "@akashnetwork/logging/otel";
 import assert from "http-assert";
 import { singleton } from "tsyringe";
 
@@ -14,6 +15,8 @@ import { ManagedUserWalletService } from "../managed-user-wallet/managed-user-wa
 
 @singleton()
 export class WalletInitializerService {
+  private readonly logger = createOtelLogger({ context: WalletInitializerService.name });
+
   constructor(
     private readonly walletManager: ManagedUserWalletService,
     private readonly managedSignerService: ManagedSignerService,
@@ -65,7 +68,9 @@ export class WalletInitializerService {
         { returning: true }
       );
     } catch (error) {
-      await this.userWalletRepository.releaseActivationClaim(claimedWallet.id, claimedWallet.activationClaimedAt!);
+      await this.userWalletRepository
+        .releaseActivationClaim(claimedWallet.id, claimedWallet.activationClaimedAt!)
+        .catch(releaseError => this.logger.error({ event: "TRIAL_CLAIM_RELEASE_ERROR", walletId: claimedWallet.id, error: releaseError }));
       throw error;
     }
 

--- a/apps/api/src/billing/services/wallet-initializer/wallet-initializer.service.ts
+++ b/apps/api/src/billing/services/wallet-initializer/wallet-initializer.service.ts
@@ -58,12 +58,14 @@ export class WalletInitializerService {
         claimedWallet.id,
         {
           deploymentAllowance: chainWallet.limits.deployment,
-          feeAllowance: chainWallet.limits.fees
+          feeAllowance: chainWallet.limits.fees,
+          activatedAt: new Date(),
+          activationClaimedAt: null
         },
         { returning: true }
       );
     } catch (error) {
-      await this.userWalletRepository.updateById(claimedWallet.id, { activatedAt: null });
+      await this.userWalletRepository.releaseActivationClaim(claimedWallet.id, claimedWallet.activationClaimedAt!);
       throw error;
     }
 

--- a/apps/api/src/user/repositories/user/user.repository.integration.ts
+++ b/apps/api/src/user/repositories/user/user.repository.integration.ts
@@ -108,7 +108,7 @@ describe(UserRepository.name, () => {
 
       const activatedTrialUser = await createTestUser({ lastFingerprint: fingerprint });
       const activatedWallet = await userWalletRepository.create({ userId: activatedTrialUser.id, address: createAkashAddress() });
-      await userWalletRepository.claimActivation(activatedWallet.id);
+      await userWalletRepository.markActivated(activatedWallet.id);
 
       const registeredOnlyUser = await createTestUser({ lastFingerprint: fingerprint });
       await userWalletRepository.create({ userId: registeredOnlyUser.id, address: createAkashAddress() });

--- a/apps/api/test/seeders/user-wallet.seeder.ts
+++ b/apps/api/test/seeders/user-wallet.seeder.ts
@@ -12,7 +12,8 @@ export function createUserWallet({
   isTrialing = faker.helpers.arrayElement([true, false]),
   createdAt = faker.date.past(),
   updatedAt = faker.date.past(),
-  activatedAt = createdAt
+  activatedAt = createdAt,
+  activationClaimedAt = null
 }: Partial<UserWalletOutput> = {}): UserWalletOutput {
   return {
     id,
@@ -24,6 +25,7 @@ export function createUserWallet({
     creditAmount: deploymentAllowance,
     createdAt,
     updatedAt,
-    activatedAt
+    activatedAt,
+    activationClaimedAt
   };
 }


### PR DESCRIPTION
## Why

Related to CON-744

After deploying #3513, every trial started in a ~2h prod window ended up with `activated_at = NULL` even though provisioning fully succeeded on-chain (fee + deposit grants landed, users were actively deploying). Verified against prod data and public LCD state.

Root cause: `activated_at` doubled as both the in-flight claim marker and the completion marker.

1. A trial start stamped `activated_at` up front and rolled it back on failure. The rollback was unconditional, so a slow failing attempt could clear a stamp it no longer owned.
2. The idempotency fast-path read the mid-flight stamp as "trial started" and returned 200 while the claiming attempt could still fail and unstamp.

Net effect: provisioned, actively-deploying wallets that are invisible to `GET /v1/wallets`, skipped by the refill cron (`findDrainingWallets`), and ignored by the trial fingerprint check. Affected prod rows were repaired manually with a one-off `UPDATE`.

## What

- New nullable `user_wallets.activation_claimed_at` column (migration 0034, additive) guards in-flight provisioning:
  - `claimActivation` sets it conditionally; a claim older than 5 minutes is considered abandoned (crashed/hung attempt) and can be taken over.
  - `releaseActivationClaim` clears only the claim identified by its own timestamp, so a stale attempt cannot clobber a newer claim.
- `activated_at` is now written **only on success**, atomically with the granted allowances — there is no rollback to get wrong, and the fast-path/`GET /v1/wallets`/refill cron/fingerprint check can only ever observe completed activations.
- `RefillService` uses the new `markActivated` (direct stamp, no claim cycle) since funding-based activation has no post-claim provisioning step to guard.

No API contract changes. The migration is a single nullable-column `ALTER TABLE` — no backfill, no locks beyond a brief ACCESS EXCLUSIVE.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new activation claim timestamp to track in-progress activation separately from completed activation.
  * Introduced stale activation claim takeover so older, abandoned claims can be recovered.

* **Bug Fixes**
  * Prevented concurrent activation attempts from overwriting each other’s claim/activation state.
  * Updated activation/release behavior so only the correct activation claim is released, enabling safe retries after failures.
  * Ensured already-activated wallets remain unchanged during activation flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->