### PR TITLE
fix(deployment): preserve GPU interconnect settings through the builder round-trip

### DIFF
--- a/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.ts
+++ b/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.ts
@@ -155,7 +155,7 @@ export const ProfileSchema = z
     hasGpu: z.boolean().optional(),
     gpu: z.number({ invalid_type_error: "GPU amount is required." }).optional(),
     gpuModels: z.array(ProfileGpuModelSchema).optional(),
-    // GPU interconnect opt-in. Presence = enabled; `group` set = explicit named group, absent = implicit "auto" group.
+    /** GPU interconnect opt-in. Presence = enabled; `group` set = explicit named group, absent = implicit "auto" group. */
     interconnect: z.object({ group: z.string().optional() }).optional(),
     ram: z.number({ invalid_type_error: "RAM is required." }),
     ramUnit: z.string().min(1, { message: "RAM unit is required." }),

--- a/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.ts
+++ b/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.ts
@@ -155,6 +155,8 @@ export const ProfileSchema = z
     hasGpu: z.boolean().optional(),
     gpu: z.number({ invalid_type_error: "GPU amount is required." }).optional(),
     gpuModels: z.array(ProfileGpuModelSchema).optional(),
+    // GPU interconnect opt-in. Presence = enabled; `group` set = explicit named group, absent = implicit "auto" group.
+    interconnect: z.object({ group: z.string().optional() }).optional(),
     ram: z.number({ invalid_type_error: "RAM is required." }),
     ramUnit: z.string().min(1, { message: "RAM unit is required." }),
     storage: z.array(ServiceStorageSchema).min(1, { message: "Storage is required." })

--- a/apps/deploy-web/src/utils/sdl/sdlGenerator.spec.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlGenerator.spec.ts
@@ -42,6 +42,30 @@ describe("sdlGenerator", () => {
       });
     });
 
+    it("emits gpu.attributes.interconnect as an empty array for an implicit opt-in", () => {
+      const result = generateSdl(buildFormValues(buildGpuService({ interconnect: {} })));
+
+      expect(gpuAttributesOf(result).interconnect).toEqual([]);
+    });
+
+    it("emits gpu.attributes.interconnect with the group for an explicit opt-in", () => {
+      const result = generateSdl(buildFormValues(buildGpuService({ interconnect: { group: "pair0" } })));
+
+      expect(gpuAttributesOf(result).interconnect).toEqual({ group: "pair0" });
+    });
+
+    it("does not emit an interconnect attribute when the gpu profile did not opt in", () => {
+      const result = generateSdl(buildFormValues(buildGpuService({ interconnect: undefined })));
+
+      expect(gpuAttributesOf(result)).not.toHaveProperty("interconnect");
+    });
+
+    it("emits the interconnect attribute before vendor to match the canonical key order", () => {
+      const result = generateSdl(buildFormValues(buildGpuService({ interconnect: {} })));
+
+      expect(Object.keys(gpuAttributesOf(result))).toEqual(["interconnect", "vendor"]);
+    });
+
     it("injects location-region attribute when placement.region is set", () => {
       const formValues = buildFormValues(buildLogCollectorService({ title: "web", image: "nginx:latest" }));
       formValues.placements[0].region = "us-west";
@@ -187,6 +211,33 @@ describe("sdlGenerator", () => {
         placements: [placement],
         services
       } as SdlBuilderFormValuesType;
+    }
+
+    function buildGpuService(opts: { interconnect?: { group?: string } }): ServiceType {
+      return {
+        id: "web-id",
+        title: "web",
+        image: "tensorflow/tensorflow:latest-gpu",
+        profile: {
+          cpu: 1,
+          ram: 2,
+          ramUnit: "Gi",
+          storage: [{ size: 10, unit: "Gi", isPersistent: false }],
+          hasGpu: true,
+          gpu: 1,
+          gpuModels: [{ vendor: "nvidia", name: "a100", memory: "80Gi", interface: "sxm" }],
+          interconnect: opts.interconnect
+        },
+        expose: [{ port: 8080, as: 80, global: true, to: [] }],
+        placementId: "p-1",
+        pricing: { amount: 1000, denom: "uakt" },
+        count: 1
+      } as ServiceType;
+    }
+
+    function gpuAttributesOf(sdl: string): Record<string, unknown> {
+      const parsed = yaml.load(sdl) as { profiles: { compute: Record<string, { resources: { gpu: { attributes: Record<string, unknown> } } }> } };
+      return parsed.profiles.compute.web.resources.gpu.attributes;
     }
   });
 

--- a/apps/deploy-web/src/utils/sdl/sdlGenerator.spec.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlGenerator.spec.ts
@@ -54,6 +54,12 @@ describe("sdlGenerator", () => {
       expect(gpuAttributesOf(result).interconnect).toEqual({ group: "pair0" });
     });
 
+    it("preserves an explicitly empty group rather than collapsing it to an implicit opt-in", () => {
+      const result = generateSdl(buildFormValues(buildGpuService({ interconnect: { group: "" } })));
+
+      expect(gpuAttributesOf(result).interconnect).toEqual({ group: "" });
+    });
+
     it("does not emit an interconnect attribute when the gpu profile did not opt in", () => {
       const result = generateSdl(buildFormValues(buildGpuService({ interconnect: undefined })));
 

--- a/apps/deploy-web/src/utils/sdl/sdlGenerator.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlGenerator.ts
@@ -23,7 +23,7 @@ export const buildCommand = (command: string): string[] => {
 const buildGpuAttributes = (interconnect: { group?: string } | undefined): Record<string, any> => {
   const attributes: Record<string, any> = {};
   if (interconnect) {
-    attributes.interconnect = interconnect.group ? { group: interconnect.group } : [];
+    attributes.interconnect = interconnect.group !== undefined ? { group: interconnect.group } : [];
   }
   attributes.vendor = {};
   return attributes;

--- a/apps/deploy-web/src/utils/sdl/sdlGenerator.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlGenerator.ts
@@ -16,6 +16,19 @@ export const buildCommand = (command: string): string[] => {
     .filter(Boolean);
 };
 
+/**
+ * Builds the GPU `attributes` map with `interconnect` emitted before `vendor` to match the canonical SDL
+ * key order. The interconnect key is present only when the profile opted in (`[]` implicit, `{ group }` explicit).
+ */
+const buildGpuAttributes = (interconnect: { group?: string } | undefined): Record<string, any> => {
+  const attributes: Record<string, any> = {};
+  if (interconnect) {
+    attributes.interconnect = interconnect.group ? { group: interconnect.group } : [];
+  }
+  attributes.vendor = {};
+  return attributes;
+};
+
 export const generateSdl = (formValues: SdlBuilderFormValuesType) => {
   const sdl: Record<string, any> = { version: "2.0", services: {}, profiles: { compute: {}, placement: {} }, deployment: {} };
 
@@ -140,9 +153,7 @@ export const generateSdl = (formValues: SdlBuilderFormValuesType) => {
     if (service.profile.hasGpu) {
       sdl.profiles.compute[service.title].resources.gpu = {
         units: service.profile.gpu,
-        attributes: {
-          vendor: {}
-        }
+        attributes: buildGpuAttributes(service.profile.interconnect)
       };
 
       const vendors =

--- a/apps/deploy-web/src/utils/sdl/sdlImport.spec.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlImport.spec.ts
@@ -213,6 +213,24 @@ describe("sdlImport", () => {
 
       expect(services[0].params).toBeUndefined();
     });
+
+    it("captures an implicit gpu interconnect opt-in onto the profile model", () => {
+      const { services } = importSimpleSdl(interconnectSdl("implicit"));
+
+      expect(services[0].profile.interconnect).toEqual({});
+    });
+
+    it("captures an explicit gpu interconnect group onto the profile model", () => {
+      const { services } = importSimpleSdl(interconnectSdl("explicit"));
+
+      expect(services[0].profile.interconnect).toEqual({ group: "pair0" });
+    });
+
+    it("leaves profile.interconnect undefined when the gpu has no interconnect attribute", () => {
+      const { services } = importSimpleSdl(interconnectSdl("none"));
+
+      expect(services[0].profile.interconnect).toBeUndefined();
+    });
   });
 
   describe("SDL roundtrip", () => {
@@ -221,6 +239,37 @@ describe("sdlImport", () => {
       const parsed = yaml.load(regenerated) as { services: Record<string, { params?: { tee?: string } }> };
 
       expect(parsed.services.web.params?.tee).toBe("cpu");
+    });
+
+    it("preserves an implicit gpu interconnect opt-in when importing then regenerating the SDL", () => {
+      const regenerated = generateSdl(importSimpleSdl(interconnectSdl("implicit")));
+      const gpu = gpuOf(regenerated);
+
+      expect(gpu.attributes.interconnect).toEqual([]);
+    });
+
+    it("preserves an explicit gpu interconnect group when importing then regenerating the SDL", () => {
+      const regenerated = generateSdl(importSimpleSdl(interconnectSdl("explicit")));
+      const gpu = gpuOf(regenerated);
+
+      expect(gpu.attributes.interconnect).toEqual({ group: "pair0" });
+    });
+
+    it("preserves the interconnect placement capability and fabric pin through the round-trip", () => {
+      const regenerated = generateSdl(importSimpleSdl(interconnectSdl("explicit", { fabric: "infiniband" })));
+      const parsed = yaml.load(regenerated) as { profiles: { placement: Record<string, { attributes?: Record<string, string> }> } };
+
+      expect(parsed.profiles.placement.dcloud.attributes).toMatchObject({
+        "capabilities/gpu-interconnect": "true",
+        "capabilities/gpu-interconnect/fabric/infiniband": "true"
+      });
+    });
+
+    it("does not emit an interconnect attribute for a gpu service that did not opt in", () => {
+      const regenerated = generateSdl(importSimpleSdl(interconnectSdl("none")));
+      const gpu = gpuOf(regenerated);
+
+      expect(gpu.attributes).not.toHaveProperty("interconnect");
     });
 
     it.each(["two-services-sdl.yml", "tini-multi-args-sdl.yml"])("imports %s, regenerates it, and produces semantically equal output", mockFile => {
@@ -354,6 +403,73 @@ const teeSdl = (tee: "cpu" | "cpu-gpu") =>
     "          - size: 512Mi",
     "  placement:",
     "    dcloud:",
+    "      pricing:",
+    "        web:",
+    "          denom: uakt",
+    "          amount: 1000",
+    "deployment:",
+    "  web:",
+    "    dcloud:",
+    "      profile: web",
+    "      count: 1"
+  ].join("\n");
+
+/** Reads the generated GPU resource block for the `web` service. */
+const gpuOf = (sdl: string) => {
+  const parsed = yaml.load(sdl) as { profiles: { compute: Record<string, { resources: { gpu: { attributes: Record<string, unknown> } } }> } };
+  return parsed.profiles.compute.web.resources.gpu;
+};
+
+const interconnectAttributeLines: Record<"implicit" | "explicit" | "none", string[]> = {
+  implicit: ["            interconnect: []"],
+  explicit: ["            interconnect:", "              group: pair0"],
+  none: []
+};
+
+/**
+ * Single GPU service SDL that opts into interconnect via `gpu.attributes.interconnect`
+ * ("implicit" → `[]`, "explicit" → `{ group: pair0 }`, "none" → no interconnect attribute),
+ * paired with the required `capabilities/gpu-interconnect` placement attribute and an optional fabric pin.
+ */
+const interconnectSdl = (form: "implicit" | "explicit" | "none", opts?: { fabric?: string }) =>
+  [
+    'version: "2.0"',
+    "services:",
+    "  web:",
+    "    image: tensorflow/tensorflow:latest-gpu",
+    "    expose:",
+    "      - port: 8080",
+    "        as: 80",
+    "        to:",
+    "          - global: true",
+    "profiles:",
+    "  compute:",
+    "    web:",
+    "      resources:",
+    "        cpu:",
+    "          units: 1",
+    "        memory:",
+    "          size: 2Gi",
+    "        storage:",
+    "          - size: 10Gi",
+    "        gpu:",
+    "          units: 1",
+    "          attributes:",
+    ...interconnectAttributeLines[form],
+    "            vendor:",
+    "              nvidia:",
+    "                - model: a100",
+    "                  ram: 80Gi",
+    "                  interface: sxm",
+    "  placement:",
+    "    dcloud:",
+    ...(form === "none"
+      ? []
+      : [
+          "      attributes:",
+          '        capabilities/gpu-interconnect: "true"',
+          ...(opts?.fabric ? [`        capabilities/gpu-interconnect/fabric/${opts.fabric}: "true"`] : [])
+        ]),
     "      pricing:",
     "        web:",
     "          denom: uakt",

--- a/apps/deploy-web/src/utils/sdl/sdlImport.spec.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlImport.spec.ts
@@ -255,6 +255,13 @@ describe("sdlImport", () => {
       expect(gpu.attributes.interconnect).toEqual({ group: "pair0" });
     });
 
+    it("preserves an explicitly empty gpu interconnect group when importing then regenerating the SDL", () => {
+      const regenerated = generateSdl(importSimpleSdl(interconnectSdl("explicit-empty")));
+      const gpu = gpuOf(regenerated);
+
+      expect(gpu.attributes.interconnect).toEqual({ group: "" });
+    });
+
     it("preserves the interconnect placement capability and fabric pin through the round-trip", () => {
       const regenerated = generateSdl(importSimpleSdl(interconnectSdl("explicit", { fabric: "infiniband" })));
       const parsed = yaml.load(regenerated) as { profiles: { placement: Record<string, { attributes?: Record<string, string> }> } };
@@ -420,18 +427,19 @@ const gpuOf = (sdl: string) => {
   return parsed.profiles.compute.web.resources.gpu;
 };
 
-const interconnectAttributeLines: Record<"implicit" | "explicit" | "none", string[]> = {
+const interconnectAttributeLines: Record<"implicit" | "explicit" | "explicit-empty" | "none", string[]> = {
   implicit: ["            interconnect: []"],
   explicit: ["            interconnect:", "              group: pair0"],
+  "explicit-empty": ["            interconnect:", '              group: ""'],
   none: []
 };
 
 /**
  * Single GPU service SDL that opts into interconnect via `gpu.attributes.interconnect`
- * ("implicit" → `[]`, "explicit" → `{ group: pair0 }`, "none" → no interconnect attribute),
- * paired with the required `capabilities/gpu-interconnect` placement attribute and an optional fabric pin.
+ * ("implicit" → `[]`, "explicit" → `{ group: pair0 }`, "explicit-empty" → `{ group: "" }`, "none" → no interconnect
+ * attribute), paired with the required `capabilities/gpu-interconnect` placement attribute and an optional fabric pin.
  */
-const interconnectSdl = (form: "implicit" | "explicit" | "none", opts?: { fabric?: string }) =>
+const interconnectSdl = (form: "implicit" | "explicit" | "explicit-empty" | "none", opts?: { fabric?: string }) =>
   [
     'version: "2.0"',
     "services:",

--- a/apps/deploy-web/src/utils/sdl/sdlImport.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlImport.ts
@@ -72,6 +72,7 @@ export const importSimpleSdl = (yamlStr: string, { placementPerService = false }
         cpu: compute.resources.cpu.units,
         gpu: compute.resources.gpu ? compute.resources.gpu.units : 0,
         gpuModels: compute.resources.gpu ? getGpuModels(compute.resources.gpu.attributes.vendor) : [],
+        interconnect: compute.resources.gpu ? getGpuInterconnect(compute.resources.gpu.attributes) : undefined,
         hasGpu: !!compute.resources.gpu,
         ram: getResourceDigit(compute.resources.memory.size),
         ramUnit: getResourceUnit(compute.resources.memory.size),
@@ -204,6 +205,18 @@ const getResourceDigit = (size: string): number => {
 const getResourceUnit = (size: string): string => {
   const match = size.match(/[a-zA-Z]+/g);
   return match ? capitalizeFirstLetter(match[0]) : "";
+};
+
+/**
+ * Reads the GPU interconnect opt-in from `gpu.attributes.interconnect`: an empty array (implicit `auto`
+ * group) maps to `{}`, an explicit `{ group }` keeps the name, and an absent attribute leaves it off.
+ */
+const getGpuInterconnect = (attributes: { interconnect?: unknown }): { group?: string } | undefined => {
+  const interconnect = attributes?.interconnect;
+  if (interconnect === undefined || interconnect === null) return undefined;
+  if (Array.isArray(interconnect)) return {};
+  const group = (interconnect as { group?: unknown }).group;
+  return typeof group === "string" ? { group } : {};
 };
 
 const getGpuModels = (vendor: { [key: string]: { model: string; ram: string; interface: string }[] }): ProfileGpuModelType[] => {


### PR DESCRIPTION
## Why

Closes CON-688.

Opening an interconnect deployment in the visual builder silently dropped the interconnect settings, because the builder only understood the GPU vendor/model and not the `gpu.attributes.interconnect` opt-in. A user who imported an interconnect SDL, edited it in the builder, and re-exported would unknowingly remove interconnect. This must be fixed before we add the first-class toggle (CON-689).

Part of the InfiniBand on Akash provider project. Stacked on #3545 (chain-sdk alpha.41 adoption) — base will be retargeted to `main` once that merges.

## What

Mirrors the existing `params.tee` round-trip preservation pattern:

- **Form model** — `ProfileSchema` gains `interconnect: { group?: string }`. Presence = opt-in; `group` set = explicit named group, absent = implicit `auto` group.
- **Import** (`sdlImport.ts`) — reads `gpu.attributes.interconnect`: `[]` → `{}` (implicit), `{ group }` → kept (explicit), absent → off.
- **Export** (`sdlGenerator.ts`) — re-emits it via a `buildGpuAttributes` helper, before `vendor`, to match the canonical SDL key order.
- The placement capabilities (`capabilities/gpu-interconnect` and the fabric pin `capabilities/gpu-interconnect/fabric/<fabric>`) already round-trip as generic placement attributes — confirmed by test, no change needed.

Tests: import capture (implicit/explicit/none), round-trip (implicit/explicit gpu attribute, fabric + capability placement attributes, non-interconnect unchanged), and generator emission + key ordering. No new type errors; lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GPU interconnect configuration support, including optional interconnect groups.
  * GPU deployments now preserve interconnect settings when exporting and importing SDL configurations.

* **Bug Fixes**
  * Preserved GPU placement capabilities and optional fabric pin settings during SDL round trips.

* **Tests**
  * Added coverage for implicit, explicit, disabled, empty-group, and round-trip GPU interconnect configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->