### PR TITLE
fix(network): pin deploy-web to the managed-wallet network without a reload

### DIFF
--- a/apps/deploy-web/src/components/alerts/DeploymentAlertsContainer/DeploymentAlertsContainer.spec.tsx
+++ b/apps/deploy-web/src/components/alerts/DeploymentAlertsContainer/DeploymentAlertsContainer.spec.tsx
@@ -6,7 +6,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { ChildrenProps, ContainerInput } from "@src/components/alerts/DeploymentAlertsContainer/DeploymentAlertsContainer";
 import { DeploymentAlertsContainer } from "@src/components/alerts/DeploymentAlertsContainer/DeploymentAlertsContainer";
-import { USDC_IBC_DENOMS } from "@src/config/denom.config";
+import { UACT_DENOM } from "@src/config/denom.config";
 import { queryClient } from "@src/queries";
 import { createApiSdk } from "@src/services/api-sdk/createApiSdk";
 import { deploymentToDto } from "@src/utils/deploymentDetailUtils";
@@ -134,8 +134,8 @@ describe(DeploymentAlertsContainer.name, () => {
 
   async function setup() {
     const rpcDeployment = buildRpcDeployment({
-      denom: USDC_IBC_DENOMS["mainnet"],
-      escrow_account: { state: { funds: [{ denom: USDC_IBC_DENOMS["mainnet"], amount: "5000000.000000000000000000" }] } }
+      denom: UACT_DENOM,
+      escrow_account: { state: { funds: [{ denom: UACT_DENOM, amount: "5000000.000000000000000000" }] } }
     });
     const deployment = deploymentToDto(rpcDeployment);
     const dseq = deployment.dseq;

--- a/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.spec.tsx
+++ b/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.spec.tsx
@@ -291,11 +291,6 @@ describe("OnboardingContainer", () => {
       update: vi.fn()
     };
 
-    const mockSetSelectedNetworkId = vi.fn();
-    const mockNetworkStore = {
-      useSelectedNetworkIdStore: vi.fn().mockReturnValue(["mainnet", mockSetSelectedNetworkId])
-    };
-
     const mockAppConfig = {
       NEXT_PUBLIC_DEFAULT_INITIAL_DEPOSIT: "5000000",
       NEXT_PUBLIC_MANAGED_WALLET_NETWORK_ID: "sandbox"
@@ -319,8 +314,7 @@ describe("OnboardingContainer", () => {
       errorHandler: mockErrorHandler,
       windowLocation,
       windowHistory,
-      template: mockTemplateService,
-      networkStore: mockNetworkStore
+      template: mockTemplateService
     });
     const mockUseRouter = vi.fn().mockReturnValue(mockRouter);
     const mockUseWallet = vi.fn().mockReturnValue({
@@ -454,8 +448,7 @@ describe("OnboardingContainer", () => {
       mockValidateDeploymentData,
       mockAppendAuditorRequirement,
       mockTransactionMessageData,
-      mockUseWallet,
-      mockSetSelectedNetworkId
+      mockUseWallet
     };
   }
 });

--- a/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.tsx
+++ b/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.tsx
@@ -74,18 +74,7 @@ export const OnboardingContainer: React.FunctionComponent<OnboardingContainerPro
   const { user } = d.useUser();
   const { data: paymentMethods = [] } = d.usePaymentMethodsQuery({ enabled: !!user?.stripeCustomerId });
   const { minDeposit } = d.useChainParam();
-  const {
-    analyticsService,
-    urlService,
-    deploymentLocalStorage,
-    errorHandler,
-    windowLocation,
-    windowHistory,
-    template: templateService,
-    networkStore,
-    publicConfig
-  } = d.useServices();
-  const [selectedNetworkId, setSelectedNetworkId] = networkStore.useSelectedNetworkIdStore();
+  const { analyticsService, urlService, deploymentLocalStorage, errorHandler, windowLocation, windowHistory, template: templateService } = d.useServices();
   const wallet = d.useWallet();
   const notificator = d.useNotificator();
   const { navigateBack } = d.useReturnTo({ defaultReturnTo: "/" });
@@ -164,10 +153,6 @@ export const OnboardingContainer: React.FunctionComponent<OnboardingContainerPro
   );
 
   const handleStartTrial = useCallback(() => {
-    if (selectedNetworkId !== publicConfig.NEXT_PUBLIC_MANAGED_WALLET_NETWORK_ID) {
-      setSelectedNetworkId(publicConfig.NEXT_PUBLIC_MANAGED_WALLET_NETWORK_ID);
-    }
-
     analyticsService.track("onboarding_free_trial_started", {
       category: "onboarding"
     });
@@ -185,18 +170,7 @@ export const OnboardingContainer: React.FunctionComponent<OnboardingContainerPro
     } else {
       router.push(urlService.newSignup({ fromSignup: "true" }));
     }
-  }, [
-    analyticsService,
-    handleStepComplete,
-    user?.userId,
-    user?.emailVerified,
-    handleStepChange,
-    router,
-    urlService,
-    selectedNetworkId,
-    publicConfig.NEXT_PUBLIC_MANAGED_WALLET_NETWORK_ID,
-    setSelectedNetworkId
-  ]);
+  }, [analyticsService, handleStepComplete, user?.userId, user?.emailVerified, handleStepChange, router, urlService]);
 
   const handlePaymentMethodComplete = useCallback(() => {
     if (paymentMethods.length > 0) {

--- a/apps/deploy-web/src/context/WalletProvider/WalletProvider.tsx
+++ b/apps/deploy-web/src/context/WalletProvider/WalletProvider.tsx
@@ -9,7 +9,6 @@ import { useManagedWallet } from "@src/hooks/useManagedWallet";
 import { useUser } from "@src/hooks/useUser";
 import { useWhen } from "@src/hooks/useWhen";
 import { useBalances } from "@src/queries/useBalancesQuery";
-import networkStore from "@src/store/networkStore";
 import type { AppError } from "@src/types";
 import { getStorageManagedWallet, updateStorageManagedWallet } from "@src/utils/walletUtils";
 import { useServices } from "../ServicesProvider";
@@ -47,7 +46,7 @@ export const WalletProviderContext = React.createContext<ContextType>({} as Cont
  * WalletProvider is a client only component
  */
 export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const { analyticsService, publicConfig: appConfig, urlService, windowLocation } = useServices();
+  const { analyticsService, publicConfig: appConfig, urlService } = useServices();
 
   const [, setSettingsId] = useAtom(settingsIdAtom);
   const [isWalletLoaded, setIsWalletLoaded] = useState<boolean>(true);
@@ -64,7 +63,6 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   const username = managedWallet?.username;
   const isWalletConnected = !!managedWallet?.isWalletConnected;
   const { refetch: refetchBalances } = useBalances(walletAddress);
-  const [selectedNetworkId, setSelectedNetworkId] = networkStore.useSelectedNetworkIdStore();
   const isLoading = deriveWalletIsLoading({
     hasAuthenticatedUserId: !!user?.userId,
     isManagedWalletLoading
@@ -85,13 +83,6 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   useEffect(() => {
     setSettingsId(walletAddress || null);
   }, [walletAddress, setSettingsId]);
-
-  // Reload in place (not nav home) so a successful deploy doesn't bounce the user back to `/`.
-  useEffect(() => {
-    if (selectedNetworkId === appConfig.NEXT_PUBLIC_MANAGED_WALLET_NETWORK_ID) return;
-    setSelectedNetworkId(appConfig.NEXT_PUBLIC_MANAGED_WALLET_NETWORK_ID);
-    windowLocation.reload();
-  }, [selectedNetworkId, appConfig.NEXT_PUBLIC_MANAGED_WALLET_NETWORK_ID, setSelectedNetworkId, windowLocation]);
 
   function connectManagedWallet() {
     if (!managedWallet) {
@@ -128,10 +119,6 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     }
 
     setIsWalletLoaded(true);
-
-    if (selectedNetworkId !== networkId) {
-      setSelectedNetworkId(networkId);
-    }
   }
 
   return (

--- a/apps/deploy-web/src/store/networkStore.ts
+++ b/apps/deploy-web/src/store/networkStore.ts
@@ -4,7 +4,8 @@ import { browserEnvConfig } from "@src/config/browser-env.config";
 import { store } from "@src/store/global-store";
 
 export default NetworkStore.create({
-  defaultNetworkId: browserEnvConfig.NEXT_PUBLIC_DEFAULT_NETWORK_ID,
+  defaultNetworkId: browserEnvConfig.NEXT_PUBLIC_MANAGED_WALLET_NETWORK_ID,
+  fixed: true,
   apiBaseUrl: "/api",
   store
 });

--- a/packages/network-store/src/network.store.ts
+++ b/packages/network-store/src/network.store.ts
@@ -10,6 +10,13 @@ interface NetworkStoreOptions {
   defaultNetworkId: Network["id"];
   apiBaseUrl: string;
   store?: ReturnType<typeof getDefaultStore>;
+  /**
+   * Pins the store to `defaultNetworkId`: `selectedNetworkId` becomes a constant, its setter throws, and a
+   * `?network=` URL param is ignored (a fixed store has no other network to switch to). Single-network apps
+   * (deploy-web is managed-wallet-only) set this so the network can neither be switched nor drift out of
+   * localStorage. Omit for multi-network apps (stats-web) that switch at runtime.
+   */
+  fixed?: boolean;
 }
 
 interface NetworksStore {
@@ -28,9 +35,14 @@ export class NetworkStore {
   private readonly allNetworks: Network[];
   readonly networksStore = atom<NetworksStore>({ isLoading: true, error: undefined, data: [] });
 
-  private readonly selectedNetworkIdStore = atomWithStorage<Network["id"]>(this.STORAGE_KEY, this.options.defaultNetworkId, undefined, {
-    getOnInit: true
-  });
+  private readonly selectedNetworkIdStore = this.options.fixed
+    ? atom<Network["id"], [Network["id"]], void>(
+        () => this.options.defaultNetworkId,
+        () => {
+          throw new Error(`Cannot change network: the store is fixed to "${this.options.defaultNetworkId}".`);
+        }
+      )
+    : atomWithStorage<Network["id"]>(this.STORAGE_KEY, this.options.defaultNetworkId, undefined, { getOnInit: true });
 
   private readonly selectedNetworkStore = atom<Network, [Network], void>(
     get => {
@@ -90,6 +102,7 @@ export class NetworkStore {
   }
 
   initiateNetworkFromUrl(url: URL): void {
+    if (this.options.fixed) return;
     if (!url.searchParams.has("network")) return;
 
     const raw = url.searchParams.get("network");
@@ -118,6 +131,10 @@ export class NetworkStore {
   useSelectedNetworkIdStore({ reloadOnChange } = { reloadOnChange: false }): [Network["id"], (networkId: Network["id"]) => void] {
     const [networkId, setNetworkId] = useAtom(this.selectedNetworkIdStore);
 
+    if (this.options.fixed && reloadOnChange) {
+      throw new Error(`Cannot reload on network change: the store is fixed to "${this.options.defaultNetworkId}".`);
+    }
+
     if (reloadOnChange) {
       return [
         networkId,
@@ -127,9 +144,9 @@ export class NetworkStore {
           window.location.href = url.toString();
         }
       ];
-    } else {
-      return [networkId, setNetworkId];
     }
+
+    return [networkId, setNetworkId];
   }
 
   useSelectedNetworkId(): Network["id"] {


### PR DESCRIPTION
## Why

A brand-new user onboarding on **beta** could hit a full page reload right after landing on `/onboarding`. The reload interrupted the background trial (managed-wallet) provisioning and bounced the onboarding gate (`/onboarding → / → /onboarding`), leaving the one-click template auto-deploy — and the "bring your own image" quote request — waiting on a trial that never became ready. It reproduced as the `onboarding-journey` e2e timing out (6 min / 3 min) against `console-beta`.

Root cause: `WalletProvider` forced `window.location.reload()` whenever the selected network differed from the managed-wallet network. This only ever fires on beta, where the default network (`mainnet`) differs from the managed-wallet network (`sandbox`) — on prod both are `mainnet`, so the reload never triggered and the bug stayed hidden.

## What

deploy-web has no network switcher — it always operates on the managed-wallet network — so the selected network is effectively a static, per-deployment config value. This change makes it exactly that and drops the reload:

- **`@akashnetwork/network-store`** — add an opt-in `fixed` option. When set, the selected network is a constant sourced from `defaultNetworkId` (no `localStorage`), and any attempt to change it (the setter or a `?network=` URL) throws. Multi-network apps (stats-web) are unaffected.
- **deploy-web** — the store is now `fixed` to `NEXT_PUBLIC_MANAGED_WALLET_NETWORK_ID`, so the network is correct from the first render on every page (including login), with nothing stored and nothing to reconcile.
- **Remove the forced reload** in `WalletProvider`, plus the now-redundant network-set in `WalletProvider.loadWallet` and the legacy `OnboardingContainer`.

No behavior change on prod (the network was already `mainnet` everywhere). On beta, onboarding no longer reloads and the trial provisions uninterrupted. The `DeploymentAlertsContainer` spec was updated to seed the network-independent ACT denom, since it previously relied on the app defaulting to mainnet in the staging test env.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for locking the app to a designated network, preventing unintended network changes from settings or URL parameters.
  * The deployment app now defaults to the managed-wallet network.
* **Bug Fixes**
  * Improved onboarding and wallet loading by removing managed-wallet network synchronization and related page reload/network switching behavior.
  * Updated deployment balance test data to use the current token denomination.
* **Tests**
  * Adjusted onboarding and deployment alert tests to match the updated network/service mocking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->