### PR TITLE
feat(ci): auto-approve low-risk fix and refactor PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,6 +16,7 @@
 # Migrations, runtime config, images
 /apps/*/drizzle/ @akash-network/console
 /apps/*/env/ @akash-network/console
+**/.env* @akash-network/console
 **/Dockerfile* @akash-network/console
 
 # Public API surface

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,9 +2,27 @@
 /.helm/ @akash-network/console
 .codecov.yml @akash-network/console
 /script/ @akash-network/console
-/apps/*/src/ @akash-network/console
-/packages/*/src/ @akash-network/console
 /config @akash-network/console
+
+# Critical business flows
+/apps/tx-signer/ @akash-network/console
+/apps/api/src/auth/ @akash-network/console
+/apps/api/src/billing/ @akash-network/console
+/apps/deploy-web/src/lib/auth0/ @akash-network/console
+/apps/deploy-web/src/pages/api/ @akash-network/console
+/packages/database/ @akash-network/console
+/packages/docker/ @akash-network/console
+
+# Migrations, runtime config, images
+/apps/*/drizzle/ @akash-network/console
+/apps/*/env/ @akash-network/console
+**/Dockerfile* @akash-network/console
+
+# Public API surface
+/apps/api/src/routes/ @akash-network/console
+/apps/api/src/routers/ @akash-network/console
+/apps/api/src/*/routes/ @akash-network/console
+/apps/api/swagger/openapi.json @akash-network/console
 
 # Exclude test files from code ownership
 *.spec.ts

--- a/.github/actions/associated-pr/action.yml
+++ b/.github/actions/associated-pr/action.yml
@@ -47,6 +47,9 @@ outputs:
   closed:
     description: Whether the PR is closed
     value: ${{ steps.associated-pr.outputs.closed }}
+  draft:
+    description: Whether the PR is a draft
+    value: ${{ steps.associated-pr.outputs.draft }}
   changes:
     description: |
       JSON array of filenames from `export-file-changes` that were modified in the PR.
@@ -181,6 +184,7 @@ runs:
           core.setOutput('head_repo', pr.head.repo?.full_name || '');
           core.setOutput('labels', JSON.stringify((pr.labels || []).map(l => l.name)));
           core.setOutput('closed', pr.closed_at ? 'true' : 'false');
+          core.setOutput('draft', pr.draft ? 'true' : 'false');
 
           const author = pr.merged_by?.login || pr.user.login;
           core.setOutput('author', author);

--- a/.github/scripts/pr-auto-approval/codeowners.js
+++ b/.github/scripts/pr-auto-approval/codeowners.js
@@ -56,7 +56,7 @@ function translateGlob(body) {
       source += "[^/]";
       i += 1;
     } else {
-      source += body[i].replace(/[.+^${}()|[\]\\]/, "\\$&");
+      source += body[i].replace(/[.+^${}()|[\]\\]/g, "\\$&");
       i += 1;
     }
   }

--- a/.github/scripts/pr-auto-approval/codeowners.js
+++ b/.github/scripts/pr-auto-approval/codeowners.js
@@ -1,0 +1,66 @@
+/**
+ * Minimal CODEOWNERS matcher implementing the gitignore-style subset GitHub
+ * supports (no `!` negation, no `[...]` ranges). Last matching pattern wins;
+ * a pattern without owners clears ownership.
+ */
+function parse(content) {
+  const rules = content
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(line => line && !line.startsWith("#"))
+    .map(line => {
+      const [pattern, ...owners] = line.split(/\s+/);
+      return { regex: patternToRegex(pattern), hasOwners: owners.length > 0 };
+    });
+
+  return {
+    isOwned(filePath) {
+      let owned = false;
+      for (const rule of rules) {
+        if (rule.regex.test(filePath)) {
+          owned = rule.hasOwners;
+        }
+      }
+      return owned;
+    }
+  };
+}
+
+function patternToRegex(pattern) {
+  const matchesDirContentsOnly = pattern.endsWith("/");
+  let body = matchesDirContentsOnly ? pattern.slice(0, -1) : pattern;
+  const anchored = body.startsWith("/") || body.includes("/");
+  if (body.startsWith("/")) {
+    body = body.slice(1);
+  }
+
+  const prefix = anchored ? "^" : "^(?:.*/)?";
+  const suffix = matchesDirContentsOnly ? "/.+$" : "(?:/.*)?$";
+  return new RegExp(prefix + translateGlob(body) + suffix);
+}
+
+function translateGlob(body) {
+  let source = "";
+  let i = 0;
+  while (i < body.length) {
+    if (body.startsWith("**/", i)) {
+      source += "(?:.*/)?";
+      i += 3;
+    } else if (body.startsWith("**", i)) {
+      source += ".*";
+      i += 2;
+    } else if (body[i] === "*") {
+      source += "[^/]*";
+      i += 1;
+    } else if (body[i] === "?") {
+      source += "[^/]";
+      i += 1;
+    } else {
+      source += body[i].replace(/[.+^${}()|[\]\\]/, "\\$&");
+      i += 1;
+    }
+  }
+  return source;
+}
+
+module.exports = { parse };

--- a/.github/scripts/pr-auto-approval/codeowners.test.js
+++ b/.github/scripts/pr-auto-approval/codeowners.test.js
@@ -93,6 +93,13 @@ describe("repository CODEOWNERS policy pins", () => {
     assert.equal(owners.isOwned("apps/api/Dockerfile"), true);
   });
 
+  test("env files outside env directories are owned wherever they live", () => {
+    assert.equal(owners.isOwned("apps/api/.env.production"), true);
+    assert.equal(owners.isOwned("apps/deploy-web/.env.local.sample"), true);
+    assert.equal(owners.isOwned(".env.example"), true);
+    assert.equal(owners.isOwned(".env"), true);
+  });
+
   test("public API surface is owned", () => {
     assert.equal(owners.isOwned("apps/api/src/routes/index.ts"), true);
     assert.equal(owners.isOwned("apps/api/src/routers/apiRouter.ts"), true);

--- a/.github/scripts/pr-auto-approval/codeowners.test.js
+++ b/.github/scripts/pr-auto-approval/codeowners.test.js
@@ -1,0 +1,113 @@
+const { describe, test } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const { parse } = require("./codeowners");
+
+describe("parse", () => {
+  test("anchored directory pattern matches only from the repo root", () => {
+    const owners = parse("/script/ @akash-network/console");
+    assert.equal(owners.isOwned("script/deploy.sh"), true);
+    assert.equal(owners.isOwned("apps/api/script/deploy.sh"), false);
+  });
+
+  test("unanchored directory pattern matches at any depth", () => {
+    const owners = parse("script/ @akash-network/console");
+    assert.equal(owners.isOwned("script/deploy.sh"), true);
+    assert.equal(owners.isOwned("apps/api/script/deploy.sh"), true);
+  });
+
+  test("unanchored file pattern matches at any depth", () => {
+    const owners = parse("*.spec.ts @akash-network/console");
+    assert.equal(owners.isOwned("foo.spec.ts"), true);
+    assert.equal(owners.isOwned("apps/api/src/billing/billing.spec.ts"), true);
+    assert.equal(owners.isOwned("apps/api/src/billing/billing.ts"), false);
+  });
+
+  test("directory pattern with trailing slash owns all nested files", () => {
+    const owners = parse("/apps/api/src/billing/ @akash-network/console");
+    assert.equal(owners.isOwned("apps/api/src/billing/checkout.ts"), true);
+    assert.equal(owners.isOwned("apps/api/src/billing/stripe/webhook.ts"), true);
+    assert.equal(owners.isOwned("apps/api/src/billing.ts"), false);
+  });
+
+  test("pattern without trailing slash matches a file exactly and a directory's contents", () => {
+    const owners = parse("/config @akash-network/console");
+    assert.equal(owners.isOwned("config"), true);
+    assert.equal(owners.isOwned("config/network.yml"), true);
+    assert.equal(owners.isOwned("config.ts"), false);
+  });
+
+  test("* does not cross directory boundaries", () => {
+    const owners = parse("/apps/*/drizzle/ @akash-network/console");
+    assert.equal(owners.isOwned("apps/api/drizzle/0001_init.sql"), true);
+    assert.equal(owners.isOwned("apps/api/nested/drizzle/0001_init.sql"), false);
+  });
+
+  test("** crosses directory boundaries", () => {
+    const owners = parse("**/Dockerfile* @akash-network/console");
+    assert.equal(owners.isOwned("Dockerfile"), true);
+    assert.equal(owners.isOwned("apps/api/Dockerfile"), true);
+    assert.equal(owners.isOwned("apps/api/Dockerfile.dev"), true);
+    assert.equal(owners.isOwned("apps/api/dockerfiles/readme.md"), false);
+  });
+
+  test("last matching pattern wins", () => {
+    const content = ["*.spec.ts", "/apps/api/src/billing/critical.spec.ts @akash-network/console"].join("\n");
+    const owners = parse(content);
+    assert.equal(owners.isOwned("apps/api/src/billing/critical.spec.ts"), true);
+    assert.equal(owners.isOwned("apps/api/src/billing/other.spec.ts"), false);
+  });
+
+  test("owner-less pattern clears ownership from earlier matches", () => {
+    const content = ["/apps/ @akash-network/console", "*.spec.ts"].join("\n");
+    const owners = parse(content);
+    assert.equal(owners.isOwned("apps/api/src/billing/billing.spec.ts"), false);
+    assert.equal(owners.isOwned("apps/api/src/billing/billing.ts"), true);
+  });
+
+  test("comments and blank lines are ignored", () => {
+    const content = ["# a comment", "", "   ", "/script/ @akash-network/console"].join("\n");
+    const owners = parse(content);
+    assert.equal(owners.isOwned("script/deploy.sh"), true);
+    assert.equal(owners.isOwned("README.md"), false);
+  });
+});
+
+describe("repository CODEOWNERS policy pins", () => {
+  const owners = parse(fs.readFileSync(path.join(__dirname, "../../CODEOWNERS"), "utf8"));
+
+  test("critical business flows stay owned", () => {
+    assert.equal(owners.isOwned("apps/api/src/billing/services/checkout.service.ts"), true);
+    assert.equal(owners.isOwned("apps/api/src/auth/services/auth.service.ts"), true);
+    assert.equal(owners.isOwned("apps/tx-signer/src/index.ts"), true);
+    assert.equal(owners.isOwned("apps/deploy-web/src/lib/auth0/session.ts"), true);
+    assert.equal(owners.isOwned("apps/deploy-web/src/pages/api/proxy.ts"), true);
+    assert.equal(owners.isOwned("packages/database/dbSchemas/user.ts"), true);
+  });
+
+  test("migrations, runtime config, and images are owned", () => {
+    assert.equal(owners.isOwned("apps/api/drizzle/0042_add_column.sql"), true);
+    assert.equal(owners.isOwned("apps/deploy-web/env/.env.production"), true);
+    assert.equal(owners.isOwned("apps/api/Dockerfile"), true);
+  });
+
+  test("public API surface is owned", () => {
+    assert.equal(owners.isOwned("apps/api/src/routes/index.ts"), true);
+    assert.equal(owners.isOwned("apps/api/src/routers/apiRouter.ts"), true);
+    assert.equal(owners.isOwned("apps/api/src/deployment/routes/deployment.router.ts"), true);
+    assert.equal(owners.isOwned("apps/api/swagger/openapi.json"), true);
+  });
+
+  test("ordinary source files are no longer owned", () => {
+    assert.equal(owners.isOwned("apps/deploy-web/src/components/deployments/DeploymentName.tsx"), false);
+    assert.equal(owners.isOwned("apps/api/src/deployment/services/deployment.service.ts"), false);
+    assert.equal(owners.isOwned("packages/ui/components/button.tsx"), false);
+  });
+
+  test("test files in owned paths are un-owned", () => {
+    assert.equal(owners.isOwned("apps/api/src/billing/services/checkout.service.spec.ts"), false);
+    assert.equal(owners.isOwned("apps/api/src/billing/services/checkout.service.integration.ts"), false);
+  });
+});

--- a/.github/scripts/pr-auto-approval/rules.js
+++ b/.github/scripts/pr-auto-approval/rules.js
@@ -2,7 +2,7 @@ const { parse } = require("./codeowners");
 
 const APPROVABLE_TYPE_PATTERN = /^(chore|test|docs|fix|refactor)[:(]/;
 const ALLOWED_SIZE_LABELS = ["size: XS", "size: S", "size: M"];
-const TEST_FILE_PATTERN = /(\.(spec|test|integration|e2e)\.(ts|tsx)$)|\/tests?\//;
+const TEST_FILE_PATTERN = /(\.(spec|test|integration|e2e)\.[cm]?[jt]sx?$)|(^|\/)tests?\//;
 const TEST_CONFIG_PATTERN = /(jest|vitest|playwright)\.config\.[tj]s$/;
 const IMAGE_FILE_PATTERN = /\.(png|jpg|jpeg|gif|svg|webp|ico|bmp)$/i;
 const SOURCE_CODE_PATTERN = /^(apps|packages)\/.*\.(ts|tsx|js|jsx)$/;

--- a/.github/scripts/pr-auto-approval/rules.js
+++ b/.github/scripts/pr-auto-approval/rules.js
@@ -5,7 +5,7 @@ const ALLOWED_SIZE_LABELS = ["size: XS", "size: S", "size: M"];
 const TEST_FILE_PATTERN = /(\.(spec|test|integration|e2e)\.[cm]?[jt]sx?$)|(^|\/)tests?\//;
 const TEST_CONFIG_PATTERN = /(jest|vitest|playwright)\.config\.[tj]s$/;
 const IMAGE_FILE_PATTERN = /\.(png|jpg|jpeg|gif|svg|webp|ico|bmp)$/i;
-const SOURCE_CODE_PATTERN = /^(apps|packages)\/.*\.(ts|tsx|js|jsx)$/;
+const SOURCE_CODE_PATTERN = /^(apps|packages)\/.*\.[cm]?[jt]sx?$/;
 const MAX_REPORTED_FILES = 5;
 
 function evaluate({ title, labels, authorLogin, headRepo, baseRepo, isDraft, files, codeownersContent }) {

--- a/.github/scripts/pr-auto-approval/rules.js
+++ b/.github/scripts/pr-auto-approval/rules.js
@@ -1,0 +1,116 @@
+const { parse } = require("./codeowners");
+
+const APPROVABLE_TYPE_PATTERN = /^(chore|test|docs|fix|refactor)[:(]/;
+const ALLOWED_SIZE_LABELS = ["size: XS", "size: S", "size: M"];
+const TEST_FILE_PATTERN = /(\.(spec|test|integration|e2e)\.(ts|tsx)$)|\/tests?\//;
+const TEST_CONFIG_PATTERN = /(jest|vitest|playwright)\.config\.[tj]s$/;
+const IMAGE_FILE_PATTERN = /\.(png|jpg|jpeg|gif|svg|webp|ico|bmp)$/i;
+const SOURCE_CODE_PATTERN = /^(apps|packages)\/.*\.(ts|tsx|js|jsx)$/;
+const MAX_REPORTED_FILES = 5;
+
+function evaluate({ title, labels, authorLogin, headRepo, baseRepo, isDraft, files, codeownersContent }) {
+  const ineligible = findIneligibilityReason({ title, labels, authorLogin, headRepo, baseRepo, isDraft });
+  if (ineligible) {
+    return { outcome: "ineligible", reason: ineligible };
+  }
+
+  const type = title.match(APPROVABLE_TYPE_PATTERN)[1];
+  const blockers = collectBlockers({ type, files, codeownersContent });
+  if (blockers.length > 0) {
+    return { outcome: "blocked", blockers };
+  }
+
+  const scopeMiss = findScopeMiss({ type, files });
+  if (scopeMiss) {
+    return { outcome: "skipped", reason: scopeMiss };
+  }
+
+  return { outcome: "approved", reason: APPROVAL_REASONS[type] };
+}
+
+const APPROVAL_REASONS = {
+  chore: "chore that does not touch source code files",
+  test: "all changes are related to tests",
+  docs: "all changes are related to documentation",
+  fix: "bug fix within approved scope that includes test changes",
+  refactor: "refactor within approved scope"
+};
+
+function findIneligibilityReason({ title, labels, authorLogin, headRepo, baseRepo, isDraft }) {
+  if (headRepo && headRepo !== baseRepo) {
+    return "PR is from a fork";
+  }
+  if (/bot/i.test(authorLogin)) {
+    return `author "${authorLogin}" appears to be a bot`;
+  }
+  if (isDraft) {
+    return "PR is a draft";
+  }
+  if (!labels.includes("experienced-contributor")) {
+    return "missing experienced-contributor label";
+  }
+  if (!APPROVABLE_TYPE_PATTERN.test(title)) {
+    return "title type is not one of: chore, test, docs, fix, refactor";
+  }
+  if (!ALLOWED_SIZE_LABELS.some(size => labels.includes(size))) {
+    return "missing required size label (XS, S, or M)";
+  }
+  return null;
+}
+
+function collectBlockers({ type, files, codeownersContent }) {
+  const blockers = [];
+
+  const ownedFiles = findCodeOwnedFiles(files, codeownersContent);
+  if (ownedFiles.length > 0) {
+    blockers.push({
+      id: "code-owned-paths",
+      message: "These files are on code-owned paths and require @akash-network/console review",
+      files: ownedFiles.slice(0, MAX_REPORTED_FILES)
+    });
+  }
+
+  if (type === "fix" && !hasRegressionTestEvidence(files)) {
+    blockers.push({
+      id: "missing-regression-test",
+      message: "Bug fixes must add or update at least one test file as regression evidence",
+      files: []
+    });
+  }
+
+  return blockers;
+}
+
+function findCodeOwnedFiles(files, codeownersContent) {
+  const owners = parse(codeownersContent);
+  return files.filter(file => owners.isOwned(file.filename) || (file.previous_filename && owners.isOwned(file.previous_filename))).map(file => file.filename);
+}
+
+function hasRegressionTestEvidence(files) {
+  return files.some(file => {
+    if (!TEST_FILE_PATTERN.test(file.filename)) {
+      return false;
+    }
+    if (file.status === "added" || file.status === "modified") {
+      return true;
+    }
+    return file.status === "renamed" && file.changes > 0;
+  });
+}
+
+function findScopeMiss({ type, files }) {
+  const filenames = files.map(file => file.filename);
+
+  if (type === "test" && !filenames.every(f => TEST_FILE_PATTERN.test(f) || TEST_CONFIG_PATTERN.test(f))) {
+    return "PR changes non-test files";
+  }
+  if (type === "docs" && !filenames.every(f => f.endsWith(".md") || IMAGE_FILE_PATTERN.test(f))) {
+    return "PR changes non-documentation files";
+  }
+  if (type === "chore" && filenames.some(f => SOURCE_CODE_PATTERN.test(f))) {
+    return "PR touches code files in packages/ or apps/";
+  }
+  return null;
+}
+
+module.exports = { evaluate };

--- a/.github/scripts/pr-auto-approval/rules.test.js
+++ b/.github/scripts/pr-auto-approval/rules.test.js
@@ -1,0 +1,287 @@
+const { describe, test } = require("node:test");
+const assert = require("node:assert/strict");
+
+const { evaluate } = require("./rules");
+
+describe("evaluate", () => {
+  const CODEOWNERS_FIXTURE = ["/apps/api/src/billing/ @akash-network/console", "/apps/*/drizzle/ @akash-network/console", "*.spec.ts"].join("\n");
+
+  describe("eligibility gates", () => {
+    test("skips PRs from forks", () => {
+      const decision = setup({ headRepo: "someone/console" });
+      assert.equal(decision.outcome, "ineligible");
+      assert.match(decision.reason, /fork/);
+    });
+
+    test("skips PRs authored by bots", () => {
+      const decision = setup({ authorLogin: "dependabot[bot]" });
+      assert.equal(decision.outcome, "ineligible");
+      assert.match(decision.reason, /bot/);
+    });
+
+    test("skips draft PRs", () => {
+      const decision = setup({ isDraft: true });
+      assert.equal(decision.outcome, "ineligible");
+      assert.match(decision.reason, /draft/);
+    });
+
+    test("skips PRs without the experienced-contributor label", () => {
+      const decision = setup({ labels: ["size: S"] });
+      assert.equal(decision.outcome, "ineligible");
+      assert.match(decision.reason, /experienced-contributor/);
+    });
+
+    test("skips feat PRs", () => {
+      const decision = setup({ title: "feat(billing): add new payment flow" });
+      assert.equal(decision.outcome, "ineligible");
+      assert.match(decision.reason, /type/);
+    });
+
+    test("skips titles whose type is only a prefix of an approvable type", () => {
+      const decision = setup({ title: "fixture: not a fix" });
+      assert.equal(decision.outcome, "ineligible");
+      assert.match(decision.reason, /type/);
+    });
+
+    for (const size of ["size: L", "size: XL"]) {
+      test(`skips PRs labeled ${size}`, () => {
+        const decision = setup({ labels: ["experienced-contributor", size] });
+        assert.equal(decision.outcome, "ineligible");
+        assert.match(decision.reason, /size/);
+      });
+    }
+
+    test("skips PRs without any size label", () => {
+      const decision = setup({ labels: ["experienced-contributor"] });
+      assert.equal(decision.outcome, "ineligible");
+      assert.match(decision.reason, /size/);
+    });
+  });
+
+  describe("legacy type parity", () => {
+    test("approves a test PR touching only test files", () => {
+      const decision = setup({
+        title: "test(api): cover wallet top-up",
+        files: [file("apps/api/src/billing/wallet.spec.ts"), file("apps/api/test/seeders/wallet.seeder.ts"), file("apps/api/vitest.config.ts")]
+      });
+      assert.deepEqual(decision, { outcome: "approved", reason: "all changes are related to tests" });
+    });
+
+    test("accepts .test. and .e2e. suffixes and playwright config as test files", () => {
+      const decision = setup({
+        title: "test(deploy-web): flows",
+        files: [file("apps/deploy-web/tests/e2e/deploy.e2e.ts"), file("apps/deploy-web/src/utils/date.test.ts"), file("apps/deploy-web/playwright.config.ts")]
+      });
+      assert.equal(decision.outcome, "approved");
+    });
+
+    test("skips a test PR touching non-test files", () => {
+      const decision = setup({
+        title: "test(api): cover wallet top-up",
+        files: [file("apps/api/src/billing/wallet.spec.ts"), file("apps/api/src/routes/wallet.ts")]
+      });
+      assert.equal(decision.outcome, "skipped");
+      assert.match(decision.reason, /non-test files/);
+    });
+
+    test("approves a docs PR touching only markdown and images", () => {
+      const decision = setup({
+        title: "docs: update readme",
+        files: [file("README.md"), file("docs/architecture.png")]
+      });
+      assert.deepEqual(decision, { outcome: "approved", reason: "all changes are related to documentation" });
+    });
+
+    test("skips a docs PR touching non-documentation files", () => {
+      const decision = setup({
+        title: "docs: update readme",
+        files: [file("README.md"), file("package.json")]
+      });
+      assert.equal(decision.outcome, "skipped");
+      assert.match(decision.reason, /non-documentation/);
+    });
+
+    test("approves a chore that does not touch source code", () => {
+      const decision = setup({
+        title: "chore(deps): bump versions",
+        files: [file("package.json"), file("package-lock.json")]
+      });
+      assert.deepEqual(decision, { outcome: "approved", reason: "chore that does not touch source code files" });
+    });
+
+    test("skips a chore touching code files under apps/ or packages/", () => {
+      const decision = setup({
+        title: "chore(deploy-web): tweak component",
+        files: [file("apps/deploy-web/src/components/Foo.tsx")]
+      });
+      assert.equal(decision.outcome, "skipped");
+      assert.match(decision.reason, /code files/);
+    });
+  });
+
+  describe("fix PRs", () => {
+    test("approves a fix that modifies a colocated spec file", () => {
+      const decision = setup({
+        title: "fix(deploy-web): guard empty deployment list",
+        files: [file("apps/deploy-web/src/components/DeploymentList.tsx"), file("apps/deploy-web/src/components/DeploymentList.spec.tsx")]
+      });
+      assert.deepEqual(decision, { outcome: "approved", reason: "bug fix within approved scope that includes test changes" });
+    });
+
+    test("blocks a fix without any test changes", () => {
+      const decision = setup({
+        title: "fix(deploy-web): guard empty deployment list",
+        files: [file("apps/deploy-web/src/components/DeploymentList.tsx")]
+      });
+      assert.equal(decision.outcome, "blocked");
+      assert.deepEqual(
+        decision.blockers.map(b => b.id),
+        ["missing-regression-test"]
+      );
+    });
+
+    test("blocks a fix whose only test change is a removal", () => {
+      const decision = setup({
+        title: "fix(deploy-web): guard empty deployment list",
+        files: [
+          file("apps/deploy-web/src/components/DeploymentList.tsx"),
+          file("apps/deploy-web/src/components/DeploymentList.spec.tsx", { status: "removed" })
+        ]
+      });
+      assert.equal(decision.outcome, "blocked");
+      assert.deepEqual(
+        decision.blockers.map(b => b.id),
+        ["missing-regression-test"]
+      );
+    });
+
+    test("does not count a pure rename of a test file as test evidence", () => {
+      const decision = setup({
+        title: "fix(deploy-web): guard empty deployment list",
+        files: [
+          file("apps/deploy-web/src/components/DeploymentList.tsx"),
+          file("apps/deploy-web/src/components/List.spec.tsx", {
+            status: "renamed",
+            previous_filename: "apps/deploy-web/src/components/DeploymentList.spec.tsx",
+            changes: 0
+          })
+        ]
+      });
+      assert.equal(decision.outcome, "blocked");
+    });
+
+    test("counts a rename with content changes as test evidence", () => {
+      const decision = setup({
+        title: "fix(deploy-web): guard empty deployment list",
+        files: [
+          file("apps/deploy-web/src/components/DeploymentList.tsx"),
+          file("apps/deploy-web/src/components/List.spec.tsx", {
+            status: "renamed",
+            previous_filename: "apps/deploy-web/src/components/DeploymentList.spec.tsx",
+            changes: 12
+          })
+        ]
+      });
+      assert.equal(decision.outcome, "approved");
+    });
+  });
+
+  describe("refactor PRs", () => {
+    test("approves a refactor without test changes", () => {
+      const decision = setup({
+        title: "refactor(deploy-web): extract deployment list hook",
+        files: [file("apps/deploy-web/src/components/DeploymentList.tsx")]
+      });
+      assert.deepEqual(decision, { outcome: "approved", reason: "refactor within approved scope" });
+    });
+  });
+
+  describe("code-owned paths blocker", () => {
+    test("blocks any qualifying PR touching an owned path", () => {
+      const decision = setup({
+        title: "refactor(api): tidy billing service",
+        files: [file("apps/api/src/billing/billing.service.ts")]
+      });
+      assert.equal(decision.outcome, "blocked");
+      assert.equal(decision.blockers[0].id, "code-owned-paths");
+      assert.deepEqual(decision.blockers[0].files, ["apps/api/src/billing/billing.service.ts"]);
+    });
+
+    test("blocks when a removed file is in an owned path", () => {
+      const decision = setup({
+        title: "refactor(api): drop old migration",
+        files: [file("apps/api/drizzle/0001_init.sql", { status: "removed" })]
+      });
+      assert.equal(decision.outcome, "blocked");
+      assert.equal(decision.blockers[0].id, "code-owned-paths");
+    });
+
+    test("blocks when a file is renamed out of an owned path", () => {
+      const decision = setup({
+        title: "refactor(api): move billing helper",
+        files: [
+          file("apps/api/src/utils/billing-helper.ts", {
+            status: "renamed",
+            previous_filename: "apps/api/src/billing/helper.ts",
+            changes: 0
+          })
+        ]
+      });
+      assert.equal(decision.outcome, "blocked");
+      assert.equal(decision.blockers[0].id, "code-owned-paths");
+      assert.deepEqual(decision.blockers[0].files, ["apps/api/src/utils/billing-helper.ts"]);
+    });
+
+    test("does not block owned-path test files excluded by CODEOWNERS", () => {
+      const decision = setup({
+        title: "fix(api): correct rounding in billing",
+        files: [file("apps/api/src/utils/rounding.ts"), file("apps/api/src/billing/rounding.spec.ts")]
+      });
+      assert.equal(decision.outcome, "approved");
+    });
+
+    test("caps the reported file list at 5", () => {
+      const ownedFiles = Array.from({ length: 7 }, (_, i) => file(`apps/api/src/billing/file-${i}.ts`));
+      const decision = setup({ title: "refactor(api): billing sweep", files: ownedFiles });
+      assert.equal(decision.outcome, "blocked");
+      assert.equal(decision.blockers[0].files.length, 5);
+    });
+  });
+
+  describe("blocker aggregation and precedence", () => {
+    test("aggregates multiple blockers", () => {
+      const decision = setup({
+        title: "fix(api): correct billing rounding",
+        files: [file("apps/api/src/billing/rounding.ts")]
+      });
+      assert.equal(decision.outcome, "blocked");
+      assert.deepEqual(decision.blockers.map(b => b.id).sort(), ["code-owned-paths", "missing-regression-test"]);
+    });
+
+    test("blockers take precedence over scope skips", () => {
+      const decision = setup({
+        title: "chore(api): reorganize billing config",
+        files: [file("apps/api/src/billing/config.ts")]
+      });
+      assert.equal(decision.outcome, "blocked");
+    });
+  });
+
+  function file(filename, overrides = {}) {
+    return { filename, status: "modified", previous_filename: undefined, changes: 10, ...overrides };
+  }
+
+  function setup(overrides = {}) {
+    return evaluate({
+      title: "refactor(deploy-web): simplify things",
+      labels: ["experienced-contributor", "size: S"],
+      authorLogin: "human-dev",
+      headRepo: "akash-network/console",
+      baseRepo: "akash-network/console",
+      isDraft: false,
+      files: [{ filename: "apps/deploy-web/src/components/Foo.tsx", status: "modified", changes: 10 }],
+      codeownersContent: CODEOWNERS_FIXTURE,
+      ...overrides
+    });
+  }
+});

--- a/.github/scripts/pr-auto-approval/rules.test.js
+++ b/.github/scripts/pr-auto-approval/rules.test.js
@@ -125,6 +125,15 @@ describe("evaluate", () => {
       assert.equal(decision.outcome, "skipped");
       assert.match(decision.reason, /code files/);
     });
+
+    test("skips a chore touching .mjs or .cjs source files", () => {
+      const decision = setup({
+        title: "chore(dx): tweak eslint config",
+        files: [file("apps/api/eslint.config.mjs")]
+      });
+      assert.equal(decision.outcome, "skipped");
+      assert.match(decision.reason, /code files/);
+    });
   });
 
   describe("fix PRs", () => {

--- a/.github/scripts/pr-auto-approval/rules.test.js
+++ b/.github/scripts/pr-auto-approval/rules.test.js
@@ -75,6 +75,14 @@ describe("evaluate", () => {
       assert.equal(decision.outcome, "approved");
     });
 
+    test("accepts JavaScript test suffixes and repository-root test directories", () => {
+      const decision = setup({
+        title: "test(ci): cover auto-approval rules",
+        files: [file(".github/scripts/pr-auto-approval/rules.test.js"), file("tests/helpers.js"), file("test/setup.mjs")]
+      });
+      assert.equal(decision.outcome, "approved");
+    });
+
     test("skips a test PR touching non-test files", () => {
       const decision = setup({
         title: "test(api): cover wallet top-up",
@@ -124,6 +132,14 @@ describe("evaluate", () => {
       const decision = setup({
         title: "fix(deploy-web): guard empty deployment list",
         files: [file("apps/deploy-web/src/components/DeploymentList.tsx"), file("apps/deploy-web/src/components/DeploymentList.spec.tsx")]
+      });
+      assert.deepEqual(decision, { outcome: "approved", reason: "bug fix within approved scope that includes test changes" });
+    });
+
+    test("counts a JavaScript test file as regression evidence", () => {
+      const decision = setup({
+        title: "fix(ci): correct auto-approval rule",
+        files: [file(".github/scripts/pr-auto-approval/rules.js"), file(".github/scripts/pr-auto-approval/rules.test.js")]
       });
       assert.deepEqual(decision, { outcome: "approved", reason: "bug fix within approved scope that includes test changes" });
     });

--- a/.github/scripts/pr-auto-approval/sticky-comment.js
+++ b/.github/scripts/pr-auto-approval/sticky-comment.js
@@ -1,0 +1,88 @@
+const STICKY_MARKER = "<!-- pr-auto-approval-sticky -->";
+const BOT_LOGIN = "github-actions[bot]";
+
+/**
+ * Maintains a single bot-owned "review blockers" comment per PR: created or
+ * updated while the PR is blocked, flipped to a resolution note once approved,
+ * and used to explain why a previous bot approval was dismissed.
+ */
+async function syncStickyComment({ github, context, core }, { prNumber, decision, dismissed }) {
+  const existing = await findStickyComment({ github, context, prNumber });
+  const body = buildBody({ decision, dismissed, hasExistingComment: Boolean(existing) });
+
+  if (!body) {
+    core.info("No sticky comment update needed");
+    return;
+  }
+
+  if (!existing) {
+    await github.rest.issues.createComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: prNumber,
+      body
+    });
+    core.info("Created sticky comment");
+    return;
+  }
+
+  if (existing.body === body) {
+    core.info("Sticky comment already up to date");
+    return;
+  }
+
+  await github.rest.issues.updateComment({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    comment_id: existing.id,
+    body
+  });
+  core.info("Updated sticky comment");
+}
+
+async function findStickyComment({ github, context, prNumber }) {
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    issue_number: prNumber,
+    per_page: 100
+  });
+  return comments.find(comment => comment.user?.login === BOT_LOGIN && comment.body?.startsWith(STICKY_MARKER));
+}
+
+function buildBody({ decision, dismissed, hasExistingComment }) {
+  if (decision.outcome === "approved") {
+    return hasExistingComment ? resolvedBody() : null;
+  }
+  if (decision.outcome === "blocked") {
+    return blockedBody(decision.blockers, dismissed);
+  }
+  return dismissed ? dismissalBody(decision.reason) : null;
+}
+
+function resolvedBody() {
+  return [STICKY_MARKER, "## PR auto-approval", "", "All previous blockers are resolved — this PR has been auto-approved. :white_check_mark:"].join("\n");
+}
+
+function blockedBody(blockers, dismissed) {
+  const lines = [STICKY_MARKER, "## PR auto-approval blocked", ""];
+  if (dismissed) {
+    lines.push("The previous bot approval was dismissed because this PR no longer qualifies:", "");
+  } else {
+    lines.push("This PR qualifies for auto-approval but is blocked by:", "");
+  }
+  for (const blocker of blockers) {
+    lines.push(`- **${blocker.id}**: ${blocker.message}`);
+    for (const file of blocker.files) {
+      lines.push(`  - \`${file}\``);
+    }
+  }
+  lines.push("", "A blocker is re-evaluated on every CI run; request a review from `@akash-network/console` to merge as-is.");
+  return lines.join("\n");
+}
+
+function dismissalBody(reason) {
+  return [STICKY_MARKER, "## PR auto-approval", "", `The previous bot approval was dismissed because this PR no longer qualifies: ${reason}.`].join("\n");
+}
+
+module.exports = { syncStickyComment, STICKY_MARKER };

--- a/.github/scripts/pr-auto-approval/sticky-comment.js
+++ b/.github/scripts/pr-auto-approval/sticky-comment.js
@@ -11,6 +11,15 @@ async function syncStickyComment({ github, context, core }, { prNumber, decision
   const body = buildBody({ decision, dismissed, hasExistingComment: Boolean(existing) });
 
   if (!body) {
+    if (existing) {
+      await github.rest.issues.deleteComment({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        comment_id: existing.id
+      });
+      core.info("Deleted stale sticky comment");
+      return;
+    }
     core.info("No sticky comment update needed");
     return;
   }
@@ -74,11 +83,26 @@ function blockedBody(blockers, dismissed) {
   for (const blocker of blockers) {
     lines.push(`- **${blocker.id}**: ${blocker.message}`);
     for (const file of blocker.files) {
-      lines.push(`  - \`${file}\``);
+      lines.push(`  - ${inlineCode(file)}`);
     }
   }
   lines.push("", "A blocker is re-evaluated on every CI run; request a review from `@akash-network/console` to merge as-is.");
   return lines.join("\n");
+}
+
+/**
+ * Wraps text in a markdown code span that survives backticks in the content.
+ * Filenames come from attacker-controllable PR paths, which may legally contain
+ * backticks/brackets/parens; a naive `${file}` span could break out and inject
+ * a link into a bot-authored comment. Per CommonMark, a code span is delimited
+ * by a backtick run longer than any run inside it, with one space of padding on
+ * each side so the content can safely start or end with a backtick.
+ */
+function inlineCode(text) {
+  const longestBacktickRun = (String(text).match(/`+/g) || []).reduce((max, run) => Math.max(max, run.length), 0);
+  const fence = "`".repeat(longestBacktickRun + 1);
+  const padding = longestBacktickRun > 0 ? " " : "";
+  return `${fence}${padding}${text}${padding}${fence}`;
 }
 
 function dismissalBody(reason) {

--- a/.github/scripts/pr-auto-approval/sticky-comment.test.js
+++ b/.github/scripts/pr-auto-approval/sticky-comment.test.js
@@ -1,0 +1,156 @@
+const { describe, test } = require("node:test");
+const assert = require("node:assert/strict");
+
+const { syncStickyComment, STICKY_MARKER } = require("./sticky-comment");
+
+describe("syncStickyComment", () => {
+  const BLOCKED_DECISION = {
+    outcome: "blocked",
+    blockers: [
+      {
+        id: "code-owned-paths",
+        message: "These files are on code-owned paths and require @akash-network/console review",
+        files: ["apps/api/src/billing/checkout.ts"]
+      }
+    ]
+  };
+
+  test("creates a comment when blocked and no sticky comment exists", async () => {
+    const { calls, sync } = setup({ comments: [] });
+
+    await sync({ decision: BLOCKED_DECISION, dismissed: false });
+
+    assert.equal(calls.created.length, 1);
+    assert.ok(calls.created[0].body.startsWith(STICKY_MARKER));
+    assert.match(calls.created[0].body, /code-owned paths/);
+    assert.match(calls.created[0].body, /apps\/api\/src\/billing\/checkout\.ts/);
+  });
+
+  test("updates the existing comment when blocked and the body differs", async () => {
+    const { calls, sync } = setup({
+      comments: [stickyComment(42, `${STICKY_MARKER}\nold body`)]
+    });
+
+    await sync({ decision: BLOCKED_DECISION, dismissed: false });
+
+    assert.equal(calls.created.length, 0);
+    assert.equal(calls.updated.length, 1);
+    assert.equal(calls.updated[0].comment_id, 42);
+    assert.match(calls.updated[0].body, /code-owned paths/);
+  });
+
+  test("does nothing when blocked and the existing comment is already up to date", async () => {
+    const body = await setup({ comments: [] }).buildBody({ decision: BLOCKED_DECISION, dismissed: false });
+    const { calls, sync } = setup({ comments: [stickyComment(42, body)] });
+
+    await sync({ decision: BLOCKED_DECISION, dismissed: false });
+
+    assert.equal(calls.created.length, 0);
+    assert.equal(calls.updated.length, 0);
+  });
+
+  test("resolves the comment when approved after being blocked", async () => {
+    const { calls, sync } = setup({
+      comments: [stickyComment(42, `${STICKY_MARKER}\nblockers...`)]
+    });
+
+    await sync({ decision: { outcome: "approved", reason: "refactor within approved scope" }, dismissed: false });
+
+    assert.equal(calls.updated.length, 1);
+    assert.match(calls.updated[0].body, /resolved/);
+    assert.match(calls.updated[0].body, /auto-approved/);
+  });
+
+  test("stays silent when approved with no prior comment", async () => {
+    const { calls, sync } = setup({ comments: [] });
+
+    await sync({ decision: { outcome: "approved", reason: "refactor within approved scope" }, dismissed: false });
+
+    assert.equal(calls.created.length, 0);
+    assert.equal(calls.updated.length, 0);
+  });
+
+  test("stays silent when ineligible without a dismissed approval", async () => {
+    const { calls, sync } = setup({ comments: [] });
+
+    await sync({ decision: { outcome: "ineligible", reason: "missing required size label (XS, S, or M)" }, dismissed: false });
+
+    assert.equal(calls.created.length, 0);
+    assert.equal(calls.updated.length, 0);
+  });
+
+  test("explains the dismissal when a non-approved outcome dismissed a prior approval", async () => {
+    const { calls, sync } = setup({ comments: [] });
+
+    await sync({ decision: { outcome: "ineligible", reason: "missing required size label (XS, S, or M)" }, dismissed: true });
+
+    assert.equal(calls.created.length, 1);
+    assert.match(calls.created[0].body, /dismissed/);
+    assert.match(calls.created[0].body, /missing required size label/);
+  });
+
+  test("mentions the dismissal in the blocked comment when an approval was dismissed", async () => {
+    const { calls, sync } = setup({ comments: [] });
+
+    await sync({ decision: BLOCKED_DECISION, dismissed: true });
+
+    assert.equal(calls.created.length, 1);
+    assert.match(calls.created[0].body, /dismissed/);
+    assert.match(calls.created[0].body, /code-owned paths/);
+  });
+
+  test("ignores marker-less and non-bot comments when locating the sticky comment", async () => {
+    const { calls, sync } = setup({
+      comments: [
+        { id: 1, body: "regular human comment", user: { login: "human-dev" } },
+        { id: 2, body: `${STICKY_MARKER}\nspoofed`, user: { login: "human-dev" } }
+      ]
+    });
+
+    await sync({ decision: BLOCKED_DECISION, dismissed: false });
+
+    assert.equal(calls.updated.length, 0);
+    assert.equal(calls.created.length, 1);
+  });
+
+  function stickyComment(id, body) {
+    return { id, body, user: { login: "github-actions[bot]" } };
+  }
+
+  function setup(input) {
+    const calls = { created: [], updated: [] };
+    const github = {
+      paginate: async (fn, params) => fn(params),
+      rest: {
+        issues: {
+          listComments: async () => input.comments,
+          createComment: async params => {
+            calls.created.push(params);
+          },
+          updateComment: async params => {
+            calls.updated.push(params);
+          }
+        }
+      }
+    };
+    const context = { repo: { owner: "akash-network", repo: "console" } };
+    const core = { info: () => {} };
+    const sync = args => syncStickyComment({ github, context, core }, { prNumber: 123, ...args });
+    const buildBody = args => {
+      let captured;
+      const capturingGithub = {
+        ...github,
+        rest: {
+          issues: {
+            ...github.rest.issues,
+            createComment: async params => {
+              captured = params.body;
+            }
+          }
+        }
+      };
+      return syncStickyComment({ github: capturingGithub, context, core }, { prNumber: 123, ...args }).then(() => captured);
+    };
+    return { calls, sync, buildBody };
+  }
+});

--- a/.github/scripts/pr-auto-approval/sticky-comment.test.js
+++ b/.github/scripts/pr-auto-approval/sticky-comment.test.js
@@ -99,6 +99,46 @@ describe("syncStickyComment", () => {
     assert.match(calls.created[0].body, /code-owned paths/);
   });
 
+  test("escapes filenames so a crafted path cannot break out of the code span", async () => {
+    const { calls, sync } = setup({ comments: [] });
+    const maliciousFile = "apps/api/src/billing/a`[click](http://evil.com)`b.ts";
+
+    await sync({
+      decision: {
+        outcome: "blocked",
+        blockers: [{ id: "code-owned-paths", message: "owned", files: [maliciousFile] }]
+      },
+      dismissed: false
+    });
+
+    const body = calls.created[0].body;
+    assert.ok(body.includes(`  - \`\` ${maliciousFile} \`\``), "filename should be wrapped in a padded double-backtick code span");
+    assert.ok(!body.includes(`  - \`${maliciousFile}\``), "must not use the naive single-backtick span the payload can break out of");
+  });
+
+  test("deletes a stale blocked comment when the PR is no longer blocked or dismissed", async () => {
+    const { calls, sync } = setup({
+      comments: [stickyComment(42, `${STICKY_MARKER}\nblocked by code-owned-paths`)]
+    });
+
+    await sync({ decision: { outcome: "skipped", reason: "PR changes non-test files" }, dismissed: false });
+
+    assert.equal(calls.deleted.length, 1);
+    assert.equal(calls.deleted[0].comment_id, 42);
+    assert.equal(calls.created.length, 0);
+    assert.equal(calls.updated.length, 0);
+  });
+
+  test("stays silent when skipped with no prior comment", async () => {
+    const { calls, sync } = setup({ comments: [] });
+
+    await sync({ decision: { outcome: "skipped", reason: "PR changes non-test files" }, dismissed: false });
+
+    assert.equal(calls.deleted.length, 0);
+    assert.equal(calls.created.length, 0);
+    assert.equal(calls.updated.length, 0);
+  });
+
   test("ignores marker-less and non-bot comments when locating the sticky comment", async () => {
     const { calls, sync } = setup({
       comments: [
@@ -118,7 +158,7 @@ describe("syncStickyComment", () => {
   }
 
   function setup(input) {
-    const calls = { created: [], updated: [] };
+    const calls = { created: [], updated: [], deleted: [] };
     const github = {
       paginate: async (fn, params) => fn(params),
       rest: {
@@ -129,6 +169,9 @@ describe("syncStickyComment", () => {
           },
           updateComment: async params => {
             calls.updated.push(params);
+          },
+          deleteComment: async params => {
+            calls.deleted.push(params);
           }
         }
       }

--- a/.github/workflows/github-actions-lint.yml
+++ b/.github/workflows/github-actions-lint.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Run workflow script tests
+        run: node --test ".github/scripts/**/*.test.js"
       - run: gh extension install https://github.com/cschleiden/gh-actionlint --pin v1.0.3
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/github-actions-lint.yml
+++ b/.github/workflows/github-actions-lint.yml
@@ -5,6 +5,7 @@ on:
     branches: ["main", "main-sdk-next"]
     paths:
       - .github/actions/**
+      - .github/scripts/**
       - .github/workflows/**
 
 permissions:
@@ -15,6 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: package.json
       - name: Run workflow script tests
         run: node --test ".github/scripts/**/*.test.js"
       - run: gh extension install https://github.com/cschleiden/gh-actionlint --pin v1.0.3

--- a/.github/workflows/pr-auto-approval.yml
+++ b/.github/workflows/pr-auto-approval.yml
@@ -19,7 +19,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: pr-auto-approval-${{ github.event.workflow_run.head_sha || inputs.pr-number }}
+  group: pr-auto-approval-${{ github.event.workflow_run.pull_requests[0].number || inputs.pr-number }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/pr-auto-approval.yml
+++ b/.github/workflows/pr-auto-approval.yml
@@ -4,6 +4,15 @@ on:
   workflow_run:
     workflows: ["CI"]
     types: [completed]
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        description: PR number to evaluate
+        required: true
+      dry-run:
+        description: Evaluate and log the decision only; skip approve/dismiss/comment
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -11,7 +20,7 @@ permissions:
 
 jobs:
   check-whether-to-approve:
-    if: github.event.workflow_run.conclusion == 'success'
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     permissions:
       contents: read
       pull-requests: write
@@ -19,61 +28,62 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           sparse-checkout: |
-            ./.github/actions
+            ./.github
       - name: Get associated PR
         id: associated-pr
+        if: github.event_name == 'workflow_run'
         uses: ./.github/actions/associated-pr
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
-      - name: Evaluate auto-approval criteria
-        id: evaluate
-        if: steps.associated-pr.outputs.number != '' && steps.associated-pr.outputs.closed != 'true'
+      - name: Resolve PR (dispatch)
+        id: dispatch-pr
+        if: github.event_name == 'workflow_dispatch'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          PR_NUMBER: ${{ steps.associated-pr.outputs.number }}
-          PR_TITLE: ${{ steps.associated-pr.outputs.title }}
-          PR_LABELS: ${{ steps.associated-pr.outputs.labels }}
-          PR_AUTHOR: ${{ steps.associated-pr.outputs.author }}
-          PR_HEAD_REPO: ${{ steps.associated-pr.outputs.head_repo }}
+          PR_NUMBER: ${{ inputs.pr-number }}
         with:
           script: | # js
-            const prNumber = parseInt(process.env.PR_NUMBER || "");
-            const baseRepo = `${context.repo.owner}/${context.repo.repo}`;
-            const headRepo = process.env.PR_HEAD_REPO ?? "";
-            if (headRepo && headRepo !== baseRepo) {
-              core.info("Skipping: PR is from a fork");
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: parseInt(process.env.PR_NUMBER, 10),
+            });
+            core.setOutput("number", pr.number);
+            core.setOutput("title", pr.title);
+            core.setOutput("author", pr.user.login);
+            core.setOutput("head_repo", pr.head.repo?.full_name || "");
+            core.setOutput("labels", JSON.stringify((pr.labels || []).map(l => l.name)));
+            core.setOutput("closed", pr.closed_at ? "true" : "false");
+            core.setOutput("draft", pr.draft ? "true" : "false");
+      - name: Evaluate auto-approval criteria
+        id: evaluate
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PR_NUMBER: ${{ steps.associated-pr.outputs.number || steps.dispatch-pr.outputs.number }}
+          PR_TITLE: ${{ steps.associated-pr.outputs.title || steps.dispatch-pr.outputs.title }}
+          PR_LABELS: ${{ steps.associated-pr.outputs.labels || steps.dispatch-pr.outputs.labels }}
+          PR_AUTHOR: ${{ steps.associated-pr.outputs.author || steps.dispatch-pr.outputs.author }}
+          PR_HEAD_REPO: ${{ steps.associated-pr.outputs.head_repo || steps.dispatch-pr.outputs.head_repo }}
+          PR_DRAFT: ${{ steps.associated-pr.outputs.draft || steps.dispatch-pr.outputs.draft }}
+          PR_CLOSED: ${{ steps.associated-pr.outputs.closed || steps.dispatch-pr.outputs.closed }}
+        with:
+          script: | # js
+            const fs = require("fs");
+            const { evaluate } = require("./.github/scripts/pr-auto-approval/rules.js");
+
+            const prNumber = parseInt(process.env.PR_NUMBER || "", 10);
+            if (!prNumber) {
+              core.info("No PR associated with this run, skipping");
               return;
             }
-
-            const login = process.env.PR_AUTHOR ?? "";
-            if (/bot/i.test(login)) {
-              core.info(`Skipping: author "${login}" appears to be a bot`);
-              return;
-            }
-
-            const labels = JSON.parse(process.env.PR_LABELS || "[]");
-            core.info(`PR labels: ${labels.join(", ")}`);
-
-            if (!labels.includes("experienced-contributor")) {
-              core.info("Skipping: missing experienced-contributor label");
-              return;
-            }
-
-            const allowedSizes = ["size: XS", "size: S", "size: M"];
-            if (!allowedSizes.some(size => labels.includes(size))) {
-              core.info("Skipping: missing required size label (XS, S, or M)");
-              return;
-            }
-
-            const title = process.env.PR_TITLE ?? "";
-            const isChore = title.startsWith("chore:") || title.startsWith("chore(");
-            const isTest = title.startsWith("test:") || title.startsWith("test(");
-            const isDocs = title.startsWith("docs:") || title.startsWith("docs(");
-
-            if (!isChore && !isTest && !isDocs) {
-              core.info(`Skipping: commit is not one of these types: chore, test, or docs`);
-              return;
+            if (process.env.PR_CLOSED === "true") {
+              if (context.eventName !== "workflow_dispatch") {
+                core.info("PR is closed, skipping");
+                return;
+              }
+              core.info("PR is closed, evaluating anyway (manual dispatch replay)");
             }
 
             const files = await github.paginate(github.rest.pulls.listFiles, {
@@ -82,45 +92,37 @@ jobs:
               pull_number: prNumber,
               per_page: 100,
             });
-            const filenames = files.map(f => f.filename);
 
-            if (isTest) {
-              const testFilePattern = /(\.(spec|integration)\.(ts|tsx)$|\/tests?\/)|(jest|vitest)\.config\.[tj]s$/;
-              const onlyTestFiles = filenames.every(f => testFilePattern.test(f));
-              if (!onlyTestFiles) {
-                core.info("Skipping test: PR changes non-test files");
-                return;
-              }
+            const decision = evaluate({
+              title: process.env.PR_TITLE ?? "",
+              labels: JSON.parse(process.env.PR_LABELS || "[]"),
+              authorLogin: process.env.PR_AUTHOR ?? "",
+              headRepo: process.env.PR_HEAD_REPO ?? "",
+              baseRepo: `${context.repo.owner}/${context.repo.repo}`,
+              isDraft: process.env.PR_DRAFT === "true",
+              files: files.map(f => ({
+                filename: f.filename,
+                status: f.status,
+                previous_filename: f.previous_filename,
+                changes: f.changes,
+              })),
+              codeownersContent: fs.readFileSync(".github/CODEOWNERS", "utf8"),
+            });
 
-              core.setOutput("approval-reason", "all changes are related to tests");
-            } else if (isDocs) {
-              const imagePattern = /\.(png|jpg|jpeg|gif|svg|webp|ico|bmp)$/i;
-              const docsFilePattern = f => f.endsWith(".md") || imagePattern.test(f);
-              const onlyDocFiles = filenames.every(docsFilePattern);
-              if (!onlyDocFiles) {
-                core.info("Skipping docs: PR changes non-documentation files");
-                return;
-              }
+            core.info(`Auto-approval decision: ${JSON.stringify(decision, null, 2)}`);
+            core.setOutput("outcome", decision.outcome);
+            core.setOutput("decision", JSON.stringify(decision));
+            core.setOutput("approval-reason", decision.outcome === "approved" ? decision.reason : "");
 
-              core.setOutput("approval-reason", "all changes are related to documentation");
-            } else if (isChore) {
-              const sourceCodeFile = /\.(ts|tsx|js|jsx)$/;
-              const touchesCode = filenames.some(f => {
-                return sourceCodeFile.test(f) && (f.includes("/packages/") || f.includes("/apps/"));
-              });
-              if (touchesCode) {
-                core.info("Skipping chore: PR touches code files in packages/ or apps/");
-                return;
-              }
-
-              core.setOutput("approval-reason", "chore that does not touch source code files");
-            }
-
+            const dismissalReason = decision.outcome === "blocked"
+              ? `auto-approval blockers: ${decision.blockers.map(b => b.id).join(", ")}`
+              : decision.reason ?? "";
+            core.setOutput("dismissal-reason", dismissalReason);
       - name: Approve PR
-        if: steps.evaluate.outputs.approval-reason != ''
+        if: steps.evaluate.outputs.outcome == 'approved' && inputs.dry-run != true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ steps.associated-pr.outputs.number }}
+          PR_NUMBER: ${{ steps.associated-pr.outputs.number || steps.dispatch-pr.outputs.number }}
           APPROVAL_REASON: ${{ steps.evaluate.outputs.approval-reason }}
         run: | # shell
           should_skip=$(gh pr view "$PR_NUMBER" \
@@ -138,3 +140,41 @@ jobs:
           else
             gh pr review "$PR_NUMBER" -R "$GITHUB_REPOSITORY" --approve --body "Auto-approved: $APPROVAL_REASON."
           fi
+      - name: Dismiss stale approval
+        id: dismiss
+        if: steps.evaluate.outputs.outcome != '' && steps.evaluate.outputs.outcome != 'approved' && inputs.dry-run != true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.associated-pr.outputs.number || steps.dispatch-pr.outputs.number }}
+          DISMISSAL_REASON: ${{ steps.evaluate.outputs.dismissal-reason }}
+        run: | # shell
+          review_id=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" --paginate \
+            --jq '[.[] | select(.user.login == "github-actions[bot]" and .state == "APPROVED")] | last | .id // empty'
+          );
+
+          if [ -z "$review_id" ]; then
+            echo "No active bot approval to dismiss";
+            echo "dismissed=false" >> "$GITHUB_OUTPUT";
+          else
+            gh api -X PUT "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews/$review_id/dismissals" \
+              -f message="Auto-approval revoked: $DISMISSAL_REASON";
+            echo "dismissed=true" >> "$GITHUB_OUTPUT";
+          fi
+      - name: Sync review-blockers comment
+        if: (steps.evaluate.outputs.outcome == 'blocked' || steps.evaluate.outputs.outcome == 'approved' || steps.dismiss.outputs.dismissed == 'true') && inputs.dry-run != true
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PR_NUMBER: ${{ steps.associated-pr.outputs.number || steps.dispatch-pr.outputs.number }}
+          DECISION: ${{ steps.evaluate.outputs.decision }}
+          DISMISSED: ${{ steps.dismiss.outputs.dismissed }}
+        with:
+          script: | # js
+            const { syncStickyComment } = require("./.github/scripts/pr-auto-approval/sticky-comment.js");
+            await syncStickyComment(
+              { github, context, core },
+              {
+                prNumber: parseInt(process.env.PR_NUMBER, 10),
+                decision: JSON.parse(process.env.DECISION),
+                dismissed: process.env.DISMISSED === "true",
+              }
+            );

--- a/.github/workflows/pr-auto-approval.yml
+++ b/.github/workflows/pr-auto-approval.yml
@@ -18,6 +18,10 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: pr-auto-approval-${{ github.event.workflow_run.head_sha || inputs.pr-number }}
+  cancel-in-progress: false
+
 jobs:
   check-whether-to-approve:
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
@@ -30,7 +34,7 @@ jobs:
         with:
           persist-credentials: false
           sparse-checkout: |
-            ./.github
+            .github
       - name: Get associated PR
         id: associated-pr
         if: github.event_name == 'workflow_run'
@@ -148,8 +152,8 @@ jobs:
           PR_NUMBER: ${{ steps.associated-pr.outputs.number || steps.dispatch-pr.outputs.number }}
           DISMISSAL_REASON: ${{ steps.evaluate.outputs.dismissal-reason }}
         run: | # shell
-          review_id=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" --paginate \
-            --jq '[.[] | select(.user.login == "github-actions[bot]" and .state == "APPROVED")] | last | .id // empty'
+          review_id=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" --paginate --slurp \
+            | jq -r '[.[][] | select(.user.login == "github-actions[bot]" and .state == "APPROVED")] | last | .id // empty'
           );
 
           if [ -z "$review_id" ]; then
@@ -161,7 +165,7 @@ jobs:
             echo "dismissed=true" >> "$GITHUB_OUTPUT";
           fi
       - name: Sync review-blockers comment
-        if: (steps.evaluate.outputs.outcome == 'blocked' || steps.evaluate.outputs.outcome == 'approved' || steps.dismiss.outputs.dismissed == 'true') && inputs.dry-run != true
+        if: steps.evaluate.outputs.outcome != '' && inputs.dry-run != true
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PR_NUMBER: ${{ steps.associated-pr.outputs.number || steps.dispatch-pr.outputs.number }}

--- a/knip.json
+++ b/knip.json
@@ -2,14 +2,7 @@
   "$schema": "https://unpkg.com/knip@6/schema.json",
   "tags": ["-lintignore"],
   "exclude": ["exports", "types", "enumMembers"],
-  "ignoreBinaries": [
-    "dc",
-    "drizzle-kit",
-    "eslint",
-    "prettier",
-    "tsc",
-    "script/safe-deps-install.sh"
-  ],
+  "ignoreBinaries": ["dc", "drizzle-kit", "eslint", "prettier", "tsc", "script/safe-deps-install.sh"],
   "ignoreDependencies": [
     "@akashnetwork/releaser",
     "@typescript-eslint/eslint-plugin",
@@ -22,32 +15,18 @@
   ],
   "workspaces": {
     ".": {
-      "entry": [".eslintrc.js", ".prettierrc.js"],
-      "ignoreDependencies": [
-        "@interchain-ui/react",
-        "drizzle-orm",
-        "nock",
-        "pg",
-        "eslint-plugin-import-x",
-        "vitest"
-      ]
+      "entry": [".eslintrc.js", ".prettierrc.js", ".github/scripts/**/*.js"],
+      "ignoreDependencies": ["@interchain-ui/react", "drizzle-orm", "nock", "pg", "eslint-plugin-import-x", "vitest"]
     },
     "apps/api": {
       "entry": ["scripts/buildAkashTemplatesCache.ts"],
       "project": ["src/**/*.ts", "test/**/*.ts", "scripts/**/*.ts"],
-      "ignore": [
-        "test/seeders/balance.seeder.ts"
-      ],
+      "ignore": ["test/seeders/balance.seeder.ts"],
       "drizzle": false
     },
     "apps/deploy-web": {
       "entry": ["next.config.js", "postcss.config.js", "src/pages/**/*.tsx", "src/pages/**/*.ts", "src/stubs/empty.ts"],
-      "ignoreDependencies": [
-        "sharp",
-        "@nivo/core",
-        "@react-spring/web",
-        "webpack"
-      ]
+      "ignoreDependencies": ["sharp", "@nivo/core", "@react-spring/web", "webpack"]
     },
     "apps/stats-web": {
       "entry": ["src/app/**/*.tsx", "src/app/**/*.ts"],
@@ -90,13 +69,7 @@
       "ignoreDependencies": ["@akashnetwork/dev-config"]
     },
     "packages/dev-config": {
-      "entry": [
-        ".eslintrc.base.js",
-        ".eslintrc.ts.js",
-        ".eslintrc.next.js",
-        "tsup-plugins.ts",
-        "eslint-plugin-akash/index.js"
-      ],
+      "entry": [".eslintrc.base.js", ".eslintrc.ts.js", ".eslintrc.next.js", "tsup-plugins.ts", "eslint-plugin-akash/index.js"],
       "ignoreDependencies": ["eslint-plugin-akash", "next"]
     },
     "packages/env-loader": {},


### PR DESCRIPTION
## Why

The auto-approval workflow only ever approved `chore`/`test`/`docs` PRs, and even those approvals were mostly decorative: the `protected3` ruleset requires a **code-owner** review and `CODEOWNERS` blanket-owned `/apps/*/src/` and `/packages/*/src/`, so any code-touching PR needed a human regardless. This implements the mechanically-checkable subset of the team's Slack rules for AI-driven tasks (size cap, task categorization, risk map, migrations/public API need humans) as a two-layer system:

1. **CODEOWNERS becomes the risk map** — only genuinely critical paths stay owned, so GitHub natively enforces human review exactly where the rules demand it, and everything else becomes bot-approvable.
2. **The approval action loosens** — `fix` (with regression-test evidence) and `refactor` PRs up to `size: M` from `experienced-contributor` authors auto-approve.

## What

### Behavior changes

**Loosening**
- `fix` PRs (must add/update at least one test file) and `refactor` PRs ≤ `size: M` now auto-approve and become mergeable without a human on un-owned paths.
- Most src paths (components, services, indexer, stats-web, most packages) lose the hard code-owner gate for **all** PRs — `feat`/XL/untrusted PRs there now need any-collaborator approval instead of specifically a code owner (accepted trade-off; in practice reviewers are the same team).
- The `test:` scope check additionally accepts `.test.`/`.e2e.` suffixes and `playwright.config.*`.

**Intentional tightening**
- `apps/*/drizzle/`, `apps/*/env/`, and all `Dockerfile*` become code-owned. Today they are un-owned **and** chore-approvable, i.e. zero-human mergeable — this closes that gap.
- Draft PRs are never auto-approved (previously a draft could be).
- Stale bot approvals are **dismissed** when a re-evaluation stops qualifying (the ruleset has `dismiss_stale_reviews_on_push: false`, so the action cleans up after itself), with a sticky comment explaining why.
- Qualifying PRs that touch owned paths get an explanatory sticky comment instead of a decorative approval.

### Mechanics

- Engine extracted to `.github/scripts/pr-auto-approval/` (CommonJS, zero-dependency, tested with `node:test`): a gitignore-style CODEOWNERS parser (**the action parses `.github/CODEOWNERS` as the single source of truth** for its owned-path blocker — no duplicated path list), a pure `evaluate()` decision engine with 4 outcomes (`ineligible`/`blocked`/`skipped`/`approved`), and a sticky-comment upserter.
- Workflow gains `workflow_dispatch` with `pr-number` + `dry-run` (default **true**) as a replay harness; the decision JSON is always logged.
- `associated-pr` action gains a `draft` output.
- `github-actions-lint.yml` runs the script tests; `knip.json` registers the scripts as entries.
- All PR-controlled values flow through `env:`, never `${{ }}` in script bodies.

### Deviations & notes for reviewers

- **`*.test.js` naming** deviates from the repo's `*.spec.ts` convention — it's the `node --test` discovery default and these files are outside vitest/tsc scope (`.github/**` is also outside the codecov patch gate).
- The legacy chore scope check (`f.includes("/apps/")`) never matched because `listFiles` paths have no leading slash; the port fixes this latent bug (`/^(apps|packages)\//`), so chores touching code are now correctly skipped.
- This PR is deliberately **atomic**: CODEOWNERS + parser + workflow move together because `codeowners.test.js` pins the real file's policy semantics (billing owned, components un-owned, spec files un-owned, drizzle owned).
- `workflow_run` executes the main-branch engine, so a PR can never approve itself with modified rules; this PR touches `.github/**` (owned) and requires console-team review.
- Known accepted gap: title-only edits and draft-conversion don't re-run CI, so re-evaluation/dismissal waits for the next push.
- Rollback: revert the workflow file (scripts become inert); reverting CODEOWNERS restores the old human gate independently.

### Verification

- 53 unit tests green (`node --test ".github/scripts/**/*.test.js"`), `actionlint` clean, `zizmor` findings identical to the pre-change baseline, `npx knip --workspace .` unchanged vs main.
- Branch `workflow_dispatch` dry-runs replayed real historical PRs; every decision matched the file evidence:

| PR | Type/size | Expected | Decision log |
|---|---|---|---|
| #3411 | fix, S, deploy-web components + spec | approved | `approved: bug fix within approved scope that includes test changes` |
| #3260 | docs, XS | approved | `approved: all changes are related to documentation` |
| #3526 | fix, M, touches `apps/api/src/billing/` + `apps/tx-signer/` | blocked | `blocked: code-owned-paths` |
| #3262 | chore, S, removes `.helm/` files | blocked | `blocked: code-owned-paths` |
| #2798 | refactor, L | ineligible | `ineligible: missing required size label (XS, S, or M)` |
| #3253 | refactor, S, drizzle dep upgrade (src + manifests only) | approved | `approved: refactor within approved scope` |

Post-merge follow-up: run a scratch `fix:` PR without a test to empirically confirm comment/dismissal permissions (`pull-requests: write` should suffice; fallback is adding `issues: write`), then monitor the first organic approvals for a week and tune CODEOWNERS as needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated pull request approval with eligibility checks, policy validation, and clear approval or blocking reasons.
  * Added optional dry-run and manual PR evaluation support.
  * Added synchronized status comments describing blockers, dismissals, or successful resolution.
  * Expanded ownership rules for critical business and public API areas.

* **Tests**
  * Added comprehensive coverage for approval rules, ownership matching, and status comments.

* **Chores**
  * Automated validation now runs script tests during workflow linting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->