### PR TITLE
fix(stats): add CSP nonce to next-themes theme script

### DIFF
--- a/apps/stats-web/src/app/layout.tsx
+++ b/apps/stats-web/src/app/layout.tsx
@@ -4,7 +4,7 @@ import "../styles/index.css";
 import { cn } from "@akashnetwork/ui/utils";
 import { GeistSans } from "geist/font/sans";
 import type { Metadata, Viewport } from "next";
-import { cookies } from "next/headers";
+import { cookies, headers } from "next/headers";
 
 import GoogleAnalytics from "@/components/layout/CustomGoogleAnalytics";
 import Providers from "@/components/layout/CustomProviders";
@@ -89,13 +89,14 @@ async function getTheme() {
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   const theme = (await getTheme()) as string;
+  const nonce = (await headers()).get("x-nonce") ?? undefined;
 
   return (
     <html lang="en" className={theme} style={{ colorScheme: theme }} suppressHydrationWarning>
       <GoogleAnalytics />
 
       <body className={cn("min-h-screen bg-background font-sans tracking-wide antialiased", GeistSans.variable)}>
-        <Providers>
+        <Providers nonce={nonce}>
           <Nav />
           <div className="flex min-h-[calc(100vh-60px)] flex-col justify-between">
             {children}

--- a/apps/stats-web/src/components/layout/CustomProviders.tsx
+++ b/apps/stats-web/src/components/layout/CustomProviders.tsx
@@ -14,14 +14,14 @@ import { PricingProvider } from "@/context/PricingProvider";
 import { customColors } from "@/lib/colors";
 import { store } from "@/store/global.store";
 
-function Providers({ children }: React.PropsWithChildren) {
+function Providers({ children, nonce }: React.PropsWithChildren<{ nonce?: string }>) {
   const [queryClient] = useState(() => new QueryClient());
 
   return (
     <CustomIntlProvider>
       <QueryClientProvider client={queryClient}>
         <Provider store={store}>
-          <ThemeProvider attribute="class" defaultTheme="system" storageKey="theme" enableSystem disableTransitionOnChange>
+          <ThemeProvider attribute="class" defaultTheme="system" storageKey="theme" enableSystem disableTransitionOnChange nonce={nonce}>
             <CustomSnackbarProvider>
               <PricingProvider>
                 <TooltipProvider>


### PR DESCRIPTION
## Why

The nonce + `strict-dynamic` CSP added to stats-web in #3473 flags the
`next-themes` theme `<script>` as a `script-src-elem` / `inline` violation on
every page load. In Sentry this is **STATS-WEB-1** — ~2345 events across ~1828
users since the CSP landed. The CSP is report-only, so nothing is blocked
today, but it floods Sentry.

Fixes STATS-WEB-1

## What

**Root cause:** `next-themes` renders its FOUC-prevention inline `<script>` as a
raw `React.createElement("script", …)`, which is outside Next.js's automatic
nonce propagation, and the app never passed a `nonce` to `<ThemeProvider>`.
Under `'strict-dynamic'` the host allowlist and `'self'` are ignored for
scripts, so any un-nonced inline `<script>` is reported. It was the only
un-nonced SSR inline script — Next's own framework scripts and the
`afterInteractive` GA scripts (client-injected by Next's trusted loader) are
already covered.

**Fix (2 files):**
- `app/layout.tsx`: read the middleware-set `x-nonce` request header via
  `headers()` and pass it to `<Providers>`. The layout already `await cookies()`,
  so it is already dynamically rendered — no caching change.
- `components/layout/CustomProviders.tsx`: accept the `nonce` prop and forward it
  to `<ThemeProvider … nonce={nonce}>`.

**Verification:** ran the app with `CSP_MODE=enforce` and inspected the SSR HTML.
- Before: the theme script renders with no `nonce` → 1 `script-src-elem` violation.
- After: every executable inline script (theme script included) carries the
  header nonce → 0 violations.
- `tsc --noEmit`, `eslint --quiet`, and `test:unit` (52 tests) all pass.

**Scope:** CSP stays report-only. deploy-web has the same un-nonced
`<ThemeProvider>` but is Pages Router (different nonce-threading) — tracked as a
separate follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Improved compatibility with Content Security Policy requirements by securely applying request-specific nonces to theme-related styles.
  * Added support for safely handling requests where a nonce is not provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->