### PR TITLE
fix(deployment): make cancel and edit reliably close deployments for trial users

### DIFF
--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -189,6 +189,34 @@ describe(DeploymentWriterService.name, () => {
       expect(rpcMessageService.getCloseDeploymentMsg).not.toHaveBeenCalled();
       expect(signerService.executeDecodedTxByUserWallet).not.toHaveBeenCalled();
     });
+
+    it("treats a failed close tx as success when a re-read shows the deployment already closed", async () => {
+      const { service, signerService, deploymentReaderService } = setup();
+      signerService.executeDecodedTxByUserWallet.mockRejectedValue(new Error("deployment already closed"));
+      deploymentReaderService.findByWalletAndDseq
+        .mockResolvedValueOnce(deploymentData)
+        .mockResolvedValueOnce({ ...deploymentData, deployment: { ...deploymentData.deployment, state: "closed" } });
+
+      await expect(service.close(wallet, "100")).resolves.toBeUndefined();
+    });
+
+    it("re-throws the original close error when a re-read shows the deployment is still open", async () => {
+      const { service, signerService, deploymentReaderService } = setup();
+      const closeError = new Error("close boom");
+      signerService.executeDecodedTxByUserWallet.mockRejectedValue(closeError);
+      deploymentReaderService.findByWalletAndDseq.mockResolvedValue(deploymentData);
+
+      await expect(service.close(wallet, "100")).rejects.toBe(closeError);
+    });
+
+    it("re-throws the original close error when the post-failure re-read also fails", async () => {
+      const { service, signerService, deploymentReaderService } = setup();
+      const closeError = new Error("close boom");
+      signerService.executeDecodedTxByUserWallet.mockRejectedValue(closeError);
+      deploymentReaderService.findByWalletAndDseq.mockResolvedValueOnce(deploymentData).mockRejectedValueOnce(new Error("indexer unavailable"));
+
+      await expect(service.close(wallet, "100")).rejects.toBe(closeError);
+    });
   });
 
   describe("deposit", () => {

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -7,10 +7,12 @@ import type { BillingConfigService } from "@src/billing/services/billing-config/
 import type { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
 import type { RpcMessageService } from "@src/billing/services/rpc-message-service/rpc-message.service";
 import type { WalletInitialized, WalletReaderService } from "@src/billing/services/wallet-reader/wallet-reader.service";
+import type { LoggerService } from "@src/core";
 import type { GetDeploymentResponse } from "@src/deployment/http-schemas/deployment.schema";
 import type { SdlService } from "@src/deployment/services/sdl/sdl.service";
 import type { ProviderService } from "@src/provider/services/provider/provider.service";
 import type { DeploymentReaderService } from "../deployment-reader/deployment-reader.service";
+import type { StaleManagedDeploymentsCleanerService } from "../stale-managed-deployments-cleaner/stale-managed-deployments-cleaner.service";
 import { DeploymentWriterService } from "./deployment-writer.service";
 
 import { mockConfigService } from "@test/mocks/config-service.mock";
@@ -116,6 +118,37 @@ describe(DeploymentWriterService.name, () => {
       await service.create({ userId: "user-1", sdl: "sdl-2.0", deposit: 5 });
 
       expect(rpcMessageService.getCreateDeploymentMsg.mock.calls[0][0].reclamation).toBeUndefined();
+    });
+
+    it("reclaims trial orphans with age 0 before signing the create when the wallet is trialing", async () => {
+      const { service, staleDeploymentsCleaner, signerService, walletReaderService } = setup();
+      walletReaderService.getWalletByUserId.mockResolvedValue({ ...wallet, isTrialing: true });
+
+      await service.create({ userId: "user-1", sdl: "valid-sdl", deposit: 5 });
+
+      expect(staleDeploymentsCleaner.cleanUpForWallet).toHaveBeenCalledWith(expect.objectContaining({ id: wallet.id, address: wallet.address }), 0);
+      expect(staleDeploymentsCleaner.cleanUpForWallet.mock.invocationCallOrder[0]).toBeLessThan(
+        signerService.executeDerivedDecodedTxByUserId.mock.invocationCallOrder[0]
+      );
+    });
+
+    it("does not reclaim orphans for a non-trial create", async () => {
+      const { service, staleDeploymentsCleaner } = setup();
+
+      await service.create({ userId: "user-1", sdl: "valid-sdl", deposit: 5 });
+
+      expect(staleDeploymentsCleaner.cleanUpForWallet).not.toHaveBeenCalled();
+    });
+
+    it("still creates the deployment when the orphan cleanup fails", async () => {
+      const { service, staleDeploymentsCleaner, signerService, walletReaderService } = setup();
+      walletReaderService.getWalletByUserId.mockResolvedValue({ ...wallet, isTrialing: true });
+      staleDeploymentsCleaner.cleanUpForWallet.mockRejectedValue(new Error("cleanup boom"));
+
+      const result = await service.create({ userId: "user-1", sdl: "valid-sdl", deposit: 5 });
+
+      expect(result.dseq).toBeDefined();
+      expect(signerService.executeDerivedDecodedTxByUserId).toHaveBeenCalled();
     });
   });
 
@@ -240,6 +273,8 @@ describe(DeploymentWriterService.name, () => {
     const providerService = mock<ProviderService>();
     const deploymentReaderService = mock<DeploymentReaderService>();
     const walletReaderService = mock<WalletReaderService>();
+    const staleDeploymentsCleaner = mock<StaleManagedDeploymentsCleanerService>();
+    const logger = mock<LoggerService>();
 
     walletReaderService.getWalletByUserId.mockResolvedValue(wallet);
     sdlService.generateManifest.mockReturnValue({ ok: true, value: manifestValue } as any);
@@ -253,7 +288,9 @@ describe(DeploymentWriterService.name, () => {
       billingConfig,
       providerService,
       deploymentReaderService,
-      walletReaderService
+      walletReaderService,
+      staleDeploymentsCleaner,
+      logger
     );
 
     return {
@@ -264,7 +301,9 @@ describe(DeploymentWriterService.name, () => {
       billingConfig,
       providerService,
       deploymentReaderService,
-      walletReaderService
+      walletReaderService,
+      staleDeploymentsCleaner,
+      logger
     };
   }
 });

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -143,6 +143,19 @@ describe(DeploymentWriterService.name, () => {
       expect(rpcMessageService.getCloseDeploymentMsg).toHaveBeenCalledWith(wallet.address, "100");
       expect(signerService.executeDecodedTxByUserWallet).toHaveBeenCalledWith(wallet, [closeMsg]);
     });
+
+    it("does not broadcast a close tx when the deployment is already closed", async () => {
+      const { service, signerService, rpcMessageService, deploymentReaderService } = setup();
+      deploymentReaderService.findByWalletAndDseq.mockResolvedValue({
+        ...deploymentData,
+        deployment: { ...deploymentData.deployment, state: "closed" }
+      });
+
+      await service.close(wallet, "100");
+
+      expect(rpcMessageService.getCloseDeploymentMsg).not.toHaveBeenCalled();
+      expect(signerService.executeDecodedTxByUserWallet).not.toHaveBeenCalled();
+    });
   });
 
   describe("deposit", () => {

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -62,6 +62,7 @@ export class DeploymentWriterService {
 
   public async close(wallet: WalletInitialized, dseq: string): Promise<void> {
     const deployment = await this.deploymentReaderService.findByWalletAndDseq(wallet, dseq);
+    if (deployment.deployment.state === "closed") return;
     const message = this.rpcMessageService.getCloseDeploymentMsg(wallet.address, deployment.deployment.id.dseq);
     await this.signerService.executeDecodedTxByUserWallet(wallet, [message]);
   }

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -7,6 +7,7 @@ import { BillingConfigService } from "@src/billing/services/billing-config/billi
 import { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
 import { RpcMessageService } from "@src/billing/services/rpc-message-service/rpc-message.service";
 import { WalletInitialized, WalletReaderService } from "@src/billing/services/wallet-reader/wallet-reader.service";
+import { LoggerService } from "@src/core";
 import {
   CreateDeploymentRequest,
   CreateDeploymentResponse,
@@ -17,6 +18,7 @@ import { SdlService } from "@src/deployment/services/sdl/sdl.service";
 import { ProviderService } from "@src/provider/services/provider/provider.service";
 import { denomToUdenom } from "@src/utils/math";
 import { DeploymentReaderService } from "../deployment-reader/deployment-reader.service";
+import { StaleManagedDeploymentsCleanerService } from "../stale-managed-deployments-cleaner/stale-managed-deployments-cleaner.service";
 
 @singleton()
 export class DeploymentWriterService {
@@ -27,12 +29,18 @@ export class DeploymentWriterService {
     private readonly billingConfig: BillingConfigService,
     private readonly providerService: ProviderService,
     private readonly deploymentReaderService: DeploymentReaderService,
-    private readonly walletReaderService: WalletReaderService
+    private readonly walletReaderService: WalletReaderService,
+    private readonly staleDeploymentsCleaner: StaleManagedDeploymentsCleanerService,
+    private readonly logger: LoggerService
   ) {}
 
   public async create(input: CreateDeploymentRequest["data"] & { userId: string }): Promise<CreateDeploymentResponse["data"]> {
     const wallet = await this.walletReaderService.getWalletByUserId(input.userId);
     const manifest = this.#parseManifest(input.sdl, { isTrialing: !!wallet.isTrialing });
+
+    if (wallet.isTrialing) {
+      await this.reclaimTrialOrphanedDeployments(wallet);
+    }
 
     const dseq = Date.now();
     const manifestVersion = await this.sdlService.generateManifestVersion(manifest.groups);
@@ -53,6 +61,22 @@ export class DeploymentWriterService {
       manifest: manifestToSortedJSON(manifest.groups),
       signTx: result
     };
+  }
+
+  /**
+   * Reclaims escrow from a trial wallet's orphaned (open, lease-less) deployments before a new create, so a stranded
+   * trial user whose earlier close failed can deploy again without waiting for the periodic cleanup job. It runs
+   * before the create tx so the freed deployment allowance is available when the create's balance check runs.
+   * Best-effort: a cleanup failure never blocks the create, which then proceeds and may 402 exactly as it would today.
+   * Age 0 also closes an actively-quoting lease-less deployment of the same trial user, acceptable since a trial
+   * balance cannot fund two deployments at once.
+   */
+  private async reclaimTrialOrphanedDeployments(wallet: WalletInitialized): Promise<void> {
+    try {
+      await this.staleDeploymentsCleaner.cleanUpForWallet(wallet, 0);
+    } catch (error) {
+      this.logger.warn({ event: "TRIAL_ORPHAN_CLEANUP_FAILED", address: wallet.address, error });
+    }
   }
 
   public async closeByUserIdAndDseq(userId: string, dseq: string): Promise<void> {

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -84,11 +84,23 @@ export class DeploymentWriterService {
     return this.close(wallet, dseq);
   }
 
+  /**
+   * Idempotent close: an already-`closed` deployment is a no-op. The state read is a check→broadcast window, so a
+   * concurrent close (a user cancel racing the cleanup cron, or two overlapping cleanup runs) can settle it between
+   * the read and the broadcast; the losing tx then fails on an already-closed deployment. Re-read once on failure and
+   * treat a now-closed deployment as success, otherwise surface the original error.
+   */
   public async close(wallet: WalletInitialized, dseq: string): Promise<void> {
     const deployment = await this.deploymentReaderService.findByWalletAndDseq(wallet, dseq);
     if (deployment.deployment.state === "closed") return;
     const message = this.rpcMessageService.getCloseDeploymentMsg(wallet.address, deployment.deployment.id.dseq);
-    await this.signerService.executeDecodedTxByUserWallet(wallet, [message]);
+    try {
+      await this.signerService.executeDecodedTxByUserWallet(wallet, [message]);
+    } catch (error) {
+      const latest = await this.deploymentReaderService.findByWalletAndDseq(wallet, dseq).catch(() => null);
+      if (latest?.deployment.state === "closed") return;
+      throw error;
+    }
   }
 
   public async deposit(options: { userId: string; dseq: string; amount: number }): Promise<GetDeploymentResponse["data"]> {

--- a/apps/api/src/deployment/services/stale-managed-deployments-cleaner/stale-managed-deployments-cleaner.service.spec.ts
+++ b/apps/api/src/deployment/services/stale-managed-deployments-cleaner/stale-managed-deployments-cleaner.service.spec.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { BillingConfig } from "@src/billing/providers";
+import type { UserWalletOutput, UserWalletRepository } from "@src/billing/repositories";
+import type { ManagedUserWalletService, RpcMessageService } from "@src/billing/services";
+import type { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
+import type { BlockRepository } from "@src/chain/repositories/block.repository";
+import type { ErrorService } from "@src/core/services/error/error.service";
+import type { DeploymentRepository } from "@src/deployment/repositories/deployment/deployment.repository";
+import { StaleManagedDeploymentsCleanerService } from "./stale-managed-deployments-cleaner.service";
+
+describe(StaleManagedDeploymentsCleanerService.name, () => {
+  const wallet = mock<UserWalletOutput>({ id: 1, address: "akash1testaddr" });
+
+  it("cuts off well below the current height when no age override is passed", async () => {
+    const { service, deploymentRepository } = setup({ currentHeight: 1_000_000 });
+
+    await service.cleanUpForWallet(wallet);
+
+    const cutoff = deploymentRepository.findStaleDeployments.mock.calls[0][0].createdHeight;
+    expect(cutoff).toBeLessThan(1_000_000);
+  });
+
+  it("uses the current height as the cutoff when age 0 is passed so every lease-less deployment is stale", async () => {
+    const { service, deploymentRepository } = setup({ currentHeight: 1_000_000 });
+
+    await service.cleanUpForWallet(wallet, 0);
+
+    expect(deploymentRepository.findStaleDeployments).toHaveBeenCalledWith({ owner: wallet.address, createdHeight: 1_000_000 });
+  });
+
+  it("does not broadcast when there are no stale deployments", async () => {
+    const { service, managedSignerService } = setup({ staleDeployments: [] });
+
+    await service.cleanUpForWallet(wallet, 0);
+
+    expect(managedSignerService.executeDerivedTx).not.toHaveBeenCalled();
+  });
+
+  it("closes all stale deployments in a single derived tx", async () => {
+    const closeMsg = { typeUrl: "/close", value: {} };
+    const { service, managedSignerService, rpcMessageService } = setup({ staleDeployments: [{ dseq: 1 }, { dseq: 2 }] });
+    rpcMessageService.getCloseDeploymentMsg.mockReturnValue(closeMsg as never);
+
+    await service.cleanUpForWallet(wallet, 0);
+
+    expect(managedSignerService.executeDerivedTx).toHaveBeenCalledWith(wallet.id, [closeMsg, closeMsg]);
+  });
+
+  function setup(input?: { currentHeight?: number; staleDeployments?: { dseq: number }[] }) {
+    const userWalletRepository = mock<UserWalletRepository>();
+    const deploymentRepository = mock<DeploymentRepository>();
+    const blockRepository = mock<BlockRepository>();
+    const rpcMessageService = mock<RpcMessageService>();
+    const managedSignerService = mock<ManagedSignerService>();
+    const config = mock<BillingConfig>();
+    const managedUserWalletService = mock<ManagedUserWalletService>();
+    const errorService = mock<ErrorService>();
+
+    blockRepository.getLatestProcessedHeight.mockResolvedValue(input?.currentHeight ?? 1_000_000);
+    deploymentRepository.findStaleDeployments.mockResolvedValue(input?.staleDeployments ?? []);
+
+    const service = new StaleManagedDeploymentsCleanerService(
+      userWalletRepository,
+      deploymentRepository,
+      blockRepository,
+      rpcMessageService,
+      managedSignerService,
+      config,
+      managedUserWalletService,
+      errorService
+    );
+
+    return {
+      service,
+      userWalletRepository,
+      deploymentRepository,
+      blockRepository,
+      rpcMessageService,
+      managedSignerService,
+      config,
+      managedUserWalletService,
+      errorService
+    };
+  }
+});

--- a/apps/api/src/deployment/services/stale-managed-deployments-cleaner/stale-managed-deployments-cleaner.service.ts
+++ b/apps/api/src/deployment/services/stale-managed-deployments-cleaner/stale-managed-deployments-cleaner.service.ts
@@ -46,11 +46,11 @@ export class StaleManagedDeploymentsCleanerService {
     });
   }
 
-  private async cleanUpForWallet(wallet: UserWalletOutput) {
+  async cleanUpForWallet(wallet: UserWalletOutput, maxLiveBlocks: number = this.MAX_LIVE_BLOCKS) {
     const currentHeight = await this.blockRepository.getLatestProcessedHeight();
     const deployments = await this.deploymentRepository.findStaleDeployments({
       owner: wallet.address!,
-      createdHeight: currentHeight - this.MAX_LIVE_BLOCKS
+      createdHeight: currentHeight - maxLiveBlocks
     });
 
     const messages = deployments.map(deployment => this.rpcMessageService.getCloseDeploymentMsg(wallet.address!, deployment.dseq));

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.spec.tsx
@@ -9,7 +9,7 @@ import { defaultService } from "@src/utils/sdl/data";
 import { ConfigurationPane } from "../ConfigurationPane/ConfigurationPane";
 import { usePlacementManager } from "../DeploymentPane/usePlacementManager/usePlacementManager";
 import { importDeploymentState } from "../importDeploymentState/importDeploymentState";
-import type { DeploymentFlow } from "../useDeploymentFlow/useDeploymentFlow";
+import type { DeploymentFlow, FlowErrorKind } from "../useDeploymentFlow/useDeploymentFlow";
 import type { DEPENDENCIES } from "./ConfigureDeploymentForm";
 import { ConfigureDeploymentForm, firstBidReadyServiceId, nextUndoneServiceId } from "./ConfigureDeploymentForm";
 
@@ -307,6 +307,20 @@ describe(ConfigureDeploymentForm.name, () => {
     expect(enqueueSnackbar).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ variant: "error" }));
   });
 
+  it("titles the toast as a close failure when the flow error is a close error", () => {
+    const { enqueueSnackbar } = setup({ initialSdl: undefined, flowError: { message: "still closing", kind: "close" } });
+
+    const toast = enqueueSnackbar.mock.calls[0][0] as { props: { title: string } };
+    expect(toast.props.title).toBe("Couldn't close the deployment");
+  });
+
+  it("keeps the quotes-error title for a non-close flow error", () => {
+    const { enqueueSnackbar } = setup({ initialSdl: undefined, flowError: { message: "No providers", kind: "no-providers" } });
+
+    const toast = enqueueSnackbar.mock.calls[0][0] as { props: { title: string } };
+    expect(toast.props.title).toBe("Couldn't get provider quotes");
+  });
+
   it("resets the trial before re-requesting quotes when a previous trial start terminally errored", () => {
     const { ConfigureDeploymentHeader, requestQuotes, retryTrial } = setup({ initialSdl: undefined, trialError: new Error("trial boom") });
     const headerFlow = (ConfigureDeploymentHeader as ReturnType<typeof vi.fn>).mock.calls[0][0].flow as DeploymentFlow;
@@ -422,7 +436,7 @@ describe(ConfigureDeploymentForm.name, () => {
     Panes?: typeof SdlProbePanes;
     draftId?: string;
     deploySucceeded?: boolean;
-    flowError?: { message?: string };
+    flowError?: { message?: string; kind?: FlowErrorKind };
     trialError?: unknown;
     vm?: boolean;
     phase?: DeploymentFlow["phase"];

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
@@ -27,7 +27,7 @@ import { ReviewAndDeployModal } from "../ReviewAndDeployModal/ReviewAndDeployMod
 import { SdlImportExport } from "../SdlImportExport/SdlImportExport";
 import { useConfigureDraft } from "../useConfigureDraft/useConfigureDraft";
 import type { DeploymentIntent } from "../useDeploymentFlow/deploymentIntent";
-import type { DeploymentFlow } from "../useDeploymentFlow/useDeploymentFlow";
+import type { DeploymentFlow, FlowErrorKind } from "../useDeploymentFlow/useDeploymentFlow";
 import { useDeploymentName } from "../useDeploymentName/useDeploymentName";
 
 export const DEPENDENCIES = {
@@ -173,17 +173,9 @@ export const ConfigureDeploymentForm: FC<Props> = ({ initialSdl, initialName, in
 
   useEffect(
     function toastFlowError() {
-      // Surfaces a failed quote request or the no-providers timeout, both of which flip the header/panes back to
-      // editable with no other cue. Guarded on identity so it fires once per new error, not on every re-render.
       if (flow.error && flow.error !== lastToastedFlowError.current) {
-        enqueueSnackbar(
-          <d.Snackbar
-            title="Couldn't get provider quotes"
-            subTitle={flow.error.message ?? "Something went wrong. Please adjust your deployment and try again."}
-            iconVariant="error"
-          />,
-          { variant: "error" }
-        );
+        const { title, fallback } = flowErrorToastCopy(flow.error.kind);
+        enqueueSnackbar(<d.Snackbar title={title} subTitle={flow.error.message ?? fallback} iconVariant="error" />, { variant: "error" });
       }
       lastToastedFlowError.current = flow.error;
     },
@@ -371,6 +363,20 @@ function getImportErrorMessage(error: unknown): string {
     return "The deployment couldn't be loaded because its SDL is invalid.";
   }
   return "The deployment couldn't be loaded.";
+}
+
+/**
+ * Title and subtitle-fallback for the flow-error toast. A failed close gets its own copy that reassures the user the
+ * stranded deployment is not lost: requesting quotes again closes it first, so no manual recovery is needed.
+ */
+function flowErrorToastCopy(kind: FlowErrorKind | undefined): { title: string; fallback: string } {
+  if (kind === "close") {
+    return {
+      title: "Couldn't close the deployment",
+      fallback: "Your previous deployment is still closing. It will be closed automatically when you request quotes again."
+    };
+  }
+  return { title: "Couldn't get provider quotes", fallback: "Something went wrong. Please adjust your deployment and try again." };
 }
 
 /** Regenerates the preview SDL, keeping the last good output while the form is mid-edit. */

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useCreateDeployment/useCreateDeployment.spec.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useCreateDeployment/useCreateDeployment.spec.ts
@@ -61,6 +61,18 @@ describe(useCreateDeployment.name, () => {
     expect(mutate).toHaveBeenCalledWith(VARIABLES, expect.objectContaining({ onError, onSuccess }));
   });
 
+  it("drops a held create so it never fires even after the wallet becomes ready", () => {
+    const { result, mutate, rerender } = setup({ isWalletReady: false });
+
+    result.current.mutate(VARIABLES, { onSuccess: vi.fn() });
+    expect(mutate).not.toHaveBeenCalled();
+
+    result.current.dropPending();
+    rerender({ isWalletReady: true });
+
+    expect(mutate).not.toHaveBeenCalled();
+  });
+
   function setup(initialProps: UseCreateDeploymentOptions) {
     const mutate = vi.fn();
     const mutation = mock<ReturnType<typeof DEPENDENCIES.useCreateDeploymentMutation>>({ mutate: mutate as never });

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useCreateDeployment/useCreateDeployment.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useCreateDeployment/useCreateDeployment.ts
@@ -34,11 +34,14 @@ export type UseCreateDeploymentOptions = {
  * (not `gatedMutate`) owns the fail-on-error decision, reading the latest `trialError`. That lets a retry which
  * resets the trial (clearing `trialError`) rescue the held create — it flushes when the re-attempted trial
  * provisions — instead of the create failing against a stale error captured at click time.
+ *
+ * `dropPending()` abandons a still-held create so a cancel during the trial wait really cancels it; a create that has
+ * already flushed is out of reach here and is instead neutralized by the flow's stale-attempt auto-close.
  */
 export function useCreateDeployment(
   { isWalletReady, trialError }: UseCreateDeploymentOptions,
   d: typeof DEPENDENCIES = DEPENDENCIES
-): CreateDeploymentMutation {
+): CreateDeploymentMutation & { dropPending: () => void } {
   const mutation = d.useCreateDeploymentMutation();
   const { mutate } = mutation;
   const pendingRef = useRef<{ variables: MutateVariables; options?: MutateOptions } | null>(null);
@@ -69,5 +72,9 @@ export function useCreateDeployment(
     [isWalletReady, mutate]
   );
 
-  return useMemo(() => ({ ...mutation, mutate: gatedMutate }), [mutation, gatedMutate]);
+  const dropPending = useCallback(function dropPending() {
+    pendingRef.current = null;
+  }, []);
+
+  return useMemo(() => ({ ...mutation, mutate: gatedMutate, dropPending }), [mutation, gatedMutate, dropPending]);
 }

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.spec.tsx
@@ -771,6 +771,27 @@ describe(useDeploymentFlow.name, () => {
       expect(result.current.phase).toBe("configuring");
       expect(result.current.dseq).toBeNull();
     });
+
+    it("drops a stale pre-create close verification instead of clobbering a cancelled-and-reconfigured session", () => {
+      const closeCalls: Array<{ onSuccess?: (result: unknown) => void; onError?: (cause: unknown) => void }> = [];
+      const closeMutate = vi.fn((_args, options) => closeCalls.push(options));
+      const verifyCalls: Array<(result: { data: { deployment: { state: string } } }) => void> = [];
+      const getDeploymentMutate = vi.fn((_args, options) => verifyCalls.push(options.onSuccess));
+      const { result } = setup({ intent: { sdlStrategy: "edit", bidStrategy: "select", dseq: "777" }, closeMutate, getDeploymentMutate });
+
+      act(() => result.current.actions.requestQuotes("sdl"));
+      act(() => closeCalls[0]?.onError?.(new Error("close boom")));
+      expect(result.current.phase).toBe("creating");
+
+      act(() => result.current.actions.cancelAndEdit());
+      act(() => closeCalls[1]?.onSuccess?.({}));
+      expect(result.current.phase).toBe("configuring");
+
+      act(() => verifyCalls[0]?.({ data: { deployment: { state: "active" } } }));
+
+      expect(result.current.phase).toBe("configuring");
+      expect(result.current.error).toBeUndefined();
+    });
   });
 
   function setup(input: {

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.spec.tsx
@@ -1,4 +1,5 @@
 import type { PropsWithChildren } from "react";
+import { ApiError } from "@akashnetwork/openapi-sdk";
 import { createStore, Provider as JotaiStoreProvider } from "jotai";
 import { describe, expect, it, vi } from "vitest";
 import { mock, mockDeep } from "vitest-mock-extended";
@@ -621,24 +622,158 @@ describe(useDeploymentFlow.name, () => {
     }
   });
 
+  describe("cancel and edit close reliability", () => {
+    it("stays in configuring and auto-closes the deployment when cancelled while it is still being created", () => {
+      const replace = vi.fn();
+      let resolveCreate: ((result: { data: { dseq: string; manifest: string } }) => void) | undefined;
+      const createMutate = vi.fn((_args, options) => {
+        resolveCreate = options.onSuccess;
+      });
+      const { result, closeDeployment } = setup({ replace, createMutate });
+
+      act(() => result.current.actions.requestQuotes("sdl"));
+      expect(result.current.phase).toBe("creating");
+
+      act(() => result.current.actions.cancelAndEdit());
+      expect(result.current.phase).toBe("configuring");
+
+      act(() => resolveCreate?.({ data: { dseq: "999", manifest: "m" } }));
+
+      expect(result.current.phase).toBe("configuring");
+      expect(result.current.dseq).toBeNull();
+      expect(closeDeployment.mutate).toHaveBeenCalledWith({ dseq: "999" }, expect.any(Object));
+      expect(replace.mock.calls.every(([url]) => !String(url).includes("/configure/999"))).toBe(true);
+    });
+
+    it("drops the held create when cancelled during create", () => {
+      const { result, createDeployment } = setup({ createMutate: vi.fn() });
+
+      act(() => result.current.actions.requestQuotes("sdl"));
+      act(() => result.current.actions.cancelAndEdit());
+
+      expect(createDeployment.dropPending).toHaveBeenCalledTimes(1);
+    });
+
+    it("tracks cancel_during_create when cancelling while the deployment is being created", () => {
+      const { result, analyticsService } = setup({ createMutate: vi.fn() });
+
+      act(() => result.current.actions.requestQuotes("sdl"));
+      act(() => result.current.actions.cancelAndEdit());
+
+      expect(analyticsService.track).toHaveBeenCalledWith("cancel_during_create", { category: "deployments" });
+    });
+
+    it("tracks cancelled_deployment_auto_close_failed when the late auto-close fails", () => {
+      let resolveCreate: ((result: { data: { dseq: string; manifest: string } }) => void) | undefined;
+      const createMutate = vi.fn((_args, options) => {
+        resolveCreate = options.onSuccess;
+      });
+      const closeMutate = vi.fn((_args, options) => options.onError?.(new Error("auto close boom")));
+      const { result, analyticsService } = setup({ createMutate, closeMutate });
+
+      act(() => result.current.actions.requestQuotes("sdl"));
+      act(() => result.current.actions.cancelAndEdit());
+      act(() => resolveCreate?.({ data: { dseq: "999", manifest: "m" } }));
+
+      expect(analyticsService.track).toHaveBeenCalledWith("cancelled_deployment_auto_close_failed", { category: "deployments", dseq: "999" });
+    });
+
+    it("closes the still-open deployment before creating when requesting quotes with a live dseq", () => {
+      const closeMutate = vi.fn((_args, options) => options.onSuccess?.({}));
+      const createMutate = vi.fn((_args, options) => options.onSuccess?.({ data: { dseq: "1000", manifest: "m" } }));
+      const { result } = setup({ intent: { sdlStrategy: "edit", bidStrategy: "select", dseq: "777" }, closeMutate, createMutate });
+
+      act(() => result.current.actions.requestQuotes("sdl"));
+
+      expect(closeMutate).toHaveBeenCalledWith({ dseq: "777" }, expect.any(Object));
+      expect(createMutate).toHaveBeenCalledWith({ data: { sdl: "sdl", deposit: expect.any(Number) } }, expect.any(Object));
+      expect(result.current.dseq).toBe("1000");
+      expect(result.current.phase).toBe("quoting");
+    });
+
+    it("does not create and surfaces a close error when the pre-create close is verified still open", () => {
+      const closeMutate = vi.fn((_args, options) => options.onError?.(new Error("close boom")));
+      const getDeploymentMutate = vi.fn((_args, options) => options.onSuccess?.({ data: { deployment: { state: "active" } } }));
+      const createMutate = vi.fn();
+      const { result } = setup({ intent: { sdlStrategy: "edit", bidStrategy: "select", dseq: "777" }, closeMutate, getDeploymentMutate, createMutate });
+
+      act(() => result.current.actions.requestQuotes("sdl"));
+
+      expect(result.current.phase).toBe("error");
+      expect(result.current.error?.kind).toBe("close");
+      expect(result.current.dseq).toBe("777");
+      expect(createMutate).not.toHaveBeenCalled();
+    });
+
+    it("returns to configuring without error when a failed close is verified already closed", () => {
+      const closeMutate = vi.fn((_args, options) => options.onError?.(new Error("close boom")));
+      const getDeploymentMutate = vi.fn((_args, options) => options.onSuccess?.({ data: { deployment: { state: "closed" } } }));
+      const { result } = setup({ intent: { sdlStrategy: "edit", bidStrategy: "select", dseq: "777" }, closeMutate, getDeploymentMutate });
+
+      act(() => result.current.actions.cancelAndEdit());
+
+      expect(result.current.phase).toBe("configuring");
+      expect(result.current.error).toBeUndefined();
+      expect(result.current.dseq).toBeNull();
+    });
+
+    it("returns to configuring without error when a failed close verifies as a 404", () => {
+      const closeMutate = vi.fn((_args, options) => options.onError?.(new Error("close boom")));
+      const getDeploymentMutate = vi.fn((_args, options) => options.onError?.(new ApiError(404, undefined, "GET deployment → 404")));
+      const { result } = setup({ intent: { sdlStrategy: "edit", bidStrategy: "select", dseq: "777" }, closeMutate, getDeploymentMutate });
+
+      act(() => result.current.actions.cancelAndEdit());
+
+      expect(result.current.phase).toBe("configuring");
+      expect(result.current.error).toBeUndefined();
+      expect(result.current.dseq).toBeNull();
+    });
+
+    it("keeps the deployment editable in error when a failed close is verified still open", () => {
+      const closeMutate = vi.fn((_args, options) => options.onError?.(new Error("close boom")));
+      const getDeploymentMutate = vi.fn((_args, options) => options.onSuccess?.({ data: { deployment: { state: "active" } } }));
+      const { result } = setup({ intent: { sdlStrategy: "edit", bidStrategy: "select", dseq: "777" }, closeMutate, getDeploymentMutate });
+
+      act(() => result.current.actions.cancelAndEdit());
+
+      expect(result.current.phase).toBe("error");
+      expect(result.current.error?.kind).toBe("close");
+      expect(result.current.dseq).toBe("777");
+    });
+
+    it("tracks close_deployment_failed with the verified outcome on a failed close", () => {
+      const closeMutate = vi.fn((_args, options) => options.onError?.(new Error("close boom")));
+      const getDeploymentMutate = vi.fn((_args, options) => options.onSuccess?.({ data: { deployment: { state: "closed" } } }));
+      const { result, analyticsService } = setup({ intent: { sdlStrategy: "edit", bidStrategy: "select", dseq: "777" }, closeMutate, getDeploymentMutate });
+
+      act(() => result.current.actions.cancelAndEdit());
+
+      expect(analyticsService.track).toHaveBeenCalledWith("close_deployment_failed", { category: "deployments", dseq: "777", verifiedClosed: true });
+    });
+  });
+
   function setup(input: {
     intent?: { sdlStrategy: "default" | "edit"; bidStrategy: "auto" | "select"; dseq?: string; templateId?: string; draftId?: string; vm?: boolean };
     replace?: ReturnType<typeof vi.fn>;
     createMutate?: ReturnType<typeof vi.fn>;
     closeMutate?: ReturnType<typeof vi.fn>;
+    getDeploymentMutate?: ReturnType<typeof vi.fn>;
   }) {
     const intent = { vm: false, ...(input.intent ?? { sdlStrategy: "edit" as const, bidStrategy: "select" as const, dseq: undefined }) };
-    const services = mockServices({ closeDeployment: mockMutation(input.closeMutate) });
+    const closeDeployment = mockMutation(input.closeMutate);
+    const getDeployment = mockMutation(input.getDeploymentMutate);
+    const services = mockServices({ closeDeployment, getDeployment });
+    const createDeployment = mock<ReturnType<typeof DEPENDENCIES.useCreateDeployment>>({ mutate: (input.createMutate ?? vi.fn()) as never });
     const dependencies: typeof DEPENDENCIES = {
       useServices: (() => services) as never,
-      useCreateDeployment: (() => mock<ReturnType<typeof DEPENDENCIES.useCreateDeployment>>({ mutate: (input.createMutate ?? vi.fn()) as never })) as never,
+      useCreateDeployment: (() => createDeployment) as never,
       useListBids: (() => ({ data: { data: [] }, isLoading: false, isError: false })) as never,
       useRouter: (() => mock<ReturnType<typeof DEPENDENCIES.useRouter>>({ replace: (input.replace ?? vi.fn()) as never })) as never,
       useQueryClient: (() => mock<ReturnType<typeof DEPENDENCIES.useQueryClient>>()) as never,
       manifestFromSdl: () => "manifest",
       deploymentResourcesFromSdl: () => ({ gpuAmount: 0, cpuAmount: 0, memoryAmount: 0, storageAmount: 0 })
     };
-    return { ...renderDeploymentFlow(intent, dependencies), analyticsService: services.analyticsService };
+    return { ...renderDeploymentFlow(intent, dependencies), analyticsService: services.analyticsService, createDeployment, closeDeployment, getDeployment };
   }
 
   function renderFlow(input?: {
@@ -676,11 +811,13 @@ describe(useDeploymentFlow.name, () => {
     closeDeployment?: ReturnType<typeof mockMutation>;
     createLease?: ReturnType<typeof mockMutation>;
     updateDeployment?: ReturnType<typeof mockMutation>;
+    getDeployment?: ReturnType<typeof mockMutation>;
   }) {
     const services = mockDeep<ReturnType<typeof DEPENDENCIES.useServices>>();
     services.api.v1.closeDeployment.useMutation.mockReturnValue((mutations?.closeDeployment ?? mockMutation()) as never);
     services.api.v1.createLease.useMutation.mockReturnValue((mutations?.createLease ?? mockMutation()) as never);
     services.api.v1.updateDeployment.useMutation.mockReturnValue((mutations?.updateDeployment ?? mockMutation()) as never);
+    services.api.v1.getDeployment.useMutation.mockReturnValue((mutations?.getDeployment ?? mockMutation()) as never);
     return services;
   }
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.spec.tsx
@@ -750,6 +750,27 @@ describe(useDeploymentFlow.name, () => {
 
       expect(analyticsService.track).toHaveBeenCalledWith("close_deployment_failed", { category: "deployments", dseq: "777", verifiedClosed: true });
     });
+
+    it("does not spawn a deployment when cancelled while the pre-create close is still in flight", () => {
+      const closeCallbacks: Array<(result: unknown) => void> = [];
+      const closeMutate = vi.fn((_args, options) => closeCallbacks.push(options.onSuccess));
+      const createMutate = vi.fn();
+      const { result } = setup({ intent: { sdlStrategy: "edit", bidStrategy: "select", dseq: "777" }, closeMutate, createMutate });
+
+      act(() => result.current.actions.requestQuotes("sdl"));
+      expect(result.current.phase).toBe("creating");
+      expect(closeMutate).toHaveBeenCalledTimes(1);
+
+      act(() => result.current.actions.cancelAndEdit());
+      expect(result.current.phase).toBe("closing");
+
+      act(() => closeCallbacks[0]?.({}));
+      expect(createMutate).not.toHaveBeenCalled();
+
+      act(() => closeCallbacks[1]?.({}));
+      expect(result.current.phase).toBe("configuring");
+      expect(result.current.dseq).toBeNull();
+    });
   });
 
   function setup(input: {

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { extractApiErrorMessage } from "@akashnetwork/openapi-sdk";
+import { extractApiErrorMessage, isApiError } from "@akashnetwork/openapi-sdk";
 import { useQueryClient } from "@tanstack/react-query";
 import { useAtomValue } from "jotai";
 import { useRouter } from "next/router";
@@ -18,6 +18,9 @@ import type { BidStrategy, DeploymentIntent } from "./deploymentIntent";
 
 export type DeploymentFlowPhase = "configuring" | "creating" | "quoting" | "closing" | "deploying" | "error";
 
+/** Which step failed, so the form can title the error toast correctly. A close failure reads differently from a failed quote request. */
+export type FlowErrorKind = "create" | "close" | "no-providers";
+
 /** The live bids the flow polls while quoting (react-query-backed). Element shape derived from the shared `listBids` query. */
 export type DeploymentBids = NonNullable<ReturnType<typeof useListBids>["data"]>["data"];
 
@@ -35,7 +38,7 @@ export interface DeploymentFlowState {
   /** True once the lease is created; the deploy overlay completes its progress before the brief redirect to the deployment. */
   deploySucceeded: boolean;
   deployError?: { message?: string };
-  error?: { message?: string };
+  error?: { message?: string; kind?: FlowErrorKind };
 }
 
 export interface DeploymentFlowActions {
@@ -107,13 +110,14 @@ export function useDeploymentFlow(
   const closeDeployment = api.v1.closeDeployment.useMutation();
   const createLease = api.v1.createLease.useMutation();
   const updateDeployment = api.v1.updateDeployment.useMutation();
+  const getDeployment = api.v1.getDeployment.useMutation();
   const queryClient = dependencies.useQueryClient();
   const settingsId = useAtomValue(settingsIdAtom);
 
   const [phase, setPhase] = useState<DeploymentFlowPhase>(intent.dseq ? "quoting" : "configuring");
   const [dseq, setDseq] = useState<string | null>(intent.dseq ?? null);
   const [bidStrategy, setBidStrategyState] = useState<BidStrategy>(intent.bidStrategy);
-  const [error, setError] = useState<{ message?: string } | undefined>(undefined);
+  const [error, setError] = useState<{ message?: string; kind?: FlowErrorKind } | undefined>(undefined);
   const [selections, setSelections] = useState<Record<string, string>>({});
   const [manifest, setManifest] = useState<string | null>(null);
   const [deployError, setDeployError] = useState<{ message?: string } | undefined>(undefined);
@@ -125,6 +129,12 @@ export function useDeploymentFlow(
   /** Read in the async create-success callback so a create resolving after a strategy switch uses the current value. */
   const bidStrategyRef = useRef(bidStrategy);
   bidStrategyRef.current = bidStrategy;
+
+  /**
+   * Bumped on every requestQuotes and on a cancel that predates create resolution. A create whose captured attempt is
+   * stale was cancelled mid-flight, so its late success auto-closes the just-created deployment instead of resuming.
+   */
+  const createAttemptRef = useRef(0);
 
   /** Held in a ref so the no-providers timeout calls the latest `cancelAndEdit` without re-arming the timer each render. */
   const cancelAndEditRef = useRef<() => void>();
@@ -179,7 +189,7 @@ export function useDeploymentFlow(
          */
         function timeOutWithoutProviders() {
           if (intentRef.current.sdlStrategy === "default" && bidStrategyRef.current === "auto") {
-            setError({ message: NO_PROVIDERS_MESSAGE });
+            setError({ message: NO_PROVIDERS_MESSAGE, kind: "no-providers" });
             setPhase("error");
             return;
           }
@@ -195,38 +205,119 @@ export function useDeploymentFlow(
     [phase, hasOpenBids]
   );
 
+  /** The success teardown, shared by a clean close and by a close whose failure verified the deployment is actually gone. */
+  const finishClose = useCallback(function finishClose() {
+    setDseq(null);
+    setSelections({});
+    setManifest(null);
+    setDeployError(undefined);
+    setDeploySucceeded(false);
+    setPhase("configuring");
+  }, []);
+
   /**
-   * Caches the SDL under the settings id + dseq at create time (the create response omits `owner`) so an in-progress
-   * deployment can resume into the flow after a reload — the same key the detail page reads.
+   * Settles an ambiguous close failure with a single live-chain read. tx-signer stops polling (~36s) only after the tx
+   * TTL (30s) has expired, so a reported failure is often a false negative and one refetch is decisive: no indexer lag,
+   * and no window left for the tx to still land. A closed deployment or a 404 means it is gone, so the caller's success
+   * path runs; anything else is a real failure, surfaced as a close error with the deployment left editable.
    */
-  const requestQuotes = useCallback(
-    function requestQuotes(sdl: string) {
-      providersEverBidRef.current = false;
-      bidsReceivedTrackedRef.current = false;
-      setPhase("creating");
-      setError(undefined);
-      createDeployment.mutate(
-        { data: { sdl, deposit: DEFAULT_DEPOSIT } },
+  const verifyCloseOutcome = useCallback(
+    function verifyCloseOutcome(dseqToVerify: string, cause: unknown, onActuallyClosed: () => void) {
+      function settle(verifiedClosed: boolean) {
+        analyticsService.track("close_deployment_failed", { category: "deployments", dseq: dseqToVerify, verifiedClosed });
+        if (verifiedClosed) {
+          onActuallyClosed();
+          return;
+        }
+        setError({ message: extractApiErrorMessage(cause) ?? undefined, kind: "close" });
+        setPhase("error");
+      }
+      getDeployment.mutate(
+        { dseq: dseqToVerify },
         {
-          onSuccess: function onCreated(result: { data: { dseq: string; manifest: string } }) {
-            setDseq(result.data.dseq);
-            setManifest(result.data.manifest);
-            setSelections({});
-            setDeployError(undefined);
-            setDeploySucceeded(false);
-            setPhase("quoting");
-            analyticsService.track("create_deployment", { category: "deployments", label: "Create deployment in wizard", dseq: result.data.dseq });
-            cacheDeployedSdl(deploymentLocalStorage, settingsId, result.data.dseq, sdl);
-            router.replace(buildConfigureUrl(intentRef.current, result.data.dseq, bidStrategyRef.current), undefined, { shallow: true });
+          onSuccess: function onVerified(result: { data: { deployment: { state: string } } }) {
+            settle(result.data.deployment.state === "closed");
           },
-          onError: function onCreateFailed(cause: unknown) {
-            setError({ message: extractApiErrorMessage(cause) ?? undefined });
-            setPhase("error");
+          onError: function onVerifyFailed(verifyError: unknown) {
+            settle(isApiError(verifyError) && verifyError.status === 404);
           }
         }
       );
     },
-    [createDeployment, router, deploymentLocalStorage, settingsId, analyticsService]
+    [getDeployment, analyticsService]
+  );
+
+  /**
+   * Caches the SDL under the settings id + dseq at create time (the create response omits `owner`) so an in-progress
+   * deployment can resume into the flow after a reload, under the same key the detail page reads. When a previous
+   * deployment is still open (a prior close failed), it is closed first so the single-open-deployment invariant holds.
+   */
+  const requestQuotes = useCallback(
+    function requestQuotes(sdl: string) {
+      const attempt = ++createAttemptRef.current;
+      providersEverBidRef.current = false;
+      bidsReceivedTrackedRef.current = false;
+      setError(undefined);
+
+      function create() {
+        setPhase("creating");
+        createDeployment.mutate(
+          { data: { sdl, deposit: DEFAULT_DEPOSIT } },
+          {
+            onSuccess: function onCreated(result: { data: { dseq: string; manifest: string } }) {
+              if (attempt !== createAttemptRef.current) {
+                closeDeployment.mutate(
+                  { dseq: result.data.dseq },
+                  {
+                    onError: function trackAutoCloseFailure() {
+                      analyticsService.track("cancelled_deployment_auto_close_failed", { category: "deployments", dseq: result.data.dseq });
+                    }
+                  }
+                );
+                return;
+              }
+              setDseq(result.data.dseq);
+              setManifest(result.data.manifest);
+              setSelections({});
+              setDeployError(undefined);
+              setDeploySucceeded(false);
+              setPhase("quoting");
+              analyticsService.track("create_deployment", { category: "deployments", label: "Create deployment in wizard", dseq: result.data.dseq });
+              cacheDeployedSdl(deploymentLocalStorage, settingsId, result.data.dseq, sdl);
+              router.replace(buildConfigureUrl(intentRef.current, result.data.dseq, bidStrategyRef.current), undefined, { shallow: true });
+            },
+            onError: function onCreateFailed(cause: unknown) {
+              if (attempt !== createAttemptRef.current) return;
+              setError({ message: extractApiErrorMessage(cause) ?? undefined, kind: "create" });
+              setPhase("error");
+            }
+          }
+        );
+      }
+
+      if (dseq) {
+        setPhase("creating");
+        closeDeployment.mutate(
+          { dseq },
+          {
+            onSuccess: function onPriorClosed() {
+              setDseq(null);
+              create();
+            },
+            onError: function onPriorCloseFailed(cause: unknown) {
+              verifyCloseOutcome(dseq, cause, function createAfterVerifiedClose() {
+                setDseq(null);
+                create();
+              });
+            }
+          }
+        );
+        return;
+      }
+
+      create();
+    },
+    [createDeployment, closeDeployment, dseq, router, deploymentLocalStorage, settingsId, analyticsService, verifyCloseOutcome]
   );
 
   /** Drops the dseq from the URL immediately, not on close-success, so a returning user never sees the abandoned deployment while the close is in flight. */
@@ -234,6 +325,10 @@ export function useDeploymentFlow(
     function cancelAndEdit() {
       router.replace(buildConfigureUrl(intentRef.current, undefined, bidStrategy), undefined, { shallow: true });
       if (!dseq) {
+        if (phase === "creating") analyticsService.track("cancel_during_create", { category: "deployments" });
+        createAttemptRef.current += 1;
+        createDeployment.dropPending();
+        setError(undefined);
         setPhase("configuring");
         return;
       }
@@ -242,22 +337,14 @@ export function useDeploymentFlow(
       closeDeployment.mutate(
         { dseq },
         {
-          onSuccess: function onClosed() {
-            setDseq(null);
-            setSelections({});
-            setManifest(null);
-            setDeployError(undefined);
-            setDeploySucceeded(false);
-            setPhase("configuring");
-          },
+          onSuccess: finishClose,
           onError: function onCloseFailed(cause: unknown) {
-            setError({ message: extractApiErrorMessage(cause) ?? undefined });
-            setPhase("error");
+            verifyCloseOutcome(dseq, cause, finishClose);
           }
         }
       );
     },
-    [closeDeployment, dseq, router, bidStrategy]
+    [closeDeployment, dseq, phase, router, bidStrategy, analyticsService, createDeployment, finishClose, verifyCloseOutcome]
   );
   cancelAndEditRef.current = cancelAndEdit;
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.ts
@@ -220,11 +220,14 @@ export function useDeploymentFlow(
    * Settles an ambiguous close failure with a single live-chain read. tx-signer stops polling (~36s) only after the tx
    * TTL (30s) has expired, so a reported failure is often a false negative and one refetch is decisive: no indexer lag,
    * and no window left for the tx to still land. A closed deployment or a 404 means it is gone, so the caller's success
-   * path runs; anything else is a real failure, surfaced as a close error with the deployment left editable.
+   * path runs; anything else is a real failure, surfaced as a close error with the deployment left editable. The read is
+   * async, so `attempt` pins it to its originating flow: a cancel or re-quote that superseded it drops the settle rather
+   * than clobbering the newer session back into an error.
    */
   const verifyCloseOutcome = useCallback(
-    function verifyCloseOutcome(dseqToVerify: string, cause: unknown, onActuallyClosed: () => void) {
+    function verifyCloseOutcome(dseqToVerify: string, cause: unknown, attempt: number, onActuallyClosed: () => void) {
       function settle(verifiedClosed: boolean) {
+        if (attempt !== createAttemptRef.current) return;
         analyticsService.track("close_deployment_failed", { category: "deployments", dseq: dseqToVerify, verifiedClosed });
         if (verifiedClosed) {
           onActuallyClosed();
@@ -307,7 +310,7 @@ export function useDeploymentFlow(
               create();
             },
             onError: function onPriorCloseFailed(cause: unknown) {
-              verifyCloseOutcome(dseq, cause, function createAfterVerifiedClose() {
+              verifyCloseOutcome(dseq, cause, attempt, function createAfterVerifiedClose() {
                 setDseq(null);
                 create();
               });
@@ -336,12 +339,13 @@ export function useDeploymentFlow(
       }
       setPhase("closing");
       setError(undefined);
+      const attempt = createAttemptRef.current;
       closeDeployment.mutate(
         { dseq },
         {
           onSuccess: finishClose,
           onError: function onCloseFailed(cause: unknown) {
-            verifyCloseOutcome(dseq, cause, finishClose);
+            verifyCloseOutcome(dseq, cause, attempt, finishClose);
           }
         }
       );

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.ts
@@ -131,8 +131,9 @@ export function useDeploymentFlow(
   bidStrategyRef.current = bidStrategy;
 
   /**
-   * Bumped on every requestQuotes and on a cancel that predates create resolution. A create whose captured attempt is
-   * stale was cancelled mid-flight, so its late success auto-closes the just-created deployment instead of resuming.
+   * Bumped on every requestQuotes and every cancel, so any create from a superseded attempt is treated as stale: one
+   * not yet started (still behind a pre-create close) is skipped in `create()`, and one already in flight has its late
+   * success auto-close the just-created deployment instead of resuming.
    */
   const createAttemptRef = useRef(0);
 
@@ -260,6 +261,7 @@ export function useDeploymentFlow(
       setError(undefined);
 
       function create() {
+        if (attempt !== createAttemptRef.current) return;
         setPhase("creating");
         createDeployment.mutate(
           { data: { sdl, deposit: DEFAULT_DEPOSIT } },
@@ -324,9 +326,9 @@ export function useDeploymentFlow(
   const cancelAndEdit = useCallback(
     function cancelAndEdit() {
       router.replace(buildConfigureUrl(intentRef.current, undefined, bidStrategy), undefined, { shallow: true });
+      createAttemptRef.current += 1;
       if (!dseq) {
         if (phase === "creating") analyticsService.track("cancel_during_create", { category: "deployments" });
-        createAttemptRef.current += 1;
         createDeployment.dropPending();
         setError(undefined);
         setPhase("configuring");

--- a/apps/deploy-web/src/services/analytics/analytics.service.ts
+++ b/apps/deploy-web/src/services/analytics/analytics.service.ts
@@ -125,7 +125,10 @@ export type AnalyticsEvent =
   | "configure_cpu_count_changed"
   | "configure_sdl_imported"
   | "configure_sdl_downloaded"
-  | "configure_sdl_copied";
+  | "configure_sdl_copied"
+  | "cancel_during_create"
+  | "close_deployment_failed"
+  | "cancelled_deployment_auto_close_failed";
 
 export type AnalyticsCategory = "user" | "billing" | "deployments" | "wallet" | "sdl_builder" | "transactions" | "profile" | "settings" | "onboarding";
 


### PR DESCRIPTION
## Why

On the configure page, "Cancel and edit" could fail to close a just-created deployment. For a trial
user ($1 credit, $0.50 minimum escrow per deployment) one failed close plus a retry of "Request
quotes" locks the whole balance in escrow: every further create then 402s ("Not enough funds to
cover the deployment costs"), and onboarding offers no recovery path until the stale-deployment
cleanup job reclaims the empty deployments (~10 min later). A race variant also existed: cancelling
while the create was still in flight did not stick, the deployment appeared anyway, the form
re-locked into quoting, and the 60s no-bids timeout later re-entered "Cancelling..." on its own.

Fixes CON-748

## What

Client state machine (deploy-web):
- Cancelling during create now sticks: the create attempt is invalidated and any still-held create
  is dropped, so a late-resolving create auto-closes its own deployment instead of re-locking the form.
- Requesting quotes while a previous deployment is still open (a prior close failed) closes that one
  first, preserving the single-open-deployment invariant.
- A failed close is verified against live chain state with a single refetch, since tx-signer can
  report failure for a close that actually landed. A genuinely failed close leaves the form editable
  and gets its own toast ("Couldn't close the deployment") instead of the quotes-error toast.
- Adds 3 analytics events (cancel_during_create, close_deployment_failed,
  cancelled_deployment_auto_close_failed) to measure residual rates.

API:
- close() is now idempotent: it short-circuits when the deployment is already closed, so a re-close
  after a false failure returns success instead of an on-chain "deployment closed" error. This lets
  the client's close-first path converge even if verification raced the settling tx.
- POST /v1/deployments reclaims a trial wallet's orphaned (open, lease-less) deployments before
  creating, independent of client state, so the durable fix survives reloads and lost sessions. It
  reuses the stale-deployment cleaner at age 0, runs before the create's balance check, and is
  best-effort so a cleanup failure never blocks the create.

Verification:
- deploy-web: full unit suite green (2930 passed / 5 skipped), lint clean, 0 new tsc errors vs main.
- api: full unit suite green (1208 passed), lint clean, 0 new tsc errors vs main.
- Manual smoke on a dev stack with a trial user (cancel-during-create, simulated close failure, and
  orphan reclamation on a drained trial allowance) is still recommended before merge; it could not be
  run in this environment.

Follow-ups (out of scope, noted for tracking): tuning the stale-deployment cleanup job cadence and
adding an in-onboarding escape hatch to view/close deployments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic stale-deployment reclamation for trial wallets before creating new deployments.
  - Enabled cancelling a pending deployment request while waiting for wallet readiness.
  - Improved close reliability with post-failure verification and idempotent handling for already-closed deployments.
  - Enhanced error reporting with distinct close vs non-close flow messaging.

- **Bug Fixes**
  - Trial cleanup is best-effort (doesn’t block create on failure).
  - Close failures are now correctly classified and handled to keep the flow consistent.

- **Analytics**
  - Added new events for configuration copying and close/cancel outcomes.

- **Tests**
  - Expanded coverage for cleanup, create/close races, and cancellation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->