### PR TITLE
chore: restrict DEPENDENCIES map to React components and hooks

### DIFF
--- a/apps/deploy-web/eslint.config.mjs
+++ b/apps/deploy-web/eslint.config.mjs
@@ -5,6 +5,7 @@ export default [
   {
     files: ["**/*.ts", "**/*.tsx"],
     rules: {
+      "akash/dependencies-component-or-hook": ["error"],
       "no-restricted-imports": [
         "error",
         {

--- a/apps/deploy-web/src/components/auth/AuthLayout/AuthLayout.tsx
+++ b/apps/deploy-web/src/components/auth/AuthLayout/AuthLayout.tsx
@@ -14,7 +14,9 @@ const DEPLOYMENT_GUIDE_URL = "https://akash.network/docs/getting-started/quick-s
 export const DEPENDENCIES = {
   Globe,
   AkashConsoleLogo,
+  // eslint-disable-next-line akash/dependencies-component-or-hook
   REGION_MARKERS,
+  // eslint-disable-next-line akash/dependencies-component-or-hook
   DEPLOYMENT_GUIDE_URL
 };
 

--- a/apps/deploy-web/src/components/auth/EmailCodeStart/EmailCodeStart.tsx
+++ b/apps/deploy-web/src/components/auth/EmailCodeStart/EmailCodeStart.tsx
@@ -23,6 +23,7 @@ export const DEPENDENCIES = {
   FormInput,
   LoadingButton,
   RemoteApiError,
+  // eslint-disable-next-line akash/dependencies-component-or-hook
   markCodeSent,
   useForm,
   useMutation

--- a/apps/deploy-web/src/components/auth/EmailCodeVerify/EmailCodeVerify.tsx
+++ b/apps/deploy-web/src/components/auth/EmailCodeVerify/EmailCodeVerify.tsx
@@ -18,7 +18,9 @@ export const DEPENDENCIES = {
   RemoteApiError,
   Spinner,
   VerificationCodeInput,
+  // eslint-disable-next-line akash/dependencies-component-or-hook
   markCodeSent,
+  // eslint-disable-next-line akash/dependencies-component-or-hook
   readCodeSentAt,
   useMutation
 };

--- a/apps/deploy-web/src/components/billing-usage/AddCreditsForm/AddCreditsForm.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AddCreditsForm/AddCreditsForm.tsx
@@ -59,7 +59,9 @@ export const DEPENDENCIES = {
   use3DSecure,
   useUser,
   useTopUpAttemptKey,
+  // eslint-disable-next-line akash/dependencies-component-or-hook
   getPaymentMethodDisplay,
+  // eslint-disable-next-line akash/dependencies-component-or-hook
   handleStripeError
 };
 

--- a/apps/deploy-web/src/components/billing-usage/RedeemCouponForm/RedeemCouponForm.tsx
+++ b/apps/deploy-web/src/components/billing-usage/RedeemCouponForm/RedeemCouponForm.tsx
@@ -26,11 +26,14 @@ type CouponFeedback = { type: "success"; amountAdded: number | null } | { type: 
 
 export const DEPENDENCIES = {
   useForm,
+  // eslint-disable-next-line akash/dependencies-component-or-hook
   zodResolver,
   useUser,
   usePaymentMutations,
   usePaymentPolling,
+  // eslint-disable-next-line akash/dependencies-component-or-hook
   handleCouponError,
+  // eslint-disable-next-line akash/dependencies-component-or-hook
   handleStripeError
 };
 

--- a/apps/deploy-web/src/components/deployments/AttestationEvidenceModal.tsx
+++ b/apps/deploy-web/src/components/deployments/AttestationEvidenceModal.tsx
@@ -19,6 +19,7 @@ type AttestationReportStatus = AttestationReportVerdict["status"];
 
 export const DEPENDENCIES = {
   useAttestationQuoteMutation,
+  // eslint-disable-next-line akash/dependencies-component-or-hook
   saveFile: saveFileInBrowser as (data: Blob, filename?: string) => void
 };
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/PresetsCard/PresetsCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/PresetsCard/PresetsCard.tsx
@@ -11,6 +11,7 @@ import { UnlockGpusButton } from "../UnlockGpusButton/UnlockGpusButton";
 import type { HardwarePreset, HardwarePresetGroup } from "./hardwarePresets";
 import { applyPreset, detectPreset, formatPresetSpecs, HARDWARE_PRESET_GROUP_LABELS, HARDWARE_PRESET_GROUP_ORDER, hardwarePresets } from "./hardwarePresets";
 
+// eslint-disable-next-line akash/dependencies-component-or-hook
 export const DEPENDENCIES = { hardwarePresets, useServices };
 
 type Props = {

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/RuntimeCard/RuntimeCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/RuntimeCard/RuntimeCard.tsx
@@ -38,6 +38,7 @@ const loadJSZip = async (): Promise<{ new (): JSZipInstance }> => {
 /** Narrowed to the single call signature used here so tests can supply a plain stub. */
 const saveBlobAs: (data: Blob, filename: string) => void = saveAs;
 
+// eslint-disable-next-line akash/dependencies-component-or-hook
 export const DEPENDENCIES = { CollapsibleCard, QuantityStepper, CodeSnippet, generateSSHKeyPair, useSnackbar, saveAs: saveBlobAs, loadJSZip };
 
 type Props = {

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentHeader/ConfigureDeploymentHeader.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentHeader/ConfigureDeploymentHeader.tsx
@@ -24,7 +24,9 @@ export const DEPENDENCIES = {
   useDeploymentHasGpu,
   useSnackbar,
   Snackbar,
+  // eslint-disable-next-line akash/dependencies-component-or-hook
   generateSdl,
+  // eslint-disable-next-line akash/dependencies-component-or-hook
   validateGeneratedSdl,
   useDeploymentCost,
   PriceValue,

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/SdlImportExport/ImportSdlDialog.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/SdlImportExport/ImportSdlDialog.tsx
@@ -23,6 +23,7 @@ import { importDeploymentState, isKnownSdlParserError, NoVisibleServiceError } f
 /** An SDL well over any real deployment is almost certainly the wrong file; reject before reading it into memory. */
 const MAX_SDL_FILE_BYTES = 512 * 1024;
 
+// eslint-disable-next-line akash/dependencies-component-or-hook
 export const DEPENDENCIES = { SDLEditor, FileButton, importDeploymentState };
 
 type Props = {

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/SdlImportExport/SdlImportExport.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/SdlImportExport/SdlImportExport.tsx
@@ -26,6 +26,7 @@ const saveBlobAs: (data: Blob, filename: string) => void = saveAs;
 /** Names the menu trigger for both the visible tooltip and the accessible label, so the two can't drift apart. */
 const MENU_TRIGGER_LABEL = "Import or export config";
 
+// eslint-disable-next-line akash/dependencies-component-or-hook
 export const DEPENDENCIES = { ImportSdlDialog, useServices, useSnackbar, Snackbar, saveAs: saveBlobAs, copyTextToClipboard, CustomNoDivTooltip };
 
 type Props = {

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useConfigureDraft/useConfigureDraft.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useConfigureDraft/useConfigureDraft.ts
@@ -12,6 +12,7 @@ const DRAFT_KEY_PREFIX = "configure-draft:";
 const MAX_DRAFTS = 20;
 
 export const DEPENDENCIES = {
+  // eslint-disable-next-line akash/dependencies-component-or-hook
   getStorage: (): Storage | undefined => {
     if (typeof window === "undefined") {
       return undefined;
@@ -23,6 +24,7 @@ export const DEPENDENCIES = {
     }
   },
   useRouter,
+  // eslint-disable-next-line akash/dependencies-component-or-hook
   mintDraftId
 };
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentCost/useDeploymentCost.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentCost/useDeploymentCost.ts
@@ -5,6 +5,7 @@ import { parseBidId } from "@src/utils/bids/bidId";
 import { PRICE_DISPLAY_PRECISION, udenomToDenom } from "@src/utils/mathHelpers";
 import { getPlacementGseq } from "@src/utils/sdl/placementGseq";
 
+// eslint-disable-next-line akash/dependencies-component-or-hook
 export const DEPENDENCIES = { useListBids, getPlacementGseq };
 
 interface Input {
@@ -35,10 +36,7 @@ type BidEntry = NonNullable<ReturnType<typeof useListBids>["data"]>["data"][numb
  * single denom per deployment (chain-guaranteed), labelling it with the first open bid's denom like the review
  * modal's total.
  */
-export function useDeploymentCost(
-  { dseq, sdl, placements, selections }: Input,
-  dependencies: typeof DEPENDENCIES = DEPENDENCIES
-): DeploymentCost | null {
+export function useDeploymentCost({ dseq, sdl, placements, selections }: Input, dependencies: typeof DEPENDENCIES = DEPENDENCIES): DeploymentCost | null {
   const bidsQuery = dependencies.useListBids(dseq);
   const bids = bidsQuery.data?.data;
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.ts
@@ -86,7 +86,9 @@ export const DEPENDENCIES = {
   useListBids,
   useRouter,
   useQueryClient,
+  // eslint-disable-next-line akash/dependencies-component-or-hook
   manifestFromSdl,
+  // eslint-disable-next-line akash/dependencies-component-or-hook
   deploymentResourcesFromSdl
 };
 

--- a/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.tsx
+++ b/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.tsx
@@ -42,6 +42,7 @@ export const DEPENDENCIES = {
   useProviderCredentials: useProviderCredentialsOriginal,
   useSnackbar: useSnackbarOriginal,
   useSettings: useSettingsOriginal,
+  // eslint-disable-next-line akash/dependencies-component-or-hook
   deploymentData: deploymentDataOriginal,
   TransactionMessageData: TransactionMessageDataOriginal
 };

--- a/apps/deploy-web/src/components/globe/Globe/Globe.tsx
+++ b/apps/deploy-web/src/components/globe/Globe/Globe.tsx
@@ -14,6 +14,7 @@ export type GlobeMarker = {
 };
 
 export const DEPENDENCIES = {
+  // eslint-disable-next-line akash/dependencies-component-or-hook
   createGlobe,
   useTheme: useCookieTheme
 };

--- a/apps/deploy-web/src/components/new-deployment/ShareDeployButton/ShareDeployButton.tsx
+++ b/apps/deploy-web/src/components/new-deployment/ShareDeployButton/ShareDeployButton.tsx
@@ -14,7 +14,9 @@ import { getBaseUrl, UrlService } from "@src/utils/urlUtils";
 export const DEPENDENCIES = {
   usePopup,
   useSnackbar,
+  // eslint-disable-next-line akash/dependencies-component-or-hook
   getBaseUrl,
+  // eslint-disable-next-line akash/dependencies-component-or-hook
   copyTextToClipboard,
   Button,
   ShareIos

--- a/apps/deploy-web/src/components/new-deployment/TemplateList.tsx
+++ b/apps/deploy-web/src/components/new-deployment/TemplateList.tsx
@@ -45,6 +45,7 @@ const previewTemplateIds = [
   "akash-network-awesome-akash-FastChat"
 ];
 
+// eslint-disable-next-line akash/dependencies-component-or-hook
 export const DEPENDENCIES = { useTemplates, useRouter, useFlag, useNewDeploymentUrl, useSnackbar, Snackbar, importSimpleSdl, FileButton, createConfigureDraft };
 
 type Props = {

--- a/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.tsx
+++ b/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.tsx
@@ -52,15 +52,23 @@ const DEPENDENCIES = {
   useWallet,
   useNotificator,
   useReturnTo,
+  // eslint-disable-next-line akash/dependencies-component-or-hook
   localStorage: typeof window !== "undefined" ? window.localStorage : null,
+  // eslint-disable-next-line akash/dependencies-component-or-hook
   deploymentData,
+  // eslint-disable-next-line akash/dependencies-component-or-hook
   validateDeploymentData,
+  // eslint-disable-next-line akash/dependencies-component-or-hook
   appendAuditorRequirement,
+  // eslint-disable-next-line akash/dependencies-component-or-hook
   applyTrialGpuPolicy,
+  // eslint-disable-next-line akash/dependencies-component-or-hook
   replaceSdlDenom,
+  // eslint-disable-next-line akash/dependencies-component-or-hook
   helloWorldTemplate,
   TransactionMessageData,
   useSearchParams,
+  // eslint-disable-next-line akash/dependencies-component-or-hook
   denomToUdenom
 };
 

--- a/apps/deploy-web/src/components/onboarding/VerifyEmailPage/VerifyEmailPage.tsx
+++ b/apps/deploy-web/src/components/onboarding/VerifyEmailPage/VerifyEmailPage.tsx
@@ -11,6 +11,7 @@ const DEPENDENCIES = {
   Loading,
   NextSeo,
   UrlService,
+  // eslint-disable-next-line akash/dependencies-component-or-hook
   redirect: (url: string) => {
     window.localStorage.setItem(ONBOARDING_STEP_KEY, OnboardingStepIndex.EMAIL_VERIFICATION.toString());
     window.location.replace(url);

--- a/apps/deploy-web/src/components/onboarding/steps/EmailVerificationStep/EmailVerificationStep.tsx
+++ b/apps/deploy-web/src/components/onboarding/steps/EmailVerificationStep/EmailVerificationStep.tsx
@@ -14,6 +14,7 @@ const COOLDOWN_DURATION = 60;
 
 export const DEPENDENCIES = {
   useNotificator,
+  // eslint-disable-next-line akash/dependencies-component-or-hook
   extractErrorMessage
 };
 

--- a/apps/deploy-web/src/context/SettingsProvider/SettingsProviderContext.tsx
+++ b/apps/deploy-web/src/context/SettingsProvider/SettingsProviderContext.tsx
@@ -36,6 +36,7 @@ const BLOCKCHAIN_STATUS_POLL_INTERVAL_MS = 5 * 60_000;
 export const DEPENDENCIES = {
   useRootContainer,
   usePreviousRoute,
+  // eslint-disable-next-line akash/dependencies-component-or-hook
   migrateLocalStorage
 };
 

--- a/apps/deploy-web/src/hooks/useAutoDeploymentFlow/useAutoDeploymentFlow.ts
+++ b/apps/deploy-web/src/hooks/useAutoDeploymentFlow/useAutoDeploymentFlow.ts
@@ -70,6 +70,7 @@ function getRequiredGseqs(sdl: string): number[] {
 export const DEPENDENCIES = {
   useProviderList,
   useFirstReachableProvider,
+  // eslint-disable-next-line akash/dependencies-component-or-hook
   getRequiredGseqs
 };
 

--- a/apps/deploy-web/src/hooks/useDeployButtonFlow/useDeployButtonFlow.ts
+++ b/apps/deploy-web/src/hooks/useDeployButtonFlow/useDeployButtonFlow.ts
@@ -3,6 +3,7 @@ import { useSearchParams as useSearchParamsOriginal } from "next/navigation";
 
 export const DEPENDENCIES = {
   useSearchParams: useSearchParamsOriginal,
+  // eslint-disable-next-line akash/dependencies-component-or-hook
   window: typeof window === "undefined" ? undefined : window
 };
 

--- a/apps/deploy-web/src/hooks/useRedeploy/useRedeploy.ts
+++ b/apps/deploy-web/src/hooks/useRedeploy/useRedeploy.ts
@@ -3,6 +3,7 @@ import { useRouter } from "next/navigation";
 import { createConfigureDraft } from "@src/components/deployments/ConfigureDeployment/useConfigureDraft/useConfigureDraft";
 import { UrlService } from "@src/utils/urlUtils";
 
+// eslint-disable-next-line akash/dependencies-component-or-hook
 export const DEPENDENCIES = { useRouter, UrlService, createConfigureDraft };
 
 export interface RedeployInput {

--- a/apps/deploy-web/src/hooks/useReturnTo/useReturnTo.ts
+++ b/apps/deploy-web/src/hooks/useReturnTo/useReturnTo.ts
@@ -7,6 +7,7 @@ export const DEPENDENCIES = {
   useRouter,
   useSearchParams,
   useServices,
+  // eslint-disable-next-line akash/dependencies-component-or-hook
   window: typeof window === "undefined" ? undefined : window
 };
 

--- a/apps/deploy-web/src/lib/XTerm/XTerm.tsx
+++ b/apps/deploy-web/src/lib/XTerm/XTerm.tsx
@@ -15,6 +15,7 @@ import { copyTextToClipboard } from "@src/utils/copyClipboard";
 
 const logger = LoggerService.forContext("XTerm");
 
+// eslint-disable-next-line akash/dependencies-component-or-hook
 export const DEPENDENCIES = { Terminal, FitAddon, useTheme, copyTextToClipboard };
 
 export interface IProps {

--- a/apps/deploy-web/src/queries/usePlacementOffers.ts
+++ b/apps/deploy-web/src/queries/usePlacementOffers.ts
@@ -36,6 +36,7 @@ interface UsePlacementOffersResult {
   isInvalid: boolean;
 }
 
+// eslint-disable-next-line akash/dependencies-component-or-hook
 export const DEPENDENCIES = { useScreenedProviders, useListBids, useProviderList, getPlacementGseq };
 
 /**

--- a/apps/deploy-web/src/queries/usePlacementsWithBids.ts
+++ b/apps/deploy-web/src/queries/usePlacementsWithBids.ts
@@ -3,6 +3,7 @@ import { useMemo } from "react";
 import { BID_POLL_INTERVAL, useListBids } from "@src/queries/useListBids";
 import { getPlacementGseq } from "@src/utils/sdl/placementGseq";
 
+// eslint-disable-next-line akash/dependencies-component-or-hook
 export const DEPENDENCIES = { useListBids, getPlacementGseq };
 
 interface Input {

--- a/apps/stats-web/eslint.config.mjs
+++ b/apps/stats-web/eslint.config.mjs
@@ -1,3 +1,11 @@
 import nextConfig from "@akashnetwork/dev-config/eslint/next.mjs";
 
-export default nextConfig;
+export default [
+  ...nextConfig,
+  {
+    files: ["**/*.ts", "**/*.tsx"],
+    rules: {
+      "akash/dependencies-component-or-hook": ["error"]
+    }
+  }
+];

--- a/packages/dev-config/eslint-plugin-akash/index.js
+++ b/packages/dev-config/eslint-plugin-akash/index.js
@@ -1,9 +1,11 @@
+const dependenciesComponentOrHook = require("./rules/dependencies-component-or-hook");
 const noMnemonic = require("./rules/no-mnemonic");
 const operationIdFormat = require("./rules/operation-id-format");
 
 module.exports = {
   rules: {
     "no-mnemonic": noMnemonic,
-    "operation-id-format": operationIdFormat
+    "operation-id-format": operationIdFormat,
+    "dependencies-component-or-hook": dependenciesComponentOrHook
   }
 };

--- a/packages/dev-config/eslint-plugin-akash/rules/dependencies-component-or-hook.js
+++ b/packages/dev-config/eslint-plugin-akash/rules/dependencies-component-or-hook.js
@@ -1,0 +1,75 @@
+const HOOK_NAME = /^use[A-Z0-9]/;
+const COMPONENT_NAME = /^[A-Z]/;
+const GUIDANCE =
+  "The DEPENDENCIES map may only contain React components (PascalCase) or hooks (use-prefixed). Inject services via the useServices hook instead.";
+
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Enforce that the injectable `const DEPENDENCIES` map in React components contains only React components (PascalCase) or hooks (use-prefixed)."
+    },
+    schema: []
+  },
+  create(context) {
+    return {
+      VariableDeclarator(node) {
+        if (!isDependenciesMap(node)) return;
+
+        for (const property of node.init.properties) {
+          if (property.type === "SpreadElement") {
+            context.report({
+              node: property,
+              message: `Spread elements are not allowed in the DEPENDENCIES map. List each React component or hook explicitly. ${GUIDANCE}`
+            });
+            continue;
+          }
+
+          const name = getPropertyName(property);
+          if (name === null || isReactComponentOrHook(name)) continue;
+
+          context.report({
+            node: property,
+            message: `"${name}" is not a React component or hook. ${GUIDANCE}`
+          });
+        }
+      }
+    };
+  }
+};
+
+/**
+ * Tests whether a VariableDeclarator is `const DEPENDENCIES = { ... }` — the
+ * injectable dependency map React components in this repo expose for testing.
+ * @param {object} node - ESTree VariableDeclarator node.
+ * @returns {boolean}
+ */
+function isDependenciesMap(node) {
+  return node.id.type === "Identifier" && node.id.name === "DEPENDENCIES" && node.init?.type === "ObjectExpression";
+}
+
+/**
+ * Returns the local name a DEPENDENCIES entry is exposed under (identifier or
+ * string-literal key), which is how it is later referenced as `d.<name>`.
+ * Returns null for computed or otherwise unnamed keys, which the rule skips.
+ * @param {object} property - ESTree Property node.
+ * @returns {string | null}
+ */
+function getPropertyName(property) {
+  if (property.computed) return null;
+  if (property.key.type === "Identifier") return property.key.name;
+  if (property.key.type === "Literal" && typeof property.key.value === "string") return property.key.value;
+  return null;
+}
+
+/**
+ * A name denotes a React component when it is PascalCase and a React hook when
+ * it is `use`-prefixed followed by an uppercase letter or digit — the same
+ * naming contract React itself relies on to tell components and hooks apart.
+ * @param {string} name
+ * @returns {boolean}
+ */
+function isReactComponentOrHook(name) {
+  return COMPONENT_NAME.test(name) || HOOK_NAME.test(name);
+}

--- a/packages/dev-config/eslint-plugin-akash/rules/dependencies-component-or-hook.js
+++ b/packages/dev-config/eslint-plugin-akash/rules/dependencies-component-or-hook.js
@@ -27,7 +27,15 @@ module.exports = {
           }
 
           const name = getPropertyName(property);
-          if (name === null || isReactComponentOrHook(name)) continue;
+          if (name === null) {
+            context.report({
+              node: property,
+              message: `Computed or dynamic keys are not allowed in the DEPENDENCIES map. List each React component or hook under a static name. ${GUIDANCE}`
+            });
+            continue;
+          }
+
+          if (isReactComponentOrHook(name)) continue;
 
           context.report({
             node: property,
@@ -46,13 +54,14 @@ module.exports = {
  * @returns {boolean}
  */
 function isDependenciesMap(node) {
-  return node.id.type === "Identifier" && node.id.name === "DEPENDENCIES" && node.init?.type === "ObjectExpression";
+  return node.parent?.kind === "const" && node.id.type === "Identifier" && node.id.name === "DEPENDENCIES" && node.init?.type === "ObjectExpression";
 }
 
 /**
  * Returns the local name a DEPENDENCIES entry is exposed under (identifier or
  * string-literal key), which is how it is later referenced as `d.<name>`.
- * Returns null for computed or otherwise unnamed keys, which the rule skips.
+ * Returns null for computed or otherwise dynamic keys, which the rule rejects
+ * because they cannot be statically verified as components or hooks.
  * @param {object} property - ESTree Property node.
  * @returns {string | null}
  */

--- a/packages/dev-config/eslint-plugin-akash/rules/dependencies-component-or-hook.js
+++ b/packages/dev-config/eslint-plugin-akash/rules/dependencies-component-or-hook.js
@@ -1,5 +1,5 @@
-const HOOK_NAME = /^use[A-Z0-9]/;
-const COMPONENT_NAME = /^[A-Z]/;
+const HOOK_NAME = /^use[A-Z0-9][A-Za-z0-9]*$/;
+const COMPONENT_NAME = /^[A-Z][A-Za-z0-9]*$/;
 const GUIDANCE =
   "The DEPENDENCIES map may only contain React components (PascalCase) or hooks (use-prefixed). Inject services via the useServices hook instead.";
 


### PR DESCRIPTION
## Why

The `DEPENDENCIES` map is our convention for making a component's collaborators injectable (and therefore mockable in tests). Its intent is to hold only React components and hooks — services are supposed to be reached through the `useServices` hook, not listed directly in the map.

Nothing enforced this, so the maps had drifted: utility functions, constants, and globals (`localStorage`, `window`, `zodResolver`, `saveAs`, …) had crept in, blurring the boundary the pattern is meant to protect and giving no signal when a service was wired in the wrong way.

## What

Adds `akash/dependencies-component-or-hook` ESLint rule enforcing that the injectable `const DEPENDENCIES` map only holds React components (PascalCase) or hooks (use-prefixed). Services must be injected via the useServices hook instead of being listed directly in the map.

Enabled at error severity only in deploy-web and stats-web. Existing entries that predate the rule are baselined with eslint-disable-next-line comments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Developer Experience**
  * Added automated validation for component and hook dependency declarations.
  * Updated development tooling configurations to apply the new checks consistently.
  * Added targeted exceptions for valid dependency patterns without changing application behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->