### PR TITLE
feat(deployment): install the akash skill via the skills CLI on /new-deployment

### DIFF
--- a/apps/deploy-web/src/components/new-deployment/AgentModePanel/AgentModePanel.spec.tsx
+++ b/apps/deploy-web/src/components/new-deployment/AgentModePanel/AgentModePanel.spec.tsx
@@ -23,16 +23,15 @@ describe(AgentModePanel.name, () => {
 
     expect(analyticsService.track).toHaveBeenCalledWith("deploy_with_agent_btn_clk", "Amplitude");
     expect(screen.getByText("Install the Akash skill")).toBeInTheDocument();
-    expect(screen.getByText("/plugin marketplace add akash-network/akash-skill")).toBeInTheDocument();
-    expect(screen.getByText("/plugin install akash-network@akash-network")).toBeInTheDocument();
+    expect(screen.getByText("npx skills add akash-network/akash-skill --skill akash")).toBeInTheDocument();
   });
 
-  it("offers a copy button for each install command", async () => {
+  it("offers a copy button for the install command", async () => {
     setup();
 
     await userEvent.click(screen.getByRole("button", { name: /Set up with your agent/ }));
 
-    expect(screen.getAllByRole("button", { name: "copy" })).toHaveLength(2);
+    expect(screen.getAllByRole("button", { name: "copy" })).toHaveLength(1);
   });
 
   it("links Create an API key to the in-app API keys page", async () => {

--- a/apps/deploy-web/src/components/new-deployment/AgentModePanel/AgentModePanel.tsx
+++ b/apps/deploy-web/src/components/new-deployment/AgentModePanel/AgentModePanel.tsx
@@ -11,7 +11,7 @@ import { useServices } from "@src/context/ServicesProvider";
 import { copyTextToClipboard } from "@src/utils/copyClipboard";
 import { UrlService } from "@src/utils/urlUtils";
 
-const SKILL_INSTALL_COMMANDS = ["/plugin marketplace add akash-network/akash-skill", "/plugin install akash-network@akash-network"];
+const SKILL_INSTALL_COMMANDS = ["npx skills add akash-network/akash-skill --skill akash"];
 const AI_AGENTS_DOCS_URL = "https://akash.network/docs/getting-started/ai-agents/";
 
 export const AgentModePanel: React.FunctionComponent = () => {
@@ -51,7 +51,7 @@ export const AgentModePanel: React.FunctionComponent = () => {
             <AgentModeStep
               index={1}
               title="Install the Akash skill"
-              description="In Claude Code, Codex, or OpenCode:"
+              description="From your terminal — works with Claude Code, Cursor, Codex, OpenCode, and more:"
               action={
                 <div className="space-y-2">
                   {SKILL_INSTALL_COMMANDS.map(command => (


### PR DESCRIPTION
## Summary
- Replaces the two Claude Code plugin commands (`/plugin marketplace add akash-network/akash-skill` + `/plugin install akash-network@akash-network`) on the /new-deployment "Deploy with your agent" panel with a single cross-agent command that installs only the deployer skill:
  ```
  npx skills add akash-network/akash-skill --skill akash
  ```
- Updates the step description since the command now runs in a terminal (works with Claude Code, Cursor, Codex, OpenCode, and 70+ other agents via the [Vercel Labs skills CLI](https://github.com/vercel-labs/skills)) instead of inside a Claude Code session.
- Updates the AgentModePanel spec accordingly (single command, single copy button).

## Depends on
akash-network/akash-skill#29 must merge first — until the deprecated root SKILL.md stub is removed there, the skills CLI resolves `--skill akash` to the deprecation stub instead of the real deployer skill (verified against the live CLI).

## Testing
- `npx vitest run src/components/new-deployment/AgentModePanel/AgentModePanel.spec.tsx` — 5/5 pass
- Verified the exact command end-to-end against the akash-skill branch: it installs the real deployer skill (frontmatter `name: akash`) into `.claude/skills/akash/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the agent setup instructions to use a single skill installation command.
  - Added compatibility guidance for Claude Code, Cursor, Codex, OpenCode, and other agents.

- **Tests**
  - Updated setup panel tests to reflect the streamlined installation command and single copy button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->