### PR TITLE
fix(sdl): preserve all args elements when importing an SDL into the builder

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/CommandsCard/CommandsCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/CommandsCard/CommandsCard.tsx
@@ -32,10 +32,9 @@ type Props = {
 
 /**
  * "Commands" card. Edits `services.${serviceIndex}.command.{command,arg}` on the
- * shared deployment model — the container's CMD/ENTRYPOINT override. The command
- * textarea holds one argv token per line (the SDL generator tokenizes by line);
- * leaving it blank keeps the image's default. Arguments are emitted as the SDL
- * `args` list only when a command is set.
+ * shared deployment model, the container's CMD/ENTRYPOINT override. Both textareas
+ * hold one argv token per line (the SDL generator tokenizes by line); leaving them
+ * blank keeps the image's defaults.
  *
  * The card is non-collapsible: its header summarizes the current command (or notes the
  * image default) and clicking it opens a Dialog for editing. Changes are committed on
@@ -117,7 +116,7 @@ export const CommandsCard: FC<Props> = ({ serviceIndex, locked = false, dependen
                     id={`command-arg-${serviceIndex}`}
                     aria-label="Arguments"
                     rows={4}
-                    placeholder="Example: apt-get update; apt-get install -y --no-install-recommends -- ssh;"
+                    placeholder={"One token per line. Example:\n-c\necho hello"}
                     value={arg.field.value ?? ""}
                     onChange={event => arg.field.onChange(event.target.value)}
                     spellCheck={false}

--- a/apps/deploy-web/src/components/sdl/CommandFormModal.tsx
+++ b/apps/deploy-web/src/components/sdl/CommandFormModal.tsx
@@ -54,7 +54,7 @@ export const CommandFormModal: React.FunctionComponent<Props> = ({ control, serv
           render={({ field }) => (
             <Textarea
               aria-label="Args"
-              placeholder="Example: apt-get update; apt-get install -y --no-install-recommends -- ssh;"
+              placeholder={"One token per line. Example:\n-c\necho hello"}
               label="Arguments"
               inputClassName="mt-2 w-full px-4 py-2 text-sm"
               value={field.value}

--- a/apps/deploy-web/src/components/sdl/CommandList.spec.tsx
+++ b/apps/deploy-web/src/components/sdl/CommandList.spec.tsx
@@ -1,0 +1,40 @@
+import { TooltipProvider } from "@akashnetwork/ui/components";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { ServiceType } from "@src/types";
+import { CommandList } from "./CommandList";
+
+import { render, screen } from "@testing-library/react";
+
+describe(CommandList.name, () => {
+  it("renders command and args when both are set", () => {
+    setup({ command: { command: "sh -c", arg: "--port\n8080" } });
+
+    expect(screen.getByText("sh -c")).toBeInTheDocument();
+    expect(screen.queryByText("None")).not.toBeInTheDocument();
+  });
+
+  it("renders args when only args are set", () => {
+    setup({ command: { command: "", arg: "--port\n8080" } });
+
+    expect(screen.getByText("--port 8080")).toBeInTheDocument();
+    expect(screen.queryByText("None")).not.toBeInTheDocument();
+  });
+
+  it("renders 'None' when command and args are empty", () => {
+    setup({ command: { command: "", arg: "" } });
+
+    expect(screen.getByText("None")).toBeInTheDocument();
+  });
+
+  function setup(input: { command?: ServiceType["command"] }) {
+    const currentService = mock<ServiceType>({ command: input.command });
+    render(
+      <TooltipProvider>
+        <CommandList currentService={currentService} setIsEditingCommands={vi.fn()} />
+      </TooltipProvider>
+    );
+    return input;
+  }
+});

--- a/apps/deploy-web/src/components/sdl/CommandList.tsx
+++ b/apps/deploy-web/src/components/sdl/CommandList.tsx
@@ -40,7 +40,7 @@ export const CommandList: React.FunctionComponent<Props> = ({ currentService, se
         </span>
       </div>
 
-      {(currentService?.command?.command?.length || 0) > 0 ? (
+      {currentService?.command?.command?.trim() || currentService?.command?.arg?.trim() ? (
         <div className="whitespace-pre-wrap text-xs">
           <div>{currentService.command?.command}</div>
           <div className="text-muted-foreground">{currentService.command?.arg}</div>

--- a/apps/deploy-web/src/utils/sdl/sdlGenerator.spec.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlGenerator.spec.ts
@@ -132,6 +132,34 @@ describe("sdlGenerator", () => {
       expect(parsed.reclamation).toEqual({ min_window: minWindow });
     });
 
+    it("emits every args token as its own array element", () => {
+      const service = buildLogCollectorService({
+        title: "web",
+        image: "nginx:latest",
+        command: { command: "/tini\n-s\n--", arg: "bash\n-c\nmkdir -p /data; apt update; sleep infinity;" }
+      });
+      const parsed = yaml.load(generateSdl(buildFormValues(service))) as { services: Record<string, { command?: string[]; args?: string[] }> };
+
+      expect(parsed.services.web.command).toEqual(["/tini", "-s", "--"]);
+      expect(parsed.services.web.args).toEqual(["bash", "-c", "mkdir -p /data; apt update; sleep infinity;"]);
+    });
+
+    it("emits args without a command when only args are set", () => {
+      const service = buildLogCollectorService({ title: "web", image: "nginx:latest", command: { command: "", arg: "--port\n8080" } });
+      const parsed = yaml.load(generateSdl(buildFormValues(service))) as { services: Record<string, { command?: string[]; args?: string[] }> };
+
+      expect(parsed.services.web).not.toHaveProperty("command");
+      expect(parsed.services.web.args).toEqual(["--port", "8080"]);
+    });
+
+    it("does not emit args when the arg field is blank", () => {
+      const service = buildLogCollectorService({ title: "web", image: "nginx:latest", command: { command: "nginx", arg: "" } });
+      const parsed = yaml.load(generateSdl(buildFormValues(service))) as { services: Record<string, { command?: string[]; args?: string[] }> };
+
+      expect(parsed.services.web.command).toEqual(["nginx"]);
+      expect(parsed.services.web).not.toHaveProperty("args");
+    });
+
     function buildLogCollectorService(overrides?: Partial<ServiceType>): ServiceType {
       return {
         id: overrides?.title ? `${overrides.title}-id` : "web-log-collector",

--- a/apps/deploy-web/src/utils/sdl/sdlGenerator.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlGenerator.ts
@@ -5,9 +5,9 @@ import type { ExposeType, PlacementType, ProfileGpuModelType, SdlBuilderFormValu
 import { defaultHttpOptions } from "./data";
 
 /**
- * Converts the Command form field (one command-array token per line) into the
- * SDL `command` array. Tokens are trimmed and empty lines dropped. The user's
- * command is preserved verbatim — no shell wrapper (e.g. `sh -c`) is forced.
+ * Converts the Command and Arguments form fields (one array token per line) into
+ * the SDL `command`/`args` arrays. Tokens are trimmed and empty lines dropped. The
+ * user's tokens are preserved verbatim; no shell wrapper (e.g. `sh -c`) is forced.
  */
 export const buildCommand = (command: string): string[] => {
   return command
@@ -110,11 +110,11 @@ export const generateSdl = (formValues: SdlBuilderFormValuesType) => {
     const trimmedCommand = service.command?.command?.trim();
     if (trimmedCommand) {
       sdl.services[service.title].command = buildCommand(trimmedCommand);
+    }
 
-      const arg = service.command?.arg;
-      if (arg) {
-        sdl.services[service.title].args = [arg];
-      }
+    const trimmedArg = service.command?.arg?.trim();
+    if (trimmedArg) {
+      sdl.services[service.title].args = buildCommand(trimmedArg);
     }
 
     if ((service.env?.length || 0) > 0) {

--- a/apps/deploy-web/src/utils/sdl/sdlImport.spec.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlImport.spec.ts
@@ -218,8 +218,8 @@ describe("sdlImport", () => {
       expect(parsed.services.web.params?.tee).toBe("cpu");
     });
 
-    it("imports an SDL, regenerates it, and produces semantically equal output", () => {
-      const yml = fs.readFileSync(path.resolve(__dirname, "../../../tests/mocks/two-services-sdl.yml"), "utf8");
+    it.each(["two-services-sdl.yml", "tini-multi-args-sdl.yml"])("imports %s, regenerates it, and produces semantically equal output", mockFile => {
+      const yml = fs.readFileSync(path.resolve(__dirname, `../../../tests/mocks/${mockFile}`), "utf8");
       const formValues = importSimpleSdl(yml);
       const regenerated = generateSdl(formValues);
 
@@ -233,55 +233,22 @@ describe("sdlImport", () => {
       { command: ["bash", "-lc"], args: ["./run.sh"] },
       { command: ["sh", "-c"], args: ["echo hi"] },
       { command: ["sh", "-c", "echo foo"], args: undefined },
-      { command: ["bash", "-c"], args: ["run"] }
+      { command: ["bash", "-c"], args: ["run"] },
+      { command: ["/tini", "-s", "--"], args: ["bash", "-c", "mkdir -p /runpod-volume; apt update; sleep infinity;"] },
+      { command: ["node"], args: ["server.js", "--port", "8080"] }
     ])("preserves command $command and args $args without forcing a shell wrapper", ({ command, args }) => {
       const formCommand = parseSvcCommand(command);
-      const formArg = args ? args[0] : "";
+      const formArg = parseSvcCommand(args);
 
       const rebuiltCommand = buildCommand(formCommand.trim());
-      const rebuiltArgs = formArg ? [formArg] : undefined;
+      const rebuiltArgs = formArg ? buildCommand(formArg.trim()) : undefined;
 
       expect(rebuiltCommand).toEqual(command);
       expect(rebuiltArgs).toEqual(args);
     });
 
     it("does not emit an args key when a service has a command but no args", () => {
-      const yml = [
-        "version: '2.0'",
-        "services:",
-        "  web:",
-        "    image: nginx:1.0",
-        "    command:",
-        "      - sh",
-        "      - -c",
-        "      - echo hello",
-        "    expose:",
-        "      - port: 80",
-        "        as: 80",
-        "        to:",
-        "          - global: true",
-        "profiles:",
-        "  compute:",
-        "    web:",
-        "      resources:",
-        "        cpu:",
-        "          units: 0.5",
-        "        memory:",
-        "          size: 512Mi",
-        "        storage:",
-        "          - size: 512Mi",
-        "  placement:",
-        "    dcloud:",
-        "      pricing:",
-        "        web:",
-        "          denom: uact",
-        "          amount: 1000",
-        "deployment:",
-        "  web:",
-        "    dcloud:",
-        "      profile: web",
-        "      count: 1"
-      ].join("\n");
+      const yml = sdlWithCommandBlock(["    command:", "      - sh", "      - -c", "      - echo hello"]);
 
       const regenerated = generateSdl(importSimpleSdl(yml));
       const parsed = yaml.load(regenerated) as { services: Record<string, { command?: unknown }> };
@@ -289,8 +256,73 @@ describe("sdlImport", () => {
       expect(parsed.services.web.command).toEqual(["sh", "-c", "echo hello"]);
       expect(parsed.services.web).not.toHaveProperty("args");
     });
+
+    it("round-trips every args element through import and regenerate", () => {
+      const yml = sdlWithCommandBlock([
+        "    command:",
+        "      - /tini",
+        "      - -s",
+        "      - --",
+        "    args:",
+        "      - bash",
+        "      - -c",
+        "      - mkdir -p /runpod-volume; apt update; sleep infinity;"
+      ]);
+
+      const regenerated = generateSdl(importSimpleSdl(yml));
+      const parsed = yaml.load(regenerated) as { services: Record<string, { command?: string[]; args?: string[] }> };
+
+      expect(parsed.services.web.command).toEqual(["/tini", "-s", "--"]);
+      expect(parsed.services.web.args).toEqual(["bash", "-c", "mkdir -p /runpod-volume; apt update; sleep infinity;"]);
+    });
+
+    it("round-trips args when the service has no command", () => {
+      const yml = sdlWithCommandBlock(["    args:", "      - --port", "      - '8080'"]);
+
+      const regenerated = generateSdl(importSimpleSdl(yml));
+      const parsed = yaml.load(regenerated) as { services: Record<string, { command?: string[]; args?: string[] }> };
+
+      expect(parsed.services.web).not.toHaveProperty("command");
+      expect(parsed.services.web.args).toEqual(["--port", "8080"]);
+    });
   });
 });
+
+/** Complete single-service SDL with the given lines spliced into the `web` service block. */
+const sdlWithCommandBlock = (serviceLines: string[]) =>
+  [
+    "version: '2.0'",
+    "services:",
+    "  web:",
+    "    image: nginx:1.0",
+    ...serviceLines,
+    "    expose:",
+    "      - port: 80",
+    "        as: 80",
+    "        to:",
+    "          - global: true",
+    "profiles:",
+    "  compute:",
+    "    web:",
+    "      resources:",
+    "        cpu:",
+    "          units: 0.5",
+    "        memory:",
+    "          size: 512Mi",
+    "        storage:",
+    "          - size: 512Mi",
+    "  placement:",
+    "    dcloud:",
+    "      pricing:",
+    "        web:",
+    "          denom: uact",
+    "          amount: 1000",
+    "deployment:",
+    "  web:",
+    "    dcloud:",
+    "      profile: web",
+    "      count: 1"
+  ].join("\n");
 
 const teeSdl = (tee: "cpu" | "cpu-gpu") =>
   [

--- a/apps/deploy-web/src/utils/sdl/sdlImport.spec.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlImport.spec.ts
@@ -45,6 +45,11 @@ describe("sdlImport", () => {
     it("joins every command element with a newline, dropping empty lines", () => {
       expect(parseSvcCommand(["sh", "-c", "echo 'foo'", "", "echo 'bar'"])).toEqual("sh\n-c\necho 'foo'\necho 'bar'");
     });
+
+    it("preserves falsy scalar tokens parsed from unquoted YAML values", () => {
+      expect(parseSvcCommand(["--retries", 0, "done"])).toEqual("--retries\n0\ndone");
+      expect(parseSvcCommand(["--verbose", false])).toEqual("--verbose\nfalse");
+    });
   });
 
   describe("importSimpleSdl", () => {

--- a/apps/deploy-web/src/utils/sdl/sdlImport.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlImport.ts
@@ -7,7 +7,8 @@ import { CustomValidationError } from "../deploymentData";
 import { capitalizeFirstLetter } from "../stringUtils";
 import { defaultHttpOptions } from "./data";
 
-export const parseSvcCommand = (command?: string | string[]): string => {
+/** YAML parses unquoted scalars like `0` or `false` into native types, so tokens are stringified instead of filtered as falsy. */
+export const parseSvcCommand = (command?: string | (string | number | boolean)[]): string => {
   if (!command) {
     return "";
   }
@@ -16,7 +17,11 @@ export const parseSvcCommand = (command?: string | string[]): string => {
     return parseSvcCommand([command]);
   }
 
-  return command.filter(Boolean).join("\n");
+  return command
+    .filter(token => token !== null && token !== undefined)
+    .map(String)
+    .filter(token => token.length > 0)
+    .join("\n");
 };
 
 /**

--- a/apps/deploy-web/src/utils/sdl/sdlImport.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlImport.ts
@@ -99,7 +99,7 @@ export const importSimpleSdl = (yamlStr: string, { placementPerService = false }
 
       service.command = {
         command: parseSvcCommand(svc.command),
-        arg: svc.args ? svc.args[0] : ""
+        arg: parseSvcCommand(svc.args)
       };
 
       service.env =

--- a/apps/deploy-web/tests/mocks/tini-multi-args-sdl.yml
+++ b/apps/deploy-web/tests/mocks/tini-multi-args-sdl.yml
@@ -1,8 +1,8 @@
 ---
 version: "2.0"
 services:
-  runpod:
-    image: ghcr.io/example/astria:latest
+  app:
+    image: ghcr.io/example/app:latest
     expose:
       - port: 22
         as: 22
@@ -16,26 +16,26 @@ services:
       - bash
       - -c
       - >-
-        mkdir -p /runpod-volume;
-        export RUNPOD_POD_ID=akash-$AKASH_DEPLOYMENT_SEQUENCE;
+        mkdir -p /data/volume;
+        export POD_ID=akash-$AKASH_DEPLOYMENT_SEQUENCE;
         mkdir -p /var/cache/apt/archives/partial;
         mkdir -p /data/models;
-        bash astria/set_runpod_mounts.sh;
+        bash scripts/set_mounts.sh;
         apt update;
         DEBIAN_FRONTEND=noninteractive apt-get install tmux rsync vim openssh-server -y;
         mkdir -p ~/.ssh; cd $_; chmod 700 ~/.ssh; echo "$PUBLIC_KEY" >> authorized_keys;
         chmod 700 authorized_keys; service ssh start;
         printf "set-option -g set-titles on\nset-option -g set-titles-string \"#{session_name} - #{host}\"\nset-option -g status-left-length 60" > ~/.tmux.conf;
         cd /app;
-        SESSION_NAME=$RUNPOD_POD_ID-$HOSTNAME
-        tmux new-session -d -s my_session "cd /app; uv run astria/init_download_models.py; ./astria/watchdog.sh";
-        tmux split-window -t my_session "cd /app; sleep 100; uv run astria/init_download_models.py secondary";
+        SESSION_NAME=$POD_ID-$HOSTNAME
+        tmux new-session -d -s my_session "cd /app; uv run scripts/init_download_models.py; ./scripts/watchdog.sh";
+        tmux split-window -t my_session "cd /app; sleep 100; uv run scripts/init_download_models.py secondary";
         tmux split-window -t my_session "cd /app; pip3 install nvitop; nvitop; bash";
-        tmux rename-session -t my_session "$RUNPOD_POD_ID-$HOSTNAME-$AKASH_CLUSTER_PUBLIC_HOSTNAME";
+        tmux rename-session -t my_session "$POD_ID-$HOSTNAME-$AKASH_CLUSTER_PUBLIC_HOSTNAME";
         sleep infinity;
 profiles:
   compute:
-    runpod:
+    app:
       resources:
         cpu:
           units: 0.5
@@ -46,11 +46,11 @@ profiles:
   placement:
     dcloud:
       pricing:
-        runpod:
+        app:
           denom: uact
           amount: 1000
 deployment:
-  runpod:
+  app:
     dcloud:
-      profile: runpod
+      profile: app
       count: 1

--- a/apps/deploy-web/tests/mocks/tini-multi-args-sdl.yml
+++ b/apps/deploy-web/tests/mocks/tini-multi-args-sdl.yml
@@ -1,0 +1,56 @@
+---
+version: "2.0"
+services:
+  runpod:
+    image: ghcr.io/example/astria:latest
+    expose:
+      - port: 22
+        as: 22
+        to:
+          - global: true
+    command:
+      - /tini
+      - -s
+      - --
+    args:
+      - bash
+      - -c
+      - >-
+        mkdir -p /runpod-volume;
+        export RUNPOD_POD_ID=akash-$AKASH_DEPLOYMENT_SEQUENCE;
+        mkdir -p /var/cache/apt/archives/partial;
+        mkdir -p /data/models;
+        bash astria/set_runpod_mounts.sh;
+        apt update;
+        DEBIAN_FRONTEND=noninteractive apt-get install tmux rsync vim openssh-server -y;
+        mkdir -p ~/.ssh; cd $_; chmod 700 ~/.ssh; echo "$PUBLIC_KEY" >> authorized_keys;
+        chmod 700 authorized_keys; service ssh start;
+        printf "set-option -g set-titles on\nset-option -g set-titles-string \"#{session_name} - #{host}\"\nset-option -g status-left-length 60" > ~/.tmux.conf;
+        cd /app;
+        SESSION_NAME=$RUNPOD_POD_ID-$HOSTNAME
+        tmux new-session -d -s my_session "cd /app; uv run astria/init_download_models.py; ./astria/watchdog.sh";
+        tmux split-window -t my_session "cd /app; sleep 100; uv run astria/init_download_models.py secondary";
+        tmux split-window -t my_session "cd /app; pip3 install nvitop; nvitop; bash";
+        tmux rename-session -t my_session "$RUNPOD_POD_ID-$HOSTNAME-$AKASH_CLUSTER_PUBLIC_HOSTNAME";
+        sleep infinity;
+profiles:
+  compute:
+    runpod:
+      resources:
+        cpu:
+          units: 0.5
+        memory:
+          size: 512Mi
+        storage:
+          - size: 512Mi
+  placement:
+    dcloud:
+      pricing:
+        runpod:
+          denom: uact
+          amount: 1000
+deployment:
+  runpod:
+    dcloud:
+      profile: runpod
+      count: 1


### PR DESCRIPTION
## Why

A user reported (via Slack) that importing an SDL with `command: [/tini, -s, --]` and `args: [bash, -c, <setup script>]` into the Console GUI silently deployed `args: [bash]` only, so the container ran an idle bash and none of the setup script executed.

Root cause: the builder form models args as a single scalar. `importSimpleSdl` kept only `args[0]` and `generateSdl` could only emit a one-element `args` list, and only when a command was set. The configure flow always deploys the SDL regenerated from form values, so the truncation landed on-chain with no warning.

## What

- `sdlImport`: import the full `args` array through the existing `parseSvcCommand` (newline-joined tokens), matching how `command` already round-trips.
- `sdlGenerator`: tokenize the arg field with the existing `buildCommand` and emit `args` independently of `command`, so an SDL with args but no command also round-trips.
- Arguments textarea placeholders (configure flow card and legacy builder modal) now document the one-token-per-line format.
- Regression tests: multi-element args round-trip cases, args-without-command, and a semantic round-trip fixture (`tini-multi-args-sdl.yml`) mirroring the reported SDL including its folded `>-` script block.

Known limitation (pre-existing, applies to `command` identically): tokens containing literal newlines (`- |` block scalars) are split per line. Follow-up candidates: a lossless `string[]` args model and a post-import round-trip diff warning for anything the builder cannot represent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Enhanced SDL generation and import to preserve newline-delimited command/argument tokens, omit empty entries, and avoid unintended shell wrappers.
  - Correctly maps `command`/`arg` presence: services omit missing fields and handle `arg`-only cases without losing additional tokens.
- **UI Updates**
  - Updated argument placeholders to a concise one-token-per-line example across the command editing dialogs.
  - Refined CommandList display logic so it won’t show “None” when `command`/`arg` contains meaningful text.
- **Tests**
  - Added/expanded roundtrip and rendering coverage for command/args behavior.
- **Documentation**
  - Reworded Commands card guidance to clarify override and token mapping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->