### PR TITLE
test(notification-channel): stabilize headless channel list read-back

### DIFF
--- a/apps/deploy-web/tests/ui/managed-wallet-notification-channels.spec.ts
+++ b/apps/deploy-web/tests/ui/managed-wallet-notification-channels.spec.ts
@@ -32,9 +32,13 @@ test.describe("Managed wallet notification channels", () => {
     });
 
     await test.step("verify channel appears in list", async () => {
-      await notificationChannelsPage.ensureOnTheLastPage();
       const row = notificationChannelsPage.getChannelRow(channelName);
-      await expect(row).toBeVisible({ timeout: 10_000 });
+
+      await expect(async () => {
+        await notificationChannelsPage.ensureOnTheLastPage();
+        await expect(row).toBeVisible({ timeout: 3_000 });
+      }).toPass({ timeout: 20_000 });
+
       await expect(row).toContainText("email");
       await expect(row).toContainText(channelEmail);
     });


### PR DESCRIPTION
## Why

The `managed-wallet-notification-channels` e2e test flaked **only in headless** (it passed reliably
headed). Creation itself always succeeded — the test asserts the "Notification channel created" toast
before reading back — so the flake was purely in the read-back: after create → redirect to the list,
the test navigated to the last page once and then looked for the new row, but in headless it outran
the list settling and the row was never found within the timeout.

Root cause: the list sorts **oldest-first** (`orderBy createdAt` ascending), so a new channel lives on
the **last page**. After the redirect the list query does a **silent background refetch** (cached data,
so no spinner to wait on), and `ensureOnTheLastPage()` made a **one-shot** decision from a single,
possibly-stale snapshot of the pagination nav. When the post-create total crossed a page boundary — the
common 10→11 case, or when orphaned `e2e-channel-*` rows from past failed runs spanned several pages —
the stale snapshot either no-op'd on page 1 (pagination not yet rendered) or clicked a stale last-page
link, landing on a page that didn't contain the new row. Headed's slower cadence let the refetch settle
first, hiding the race.

## What

Test-only change; no product/application code touched.

- Wrap the "verify channel appears in list" read-back in `expect(...).toPass()` so it re-targets the
  **genuine current last page** each iteration until the row appears, retrying on any transient error
  (including mid-refetch click failures). `toPass` retries on any throw, unlike `expect.poll`, whose
  callback throwing is fatal — verified against the Playwright 1.57 source.
- Robust to both the refetch race and orphaned `e2e-channel-*` rows that push the list across multiple
  pages. The delete and "verify removed" steps are unchanged, and the Page Object stays assertion-free.

**Verification**

- `playwright test --list`, Prettier, and `eslint --quiet` are clean; `tsc --noEmit` reports only
  pre-existing, unrelated errors (identical count with and without the change, none in the touched file).
- The full headless run loop must be exercised in CI against a deployed preview environment — a live
  deploy-web + API + notifications + Postgres stack (plus Auth0 and Mailsac) is required, so it can't be
  run in a bare local sandbox.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved verification of notification channel lists by retrying pagination and row visibility checks.
  * Increased reliability for channel-list checks in managed wallet workflows, especially when data takes longer to load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->