### PR TITLE
fix(analytics): report account_created from the client

### DIFF
--- a/apps/api/src/core/services/analytics/analytics.service.ts
+++ b/apps/api/src/core/services/analytics/analytics.service.ts
@@ -3,7 +3,7 @@ import { inject, singleton } from "tsyringe";
 import { AMPLITUDE, type Amplitude } from "@src/core/providers/amplitude.provider";
 import { LoggerService } from "@src/core/providers/logging.provider";
 
-type AnalyticsEvent = "user_registered" | "account_created" | "balance_top_up" | "balance_refund" | "first_purchase_bonus_granted";
+type AnalyticsEvent = "user_registered" | "balance_top_up" | "balance_refund" | "first_purchase_bonus_granted";
 
 @singleton()
 export class AnalyticsService {

--- a/apps/api/src/user/controllers/user/user.controller.ts
+++ b/apps/api/src/user/controllers/user/user.controller.ts
@@ -26,7 +26,7 @@ export class UserController {
     const { req, env, var: httpVars } = this.httpContext;
     const userId = await this.userAuthTokenService.getValidUserId(req.header("authorization") || "", env);
     assert(userId, 401, "Invalid or expired token");
-    const user = await this.userService.registerUser({
+    const { isNewUser, ...user } = await this.userService.registerUser({
       userId,
       wantedUsername: data.wantedUsername,
       email: data.email,
@@ -36,7 +36,7 @@ export class UserController {
       userAgent: httpVars.clientInfo?.userAgent,
       fingerprint: httpVars.clientInfo?.fingerprint
     });
-    return { data: user };
+    return { data: user, isNewUser };
   }
 
   @Protected([{ action: "read", subject: "User" }])

--- a/apps/api/src/user/routes/register-user/register-user.router.ts
+++ b/apps/api/src/user/routes/register-user/register-user.router.ts
@@ -16,7 +16,8 @@ const registerUserInputSchema = z.object({
 export type RegisterUserInput = z.infer<typeof registerUserInputSchema>;
 
 const registerUserResponseSchema = z.object({
-  data: UserSchema
+  data: UserSchema,
+  isNewUser: z.boolean()
 });
 export type RegisterUserResponse = z.infer<typeof registerUserResponseSchema>;
 

--- a/apps/api/src/user/services/user/user.service.spec.ts
+++ b/apps/api/src/user/services/user/user.service.spec.ts
@@ -59,28 +59,28 @@ describe(UserService.name, () => {
       expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "FAILED_TO_SEND_INITIAL_VERIFICATION_CODE", id: user.id, error: sendError }));
     });
 
-    it("tracks account_created when the user was newly created", async () => {
+    it("returns isNewUser true when the user was newly created", async () => {
       const user = createUser({ emailVerified: true, email: "test@example.com" });
-      const { service, userRepository, analyticsService, notificationService } = setup();
+      const { service, userRepository, notificationService } = setup();
 
       userRepository.upsertOnExternalIdConflict.mockResolvedValue({ user, wasInserted: true });
       notificationService.createDefaultChannel.mockResolvedValue(undefined);
 
-      await service.registerUser(createRegisterInput({ emailVerified: true }));
+      const result = await service.registerUser(createRegisterInput({ emailVerified: true }));
 
-      expect(analyticsService.track).toHaveBeenCalledWith(user.id, "account_created", { category: "user" });
+      expect(result.isNewUser).toBe(true);
     });
 
-    it("does not track account_created when the user already existed", async () => {
+    it("returns isNewUser false when the user already existed", async () => {
       const user = createUser({ emailVerified: true, email: "test@example.com" });
-      const { service, userRepository, analyticsService, notificationService } = setup();
+      const { service, userRepository, notificationService } = setup();
 
       userRepository.upsertOnExternalIdConflict.mockResolvedValue({ user, wasInserted: false });
       notificationService.createDefaultChannel.mockResolvedValue(undefined);
 
-      await service.registerUser(createRegisterInput({ emailVerified: true }));
+      const result = await service.registerUser(createRegisterInput({ emailVerified: true }));
 
-      expect(analyticsService.track).not.toHaveBeenCalled();
+      expect(result.isNewUser).toBe(false);
     });
 
     it("ensures the user has a wallet even when the user already existed", async () => {

--- a/apps/api/src/user/services/user/user.service.ts
+++ b/apps/api/src/user/services/user/user.service.ts
@@ -35,6 +35,7 @@ export class UserService {
     youtubeUsername: string | null;
     twitterUsername: string | null;
     githubUsername: string | null;
+    isNewUser: boolean;
   }> {
     const userDetails = {
       userId: data.userId,
@@ -56,10 +57,6 @@ export class UserService {
       username: user.username,
       email: user.email
     });
-
-    if (wasInserted) {
-      this.analyticsService.track(user.id, "account_created", { category: "user" });
-    }
 
     await this.walletInitializer.ensureWallet(user.id).catch(error => {
       this.logger.error({ event: "FAILED_TO_ENSURE_USER_WALLET", id: user.id, error });
@@ -91,7 +88,8 @@ export class UserService {
       subscribedToNewsletter,
       youtubeUsername,
       twitterUsername,
-      githubUsername
+      githubUsername,
+      isNewUser: wasInserted
     } as Awaited<ReturnType<this["registerUser"]>>;
   }
 

--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -2136,10 +2136,14 @@
                         "emailVerified",
                         "subscribedToNewsletter"
                       ]
+                    },
+                    "isNewUser": {
+                      "type": "boolean"
                     }
                   },
                   "required": [
-                    "data"
+                    "data",
+                    "isNewUser"
                   ]
                 }
               }

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -13264,9 +13264,13 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                       ],
                       "type": "object",
                     },
+                    "isNewUser": {
+                      "type": "boolean",
+                    },
                   },
                   "required": [
                     "data",
+                    "isNewUser",
                   ],
                   "type": "object",
                 },

--- a/apps/deploy-web/src/components/analytics/AccountCreatedTracker/AccountCreatedTracker.spec.tsx
+++ b/apps/deploy-web/src/components/analytics/AccountCreatedTracker/AccountCreatedTracker.spec.tsx
@@ -1,0 +1,57 @@
+import type { NextRouter } from "next/router";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import { ACCOUNT_CREATED_COOKIE } from "@src/lib/analytics/account-created-cookie";
+import type { AnalyticsService } from "@src/services/analytics/analytics.service";
+import type { DEPENDENCIES } from "./AccountCreatedTracker";
+import { AccountCreatedTracker } from "./AccountCreatedTracker";
+
+import { render } from "@testing-library/react";
+
+describe(AccountCreatedTracker.name, () => {
+  it("tracks and flushes account_created when the cookie is present, then clears it", () => {
+    const { analyticsService } = setup({ hasCookie: true });
+
+    expect(analyticsService.track).toHaveBeenCalledWith("account_created", { category: "user" });
+    expect(analyticsService.flush).toHaveBeenCalled();
+    expect(document.cookie).not.toContain(`${ACCOUNT_CREATED_COOKIE}=1`);
+  });
+
+  it("does nothing when the cookie is absent", () => {
+    const { analyticsService } = setup();
+
+    expect(analyticsService.track).not.toHaveBeenCalled();
+    expect(analyticsService.flush).not.toHaveBeenCalled();
+  });
+
+  it("tracks account_created on a client-side route change when the cookie appears after mount", () => {
+    const routeChangeHandlers: Array<() => void> = [];
+    const events = mock<NextRouter["events"]>({
+      on: vi.fn((event, handler) => {
+        if (event === "routeChangeComplete") routeChangeHandlers.push(handler as () => void);
+      })
+    });
+    const { analyticsService } = setup({ router: mock<NextRouter>({ events }) });
+
+    document.cookie = `${ACCOUNT_CREATED_COOKIE}=1`;
+    routeChangeHandlers.forEach(handler => handler());
+
+    expect(analyticsService.track).toHaveBeenCalledWith("account_created", { category: "user" });
+    expect(analyticsService.flush).toHaveBeenCalled();
+  });
+
+  function setup(input: { hasCookie?: boolean; router?: NextRouter } = {}) {
+    document.cookie = `${ACCOUNT_CREATED_COOKIE}=; Path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+    if (input.hasCookie) document.cookie = `${ACCOUNT_CREATED_COOKIE}=1`;
+
+    const analyticsService = mock<AnalyticsService>();
+    const useServices: typeof DEPENDENCIES.useServices = () => mock<ReturnType<typeof DEPENDENCIES.useServices>>({ analyticsService });
+    const router = input.router ?? mock<NextRouter>({ events: mock<NextRouter["events"]>() });
+    const useRouter: typeof DEPENDENCIES.useRouter = () => router;
+
+    render(<AccountCreatedTracker dependencies={{ useServices, useRouter }} />);
+
+    return { analyticsService, router };
+  }
+});

--- a/apps/deploy-web/src/components/analytics/AccountCreatedTracker/AccountCreatedTracker.tsx
+++ b/apps/deploy-web/src/components/analytics/AccountCreatedTracker/AccountCreatedTracker.tsx
@@ -1,0 +1,52 @@
+import { useEffect } from "react";
+import { useRouter } from "next/router";
+
+import { useServices } from "@src/context/ServicesProvider";
+import { ACCOUNT_CREATED_COOKIE } from "@src/lib/analytics/account-created-cookie";
+
+export const DEPENDENCIES = { useServices, useRouter };
+
+type AccountCreatedTrackerProps = {
+  dependencies?: typeof DEPENDENCIES;
+};
+
+/**
+ * Fires `account_created` from the browser once, right after a new account is created. The server auth callbacks hand
+ * off the signal via a one-shot cookie; checked on mount (OAuth full-reload landing) and on route changes (passwordless
+ * client-side nav).
+ */
+export function AccountCreatedTracker({ dependencies: d = DEPENDENCIES }: AccountCreatedTrackerProps = {}) {
+  const { analyticsService } = d.useServices();
+  const router = d.useRouter();
+
+  useEffect(
+    function trackAccountCreatedFromCookie() {
+      function fireWhenNewAccount() {
+        if (!consumeAccountCreatedCookie()) return;
+        analyticsService.track("account_created", { category: "user" });
+        analyticsService.flush();
+      }
+
+      fireWhenNewAccount();
+      router.events?.on("routeChangeComplete", fireWhenNewAccount);
+      return function unsubscribe() {
+        router.events?.off("routeChangeComplete", fireWhenNewAccount);
+      };
+    },
+    [analyticsService, router.events]
+  );
+
+  return null;
+}
+
+/** Reads the one-shot cookie and clears it, returning whether it was set so the event fires exactly once. */
+function consumeAccountCreatedCookie() {
+  if (typeof document === "undefined") return false;
+
+  const isPresent = document.cookie.split("; ").some(entry => entry === `${ACCOUNT_CREATED_COOKIE}=1`);
+  if (isPresent) {
+    document.cookie = `${ACCOUNT_CREATED_COOKIE}=; Path=/; Max-Age=0; SameSite=Lax`;
+  }
+
+  return isPresent;
+}

--- a/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.spec.tsx
+++ b/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.spec.tsx
@@ -343,6 +343,23 @@ describe(OnboardingPickerPage.name, () => {
     expect(analyticsService.track).toHaveBeenCalledWith("onboarding_deploy_click", { category: "onboarding", option: "custom-image" });
   });
 
+  it("flushes the deploy click before redirecting so it survives the navigation", () => {
+    const DeploymentTemplatePickerCard = vi.fn(ComponentMock);
+    const { analyticsService } = setup({ dependencies: { DeploymentTemplatePickerCard } });
+
+    act(() => getCard(DeploymentTemplatePickerCard, "Hello world").onDeploy!());
+
+    expect(analyticsService.flush).toHaveBeenCalled();
+  });
+
+  it("flushes the deploy click when the custom-image Deploy image link is clicked", () => {
+    const { analyticsService } = setup({});
+
+    act(() => fireEvent.click(screen.getByRole("link", { name: /deploy image/i })));
+
+    expect(analyticsService.flush).toHaveBeenCalled();
+  });
+
   it("tracks skipping the trial as an add-credits click", () => {
     const Button = vi.fn(ComponentMock);
     const { analyticsService } = setup({ isTrialing: true, dependencies: { Button: Button as unknown as typeof DEPENDENCIES.Button } });

--- a/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.tsx
+++ b/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.tsx
@@ -77,11 +77,13 @@ export function OnboardingPickerPage({ dependencies: d = DEPENDENCIES }: Onboard
 
   function deployTemplate(templateId: string) {
     analyticsService.track("onboarding_deploy_click", { category: "onboarding", option: templateId });
+    analyticsService.flush();
     redirectToConfigure(templateId);
   }
 
   function trackCustomImageDeploy() {
     analyticsService.track("onboarding_deploy_click", { category: "onboarding", option: "custom-image" });
+    analyticsService.flush();
   }
 
   function openSkipTrialCredits() {

--- a/apps/deploy-web/src/lib/analytics/account-created-cookie.spec.ts
+++ b/apps/deploy-web/src/lib/analytics/account-created-cookie.spec.ts
@@ -1,0 +1,33 @@
+import type { NextApiResponse } from "next";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import { ACCOUNT_CREATED_COOKIE, setAccountCreatedCookie } from "./account-created-cookie";
+
+describe(setAccountCreatedCookie.name, () => {
+  it("sets the one-shot account-created cookie", () => {
+    const { res, setHeader } = setup();
+
+    setAccountCreatedCookie(res);
+
+    expect(setHeader).toHaveBeenCalledWith("Set-Cookie", [expect.stringContaining(`${ACCOUNT_CREATED_COOKIE}=1`)]);
+  });
+
+  it("preserves cookies already set on the response", () => {
+    const existing = "appSession=abc; Path=/";
+    const { res, setHeader } = setup({ existing });
+
+    setAccountCreatedCookie(res);
+
+    expect(setHeader).toHaveBeenCalledWith("Set-Cookie", [existing, expect.stringContaining(`${ACCOUNT_CREATED_COOKIE}=1`)]);
+  });
+
+  function setup(input: { existing?: string | string[] } = {}) {
+    const setHeader = vi.fn();
+    const res = mock<NextApiResponse>({
+      getHeader: vi.fn().mockReturnValue(input.existing),
+      setHeader
+    });
+    return { res, setHeader };
+  }
+});

--- a/apps/deploy-web/src/lib/analytics/account-created-cookie.ts
+++ b/apps/deploy-web/src/lib/analytics/account-created-cookie.ts
@@ -1,0 +1,18 @@
+import type { NextApiResponse } from "next";
+
+/** One-shot, JS-readable cookie the server auth callbacks set right after a brand-new account is created. */
+export const ACCOUNT_CREATED_COOKIE = "account_created";
+
+/** Short-lived: the client reads and clears it on the next load; this only bounds the window if it never does. */
+const COOKIE_OPTIONS = "Path=/; Max-Age=300; SameSite=Lax";
+
+/**
+ * Hands the "a new account was just created" signal from the server auth callbacks to the browser so the client can
+ * emit `account_created` in the user's own session/device context. Appends to any cookies already on the response
+ * (e.g. the session cookie) rather than replacing them.
+ */
+export function setAccountCreatedCookie(res: NextApiResponse): void {
+  const existing = res.getHeader("Set-Cookie");
+  const existingCookies = Array.isArray(existing) ? existing.map(String) : existing ? [String(existing)] : [];
+  res.setHeader("Set-Cookie", [...existingCookies, `${ACCOUNT_CREATED_COOKIE}=1; ${COOKIE_OPTIONS}`]);
+}

--- a/apps/deploy-web/src/lib/nextjs/api-routes-specs/auth-email-code-verify.spec.ts
+++ b/apps/deploy-web/src/lib/nextjs/api-routes-specs/auth-email-code-verify.spec.ts
@@ -4,6 +4,7 @@ import { Err, Ok } from "ts-results";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
+import { ACCOUNT_CREATED_COOKIE } from "@src/lib/analytics/account-created-cookie";
 import { Session } from "@src/lib/auth0";
 import type { NextApiRequestWithServices } from "@src/lib/nextjs/defineApiHandler/defineApiHandler";
 import { REQ_SERVICES_KEY } from "@src/lib/nextjs/defineApiHandler/defineApiHandler";
@@ -24,6 +25,28 @@ describe("POST /api/auth/email-code-verify", () => {
     expect(setSession).toHaveBeenCalled();
     expect(sessionService.createLocalUser.mock.invocationCallOrder[0]).toBeLessThan(setSession.mock.invocationCallOrder[0]);
     expect(res.status).toHaveBeenCalledWith(204);
+  });
+
+  it("sets the account-created cookie when the user is newly created", async () => {
+    const session = Object.assign(new Session({ sub: "auth0|email|abc", email: "user@example.com" }), { accessToken: "at" });
+    const { res } = await callHandler({
+      body: { email: "user@example.com", code: "123456", captchaToken: "tok" },
+      verifyResult: Ok(session),
+      isNewUser: true
+    });
+
+    expect(res.setHeader).toHaveBeenCalledWith("Set-Cookie", [expect.stringContaining(`${ACCOUNT_CREATED_COOKIE}=1`)]);
+  });
+
+  it("does not set the account-created cookie for an existing user", async () => {
+    const session = Object.assign(new Session({ sub: "auth0|email|abc", email: "user@example.com" }), { accessToken: "at" });
+    const { res } = await callHandler({
+      body: { email: "user@example.com", code: "123456", captchaToken: "tok" },
+      verifyResult: Ok(session),
+      isNewUser: false
+    });
+
+    expect(res.setHeader).not.toHaveBeenCalledWith("Set-Cookie", expect.anything());
   });
 
   it("does not set the session if createLocalUser throws", async () => {
@@ -74,6 +97,7 @@ describe("POST /api/auth/email-code-verify", () => {
     body: object;
     verifyResult?: Awaited<ReturnType<SessionService["verifyEmailCode"]>>;
     createLocalUserError?: Error;
+    isNewUser?: boolean;
     expectThrow?: boolean;
   }) {
     const sessionService = mock<SessionService>();
@@ -83,7 +107,7 @@ describe("POST /api/auth/email-code-verify", () => {
     if (input.createLocalUserError) {
       sessionService.createLocalUser.mockRejectedValue(input.createLocalUserError);
     } else {
-      sessionService.createLocalUser.mockResolvedValue({ username: "user", subscribedToNewsletter: false });
+      sessionService.createLocalUser.mockResolvedValue({ userSettings: { username: "user", subscribedToNewsletter: false }, isNewUser: input.isNewUser ?? false });
     }
 
     const logger = mock<LoggerService>();

--- a/apps/deploy-web/src/pages/_app.tsx
+++ b/apps/deploy-web/src/pages/_app.tsx
@@ -18,6 +18,7 @@ import type { NextSeoProps } from "next-seo/lib/types";
 import { ThemeProvider } from "next-themes";
 import NProgress from "nprogress";
 
+import { AccountCreatedTracker } from "@src/components/analytics/AccountCreatedTracker/AccountCreatedTracker";
 import { RequireAuth } from "@src/components/auth/RequireAuth/RequireAuth";
 import { CustomIntlProvider } from "@src/components/layout/CustomIntlProvider";
 import { PageHead } from "@src/components/layout/PageHead";
@@ -54,6 +55,7 @@ const App: React.FunctionComponent<Props> = props => {
     <AppRoot {...props}>
       <>
         <UserProviders>
+          <AccountCreatedTracker />
           <RequireAuth isPublic={isPublic}>
             <FlagProvider>
               <WalletProvider>

--- a/apps/deploy-web/src/pages/api/auth/[...auth0].ts
+++ b/apps/deploy-web/src/pages/api/auth/[...auth0].ts
@@ -4,6 +4,7 @@ import { isAxiosError } from "axios";
 import { once } from "lodash";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { setAccountCreatedCookie } from "@src/lib/analytics/account-created-cookie";
 import type { Session } from "@src/lib/auth0";
 import { CallbackHandlerError, IdentityProviderError, MissingStateCookieError } from "@src/lib/auth0";
 import { handleAuth, handleCallback, handleLogin, handleLogout } from "@src/lib/auth0";
@@ -42,8 +43,9 @@ const authHandler = once((services: AppServices) =>
         await handleCallback(req, res, {
           afterCallback: async (req: NextApiRequest, res: NextApiResponse, session: Session) => {
             try {
-              const userSettings = await services.sessionService.createLocalUser(session);
+              const { userSettings, isNewUser } = await services.sessionService.createLocalUser(session);
               session.user = { ...session.user, ...userSettings };
+              if (isNewUser) setAccountCreatedCookie(res);
             } catch (error) {
               services.errorHandler.reportError({ error, tags: { category: "auth0" } });
             }

--- a/apps/deploy-web/src/pages/api/auth/email-code-verify.ts
+++ b/apps/deploy-web/src/pages/api/auth/email-code-verify.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import { setAccountCreatedCookie } from "@src/lib/analytics/account-created-cookie";
 import { defineApiHandler } from "@src/lib/nextjs/defineApiHandler/defineApiHandler";
 import { verifyCaptcha } from "@src/middleware/verify-captcha/verify-captcha";
 
@@ -22,8 +23,9 @@ export default defineApiHandler({
     const result = await services.sessionService.verifyEmailCode({ email: body.email, code: body.code });
 
     if (result.ok) {
-      await services.sessionService.createLocalUser(result.val);
+      const { isNewUser } = await services.sessionService.createLocalUser(result.val);
       await services.setSession(req, res, result.val);
+      if (isNewUser) setAccountCreatedCookie(res);
       res.status(204).end();
       return;
     }

--- a/apps/deploy-web/src/services/analytics/analytics.service.spec.ts
+++ b/apps/deploy-web/src/services/analytics/analytics.service.spec.ts
@@ -215,6 +215,38 @@ describe(AnalyticsService.name, () => {
     });
   });
 
+  describe("flush", () => {
+    it("sends queued events immediately when Amplitude is enabled", () => {
+      const flush = vi.fn();
+      const service = setup({
+        amplitude: { flush },
+        options: {
+          amplitude: { enabled: true, apiKey: mockAmplitudeApiKey },
+          ga: { enabled: false, measurementId: mockGaMeasurementId }
+        }
+      });
+
+      service.flush();
+
+      expect(flush).toHaveBeenCalled();
+    });
+
+    it("does not flush when Amplitude is disabled", () => {
+      const flush = vi.fn();
+      const service = setup({
+        amplitude: { flush },
+        options: {
+          amplitude: { enabled: false, apiKey: mockAmplitudeApiKey },
+          ga: { enabled: false, measurementId: mockGaMeasurementId }
+        }
+      });
+
+      service.flush();
+
+      expect(flush).not.toHaveBeenCalled();
+    });
+  });
+
   function setup(params: {
     amplitude?: Mocked<Amplitude>;
     dataLayer?: Record<string, unknown>[];
@@ -230,6 +262,7 @@ describe(AnalyticsService.name, () => {
       track: vi.fn(),
       setUserId: vi.fn(),
       add: vi.fn(),
+      flush: vi.fn(),
       ...(params.amplitude ?? {})
     };
     const storage = params.storage ?? {

--- a/apps/deploy-web/src/services/analytics/analytics.service.ts
+++ b/apps/deploy-web/src/services/analytics/analytics.service.ts
@@ -73,6 +73,7 @@ export type AnalyticsEvent =
   | "user_profile_template_tab"
   | "user_settings_save"
   | "anonymous_user_created"
+  | "account_created"
   | "trial_started"
   | "trial_completed"
   | "create_api_key"
@@ -147,7 +148,7 @@ const AMPLITUDE_USER_PROPERTIES_MAP = {
 
 const isBrowser = typeof window !== "undefined";
 
-export type Amplitude = Pick<typeof amplitude, "init" | "Identify" | "identify" | "track" | "setUserId" | "add">;
+export type Amplitude = Pick<typeof amplitude, "init" | "Identify" | "identify" | "track" | "setUserId" | "add" | "flush">;
 
 export class AnalyticsService {
   private readonly STORAGE_KEY = "analytics_values_cache";
@@ -262,6 +263,14 @@ export class AnalyticsService {
       const [name, props] = this.transformGaEvent(eventName, eventProperties);
       this.getDataLayer()?.push({ ...props, event: name });
     }
+  }
+
+  flush(): void {
+    if (!isBrowser || !this.isAmplitudeEnabled) {
+      return;
+    }
+
+    this.amplitudeClient.flush();
   }
 
   private transformGaEvent(eventName: AnalyticsEvent, eventProperties: EventProperties): [string, Record<string, unknown>] {

--- a/apps/deploy-web/src/services/session/session.service.spec.ts
+++ b/apps/deploy-web/src/services/session/session.service.spec.ts
@@ -286,7 +286,7 @@ describe(SessionService.name, () => {
       };
 
       const { service, consoleApiHttpClient } = setup();
-      consoleApiHttpClient.post.mockResolvedValueOnce({ data: { data: expectedSettings } });
+      consoleApiHttpClient.post.mockResolvedValueOnce({ data: { data: expectedSettings, isNewUser: true } });
 
       const result = await service.createLocalUser(session);
 
@@ -302,7 +302,7 @@ describe(SessionService.name, () => {
           headers: { Authorization: "Bearer local-access-token" }
         }
       );
-      expect(result).toEqual(expectedSettings);
+      expect(result).toEqual({ userSettings: expectedSettings, isNewUser: true });
     });
   });
 

--- a/apps/deploy-web/src/services/session/session.service.ts
+++ b/apps/deploy-web/src/services/session/session.service.ts
@@ -109,7 +109,7 @@ export class SessionService {
 
     if (result.ok) {
       const session = result.val;
-      const userSettings = await this.createLocalUser(result.val);
+      const { userSettings } = await this.createLocalUser(result.val);
       session.user = { ...session.user, nickname: userSettings.username };
       return Ok(session);
     }
@@ -132,13 +132,13 @@ export class SessionService {
   /**
    * This method calls idempotent API call to create a local user in the database.
    */
-  async createLocalUser(session: Session): Promise<UserSettings> {
+  async createLocalUser(session: Session): Promise<{ userSettings: UserSettings; isNewUser: boolean }> {
     const user_metadata = session.user["https://console.akash.network/user_metadata"];
     const headers: Record<string, string> = {
       Authorization: `Bearer ${session.accessToken}`
     };
 
-    const userSettings = await this.#consoleApiHttpClient.post<{ data: UserSettings }>(
+    const response = await this.#consoleApiHttpClient.post<{ data: UserSettings; isNewUser: boolean }>(
       "/v1/register-user",
       {
         wantedUsername: session.user.nickname,
@@ -151,7 +151,7 @@ export class SessionService {
       }
     );
 
-    return userSettings.data.data;
+    return { userSettings: response.data.data, isNewUser: response.data.isNewUser };
   }
 
   async getLocalUserDetails(session: Session): Promise<UserSettings> {


### PR DESCRIPTION
## Why

`account_created` was the only onboarding-funnel event emitted from the **backend** (on user registration), while `trial_started`, `onboarding_deploy_click`, and the rest fire from the **browser**. Because the two sources never shared a clock, device id, or session, Amplitude stitched them together inconsistently — events showed up out of order and the very first funnel step (`account_created → trial_started`) reported inflated drop-off even though nothing was actually dropping off there.

## What

- **Report `account_created` from the client.** `POST /v1/register-user` now returns `isNewUser` (from the repository's `wasInserted`); the server-side emission is removed, so the event has a single source.
- **Hand the signal to the browser.** The OAuth (`[...auth0]`) and passwordless (`email-code-verify`) auth callbacks set a short-lived, one-shot cookie when `isNewUser` is true.
- **Fire it once, in the user's own session.** A mounted `AccountCreatedTracker` consumes the cookie — on mount for full-reload landings (OAuth) and on `routeChangeComplete` for client-side ones (passwordless) — emits `account_created` with the browser's device id/session, and clears the cookie.
- **Flush high-value click events before navigation.** The onboarding deploy CTA now flushes the Amplitude queue right after tracking, so the click event isn't lost to the batch window when the page transitions.

The `register-user` response change is additive (a new `isNewUser` field), so it's backward-compatible — no breaking production contract.

Out of scope: `onboarding_account_created` (a separate onboarding-flow event) and the password-signup path (not an active signup method) are left untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Registration responses now include an `isNewUser` boolean.
  * Added “account created” analytics tracking driven by a one-time cookie during signup.
  * Introduced analytics flushing around key navigation/actions to improve event delivery.
* **Bug Fixes**
  * Prevented “account created” analytics from being emitted when the user already existed.
  * Improved analytics timing across authentication callbacks and onboarding redirects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->