### PR TITLE
fix(deployment): skip initial funding terminally when the escrow account is closed

### DIFF
--- a/apps/api/src/app/services/fund-deployment/fund-deployment.handler.spec.ts
+++ b/apps/api/src/app/services/fund-deployment/fund-deployment.handler.spec.ts
@@ -12,7 +12,6 @@ describe(FundDeploymentHandler.name, () => {
     const { handler, initialDeploymentFundingService } = setup();
 
     const payload: JobPayload<FundDeploymentCommand> = {
-      userId: "user-1",
       walletId: 1,
       address: "akash1abc",
       dseq: "123",

--- a/apps/api/src/billing/commands/fund-deployment.command.ts
+++ b/apps/api/src/billing/commands/fund-deployment.command.ts
@@ -9,7 +9,6 @@ export class FundDeploymentCommand implements Job {
 
   constructor(
     public readonly data: {
-      userId: string;
       walletId: number;
       address: string;
       dseq: string;

--- a/apps/api/src/billing/services/chain-error/chain-error.service.spec.ts
+++ b/apps/api/src/billing/services/chain-error/chain-error.service.spec.ts
@@ -165,6 +165,17 @@ describe(ChainErrorService.name, () => {
       expect(appErr.message).toBe("Failed to create deployment: Unit price exceeds the maximum allowed by the network");
     });
 
+    it("returns 400 for account closed error", async () => {
+      const { service } = setup();
+      const err = new Error(
+        "Query failed with (6): rpc error: code = Unknown desc = failed to execute message; message index: 0: account closed [cosmos/cosmos-sdk@v0.53.6/baseapp/baseapp.go:1052] with gas used: '34881': unknown request"
+      );
+
+      const appErr = await service.toAppError(err, encodeMessages);
+      expect(appErr).toBeInstanceOf(BadRequest);
+      expect(appErr.message).toBe("Deployment closed");
+    });
+
     it("returns 402 for insufficient balance error", async () => {
       const { service } = setup();
       const err = new Error(
@@ -248,6 +259,24 @@ describe(ChainErrorService.name, () => {
 
       const appErr = await service.toAppError(err, encodeMessages);
       expect(appErr).toBe(err);
+    });
+  });
+
+  describe("isDeploymentClosedError", () => {
+    it("returns true for a raw chain account closed message", () => {
+      const { service } = setup();
+      const err = new Error("Query failed with (6): rpc error: code = Unknown desc = failed to execute message; message index: 0: account closed");
+      expect(service.isDeploymentClosedError(err)).toBe(true);
+    });
+
+    it("returns true for a mapped Deployment closed message", () => {
+      const { service } = setup();
+      expect(service.isDeploymentClosedError(new Error("Deployment closed"))).toBe(true);
+    });
+
+    it("returns false for unrelated errors", () => {
+      const { service } = setup();
+      expect(service.isDeploymentClosedError(new Error("insufficient funds: 10uakt is smaller than 20uakt"))).toBe(false);
     });
   });
 

--- a/apps/api/src/billing/services/chain-error/chain-error.service.ts
+++ b/apps/api/src/billing/services/chain-error/chain-error.service.ts
@@ -22,6 +22,10 @@ export class ChainErrorService {
       code: 400,
       message: "Deployment closed"
     },
+    "account closed": {
+      code: 400,
+      message: "Deployment closed"
+    },
     "invalid coin denominations": {
       code: 400,
       message: "Invalid coin denominations"
@@ -110,6 +114,10 @@ export class ChainErrorService {
 
     const status = cause.response.status;
     return status >= 500 ? status : undefined;
+  }
+
+  public isDeploymentClosedError(error: Error): boolean {
+    return /account closed|deployment closed/i.test(error.message);
   }
 
   public async isMasterWalletInsufficientFundsError(error: Error) {

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
@@ -270,7 +270,6 @@ describe(ManagedSignerService.name, () => {
       const fundCall = vi.mocked(domainEvents.publish).mock.calls.find(([event]) => event instanceof FundDeploymentCommand);
       const [fundCommand, options] = fundCall as [FundDeploymentCommand, { singletonKey: string }];
       expect(fundCommand.data).toEqual({
-        userId: "user-123",
         walletId: wallet.id,
         address: wallet.address,
         dseq: "123"

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
@@ -150,7 +150,6 @@ export class ManagedSignerService {
         const dseq = createLeaseMessage.value.bidId!.dseq.toString();
         await this.domainEvents.publish(
           new FundDeploymentCommand({
-            userId: userWallet.userId,
             walletId: userWallet.id,
             address: userWallet.address!,
             dseq

--- a/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.spec.ts
+++ b/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.spec.ts
@@ -5,6 +5,7 @@ import type { UserWalletRepository } from "@src/billing/repositories";
 import type { RpcMessageService } from "@src/billing/services";
 import type { BalancesService } from "@src/billing/services/balances/balances.service";
 import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
+import type { ChainErrorService } from "@src/billing/services/chain-error/chain-error.service";
 import type { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
 import type { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
 import type { BlockHttpService } from "@src/chain/services/block-http/block-http.service";
@@ -82,6 +83,48 @@ describe(InitialDeploymentFundingService.name, () => {
 
     expect(walletReloadJobService.scheduleImmediate).not.toHaveBeenCalled();
     expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "INITIAL_FUNDING_TX_FAILED", code: 5, txHash: "TESTHASH" }));
+  });
+
+  it("skips terminally when the deposit is rejected because the deployment escrow is closed", async () => {
+    const { service, drainingDeploymentService, balancesService, managedSignerService, chainErrorService, walletReloadJobService, logger } = setup();
+    drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
+    drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(500000);
+    balancesService.getFreshLimits.mockResolvedValue({ fee: 100000, deployment: 1000000 });
+    managedSignerService.executeDerivedTx.mockRejectedValue(new Error("Deployment closed"));
+    chainErrorService.isDeploymentClosedError.mockReturnValue(true);
+
+    await service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" });
+
+    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "INITIAL_FUNDING_SKIPPED", reason: "DEPLOYMENT_CLOSED" }));
+    expect(walletReloadJobService.scheduleImmediate).not.toHaveBeenCalled();
+  });
+
+  it("rethrows deposit errors unrelated to a closed deployment", async () => {
+    const { service, drainingDeploymentService, balancesService, managedSignerService, walletReloadJobService, logger } = setup();
+    drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
+    drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(500000);
+    balancesService.getFreshLimits.mockResolvedValue({ fee: 100000, deployment: 1000000 });
+    managedSignerService.executeDerivedTx.mockRejectedValue(new Error("Bad status on response: 503"));
+
+    await expect(service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" })).rejects.toThrow("Bad status on response: 503");
+
+    expect(logger.info).not.toHaveBeenCalledWith(expect.objectContaining({ event: "INITIAL_FUNDING_SKIPPED" }));
+    expect(walletReloadJobService.scheduleImmediate).not.toHaveBeenCalled();
+  });
+
+  it("skips terminally when the deposit tx lands with a closed account in the raw log", async () => {
+    const { service, drainingDeploymentService, balancesService, managedSignerService, chainErrorService, walletReloadJobService, logger } = setup();
+    drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
+    drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(500000);
+    balancesService.getFreshLimits.mockResolvedValue({ fee: 100000, deployment: 1000000 });
+    managedSignerService.executeDerivedTx.mockResolvedValue({ code: 5, hash: "TESTHASH", rawLog: "account closed" });
+    chainErrorService.isDeploymentClosedError.mockReturnValue(true);
+
+    await service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" });
+
+    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "INITIAL_FUNDING_SKIPPED", reason: "DEPLOYMENT_CLOSED", txHash: "TESTHASH" }));
+    expect(logger.error).not.toHaveBeenCalledWith(expect.objectContaining({ event: "INITIAL_FUNDING_TX_FAILED" }));
+    expect(walletReloadJobService.scheduleImmediate).not.toHaveBeenCalled();
   });
 
   it("falls back to a descriptive error when the failed deposit tx has no raw log", async () => {
@@ -166,6 +209,7 @@ describe(InitialDeploymentFundingService.name, () => {
     const billingConfig = mockConfigService<BillingConfigService>({ DEPLOYMENT_GRANT_DENOM: "uakt" });
     const deploymentConfig = mockConfigService<DeploymentConfigService>({ AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H: 24 });
     const walletReloadJobService = mock<WalletReloadJobService>();
+    const chainErrorService = mock<ChainErrorService>();
     const logger = mock<ReturnType<CreateLogger>>();
     const createLogger: CreateLogger = () => logger;
 
@@ -173,6 +217,7 @@ describe(InitialDeploymentFundingService.name, () => {
     userWalletRepository.findById.mockResolvedValue(createUserWallet({ id: 1, address: "akash1owner" }));
     managedSignerService.ensureFeeGrants.mockResolvedValue(100000);
     managedSignerService.executeDerivedTx.mockResolvedValue({ code: 0, hash: "TESTHASH", rawLog: "[]" });
+    chainErrorService.isDeploymentClosedError.mockReturnValue(false);
 
     const service = new InitialDeploymentFundingService(
       blockHttpService,
@@ -184,6 +229,7 @@ describe(InitialDeploymentFundingService.name, () => {
       billingConfig,
       deploymentConfig,
       walletReloadJobService,
+      chainErrorService,
       createLogger
     );
 
@@ -196,6 +242,7 @@ describe(InitialDeploymentFundingService.name, () => {
       managedSignerService,
       userWalletRepository,
       walletReloadJobService,
+      chainErrorService,
       logger
     };
   }

--- a/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.ts
+++ b/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.ts
@@ -52,7 +52,6 @@ export class InitialDeploymentFundingService {
    * Every other early exit is terminal: the hourly cron remains the safety net.
    */
   async fundOnLeaseStarted({ walletId, address, dseq }: FundOnLeaseStartedInput): Promise<void> {
-    const currentHeight = await this.blockHttpService.getCurrentHeight();
     const [deployment] = await this.drainingDeploymentService.findLeases(Number.MAX_SAFE_INTEGER, address, [dseq]);
 
     if (!deployment) {
@@ -64,6 +63,7 @@ export class InitialDeploymentFundingService {
       return;
     }
 
+    const currentHeight = await this.blockHttpService.getCurrentHeight();
     const lookAheadHeight = currentHeight + averageBlockCountInAnHour * this.deploymentConfig.get("AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H");
 
     if (deployment.predictedClosedHeight > lookAheadHeight) {

--- a/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.ts
+++ b/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.ts
@@ -4,6 +4,7 @@ import { UserWalletRepository } from "@src/billing/repositories";
 import { RpcMessageService } from "@src/billing/services";
 import { BalancesService } from "@src/billing/services/balances/balances.service";
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
+import { ChainErrorService } from "@src/billing/services/chain-error/chain-error.service";
 import { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
 import { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
 import { BlockHttpService } from "@src/chain/services/block-http/block-http.service";
@@ -37,6 +38,7 @@ export class InitialDeploymentFundingService {
     private readonly billingConfig: BillingConfigService,
     private readonly deploymentConfig: DeploymentConfigService,
     private readonly walletReloadJobService: WalletReloadJobService,
+    private readonly chainErrorService: ChainErrorService,
     @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
     this.logger = createLogger({ context: InitialDeploymentFundingService.name });
@@ -45,6 +47,8 @@ export class InitialDeploymentFundingService {
   /**
    * Throws when the lease is not yet visible over chain REST (indexing lag) or
    * when the deposit tx fails on-chain, so the job queue retries with backoff.
+   * A deposit rejected because the deployment escrow account is already closed
+   * is terminal — retrying against a closed account can never succeed.
    * Every other early exit is terminal: the hourly cron remains the safety net.
    */
   async fundOnLeaseStarted({ walletId, address, dseq }: FundOnLeaseStartedInput): Promise<void> {
@@ -105,11 +109,27 @@ export class InitialDeploymentFundingService {
       signer: address
     });
 
-    const tx = await this.managedSignerService.executeDerivedTx(walletId, [message]);
+    let tx;
+    try {
+      tx = await this.managedSignerService.executeDerivedTx(walletId, [message]);
+    } catch (error) {
+      if (error instanceof Error && this.chainErrorService.isDeploymentClosedError(error)) {
+        this.logger.info({ event: "INITIAL_FUNDING_SKIPPED", reason: "DEPLOYMENT_CLOSED", dseq, address, error: error.message });
+        return;
+      }
+      throw error;
+    }
 
     if (tx.code !== COSMOS_TX_CODE_OK) {
+      const txError = new Error(tx.rawLog || `Deposit tx ${tx.hash} failed on-chain with code ${tx.code}`);
+
+      if (this.chainErrorService.isDeploymentClosedError(txError)) {
+        this.logger.info({ event: "INITIAL_FUNDING_SKIPPED", reason: "DEPLOYMENT_CLOSED", dseq, address, txHash: tx.hash });
+        return;
+      }
+
       this.logger.error({ event: "INITIAL_FUNDING_TX_FAILED", dseq, address, txHash: tx.hash, code: tx.code, rawLog: tx.rawLog });
-      throw new Error(tx.rawLog || `Deposit tx ${tx.hash} failed on-chain with code ${tx.code}`);
+      throw txError;
     }
 
     await this.walletReloadJobService.scheduleImmediate({ walletId });

--- a/apps/tx-signer/src/services/chain-error/chain-error.service.spec.ts
+++ b/apps/tx-signer/src/services/chain-error/chain-error.service.spec.ts
@@ -18,6 +18,15 @@ describe(ChainErrorService.name, () => {
     expect(service.getChainErrorStatus("Deployment closed")).toBe(400);
   });
 
+  it("returns 400 for account closed error", () => {
+    const { service } = setup();
+    expect(
+      service.getChainErrorStatus(
+        "Query failed with (6): rpc error: code = Unknown desc = failed to execute message; message index: 0: account closed [cosmos/cosmos-sdk@v0.53.6/baseapp/baseapp.go:1052] with gas used: '34881': unknown request"
+      )
+    ).toBe(400);
+  });
+
   it("returns 400 for invalid coin denominations error", () => {
     const { service } = setup();
     expect(service.getChainErrorStatus("invalid coin denominations")).toBe(400);

--- a/apps/tx-signer/src/services/chain-error/chain-error.service.ts
+++ b/apps/tx-signer/src/services/chain-error/chain-error.service.ts
@@ -6,6 +6,7 @@ export class ChainErrorService {
     "insufficient funds": 400,
     "deposit too low": 400,
     "deployment closed": 400,
+    "account closed": 400,
     "invalid coin denominations": 400,
     "invalid gpu attributes": 400,
     "invalid: deployment version": 400,


### PR DESCRIPTION
## Why

Related to CON-735

The new initial-funding flow (#3527) produced this production error in tx-signer during gas simulation of the initial deposit:

```
Query failed with (6): rpc error: code = Unknown desc = failed to execute message; message index: 0: account closed
```

The chain's escrow module rejects the deposit because the deployment's escrow account is already closed by the time the async `FundDeploymentCommand` job runs (the user closed the deployment right after creation, the provider closed it, or the small initial deposit fully drained). The pre-check in `fundOnLeaseStarted` can't reliably catch this: it reads a lagging REST snapshot (`lease.closed_on`), and its escrow-balance check counts already-`transferred` funds.

The actual defect is error classification: "account closed" was unmapped in both chain-error services, so a permanently terminal condition surfaced as a 500 and pg-boss retried it 5 times (exp backoff) against the still-closed account. The hourly top-up cron never has this problem because it tolerates per-deployment deposit failures instead of throwing.

## What

- **apps/tx-signer** `ChainErrorService`: map `account closed` → 400 (next to the existing `deployment closed` pattern).
- **apps/api** `ChainErrorService`: add the `account closed` clue (→ 400 "Deployment closed") and a public `isDeploymentClosedError` helper, following the `isMasterWalletInsufficientFundsError` precedent used by the top-up cron.
- **apps/api** `InitialDeploymentFundingService`: a deposit that fails because the deployment is closed is now a terminal skip (`INITIAL_FUNDING_SKIPPED` / `DEPLOYMENT_CLOSED`) on both failure paths — the thrown simulation error and a landed tx with non-zero code. All other errors keep throwing so pg-boss retry still covers transient failures (indexing lag, RPC 5xx).

Side benefit: user-facing deposits into an already-closed deployment now return 400 "Deployment closed" instead of 500.

Deliberately out of scope: a pre-check on `escrow_account.state.state` from chain REST — it reads the same lagging snapshot so it can only shrink the race window, and plumbing it through `RpcDeploymentInfo`/`DrainingDeploymentOutput` touches types shared with the top-up cron. Possible follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of closed deployment/escrow accounts during initial funding by treating them as terminal, non-retryable outcomes.
  * Added robust detection for “account closed” / “deployment closed” conditions and consistent mapping to a “Deployment closed” error.
  * Ensured jobs skip unnecessary follow-up actions (such as wallet reload scheduling) when funding is skipped due to a closed deployment.
  * Updated funding command payloads to omit the user identifier, and aligned related tests accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->