### PR TITLE
refactor(billing): move the top-up flow into a dedicated service

### DIFF
--- a/apps/api/src/billing/controllers/stripe/stripe.controller.spec.ts
+++ b/apps/api/src/billing/controllers/stripe/stripe.controller.spec.ts
@@ -15,9 +15,9 @@ import { type PaymentMethod } from "@src/billing/services/payment-method/payment
 import type { StripeService } from "@src/billing/services/stripe/stripe.service";
 import type { StripeErrorService } from "@src/billing/services/stripe-error/stripe-error.service";
 import type { StripeTransactionService } from "@src/billing/services/stripe-transaction/stripe-transaction.service";
+import type { TopUpService } from "@src/billing/services/top-up/top-up.service";
 import type { TransactionReportingService } from "@src/billing/services/transaction-reporting/transaction-reporting.service";
 import type { TrialActivationJobService } from "@src/billing/services/trial-activation-job/trial-activation-job.service";
-import type { TrialValidationService } from "@src/billing/services/trial-validation/trial-validation.service";
 import { StripeController } from "./stripe.controller";
 
 import { generateDatabaseStripeTransaction } from "@test/seeders/database-stripe-transaction.seeder";
@@ -25,211 +25,58 @@ import { createUser } from "@test/seeders/user.seeder";
 
 describe(StripeController.name, () => {
   describe("confirmPayment", () => {
-    it("throws a retriable 409 without charging when the wallet is still provisioning", async () => {
-      const { controller, stripeTransaction, trialActivationJobService, userWalletRepository, user } = setup();
-      userWalletRepository.findOneByUserId.mockResolvedValue(mock<UserWalletOutput>({ activatedAt: null }));
-      trialActivationJobService.assertActivated.mockRejectedValue(createError(409, "provisioning", { errorCode: "wallet_provisioning" }));
-
-      await expect(controller.confirmPayment({ userId: user.id, paymentMethodId: faker.string.uuid(), amount: 100 })).rejects.toMatchObject({
-        status: 409,
-        errorCode: "wallet_provisioning"
-      });
-      expect(stripeTransaction.createPaymentIntent).not.toHaveBeenCalled();
-    });
-
-    it("returns transactionId and transactionStatus on successful payment", async () => {
-      const { controller, stripeTransaction, paymentMethodService, user } = setup();
-      const transactionId = faker.string.uuid();
-
-      paymentMethodService.hasPaymentMethod.mockResolvedValue(true);
-      stripeTransaction.createPaymentIntent.mockResolvedValue({
-        success: true,
-        paymentIntentId: faker.string.uuid(),
-        transactionId,
-        transactionStatus: "pending"
-      });
+    it("delegates to TopUpService and wraps the result in a data envelope", async () => {
+      const { controller, topUpService, authService, user } = setup();
+      const data = { success: true as const, transactionId: faker.string.uuid(), transactionStatus: "pending" as const };
+      topUpService.topUp.mockResolvedValue(data);
 
       const result = await controller.confirmPayment({
         userId: user.id,
-        paymentMethodId: faker.string.uuid(),
-        amount: 100
-      });
-
-      expect(result).toEqual({
-        data: {
-          success: true,
-          transactionId,
-          transactionStatus: "pending"
-        }
-      });
-    });
-
-    it("resolves transaction when awaitResolved is true", async () => {
-      const { controller, stripeTransaction, paymentMethodService, user } = setup();
-      const transactionId = faker.string.uuid();
-      const resolvedTransaction = generateDatabaseStripeTransaction({ id: transactionId, status: "succeeded" });
-
-      paymentMethodService.hasPaymentMethod.mockResolvedValue(true);
-      stripeTransaction.createPaymentIntent.mockResolvedValue({
-        success: true,
-        paymentIntentId: faker.string.uuid(),
-        transactionId,
-        transactionStatus: "pending"
-      });
-      stripeTransaction.resolveTransaction.mockResolvedValue(resolvedTransaction);
-
-      const result = await controller.confirmPayment({
-        userId: user.id,
-        paymentMethodId: faker.string.uuid(),
+        paymentMethodId: "pm_1",
         amount: 100,
+        idempotencyKey: "key_1",
         awaitResolved: true
       });
 
-      expect(stripeTransaction.resolveTransaction).toHaveBeenCalledWith(transactionId);
-      expect(result).toEqual({
-        data: {
-          success: true,
-          transactionId,
-          transactionStatus: "succeeded"
-        }
-      });
-    });
-
-    it("invokes trial-min validation before contacting Stripe", async () => {
-      const { controller, stripeTransaction, userWalletRepository, trialValidationService, paymentMethodService, user } = setup();
-      const wallet = mock<UserWalletOutput>({ isTrialing: true });
-      userWalletRepository.findOneByUserId.mockResolvedValue(wallet);
-      paymentMethodService.hasPaymentMethod.mockResolvedValue(true);
-      stripeTransaction.createPaymentIntent.mockResolvedValue({
-        success: true,
-        paymentIntentId: faker.string.uuid(),
-        transactionId: faker.string.uuid(),
-        transactionStatus: "pending"
-      });
-
-      await controller.confirmPayment({
-        userId: user.id,
-        paymentMethodId: faker.string.uuid(),
-        amount: 100
-      });
-
-      expect(trialValidationService.validateTopUpAmount).toHaveBeenCalledWith(wallet, 100);
-    });
-
-    it("propagates the trial-min rejection without ever calling Stripe", async () => {
-      const { controller, stripeTransaction, userWalletRepository, trialValidationService, paymentMethodService, user } = setup();
-      const wallet = mock<UserWalletOutput>({ isTrialing: true });
-      userWalletRepository.findOneByUserId.mockResolvedValue(wallet);
-      const trialError = Object.assign(new Error("First top-up must be at least $100 while on the free trial."), { status: 402 });
-      trialValidationService.validateTopUpAmount.mockImplementation(() => {
-        throw trialError;
-      });
-
-      await expect(
-        controller.confirmPayment({
-          userId: user.id,
-          paymentMethodId: faker.string.uuid(),
-          amount: 50
-        })
-      ).rejects.toBe(trialError);
-      expect(paymentMethodService.hasPaymentMethod).not.toHaveBeenCalled();
-      expect(stripeTransaction.createPaymentIntent).not.toHaveBeenCalled();
-    });
-
-    it("forwards an undefined wallet to trial-min validation when no wallet exists", async () => {
-      const { controller, stripeTransaction, userWalletRepository, trialValidationService, paymentMethodService, user } = setup();
-      userWalletRepository.findOneByUserId.mockResolvedValue(undefined);
-      paymentMethodService.hasPaymentMethod.mockResolvedValue(true);
-      stripeTransaction.createPaymentIntent.mockResolvedValue({
-        success: true,
-        paymentIntentId: faker.string.uuid(),
-        transactionId: faker.string.uuid(),
-        transactionStatus: "pending"
-      });
-
-      await controller.confirmPayment({
-        userId: user.id,
-        paymentMethodId: faker.string.uuid(),
-        amount: 50
-      });
-
-      expect(trialValidationService.validateTopUpAmount).toHaveBeenCalledWith(undefined, 50);
-    });
-
-    it("returns 3DS data with transactionId and transactionStatus", async () => {
-      const { controller, stripeTransaction, paymentMethodService, user } = setup();
-      const transactionId = faker.string.uuid();
-      const paymentIntentId = faker.string.uuid();
-      const clientSecret = faker.string.alphanumeric(32);
-
-      paymentMethodService.hasPaymentMethod.mockResolvedValue(true);
-      stripeTransaction.createPaymentIntent.mockResolvedValue({
-        success: false,
-        requiresAction: true,
-        clientSecret,
-        paymentIntentId,
-        transactionId,
-        transactionStatus: "requires_action"
-      });
-
-      const result = await controller.confirmPayment({
-        userId: user.id,
-        paymentMethodId: faker.string.uuid(),
-        amount: 100
-      });
-
-      expect(result).toEqual({
-        data: {
-          success: false,
-          requiresAction: true,
-          clientSecret,
-          paymentIntentId,
-          transactionId,
-          transactionStatus: "requires_action"
-        }
-      });
-    });
-
-    it("namespaces the client attempt key with the user id before calling Stripe", async () => {
-      const { controller, stripeTransaction, paymentMethodService, user } = setup();
-      const clientKey = faker.string.uuid();
-
-      paymentMethodService.hasPaymentMethod.mockResolvedValue(true);
-      stripeTransaction.createPaymentIntent.mockResolvedValue({
-        success: true,
-        paymentIntentId: faker.string.uuid(),
-        transactionId: faker.string.uuid(),
-        transactionStatus: "pending"
-      });
-
-      await controller.confirmPayment({
-        userId: user.id,
-        paymentMethodId: faker.string.uuid(),
+      expect(topUpService.topUp).toHaveBeenCalledWith(authService.getCurrentPayingUser(), {
         amount: 100,
-        idempotencyKey: clientKey
+        paymentMethodId: "pm_1",
+        idempotencyKey: "key_1",
+        awaitResolved: true
       });
-
-      expect(stripeTransaction.createPaymentIntent).toHaveBeenCalledWith(expect.objectContaining({ idempotencyKey: `topup_${user.id}_${clientKey}` }));
+      expect(result).toEqual({ data });
     });
 
-    it("passes no idempotency key to Stripe when the client sends none", async () => {
-      const { controller, stripeTransaction, paymentMethodService, user } = setup();
+    it("throws a 500 without charging when there is no current paying user", async () => {
+      const { controller, topUpService, authService } = setup();
+      authService.getCurrentPayingUser.mockReturnValue(undefined as unknown as PayingUser);
 
-      paymentMethodService.hasPaymentMethod.mockResolvedValue(true);
-      stripeTransaction.createPaymentIntent.mockResolvedValue({
-        success: true,
-        paymentIntentId: faker.string.uuid(),
-        transactionId: faker.string.uuid(),
-        transactionStatus: "pending"
+      await expect(controller.confirmPayment({ userId: faker.string.uuid(), paymentMethodId: "pm_1", amount: 100 })).rejects.toMatchObject({
+        status: 500
       });
+      expect(topUpService.topUp).not.toHaveBeenCalled();
+    });
 
-      await controller.confirmPayment({
-        userId: user.id,
-        paymentMethodId: faker.string.uuid(),
-        amount: 100
-      });
+    it("maps a known payment error through StripeErrorService", async () => {
+      const { controller, topUpService, stripeErrorService, user } = setup();
+      const rawError = new Error("Payment not successful");
+      const mappedError = createError(402, "Payment not successful");
+      topUpService.topUp.mockRejectedValue(rawError);
+      stripeErrorService.isKnownError.mockReturnValue(true);
+      stripeErrorService.toAppError.mockReturnValue(mappedError);
 
-      expect(stripeTransaction.createPaymentIntent).toHaveBeenCalledWith(expect.objectContaining({ idempotencyKey: undefined }));
+      await expect(controller.confirmPayment({ userId: user.id, paymentMethodId: "pm_1", amount: 100 })).rejects.toBe(mappedError);
+      expect(stripeErrorService.toAppError).toHaveBeenCalledWith(rawError, "payment");
+    });
+
+    it("rethrows an unknown error unchanged", async () => {
+      const { controller, topUpService, stripeErrorService, user } = setup();
+      const rawError = new Error("boom");
+      topUpService.topUp.mockRejectedValue(rawError);
+      stripeErrorService.isKnownError.mockReturnValue(false);
+
+      await expect(controller.confirmPayment({ userId: user.id, paymentMethodId: "pm_1", amount: 100 })).rejects.toBe(rawError);
+      expect(stripeErrorService.toAppError).not.toHaveBeenCalled();
     });
   });
 
@@ -462,22 +309,22 @@ describe(StripeController.name, () => {
     const couponRedemptionService = mock<CouponRedemptionService>();
     const customerService = mock<CustomerService>();
     const stripeTransaction = mock<StripeTransactionService>();
+    const topUpService = mock<TopUpService>();
     const authService = mock<AuthService>({
       currentUser: user
     });
     authService.getCurrentPayingUser.mockReturnValue(payingUser);
     const stripeErrorService = mock<StripeErrorService>();
     const userWalletRepository = mock<UserWalletRepository>();
-    const trialValidationService = mock<TrialValidationService>();
     const trialActivationJobService = mock<TrialActivationJobService>();
     const transactionReporting = mock<TransactionReportingService>();
     const controller = new StripeController(
       stripe,
       stripeTransaction,
+      topUpService,
       authService,
       stripeErrorService,
       userWalletRepository,
-      trialValidationService,
       trialActivationJobService,
       transactionReporting,
       paymentMethodService,
@@ -493,10 +340,10 @@ describe(StripeController.name, () => {
       couponRedemptionService,
       customerService,
       stripeTransaction,
+      topUpService,
       authService,
       stripeErrorService,
       userWalletRepository,
-      trialValidationService,
       trialActivationJobService,
       user
     };

--- a/apps/api/src/billing/controllers/stripe/stripe.controller.ts
+++ b/apps/api/src/billing/controllers/stripe/stripe.controller.ts
@@ -24,21 +24,21 @@ import { UserWalletRepository } from "@src/billing/repositories";
 import { CouponRedemptionService } from "@src/billing/services/coupon-redemption/coupon-redemption.service";
 import { CustomerService } from "@src/billing/services/customer/customer.service";
 import { PaymentMethodService } from "@src/billing/services/payment-method/payment-method.service";
-import { StripeService, TOP_UP_IDEMPOTENCY_KEY_PREFIX } from "@src/billing/services/stripe/stripe.service";
+import { StripeService } from "@src/billing/services/stripe/stripe.service";
 import { StripeErrorService } from "@src/billing/services/stripe-error/stripe-error.service";
 import { StripeTransactionService } from "@src/billing/services/stripe-transaction/stripe-transaction.service";
+import { TopUpService } from "@src/billing/services/top-up/top-up.service";
 import { TransactionReportingService } from "@src/billing/services/transaction-reporting/transaction-reporting.service";
 import { TrialActivationJobService } from "@src/billing/services/trial-activation-job/trial-activation-job.service";
-import { TrialValidationService } from "@src/billing/services/trial-validation/trial-validation.service";
 @singleton()
 export class StripeController {
   constructor(
     private readonly stripe: StripeService,
     private readonly stripeTransaction: StripeTransactionService,
+    private readonly topUpService: TopUpService,
     private readonly authService: AuthService,
     private readonly stripeErrorService: StripeErrorService,
     private readonly userWalletRepository: UserWalletRepository,
-    private readonly trialValidationService: TrialValidationService,
     private readonly trialActivationJobService: TrialActivationJobService,
     private readonly transactionReporting: TransactionReportingService,
     private readonly paymentMethodService: PaymentMethodService,
@@ -108,48 +108,15 @@ export class StripeController {
 
     assert(currentUser, 500, "Payment account not properly configured. Please contact support.");
 
-    const userWallet = await this.userWalletRepository.findOneByUserId(currentUser.id);
-    await this.trialActivationJobService.assertActivated({ userId: currentUser.id, activatedAt: userWallet?.activatedAt });
-    this.trialValidationService.validateTopUpAmount(userWallet, params.amount);
-
     try {
-      assert(await this.paymentMethodService.hasPaymentMethod(params.paymentMethodId, currentUser), 403, "Payment method does not belong to the user");
-
-      const result = await this.stripeTransaction.createPaymentIntent({
-        userId: currentUser.id,
-        customer: currentUser.stripeCustomerId,
-        payment_method: params.paymentMethodId,
+      const data = await this.topUpService.topUp(currentUser, {
         amount: params.amount,
-        confirm: true,
-        idempotencyKey: params.idempotencyKey ? `${TOP_UP_IDEMPOTENCY_KEY_PREFIX}${currentUser.id}_${params.idempotencyKey}` : undefined,
-        onAmountMismatch: "reject"
+        paymentMethodId: params.paymentMethodId,
+        idempotencyKey: params.idempotencyKey,
+        awaitResolved: params.awaitResolved
       });
 
-      // Handle 3D Secure authentication requirement
-      if (result.requiresAction && result.clientSecret && result.paymentIntentId) {
-        return {
-          data: {
-            success: false,
-            requiresAction: true,
-            clientSecret: result.clientSecret,
-            paymentIntentId: result.paymentIntentId,
-            transactionId: result.transactionId,
-            transactionStatus: result.transactionStatus
-          }
-        };
-      }
-
-      // If payment was not successful and it's not a 3D Secure case, throw an error
-      if (!result.success) {
-        throw new Error("Payment not successful");
-      }
-
-      if (params.awaitResolved) {
-        const transaction = await this.stripeTransaction.resolveTransaction(result.transactionId);
-        return { data: { success: true, transactionId: result.transactionId, transactionStatus: transaction.status } };
-      }
-
-      return { data: { success: true, transactionId: result.transactionId, transactionStatus: result.transactionStatus } };
+      return { data };
     } catch (error) {
       if (this.stripeErrorService.isKnownError(error, "payment")) {
         throw this.stripeErrorService.toAppError(error, "payment");

--- a/apps/api/src/billing/services/stripe/stripe.service.ts
+++ b/apps/api/src/billing/services/stripe/stripe.service.ts
@@ -17,14 +17,6 @@ interface StripePrices {
  */
 export const STRIPE_CURRENCY = "usd";
 
-/**
- * Namespace prefix the confirm-payment controller adds to client attempt keys so top-up
- * idempotency keys never collide with other flows'. Whether a reused key tolerates a changed
- * amount is an explicit policy the caller passes to StripeTransactionService, not something
- * inferred from this prefix.
- */
-export const TOP_UP_IDEMPOTENCY_KEY_PREFIX = "topup_";
-
 @singleton()
 export class StripeService {
   readonly isProduction = this.billingConfig.get("STRIPE_SECRET_KEY").startsWith("sk_live");

--- a/apps/api/src/billing/services/top-up/top-up.service.spec.ts
+++ b/apps/api/src/billing/services/top-up/top-up.service.spec.ts
@@ -1,0 +1,226 @@
+import { faker } from "@faker-js/faker";
+import createError from "http-errors";
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { UserWalletOutput, UserWalletRepository } from "@src/billing/repositories";
+import type { PayingUser } from "@src/billing/services/paying-user/paying-user";
+import type { PaymentMethodService } from "@src/billing/services/payment-method/payment-method.service";
+import type { StripeTransactionService } from "@src/billing/services/stripe-transaction/stripe-transaction.service";
+import type { TrialActivationJobService } from "@src/billing/services/trial-activation-job/trial-activation-job.service";
+import type { TrialValidationService } from "@src/billing/services/trial-validation/trial-validation.service";
+import { TopUpService } from "./top-up.service";
+
+import { generateDatabaseStripeTransaction } from "@test/seeders/database-stripe-transaction.seeder";
+import { createUser } from "@test/seeders/user.seeder";
+
+describe(TopUpService.name, () => {
+  describe("topUp", () => {
+    it("throws a retriable 409 without charging when the wallet is still provisioning", async () => {
+      const { service, stripeTransactionService, trialActivationJobService, userWalletRepository, payingUser } = setup();
+      userWalletRepository.findOneByUserId.mockResolvedValue(mock<UserWalletOutput>({ activatedAt: null }));
+      trialActivationJobService.assertActivated.mockRejectedValue(createError(409, "provisioning", { errorCode: "wallet_provisioning" }));
+
+      await expect(service.topUp(payingUser, { paymentMethodId: faker.string.uuid(), amount: 100 })).rejects.toMatchObject({
+        status: 409,
+        errorCode: "wallet_provisioning"
+      });
+      expect(stripeTransactionService.createPaymentIntent).not.toHaveBeenCalled();
+    });
+
+    it("returns transactionId and transactionStatus on successful payment", async () => {
+      const { service, stripeTransactionService, paymentMethodService, payingUser } = setup();
+      const transactionId = faker.string.uuid();
+
+      paymentMethodService.hasPaymentMethod.mockResolvedValue(true);
+      stripeTransactionService.createPaymentIntent.mockResolvedValue({
+        success: true,
+        paymentIntentId: faker.string.uuid(),
+        transactionId,
+        transactionStatus: "pending"
+      });
+
+      const result = await service.topUp(payingUser, { paymentMethodId: faker.string.uuid(), amount: 100 });
+
+      expect(result).toEqual({ success: true, transactionId, transactionStatus: "pending" });
+    });
+
+    it("resolves the transaction when awaitResolved is true", async () => {
+      const { service, stripeTransactionService, paymentMethodService, payingUser } = setup();
+      const transactionId = faker.string.uuid();
+      const resolvedTransaction = generateDatabaseStripeTransaction({ id: transactionId, status: "succeeded" });
+
+      paymentMethodService.hasPaymentMethod.mockResolvedValue(true);
+      stripeTransactionService.createPaymentIntent.mockResolvedValue({
+        success: true,
+        paymentIntentId: faker.string.uuid(),
+        transactionId,
+        transactionStatus: "pending"
+      });
+      stripeTransactionService.resolveTransaction.mockResolvedValue(resolvedTransaction);
+
+      const result = await service.topUp(payingUser, { paymentMethodId: faker.string.uuid(), amount: 100, awaitResolved: true });
+
+      expect(stripeTransactionService.resolveTransaction).toHaveBeenCalledWith(transactionId);
+      expect(result).toEqual({ success: true, transactionId, transactionStatus: "succeeded" });
+    });
+
+    it("validates the top-up amount against the wallet before contacting Stripe", async () => {
+      const { service, stripeTransactionService, userWalletRepository, trialValidationService, paymentMethodService, payingUser } = setup();
+      const wallet = mock<UserWalletOutput>({ isTrialing: true });
+      userWalletRepository.findOneByUserId.mockResolvedValue(wallet);
+      paymentMethodService.hasPaymentMethod.mockResolvedValue(true);
+      stripeTransactionService.createPaymentIntent.mockResolvedValue({
+        success: true,
+        paymentIntentId: faker.string.uuid(),
+        transactionId: faker.string.uuid(),
+        transactionStatus: "pending"
+      });
+
+      await service.topUp(payingUser, { paymentMethodId: faker.string.uuid(), amount: 100 });
+
+      expect(trialValidationService.validateTopUpAmount).toHaveBeenCalledWith(wallet, 100);
+    });
+
+    it("propagates the amount-validation rejection without ever calling Stripe", async () => {
+      const { service, stripeTransactionService, userWalletRepository, trialValidationService, paymentMethodService, payingUser } = setup();
+      userWalletRepository.findOneByUserId.mockResolvedValue(mock<UserWalletOutput>({ isTrialing: true }));
+      const trialError = Object.assign(new Error("First top-up must be at least $100 while on the free trial."), { status: 402 });
+      trialValidationService.validateTopUpAmount.mockImplementation(() => {
+        throw trialError;
+      });
+
+      await expect(service.topUp(payingUser, { paymentMethodId: faker.string.uuid(), amount: 50 })).rejects.toBe(trialError);
+      expect(paymentMethodService.hasPaymentMethod).not.toHaveBeenCalled();
+      expect(stripeTransactionService.createPaymentIntent).not.toHaveBeenCalled();
+    });
+
+    it("forwards an undefined wallet to amount validation when no wallet exists", async () => {
+      const { service, stripeTransactionService, userWalletRepository, trialValidationService, paymentMethodService, payingUser } = setup();
+      userWalletRepository.findOneByUserId.mockResolvedValue(undefined);
+      paymentMethodService.hasPaymentMethod.mockResolvedValue(true);
+      stripeTransactionService.createPaymentIntent.mockResolvedValue({
+        success: true,
+        paymentIntentId: faker.string.uuid(),
+        transactionId: faker.string.uuid(),
+        transactionStatus: "pending"
+      });
+
+      await service.topUp(payingUser, { paymentMethodId: faker.string.uuid(), amount: 50 });
+
+      expect(trialValidationService.validateTopUpAmount).toHaveBeenCalledWith(undefined, 50);
+    });
+
+    it("rejects when the payment method does not belong to the user", async () => {
+      const { service, stripeTransactionService, paymentMethodService, payingUser } = setup();
+      paymentMethodService.hasPaymentMethod.mockResolvedValue(false);
+
+      await expect(service.topUp(payingUser, { paymentMethodId: faker.string.uuid(), amount: 100 })).rejects.toMatchObject({ status: 403 });
+      expect(stripeTransactionService.createPaymentIntent).not.toHaveBeenCalled();
+    });
+
+    it("charges with the reject amount-mismatch policy", async () => {
+      const { service, stripeTransactionService, paymentMethodService, payingUser } = setup();
+
+      paymentMethodService.hasPaymentMethod.mockResolvedValue(true);
+      stripeTransactionService.createPaymentIntent.mockResolvedValue({
+        success: true,
+        paymentIntentId: faker.string.uuid(),
+        transactionId: faker.string.uuid(),
+        transactionStatus: "pending"
+      });
+
+      await service.topUp(payingUser, { paymentMethodId: faker.string.uuid(), amount: 100 });
+
+      expect(stripeTransactionService.createPaymentIntent).toHaveBeenCalledWith(expect.objectContaining({ onAmountMismatch: "reject" }));
+    });
+
+    it("returns 3DS data when the charge requires action", async () => {
+      const { service, stripeTransactionService, paymentMethodService, payingUser } = setup();
+      const transactionId = faker.string.uuid();
+      const paymentIntentId = faker.string.uuid();
+      const clientSecret = faker.string.alphanumeric(32);
+
+      paymentMethodService.hasPaymentMethod.mockResolvedValue(true);
+      stripeTransactionService.createPaymentIntent.mockResolvedValue({
+        success: false,
+        requiresAction: true,
+        clientSecret,
+        paymentIntentId,
+        transactionId,
+        transactionStatus: "requires_action"
+      });
+
+      const result = await service.topUp(payingUser, { paymentMethodId: faker.string.uuid(), amount: 100 });
+
+      expect(result).toEqual({
+        success: false,
+        requiresAction: true,
+        clientSecret,
+        paymentIntentId,
+        transactionId,
+        transactionStatus: "requires_action"
+      });
+    });
+
+    it("throws when the charge is neither successful nor a 3DS challenge", async () => {
+      const { service, stripeTransactionService, paymentMethodService, payingUser } = setup();
+
+      paymentMethodService.hasPaymentMethod.mockResolvedValue(true);
+      stripeTransactionService.createPaymentIntent.mockResolvedValue({
+        success: false,
+        transactionId: faker.string.uuid()
+      });
+
+      await expect(service.topUp(payingUser, { paymentMethodId: faker.string.uuid(), amount: 100 })).rejects.toThrow("Payment not successful");
+    });
+
+    it("namespaces the client attempt key with the user id before calling Stripe", async () => {
+      const { service, stripeTransactionService, paymentMethodService, payingUser } = setup();
+      const clientKey = faker.string.uuid();
+
+      paymentMethodService.hasPaymentMethod.mockResolvedValue(true);
+      stripeTransactionService.createPaymentIntent.mockResolvedValue({
+        success: true,
+        paymentIntentId: faker.string.uuid(),
+        transactionId: faker.string.uuid(),
+        transactionStatus: "pending"
+      });
+
+      await service.topUp(payingUser, { paymentMethodId: faker.string.uuid(), amount: 100, idempotencyKey: clientKey });
+
+      expect(stripeTransactionService.createPaymentIntent).toHaveBeenCalledWith(
+        expect.objectContaining({ idempotencyKey: `topup_${payingUser.id}_${clientKey}` })
+      );
+    });
+
+    it("passes no idempotency key to Stripe when the client sends none", async () => {
+      const { service, stripeTransactionService, paymentMethodService, payingUser } = setup();
+
+      paymentMethodService.hasPaymentMethod.mockResolvedValue(true);
+      stripeTransactionService.createPaymentIntent.mockResolvedValue({
+        success: true,
+        paymentIntentId: faker.string.uuid(),
+        transactionId: faker.string.uuid(),
+        transactionStatus: "pending"
+      });
+
+      await service.topUp(payingUser, { paymentMethodId: faker.string.uuid(), amount: 100 });
+
+      expect(stripeTransactionService.createPaymentIntent).toHaveBeenCalledWith(expect.objectContaining({ idempotencyKey: undefined }));
+    });
+  });
+
+  function setup() {
+    const user = createUser();
+    const payingUser: PayingUser = { ...user, stripeCustomerId: user.stripeCustomerId! };
+    const userWalletRepository = mock<UserWalletRepository>();
+    const trialActivationJobService = mock<TrialActivationJobService>();
+    const trialValidationService = mock<TrialValidationService>();
+    const paymentMethodService = mock<PaymentMethodService>();
+    const stripeTransactionService = mock<StripeTransactionService>();
+    const service = new TopUpService(userWalletRepository, trialActivationJobService, trialValidationService, paymentMethodService, stripeTransactionService);
+
+    return { service, userWalletRepository, trialActivationJobService, trialValidationService, paymentMethodService, stripeTransactionService, payingUser };
+  }
+});

--- a/apps/api/src/billing/services/top-up/top-up.service.ts
+++ b/apps/api/src/billing/services/top-up/top-up.service.ts
@@ -1,0 +1,80 @@
+import assert from "http-assert";
+import { singleton } from "tsyringe";
+
+import type { ConfirmPaymentResponse } from "@src/billing/http-schemas/stripe.schema";
+import { UserWalletRepository } from "@src/billing/repositories";
+import type { PayingUser } from "@src/billing/services/paying-user/paying-user";
+import { PaymentMethodService } from "@src/billing/services/payment-method/payment-method.service";
+import { StripeTransactionService } from "@src/billing/services/stripe-transaction/stripe-transaction.service";
+import { TrialActivationJobService } from "@src/billing/services/trial-activation-job/trial-activation-job.service";
+import { TrialValidationService } from "@src/billing/services/trial-validation/trial-validation.service";
+
+/**
+ * Namespace prefix added to a client attempt key so a top-up idempotency key can never collide with
+ * another flow's. The full key is `topup_<userId>_<clientAttemptKey>`.
+ */
+export const TOP_UP_IDEMPOTENCY_KEY_PREFIX = "topup_";
+
+@singleton()
+export class TopUpService {
+  constructor(
+    private readonly userWalletRepository: UserWalletRepository,
+    private readonly trialActivationJobService: TrialActivationJobService,
+    private readonly trialValidationService: TrialValidationService,
+    private readonly paymentMethodService: PaymentMethodService,
+    private readonly stripeTransactionService: StripeTransactionService
+  ) {}
+
+  /**
+   * Runs the user-initiated top-up: trial-activation gating, top-up amount validation, payment-method
+   * ownership, and a confirmed charge through the payment-transaction owner, followed by 3DS/success
+   * interpretation and (optionally) settlement resolution.
+   *
+   * Amount-mismatch policy: `reject`. Reusing an attempt key whose recorded amount differs from the
+   * requested one is treated as a definitive client error. The client rotates its key whenever the
+   * amount changes, so a changed amount on a reused key means a stale or misbehaving client — never a
+   * legitimate re-attempt of the same charge.
+   */
+  async topUp(
+    currentUser: PayingUser,
+    params: { amount: number; paymentMethodId: string; idempotencyKey?: string; awaitResolved?: boolean }
+  ): Promise<ConfirmPaymentResponse["data"]> {
+    const userWallet = await this.userWalletRepository.findOneByUserId(currentUser.id);
+    await this.trialActivationJobService.assertActivated({ userId: currentUser.id, activatedAt: userWallet?.activatedAt });
+    this.trialValidationService.validateTopUpAmount(userWallet, params.amount);
+
+    assert(await this.paymentMethodService.hasPaymentMethod(params.paymentMethodId, currentUser), 403, "Payment method does not belong to the user");
+
+    const result = await this.stripeTransactionService.createPaymentIntent({
+      userId: currentUser.id,
+      customer: currentUser.stripeCustomerId,
+      payment_method: params.paymentMethodId,
+      amount: params.amount,
+      confirm: true,
+      idempotencyKey: params.idempotencyKey ? `${TOP_UP_IDEMPOTENCY_KEY_PREFIX}${currentUser.id}_${params.idempotencyKey}` : undefined,
+      onAmountMismatch: "reject"
+    });
+
+    if (result.requiresAction && result.clientSecret && result.paymentIntentId) {
+      return {
+        success: false,
+        requiresAction: true,
+        clientSecret: result.clientSecret,
+        paymentIntentId: result.paymentIntentId,
+        transactionId: result.transactionId,
+        transactionStatus: result.transactionStatus
+      };
+    }
+
+    if (!result.success) {
+      throw new Error("Payment not successful");
+    }
+
+    if (params.awaitResolved) {
+      const transaction = await this.stripeTransactionService.resolveTransaction(result.transactionId);
+      return { success: true, transactionId: result.transactionId, transactionStatus: transaction.status };
+    }
+
+    return { success: true, transactionId: result.transactionId, transactionStatus: result.transactionStatus };
+  }
+}


### PR DESCRIPTION
## Why

Part of CON-718. Closes CON-728.

The user-initiated top-up flow was orchestration living inline in `StripeController.confirmPayment` —
trial-activation gating, top-up amount validation, payment-method ownership, the confirmed charge, and
3DS/success interpretation all mixed in with HTTP-adapter concerns. That business logic belongs in a
dedicated service over the payment-transaction owner, not in the controller.

## What

Behavior-preserving refactor; no user-facing change to top-up.

- Add `TopUpService`, which owns the full user-initiated top-up flow over `StripeTransactionService`:
  trial-activation gating → top-up amount validation → payment-method ownership → confirmed charge →
  3DS/success interpretation → optional settlement resolution.
- State the amount-mismatch policy explicitly on the service: a reused attempt key whose recorded
  amount differs from the requested one is **rejected** (the client rotates its key whenever the amount
  changes, so a changed amount on a reused key means a stale or misbehaving client). The policy is
  passed as `onAmountMismatch: "reject"` and documented on `topUp`.
- Slim `StripeController.confirmPayment` to a thin adapter: resolve the paying user, delegate to
  `TopUpService`, map known Stripe errors, and shape the response. It no longer depends on
  `TrialValidationService`.
- Move `TOP_UP_IDEMPOTENCY_KEY_PREFIX` out of `StripeService` and next to the flow that uses it.
- Move the top-up orchestration tests into `top-up.service.spec.ts` (plus coverage for the reject
  policy, the 403 ownership guard, and the "payment not successful" path). The controller spec keeps
  thin delegation, error-mapping, and no-paying-user tests.

**Verification**

- `top-up.service.spec.ts`, `stripe.controller.spec.ts`, and `stripe.service.spec.ts` pass; the full
  billing **unit** suite is green (integration specs require a live Postgres and are skipped locally).
- `eslint --quiet` and Prettier are clean on the touched files; `tsc --noEmit` reports only
  pre-existing, unrelated errors (none in the touched files).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a centralized payment top-up flow supporting wallet provisioning, trial activation, payment validation, 3D Secure responses, and optional transaction resolution.
  * Added safeguards for payment-method ownership, amount mismatches, unsuccessful payments, and repeated payment requests.
* **Bug Fixes**
  * Improved handling of missing users, wallets, and known payment-provider errors.
  * Preserved clear propagation of unexpected payment errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->