### PR TITLE
refactor(deployment): instrument the fund-on-create deployment job

### DIFF
--- a/apps/api/src/app/services/fund-deployment/fund-deployment.handler.spec.ts
+++ b/apps/api/src/app/services/fund-deployment/fund-deployment.handler.spec.ts
@@ -5,18 +5,19 @@ import type { FundDeploymentCommand } from "@src/billing/commands/fund-deploymen
 import type { JobPayload } from "@src/core";
 import type { CreateLogger } from "@src/core/providers/logging.provider";
 import type { InitialDeploymentFundingService } from "@src/deployment/services/initial-deployment-funding/initial-deployment-funding.service";
+import type { InitialDeploymentFundingInstrumentationService } from "@src/deployment/services/initial-deployment-funding/initial-deployment-funding-instrumentation.service";
 import { FundDeploymentHandler } from "./fund-deployment.handler";
 
 describe(FundDeploymentHandler.name, () => {
+  const payload: JobPayload<FundDeploymentCommand> = {
+    walletId: 1,
+    address: "akash1abc",
+    dseq: "123",
+    version: 1
+  };
+
   it("delegates the payload identifiers to the funding service", async () => {
     const { handler, initialDeploymentFundingService } = setup();
-
-    const payload: JobPayload<FundDeploymentCommand> = {
-      walletId: 1,
-      address: "akash1abc",
-      dseq: "123",
-      version: 1
-    };
 
     await handler.handle(payload);
 
@@ -27,16 +28,38 @@ describe(FundDeploymentHandler.name, () => {
     });
   });
 
+  it("records a successful job when the funding service resolves", async () => {
+    const { handler, instrumentation } = setup();
+
+    await handler.handle(payload);
+
+    expect(instrumentation.recordJobSucceeded).toHaveBeenCalledWith(expect.any(Number));
+    expect(instrumentation.recordJobFailed).not.toHaveBeenCalled();
+  });
+
+  it("records a failed job and rethrows when the funding service throws", async () => {
+    const error = new Error("deposit failed");
+    const { handler, instrumentation } = setup({
+      initialDeploymentFundingService: { fundOnLeaseStarted: vi.fn().mockRejectedValue(error) }
+    });
+
+    await expect(handler.handle(payload)).rejects.toThrow(error);
+
+    expect(instrumentation.recordJobFailed).toHaveBeenCalledWith(expect.any(Number), error);
+    expect(instrumentation.recordJobSucceeded).not.toHaveBeenCalled();
+  });
+
   function setup(params?: { initialDeploymentFundingService?: Partial<InitialDeploymentFundingService> }) {
     const initialDeploymentFundingService = mock<InitialDeploymentFundingService>({
       fundOnLeaseStarted: vi.fn().mockResolvedValue(undefined),
       ...params?.initialDeploymentFundingService
     });
+    const instrumentation = mock<InitialDeploymentFundingInstrumentationService>();
     const logger = mock<ReturnType<CreateLogger>>();
     const createLogger: CreateLogger = () => logger;
 
-    const handler = new FundDeploymentHandler(initialDeploymentFundingService, createLogger);
+    const handler = new FundDeploymentHandler(initialDeploymentFundingService, instrumentation, createLogger);
 
-    return { handler, initialDeploymentFundingService, logger };
+    return { handler, initialDeploymentFundingService, instrumentation, logger };
   }
 });

--- a/apps/api/src/app/services/fund-deployment/fund-deployment.handler.ts
+++ b/apps/api/src/app/services/fund-deployment/fund-deployment.handler.ts
@@ -4,6 +4,7 @@ import { FundDeploymentCommand } from "@src/billing/commands/fund-deployment.com
 import type { JobHandler, JobPayload } from "@src/core";
 import { type CreateLogger, LOGGER_FACTORY } from "@src/core/providers/logging.provider";
 import { InitialDeploymentFundingService } from "@src/deployment/services/initial-deployment-funding/initial-deployment-funding.service";
+import { InitialDeploymentFundingInstrumentationService } from "@src/deployment/services/initial-deployment-funding/initial-deployment-funding-instrumentation.service";
 
 @singleton()
 export class FundDeploymentHandler implements JobHandler<FundDeploymentCommand> {
@@ -15,6 +16,7 @@ export class FundDeploymentHandler implements JobHandler<FundDeploymentCommand> 
 
   constructor(
     private readonly initialDeploymentFundingService: InitialDeploymentFundingService,
+    private readonly instrumentation: InitialDeploymentFundingInstrumentationService,
     @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
     this.logger = createLogger({ context: FundDeploymentHandler.name });
@@ -23,10 +25,18 @@ export class FundDeploymentHandler implements JobHandler<FundDeploymentCommand> 
   async handle(payload: JobPayload<FundDeploymentCommand>): Promise<void> {
     this.logger.debug({ event: "FUND_DEPLOYMENT", dseq: payload.dseq, walletId: payload.walletId });
 
-    await this.initialDeploymentFundingService.fundOnLeaseStarted({
-      walletId: payload.walletId,
-      address: payload.address,
-      dseq: payload.dseq
-    });
+    const startTime = Date.now();
+
+    try {
+      await this.initialDeploymentFundingService.fundOnLeaseStarted({
+        walletId: payload.walletId,
+        address: payload.address,
+        dseq: payload.dseq
+      });
+      this.instrumentation.recordJobSucceeded(Date.now() - startTime);
+    } catch (error) {
+      this.instrumentation.recordJobFailed(Date.now() - startTime, error);
+      throw error;
+    }
   }
 }

--- a/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding-instrumentation.service.spec.ts
+++ b/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding-instrumentation.service.spec.ts
@@ -1,0 +1,126 @@
+const mockLogger = vi.hoisted(() => ({
+  info: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  debug: vi.fn()
+}));
+
+vi.mock("@akashnetwork/logging/otel", () => ({
+  createOtelLogger: () => mockLogger
+}));
+
+import { faker } from "@faker-js/faker";
+import type { Counter, Histogram } from "@opentelemetry/api";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { MetricsService } from "@src/core";
+import { classifyFailure, type FundingSkipReason, InitialDeploymentFundingInstrumentationService } from "./initial-deployment-funding-instrumentation.service";
+
+describe(InitialDeploymentFundingInstrumentationService.name, () => {
+  describe("recordJobSucceeded", () => {
+    it("increments completions and duration with a success status and logs completion", () => {
+      const { service, jobCompletions, jobDuration } = setup();
+
+      service.recordJobSucceeded(1234);
+
+      expect(jobCompletions.add).toHaveBeenCalledWith(1, { status: "success" });
+      expect(jobDuration.record).toHaveBeenCalledWith(1234, { status: "success" });
+      expect(mockLogger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "INITIAL_FUNDING_JOB_COMPLETED", status: "success", durationMs: 1234 }));
+    });
+  });
+
+  describe("recordJobFailed", () => {
+    it("marks a lease-not-visible failure as retriable", () => {
+      const { service, jobCompletions, jobDuration } = setup();
+      const error = new Error("Lease for deployment 123 owned by akash1owner is not visible on chain yet");
+
+      service.recordJobFailed(50, error);
+
+      expect(jobCompletions.add).toHaveBeenCalledWith(1, { status: "failure", reason: "lease_not_visible", retriable: true });
+      expect(jobDuration.record).toHaveBeenCalledWith(50, { status: "failure" });
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ event: "INITIAL_FUNDING_JOB_FAILED", reason: "lease_not_visible", retriable: true, error })
+      );
+    });
+
+    it("marks a generic deposit failure as non-retriable", () => {
+      const { service, jobCompletions } = setup();
+      const error = new Error("Bad status on response: 503");
+
+      service.recordJobFailed(50, error);
+
+      expect(jobCompletions.add).toHaveBeenCalledWith(1, { status: "failure", reason: "deposit_tx_failed", retriable: false });
+    });
+  });
+
+  describe("recordDeposit", () => {
+    it("increments deposits, records the amount under its denom, and logs the deposit", () => {
+      const { service, deposits, depositAmount } = setup();
+      const logContext = { dseq: "123", address: "akash1owner", blockRate: 50 };
+
+      service.recordDeposit(500000, "uakt", logContext);
+
+      expect(deposits.add).toHaveBeenCalledWith(1);
+      expect(depositAmount.record).toHaveBeenCalledWith(500000, { denom: "uakt" });
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.objectContaining({ ...logContext, event: "INITIAL_FUNDING_DEPOSITED", amount: 500000, denom: "uakt" })
+      );
+    });
+  });
+
+  describe("recordSkipped", () => {
+    it.each([
+      ["sufficient_runway", "info"],
+      ["deployment_closed", "info"],
+      ["insufficient_balance", "warn"],
+      ["no_fee_allowance", "warn"],
+      ["wallet_not_found", "error"]
+    ] as Array<[FundingSkipReason, "info" | "warn" | "error"]>)("increments skips for %s and logs it at %s level", (reason, level) => {
+      const { service, skips } = setup();
+      const logContext = { dseq: "123", address: "akash1owner" };
+
+      service.recordSkipped(reason, logContext);
+
+      expect(skips.add).toHaveBeenCalledWith(1, { reason });
+      expect(mockLogger[level]).toHaveBeenCalledWith(expect.objectContaining({ ...logContext, event: "INITIAL_FUNDING_SKIPPED", reason }));
+    });
+  });
+
+  describe("classifyFailure", () => {
+    it("classifies a lease-not-visible error, case-insensitively", () => {
+      expect(classifyFailure(new Error("deployment is Not Visible On Chain Yet"))).toBe("lease_not_visible");
+    });
+
+    it("classifies any other error as a deposit tx failure", () => {
+      expect(classifyFailure(new Error(faker.lorem.sentence()))).toBe("deposit_tx_failed");
+    });
+
+    it("classifies a non-error throw as unknown", () => {
+      expect(classifyFailure("boom")).toBe("unknown");
+    });
+  });
+
+  function setup() {
+    vi.clearAllMocks();
+
+    const counters: Record<string, Counter> = {};
+    const histograms: Record<string, Histogram> = {};
+
+    const metricsService = mock<MetricsService>();
+    metricsService.getMeter.mockReturnValue(mock());
+    metricsService.createCounter.mockImplementation((_meter, name) => (counters[name] = mock<Counter>()));
+    metricsService.createHistogram.mockImplementation((_meter, name) => (histograms[name] = mock<Histogram>()));
+
+    const service = new InitialDeploymentFundingInstrumentationService(metricsService);
+
+    return {
+      service,
+      jobCompletions: counters["initial_deployment_funding_job_completions_total"],
+      deposits: counters["initial_deployment_funding_deposits_total"],
+      skips: counters["initial_deployment_funding_skips_total"],
+      jobDuration: histograms["initial_deployment_funding_job_duration_ms"],
+      depositAmount: histograms["initial_deployment_funding_deposit_amount"]
+    };
+  }
+});

--- a/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding-instrumentation.service.spec.ts
+++ b/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding-instrumentation.service.spec.ts
@@ -87,6 +87,50 @@ describe(InitialDeploymentFundingInstrumentationService.name, () => {
     });
   });
 
+  describe("when the logger throws", () => {
+    it("still records job completion metrics and does not propagate the failure", () => {
+      const { service, jobCompletions, jobDuration } = setup();
+      mockLogger.info.mockImplementationOnce(() => {
+        throw new Error("logger down");
+      });
+
+      expect(() => service.recordJobSucceeded(1234)).not.toThrow();
+      expect(jobCompletions.add).toHaveBeenCalledWith(1, { status: "success" });
+      expect(jobDuration.record).toHaveBeenCalledWith(1234, { status: "success" });
+    });
+
+    it("still records deposit metrics and does not propagate the failure", () => {
+      const { service, deposits, depositAmount } = setup();
+      mockLogger.info.mockImplementationOnce(() => {
+        throw new Error("logger down");
+      });
+
+      expect(() => service.recordDeposit(500000, "uakt", { dseq: "123" })).not.toThrow();
+      expect(deposits.add).toHaveBeenCalledWith(1);
+      expect(depositAmount.record).toHaveBeenCalledWith(500000, { denom: "uakt" });
+    });
+
+    it("still records failure metrics and does not propagate the failure", () => {
+      const { service, jobCompletions } = setup();
+      mockLogger.error.mockImplementationOnce(() => {
+        throw new Error("logger down");
+      });
+
+      expect(() => service.recordJobFailed(50, new Error("boom"))).not.toThrow();
+      expect(jobCompletions.add).toHaveBeenCalledWith(1, { status: "failure", reason: "deposit_tx_failed", retriable: false });
+    });
+
+    it("still records skip metrics and does not propagate the failure", () => {
+      const { service, skips } = setup();
+      mockLogger.warn.mockImplementationOnce(() => {
+        throw new Error("logger down");
+      });
+
+      expect(() => service.recordSkipped("insufficient_balance", { dseq: "123" })).not.toThrow();
+      expect(skips.add).toHaveBeenCalledWith(1, { reason: "insufficient_balance" });
+    });
+  });
+
   describe("classifyFailure", () => {
     it("classifies a lease-not-visible error, case-insensitively", () => {
       expect(classifyFailure(new Error("deployment is Not Visible On Chain Yet"))).toBe("lease_not_visible");

--- a/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding-instrumentation.service.ts
+++ b/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding-instrumentation.service.ts
@@ -67,7 +67,7 @@ export class InitialDeploymentFundingInstrumentationService {
   recordJobSucceeded(durationMs: number): void {
     this.jobCompletions.add(1, { status: "success" });
     this.jobDuration.record(durationMs, { status: "success" });
-    this.logger.info({ event: "INITIAL_FUNDING_JOB_COMPLETED", durationMs, status: "success" });
+    this.emitLog("info", { event: "INITIAL_FUNDING_JOB_COMPLETED", durationMs, status: "success" });
   }
 
   recordJobFailed(durationMs: number, error: unknown): void {
@@ -76,17 +76,31 @@ export class InitialDeploymentFundingInstrumentationService {
 
     this.jobCompletions.add(1, { status: "failure", reason, retriable });
     this.jobDuration.record(durationMs, { status: "failure" });
-    this.logger.error({ event: "INITIAL_FUNDING_JOB_FAILED", durationMs, reason, retriable, error });
+    this.emitLog("error", { event: "INITIAL_FUNDING_JOB_FAILED", durationMs, reason, retriable, error });
   }
 
   recordDeposit(amount: number, denom: string, logContext: Record<string, unknown>): void {
     this.deposits.add(1);
     this.depositAmount.record(amount, { denom });
-    this.logger.info({ ...logContext, event: "INITIAL_FUNDING_DEPOSITED", amount, denom });
+    this.emitLog("info", { ...logContext, event: "INITIAL_FUNDING_DEPOSITED", amount, denom });
   }
 
   recordSkipped(reason: FundingSkipReason, logContext: Record<string, unknown>): void {
     this.skips.add(1, { reason });
-    this.logger[SKIP_LOG_LEVEL[reason]]({ ...logContext, event: "INITIAL_FUNDING_SKIPPED", reason });
+    this.emitLog(SKIP_LOG_LEVEL[reason], { ...logContext, event: "INITIAL_FUNDING_SKIPPED", reason });
+  }
+
+  /**
+   * Telemetry must never break the funding job. This runs on pg-boss, so a
+   * synchronous logger failure escaping a record* call would mark an
+   * already-completed deposit as failed and trigger a retry. Metrics are
+   * emitted before logging because the OTel spec guarantees they never throw.
+   */
+  private emitLog(level: "info" | "warn" | "error", payload: Record<string, unknown>): void {
+    try {
+      this.logger[level](payload);
+    } catch {
+      return;
+    }
   }
 }

--- a/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding-instrumentation.service.ts
+++ b/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding-instrumentation.service.ts
@@ -1,0 +1,92 @@
+import { createOtelLogger } from "@akashnetwork/logging/otel";
+import type { Counter, Histogram, Meter } from "@opentelemetry/api";
+import { singleton } from "tsyringe";
+
+import { MetricsService } from "@src/core";
+
+export type FundingFailureReason = "lease_not_visible" | "deposit_tx_failed" | "unknown";
+
+export type FundingSkipReason = "deployment_closed" | "sufficient_runway" | "insufficient_balance" | "no_fee_allowance" | "wallet_not_found";
+
+const SKIP_LOG_LEVEL: Record<FundingSkipReason, "info" | "warn" | "error"> = {
+  sufficient_runway: "info",
+  deployment_closed: "info",
+  insufficient_balance: "warn",
+  no_fee_allowance: "warn",
+  wallet_not_found: "error"
+};
+
+export function classifyFailure(error: unknown): FundingFailureReason {
+  if (!(error instanceof Error)) {
+    return "unknown";
+  }
+
+  if (/not visible on chain yet/i.test(error.message)) {
+    return "lease_not_visible";
+  }
+
+  return "deposit_tx_failed";
+}
+
+@singleton()
+export class InitialDeploymentFundingInstrumentationService {
+  private readonly meter: Meter;
+  private readonly jobCompletions: Counter;
+  private readonly jobDuration: Histogram;
+  private readonly deposits: Counter;
+  private readonly depositAmount: Histogram;
+  private readonly skips: Counter;
+
+  private readonly logger = createOtelLogger({ context: "InitialDeploymentFundingService" });
+
+  constructor(private readonly metricsService: MetricsService) {
+    this.meter = this.metricsService.getMeter("initial-deployment-funding", "1.0.0");
+
+    this.jobCompletions = this.metricsService.createCounter(this.meter, "initial_deployment_funding_job_completions_total", {
+      description: "Total number of initial deployment funding job completions by status"
+    });
+
+    this.jobDuration = this.metricsService.createHistogram(this.meter, "initial_deployment_funding_job_duration_ms", {
+      description: "Duration of initial deployment funding job execution in milliseconds",
+      unit: "ms"
+    });
+
+    this.deposits = this.metricsService.createCounter(this.meter, "initial_deployment_funding_deposits_total", {
+      description: "Total number of initial deployment funding deposits made on-chain"
+    });
+
+    this.depositAmount = this.metricsService.createHistogram(this.meter, "initial_deployment_funding_deposit_amount", {
+      description: "Amount deposited on-chain by the initial deployment funding job, in raw base units"
+    });
+
+    this.skips = this.metricsService.createCounter(this.meter, "initial_deployment_funding_skips_total", {
+      description: "Total number of initial deployment funding runs that skipped depositing, by reason"
+    });
+  }
+
+  recordJobSucceeded(durationMs: number): void {
+    this.jobCompletions.add(1, { status: "success" });
+    this.jobDuration.record(durationMs, { status: "success" });
+    this.logger.info({ event: "INITIAL_FUNDING_JOB_COMPLETED", durationMs, status: "success" });
+  }
+
+  recordJobFailed(durationMs: number, error: unknown): void {
+    const reason = classifyFailure(error);
+    const retriable = reason === "lease_not_visible";
+
+    this.jobCompletions.add(1, { status: "failure", reason, retriable });
+    this.jobDuration.record(durationMs, { status: "failure" });
+    this.logger.error({ event: "INITIAL_FUNDING_JOB_FAILED", durationMs, reason, retriable, error });
+  }
+
+  recordDeposit(amount: number, denom: string, logContext: Record<string, unknown>): void {
+    this.deposits.add(1);
+    this.depositAmount.record(amount, { denom });
+    this.logger.info({ ...logContext, event: "INITIAL_FUNDING_DEPOSITED", amount, denom });
+  }
+
+  recordSkipped(reason: FundingSkipReason, logContext: Record<string, unknown>): void {
+    this.skips.add(1, { reason });
+    this.logger[SKIP_LOG_LEVEL[reason]]({ ...logContext, event: "INITIAL_FUNDING_SKIPPED", reason });
+  }
+}

--- a/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.spec.ts
+++ b/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.spec.ts
@@ -88,6 +88,21 @@ describe(InitialDeploymentFundingService.name, () => {
     expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "INITIAL_FUNDING_WALLET_RELOAD_SCHEDULE_FAILED", walletId: 1, dseq: "123" }));
   });
 
+  it("completes the job when logging the wallet reload scheduling failure itself throws", async () => {
+    const { service, drainingDeploymentService, balancesService, walletReloadJobService, instrumentation, logger } = setup();
+    drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
+    drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(500000);
+    balancesService.getFreshLimits.mockResolvedValue({ fee: 100000, deployment: 1000000 });
+    walletReloadJobService.scheduleImmediate.mockRejectedValue(new Error("Failed to schedule wallet balance reload check"));
+    logger.error.mockImplementation(() => {
+      throw new Error("logger transport failure");
+    });
+
+    await expect(service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" })).resolves.toBeUndefined();
+
+    expect(instrumentation.recordDeposit).toHaveBeenCalledWith(500000, "uakt", expect.objectContaining({ dseq: "123", address: "akash1owner" }));
+  });
+
   it("throws and skips the wallet reload when the deposit tx fails on-chain", async () => {
     const { service, drainingDeploymentService, balancesService, managedSignerService, walletReloadJobService, logger } = setup();
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);

--- a/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.spec.ts
+++ b/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.spec.ts
@@ -74,6 +74,20 @@ describe(InitialDeploymentFundingService.name, () => {
     expect(instrumentation.recordDeposit).toHaveBeenCalledWith(500000, "uakt", expect.objectContaining({ dseq: "123", address: "akash1owner" }));
   });
 
+  it("records the deposit and tolerates a wallet reload scheduling failure without failing the job", async () => {
+    const { service, drainingDeploymentService, balancesService, managedSignerService, walletReloadJobService, instrumentation, logger } = setup();
+    drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
+    drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(500000);
+    balancesService.getFreshLimits.mockResolvedValue({ fee: 100000, deployment: 1000000 });
+    managedSignerService.executeDerivedTx.mockResolvedValue({ code: 0, hash: "TESTHASH", rawLog: "[]" });
+    walletReloadJobService.scheduleImmediate.mockRejectedValue(new Error("Failed to schedule wallet balance reload check"));
+
+    await expect(service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" })).resolves.toBeUndefined();
+
+    expect(instrumentation.recordDeposit).toHaveBeenCalledWith(500000, "uakt", expect.objectContaining({ dseq: "123", address: "akash1owner" }));
+    expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "INITIAL_FUNDING_WALLET_RELOAD_SCHEDULE_FAILED", walletId: 1, dseq: "123" }));
+  });
+
   it("throws and skips the wallet reload when the deposit tx fails on-chain", async () => {
     const { service, drainingDeploymentService, balancesService, managedSignerService, walletReloadJobService, logger } = setup();
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);

--- a/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.spec.ts
+++ b/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.spec.ts
@@ -14,6 +14,7 @@ import type { DrainingDeploymentOutput } from "@src/deployment/repositories/leas
 import type { DeploymentConfigService } from "@src/deployment/services/deployment-config/deployment-config.service";
 import type { DrainingDeploymentService } from "@src/deployment/services/draining-deployment/draining-deployment.service";
 import { InitialDeploymentFundingService } from "./initial-deployment-funding.service";
+import type { InitialDeploymentFundingInstrumentationService } from "./initial-deployment-funding-instrumentation.service";
 
 import { mockConfigService } from "@test/mocks/config-service.mock";
 import { createUserWallet } from "@test/seeders/user-wallet.seeder";
@@ -32,27 +33,27 @@ describe(InitialDeploymentFundingService.name, () => {
   });
 
   it("skips funding when the deployment is closed", async () => {
-    const { service, drainingDeploymentService, managedSignerService, logger } = setup();
+    const { service, drainingDeploymentService, managedSignerService, instrumentation } = setup();
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment({ closedHeight: 900 })]);
 
     await service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" });
 
     expect(managedSignerService.executeDerivedTx).not.toHaveBeenCalled();
-    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "INITIAL_FUNDING_SKIPPED", reason: "DEPLOYMENT_CLOSED" }));
+    expect(instrumentation.recordSkipped).toHaveBeenCalledWith("deployment_closed", expect.objectContaining({ dseq: "123", address: "akash1owner" }));
   });
 
   it("skips funding when the deployment already has more runway than the look-ahead window", async () => {
-    const { service, drainingDeploymentService, managedSignerService, logger } = setup();
+    const { service, drainingDeploymentService, managedSignerService, instrumentation } = setup();
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment({ predictedClosedHeight: LOOK_AHEAD_HEIGHT + 1 })]);
 
     await service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" });
 
     expect(managedSignerService.executeDerivedTx).not.toHaveBeenCalled();
-    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "INITIAL_FUNDING_SKIPPED", reason: "SUFFICIENT_RUNWAY" }));
+    expect(instrumentation.recordSkipped).toHaveBeenCalledWith("sufficient_runway", expect.objectContaining({ dseq: "123", address: "akash1owner" }));
   });
 
   it("deposits the calculated top-up amount and schedules a wallet reload", async () => {
-    const { service, drainingDeploymentService, balancesService, rpcMessageService, managedSignerService, walletReloadJobService } = setup();
+    const { service, drainingDeploymentService, balancesService, rpcMessageService, managedSignerService, walletReloadJobService, instrumentation } = setup();
     const depositMessage = { typeUrl: "/akash.escrow.v1.MsgAccountDeposit", value: {} };
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
     drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(500000);
@@ -70,6 +71,7 @@ describe(InitialDeploymentFundingService.name, () => {
     });
     expect(managedSignerService.executeDerivedTx).toHaveBeenCalledWith(1, [depositMessage]);
     expect(walletReloadJobService.scheduleImmediate).toHaveBeenCalledWith({ walletId: 1 });
+    expect(instrumentation.recordDeposit).toHaveBeenCalledWith(500000, "uakt", expect.objectContaining({ dseq: "123", address: "akash1owner" }));
   });
 
   it("throws and skips the wallet reload when the deposit tx fails on-chain", async () => {
@@ -86,7 +88,7 @@ describe(InitialDeploymentFundingService.name, () => {
   });
 
   it("skips terminally when the deposit is rejected because the deployment escrow is closed", async () => {
-    const { service, drainingDeploymentService, balancesService, managedSignerService, chainErrorService, walletReloadJobService, logger } = setup();
+    const { service, drainingDeploymentService, balancesService, managedSignerService, chainErrorService, walletReloadJobService, instrumentation } = setup();
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
     drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(500000);
     balancesService.getFreshLimits.mockResolvedValue({ fee: 100000, deployment: 1000000 });
@@ -95,12 +97,12 @@ describe(InitialDeploymentFundingService.name, () => {
 
     await service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" });
 
-    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "INITIAL_FUNDING_SKIPPED", reason: "DEPLOYMENT_CLOSED" }));
+    expect(instrumentation.recordSkipped).toHaveBeenCalledWith("deployment_closed", expect.objectContaining({ dseq: "123", address: "akash1owner" }));
     expect(walletReloadJobService.scheduleImmediate).not.toHaveBeenCalled();
   });
 
   it("rethrows deposit errors unrelated to a closed deployment", async () => {
-    const { service, drainingDeploymentService, balancesService, managedSignerService, walletReloadJobService, logger } = setup();
+    const { service, drainingDeploymentService, balancesService, managedSignerService, walletReloadJobService, instrumentation } = setup();
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
     drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(500000);
     balancesService.getFreshLimits.mockResolvedValue({ fee: 100000, deployment: 1000000 });
@@ -108,12 +110,13 @@ describe(InitialDeploymentFundingService.name, () => {
 
     await expect(service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" })).rejects.toThrow("Bad status on response: 503");
 
-    expect(logger.info).not.toHaveBeenCalledWith(expect.objectContaining({ event: "INITIAL_FUNDING_SKIPPED" }));
+    expect(instrumentation.recordSkipped).not.toHaveBeenCalled();
     expect(walletReloadJobService.scheduleImmediate).not.toHaveBeenCalled();
   });
 
   it("skips terminally when the deposit tx lands with a closed account in the raw log", async () => {
-    const { service, drainingDeploymentService, balancesService, managedSignerService, chainErrorService, walletReloadJobService, logger } = setup();
+    const { service, drainingDeploymentService, balancesService, managedSignerService, chainErrorService, walletReloadJobService, instrumentation, logger } =
+      setup();
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
     drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(500000);
     balancesService.getFreshLimits.mockResolvedValue({ fee: 100000, deployment: 1000000 });
@@ -122,7 +125,7 @@ describe(InitialDeploymentFundingService.name, () => {
 
     await service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" });
 
-    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "INITIAL_FUNDING_SKIPPED", reason: "DEPLOYMENT_CLOSED", txHash: "TESTHASH" }));
+    expect(instrumentation.recordSkipped).toHaveBeenCalledWith("deployment_closed", expect.objectContaining({ txHash: "TESTHASH" }));
     expect(logger.error).not.toHaveBeenCalledWith(expect.objectContaining({ event: "INITIAL_FUNDING_TX_FAILED" }));
     expect(walletReloadJobService.scheduleImmediate).not.toHaveBeenCalled();
   });
@@ -151,7 +154,7 @@ describe(InitialDeploymentFundingService.name, () => {
   });
 
   it("skips funding when the deployment limit is exhausted", async () => {
-    const { service, drainingDeploymentService, balancesService, managedSignerService, logger } = setup();
+    const { service, drainingDeploymentService, balancesService, managedSignerService, instrumentation } = setup();
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
     drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(500000);
     balancesService.getFreshLimits.mockResolvedValue({ fee: 100000, deployment: 0 });
@@ -159,11 +162,11 @@ describe(InitialDeploymentFundingService.name, () => {
     await service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" });
 
     expect(managedSignerService.executeDerivedTx).not.toHaveBeenCalled();
-    expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "INITIAL_FUNDING_INSUFFICIENT_BALANCE" }));
+    expect(instrumentation.recordSkipped).toHaveBeenCalledWith("insufficient_balance", expect.objectContaining({ dseq: "123", address: "akash1owner" }));
   });
 
   it("skips funding when the wallet is not found", async () => {
-    const { service, drainingDeploymentService, balancesService, userWalletRepository, managedSignerService, logger } = setup();
+    const { service, drainingDeploymentService, balancesService, userWalletRepository, managedSignerService, instrumentation } = setup();
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
     drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(500000);
     balancesService.getFreshLimits.mockResolvedValue({ fee: 100000, deployment: 1000000 });
@@ -172,11 +175,11 @@ describe(InitialDeploymentFundingService.name, () => {
     await service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" });
 
     expect(managedSignerService.executeDerivedTx).not.toHaveBeenCalled();
-    expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "INITIAL_FUNDING_WALLET_NOT_FOUND" }));
+    expect(instrumentation.recordSkipped).toHaveBeenCalledWith("wallet_not_found", expect.objectContaining({ walletId: 1, dseq: "123" }));
   });
 
   it("skips funding when the fee allowance is exhausted", async () => {
-    const { service, drainingDeploymentService, balancesService, managedSignerService, logger } = setup();
+    const { service, drainingDeploymentService, balancesService, managedSignerService, instrumentation } = setup();
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
     drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(500000);
     balancesService.getFreshLimits.mockResolvedValue({ fee: 100000, deployment: 1000000 });
@@ -185,7 +188,7 @@ describe(InitialDeploymentFundingService.name, () => {
     await service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" });
 
     expect(managedSignerService.executeDerivedTx).not.toHaveBeenCalled();
-    expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "INITIAL_FUNDING_NO_FEE_ALLOWANCE" }));
+    expect(instrumentation.recordSkipped).toHaveBeenCalledWith("no_fee_allowance", expect.objectContaining({ dseq: "123", address: "akash1owner" }));
   });
 
   function createDrainingDeployment(overrides: Partial<DrainingDeploymentOutput> = {}): DrainingDeploymentOutput {
@@ -210,6 +213,7 @@ describe(InitialDeploymentFundingService.name, () => {
     const deploymentConfig = mockConfigService<DeploymentConfigService>({ AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H: 24 });
     const walletReloadJobService = mock<WalletReloadJobService>();
     const chainErrorService = mock<ChainErrorService>();
+    const instrumentation = mock<InitialDeploymentFundingInstrumentationService>();
     const logger = mock<ReturnType<CreateLogger>>();
     const createLogger: CreateLogger = () => logger;
 
@@ -230,6 +234,7 @@ describe(InitialDeploymentFundingService.name, () => {
       deploymentConfig,
       walletReloadJobService,
       chainErrorService,
+      instrumentation,
       createLogger
     );
 
@@ -243,6 +248,7 @@ describe(InitialDeploymentFundingService.name, () => {
       userWalletRepository,
       walletReloadJobService,
       chainErrorService,
+      instrumentation,
       logger
     };
   }

--- a/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.ts
+++ b/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.ts
@@ -11,6 +11,7 @@ import { BlockHttpService } from "@src/chain/services/block-http/block-http.serv
 import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
 import { DeploymentConfigService } from "@src/deployment/services/deployment-config/deployment-config.service";
 import { DrainingDeploymentService } from "@src/deployment/services/draining-deployment/draining-deployment.service";
+import { InitialDeploymentFundingInstrumentationService } from "@src/deployment/services/initial-deployment-funding/initial-deployment-funding-instrumentation.service";
 import { averageBlockCountInAnHour, COSMOS_TX_CODE_OK } from "@src/utils/constants";
 
 export interface FundOnLeaseStartedInput {
@@ -39,6 +40,7 @@ export class InitialDeploymentFundingService {
     private readonly deploymentConfig: DeploymentConfigService,
     private readonly walletReloadJobService: WalletReloadJobService,
     private readonly chainErrorService: ChainErrorService,
+    private readonly instrumentation: InitialDeploymentFundingInstrumentationService,
     @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
     this.logger = createLogger({ context: InitialDeploymentFundingService.name });
@@ -59,7 +61,7 @@ export class InitialDeploymentFundingService {
     }
 
     if (deployment.closedHeight) {
-      this.logger.info({ event: "INITIAL_FUNDING_SKIPPED", reason: "DEPLOYMENT_CLOSED", dseq, address });
+      this.instrumentation.recordSkipped("deployment_closed", { dseq, address });
       return;
     }
 
@@ -67,9 +69,7 @@ export class InitialDeploymentFundingService {
     const lookAheadHeight = currentHeight + averageBlockCountInAnHour * this.deploymentConfig.get("AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H");
 
     if (deployment.predictedClosedHeight > lookAheadHeight) {
-      this.logger.info({
-        event: "INITIAL_FUNDING_SKIPPED",
-        reason: "SUFFICIENT_RUNWAY",
+      this.instrumentation.recordSkipped("sufficient_runway", {
         dseq,
         address,
         predictedClosedHeight: deployment.predictedClosedHeight,
@@ -83,28 +83,29 @@ export class InitialDeploymentFundingService {
     const amount = Math.min(desiredAmount, deploymentLimit);
 
     if (amount <= 0) {
-      this.logger.warn({ event: "INITIAL_FUNDING_INSUFFICIENT_BALANCE", dseq, address, desiredAmount, deploymentLimit });
+      this.instrumentation.recordSkipped("insufficient_balance", { dseq, address, desiredAmount, deploymentLimit });
       return;
     }
 
     const userWallet = await this.userWalletRepository.findById(walletId);
 
     if (!userWallet) {
-      this.logger.error({ event: "INITIAL_FUNDING_WALLET_NOT_FOUND", walletId, dseq });
+      this.instrumentation.recordSkipped("wallet_not_found", { walletId, dseq });
       return;
     }
 
     const feeAllowance = await this.managedSignerService.ensureFeeGrants(userWallet);
 
     if (feeAllowance <= 0) {
-      this.logger.warn({ event: "INITIAL_FUNDING_NO_FEE_ALLOWANCE", dseq, address });
+      this.instrumentation.recordSkipped("no_fee_allowance", { dseq, address });
       return;
     }
 
+    const denom = this.billingConfig.get("DEPLOYMENT_GRANT_DENOM");
     const message = this.rpcMessageService.getDepositDeploymentMsg({
       dseq: Number(dseq),
       amount,
-      denom: this.billingConfig.get("DEPLOYMENT_GRANT_DENOM"),
+      denom,
       owner: address,
       signer: address
     });
@@ -114,7 +115,7 @@ export class InitialDeploymentFundingService {
       tx = await this.managedSignerService.executeDerivedTx(walletId, [message]);
     } catch (error) {
       if (error instanceof Error && this.chainErrorService.isDeploymentClosedError(error)) {
-        this.logger.info({ event: "INITIAL_FUNDING_SKIPPED", reason: "DEPLOYMENT_CLOSED", dseq, address, error: error.message });
+        this.instrumentation.recordSkipped("deployment_closed", { dseq, address, error: error.message });
         return;
       }
       throw error;
@@ -124,7 +125,7 @@ export class InitialDeploymentFundingService {
       const txError = new Error(tx.rawLog || `Deposit tx ${tx.hash} failed on-chain with code ${tx.code}`);
 
       if (this.chainErrorService.isDeploymentClosedError(txError)) {
-        this.logger.info({ event: "INITIAL_FUNDING_SKIPPED", reason: "DEPLOYMENT_CLOSED", dseq, address, txHash: tx.hash });
+        this.instrumentation.recordSkipped("deployment_closed", { dseq, address, txHash: tx.hash });
         return;
       }
 
@@ -134,6 +135,6 @@ export class InitialDeploymentFundingService {
 
     await this.walletReloadJobService.scheduleImmediate({ walletId });
 
-    this.logger.info({ event: "INITIAL_FUNDING_DEPOSITED", dseq, address, amount, blockRate: deployment.blockRate });
+    this.instrumentation.recordDeposit(amount, denom, { dseq, address, blockRate: deployment.blockRate });
   }
 }

--- a/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.ts
+++ b/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.ts
@@ -133,8 +133,22 @@ export class InitialDeploymentFundingService {
       throw txError;
     }
 
-    await this.walletReloadJobService.scheduleImmediate({ walletId });
-
     this.instrumentation.recordDeposit(amount, denom, { dseq, address, blockRate: deployment.blockRate });
+
+    await this.scheduleWalletReload({ walletId, dseq, address });
+  }
+
+  /**
+   * The deposit is already final on-chain by the time we schedule the follow-up
+   * wallet reload check, so a scheduling failure must not fail the funding job:
+   * a retry would skip the now-funded deployment (sufficient runway) and
+   * misreport a deposit failure. The hourly top-up cron remains the safety net.
+   */
+  private async scheduleWalletReload({ walletId, dseq, address }: { walletId: number; dseq: string; address: string }): Promise<void> {
+    try {
+      await this.walletReloadJobService.scheduleImmediate({ walletId });
+    } catch (error) {
+      this.logger.error({ event: "INITIAL_FUNDING_WALLET_RELOAD_SCHEDULE_FAILED", walletId, dseq, address, error });
+    }
   }
 }

--- a/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.ts
+++ b/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.ts
@@ -142,13 +142,18 @@ export class InitialDeploymentFundingService {
    * The deposit is already final on-chain by the time we schedule the follow-up
    * wallet reload check, so a scheduling failure must not fail the funding job:
    * a retry would skip the now-funded deployment (sufficient runway) and
-   * misreport a deposit failure. The hourly top-up cron remains the safety net.
+   * misreport a deposit failure. The failure log is best effort for the same
+   * reason. The hourly top-up cron remains the safety net.
    */
   private async scheduleWalletReload({ walletId, dseq, address }: { walletId: number; dseq: string; address: string }): Promise<void> {
     try {
       await this.walletReloadJobService.scheduleImmediate({ walletId });
     } catch (error) {
-      this.logger.error({ event: "INITIAL_FUNDING_WALLET_RELOAD_SCHEDULE_FAILED", walletId, dseq, address, error });
+      try {
+        this.logger.error({ event: "INITIAL_FUNDING_WALLET_RELOAD_SCHEDULE_FAILED", walletId, dseq, address, error });
+      } catch {
+        return;
+      }
     }
   }
 }


### PR DESCRIPTION
## Why

The fund-on-create deployment job (`FundDeploymentHandler` -> `InitialDeploymentFundingService.fundOnLeaseStarted`) deposits escrow funds right after a lease starts so high-cost deployments cannot drain their small initial deposit and close before the hourly top-up cron first sees them. Until now it was logs-only: no OTel metrics, unlike every other money-moving job (`wallet-balance-reload-check`, the hourly `top-up-managed-deployments` cron it mirrors, and `activate-trial`). That left create-path deposit volume, skips, and failures invisible on dashboards and unalertable.

Part of CON-735

## What

Adds the metrics tier to the job, matching the hourly cron it mirrors:

- **New `InitialDeploymentFundingInstrumentationService`** (`@singleton()`, dedicated meter `initial-deployment-funding`) exposing `recordJobSucceeded` / `recordJobFailed` / `recordDeposit` / `recordSkipped`, each emitting a metric and a structured log together.
- **Metrics:** `initial_deployment_funding_job_completions_total` (`{status}`, plus `{reason, retriable}` on failure), `_job_duration_ms`, `_deposits_total`, `_deposit_amount` (`{denom}`, raw base units), `_skips_total` (`{reason}`).
- **Failure taxonomy:** a coarse `classifyFailure` maps the benign lease-not-visible indexer-lag throw to `retriable=true` so it does not drown the failure signal; alerts can key off `status="failure" AND retriable=false`. The forensic `INITIAL_FUNDING_TX_FAILED` log stays in the service.
- **Handler** owns job-level timing in a try/catch and rethrows so pg-boss still retries.
- **Log consolidation:** the granular `INITIAL_FUNDING_INSUFFICIENT_BALANCE` / `_WALLET_NOT_FOUND` / `_NO_FEE_ALLOWANCE` skip events collapse into a single `INITIAL_FUNDING_SKIPPED` event carrying a `reason` attribute, at a severity chosen per reason (mirrors reload-check's `WALLET_BALANCE_RELOAD_SKIPPED`).

No DI registration needed (`@singleton()` auto-resolves). Skips remain non-throwing and count as job successes.

### Verification
- `npm run test:unit -- initial-deployment-funding fund-deployment` -> 28/28 pass
- `npm run lint -- --quiet` -> clean
- `npx tsc --noEmit` -> 0 new errors vs `origin/main` baseline

### Follow-up
- Post-merge: confirm the `initial_deployment_funding_*` series appear in Grafana/Prometheus and build a panel/alert (`status="failure" AND retriable=false`) alongside the existing `auto_top_up_*` cron metrics. The pre-merge Grafana check for existing consumers of the now-collapsed granular skip event names could not be run from this environment (Grafana is behind the tailnet); the events are only days old so the risk is low, but worth a quick confirm.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added monitoring for initial deployment funding jobs, including success, failure, deposit amounts, duration, retryability, and skipped outcomes.
  - Added clearer classifications and structured logs for skipped funding and failure scenarios.

- **Bug Fixes**
  - Funding errors continue to be surfaced while being recorded accurately.
  - Retry behavior is preserved for recoverable transaction failures.
  - Wallet reload scheduling issues no longer prevent successful funding from completing.
  - Monitoring or logging issues no longer interrupt funding operations.

- **Tests**
  - Expanded coverage for successful, failed, skipped, and deposit-related funding scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->