### PR TITLE
feat(ci): trigger template publisher via repository_dispatch

### DIFF
--- a/.github/workflows/akash-templates-publisher.yml
+++ b/.github/workflows/akash-templates-publisher.yml
@@ -5,6 +5,8 @@ on:
     # Run daily at 15:00 UTC
     - cron: "0 15 * * *"
   workflow_dispatch:
+  repository_dispatch:
+    types: [awesome-akash-updated]
 
 permissions:
   contents: read

--- a/.github/workflows/akash-templates-publisher.yml
+++ b/.github/workflows/akash-templates-publisher.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: akash-templates-publisher
+  cancel-in-progress: false
+
 jobs:
   build-and-deploy-templates:
     runs-on: [self-hosted, akash]


### PR DESCRIPTION
## Why

Templates published by [\`akash-templates-publisher.yml\`](.github/workflows/akash-templates-publisher.yml) are sourced from [\`akash-network/awesome-akash\`](https://github.com/akash-network/awesome-akash), but the workflow only runs on a daily cron (15:00 UTC) and manual dispatch. A commit to awesome-akash currently waits up to ~24h to be republished.

A \`push\` in awesome-akash cannot trigger a workflow in this repo directly, so this adds a cross-repo \`repository_dispatch\` trigger that awesome-akash can POST to on push.

## What

Adds a \`repository_dispatch\` trigger (\`types: [awesome-akash-updated]\`) to the template publisher workflow. The daily cron stays as a backstop.

Companion change lives in \`akash-network/awesome-akash\`: a push-triggered workflow that POSTs to \`/repos/akash-network/console/dispatches\` using an org GitHub App token (or fine-grained PAT) scoped to this repo.

\`repository_dispatch\` only fires on the default branch, so this must be merged to \`main\` before the trigger is live. The workflow does not consume \`client_payload\` in any \`run:\`/\`ref:\` step, so there is no injection surface.

Verify (after merge):
\`\`\`bash
gh api repos/akash-network/console/dispatches -f event_type=awesome-akash-updated
\`\`\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added support for triggering the Akash templates publishing workflow via a repository update event.
  * Existing scheduled and manual trigger options remain available.
  * Introduced run overlap control to ensure multiple executions don’t interfere with each other.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->