### PR TITLE
fix(deployment): upgrade chain-sdk to alpha.41 and adapt bigint resource decode

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@akashnetwork/akash-api": "1.4.3",
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.39",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
     "@akashnetwork/console-api-types": "*",
     "@akashnetwork/database": "*",
     "@akashnetwork/env-loader": "*",

--- a/apps/api/src/billing/services/trial-validation/trial-validation.service.spec.ts
+++ b/apps/api/src/billing/services/trial-validation/trial-validation.service.spec.ts
@@ -142,7 +142,7 @@ describe(TrialValidationService.name, () => {
                 resource: {
                   id: 1,
                   gpu: {
-                    units: { val: new Uint8Array([1]) },
+                    units: { val: BigInt(1) },
                     attributes: [{ key: `vendor/${vendor}/model/${model}`, value: "true" }]
                   }
                 },

--- a/apps/api/src/deployment/services/blocked-gpu/blocked-gpu.service.spec.ts
+++ b/apps/api/src/deployment/services/blocked-gpu/blocked-gpu.service.spec.ts
@@ -41,7 +41,7 @@ describe(BlockedGpuService.name, () => {
                 resource: {
                   id: 1,
                   gpu: {
-                    units: { val: new Uint8Array([1]) },
+                    units: { val: BigInt(1) },
                     attributes: [{ key: "vendor/nvidia/model/h100", value: "true" }]
                   }
                 },

--- a/apps/api/src/gpu/services/gpu-price/gpu-price.service.spec.ts
+++ b/apps/api/src/gpu/services/gpu-price/gpu-price.service.spec.ts
@@ -142,6 +142,7 @@ describe(GpuPriceService.name, () => {
       const bestBid = result.models[0].providersWithBestBid![0].bestBid;
       expect(bestBid.deployment.cpuUnits).toBe(2000);
       expect(bestBid.deployment.memoryUnits).toBe(1073741824);
+      expect(bestBid.deployment.storageUnits).toBe(10737418240);
       expect(bestBid.deployment.gpus).toHaveLength(1);
     });
 

--- a/apps/api/src/gpu/services/gpu-price/gpu-price.service.spec.ts
+++ b/apps/api/src/gpu/services/gpu-price/gpu-price.service.spec.ts
@@ -105,6 +105,46 @@ describe(GpuPriceService.name, () => {
       expect(result.models[0].priceUakt?.currency).toBe("uakt");
     });
 
+    it("parses v1beta5 resource units that decode as bigint", async () => {
+      const provider = createProvider();
+      const gpu = createGpuType({
+        vendor: "nvidia",
+        model: "a100",
+        ram: "80Gi",
+        interface: "pcie",
+        providers: [provider]
+      });
+
+      const bidData = createMsgCreateBidV5({
+        provider: provider.owner,
+        gpuVendor: "nvidia",
+        gpuModel: "a100",
+        gpuRam: "80Gi",
+        gpuInterface: "pcie",
+        cpuUnits: 2000
+      });
+
+      const days = [createDay({ aktPrice: 3.0 })];
+      const deployment = createDeploymentWithBid({
+        dayId: days[0].id,
+        bidData: bidData.encoded,
+        bidType: `/akash.market.v1beta5.MsgCreateBid`
+      });
+
+      const { service } = setup({
+        gpusForPricing: [gpu],
+        deploymentsWithGpu: [deployment],
+        days
+      });
+
+      const result = await service.getGpuPrices(true);
+
+      const bestBid = result.models[0].providersWithBestBid![0].bestBid;
+      expect(bestBid.deployment.cpuUnits).toBe(2000);
+      expect(bestBid.deployment.memoryUnits).toBe(1073741824);
+      expect(bestBid.deployment.gpus).toHaveLength(1);
+    });
+
     it("ignores bids with IBC denomination", async () => {
       const provider = createProvider();
       const gpu = createGpuType({
@@ -723,13 +763,13 @@ describe(GpuPriceService.name, () => {
             id: 1,
             cpu: {
               units: {
-                val: new TextEncoder().encode(cpuUnits.toString())
+                val: BigInt(cpuUnits)
               },
               attributes: []
             },
             memory: {
               quantity: {
-                val: new TextEncoder().encode(memoryUnits.toString())
+                val: BigInt(memoryUnits)
               },
               attributes: []
             },
@@ -737,14 +777,14 @@ describe(GpuPriceService.name, () => {
               {
                 name: "default",
                 quantity: {
-                  val: new TextEncoder().encode(storageUnits.toString())
+                  val: BigInt(storageUnits)
                 },
                 attributes: []
               }
             ],
             gpu: {
               units: {
-                val: new TextEncoder().encode(gpuCount.toString())
+                val: BigInt(gpuCount)
               },
               attributes: gpuAttributes
             },
@@ -794,13 +834,13 @@ describe(GpuPriceService.name, () => {
             id: 1,
             cpu: {
               units: {
-                val: new TextEncoder().encode(cpuUnits.toString())
+                val: BigInt(cpuUnits)
               },
               attributes: []
             },
             memory: {
               quantity: {
-                val: new TextEncoder().encode(memoryUnits.toString())
+                val: BigInt(memoryUnits)
               },
               attributes: []
             },
@@ -808,14 +848,14 @@ describe(GpuPriceService.name, () => {
               {
                 name: "default",
                 quantity: {
-                  val: new TextEncoder().encode(storageUnits.toString())
+                  val: BigInt(storageUnits)
                 },
                 attributes: []
               }
             ],
             gpu: {
               units: {
-                val: new TextEncoder().encode(input.gpuTypes.length.toString())
+                val: BigInt(input.gpuTypes.length)
               },
               attributes: gpuAttributes
             },

--- a/apps/api/src/gpu/services/gpu-price/gpu-price.service.ts
+++ b/apps/api/src/gpu/services/gpu-price/gpu-price.service.ts
@@ -20,6 +20,12 @@ import type { GpuConfig } from "../../config/env.config";
 import { GPU_CONFIG } from "../../providers/config.provider";
 import { DayRepository } from "../../repositories/day.repository";
 
+/** Resource quantities decode as bigint from chain-sdk (v1beta5) bids but as Uint8Array from akash-api (v1beta4). */
+function resourceValToInt(val: Uint8Array | bigint | undefined): number {
+  if (typeof val === "bigint") return Number(val);
+  return val ? parseInt(uint8arrayToString(val)) : 0;
+}
+
 @injectable()
 export class GpuPriceService {
   readonly #gpuConfig: GpuConfig;
@@ -93,7 +99,7 @@ export class GpuPriceService {
         if (isUakt && (!day || !day.aktPrice)) return; // uakt bids need AKT price for USD conversion
 
         const bidGpus = decodedBid.resourcesOffer
-          .filter((x: any) => (x.resources?.gpu?.units?.val ? parseInt(uint8arrayToString(x.resources.gpu.units.val)) : 0) > 0)
+          .filter((x: any) => resourceValToInt(x.resources?.gpu?.units?.val) > 0)
           .flatMap((r: any) => (r.resources?.gpu?.attributes ? this.getGpusFromAttributes(r.resources.gpu.attributes) : []));
 
         // Ignore bids for deployments with more than 1 GPU
@@ -114,15 +120,13 @@ export class GpuPriceService {
           monthlyPriceUakt: isUakt ? this.blockPriceToMonthlyUakt(priceAmount) : aktPrice ? this.blockPriceToMonthlyUakt(priceAmount / aktPrice) : null,
           deployment: {
             owner: d.owner,
-            cpuUnits: decodedBid.resourcesOffer
-              .flatMap((r: any) => (r.resources?.cpu?.units?.val ? parseInt(uint8arrayToString(r.resources.cpu.units.val)) : 0))
-              .reduce((a: number, b: number) => a + b, 0),
+            cpuUnits: decodedBid.resourcesOffer.flatMap((r: any) => resourceValToInt(r.resources?.cpu?.units?.val)).reduce((a: number, b: number) => a + b, 0),
             memoryUnits: decodedBid.resourcesOffer
-              .flatMap((r: any) => (r.resources?.memory?.quantity?.val ? parseInt(uint8arrayToString(r.resources.memory.quantity.val)) : 0))
+              .flatMap((r: any) => resourceValToInt(r.resources?.memory?.quantity?.val))
               .reduce((a: number, b: number) => a + b, 0),
             storageUnits: decodedBid.resourcesOffer
               .flatMap((r: any) => r.resources?.storage)
-              .map((s: any) => (s?.quantity?.val ? parseInt(uint8arrayToString(s.quantity.val)) : 0))
+              .map((s: any) => resourceValToInt(s?.quantity?.val))
               .reduce((a: number, b: number) => a + b, 0),
             gpus: bidGpus
           },

--- a/apps/api/src/gpu/services/gpu-price/gpu-price.service.ts
+++ b/apps/api/src/gpu/services/gpu-price/gpu-price.service.ts
@@ -23,7 +23,8 @@ import { DayRepository } from "../../repositories/day.repository";
 /** Resource quantities decode as bigint from chain-sdk (v1beta5) bids but as Uint8Array from akash-api (v1beta4). */
 function resourceValToInt(val: Uint8Array | bigint | undefined): number {
   if (typeof val === "bigint") return Number(val);
-  return val ? parseInt(uint8arrayToString(val)) : 0;
+  if (!val || val.length === 0) return 0;
+  return parseInt(uint8arrayToString(val), 10);
 }
 
 @injectable()

--- a/apps/api/test/functional/gpu.spec.ts
+++ b/apps/api/test/functional/gpu.spec.ts
@@ -642,18 +642,18 @@ describe("GPU API", () => {
                   resources: {
                     cpu: {
                       units: {
-                        val: Buffer.from("1000000")
+                        val: BigInt("1000000")
                       }
                     },
                     memory: {
                       quantity: {
-                        val: Buffer.from("1024")
+                        val: BigInt("1024")
                       }
                     },
                     storage: [
                       {
                         quantity: {
-                          val: Buffer.from("1024")
+                          val: BigInt("1024")
                         }
                       }
                     ],
@@ -665,7 +665,7 @@ describe("GPU API", () => {
                         }
                       ],
                       units: {
-                        val: Buffer.from("2")
+                        val: BigInt("2")
                       }
                     }
                   }
@@ -706,18 +706,18 @@ describe("GPU API", () => {
                   resources: {
                     cpu: {
                       units: {
-                        val: Buffer.from("1000000")
+                        val: BigInt("1000000")
                       }
                     },
                     memory: {
                       quantity: {
-                        val: Buffer.from("1024")
+                        val: BigInt("1024")
                       }
                     },
                     storage: [
                       {
                         quantity: {
-                          val: Buffer.from("1024")
+                          val: BigInt("1024")
                         }
                       }
                     ],
@@ -729,7 +729,7 @@ describe("GPU API", () => {
                         }
                       ],
                       units: {
-                        val: Buffer.from("2")
+                        val: BigInt("2")
                       }
                     }
                   }

--- a/apps/deploy-web/package.json
+++ b/apps/deploy-web/package.json
@@ -26,7 +26,7 @@
     "type-check": "tsc"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.39",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
     "@akashnetwork/console-api-types": "*",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",

--- a/apps/deploy-web/src/queries/useScreenedProviders.spec.tsx
+++ b/apps/deploy-web/src/queries/useScreenedProviders.spec.tsx
@@ -190,7 +190,7 @@ describe("buildPlacementScreeningRequest", () => {
     const request = buildPlacementScreeningRequest(SMALL_PRESET_SDL_NO_IMAGE, "dcloud");
 
     expect(request).not.toBeNull();
-    expect(atob(request?.resources[0].resource.cpu.units.val ?? "")).toBe("1000");
+    expect(request?.resources[0].resource.cpu.units.val).toBe("1000");
   });
 
   it("returns null when the placement is not in the SDL", () => {

--- a/apps/deploy-web/src/queries/useScreenedProviders.ts
+++ b/apps/deploy-web/src/queries/useScreenedProviders.ts
@@ -95,7 +95,7 @@ export function useScreenedProviders({ sdl, placementName, enabled = true }: Use
  * when the SDL is incomplete/invalid (e.g. mid-edit) or the placement isn't in it yet, so the caller can
  * fall back to the full catalog. `signedBy` forces audited-only screening; `attributes` are passed through
  * from the placement and carry the `location-region` filter (and any other declared attribute). The proto
- * JSON encodes resource values as base64 integer strings, which the screening endpoint accepts.
+ * JSON encodes resource values as decimal integer strings, which the screening endpoint accepts.
  */
 export function buildPlacementScreeningRequest(rawSdl: string, placementName: string): ScreeningRequestBody | null {
   if (!rawSdl) return null;

--- a/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.spec.ts
+++ b/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.spec.ts
@@ -49,17 +49,18 @@ describe(ProviderProxyService.name, () => {
               expose: [],
               credentials: undefined,
               params: undefined,
+              interconnectGroup: "",
               resources: {
                 id: 1,
                 cpu: {
                   units: {
-                    val: new TextEncoder().encode("0.5")
+                    val: BigInt(500)
                   },
                   attributes: []
                 },
                 memory: {
                   quantity: {
-                    val: new TextEncoder().encode("512Mi")
+                    val: BigInt(536870912)
                   },
                   attributes: []
                 },
@@ -67,7 +68,7 @@ describe(ProviderProxyService.name, () => {
                   {
                     name: "test",
                     quantity: {
-                      val: new TextEncoder().encode("512Mi")
+                      val: BigInt(536870912)
                     },
                     attributes: []
                   }

--- a/apps/indexer/package.json
+++ b/apps/indexer/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@akashnetwork/akash-api": "1.4.3",
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.39",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
     "@akashnetwork/database": "*",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/instrumentation": "*",

--- a/apps/indexer/src/indexers/akashStatsIndexer.ts
+++ b/apps/indexer/src/indexers/akashStatsIndexer.ts
@@ -508,20 +508,20 @@ export class AkashStatsIndexer extends Indexer {
         await DeploymentGroupResource.create(
           {
             deploymentGroupId: createdGroup.id,
-            cpuUnits: parseInt(uint8arrayToString(groupResource.resource?.cpu?.units?.val) || "0"),
-            gpuUnits: parseInt(uint8arrayToString(groupResource.resource?.gpu?.units?.val) || "0"),
+            cpuUnits: Number(groupResource.resource?.cpu?.units?.val ?? 0),
+            gpuUnits: Number(groupResource.resource?.gpu?.units?.val ?? 0),
             gpuVendor: gpuVendor,
             gpuModel: gpuModel,
-            memoryQuantity: parseInt(uint8arrayToString(groupResource.resource?.memory?.quantity?.val) || "0"),
+            memoryQuantity: Number(groupResource.resource?.memory?.quantity?.val ?? 0),
             ephemeralStorageQuantity:
               groupResource.resource?.storage
                 ?.filter(x => !isPersistentStorage(x))
-                .map(x => parseInt(uint8arrayToString(x.quantity?.val) || "0"))
+                .map(x => Number(x.quantity?.val ?? 0))
                 .reduce((a, b) => a + b, 0) ?? 0,
             persistentStorageQuantity:
               groupResource.resource?.storage
                 ?.filter(x => isPersistentStorage(x))
-                .map(x => parseInt(uint8arrayToString(x.quantity?.val) || "0"))
+                .map(x => Number(x.quantity?.val ?? 0))
                 .reduce((a, b) => a + b, 0) ?? 0,
             count: groupResource.count,
             price: parseFloat(groupResource.price?.amount ?? "0") // TODO: handle denom

--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -36,7 +36,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.39",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",
     "@akashnetwork/instrumentation": "*",

--- a/apps/provider-inventory/package.json
+++ b/apps/provider-inventory/package.json
@@ -24,7 +24,7 @@
     "test:unit": "vitest run --project unit"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.39",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/instrumentation": "*",
     "@akashnetwork/logging": "*",

--- a/apps/provider-proxy/package.json
+++ b/apps/provider-proxy/package.json
@@ -20,7 +20,7 @@
     "test:unit": "vitest run --project unit"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.39",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/instrumentation": "*",
     "@akashnetwork/logging": "*",

--- a/apps/stats-web/package.json
+++ b/apps/stats-web/package.json
@@ -14,7 +14,7 @@
     "test:unit": "NODE_ENV=test vitest run"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.39",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/logging": "*",
     "@akashnetwork/network-store": "*",

--- a/apps/tx-signer/package.json
+++ b/apps/tx-signer/package.json
@@ -21,7 +21,7 @@
     "test:unit": "vitest run --project unit"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.39",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",
     "@akashnetwork/instrumentation": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akash-api": "1.4.3",
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.39",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
         "@akashnetwork/console-api-types": "*",
         "@akashnetwork/database": "*",
         "@akashnetwork/env-loader": "*",
@@ -536,7 +536,7 @@
       "version": "3.31.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.39",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
         "@akashnetwork/console-api-types": "*",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
@@ -2164,7 +2164,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akash-api": "1.4.3",
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.39",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
         "@akashnetwork/database": "*",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/instrumentation": "*",
@@ -2542,7 +2542,7 @@
       "version": "2.16.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.39",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
         "@akashnetwork/instrumentation": "*",
@@ -3687,7 +3687,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.39",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/instrumentation": "*",
         "@akashnetwork/logging": "*",
@@ -4027,7 +4027,7 @@
       "version": "2.10.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.39",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/instrumentation": "*",
         "@akashnetwork/logging": "*",
@@ -4204,7 +4204,7 @@
       "name": "@akashnetwork/stats-web",
       "version": "1.14.1",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.39",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/logging": "*",
         "@akashnetwork/network-store": "*",
@@ -4968,7 +4968,7 @@
       "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.39",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
         "@akashnetwork/instrumentation": "*",
@@ -5203,9 +5203,9 @@
       }
     },
     "node_modules/@akashnetwork/chain-sdk": {
-      "version": "1.0.0-alpha.39",
-      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.39.tgz",
-      "integrity": "sha512-u8Dk90wcns86ZaYtHF0m+fOJCCzY7uwtX3JpEmc7Mn8ogsjCaCoBhHYb7RnnZLURAtF9xLvTDtOjdXYjPwjdFg==",
+      "version": "1.0.0-alpha.41",
+      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.41.tgz",
+      "integrity": "sha512-mr3fGDBSISxl0eZF83+IJLVulGSuJVu+MRj6fG61pi2rgfgnv9QEKpdU3w7wtFFt5saJaJNgsqAlyjGZQecZ1A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.12.0",
@@ -45213,7 +45213,7 @@
       "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.39",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
         "@akashnetwork/net": "*",
         "jotai": "^2.9.2"
       },

--- a/packages/network-store/package.json
+++ b/packages/network-store/package.json
@@ -18,7 +18,7 @@
     "validate:types": "tsc --noEmit && echo"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.39",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
     "@akashnetwork/net": "*",
     "jotai": "^2.9.2"
   },


### PR DESCRIPTION
## Why

Bumps `@akashnetwork/chain-sdk` from `1.0.0-alpha.39` to `1.0.0-alpha.41` (the latest alpha, published from [this release run](https://github.com/akash-network/chain-sdk/actions/runs/30635384387)). alpha.40 shipped a breaking change to how resource quantities decode, so the bump is not purely mechanical; this PR adapts the affected code.

## What

Bumps chain-sdk to `alpha.41` across all 9 workspace packages plus the lockfile.

**chain-sdk breaking change (alpha.40, [chain-sdk#347](https://github.com/akash-network/chain-sdk/pull/347)):** `ResourceValue.val` (the cpu/memory/storage/gpu quantity fields inside deployment and bid protobuf messages) changed from `Uint8Array` to `bigint`. Only the two places that decode chain-sdk protobuf and read `.val` directly are affected:

- **`apps/indexer`** `handleCreateDeploymentV4` (v1beta4 deployment decode): was a hard `tsc` compile error. Now reads the bigint directly via `Number(...)`. The sibling v1beta1/2/3 handlers decode `@akashnetwork/akash-api` messages (still `Uint8Array`) and are left untouched.
- **`apps/api`** gpu-price service (v1beta5 bid decode): the callbacks are `any`-typed, so `tsc` did **not** catch this, but at runtime `uint8arrayToString(bigint)` throws, crashing GPU pricing for every v1beta5 GPU bid. Routed the four call sites through a small helper that accepts both `bigint` (chain-sdk v1beta5) and `Uint8Array` (akash-api v1beta4). Added a v1beta5 unit test that asserts the decoded units as a regression guard for this compiler-invisible break.

alpha.40 also made manifest `Service.interconnectGroup` required (GPU interconnect multinode, chain-sdk#315); updated the one hand-built manifest fixture. Test fixtures that built chain-sdk resources with `Uint8Array` val were switched to `bigint`.

Everything else in the repo reads `.val` via `@akashnetwork/http-sdk` REST types (plain strings), so it is unaffected. No production output contract changes: resource units are still emitted as the same integers.

### Verification
- `tsc --noEmit` across all 9 affected apps: zero new errors (every remaining error is pre-existing baseline; all modified files compile clean).
- Full `apps/api` unit suite (1224 tests) and the affected `apps/deploy-web` provider-proxy spec pass; lint clean on all changed files.
- `apps/api` functional gpu spec type-checks; not run locally (no Docker), will run in CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of resource quantities across deployment, provider, GPU pricing, and statistics workflows.
  * Corrected interpretation of CPU, memory, storage, and GPU values for accurate resource displays and pricing calculations.
  * Improved compatibility with newer and legacy resource formats.
  * Added safeguards for missing resource values, defaulting them appropriately instead of producing parsing errors.

* **Documentation**
  * Clarified the expected format for resource values in placement screening requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->