### PR TITLE
fix(deployment): double gpu bot gas headroom to cover close settlement growth

### DIFF
--- a/apps/api/src/deployment/services/gpu-bids-creator/gpu-bids-creator.service.spec.ts
+++ b/apps/api/src/deployment/services/gpu-bids-creator/gpu-bids-creator.service.spec.ts
@@ -3,7 +3,7 @@ import "@test/mocks/logger-service.mock";
 import type { QueryBidsResponse } from "@akashnetwork/chain-sdk/private-types/akash.v1beta5";
 import type { BlockHttpService } from "@akashnetwork/http-sdk";
 import type { Registry } from "@cosmjs/proto-signing";
-import type { SigningStargateClient } from "@cosmjs/stargate";
+import { calculateFee, type SigningStargateClient } from "@cosmjs/stargate";
 import { describe, expect, it, vi } from "vitest";
 import { mock, mockDeep } from "vitest-mock-extended";
 
@@ -225,6 +225,15 @@ describe(GpuBidsCreatorService.name, () => {
       const result = await service["signAndBroadcast"]("akash1owner", signingClient, []);
 
       expect(result).toEqual(expect.objectContaining({ code: 0 }));
+    });
+
+    it("doubles the simulated gas when calculating the fee", async () => {
+      const { service, signingClient } = setup();
+      signingClient.simulate.mockResolvedValue(205481);
+
+      await service["signAndBroadcast"]("akash1owner", signingClient, []);
+
+      expect(calculateFee).toHaveBeenCalledWith(410962, "0.025uakt");
     });
   });
 

--- a/apps/api/src/deployment/services/gpu-bids-creator/gpu-bids-creator.service.ts
+++ b/apps/api/src/deployment/services/gpu-bids-creator/gpu-bids-creator.service.ts
@@ -19,6 +19,9 @@ import { DEPLOYMENT_CONFIG, type DeploymentConfig } from "@src/deployment/config
 import { GpuService } from "@src/gpu/services/gpu.service";
 import { sdlTemplateWithRam, sdlTemplateWithRamAndInterface } from "./sdl-templates";
 
+/** Close settlement gas grows with bids placed between simulation and inclusion; matches tx-signer GAS_DEFAULT_MULTIPLIER (PR #3501). */
+const GAS_MULTIPLIER = 2;
+
 @singleton()
 export class GpuBidsCreatorService {
   readonly #deploymentConfig: DeploymentConfig;
@@ -72,7 +75,7 @@ export class GpuBidsCreatorService {
   private async signAndBroadcast(address: string, client: SigningStargateClient, messages: readonly EncodeObject[]) {
     const simulation = await client.simulate(address, messages, "");
 
-    const fee = calculateFee(Math.round(simulation * 1.35), `${this.config.get("AVERAGE_GAS_PRICE")}uakt`);
+    const fee = calculateFee(Math.round(simulation * GAS_MULTIPLIER), `${this.config.get("AVERAGE_GAS_PRICE")}uakt`);
 
     const txRaw = await client.sign(address, messages, fee, "");
 


### PR DESCRIPTION
## Why

The `gpu-pricing-bot` cron aborted mid-run on mainnet with an out-of-gas error while broadcasting `MsgCloseDeployment` (tx `9CD84B146888C07BC1DF67985B6D8E95358D76C5CA9264D492B021095E0E4D14`, `gasWanted: 277399, gasUsed: 278090` — a ~0.25% overshoot of the 1.35× padded simulation).

Close-deployment gas grows with the number of bids being settled, and the bot's deployments intentionally attract bids from every provider — bids landing between simulation and block inclusion add `ReadFlat` store reads the simulation never saw, so 1.35× headroom is too tight for this message type. tx-signer hit the same failure and fixed it in #3501 by moving to a 2.0× default multiplier; the GPU bot has its own `SigningStargateClient` and never got that fix.

When the close fails, the whole run aborts (remaining GPU models get no price samples that cycle) and the unclosed deployment leaks its 0.5 ACT deposit in escrow.

## What

- Bump the GPU bot's gas multiplier from a hardcoded `1.35` to a named `GAS_MULTIPLIER = 2` constant, matching tx-signer's `GAS_DEFAULT_MULTIPLIER`.
- Add a unit test pinning that the fee uses 2× the simulated gas.

Fee cost impact is negligible (~0.007 AKT vs ~0.005 per tx for this internal bot). Out of scope, worth a follow-up if this recurs: an out-of-gas retry with a recovery multiplier, and a startup sweep closing leftover open deployments on the bot wallet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved transaction fee calculation for GPU bid settlements by using a more reliable multiplier based on simulated gas usage.
  - Added verification to ensure calculated fees match the expected gas estimate and fee rate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->