### PR TITLE
feat(analytics): track gated onboarding deploys, review modal, and utm

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.spec.tsx
@@ -350,6 +350,42 @@ describe(ConfigureDeploymentForm.name, () => {
     expect(screen.queryByRole("button", { name: "back to marketplace" })).not.toBeInTheDocument();
   });
 
+  it("tracks the review modal opening from the header deploy action", () => {
+    const { ConfigureDeploymentHeader, analyticsService } = setup({ initialSdl: VALID_SDL });
+    const onDeploy = (ConfigureDeploymentHeader as ReturnType<typeof vi.fn>).mock.calls[0][0].onDeploy as () => void;
+
+    act(() => onDeploy());
+
+    expect(analyticsService.track).toHaveBeenCalledWith("review_deploy_opened", expect.objectContaining({ category: "deployments" }));
+  });
+
+  it("reports the completed selection count when the modal auto-opens after the last provider is picked", async () => {
+    const { analyticsService } = setup({ initialSdl: VALID_SDL, Panes: ProviderSelectProbePanes });
+
+    await userEvent.click(screen.getByRole("button", { name: "select provider" }));
+
+    expect(analyticsService.track).toHaveBeenCalledWith("review_deploy_opened", expect.objectContaining({ placementCount: 1, selectionCount: 1 }));
+  });
+
+  it("tracks the review confirmation and starts the deploy when Confirm and deploy is clicked", async () => {
+    const { flow, analyticsService } = setup({ initialSdl: VALID_SDL, Panes: ProviderSelectProbePanes });
+
+    await userEvent.click(screen.getByRole("button", { name: "select provider" }));
+    await userEvent.click(screen.getByRole("button", { name: "confirm and deploy" }));
+
+    expect(analyticsService.track).toHaveBeenCalledWith("review_deploy_confirmed", expect.objectContaining({ category: "deployments" }));
+    expect(flow.actions.deploy).toHaveBeenCalled();
+  });
+
+  it("tracks a dismissal when the review modal is closed via Back", async () => {
+    const { analyticsService } = setup({ initialSdl: VALID_SDL, Panes: ProviderSelectProbePanes });
+
+    await userEvent.click(screen.getByRole("button", { name: "select provider" }));
+    await userEvent.click(screen.getByRole("button", { name: "back to marketplace" }));
+
+    expect(analyticsService.track).toHaveBeenCalledWith("review_deploy_dismissed", expect.objectContaining({ category: "deployments" }));
+  });
+
   it("seeds an ssh-ready vm service on a vm entry with no carried-in SDL", () => {
     setup({ initialSdl: undefined, vm: true, Panes: VmStateProbePanes });
 
@@ -453,11 +489,16 @@ describe(ConfigureDeploymentForm.name, () => {
     const requestQuotes = vi.fn();
     const retryTrial = vi.fn();
     const setDeploymentName = vi.fn();
-    const ReviewAndDeployModal = vi.fn((props: { open: boolean; onBack: () => void }) =>
+    const ReviewAndDeployModal = vi.fn((props: { open: boolean; onBack: () => void; onConfirm: () => void }) =>
       props.open ? (
-        <button type="button" onClick={props.onBack}>
-          back to marketplace
-        </button>
+        <div>
+          <button type="button" onClick={props.onBack}>
+            back to marketplace
+          </button>
+          <button type="button" onClick={props.onConfirm}>
+            confirm and deploy
+          </button>
+        </div>
       ) : null
     );
     const useConfigureDraft = vi.fn(() =>

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
@@ -214,15 +214,28 @@ export const ConfigureDeploymentForm: FC<Props> = ({ initialSdl, initialName, in
    */
   function selectProviderAndAdvance(placementId: string, bidId: string) {
     flow.actions.selectProvider(placementId, bidId);
-    const nextServiceId = nextUndoneServiceId(placements, services, { ...flow.selections, [placementId]: bidId }, placementsWithBids);
+    const selections = { ...flow.selections, [placementId]: bidId };
+    const nextServiceId = nextUndoneServiceId(placements, services, selections, placementsWithBids);
     if (nextServiceId) {
       setSelectedServiceId(nextServiceId);
     } else {
-      setReviewOpen(true);
+      openReview(selections);
     }
   }
 
+  /** Takes `selections` explicitly: the auto-open path fires in the same tick as the final `selectProvider`, before that selection lands in `flow.selections`, so the closure value would undercount by one. */
+  function openReview(selections: Record<string, string>) {
+    analyticsService.track("review_deploy_opened", {
+      category: "deployments",
+      dseq: flow.dseq,
+      placementCount: placements.length,
+      selectionCount: Object.keys(selections).length
+    });
+    setReviewOpen(true);
+  }
+
   function closeReview() {
+    analyticsService.track("review_deploy_dismissed", { category: "deployments", dseq: flow.dseq });
     setReviewOpen(false);
   }
 
@@ -268,7 +281,12 @@ export const ConfigureDeploymentForm: FC<Props> = ({ initialSdl, initialName, in
           <div className="px-6 pt-6">
             <d.ConfigureDeploymentBackButton />
             <div className="mt-2">
-              <d.ConfigureDeploymentHeader flow={headerFlow} sdl={liveSdl} onDeploy={() => setReviewOpen(true)} allPlacementsHaveBids={allPlacementsHaveBids} />
+              <d.ConfigureDeploymentHeader
+                flow={headerFlow}
+                sdl={liveSdl}
+                onDeploy={() => openReview(flow.selections)}
+                allPlacementsHaveBids={allPlacementsHaveBids}
+              />
             </div>
           </div>
           <div className="relative mt-6 flex min-h-0 flex-1 overflow-x-auto">
@@ -305,6 +323,7 @@ export const ConfigureDeploymentForm: FC<Props> = ({ initialSdl, initialName, in
           selections={flow.selections}
           onBack={closeReview}
           onConfirm={() => {
+            analyticsService.track("review_deploy_confirmed", { category: "deployments", dseq: flow.dseq });
             setReviewOpen(false);
             flow.actions.deploy(liveSdl);
           }}

--- a/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.spec.tsx
+++ b/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.spec.tsx
@@ -360,26 +360,26 @@ describe(OnboardingPickerPage.name, () => {
     expect(analyticsService.flush).toHaveBeenCalled();
   });
 
-  it("tracks skipping the trial as an add-credits click", () => {
+  it("tracks a dedicated skip-trial click when skipping the trial", () => {
     const Button = vi.fn(ComponentMock);
     const { analyticsService } = setup({ isTrialing: true, dependencies: { Button: Button as unknown as typeof DEPENDENCIES.Button } });
 
     const skipButton = Button.mock.calls.at(-1)![0] as ButtonProps;
     act(() => (skipButton.onClick as () => void)());
 
-    expect(analyticsService.track).toHaveBeenCalledWith("onboarding_add_credits_click", { category: "onboarding", reason: "skip-trial" });
+    expect(analyticsService.track).toHaveBeenCalledWith("onboarding_skip_trial_click", { category: "onboarding" });
   });
 
-  it("tracks the add-credits-to-unlock click on the gated LLM card", () => {
+  it("tracks a deploy click with the llm option when the gated LLM card is clicked while trialing", () => {
     const DeploymentTemplatePickerCard = vi.fn(ComponentMock);
     const { analyticsService } = setup({ isTrialing: true, dependencies: { DeploymentTemplatePickerCard } });
 
     act(() => getCard(DeploymentTemplatePickerCard, "LLM Chatbot").onDeploy!());
 
-    expect(analyticsService.track).toHaveBeenCalledWith("onboarding_add_credits_click", { category: "onboarding", reason: "unlock-gpu" });
+    expect(analyticsService.track).toHaveBeenCalledWith("onboarding_deploy_click", { category: "onboarding", option: LLM_ID });
   });
 
-  it("does not track a deploy click when the llm auto-deploys after adding credits", () => {
+  it("fires the gated LLM deploy click once and does not re-fire it when the sheet completes", () => {
     const DeploymentTemplatePickerCard = vi.fn(ComponentMock);
     const AddCreditsSheet = vi.fn(ComponentMock);
     const { analyticsService } = setup({ isTrialing: true, dependencies: { DeploymentTemplatePickerCard, AddCreditsSheet } });
@@ -387,7 +387,8 @@ describe(OnboardingPickerPage.name, () => {
     act(() => getCard(DeploymentTemplatePickerCard, "LLM Chatbot").onDeploy!());
     act(() => (AddCreditsSheet.mock.calls.at(-1)![0] as SheetProps).onDone(100, "Acme"));
 
-    expect(analyticsService.track).not.toHaveBeenCalledWith("onboarding_deploy_click", expect.anything());
+    const deployClicks = analyticsService.track.mock.calls.filter(call => call[0] === "onboarding_deploy_click");
+    expect(deployClicks).toHaveLength(1);
   });
 
   function getCard(DeploymentTemplatePickerCard: ReturnType<typeof vi.fn>, title: string) {

--- a/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.tsx
+++ b/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.tsx
@@ -75,25 +75,33 @@ export function OnboardingPickerPage({ dependencies: d = DEPENDENCIES }: Onboard
     router.push(urlService.configureDeployment({ templateId, sdlStrategy: "default", bidStrategy: "auto" }));
   }
 
-  function deployTemplate(templateId: string) {
-    analyticsService.track("onboarding_deploy_click", { category: "onboarding", option: templateId });
+  function trackDeployClick(option: string) {
+    analyticsService.track("onboarding_deploy_click", { category: "onboarding", option });
     analyticsService.flush();
+  }
+
+  function deployTemplate(templateId: string) {
+    trackDeployClick(templateId);
     redirectToConfigure(templateId);
   }
 
+  /** The LLM card reports the same deploy click whether it deploys or is credit-gated; the gated path is told apart downstream by the add-credits sheet events that follow rather than a distinct click event. */
+  function deployLlmChatbot() {
+    trackDeployClick(TEMPLATE_IDS.llmChatbot);
+    if (isLlmAvailable) {
+      redirectToConfigure(TEMPLATE_IDS.llmChatbot);
+    } else {
+      setAddCreditsSheetReason("unlock-gpu");
+    }
+  }
+
   function trackCustomImageDeploy() {
-    analyticsService.track("onboarding_deploy_click", { category: "onboarding", option: "custom-image" });
-    analyticsService.flush();
+    trackDeployClick("custom-image");
   }
 
-  function openSkipTrialCredits() {
-    analyticsService.track("onboarding_add_credits_click", { category: "onboarding", reason: "skip-trial" });
+  function skipTrial() {
+    analyticsService.track("onboarding_skip_trial_click", { category: "onboarding" });
     setAddCreditsSheetReason("skip-trial");
-  }
-
-  function openGpuUnlockCredits() {
-    analyticsService.track("onboarding_add_credits_click", { category: "onboarding", reason: "unlock-gpu" });
-    setAddCreditsSheetReason("unlock-gpu");
   }
 
   return (
@@ -177,7 +185,7 @@ export function OnboardingPickerPage({ dependencies: d = DEPENDENCIES }: Onboard
                 ctaVariant="outline"
                 heroImageSrc="/images/onboarding/llm-chatbot.png"
                 heroImageAlt="LLM chatbot template"
-                onDeploy={() => (isLlmAvailable ? deployTemplate(TEMPLATE_IDS.llmChatbot) : openGpuUnlockCredits())}
+                onDeploy={deployLlmChatbot}
               />
             </div>
 
@@ -198,7 +206,7 @@ export function OnboardingPickerPage({ dependencies: d = DEPENDENCIES }: Onboard
 
               {(isTrialing || !wallet?.creditAmount) && (
                 <div className="text-center">
-                  <d.Button onClick={openSkipTrialCredits} variant="ghost">
+                  <d.Button onClick={skipTrial} variant="ghost">
                     Skip the trial - unlock Console
                     <ArrowRight className="ml-2 h-4 w-4" />
                   </d.Button>

--- a/apps/deploy-web/src/services/analytics/analytics.service.spec.ts
+++ b/apps/deploy-web/src/services/analytics/analytics.service.spec.ts
@@ -215,6 +215,80 @@ describe(AnalyticsService.name, () => {
     });
   });
 
+  describe("utm attribution", () => {
+    it("stamps utm params from the landing url onto tracked events in both services", () => {
+      const track = vi.fn();
+      const dataLayer: Record<string, unknown>[] = [];
+      const service = setup({
+        amplitude: { track },
+        dataLayer,
+        locationSearch: "?utm_source=twitter&utm_campaign=launch",
+        options: {
+          amplitude: { enabled: true, apiKey: mockAmplitudeApiKey },
+          ga: { enabled: true, measurementId: mockGaMeasurementId }
+        }
+      });
+
+      service.track("onboarding_deploy_click", { category: "onboarding" });
+
+      expect(track).toHaveBeenCalledWith("onboarding_deploy_click", {
+        category: "onboarding",
+        utm_source: "twitter",
+        utm_campaign: "launch"
+      });
+      expect(dataLayer).toContainEqual({ event: "onboarding_deploy_click", category: "onboarding", utm_source: "twitter", utm_campaign: "launch" });
+    });
+
+    it("persists the captured utm params under the utm storage key", () => {
+      const setItem = vi.fn();
+      setup({
+        storage: { getItem: vi.fn(), setItem },
+        locationSearch: "?utm_source=twitter",
+        options: {
+          amplitude: { enabled: true, apiKey: mockAmplitudeApiKey },
+          ga: { enabled: false, measurementId: mockGaMeasurementId }
+        }
+      });
+
+      expect(setItem).toHaveBeenCalledWith("analytics_utm", JSON.stringify({ utm_source: "twitter" }));
+    });
+
+    it("freezes the first-touch snapshot and ignores params from a later visit", () => {
+      const track = vi.fn();
+      const setItem = vi.fn();
+      const service = setup({
+        amplitude: { track },
+        storage: { getItem: key => (key === "analytics_utm" ? JSON.stringify({ utm_source: "google" }) : null), setItem },
+        locationSearch: "?utm_source=twitter&utm_medium=cpc",
+        options: {
+          amplitude: { enabled: true, apiKey: mockAmplitudeApiKey },
+          ga: { enabled: false, measurementId: mockGaMeasurementId }
+        }
+      });
+
+      service.track("onboarding_deploy_click", { category: "onboarding" });
+
+      expect(track).toHaveBeenCalledWith("onboarding_deploy_click", { category: "onboarding", utm_source: "google" });
+      expect(setItem).not.toHaveBeenCalledWith("analytics_utm", expect.anything());
+    });
+
+    it("does not stamp any utm params when the landing url carries none", () => {
+      const track = vi.fn();
+      const service = setup({
+        amplitude: { track },
+        locationSearch: "",
+        options: {
+          amplitude: { enabled: true, apiKey: mockAmplitudeApiKey },
+          ga: { enabled: false, measurementId: mockGaMeasurementId }
+        }
+      });
+
+      service.track("onboarding_deploy_click", { category: "onboarding" });
+
+      expect(track).toHaveBeenCalledWith("onboarding_deploy_click", { category: "onboarding" });
+    });
+  });
+
   describe("static deployment page views", () => {
     it("strips the deployment sequence from the page title so every deployment detail view shares one title", async () => {
       const plugin = setupPageViewPlugin();
@@ -331,6 +405,7 @@ describe(AnalyticsService.name, () => {
     dataLayer?: Record<string, unknown>[];
     options?: AnalyticsOptions;
     storage?: Pick<Storage, "getItem" | "setItem">;
+    locationSearch?: string;
   }) {
     const amplitude = {
       init: vi.fn(),
@@ -357,7 +432,8 @@ describe(AnalyticsService.name, () => {
       },
       amplitude,
       () => dataLayer,
-      storage
+      storage,
+      () => params.locationSearch ?? ""
     );
   }
 });

--- a/apps/deploy-web/src/services/analytics/analytics.service.ts
+++ b/apps/deploy-web/src/services/analytics/analytics.service.ts
@@ -112,7 +112,7 @@ export type AnalyticsEvent =
   | "log_collector_disabled"
   | "log_collector_deployed"
   | "onboarding_deploy_click"
-  | "onboarding_add_credits_click"
+  | "onboarding_skip_trial_click"
   | "add_credits_opened"
   | "add_credits_amount_selected"
   | "add_credits_payment_method_selected"
@@ -128,7 +128,10 @@ export type AnalyticsEvent =
   | "configure_sdl_copied"
   | "cancel_during_create"
   | "close_deployment_failed"
-  | "cancelled_deployment_auto_close_failed";
+  | "cancelled_deployment_auto_close_failed"
+  | "review_deploy_opened"
+  | "review_deploy_confirmed"
+  | "review_deploy_dismissed";
 
 export type AnalyticsCategory = "user" | "billing" | "deployments" | "wallet" | "sdl_builder" | "transactions" | "profile" | "settings" | "onboarding";
 
@@ -163,25 +166,85 @@ const DEPLOYMENT_SEQUENCE_TITLE_MARKER = / #[\d*]+/;
 const DEPLOYMENT_SEQUENCE_PATH = /\/deployments\/\d+/g;
 const STATIC_DEPLOYMENT_PATH = "/deployments/[dseq]";
 
+const UTM_PARAM_KEYS = ["utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content"] as const;
+
 const isBrowser = typeof window !== "undefined";
 
 export type Amplitude = Pick<typeof amplitude, "init" | "Identify" | "identify" | "track" | "setUserId" | "add" | "flush">;
 
 export class AnalyticsService {
   private readonly STORAGE_KEY = "analytics_values_cache";
+  private readonly UTM_STORAGE_KEY = "analytics_utm";
 
   private readonly valuesCache: Map<string, string> = this.loadSwitchValuesFromStorage();
 
   private readonly isAmplitudeEnabled: boolean;
   private amplitudeInitialized = false;
 
+  /** First-touch UTM params, stamped onto every tracked event so acquisition funnels can be attributed to a campaign. */
+  private readonly utmProperties: Record<string, string>;
+
   constructor(
     private readonly options: AnalyticsOptions,
     private readonly amplitudeClient: Amplitude = amplitude,
     private readonly getDataLayer: () => Record<string, unknown>[] | undefined = () => (isBrowser ? window.dataLayer : undefined),
-    private readonly storage: Pick<Storage, "getItem" | "setItem"> | undefined = isBrowser ? window.localStorage : undefined
+    private readonly storage: Pick<Storage, "getItem" | "setItem"> | undefined = isBrowser ? window.localStorage : undefined,
+    private readonly getLocationSearch: () => string = () => (isBrowser ? window.location.search : "")
   ) {
     this.isAmplitudeEnabled = this.options.amplitude.enabled;
+    this.utmProperties = this.captureFirstTouchUtm();
+  }
+
+  /**
+   * Captures `utm_*` from the first UTM-bearing visit and freezes it: once a snapshot is stored it is returned
+   * unchanged, so a later visit from a different campaign can't blend its params into the original acquisition touch.
+   */
+  private captureFirstTouchUtm(): Record<string, string> {
+    if (!isBrowser) {
+      return {};
+    }
+
+    const storedUtm = this.readStoredUtm();
+    if (Object.keys(storedUtm).length > 0) {
+      return storedUtm;
+    }
+
+    const urlUtm = this.readUrlUtm();
+    if (Object.keys(urlUtm).length > 0) {
+      this.storage?.setItem(this.UTM_STORAGE_KEY, JSON.stringify(urlUtm));
+    }
+
+    return urlUtm;
+  }
+
+  private readUrlUtm(): Record<string, string> {
+    const params = new URLSearchParams(this.getLocationSearch());
+    return this.pickUtmParams(key => params.get(key));
+  }
+
+  private readStoredUtm(): Record<string, string> {
+    const stored = this.storage?.getItem(this.UTM_STORAGE_KEY);
+    if (!stored) {
+      return {};
+    }
+
+    try {
+      const parsed = JSON.parse(stored) as Record<string, unknown>;
+      return this.pickUtmParams(key => (typeof parsed[key] === "string" ? (parsed[key] as string) : null));
+    } catch {
+      return {};
+    }
+  }
+
+  private pickUtmParams(getValue: (key: string) => string | null): Record<string, string> {
+    const utm: Record<string, string> = {};
+    for (const key of UTM_PARAM_KEYS) {
+      const value = getValue(key);
+      if (value) {
+        utm[key] = value;
+      }
+    }
+    return utm;
   }
 
   private loadSwitchValuesFromStorage() {
@@ -271,14 +334,15 @@ export class AnalyticsService {
 
     const analyticsTarget = typeof eventPropertiesOrTarget === "string" ? eventPropertiesOrTarget : target;
     const eventProperties = typeof eventPropertiesOrTarget === "object" ? eventPropertiesOrTarget : {};
+    const enrichedProperties = { ...this.utmProperties, ...eventProperties };
 
     if (this.isAmplitudeEnabled && (!analyticsTarget || analyticsTarget === "Amplitude")) {
       this.initAmplitude();
-      this.amplitudeClient.track(eventName, eventProperties);
+      this.amplitudeClient.track(eventName, enrichedProperties);
     }
 
     if (this.options.ga.enabled && (!analyticsTarget || analyticsTarget === "GA")) {
-      const [name, props] = this.transformGaEvent(eventName, eventProperties);
+      const [name, props] = this.transformGaEvent(eventName, enrichedProperties);
       this.getDataLayer()?.push({ ...props, event: name });
     }
   }


### PR DESCRIPTION
## Why

The onboarding acquisition funnel has blind spots. On the onboarding picker, a click on the credit-gated LLM template was recorded as an "add credits" click rather than a deploy intent, so gated deploy attempts were invisible next to the ungated cards. The "skip the trial" CTA shared that same `onboarding_add_credits_click` event, conflating two very different intents. On the configure page, the review-and-deploy step — the last thing between choosing a provider and creating a lease — emitted nothing, so we couldn't see drop-off there. And campaign attribution (UTM) never reached our events, so deploys and conversions couldn't be tied back to the campaign that drove them.

## What

Analytics only — no user-facing/visual change.

**Onboarding picker**

- Every template card click now reports `onboarding_deploy_click` with the template as `option`, including the credit-gated LLM card. The gated path is distinguished downstream by the add-credits sheet events (`add_credits_opened`, …) that follow, not by a separate click event.
- The "skip the trial" CTA now emits a dedicated `onboarding_skip_trial_click`.
- The now-unused `onboarding_add_credits_click` event is removed.

**Configure review-and-deploy modal**

- Emits `review_deploy_opened` (with `dseq`, placement and selection counts), `review_deploy_confirmed`, and `review_deploy_dismissed`, making the step between provider selection and lease creation visible in the deploy funnel.

**UTM attribution**

- `AnalyticsService` captures first-touch `utm_*` params from the landing URL, persists them (earlier values win across later visits), and stamps them onto every tracked event in both Amplitude and GA. Amplitude's built-in attribution is left as-is.

**Downstream note:** removing `onboarding_add_credits_click` will silence any Amplitude/GA charts or funnels built on it; the new events (`onboarding_skip_trial_click`, `review_deploy_*`) need to be added to those dashboards.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Analytics**
  * Updated onboarding tracking for trial users: skip-trial and LLM deploy clicks now emit dedicated events with the correct payloads, including deduplicated deploy-click assertions after verification.
  * Enhanced the “review and deploy” modal analytics with events for opened, dismissed, and confirmed actions, including selection/placement counts.
  * Added first-touch UTM attribution: captures allowed UTM parameters from the landing URL, persists them, and applies them to both Amplitude and GA events.
* **Tests**
  * Expanded coverage for the new toast titling and “review and deploy” modal lifecycle/analytics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->