### PR TITLE
feat(onboarding): let users permanently skip the onboarding flow

### DIFF
--- a/apps/api/drizzle/0034_add_onboarding_skipped_at.sql
+++ b/apps/api/drizzle/0034_add_onboarding_skipped_at.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "userSetting" ADD COLUMN "onboardingSkippedAt" timestamp;

--- a/apps/api/drizzle/meta/0034_snapshot.json
+++ b/apps/api/drizzle/meta/0034_snapshot.json
@@ -1,0 +1,1367 @@
+{
+  "id": "15befea9-f731-44fd-8390-2236155dc978",
+  "prevId": "0e3866c6-bb02-4bb0-8241-6e6ac040f4f7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.user_wallets": {
+      "name": "user_wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_allowance": {
+          "name": "deployment_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "fee_allowance": {
+          "name": "fee_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "trial": {
+          "name": "trial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_wallets_user_id_userSetting_id_fk": {
+          "name": "user_wallets_user_id_userSetting_id_fk",
+          "tableFrom": "user_wallets",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_wallets_user_id_unique": {
+          "name": "user_wallets_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "user_wallets_address_unique": {
+          "name": "user_wallets_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_methods": {
+      "name": "payment_methods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_method_id": {
+          "name": "payment_method_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_validated": {
+          "name": "is_validated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payment_methods_fingerprint_payment_method_id_unique": {
+          "name": "payment_methods_fingerprint_payment_method_id_unique",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_default_unique": {
+          "name": "payment_methods_user_id_is_default_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"payment_methods\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_fingerprint_idx": {
+          "name": "payment_methods_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_idx": {
+          "name": "payment_methods_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_validated_idx": {
+          "name": "payment_methods_user_id_is_validated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_validated",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_fingerprint_payment_method_id_idx": {
+          "name": "payment_methods_user_id_fingerprint_payment_method_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_methods_user_id_userSetting_id_fk": {
+          "name": "payment_methods_user_id_userSetting_id_fk",
+          "tableFrom": "payment_methods",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_transactions": {
+      "name": "stripe_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "stripe_transaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "stripe_transaction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created'"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_refunded": {
+          "name": "amount_refunded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bonus_amount": {
+          "name": "bonus_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_charge_id": {
+          "name": "stripe_charge_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_coupon_id": {
+          "name": "stripe_coupon_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_promotion_code_id": {
+          "name": "stripe_promotion_code_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_idempotency_key": {
+          "name": "stripe_idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method_type": {
+          "name": "payment_method_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_brand": {
+          "name": "card_brand",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_last4": {
+          "name": "card_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_url": {
+          "name": "receipt_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_transactions_stripe_invoice_id_unique": {
+          "name": "stripe_transactions_stripe_invoice_id_unique",
+          "columns": [
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stripe_transactions\".\"stripe_invoice_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_idempotency_key_unique": {
+          "name": "stripe_transactions_stripe_idempotency_key_unique",
+          "columns": [
+            {
+              "expression": "stripe_idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stripe_transactions\".\"stripe_idempotency_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_user_id_idx": {
+          "name": "stripe_transactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_payment_intent_id_idx": {
+          "name": "stripe_transactions_stripe_payment_intent_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_payment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_charge_id_idx": {
+          "name": "stripe_transactions_stripe_charge_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_coupon_id_idx": {
+          "name": "stripe_transactions_stripe_coupon_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_coupon_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_promotion_code_id_idx": {
+          "name": "stripe_transactions_stripe_promotion_code_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_promotion_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_status_idx": {
+          "name": "stripe_transactions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_created_at_idx": {
+          "name": "stripe_transactions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_user_id_created_at_idx": {
+          "name": "stripe_transactions_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_transactions_user_id_userSetting_id_fk": {
+          "name": "stripe_transactions_user_id_userSetting_id_fk",
+          "tableFrom": "stripe_transactions",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_settings": {
+      "name": "wallet_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_reload_enabled": {
+          "name": "auto_reload_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_settings_user_id_idx": {
+          "name": "wallet_settings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_settings_wallet_id_user_wallets_id_fk": {
+          "name": "wallet_settings_wallet_id_user_wallets_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "user_wallets",
+          "columnsFrom": [
+            "wallet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wallet_settings_user_id_userSetting_id_fk": {
+          "name": "wallet_settings_user_id_userSetting_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallet_settings_wallet_id_unique": {
+          "name": "wallet_settings_wallet_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wallet_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.userSetting": {
+      "name": "userSetting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscribedToNewsletter": {
+          "name": "subscribedToNewsletter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "youtubeUsername": {
+          "name": "youtubeUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitterUsername": {
+          "name": "twitterUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "githubUsername": {
+          "name": "githubUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_ip": {
+          "name": "last_ip",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_user_agent": {
+          "name": "last_user_agent",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fingerprint": {
+          "name": "last_fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboardingSkippedAt": {
+          "name": "onboardingSkippedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "userSetting_userId_unique": {
+          "name": "userSetting_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        },
+        "userSetting_username_unique": {
+          "name": "userSetting_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.template": {
+      "name": "template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "copiedFromId": {
+          "name": "copiedFromId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cpu": {
+          "name": "cpu",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ram": {
+          "name": "ram",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage": {
+          "name": "storage",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sdl": {
+          "name": "sdl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "template_userId_idx": {
+          "name": "template_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.templateFavorite": {
+      "name": "templateFavorite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "templateId": {
+          "name": "templateId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addedDate": {
+          "name": "addedDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "templateFavorite_userId_templateId_unique": {
+          "name": "templateFavorite_userId_templateId_unique",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "templateId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "templateFavorite_templateId_template_id_fk": {
+          "name": "templateFavorite_templateId_template_id_fk",
+          "tableFrom": "templateFavorite",
+          "tableTo": "template",
+          "columnsFrom": [
+            "templateId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_settings": {
+      "name": "deployment_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dseq": {
+          "name": "dseq",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_top_up_enabled": {
+          "name": "auto_top_up_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "closed": {
+          "name": "closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "id_auto_top_up_enabled_closed_idx": {
+          "name": "id_auto_top_up_enabled_closed_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auto_top_up_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "closed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_settings_user_id_userSetting_id_fk": {
+          "name": "deployment_settings_user_id_userSetting_id_fk",
+          "tableFrom": "deployment_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dseq_user_id_idx": {
+          "name": "dseq_user_id_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "dseq",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_key": {
+          "name": "hashed_key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_format": {
+          "name": "key_format",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_user_id_userSetting_id_fk": {
+          "name": "api_keys_user_id_userSetting_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_hashed_key_unique": {
+          "name": "api_keys_hashed_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hashed_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_verification_codes": {
+      "name": "email_verification_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_verification_codes_user_id_idx": {
+          "name": "email_verification_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_verification_codes_user_id_userSetting_id_fk": {
+          "name": "email_verification_codes_user_id_userSetting_id_fk",
+          "tableFrom": "email_verification_codes",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.stripe_transaction_status": {
+      "name": "stripe_transaction_status",
+      "schema": "public",
+      "values": [
+        "created",
+        "pending",
+        "requires_action",
+        "succeeded",
+        "failed",
+        "refunded",
+        "canceled"
+      ]
+    },
+    "public.stripe_transaction_type": {
+      "name": "stripe_transaction_type",
+      "schema": "public",
+      "values": [
+        "payment_intent",
+        "coupon_claim",
+        "manual_credit"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -239,6 +239,13 @@
       "when": 1784819171143,
       "tag": "0033_long_solo",
       "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "7",
+      "when": 1785154240079,
+      "tag": "0034_add_onboarding_skipped_at",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/app/console.ts
+++ b/apps/api/src/app/console.ts
@@ -117,6 +117,7 @@ async function executeCliHandler(name: string, handler: () => Promise<unknown>, 
           youtubeUsername: null,
           twitterUsername: null,
           githubUsername: null,
+          onboardingSkippedAt: null,
           userId: "system:cli-user",
           username: "___cli_user___",
           trial: false

--- a/apps/api/src/core/services/job-queue/job-queue.service.ts
+++ b/apps/api/src/core/services/job-queue/job-queue.service.ts
@@ -227,6 +227,7 @@ export class JobQueueService implements Disposable {
                 youtubeUsername: null,
                 twitterUsername: null,
                 githubUsername: null,
+                onboardingSkippedAt: null,
                 userId: "system:bg-job-user",
                 username: "___bg_job_user___",
                 trial: false

--- a/apps/api/src/user/controllers/user/user.controller.spec.ts
+++ b/apps/api/src/user/controllers/user/user.controller.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { AuthService } from "@src/auth/services/auth.service";
+import type { UserAuthTokenService } from "@src/auth/services/user-auth-token/user-auth-token.service";
+import type { ExecutionContextService } from "@src/core/services/execution-context/execution-context.service";
+import type { UserOutput } from "@src/user/repositories/user/user.repository";
+import type { UserService } from "@src/user/services/user/user.service";
+import { UserController } from "./user.controller";
+
+import { createUser } from "@test/seeders/user.seeder";
+
+describe(UserController.name, () => {
+  describe("skipOnboarding", () => {
+    it("delegates to the user service with the current user id", async () => {
+      const user = createUser();
+      const { controller, authService, userService } = setup();
+      authService.currentUser = user;
+
+      await controller.skipOnboarding();
+
+      expect(userService.skipOnboarding).toHaveBeenCalledWith(user.id);
+    });
+
+    it("throws 401 when there is no current user", async () => {
+      const { controller, authService, userService } = setup();
+      authService.currentUser = undefined as unknown as UserOutput;
+
+      await expect(controller.skipOnboarding()).rejects.toMatchObject({ status: 401 });
+      expect(userService.skipOnboarding).not.toHaveBeenCalled();
+    });
+  });
+
+  function setup() {
+    const authService = mock<AuthService>();
+    const executionContextService = mock<ExecutionContextService>();
+    const userService = mock<UserService>();
+    const userAuthTokenService = mock<UserAuthTokenService>();
+
+    const controller = new UserController(authService, executionContextService, userService, userAuthTokenService);
+
+    return { controller, authService, executionContextService, userService, userAuthTokenService };
+  }
+});

--- a/apps/api/src/user/controllers/user/user.controller.ts
+++ b/apps/api/src/user/controllers/user/user.controller.ts
@@ -77,4 +77,10 @@ export class UserController {
     const userId = this.authService.currentUser.id;
     await this.userService.subscribeToNewsletter(userId);
   }
+
+  async skipOnboarding() {
+    assert(this.authService.currentUser?.id, 401);
+    const userId = this.authService.currentUser.id;
+    await this.userService.skipOnboarding(userId);
+  }
 }

--- a/apps/api/src/user/model-schemas/user/user.schema.ts
+++ b/apps/api/src/user/model-schemas/user/user.schema.ts
@@ -1,7 +1,9 @@
 import { relations, sql } from "drizzle-orm";
 import { boolean, pgTable, text, timestamp, uuid, varchar } from "drizzle-orm/pg-core";
 
+// eslint-disable-next-line import-x/no-cycle
 import { UserWallets } from "@src/billing/model-schemas/user-wallet/user-wallet.schema";
+// eslint-disable-next-line import-x/no-cycle
 import { Templates } from "@src/user/model-schemas/template/template.schema";
 
 export const userAgentMaxLength = 500;

--- a/apps/api/src/user/model-schemas/user/user.schema.ts
+++ b/apps/api/src/user/model-schemas/user/user.schema.ts
@@ -1,9 +1,7 @@
 import { relations, sql } from "drizzle-orm";
 import { boolean, pgTable, text, timestamp, uuid, varchar } from "drizzle-orm/pg-core";
 
-// eslint-disable-next-line import-x/no-cycle
 import { UserWallets } from "@src/billing/model-schemas/user-wallet/user-wallet.schema";
-// eslint-disable-next-line import-x/no-cycle
 import { Templates } from "@src/user/model-schemas/template/template.schema";
 
 export const userAgentMaxLength = 500;
@@ -27,6 +25,7 @@ export const Users = pgTable("userSetting", {
   lastIp: varchar("last_ip", { length: 255 }),
   lastUserAgent: varchar("last_user_agent", { length: userAgentMaxLength }),
   lastFingerprint: varchar("last_fingerprint", { length: 255 }),
+  onboardingSkippedAt: timestamp("onboardingSkippedAt"),
   createdAt: timestamp("created_at").defaultNow()
 });
 

--- a/apps/api/src/user/routes/user-settings/user-settings.router.ts
+++ b/apps/api/src/user/routes/user-settings/user-settings.router.ts
@@ -135,3 +135,24 @@ userSettingsRouter.openapi(subscribeToNewsletterRoute, async function subscribeT
   await container.resolve(UserController).subscribeToNewsletter();
   return c.body(null, 204);
 });
+
+const skipOnboardingRoute = createRoute({
+  method: "post",
+  path: "/v1/user/skipOnboarding",
+  summary: "Skip onboarding",
+  tags: ["Users"],
+  security: SECURITY_BEARER_OR_API_KEY,
+  responses: {
+    204: {
+      description: "Onboarding skipped"
+    },
+    401: {
+      description: "Unauthorized"
+    }
+  }
+});
+
+userSettingsRouter.openapi(skipOnboardingRoute, async function skipOnboarding(c) {
+  await container.resolve(UserController).skipOnboarding();
+  return c.body(null, 204);
+});

--- a/apps/api/src/user/schemas/user.schema.ts
+++ b/apps/api/src/user/schemas/user.schema.ts
@@ -11,7 +11,8 @@ export const UserSchema = z.object({
   subscribedToNewsletter: z.boolean(),
   youtubeUsername: z.string().optional().nullable(),
   twitterUsername: z.string().optional().nullable(),
-  githubUsername: z.string().optional().nullable()
+  githubUsername: z.string().optional().nullable(),
+  onboardingSkippedAt: z.string().datetime().nullable().optional()
 });
 
 export type UserSchema = z.infer<typeof UserSchema>;

--- a/apps/api/src/user/services/user/user.service.integration.ts
+++ b/apps/api/src/user/services/user/user.service.integration.ts
@@ -336,6 +336,43 @@ describe(UserService.name, () => {
     });
   });
 
+  describe("skipOnboarding", () => {
+    it("sets onboardingSkippedAt when it has not been set", async () => {
+      const { service, userRepository } = setup();
+      const user = await userRepository.create({
+        userId: faker.string.uuid(),
+        username: `test-user-${Date.now()}`,
+        email: faker.internet.email(),
+        emailVerified: false,
+        subscribedToNewsletter: false
+      });
+
+      await service.skipOnboarding(user.id);
+
+      const updatedUser = await userRepository.findById(user.id);
+      expect(updatedUser?.onboardingSkippedAt).toBeInstanceOf(Date);
+    });
+
+    it("preserves the original timestamp when called again", async () => {
+      const { service, userRepository } = setup();
+      const user = await userRepository.create({
+        userId: faker.string.uuid(),
+        username: `test-user-${Date.now()}`,
+        email: faker.internet.email(),
+        emailVerified: false,
+        subscribedToNewsletter: false
+      });
+
+      await service.skipOnboarding(user.id);
+      const firstSkippedAt = (await userRepository.findById(user.id))?.onboardingSkippedAt;
+
+      await service.skipOnboarding(user.id);
+      const secondSkippedAt = (await userRepository.findById(user.id))?.onboardingSkippedAt;
+
+      expect(secondSkippedAt).toEqual(firstSkippedAt);
+    });
+  });
+
   function setup(input?: { createDefaultNotificationChannel?: NotificationService["createDefaultChannel"] }) {
     const analyticsService = mock<AnalyticsService>();
     const logger = mock<LoggerService>();

--- a/apps/api/src/user/services/user/user.service.integration.ts
+++ b/apps/api/src/user/services/user/user.service.integration.ts
@@ -202,7 +202,7 @@ describe(UserService.name, () => {
 
       const user = await userRepository.create({
         userId: faker.string.uuid(),
-        username: `test-user-${Date.now()}`,
+        username: `test-user-${faker.string.uuid()}`,
         email: faker.internet.email(),
         emailVerified: false,
         subscribedToNewsletter: false,
@@ -232,7 +232,7 @@ describe(UserService.name, () => {
 
       const user = await userRepository.create({
         userId: faker.string.uuid(),
-        username: `test-user-${Date.now()}`,
+        username: `test-user-${faker.string.uuid()}`,
         email: faker.internet.email(),
         emailVerified: false,
         subscribedToNewsletter: false
@@ -258,7 +258,7 @@ describe(UserService.name, () => {
 
       const user = await userRepository.create({
         userId: faker.string.uuid(),
-        username: `test-user-${Date.now()}`,
+        username: `test-user-${faker.string.uuid()}`,
         email: faker.internet.email(),
         emailVerified: false,
         subscribedToNewsletter: false
@@ -323,7 +323,7 @@ describe(UserService.name, () => {
 
       const user = await userRepository.create({
         userId: faker.string.uuid(),
-        username: `test-user-${Date.now()}`,
+        username: `test-user-${faker.string.uuid()}`,
         email: faker.internet.email(),
         emailVerified: false,
         subscribedToNewsletter: false
@@ -341,7 +341,7 @@ describe(UserService.name, () => {
       const { service, userRepository } = setup();
       const user = await userRepository.create({
         userId: faker.string.uuid(),
-        username: `test-user-${Date.now()}`,
+        username: `test-user-${faker.string.uuid()}`,
         email: faker.internet.email(),
         emailVerified: false,
         subscribedToNewsletter: false
@@ -357,7 +357,7 @@ describe(UserService.name, () => {
       const { service, userRepository } = setup();
       const user = await userRepository.create({
         userId: faker.string.uuid(),
-        username: `test-user-${Date.now()}`,
+        username: `test-user-${faker.string.uuid()}`,
         email: faker.internet.email(),
         emailVerified: false,
         subscribedToNewsletter: false

--- a/apps/api/src/user/services/user/user.service.spec.ts
+++ b/apps/api/src/user/services/user/user.service.spec.ts
@@ -111,6 +111,17 @@ describe(UserService.name, () => {
     });
   });
 
+  describe("skipOnboarding", () => {
+    it("persists the skip time with a set-if-null guard so it is written once and never overwritten", async () => {
+      const userId = faker.string.uuid();
+      const { service, userRepository } = setup();
+
+      await service.skipOnboarding(userId);
+
+      expect(userRepository.updateBy).toHaveBeenCalledWith({ id: userId, onboardingSkippedAt: null }, { onboardingSkippedAt: expect.any(Date) });
+    });
+  });
+
   function setup() {
     const userRepository = mock<UserRepository>();
     const analyticsService = mock<AnalyticsService>();

--- a/apps/api/src/user/services/user/user.service.ts
+++ b/apps/api/src/user/services/user/user.service.ts
@@ -166,6 +166,10 @@ export class UserService {
   async subscribeToNewsletter(userId: string) {
     await this.userRepository.updateById(userId, { subscribedToNewsletter: true });
   }
+
+  async skipOnboarding(userId: string) {
+    await this.userRepository.updateBy({ id: userId, onboardingSkippedAt: null }, { onboardingSkippedAt: new Date() });
+  }
 }
 
 function adjustUsername(wantedUsername: string) {

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -13232,6 +13232,11 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                         "id": {
                           "type": "string",
                         },
+                        "onboardingSkippedAt": {
+                          "format": "date-time",
+                          "nullable": true,
+                          "type": "string",
+                        },
                         "stripeCustomerId": {
                           "nullable": true,
                           "type": "string",
@@ -14411,6 +14416,11 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                         "id": {
                           "type": "string",
                         },
+                        "onboardingSkippedAt": {
+                          "format": "date-time",
+                          "nullable": true,
+                          "type": "string",
+                        },
                         "stripeCustomerId": {
                           "nullable": true,
                           "type": "string",
@@ -14619,6 +14629,30 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
           },
         ],
         "summary": "Save template description",
+        "tags": [
+          "Users",
+        ],
+      },
+    },
+    "/v1/user/skipOnboarding": {
+      "post": {
+        "responses": {
+          "204": {
+            "description": "Onboarding skipped",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+        },
+        "security": [
+          {
+            "BearerAuth": [],
+          },
+          {
+            "ApiKeyAuth": [],
+          },
+        ],
+        "summary": "Skip onboarding",
         "tags": [
           "Users",
         ],

--- a/apps/api/test/seeders/user.seeder.ts
+++ b/apps/api/test/seeders/user.seeder.ts
@@ -18,6 +18,7 @@ export function createUser({
   lastIp = faker.internet.ip(),
   lastUserAgent = faker.internet.userAgent(),
   lastFingerprint = faker.word.noun(),
+  onboardingSkippedAt = null,
   createdAt = faker.date.recent(),
   trial = false
 }: Partial<UserOutput> = {}): UserOutput {
@@ -37,6 +38,7 @@ export function createUser({
     lastIp,
     lastUserAgent,
     lastFingerprint,
+    onboardingSkippedAt,
     createdAt,
     trial
   };

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.spec.tsx
@@ -42,6 +42,12 @@ describe(MarketplacePane.name, () => {
     expect(MarketplaceProvidersTable).toHaveBeenCalledWith(expect.objectContaining({ gpuCount: 0 }), expect.anything());
   });
 
+  it("hides provider links from the table until the user is onboarded", () => {
+    const { MarketplaceProvidersTable } = setup({ isOnboarded: false, offers: [buildOffer()] });
+
+    expect(MarketplaceProvidersTable).toHaveBeenCalledWith(expect.objectContaining({ showProviderLink: false }), expect.anything());
+  });
+
   it("allows provider selection only while quoting", () => {
     const { MarketplaceProvidersTable } = setup({ phase: "quoting", offers: [buildOffer()] });
 
@@ -124,6 +130,7 @@ describe(MarketplacePane.name, () => {
       isInvalid?: boolean;
       isSearchActive?: boolean;
       gpuCount?: number;
+      isOnboarded?: boolean;
       selectedPlacementId?: string;
       selectedBidId?: string;
       onSelectProvider?: (placementId: string, bidId: string) => void;
@@ -153,7 +160,8 @@ describe(MarketplacePane.name, () => {
       useProviderSearch: useProviderSearch as never,
       MarketplaceProvidersTable: MarketplaceProvidersTable as never,
       ProviderSearchInput,
-      useDeploymentGpuCount
+      useDeploymentGpuCount,
+      useIsOnboarded: () => input.isOnboarded ?? true
     };
     const user = userEvent.setup();
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.tsx
@@ -1,5 +1,6 @@
 import type { FC } from "react";
 
+import { useIsOnboarded } from "@src/hooks/useIsOnboarded";
 import { usePlacementOffers } from "@src/queries/usePlacementOffers";
 import { useDeploymentGpuCount } from "../DeploymentResourceSummary/useDeploymentResourceSummary";
 import type { DeploymentFlowPhase } from "../useDeploymentFlow/useDeploymentFlow";
@@ -7,7 +8,7 @@ import { MarketplaceProvidersTable } from "./MarketplaceProvidersTable/Marketpla
 import { useProviderSearch } from "./MarketplaceProvidersTable/useProviderSearch/useProviderSearch";
 import { ProviderSearchInput } from "./ProviderSearchInput/ProviderSearchInput";
 
-export const DEPENDENCIES = { usePlacementOffers, useProviderSearch, MarketplaceProvidersTable, ProviderSearchInput, useDeploymentGpuCount };
+export const DEPENDENCIES = { usePlacementOffers, useProviderSearch, MarketplaceProvidersTable, ProviderSearchInput, useDeploymentGpuCount, useIsOnboarded };
 
 interface Props {
   sdl: string;
@@ -36,6 +37,8 @@ export const MarketplacePane: FC<Props> = ({
   const { query, setQuery, clear, filteredProviders, isSearchActive } = d.useProviderSearch(offers);
   const hasFailedWithoutData = isError && offers.length === 0;
   const gpuCount = d.useDeploymentGpuCount(selectedPlacementId);
+  /** Provider names link out only once the user is onboarded: the route gate bounces a not-yet-onboarded user back into the funnel, so the link would dead-end. */
+  const showProviderLink = d.useIsOnboarded();
 
   return (
     <section aria-labelledby="configure-marketplace-pane-heading" className="flex h-full min-h-0 flex-col">
@@ -70,6 +73,7 @@ export const MarketplacePane: FC<Props> = ({
             onSelect={bidId => onSelectProvider(selectedPlacementId, bidId)}
             isSelectable={phase === "quoting"}
             gpuCount={gpuCount}
+            showProviderLink={showProviderLink}
           />
         )}
       </div>

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProviderCell.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProviderCell.tsx
@@ -19,29 +19,36 @@ function getProviderHost(hostUri?: string | null): string | null {
 
 interface Props {
   offer: PlacementOffer;
+  /** Whether the name links to the provider's detail page. */
+  showProviderLink: boolean;
 }
 
 /**
- * Provider column: the display name links to the provider's detail page, opened in a new tab so the in-progress
- * deployment isn't lost. When the name is a moniker (organization), the actual host is shown beneath it — the
- * self-declared name alone doesn't tell you which provider you're really getting.
+ * Provider column: shows the display name, linked to the provider's detail page (opened in a new tab so the
+ * in-progress deployment isn't lost) when `showProviderLink` allows it. When the name is a moniker (organization), the
+ * actual host is shown beneath it — the self-declared name alone doesn't tell you which provider you're really getting.
  */
-export const MarketplaceProviderCell: FC<Props> = ({ offer }) => {
+export const MarketplaceProviderCell: FC<Props> = ({ offer, showProviderLink }) => {
   const displayName = providerDisplayName(offer);
   const host = getProviderHost(offer.hostUri);
   const subtitle = host && host !== displayName ? host : null;
+  const name = <ShortenedValue value={displayName} maxLength={40} headLength={14} />;
 
   return (
     <div className="flex min-w-0 flex-col">
-      <Link
-        href={UrlService.providerDetail(offer.owner)}
-        target="_blank"
-        rel="noopener noreferrer"
-        onClick={event => event.stopPropagation()}
-        className="min-w-0 truncate font-medium text-primary hover:underline"
-      >
-        <ShortenedValue value={displayName} maxLength={40} headLength={14} />
-      </Link>
+      {showProviderLink ? (
+        <Link
+          href={UrlService.providerDetail(offer.owner)}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={event => event.stopPropagation()}
+          className="min-w-0 truncate font-medium text-primary hover:underline"
+        >
+          {name}
+        </Link>
+      ) : (
+        <span className="min-w-0 truncate font-medium">{name}</span>
+      )}
       {subtitle && <span className="min-w-0 truncate text-xs font-normal text-muted-foreground">{subtitle}</span>}
     </div>
   );

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.spec.tsx
@@ -101,6 +101,13 @@ describe(MarketplaceProvidersTable.name, () => {
     expect(link).toHaveAttribute("target", "_blank");
   });
 
+  it("renders the provider name as plain text, not a link, when provider links are hidden", () => {
+    setup({ providers: [buildOffer({ organization: "Polaris Compute", hostUri: "https://a.example:8443", owner: "akash1prov" })], showProviderLink: false });
+
+    expect(screen.getByText("Polaris Compute")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Polaris Compute" })).not.toBeInTheDocument();
+  });
+
   it("shows a search empty state with a clear action when a search excludes all rows", async () => {
     const onClearSearch = vi.fn();
     setup({ providers: [], isSearchActive: true, onClearSearch });
@@ -330,6 +337,7 @@ describe(MarketplaceProvidersTable.name, () => {
     selectedBidId?: string;
     isSelectable?: boolean;
     gpuCount?: number;
+    showProviderLink?: boolean;
   }) {
     const onSelect = vi.fn();
     const user = userEvent.setup();
@@ -346,6 +354,7 @@ describe(MarketplaceProvidersTable.name, () => {
               onSelect={onSelect}
               isSelectable={input.isSelectable}
               gpuCount={input.gpuCount}
+              showProviderLink={input.showProviderLink ?? true}
             />
           </TooltipProvider>
         </IntlProvider>

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.tsx
@@ -45,6 +45,8 @@ interface Props {
   isSelectable?: boolean;
   /** Total GPUs the spec requests. Above zero, the cost column headlines an hourly rate (GPU specs); at zero it shows a monthly rate, so inexpensive CPU-only deployments don't round to `$0.00/hr`. Also drives the per-hour-per-GPU tooltip line. */
   gpuCount?: number;
+  /** Whether provider names link to their detail pages. */
+  showProviderLink: boolean;
 }
 
 export const MarketplaceProvidersTable: FC<Props> = ({
@@ -55,7 +57,8 @@ export const MarketplaceProvidersTable: FC<Props> = ({
   selectedBidId,
   onSelect,
   isSelectable = true,
-  gpuCount = 0
+  gpuCount = 0,
+  showProviderLink
 }) => {
   const [sorting, setSorting] = useState<SortingState>([]);
 
@@ -65,8 +68,8 @@ export const MarketplaceProvidersTable: FC<Props> = ({
   /** Cost only makes sense once bids arrive: a submitted bid is priced and a closed/expired one keeps its last price, but a screened-only candidate has none. */
   const showCost = providers.some(provider => !!provider.price);
   const columns = useMemo(
-    () => buildColumns(uptimeByOwner, { selectedBidId, onSelect, isSelectable, showCost, showStatus: isMerged, gpuCount }),
-    [uptimeByOwner, selectedBidId, onSelect, isSelectable, showCost, isMerged, gpuCount]
+    () => buildColumns(uptimeByOwner, { selectedBidId, onSelect, isSelectable, showCost, showStatus: isMerged, gpuCount, showProviderLink }),
+    [uptimeByOwner, selectedBidId, onSelect, isSelectable, showCost, isMerged, gpuCount, showProviderLink]
   );
 
   const table = useReactTable({
@@ -230,13 +233,21 @@ function SortableHeader({ column, title }: { column: Column<PlacementOffer, unkn
 /** Builds the columns, closing over the per-provider uptime derived once in the component. Every column is an accessor so it sorts; the trailing status column is display-only. */
 function buildColumns(
   uptimeByOwner: Map<string, ProviderUptime>,
-  selection: { selectedBidId?: string; onSelect?: (bidId: string) => void; isSelectable: boolean; showCost: boolean; showStatus: boolean; gpuCount: number }
+  selection: {
+    selectedBidId?: string;
+    onSelect?: (bidId: string) => void;
+    isSelectable: boolean;
+    showCost: boolean;
+    showStatus: boolean;
+    gpuCount: number;
+    showProviderLink: boolean;
+  }
 ) {
   return [
     columnHelper.accessor(providerDisplayName, {
       id: "hostUri",
       header: ({ column }) => <SortableHeader column={column} title="Provider" />,
-      cell: info => <MarketplaceProviderCell offer={info.row.original} />
+      cell: info => <MarketplaceProviderCell offer={info.row.original} showProviderLink={selection.showProviderLink} />
     }),
     columnHelper.accessor("location", {
       header: ({ column }) => <SortableHeader column={column} title="Region" />,

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/SdlImportExport/SdlImportExport.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/SdlImportExport/SdlImportExport.spec.tsx
@@ -9,6 +9,7 @@ import { SdlImportExport } from "./SdlImportExport";
 
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { ComponentMock } from "@tests/unit/mocks";
 
 const IMPORTED_STATE: ImportedDeploymentState = { values: mock<SdlBuilderFormValuesType>(), sdl: "imported-sdl", selectedServiceId: "svc-1" };
 
@@ -104,7 +105,7 @@ describe(SdlImportExport.name, () => {
   });
 
   function openMenu() {
-    return userEvent.click(screen.getByRole("button", { name: "SDL import and export" }));
+    return userEvent.click(screen.getByRole("button", { name: "Import or export config" }));
   }
 
   function setup(input: { sdl?: string; deploymentName?: string; canImport?: boolean; canCopy?: boolean }) {
@@ -132,7 +133,8 @@ describe(SdlImportExport.name, () => {
           useSnackbar: () => mock<ReturnType<typeof DEPENDENCIES.useSnackbar>>({ enqueueSnackbar }),
           Snackbar: () => null,
           saveAs,
-          copyTextToClipboard
+          copyTextToClipboard,
+          CustomNoDivTooltip: ComponentMock
         }}
       />
     );

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/SdlImportExport/SdlImportExport.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/SdlImportExport/SdlImportExport.tsx
@@ -1,10 +1,19 @@
 "use client";
 import type { FC } from "react";
 import { useState } from "react";
-import { Button, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger, Snackbar } from "@akashnetwork/ui/components";
+import {
+  Button,
+  CustomNoDivTooltip,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  Snackbar
+} from "@akashnetwork/ui/components";
 import { copyTextToClipboard } from "@akashnetwork/ui/utils";
 import { saveAs } from "file-saver";
-import { MoreHoriz } from "iconoir-react";
+import { Settings } from "iconoir-react";
 import { useSnackbar } from "notistack";
 
 import { useServices } from "@src/context/ServicesProvider";
@@ -14,7 +23,10 @@ import { ImportSdlDialog } from "./ImportSdlDialog";
 /** Narrowed to the single call signature used here so tests can supply a plain stub. */
 const saveBlobAs: (data: Blob, filename: string) => void = saveAs;
 
-export const DEPENDENCIES = { ImportSdlDialog, useServices, useSnackbar, Snackbar, saveAs: saveBlobAs, copyTextToClipboard };
+/** Names the menu trigger for both the visible tooltip and the accessible label, so the two can't drift apart. */
+const MENU_TRIGGER_LABEL = "Import or export config";
+
+export const DEPENDENCIES = { ImportSdlDialog, useServices, useSnackbar, Snackbar, saveAs: saveBlobAs, copyTextToClipboard, CustomNoDivTooltip };
 
 type Props = {
   /** The live SDL — exactly what Deploy would submit — used as the export source. */
@@ -58,11 +70,13 @@ export const SdlImportExport: FC<Props> = ({ sdl, deploymentName, canImport, onI
   return (
     <>
       <DropdownMenu modal={false}>
-        <DropdownMenuTrigger asChild>
-          <Button variant="ghost" size="icon" className="rounded-full" aria-label="SDL import and export">
-            <MoreHoriz />
-          </Button>
-        </DropdownMenuTrigger>
+        <d.CustomNoDivTooltip title={MENU_TRIGGER_LABEL}>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="icon" className="rounded-full" aria-label={MENU_TRIGGER_LABEL}>
+              <Settings />
+            </Button>
+          </DropdownMenuTrigger>
+        </d.CustomNoDivTooltip>
         <DropdownMenuContent align="end">
           <DropdownMenuItem disabled={!canImport} onClick={() => setImportOpen(true)}>
             Import Config

--- a/apps/deploy-web/src/components/layout/Nav.spec.tsx
+++ b/apps/deploy-web/src/components/layout/Nav.spec.tsx
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { DEPENDENCIES, Nav } from "./Nav";
+
+import { render } from "@testing-library/react";
+import { MockComponents } from "@tests/unit/mocks";
+
+describe("Nav", () => {
+  it("shows the skip onboarding button next to the reduced account menu in minimal mode", () => {
+    const { skipOnboardingButton, accountMenu } = setup({ minimal: true });
+
+    expect(skipOnboardingButton.mock.calls[0][0]).toMatchObject({ source: "auto_deploy" });
+    expect(accountMenu.mock.calls[0][0]).toMatchObject({ minimal: true });
+  });
+
+  it("does not show the skip onboarding button in the full chrome", () => {
+    const { skipOnboardingButton } = setup({ minimal: false });
+
+    expect(skipOnboardingButton).not.toHaveBeenCalled();
+  });
+
+  function setup(input: { minimal?: boolean }) {
+    const skipOnboardingButton = vi.fn<typeof DEPENDENCIES.SkipOnboardingButton>(() => <></>);
+    const accountMenu = vi.fn<typeof DEPENDENCIES.AccountMenu>(() => <></>);
+
+    const dependencies = MockComponents(DEPENDENCIES, {
+      SkipOnboardingButton: skipOnboardingButton,
+      AccountMenu: accountMenu
+    });
+
+    render(<Nav isMobileOpen={false} handleDrawerToggle={vi.fn()} minimal={input.minimal} dependencies={dependencies} />);
+
+    return { skipOnboardingButton, accountMenu };
+  }
+});

--- a/apps/deploy-web/src/components/layout/Nav.tsx
+++ b/apps/deploy-web/src/components/layout/Nav.tsx
@@ -16,24 +16,36 @@ import { TopBanner } from "./TopBanner";
 import { usePublishHeaderHeight } from "./usePublishHeaderHeight";
 import { WalletStatus } from "./WalletStatus";
 
+export const DEPENDENCIES = {
+  useCookieTheme,
+  usePublishHeaderHeight,
+  TopBanner,
+  HackathonCouponNavEntry,
+  AccountMenu,
+  WalletStatus,
+  SkipOnboardingButton
+};
+
 export const Nav = ({
   isMobileOpen,
   handleDrawerToggle,
   className,
-  minimal = false
+  minimal = false,
+  dependencies: d = DEPENDENCIES
 }: React.PropsWithChildren<{
   isMobileOpen: boolean;
   handleDrawerToggle: () => void;
   className?: ClassValue;
   minimal?: boolean;
+  dependencies?: typeof DEPENDENCIES;
 }>) => {
-  const theme = useCookieTheme();
+  const theme = d.useCookieTheme();
   const headerRef = useRef<HTMLElement>(null);
-  usePublishHeaderHeight(headerRef);
+  d.usePublishHeaderHeight(headerRef);
 
   return (
     <header ref={headerRef} className={cn("fixed left-0 right-0 top-0 z-50 border-b border-border bg-header", className, REMOVE_SCROLL_CLASS_NAMES.zeroRight)}>
-      <TopBanner />
+      <d.TopBanner />
 
       <div className="flex h-14 items-center justify-between pl-4 pr-4">
         {!!theme && (
@@ -53,19 +65,19 @@ export const Nav = ({
         {minimal ? (
           // Onboarding: no sidebar drawer, so the reduced menu is the only logout path and must show on mobile too.
           <div style={{ height: `${ACCOUNT_BAR_HEIGHT}px` }} className="flex items-center gap-2">
-            <SkipOnboardingButton source="auto_deploy" />
-            <AccountMenu minimal />
+            <d.SkipOnboardingButton source="auto_deploy" />
+            <d.AccountMenu minimal />
           </div>
         ) : (
           <div style={{ height: `${ACCOUNT_BAR_HEIGHT}px` }} className="hidden items-center md:flex">
             <div className="flex items-center gap-2">
-              <HackathonCouponNavEntry />
+              <d.HackathonCouponNavEntry />
 
               <div className="ml-4 flex items-center gap-2">
-                <WalletStatus />
+                <d.WalletStatus />
               </div>
 
-              <AccountMenu />
+              <d.AccountMenu />
             </div>
           </div>
         )}

--- a/apps/deploy-web/src/components/layout/Nav.tsx
+++ b/apps/deploy-web/src/components/layout/Nav.tsx
@@ -6,6 +6,7 @@ import type { ClassValue } from "clsx";
 import { Menu, Xmark } from "iconoir-react";
 import Link from "next/link";
 
+import { SkipOnboardingButton } from "@src/components/onboarding-picker/SkipOnboardingButton/SkipOnboardingButton";
 import { ACCOUNT_BAR_HEIGHT } from "@src/config/ui.config";
 import useCookieTheme from "@src/hooks/useTheme";
 import { HackathonCouponNavEntry } from "./HackathonCouponNavEntry/HackathonCouponNavEntry";
@@ -51,7 +52,8 @@ export const Nav = ({
 
         {minimal ? (
           // Onboarding: no sidebar drawer, so the reduced menu is the only logout path and must show on mobile too.
-          <div style={{ height: `${ACCOUNT_BAR_HEIGHT}px` }} className="flex items-center">
+          <div style={{ height: `${ACCOUNT_BAR_HEIGHT}px` }} className="flex items-center gap-2">
+            <SkipOnboardingButton source="auto_deploy" />
             <AccountMenu minimal />
           </div>
         ) : (

--- a/apps/deploy-web/src/components/layout/TopNav/TopNav.tsx
+++ b/apps/deploy-web/src/components/layout/TopNav/TopNav.tsx
@@ -108,7 +108,7 @@ export function TopNav({ dependencies: d = DEPENDENCIES, minimal = false }: Prop
           )}
         </div>
 
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-6">
           {!minimal && (
             <div className="hidden md:block">
               <d.HackathonCouponNavEntry />

--- a/apps/deploy-web/src/components/layout/TopNav/TopNav.tsx
+++ b/apps/deploy-web/src/components/layout/TopNav/TopNav.tsx
@@ -17,6 +17,7 @@ import { Cloud, CreditCard, Key, Menu, MessageAlert, MultiplePages, NavArrowDown
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
+import { SkipOnboardingButton } from "@src/components/onboarding-picker/SkipOnboardingButton/SkipOnboardingButton";
 import { useFlag } from "@src/hooks/useFlag";
 import useCookieTheme from "@src/hooks/useTheme";
 import { useUser } from "@src/hooks/useUser";
@@ -27,7 +28,7 @@ import { TopBanner } from "../TopBanner";
 import { usePublishHeaderHeight } from "../usePublishHeaderHeight";
 import { TopNavAccountMenu } from "./TopNavAccountMenu";
 
-export const DEPENDENCIES = { useUser, useFlag, usePathname, useCookieTheme, TopBanner, HackathonCouponNavEntry, TopNavAccountMenu };
+export const DEPENDENCIES = { useUser, useFlag, usePathname, useCookieTheme, TopBanner, HackathonCouponNavEntry, TopNavAccountMenu, SkipOnboardingButton };
 
 interface Props {
   dependencies?: typeof DEPENDENCIES;
@@ -113,6 +114,8 @@ export function TopNav({ dependencies: d = DEPENDENCIES, minimal = false }: Prop
               <d.HackathonCouponNavEntry />
             </div>
           )}
+
+          {minimal && <d.SkipOnboardingButton source="auto_deploy" />}
 
           <div className={cn({ "hidden md:block": showNavLinks })}>
             <d.TopNavAccountMenu minimal={minimal} />

--- a/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.spec.tsx
+++ b/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.spec.tsx
@@ -1,4 +1,3 @@
-import type { ApiManagedWalletOutput } from "@akashnetwork/http-sdk";
 import type { AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";
 import type { ReadonlyURLSearchParams } from "next/navigation";
 import { describe, expect, it, vi } from "vitest";
@@ -72,7 +71,7 @@ describe(OnboardingPickerPage.name, () => {
 
   it("renders an error alert when trial start fails terminally", () => {
     const useEnsureTrialStarted: () => EnsureTrialStartedResult = () =>
-      mock<EnsureTrialStartedResult>({ wallet: undefined, isWalletReady: false, isLoading: false, error: new Error("boom") });
+      mock<EnsureTrialStartedResult>({ isWalletReady: false, isLoading: false, error: new Error("boom") });
     setup({ dependencies: { useEnsureTrialStarted } });
 
     expect(screen.getByText(/We couldn't set up your trial/i)).toBeInTheDocument();
@@ -106,7 +105,7 @@ describe(OnboardingPickerPage.name, () => {
       isTrialing: true,
       dependencies: {
         DeploymentTemplatePickerCard,
-        useEnsureTrialStarted: () => mock<EnsureTrialStartedResult>({ wallet: undefined, isWalletReady: false, isLoading: true, error: null })
+        useEnsureTrialStarted: () => mock<EnsureTrialStartedResult>({ isWalletReady: false, isLoading: true, error: null })
       }
     });
 
@@ -143,7 +142,7 @@ describe(OnboardingPickerPage.name, () => {
       isTrialing: true,
       dependencies: {
         AddCreditsSheet,
-        useEnsureTrialStarted: () => mock<EnsureTrialStartedResult>({ wallet: undefined, isWalletReady: false, isLoading: true, error: null })
+        useEnsureTrialStarted: () => mock<EnsureTrialStartedResult>({ isWalletReady: false, isLoading: true, error: null })
       }
     });
 
@@ -190,55 +189,18 @@ describe(OnboardingPickerPage.name, () => {
     expect(push).toHaveBeenCalledWith(UrlService.configureDeployment({ templateId: LLM_ID, sdlStrategy: "default", bidStrategy: "auto" }));
   });
 
-  it("renders a button to skip the trial and unlock Console while trialing", () => {
-    setup({ isTrialing: true, wallet: mock<ApiManagedWalletOutput>({ creditAmount: 100 }) });
+  it("renders the skip-onboarding button in the body with the picker source", () => {
+    const SkipOnboardingButton = vi.fn(ComponentMock);
+    setup({ dependencies: { SkipOnboardingButton } });
 
-    expect(screen.getByText(/Skip the trial - unlock Console/i)).toBeInTheDocument();
+    expect((SkipOnboardingButton.mock.calls.at(-1)![0] as { source?: string }).source).toBe("picker");
   });
 
-  it("hides the skip-the-trial button once the user is no longer trialing and the wallet is funded", () => {
-    setup({ isTrialing: false, wallet: mock<ApiManagedWalletOutput>({ creditAmount: 100 }) });
+  it("keeps the skip-onboarding button visible after the trial ends", () => {
+    const SkipOnboardingButton = vi.fn(ComponentMock);
+    setup({ isTrialing: false, dependencies: { SkipOnboardingButton } });
 
-    expect(screen.queryByText(/Skip the trial - unlock Console/i)).not.toBeInTheDocument();
-  });
-
-  it("renders the skip-the-trial button when the wallet has no credit even after the trial has ended", () => {
-    setup({ isTrialing: false, wallet: mock<ApiManagedWalletOutput>({ creditAmount: 0 }) });
-
-    expect(screen.getByText(/Skip the trial - unlock Console/i)).toBeInTheDocument();
-  });
-
-  it("renders the skip-the-trial button when no wallet exists yet and the trial has ended", () => {
-    setup({ isTrialing: false, wallet: undefined });
-
-    expect(screen.getByText(/Skip the trial - unlock Console/i)).toBeInTheDocument();
-  });
-
-  it("opens the verification sheet when the skip-the-trial button is clicked", () => {
-    const push = vi.fn();
-    // Button is a forwardRef component; a plain mock can't satisfy its ref type, so cast the override only.
-    const Button = vi.fn(ComponentMock);
-    const AddCreditsSheet = vi.fn(ComponentMock);
-    setup({ isTrialing: true, push, dependencies: { Button: Button as unknown as typeof DEPENDENCIES.Button, AddCreditsSheet } });
-
-    const skipButton = Button.mock.calls.at(-1)![0] as ButtonProps;
-    act(() => (skipButton.onClick as () => void)());
-
-    expect((AddCreditsSheet.mock.calls.at(-1)![0] as SheetProps).open).toBe(true);
-    expect(push).not.toHaveBeenCalled();
-  });
-
-  it("redirects to the configure view when the verification sheet completes after skipping the trial", () => {
-    const push = vi.fn();
-    const Button = vi.fn(ComponentMock);
-    const AddCreditsSheet = vi.fn(ComponentMock);
-    setup({ isTrialing: true, push, dependencies: { Button: Button as unknown as typeof DEPENDENCIES.Button, AddCreditsSheet } });
-
-    const skipButton = Button.mock.calls.at(-1)![0] as ButtonProps;
-    act(() => (skipButton.onClick as () => void)());
-    act(() => (AddCreditsSheet.mock.calls.at(-1)![0] as SheetProps).onDone(100, "Acme"));
-
-    expect(push).toHaveBeenCalledWith(UrlService.configureDeployment());
+    expect(SkipOnboardingButton).toHaveBeenCalled();
   });
 
   it("renders a 'Hackathon? click here' header link while trialing when the hackathons flag is on", () => {
@@ -360,16 +322,6 @@ describe(OnboardingPickerPage.name, () => {
     expect(analyticsService.flush).toHaveBeenCalled();
   });
 
-  it("tracks a dedicated skip-trial click when skipping the trial", () => {
-    const Button = vi.fn(ComponentMock);
-    const { analyticsService } = setup({ isTrialing: true, dependencies: { Button: Button as unknown as typeof DEPENDENCIES.Button } });
-
-    const skipButton = Button.mock.calls.at(-1)![0] as ButtonProps;
-    act(() => (skipButton.onClick as () => void)());
-
-    expect(analyticsService.track).toHaveBeenCalledWith("onboarding_skip_trial_click", { category: "onboarding" });
-  });
-
   it("tracks a deploy click with the llm option when the gated LLM card is clicked while trialing", () => {
     const DeploymentTemplatePickerCard = vi.fn(ComponentMock);
     const { analyticsService } = setup({ isTrialing: true, dependencies: { DeploymentTemplatePickerCard } });
@@ -412,7 +364,6 @@ describe(OnboardingPickerPage.name, () => {
       isTrialing?: boolean;
       isHackathonsEnabled?: boolean;
       trialCreditsAmount?: number;
-      wallet?: EnsureTrialStartedResult["wallet"];
       dependencies?: Partial<typeof DEPENDENCIES>;
     } = {}
   ) {
@@ -421,13 +372,11 @@ describe(OnboardingPickerPage.name, () => {
     const isTrialing = input.isTrialing ?? true;
     const isHackathonsEnabled = input.isHackathonsEnabled ?? false;
     const trialCreditsAmount = input.trialCreditsAmount ?? 100;
-    const wallet = "wallet" in input ? input.wallet : mock<ApiManagedWalletOutput>({ creditAmount: 100 });
 
     const useRouter: typeof DEPENDENCIES.useRouter = vi.fn(() => mock<AppRouterInstance>({ push, replace }));
     const useSearchParams: typeof DEPENDENCIES.useSearchParams = () => new URLSearchParams(input.searchParams ?? "") as ReadonlyURLSearchParams;
     const useEnsureTrialStarted: typeof DEPENDENCIES.useEnsureTrialStarted = vi.fn(() =>
       mock<EnsureTrialStartedResult>({
-        wallet,
         isWalletReady: true,
         isLoading: false,
         error: null

--- a/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.tsx
+++ b/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.tsx
@@ -54,8 +54,8 @@ export function OnboardingPickerPage({ dependencies: d = DEPENDENCIES }: Onboard
   const { isTrialing } = d.useWallet();
   const { publicConfig, urlService, analyticsService } = d.useServices();
   const trialCreditsAmount = publicConfig.NEXT_PUBLIC_TRIAL_CREDITS_AMOUNT;
-  const [addCreditsSheetReason, setAddCreditsSheetReason] = useState<"unlock-gpu" | "skip-trial" | "hackathon-coupon" | null>(null);
-  const { isWalletReady, error: trialError, wallet } = d.useEnsureTrialStarted();
+  const [addCreditsSheetReason, setAddCreditsSheetReason] = useState<"unlock-gpu" | "hackathon-coupon" | null>(null);
+  const { isWalletReady, error: trialError } = d.useEnsureTrialStarted();
   const isHackathonsEnabled = d.useFlag("hackathons");
   const isLlmGated = isTrialing || !isWalletReady;
   const isLlmAvailable = !isLlmGated;
@@ -101,11 +101,6 @@ export function OnboardingPickerPage({ dependencies: d = DEPENDENCIES }: Onboard
     trackDeployClick("custom-image");
   }
 
-  function skipTrial() {
-    analyticsService.track("onboarding_skip_trial_click", { category: "onboarding" });
-    setAddCreditsSheetReason("skip-trial");
-  }
-
   return (
     <>
       <Head>
@@ -123,7 +118,6 @@ export function OnboardingPickerPage({ dependencies: d = DEPENDENCIES }: Onboard
                   <ArrowRight className="ml-2 h-4 w-4" />
                 </d.Button>
               )}
-              <d.SkipOnboardingButton source="picker" />
               <d.AccountMenu minimal />
             </div>
           </div>
@@ -207,14 +201,9 @@ export function OnboardingPickerPage({ dependencies: d = DEPENDENCIES }: Onboard
                 </Button>
               </div>
 
-              {(isTrialing || !wallet?.creditAmount) && (
-                <div className="text-center">
-                  <d.Button onClick={skipTrial} variant="ghost">
-                    Skip the trial - unlock Console
-                    <ArrowRight className="ml-2 h-4 w-4" />
-                  </d.Button>
-                </div>
-              )}
+              <div className="text-center">
+                <d.SkipOnboardingButton source="picker" />
+              </div>
             </div>
           </div>
         </div>
@@ -229,8 +218,6 @@ export function OnboardingPickerPage({ dependencies: d = DEPENDENCIES }: Onboard
           onDone={() => {
             if (addCreditsSheetReason === "unlock-gpu") {
               redirectToConfigure(TEMPLATE_IDS.llmChatbot);
-            } else if (addCreditsSheetReason === "skip-trial") {
-              router.push(urlService.configureDeployment());
             } else {
               setAddCreditsSheetReason(null);
             }

--- a/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.tsx
+++ b/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.tsx
@@ -13,6 +13,7 @@ import { BONUS_PERCENT, MAX_BONUS } from "@src/components/billing-usage/FirstPur
 import { DeploymentTemplatePickerCard } from "@src/components/deployments/DeploymentTemplatePickerCard/DeploymentTemplatePickerCard";
 import { AkashConsoleLogo } from "@src/components/icons/AkashConsoleLogo";
 import { AccountMenu } from "@src/components/layout/AccountMenu";
+import { SkipOnboardingButton } from "@src/components/onboarding-picker/SkipOnboardingButton/SkipOnboardingButton";
 import { useServices } from "@src/context/ServicesProvider";
 import { useWallet } from "@src/context/WalletProvider";
 import { useEnsureTrialStarted } from "@src/hooks/useEnsureTrialStarted";
@@ -40,6 +41,7 @@ export const DEPENDENCIES = {
   DeploymentTemplatePickerCard,
   AddCreditsSheet,
   AccountMenu,
+  SkipOnboardingButton,
   Button
 };
 
@@ -121,6 +123,7 @@ export function OnboardingPickerPage({ dependencies: d = DEPENDENCIES }: Onboard
                   <ArrowRight className="ml-2 h-4 w-4" />
                 </d.Button>
               )}
+              <d.SkipOnboardingButton source="picker" />
               <d.AccountMenu minimal />
             </div>
           </div>

--- a/apps/deploy-web/src/components/onboarding-picker/SkipOnboardingButton/SkipOnboardingButton.spec.tsx
+++ b/apps/deploy-web/src/components/onboarding-picker/SkipOnboardingButton/SkipOnboardingButton.spec.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { SkipOnboardingSource } from "@src/hooks/useSkipOnboarding";
+import type { DEPENDENCIES } from "./SkipOnboardingButton";
+import { SkipOnboardingButton } from "./SkipOnboardingButton";
+
+import { fireEvent, render, screen } from "@testing-library/react";
+
+describe(SkipOnboardingButton.name, () => {
+  it("skips with the given source when clicked", () => {
+    const skip = vi.fn();
+    setup({ source: "picker", skip });
+
+    fireEvent.click(screen.getByRole("button", { name: /skip/i }));
+
+    expect(skip).toHaveBeenCalledWith("picker");
+  });
+
+  it("forwards the auto_deploy source when clicked", () => {
+    const skip = vi.fn();
+    setup({ source: "auto_deploy", skip });
+
+    fireEvent.click(screen.getByRole("button", { name: /skip/i }));
+
+    expect(skip).toHaveBeenCalledWith("auto_deploy");
+  });
+
+  it("disables the button while a skip is in progress", () => {
+    setup({ source: "picker", isSkipping: true });
+
+    expect(screen.getByRole("button", { name: /skip/i })).toBeDisabled();
+  });
+
+  function setup(input: { source: SkipOnboardingSource; skip?: () => Promise<void>; isSkipping?: boolean }) {
+    const skip = input.skip ?? vi.fn();
+    const useSkipOnboarding: typeof DEPENDENCIES.useSkipOnboarding = () =>
+      mock<ReturnType<typeof DEPENDENCIES.useSkipOnboarding>>({ skip, isSkipping: input.isSkipping ?? false });
+
+    return render(<SkipOnboardingButton source={input.source} dependencies={{ useSkipOnboarding }} />);
+  }
+});

--- a/apps/deploy-web/src/components/onboarding-picker/SkipOnboardingButton/SkipOnboardingButton.tsx
+++ b/apps/deploy-web/src/components/onboarding-picker/SkipOnboardingButton/SkipOnboardingButton.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { Button } from "@akashnetwork/ui/components";
+
+import type { SkipOnboardingSource } from "@src/hooks/useSkipOnboarding";
+import { useSkipOnboarding } from "@src/hooks/useSkipOnboarding";
+
+export const DEPENDENCIES = { useSkipOnboarding };
+
+type Props = {
+  source: SkipOnboardingSource;
+  className?: string;
+  dependencies?: typeof DEPENDENCIES;
+};
+
+export function SkipOnboardingButton({ source, className, dependencies: d = DEPENDENCIES }: Props) {
+  const { skip, isSkipping } = d.useSkipOnboarding();
+
+  return (
+    <Button variant="ghost" size="sm" className={className} disabled={isSkipping} onClick={() => skip(source)}>
+      Skip
+    </Button>
+  );
+}

--- a/apps/deploy-web/src/components/onboarding-picker/SkipOnboardingButton/SkipOnboardingButton.tsx
+++ b/apps/deploy-web/src/components/onboarding-picker/SkipOnboardingButton/SkipOnboardingButton.tsx
@@ -9,16 +9,15 @@ export const DEPENDENCIES = { useSkipOnboarding };
 
 type Props = {
   source: SkipOnboardingSource;
-  className?: string;
   dependencies?: typeof DEPENDENCIES;
 };
 
-export function SkipOnboardingButton({ source, className, dependencies: d = DEPENDENCIES }: Props) {
+export function SkipOnboardingButton({ source, dependencies: d = DEPENDENCIES }: Props) {
   const { skip, isSkipping } = d.useSkipOnboarding();
 
   return (
-    <Button variant="ghost" size="sm" className={className} disabled={isSkipping} onClick={() => skip(source)}>
-      Skip
+    <Button variant="ghost" size="sm" className="text-xs text-muted-foreground" disabled={isSkipping} onClick={() => skip(source)}>
+      Skip onboarding - Explore Console
     </Button>
   );
 }

--- a/apps/deploy-web/src/components/onboarding/RequireOnboarding/RequireOnboarding.spec.tsx
+++ b/apps/deploy-web/src/components/onboarding/RequireOnboarding/RequireOnboarding.spec.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
+import type { CustomUserProfile } from "@src/types/user";
 import { DEPENDENCIES, RequireOnboarding } from "./RequireOnboarding";
 
 import { render, screen } from "@testing-library/react";
@@ -157,7 +158,7 @@ describe(RequireOnboarding.name, () => {
       ...DEPENDENCIES,
       useUser: (() =>
         mock<ReturnType<typeof DEPENDENCIES.useUser>>({
-          user: props.loggedOut ? undefined : ({ userId: props.userId ?? "u1", onboardingSkippedAt: props.onboardingSkippedAt ?? null } as never),
+          user: props.loggedOut ? undefined : mock<CustomUserProfile>({ userId: props.userId ?? "u1", onboardingSkippedAt: props.onboardingSkippedAt ?? null }),
           isLoading: false
         })) as typeof DEPENDENCIES.useUser,
       useWallet: (() =>

--- a/apps/deploy-web/src/components/onboarding/RequireOnboarding/RequireOnboarding.spec.tsx
+++ b/apps/deploy-web/src/components/onboarding/RequireOnboarding/RequireOnboarding.spec.tsx
@@ -6,6 +6,8 @@ import { DEPENDENCIES, RequireOnboarding } from "./RequireOnboarding";
 
 import { render, screen } from "@testing-library/react";
 
+const SKIPPED_AT = "2026-07-27T00:00:00.000Z";
+
 describe(RequireOnboarding.name, () => {
   it("shows loading until the initial wallet lookup and leases resolve", () => {
     setup({ isWalletInitializing: true, path: "/deployments" });
@@ -100,6 +102,30 @@ describe(RequireOnboarding.name, () => {
     expect(screen.getByText("child")).toBeInTheDocument();
   });
 
+  it("renders children for a skipped user on an app route with no leases", () => {
+    const { replace } = setup({ address: "akash1", hasManagedWallet: true, leases: 0, path: "/deployments", onboardingSkippedAt: SKIPPED_AT });
+    expect(screen.getByText("child")).toBeInTheDocument();
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it("redirects a skipped user away from /onboarding to returnTo", () => {
+    const { replace } = setup({
+      address: "akash1",
+      hasManagedWallet: true,
+      leases: 0,
+      path: "/onboarding",
+      returnTo: "/deployments",
+      onboardingSkippedAt: SKIPPED_AT
+    });
+    expect(replace).toHaveBeenCalledWith("/deployments");
+  });
+
+  it("renders a skipped user immediately on an app route without waiting for leases", () => {
+    const { replace } = setup({ address: "akash1", hasManagedWallet: true, leasesLoading: true, path: "/deployments", onboardingSkippedAt: SKIPPED_AT });
+    expect(screen.getByText("child")).toBeInTheDocument();
+    expect(replace).not.toHaveBeenCalled();
+  });
+
   function setup(input: {
     path: string;
     isPublic?: boolean;
@@ -114,6 +140,7 @@ describe(RequireOnboarding.name, () => {
     leasesLoading?: boolean;
     leasesError?: boolean;
     returnTo?: string;
+    onboardingSkippedAt?: string | null;
   }) {
     const replace = vi.fn();
     let mountCount = 0;
@@ -130,7 +157,7 @@ describe(RequireOnboarding.name, () => {
       ...DEPENDENCIES,
       useUser: (() =>
         mock<ReturnType<typeof DEPENDENCIES.useUser>>({
-          user: props.loggedOut ? undefined : ({ userId: props.userId ?? "u1" } as never),
+          user: props.loggedOut ? undefined : ({ userId: props.userId ?? "u1", onboardingSkippedAt: props.onboardingSkippedAt ?? null } as never),
           isLoading: false
         })) as typeof DEPENDENCIES.useUser,
       useWallet: (() =>

--- a/apps/deploy-web/src/components/onboarding/RequireOnboarding/RequireOnboarding.tsx
+++ b/apps/deploy-web/src/components/onboarding/RequireOnboarding/RequireOnboarding.tsx
@@ -60,6 +60,7 @@ function LeaseBasedGate({
   const isLeasesLoading = hasWallet && leaseExistenceQuery.isLoading;
   const leasesErrored = hasWallet && leaseExistenceQuery.isError;
   const isOnboarded = hasWallet && !!leaseExistenceQuery.data;
+  const hasSkippedOnboarding = !!user?.onboardingSkippedAt;
 
   const path = router.asPath.split("?")[0];
   const isOnOnboarding = path === ONBOARDING_ROUTE;
@@ -74,6 +75,7 @@ function LeaseBasedGate({
     leasesErrored,
     isAuthenticated: !!user?.userId,
     isOnboarded,
+    hasSkippedOnboarding,
     isOnOnboarding,
     isAllowed
   });
@@ -103,6 +105,10 @@ function LeaseBasedGate({
  * leases *error* leaves onboarding unknowable (an undefined result is not "no leases"), so we fail open and render
  * where the user is rather than eject a genuinely onboarded user into the first-deploy funnel on a transient
  * chain-API blip.
+ *
+ * A user who has explicitly skipped onboarding (`hasSkippedOnboarding`) is treated exactly like an onboarded one, and
+ * this is known as soon as identity is (before the leases query), so a skipper never waits on leases and is never
+ * sent back into the funnel.
  */
 function decideLeaseGate(input: {
   isPublic: boolean;
@@ -111,6 +117,7 @@ function decideLeaseGate(input: {
   leasesErrored: boolean;
   isAuthenticated: boolean;
   isOnboarded: boolean;
+  hasSkippedOnboarding: boolean;
   isOnOnboarding: boolean;
   isAllowed: boolean;
 }): GateDecision {
@@ -118,7 +125,7 @@ function decideLeaseGate(input: {
   if (input.isAllowed) return "render";
   if (!input.identityKnown) return "loading";
   if (!input.isAuthenticated) return "render";
-  if (input.isOnboarded) return input.isOnOnboarding ? "toReturn" : "render";
+  if (input.isOnboarded || input.hasSkippedOnboarding) return input.isOnOnboarding ? "toReturn" : "render";
   if (input.isOnOnboarding) return "render";
   if (!input.leasesSettled) return "loading";
   if (input.leasesErrored) return "render";

--- a/apps/deploy-web/src/hooks/useEnsureTrialStarted.ts
+++ b/apps/deploy-web/src/hooks/useEnsureTrialStarted.ts
@@ -1,5 +1,4 @@
 import { useCallback, useEffect } from "react";
-import type { ApiManagedWalletOutput } from "@akashnetwork/http-sdk";
 import { useIsMutating } from "@tanstack/react-query";
 
 import { useManagedWallet } from "@src/hooks/useManagedWallet";
@@ -11,7 +10,6 @@ export const DEPENDENCIES = {
 };
 
 export type EnsureTrialStartedResult = {
-  wallet: ApiManagedWalletOutput | undefined;
   isWalletReady: boolean;
   isLoading: boolean;
   error: ReturnType<typeof useManagedWallet>["createError"];
@@ -56,5 +54,5 @@ export const useEnsureTrialStarted = (d = DEPENDENCIES): EnsureTrialStartedResul
 
   const retryTrial = useCallback(() => resetCreate(), [resetCreate]);
 
-  return { isWalletReady, isLoading, error: createError, refreshWallet: refetch, retryTrial, wallet: wallet as ApiManagedWalletOutput | undefined };
+  return { isWalletReady, isLoading, error: createError, refreshWallet: refetch, retryTrial };
 };

--- a/apps/deploy-web/src/hooks/useIsOnboarded.spec.ts
+++ b/apps/deploy-web/src/hooks/useIsOnboarded.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { DEPENDENCIES } from "@src/hooks/useIsOnboarded";
+import { useIsOnboarded } from "@src/hooks/useIsOnboarded";
+
+import { renderHook } from "@testing-library/react";
+
+describe(useIsOnboarded.name, () => {
+  it("returns true when the managed wallet has at least one lease", () => {
+    const { result } = setup({ hasManagedWallet: true, address: "akash1abc", hasLease: true });
+
+    expect(result.current).toBe(true);
+  });
+
+  it("returns false when the managed wallet has no lease and onboarding was not skipped", () => {
+    const { result } = setup({ hasManagedWallet: true, address: "akash1abc", hasLease: false });
+
+    expect(result.current).toBe(false);
+  });
+
+  it("returns false when the wallet has no address yet", () => {
+    const { result } = setup({ hasManagedWallet: true, address: "", hasLease: true });
+
+    expect(result.current).toBe(false);
+  });
+
+  it("returns false when there is no managed wallet and onboarding was not skipped", () => {
+    const { result } = setup({ hasManagedWallet: false });
+
+    expect(result.current).toBe(false);
+  });
+
+  it("returns true when onboarding was explicitly skipped even without a lease", () => {
+    const { result } = setup({ hasManagedWallet: false, onboardingSkippedAt: "2026-07-30T00:00:00Z" });
+
+    expect(result.current).toBe(true);
+  });
+
+  function setup(input?: { hasManagedWallet?: boolean; address?: string; hasLease?: boolean; onboardingSkippedAt?: string | null }) {
+    const useWallet: typeof DEPENDENCIES.useWallet = () =>
+      mock<ReturnType<typeof DEPENDENCIES.useWallet>>({
+        address: input?.address ?? "akash1abc",
+        hasManagedWallet: input?.hasManagedWallet ?? false
+      });
+    const useUser: typeof DEPENDENCIES.useUser = () =>
+      mock<ReturnType<typeof DEPENDENCIES.useUser>>({
+        user: { onboardingSkippedAt: input?.onboardingSkippedAt ?? null }
+      });
+    const useLeaseExistenceQuery: typeof DEPENDENCIES.useLeaseExistenceQuery = () =>
+      mock<ReturnType<typeof DEPENDENCIES.useLeaseExistenceQuery>>({ data: input?.hasLease ?? false });
+
+    return renderHook(() => useIsOnboarded({ useWallet, useUser, useLeaseExistenceQuery }));
+  }
+});

--- a/apps/deploy-web/src/hooks/useIsOnboarded.ts
+++ b/apps/deploy-web/src/hooks/useIsOnboarded.ts
@@ -1,0 +1,25 @@
+import { useWallet } from "@src/context/WalletProvider";
+import { useUser } from "@src/hooks/useUser";
+import { useLeaseExistenceQuery } from "@src/queries/useLeaseQuery";
+
+export const DEPENDENCIES = { useWallet, useUser, useLeaseExistenceQuery };
+
+/**
+ * Whether the user has finished onboarding: they own a managed wallet with at least one lease (their first deployment)
+ * or have explicitly skipped. Shares the lease-existence query key with the always-mounted onboarding gate (see
+ * `RequireOnboarding`), which keeps it fresh; `refetchOnMount: false` stops this extra observer from re-firing the
+ * request on every mount while the answer is `false` (a `false` answer is kept permanently stale by design).
+ * While the query is unresolved or errored this returns `false`, unlike the gate's fail-open: consumers hide
+ * affordances such as links into gated routes, where wrongly hiding is harmless but wrongly showing dead-ends.
+ */
+export function useIsOnboarded(d: typeof DEPENDENCIES = DEPENDENCIES): boolean {
+  const { address, hasManagedWallet } = d.useWallet();
+  const { user } = d.useUser();
+
+  const hasWallet = hasManagedWallet && !!address;
+  const leaseExistenceQuery = d.useLeaseExistenceQuery(address, { enabled: hasWallet, refetchOnMount: false });
+  const isOnboarded = hasWallet && !!leaseExistenceQuery.data;
+  const hasSkippedOnboarding = !!user?.onboardingSkippedAt;
+
+  return isOnboarded || hasSkippedOnboarding;
+}

--- a/apps/deploy-web/src/hooks/useOnboardingChrome.spec.ts
+++ b/apps/deploy-web/src/hooks/useOnboardingChrome.spec.ts
@@ -4,6 +4,7 @@ import { mock } from "vitest-mock-extended";
 import type { DEPENDENCIES } from "@src/hooks/useOnboardingChrome";
 import { useOnboardingChrome } from "@src/hooks/useOnboardingChrome";
 import type { AppError } from "@src/types";
+import type { CustomUserProfile } from "@src/types/user";
 
 import { renderHook } from "@testing-library/react";
 
@@ -93,6 +94,14 @@ describe(useOnboardingChrome.name, () => {
     expect(result.current).toEqual({ isStripped: false });
   });
 
+  it("shows full chrome for a user who has skipped onboarding, even on the configure route with no leases", () => {
+    const { dependencies } = setup({ pathname: "/new-deployment/configure", leaseCount: 0, onboardingSkippedAt: "2026-07-27T00:00:00.000Z" });
+
+    const { result } = renderHook(() => useOnboardingChrome(dependencies));
+
+    expect(result.current).toEqual({ isStripped: false });
+  });
+
   function setup(input: {
     pathname: string;
     leaseCount?: number;
@@ -101,6 +110,7 @@ describe(useOnboardingChrome.name, () => {
     isWalletLoading?: boolean;
     hasManagedWallet?: boolean;
     managedWalletError?: AppError;
+    onboardingSkippedAt?: string | null;
   }) {
     const useWallet: typeof DEPENDENCIES.useWallet = () =>
       mock<ReturnType<typeof DEPENDENCIES.useWallet>>({
@@ -116,7 +126,11 @@ describe(useOnboardingChrome.name, () => {
         isError: (input.isLeasesError ?? false) as never,
         data: (input.isLeasesError ? undefined : (input.leaseCount ?? 0) > 0) as never
       })) as typeof DEPENDENCIES.useLeaseExistenceQuery;
+    const useUser: typeof DEPENDENCIES.useUser = () =>
+      mock<ReturnType<typeof DEPENDENCIES.useUser>>({
+        user: mock<CustomUserProfile>({ onboardingSkippedAt: input.onboardingSkippedAt ?? null })
+      });
 
-    return { dependencies: { useWallet, usePathname, useLeaseExistenceQuery } };
+    return { dependencies: { useWallet, usePathname, useLeaseExistenceQuery, useUser } };
   }
 });

--- a/apps/deploy-web/src/hooks/useOnboardingChrome.ts
+++ b/apps/deploy-web/src/hooks/useOnboardingChrome.ts
@@ -1,9 +1,10 @@
 import { usePathname } from "next/navigation";
 
 import { useWallet } from "@src/context/WalletProvider";
+import { useUser } from "@src/hooks/useUser";
 import { useLeaseExistenceQuery } from "@src/queries/useLeaseQuery";
 
-export const DEPENDENCIES = { useWallet, usePathname, useLeaseExistenceQuery };
+export const DEPENDENCIES = { useWallet, usePathname, useLeaseExistenceQuery, useUser };
 
 /**
  * Routes that get the stripped onboarding chrome. Matched with `startsWith`, so this
@@ -27,10 +28,12 @@ export type OnboardingChromeState = {
  */
 export const useOnboardingChrome = (d: typeof DEPENDENCIES = DEPENDENCIES): OnboardingChromeState => {
   const { address, hasManagedWallet, managedWalletError } = d.useWallet();
+  const { user } = d.useUser();
   const pathname = d.usePathname();
 
   const isRelevant = !!pathname && ONBOARDING_CHROME_PATHS.some(path => pathname.startsWith(path));
   const hasWallet = hasManagedWallet && !!address;
+  const hasSkippedOnboarding = !!user?.onboardingSkippedAt;
 
   const leaseExistenceQuery = d.useLeaseExistenceQuery(address, { enabled: isRelevant && hasWallet });
   const isOnboarded = hasWallet && !!leaseExistenceQuery.data;
@@ -38,8 +41,9 @@ export const useOnboardingChrome = (d: typeof DEPENDENCIES = DEPENDENCIES): Onbo
 
   // A wallet error — or a leases error that leaves onboarding unknowable (an undefined result is not "no leases") —
   // makes the funnel decision unresolvable, so fail open to the full chrome rather than trap a possibly-onboarded
-  // user in the stripped funnel. Mirrors the gate's fail-open on a transient chain-API blip.
-  if (!isRelevant || managedWalletError || leasesErrored) {
+  // user in the stripped funnel. Mirrors the gate's fail-open on a transient chain-API blip. A user who has skipped
+  // onboarding is treated as onboarded, so their chrome is never stripped when they return to the configure route.
+  if (!isRelevant || managedWalletError || leasesErrored || hasSkippedOnboarding) {
     return { isStripped: false };
   }
 

--- a/apps/deploy-web/src/hooks/useSkipOnboarding.spec.ts
+++ b/apps/deploy-web/src/hooks/useSkipOnboarding.spec.ts
@@ -11,7 +11,7 @@ import { setupQuery } from "../../tests/unit/query-client";
 import { act } from "@testing-library/react";
 
 describe(useSkipOnboarding.name, () => {
-  it("tracks the event, persists the flag, refreshes the session, then navigates to the deployments list", async () => {
+  it("tracks the event, persists the flag, refreshes the session, then navigates to the new-deployment page", async () => {
     const { result, consoleApiHttpClient, analyticsService, checkSession, push } = setup();
 
     await act(async () => {
@@ -21,7 +21,7 @@ describe(useSkipOnboarding.name, () => {
     expect(analyticsService.track).toHaveBeenCalledWith("onboarding_skipped", { category: "onboarding", source: "picker" });
     expect(consoleApiHttpClient.post).toHaveBeenCalledWith("/v1/user/skipOnboarding");
     expect(checkSession).toHaveBeenCalled();
-    expect(push).toHaveBeenCalledWith("/deployments");
+    expect(push).toHaveBeenCalledWith("/new-deployment");
   });
 
   it("forwards the auto_deploy source to analytics", async () => {

--- a/apps/deploy-web/src/hooks/useSkipOnboarding.spec.ts
+++ b/apps/deploy-web/src/hooks/useSkipOnboarding.spec.ts
@@ -34,14 +34,15 @@ describe(useSkipOnboarding.name, () => {
     expect(analyticsService.track).toHaveBeenCalledWith("onboarding_skipped", { category: "onboarding", source: "auto_deploy" });
   });
 
-  it("navigates even when the session refresh fails", async () => {
-    const { result, push } = setup({ checkSessionRejects: true });
+  it("reports the error and does not navigate when the session refresh fails", async () => {
+    const { result, push, errorHandler } = setup({ checkSessionRejects: true });
 
     await act(async () => {
       await result.current.skip("picker");
     });
 
-    expect(push).toHaveBeenCalledWith("/deployments");
+    expect(push).not.toHaveBeenCalled();
+    expect(errorHandler.reportError).toHaveBeenCalledWith(expect.objectContaining({ tags: { category: "onboarding" } }));
   });
 
   it("does not navigate or refresh the session when persisting the flag fails", async () => {

--- a/apps/deploy-web/src/hooks/useSkipOnboarding.spec.ts
+++ b/apps/deploy-web/src/hooks/useSkipOnboarding.spec.ts
@@ -1,0 +1,82 @@
+import type { AxiosInstance } from "axios";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { DEPENDENCIES } from "@src/hooks/useSkipOnboarding";
+import { useSkipOnboarding } from "@src/hooks/useSkipOnboarding";
+import type { AnalyticsService } from "@src/services/analytics/analytics.service";
+import type { ErrorHandlerService } from "@src/services/error-handler/error-handler.service";
+import { setupQuery } from "../../tests/unit/query-client";
+
+import { act } from "@testing-library/react";
+
+describe(useSkipOnboarding.name, () => {
+  it("tracks the event, persists the flag, refreshes the session, then navigates to the deployments list", async () => {
+    const { result, consoleApiHttpClient, analyticsService, checkSession, push } = setup();
+
+    await act(async () => {
+      await result.current.skip("picker");
+    });
+
+    expect(analyticsService.track).toHaveBeenCalledWith("onboarding_skipped", { category: "onboarding", source: "picker" });
+    expect(consoleApiHttpClient.post).toHaveBeenCalledWith("/v1/user/skipOnboarding");
+    expect(checkSession).toHaveBeenCalled();
+    expect(push).toHaveBeenCalledWith("/deployments");
+  });
+
+  it("forwards the auto_deploy source to analytics", async () => {
+    const { result, analyticsService } = setup();
+
+    await act(async () => {
+      await result.current.skip("auto_deploy");
+    });
+
+    expect(analyticsService.track).toHaveBeenCalledWith("onboarding_skipped", { category: "onboarding", source: "auto_deploy" });
+  });
+
+  it("navigates even when the session refresh fails", async () => {
+    const { result, push } = setup({ checkSessionRejects: true });
+
+    await act(async () => {
+      await result.current.skip("picker");
+    });
+
+    expect(push).toHaveBeenCalledWith("/deployments");
+  });
+
+  it("does not navigate or refresh the session when persisting the flag fails", async () => {
+    const { result, checkSession, push, errorHandler } = setup({ postRejects: true });
+
+    await act(async () => {
+      await result.current.skip("picker");
+    });
+
+    expect(checkSession).not.toHaveBeenCalled();
+    expect(push).not.toHaveBeenCalled();
+    expect(errorHandler.reportError).toHaveBeenCalled();
+  });
+
+  function setup(input?: { postRejects?: boolean; checkSessionRejects?: boolean }) {
+    const consoleApiHttpClient = mock<AxiosInstance>();
+    if (input?.postRejects) consoleApiHttpClient.post.mockRejectedValue(new Error("network error"));
+    else consoleApiHttpClient.post.mockResolvedValue({ status: 204 } as never);
+
+    const analyticsService = mock<AnalyticsService>();
+    const errorHandler = mock<ErrorHandlerService>();
+    const checkSession = vi.fn(input?.checkSessionRejects ? () => Promise.reject(new Error("refresh failed")) : () => Promise.resolve());
+    const push = vi.fn();
+
+    const useUser: typeof DEPENDENCIES.useUser = () => mock<ReturnType<typeof DEPENDENCIES.useUser>>({ checkSession });
+    const useRouter: typeof DEPENDENCIES.useRouter = () => mock<ReturnType<typeof DEPENDENCIES.useRouter>>({ push });
+
+    const { result } = setupQuery(() => useSkipOnboarding({ useUser, useRouter }), {
+      services: {
+        consoleApiHttpClient: () => consoleApiHttpClient,
+        analyticsService: () => analyticsService,
+        errorHandler: () => errorHandler
+      }
+    });
+
+    return { result, consoleApiHttpClient, analyticsService, errorHandler, checkSession, push };
+  }
+});

--- a/apps/deploy-web/src/hooks/useSkipOnboarding.spec.ts
+++ b/apps/deploy-web/src/hooks/useSkipOnboarding.spec.ts
@@ -100,14 +100,19 @@ describe(useSkipOnboarding.name, () => {
 
     const analyticsService = mock<AnalyticsService>();
     const errorHandler = mock<ErrorHandlerService>();
-    const checkSession = vi.fn(
-      input?.checkSession ?? (input?.checkSessionRejects ? () => Promise.reject(new Error("refresh failed")) : () => Promise.resolve())
-    );
+
+    let onboardingSkippedAt: string | null = null;
+    const refreshedOnboardingSkippedAt = input?.refreshedOnboardingSkippedAt === undefined ? "2026-07-30T00:00:00Z" : input.refreshedOnboardingSkippedAt;
+    const refreshProfile = () => {
+      onboardingSkippedAt = refreshedOnboardingSkippedAt;
+      return Promise.resolve();
+    };
+    const checkSession = vi.fn(input?.checkSession ?? (input?.checkSessionRejects ? () => Promise.reject(new Error("refresh failed")) : refreshProfile));
     const push = vi.fn();
 
     const useUser: typeof DEPENDENCIES.useUser = () =>
       mock<ReturnType<typeof DEPENDENCIES.useUser>>({
-        user: { onboardingSkippedAt: input?.refreshedOnboardingSkippedAt === undefined ? "2026-07-30T00:00:00Z" : input.refreshedOnboardingSkippedAt },
+        user: { onboardingSkippedAt },
         checkSession
       });
     const useRouter: typeof DEPENDENCIES.useRouter = () => mock<ReturnType<typeof DEPENDENCIES.useRouter>>({ push });

--- a/apps/deploy-web/src/hooks/useSkipOnboarding.spec.ts
+++ b/apps/deploy-web/src/hooks/useSkipOnboarding.spec.ts
@@ -45,6 +45,17 @@ describe(useSkipOnboarding.name, () => {
     expect(errorHandler.reportError).toHaveBeenCalledWith(expect.objectContaining({ tags: { category: "onboarding" } }));
   });
 
+  it("does not navigate when the refreshed profile still lacks the skip flag", async () => {
+    const { result, checkSession, push } = setup({ refreshedOnboardingSkippedAt: null });
+
+    await act(async () => {
+      await result.current.skip("picker");
+    });
+
+    expect(checkSession).toHaveBeenCalled();
+    expect(push).not.toHaveBeenCalled();
+  });
+
   it("does not navigate or refresh the session when persisting the flag fails", async () => {
     const { result, checkSession, push, errorHandler } = setup({ postRejects: true });
 
@@ -57,17 +68,48 @@ describe(useSkipOnboarding.name, () => {
     expect(errorHandler.reportError).toHaveBeenCalled();
   });
 
-  function setup(input?: { postRejects?: boolean; checkSessionRejects?: boolean }) {
+  it("keeps isSkipping true until the session refresh settles", async () => {
+    let resolveRefresh: (() => void) | undefined;
+    const { result } = setup({ checkSession: () => new Promise<void>(resolve => (resolveRefresh = resolve)) });
+
+    let skipPromise: Promise<void> | undefined;
+    act(() => {
+      skipPromise = result.current.skip("picker");
+    });
+
+    await vi.waitFor(() => expect(resolveRefresh).toBeDefined());
+    expect(result.current.isSkipping).toBe(true);
+
+    await act(async () => {
+      resolveRefresh?.();
+      await skipPromise;
+    });
+
+    expect(result.current.isSkipping).toBe(false);
+  });
+
+  function setup(input?: {
+    postRejects?: boolean;
+    checkSessionRejects?: boolean;
+    checkSession?: () => Promise<void>;
+    refreshedOnboardingSkippedAt?: string | null;
+  }) {
     const consoleApiHttpClient = mock<AxiosInstance>();
     if (input?.postRejects) consoleApiHttpClient.post.mockRejectedValue(new Error("network error"));
     else consoleApiHttpClient.post.mockResolvedValue({ status: 204 } as never);
 
     const analyticsService = mock<AnalyticsService>();
     const errorHandler = mock<ErrorHandlerService>();
-    const checkSession = vi.fn(input?.checkSessionRejects ? () => Promise.reject(new Error("refresh failed")) : () => Promise.resolve());
+    const checkSession = vi.fn(
+      input?.checkSession ?? (input?.checkSessionRejects ? () => Promise.reject(new Error("refresh failed")) : () => Promise.resolve())
+    );
     const push = vi.fn();
 
-    const useUser: typeof DEPENDENCIES.useUser = () => mock<ReturnType<typeof DEPENDENCIES.useUser>>({ checkSession });
+    const useUser: typeof DEPENDENCIES.useUser = () =>
+      mock<ReturnType<typeof DEPENDENCIES.useUser>>({
+        user: { onboardingSkippedAt: input?.refreshedOnboardingSkippedAt === undefined ? "2026-07-30T00:00:00Z" : input.refreshedOnboardingSkippedAt },
+        checkSession
+      });
     const useRouter: typeof DEPENDENCIES.useRouter = () => mock<ReturnType<typeof DEPENDENCIES.useRouter>>({ push });
 
     const { result } = setupQuery(() => useSkipOnboarding({ useUser, useRouter }), {

--- a/apps/deploy-web/src/hooks/useSkipOnboarding.ts
+++ b/apps/deploy-web/src/hooks/useSkipOnboarding.ts
@@ -1,0 +1,48 @@
+import { useCallback } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+
+import { useServices } from "@src/context/ServicesProvider";
+import { useUser } from "@src/hooks/useUser";
+
+export type SkipOnboardingSource = "picker" | "auto_deploy";
+
+export const DEPENDENCIES = {
+  useUser,
+  useRouter
+};
+
+/**
+ * Permanently skips the onboarding flow: records the intent in analytics, persists the server-side flag, refreshes the
+ * profile so the onboarding gate stops routing the user back in, then lands them on the deployments list. The profile
+ * refresh is awaited before navigating to avoid a race where the gate bounces a still-flagless user back to onboarding;
+ * a failed refresh still navigates because the server is the source of truth and the next session load self-heals.
+ */
+export function useSkipOnboarding(dependencies: typeof DEPENDENCIES = DEPENDENCIES) {
+  const { consoleApiHttpClient, analyticsService, urlService, errorHandler } = useServices();
+  const { checkSession } = dependencies.useUser();
+  const router = dependencies.useRouter();
+
+  const { mutateAsync, isPending } = useMutation({
+    mutationFn: () => consoleApiHttpClient.post("/v1/user/skipOnboarding"),
+    onError: error => errorHandler.reportError({ error, tags: { category: "onboarding" } })
+  });
+
+  const skip = useCallback(
+    async (source: SkipOnboardingSource) => {
+      analyticsService.track("onboarding_skipped", { category: "onboarding", source });
+
+      try {
+        await mutateAsync();
+      } catch {
+        return;
+      }
+
+      await checkSession().catch(() => undefined);
+      router.push(urlService.deploymentList());
+    },
+    [analyticsService, mutateAsync, checkSession, router, urlService]
+  );
+
+  return { skip, isSkipping: isPending };
+}

--- a/apps/deploy-web/src/hooks/useSkipOnboarding.ts
+++ b/apps/deploy-web/src/hooks/useSkipOnboarding.ts
@@ -16,7 +16,8 @@ export const DEPENDENCIES = {
  * Permanently skips the onboarding flow: records the intent in analytics, persists the server-side flag, refreshes the
  * profile so the onboarding gate stops routing the user back in, then lands them on the deployments list. The profile
  * refresh is awaited before navigating to avoid a race where the gate bounces a still-flagless user back to onboarding;
- * a failed refresh still navigates because the server is the source of truth and the next session load self-heals.
+ * a failed refresh reports the error and stays put — the gate would still see a flagless user and bounce the navigation
+ * anyway, and since the flag is already persisted the user can retry or simply reload to get through.
  */
 export function useSkipOnboarding(dependencies: typeof DEPENDENCIES = DEPENDENCIES) {
   const { consoleApiHttpClient, analyticsService, urlService, errorHandler } = useServices();
@@ -38,10 +39,16 @@ export function useSkipOnboarding(dependencies: typeof DEPENDENCIES = DEPENDENCI
         return;
       }
 
-      await checkSession().catch(() => undefined);
+      try {
+        await checkSession();
+      } catch (error) {
+        errorHandler.reportError({ error, tags: { category: "onboarding" } });
+        return;
+      }
+
       router.push(urlService.deploymentList());
     },
-    [analyticsService, mutateAsync, checkSession, router, urlService]
+    [analyticsService, mutateAsync, checkSession, router, urlService, errorHandler]
   );
 
   return { skip, isSkipping: isPending };

--- a/apps/deploy-web/src/hooks/useSkipOnboarding.ts
+++ b/apps/deploy-web/src/hooks/useSkipOnboarding.ts
@@ -14,7 +14,7 @@ export const DEPENDENCIES = {
 
 /**
  * Permanently skips the onboarding flow: records the intent in analytics, persists the server-side flag, refreshes the
- * profile, then lands the user on the deployments list. Navigation waits until the refreshed profile actually carries
+ * profile, then lands the user on the new-deployment page. Navigation waits until the refreshed profile actually carries
  * the skip flag — the onboarding gate reads that same profile, so navigating any earlier would bounce right back into
  * the funnel. This also covers the profile route failing open with a flagless 200 (it swallows its internal user
  * lookup's errors), which a resolved `checkSession()` alone cannot reveal. Any failure reports the error and stays
@@ -40,7 +40,7 @@ export function useSkipOnboarding(dependencies: typeof DEPENDENCIES = DEPENDENCI
 
   useEffect(
     function navigateOnceProfileCarriesSkipFlag() {
-      if (isAwaitingSkippedProfile && user?.onboardingSkippedAt) router.push(urlService.deploymentList());
+      if (isAwaitingSkippedProfile && user?.onboardingSkippedAt) router.push(urlService.newDeployment());
     },
     [isAwaitingSkippedProfile, user?.onboardingSkippedAt, router, urlService]
   );

--- a/apps/deploy-web/src/hooks/useSkipOnboarding.ts
+++ b/apps/deploy-web/src/hooks/useSkipOnboarding.ts
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useMutation } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 
@@ -14,41 +14,42 @@ export const DEPENDENCIES = {
 
 /**
  * Permanently skips the onboarding flow: records the intent in analytics, persists the server-side flag, refreshes the
- * profile so the onboarding gate stops routing the user back in, then lands them on the deployments list. The profile
- * refresh is awaited before navigating to avoid a race where the gate bounces a still-flagless user back to onboarding;
- * a failed refresh reports the error and stays put — the gate would still see a flagless user and bounce the navigation
- * anyway, and since the flag is already persisted the user can retry or simply reload to get through.
+ * profile, then lands the user on the deployments list. Navigation waits until the refreshed profile actually carries
+ * the skip flag — the onboarding gate reads that same profile, so navigating any earlier would bounce right back into
+ * the funnel. This also covers the profile route failing open with a flagless 200 (it swallows its internal user
+ * lookup's errors), which a resolved `checkSession()` alone cannot reveal. Any failure reports the error and stays
+ * put: the flag is already persisted server-side, so retrying the (idempotent) skip or reloading gets the user
+ * through. The whole persist-and-refresh sequence runs inside the mutation so `isSkipping` disables the trigger for
+ * its full duration.
  */
 export function useSkipOnboarding(dependencies: typeof DEPENDENCIES = DEPENDENCIES) {
   const { consoleApiHttpClient, analyticsService, urlService, errorHandler } = useServices();
-  const { checkSession } = dependencies.useUser();
+  const { user, checkSession } = dependencies.useUser();
   const router = dependencies.useRouter();
+  const [isAwaitingSkippedProfile, setIsAwaitingSkippedProfile] = useState(false);
 
   const { mutateAsync, isPending } = useMutation({
-    mutationFn: () => consoleApiHttpClient.post("/v1/user/skipOnboarding"),
+    mutationFn: async (source: SkipOnboardingSource) => {
+      analyticsService.track("onboarding_skipped", { category: "onboarding", source });
+      await consoleApiHttpClient.post("/v1/user/skipOnboarding");
+      await checkSession();
+    },
+    onSuccess: () => setIsAwaitingSkippedProfile(true),
     onError: error => errorHandler.reportError({ error, tags: { category: "onboarding" } })
   });
 
+  useEffect(
+    function navigateOnceProfileCarriesSkipFlag() {
+      if (isAwaitingSkippedProfile && user?.onboardingSkippedAt) router.push(urlService.deploymentList());
+    },
+    [isAwaitingSkippedProfile, user?.onboardingSkippedAt, router, urlService]
+  );
+
   const skip = useCallback(
     async (source: SkipOnboardingSource) => {
-      analyticsService.track("onboarding_skipped", { category: "onboarding", source });
-
-      try {
-        await mutateAsync();
-      } catch {
-        return;
-      }
-
-      try {
-        await checkSession();
-      } catch (error) {
-        errorHandler.reportError({ error, tags: { category: "onboarding" } });
-        return;
-      }
-
-      router.push(urlService.deploymentList());
+      await mutateAsync(source).catch(() => undefined);
     },
-    [analyticsService, mutateAsync, checkSession, router, urlService, errorHandler]
+    [mutateAsync]
   );
 
   return { skip, isSkipping: isPending };

--- a/apps/deploy-web/src/services/analytics/analytics.service.ts
+++ b/apps/deploy-web/src/services/analytics/analytics.service.ts
@@ -112,7 +112,6 @@ export type AnalyticsEvent =
   | "log_collector_disabled"
   | "log_collector_deployed"
   | "onboarding_deploy_click"
-  | "onboarding_add_credits_click"
   | "onboarding_skipped"
   | "add_credits_opened"
   | "add_credits_amount_selected"

--- a/apps/deploy-web/src/services/analytics/analytics.service.ts
+++ b/apps/deploy-web/src/services/analytics/analytics.service.ts
@@ -113,6 +113,8 @@ export type AnalyticsEvent =
   | "log_collector_deployed"
   | "onboarding_deploy_click"
   | "onboarding_skip_trial_click"
+  | "onboarding_add_credits_click"
+  | "onboarding_skipped"
   | "add_credits_opened"
   | "add_credits_amount_selected"
   | "add_credits_payment_method_selected"

--- a/apps/deploy-web/src/services/analytics/analytics.service.ts
+++ b/apps/deploy-web/src/services/analytics/analytics.service.ts
@@ -112,7 +112,6 @@ export type AnalyticsEvent =
   | "log_collector_disabled"
   | "log_collector_deployed"
   | "onboarding_deploy_click"
-  | "onboarding_skip_trial_click"
   | "onboarding_add_credits_click"
   | "onboarding_skipped"
   | "add_credits_opened"

--- a/apps/deploy-web/src/types/user.ts
+++ b/apps/deploy-web/src/types/user.ts
@@ -14,6 +14,7 @@ export interface UserSettings {
   planCode?: PlanCode;
   plan?: IPlan;
   emailVerified?: boolean;
+  onboardingSkippedAt?: string | null;
 }
 
 export type CustomUserProfile = UserProfile & UserSettings;


### PR DESCRIPTION
## Why

The new onboarding flow has no exit. An authenticated user with a managed wallet but zero leases is force-routed to `/onboarding`, and "onboarded" is derived purely from on-chain lease count, so a broken auto-deploy can strand the user on the stripped `/new-deployment/configure` screen with only a logout. This adds a permanent, cross-device skip so the gate never routes them back in.

Closes CON-750

## What

**Backend (apps/api)**
- New nullable `onboardingSkippedAt` timestamp on the `userSetting` table (migration `0034`), exposed on `/v1/user/me`.
- New idempotent `POST /v1/user/skipOnboarding` that sets the flag once via a set-if-null update, so the original skip time is never overwritten by repeat calls.

**Frontend (apps/deploy-web)**
- `useSkipOnboarding` hook: tracks `onboarding_skipped`, persists the flag, awaits a session refresh, then routes to the deployments list (navigates even if the refresh fails; skips navigation if the persist fails).
- The onboarding gate (`RequireOnboarding`) and the stripped-chrome hook (`useOnboardingChrome`) both treat a skipped user as onboarded, known as soon as identity is, so a skipper never waits on leases and is never sent back into the funnel.
- Shared `SkipOnboardingButton` on the picker header (`source: "picker"`) and the minimal nav of the auto-deploy screen (`source: "auto_deploy"`).

Skipping is pure navigation and touches nothing on-chain: any orphaned in-flight deployment is left intact for the user to close from `/deployments`.

The legacy `/signup` stepper is intentionally untouched (out of scope; slated for removal).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Skip onboarding** action across the app, including a **POST /v1/user/skipOnboarding** flow that stores `onboardingSkippedAt`.
  * Skipped onboarding now bypasses onboarding gating (no onboarding funnel redirect) and sends users to the **new deployment** experience; onboarding UI updated (including minimal navigation).
  * Added **onboarding_skipped** analytics tracking, and updated onboarding-related event naming.
  * Exposed **isNewUser** on user registration responses.

* **Bug Fixes**
  * Prevent overwriting `onboardingSkippedAt` after it’s set.

* **Tests**
  * Added/updated API, service, and UI/hook tests for skip-onboarding and onboarding-gated rendering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->