### PR TITLE
feat(billing): add fixed-threshold auto top-up API behind a feature flag

### DIFF
--- a/apps/api/drizzle/0035_cheerful_electro.sql
+++ b/apps/api/drizzle/0035_cheerful_electro.sql
@@ -1,2 +1,2 @@
-ALTER TABLE "wallet_settings" ADD COLUMN "auto_reload_threshold" numeric(20, 2) DEFAULT 20 NOT NULL;--> statement-breakpoint
-ALTER TABLE "wallet_settings" ADD COLUMN "auto_reload_amount" numeric(20, 2) DEFAULT 100 NOT NULL;
+ALTER TABLE "wallet_settings" ADD COLUMN "auto_reload_threshold" integer DEFAULT 2000 NOT NULL;--> statement-breakpoint
+ALTER TABLE "wallet_settings" ADD COLUMN "auto_reload_amount" integer DEFAULT 10000 NOT NULL;

--- a/apps/api/drizzle/0035_cheerful_electro.sql
+++ b/apps/api/drizzle/0035_cheerful_electro.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "wallet_settings" ADD COLUMN "auto_reload_threshold" numeric(20, 2) DEFAULT 20 NOT NULL;--> statement-breakpoint
+ALTER TABLE "wallet_settings" ADD COLUMN "auto_reload_amount" numeric(20, 2) DEFAULT 100 NOT NULL;

--- a/apps/api/drizzle/meta/0035_snapshot.json
+++ b/apps/api/drizzle/meta/0035_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "3d1e508c-8c34-431c-aa00-d12c0087f6f8",
+  "id": "c956c0bc-db50-48a0-970c-7a2e9f1630d9",
   "prevId": "15befea9-f731-44fd-8390-2236155dc978",
   "version": "7",
   "dialect": "postgresql",
@@ -666,17 +666,17 @@
         },
         "auto_reload_threshold": {
           "name": "auto_reload_threshold",
-          "type": "numeric(20, 2)",
+          "type": "integer",
           "primaryKey": false,
           "notNull": true,
-          "default": 20
+          "default": 2000
         },
         "auto_reload_amount": {
           "name": "auto_reload_amount",
-          "type": "numeric(20, 2)",
+          "type": "integer",
           "primaryKey": false,
           "notNull": true,
-          "default": 100
+          "default": 10000
         },
         "created_at": {
           "name": "created_at",

--- a/apps/api/drizzle/meta/0035_snapshot.json
+++ b/apps/api/drizzle/meta/0035_snapshot.json
@@ -1,0 +1,1381 @@
+{
+  "id": "3d1e508c-8c34-431c-aa00-d12c0087f6f8",
+  "prevId": "15befea9-f731-44fd-8390-2236155dc978",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.user_wallets": {
+      "name": "user_wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_allowance": {
+          "name": "deployment_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "fee_allowance": {
+          "name": "fee_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "trial": {
+          "name": "trial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_wallets_user_id_userSetting_id_fk": {
+          "name": "user_wallets_user_id_userSetting_id_fk",
+          "tableFrom": "user_wallets",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_wallets_user_id_unique": {
+          "name": "user_wallets_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "user_wallets_address_unique": {
+          "name": "user_wallets_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_methods": {
+      "name": "payment_methods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_method_id": {
+          "name": "payment_method_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_validated": {
+          "name": "is_validated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payment_methods_fingerprint_payment_method_id_unique": {
+          "name": "payment_methods_fingerprint_payment_method_id_unique",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_default_unique": {
+          "name": "payment_methods_user_id_is_default_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"payment_methods\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_fingerprint_idx": {
+          "name": "payment_methods_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_idx": {
+          "name": "payment_methods_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_validated_idx": {
+          "name": "payment_methods_user_id_is_validated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_validated",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_fingerprint_payment_method_id_idx": {
+          "name": "payment_methods_user_id_fingerprint_payment_method_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_methods_user_id_userSetting_id_fk": {
+          "name": "payment_methods_user_id_userSetting_id_fk",
+          "tableFrom": "payment_methods",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_transactions": {
+      "name": "stripe_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "stripe_transaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "stripe_transaction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created'"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_refunded": {
+          "name": "amount_refunded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bonus_amount": {
+          "name": "bonus_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_charge_id": {
+          "name": "stripe_charge_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_coupon_id": {
+          "name": "stripe_coupon_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_promotion_code_id": {
+          "name": "stripe_promotion_code_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_idempotency_key": {
+          "name": "stripe_idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method_type": {
+          "name": "payment_method_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_brand": {
+          "name": "card_brand",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_last4": {
+          "name": "card_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_url": {
+          "name": "receipt_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_transactions_stripe_invoice_id_unique": {
+          "name": "stripe_transactions_stripe_invoice_id_unique",
+          "columns": [
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stripe_transactions\".\"stripe_invoice_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_idempotency_key_unique": {
+          "name": "stripe_transactions_stripe_idempotency_key_unique",
+          "columns": [
+            {
+              "expression": "stripe_idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stripe_transactions\".\"stripe_idempotency_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_user_id_idx": {
+          "name": "stripe_transactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_payment_intent_id_idx": {
+          "name": "stripe_transactions_stripe_payment_intent_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_payment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_charge_id_idx": {
+          "name": "stripe_transactions_stripe_charge_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_coupon_id_idx": {
+          "name": "stripe_transactions_stripe_coupon_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_coupon_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_promotion_code_id_idx": {
+          "name": "stripe_transactions_stripe_promotion_code_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_promotion_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_status_idx": {
+          "name": "stripe_transactions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_created_at_idx": {
+          "name": "stripe_transactions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_user_id_created_at_idx": {
+          "name": "stripe_transactions_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_transactions_user_id_userSetting_id_fk": {
+          "name": "stripe_transactions_user_id_userSetting_id_fk",
+          "tableFrom": "stripe_transactions",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_settings": {
+      "name": "wallet_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_reload_enabled": {
+          "name": "auto_reload_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_reload_threshold": {
+          "name": "auto_reload_threshold",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20
+        },
+        "auto_reload_amount": {
+          "name": "auto_reload_amount",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_settings_user_id_idx": {
+          "name": "wallet_settings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_settings_wallet_id_user_wallets_id_fk": {
+          "name": "wallet_settings_wallet_id_user_wallets_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "user_wallets",
+          "columnsFrom": [
+            "wallet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wallet_settings_user_id_userSetting_id_fk": {
+          "name": "wallet_settings_user_id_userSetting_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallet_settings_wallet_id_unique": {
+          "name": "wallet_settings_wallet_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wallet_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.userSetting": {
+      "name": "userSetting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscribedToNewsletter": {
+          "name": "subscribedToNewsletter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "youtubeUsername": {
+          "name": "youtubeUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitterUsername": {
+          "name": "twitterUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "githubUsername": {
+          "name": "githubUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_ip": {
+          "name": "last_ip",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_user_agent": {
+          "name": "last_user_agent",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fingerprint": {
+          "name": "last_fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboardingSkippedAt": {
+          "name": "onboardingSkippedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "userSetting_userId_unique": {
+          "name": "userSetting_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        },
+        "userSetting_username_unique": {
+          "name": "userSetting_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.template": {
+      "name": "template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "copiedFromId": {
+          "name": "copiedFromId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cpu": {
+          "name": "cpu",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ram": {
+          "name": "ram",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage": {
+          "name": "storage",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sdl": {
+          "name": "sdl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "template_userId_idx": {
+          "name": "template_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.templateFavorite": {
+      "name": "templateFavorite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "templateId": {
+          "name": "templateId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addedDate": {
+          "name": "addedDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "templateFavorite_userId_templateId_unique": {
+          "name": "templateFavorite_userId_templateId_unique",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "templateId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "templateFavorite_templateId_template_id_fk": {
+          "name": "templateFavorite_templateId_template_id_fk",
+          "tableFrom": "templateFavorite",
+          "tableTo": "template",
+          "columnsFrom": [
+            "templateId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_settings": {
+      "name": "deployment_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dseq": {
+          "name": "dseq",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_top_up_enabled": {
+          "name": "auto_top_up_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "closed": {
+          "name": "closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "id_auto_top_up_enabled_closed_idx": {
+          "name": "id_auto_top_up_enabled_closed_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auto_top_up_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "closed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_settings_user_id_userSetting_id_fk": {
+          "name": "deployment_settings_user_id_userSetting_id_fk",
+          "tableFrom": "deployment_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dseq_user_id_idx": {
+          "name": "dseq_user_id_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "dseq",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_key": {
+          "name": "hashed_key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_format": {
+          "name": "key_format",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_user_id_userSetting_id_fk": {
+          "name": "api_keys_user_id_userSetting_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_hashed_key_unique": {
+          "name": "api_keys_hashed_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hashed_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_verification_codes": {
+      "name": "email_verification_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_verification_codes_user_id_idx": {
+          "name": "email_verification_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_verification_codes_user_id_userSetting_id_fk": {
+          "name": "email_verification_codes_user_id_userSetting_id_fk",
+          "tableFrom": "email_verification_codes",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.stripe_transaction_status": {
+      "name": "stripe_transaction_status",
+      "schema": "public",
+      "values": [
+        "created",
+        "pending",
+        "requires_action",
+        "succeeded",
+        "failed",
+        "refunded",
+        "canceled"
+      ]
+    },
+    "public.stripe_transaction_type": {
+      "name": "stripe_transaction_type",
+      "schema": "public",
+      "values": [
+        "payment_intent",
+        "coupon_claim",
+        "manual_credit"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -250,7 +250,7 @@
     {
       "idx": 35,
       "version": "7",
-      "when": 1785882988708,
+      "when": 1785917316638,
       "tag": "0035_cheerful_electro",
       "breakpoints": true
     }

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -246,6 +246,13 @@
       "when": 1785154240079,
       "tag": "0034_add_onboarding_skipped_at",
       "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "7",
+      "when": 1785882988708,
+      "tag": "0035_cheerful_electro",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/billing/config/index.ts
+++ b/apps/api/src/billing/config/index.ts
@@ -3,3 +3,5 @@ import { USDC_IBC_DENOMS } from "./network.config";
 export const appConfig = {
   USDC_IBC_DENOMS
 };
+
+export { STANDARD_TOP_UP_MIN_AMOUNT_USD } from "./top-up.config";

--- a/apps/api/src/billing/config/top-up.config.ts
+++ b/apps/api/src/billing/config/top-up.config.ts
@@ -1,0 +1,2 @@
+/** Minimum USD amount accepted by a standard (non-trial) paid top-up, shared by trial validation, wallet-settings input validation, and the auto-reload charge clamp. */
+export const STANDARD_TOP_UP_MIN_AMOUNT_USD = 20;

--- a/apps/api/src/billing/controllers/wallet-settings/wallet-settings.controller.spec.ts
+++ b/apps/api/src/billing/controllers/wallet-settings/wallet-settings.controller.spec.ts
@@ -50,6 +50,25 @@ describe(WalletSettingController.name, () => {
         autoReloadEnabled: true
       });
     });
+
+    it("passes threshold and amount through to the service", async () => {
+      const { user, walletSettingService, controller, walletSetting } = setup();
+      walletSettingService.upsertWalletSetting.mockResolvedValue(walletSetting);
+
+      await controller.createWalletSettings({
+        data: {
+          autoReloadEnabled: true,
+          autoReloadThreshold: 25,
+          autoReloadAmount: 150
+        }
+      });
+
+      expect(walletSettingService.upsertWalletSetting).toHaveBeenCalledWith(user.id, {
+        autoReloadEnabled: true,
+        autoReloadThreshold: 25,
+        autoReloadAmount: 150
+      });
+    });
   });
 
   describe("updateWalletSettings", () => {

--- a/apps/api/src/billing/http-schemas/wallet.schema.ts
+++ b/apps/api/src/billing/http-schemas/wallet.schema.ts
@@ -1,5 +1,13 @@
 import { z } from "@hono/zod-openapi";
 
+import { STANDARD_TOP_UP_MIN_AMOUNT_USD } from "@src/billing/config";
+
+const AUTO_RELOAD_THRESHOLD_MIN_USD = 5;
+
+/** Upper bounds keep oversized input from overflowing the numeric(20, 2) columns (a 500) or being charged verbatim to the card. */
+const AUTO_RELOAD_THRESHOLD_MAX_USD = 10_000;
+const AUTO_RELOAD_AMOUNT_MAX_USD = 10_000;
+
 const WalletOutputSchema = z.object({
   id: z.number().nullable().openapi({}),
   userId: z.string().nullable().openapi({}),
@@ -40,20 +48,44 @@ export const StartTrialRequestInputSchema = z.object({
   })
 });
 
-export const WalletSettingsSchema = z.object({
-  autoReloadEnabled: z.boolean().openapi({})
+export const WalletSettingsOutputSchema = z.object({
+  autoReloadEnabled: z.boolean().openapi({}),
+  autoReloadThreshold: z.number().openapi({ description: "USD credit balance at or below which an automatic top-up is triggered." }),
+  autoReloadAmount: z.number().openapi({ description: "USD amount charged to the default payment method on each automatic top-up." })
+});
+
+export const WalletSettingsInputSchema = z.object({
+  autoReloadEnabled: z.boolean().openapi({}),
+  autoReloadThreshold: z
+    .number()
+    .min(AUTO_RELOAD_THRESHOLD_MIN_USD)
+    .max(AUTO_RELOAD_THRESHOLD_MAX_USD)
+    .multipleOf(0.01)
+    .optional()
+    .openapi({
+      description: `USD credit balance at or below which an automatic top-up is triggered (minimum ${AUTO_RELOAD_THRESHOLD_MIN_USD}, maximum ${AUTO_RELOAD_THRESHOLD_MAX_USD}). Defaults are applied on create when omitted.`
+    }),
+  autoReloadAmount: z
+    .number()
+    .min(STANDARD_TOP_UP_MIN_AMOUNT_USD)
+    .max(AUTO_RELOAD_AMOUNT_MAX_USD)
+    .multipleOf(0.01)
+    .optional()
+    .openapi({
+      description: `USD amount charged on each automatic top-up (minimum ${STANDARD_TOP_UP_MIN_AMOUNT_USD}, maximum ${AUTO_RELOAD_AMOUNT_MAX_USD}). Defaults are applied on create when omitted.`
+    })
 });
 
 export const WalletSettingsResponseSchema = z.object({
-  data: WalletSettingsSchema
+  data: WalletSettingsOutputSchema
 });
 
 export const CreateWalletSettingsRequestSchema = z.object({
-  data: WalletSettingsSchema
+  data: WalletSettingsInputSchema
 });
 
 export const UpdateWalletSettingsRequestSchema = z.object({
-  data: WalletSettingsSchema
+  data: WalletSettingsInputSchema
 });
 
 export type StartTrialRequestInput = z.infer<typeof StartTrialRequestInputSchema>;

--- a/apps/api/src/billing/http-schemas/wallet.schema.ts
+++ b/apps/api/src/billing/http-schemas/wallet.schema.ts
@@ -4,7 +4,7 @@ import { STANDARD_TOP_UP_MIN_AMOUNT_USD } from "@src/billing/config";
 
 const AUTO_RELOAD_THRESHOLD_MIN_USD = 5;
 
-/** Upper bounds keep oversized input from overflowing the numeric(20, 2) columns (a 500) or being charged verbatim to the card. */
+/** Upper bounds stop an oversized value from being charged verbatim to the card. */
 const AUTO_RELOAD_THRESHOLD_MAX_USD = 10_000;
 const AUTO_RELOAD_AMOUNT_MAX_USD = 10_000;
 

--- a/apps/api/src/billing/lib/currency/currency.spec.ts
+++ b/apps/api/src/billing/lib/currency/currency.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { centsToUsd, usdToCents } from "./currency";
+
+describe("currency", () => {
+  describe("usdToCents", () => {
+    it("converts whole dollars to cents", () => {
+      expect(usdToCents(20)).toBe(2000);
+    });
+
+    it("rounds cent-level fractions without float drift", () => {
+      expect(usdToCents(20.01)).toBe(2001);
+      expect(usdToCents(99.99)).toBe(9999);
+    });
+  });
+
+  describe("centsToUsd", () => {
+    it("converts cents back to dollars", () => {
+      expect(centsToUsd(2001)).toBe(20.01);
+    });
+
+    it("round-trips with usdToCents", () => {
+      expect(centsToUsd(usdToCents(150.5))).toBe(150.5);
+    });
+  });
+});

--- a/apps/api/src/billing/lib/currency/currency.ts
+++ b/apps/api/src/billing/lib/currency/currency.ts
@@ -1,0 +1,10 @@
+const CENTS_PER_USD = 100;
+
+/** Wallet-setting amounts are persisted as integer cents; the API and domain layers speak whole USD. */
+export function usdToCents(usd: number): number {
+  return Math.round(usd * CENTS_PER_USD);
+}
+
+export function centsToUsd(cents: number): number {
+  return cents / CENTS_PER_USD;
+}

--- a/apps/api/src/billing/model-schemas/wallet-setting/wallet-setting.schema.ts
+++ b/apps/api/src/billing/model-schemas/wallet-setting/wallet-setting.schema.ts
@@ -1,5 +1,5 @@
 import { relations, sql } from "drizzle-orm";
-import { boolean, index, integer, pgTable, timestamp, unique, uuid } from "drizzle-orm/pg-core";
+import { boolean, index, integer, numeric, pgTable, timestamp, unique, uuid } from "drizzle-orm/pg-core";
 
 import { UserWallets } from "@src/billing/model-schemas/user-wallet/user-wallet.schema";
 import { Users } from "@src/user/model-schemas";
@@ -18,6 +18,8 @@ export const WalletSetting = pgTable(
       .references(() => Users.id, { onDelete: "cascade" })
       .notNull(),
     autoReloadEnabled: boolean("auto_reload_enabled").default(false).notNull(),
+    autoReloadThreshold: numeric("auto_reload_threshold", { precision: 20, scale: 2, mode: "number" }).notNull().default(20),
+    autoReloadAmount: numeric("auto_reload_amount", { precision: 20, scale: 2, mode: "number" }).notNull().default(100),
     createdAt: timestamp("created_at").defaultNow(),
     updatedAt: timestamp("updated_at").defaultNow()
   },

--- a/apps/api/src/billing/model-schemas/wallet-setting/wallet-setting.schema.ts
+++ b/apps/api/src/billing/model-schemas/wallet-setting/wallet-setting.schema.ts
@@ -1,5 +1,5 @@
 import { relations, sql } from "drizzle-orm";
-import { boolean, index, integer, numeric, pgTable, timestamp, unique, uuid } from "drizzle-orm/pg-core";
+import { boolean, index, integer, pgTable, timestamp, unique, uuid } from "drizzle-orm/pg-core";
 
 import { UserWallets } from "@src/billing/model-schemas/user-wallet/user-wallet.schema";
 import { Users } from "@src/user/model-schemas";
@@ -18,8 +18,8 @@ export const WalletSetting = pgTable(
       .references(() => Users.id, { onDelete: "cascade" })
       .notNull(),
     autoReloadEnabled: boolean("auto_reload_enabled").default(false).notNull(),
-    autoReloadThreshold: numeric("auto_reload_threshold", { precision: 20, scale: 2, mode: "number" }).notNull().default(20),
-    autoReloadAmount: numeric("auto_reload_amount", { precision: 20, scale: 2, mode: "number" }).notNull().default(100),
+    autoReloadThreshold: integer("auto_reload_threshold").notNull().default(2000),
+    autoReloadAmount: integer("auto_reload_amount").notNull().default(10000),
     createdAt: timestamp("created_at").defaultNow(),
     updatedAt: timestamp("updated_at").defaultNow()
   },

--- a/apps/api/src/billing/repositories/wallet-settings/wallet-settings.repository.ts
+++ b/apps/api/src/billing/repositories/wallet-settings/wallet-settings.repository.ts
@@ -9,17 +9,9 @@ type Table = ApiPgTables["WalletSetting"];
 type DbWalletSettingInput = ApiPgTables["WalletSetting"]["$inferInsert"];
 type DbWalletSettingOutput = ApiPgTables["WalletSetting"]["$inferSelect"];
 
-export type WalletSettingInput = Partial<
-  Omit<DbWalletSettingInput, "autoReloadThreshold" | "autoReloadAmount"> & {
-    autoReloadThreshold: number;
-    autoReloadAmount: number;
-  }
->;
+export type WalletSettingInput = Partial<DbWalletSettingInput>;
 
-export type WalletSettingOutput = Omit<DbWalletSettingOutput, "autoReloadThreshold" | "autoReloadAmount"> & {
-  autoReloadThreshold?: number;
-  autoReloadAmount?: number;
-};
+export type WalletSettingOutput = DbWalletSettingOutput;
 
 @singleton()
 export class WalletSettingRepository extends BaseRepository<Table, WalletSettingInput, WalletSettingOutput> {

--- a/apps/api/src/billing/services/trial-validation/trial-validation.service.ts
+++ b/apps/api/src/billing/services/trial-validation/trial-validation.service.ts
@@ -6,14 +6,13 @@ import { EncodeObject } from "@cosmjs/proto-signing";
 import assert from "http-assert";
 import { singleton } from "tsyringe";
 
+import { STANDARD_TOP_UP_MIN_AMOUNT_USD } from "@src/billing/config";
 import type { UserWalletOutput } from "@src/billing/repositories";
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import { AUDITOR, TRIAL_ATTRIBUTE, TRIAL_REGISTERED_ATTRIBUTE } from "@src/deployment/config/provider.config";
 import { BlockedGpuService } from "@src/deployment/services/blocked-gpu/blocked-gpu.service";
 import { ProviderRepository } from "@src/provider/repositories/provider/provider.repository";
 import type { UserOutput } from "@src/user/repositories";
-
-const STANDARD_TOP_UP_MIN_AMOUNT_USD = 20;
 
 @singleton()
 export class TrialValidationService {

--- a/apps/api/src/billing/services/wallet-balance-reload-check/README.md
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/README.md
@@ -2,191 +2,90 @@
 
 ## Overview
 
-This job worker automatically reloads user wallet balances when they're running low relative to projected deployment costs for deployments with auto top-up enabled. It runs daily and proactively reloads funds when the balance can only cover less than 25% of the next 7 days of deployment costs.
+This job worker automatically tops up a user's credit balance when it drops to or below a user-configured threshold. When a user has auto top-up enabled, the handler charges their default payment method a fixed amount as soon as the balance reaches the trigger point.
 
-## Core Logic
+The algorithm is selected by the `auto_reload_fixed_threshold` feature flag:
 
-### The Problem
+- **Flag ON** — fixed threshold/amount (the algorithm described below). This is the target behavior.
+- **Flag OFF** — legacy predicted-spend algorithm (documented at the end; removed once the flag is cleaned up).
 
-Users need sufficient funds to keep their deployments with auto top-up enabled running. Without auto-reload, deployments would stop when funds run out, requiring manual intervention.
+## Fixed-threshold algorithm (primary)
 
-### The Solution
+A user configures two values on their wallet settings:
 
-1. **Calculate** how much money is needed to keep all deployments with auto top-up enabled running for 7 days
-2. **Compare** current balance with 25% of that cost (threshold check)
-3. **Reload** if balance is below threshold (with a $20 minimum)
-4. **Schedule** the next check for 24 hours from now
+- **`autoReloadThreshold`** — the credit balance at or below which a top-up fires. Default **$20**, minimum $5.
+- **`autoReloadAmount`** — the fixed amount charged on each top-up. Default **$100**, minimum $20 (`STANDARD_TOP_UP_MIN_AMOUNT_USD`).
 
-### Key Design Decisions
-
-**Why check daily?**
-
-- Daily checks allow proactive reloading before funds run critically low
-- Catches issues quickly if deployment costs spike
-- Balances responsiveness with system load
-
-**Why calculate costs for 7 days?**
-
-- Provides a meaningful projection window for deployment costs
-- Ensures reloads cover a full week of operations for deployments with auto top-up enabled
-- Balances UX (users don't get charged too frequently) with transaction costs
-- Reduces the number of payment transactions while maintaining adequate coverage
-
-**Why reload at 25% threshold?**
-
-- Reloads when balance can only cover less than ~1.75 days (25% of 7 days)
-- Provides a safety margin before funds run out
-- Prevents emergency situations
-
-## When Does the Check Run?
-
-The handler runs in four scenarios:
-
-1. **When feature is enabled**: Immediately when a user enables auto-reload
-2. **When deployment auto top-up is enabled**: Immediately when a user enables auto top-up on a deployment
-3. **Scheduled checks**: Every 24 hours (1 day) for users with auto-reload enabled
-4. **Immediate triggers**: When a user creates a deployment or makes a deposit
-
-When auto-reload is enabled, the first check runs immediately. When deployment auto top-up is enabled, an immediate check is scheduled to ensure the wallet balance can cover the new deployment costs. Subsequent checks run on a daily schedule. Immediate triggers (deployments/deposits) ensure the balance is checked right after spending or depositing funds, rather than waiting for the next scheduled check.
-
-## Sequence Diagram
+### The rule
 
 ```
-User enables auto-reload
-    │
-    ▼
-WalletSettingService schedules immediate check
-    │
-    ├─► [OR] User enables deployment auto top-up
-    │   │
-    │   ▼
-    │   DeploymentSettingService.scheduleImmediate()
-    │   │
-    │   ▼
-    │   WalletReloadJobService.scheduleImmediate()
-    │
-    ├─► [OR] User creates deployment / makes deposit
-    │   │
-    │   ▼
-    │   ManagedSignerService.scheduleImmediate()
-    │   │
-    │   ▼
-    │   WalletSettingService cancels existing job
-    │   │
-    │   ▼
-    │   WalletSettingService enqueues immediate check
-    │
-    ▼
-[Immediately when enabled, OR when deployment auto top-up enabled, OR 24 hours later for scheduled checks, OR immediately on deployment/deposit]
-    │
-    ▼
-WalletBalanceReloadCheckHandler.handle()
-    │
-    ├─► Collect Resources
-    │   ├─► Get wallet setting (verify auto-reload enabled)
-    │   ├─► Get user wallet (verify initialized)
-    │   ├─► Get user (verify Stripe customer ID)
-    │   ├─► Get default payment method
-    │   ├─► Get available balance excluding escrow (in USD)
-    │   └─► Calculate cost for 7 days ahead (deployments with auto top-up enabled)
-    │
-    ├─► Try to Reload
-    │   ├─► Compare: balance >= 25% of 7-day cost?
-    │   │   ├─► YES: Skip reload, log "RELOAD_SKIPPED"
-    │   │   └─► NO: Continue (balance can only cover < ~1.75 days)
-    │   │
-    │   ├─► Calculate reload amount
-    │   │   └─► max(7-day-cost - balance, $20)
-    │   │
-    │   └─► Create Stripe payment intent
-    │       └─► Charge user's default payment method
-    │
-    └─► Schedule Next Check
-        ├─► Enqueue job for 24 hours from now
-        └─► Update wallet setting with new job ID
+if (balance <= autoReloadThreshold) {
+  charge max(autoReloadAmount, $20)
+}
 ```
 
-## Reload Threshold Logic
+The comparison is **inclusive**: a balance exactly at the threshold triggers a top-up. The `max(..., $20)` is a defensive clamp — there is no DB CHECK constraint, so the handler guarantees Stripe's minimum even if a smaller amount was somehow persisted.
 
-The handler reloads when:
+The check is a pure balance comparison. It fires even when the user has no active deployments, and it does not project future spend. The balance compared is the deployment-grant balance in USD (`getDeploymentBalanceInFiat`) — the same "Available Balance" shown on the billing page.
 
-```
-balance < 0.25 * costUntilTargetDateInFiat
-```
+### Worked examples (defaults: threshold $20, amount $100)
 
-This means: reload when balance can only cover less than 25% of the 7-day cost projection (~1.75 days).
+| Balance | Threshold | Amount | Outcome |
+| ------- | --------- | ------ | ------- |
+| $20.00  | $20       | $100   | `balance <= threshold` → **charge $100** |
+| $20.01  | $20       | $100   | `balance > threshold` → **skip** |
+| $0.00   | $20       | $100   | **charge $100** (fires with no deployments) |
+| $5.00   | $20       | $15\*  | **charge $20** (clamped to the $20 minimum) |
 
-**Example scenarios:**
+\* An amount below $20 should never persist (zod rejects it on write); the clamp is defensive only.
 
-1. **Balance: $10, 7-day Cost: $40**
+## When does the check run?
 
-   - 25% threshold: $10
-   - Balance ($10) >= threshold ($10) → **Skip reload** (exactly at threshold)
+Checks are **spend-event-driven**, not fixed to a daily cadence. A check is enqueued:
 
-2. **Balance: $9, 7-day Cost: $40**
+1. When a user enables auto top-up (immediate, prefilled from the settings dialog).
+2. When a user changes their threshold or amount while enabled (immediate — backs the dialog's "top-up runs shortly after saving").
+3. After every spending broadcast, after initial deployment funding, and after each escrow top-up cycle.
+4. On a self-rescheduled 24h job that acts only as a safety net.
 
-   - 25% threshold: $10
-   - Balance ($9) < threshold ($10) → **Reload**
-   - Reload amount: max($40 - $9, $20) = $31
+Because pg-boss's `singleton` policy uniqueness applies only to *active* jobs, an immediate enqueue is never swallowed by the pending daily safety-net job. Top-ups therefore happen within seconds of the balance crossing the threshold.
 
-3. **Balance: $5, 7-day Cost: $20**
+## Validation flow
 
-   - 25% threshold: $5
-   - Balance ($5) >= threshold ($5) → **Skip reload** (exactly at threshold)
-
-4. **Balance: $4, 7-day Cost: $20**
-   - 25% threshold: $5
-   - Balance ($4) < threshold ($5) → **Reload**
-   - Reload amount: max($20 - $4, $20) = $20 (minimum applies)
-
-## Cost Calculation
-
-The handler calculates the **unfunded** cost for all active deployments with auto top-up enabled — i.e. only the portion not already covered by escrow:
-
-1. Gets all auto-top-up deployments for the user's wallet
-2. For each deployment that would close before the target date (7 days from now):
-   - Finds when it would close (predicted closed height, when escrow runs out)
-   - Calculates blocks needed from closure to target date
-   - Multiplies by block rate to get the unfunded cost
-3. Sums all unfunded costs (deployments whose escrow lasts beyond 7 days are excluded)
-
-**Note**: Only deployments with auto top-up enabled are considered in the cost calculation.
-
-**Target date**: 7 days from now (`RELOAD_COVERAGE_PERIOD_IN_MS`)
-
-## Reload Amount Calculation
-
-```
-reloadAmount = max(costUntilTargetDateInFiat - balance, $20)
-```
-
-The reload amount ensures the balance can cover the full 7-day cost projection, with a $20 minimum to prevent tiny charges and meet Stripe's requirements.
-
-## Validation Flow
-
-Before processing, the handler validates:
+Before charging, the handler validates:
 
 1. ✅ Wallet setting exists
 2. ✅ Auto-reload is enabled
 3. ✅ Wallet is initialized (has address)
-4. ✅ User has Stripe customer ID
+4. ✅ User has a Stripe customer ID
 5. ✅ Default payment method exists
 
-If any validation fails, the handler logs an error and skips processing (doesn't throw).
+If any validation fails, the handler logs and skips processing (does not throw).
 
-## Key Constants
+## Payment intent
 
-- **Check Interval**: 24 hours (1 day) - how often the job runs
-- **Reload Coverage Period**: 7 days - period for which costs are calculated
-- **Minimum Coverage Percentage**: 25% - triggers reload when balance falls below this percentage of 7-day cost
-- **Minimum Reload**: $20 USD - prevents tiny charges
+The charge uses a job-scoped idempotency key (`WalletBalanceReloadCheck.<jobId>`), `confirm: true`, and `onAmountMismatch: "tolerate"`. Tolerate keeps retries safe when the computed amount differs between attempts — e.g. settings were edited or the feature flag flipped between the original charge and a retry under the reused key.
 
-**Note**: These constants can be fine-tuned based on real-life UX data and user feedback to optimize the balance between user experience, transaction frequency, and system efficiency.
+## What happens on failure?
 
-## What Happens on Failure?
+- **Payment fails**: Error is logged and re-thrown (job fails, will retry).
+- **Validation fails**: Error is logged, job completes successfully (no retry needed).
+- **Scheduling next check fails**: Error is logged and re-thrown.
 
-- **Payment fails**: Error is logged and re-thrown (job fails, will retry)
-- **Validation fails**: Error is logged, job completes successfully (no retry needed)
-- **Job ID update fails**: Error is logged, job completes (next check still scheduled)
+**Observability**: alerts fire on failures even when the job ends successfully on validation errors, so the team can react promptly.
 
-**Observability**: Observability is configured to alert on any issues when failures happen. Even when the job ends successfully on validation errors, alerts are triggered so the team can react and ensure issues are fixed promptly.
+---
+
+## Legacy predicted-spend algorithm (behind the flag, `auto_reload_fixed_threshold` OFF)
+
+> This section describes the pre-CON-717 behavior. It is retained only while the flag is being rolled out and is removed by the flag-cleanup follow-up.
+
+The legacy path predicts upcoming spend instead of comparing against a fixed threshold:
+
+1. **Calculate** the unfunded cost to keep all auto-top-up deployments running for the next 7 days (`RELOAD_COVERAGE_PERIOD_IN_MS`), excluding the portion already covered by escrow.
+2. **Compare** the balance against 25% of that projection (`MIN_COVERAGE_PERCENTAGE`). Reload when `balance < 0.25 * costUntilTargetDate` (~1.75 days of coverage remaining).
+3. **Charge** `max(costUntilTargetDate - balance, $20)`.
+4. **Skip** entirely when the projected cost is 0 (no active auto-top-up deployments).
+5. **Schedule** the next check 24 hours out.
+
+Legacy key constants: Check Interval 24h, Reload Coverage Period 7 days, Minimum Coverage Percentage 25%, Minimum Reload $20.

--- a/apps/api/src/billing/services/wallet-balance-reload-check/README.md
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/README.md
@@ -18,7 +18,7 @@ A user configures two values on their wallet settings:
 
 ### The rule
 
-```
+```text
 if (balance <= autoReloadThreshold) {
   charge max(autoReloadAmount, $20)
 }

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check-instrumentation.service.spec.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check-instrumentation.service.spec.ts
@@ -58,14 +58,49 @@ describe(WalletBalanceReloadCheckInstrumentationService.name, () => {
     });
   });
 
+  describe("recordReloadTriggered", () => {
+    it("records the coverage ratio and projected cost on the legacy path and logs the reload", () => {
+      const { service, histograms } = setup();
+      const logContext = { walletAddress: faker.string.alphanumeric(44), balance: 10 };
+
+      service.recordReloadTriggered({ amount: 40, coverageRatio: 0.2, projectedCost: 50, logContext });
+
+      expect(histograms.wallet_balance_reload_check_balance_coverage_ratio.record).toHaveBeenCalledWith(0.2);
+      expect(histograms.wallet_balance_reload_check_projected_cost_usd.record).toHaveBeenCalledWith(50);
+      expect(mockLogger.info).toHaveBeenCalledWith(expect.objectContaining({ ...logContext, amount: 40, event: "WALLET_BALANCE_RELOADED" }));
+    });
+
+    it("omits the projected cost histogram on the fixed-threshold path", () => {
+      const { service, histograms } = setup();
+
+      service.recordReloadTriggered({ amount: 100, coverageRatio: 0.5, logContext: { threshold: 20 } });
+
+      expect(histograms.wallet_balance_reload_check_balance_coverage_ratio.record).toHaveBeenCalledWith(0.5);
+      expect(histograms.wallet_balance_reload_check_projected_cost_usd.record).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("recordReloadSkipped", () => {
+    it("increments the skipped counter with the reason and logs the skip", () => {
+      const { service, counters } = setup();
+
+      service.recordReloadSkipped({ reason: "sufficient_balance", coverageRatio: 1.5, logContext: { threshold: 20 } });
+
+      expect(counters.wallet_balance_reload_check_reloads_skipped_total.add).toHaveBeenCalledWith(1, { reason: "sufficient_balance" });
+      expect(mockLogger.info).toHaveBeenCalledWith(expect.objectContaining({ threshold: 20, event: "WALLET_BALANCE_RELOAD_SKIPPED" }));
+    });
+  });
+
   function setup() {
     const metricsService = mock<MetricsService>();
+    const histograms: Record<string, ReturnType<typeof mock<Histogram>>> = {};
+    const counters: Record<string, ReturnType<typeof mock<Counter>>> = {};
     metricsService.getMeter.mockReturnValue(mock());
-    metricsService.createCounter.mockReturnValue(mock<Counter>());
-    metricsService.createHistogram.mockReturnValue(mock<Histogram>());
+    metricsService.createCounter.mockImplementation((_meter, name) => (counters[name] = mock<Counter>()));
+    metricsService.createHistogram.mockImplementation((_meter, name) => (histograms[name] = mock<Histogram>()));
 
     const service = new WalletBalanceReloadCheckInstrumentationService(metricsService);
 
-    return { service };
+    return { service, histograms, counters };
   }
 });

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check-instrumentation.service.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check-instrumentation.service.ts
@@ -4,6 +4,12 @@ import { singleton } from "tsyringe";
 
 import { MetricsService } from "@src/core";
 
+type ReloadMetricInput = {
+  coverageRatio?: number;
+  projectedCost?: number;
+  logContext: Record<string, unknown>;
+};
+
 @singleton()
 export class WalletBalanceReloadCheckInstrumentationService {
   private readonly meter: Meter;
@@ -52,11 +58,12 @@ export class WalletBalanceReloadCheckInstrumentationService {
     });
 
     this.balanceCoverageRatio = this.metricsService.createHistogram(this.meter, "wallet_balance_reload_check_balance_coverage_ratio", {
-      description: "Ratio of current balance to projected cost (balance / costUntilTargetDate)"
+      description:
+        "Ratio of current balance to the reload trigger point (balance / threshold on the fixed-threshold path, balance / costUntilTargetDate on the legacy path)"
     });
 
     this.projectedCost = this.metricsService.createHistogram(this.meter, "wallet_balance_reload_check_projected_cost_usd", {
-      description: "Projected deployment cost until target date in USD",
+      description: "Projected deployment cost until target date in USD (legacy predicted-spend path only)",
       unit: "USD"
     });
   }
@@ -76,40 +83,34 @@ export class WalletBalanceReloadCheckInstrumentationService {
     });
   }
 
-  recordReloadTriggered(amount: number, balance: number, threshold: number, costUntilTargetDate: number, logContext: Record<string, unknown>): void {
+  recordReloadTriggered(input: ReloadMetricInput & { amount: number }): void {
     this.reloadsTriggered.add(1);
-    // Only record balance coverage ratio if cost is greater than 0 to avoid division by zero
-    if (costUntilTargetDate > 0) {
-      this.balanceCoverageRatio.record(balance / costUntilTargetDate);
-    }
-    this.projectedCost.record(costUntilTargetDate);
+    this.#recordCoverage(input);
     this.logger.info({
-      ...logContext,
-      amount,
+      ...input.logContext,
+      amount: input.amount,
       event: "WALLET_BALANCE_RELOADED"
     });
   }
 
-  recordReloadSkipped(
-    balance: number,
-    threshold: number,
-    costUntilTargetDate: number,
-    reason: "zero_cost" | "sufficient_balance",
-    logContext: Record<string, unknown>
-  ): void {
+  recordReloadSkipped(input: ReloadMetricInput & { reason: "zero_cost" | "sufficient_balance" }): void {
     this.reloadsSkipped.add(1, {
-      reason
+      reason: input.reason
     });
-    // Only record balance coverage ratio if cost is greater than 0 to avoid division by zero
-    // For zero_cost reason, costUntilTargetDate will be 0, so we skip recording the ratio
-    if (costUntilTargetDate > 0) {
-      this.balanceCoverageRatio.record(balance / costUntilTargetDate);
-    }
-    this.projectedCost.record(costUntilTargetDate);
+    this.#recordCoverage(input);
     this.logger.info({
-      ...logContext,
+      ...input.logContext,
       event: "WALLET_BALANCE_RELOAD_SKIPPED"
     });
+  }
+
+  #recordCoverage(input: ReloadMetricInput): void {
+    if (input.coverageRatio !== undefined) {
+      this.balanceCoverageRatio.record(input.coverageRatio);
+    }
+    if (input.projectedCost !== undefined) {
+      this.projectedCost.record(input.projectedCost);
+    }
   }
 
   recordReloadFailed(error: unknown, logContext: Record<string, unknown>): void {

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.spec.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.spec.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import { WalletBalanceReloadCheck } from "@src/billing/events/wallet-balance-reload-check";
+import { usdToCents } from "@src/billing/lib/currency/currency";
 import type { WalletSettingRepository } from "@src/billing/repositories";
 import type { BalancesService } from "@src/billing/services/balances/balances.service";
 import type { PaymentMethodService } from "@src/billing/services/payment-method/payment-method.service";
@@ -354,8 +355,8 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       const { handler, stripeTransactionService, drainingDeploymentService, instrumentationService, job, jobMeta } = setup({
         fixedThresholdEnabled: true,
         balance: 10,
-        autoReloadThreshold: 20,
-        autoReloadAmount: 100
+        autoReloadThresholdUsd: 20,
+        autoReloadAmountUsd: 100
       });
 
       await handler.handle(job, jobMeta);
@@ -382,8 +383,8 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       const { handler, stripeTransactionService, job, jobMeta } = setup({
         fixedThresholdEnabled: true,
         balance: 20,
-        autoReloadThreshold: 20,
-        autoReloadAmount: 100
+        autoReloadThresholdUsd: 20,
+        autoReloadAmountUsd: 100
       });
 
       await handler.handle(job, jobMeta);
@@ -395,8 +396,8 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       const { handler, stripeTransactionService, instrumentationService, job, jobMeta } = setup({
         fixedThresholdEnabled: true,
         balance: 20.01,
-        autoReloadThreshold: 20,
-        autoReloadAmount: 100
+        autoReloadThresholdUsd: 20,
+        autoReloadAmountUsd: 100
       });
 
       await handler.handle(job, jobMeta);
@@ -414,8 +415,8 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       const { handler, stripeTransactionService, drainingDeploymentService, job, jobMeta } = setup({
         fixedThresholdEnabled: true,
         balance: 0,
-        autoReloadThreshold: 20,
-        autoReloadAmount: 100
+        autoReloadThresholdUsd: 20,
+        autoReloadAmountUsd: 100
       });
 
       await handler.handle(job, jobMeta);
@@ -428,8 +429,8 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       const { handler, stripeTransactionService, job, jobMeta } = setup({
         fixedThresholdEnabled: true,
         balance: 5,
-        autoReloadThreshold: 20,
-        autoReloadAmount: 15
+        autoReloadThresholdUsd: 20,
+        autoReloadAmountUsd: 15
       });
 
       await handler.handle(job, jobMeta);
@@ -442,8 +443,8 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       const { handler, stripeTransactionService, instrumentationService, job, jobMeta } = setup({
         fixedThresholdEnabled: true,
         balance: 10,
-        autoReloadThreshold: 20,
-        autoReloadAmount: 100
+        autoReloadThresholdUsd: 20,
+        autoReloadAmountUsd: 100
       });
       stripeTransactionService.createPaymentIntent.mockRejectedValue(error);
 
@@ -463,8 +464,8 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
     jobId?: string | null;
     walletSettingNotFound?: boolean;
     autoReloadEnabled?: boolean;
-    autoReloadThreshold?: number;
-    autoReloadAmount?: number;
+    autoReloadThresholdUsd?: number;
+    autoReloadAmountUsd?: number;
     fixedThresholdEnabled?: boolean;
     user?: ReturnType<typeof createUser>;
     wallet?: ReturnType<typeof createUserWallet>;
@@ -483,8 +484,8 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       userId: user.id,
       walletId: wallet.id,
       autoReloadEnabled: input?.autoReloadEnabled ?? true,
-      ...(input?.autoReloadThreshold !== undefined && { autoReloadThreshold: input.autoReloadThreshold }),
-      ...(input?.autoReloadAmount !== undefined && { autoReloadAmount: input.autoReloadAmount })
+      ...(input?.autoReloadThresholdUsd !== undefined && { autoReloadThreshold: usdToCents(input.autoReloadThresholdUsd) }),
+      ...(input?.autoReloadAmountUsd !== undefined && { autoReloadAmount: usdToCents(input.autoReloadAmountUsd) })
     });
     const walletSettingWithWallet = {
       ...walletSetting,

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.spec.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.spec.ts
@@ -10,6 +10,7 @@ import type { PaymentMethodService } from "@src/billing/services/payment-method/
 import type { StripeTransactionService } from "@src/billing/services/stripe-transaction/stripe-transaction.service";
 import type { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
 import type { JobMeta } from "@src/core";
+import type { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
 import type { DrainingDeploymentService } from "@src/deployment/services/draining-deployment/draining-deployment.service";
 import type { JobPayload } from "../../../core";
 import { WalletBalanceReloadCheckHandler } from "./wallet-balance-reload-check.handler";
@@ -74,14 +75,14 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
         onAmountMismatch: "tolerate"
       });
       expect(instrumentationService.recordReloadTriggered).toHaveBeenCalledWith(
-        expectedReloadAmount,
-        balance,
-        expect.any(Number),
-        costUntilTargetDateInFiat,
         expect.objectContaining({
-          walletAddress: expect.any(String),
-          balance,
-          costUntilTargetDateInFiat
+          amount: expectedReloadAmount,
+          projectedCost: costUntilTargetDateInFiat,
+          logContext: expect.objectContaining({
+            walletAddress: expect.any(String),
+            balance,
+            costUntilTargetDateInFiat
+          })
         })
       );
     });
@@ -131,14 +132,14 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
 
       expect(stripeTransactionService.createPaymentIntent).not.toHaveBeenCalled();
       expect(instrumentationService.recordReloadSkipped).toHaveBeenCalledWith(
-        balance,
-        expect.any(Number),
-        costUntilTargetDateInFiat,
-        "sufficient_balance",
         expect.objectContaining({
-          walletAddress: expect.any(String),
-          balance,
-          costUntilTargetDateInFiat
+          reason: "sufficient_balance",
+          projectedCost: costUntilTargetDateInFiat,
+          logContext: expect.objectContaining({
+            walletAddress: expect.any(String),
+            balance,
+            costUntilTargetDateInFiat
+          })
         })
       );
     });
@@ -160,16 +161,29 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
 
       expect(stripeTransactionService.createPaymentIntent).not.toHaveBeenCalled();
       expect(instrumentationService.recordReloadSkipped).toHaveBeenCalledWith(
-        balance,
-        expect.any(Number),
-        costUntilTargetDateInFiat,
-        "sufficient_balance",
         expect.objectContaining({
-          walletAddress: expect.any(String),
-          balance,
-          costUntilTargetDateInFiat
+          reason: "sufficient_balance",
+          projectedCost: costUntilTargetDateInFiat,
+          logContext: expect.objectContaining({
+            walletAddress: expect.any(String),
+            balance,
+            costUntilTargetDateInFiat
+          })
         })
       );
+    });
+
+    it("skips reload when the projected cost is zero", async () => {
+      const { handler, stripeTransactionService, instrumentationService, job, jobMeta } = setup({
+        balance: 10.0,
+        weeklyCostInDenom: 0,
+        weeklyCostInFiat: 0
+      });
+
+      await handler.handle(job, jobMeta);
+
+      expect(stripeTransactionService.createPaymentIntent).not.toHaveBeenCalled();
+      expect(instrumentationService.recordReloadSkipped).toHaveBeenCalledWith(expect.objectContaining({ reason: "zero_cost" }));
     });
 
     it("schedules next check", async () => {
@@ -335,6 +349,113 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
     });
   });
 
+  describe("when the fixed-threshold flag is enabled", () => {
+    it("charges the configured amount when balance is at or below the threshold", async () => {
+      const { handler, stripeTransactionService, drainingDeploymentService, instrumentationService, job, jobMeta } = setup({
+        fixedThresholdEnabled: true,
+        balance: 10,
+        autoReloadThreshold: 20,
+        autoReloadAmount: 100
+      });
+
+      await handler.handle(job, jobMeta);
+
+      expect(stripeTransactionService.createPaymentIntent).toHaveBeenCalledWith({
+        userId: expect.any(String),
+        customer: expect.any(String),
+        payment_method: expect.any(String),
+        amount: 100,
+        confirm: true,
+        idempotencyKey: `${WalletBalanceReloadCheck.name}.${jobMeta.id}`,
+        onAmountMismatch: "tolerate"
+      });
+      expect(drainingDeploymentService.calculateAllDeploymentCostUntilDate).not.toHaveBeenCalled();
+      expect(instrumentationService.recordReloadTriggered).toHaveBeenCalledWith(
+        expect.objectContaining({
+          amount: 100,
+          logContext: expect.objectContaining({ balance: 10, threshold: 20, reloadAmount: 100 })
+        })
+      );
+    });
+
+    it("charges when balance equals the threshold", async () => {
+      const { handler, stripeTransactionService, job, jobMeta } = setup({
+        fixedThresholdEnabled: true,
+        balance: 20,
+        autoReloadThreshold: 20,
+        autoReloadAmount: 100
+      });
+
+      await handler.handle(job, jobMeta);
+
+      expect(stripeTransactionService.createPaymentIntent).toHaveBeenCalledWith(expect.objectContaining({ amount: 100 }));
+    });
+
+    it("skips when balance is above the threshold", async () => {
+      const { handler, stripeTransactionService, instrumentationService, job, jobMeta } = setup({
+        fixedThresholdEnabled: true,
+        balance: 20.01,
+        autoReloadThreshold: 20,
+        autoReloadAmount: 100
+      });
+
+      await handler.handle(job, jobMeta);
+
+      expect(stripeTransactionService.createPaymentIntent).not.toHaveBeenCalled();
+      expect(instrumentationService.recordReloadSkipped).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reason: "sufficient_balance",
+          logContext: expect.objectContaining({ balance: 20.01, threshold: 20 })
+        })
+      );
+    });
+
+    it("reloads even when there are no active deployments", async () => {
+      const { handler, stripeTransactionService, drainingDeploymentService, job, jobMeta } = setup({
+        fixedThresholdEnabled: true,
+        balance: 0,
+        autoReloadThreshold: 20,
+        autoReloadAmount: 100
+      });
+
+      await handler.handle(job, jobMeta);
+
+      expect(drainingDeploymentService.calculateAllDeploymentCostUntilDate).not.toHaveBeenCalled();
+      expect(stripeTransactionService.createPaymentIntent).toHaveBeenCalledWith(expect.objectContaining({ amount: 100 }));
+    });
+
+    it("clamps the charge to the $20 minimum when the stored amount is below it", async () => {
+      const { handler, stripeTransactionService, job, jobMeta } = setup({
+        fixedThresholdEnabled: true,
+        balance: 5,
+        autoReloadThreshold: 20,
+        autoReloadAmount: 15
+      });
+
+      await handler.handle(job, jobMeta);
+
+      expect(stripeTransactionService.createPaymentIntent).toHaveBeenCalledWith(expect.objectContaining({ amount: 20 }));
+    });
+
+    it("records the failure and rethrows when the payment intent fails", async () => {
+      const error = new Error("Payment failed");
+      const { handler, stripeTransactionService, instrumentationService, job, jobMeta } = setup({
+        fixedThresholdEnabled: true,
+        balance: 10,
+        autoReloadThreshold: 20,
+        autoReloadAmount: 100
+      });
+      stripeTransactionService.createPaymentIntent.mockRejectedValue(error);
+
+      await expect(handler.handle(job, jobMeta)).rejects.toThrow(error);
+
+      expect(instrumentationService.recordReloadFailed).toHaveBeenCalledWith(
+        error,
+        expect.objectContaining({ walletAddress: expect.any(String), balance: 10, threshold: 20, reloadAmount: 100 })
+      );
+    });
+  });
+
   function setup(input?: {
     balance?: number;
     weeklyCostInDenom?: number;
@@ -342,6 +463,9 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
     jobId?: string | null;
     walletSettingNotFound?: boolean;
     autoReloadEnabled?: boolean;
+    autoReloadThreshold?: number;
+    autoReloadAmount?: number;
+    fixedThresholdEnabled?: boolean;
     user?: ReturnType<typeof createUser>;
     wallet?: ReturnType<typeof createUserWallet>;
   }) {
@@ -358,7 +482,9 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
     const walletSetting = generateWalletSetting({
       userId: user.id,
       walletId: wallet.id,
-      autoReloadEnabled: input?.autoReloadEnabled ?? true
+      autoReloadEnabled: input?.autoReloadEnabled ?? true,
+      ...(input?.autoReloadThreshold !== undefined && { autoReloadThreshold: input.autoReloadThreshold }),
+      ...(input?.autoReloadAmount !== undefined && { autoReloadAmount: input.autoReloadAmount })
     });
     const walletSettingWithWallet = {
       ...walletSetting,
@@ -391,6 +517,8 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       recordValidationError: vi.fn(),
       recordSchedulingError: vi.fn()
     });
+    const featureFlagsService = mock<FeatureFlagsService>();
+    featureFlagsService.isEnabled.mockReturnValue(input?.fixedThresholdEnabled ?? false);
 
     const balance = input?.balance ?? 50.0;
     const weeklyCostInDenom = input?.weeklyCostInDenom ?? 50_000_000;
@@ -419,7 +547,8 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       paymentMethodService,
       stripeTransactionService,
       drainingDeploymentService,
-      instrumentationService
+      instrumentationService,
+      featureFlagsService
     );
 
     return {
@@ -431,6 +560,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       paymentMethodService,
       stripeTransactionService,
       instrumentationService,
+      featureFlagsService,
       walletSetting,
       walletSettingWithWallet,
       wallet,

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.ts
@@ -3,6 +3,7 @@ import { addMilliseconds, millisecondsInHour } from "date-fns";
 import { Err, Ok, Result } from "ts-results";
 import { singleton } from "tsyringe";
 
+import { STANDARD_TOP_UP_MIN_AMOUNT_USD } from "@src/billing/config";
 import { WalletBalanceReloadCheck } from "@src/billing/events/wallet-balance-reload-check";
 import type { GetBalancesResponseOutput } from "@src/billing/http-schemas/balance.schema";
 import { UserWalletOutput, WalletSettingOutput, WalletSettingRepository } from "@src/billing/repositories";
@@ -11,6 +12,8 @@ import { type PaymentMethod, PaymentMethodService } from "@src/billing/services/
 import { StripeTransactionService } from "@src/billing/services/stripe-transaction/stripe-transaction.service";
 import { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
 import { JobHandler, JobMeta, JobPayload } from "@src/core";
+import { FeatureFlags } from "@src/core/services/feature-flags/feature-flags";
+import { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
 import type { Require } from "@src/core/types/require.type";
 import { DrainingDeploymentService } from "@src/deployment/services/draining-deployment/draining-deployment.service";
 import { isPayingUser, PayingUser } from "../paying-user/paying-user";
@@ -22,7 +25,7 @@ type ValidationError = {
 };
 
 type InitializedWallet = Require<Pick<UserWalletOutput, "address">, "address">;
-type ActionableWalletSetting = Pick<WalletSettingOutput, "id" | "userId">;
+type ActionableWalletSetting = Pick<WalletSettingOutput, "id" | "userId" | "autoReloadThreshold" | "autoReloadAmount">;
 
 type Resources = {
   walletSetting: ActionableWalletSetting;
@@ -56,7 +59,8 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
     private readonly paymentMethodService: PaymentMethodService,
     private readonly stripeTransactionService: StripeTransactionService,
     private readonly drainingDeploymentService: DrainingDeploymentService,
-    private readonly instrumentationService: WalletBalanceReloadCheckInstrumentationService
+    private readonly instrumentationService: WalletBalanceReloadCheckInstrumentationService,
+    private readonly featureFlagsService: FeatureFlagsService
   ) {}
 
   async handle(payload: JobPayload<WalletBalanceReloadCheck>, job: JobMeta): Promise<void> {
@@ -167,6 +171,48 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
   }
 
   async #tryToReload(resources: AllResources & { job: JobMeta }): Promise<void> {
+    if (this.featureFlagsService.isEnabled(FeatureFlags.AUTO_RELOAD_FIXED_THRESHOLD)) {
+      return this.#tryToReloadOnFixedThreshold(resources);
+    }
+
+    return this.#tryToReloadOnPredictedSpend(resources);
+  }
+
+  async #tryToReloadOnFixedThreshold(resources: AllResources & { job: JobMeta }): Promise<void> {
+    const { balance } = resources;
+    const threshold = resources.walletSetting.autoReloadThreshold;
+    const reloadAmount = Math.max(resources.walletSetting.autoReloadAmount, STANDARD_TOP_UP_MIN_AMOUNT_USD);
+    const log = {
+      walletAddress: resources.wallet.address,
+      balance,
+      threshold,
+      reloadAmount
+    };
+    const coverageRatio = threshold > 0 ? balance / threshold : undefined;
+
+    if (balance > threshold) {
+      this.instrumentationService.recordReloadSkipped({ reason: "sufficient_balance", coverageRatio, logContext: log });
+      return;
+    }
+
+    try {
+      await this.stripeTransactionService.createPaymentIntent({
+        userId: resources.user.id,
+        customer: resources.user.stripeCustomerId,
+        payment_method: resources.paymentMethod.id,
+        amount: reloadAmount,
+        confirm: true,
+        idempotencyKey: `${WalletBalanceReloadCheck.name}.${resources.job.id}`,
+        onAmountMismatch: "tolerate"
+      });
+      this.instrumentationService.recordReloadTriggered({ amount: reloadAmount, coverageRatio, logContext: log });
+    } catch (error) {
+      this.instrumentationService.recordReloadFailed(error, log);
+      throw error;
+    }
+  }
+
+  async #tryToReloadOnPredictedSpend(resources: AllResources & { job: JobMeta }): Promise<void> {
     const reloadTargetDate = addMilliseconds(new Date(), this.#RELOAD_COVERAGE_PERIOD_IN_MS);
     const costUntilTargetDateInDenom = await this.drainingDeploymentService.calculateAllDeploymentCostUntilDate(resources.wallet.address, reloadTargetDate);
     const costUntilTargetDateInFiat = await this.balancesService.toFiatAmount(costUntilTargetDateInDenom);
@@ -177,14 +223,20 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
       costUntilTargetDateInFiat,
       threshold
     };
+    const coverageRatio = costUntilTargetDateInFiat > 0 ? resources.balance / costUntilTargetDateInFiat : undefined;
 
     if (costUntilTargetDateInFiat === 0) {
-      this.instrumentationService.recordReloadSkipped(resources.balance, threshold, costUntilTargetDateInFiat, "zero_cost", log);
+      this.instrumentationService.recordReloadSkipped({ reason: "zero_cost", coverageRatio, projectedCost: costUntilTargetDateInFiat, logContext: log });
       return;
     }
 
     if (resources.balance >= threshold) {
-      this.instrumentationService.recordReloadSkipped(resources.balance, threshold, costUntilTargetDateInFiat, "sufficient_balance", log);
+      this.instrumentationService.recordReloadSkipped({
+        reason: "sufficient_balance",
+        coverageRatio,
+        projectedCost: costUntilTargetDateInFiat,
+        logContext: log
+      });
       return;
     }
 
@@ -200,7 +252,12 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
         idempotencyKey: `${WalletBalanceReloadCheck.name}.${resources.job.id}`,
         onAmountMismatch: "tolerate"
       });
-      this.instrumentationService.recordReloadTriggered(reloadAmountInFiat, resources.balance, threshold, costUntilTargetDateInFiat, log);
+      this.instrumentationService.recordReloadTriggered({
+        amount: reloadAmountInFiat,
+        coverageRatio,
+        projectedCost: costUntilTargetDateInFiat,
+        logContext: log
+      });
     } catch (error) {
       this.instrumentationService.recordReloadFailed(error, log);
       throw error;

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.ts
@@ -6,6 +6,7 @@ import { singleton } from "tsyringe";
 import { STANDARD_TOP_UP_MIN_AMOUNT_USD } from "@src/billing/config";
 import { WalletBalanceReloadCheck } from "@src/billing/events/wallet-balance-reload-check";
 import type { GetBalancesResponseOutput } from "@src/billing/http-schemas/balance.schema";
+import { centsToUsd } from "@src/billing/lib/currency/currency";
 import { UserWalletOutput, WalletSettingOutput, WalletSettingRepository } from "@src/billing/repositories";
 import { BalancesService } from "@src/billing/services/balances/balances.service";
 import { type PaymentMethod, PaymentMethodService } from "@src/billing/services/payment-method/payment-method.service";
@@ -180,8 +181,8 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
 
   async #tryToReloadOnFixedThreshold(resources: AllResources & { job: JobMeta }): Promise<void> {
     const { balance } = resources;
-    const threshold = resources.walletSetting.autoReloadThreshold;
-    const reloadAmount = Math.max(resources.walletSetting.autoReloadAmount, STANDARD_TOP_UP_MIN_AMOUNT_USD);
+    const threshold = centsToUsd(resources.walletSetting.autoReloadThreshold);
+    const reloadAmount = Math.max(centsToUsd(resources.walletSetting.autoReloadAmount), STANDARD_TOP_UP_MIN_AMOUNT_USD);
     const log = {
       walletAddress: resources.wallet.address,
       balance,

--- a/apps/api/src/billing/services/wallet-settings/wallet-settings.service.integration.ts
+++ b/apps/api/src/billing/services/wallet-settings/wallet-settings.service.integration.ts
@@ -5,7 +5,8 @@ import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { AuthService } from "@src/auth/services/auth.service";
-import type { UserWalletRepository, WalletSettingRepository } from "@src/billing/repositories";
+import { centsToUsd } from "@src/billing/lib/currency/currency";
+import type { UserWalletRepository, WalletSettingOutput, WalletSettingRepository } from "@src/billing/repositories";
 import type { PaymentMethodService } from "@src/billing/services/payment-method/payment-method.service";
 import { type PaymentMethod } from "@src/billing/services/payment-method/payment-method.service";
 import type { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
@@ -53,7 +54,7 @@ describe(WalletSettingService.name, () => {
         autoReloadEnabled: false
       });
 
-      expect(result).toEqual(updatedSetting);
+      expect(result).toEqual(toPublicSetting(updatedSetting));
       expect(walletSettingRepository.findByUserId).toHaveBeenCalledWith(user.id);
       expect(walletSettingRepository.updateById).toHaveBeenCalledWith(publicSetting.id, { autoReloadEnabled: false }, { returning: true });
     });
@@ -73,7 +74,7 @@ describe(WalletSettingService.name, () => {
         autoReloadEnabled: true
       });
 
-      expect(result).toEqual(newSetting);
+      expect(result).toEqual(toPublicSetting(newSetting));
       expect(walletSettingRepository.findByUserId).toHaveBeenCalledWith(user.id);
       expect(userWalletRepository.findOneByUserId).toHaveBeenCalledWith(user.id);
       expect(walletSettingRepository.create).toHaveBeenCalledWith({
@@ -105,7 +106,7 @@ describe(WalletSettingService.name, () => {
         autoReloadEnabled: true
       });
 
-      expect(result).toEqual(newSetting);
+      expect(result).toEqual(toPublicSetting(newSetting));
       expect(walletSettingRepository.findByUserId).toHaveBeenCalledWith(user.id);
       expect(userWalletRepository.findOneByUserId).toHaveBeenCalledWith(user.id);
       expect(walletSettingRepository.create).toHaveBeenCalledWith({
@@ -130,7 +131,7 @@ describe(WalletSettingService.name, () => {
         autoReloadEnabled: true
       });
 
-      expect(result).toEqual(updatedSetting);
+      expect(result).toEqual(toPublicSetting(updatedSetting));
       expect(walletSettingRepository.updateById).toHaveBeenCalledWith(
         existingSetting.id,
         {
@@ -149,8 +150,8 @@ describe(WalletSettingService.name, () => {
 
     it("schedules an immediate check when reload values change while enabled", async () => {
       const { user, walletSetting, walletSettingRepository, walletReloadJobService, jobId, service } = setup();
-      const enabledPrev = { ...walletSetting, autoReloadEnabled: true, autoReloadThreshold: 20, autoReloadAmount: 100 };
-      const updated = { ...enabledPrev, autoReloadThreshold: 30 };
+      const enabledPrev = { ...walletSetting, autoReloadEnabled: true, autoReloadThreshold: 2000, autoReloadAmount: 10000 };
+      const updated = { ...enabledPrev, autoReloadThreshold: 3000 };
       walletSettingRepository.findByUserId.mockResolvedValue(enabledPrev);
       walletSettingRepository.updateById.mockResolvedValue(updated as any);
       walletReloadJobService.scheduleForWalletSetting.mockResolvedValue(jobId);
@@ -162,13 +163,31 @@ describe(WalletSettingService.name, () => {
 
     it("does not schedule a check when reload values are unchanged while enabled", async () => {
       const { user, walletSetting, walletSettingRepository, walletReloadJobService, service } = setup();
-      const enabledSetting = { ...walletSetting, autoReloadEnabled: true, autoReloadThreshold: 20, autoReloadAmount: 100 };
+      const enabledSetting = { ...walletSetting, autoReloadEnabled: true, autoReloadThreshold: 2000, autoReloadAmount: 10000 };
       walletSettingRepository.findByUserId.mockResolvedValue(enabledSetting);
       walletSettingRepository.updateById.mockResolvedValue(enabledSetting as any);
 
       await service.upsertWalletSetting(user.id, { autoReloadEnabled: true });
 
       expect(walletReloadJobService.scheduleForWalletSetting).not.toHaveBeenCalled();
+    });
+
+    it("persists reload amounts as integer cents and returns them in dollars", async () => {
+      const { user, walletSetting, walletSettingRepository, walletReloadJobService, jobId, service } = setup();
+      const existingSetting = { ...walletSetting, autoReloadEnabled: true };
+      walletSettingRepository.findByUserId.mockResolvedValue(existingSetting);
+      walletSettingRepository.updateById.mockResolvedValue({ ...existingSetting, autoReloadThreshold: 2500, autoReloadAmount: 15000 } as any);
+      walletReloadJobService.scheduleForWalletSetting.mockResolvedValue(jobId);
+
+      const result = await service.upsertWalletSetting(user.id, { autoReloadThreshold: 25, autoReloadAmount: 150 });
+
+      expect(walletSettingRepository.updateById).toHaveBeenCalledWith(
+        existingSetting.id,
+        { autoReloadThreshold: 2500, autoReloadAmount: 15000 },
+        { returning: true }
+      );
+      expect(result.autoReloadThreshold).toBe(25);
+      expect(result.autoReloadAmount).toBe(150);
     });
 
     it("throws when enabling without a default payment method", async () => {
@@ -243,7 +262,7 @@ describe(WalletSettingService.name, () => {
       user: userWithStripe,
       userWallet,
       walletSetting,
-      publicSetting: walletSetting,
+      publicSetting: toPublicSetting(walletSetting),
       walletSettingRepository,
       userWalletRepository,
       userRepository,
@@ -255,3 +274,11 @@ describe(WalletSettingService.name, () => {
     };
   }
 });
+
+function toPublicSetting(setting: WalletSettingOutput): WalletSettingOutput {
+  return {
+    ...setting,
+    autoReloadThreshold: centsToUsd(setting.autoReloadThreshold),
+    autoReloadAmount: centsToUsd(setting.autoReloadAmount)
+  };
+}

--- a/apps/api/src/billing/services/wallet-settings/wallet-settings.service.integration.ts
+++ b/apps/api/src/billing/services/wallet-settings/wallet-settings.service.integration.ts
@@ -147,6 +147,40 @@ describe(WalletSettingService.name, () => {
       );
     });
 
+    it("schedules an immediate check when reload values change while enabled", async () => {
+      const { user, walletSetting, walletSettingRepository, walletReloadJobService, jobId, service } = setup();
+      const enabledPrev = { ...walletSetting, autoReloadEnabled: true, autoReloadThreshold: 20, autoReloadAmount: 100 };
+      const updated = { ...enabledPrev, autoReloadThreshold: 30 };
+      walletSettingRepository.findByUserId.mockResolvedValue(enabledPrev);
+      walletSettingRepository.updateById.mockResolvedValue(updated as any);
+      walletReloadJobService.scheduleForWalletSetting.mockResolvedValue(jobId);
+
+      await service.upsertWalletSetting(user.id, { autoReloadThreshold: 30 });
+
+      expect(walletReloadJobService.scheduleForWalletSetting).toHaveBeenCalledWith(expect.objectContaining({ id: updated.id, userId: user.id }));
+    });
+
+    it("does not schedule a check when reload values are unchanged while enabled", async () => {
+      const { user, walletSetting, walletSettingRepository, walletReloadJobService, service } = setup();
+      const enabledSetting = { ...walletSetting, autoReloadEnabled: true, autoReloadThreshold: 20, autoReloadAmount: 100 };
+      walletSettingRepository.findByUserId.mockResolvedValue(enabledSetting);
+      walletSettingRepository.updateById.mockResolvedValue(enabledSetting as any);
+
+      await service.upsertWalletSetting(user.id, { autoReloadEnabled: true });
+
+      expect(walletReloadJobService.scheduleForWalletSetting).not.toHaveBeenCalled();
+    });
+
+    it("throws when enabling without a default payment method", async () => {
+      const { user, walletSetting, walletSettingRepository, paymentMethodService, service } = setup();
+      walletSettingRepository.findByUserId.mockResolvedValue({ ...walletSetting, autoReloadEnabled: false });
+      paymentMethodService.getDefaultPaymentMethod.mockResolvedValue(undefined);
+
+      await expect(() => service.upsertWalletSetting(user.id, { autoReloadEnabled: true })).rejects.toThrow(
+        "Default payment method is required to enable automatic wallet balance reload"
+      );
+    });
+
     it("throws 404 when user wallet not found during create", async () => {
       const { user, userWalletRepository, walletSettingRepository, service } = setup();
       walletSettingRepository.findByUserId.mockResolvedValue(undefined);

--- a/apps/api/src/billing/services/wallet-settings/wallet-settings.service.ts
+++ b/apps/api/src/billing/services/wallet-settings/wallet-settings.service.ts
@@ -2,6 +2,7 @@ import assert from "http-assert";
 import { singleton } from "tsyringe";
 
 import { AuthService } from "@src/auth/services/auth.service";
+import { centsToUsd, usdToCents } from "@src/billing/lib/currency/currency";
 import { UserWalletRepository, type WalletSettingOutput, WalletSettingRepository } from "@src/billing/repositories";
 import { PaymentMethodService } from "@src/billing/services/payment-method/payment-method.service";
 import { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
@@ -29,7 +30,9 @@ export class WalletSettingService {
   async getWalletSetting(userId: string): Promise<WalletSettingOutput | undefined> {
     const { ability } = this.authService;
 
-    return await this.walletSettingRepository.accessibleBy(ability, "read").findByUserId(userId);
+    const setting = await this.walletSettingRepository.accessibleBy(ability, "read").findByUserId(userId);
+
+    return setting && this.#toDomainSetting(setting);
   }
 
   @WithTransaction()
@@ -42,7 +45,7 @@ export class WalletSettingService {
 
     await this.#arrangeSchedule(mutationResult.prev, mutationResult.next);
 
-    return mutationResult.next!;
+    return this.#toDomainSetting(mutationResult.next!);
   }
 
   async #update(userId: UserOutput["id"], settings: WalletSettingInput): Promise<{ prev?: WalletSettingOutput; next?: WalletSettingOutput }> {
@@ -55,7 +58,7 @@ export class WalletSettingService {
     }
 
     await this.#validate({ next: settings, userId });
-    const next = await this.walletSettingRepository.accessibleBy(ability, "update").updateById(prev.id, settings, { returning: true });
+    const next = await this.walletSettingRepository.accessibleBy(ability, "update").updateById(prev.id, this.#toStoredSettings(settings), { returning: true });
 
     if (!next) {
       return {};
@@ -76,7 +79,7 @@ export class WalletSettingService {
         next: await this.walletSettingRepository.accessibleBy(this.authService.ability, "create").create({
           userId,
           walletId: userWallet.id,
-          ...settings
+          ...this.#toStoredSettings(settings)
         })
       };
     } catch (error: unknown) {
@@ -128,6 +131,22 @@ export class WalletSettingService {
 
   #hasReloadValuesChanged(prev: WalletSettingOutput, next: WalletSettingOutput) {
     return prev.autoReloadThreshold !== next.autoReloadThreshold || prev.autoReloadAmount !== next.autoReloadAmount;
+  }
+
+  #toStoredSettings(settings: WalletSettingInput): WalletSettingInput {
+    return {
+      ...settings,
+      ...(settings.autoReloadThreshold !== undefined && { autoReloadThreshold: usdToCents(settings.autoReloadThreshold) }),
+      ...(settings.autoReloadAmount !== undefined && { autoReloadAmount: usdToCents(settings.autoReloadAmount) })
+    };
+  }
+
+  #toDomainSetting(setting: WalletSettingOutput): WalletSettingOutput {
+    return {
+      ...setting,
+      autoReloadThreshold: centsToUsd(setting.autoReloadThreshold),
+      autoReloadAmount: centsToUsd(setting.autoReloadAmount)
+    };
   }
 
   async deleteWalletSetting(userId: string): Promise<void> {

--- a/apps/api/src/billing/services/wallet-settings/wallet-settings.service.ts
+++ b/apps/api/src/billing/services/wallet-settings/wallet-settings.service.ts
@@ -112,9 +112,22 @@ export class WalletSettingService {
   }
 
   async #arrangeSchedule(prev?: WalletSettingOutput, next?: WalletSettingOutput) {
-    if (!prev?.autoReloadEnabled && next?.autoReloadEnabled) {
-      await this.walletReloadJobService.scheduleForWalletSetting(next, { withCleanup: true });
+    if (!next?.autoReloadEnabled) {
+      return;
     }
+
+    if (!prev?.autoReloadEnabled) {
+      await this.walletReloadJobService.scheduleForWalletSetting(next, { withCleanup: true });
+      return;
+    }
+
+    if (this.#hasReloadValuesChanged(prev, next)) {
+      await this.walletReloadJobService.scheduleForWalletSetting(next);
+    }
+  }
+
+  #hasReloadValuesChanged(prev: WalletSettingOutput, next: WalletSettingOutput) {
+    return prev.autoReloadThreshold !== next.autoReloadThreshold || prev.autoReloadAmount !== next.autoReloadAmount;
   }
 
   async deleteWalletSetting(userId: string): Promise<void> {

--- a/apps/api/src/core/services/feature-flags/feature-flags.ts
+++ b/apps/api/src/core/services/feature-flags/feature-flags.ts
@@ -2,6 +2,7 @@ export const FeatureFlags = {
   NOTIFICATIONS_ALERT_CREATE: "notifications_general_alerts_create",
   NOTIFICATIONS_ALERT_UPDATE: "notifications_general_alerts_update",
   AUTO_CREDIT_RELOAD: "auto_credit_reload",
+  AUTO_RELOAD_FIXED_THRESHOLD: "auto_reload_fixed_threshold",
   TRIAL_FINGERPRINT_CHECK: "trial_fingerprint_check"
 } as const;
 

--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -334,10 +334,20 @@
                       "properties": {
                         "autoReloadEnabled": {
                           "type": "boolean"
+                        },
+                        "autoReloadThreshold": {
+                          "type": "number",
+                          "description": "USD credit balance at or below which an automatic top-up is triggered."
+                        },
+                        "autoReloadAmount": {
+                          "type": "number",
+                          "description": "USD amount charged to the default payment method on each automatic top-up."
                         }
                       },
                       "required": [
-                        "autoReloadEnabled"
+                        "autoReloadEnabled",
+                        "autoReloadThreshold",
+                        "autoReloadAmount"
                       ]
                     }
                   },
@@ -379,6 +389,18 @@
                     "properties": {
                       "autoReloadEnabled": {
                         "type": "boolean"
+                      },
+                      "autoReloadThreshold": {
+                        "type": "number",
+                        "minimum": 5,
+                        "maximum": 10000,
+                        "description": "USD credit balance at or below which an automatic top-up is triggered (minimum 5, maximum 10000). Defaults are applied on create when omitted."
+                      },
+                      "autoReloadAmount": {
+                        "type": "number",
+                        "minimum": 20,
+                        "maximum": 10000,
+                        "description": "USD amount charged on each automatic top-up (minimum 20, maximum 10000). Defaults are applied on create when omitted."
                       }
                     },
                     "required": [
@@ -406,10 +428,20 @@
                       "properties": {
                         "autoReloadEnabled": {
                           "type": "boolean"
+                        },
+                        "autoReloadThreshold": {
+                          "type": "number",
+                          "description": "USD credit balance at or below which an automatic top-up is triggered."
+                        },
+                        "autoReloadAmount": {
+                          "type": "number",
+                          "description": "USD amount charged to the default payment method on each automatic top-up."
                         }
                       },
                       "required": [
-                        "autoReloadEnabled"
+                        "autoReloadEnabled",
+                        "autoReloadThreshold",
+                        "autoReloadAmount"
                       ]
                     }
                   },
@@ -451,6 +483,18 @@
                     "properties": {
                       "autoReloadEnabled": {
                         "type": "boolean"
+                      },
+                      "autoReloadThreshold": {
+                        "type": "number",
+                        "minimum": 5,
+                        "maximum": 10000,
+                        "description": "USD credit balance at or below which an automatic top-up is triggered (minimum 5, maximum 10000). Defaults are applied on create when omitted."
+                      },
+                      "autoReloadAmount": {
+                        "type": "number",
+                        "minimum": 20,
+                        "maximum": 10000,
+                        "description": "USD amount charged on each automatic top-up (minimum 20, maximum 10000). Defaults are applied on create when omitted."
                       }
                     },
                     "required": [
@@ -478,10 +522,20 @@
                       "properties": {
                         "autoReloadEnabled": {
                           "type": "boolean"
+                        },
+                        "autoReloadThreshold": {
+                          "type": "number",
+                          "description": "USD credit balance at or below which an automatic top-up is triggered."
+                        },
+                        "autoReloadAmount": {
+                          "type": "number",
+                          "description": "USD amount charged to the default payment method on each automatic top-up."
                         }
                       },
                       "required": [
-                        "autoReloadEnabled"
+                        "autoReloadEnabled",
+                        "autoReloadThreshold",
+                        "autoReloadAmount"
                       ]
                     }
                   },

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -15119,12 +15119,22 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                   "properties": {
                     "data": {
                       "properties": {
+                        "autoReloadAmount": {
+                          "description": "USD amount charged to the default payment method on each automatic top-up.",
+                          "type": "number",
+                        },
                         "autoReloadEnabled": {
                           "type": "boolean",
+                        },
+                        "autoReloadThreshold": {
+                          "description": "USD credit balance at or below which an automatic top-up is triggered.",
+                          "type": "number",
                         },
                       },
                       "required": [
                         "autoReloadEnabled",
+                        "autoReloadThreshold",
+                        "autoReloadAmount",
                       ],
                       "type": "object",
                     },
@@ -15165,8 +15175,20 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                 "properties": {
                   "data": {
                     "properties": {
+                      "autoReloadAmount": {
+                        "description": "USD amount charged on each automatic top-up (minimum 20, maximum 10000). Defaults are applied on create when omitted.",
+                        "maximum": 10000,
+                        "minimum": 20,
+                        "type": "number",
+                      },
                       "autoReloadEnabled": {
                         "type": "boolean",
+                      },
+                      "autoReloadThreshold": {
+                        "description": "USD credit balance at or below which an automatic top-up is triggered (minimum 5, maximum 10000). Defaults are applied on create when omitted.",
+                        "maximum": 10000,
+                        "minimum": 5,
+                        "type": "number",
                       },
                     },
                     "required": [
@@ -15191,12 +15213,22 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                   "properties": {
                     "data": {
                       "properties": {
+                        "autoReloadAmount": {
+                          "description": "USD amount charged to the default payment method on each automatic top-up.",
+                          "type": "number",
+                        },
                         "autoReloadEnabled": {
                           "type": "boolean",
+                        },
+                        "autoReloadThreshold": {
+                          "description": "USD credit balance at or below which an automatic top-up is triggered.",
+                          "type": "number",
                         },
                       },
                       "required": [
                         "autoReloadEnabled",
+                        "autoReloadThreshold",
+                        "autoReloadAmount",
                       ],
                       "type": "object",
                     },
@@ -15237,8 +15269,20 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                 "properties": {
                   "data": {
                     "properties": {
+                      "autoReloadAmount": {
+                        "description": "USD amount charged on each automatic top-up (minimum 20, maximum 10000). Defaults are applied on create when omitted.",
+                        "maximum": 10000,
+                        "minimum": 20,
+                        "type": "number",
+                      },
                       "autoReloadEnabled": {
                         "type": "boolean",
+                      },
+                      "autoReloadThreshold": {
+                        "description": "USD credit balance at or below which an automatic top-up is triggered (minimum 5, maximum 10000). Defaults are applied on create when omitted.",
+                        "maximum": 10000,
+                        "minimum": 5,
+                        "type": "number",
                       },
                     },
                     "required": [
@@ -15263,12 +15307,22 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                   "properties": {
                     "data": {
                       "properties": {
+                        "autoReloadAmount": {
+                          "description": "USD amount charged to the default payment method on each automatic top-up.",
+                          "type": "number",
+                        },
                         "autoReloadEnabled": {
                           "type": "boolean",
+                        },
+                        "autoReloadThreshold": {
+                          "description": "USD credit balance at or below which an automatic top-up is triggered.",
+                          "type": "number",
                         },
                       },
                       "required": [
                         "autoReloadEnabled",
+                        "autoReloadThreshold",
+                        "autoReloadAmount",
                       ],
                       "type": "object",
                     },

--- a/apps/api/test/functional/wallet-settings.spec.ts
+++ b/apps/api/test/functional/wallet-settings.spec.ts
@@ -1,0 +1,92 @@
+import { faker } from "@faker-js/faker";
+import { container } from "tsyringe";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { UserAuthTokenService } from "@src/auth/services/user-auth-token/user-auth-token.service";
+import { UserWalletRepository } from "@src/billing/repositories";
+import { app } from "@src/rest-app";
+import { UserRepository } from "@src/user/repositories/user/user.repository";
+
+import { createAkashAddress } from "@test/seeders/akash-address.seeder";
+import { createUserWallet } from "@test/seeders/user-wallet.seeder";
+
+describe("Wallet Settings", () => {
+  const userRepository = container.resolve(UserRepository);
+  const userAuthTokenService = container.resolve(UserAuthTokenService);
+  const userWalletRepository = container.resolve(UserWalletRepository);
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("PUT /v1/wallet-settings", () => {
+    it("returns 401 if user is not authenticated", async () => {
+      const response = await app.request("/v1/wallet-settings", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ data: { autoReloadEnabled: false } })
+      });
+
+      expect(response.status).toBe(401);
+    });
+
+    it("returns 400 when autoReloadAmount is below the minimum", async () => {
+      const { token } = await setup();
+
+      const response = await app.request("/v1/wallet-settings", {
+        method: "PUT",
+        headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+        body: JSON.stringify({ data: { autoReloadEnabled: true, autoReloadAmount: 5 } })
+      });
+
+      expect(response.status).toBe(400);
+    });
+
+    it("returns 400 when autoReloadThreshold is below the minimum", async () => {
+      const { token } = await setup();
+
+      const response = await app.request("/v1/wallet-settings", {
+        method: "PUT",
+        headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+        body: JSON.stringify({ data: { autoReloadEnabled: true, autoReloadThreshold: 1 } })
+      });
+
+      expect(response.status).toBe(400);
+    });
+
+    it("returns 400 when autoReloadAmount exceeds the maximum", async () => {
+      const { token } = await setup();
+
+      const response = await app.request("/v1/wallet-settings", {
+        method: "PUT",
+        headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+        body: JSON.stringify({ data: { autoReloadEnabled: true, autoReloadAmount: 10_001 } })
+      });
+
+      expect(response.status).toBe(400);
+    });
+
+    it("returns 400 when autoReloadThreshold exceeds the maximum", async () => {
+      const { token } = await setup();
+
+      const response = await app.request("/v1/wallet-settings", {
+        method: "PUT",
+        headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+        body: JSON.stringify({ data: { autoReloadEnabled: true, autoReloadThreshold: 10_001 } })
+      });
+
+      expect(response.status).toBe(400);
+    });
+  });
+
+  async function setup() {
+    const user = await userRepository.create({ userId: faker.string.uuid() });
+    const token = faker.string.alphanumeric(40);
+    const wallet = createUserWallet({ userId: user.id, address: createAkashAddress() });
+
+    vi.spyOn(userAuthTokenService, "getValidUserId").mockResolvedValue(user.userId);
+    vi.spyOn(userWalletRepository, "findOneByUserId").mockResolvedValue(wallet);
+
+    return { user, token, wallet };
+  }
+});

--- a/apps/api/test/seeders/wallet-setting.seeder.ts
+++ b/apps/api/test/seeders/wallet-setting.seeder.ts
@@ -8,8 +8,8 @@ export const generateWalletSetting = (overrides: Partial<WalletSettingOutput>) =
     userId: faker.string.uuid(),
     walletId: faker.number.int({ min: 1, max: 1000 }),
     autoReloadEnabled: faker.datatype.boolean(),
-    autoReloadThreshold: faker.number.float({ min: 0, max: 1000, fractionDigits: 2 }),
-    autoReloadAmount: faker.number.float({ min: 0, max: 1000, fractionDigits: 2 }),
+    autoReloadThreshold: faker.number.float({ min: 5, max: 1000, fractionDigits: 2 }),
+    autoReloadAmount: faker.number.float({ min: 20, max: 1000, fractionDigits: 2 }),
     createdAt: faker.date.recent(),
     updatedAt: faker.date.recent(),
     ...overrides

--- a/apps/api/test/seeders/wallet-setting.seeder.ts
+++ b/apps/api/test/seeders/wallet-setting.seeder.ts
@@ -8,8 +8,8 @@ export const generateWalletSetting = (overrides: Partial<WalletSettingOutput>) =
     userId: faker.string.uuid(),
     walletId: faker.number.int({ min: 1, max: 1000 }),
     autoReloadEnabled: faker.datatype.boolean(),
-    autoReloadThreshold: faker.number.float({ min: 5, max: 1000, fractionDigits: 2 }),
-    autoReloadAmount: faker.number.float({ min: 20, max: 1000, fractionDigits: 2 }),
+    autoReloadThreshold: faker.number.int({ min: 500, max: 100000 }),
+    autoReloadAmount: faker.number.int({ min: 2000, max: 100000 }),
     createdAt: faker.date.recent(),
     updatedAt: faker.date.recent(),
     ...overrides

--- a/packages/console-api-types/src/schema.d.ts
+++ b/packages/console-api-types/src/schema.d.ts
@@ -7144,6 +7144,10 @@ export interface operations {
           "application/json": {
             data: {
               autoReloadEnabled: boolean;
+              /** @description USD credit balance at or below which an automatic top-up is triggered. */
+              autoReloadThreshold: number;
+              /** @description USD amount charged to the default payment method on each automatic top-up. */
+              autoReloadAmount: number;
             };
           };
         };
@@ -7169,6 +7173,10 @@ export interface operations {
         "application/json": {
           data: {
             autoReloadEnabled: boolean;
+            /** @description USD credit balance at or below which an automatic top-up is triggered (minimum 5, maximum 10000). Defaults are applied on create when omitted. */
+            autoReloadThreshold?: number;
+            /** @description USD amount charged on each automatic top-up (minimum 20, maximum 10000). Defaults are applied on create when omitted. */
+            autoReloadAmount?: number;
           };
         };
       };
@@ -7183,6 +7191,10 @@ export interface operations {
           "application/json": {
             data: {
               autoReloadEnabled: boolean;
+              /** @description USD credit balance at or below which an automatic top-up is triggered. */
+              autoReloadThreshold: number;
+              /** @description USD amount charged to the default payment method on each automatic top-up. */
+              autoReloadAmount: number;
             };
           };
         };
@@ -7208,6 +7220,10 @@ export interface operations {
         "application/json": {
           data: {
             autoReloadEnabled: boolean;
+            /** @description USD credit balance at or below which an automatic top-up is triggered (minimum 5, maximum 10000). Defaults are applied on create when omitted. */
+            autoReloadThreshold?: number;
+            /** @description USD amount charged on each automatic top-up (minimum 20, maximum 10000). Defaults are applied on create when omitted. */
+            autoReloadAmount?: number;
           };
         };
       };
@@ -7222,6 +7238,10 @@ export interface operations {
           "application/json": {
             data: {
               autoReloadEnabled: boolean;
+              /** @description USD credit balance at or below which an automatic top-up is triggered. */
+              autoReloadThreshold: number;
+              /** @description USD amount charged to the default payment method on each automatic top-up. */
+              autoReloadAmount: number;
             };
           };
         };


### PR DESCRIPTION
## Why

Auto reload currently predicts upcoming spend: it projects the cost of all auto-top-up deployments over the next 7 days, triggers when the balance is below 25% of that projection, and charges `max(projection − balance, $20)`. Both charge timing and amount shift as deployments change, and the settings UI can only say "approximately $X per week".

CON-717 replaces this with a fixed, user-configurable rule: when the credit balance is at or below threshold X, charge the default payment method exactly amount Y.

This is the **backend half** of CON-717, split out from the original combined PR. The frontend is in **#3535** (stacked on this branch — it consumes the wallet-settings types regenerated here). This PR is safe to merge on its own: everything is behind a flag that is off by default.

Part of CON-717

## What

Everything is gated behind a new feature flag `auto_reload_fixed_threshold` (off by default). With the flag **off**, the legacy predicted-spend algorithm is untouched.

- Re-add `auto_reload_threshold` / `auto_reload_amount` columns (NUMERIC NOT NULL, defaults **$20 / $100**). The additive `ADD COLUMN … DEFAULT … NOT NULL` migration backfills existing enabled users — that is the backfill story, no script.
- Split the wallet-settings HTTP schema into input/output: threshold `>= 5`, amount `>= $20`, both optional on write (DB defaults on create).
- `WalletBalanceReloadCheckHandler` branches on the flag: **flag on** charges `max(autoReloadAmount, $20)` when `balance <= autoReloadThreshold` (inclusive), fires even with no active deployments, and never projects spend; **flag off** keeps the legacy path.
- Schedule an immediate reload check when threshold/amount change while enabled (backs the dialog's "top-up runs shortly after saving").
- Instrumentation reworked to serve both paths; `createPaymentIntent` unchanged (`confirm: true`, job-scoped idempotency key, `onAmountMismatch: "tolerate"`).
- Reload-check README rewritten with the new algorithm as primary.

**Behavior change at flag GA (needs a release note):** enabled users with a balance ≤ their threshold get charged the fixed amount on their next check (spend-event-driven or the daily safety net). This was product-approved.

**Rollout note for ops:** in background jobs there is no unleash `userId`, so the flag acts as a global on/off there (fine as a kill-switch, not per-user rollout). Metric changes (`projected_cost_usd`, `zero_cost` reason) are deferred to the flag-cleanup follow-up.

**Follow-ups (filed separately):** CON-763 — flag cleanup (remove the legacy algorithm, weekly-cost chain + `GET /v1/weekly-cost`, old UI branch, and legacy metrics); CON-764 — notification on auto-top-up payment failure.

## Testing

- reload-check handler (legacy + fixed-threshold cases incl. boundary, no-deployments, $20 clamp), wallet-settings service (immediate check on value change, enable requires payment method), controller pass-through, instrumentation, seeder ranges, and a functional test asserting `PUT /v1/wallet-settings` 400s on amount < 20 / threshold < 5. `docs.spec` snapshot regenerated.
- `npm run lint -- --quiet` and `npx tsc --noEmit` clean for the changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable automatic wallet top-ups using a balance threshold and reload amount.
  * Added validation, defaults, API support, and currency handling for reload settings.
  * Added a feature flag for the fixed-threshold reload strategy.
  * Reload charges now enforce a minimum amount of $20.
* **Bug Fixes**
  * Improved reload scheduling when settings are enabled or changed.
  * Added safeguards for missing payment methods and invalid configuration values.
* **Documentation**
  * Updated API documentation and automatic reload behavior guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->