### PR TITLE
feat(deployment): show provider host and hourly pricing in compute marketplace

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ConfigurationPane.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ConfigurationPane.spec.tsx
@@ -10,7 +10,6 @@ import type { ConfigurationLock } from "./configurationLock";
 import { ConfigurationPane, DEPENDENCIES } from "./ConfigurationPane";
 
 import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import { MockComponents } from "@tests/unit/mocks";
 
 describe(ConfigurationPane.name, () => {
@@ -107,16 +106,6 @@ describe(ConfigurationPane.name, () => {
     expect(screen.getByLabelText("Storage")).toHaveValue(9);
   });
 
-  it("shows the lock banner with cancel-and-edit while locked", async () => {
-    const onCancelAndEdit = vi.fn();
-    const values = defaultServiceWithPlacement({ title: "api" });
-    setup({ values, selectedServiceId: values.services[0].id, locked: "onchain", onCancelAndEdit });
-
-    await userEvent.click(screen.getByRole("button", { name: /cancel and edit/i }));
-
-    expect(onCancelAndEdit).toHaveBeenCalled();
-  });
-
   it("locks the structural sections but leaves the image editable while only the on-chain fields are locked", () => {
     const ImageSection = vi.fn(() => null);
     const HardwareSection = vi.fn(() => null);
@@ -154,7 +143,6 @@ describe(ConfigurationPane.name, () => {
     values: SdlBuilderFormValuesType;
     selectedServiceId: string;
     locked?: ConfigurationLock;
-    onCancelAndEdit?: () => void;
     actions?: ReactNode;
     dependencies?: Partial<typeof DEPENDENCIES>;
   }) {
@@ -167,7 +155,6 @@ describe(ConfigurationPane.name, () => {
         <ConfigurationPane
           selectedServiceId={input.selectedServiceId}
           locked={input.locked}
-          onCancelAndEdit={input.onCancelAndEdit}
           actions={input.actions}
           dependencies={MockComponents(DEPENDENCIES, input.dependencies)}
         />

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ConfigurationPane.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ConfigurationPane.tsx
@@ -2,7 +2,6 @@ import type { FC, ReactNode } from "react";
 import { useFormContext, useWatch } from "react-hook-form";
 
 import type { SdlBuilderFormValuesType } from "@src/types";
-import { PaneLockBanner } from "../PaneLockBanner/PaneLockBanner";
 import { AdditionalSection } from "./AdditionalSection/AdditionalSection";
 import { HardwareSection } from "./HardwareSection/HardwareSection";
 import { ImageSection } from "./ImageSection/ImageSection";
@@ -15,11 +14,10 @@ type Props = {
   /**
    * How much of the pane is locked. `"onchain"` locks only the cards baked into the deployment (resources, placement,
    * ports, …) while the manifest-only image/env/command cards stay editable; `"all"` locks every card while a
-   * create/close/deploy is in flight. Absent leaves everything editable. See {@link ConfigurationLock}.
+   * create/close/deploy is in flight. Absent leaves everything editable. The lock banner itself is rendered
+   * once across both spec panes by the parent. See {@link ConfigurationLock}.
    */
   locked?: ConfigurationLock;
-  isClosing?: boolean;
-  onCancelAndEdit?: () => void;
   /** Rendered at the trailing edge of the pane header, e.g. the SDL import/export menu. */
   actions?: ReactNode;
   dependencies?: typeof DEPENDENCIES;
@@ -32,7 +30,7 @@ type Props = {
  * index per mount rather than reacting to a changing one, which would otherwise
  * leave the previous service's values and errors on screen.
  */
-export const ConfigurationPane: FC<Props> = ({ selectedServiceId, locked, isClosing = false, onCancelAndEdit, actions, dependencies: d = DEPENDENCIES }) => {
+export const ConfigurationPane: FC<Props> = ({ selectedServiceId, locked, actions, dependencies: d = DEPENDENCIES }) => {
   const { control } = useFormContext<SdlBuilderFormValuesType>();
   const watchedServices = useWatch<SdlBuilderFormValuesType>({ control, name: "services" });
   const services = Array.isArray(watchedServices) ? (watchedServices as SdlBuilderFormValuesType["services"]) : [];
@@ -40,16 +38,15 @@ export const ConfigurationPane: FC<Props> = ({ selectedServiceId, locked, isClos
   const selectedService = selectedServiceIndex >= 0 ? services[selectedServiceIndex] : undefined;
 
   return (
-    <section aria-labelledby="configure-configuration-pane-heading" className="flex h-full min-h-0 flex-col">
-      <header className="flex h-[52px] shrink-0 items-center gap-2 border-b border-zinc-300 px-4 dark:border-zinc-700">
+    <section aria-labelledby="configure-configuration-pane-heading" className="col-start-2 row-start-1 row-end-4 grid h-full min-h-0 grid-rows-subgrid">
+      <header className="flex h-[52px] items-center gap-2 border-b border-l border-zinc-300 px-4 dark:border-zinc-700">
         <h2 id="configure-configuration-pane-heading" className="shrink-0 font-mono text-sm font-medium uppercase text-muted-foreground">
           2. Configuration
         </h2>
         {selectedService && <span className="min-w-0 truncate font-mono text-sm font-semibold text-blue-500">• {selectedService.title}</span>}
         {actions ? <div className="ml-auto shrink-0">{actions}</div> : null}
       </header>
-      {locked ? <PaneLockBanner onCancelAndEdit={onCancelAndEdit ?? noop} isClosing={isClosing} /> : null}
-      <div className="flex-1 overflow-y-auto py-4">
+      <div className="row-start-3 min-h-0 overflow-y-auto border-l border-zinc-300 py-4 dark:border-zinc-700">
         {selectedServiceIndex >= 0 && (
           <div key={selectedServiceId} className="flex flex-col gap-6">
             <d.ImageSection serviceIndex={selectedServiceIndex} locked={locked === "all"} />
@@ -61,6 +58,3 @@ export const ConfigurationPane: FC<Props> = ({ selectedServiceId, locked, isClos
     </section>
   );
 };
-
-/** Fallback when the pane is locked without a cancel handler (defensive; the parent always supplies one while locked). */
-function noop() {}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentPanes/ConfigureDeploymentPanes.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentPanes/ConfigureDeploymentPanes.spec.tsx
@@ -77,25 +77,29 @@ describe("ConfigureDeploymentPanes", () => {
     );
   });
 
-  it("locks both spec panes and supplies cancel-and-edit while not configuring", () => {
-    const { DeploymentPane, ConfigurationPane } = setup({ phase: "quoting" });
+  it("locks both spec panes and shows a single cancel-and-edit banner while not configuring", () => {
+    const { DeploymentPane, ConfigurationPane, PaneLockBanner } = setup({ phase: "quoting" });
 
-    expect(DeploymentPane).toHaveBeenCalledWith(expect.objectContaining({ locked: true, onCancelAndEdit: expect.any(Function) }), expect.anything());
-    expect(ConfigurationPane).toHaveBeenCalledWith(expect.objectContaining({ locked: "onchain", onCancelAndEdit: expect.any(Function) }), expect.anything());
+    expect(DeploymentPane).toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
+    expect(ConfigurationPane).toHaveBeenCalledWith(expect.objectContaining({ locked: "onchain" }), expect.anything());
+    expect(PaneLockBanner).toHaveBeenCalledTimes(1);
+    expect(PaneLockBanner).toHaveBeenCalledWith(expect.objectContaining({ onCancelAndEdit: expect.any(Function) }), expect.anything());
   });
 
-  it("flags close progress to both spec panes while closing", () => {
-    const { DeploymentPane, ConfigurationPane } = setup({ phase: "closing" });
+  it("flags close progress on the shared lock banner while closing", () => {
+    const { DeploymentPane, ConfigurationPane, PaneLockBanner } = setup({ phase: "closing" });
 
-    expect(DeploymentPane).toHaveBeenCalledWith(expect.objectContaining({ locked: true, isClosing: true }), expect.anything());
-    expect(ConfigurationPane).toHaveBeenCalledWith(expect.objectContaining({ locked: "all", isClosing: true }), expect.anything());
+    expect(DeploymentPane).toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
+    expect(ConfigurationPane).toHaveBeenCalledWith(expect.objectContaining({ locked: "all" }), expect.anything());
+    expect(PaneLockBanner).toHaveBeenCalledWith(expect.objectContaining({ isClosing: true }), expect.anything());
   });
 
-  it("leaves both spec panes unlocked while configuring", () => {
-    const { DeploymentPane, ConfigurationPane } = setup({ phase: "configuring" });
+  it("leaves both spec panes unlocked and hides the lock banner while configuring", () => {
+    const { DeploymentPane, ConfigurationPane, PaneLockBanner } = setup({ phase: "configuring" });
 
     expect(DeploymentPane).toHaveBeenCalledWith(expect.objectContaining({ locked: false }), expect.anything());
     expect(ConfigurationPane).toHaveBeenCalledWith(expect.objectContaining({ locked: undefined }), expect.anything());
+    expect(PaneLockBanner).not.toHaveBeenCalled();
   });
 
   it("locks every configuration card while the deployment is being created", () => {
@@ -139,10 +143,12 @@ describe("ConfigureDeploymentPanes", () => {
     const DeploymentPane = vi.fn(() => <div data-testid="deployment-pane-mock" />);
     const ConfigurationPane = vi.fn(() => <div data-testid="configuration-pane-mock" />);
     const MarketplacePane = vi.fn(() => <div data-testid="marketplace-pane-mock" />);
+    const PaneLockBanner = vi.fn(() => <div data-testid="pane-lock-banner-mock" />);
     const dependencies: typeof DEPENDENCIES = {
       DeploymentPane: DeploymentPane as never,
       ConfigurationPane: ConfigurationPane as never,
       MarketplacePane: MarketplacePane as never,
+      PaneLockBanner: PaneLockBanner as never,
       SdlPreviewPane: SdlPreviewPane as never,
       useFlag: (() => input.isSdlPreviewEnabled ?? false) as never
     };
@@ -174,6 +180,6 @@ describe("ConfigureDeploymentPanes", () => {
       </JotaiStoreProvider>
     );
 
-    return { SdlPreviewPane, DeploymentPane, ConfigurationPane, MarketplacePane, unmount };
+    return { SdlPreviewPane, DeploymentPane, ConfigurationPane, MarketplacePane, PaneLockBanner, unmount };
   }
 });

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentPanes/ConfigureDeploymentPanes.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentPanes/ConfigureDeploymentPanes.tsx
@@ -7,10 +7,11 @@ import type { ConfigurationLock } from "../ConfigurationPane/configurationLock";
 import { ConfigurationPane } from "../ConfigurationPane/ConfigurationPane";
 import { DeploymentPane } from "../DeploymentPane/DeploymentPane";
 import { MarketplacePane } from "../MarketplacePane/MarketplacePane";
+import { PaneLockBanner } from "../PaneLockBanner/PaneLockBanner";
 import { SdlPreviewPane } from "../SdlPreviewPane/SdlPreviewPane";
 import type { DeploymentFlowPhase } from "../useDeploymentFlow/useDeploymentFlow";
 
-export const DEPENDENCIES = { DeploymentPane, ConfigurationPane, MarketplacePane, SdlPreviewPane, useFlag };
+export const DEPENDENCIES = { DeploymentPane, ConfigurationPane, MarketplacePane, PaneLockBanner, SdlPreviewPane, useFlag };
 
 type Props = {
   sdl: string;
@@ -63,32 +64,25 @@ export const ConfigureDeploymentPanes: FC<Props> = ({
 
   return (
     <div className="grid h-full min-h-0 flex-1 auto-cols-fr grid-flow-col grid-cols-[auto_minmax(560px,1fr)] grid-rows-1 border-t border-zinc-300 dark:border-zinc-700">
-      <div className="grid min-h-0 grid-flow-col grid-cols-[auto_360px] grid-rows-1 divide-x divide-zinc-300 dark:divide-zinc-700">
-        <div className="min-h-0">
-          <d.DeploymentPane
-            selectedServiceId={selectedServiceId}
-            onSelectService={onSelectService}
-            locked={isLocked}
-            isClosing={isClosing}
-            onCancelAndEdit={onCancelAndEdit}
-            phase={phase}
-            selections={selections}
-            selectedPlacementId={selectedPlacementId}
-            sdl={sdl}
-            dseq={dseq}
-            deploymentName={deploymentName}
-            onDeploymentNameChange={onDeploymentNameChange}
-          />
-        </div>
-        <div className="min-h-0">
-          <d.ConfigurationPane
-            selectedServiceId={selectedServiceId}
-            locked={configurationLock}
-            isClosing={isClosing}
-            onCancelAndEdit={onCancelAndEdit}
-            actions={configurationActions}
-          />
-        </div>
+      <div className="grid min-h-0 grid-cols-[auto_360px] grid-rows-[auto_auto_1fr]">
+        <d.DeploymentPane
+          selectedServiceId={selectedServiceId}
+          onSelectService={onSelectService}
+          locked={isLocked}
+          phase={phase}
+          selections={selections}
+          selectedPlacementId={selectedPlacementId}
+          sdl={sdl}
+          dseq={dseq}
+          deploymentName={deploymentName}
+          onDeploymentNameChange={onDeploymentNameChange}
+        />
+        <d.ConfigurationPane selectedServiceId={selectedServiceId} locked={configurationLock} actions={configurationActions} />
+        {isLocked && (
+          <div className="col-start-1 col-end-3 row-start-2">
+            <d.PaneLockBanner onCancelAndEdit={onCancelAndEdit} isClosing={isClosing} />
+          </div>
+        )}
       </div>
       <div className="min-h-0 border-l border-zinc-300 dark:border-zinc-700">
         <d.MarketplacePane

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/DeploymentPane.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/DeploymentPane.spec.tsx
@@ -72,13 +72,10 @@ describe("DeploymentPane", () => {
     expect(onSelectService).toHaveBeenCalledWith("new-service-id");
   });
 
-  it("shows the lock banner and disables adding placements while locked", async () => {
-    const onCancelAndEdit = vi.fn();
-    setup({ locked: true, onCancelAndEdit });
+  it("disables adding placements while locked", () => {
+    setup({ locked: true });
 
     expect(screen.getByRole("button", { name: "Add Placement" })).toBeDisabled();
-    await userEvent.click(screen.getByRole("button", { name: /cancel and edit/i }));
-    expect(onCancelAndEdit).toHaveBeenCalled();
   });
 
   it("keeps placements selectable but blocks removing them while locked", () => {
@@ -105,7 +102,6 @@ describe("DeploymentPane", () => {
     placements?: ReturnType<typeof defaultPlacement>[];
     onSelectService?: (serviceId: string) => void;
     locked?: boolean;
-    onCancelAndEdit?: () => void;
     deploymentName?: string;
     onDeploymentNameChange?: (value: string) => void;
     dependencies?: Partial<typeof DEPENDENCIES>;
@@ -125,7 +121,6 @@ describe("DeploymentPane", () => {
           selectedServiceId=""
           onSelectService={input.onSelectService ?? vi.fn()}
           locked={input.locked}
-          onCancelAndEdit={input.onCancelAndEdit}
           phase="configuring"
           selections={{}}
           selectedPlacementId=""

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/DeploymentPane.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/DeploymentPane.tsx
@@ -4,7 +4,6 @@ import { Button, CustomTooltip } from "@akashnetwork/ui/components";
 import { InfoCircle, Plus, SidebarCollapse, SidebarExpand } from "iconoir-react";
 
 import { usePlacementsWithBids } from "@src/queries/usePlacementsWithBids";
-import { PaneLockBanner } from "../PaneLockBanner/PaneLockBanner";
 import type { DeploymentFlowPhase } from "../useDeploymentFlow/useDeploymentFlow";
 import { DeploymentNameField } from "./DeploymentNameField/DeploymentNameField";
 import { PlacementCard } from "./PlacementCard/PlacementCard";
@@ -17,10 +16,8 @@ export const DEPENDENCIES = { PlacementCard, usePlacementManager, usePlacementsW
 type Props = {
   selectedServiceId: string;
   onSelectService: (serviceId: string) => void;
-  /** While quotes are active the pane is locked: placements/services stay selectable, but SDL-mutating controls are disabled and a lock banner is shown. */
+  /** While quotes are active the pane is locked: placements/services stay selectable, but SDL-mutating controls are disabled. The lock banner itself is rendered once across both spec panes by the parent. */
   locked?: boolean;
-  isClosing?: boolean;
-  onCancelAndEdit?: () => void;
   phase: DeploymentFlowPhase;
   selections: Record<string, string>;
   selectedPlacementId: string;
@@ -35,8 +32,6 @@ export const DeploymentPane: FC<Props> = ({
   selectedServiceId,
   onSelectService,
   locked = false,
-  isClosing = false,
-  onCancelAndEdit,
   phase,
   selections,
   selectedPlacementId,
@@ -53,7 +48,7 @@ export const DeploymentPane: FC<Props> = ({
 
   if (minimized) {
     return (
-      <aside aria-label="Deployment pane (minimized)" className="flex h-full min-h-0 w-[48px] flex-col items-center pt-2">
+      <aside aria-label="Deployment pane (minimized)" className="col-start-1 row-start-1 row-end-4 flex h-full min-h-0 w-[48px] flex-col items-center pt-2">
         <Button type="button" variant="ghost" onClick={toggle} aria-label="Show deployment pane" className="h-8 w-8 rounded p-0 text-foreground">
           <SidebarExpand className="h-5 w-5" />
         </Button>
@@ -62,8 +57,8 @@ export const DeploymentPane: FC<Props> = ({
   }
 
   return (
-    <section aria-labelledby="configure-deployment-pane-heading" className="flex h-full min-h-0 w-[231px] flex-col">
-      <header className="flex h-[52px] shrink-0 items-center justify-between gap-2 border-b border-zinc-300 px-4 dark:border-zinc-700">
+    <section aria-labelledby="configure-deployment-pane-heading" className="col-start-1 row-start-1 row-end-4 grid h-full min-h-0 w-[231px] grid-rows-subgrid">
+      <header className="flex h-[52px] items-center justify-between gap-2 border-b border-zinc-300 px-4 dark:border-zinc-700">
         <h2 id="configure-deployment-pane-heading" className="font-mono text-sm font-medium uppercase text-muted-foreground">
           1. Deployment
         </h2>
@@ -71,8 +66,7 @@ export const DeploymentPane: FC<Props> = ({
           <SidebarCollapse className="h-5 w-5" />
         </Button>
       </header>
-      {locked ? <PaneLockBanner onCancelAndEdit={onCancelAndEdit ?? noop} isClosing={isClosing} /> : null}
-      <div className="flex-1 space-y-6 overflow-y-auto p-4">
+      <div className="row-start-3 min-h-0 space-y-6 overflow-y-auto p-4">
         <d.DeploymentNameField value={deploymentName} onChange={onDeploymentNameChange} disabled={locked} />
         <d.ReclamationSection locked={locked} />
         <div className="space-y-2">
@@ -125,9 +119,6 @@ export const DeploymentPane: FC<Props> = ({
     </section>
   );
 };
-
-/** Fallback when the pane is locked without a cancel handler (defensive; the parent always supplies one while locked). */
-function noop() {}
 
 /**
  * Derives the selection badge state for a single placement chip. Badges run from the moment quotes are

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentResourceSummary/useDeploymentResourceSummary.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentResourceSummary/useDeploymentResourceSummary.spec.tsx
@@ -3,10 +3,49 @@ import { FormProvider, useForm } from "react-hook-form";
 import { describe, expect, it } from "vitest";
 
 import type { SdlBuilderFormValuesType } from "@src/types";
-import { defaultServiceWithPlacement } from "@src/utils/sdl/data";
-import { useDeploymentHasGpu } from "./useDeploymentResourceSummary";
+import { defaultService, defaultServiceWithPlacement } from "@src/utils/sdl/data";
+import { useDeploymentGpuCount, useDeploymentHasGpu } from "./useDeploymentResourceSummary";
 
 import { renderHook } from "@testing-library/react";
+
+describe(useDeploymentGpuCount.name, () => {
+  it("counts GPUs across the whole spec when no placement is given", () => {
+    const { result } = setup();
+
+    expect(result.current).toBe(3);
+  });
+
+  it("counts only the given placement's GPUs", () => {
+    const { result } = setup("placement-a");
+
+    expect(result.current).toBe(2);
+  });
+
+  it("returns zero for a placement with no GPUs", () => {
+    const { result } = setup("placement-b");
+
+    expect(result.current).toBe(0);
+  });
+
+  function setup(placementId?: string) {
+    const values: SdlBuilderFormValuesType = {
+      placements: [],
+      endpoints: [],
+      services: [withGpu(defaultService("placement-a"), 2), withGpu(defaultService("placement-b"), 0), withGpu(defaultService("placement-c"), 1)]
+    };
+
+    const Wrapper = ({ children }: PropsWithChildren) => {
+      const form = useForm<SdlBuilderFormValuesType>({ defaultValues: values });
+      return <FormProvider {...form}>{children}</FormProvider>;
+    };
+
+    return renderHook(() => useDeploymentGpuCount(placementId), { wrapper: Wrapper });
+  }
+
+  function withGpu(service: ReturnType<typeof defaultService>, gpu: number) {
+    return { ...service, profile: { ...service.profile, hasGpu: gpu > 0, gpu } };
+  }
+});
 
 describe(useDeploymentHasGpu.name, () => {
   it("returns true when a service requests a GPU", () => {

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentResourceSummary/useDeploymentResourceSummary.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentResourceSummary/useDeploymentResourceSummary.ts
@@ -11,13 +11,18 @@ export function useDeploymentResourceSummary(): string {
   return useMemo(() => formatDeploymentResources(aggregateDeploymentResources(services ?? [])), [services]);
 }
 
+/** Total GPUs requested across the current spec — the same count every provider bids on, so it applies to every marketplace row. */
+export function useDeploymentGpuCount(): number {
+  const { control } = useFormContext<SdlBuilderFormValuesType>();
+  const services = useWatch({ control, name: "services" });
+  return useMemo(() => aggregateDeploymentResources(services ?? []).gpu, [services]);
+}
+
 /**
  * True when the current spec requests any GPU. Drives GPU-vs-CPU-only presentation choices — notably the
  * marketplace cost unit, which shows hourly for GPU (meaningful at that scale) and monthly for CPU-only (so an
  * inexpensive deployment reads as e.g. `$30/month` rather than rounding to `$0.00/hr`).
  */
 export function useDeploymentHasGpu(): boolean {
-  const { control } = useFormContext<SdlBuilderFormValuesType>();
-  const services = useWatch({ control, name: "services" });
-  return useMemo(() => aggregateDeploymentResources(services ?? []).gpu > 0, [services]);
+  return useDeploymentGpuCount() > 0;
 }

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentResourceSummary/useDeploymentResourceSummary.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentResourceSummary/useDeploymentResourceSummary.ts
@@ -11,11 +11,19 @@ export function useDeploymentResourceSummary(): string {
   return useMemo(() => formatDeploymentResources(aggregateDeploymentResources(services ?? [])), [services]);
 }
 
-/** Total GPUs requested across the current spec — the same count every provider bids on, so it applies to every marketplace row. */
-export function useDeploymentGpuCount(): number {
+/**
+ * Total GPUs requested — the same count every provider bids on, so it applies to every marketplace row.
+ * Scope to a single placement by passing its id; without one, counts GPUs across the whole spec. The
+ * marketplace shows bids per placement, so it must pass the viewed placement's id or a multi-placement spec
+ * leaks another placement's GPU count into this one.
+ */
+export function useDeploymentGpuCount(placementId?: string): number {
   const { control } = useFormContext<SdlBuilderFormValuesType>();
   const services = useWatch({ control, name: "services" });
-  return useMemo(() => aggregateDeploymentResources(services ?? []).gpu, [services]);
+  return useMemo(() => {
+    const scoped = placementId ? (services ?? []).filter(service => service.placementId === placementId) : services ?? [];
+    return aggregateDeploymentResources(scoped).gpu;
+  }, [services, placementId]);
 }
 
 /**

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.spec.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import type { PlacementOffer } from "@src/queries/usePlacementOffers";
+import type { DeploymentFlowPhase } from "../useDeploymentFlow/useDeploymentFlow";
 import { ProviderSearchInput } from "./ProviderSearchInput/ProviderSearchInput";
 import type { DEPENDENCIES } from "./MarketplacePane";
 import { MarketplacePane } from "./MarketplacePane";
@@ -39,6 +40,18 @@ describe(MarketplacePane.name, () => {
     const { MarketplaceProvidersTable } = setup({ gpuCount: 0, offers: [buildOffer()] });
 
     expect(MarketplaceProvidersTable).toHaveBeenCalledWith(expect.objectContaining({ gpuCount: 0 }), expect.anything());
+  });
+
+  it("allows provider selection only while quoting", () => {
+    const { MarketplaceProvidersTable } = setup({ phase: "quoting", offers: [buildOffer()] });
+
+    expect(MarketplaceProvidersTable).toHaveBeenCalledWith(expect.objectContaining({ isSelectable: true }), expect.anything());
+  });
+
+  it("blocks provider selection while the deployment is being cancelled", () => {
+    const { MarketplaceProvidersTable } = setup({ phase: "closing", offers: [buildOffer()] });
+
+    expect(MarketplaceProvidersTable).toHaveBeenCalledWith(expect.objectContaining({ isSelectable: false }), expect.anything());
   });
 
   it("scopes the GPU count to the placement it renders bids for", () => {
@@ -102,7 +115,7 @@ describe(MarketplacePane.name, () => {
       sdl?: string;
       placementName?: string;
       region?: string;
-      phase?: "configuring" | "creating" | "quoting" | "error";
+      phase?: DeploymentFlowPhase;
       dseq?: string | null;
       offers?: PlacementOffer[];
       filteredProviders?: PlacementOffer[];

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.spec.tsx
@@ -41,6 +41,12 @@ describe(MarketplacePane.name, () => {
     expect(MarketplaceProvidersTable).toHaveBeenCalledWith(expect.objectContaining({ gpuCount: 0 }), expect.anything());
   });
 
+  it("scopes the GPU count to the placement it renders bids for", () => {
+    const { useDeploymentGpuCount } = setup({ selectedPlacementId: "placement-2", offers: [buildOffer()] });
+
+    expect(useDeploymentGpuCount).toHaveBeenCalledWith("placement-2");
+  });
+
   it("renders an error message and no table when offers fail to load with no data", () => {
     const { MarketplaceProvidersTable } = setup({ isError: true });
 
@@ -128,12 +134,13 @@ describe(MarketplacePane.name, () => {
         {selectedBidId ? "selected" : "select"}
       </button>
     ));
+    const useDeploymentGpuCount = vi.fn(() => input.gpuCount ?? 0);
     const dependencies: typeof DEPENDENCIES = {
       usePlacementOffers: usePlacementOffers as never,
       useProviderSearch: useProviderSearch as never,
       MarketplaceProvidersTable: MarketplaceProvidersTable as never,
       ProviderSearchInput,
-      useDeploymentGpuCount: vi.fn(() => input.gpuCount ?? 0)
+      useDeploymentGpuCount
     };
     const user = userEvent.setup();
 
@@ -150,6 +157,6 @@ describe(MarketplacePane.name, () => {
         dependencies={dependencies}
       />
     );
-    return { usePlacementOffers, useProviderSearch, MarketplaceProvidersTable, user };
+    return { usePlacementOffers, useProviderSearch, MarketplaceProvidersTable, useDeploymentGpuCount, user };
   }
 });

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.spec.tsx
@@ -29,16 +29,16 @@ describe(MarketplacePane.name, () => {
     expect(MarketplaceProvidersTable).toHaveBeenCalledWith(expect.objectContaining({ providers: offers, isLoading: false }), expect.anything());
   });
 
-  it("tells the table to show hourly cost when the spec uses a GPU", () => {
-    const { MarketplaceProvidersTable } = setup({ hasGpu: true, offers: [buildOffer()] });
+  it("passes the spec's GPU count to the table", () => {
+    const { MarketplaceProvidersTable } = setup({ gpuCount: 8, offers: [buildOffer()] });
 
-    expect(MarketplaceProvidersTable).toHaveBeenCalledWith(expect.objectContaining({ showCostAsHourly: true }), expect.anything());
+    expect(MarketplaceProvidersTable).toHaveBeenCalledWith(expect.objectContaining({ gpuCount: 8 }), expect.anything());
   });
 
-  it("tells the table to show monthly cost for a CPU-only spec", () => {
-    const { MarketplaceProvidersTable } = setup({ hasGpu: false, offers: [buildOffer()] });
+  it("passes a zero GPU count for a CPU-only spec", () => {
+    const { MarketplaceProvidersTable } = setup({ gpuCount: 0, offers: [buildOffer()] });
 
-    expect(MarketplaceProvidersTable).toHaveBeenCalledWith(expect.objectContaining({ showCostAsHourly: false }), expect.anything());
+    expect(MarketplaceProvidersTable).toHaveBeenCalledWith(expect.objectContaining({ gpuCount: 0 }), expect.anything());
   });
 
   it("renders an error message and no table when offers fail to load with no data", () => {
@@ -104,7 +104,7 @@ describe(MarketplacePane.name, () => {
       isError?: boolean;
       isInvalid?: boolean;
       isSearchActive?: boolean;
-      hasGpu?: boolean;
+      gpuCount?: number;
       selectedPlacementId?: string;
       selectedBidId?: string;
       onSelectProvider?: (placementId: string, bidId: string) => void;
@@ -133,7 +133,7 @@ describe(MarketplacePane.name, () => {
       useProviderSearch: useProviderSearch as never,
       MarketplaceProvidersTable: MarketplaceProvidersTable as never,
       ProviderSearchInput,
-      useDeploymentHasGpu: vi.fn(() => input.hasGpu ?? false)
+      useDeploymentGpuCount: vi.fn(() => input.gpuCount ?? 0)
     };
     const user = userEvent.setup();
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.tsx
@@ -1,13 +1,13 @@
 import type { FC } from "react";
 
 import { usePlacementOffers } from "@src/queries/usePlacementOffers";
-import { useDeploymentHasGpu } from "../DeploymentResourceSummary/useDeploymentResourceSummary";
+import { useDeploymentGpuCount } from "../DeploymentResourceSummary/useDeploymentResourceSummary";
 import type { DeploymentFlowPhase } from "../useDeploymentFlow/useDeploymentFlow";
 import { MarketplaceProvidersTable } from "./MarketplaceProvidersTable/MarketplaceProvidersTable";
 import { useProviderSearch } from "./MarketplaceProvidersTable/useProviderSearch/useProviderSearch";
 import { ProviderSearchInput } from "./ProviderSearchInput/ProviderSearchInput";
 
-export const DEPENDENCIES = { usePlacementOffers, useProviderSearch, MarketplaceProvidersTable, ProviderSearchInput, useDeploymentHasGpu };
+export const DEPENDENCIES = { usePlacementOffers, useProviderSearch, MarketplaceProvidersTable, ProviderSearchInput, useDeploymentGpuCount };
 
 interface Props {
   sdl: string;
@@ -35,7 +35,7 @@ export const MarketplacePane: FC<Props> = ({
   const { offers, isLoading, isError, isInvalid } = d.usePlacementOffers({ phase, dseq: dseq ?? undefined, sdl, placementName, region });
   const { query, setQuery, clear, filteredProviders, isSearchActive } = d.useProviderSearch(offers);
   const hasFailedWithoutData = isError && offers.length === 0;
-  const showCostAsHourly = d.useDeploymentHasGpu();
+  const gpuCount = d.useDeploymentGpuCount();
 
   return (
     <section aria-labelledby="configure-marketplace-pane-heading" className="flex h-full min-h-0 flex-col">
@@ -68,7 +68,7 @@ export const MarketplacePane: FC<Props> = ({
             onClearSearch={clear}
             selectedBidId={selectedBidId}
             onSelect={bidId => onSelectProvider(selectedPlacementId, bidId)}
-            showCostAsHourly={showCostAsHourly}
+            gpuCount={gpuCount}
           />
         )}
       </div>

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.tsx
@@ -35,7 +35,7 @@ export const MarketplacePane: FC<Props> = ({
   const { offers, isLoading, isError, isInvalid } = d.usePlacementOffers({ phase, dseq: dseq ?? undefined, sdl, placementName, region });
   const { query, setQuery, clear, filteredProviders, isSearchActive } = d.useProviderSearch(offers);
   const hasFailedWithoutData = isError && offers.length === 0;
-  const gpuCount = d.useDeploymentGpuCount();
+  const gpuCount = d.useDeploymentGpuCount(selectedPlacementId);
 
   return (
     <section aria-labelledby="configure-marketplace-pane-heading" className="flex h-full min-h-0 flex-col">

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.tsx
@@ -68,6 +68,7 @@ export const MarketplacePane: FC<Props> = ({
             onClearSearch={clear}
             selectedBidId={selectedBidId}
             onSelect={bidId => onSelectProvider(selectedPlacementId, bidId)}
+            isSelectable={phase === "quoting"}
             gpuCount={gpuCount}
           />
         )}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceCostCell.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceCostCell.tsx
@@ -1,0 +1,38 @@
+import type { FC } from "react";
+
+import { PricePerTimeUnit } from "@src/components/shared/PricePerTimeUnit";
+import { PRICE_DISPLAY_PRECISION, udenomToDenom } from "@src/utils/mathHelpers";
+import { MarketplaceCostTooltip } from "./MarketplaceCostTooltip";
+
+interface Props {
+  price: { amount: string; denom: string };
+  gpuCount: number;
+}
+
+/**
+ * Cost column: a GPU spec headlines the hourly rate (digestible at that scale) with the monthly rate beneath it;
+ * a CPU-only spec shows just the monthly rate so an inexpensive deployment doesn't read as `$0.00/hr`. The info
+ * tooltip fills in the rates that aren't already shown (hourly for CPU, per-hour-per-GPU for GPU, plus daily).
+ */
+export const MarketplaceCostCell: FC<Props> = ({ price, gpuCount }) => {
+  const showAsHourly = gpuCount > 0;
+  const perBlockValue = udenomToDenom(price.amount, PRICE_DISPLAY_PRECISION);
+
+  return (
+    <div className="flex min-w-0 flex-col">
+      <span className="inline-flex items-center">
+        <PricePerTimeUnit denom={price.denom} perBlockValue={perBlockValue} showAsHourly={showAsHourly} abbreviated />
+        <MarketplaceCostTooltip perBlockValue={perBlockValue} denom={price.denom} gpuCount={gpuCount} />
+      </span>
+      {showAsHourly && (
+        <PricePerTimeUnit
+          className="text-xs font-normal text-muted-foreground"
+          denom={price.denom}
+          perBlockValue={perBlockValue}
+          showAsHourly={false}
+          abbreviated
+        />
+      )}
+    </div>
+  );
+};

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceCostTooltip.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceCostTooltip.spec.tsx
@@ -1,0 +1,46 @@
+import { IntlProvider } from "react-intl";
+import { TooltipProvider } from "@akashnetwork/ui/components";
+import { describe, expect, it } from "vitest";
+
+import { MarketplaceCostTooltip } from "./MarketplaceCostTooltip";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { TestContainerProvider } from "@tests/unit/TestContainerProvider";
+
+describe(MarketplaceCostTooltip.name, () => {
+  it("surfaces the hourly and daily rate for a CPU-only spec, without repeating the monthly rate or mentioning blocks", async () => {
+    const { user, trigger } = setup({ gpuCount: 0 });
+
+    await user.hover(trigger);
+
+    expect(await screen.findAllByText(/per hour/i)).not.toHaveLength(0);
+    expect(screen.getAllByText(/per day/i)).not.toHaveLength(0);
+    expect(screen.queryAllByText(/per month/i)).toHaveLength(0);
+    expect(screen.queryAllByText(/block/i)).toHaveLength(0);
+  });
+
+  it("surfaces the per-hour-per-GPU and daily rate for a GPU spec", async () => {
+    const { user, trigger } = setup({ gpuCount: 2 });
+
+    await user.hover(trigger);
+
+    expect(await screen.findAllByText(/per hour \/ GPU/i)).not.toHaveLength(0);
+    expect(screen.getAllByText(/per day/i)).not.toHaveLength(0);
+    expect(screen.queryAllByText(/per month/i)).toHaveLength(0);
+  });
+
+  function setup(input: { gpuCount: number }) {
+    const user = userEvent.setup();
+    const { container } = render(
+      <TestContainerProvider>
+        <IntlProvider locale="en">
+          <TooltipProvider>
+            <MarketplaceCostTooltip perBlockValue={0.0001} denom="uakt" gpuCount={input.gpuCount} />
+          </TooltipProvider>
+        </IntlProvider>
+      </TestContainerProvider>
+    );
+    return { user, trigger: container.querySelector("svg") as SVGElement };
+  }
+});

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceCostTooltip.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceCostTooltip.tsx
@@ -1,0 +1,59 @@
+import type { FC } from "react";
+import { CustomTooltip } from "@akashnetwork/ui/components";
+import { InfoCircle } from "iconoir-react";
+
+import { PriceValue } from "@src/components/shared/PriceValue";
+import { perBlockToHourly } from "@src/utils/priceUtils";
+
+interface Props {
+  perBlockValue: number;
+  denom: string;
+  gpuCount: number;
+}
+
+/**
+ * Cost breakdown for a marketplace row. The row already shows the monthly rate (and the hourly rate for GPU
+ * specs), so this only surfaces the rates that aren't already visible: the hourly rate for CPU-only specs, the
+ * per-hour-per-GPU rate for GPU specs, and the daily rate.
+ */
+export const MarketplaceCostTooltip: FC<Props> = ({ perBlockValue, denom, gpuCount }) => {
+  const hourlyValue = perBlockToHourly(perBlockValue);
+  const dailyValue = hourlyValue * 24;
+  const hasGpu = gpuCount > 0;
+  const hourlyPerGpuValue = hasGpu ? hourlyValue / gpuCount : 0;
+
+  return (
+    <CustomTooltip
+      title={
+        <div>
+          <span className="text-sm text-muted-foreground">Price breakdown</span>
+
+          {hasGpu ? (
+            <div>
+              <strong>
+                <PriceValue value={hourlyPerGpuValue} denom={denom} />
+              </strong>
+              &nbsp; per hour / GPU
+            </div>
+          ) : (
+            <div>
+              <strong>
+                <PriceValue value={hourlyValue} denom={denom} />
+              </strong>
+              &nbsp; per hour
+            </div>
+          )}
+
+          <div>
+            <strong>
+              <PriceValue value={dailyValue} denom={denom} />
+            </strong>
+            &nbsp; per day
+          </div>
+        </div>
+      }
+    >
+      <InfoCircle className="ml-2 text-xs text-muted-foreground" />
+    </CustomTooltip>
+  );
+};

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProviderCell.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProviderCell.tsx
@@ -1,0 +1,48 @@
+import type { FC } from "react";
+import Link from "next/link";
+
+import { ShortenedValue } from "@src/components/shared/ShortenedValue";
+import type { PlacementOffer } from "@src/queries/usePlacementOffers";
+import { getProviderNameFromUri, providerDisplayName } from "@src/utils/providerUtils";
+import { UrlService } from "@src/utils/urlUtils";
+
+/** Host from the provider's URI, or null when it has none (bid-sourced offers) or the URI is malformed. */
+function getProviderHost(hostUri?: string | null): string | null {
+  const trimmed = hostUri?.trim();
+  if (!trimmed) return null;
+  try {
+    return getProviderNameFromUri(trimmed);
+  } catch {
+    return null;
+  }
+}
+
+interface Props {
+  offer: PlacementOffer;
+}
+
+/**
+ * Provider column: the display name links to the provider's detail page, opened in a new tab so the in-progress
+ * deployment isn't lost. When the name is a moniker (organization), the actual host is shown beneath it — the
+ * self-declared name alone doesn't tell you which provider you're really getting.
+ */
+export const MarketplaceProviderCell: FC<Props> = ({ offer }) => {
+  const displayName = providerDisplayName(offer);
+  const host = getProviderHost(offer.hostUri);
+  const subtitle = host && host !== displayName ? host : null;
+
+  return (
+    <div className="flex min-w-0 flex-col">
+      <Link
+        href={UrlService.providerDetail(offer.owner)}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={event => event.stopPropagation()}
+        className="min-w-0 truncate font-medium text-primary hover:underline"
+      >
+        <ShortenedValue value={displayName} maxLength={40} headLength={14} />
+      </Link>
+      {subtitle && <span className="min-w-0 truncate text-xs font-normal text-muted-foreground">{subtitle}</span>}
+    </div>
+  );
+};

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.spec.tsx
@@ -74,13 +74,14 @@ describe(MarketplaceProvidersTable.name, () => {
     expect(within(rows[2]).getByText("up.example")).toBeInTheDocument();
   });
 
-  it("displays the organization name when present", () => {
-    setup({ providers: [buildOffer({ organization: "Polaris Compute", hostUri: "https://a.example:8443" })] });
+  it("displays the organization name with the actual host beneath it", () => {
+    setup({ providers: [buildOffer({ organization: "Polaris Compute", hostUri: "https://provider.wdc.com:8443" })] });
 
     expect(screen.getByText("Polaris Compute")).toBeInTheDocument();
+    expect(screen.getByText("provider.wdc.com")).toBeInTheDocument();
   });
 
-  it("falls back to the host name when organization is absent", () => {
+  it("falls back to the host name when organization is absent and shows no duplicate host beneath it", () => {
     setup({ providers: [buildOffer({ organization: null, hostUri: "https://a.example:8443" })] });
 
     expect(screen.getByText("a.example")).toBeInTheDocument();
@@ -90,6 +91,14 @@ describe(MarketplaceProvidersTable.name, () => {
     setup({ providers: [buildOffer({ organization: null, hostUri: "", owner: "akash1bidder" })] });
 
     expect(screen.getByText("akash1bidder")).toBeInTheDocument();
+  });
+
+  it("links the provider name to its detail page in a new tab", () => {
+    setup({ providers: [buildOffer({ organization: "Polaris Compute", hostUri: "https://a.example:8443", owner: "akash1prov" })] });
+
+    const link = screen.getByRole("link", { name: "Polaris Compute" });
+    expect(link).toHaveAttribute("href", expect.stringContaining("/providers/akash1prov"));
+    expect(link).toHaveAttribute("target", "_blank");
   });
 
   it("shows a search empty state with a clear action when a search excludes all rows", async () => {
@@ -130,14 +139,16 @@ describe(MarketplaceProvidersTable.name, () => {
     expect(screen.getByText("Cost")).toBeInTheDocument();
   });
 
-  it("shows the cost per hour when the spec uses a GPU", () => {
-    setup({ providers: [submittedOffer({ owner: "akash1a", bidId: "akash1a/1/1/1" })], showCostAsHourly: true });
+  it("shows both hourly and monthly cost for a GPU spec", () => {
+    setup({ providers: [submittedOffer({ owner: "akash1a", bidId: "akash1a/1/1/1" })], gpuCount: 8 });
     expect(screen.getByText("/hr")).toBeInTheDocument();
+    expect(screen.getByText("/month")).toBeInTheDocument();
   });
 
-  it("shows the cost per month for a CPU-only spec so an inexpensive deployment doesn't read as $0.00/hr", () => {
-    setup({ providers: [submittedOffer({ owner: "akash1a", bidId: "akash1a/1/1/1" })], showCostAsHourly: false });
+  it("shows only the monthly cost for a CPU-only spec so an inexpensive deployment doesn't read as $0.00/hr", () => {
+    setup({ providers: [submittedOffer({ owner: "akash1a", bidId: "akash1a/1/1/1" })], gpuCount: 0 });
     expect(screen.getByText("/month")).toBeInTheDocument();
+    expect(screen.queryByText("/hr")).not.toBeInTheDocument();
   });
 
   it("shows only Provider, Region, and Uptime while every offer is still searching", () => {
@@ -312,7 +323,7 @@ describe(MarketplaceProvidersTable.name, () => {
     isSearchActive?: boolean;
     onClearSearch?: () => void;
     selectedBidId?: string;
-    showCostAsHourly?: boolean;
+    gpuCount?: number;
   }) {
     const onSelect = vi.fn();
     const user = userEvent.setup();
@@ -327,7 +338,7 @@ describe(MarketplaceProvidersTable.name, () => {
               onClearSearch={input.onClearSearch}
               selectedBidId={input.selectedBidId}
               onSelect={onSelect}
-              showCostAsHourly={input.showCostAsHourly}
+              gpuCount={input.gpuCount}
             />
           </TooltipProvider>
         </IntlProvider>

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.spec.tsx
@@ -168,6 +168,11 @@ describe(MarketplaceProvidersTable.name, () => {
     expect(onSelect).toHaveBeenCalledWith("akash1a/1/1/1");
   });
 
+  it("disables every Select button when selection is turned off", () => {
+    setup({ providers: [submittedOffer({ owner: "akash1a", bidId: "akash1a/1/1/1" })], isSelectable: false });
+    expect(screen.getByRole("button", { name: "Select akash1a" })).toBeDisabled();
+  });
+
   it("marks the selected offer's row and makes its button non-clickable", () => {
     setup({ providers: [submittedOffer({ owner: "akash1a", bidId: "akash1a/1/1/1" })], selectedBidId: "akash1a/1/1/1" });
     expect(screen.getByRole("button", { name: /selected/i })).toBeDisabled();
@@ -323,6 +328,7 @@ describe(MarketplaceProvidersTable.name, () => {
     isSearchActive?: boolean;
     onClearSearch?: () => void;
     selectedBidId?: string;
+    isSelectable?: boolean;
     gpuCount?: number;
   }) {
     const onSelect = vi.fn();
@@ -338,6 +344,7 @@ describe(MarketplaceProvidersTable.name, () => {
               onClearSearch={input.onClearSearch}
               selectedBidId={input.selectedBidId}
               onSelect={onSelect}
+              isSelectable={input.isSelectable}
               gpuCount={input.gpuCount}
             />
           </TooltipProvider>

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.tsx
@@ -6,14 +6,13 @@ import type { Column, Row, SortingState } from "@tanstack/react-table";
 import { createColumnHelper, flexRender, getCoreRowModel, getSortedRowModel, useReactTable } from "@tanstack/react-table";
 import { ArrowDown, ArrowUp, ChevronsUpDown } from "lucide-react";
 
-import { PricePerTimeUnit } from "@src/components/shared/PricePerTimeUnit";
-import { ShortenedValue } from "@src/components/shared/ShortenedValue";
 import type { PlacementOffer } from "@src/queries/usePlacementOffers";
-import { PRICE_DISPLAY_PRECISION, udenomToDenom } from "@src/utils/mathHelpers";
 import { providerDisplayName } from "@src/utils/providerUtils";
 import type { ProviderUptime } from "./ProviderUptimeCell/deriveProviderUptime";
 import { useProvidersUptime } from "./ProviderUptimeCell/deriveProviderUptime";
 import { ProviderUptimeCell } from "./ProviderUptimeCell/ProviderUptimeCell";
+import { MarketplaceCostCell } from "./MarketplaceCostCell";
+import { MarketplaceProviderCell } from "./MarketplaceProviderCell";
 
 const columnHelper = createColumnHelper<PlacementOffer>();
 
@@ -42,19 +41,11 @@ interface Props {
   onClearSearch?: () => void;
   selectedBidId?: string;
   onSelect?: (bidId: string) => void;
-  /** When true the cost column renders an hourly rate (GPU specs); otherwise a monthly rate, so inexpensive CPU-only deployments don't round to `$0.00/hr`. */
-  showCostAsHourly?: boolean;
+  /** Total GPUs the spec requests. Above zero, the cost column headlines an hourly rate (GPU specs); at zero it shows a monthly rate, so inexpensive CPU-only deployments don't round to `$0.00/hr`. Also drives the per-hour-per-GPU tooltip line. */
+  gpuCount?: number;
 }
 
-export const MarketplaceProvidersTable: FC<Props> = ({
-  providers,
-  isLoading,
-  isSearchActive,
-  onClearSearch,
-  selectedBidId,
-  onSelect,
-  showCostAsHourly = false
-}) => {
+export const MarketplaceProvidersTable: FC<Props> = ({ providers, isLoading, isSearchActive, onClearSearch, selectedBidId, onSelect, gpuCount = 0 }) => {
   const [sorting, setSorting] = useState<SortingState>([]);
 
   const uptimeByOwner = useProvidersUptime(providers);
@@ -63,8 +54,8 @@ export const MarketplaceProvidersTable: FC<Props> = ({
   /** Cost only makes sense once bids arrive: a submitted bid is priced and a closed/expired one keeps its last price, but a screened-only candidate has none. */
   const showCost = providers.some(provider => !!provider.price);
   const columns = useMemo(
-    () => buildColumns(uptimeByOwner, { selectedBidId, onSelect, showCost, showStatus: isMerged, showCostAsHourly }),
-    [uptimeByOwner, selectedBidId, onSelect, showCost, isMerged, showCostAsHourly]
+    () => buildColumns(uptimeByOwner, { selectedBidId, onSelect, showCost, showStatus: isMerged, gpuCount }),
+    [uptimeByOwner, selectedBidId, onSelect, showCost, isMerged, gpuCount]
   );
 
   const table = useReactTable({
@@ -166,7 +157,7 @@ function ProvidersTableSkeleton() {
         </TableHeader>
         <TableBody>
           {Array.from({ length: SKELETON_ROW_COUNT }, (_, rowIndex) => (
-            <TableRow key={rowIndex} className="h-[52px] hover:bg-transparent">
+            <TableRow key={rowIndex} className="h-16 hover:bg-transparent">
               {SKELETON_COLUMNS.map(column => (
                 <TableCell key={column.id} className="py-2 pl-4 pr-2">
                   <Skeleton className={cn("h-4", column.barWidth)} />
@@ -190,16 +181,13 @@ function isNonSelectable(state: PlacementOffer["offerState"]): boolean {
   return state === "closed" || state === "unavailable";
 }
 
-/** One marketplace row. Selectable rows read normally; closed/expired and never-bid rows are muted (which also greys their price). Cell content (price vs "—", Select vs status badge) comes from the column defs. */
+/** One marketplace row. Selectable rows read normally; closed/expired and never-bid rows are muted (which also greys their price). Cell content (price vs "—", Select vs status badge) comes from the column defs. Two-line Provider and Cost cells set the taller row height. */
 function OfferRow({ row }: { row: Row<PlacementOffer> }) {
   const isDisabled = isNonSelectable(row.original.offerState);
   return (
-    <TableRow className={cn("h-[52px]", isDisabled && "text-muted-foreground hover:bg-transparent")}>
+    <TableRow className={cn("h-16", isDisabled && "text-muted-foreground hover:bg-transparent")}>
       {row.getVisibleCells().map(cell => (
-        <TableCell
-          key={cell.id}
-          className={cn("py-2 pl-4 pr-2 text-sm", cell.column.id === "hostUri" && "truncate", !isDisabled && "font-medium text-foreground")}
-        >
+        <TableCell key={cell.id} className={cn("py-2 pl-4 pr-2 text-sm", !isDisabled && "font-medium text-foreground")}>
           {flexRender(cell.column.columnDef.cell, cell.getContext())}
         </TableCell>
       ))}
@@ -231,13 +219,13 @@ function SortableHeader({ column, title }: { column: Column<PlacementOffer, unkn
 /** Builds the columns, closing over the per-provider uptime derived once in the component. Every column is an accessor so it sorts; the trailing status column is display-only. */
 function buildColumns(
   uptimeByOwner: Map<string, ProviderUptime>,
-  selection: { selectedBidId?: string; onSelect?: (bidId: string) => void; showCost: boolean; showStatus: boolean; showCostAsHourly: boolean }
+  selection: { selectedBidId?: string; onSelect?: (bidId: string) => void; showCost: boolean; showStatus: boolean; gpuCount: number }
 ) {
   return [
     columnHelper.accessor(providerDisplayName, {
       id: "hostUri",
       header: ({ column }) => <SortableHeader column={column} title="Provider" />,
-      cell: info => <ShortenedValue value={info.getValue()} maxLength={40} headLength={14} />
+      cell: info => <MarketplaceProviderCell offer={info.row.original} />
     }),
     columnHelper.accessor("location", {
       header: ({ column }) => <SortableHeader column={column} title="Region" />,
@@ -256,14 +244,7 @@ function buildColumns(
             cell: ({ row }) => {
               const { price } = row.original;
               if (!price) return <span className="text-muted-foreground">{NO_REGION}</span>;
-              return (
-                <PricePerTimeUnit
-                  denom={price.denom}
-                  perBlockValue={udenomToDenom(price.amount, PRICE_DISPLAY_PRECISION)}
-                  showAsHourly={selection.showCostAsHourly}
-                  abbreviated
-                />
-              );
+              return <MarketplaceCostCell price={price} gpuCount={selection.gpuCount} />;
             }
           })
         ]

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.tsx
@@ -41,11 +41,22 @@ interface Props {
   onClearSearch?: () => void;
   selectedBidId?: string;
   onSelect?: (bidId: string) => void;
+  /** False disables every Select button — bids are only selectable while quoting, not while the deployment is being created, closed (cancelled), or deployed. */
+  isSelectable?: boolean;
   /** Total GPUs the spec requests. Above zero, the cost column headlines an hourly rate (GPU specs); at zero it shows a monthly rate, so inexpensive CPU-only deployments don't round to `$0.00/hr`. Also drives the per-hour-per-GPU tooltip line. */
   gpuCount?: number;
 }
 
-export const MarketplaceProvidersTable: FC<Props> = ({ providers, isLoading, isSearchActive, onClearSearch, selectedBidId, onSelect, gpuCount = 0 }) => {
+export const MarketplaceProvidersTable: FC<Props> = ({
+  providers,
+  isLoading,
+  isSearchActive,
+  onClearSearch,
+  selectedBidId,
+  onSelect,
+  isSelectable = true,
+  gpuCount = 0
+}) => {
   const [sorting, setSorting] = useState<SortingState>([]);
 
   const uptimeByOwner = useProvidersUptime(providers);
@@ -54,8 +65,8 @@ export const MarketplaceProvidersTable: FC<Props> = ({ providers, isLoading, isS
   /** Cost only makes sense once bids arrive: a submitted bid is priced and a closed/expired one keeps its last price, but a screened-only candidate has none. */
   const showCost = providers.some(provider => !!provider.price);
   const columns = useMemo(
-    () => buildColumns(uptimeByOwner, { selectedBidId, onSelect, showCost, showStatus: isMerged, gpuCount }),
-    [uptimeByOwner, selectedBidId, onSelect, showCost, isMerged, gpuCount]
+    () => buildColumns(uptimeByOwner, { selectedBidId, onSelect, isSelectable, showCost, showStatus: isMerged, gpuCount }),
+    [uptimeByOwner, selectedBidId, onSelect, isSelectable, showCost, isMerged, gpuCount]
   );
 
   const table = useReactTable({
@@ -219,7 +230,7 @@ function SortableHeader({ column, title }: { column: Column<PlacementOffer, unkn
 /** Builds the columns, closing over the per-provider uptime derived once in the component. Every column is an accessor so it sorts; the trailing status column is display-only. */
 function buildColumns(
   uptimeByOwner: Map<string, ProviderUptime>,
-  selection: { selectedBidId?: string; onSelect?: (bidId: string) => void; showCost: boolean; showStatus: boolean; gpuCount: number }
+  selection: { selectedBidId?: string; onSelect?: (bidId: string) => void; isSelectable: boolean; showCost: boolean; showStatus: boolean; gpuCount: number }
 ) {
   return [
     columnHelper.accessor(providerDisplayName, {
@@ -265,7 +276,7 @@ function buildColumns(
                   type="button"
                   size="sm"
                   variant={isSelected ? "default" : "outline"}
-                  disabled={isSelected}
+                  disabled={isSelected || !selection.isSelectable}
                   aria-label={isSelected ? `Selected ${providerDisplayName(offer)}` : `Select ${providerDisplayName(offer)}`}
                   onClick={() => selection.onSelect?.(offer.bidId!)}
                 >

--- a/apps/deploy-web/src/components/shared/PriceEstimateTooltip.spec.tsx
+++ b/apps/deploy-web/src/components/shared/PriceEstimateTooltip.spec.tsx
@@ -1,0 +1,52 @@
+import { IntlProvider } from "react-intl";
+import { TooltipProvider } from "@akashnetwork/ui/components";
+import { describe, expect, it } from "vitest";
+
+import { PriceEstimateTooltip } from "./PriceEstimateTooltip";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { TestContainerProvider } from "@tests/unit/TestContainerProvider";
+
+describe(PriceEstimateTooltip.name, () => {
+  it("shows the daily and monthly rates without any block or blockchain wording", async () => {
+    const { user, trigger } = setup({});
+
+    await user.hover(trigger);
+
+    expect(await screen.findAllByText(/per day/i)).not.toHaveLength(0);
+    expect(screen.getAllByText(/per month/i)).not.toHaveLength(0);
+    expect(screen.queryAllByText(/block/i)).toHaveLength(0);
+  });
+
+  it("adds the hourly rate when showAsHourly is set", async () => {
+    const { user, trigger } = setup({ showAsHourly: true });
+
+    await user.hover(trigger);
+
+    expect(await screen.findAllByText(/per hour/i)).not.toHaveLength(0);
+  });
+
+  it("omits the hourly rate by default", async () => {
+    const { user, trigger } = setup({});
+
+    await user.hover(trigger);
+
+    expect(await screen.findAllByText(/per month/i)).not.toHaveLength(0);
+    expect(screen.queryAllByText(/per hour/i)).toHaveLength(0);
+  });
+
+  function setup(input: { showAsHourly?: boolean }) {
+    const user = userEvent.setup();
+    const { container } = render(
+      <TestContainerProvider>
+        <IntlProvider locale="en">
+          <TooltipProvider>
+            <PriceEstimateTooltip value="100" denom="uakt" showAsHourly={input.showAsHourly} />
+          </TooltipProvider>
+        </IntlProvider>
+      </TestContainerProvider>
+    );
+    return { user, trigger: container.querySelector("svg") as SVGElement };
+  }
+});

--- a/apps/deploy-web/src/components/shared/PriceEstimateTooltip.tsx
+++ b/apps/deploy-web/src/components/shared/PriceEstimateTooltip.tsx
@@ -16,22 +16,16 @@ type Props = {
 };
 
 export const PriceEstimateTooltip: React.FunctionComponent<Props> = ({ value, denom, showAsHourly = false }) => {
-  const _value = udenomToDenom(typeof value === "string" ? parseFloat(value) : value, 10);
-  const perHourValue = _value * (60 / averageBlockTime) * 60;
-  const perDayValue = _value * (60 / averageBlockTime) * 60 * 24;
-  const perMonthValue = _value * (60 / averageBlockTime) * 60 * 24 * averageDaysInMonth;
+  const denomValue = udenomToDenom(typeof value === "string" ? parseFloat(value) : value, 10);
+  const perHourValue = denomValue * (60 / averageBlockTime) * 60;
+  const perDayValue = perHourValue * 24;
+  const perMonthValue = perHourValue * 24 * averageDaysInMonth;
 
   return (
     <CustomTooltip
       title={
         <div>
-          <span className="text-sm text-muted-foreground">Price estimation:</span>
-          <div>
-            <strong>
-              <PriceValue value={_value} denom={denom} />
-            </strong>
-            &nbsp; per block (~{averageBlockTime}sec.)
-          </div>
+          <span className="text-sm text-muted-foreground">Price breakdown</span>
 
           {showAsHourly && (
             <div>


### PR DESCRIPTION
## Why

Team feedback on the redesign-v2 compute marketplace provider list:

- The provider column showed only the moniker (e.g. "overclock"), which does not reveal the actual provider host.
- The cost column showed a single figure, so large GPU amounts (e.g. `$4,613/month`) were hard to read as an hourly rate.

The asks were to surface the actual host, show price per hour alongside price per month (and price per hour per GPU), and make the provider clickable, while keeping the table slick.

## What

Frontend-only change to the compute marketplace provider table (deployment `/configure` flow):

- **Provider column**: two-line cell with the moniker on top and the actual host beneath it. The name links to the provider detail page and opens in a new tab so the in-progress deployment is not lost. Falls back to host-only when there is no moniker.
- **Cost column**: GPU specs headline the hourly rate with the monthly rate beneath; CPU-only shows just the monthly rate (so a cheap deployment does not read as `$0.00/hr`).
- **Info tooltip**: surfaces only the rates not already shown on the row (hourly for CPU-only, per hour per GPU for GPU, plus daily). Removed the per-block / blockchain wording and renamed the header to "Price breakdown".
- Added `useDeploymentGpuCount`; `useDeploymentHasGpu` now derives from it.

The per-block line removal also applies to the shared price tooltip used in lease rows, the deployment list, and the old bid flow.

> Screenshots to add: a GPU marketplace row (hourly + monthly + tooltip) and a CPU-only row.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Marketplace offers now display provider names with optional host details and open provider pages in a new tab.
  - Marketplace pricing includes an info tooltip with a GPU-aware per-day/per-month breakdown and per-hour-per-GPU labeling when applicable.
- **Bug Fixes**
  - GPU pricing/hourly markers now use the total requested GPU count for the selected placement, with CPU-only specs correctly hiding GPU-specific hourly details.
  - Lock banner is shown once at the top level for the configuration flow.
- **Tests**
  - Added/updated hook and UI tests to cover GPU-count-driven behavior and tooltip/provider rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->