### PR TITLE
feat(billing): add fixed-threshold auto top-up UI behind a feature flag

### DIFF
--- a/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.spec.ts
+++ b/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.spec.ts
@@ -49,6 +49,10 @@ describe(WalletReloadJobService.name, () => {
 
       expect(result).toBe(true);
       expect(walletSettingRepository.findByUserId).toHaveBeenCalledWith(userId);
+      expect(jobQueueService.cancelCreatedBy).toHaveBeenCalledWith({
+        name: WalletBalanceReloadCheck.name,
+        singletonKey: `${WalletBalanceReloadCheck.name}.${walletSetting.userId}`
+      });
       expect(jobQueueService.enqueue).toHaveBeenCalledWith(
         expect.any(WalletBalanceReloadCheck),
         expect.objectContaining({
@@ -69,6 +73,10 @@ describe(WalletReloadJobService.name, () => {
       expect(result).toBe(true);
       expect(walletSettingRepository.findOneBy).toHaveBeenCalledWith({ walletId });
       expect(walletSettingRepository.findByUserId).not.toHaveBeenCalled();
+      expect(jobQueueService.cancelCreatedBy).toHaveBeenCalledWith({
+        name: WalletBalanceReloadCheck.name,
+        singletonKey: `${WalletBalanceReloadCheck.name}.${walletSetting.userId}`
+      });
       expect(jobQueueService.enqueue).toHaveBeenCalledWith(
         expect.any(WalletBalanceReloadCheck),
         expect.objectContaining({

--- a/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.ts
+++ b/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.ts
@@ -22,7 +22,7 @@ export class WalletReloadJobService {
         : await this.walletSettingRepository.findOneBy({ walletId: input.walletId });
 
     if (walletSetting?.autoReloadEnabled) {
-      await this.scheduleForWalletSetting(walletSetting);
+      await this.scheduleForWalletSetting(walletSetting, { withCleanup: true });
       return true;
     }
 

--- a/apps/api/src/billing/services/wallet-settings/wallet-settings.service.integration.ts
+++ b/apps/api/src/billing/services/wallet-settings/wallet-settings.service.integration.ts
@@ -159,7 +159,9 @@ describe(WalletSettingService.name, () => {
 
       await service.upsertWalletSetting(user.id, { autoReloadThreshold: 30 });
 
-      expect(walletReloadJobService.scheduleForWalletSetting).toHaveBeenCalledWith(expect.objectContaining({ id: updated.id, userId: user.id }));
+      expect(walletReloadJobService.scheduleForWalletSetting).toHaveBeenCalledWith(expect.objectContaining({ id: updated.id, userId: user.id }), {
+        withCleanup: true
+      });
     });
 
     it("does not schedule a check when reload values are unchanged while enabled", async () => {

--- a/apps/api/src/billing/services/wallet-settings/wallet-settings.service.ts
+++ b/apps/api/src/billing/services/wallet-settings/wallet-settings.service.ts
@@ -142,7 +142,7 @@ export class WalletSettingService {
     }
 
     if (this.#hasReloadValuesChanged(prev, next)) {
-      await this.walletReloadJobService.scheduleForWalletSetting(next);
+      await this.walletReloadJobService.scheduleForWalletSetting(next, { withCleanup: true });
     }
   }
 

--- a/apps/deploy-web/src/components/billing-usage/AccountOverview/AccountOverview.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AccountOverview/AccountOverview.spec.tsx
@@ -177,15 +177,15 @@ describe(AccountOverview.name, () => {
       expect(dependencies.AutoTopUpSettingsPopup).toHaveBeenCalledWith(expect.objectContaining({ open: true, enableOnSave: false }), expect.anything());
     });
 
-    it("disables the switch and edit button without a payment method", () => {
+    it("disables the switch and hides the edit button without a payment method", () => {
       setup({ isFixedThresholdEnabled: true, defaultPaymentMethod: undefined, isLoading: false });
 
       expect(screen.getByRole("switch")).toBeDisabled();
-      expect(screen.getByRole("button", { name: /edit auto top-up settings/i })).toBeDisabled();
+      expect(screen.queryByRole("button", { name: /edit auto top-up settings/i })).not.toBeInTheDocument();
       expect(screen.getByText(/Add a payment method/)).toBeInTheDocument();
     });
 
-    it("disables the edit button while auto top-up is off so saving cannot silently re-enable it", () => {
+    it("hides the edit button while auto top-up is off", () => {
       setup({
         isFixedThresholdEnabled: true,
         defaultPaymentMethod: { id: "pm_123" },
@@ -193,7 +193,7 @@ describe(AccountOverview.name, () => {
         walletSettings: { autoReloadEnabled: false }
       });
 
-      expect(screen.getByRole("button", { name: /edit auto top-up settings/i })).toBeDisabled();
+      expect(screen.queryByRole("button", { name: /edit auto top-up settings/i })).not.toBeInTheDocument();
     });
 
     it("disables the edit button while a settings update is in flight", () => {

--- a/apps/deploy-web/src/components/billing-usage/AccountOverview/AccountOverview.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AccountOverview/AccountOverview.spec.tsx
@@ -185,6 +185,29 @@ describe(AccountOverview.name, () => {
       expect(screen.getByText(/Add a payment method/)).toBeInTheDocument();
     });
 
+    it("disables the edit button while auto top-up is off so saving cannot silently re-enable it", () => {
+      setup({
+        isFixedThresholdEnabled: true,
+        defaultPaymentMethod: { id: "pm_123" },
+        isLoading: false,
+        walletSettings: { autoReloadEnabled: false }
+      });
+
+      expect(screen.getByRole("button", { name: /edit auto top-up settings/i })).toBeDisabled();
+    });
+
+    it("disables the edit button while a settings update is in flight", () => {
+      setup({
+        isFixedThresholdEnabled: true,
+        defaultPaymentMethod: { id: "pm_123" },
+        isLoading: false,
+        walletSettings: { autoReloadEnabled: true, autoReloadThreshold: 20, autoReloadAmount: 100 },
+        isPending: true
+      });
+
+      expect(screen.getByRole("button", { name: /edit auto top-up settings/i })).toBeDisabled();
+    });
+
     it("does not disable auto top-up when the confirmation is cancelled", async () => {
       const upsertMutate = vi.fn();
       setup({
@@ -271,6 +294,7 @@ describe(AccountOverview.name, () => {
     confirmResult?: boolean;
     upsertMutate?: ReturnType<typeof vi.fn>;
     enqueueSnackbar?: ReturnType<typeof vi.fn>;
+    isPending?: boolean;
   }) {
     const mockReplace = input.routerReplace ?? vi.fn();
     const mockSearchParams = { get: vi.fn(input.searchParamsGet ?? (() => null)) };
@@ -305,7 +329,7 @@ describe(AccountOverview.name, () => {
       useWalletSettingsQuery: vi.fn(() => ({ data: input.walletSettings ?? { autoReloadEnabled: false } })),
       useWeeklyDeploymentCostQuery: vi.fn(() => ({ data: 5 })),
       useWalletSettingsMutations: vi.fn(() => ({
-        upsertWalletSettings: { mutate: upsertMutate, isPending: false }
+        upsertWalletSettings: { mutate: upsertMutate, isPending: input.isPending ?? false }
       })),
       usePopup: vi.fn(() => ({ confirm: vi.fn().mockResolvedValue(input.confirmResult ?? true) })),
       useSearchParams: vi.fn(() => mockSearchParams),

--- a/apps/deploy-web/src/components/billing-usage/AccountOverview/AccountOverview.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AccountOverview/AccountOverview.spec.tsx
@@ -102,15 +102,181 @@ describe(AccountOverview.name, () => {
     );
   });
 
+  describe("when the fixed-threshold flag is enabled", () => {
+    it("renders the Auto Top-Up title", () => {
+      setup({ isFixedThresholdEnabled: true, defaultPaymentMethod: { id: "pm_123" }, isLoading: false });
+
+      expect(screen.getByText("Auto Top-Up")).toBeInTheDocument();
+    });
+
+    it("shows the threshold summary with stored values when enabled", () => {
+      setup({
+        isFixedThresholdEnabled: true,
+        defaultPaymentMethod: { id: "pm_123" },
+        isLoading: false,
+        walletSettings: { autoReloadEnabled: true, autoReloadThreshold: 20, autoReloadAmount: 100 }
+      });
+
+      expect(screen.getByText(/Top up/)).toHaveTextContent("Top up 100 when balance ≤ 20");
+      expect(screen.queryByText(/per week/)).not.toBeInTheDocument();
+    });
+
+    it("shows 'Add funds automatically' when disabled with a payment method", () => {
+      setup({
+        isFixedThresholdEnabled: true,
+        defaultPaymentMethod: { id: "pm_123" },
+        isLoading: false,
+        walletSettings: { autoReloadEnabled: false }
+      });
+
+      expect(screen.getByText("Add funds automatically")).toBeInTheDocument();
+    });
+
+    it("opens the settings dialog in enable mode without mutating when the switch is turned on", () => {
+      const { dependencies, upsertMutate } = setup({
+        isFixedThresholdEnabled: true,
+        defaultPaymentMethod: { id: "pm_123" },
+        isLoading: false,
+        walletSettings: { autoReloadEnabled: false }
+      });
+
+      fireEvent.click(screen.getByRole("switch"));
+
+      expect(upsertMutate).not.toHaveBeenCalled();
+      expect(dependencies.AutoTopUpSettingsPopup).toHaveBeenCalledWith(expect.objectContaining({ open: true, enableOnSave: true }), expect.anything());
+    });
+
+    it("confirms then disables auto top-up when the switch is turned off", async () => {
+      const upsertMutate = vi.fn();
+      setup({
+        isFixedThresholdEnabled: true,
+        defaultPaymentMethod: { id: "pm_123" },
+        isLoading: false,
+        walletSettings: { autoReloadEnabled: true, autoReloadThreshold: 20, autoReloadAmount: 100 },
+        confirmResult: true,
+        upsertMutate
+      });
+
+      fireEvent.click(screen.getByRole("switch"));
+
+      await vi.waitFor(() => {
+        expect(upsertMutate).toHaveBeenCalledWith(expect.objectContaining({ data: { autoReloadEnabled: false } }), expect.anything());
+      });
+    });
+
+    it("opens the settings dialog in edit mode from the edit button", () => {
+      const { dependencies } = setup({
+        isFixedThresholdEnabled: true,
+        defaultPaymentMethod: { id: "pm_123" },
+        isLoading: false,
+        walletSettings: { autoReloadEnabled: true, autoReloadThreshold: 20, autoReloadAmount: 100 }
+      });
+
+      fireEvent.click(screen.getByRole("button", { name: /edit auto top-up settings/i }));
+
+      expect(dependencies.AutoTopUpSettingsPopup).toHaveBeenCalledWith(expect.objectContaining({ open: true, enableOnSave: false }), expect.anything());
+    });
+
+    it("disables the switch and edit button without a payment method", () => {
+      setup({ isFixedThresholdEnabled: true, defaultPaymentMethod: undefined, isLoading: false });
+
+      expect(screen.getByRole("switch")).toBeDisabled();
+      expect(screen.getByRole("button", { name: /edit auto top-up settings/i })).toBeDisabled();
+      expect(screen.getByText(/Add a payment method/)).toBeInTheDocument();
+    });
+
+    it("does not disable auto top-up when the confirmation is cancelled", async () => {
+      const upsertMutate = vi.fn();
+      setup({
+        isFixedThresholdEnabled: true,
+        defaultPaymentMethod: { id: "pm_123" },
+        isLoading: false,
+        walletSettings: { autoReloadEnabled: true, autoReloadThreshold: 20, autoReloadAmount: 100 },
+        confirmResult: false,
+        upsertMutate
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("switch"));
+      });
+
+      expect(upsertMutate).not.toHaveBeenCalled();
+    });
+
+    it("shows a success snackbar when disabling auto top-up succeeds", async () => {
+      const enqueueSnackbar = vi.fn();
+      const upsertMutate = vi.fn((_payload, options) => options?.onSuccess?.({ data: { autoReloadEnabled: false } }));
+      setup({
+        isFixedThresholdEnabled: true,
+        defaultPaymentMethod: { id: "pm_123" },
+        isLoading: false,
+        walletSettings: { autoReloadEnabled: true, autoReloadThreshold: 20, autoReloadAmount: 100 },
+        confirmResult: true,
+        upsertMutate,
+        enqueueSnackbar
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("switch"));
+      });
+
+      expect(enqueueSnackbar).toHaveBeenCalled();
+    });
+
+    it("shows an error snackbar when disabling auto top-up fails", async () => {
+      const enqueueSnackbar = vi.fn();
+      const upsertMutate = vi.fn((_payload, options) => options?.onError?.(new Error("failed")));
+      setup({
+        isFixedThresholdEnabled: true,
+        defaultPaymentMethod: { id: "pm_123" },
+        isLoading: false,
+        walletSettings: { autoReloadEnabled: true, autoReloadThreshold: 20, autoReloadAmount: 100 },
+        confirmResult: true,
+        upsertMutate,
+        enqueueSnackbar
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("switch"));
+      });
+
+      expect(enqueueSnackbar).toHaveBeenCalled();
+    });
+
+    it("closes the settings dialog when the popup requests it", () => {
+      const { dependencies } = setup({
+        isFixedThresholdEnabled: true,
+        defaultPaymentMethod: { id: "pm_123" },
+        isLoading: false,
+        walletSettings: { autoReloadEnabled: true, autoReloadThreshold: 20, autoReloadAmount: 100 }
+      });
+
+      fireEvent.click(screen.getByRole("button", { name: /edit auto top-up settings/i }));
+      const openedProps = vi.mocked(dependencies.AutoTopUpSettingsPopup).mock.calls.at(-1)![0];
+      expect(openedProps.open).toBe(true);
+
+      act(() => openedProps.onClose());
+
+      expect(dependencies.AutoTopUpSettingsPopup).toHaveBeenLastCalledWith(expect.objectContaining({ open: false }), expect.anything());
+    });
+  });
+
   function setup(input: {
     searchParamsGet?: (key: string) => string | null;
     routerReplace?: ReturnType<typeof vi.fn>;
     defaultPaymentMethod?: { id: string };
     isLoading?: boolean;
+    isFixedThresholdEnabled?: boolean;
+    walletSettings?: { autoReloadEnabled: boolean; autoReloadThreshold?: number; autoReloadAmount?: number };
+    confirmResult?: boolean;
+    upsertMutate?: ReturnType<typeof vi.fn>;
+    enqueueSnackbar?: ReturnType<typeof vi.fn>;
   }) {
     const mockReplace = input.routerReplace ?? vi.fn();
     const mockSearchParams = { get: vi.fn(input.searchParamsGet ?? (() => null)) };
     const mockRouter = { replace: mockReplace, push: vi.fn() };
+    const upsertMutate = input.upsertMutate ?? vi.fn();
+    const enqueueSnackbar = input.enqueueSnackbar ?? vi.fn();
 
     const MockAddCreditsSheet = vi.fn((props: Parameters<typeof DEPENDENCIES.AddCreditsSheet>[0]) =>
       props.open ? <div data-testid="add-credits-sheet" /> : null
@@ -118,9 +284,16 @@ describe(AccountOverview.name, () => {
 
     const MockButton = vi.fn(({ children, ...props }: Parameters<typeof DEPENDENCIES.Button>[0]) => <button {...props}>{children}</button>);
 
+    const MockSwitch = vi.fn(({ checked, onCheckedChange, disabled }: Parameters<typeof DEPENDENCIES.Switch>[0]) => (
+      <input type="checkbox" role="switch" checked={checked} disabled={disabled} onChange={e => onCheckedChange?.(e.target.checked)} />
+    ));
+
+    const MockFormattedNumber = vi.fn(({ value }: Parameters<typeof DEPENDENCIES.FormattedNumber>[0]) => <>{value}</>);
+
     const dependencies = {
       ...MockComponents(DEPENDENCIES),
-      useSnackbar: vi.fn(() => ({ enqueueSnackbar: vi.fn() })),
+      useFlag: vi.fn(() => input.isFixedThresholdEnabled ?? false),
+      useSnackbar: vi.fn(() => ({ enqueueSnackbar })),
       useDefaultPaymentMethodQuery: vi.fn(() => ({
         data: input.defaultPaymentMethod,
         isLoading: input.isLoading ?? false
@@ -129,12 +302,12 @@ describe(AccountOverview.name, () => {
         balance: { totalDeploymentGrantsUSD: 100, totalDeploymentEscrowUSD: 10 },
         isLoading: false
       })),
-      useWalletSettingsQuery: vi.fn(() => ({ data: { autoReloadEnabled: false } })),
+      useWalletSettingsQuery: vi.fn(() => ({ data: input.walletSettings ?? { autoReloadEnabled: false } })),
       useWeeklyDeploymentCostQuery: vi.fn(() => ({ data: 5 })),
       useWalletSettingsMutations: vi.fn(() => ({
-        upsertWalletSettings: { mutate: vi.fn(), isPending: false }
+        upsertWalletSettings: { mutate: upsertMutate, isPending: false }
       })),
-      usePopup: vi.fn(() => ({ confirm: vi.fn() })),
+      usePopup: vi.fn(() => ({ confirm: vi.fn().mockResolvedValue(input.confirmResult ?? true) })),
       useSearchParams: vi.fn(() => mockSearchParams),
       useRouter: vi.fn(() => mockRouter),
       useServices: vi.fn(() => ({
@@ -144,11 +317,13 @@ describe(AccountOverview.name, () => {
         }
       })),
       Button: MockButton,
+      Switch: MockSwitch,
+      FormattedNumber: MockFormattedNumber,
       AddCreditsSheet: MockAddCreditsSheet
     } as unknown as typeof DEPENDENCIES;
 
     render(<AccountOverview dependencies={dependencies} />);
 
-    return { dependencies, MockAddCreditsSheet };
+    return { dependencies, MockAddCreditsSheet, upsertMutate };
   }
 });

--- a/apps/deploy-web/src/components/billing-usage/AccountOverview/AccountOverview.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AccountOverview/AccountOverview.tsx
@@ -244,7 +244,7 @@ export const AccountOverview: React.FunctionComponent<{ dependencies?: typeof DE
                   variant="ghost"
                   size="icon"
                   aria-label="Edit auto top-up settings"
-                  disabled={!hasPaymentMethod}
+                  disabled={isReloadChangeDisabled || !walletSettings?.autoReloadEnabled}
                   onClick={() => setAutoTopUpPopup({ open: true, enableOnSave: false })}
                 >
                   <d.Edit className="h-4 w-4" />

--- a/apps/deploy-web/src/components/billing-usage/AccountOverview/AccountOverview.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AccountOverview/AccountOverview.tsx
@@ -254,7 +254,7 @@ export const AccountOverview: React.FunctionComponent<{ dependencies?: typeof DE
                   </p>
                 ) : isFixedThresholdEnabled ? (
                   walletSettings?.autoReloadEnabled ? (
-                    <div className="flex items-center justify-between gap-2">
+                    <div className="flex items-center justify-start gap-2">
                       <p className="text-sm text-muted-foreground">
                         Top up{" "}
                         <span className="font-medium text-foreground">

--- a/apps/deploy-web/src/components/billing-usage/AccountOverview/AccountOverview.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AccountOverview/AccountOverview.tsx
@@ -3,15 +3,21 @@ import { FormattedNumber } from "react-intl";
 import { Button, Card, CardContent, CardHeader, CustomTooltip, Skeleton, Snackbar, Switch } from "@akashnetwork/ui/components";
 import { usePopup } from "@akashnetwork/ui/context";
 import { LinearProgress } from "@mui/material";
-import { InfoCircle, Plus, Wallet } from "iconoir-react";
+import { Edit, InfoCircle, Plus, Wallet } from "iconoir-react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useSnackbar } from "notistack";
 
 import { AddCreditsSheet } from "@src/components/auth/AddCreditsSheet/AddCreditsSheet";
+import {
+  AutoTopUpSettingsPopup,
+  DEFAULT_AUTO_RELOAD_AMOUNT,
+  DEFAULT_AUTO_RELOAD_THRESHOLD
+} from "@src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup";
 import { PaymentSuccessAnimation } from "@src/components/billing-usage/PaymentSuccessAnimation/PaymentSuccessAnimation";
 import { Title } from "@src/components/shared/Title";
 import { useServices } from "@src/context/ServicesProvider/ServicesProvider";
+import { useFlag } from "@src/hooks/useFlag";
 import { useWalletBalance } from "@src/hooks/useWalletBalance";
 import { useDefaultPaymentMethodQuery, useWalletSettingsMutations, useWalletSettingsQuery, useWeeklyDeploymentCostQuery } from "@src/queries";
 
@@ -26,7 +32,9 @@ export const DEPENDENCIES = {
   useSearchParams,
   useRouter,
   useServices,
+  useFlag,
   AddCreditsSheet,
+  AutoTopUpSettingsPopup,
   PaymentSuccessAnimation,
   Title,
   FormattedNumber,
@@ -39,21 +47,24 @@ export const DEPENDENCIES = {
   Skeleton,
   Snackbar,
   Switch,
+  Edit,
   LinearProgress
 };
 
 export const AccountOverview: React.FunctionComponent<{ dependencies?: typeof DEPENDENCIES }> = ({ dependencies: d = DEPENDENCIES }) => {
   const [showAddCredits, setShowAddCredits] = useState(false);
+  const [autoTopUpPopup, setAutoTopUpPopup] = useState<{ open: boolean; enableOnSave: boolean }>({ open: false, enableOnSave: false });
   const [showPaymentSuccess, setShowPaymentSuccess] = useState<{ amount: string; bonusAmount: string; show: boolean }>({
     amount: "",
     bonusAmount: "",
     show: false
   });
+  const isFixedThresholdEnabled = d.useFlag("auto_reload_fixed_threshold");
   const { enqueueSnackbar } = d.useSnackbar();
   const { data: defaultPaymentMethod, isLoading: isLoadingDefaultPaymentMethod } = d.useDefaultPaymentMethodQuery();
   const { balance: walletBalance, isLoading: isWalletBalanceLoading } = d.useWalletBalance();
   const { data: walletSettings } = d.useWalletSettingsQuery();
-  const { data: weeklyCost } = d.useWeeklyDeploymentCostQuery();
+  const { data: weeklyCost } = d.useWeeklyDeploymentCostQuery({ enabled: !isFixedThresholdEnabled });
   const { upsertWalletSettings } = d.useWalletSettingsMutations();
   const { confirm } = d.usePopup();
 
@@ -104,7 +115,33 @@ export const AccountOverview: React.FunctionComponent<{ dependencies?: typeof DE
     [confirm, enqueueSnackbar, upsertWalletSettings]
   );
 
+  const disableAutoTopUp = useCallback(async () => {
+    const isConfirmed = await confirm({
+      title: "Disable Auto Top-Up?",
+      message: "Your deployments may stop if your credit balance runs out, and no automatic charges will be made."
+    });
+
+    if (!isConfirmed) {
+      return;
+    }
+
+    upsertWalletSettings.mutate(
+      { data: { autoReloadEnabled: false } },
+      {
+        onSuccess: () => enqueueSnackbar(<d.Snackbar title="Auto Top-Up disabled" iconVariant="success" />, { variant: "success", autoHideDuration: 3000 }),
+        onError: () => enqueueSnackbar(<d.Snackbar title="Failed to update Auto Top-Up settings" iconVariant="error" />, { variant: "error" })
+      }
+    );
+  }, [confirm, enqueueSnackbar, upsertWalletSettings, d]);
+
+  const handleAutoTopUpSwitch = useCallback(
+    (checked: boolean) => (checked ? setAutoTopUpPopup({ open: true, enableOnSave: true }) : disableAutoTopUp()),
+    [disableAutoTopUp]
+  );
+
   const hasPaymentMethod = !!defaultPaymentMethod;
+  const autoReloadThreshold = walletSettings?.autoReloadThreshold ?? DEFAULT_AUTO_RELOAD_THRESHOLD;
+  const autoReloadAmount = walletSettings?.autoReloadAmount ?? DEFAULT_AUTO_RELOAD_AMOUNT;
 
   const isReloadChangeDisabled = useMemo(() => {
     return !hasPaymentMethod || upsertWalletSettings.isPending;
@@ -191,29 +228,65 @@ export const AccountOverview: React.FunctionComponent<{ dependencies?: typeof DE
             )}
             <d.CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
               <div className="flex items-center gap-1">
-                <h3 className="text-sm font-medium leading-none text-muted-foreground">Auto Recharge</h3>
-                <d.CustomTooltip title="Automatically add credits to your account using your default payment method to keep deployments running.">
+                <h3 className="text-sm font-medium leading-none text-muted-foreground">{isFixedThresholdEnabled ? "Auto Top-Up" : "Auto Recharge"}</h3>
+                <d.CustomTooltip
+                  title={
+                    isFixedThresholdEnabled
+                      ? "Automatically charge your default payment method a fixed amount whenever your balance drops to or below your chosen threshold."
+                      : "Automatically add credits to your account using your default payment method to keep deployments running."
+                  }
+                >
                   <InfoCircle className="h-4 w-4 cursor-pointer text-muted-foreground" />
                 </d.CustomTooltip>
               </div>
+              {isFixedThresholdEnabled && (
+                <d.Button
+                  variant="ghost"
+                  size="icon"
+                  aria-label="Edit auto top-up settings"
+                  disabled={!hasPaymentMethod}
+                  onClick={() => setAutoTopUpPopup({ open: true, enableOnSave: false })}
+                >
+                  <d.Edit className="h-4 w-4" />
+                </d.Button>
+              )}
             </d.CardHeader>
             <d.CardContent>
               <div className="flex flex-col gap-2">
-                <d.Switch checked={walletSettings?.autoReloadEnabled ?? false} onCheckedChange={toggleAutoReload} disabled={isReloadChangeDisabled} />
-                {hasPaymentMethod ? (
+                <d.Switch
+                  checked={walletSettings?.autoReloadEnabled ?? false}
+                  onCheckedChange={isFixedThresholdEnabled ? handleAutoTopUpSwitch : toggleAutoReload}
+                  disabled={isReloadChangeDisabled}
+                />
+                {!hasPaymentMethod ? (
+                  <p className="text-sm text-muted-foreground">
+                    <d.Link href={urlService.paymentMethods()} className="text-primary underline">
+                      Add a payment method
+                    </d.Link>{" "}
+                    to enable auto {isFixedThresholdEnabled ? "top-up" : "recharge"}
+                  </p>
+                ) : isFixedThresholdEnabled ? (
+                  walletSettings?.autoReloadEnabled ? (
+                    <p className="text-sm text-muted-foreground">
+                      Top up{" "}
+                      <span className="font-medium text-foreground">
+                        <d.FormattedNumber value={autoReloadAmount} style="currency" currency="USD" />
+                      </span>{" "}
+                      when balance ≤{" "}
+                      <span className="font-medium text-foreground">
+                        <d.FormattedNumber value={autoReloadThreshold} style="currency" currency="USD" />
+                      </span>
+                    </p>
+                  ) : (
+                    <p className="text-sm text-muted-foreground">Add funds automatically</p>
+                  )
+                ) : (
                   <p className="text-sm text-muted-foreground">
                     Recharge amount is approximately{" "}
                     <span className="font-medium text-foreground">
                       <d.FormattedNumber value={weeklyCost ?? 0} style="currency" currency="USD" />
                     </span>{" "}
                     per week
-                  </p>
-                ) : (
-                  <p className="text-sm text-muted-foreground">
-                    <d.Link href={urlService.paymentMethods()} className="text-primary underline">
-                      Add a payment method
-                    </d.Link>{" "}
-                    to enable auto recharge
                   </p>
                 )}
               </div>
@@ -239,6 +312,16 @@ export const AccountOverview: React.FunctionComponent<{ dependencies?: typeof DE
           setShowAddCredits(false);
         }}
       />
+
+      {isFixedThresholdEnabled && (
+        <d.AutoTopUpSettingsPopup
+          open={autoTopUpPopup.open}
+          onClose={() => setAutoTopUpPopup(prev => ({ ...prev, open: false }))}
+          enableOnSave={autoTopUpPopup.enableOnSave}
+          threshold={walletSettings?.autoReloadThreshold}
+          amount={walletSettings?.autoReloadAmount}
+        />
+      )}
     </div>
   );
 };

--- a/apps/deploy-web/src/components/billing-usage/AccountOverview/AccountOverview.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AccountOverview/AccountOverview.tsx
@@ -227,29 +227,16 @@ export const AccountOverview: React.FunctionComponent<{ dependencies?: typeof DE
               </div>
             )}
             <d.CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
-              <div className="flex items-center gap-1">
-                <h3 className="text-sm font-medium leading-none text-muted-foreground">{isFixedThresholdEnabled ? "Auto Top-Up" : "Auto Recharge"}</h3>
-                <d.CustomTooltip
-                  title={
-                    isFixedThresholdEnabled
-                      ? "Automatically charge your default payment method a fixed amount whenever your balance drops to or below your chosen threshold."
-                      : "Automatically add credits to your account using your default payment method to keep deployments running."
-                  }
-                >
-                  <InfoCircle className="h-4 w-4 cursor-pointer text-muted-foreground" />
-                </d.CustomTooltip>
-              </div>
-              {isFixedThresholdEnabled && (
-                <d.Button
-                  variant="ghost"
-                  size="icon"
-                  aria-label="Edit auto top-up settings"
-                  disabled={isReloadChangeDisabled || !walletSettings?.autoReloadEnabled}
-                  onClick={() => setAutoTopUpPopup({ open: true, enableOnSave: false })}
-                >
-                  <d.Edit className="h-4 w-4" />
-                </d.Button>
-              )}
+              <h3 className="text-sm font-medium leading-none text-muted-foreground">{isFixedThresholdEnabled ? "Auto Top-Up" : "Auto Recharge"}</h3>
+              <d.CustomTooltip
+                title={
+                  isFixedThresholdEnabled
+                    ? "Automatically charge your default payment method a fixed amount whenever your balance drops to or below your chosen threshold."
+                    : "Automatically add credits to your account using your default payment method to keep deployments running."
+                }
+              >
+                <InfoCircle className="h-4 w-4 cursor-pointer text-muted-foreground" />
+              </d.CustomTooltip>
             </d.CardHeader>
             <d.CardContent>
               <div className="flex flex-col gap-2">
@@ -267,16 +254,28 @@ export const AccountOverview: React.FunctionComponent<{ dependencies?: typeof DE
                   </p>
                 ) : isFixedThresholdEnabled ? (
                   walletSettings?.autoReloadEnabled ? (
-                    <p className="text-sm text-muted-foreground">
-                      Top up{" "}
-                      <span className="font-medium text-foreground">
-                        <d.FormattedNumber value={autoReloadAmount} style="currency" currency="USD" />
-                      </span>{" "}
-                      when balance ≤{" "}
-                      <span className="font-medium text-foreground">
-                        <d.FormattedNumber value={autoReloadThreshold} style="currency" currency="USD" />
-                      </span>
-                    </p>
+                    <div className="flex items-center justify-between gap-2">
+                      <p className="text-sm text-muted-foreground">
+                        Top up{" "}
+                        <span className="font-medium text-foreground">
+                          <d.FormattedNumber value={autoReloadAmount} style="currency" currency="USD" />
+                        </span>{" "}
+                        when balance ≤{" "}
+                        <span className="font-medium text-foreground">
+                          <d.FormattedNumber value={autoReloadThreshold} style="currency" currency="USD" />
+                        </span>
+                      </p>
+                      <d.Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8 shrink-0"
+                        aria-label="Edit auto top-up settings"
+                        disabled={isReloadChangeDisabled}
+                        onClick={() => setAutoTopUpPopup({ open: true, enableOnSave: false })}
+                      >
+                        <d.Edit className="h-4 w-4" />
+                      </d.Button>
+                    </div>
                   ) : (
                     <p className="text-sm text-muted-foreground">Add funds automatically</p>
                   )

--- a/apps/deploy-web/src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup.spec.tsx
@@ -137,7 +137,7 @@ describe(AutoTopUpSettingsPopup.name, () => {
   });
 
   function thresholdInput() {
-    return screen.getByLabelText(/when credit balance goes below/i) as HTMLInputElement;
+    return screen.getByLabelText(/when credit balance drops to or below/i) as HTMLInputElement;
   }
 
   function amountInput() {

--- a/apps/deploy-web/src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup.spec.tsx
@@ -54,6 +54,28 @@ describe(AutoTopUpSettingsPopup.name, () => {
     expect(upsertMutate).not.toHaveBeenCalled();
   });
 
+  it("blocks submit and shows an error when the amount is above the maximum", async () => {
+    const upsertMutate = vi.fn();
+    setup({ upsertMutate });
+
+    fireEvent.change(amountInput(), { target: { value: "20000" } });
+    await submit();
+
+    expect(screen.getByText(/Maximum amount is \$10000/)).toBeInTheDocument();
+    expect(upsertMutate).not.toHaveBeenCalled();
+  });
+
+  it("blocks submit and shows an error when the threshold is above the maximum", async () => {
+    const upsertMutate = vi.fn();
+    setup({ upsertMutate });
+
+    fireEvent.change(thresholdInput(), { target: { value: "20000" } });
+    await submit();
+
+    expect(screen.getByText(/Maximum threshold is \$10000/)).toBeInTheDocument();
+    expect(upsertMutate).not.toHaveBeenCalled();
+  });
+
   it("saves the enabled flag with values in enable-on-save mode", async () => {
     const upsertMutate = vi.fn();
     setup({ enableOnSave: true, threshold: 20, amount: 100, upsertMutate });

--- a/apps/deploy-web/src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup.spec.tsx
@@ -1,0 +1,179 @@
+import React from "react";
+import { useForm } from "react-hook-form";
+import type { PaymentMethod } from "@akashnetwork/http-sdk";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { DEPENDENCIES } from "./AutoTopUpSettingsPopup";
+import { AutoTopUpSettingsPopup } from "./AutoTopUpSettingsPopup";
+
+import { act, fireEvent, render, screen } from "@testing-library/react";
+
+describe(AutoTopUpSettingsPopup.name, () => {
+  it("prefills the default threshold and amount when no stored values are provided", () => {
+    setup({});
+
+    expect(thresholdInput().value).toBe("20");
+    expect(amountInput().value).toBe("100");
+  });
+
+  it("prefills the stored threshold and amount when provided", () => {
+    setup({ threshold: 30, amount: 250 });
+
+    expect(thresholdInput().value).toBe("30");
+    expect(amountInput().value).toBe("250");
+  });
+
+  it("renders the default payment method row", () => {
+    setup({});
+
+    expect(screen.getByText(/VISA •••• 5720/)).toBeInTheDocument();
+    expect(screen.getByText(/Expires 5\/30/)).toBeInTheDocument();
+  });
+
+  it("blocks submit and shows an error when the amount is below the minimum", async () => {
+    const upsertMutate = vi.fn();
+    setup({ upsertMutate });
+
+    fireEvent.change(amountInput(), { target: { value: "5" } });
+    await submit();
+
+    expect(screen.getByText(/Minimum amount is \$20/)).toBeInTheDocument();
+    expect(upsertMutate).not.toHaveBeenCalled();
+  });
+
+  it("blocks submit and shows an error when the threshold is below the minimum", async () => {
+    const upsertMutate = vi.fn();
+    setup({ upsertMutate });
+
+    fireEvent.change(thresholdInput(), { target: { value: "1" } });
+    await submit();
+
+    expect(screen.getByText(/Minimum threshold is \$5/)).toBeInTheDocument();
+    expect(upsertMutate).not.toHaveBeenCalled();
+  });
+
+  it("saves the enabled flag with values in enable-on-save mode", async () => {
+    const upsertMutate = vi.fn();
+    setup({ enableOnSave: true, threshold: 20, amount: 100, upsertMutate });
+
+    await submit();
+
+    expect(upsertMutate).toHaveBeenCalledWith({ data: { autoReloadEnabled: true, autoReloadThreshold: 20, autoReloadAmount: 100 } }, expect.anything());
+  });
+
+  it("saves the enabled flag with values in edit mode", async () => {
+    const upsertMutate = vi.fn();
+    setup({ enableOnSave: false, threshold: 30, amount: 150, upsertMutate });
+
+    await submit();
+
+    expect(upsertMutate).toHaveBeenCalledWith({ data: { autoReloadEnabled: true, autoReloadThreshold: 30, autoReloadAmount: 150 } }, expect.anything());
+  });
+
+  it("closes and shows a success snackbar when the save succeeds", async () => {
+    const onClose = vi.fn();
+    const enqueueSnackbar = vi.fn();
+    const upsertMutate = vi.fn((_payload, options) => options?.onSuccess?.());
+    setup({ onClose, enqueueSnackbar, upsertMutate });
+
+    await submit();
+
+    expect(enqueueSnackbar).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("keeps the dialog open and shows an error snackbar when the save fails", async () => {
+    const onClose = vi.fn();
+    const enqueueSnackbar = vi.fn();
+    const upsertMutate = vi.fn((_payload, options) => options?.onError?.());
+    setup({ onClose, enqueueSnackbar, upsertMutate });
+
+    await submit();
+
+    expect(enqueueSnackbar).toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("resets to the stored values when the dialog transitions from closed to open", () => {
+    const { props, rerender } = setup({ open: false, threshold: 30, amount: 250 });
+
+    rerender(<AutoTopUpSettingsPopup {...props} open threshold={40} amount={300} />);
+
+    expect(thresholdInput().value).toBe("40");
+    expect(amountInput().value).toBe("300");
+  });
+
+  it("keeps in-progress edits when the stored values change while the dialog stays open", () => {
+    const { props, rerender } = setup({ open: true, threshold: 20, amount: 100 });
+
+    fireEvent.change(amountInput(), { target: { value: "150" } });
+    rerender(<AutoTopUpSettingsPopup {...props} amount={120} />);
+
+    expect(amountInput().value).toBe("150");
+  });
+
+  function thresholdInput() {
+    return screen.getByLabelText(/when credit balance goes below/i) as HTMLInputElement;
+  }
+
+  function amountInput() {
+    return screen.getByLabelText(/purchase this amount/i) as HTMLInputElement;
+  }
+
+  async function submit() {
+    await act(async () => {
+      fireEvent.submit(screen.getByRole("button", { name: /save changes/i }).closest("form")!);
+    });
+  }
+
+  function setup(input: {
+    open?: boolean;
+    enableOnSave?: boolean;
+    threshold?: number;
+    amount?: number;
+    onClose?: () => void;
+    enqueueSnackbar?: ReturnType<typeof vi.fn>;
+    upsertMutate?: ReturnType<typeof vi.fn>;
+    isPending?: boolean;
+  }) {
+    const useSnackbar: typeof DEPENDENCIES.useSnackbar = () =>
+      ({ enqueueSnackbar: input.enqueueSnackbar ?? vi.fn(), closeSnackbar: vi.fn() }) as unknown as ReturnType<typeof DEPENDENCIES.useSnackbar>;
+
+    const useWallet: typeof DEPENDENCIES.useWallet = () => mock<ReturnType<typeof DEPENDENCIES.useWallet>>({ topUpMinAmountUsd: 20 });
+
+    const paymentMethod = mock<PaymentMethod>({
+      card: { brand: "visa", last4: "5720", exp_month: 5, exp_year: 30 } as PaymentMethod["card"]
+    });
+    const useDefaultPaymentMethodQuery: typeof DEPENDENCIES.useDefaultPaymentMethodQuery = () =>
+      mock<ReturnType<typeof DEPENDENCIES.useDefaultPaymentMethodQuery>>({ data: paymentMethod });
+
+    const useWalletSettingsMutations: typeof DEPENDENCIES.useWalletSettingsMutations = () =>
+      ({
+        upsertWalletSettings: { mutate: input.upsertMutate ?? vi.fn(), isPending: input.isPending ?? false }
+      }) as unknown as ReturnType<typeof DEPENDENCIES.useWalletSettingsMutations>;
+
+    const dependencies = {
+      useForm,
+      zodResolver,
+      useSnackbar,
+      useWallet,
+      useDefaultPaymentMethodQuery,
+      useWalletSettingsMutations
+    };
+
+    const props = {
+      open: input.open ?? true,
+      onClose: input.onClose ?? vi.fn(),
+      enableOnSave: input.enableOnSave ?? false,
+      threshold: input.threshold,
+      amount: input.amount,
+      dependencies
+    };
+
+    const utils = render(<AutoTopUpSettingsPopup {...props} />);
+
+    return { ...utils, props };
+  }
+});

--- a/apps/deploy-web/src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup.spec.tsx
@@ -163,8 +163,6 @@ describe(AutoTopUpSettingsPopup.name, () => {
     const useSnackbar: typeof DEPENDENCIES.useSnackbar = () =>
       ({ enqueueSnackbar: input.enqueueSnackbar ?? vi.fn(), closeSnackbar: vi.fn() }) as unknown as ReturnType<typeof DEPENDENCIES.useSnackbar>;
 
-    const useWallet: typeof DEPENDENCIES.useWallet = () => mock<ReturnType<typeof DEPENDENCIES.useWallet>>({ topUpMinAmountUsd: 20 });
-
     const paymentMethod = mock<PaymentMethod>({
       card: { brand: "visa", last4: "5720", exp_month: 5, exp_year: 30 } as PaymentMethod["card"]
     });
@@ -180,7 +178,6 @@ describe(AutoTopUpSettingsPopup.name, () => {
       useForm,
       zodResolver,
       useSnackbar,
-      useWallet,
       useDefaultPaymentMethodQuery,
       useWalletSettingsMutations
     };

--- a/apps/deploy-web/src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup.spec.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { useForm } from "react-hook-form";
 import type { PaymentMethod } from "@akashnetwork/http-sdk";
-import { zodResolver } from "@hookform/resolvers/zod";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
@@ -176,7 +175,6 @@ describe(AutoTopUpSettingsPopup.name, () => {
 
     const dependencies = {
       useForm,
-      zodResolver,
       useSnackbar,
       useDefaultPaymentMethodQuery,
       useWalletSettingsMutations

--- a/apps/deploy-web/src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup.tsx
@@ -139,7 +139,7 @@ export const AutoTopUpSettingsPopup: React.FC<AutoTopUpSettingsPopupProps> = ({
                 {...field}
                 type="number"
                 step="0.01"
-                label={`When credit balance goes below (minimum $${AUTO_RELOAD_THRESHOLD_MIN_USD})`}
+                label={`When credit balance drops to or below (minimum $${AUTO_RELOAD_THRESHOLD_MIN_USD})`}
                 description="If your current balance is at or below the threshold you set, your top-up will kick in shortly after you save."
                 startIcon={<div className="pl-3 text-sm text-muted-foreground">$</div>}
               />

--- a/apps/deploy-web/src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import React, { useEffect, useMemo, useRef } from "react";
+import { useForm } from "react-hook-form";
+import type { PaymentMethod } from "@akashnetwork/http-sdk";
+import { Form, FormField, FormInput, LoadingButton, Popup, Snackbar } from "@akashnetwork/ui/components";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { CreditCard } from "iconoir-react";
+import { useSnackbar } from "notistack";
+import { z } from "zod";
+
+import { getPaymentMethodDisplay } from "@src/components/shared/PaymentMethodCard/PaymentMethodCard";
+import { useWallet } from "@src/context/WalletProvider/WalletProvider";
+import { useDefaultPaymentMethodQuery, useWalletSettingsMutations } from "@src/queries";
+
+export const DEFAULT_AUTO_RELOAD_THRESHOLD = 20;
+export const DEFAULT_AUTO_RELOAD_AMOUNT = 100;
+
+/** Matches AkashML's minimum credit-balance threshold. */
+const AUTO_RELOAD_THRESHOLD_MIN_USD = 5;
+
+const createAutoTopUpSchema = (amountMinUsd: number) =>
+  z.object({
+    autoReloadThreshold: z.coerce.number().min(AUTO_RELOAD_THRESHOLD_MIN_USD, `Minimum threshold is $${AUTO_RELOAD_THRESHOLD_MIN_USD}`),
+    autoReloadAmount: z.coerce.number().min(amountMinUsd, `Minimum amount is $${amountMinUsd}`)
+  });
+
+type AutoTopUpFormValues = z.infer<ReturnType<typeof createAutoTopUpSchema>>;
+
+export const DEPENDENCIES = {
+  useForm,
+  zodResolver,
+  useSnackbar,
+  useWallet,
+  useDefaultPaymentMethodQuery,
+  useWalletSettingsMutations
+};
+
+interface AutoTopUpSettingsPopupProps {
+  open: boolean;
+  onClose: () => void;
+  /** True for the first-enable flow (Save turns auto top-up on); false when editing an already-enabled account. */
+  enableOnSave: boolean;
+  threshold?: number;
+  amount?: number;
+  dependencies?: typeof DEPENDENCIES;
+}
+
+export const AutoTopUpSettingsPopup: React.FC<AutoTopUpSettingsPopupProps> = ({
+  open,
+  onClose,
+  enableOnSave,
+  threshold,
+  amount,
+  dependencies: d = DEPENDENCIES
+}) => {
+  const { enqueueSnackbar } = d.useSnackbar();
+  const { topUpMinAmountUsd } = d.useWallet();
+  const { data: defaultPaymentMethod } = d.useDefaultPaymentMethodQuery();
+  const { upsertWalletSettings } = d.useWalletSettingsMutations();
+
+  const amountMinUsd = topUpMinAmountUsd ?? DEFAULT_AUTO_RELOAD_THRESHOLD;
+  const schema = useMemo(() => createAutoTopUpSchema(amountMinUsd), [amountMinUsd]);
+
+  const defaultValues = useMemo<AutoTopUpFormValues>(
+    () => ({
+      autoReloadThreshold: threshold ?? DEFAULT_AUTO_RELOAD_THRESHOLD,
+      autoReloadAmount: amount ?? DEFAULT_AUTO_RELOAD_AMOUNT
+    }),
+    [threshold, amount]
+  );
+
+  const form = d.useForm<AutoTopUpFormValues>({
+    resolver: d.zodResolver(schema),
+    defaultValues
+  });
+
+  const wasOpen = useRef(open);
+  useEffect(
+    function resetOnOpen() {
+      if (open && !wasOpen.current) {
+        form.reset(defaultValues);
+      }
+      wasOpen.current = open;
+    },
+    [open, defaultValues, form]
+  );
+
+  const cardDisplay = defaultPaymentMethod ? getPaymentMethodDisplay(defaultPaymentMethod as PaymentMethod) : null;
+
+  const saveSettings = form.handleSubmit(values => {
+    upsertWalletSettings.mutate(
+      {
+        data: {
+          autoReloadEnabled: true,
+          autoReloadThreshold: values.autoReloadThreshold,
+          autoReloadAmount: values.autoReloadAmount
+        }
+      },
+      {
+        onSuccess: () => {
+          enqueueSnackbar(<Snackbar title={enableOnSave ? "Auto Top-Up enabled" : "Auto Top-Up settings updated"} iconVariant="success" />, {
+            variant: "success",
+            autoHideDuration: 3000
+          });
+          onClose();
+        },
+        onError: () => enqueueSnackbar(<Snackbar title="Failed to save Auto Top-Up settings" iconVariant="error" />, { variant: "error" })
+      }
+    );
+  });
+
+  return (
+    <Popup open={open} onClose={onClose} title="Auto Top-Up Settings" variant="custom" actions={[]} maxWidth="sm">
+      <Form {...form}>
+        <form className="space-y-6" onSubmit={saveSettings}>
+          <p className="text-sm text-muted-foreground">This will use your default payment method on file.</p>
+
+          {cardDisplay && (
+            <div className="flex items-center gap-3 rounded-md border p-3">
+              <CreditCard className="h-5 w-5 text-muted-foreground" />
+              <p className="text-sm font-medium">
+                {cardDisplay.label}
+                {cardDisplay.expiry ? ` · ${cardDisplay.expiry}` : ""}
+              </p>
+            </div>
+          )}
+
+          <FormField
+            control={form.control}
+            name="autoReloadThreshold"
+            render={({ field }) => (
+              <FormInput
+                {...field}
+                type="number"
+                step="0.01"
+                label={`When credit balance goes below (minimum $${AUTO_RELOAD_THRESHOLD_MIN_USD})`}
+                description="If your current balance is at or below the threshold you set, your top-up will kick in shortly after you save."
+                startIcon={<div className="pl-3 text-sm text-muted-foreground">$</div>}
+              />
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="autoReloadAmount"
+            render={({ field }) => (
+              <FormInput
+                {...field}
+                type="number"
+                step="0.01"
+                label={`Purchase this amount (minimum $${amountMinUsd})`}
+                startIcon={<div className="pl-3 text-sm text-muted-foreground">$</div>}
+              />
+            )}
+          />
+
+          <LoadingButton type="submit" className="w-full" loading={upsertWalletSettings.isPending}>
+            Save changes
+          </LoadingButton>
+        </form>
+      </Form>
+    </Popup>
+  );
+};

--- a/apps/deploy-web/src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup.tsx
@@ -19,10 +19,19 @@ export const DEFAULT_AUTO_RELOAD_AMOUNT = 100;
 /** Matches AkashML's minimum credit-balance threshold. */
 const AUTO_RELOAD_THRESHOLD_MIN_USD = 5;
 
+/** Mirrors the max bound on both fields in the backend's WalletSettingsInputSchema so over-limit values fail inline instead of as a generic 400. */
+const AUTO_RELOAD_MAX_USD = 10_000;
+
 const createAutoTopUpSchema = (amountMinUsd: number) =>
   z.object({
-    autoReloadThreshold: z.coerce.number().min(AUTO_RELOAD_THRESHOLD_MIN_USD, `Minimum threshold is $${AUTO_RELOAD_THRESHOLD_MIN_USD}`),
-    autoReloadAmount: z.coerce.number().min(amountMinUsd, `Minimum amount is $${amountMinUsd}`)
+    autoReloadThreshold: z.coerce
+      .number()
+      .min(AUTO_RELOAD_THRESHOLD_MIN_USD, `Minimum threshold is $${AUTO_RELOAD_THRESHOLD_MIN_USD}`)
+      .max(AUTO_RELOAD_MAX_USD, `Maximum threshold is $${AUTO_RELOAD_MAX_USD}`),
+    autoReloadAmount: z.coerce
+      .number()
+      .min(amountMinUsd, `Minimum amount is $${amountMinUsd}`)
+      .max(AUTO_RELOAD_MAX_USD, `Maximum amount is $${AUTO_RELOAD_MAX_USD}`)
   });
 
 type AutoTopUpFormValues = z.infer<ReturnType<typeof createAutoTopUpSchema>>;

--- a/apps/deploy-web/src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup.tsx
@@ -10,7 +10,6 @@ import { useSnackbar } from "notistack";
 import { z } from "zod";
 
 import { getPaymentMethodDisplay } from "@src/components/shared/PaymentMethodCard/PaymentMethodCard";
-import { useWallet } from "@src/context/WalletProvider/WalletProvider";
 import { useDefaultPaymentMethodQuery, useWalletSettingsMutations } from "@src/queries";
 
 export const DEFAULT_AUTO_RELOAD_THRESHOLD = 20;
@@ -22,25 +21,26 @@ const AUTO_RELOAD_THRESHOLD_MIN_USD = 5;
 /** Mirrors the max bound on both fields in the backend's WalletSettingsInputSchema so over-limit values fail inline instead of as a generic 400. */
 const AUTO_RELOAD_MAX_USD = 10_000;
 
-const createAutoTopUpSchema = (amountMinUsd: number) =>
-  z.object({
-    autoReloadThreshold: z.coerce
-      .number()
-      .min(AUTO_RELOAD_THRESHOLD_MIN_USD, `Minimum threshold is $${AUTO_RELOAD_THRESHOLD_MIN_USD}`)
-      .max(AUTO_RELOAD_MAX_USD, `Maximum threshold is $${AUTO_RELOAD_MAX_USD}`),
-    autoReloadAmount: z.coerce
-      .number()
-      .min(amountMinUsd, `Minimum amount is $${amountMinUsd}`)
-      .max(AUTO_RELOAD_MAX_USD, `Maximum amount is $${AUTO_RELOAD_MAX_USD}`)
-  });
+/** Mirrors STANDARD_TOP_UP_MIN_AMOUNT_USD — the fixed floor the backend applies to every recurring auto-top-up charge, independent of the trial-aware one-time top-up minimum. */
+const AUTO_RELOAD_AMOUNT_MIN_USD = 20;
 
-type AutoTopUpFormValues = z.infer<ReturnType<typeof createAutoTopUpSchema>>;
+const autoTopUpSchema = z.object({
+  autoReloadThreshold: z.coerce
+    .number()
+    .min(AUTO_RELOAD_THRESHOLD_MIN_USD, `Minimum threshold is $${AUTO_RELOAD_THRESHOLD_MIN_USD}`)
+    .max(AUTO_RELOAD_MAX_USD, `Maximum threshold is $${AUTO_RELOAD_MAX_USD}`),
+  autoReloadAmount: z.coerce
+    .number()
+    .min(AUTO_RELOAD_AMOUNT_MIN_USD, `Minimum amount is $${AUTO_RELOAD_AMOUNT_MIN_USD}`)
+    .max(AUTO_RELOAD_MAX_USD, `Maximum amount is $${AUTO_RELOAD_MAX_USD}`)
+});
+
+type AutoTopUpFormValues = z.infer<typeof autoTopUpSchema>;
 
 export const DEPENDENCIES = {
   useForm,
   zodResolver,
   useSnackbar,
-  useWallet,
   useDefaultPaymentMethodQuery,
   useWalletSettingsMutations
 };
@@ -64,12 +64,8 @@ export const AutoTopUpSettingsPopup: React.FC<AutoTopUpSettingsPopupProps> = ({
   dependencies: d = DEPENDENCIES
 }) => {
   const { enqueueSnackbar } = d.useSnackbar();
-  const { topUpMinAmountUsd } = d.useWallet();
   const { data: defaultPaymentMethod } = d.useDefaultPaymentMethodQuery();
   const { upsertWalletSettings } = d.useWalletSettingsMutations();
-
-  const amountMinUsd = topUpMinAmountUsd ?? DEFAULT_AUTO_RELOAD_THRESHOLD;
-  const schema = useMemo(() => createAutoTopUpSchema(amountMinUsd), [amountMinUsd]);
 
   const defaultValues = useMemo<AutoTopUpFormValues>(
     () => ({
@@ -80,7 +76,7 @@ export const AutoTopUpSettingsPopup: React.FC<AutoTopUpSettingsPopupProps> = ({
   );
 
   const form = d.useForm<AutoTopUpFormValues>({
-    resolver: d.zodResolver(schema),
+    resolver: d.zodResolver(autoTopUpSchema),
     defaultValues
   });
 
@@ -158,7 +154,7 @@ export const AutoTopUpSettingsPopup: React.FC<AutoTopUpSettingsPopupProps> = ({
                 {...field}
                 type="number"
                 step="0.01"
-                label={`Purchase this amount (minimum $${amountMinUsd})`}
+                label={`Purchase this amount (minimum $${AUTO_RELOAD_AMOUNT_MIN_USD})`}
                 startIcon={<div className="pl-3 text-sm text-muted-foreground">$</div>}
               />
             )}

--- a/apps/deploy-web/src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup.tsx
@@ -39,7 +39,6 @@ type AutoTopUpFormValues = z.infer<typeof autoTopUpSchema>;
 
 export const DEPENDENCIES = {
   useForm,
-  zodResolver,
   useSnackbar,
   useDefaultPaymentMethodQuery,
   useWalletSettingsMutations
@@ -76,7 +75,7 @@ export const AutoTopUpSettingsPopup: React.FC<AutoTopUpSettingsPopupProps> = ({
   );
 
   const form = d.useForm<AutoTopUpFormValues>({
-    resolver: d.zodResolver(autoTopUpSchema),
+    resolver: zodResolver(autoTopUpSchema),
     defaultValues
   });
 

--- a/apps/deploy-web/src/queries/useWalletSettingsQueries.spec.tsx
+++ b/apps/deploy-web/src/queries/useWalletSettingsQueries.spec.tsx
@@ -35,7 +35,7 @@ function setupQueryWithClient<T>(hook: () => T, options?: RenderAppHookOptions) 
 describe("useWalletSettingsQueries", () => {
   describe(useWalletSettingsQuery.name, () => {
     it("returns wallet settings data on success", async () => {
-      const settings = { autoReloadEnabled: true };
+      const settings = { autoReloadEnabled: true, autoReloadThreshold: 20, autoReloadAmount: 100 };
       const getWalletSettings = vi.fn().mockResolvedValue({ data: settings });
       const api = createProxy({ v1: { getWalletSettings } }) as unknown as ApiService;
 
@@ -82,7 +82,7 @@ describe("useWalletSettingsQueries", () => {
 
   describe(useWalletSettingsMutations.name, () => {
     it("updates wallet settings and invalidates the query", async () => {
-      const params = { data: { autoReloadEnabled: true } };
+      const params = { data: { autoReloadEnabled: true, autoReloadThreshold: 25, autoReloadAmount: 150 } };
       const { result, queryClient, api, v1 } = setupMutations();
       const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries");
 

--- a/apps/deploy-web/src/types/feature-flags.ts
+++ b/apps/deploy-web/src/types/feature-flags.ts
@@ -6,6 +6,7 @@ export type FeatureFlag =
   | "ui_sdl_log_collector_enabled"
   | "maintenance_banner"
   | "auto_credit_reload"
+  | "auto_reload_fixed_threshold"
   | "ui_sdl_preview_panel"
   | "ui_build_and_deploy"
   | "ui_gpu_interconnect"


### PR DESCRIPTION
## Why

CON-717 replaces the predicted-spend auto-reload with a fixed, user-configurable rule: when the credit balance is at or below threshold X, charge the default payment method exactly amount Y.

This is the **frontend half** of CON-717, split out from the original combined PR and **stacked on the backend PR #3533** — it consumes the wallet-settings types regenerated there, so #3533 must merge first. GitHub will retarget this PR's base to `main` automatically once #3533 lands.

Closes CON-717

## What

All new behavior is gated behind `useFlag("auto_reload_fixed_threshold")` (off by default). Flag **off** → the current Auto Top-Up card is unchanged.

- New `AutoTopUpSettingsPopup` (AkashML-style dialog): threshold + fixed-amount fields with client validation, a read-only default-payment-method row, and enable-on-save vs. edit modes.
- `AccountOverview` card reworked under the flag: "Auto Top-Up" title, threshold-semantics tooltip, edit button, and a summary line ("Top up $100 when balance ≤ $20"). Toggle-on opens the dialog (no optimistic flip); toggle-off keeps the confirm popup.

## Testing

- `AutoTopUpSettingsPopup` (prefill, default-card row, validation, enable vs. edit payloads, success/error), `AccountOverview` (summary variants, switch-on opens dialog without mutating, switch-off confirm, edit button, disabled without payment method), and the wallet-settings query fixtures.
- `npm run lint -- --quiet` and `npx tsc --noEmit` clean for the changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fixed-threshold automatic top-up settings, including editable threshold and amount values.
  * Added payment-method requirements, validation, confirmations, notifications, and popup controls for managing auto top-up.
  * Feature is available behind a feature flag; existing auto-recharge behavior remains unchanged when disabled.

* **Bug Fixes**
  * Updated wallet reload scheduling to cancel previous jobs before creating a new one, preventing duplicate reloads.
  * Changing auto-reload settings now correctly replaces previously scheduled reload jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->