### PR TITLE
feat(onboarding): add animated boot loader and parallelize boot gates

### DIFF
--- a/apps/deploy-web/src/components/auth/RequireAuth/RequireAuth.tsx
+++ b/apps/deploy-web/src/components/auth/RequireAuth/RequireAuth.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 import React, { useEffect } from "react";
 import { useRouter } from "next/router";
 
-import { Loading } from "@src/components/layout/Layout";
+import { BootLoading } from "@src/context/BootLoadingProvider/BootLoadingProvider";
 import { useUser } from "@src/hooks/useUser";
 import { UrlService } from "@src/utils/urlUtils";
 
@@ -39,5 +39,5 @@ export const RequireAuth = ({ isPublic, children, dependencies: d = DEPENDENCIES
   );
 
   if (canRender) return <>{children}</>;
-  return <Loading text="" />;
+  return <BootLoading />;
 };

--- a/apps/deploy-web/src/components/layout/AkashLoadingMark.spec.tsx
+++ b/apps/deploy-web/src/components/layout/AkashLoadingMark.spec.tsx
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { AkashLoadingMark } from "./AkashLoadingMark";
+
+import { render, screen } from "@testing-library/react";
+
+describe(AkashLoadingMark.name, () => {
+  it("renders the mark sized to the given width, keeping the mark aspect ratio", () => {
+    setup({ width: 120 });
+
+    const mark = screen.getByRole("status", { name: /loading/i });
+    expect(mark).toHaveAttribute("width", "120");
+    expect(mark).toHaveAttribute("height", "105");
+  });
+
+  function setup(input?: { width?: number }) {
+    return render(<AkashLoadingMark width={input?.width} />);
+  }
+});

--- a/apps/deploy-web/src/components/layout/AkashLoadingMark.tsx
+++ b/apps/deploy-web/src/components/layout/AkashLoadingMark.tsx
@@ -2,9 +2,9 @@
  * Animated Akash mark shown while the app boots (the initial-load gates).
  *
  * The three shards of the official mark pulse from dim to lit in a staggered chase, so the light appears to
- * travel around the mark. Delays follow the mark's visual order (bottom shard leads); the shorthand animation and
- * theme-aware fills live in the global stylesheet under `.akash-loading-mark` so it follows light/dark and honours
- * reduced-motion.
+ * travel around the mark. Delays follow the mark's visual order (bottom shard leads); the pulse keyframes live
+ * in the app tailwind config (`akash-loading-shard`), while theme-token fills and `motion-reduce` classes keep
+ * it following light/dark and honouring reduced motion.
  */
 const SHARDS = [
   { d: "M321.355 279.4L400.615 419.038H240.511L160.415 279.4Z", delayMs: 600 },
@@ -16,17 +16,14 @@ const MARK_ASPECT_RATIO = 420 / 481;
 
 export const AkashLoadingMark = ({ width = 96 }: { width?: number }) => {
   return (
-    <svg
-      className="akash-loading-mark"
-      width={width}
-      height={Math.round(width * MARK_ASPECT_RATIO)}
-      viewBox="0 0 481 420"
-      fill="none"
-      role="status"
-      aria-label="Loading"
-    >
+    <svg width={width} height={Math.round(width * MARK_ASPECT_RATIO)} viewBox="0 0 481 420" fill="none" role="status" aria-label="Loading">
       {SHARDS.map(shard => (
-        <path key={shard.d} d={shard.d} style={{ animationDelay: `${shard.delayMs}ms` }} />
+        <path
+          key={shard.d}
+          d={shard.d}
+          className="animate-akash-loading-shard fill-border motion-reduce:animate-none motion-reduce:fill-foreground"
+          style={{ animationDelay: `${shard.delayMs}ms` }}
+        />
       ))}
     </svg>
   );

--- a/apps/deploy-web/src/components/layout/AkashLoadingMark.tsx
+++ b/apps/deploy-web/src/components/layout/AkashLoadingMark.tsx
@@ -1,0 +1,33 @@
+/**
+ * Animated Akash mark shown while the app boots (the initial-load gates).
+ *
+ * The three shards of the official mark pulse from dim to lit in a staggered chase, so the light appears to
+ * travel around the mark. Delays follow the mark's visual order (bottom shard leads); the shorthand animation and
+ * theme-aware fills live in the global stylesheet under `.akash-loading-mark` so it follows light/dark and honours
+ * reduced-motion.
+ */
+const SHARDS = [
+  { d: "M321.355 279.4L400.615 419.038H240.511L160.415 279.4Z", delayMs: 600 },
+  { d: "M400.572 419.061L480.536 279.423L320.476 0.0800781H160.415L400.572 419.061Z", delayMs: 300 },
+  { d: "M80.3874 139.682H240.449L80.454 419.025L0.357422 279.387L80.3874 139.682Z", delayMs: 0 }
+];
+
+const MARK_ASPECT_RATIO = 420 / 481;
+
+export const AkashLoadingMark = ({ width = 96 }: { width?: number }) => {
+  return (
+    <svg
+      className="akash-loading-mark"
+      width={width}
+      height={Math.round(width * MARK_ASPECT_RATIO)}
+      viewBox="0 0 481 420"
+      fill="none"
+      role="status"
+      aria-label="Loading"
+    >
+      {SHARDS.map(shard => (
+        <path key={shard.d} d={shard.d} style={{ animationDelay: `${shard.delayMs}ms` }} />
+      ))}
+    </svg>
+  );
+};

--- a/apps/deploy-web/src/components/layout/Layout.tsx
+++ b/apps/deploy-web/src/components/layout/Layout.tsx
@@ -182,7 +182,7 @@ const LayoutApp: React.FunctionComponent<Props> = ({
   );
 };
 
-export const Loading: React.FunctionComponent<{ text: string; testId?: string }> = ({ text, testId }) => {
+export const Loading: React.FunctionComponent<{ text?: string; testId?: string }> = ({ text, testId }) => {
   return (
     <div className="flex h-full w-full flex-col items-center justify-center pb-12 pt-12" data-testid={testId}>
       <AkashLoadingMark />

--- a/apps/deploy-web/src/components/layout/Layout.tsx
+++ b/apps/deploy-web/src/components/layout/Layout.tsx
@@ -3,7 +3,7 @@ import type { CSSProperties, ReactNode } from "react";
 import React, { Suspense, useEffect, useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { IntlProvider } from "react-intl";
-import { ErrorFallback, Spinner } from "@akashnetwork/ui/components";
+import { ErrorFallback } from "@akashnetwork/ui/components";
 import { cn } from "@akashnetwork/ui/utils";
 import { useMediaQuery, useTheme as useMuiTheme } from "@mui/material";
 
@@ -15,6 +15,7 @@ import { useOnboardingChrome } from "@src/hooks/useOnboardingChrome";
 import { useTopBanner } from "@src/hooks/useTopBanner";
 import { LinearLoadingSkeleton } from "../shared/LinearLoadingSkeleton";
 import { TopNav } from "./TopNav/TopNav";
+import { AkashLoadingMark } from "./AkashLoadingMark";
 import { Nav } from "./Nav";
 import { Sidebar } from "./Sidebar";
 import { TrackingScripts } from "./TrackingScripts";
@@ -184,12 +185,8 @@ const LayoutApp: React.FunctionComponent<Props> = ({
 export const Loading: React.FunctionComponent<{ text: string; testId?: string }> = ({ text, testId }) => {
   return (
     <div className="flex h-full w-full flex-col items-center justify-center pb-12 pt-12" data-testid={testId}>
-      <div className="pb-4">
-        <Spinner size="large" />
-      </div>
-      <div>
-        <h5>{text}</h5>
-      </div>
+      <AkashLoadingMark />
+      {text && <h5 className="pt-4">{text}</h5>}
     </div>
   );
 };

--- a/apps/deploy-web/src/components/layout/LoadingBlocker/LoadingBlocker.tsx
+++ b/apps/deploy-web/src/components/layout/LoadingBlocker/LoadingBlocker.tsx
@@ -10,5 +10,5 @@ interface LoadingBlockerProps {
 }
 
 export const LoadingBlocker: FCWithChildren<LoadingBlockerProps> = ({ children, isLoading, testId, text }) => {
-  return isLoading ? <Loading text={text || ""} testId={testId} /> : <>{children}</>;
+  return isLoading ? <Loading text={text} testId={testId} /> : <>{children}</>;
 };

--- a/apps/deploy-web/src/components/new-deployment/RedirectDeployLinuxToConfigure/RedirectDeployLinuxToConfigure.tsx
+++ b/apps/deploy-web/src/components/new-deployment/RedirectDeployLinuxToConfigure/RedirectDeployLinuxToConfigure.tsx
@@ -3,7 +3,7 @@
 import { useEffect } from "react";
 import { useRouter } from "next/router";
 
-import { Loading } from "@src/components/layout/Layout";
+import { BootLoading } from "@src/context/BootLoadingProvider/BootLoadingProvider";
 import { UrlService } from "@src/utils/urlUtils";
 
 export const DEPENDENCIES = { useRouter, UrlService };
@@ -25,5 +25,5 @@ export function RedirectDeployLinuxToConfigure({ dependencies: d = DEPENDENCIES 
     [router, d.UrlService]
   );
 
-  return <Loading text="" />;
+  return <BootLoading />;
 }

--- a/apps/deploy-web/src/components/new-deployment/RedirectMappableBuilderToConfigure/RedirectMappableBuilderToConfigure.tsx
+++ b/apps/deploy-web/src/components/new-deployment/RedirectMappableBuilderToConfigure/RedirectMappableBuilderToConfigure.tsx
@@ -4,8 +4,8 @@ import type { ReactNode } from "react";
 import { useEffect } from "react";
 import { useRouter } from "next/router";
 
-import { Loading } from "@src/components/layout/Layout";
 import { CI_CD_TEMPLATE_ID } from "@src/config/remote-deploy.config";
+import { BootLoading } from "@src/context/BootLoadingProvider/BootLoadingProvider";
 import { UrlService } from "@src/utils/urlUtils";
 
 export const DEPENDENCIES = { useRouter, UrlService };
@@ -39,6 +39,6 @@ export function RedirectMappableBuilderToConfigure({ children, dependencies: d =
     [shouldRedirect, templateId, router, d.UrlService]
   );
 
-  if (shouldRedirect) return <Loading text="" />;
+  if (shouldRedirect) return <BootLoading />;
   return <>{children}</>;
 }

--- a/apps/deploy-web/src/components/onboarding/RequireOnboarding/RequireOnboarding.spec.tsx
+++ b/apps/deploy-web/src/components/onboarding/RequireOnboarding/RequireOnboarding.spec.tsx
@@ -141,12 +141,12 @@ describe(RequireOnboarding.name, () => {
           isWalletLoading: props.isWalletLoading ?? false,
           isWalletInitializing: props.isWalletInitializing ?? false
         })) as typeof DEPENDENCIES.useWallet,
-      useAllLeases: (() =>
-        mock<ReturnType<typeof DEPENDENCIES.useAllLeases>>({
-          data: props.leasesError ? (undefined as never) : props.leases ? (Array.from({ length: props.leases }) as never) : [],
+      useLeaseExistenceQuery: (() =>
+        mock<ReturnType<typeof DEPENDENCIES.useLeaseExistenceQuery>>({
+          data: (props.leasesError ? undefined : (props.leases ?? 0) > 0) as never,
           isLoading: (props.leasesLoading ?? false) as never,
           isError: (props.leasesError ?? false) as never
-        })) as typeof DEPENDENCIES.useAllLeases,
+        })) as typeof DEPENDENCIES.useLeaseExistenceQuery,
       useReturnTo: (() => mock<ReturnType<typeof DEPENDENCIES.useReturnTo>>({ returnTo: props.returnTo ?? "/" })) as typeof DEPENDENCIES.useReturnTo,
       useRouter: (() => mock<ReturnType<typeof DEPENDENCIES.useRouter>>({ asPath: props.path, pathname: props.path, replace })) as typeof DEPENDENCIES.useRouter
     });

--- a/apps/deploy-web/src/components/onboarding/RequireOnboarding/RequireOnboarding.tsx
+++ b/apps/deploy-web/src/components/onboarding/RequireOnboarding/RequireOnboarding.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from "react";
 import { useEffect } from "react";
 import { useRouter } from "next/router";
 
-import { Loading } from "@src/components/layout/Layout";
+import { BootLoading } from "@src/context/BootLoadingProvider/BootLoadingProvider";
 import { useWallet } from "@src/context/WalletProvider";
 import { useReturnTo } from "@src/hooks/useReturnTo/useReturnTo";
 import { useUser } from "@src/hooks/useUser";
@@ -87,7 +87,7 @@ function LeaseBasedGate({
   );
 
   if (decision === "render") return <>{children}</>;
-  return <Loading text="" />;
+  return <BootLoading />;
 }
 
 /**

--- a/apps/deploy-web/src/components/onboarding/RequireOnboarding/RequireOnboarding.tsx
+++ b/apps/deploy-web/src/components/onboarding/RequireOnboarding/RequireOnboarding.tsx
@@ -8,7 +8,7 @@ import { Loading } from "@src/components/layout/Layout";
 import { useWallet } from "@src/context/WalletProvider";
 import { useReturnTo } from "@src/hooks/useReturnTo/useReturnTo";
 import { useUser } from "@src/hooks/useUser";
-import { useAllLeases } from "@src/queries/useLeaseQuery";
+import { useLeaseExistenceQuery } from "@src/queries/useLeaseQuery";
 
 const ONBOARDING_ROUTE = "/onboarding";
 
@@ -20,7 +20,7 @@ const ONBOARDING_ALLOWED_PREFIXES = ["/new-deployment/configure"];
 export const DEPENDENCIES = {
   useUser,
   useWallet,
-  useAllLeases,
+  useLeaseExistenceQuery,
   useReturnTo,
   useRouter
 };
@@ -56,10 +56,10 @@ function LeaseBasedGate({
   const { returnTo } = d.useReturnTo({ defaultReturnTo: "/" });
 
   const hasWallet = hasManagedWallet && !!address;
-  const leasesQuery = d.useAllLeases(address, { enabled: hasWallet });
-  const isLeasesLoading = hasWallet && leasesQuery.isLoading;
-  const leasesErrored = hasWallet && leasesQuery.isError;
-  const isOnboarded = hasWallet && (leasesQuery.data?.length ?? 0) > 0;
+  const leaseExistenceQuery = d.useLeaseExistenceQuery(address, { enabled: hasWallet });
+  const isLeasesLoading = hasWallet && leaseExistenceQuery.isLoading;
+  const leasesErrored = hasWallet && leaseExistenceQuery.isError;
+  const isOnboarded = hasWallet && !!leaseExistenceQuery.data;
 
   const path = router.asPath.split("?")[0];
   const isOnOnboarding = path === ONBOARDING_ROUTE;

--- a/apps/deploy-web/src/components/user/UserInitLoader.tsx
+++ b/apps/deploy-web/src/components/user/UserInitLoader.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 
-import { LoadingBlocker } from "@src/components/layout/LoadingBlocker/LoadingBlocker";
+import { BootLoading } from "@src/context/BootLoadingProvider/BootLoadingProvider";
 import { useCustomUser } from "@src/hooks/useCustomUser";
 import type { FCWithChildren } from "@src/types/component";
 
 export const UserInitLoader: FCWithChildren = ({ children }) => {
   const { isLoading } = useCustomUser();
 
-  return <LoadingBlocker isLoading={isLoading}>{children}</LoadingBlocker>;
+  if (isLoading) return <BootLoading />;
+  return <>{children}</>;
 };

--- a/apps/deploy-web/src/components/user/UserProviders/UserProviders.spec.tsx
+++ b/apps/deploy-web/src/components/user/UserProviders/UserProviders.spec.tsx
@@ -4,6 +4,7 @@ import { type AxiosInstance } from "axios";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
+import { BootLoadingProvider } from "@src/context/BootLoadingProvider/BootLoadingProvider";
 import type { AnalyticsService } from "@src/services/analytics/analytics.service";
 import type { UserTracker } from "@src/services/user-tracker/user-tracker.service";
 import type { CustomUserProfile } from "@src/types/user";
@@ -103,11 +104,13 @@ describe(UserProviders.name, () => {
     const Content = input?.Content || ComponentMock;
     let id = 0;
     const genContent = () => (
-      <TestContainerProvider services={services}>
-        <UserProviders key={++id}>
-          <Content>content</Content>
-        </UserProviders>
-      </TestContainerProvider>
+      <BootLoadingProvider>
+        <TestContainerProvider services={services}>
+          <UserProviders key={++id}>
+            <Content>content</Content>
+          </UserProviders>
+        </TestContainerProvider>
+      </BootLoadingProvider>
     );
 
     const result = render(genContent());

--- a/apps/deploy-web/src/context/BootLoadingProvider/BootLoadingProvider.spec.tsx
+++ b/apps/deploy-web/src/context/BootLoadingProvider/BootLoadingProvider.spec.tsx
@@ -1,0 +1,77 @@
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { BOOT_LOADING_FADE_MS, BOOT_LOADING_GRACE_MS, BootLoading, BootLoadingProvider } from "./BootLoadingProvider";
+
+import { act, render, screen } from "@testing-library/react";
+
+describe(BootLoadingProvider.name, () => {
+  it("does not render the boot overlay when nothing is loading", () => {
+    setup({ children: <div>page</div> });
+
+    expect(screen.queryByTestId("app-boot-loading")).not.toBeInTheDocument();
+    expect(screen.getByText("page")).toBeInTheDocument();
+  });
+
+  it("renders a single boot overlay with the mark while a gate is loading", () => {
+    setup({ children: <BootLoading /> });
+
+    expect(screen.getByTestId("app-boot-loading")).toBeInTheDocument();
+    expect(screen.getByRole("status", { name: /loading/i })).toBeInTheDocument();
+  });
+
+  it("keeps the overlay while at least one gate is still loading", () => {
+    const { rerender } = setup({
+      children: (
+        <>
+          <BootLoading />
+          <BootLoading />
+        </>
+      )
+    });
+
+    rerender(<BootLoading />);
+
+    expect(screen.getByTestId("app-boot-loading")).toBeInTheDocument();
+  });
+
+  it("keeps the overlay mounted across a gate handoff", () => {
+    vi.useFakeTimers();
+    try {
+      const { rerender } = setup({ children: <BootLoading key="first" /> });
+      expect(screen.getByTestId("app-boot-loading")).toBeInTheDocument();
+
+      rerender(<BootLoading key="second" />);
+      act(() => vi.advanceTimersByTime(BOOT_LOADING_GRACE_MS * 2));
+
+      expect(screen.getByTestId("app-boot-loading")).toBeInTheDocument();
+      expect(screen.getByRole("status", { name: /loading/i })).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("hides the mark but keeps the background fading, then unmounts once boot finishes", () => {
+    vi.useFakeTimers();
+    try {
+      const { rerender } = setup({ children: <BootLoading /> });
+
+      rerender(<div>page</div>);
+
+      act(() => vi.advanceTimersByTime(BOOT_LOADING_GRACE_MS));
+      expect(screen.getByTestId("app-boot-loading")).toBeInTheDocument();
+      expect(screen.queryByRole("status", { name: /loading/i })).not.toBeInTheDocument();
+
+      act(() => vi.advanceTimersByTime(BOOT_LOADING_FADE_MS));
+      expect(screen.queryByTestId("app-boot-loading")).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  function setup(input: { children: ReactNode }) {
+    const result = render(<BootLoadingProvider>{input.children}</BootLoadingProvider>);
+    const rerender = (children: ReactNode) => result.rerender(<BootLoadingProvider>{children}</BootLoadingProvider>);
+    return { ...result, rerender };
+  }
+});

--- a/apps/deploy-web/src/context/BootLoadingProvider/BootLoadingProvider.spec.tsx
+++ b/apps/deploy-web/src/context/BootLoadingProvider/BootLoadingProvider.spec.tsx
@@ -38,11 +38,12 @@ describe(BootLoadingProvider.name, () => {
   it("keeps the overlay mounted across a gate handoff", () => {
     vi.useFakeTimers();
     try {
-      const { rerender } = setup({ children: <BootLoading key="first" /> });
+      const { rerender } = setup({ children: <BootLoading /> });
       expect(screen.getByTestId("app-boot-loading")).toBeInTheDocument();
 
-      rerender(<BootLoading key="second" />);
-      act(() => vi.advanceTimersByTime(BOOT_LOADING_GRACE_MS * 2));
+      rerender(<div>between gates</div>);
+      act(() => vi.advanceTimersByTime(BOOT_LOADING_GRACE_MS - 1));
+      rerender(<BootLoading />);
 
       expect(screen.getByTestId("app-boot-loading")).toBeInTheDocument();
       expect(screen.getByRole("status", { name: /loading/i })).toBeInTheDocument();

--- a/apps/deploy-web/src/context/BootLoadingProvider/BootLoadingProvider.tsx
+++ b/apps/deploy-web/src/context/BootLoadingProvider/BootLoadingProvider.tsx
@@ -1,0 +1,92 @@
+import type { ReactNode } from "react";
+import { createContext, useCallback, useContext, useEffect, useState } from "react";
+import { cn } from "@akashnetwork/ui/utils";
+
+import { AkashLoadingMark } from "@src/components/layout/AkashLoadingMark";
+
+/**
+ * Keeps the single boot overlay mounted across the brief handoff when one gate resolves and the next
+ * starts loading, so the mark never unmounts and re-pulses. Long enough to bridge an async gap between
+ * gates, short enough to be imperceptible once the whole boot finishes.
+ */
+export const BOOT_LOADING_GRACE_MS = 150;
+
+/** How long the background curtain fades out once boot finishes. Must match the `duration-500` class below. */
+export const BOOT_LOADING_FADE_MS = 500;
+
+type BootLoadingContextValue = {
+  begin: () => void;
+  end: () => void;
+};
+
+const BootLoadingContext = createContext<BootLoadingContextValue>({
+  begin: () => {},
+  end: () => {}
+});
+
+type Props = {
+  children: ReactNode;
+};
+
+export function BootLoadingProvider({ children }: Props) {
+  const [pendingCount, setPendingCount] = useState(0);
+  const [isBooting, setIsBooting] = useState(false);
+  const [isMounted, setIsMounted] = useState(false);
+
+  const begin = useCallback(() => setPendingCount(count => count + 1), []);
+  const end = useCallback(() => setPendingCount(count => Math.max(0, count - 1)), []);
+
+  useEffect(() => {
+    if (pendingCount > 0) {
+      setIsBooting(true);
+      return;
+    }
+
+    const graceTimer = setTimeout(() => setIsBooting(false), BOOT_LOADING_GRACE_MS);
+    return () => clearTimeout(graceTimer);
+  }, [pendingCount]);
+
+  useEffect(() => {
+    if (isBooting) {
+      setIsMounted(true);
+      return;
+    }
+
+    if (!isMounted) return;
+
+    const fadeTimer = setTimeout(() => setIsMounted(false), BOOT_LOADING_FADE_MS);
+    return () => clearTimeout(fadeTimer);
+  }, [isBooting, isMounted]);
+
+  return (
+    <BootLoadingContext.Provider value={{ begin, end }}>
+      {children}
+      {isMounted && (
+        <div
+          data-testid="app-boot-loading"
+          className={cn(
+            "fixed inset-0 z-50 flex items-center justify-center bg-background transition-opacity duration-500 motion-reduce:transition-none",
+            isBooting ? "opacity-100" : "pointer-events-none opacity-0"
+          )}
+        >
+          {isBooting && <AkashLoadingMark />}
+        </div>
+      )}
+    </BootLoadingContext.Provider>
+  );
+}
+
+/**
+ * Rendered by a boot gate while it is still resolving. It registers as pending for its whole lifetime
+ * and renders nothing itself, letting the provider's single overlay cover the viewport.
+ */
+export function BootLoading() {
+  const { begin, end } = useContext(BootLoadingContext);
+
+  useEffect(() => {
+    begin();
+    return end;
+  }, [begin, end]);
+
+  return null;
+}

--- a/apps/deploy-web/src/context/BootLoadingProvider/BootLoadingProvider.tsx
+++ b/apps/deploy-web/src/context/BootLoadingProvider/BootLoadingProvider.tsx
@@ -11,7 +11,7 @@ import { AkashLoadingMark } from "@src/components/layout/AkashLoadingMark";
  */
 export const BOOT_LOADING_GRACE_MS = 150;
 
-/** How long the background curtain fades out once boot finishes. Must match the `duration-500` class below. */
+/** How long the background curtain fades out once boot finishes. */
 export const BOOT_LOADING_FADE_MS = 500;
 
 type BootLoadingContextValue = {
@@ -39,24 +39,17 @@ export function BootLoadingProvider({ children }: Props) {
   useEffect(() => {
     if (pendingCount > 0) {
       setIsBooting(true);
-      return;
-    }
-
-    const graceTimer = setTimeout(() => setIsBooting(false), BOOT_LOADING_GRACE_MS);
-    return () => clearTimeout(graceTimer);
-  }, [pendingCount]);
-
-  useEffect(() => {
-    if (isBooting) {
       setIsMounted(true);
       return;
     }
 
-    if (!isMounted) return;
-
-    const fadeTimer = setTimeout(() => setIsMounted(false), BOOT_LOADING_FADE_MS);
-    return () => clearTimeout(fadeTimer);
-  }, [isBooting, isMounted]);
+    const graceTimer = setTimeout(() => setIsBooting(false), BOOT_LOADING_GRACE_MS);
+    const unmountTimer = setTimeout(() => setIsMounted(false), BOOT_LOADING_GRACE_MS + BOOT_LOADING_FADE_MS);
+    return () => {
+      clearTimeout(graceTimer);
+      clearTimeout(unmountTimer);
+    };
+  }, [pendingCount]);
 
   return (
     <BootLoadingContext.Provider value={{ begin, end }}>
@@ -64,8 +57,9 @@ export function BootLoadingProvider({ children }: Props) {
       {isMounted && (
         <div
           data-testid="app-boot-loading"
+          style={{ transitionDuration: `${BOOT_LOADING_FADE_MS}ms` }}
           className={cn(
-            "fixed inset-0 z-50 flex items-center justify-center bg-background transition-opacity duration-500 motion-reduce:transition-none",
+            "fixed inset-0 z-50 flex items-center justify-center bg-background transition-opacity motion-reduce:transition-none",
             isBooting ? "opacity-100" : "pointer-events-none opacity-0"
           )}
         >

--- a/apps/deploy-web/src/context/FlagProvider/FlagProvider.spec.tsx
+++ b/apps/deploy-web/src/context/FlagProvider/FlagProvider.spec.tsx
@@ -97,6 +97,20 @@ describe(WaitForFeatureFlags.name, () => {
     expect(client.off).toHaveBeenCalledWith("error", expect.any(Function));
   });
 
+  it("clears the ready timeout on unmount so it cannot fire afterwards", () => {
+    vi.useFakeTimers();
+    try {
+      const { unmount } = setup({ isReady: false });
+      expect(vi.getTimerCount()).toBe(1);
+
+      unmount();
+
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   function setup(input: { isReady: boolean }) {
     const listeners: Record<string, () => void> = {};
     const client = mock<ReturnType<typeof WAIT_FOR_FEATURE_FLAGS_DEPENDENCIES.useUnleashClient>>();

--- a/apps/deploy-web/src/context/FlagProvider/FlagProvider.spec.tsx
+++ b/apps/deploy-web/src/context/FlagProvider/FlagProvider.spec.tsx
@@ -98,12 +98,11 @@ describe(WaitForFeatureFlags.name, () => {
   });
 
   function setup(input: { isReady: boolean }) {
-    const listeners = new Map<string, Array<() => void>>();
+    const listeners: Record<string, () => void> = {};
     const client = mock<ReturnType<typeof WAIT_FOR_FEATURE_FLAGS_DEPENDENCIES.useUnleashClient>>();
     client.isReady.mockReturnValue(input.isReady);
     client.once.mockImplementation((event, callback) => {
-      const callbacks = listeners.get(event) ?? [];
-      listeners.set(event, [...callbacks, callback as () => void]);
+      listeners[event] = callback as () => void;
       return client;
     });
 
@@ -116,7 +115,7 @@ describe(WaitForFeatureFlags.name, () => {
     return {
       client,
       unmount,
-      fire: (event: string) => listeners.get(event)?.forEach(callback => callback())
+      fire: (event: string) => listeners[event]?.()
     };
   }
 });

--- a/apps/deploy-web/src/context/FlagProvider/FlagProvider.spec.tsx
+++ b/apps/deploy-web/src/context/FlagProvider/FlagProvider.spec.tsx
@@ -88,6 +88,15 @@ describe(WaitForFeatureFlags.name, () => {
     }
   });
 
+  it("unsubscribes from both client events once readiness resolves", () => {
+    const { client, fire } = setup({ isReady: false });
+
+    act(() => fire("ready"));
+
+    expect(client.off).toHaveBeenCalledWith("ready", expect.any(Function));
+    expect(client.off).toHaveBeenCalledWith("error", expect.any(Function));
+  });
+
   it("unsubscribes from client events on unmount", () => {
     const { client, unmount } = setup({ isReady: false });
 
@@ -115,7 +124,7 @@ describe(WaitForFeatureFlags.name, () => {
     const listeners: Record<string, () => void> = {};
     const client = mock<ReturnType<typeof WAIT_FOR_FEATURE_FLAGS_DEPENDENCIES.useUnleashClient>>();
     client.isReady.mockReturnValue(input.isReady);
-    client.once.mockImplementation((event, callback) => {
+    client.on.mockImplementation((event, callback) => {
       listeners[event] = callback as () => void;
       return client;
     });

--- a/apps/deploy-web/src/context/FlagProvider/FlagProvider.spec.tsx
+++ b/apps/deploy-web/src/context/FlagProvider/FlagProvider.spec.tsx
@@ -1,27 +1,29 @@
 import React from "react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
 
-import { FlagProvider } from "./FlagProvider";
+import type { useUser } from "@src/hooks/useUser";
+import type { WAIT_FOR_FEATURE_FLAGS_DEPENDENCIES } from "./FlagProvider";
+import { FlagProvider, UNLEASH_READY_TIMEOUT_MS, WaitForFeatureFlags } from "./FlagProvider";
 
-import { render } from "@testing-library/react";
-import { ComponentMock } from "@tests/unit/mocks";
+import { act, render, screen } from "@testing-library/react";
 
 describe(FlagProvider.name, () => {
   it("passes userId from useUser to the custom FlagProvider", () => {
-    const testUser = { id: "my-user-id" };
     const customFlagProvider = ({ config, children }: any) => (
       <div data-testid="flag-provider">
         {config.context.userId}
         {children}
       </div>
     );
-    const customUseUser = () => ({
-      user: testUser,
-      isLoading: false
-    });
+    const customUseUser = () =>
+      mock<ReturnType<typeof useUser>>({
+        user: { id: "my-user-id" } as never,
+        isLoading: false
+      });
 
     const { getByTestId } = render(
-      <FlagProvider components={{ FlagProvider: customFlagProvider, useUser: customUseUser, WaitForFeatureFlags: ComponentMock }}>
+      <FlagProvider components={{ FlagProvider: customFlagProvider, useUser: customUseUser }}>
         <div data-testid="child" />
       </FlagProvider>
     );
@@ -29,4 +31,92 @@ describe(FlagProvider.name, () => {
     expect(getByTestId("flag-provider").textContent).toContain("my-user-id");
     expect(getByTestId("child")).toBeInTheDocument();
   });
+
+  it("renders children without waiting for feature flags", () => {
+    const customFlagProvider = ({ children }: any) => <>{children}</>;
+    const customUseUser = () => mock<ReturnType<typeof useUser>>({ user: undefined, isLoading: true });
+
+    const { getByTestId } = render(
+      <FlagProvider components={{ FlagProvider: customFlagProvider, useUser: customUseUser }}>
+        <div data-testid="child" />
+      </FlagProvider>
+    );
+
+    expect(getByTestId("child")).toBeInTheDocument();
+  });
+});
+
+describe(WaitForFeatureFlags.name, () => {
+  it("renders children immediately when the client is already ready", () => {
+    setup({ isReady: true });
+    expect(screen.getByTestId("child")).toBeInTheDocument();
+  });
+
+  it("shows a loader instead of children while the client is not ready", () => {
+    setup({ isReady: false });
+    expect(screen.queryByTestId("child")).not.toBeInTheDocument();
+  });
+
+  it("reveals children when the client becomes ready", () => {
+    const { fire } = setup({ isReady: false });
+
+    act(() => fire("ready"));
+
+    expect(screen.getByTestId("child")).toBeInTheDocument();
+  });
+
+  it("fails open and reveals children when the client errors", () => {
+    const { fire } = setup({ isReady: false });
+
+    act(() => fire("error"));
+
+    expect(screen.getByTestId("child")).toBeInTheDocument();
+  });
+
+  it("fails open and reveals children after the ready timeout", () => {
+    vi.useFakeTimers();
+    try {
+      setup({ isReady: false });
+
+      act(() => {
+        vi.advanceTimersByTime(UNLEASH_READY_TIMEOUT_MS);
+      });
+
+      expect(screen.getByTestId("child")).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("unsubscribes from client events on unmount", () => {
+    const { client, unmount } = setup({ isReady: false });
+
+    unmount();
+
+    expect(client.off).toHaveBeenCalledWith("ready", expect.any(Function));
+    expect(client.off).toHaveBeenCalledWith("error", expect.any(Function));
+  });
+
+  function setup(input: { isReady: boolean }) {
+    const listeners = new Map<string, Array<() => void>>();
+    const client = mock<ReturnType<typeof WAIT_FOR_FEATURE_FLAGS_DEPENDENCIES.useUnleashClient>>();
+    client.isReady.mockReturnValue(input.isReady);
+    client.once.mockImplementation((event, callback) => {
+      const callbacks = listeners.get(event) ?? [];
+      listeners.set(event, [...callbacks, callback as () => void]);
+      return client;
+    });
+
+    const { unmount } = render(
+      <WaitForFeatureFlags dependencies={{ useUnleashClient: () => client }}>
+        <div data-testid="child" />
+      </WaitForFeatureFlags>
+    );
+
+    return {
+      client,
+      unmount,
+      fire: (event: string) => listeners.get(event)?.forEach(callback => callback())
+    };
+  }
 });

--- a/apps/deploy-web/src/context/FlagProvider/FlagProvider.tsx
+++ b/apps/deploy-web/src/context/FlagProvider/FlagProvider.tsx
@@ -9,8 +9,7 @@ import { useServices } from "../ServicesProvider";
 
 const COMPONENTS = {
   FlagProvider: FlagProviderOriginal,
-  useUser,
-  WaitForFeatureFlags
+  useUser
 };
 
 export type Props = { components?: typeof COMPONENTS };
@@ -30,13 +29,26 @@ export const FlagProvider: FCWithChildren<Props> = ({ children, components: c = 
         fetch: isEnableAll ? () => new Response(JSON.stringify({ toggles: [] })) : undefined
       }}
     >
-      <c.WaitForFeatureFlags>{children}</c.WaitForFeatureFlags>
+      {children}
     </c.FlagProvider>
   );
 };
 
-function WaitForFeatureFlags({ children }: { children: ReactNode }) {
-  const client = useUnleashClient();
+/** Fail open with default flag values if Unleash never answers, rather than block the app forever. */
+export const UNLEASH_READY_TIMEOUT_MS = 10_000;
+
+export const WAIT_FOR_FEATURE_FLAGS_DEPENDENCIES = {
+  useUnleashClient
+};
+
+export function WaitForFeatureFlags({
+  children,
+  dependencies: d = WAIT_FOR_FEATURE_FLAGS_DEPENDENCIES
+}: {
+  children: ReactNode;
+  dependencies?: typeof WAIT_FOR_FEATURE_FLAGS_DEPENDENCIES;
+}) {
+  const client = d.useUnleashClient();
   const [isReady, setIsReady] = useState(false);
 
   useEffect(() => {
@@ -51,7 +63,7 @@ function WaitForFeatureFlags({ children }: { children: ReactNode }) {
         if (timerId) clearTimeout(timerId);
         setIsReady(true);
       };
-      const timerId = setTimeout(callback, 10_000);
+      const timerId = setTimeout(callback, UNLEASH_READY_TIMEOUT_MS);
       client.once("ready", callback);
       client.once("error", callback);
     }
@@ -65,7 +77,7 @@ function WaitForFeatureFlags({ children }: { children: ReactNode }) {
   }, [client]);
 
   if (!isReady) {
-    return <Loading text="Loading application..." />;
+    return <Loading text="" />;
   }
   return <>{children}</>;
 }

--- a/apps/deploy-web/src/context/FlagProvider/FlagProvider.tsx
+++ b/apps/deploy-web/src/context/FlagProvider/FlagProvider.tsx
@@ -57,19 +57,20 @@ export function WaitForFeatureFlags({
       return;
     }
 
-    const markReady = () => {
-      clearTimeout(timerId);
-      setIsReady(true);
-    };
-    const timerId = setTimeout(markReady, UNLEASH_READY_TIMEOUT_MS);
-    client.once("ready", markReady);
-    client.once("error", markReady);
-
-    return () => {
+    const stopWaiting = () => {
       clearTimeout(timerId);
       client.off("ready", markReady);
       client.off("error", markReady);
     };
+    const markReady = () => {
+      stopWaiting();
+      setIsReady(true);
+    };
+    const timerId = setTimeout(markReady, UNLEASH_READY_TIMEOUT_MS);
+    client.on("ready", markReady);
+    client.on("error", markReady);
+
+    return stopWaiting;
   }, [client]);
 
   if (!isReady) {

--- a/apps/deploy-web/src/context/FlagProvider/FlagProvider.tsx
+++ b/apps/deploy-web/src/context/FlagProvider/FlagProvider.tsx
@@ -3,9 +3,9 @@ import { useEffect, useState } from "react";
 import { FlagProvider as FlagProviderOriginal, useUnleashClient } from "@unleash/nextjs";
 
 import { BootLoading } from "@src/context/BootLoadingProvider/BootLoadingProvider";
+import { useServices } from "@src/context/ServicesProvider";
 import { useUser } from "@src/hooks/useUser";
 import type { FCWithChildren } from "@src/types/component";
-import { useServices } from "../ServicesProvider";
 
 const COMPONENTS = {
   FlagProvider: FlagProviderOriginal,
@@ -57,22 +57,18 @@ export function WaitForFeatureFlags({
       return;
     }
 
-    let callback: (() => void) | undefined;
-    if (!client.isReady()) {
-      callback = () => {
-        if (timerId) clearTimeout(timerId);
-        setIsReady(true);
-      };
-      const timerId = setTimeout(callback, UNLEASH_READY_TIMEOUT_MS);
-      client.once("ready", callback);
-      client.once("error", callback);
-    }
+    const markReady = () => {
+      clearTimeout(timerId);
+      setIsReady(true);
+    };
+    const timerId = setTimeout(markReady, UNLEASH_READY_TIMEOUT_MS);
+    client.once("ready", markReady);
+    client.once("error", markReady);
 
     return () => {
-      if (callback) {
-        client.off("ready", callback);
-        client.off("error", callback);
-      }
+      clearTimeout(timerId);
+      client.off("ready", markReady);
+      client.off("error", markReady);
     };
   }, [client]);
 

--- a/apps/deploy-web/src/context/FlagProvider/FlagProvider.tsx
+++ b/apps/deploy-web/src/context/FlagProvider/FlagProvider.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
 import { FlagProvider as FlagProviderOriginal, useUnleashClient } from "@unleash/nextjs";
 
-import { Loading } from "@src/components/layout/Layout";
+import { BootLoading } from "@src/context/BootLoadingProvider/BootLoadingProvider";
 import { useUser } from "@src/hooks/useUser";
 import type { FCWithChildren } from "@src/types/component";
 import { useServices } from "../ServicesProvider";
@@ -77,7 +77,7 @@ export function WaitForFeatureFlags({
   }, [client]);
 
   if (!isReady) {
-    return <Loading text="" />;
+    return <BootLoading />;
   }
   return <>{children}</>;
 }

--- a/apps/deploy-web/src/context/ServicesProvider/ServicesProvider.tsx
+++ b/apps/deploy-web/src/context/ServicesProvider/ServicesProvider.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useMemo } from "react";
 import type { NetworkId } from "@akashnetwork/chain-sdk/web";
-import { AuthzHttpService, BmeHttpService } from "@akashnetwork/http-sdk";
+import { AuthzHttpService, BmeHttpService, LeaseHttpService } from "@akashnetwork/http-sdk";
 
 import { UACT_DENOM, UAKT_DENOM, USDC_IBC_DENOMS } from "@src/config/denom.config";
 import { services as rootContainer } from "@src/services/app-di-container/browser-di-container";
@@ -39,6 +39,7 @@ function createAppContainer<T extends Factories>(settingsState: SettingsContextT
   const di = createChildContainer(rootContainer, {
     authzHttpService: () => new AuthzHttpService(di.chainApiHttpClient),
     bmeHttpService: () => new BmeHttpService(di.chainApiHttpClient),
+    leaseHttpService: () => new LeaseHttpService(di.chainApiHttpClient),
     walletBalancesService: () =>
       new WalletBalancesService(di.authzHttpService, di.chainApiHttpClient, {
         uakt: UAKT_DENOM,

--- a/apps/deploy-web/src/hoc/guard/guard.hoc.tsx
+++ b/apps/deploy-web/src/hoc/guard/guard.hoc.tsx
@@ -1,4 +1,4 @@
-import { Loading } from "@src/components/layout/Layout";
+import { BootLoading } from "@src/context/BootLoadingProvider/BootLoadingProvider";
 import FourOhFour from "@src/pages/404";
 
 type UseCheck = () => {
@@ -11,7 +11,7 @@ export const Guard = <P extends object>(Component: React.ComponentType<P>, useCh
     const { canVisit, isLoading } = useCheck();
 
     if (isLoading) {
-      return <Loading text="" />;
+      return <BootLoading />;
     }
 
     if (canVisit) {

--- a/apps/deploy-web/src/hooks/useOnboardingChrome.spec.ts
+++ b/apps/deploy-web/src/hooks/useOnboardingChrome.spec.ts
@@ -110,13 +110,13 @@ describe(useOnboardingChrome.name, () => {
         managedWalletError: input.managedWalletError
       });
     const usePathname: typeof DEPENDENCIES.usePathname = () => input.pathname;
-    const useAllLeases = (() =>
-      mock<ReturnType<typeof DEPENDENCIES.useAllLeases>>({
+    const useLeaseExistenceQuery = (() =>
+      mock<ReturnType<typeof DEPENDENCIES.useLeaseExistenceQuery>>({
         isLoading: (input.isLeasesLoading ?? false) as never,
         isError: (input.isLeasesError ?? false) as never,
-        data: (input.isLeasesError ? undefined : Array.from({ length: input.leaseCount ?? 0 })) as never
-      })) as typeof DEPENDENCIES.useAllLeases;
+        data: (input.isLeasesError ? undefined : (input.leaseCount ?? 0) > 0) as never
+      })) as typeof DEPENDENCIES.useLeaseExistenceQuery;
 
-    return { dependencies: { useWallet, usePathname, useAllLeases } };
+    return { dependencies: { useWallet, usePathname, useLeaseExistenceQuery } };
   }
 });

--- a/apps/deploy-web/src/hooks/useOnboardingChrome.ts
+++ b/apps/deploy-web/src/hooks/useOnboardingChrome.ts
@@ -1,9 +1,9 @@
 import { usePathname } from "next/navigation";
 
 import { useWallet } from "@src/context/WalletProvider";
-import { useAllLeases } from "@src/queries/useLeaseQuery";
+import { useLeaseExistenceQuery } from "@src/queries/useLeaseQuery";
 
-export const DEPENDENCIES = { useWallet, usePathname, useAllLeases };
+export const DEPENDENCIES = { useWallet, usePathname, useLeaseExistenceQuery };
 
 /**
  * Routes that get the stripped onboarding chrome. Matched with `startsWith`, so this
@@ -22,8 +22,8 @@ export type OnboardingChromeState = {
  *
  * "Onboarding" here means the user's *first* deployment — chrome is stripped only until they have a lease, the
  * same signal the onboarding gate uses (see `RequireOnboarding`). A trial user who has already deployed keeps the
- * full chrome when creating further deployments; trial status alone is not onboarding. The lease query is shared
- * (same key) with the gate, so it's usually cached and resolves without a spinner.
+ * full chrome when creating further deployments; trial status alone is not onboarding. The lease-existence query
+ * is shared (same key) with the gate, so it's usually cached and resolves without a spinner.
  */
 export const useOnboardingChrome = (d: typeof DEPENDENCIES = DEPENDENCIES): OnboardingChromeState => {
   const { address, hasManagedWallet, managedWalletError } = d.useWallet();
@@ -32,9 +32,9 @@ export const useOnboardingChrome = (d: typeof DEPENDENCIES = DEPENDENCIES): Onbo
   const isRelevant = !!pathname && ONBOARDING_CHROME_PATHS.some(path => pathname.startsWith(path));
   const hasWallet = hasManagedWallet && !!address;
 
-  const leasesQuery = d.useAllLeases(address, { enabled: isRelevant && hasWallet });
-  const isOnboarded = hasWallet && (leasesQuery.data?.length ?? 0) > 0;
-  const leasesErrored = hasWallet && leasesQuery.isError;
+  const leaseExistenceQuery = d.useLeaseExistenceQuery(address, { enabled: isRelevant && hasWallet });
+  const isOnboarded = hasWallet && !!leaseExistenceQuery.data;
+  const leasesErrored = hasWallet && leaseExistenceQuery.isError;
 
   // A wallet error — or a leases error that leaves onboarding unknowable (an undefined result is not "no leases") —
   // makes the funnel decision unresolvable, so fail open to the full chrome rather than trap a possibly-onboarded

--- a/apps/deploy-web/src/pages/_app.tsx
+++ b/apps/deploy-web/src/pages/_app.tsx
@@ -24,6 +24,7 @@ import { CustomIntlProvider } from "@src/components/layout/CustomIntlProvider";
 import { PageHead } from "@src/components/layout/PageHead";
 import { RequireOnboarding } from "@src/components/onboarding/RequireOnboarding/RequireOnboarding";
 import { UserProviders } from "@src/components/user/UserProviders/UserProviders";
+import { BootLoadingProvider } from "@src/context/BootLoadingProvider/BootLoadingProvider";
 import { ColorModeProvider } from "@src/context/CustomThemeContext";
 import { FlagProvider, WaitForFeatureFlags } from "@src/context/FlagProvider/FlagProvider";
 import { PaymentPollingProvider } from "@src/context/PaymentPollingProvider";
@@ -53,7 +54,7 @@ const App: React.FunctionComponent<Props> = props => {
 
   return (
     <AppRoot {...props}>
-      <>
+      <BootLoadingProvider>
         <UserProviders>
           <AccountCreatedTracker />
           <RequireAuth isPublic={isPublic}>
@@ -72,7 +73,7 @@ const App: React.FunctionComponent<Props> = props => {
             </FlagProvider>
           </RequireAuth>
         </UserProviders>
-      </>
+      </BootLoadingProvider>
     </AppRoot>
   );
 };

--- a/apps/deploy-web/src/pages/_app.tsx
+++ b/apps/deploy-web/src/pages/_app.tsx
@@ -25,7 +25,7 @@ import { PageHead } from "@src/components/layout/PageHead";
 import { RequireOnboarding } from "@src/components/onboarding/RequireOnboarding/RequireOnboarding";
 import { UserProviders } from "@src/components/user/UserProviders/UserProviders";
 import { ColorModeProvider } from "@src/context/CustomThemeContext";
-import { FlagProvider } from "@src/context/FlagProvider/FlagProvider";
+import { FlagProvider, WaitForFeatureFlags } from "@src/context/FlagProvider/FlagProvider";
 import { PaymentPollingProvider } from "@src/context/PaymentPollingProvider";
 import { ServicesProvider } from "@src/context/ServicesProvider";
 import { RootContainerProvider, useRootContainer } from "@src/context/ServicesProvider/RootContainerProvider";
@@ -62,7 +62,9 @@ const App: React.FunctionComponent<Props> = props => {
                 <PaymentPollingProvider>
                   <NavigationGuardProvider>
                     <RequireOnboarding isPublic={isPublic}>
-                      <Component {...pageProps} />
+                      <WaitForFeatureFlags>
+                        <Component {...pageProps} />
+                      </WaitForFeatureFlags>
                     </RequireOnboarding>
                   </NavigationGuardProvider>
                 </PaymentPollingProvider>

--- a/apps/deploy-web/src/queries/queryKeys.ts
+++ b/apps/deploy-web/src/queries/queryKeys.ts
@@ -24,6 +24,8 @@ export class QueryKeys {
   static getDeploymentListKey = (address: string) => ["DEPLOYMENT_LIST", address];
   static getDeploymentDetailKey = (address: string, dseq?: string) => ["DEPLOYMENT_DETAIL", address, dseq].filter(Boolean);
   static getAllLeasesKey = (address: string) => ["ALL_LEASES", address];
+  /** Extends the all-leases key so prefix-based invalidation after a deploy also refreshes the existence check. */
+  static getLeaseExistenceKey = (address: string) => [...QueryKeys.getAllLeasesKey(address), "EXISTENCE"];
   static getLeasesKey = (address: string, dseq: string) => ["LEASE_LIST", address, dseq];
   static getLeaseStatusKey = (dseq: string, gseq: number, oseq: number) => ["LEASE_STATUS", dseq, gseq, oseq];
   static getBidListKey = (address: string, dseq: string) => ["BID_LIST", address, dseq];

--- a/apps/deploy-web/src/queries/useLeaseQuery.spec.tsx
+++ b/apps/deploy-web/src/queries/useLeaseQuery.spec.tsx
@@ -12,7 +12,14 @@ import type { ApiProviderList } from "@src/types/provider";
 import { leaseToDto } from "@src/utils/deploymentDetailUtils";
 import { setupQuery } from "../../tests/unit/query-client";
 import { QueryKeys } from "./queryKeys";
-import { type LeaseStatusDto, USE_LEASE_STATUS_DEPENDENCIES, useAllLeases, useDeploymentLeaseList, useLeaseStatus } from "./useLeaseQuery";
+import {
+  type LeaseStatusDto,
+  USE_LEASE_STATUS_DEPENDENCIES,
+  useAllLeases,
+  useDeploymentLeaseList,
+  useLeaseExistenceQuery,
+  useLeaseStatus
+} from "./useLeaseQuery";
 
 import { act } from "@testing-library/react";
 import { buildProvider } from "@tests/seeders/provider";
@@ -261,6 +268,59 @@ describe("useLeaseQuery", () => {
       expect(queries[0].queryKey).toContain("ALL_LEASES");
       expect(queries[0].queryKey).toContain("test-address");
     });
+  });
+
+  describe("useLeaseExistenceQuery", () => {
+    it("returns true when the address has at least one lease", async () => {
+      const { result } = setupLeaseExistence({ leases: mockLeases });
+
+      await vi.waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+      expect(result.current.data).toBe(true);
+    });
+
+    it("returns false when the address has no leases", async () => {
+      const { result } = setupLeaseExistence({ leases: [] });
+
+      await vi.waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+      expect(result.current.data).toBe(false);
+    });
+
+    it("requests a single lease without a total count", async () => {
+      const { result, chainApiHttpClient } = setupLeaseExistence({ leases: mockLeases });
+
+      await vi.waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+      expect(chainApiHttpClient.get).toHaveBeenCalledTimes(1);
+      expect(chainApiHttpClient.get).toHaveBeenCalledWith(expect.stringContaining("filters.owner=test-address"));
+      expect(chainApiHttpClient.get).toHaveBeenCalledWith(expect.stringContaining("pagination.limit=1"));
+      expect(chainApiHttpClient.get).toHaveBeenCalledWith(expect.stringContaining("pagination.count_total=false"));
+    });
+
+    it("keys under the all-leases prefix so deploy-success invalidation refreshes it", () => {
+      expect(QueryKeys.getLeaseExistenceKey("test-address").slice(0, 2)).toEqual(QueryKeys.getAllLeasesKey("test-address"));
+    });
+
+    function setupLeaseExistence(input: { leases: unknown[] }) {
+      const chainApiHttpClient = mock<FallbackableHttpClient>({
+        get: vi.fn().mockResolvedValue({
+          data: {
+            leases: input.leases,
+            pagination: { next_key: null }
+          }
+        })
+      } as unknown as FallbackableHttpClient);
+      const { result } = setupQuery(() => useLeaseExistenceQuery("test-address"), {
+        services: {
+          chainApiHttpClient: () => chainApiHttpClient
+        }
+      });
+      return { result, chainApiHttpClient };
+    }
   });
 
   describe("useLeaseStatus", () => {

--- a/apps/deploy-web/src/queries/useLeaseQuery.spec.tsx
+++ b/apps/deploy-web/src/queries/useLeaseQuery.spec.tsx
@@ -1,3 +1,4 @@
+import type { LeaseHttpService } from "@akashnetwork/http-sdk";
 import { useQueryClient } from "@tanstack/react-query";
 import { AxiosError } from "axios";
 import { describe, expect, it, vi } from "vitest";
@@ -272,7 +273,7 @@ describe("useLeaseQuery", () => {
 
   describe("useLeaseExistenceQuery", () => {
     it("returns true when the address has at least one lease", async () => {
-      const { result } = setupLeaseExistence({ leases: mockLeases });
+      const { result } = setupLeaseExistence({ hasLeases: true });
 
       await vi.waitFor(() => {
         expect(result.current.isSuccess).toBe(true);
@@ -281,7 +282,7 @@ describe("useLeaseQuery", () => {
     });
 
     it("returns false when the address has no leases", async () => {
-      const { result } = setupLeaseExistence({ leases: [] });
+      const { result } = setupLeaseExistence({ hasLeases: false });
 
       await vi.waitFor(() => {
         expect(result.current.isSuccess).toBe(true);
@@ -289,37 +290,30 @@ describe("useLeaseQuery", () => {
       expect(result.current.data).toBe(false);
     });
 
-    it("requests a single lease without a total count", async () => {
-      const { result, chainApiHttpClient } = setupLeaseExistence({ leases: mockLeases });
+    it("asks the lease service about the queried address", async () => {
+      const { result, leaseHttpService } = setupLeaseExistence({ hasLeases: true });
 
       await vi.waitFor(() => {
         expect(result.current.isSuccess).toBe(true);
       });
-      expect(chainApiHttpClient.get).toHaveBeenCalledTimes(1);
-      expect(chainApiHttpClient.get).toHaveBeenCalledWith(expect.stringContaining("filters.owner=test-address"));
-      expect(chainApiHttpClient.get).toHaveBeenCalledWith(expect.stringContaining("pagination.limit=1"));
-      expect(chainApiHttpClient.get).toHaveBeenCalledWith(expect.stringContaining("pagination.count_total=false"));
+      expect(leaseHttpService.hasLeases).toHaveBeenCalledWith("test-address");
     });
 
     it("keys under the all-leases prefix so deploy-success invalidation refreshes it", () => {
-      expect(QueryKeys.getLeaseExistenceKey("test-address").slice(0, 2)).toEqual(QueryKeys.getAllLeasesKey("test-address"));
+      const allLeasesKey = QueryKeys.getAllLeasesKey("test-address");
+
+      expect(QueryKeys.getLeaseExistenceKey("test-address").slice(0, allLeasesKey.length)).toEqual(allLeasesKey);
     });
 
-    function setupLeaseExistence(input: { leases: unknown[] }) {
-      const chainApiHttpClient = mock<FallbackableHttpClient>({
-        get: vi.fn().mockResolvedValue({
-          data: {
-            leases: input.leases,
-            pagination: { next_key: null }
-          }
-        })
-      } as unknown as FallbackableHttpClient);
+    function setupLeaseExistence(input: { hasLeases: boolean }) {
+      const leaseHttpService = mock<LeaseHttpService>();
+      leaseHttpService.hasLeases.mockResolvedValue(input.hasLeases);
       const { result } = setupQuery(() => useLeaseExistenceQuery("test-address"), {
         services: {
-          chainApiHttpClient: () => chainApiHttpClient
+          leaseHttpService: () => leaseHttpService
         }
       });
-      return { result, chainApiHttpClient };
+      return { result, leaseHttpService };
     }
   });
 

--- a/apps/deploy-web/src/queries/useLeaseQuery.ts
+++ b/apps/deploy-web/src/queries/useLeaseQuery.ts
@@ -71,6 +71,26 @@ export function useAllLeases(address: string, options = {}) {
   });
 }
 
+/**
+ * Answers "has this address ever had a lease?" with a single limit-1 request, unlike
+ * `useAllLeases` which pages through the address's full lease history. Boot gates
+ * (`RequireOnboarding`, `useOnboardingChrome`) only need this boolean, so they can
+ * unblock without paying for the full paginated fetch.
+ */
+export function useLeaseExistenceQuery(address: string, options: Omit<UseQueryOptions<boolean>, "queryKey" | "queryFn"> = {}) {
+  const { chainApiHttpClient } = useServices();
+
+  return useQuery({
+    queryKey: QueryKeys.getLeaseExistenceKey(address),
+    queryFn: async () => {
+      const url = `${ApiUrlService.leaseList("", address, "")}&pagination.limit=1&pagination.count_total=false`;
+      const response = await chainApiHttpClient.get<{ leases: RpcLease[] }>(url);
+      return response.data.leases.length > 0;
+    },
+    ...options
+  });
+}
+
 export function useLeaseStatus(
   params: {
     provider?: ApiProviderList | null;

--- a/apps/deploy-web/src/queries/useLeaseQuery.ts
+++ b/apps/deploy-web/src/queries/useLeaseQuery.ts
@@ -72,21 +72,20 @@ export function useAllLeases(address: string, options = {}) {
 }
 
 /**
- * Answers "has this address ever had a lease?" with a single limit-1 request, unlike
+ * Answers "has this address ever had a lease?" with the SDK's single limit-1 request, unlike
  * `useAllLeases` which pages through the address's full lease history. Boot gates
  * (`RequireOnboarding`, `useOnboardingChrome`) only need this boolean, so they can
- * unblock without paying for the full paginated fetch.
+ * unblock without paying for the full paginated fetch. A `true` answer never goes stale
+ * (a lease cannot un-exist); while `false`, default staleness keeps refetching on focus
+ * so a first deploy made outside this tab is still picked up.
  */
 export function useLeaseExistenceQuery(address: string, options: Omit<UseQueryOptions<boolean>, "queryKey" | "queryFn"> = {}) {
-  const { chainApiHttpClient } = useServices();
+  const { leaseHttpService } = useServices();
 
   return useQuery({
     queryKey: QueryKeys.getLeaseExistenceKey(address),
-    queryFn: async () => {
-      const url = `${ApiUrlService.leaseList("", address, "")}&pagination.limit=1&pagination.count_total=false`;
-      const response = await chainApiHttpClient.get<{ leases: RpcLease[] }>(url);
-      return response.data.leases.length > 0;
-    },
+    queryFn: () => leaseHttpService.hasLeases(address),
+    staleTime: query => (query.state.data ? Infinity : 0),
     ...options
   });
 }

--- a/apps/deploy-web/src/styles/index.css
+++ b/apps/deploy-web/src/styles/index.css
@@ -8,7 +8,12 @@ html {
 body {
   height: calc(100% - 57px) !important;
   padding: 0 !important;
-  font-family: var(--font-geist-sans), ui-sans-serif, system-ui, -apple-system, sans-serif;
+  font-family:
+    var(--font-geist-sans),
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    sans-serif;
 }
 
 .text-truncate {
@@ -126,38 +131,6 @@ body {
   pointer-events: all !important;
 }
 
-
 .monaco-editor {
   position: absolute !important;
-}
-
-/* Initial app loading — pulsing Akash mark (see AkashLoadingMark). Fills are theme tokens so it follows light/dark. */
-.akash-loading-mark path {
-  fill: hsl(var(--border));
-  animation: akash-loading-shard 1.8s linear infinite;
-}
-
-@keyframes akash-loading-shard {
-  0% {
-    fill: hsl(var(--border));
-  }
-  14% {
-    fill: hsl(var(--foreground));
-  }
-  46% {
-    fill: hsl(var(--foreground));
-  }
-  72% {
-    fill: hsl(var(--border));
-  }
-  100% {
-    fill: hsl(var(--border));
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .akash-loading-mark path {
-    animation: none;
-    fill: hsl(var(--foreground));
-  }
 }

--- a/apps/deploy-web/src/styles/index.css
+++ b/apps/deploy-web/src/styles/index.css
@@ -130,3 +130,34 @@ body {
 .monaco-editor {
   position: absolute !important;
 }
+
+/* Initial app loading — pulsing Akash mark (see AkashLoadingMark). Fills are theme tokens so it follows light/dark. */
+.akash-loading-mark path {
+  fill: hsl(var(--border));
+  animation: akash-loading-shard 1.8s linear infinite;
+}
+
+@keyframes akash-loading-shard {
+  0% {
+    fill: hsl(var(--border));
+  }
+  14% {
+    fill: hsl(var(--foreground));
+  }
+  46% {
+    fill: hsl(var(--foreground));
+  }
+  72% {
+    fill: hsl(var(--border));
+  }
+  100% {
+    fill: hsl(var(--border));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .akash-loading-mark path {
+    animation: none;
+    fill: hsl(var(--foreground));
+  }
+}

--- a/apps/deploy-web/tailwind.config.ts
+++ b/apps/deploy-web/tailwind.config.ts
@@ -1,3 +1,24 @@
 import createTailwindConfig from "@akashnetwork/ui/tailwind";
 
-export default createTailwindConfig("deploy-web");
+const config = createTailwindConfig("deploy-web");
+
+/** Boot overlay mark pulse (see AkashLoadingMark): each shard chases from dim (border) to lit (foreground). */
+config.theme = {
+  ...config.theme,
+  extend: {
+    ...config.theme?.extend,
+    keyframes: {
+      ...config.theme?.extend?.keyframes,
+      "akash-loading-shard": {
+        "0%, 72%, 100%": { fill: "hsl(var(--border))" },
+        "14%, 46%": { fill: "hsl(var(--foreground))" }
+      }
+    },
+    animation: {
+      ...config.theme?.extend?.animation,
+      "akash-loading-shard": "akash-loading-shard 1.8s linear infinite"
+    }
+  }
+};
+
+export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -44429,7 +44429,8 @@
       },
       "devDependencies": {
         "@akashnetwork/dev-config": "*",
-        "vitest": "^4.1.5"
+        "vitest": "^4.1.5",
+        "vitest-mock-extended": "^4.0.0"
       },
       "peerDependencies": {
         "@cosmjs/proto-signing": "~0.38.0",

--- a/packages/http-sdk/package.json
+++ b/packages/http-sdk/package.json
@@ -26,7 +26,8 @@
   },
   "devDependencies": {
     "@akashnetwork/dev-config": "*",
-    "vitest": "^4.1.5"
+    "vitest": "^4.1.5",
+    "vitest-mock-extended": "^4.0.0"
   },
   "peerDependencies": {
     "@cosmjs/proto-signing": "~0.38.0",

--- a/packages/http-sdk/src/lease/lease-http.service.spec.ts
+++ b/packages/http-sdk/src/lease/lease-http.service.spec.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
 
 import type { HttpClient } from "../utils/httpClient";
 import type { RestAkashLeaseListResponse, RpcLease } from "./lease-http.service";
@@ -48,9 +49,8 @@ describe(LeaseHttpService.name, () => {
         pagination: input?.pagination ?? { next_key: null, total: "0" }
       }
     };
-    const httpClient = {
-      get: vi.fn().mockResolvedValue(response)
-    } as unknown as HttpClient & { get: ReturnType<typeof vi.fn> };
+    const httpClient = mock<HttpClient>();
+    httpClient.get.mockResolvedValue(response);
     const service = new LeaseHttpService(httpClient);
     return { service, httpClient };
   }

--- a/packages/http-sdk/src/lease/lease-http.service.spec.ts
+++ b/packages/http-sdk/src/lease/lease-http.service.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { HttpClient } from "../utils/httpClient";
+import type { RestAkashLeaseListResponse, RpcLease } from "./lease-http.service";
+import { LeaseHttpService } from "./lease-http.service";
+
+describe(LeaseHttpService.name, () => {
+  describe("hasLeases", () => {
+    it("requests a single lease for the address", async () => {
+      const { service, httpClient } = setup();
+
+      await service.hasLeases("akash1abc");
+
+      expect(httpClient.get).toHaveBeenCalledWith(
+        "/akash/market/v1beta5/leases/list",
+        expect.objectContaining({
+          params: expect.objectContaining({
+            "filters.owner": "akash1abc",
+            "pagination.limit": 1
+          })
+        })
+      );
+    });
+
+    it("returns true when the page contains a lease", async () => {
+      const { service } = setup({ leases: [{} as RpcLease] });
+
+      await expect(service.hasLeases("akash1abc")).resolves.toBe(true);
+    });
+
+    it("returns true when the page is empty but pagination reports more results", async () => {
+      const { service } = setup({ pagination: { next_key: "next", total: "0" } });
+
+      await expect(service.hasLeases("akash1abc")).resolves.toBe(true);
+    });
+
+    it("returns false when the address has no leases", async () => {
+      const { service } = setup();
+
+      await expect(service.hasLeases("akash1abc")).resolves.toBe(false);
+    });
+  });
+
+  function setup(input?: Partial<RestAkashLeaseListResponse>) {
+    const response = {
+      data: {
+        leases: input?.leases ?? [],
+        pagination: input?.pagination ?? { next_key: null, total: "0" }
+      }
+    };
+    const httpClient = {
+      get: vi.fn().mockResolvedValue(response)
+    } as unknown as HttpClient & { get: ReturnType<typeof vi.fn> };
+    const service = new LeaseHttpService(httpClient);
+    return { service, httpClient };
+  }
+});


### PR DESCRIPTION
## Why

The initial app load rendered a relay of separate spinners: each boot gate (user init, auth, feature flags, onboarding, page guard) showed its own loader as it resolved, so users saw multiple loaders flash at different positions during boot. The gates also resolved sequentially. This PR makes the boot one continuous, centered loader and parallelizes the gates so the app is ready sooner.

## What

https://github.com/user-attachments/assets/a9e68506-2814-4627-a8e3-53c948e657af




**Parallelize boot gates** (`fix(onboarding)`): the app-boot gates now resolve concurrently instead of in a sequential relay.

**Unified animated boot loader** (`feat(onboarding)`):
- New `BootLoadingProvider` owns a single fixed, centered overlay for the whole boot. Each gate registers as pending via `BootLoading` and renders nothing while resolving, so the boot is one continuous loader. A short grace period bridges gate handoffs so the mark never re-pulses.
- New `AkashLoadingMark`: a pulsing three-shard Akash mark that follows light/dark via theme tokens and honors `prefers-reduced-motion`.
- On completion the mark disappears and the background curtain fades out to reveal the app (the app is immediately interactive during the fade).

### Visuals

Boot shows a single centered, pulsing Akash mark; on completion the mark disappears and the `bg-background` curtain fades out (~500ms) to reveal the app. Screenshots to be attached.

### Tests

- Unit specs for `AkashLoadingMark` and `BootLoadingProvider` (registry counting, grace-period gate handoff stays continuous, fade-out lifecycle: mark hides then background fades then unmounts).
- Existing gate specs (auth / onboarding / feature-flags) kept green after switching them to the shared registrar.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rolled out a branded boot-loading overlay across auth, onboarding, redirects, user init, and layout loading, with feature-flag readiness gating during app startup.
  * Added lease-existence queries to drive onboarding/onboarded state and improved cache keying for existence checks.
* **Bug Fixes**
  * Refined boot-overlay lifecycle (grace/fade and unmount timing) and updated loading mark animation styling.
* **Tests**
  * Added/expanded unit tests for boot-loading overlay behavior, loading mark rendering, feature-flag gating, onboarding/lease gates, and `hasLeases` logic.
* **Documentation**
  * Updated boot-loading timing documentation for fade behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->