### PR TITLE
fix(deployment): fund deployments immediately when a lease starts

### DIFF
--- a/apps/api/src/app/providers/jobs.provider.ts
+++ b/apps/api/src/app/providers/jobs.provider.ts
@@ -8,6 +8,7 @@ import { NotificationHandler } from "@src/notifications/services/notification-ha
 import { CloseTrialDeploymentHandler } from "../services/close-trial-deployment/close-trial-deployment.handler";
 import { EnableDeploymentAlertHandler } from "../services/enable-deployment-alert/enable-deployment-alert.handler";
 import { FirstPurchaseBonusGrantedHandler } from "../services/first-purchase-bonus-granted/first-purchase-bonus-granted.handler";
+import { FundDeploymentHandler } from "../services/fund-deployment/fund-deployment.handler";
 import { TrialDeploymentLeaseCreatedHandler } from "../services/trial-deployment-lease-created/trial-deployment-lease-created.handler";
 import { TrialStartedHandler } from "../services/trial-started/trial-started.handler";
 
@@ -22,6 +23,7 @@ container.register(APP_INITIALIZER, {
         container.resolve(CloseTrialDeploymentHandler),
         container.resolve(TrialDeploymentLeaseCreatedHandler),
         container.resolve(EnableDeploymentAlertHandler),
+        container.resolve(FundDeploymentHandler),
         container.resolve(WalletBalanceReloadCheckHandler),
         container.resolve(FirstPurchaseBonusGrantedHandler)
       ]);

--- a/apps/api/src/app/services/fund-deployment/fund-deployment.handler.spec.ts
+++ b/apps/api/src/app/services/fund-deployment/fund-deployment.handler.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { FundDeploymentCommand } from "@src/billing/commands/fund-deployment.command";
+import type { JobPayload } from "@src/core";
+import type { LoggerService } from "@src/core/providers/logging.provider";
+import type { InitialDeploymentFundingService } from "@src/deployment/services/initial-deployment-funding/initial-deployment-funding.service";
+import { FundDeploymentHandler } from "./fund-deployment.handler";
+
+describe(FundDeploymentHandler.name, () => {
+  it("delegates the payload identifiers to the funding service", async () => {
+    const { handler, initialDeploymentFundingService } = setup();
+
+    const payload: JobPayload<FundDeploymentCommand> = {
+      userId: "user-1",
+      walletId: 1,
+      address: "akash1abc",
+      dseq: "123",
+      version: 1
+    };
+
+    await handler.handle(payload);
+
+    expect(initialDeploymentFundingService.fundOnLeaseStarted).toHaveBeenCalledWith({
+      walletId: 1,
+      address: "akash1abc",
+      dseq: "123"
+    });
+  });
+
+  function setup(params?: { initialDeploymentFundingService?: Partial<InitialDeploymentFundingService> }) {
+    const initialDeploymentFundingService = mock<InitialDeploymentFundingService>({
+      fundOnLeaseStarted: vi.fn().mockResolvedValue(undefined),
+      ...params?.initialDeploymentFundingService
+    });
+    const logger = mock<LoggerService>();
+
+    const handler = new FundDeploymentHandler(initialDeploymentFundingService, logger);
+
+    return { handler, initialDeploymentFundingService, logger };
+  }
+});

--- a/apps/api/src/app/services/fund-deployment/fund-deployment.handler.spec.ts
+++ b/apps/api/src/app/services/fund-deployment/fund-deployment.handler.spec.ts
@@ -3,7 +3,7 @@ import { mock } from "vitest-mock-extended";
 
 import type { FundDeploymentCommand } from "@src/billing/commands/fund-deployment.command";
 import type { JobPayload } from "@src/core";
-import type { LoggerService } from "@src/core/providers/logging.provider";
+import type { CreateLogger } from "@src/core/providers/logging.provider";
 import type { InitialDeploymentFundingService } from "@src/deployment/services/initial-deployment-funding/initial-deployment-funding.service";
 import { FundDeploymentHandler } from "./fund-deployment.handler";
 
@@ -33,9 +33,10 @@ describe(FundDeploymentHandler.name, () => {
       fundOnLeaseStarted: vi.fn().mockResolvedValue(undefined),
       ...params?.initialDeploymentFundingService
     });
-    const logger = mock<LoggerService>();
+    const logger = mock<ReturnType<CreateLogger>>();
+    const createLogger: CreateLogger = () => logger;
 
-    const handler = new FundDeploymentHandler(initialDeploymentFundingService, logger);
+    const handler = new FundDeploymentHandler(initialDeploymentFundingService, createLogger);
 
     return { handler, initialDeploymentFundingService, logger };
   }

--- a/apps/api/src/app/services/fund-deployment/fund-deployment.handler.ts
+++ b/apps/api/src/app/services/fund-deployment/fund-deployment.handler.ts
@@ -1,8 +1,8 @@
-import { singleton } from "tsyringe";
+import { inject, singleton } from "tsyringe";
 
 import { FundDeploymentCommand } from "@src/billing/commands/fund-deployment.command";
 import type { JobHandler, JobPayload } from "@src/core";
-import { LoggerService } from "@src/core/providers/logging.provider";
+import { type CreateLogger, LOGGER_FACTORY } from "@src/core/providers/logging.provider";
 import { InitialDeploymentFundingService } from "@src/deployment/services/initial-deployment-funding/initial-deployment-funding.service";
 
 @singleton()
@@ -11,10 +11,14 @@ export class FundDeploymentHandler implements JobHandler<FundDeploymentCommand> 
 
   public readonly concurrency = 2;
 
+  private readonly logger: ReturnType<CreateLogger>;
+
   constructor(
     private readonly initialDeploymentFundingService: InitialDeploymentFundingService,
-    private readonly logger: LoggerService
-  ) {}
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
+  ) {
+    this.logger = createLogger({ context: FundDeploymentHandler.name });
+  }
 
   async handle(payload: JobPayload<FundDeploymentCommand>): Promise<void> {
     this.logger.debug({ event: "FUND_DEPLOYMENT", dseq: payload.dseq, walletId: payload.walletId });

--- a/apps/api/src/app/services/fund-deployment/fund-deployment.handler.ts
+++ b/apps/api/src/app/services/fund-deployment/fund-deployment.handler.ts
@@ -1,0 +1,28 @@
+import { singleton } from "tsyringe";
+
+import { FundDeploymentCommand } from "@src/billing/commands/fund-deployment.command";
+import type { JobHandler, JobPayload } from "@src/core";
+import { LoggerService } from "@src/core/providers/logging.provider";
+import { InitialDeploymentFundingService } from "@src/deployment/services/initial-deployment-funding/initial-deployment-funding.service";
+
+@singleton()
+export class FundDeploymentHandler implements JobHandler<FundDeploymentCommand> {
+  public readonly accepts = FundDeploymentCommand;
+
+  public readonly concurrency = 2;
+
+  constructor(
+    private readonly initialDeploymentFundingService: InitialDeploymentFundingService,
+    private readonly logger: LoggerService
+  ) {}
+
+  async handle(payload: JobPayload<FundDeploymentCommand>): Promise<void> {
+    this.logger.debug({ event: "FUND_DEPLOYMENT", dseq: payload.dseq, walletId: payload.walletId });
+
+    await this.initialDeploymentFundingService.fundOnLeaseStarted({
+      walletId: payload.walletId,
+      address: payload.address,
+      dseq: payload.dseq
+    });
+  }
+}

--- a/apps/api/src/billing/commands/fund-deployment.command.ts
+++ b/apps/api/src/billing/commands/fund-deployment.command.ts
@@ -1,0 +1,18 @@
+import type { Job } from "@src/core";
+import { JOB_NAME } from "@src/core";
+
+export class FundDeploymentCommand implements Job {
+  static readonly [JOB_NAME] = "FundDeploymentCommand";
+
+  public readonly name = FundDeploymentCommand[JOB_NAME];
+  public readonly version = 1;
+
+  constructor(
+    public readonly data: {
+      userId: string;
+      walletId: number;
+      address: string;
+      dseq: string;
+    }
+  ) {}
+}

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
@@ -10,6 +10,7 @@ import { mock } from "vitest-mock-extended";
 
 import type { AuthService } from "@src/auth/services/auth.service";
 import { EnableDeploymentAlertCommand } from "@src/billing/commands/enable-deployment-alert.command";
+import { FundDeploymentCommand } from "@src/billing/commands/fund-deployment.command";
 import { TrialDeploymentLeaseCreated } from "@src/billing/events/trial-deployment-lease-created";
 import type { UserWalletRepository } from "@src/billing/repositories";
 import type { BalancesService } from "@src/billing/services/balances/balances.service";
@@ -229,6 +230,120 @@ describe(ManagedSignerService.name, () => {
         createdAt: expect.any(String),
         isFirstLease: false
       });
+    });
+
+    it("publishes FundDeploymentCommand with a singleton key when a non-trialing wallet creates a lease", async () => {
+      const wallet = createUserWallet({
+        userId: "user-123",
+        feeAllowance: 100,
+        deploymentAllowance: 100,
+        isTrialing: false
+      });
+      const user = createUser({ userId: "user-123" });
+      const leaseMessage: EncodeObject = {
+        typeUrl: MsgCreateLease.$type,
+        value: MsgCreateLease.fromPartial({
+          bidId: {
+            dseq: 123,
+            owner: "akash1test",
+            gseq: 1,
+            oseq: 1,
+            provider: "akash1test"
+          }
+        })
+      };
+
+      const { service, domainEvents } = setup({
+        findOneByUserId: vi.fn().mockResolvedValue(wallet),
+        findById: vi.fn().mockResolvedValue(user),
+        signAndBroadcastWithDerivedWallet: vi.fn().mockResolvedValue({
+          code: 0,
+          hash: "tx-hash",
+          rawLog: "success"
+        }),
+        refreshUserWalletLimits: vi.fn().mockResolvedValue(undefined),
+        publish: vi.fn().mockResolvedValue(undefined)
+      });
+
+      await service.executeDerivedDecodedTxByUserId("user-123", [leaseMessage]);
+
+      const fundCall = vi.mocked(domainEvents.publish).mock.calls.find(([event]) => event instanceof FundDeploymentCommand);
+      const [fundCommand, options] = fundCall as [FundDeploymentCommand, { singletonKey: string }];
+      expect(fundCommand.data).toEqual({
+        userId: "user-123",
+        walletId: wallet.id,
+        address: wallet.address,
+        dseq: "123"
+      });
+      expect(options).toEqual({ singletonKey: `FundDeploymentCommand.123.${wallet.id}` });
+    });
+
+    it("does not publish FundDeploymentCommand when a trialing wallet creates a lease", async () => {
+      const wallet = createUserWallet({
+        userId: "user-123",
+        feeAllowance: 100,
+        deploymentAllowance: 100,
+        isTrialing: true
+      });
+      const user = createUser({ userId: "user-123" });
+      const leaseMessage: EncodeObject = {
+        typeUrl: MsgCreateLease.$type,
+        value: MsgCreateLease.fromPartial({
+          bidId: {
+            dseq: 123,
+            owner: "akash1test",
+            gseq: 1,
+            oseq: 1,
+            provider: "akash1test"
+          }
+        })
+      };
+
+      const { service, domainEvents } = setup({
+        findOneByUserId: vi.fn().mockResolvedValue(wallet),
+        findById: vi.fn().mockResolvedValue(user),
+        signAndBroadcastWithDerivedWallet: vi.fn().mockResolvedValue({
+          code: 0,
+          hash: "tx-hash",
+          rawLog: "success"
+        }),
+        refreshUserWalletLimits: vi.fn().mockResolvedValue(undefined),
+        publish: vi.fn().mockResolvedValue(undefined)
+      });
+
+      await service.executeDerivedDecodedTxByUserId("user-123", [leaseMessage]);
+
+      expect(domainEvents.publish).not.toHaveBeenCalledWith(expect.any(FundDeploymentCommand), expect.anything());
+    });
+
+    it("does not publish FundDeploymentCommand for transactions without a lease message", async () => {
+      const wallet = createUserWallet({
+        userId: "user-123",
+        feeAllowance: 100,
+        deploymentAllowance: 100,
+        isTrialing: false
+      });
+      const user = createUser({ userId: "user-123" });
+      const deploymentMessage: EncodeObject = {
+        typeUrl: MsgCreateDeployment.$type,
+        value: MsgCreateDeployment.fromPartial({})
+      };
+
+      const { service, domainEvents } = setup({
+        findOneByUserId: vi.fn().mockResolvedValue(wallet),
+        findById: vi.fn().mockResolvedValue(user),
+        signAndBroadcastWithDerivedWallet: vi.fn().mockResolvedValue({
+          code: 0,
+          hash: "tx-hash",
+          rawLog: "success"
+        }),
+        refreshUserWalletLimits: vi.fn().mockResolvedValue(undefined),
+        publish: vi.fn().mockResolvedValue(undefined)
+      });
+
+      await service.executeDerivedDecodedTxByUserId("user-123", [deploymentMessage]);
+
+      expect(domainEvents.publish).not.toHaveBeenCalled();
     });
 
     it("throws and skips side-effects when the broadcast tx lands on-chain with a non-zero code", async () => {

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
@@ -13,6 +13,7 @@ import { singleton } from "tsyringe";
 
 import { AuthService } from "@src/auth/services/auth.service";
 import { EnableDeploymentAlertCommand } from "@src/billing/commands/enable-deployment-alert.command";
+import { FundDeploymentCommand } from "@src/billing/commands/fund-deployment.command";
 import { TrialDeploymentLeaseCreated } from "@src/billing/events/trial-deployment-lease-created";
 import { InjectTypeRegistry } from "@src/billing/providers/type-registry.provider";
 import { type UserWalletOutput, UserWalletRepository } from "@src/billing/repositories";
@@ -144,6 +145,19 @@ export class ManagedSignerService {
           dseq: createLeaseMessage.value.bidId!.dseq.toString()
         })
       );
+
+      if (!userWallet.isTrialing) {
+        const dseq = createLeaseMessage.value.bidId!.dseq.toString();
+        await this.domainEvents.publish(
+          new FundDeploymentCommand({
+            userId: userWallet.userId,
+            walletId: userWallet.id,
+            address: userWallet.address!,
+            dseq
+          }),
+          { singletonKey: `${FundDeploymentCommand.name}.${dseq}.${userWallet.id}` }
+        );
+      }
     }
 
     await this.balancesService.refreshUserWalletLimits(userWallet);

--- a/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.spec.ts
+++ b/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.spec.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { UserWalletRepository } from "@src/billing/repositories";
+import type { RpcMessageService } from "@src/billing/services";
+import type { BalancesService } from "@src/billing/services/balances/balances.service";
+import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
+import type { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
+import type { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
+import type { BlockHttpService } from "@src/chain/services/block-http/block-http.service";
+import type { LoggerService } from "@src/core";
+import type { DrainingDeploymentOutput } from "@src/deployment/repositories/lease/lease.repository";
+import type { DeploymentConfigService } from "../deployment-config/deployment-config.service";
+import type { DrainingDeploymentService } from "../draining-deployment/draining-deployment.service";
+import { InitialDeploymentFundingService } from "./initial-deployment-funding.service";
+
+import { mockConfigService } from "@test/mocks/config-service.mock";
+import { createUserWallet } from "@test/seeders/user-wallet.seeder";
+
+describe(InitialDeploymentFundingService.name, () => {
+  const CURRENT_HEIGHT = 1000;
+  const LOOK_AHEAD_HEIGHT = CURRENT_HEIGHT + 600 * 24;
+
+  it("throws when the lease is not visible on chain yet", async () => {
+    const { service, drainingDeploymentService, managedSignerService } = setup();
+    drainingDeploymentService.findLeases.mockResolvedValue([]);
+
+    await expect(service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" })).rejects.toThrow("not visible on chain yet");
+
+    expect(managedSignerService.executeDerivedTx).not.toHaveBeenCalled();
+  });
+
+  it("skips funding when the deployment is closed", async () => {
+    const { service, drainingDeploymentService, managedSignerService, logger } = setup();
+    drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment({ closedHeight: 900 })]);
+
+    await service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" });
+
+    expect(managedSignerService.executeDerivedTx).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "INITIAL_FUNDING_SKIPPED", reason: "DEPLOYMENT_CLOSED" }));
+  });
+
+  it("skips funding when the deployment already has more runway than the look-ahead window", async () => {
+    const { service, drainingDeploymentService, managedSignerService, logger } = setup();
+    drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment({ predictedClosedHeight: LOOK_AHEAD_HEIGHT + 1 })]);
+
+    await service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" });
+
+    expect(managedSignerService.executeDerivedTx).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "INITIAL_FUNDING_SKIPPED", reason: "SUFFICIENT_RUNWAY" }));
+  });
+
+  it("deposits the calculated top-up amount and schedules a wallet reload", async () => {
+    const { service, drainingDeploymentService, balancesService, rpcMessageService, managedSignerService, walletReloadJobService } = setup();
+    const depositMessage = { typeUrl: "/akash.escrow.v1.MsgAccountDeposit", value: {} };
+    drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
+    drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(500000);
+    balancesService.getFreshLimits.mockResolvedValue({ fee: 100000, deployment: 1000000 });
+    rpcMessageService.getDepositDeploymentMsg.mockReturnValue(depositMessage as ReturnType<RpcMessageService["getDepositDeploymentMsg"]>);
+
+    await service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" });
+
+    expect(rpcMessageService.getDepositDeploymentMsg).toHaveBeenCalledWith({
+      dseq: 123,
+      amount: 500000,
+      denom: "uakt",
+      owner: "akash1owner",
+      signer: "akash1owner"
+    });
+    expect(managedSignerService.executeDerivedTx).toHaveBeenCalledWith(1, [depositMessage]);
+    expect(walletReloadJobService.scheduleImmediate).toHaveBeenCalledWith({ walletId: 1 });
+  });
+
+  it("clamps the deposit to the fresh deployment limit", async () => {
+    const { service, drainingDeploymentService, balancesService, rpcMessageService } = setup();
+    drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
+    drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(500000);
+    balancesService.getFreshLimits.mockResolvedValue({ fee: 100000, deployment: 200000 });
+
+    await service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" });
+
+    expect(rpcMessageService.getDepositDeploymentMsg).toHaveBeenCalledWith(expect.objectContaining({ amount: 200000 }));
+  });
+
+  it("skips funding when the deployment limit is exhausted", async () => {
+    const { service, drainingDeploymentService, balancesService, managedSignerService, logger } = setup();
+    drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
+    drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(500000);
+    balancesService.getFreshLimits.mockResolvedValue({ fee: 100000, deployment: 0 });
+
+    await service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" });
+
+    expect(managedSignerService.executeDerivedTx).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "INITIAL_FUNDING_INSUFFICIENT_BALANCE" }));
+  });
+
+  it("skips funding when the wallet is not found", async () => {
+    const { service, drainingDeploymentService, balancesService, userWalletRepository, managedSignerService, logger } = setup();
+    drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
+    drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(500000);
+    balancesService.getFreshLimits.mockResolvedValue({ fee: 100000, deployment: 1000000 });
+    userWalletRepository.findById.mockResolvedValue(undefined);
+
+    await service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" });
+
+    expect(managedSignerService.executeDerivedTx).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "INITIAL_FUNDING_WALLET_NOT_FOUND" }));
+  });
+
+  it("skips funding when the fee allowance is exhausted", async () => {
+    const { service, drainingDeploymentService, balancesService, managedSignerService, logger } = setup();
+    drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
+    drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(500000);
+    balancesService.getFreshLimits.mockResolvedValue({ fee: 100000, deployment: 1000000 });
+    managedSignerService.ensureFeeGrants.mockResolvedValue(0);
+
+    await service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" });
+
+    expect(managedSignerService.executeDerivedTx).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "INITIAL_FUNDING_NO_FEE_ALLOWANCE" }));
+  });
+
+  function createDrainingDeployment(overrides: Partial<DrainingDeploymentOutput> = {}): DrainingDeploymentOutput {
+    return {
+      dseq: 123,
+      owner: "akash1owner",
+      denom: "uakt",
+      blockRate: 50,
+      predictedClosedHeight: CURRENT_HEIGHT + 100,
+      ...overrides
+    };
+  }
+
+  function setup() {
+    const blockHttpService = mock<BlockHttpService>();
+    const drainingDeploymentService = mock<DrainingDeploymentService>();
+    const balancesService = mock<BalancesService>();
+    const rpcMessageService = mock<RpcMessageService>();
+    const managedSignerService = mock<ManagedSignerService>();
+    const userWalletRepository = mock<UserWalletRepository>();
+    const billingConfig = mockConfigService<BillingConfigService>({ DEPLOYMENT_GRANT_DENOM: "uakt" });
+    const deploymentConfig = mockConfigService<DeploymentConfigService>({ AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H: 24 });
+    const walletReloadJobService = mock<WalletReloadJobService>();
+    const logger = mock<LoggerService>();
+
+    blockHttpService.getCurrentHeight.mockResolvedValue(CURRENT_HEIGHT);
+    userWalletRepository.findById.mockResolvedValue(createUserWallet({ id: 1, address: "akash1owner" }));
+    managedSignerService.ensureFeeGrants.mockResolvedValue(100000);
+
+    const service = new InitialDeploymentFundingService(
+      blockHttpService,
+      drainingDeploymentService,
+      balancesService,
+      rpcMessageService,
+      managedSignerService,
+      userWalletRepository,
+      billingConfig,
+      deploymentConfig,
+      walletReloadJobService,
+      logger
+    );
+
+    return {
+      service,
+      blockHttpService,
+      drainingDeploymentService,
+      balancesService,
+      rpcMessageService,
+      managedSignerService,
+      userWalletRepository,
+      walletReloadJobService,
+      logger
+    };
+  }
+});

--- a/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.spec.ts
+++ b/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.spec.ts
@@ -8,10 +8,10 @@ import type { BillingConfigService } from "@src/billing/services/billing-config/
 import type { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
 import type { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
 import type { BlockHttpService } from "@src/chain/services/block-http/block-http.service";
-import type { LoggerService } from "@src/core";
+import type { CreateLogger } from "@src/core";
 import type { DrainingDeploymentOutput } from "@src/deployment/repositories/lease/lease.repository";
-import type { DeploymentConfigService } from "../deployment-config/deployment-config.service";
-import type { DrainingDeploymentService } from "../draining-deployment/draining-deployment.service";
+import type { DeploymentConfigService } from "@src/deployment/services/deployment-config/deployment-config.service";
+import type { DrainingDeploymentService } from "@src/deployment/services/draining-deployment/draining-deployment.service";
 import { InitialDeploymentFundingService } from "./initial-deployment-funding.service";
 
 import { mockConfigService } from "@test/mocks/config-service.mock";
@@ -69,6 +69,31 @@ describe(InitialDeploymentFundingService.name, () => {
     });
     expect(managedSignerService.executeDerivedTx).toHaveBeenCalledWith(1, [depositMessage]);
     expect(walletReloadJobService.scheduleImmediate).toHaveBeenCalledWith({ walletId: 1 });
+  });
+
+  it("throws and skips the wallet reload when the deposit tx fails on-chain", async () => {
+    const { service, drainingDeploymentService, balancesService, managedSignerService, walletReloadJobService, logger } = setup();
+    drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
+    drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(500000);
+    balancesService.getFreshLimits.mockResolvedValue({ fee: 100000, deployment: 1000000 });
+    managedSignerService.executeDerivedTx.mockResolvedValue({ code: 5, hash: "TESTHASH", rawLog: "insufficient funds" });
+
+    await expect(service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" })).rejects.toThrow("insufficient funds");
+
+    expect(walletReloadJobService.scheduleImmediate).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "INITIAL_FUNDING_TX_FAILED", code: 5, txHash: "TESTHASH" }));
+  });
+
+  it("falls back to a descriptive error when the failed deposit tx has no raw log", async () => {
+    const { service, drainingDeploymentService, balancesService, managedSignerService } = setup();
+    drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
+    drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(500000);
+    balancesService.getFreshLimits.mockResolvedValue({ fee: 100000, deployment: 1000000 });
+    managedSignerService.executeDerivedTx.mockResolvedValue({ code: 5, hash: "TESTHASH", rawLog: "" });
+
+    await expect(service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" })).rejects.toThrow(
+      "Deposit tx TESTHASH failed on-chain with code 5"
+    );
   });
 
   it("clamps the deposit to the fresh deployment limit", async () => {
@@ -141,11 +166,13 @@ describe(InitialDeploymentFundingService.name, () => {
     const billingConfig = mockConfigService<BillingConfigService>({ DEPLOYMENT_GRANT_DENOM: "uakt" });
     const deploymentConfig = mockConfigService<DeploymentConfigService>({ AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H: 24 });
     const walletReloadJobService = mock<WalletReloadJobService>();
-    const logger = mock<LoggerService>();
+    const logger = mock<ReturnType<CreateLogger>>();
+    const createLogger: CreateLogger = () => logger;
 
     blockHttpService.getCurrentHeight.mockResolvedValue(CURRENT_HEIGHT);
     userWalletRepository.findById.mockResolvedValue(createUserWallet({ id: 1, address: "akash1owner" }));
     managedSignerService.ensureFeeGrants.mockResolvedValue(100000);
+    managedSignerService.executeDerivedTx.mockResolvedValue({ code: 0, hash: "TESTHASH", rawLog: "[]" });
 
     const service = new InitialDeploymentFundingService(
       blockHttpService,
@@ -157,7 +184,7 @@ describe(InitialDeploymentFundingService.name, () => {
       billingConfig,
       deploymentConfig,
       walletReloadJobService,
-      logger
+      createLogger
     );
 
     return {

--- a/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.ts
+++ b/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.ts
@@ -1,0 +1,111 @@
+import { singleton } from "tsyringe";
+
+import { UserWalletRepository } from "@src/billing/repositories";
+import { RpcMessageService } from "@src/billing/services";
+import { BalancesService } from "@src/billing/services/balances/balances.service";
+import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
+import { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
+import { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
+import { BlockHttpService } from "@src/chain/services/block-http/block-http.service";
+import { LoggerService } from "@src/core";
+import { averageBlockCountInAnHour } from "@src/utils/constants";
+import { DeploymentConfigService } from "../deployment-config/deployment-config.service";
+import { DrainingDeploymentService } from "../draining-deployment/draining-deployment.service";
+
+export interface FundOnLeaseStartedInput {
+  walletId: number;
+  address: string;
+  dseq: string;
+}
+
+/**
+ * Funds a deployment right after its lease starts so high-cost deployments
+ * cannot burn through the small initial deposit and get closed by the provider
+ * before the hourly top-up cron first sees them.
+ */
+@singleton()
+export class InitialDeploymentFundingService {
+  constructor(
+    private readonly blockHttpService: BlockHttpService,
+    private readonly drainingDeploymentService: DrainingDeploymentService,
+    private readonly balancesService: BalancesService,
+    private readonly rpcMessageService: RpcMessageService,
+    private readonly managedSignerService: ManagedSignerService,
+    private readonly userWalletRepository: UserWalletRepository,
+    private readonly billingConfig: BillingConfigService,
+    private readonly deploymentConfig: DeploymentConfigService,
+    private readonly walletReloadJobService: WalletReloadJobService,
+    private readonly logger: LoggerService
+  ) {
+    this.logger.setContext(InitialDeploymentFundingService.name);
+  }
+
+  /**
+   * Throws when the lease is not yet visible over chain REST so the job queue
+   * retries with backoff through the indexing lag. Every other early exit is
+   * terminal: the hourly cron remains the safety net.
+   */
+  async fundOnLeaseStarted({ walletId, address, dseq }: FundOnLeaseStartedInput): Promise<void> {
+    const currentHeight = await this.blockHttpService.getCurrentHeight();
+    const [deployment] = await this.drainingDeploymentService.findLeases(Number.MAX_SAFE_INTEGER, address, [dseq]);
+
+    if (!deployment) {
+      throw new Error(`Lease for deployment ${dseq} owned by ${address} is not visible on chain yet`);
+    }
+
+    if (deployment.closedHeight) {
+      this.logger.info({ event: "INITIAL_FUNDING_SKIPPED", reason: "DEPLOYMENT_CLOSED", dseq, address });
+      return;
+    }
+
+    const lookAheadHeight = currentHeight + averageBlockCountInAnHour * this.deploymentConfig.get("AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H");
+
+    if (deployment.predictedClosedHeight > lookAheadHeight) {
+      this.logger.info({
+        event: "INITIAL_FUNDING_SKIPPED",
+        reason: "SUFFICIENT_RUNWAY",
+        dseq,
+        address,
+        predictedClosedHeight: deployment.predictedClosedHeight,
+        lookAheadHeight
+      });
+      return;
+    }
+
+    const desiredAmount = await this.drainingDeploymentService.calculateTopUpAmount(deployment);
+    const { deployment: deploymentLimit } = await this.balancesService.getFreshLimits({ address });
+    const amount = Math.min(desiredAmount, deploymentLimit);
+
+    if (amount <= 0) {
+      this.logger.warn({ event: "INITIAL_FUNDING_INSUFFICIENT_BALANCE", dseq, address, desiredAmount, deploymentLimit });
+      return;
+    }
+
+    const userWallet = await this.userWalletRepository.findById(walletId);
+
+    if (!userWallet) {
+      this.logger.error({ event: "INITIAL_FUNDING_WALLET_NOT_FOUND", walletId, dseq });
+      return;
+    }
+
+    const feeAllowance = await this.managedSignerService.ensureFeeGrants(userWallet);
+
+    if (feeAllowance <= 0) {
+      this.logger.warn({ event: "INITIAL_FUNDING_NO_FEE_ALLOWANCE", dseq, address });
+      return;
+    }
+
+    const message = this.rpcMessageService.getDepositDeploymentMsg({
+      dseq: Number(dseq),
+      amount,
+      denom: this.billingConfig.get("DEPLOYMENT_GRANT_DENOM"),
+      owner: address,
+      signer: address
+    });
+
+    await this.managedSignerService.executeDerivedTx(walletId, [message]);
+    await this.walletReloadJobService.scheduleImmediate({ walletId });
+
+    this.logger.info({ event: "INITIAL_FUNDING_DEPOSITED", dseq, address, amount, blockRate: deployment.blockRate });
+  }
+}

--- a/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.ts
+++ b/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.ts
@@ -1,4 +1,4 @@
-import { singleton } from "tsyringe";
+import { inject, singleton } from "tsyringe";
 
 import { UserWalletRepository } from "@src/billing/repositories";
 import { RpcMessageService } from "@src/billing/services";
@@ -7,10 +7,10 @@ import { BillingConfigService } from "@src/billing/services/billing-config/billi
 import { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
 import { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
 import { BlockHttpService } from "@src/chain/services/block-http/block-http.service";
-import { LoggerService } from "@src/core";
-import { averageBlockCountInAnHour } from "@src/utils/constants";
-import { DeploymentConfigService } from "../deployment-config/deployment-config.service";
-import { DrainingDeploymentService } from "../draining-deployment/draining-deployment.service";
+import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
+import { DeploymentConfigService } from "@src/deployment/services/deployment-config/deployment-config.service";
+import { DrainingDeploymentService } from "@src/deployment/services/draining-deployment/draining-deployment.service";
+import { averageBlockCountInAnHour, COSMOS_TX_CODE_OK } from "@src/utils/constants";
 
 export interface FundOnLeaseStartedInput {
   walletId: number;
@@ -25,6 +25,8 @@ export interface FundOnLeaseStartedInput {
  */
 @singleton()
 export class InitialDeploymentFundingService {
+  private readonly logger: ReturnType<CreateLogger>;
+
   constructor(
     private readonly blockHttpService: BlockHttpService,
     private readonly drainingDeploymentService: DrainingDeploymentService,
@@ -35,15 +37,15 @@ export class InitialDeploymentFundingService {
     private readonly billingConfig: BillingConfigService,
     private readonly deploymentConfig: DeploymentConfigService,
     private readonly walletReloadJobService: WalletReloadJobService,
-    private readonly logger: LoggerService
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
-    this.logger.setContext(InitialDeploymentFundingService.name);
+    this.logger = createLogger({ context: InitialDeploymentFundingService.name });
   }
 
   /**
-   * Throws when the lease is not yet visible over chain REST so the job queue
-   * retries with backoff through the indexing lag. Every other early exit is
-   * terminal: the hourly cron remains the safety net.
+   * Throws when the lease is not yet visible over chain REST (indexing lag) or
+   * when the deposit tx fails on-chain, so the job queue retries with backoff.
+   * Every other early exit is terminal: the hourly cron remains the safety net.
    */
   async fundOnLeaseStarted({ walletId, address, dseq }: FundOnLeaseStartedInput): Promise<void> {
     const currentHeight = await this.blockHttpService.getCurrentHeight();
@@ -103,7 +105,13 @@ export class InitialDeploymentFundingService {
       signer: address
     });
 
-    await this.managedSignerService.executeDerivedTx(walletId, [message]);
+    const tx = await this.managedSignerService.executeDerivedTx(walletId, [message]);
+
+    if (tx.code !== COSMOS_TX_CODE_OK) {
+      this.logger.error({ event: "INITIAL_FUNDING_TX_FAILED", dseq, address, txHash: tx.hash, code: tx.code, rawLog: tx.rawLog });
+      throw new Error(tx.rawLog || `Deposit tx ${tx.hash} failed on-chain with code ${tx.code}`);
+    }
+
     await this.walletReloadJobService.scheduleImmediate({ walletId });
 
     this.logger.info({ event: "INITIAL_FUNDING_DEPOSITED", dseq, address, amount, blockRate: deployment.blockRate });


### PR DESCRIPTION
## Why

Fixes CON-735

A managed-wallet deployment is created with a small fixed initial deposit (~\$0.50), and the only funding mechanism afterward is the hourly `top-up-deployments` cron. High-cost (GPU) deployments can burn through the initial deposit and get closed by the provider before the first cron run ever sees them — this has caused real user-facing failures.

## What

When a `MsgCreateLease` tx lands for a non-trialing managed wallet, `ManagedSignerService` now publishes an async `FundDeploymentCommand` (pg-boss, deduped via singleton key). The new `FundDeploymentHandler` → `InitialDeploymentFundingService`:

- reads the deployment's live block rate and predicted close height from chain (`DrainingDeploymentService.findLeases`), throwing while the lease isn't indexed yet so the job's 5 retries with backoff cover chain-REST lag
- skips deployments that are closed or already have more than the 24h look-ahead of runway (makes retries and cron overlap no-ops)
- deposits the same 48h runway the cron uses (`calculateTopUpAmount`), clamped to the wallet's fresh deployment allowance, then schedules a wallet reload check

Deliberate decisions:
- **Trials are excluded**: trials start with \$1 and the minimum deposit is \$0.50 — the goal is that a trial can create 2 deployments, and a 48h escrow lock would consume the credit needed for the second. Trials keep today's cron-only behavior.
- **No gate on the per-deployment auto-top-up setting**: the settings row is created lazily by the frontend and usually doesn't exist at lease time; CON-734 makes funding always-on anyway.
- **Funding can never fail lease creation**: the command is published through `DomainEventsService`, which swallows enqueue errors; terminal job failures are logged and the hourly cron remains the safety net.
- The cron/job race is accepted as bounded: worst case one extra 48h deposit, clamped to balance and refunded on close.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deployments can now receive initial funding automatically when their lease starts.
  * Funding is initiated via background job handling for eligible non-trialing wallets, and wallet balances are refreshed after successful funding.
* **Bug Fixes**
  * Added safeguards to avoid funding closed deployments and to skip when the system predicts sufficient runway, or when wallet/fee conditions are not met.
* **Tests**
  * Introduced coverage for funding behavior across lease visibility, skip reasons, deposit failures, and job/event wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->