### PR TITLE
fix(billing): prevent duplicate payment-processing snackbar on re-entrant poll start

### DIFF
--- a/apps/deploy-web/src/context/PaymentPollingProvider/PaymentPollingProvider.spec.tsx
+++ b/apps/deploy-web/src/context/PaymentPollingProvider/PaymentPollingProvider.spec.tsx
@@ -41,6 +41,23 @@ describe(PaymentPollingProvider.name, () => {
     expect(refetchBalance.mock.calls.length).toBe(initialCallCount);
   });
 
+  it("enqueues a single loading snackbar when polling is triggered twice in the same tick", async () => {
+    const { enqueueSnackbar, cleanup } = setup({
+      isTrialing: false,
+      balance: { totalUsd: 100 },
+      isWalletBalanceLoading: false
+    });
+
+    await act(async () => {
+      screen.getByTestId("start-polling-twice").click();
+    });
+
+    const loadingSnackbarCalls = enqueueSnackbar.mock.calls.filter(([, options]) => options?.persist === true);
+    expect(loadingSnackbarCalls).toHaveLength(1);
+
+    cleanup();
+  });
+
   it("shows loading snackbar when polling starts", async () => {
     const { enqueueSnackbar } = setup({
       isTrialing: false,
@@ -440,6 +457,15 @@ describe(PaymentPollingProvider.name, () => {
           </button>
           <button data-testid="start-polling-coupon" onClick={() => pollForPayment({ variant: "coupon" })}>
             Start Coupon Polling
+          </button>
+          <button
+            data-testid="start-polling-twice"
+            onClick={() => {
+              pollForPayment();
+              pollForPayment();
+            }}
+          >
+            Start Polling Twice
           </button>
           <button data-testid="stop-polling" onClick={stopPolling}>
             Stop Polling

--- a/apps/deploy-web/src/context/PaymentPollingProvider/PaymentPollingProvider.tsx
+++ b/apps/deploy-web/src/context/PaymentPollingProvider/PaymentPollingProvider.tsx
@@ -143,9 +143,10 @@ export const PaymentPollingProvider: React.FC<PaymentPollingProviderProps> = ({ 
     refetchManagedWallet();
   }, [stopPolling, enqueueSnackbar, refetchBalance, refetchManagedWallet, d]);
 
+  /** Guards on the ref, not `isPolling` state, so two calls in the same tick can't each enqueue a persistent loading snackbar (the second would orphan the first, leaving it stuck on screen). */
   const pollForPayment = useCallback(
     (options?: { initialBalance?: number | null; variant?: PaymentPollingVariant }) => {
-      if (isPolling) {
+      if (isPollingRef.current) {
         return;
       }
 
@@ -170,7 +171,7 @@ export const PaymentPollingProvider: React.FC<PaymentPollingProviderProps> = ({ 
       // Start the first poll immediately
       executePoll();
     },
-    [isPolling, currentBalance, executePoll, enqueueSnackbar, wasTrialing, d]
+    [currentBalance, executePoll, enqueueSnackbar, wasTrialing, d]
   );
 
   useEffect(


### PR DESCRIPTION
## Why

The beta post-deploy E2E suite intermittently fails the Add Credits flow with a Playwright strict-mode violation: `getByText("Processing payment...")` resolves to 2 elements.

Root cause is a re-entrancy gap in `PaymentPollingProvider`. `pollForPayment()` guards on the `isPolling` React **state**, which is stale within a tick. Two calls in the same tick both read `false` and each enqueue a **persistent** "Processing payment..." snackbar; only the last key is tracked in `loadingSnackbarKeyRef`, so the first snackbar is orphaned and never closed. That produces both symptoms seen on beta: the transient "2 elements" strict-mode error, and a loading toast left stuck on screen next to "Payment successful!".

## What

- Guard `pollForPayment` on the synchronous `isPollingRef.current` instead of the async `isPolling` state, so a re-entrant start bails before enqueueing a second loading snackbar.
- Add a regression test that starts polling twice in one tick and asserts a single persistent loading snackbar is enqueued (2 on the old guard, 1 with the fix).

No functional change to the happy path; the loading/success/timeout snackbar behavior is otherwise unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate payment polling notifications when polling is triggered multiple times in quick succession.
  * Improved polling safeguards to avoid overlapping payment checks while maintaining accurate balance information.

* **Tests**
  * Added coverage for back-to-back polling triggers to verify that only one loading notification is displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->