### PR TITLE
feat(deployment): add a gpu interconnect toggle to the deployment configuration

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/GpuInterconnectCard/GpuInterconnectCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/GpuInterconnectCard/GpuInterconnectCard.spec.tsx
@@ -1,0 +1,203 @@
+import type { PropsWithChildren } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import { TooltipProvider } from "@akashnetwork/ui/components";
+import { describe, expect, it } from "vitest";
+
+import type { PlacementAttributeType, SdlBuilderFormValuesType, ServiceType } from "@src/types";
+import { defaultPlacement, defaultService, defaultServiceWithPlacement } from "@src/utils/sdl/data";
+import { GPU_INTERCONNECT_CAPABILITY_KEY, GPU_INTERCONNECT_FABRIC_PREFIX } from "@src/utils/sdl/gpuInterconnect";
+import { GpuInterconnectCard } from "./GpuInterconnectCard";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+describe(GpuInterconnectCard.name, () => {
+  it("hides the body and leaves the switch off when the service does not opt in", () => {
+    setup({});
+
+    expect(screen.getByRole("switch", { name: "Enable GPU interconnect" })).not.toBeChecked();
+    expect(screen.queryByText(/high-bandwidth GPU-to-GPU interconnect/i)).not.toBeInTheDocument();
+  });
+
+  it("sets the implicit auto group, enables GPU and adds the placement capability when toggled on", async () => {
+    const { getValues } = setup({ profile: { hasGpu: false, gpu: 0, gpuModels: [] } });
+
+    await userEvent.click(screen.getByRole("switch", { name: "Enable GPU interconnect" }));
+
+    const service = getValues().services[0];
+    expect(service.profile.interconnect).toEqual({});
+    expect(service.profile.hasGpu).toBe(true);
+    expect(service.profile.gpu).toBeGreaterThanOrEqual(1);
+    expect((service.profile.gpuModels ?? []).length).toBeGreaterThanOrEqual(1);
+    expect(getValues().placements[0].attributes).toEqual([{ id: expect.any(String), key: GPU_INTERCONNECT_CAPABILITY_KEY, value: "true" }]);
+  });
+
+  it("preserves an already-configured GPU instead of resetting it when toggled on", async () => {
+    const { getValues } = setup({ profile: { hasGpu: true, gpu: 4, gpuModels: [{ vendor: "nvidia", name: "h100" }] } });
+
+    await userEvent.click(screen.getByRole("switch", { name: "Enable GPU interconnect" }));
+
+    expect(getValues().services[0].profile.gpu).toBe(4);
+    expect(getValues().services[0].profile.gpuModels).toEqual([{ vendor: "nvidia", name: "h100" }]);
+  });
+
+  it("normalizes an imported false capability to true instead of appending a duplicate", async () => {
+    const { getValues } = setup({ attributes: [{ id: "c1", key: GPU_INTERCONNECT_CAPABILITY_KEY, value: "false" }] });
+
+    await userEvent.click(screen.getByRole("switch", { name: "Enable GPU interconnect" }));
+
+    expect(getValues().placements[0].attributes).toEqual([{ id: "c1", key: GPU_INTERCONNECT_CAPABILITY_KEY, value: "true" }]);
+  });
+
+  it("renders enabled for an imported implicit group", () => {
+    setup({ interconnect: {} });
+
+    expect(screen.getByRole("switch", { name: "Enable GPU interconnect" })).toBeChecked();
+  });
+
+  it("renders enabled for an imported explicit group", () => {
+    setup({ interconnect: { group: "pair0" } });
+
+    expect(screen.getByRole("switch", { name: "Enable GPU interconnect" })).toBeChecked();
+    expect(screen.getByText(/high-bandwidth GPU-to-GPU interconnect/i)).toBeInTheDocument();
+  });
+
+  it("clears the opt-in and removes the capability and fabric pins when toggled off", async () => {
+    const { getValues } = setup({
+      interconnect: {},
+      attributes: [
+        { id: "r1", key: "region", value: "us-west" },
+        { id: "c1", key: GPU_INTERCONNECT_CAPABILITY_KEY, value: "true" },
+        { id: "f1", key: `${GPU_INTERCONNECT_FABRIC_PREFIX}infiniband`, value: "true" }
+      ]
+    });
+
+    await userEvent.click(screen.getByRole("switch", { name: "Enable GPU interconnect" }));
+
+    expect(getValues().services[0].profile.interconnect).toBeUndefined();
+    expect(getValues().placements[0].attributes).toEqual([{ id: "r1", key: "region", value: "us-west" }]);
+  });
+
+  it("keeps the placement capability when a same-placement sibling still opts in", async () => {
+    const { getValues } = setup({
+      interconnect: {},
+      attributes: [{ id: "c1", key: GPU_INTERCONNECT_CAPABILITY_KEY, value: "true" }],
+      sibling: "same-placement"
+    });
+
+    await userEvent.click(screen.getByRole("switch", { name: "Enable GPU interconnect" }));
+
+    expect(getValues().services[0].profile.interconnect).toBeUndefined();
+    expect(getValues().placements[0].attributes).toEqual([{ id: "c1", key: GPU_INTERCONNECT_CAPABILITY_KEY, value: "true" }]);
+  });
+
+  it("removes the placement capability when the only other opted-in service is on a different placement", async () => {
+    const { getValues } = setup({
+      interconnect: {},
+      attributes: [{ id: "c1", key: GPU_INTERCONNECT_CAPABILITY_KEY, value: "true" }],
+      sibling: "other-placement"
+    });
+
+    await userEvent.click(screen.getByRole("switch", { name: "Enable GPU interconnect" }));
+
+    expect(getValues().placements[0].attributes).toEqual([]);
+  });
+
+  it("shows the multi-node hint for a single-replica service", () => {
+    setup({ interconnect: {}, count: 1 });
+
+    expect(screen.getByText(/2\+ nodes/)).toBeInTheDocument();
+  });
+
+  it("leaves the replica count untouched when toggled on", async () => {
+    const { getValues } = setup({ count: 1 });
+
+    await userEvent.click(screen.getByRole("switch", { name: "Enable GPU interconnect" }));
+
+    expect(getValues().services[0].count).toBe(1);
+  });
+
+  it("hides the multi-node hint at two or more replicas", () => {
+    setup({ interconnect: {}, count: 2 });
+
+    expect(screen.queryByText(/2\+ nodes/)).not.toBeInTheDocument();
+  });
+
+  it("hides the multi-node hint when a same-placement sibling participates", () => {
+    setup({ interconnect: {}, count: 1, sibling: "same-placement" });
+
+    expect(screen.queryByText(/2\+ nodes/)).not.toBeInTheDocument();
+  });
+
+  it("warns when enabled while the service has no GPU resources", () => {
+    setup({ interconnect: {}, profile: { hasGpu: false, gpu: 0, gpuModels: [] } });
+
+    expect(screen.getByText(/needs GPU resources/i)).toBeInTheDocument();
+  });
+
+  it("does not warn right after enabling turns the GPU on", async () => {
+    setup({ profile: { hasGpu: false, gpu: 0, gpuModels: [] } });
+
+    await userEvent.click(screen.getByRole("switch", { name: "Enable GPU interconnect" }));
+
+    expect(screen.queryByText(/needs GPU resources/i)).not.toBeInTheDocument();
+  });
+
+  it("disables the switch while the pane is locked", () => {
+    setup({ interconnect: {}, locked: true });
+
+    expect(screen.getByRole("switch", { name: "Enable GPU interconnect" })).toBeDisabled();
+  });
+
+  it("shows an off-state hint when opened while off and locked", async () => {
+    setup({ locked: true });
+
+    await userEvent.click(screen.getByRole("button", { name: "Expand GPU Interconnect" }));
+
+    expect(screen.getByText("GPU interconnect is off.")).toBeInTheDocument();
+  });
+
+  function setup(input: {
+    interconnect?: { group?: string };
+    profile?: Partial<ServiceType["profile"]>;
+    count?: number;
+    attributes?: PlacementAttributeType[];
+    sibling?: "same-placement" | "other-placement";
+    locked?: boolean;
+  }) {
+    const base = defaultServiceWithPlacement();
+    const placements: SdlBuilderFormValuesType["placements"] = [{ ...base.placements[0], attributes: input.attributes ?? [] }];
+    const services: SdlBuilderFormValuesType["services"] = [
+      {
+        ...base.services[0],
+        count: input.count ?? base.services[0].count,
+        profile: { ...base.services[0].profile, ...input.profile, interconnect: input.interconnect }
+      }
+    ];
+
+    if (input.sibling) {
+      const siblingPlacement = input.sibling === "same-placement" ? placements[0] : defaultPlacement({ name: "dcloud-2" });
+      if (input.sibling === "other-placement") placements.push(siblingPlacement);
+      services.push(defaultService(siblingPlacement.id, { title: "service-2", profile: { ...base.services[0].profile, interconnect: {} } }));
+    }
+
+    const values: SdlBuilderFormValuesType = { placements, services, endpoints: [] };
+
+    let getValues: () => SdlBuilderFormValuesType = () => values;
+    const Wrapper = ({ children }: PropsWithChildren) => {
+      const form = useForm<SdlBuilderFormValuesType>({ defaultValues: values, mode: "onChange" });
+      getValues = form.getValues;
+      return <FormProvider {...form}>{children}</FormProvider>;
+    };
+
+    render(
+      <Wrapper>
+        <TooltipProvider>
+          <GpuInterconnectCard serviceIndex={0} locked={input.locked} />
+        </TooltipProvider>
+      </Wrapper>
+    );
+
+    return { getValues: () => getValues() };
+  }
+});

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/GpuInterconnectCard/GpuInterconnectCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/GpuInterconnectCard/GpuInterconnectCard.tsx
@@ -42,8 +42,10 @@ export const GpuInterconnectCard: FC<Props> = ({ serviceIndex, locked = false, d
 
   const isEnabled = !!interconnect;
 
-  // Enabling turns the GPU card on, but the user can still turn GPU back off afterwards — surface the
-  // resulting mismatch since an interconnect only filters providers for a service that requests GPUs.
+  /**
+   * Enabling turns the GPU card on, but the user can still turn GPU back off afterwards — surface the
+   * resulting mismatch since an interconnect only filters providers for a service that requests GPUs.
+   */
   const gpuMismatch = isEnabled && !hasGpu;
 
   const hasParticipatingSibling = hasOtherInterconnectService(services, serviceIndex);

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/GpuInterconnectCard/GpuInterconnectCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/GpuInterconnectCard/GpuInterconnectCard.tsx
@@ -1,0 +1,130 @@
+import type { FC } from "react";
+import { useCallback } from "react";
+import { useFormContext, useWatch } from "react-hook-form";
+import { Alert, CollapsibleCard } from "@akashnetwork/ui/components";
+import { NetworkIcon } from "lucide-react";
+
+import type { SdlBuilderFormValuesType } from "@src/types";
+import { defaultGpuModel } from "@src/utils/sdl/data";
+import { hasOtherInterconnectService, withGpuInterconnectCapability, withoutGpuInterconnectCapability } from "@src/utils/sdl/gpuInterconnect";
+import { gpuInterconnectTooltip } from "../cardTooltips";
+
+export const DEPENDENCIES = { CollapsibleCard, Alert };
+
+type Props = {
+  serviceIndex: number;
+  locked?: boolean;
+  dependencies?: typeof DEPENDENCIES;
+};
+
+/**
+ * Hardware "GPU Interconnect" card. A header switch toggles whether the service
+ * opts into a high-bandwidth GPU-to-GPU interconnect, persisted as
+ * `services.${serviceIndex}.profile.interconnect` (presence = enabled, `{}` =
+ * implicit "auto" group). Enabling also turns on the GPU card (an interconnect
+ * without GPUs is meaningless) and upserts the placement attribute
+ * `capabilities/gpu-interconnect: "true"` so only interconnect-capable providers
+ * bid. Disabling clears the opt-in and removes the placement capability (plus
+ * any fabric pins) unless another service on the same placement still opts in.
+ *
+ * The card never mutates on mount, preserving the SDL import round-trip: an
+ * imported explicit group (`{ group: "x" }`) simply shows as ON, and toggling it
+ * off and on collapses it to the implicit `{}` group (explicit group editing is
+ * out of scope here, see CON-692).
+ */
+export const GpuInterconnectCard: FC<Props> = ({ serviceIndex, locked = false, dependencies: d = DEPENDENCIES }) => {
+  const { control, getValues, setValue } = useFormContext<SdlBuilderFormValuesType>();
+  const interconnect = useWatch({ control, name: `services.${serviceIndex}.profile.interconnect` });
+  const hasGpu = useWatch({ control, name: `services.${serviceIndex}.profile.hasGpu` });
+  const count = useWatch({ control, name: `services.${serviceIndex}.count` });
+  const watchedServices = useWatch({ control, name: "services" });
+  const services = Array.isArray(watchedServices) ? (watchedServices as SdlBuilderFormValuesType["services"]) : [];
+
+  const isEnabled = !!interconnect;
+
+  // Enabling turns the GPU card on, but the user can still turn GPU back off afterwards — surface the
+  // resulting mismatch since an interconnect only filters providers for a service that requests GPUs.
+  const gpuMismatch = isEnabled && !hasGpu;
+
+  const hasParticipatingSibling = hasOtherInterconnectService(services, serviceIndex);
+  const showSingleNodeHint = isEnabled && count === 1 && !hasParticipatingSibling;
+
+  /**
+   * Brings the GPU card to its enabled state — `profile.hasGpu` on, a count of at least one, and at least
+   * one GPU model — matching what the GPU card's own switch does. Only ever turns GPU on (never off), so a
+   * GPU the user configured independently, or one left over after toggling the interconnect off, is preserved.
+   */
+  const enableGpu = useCallback(() => {
+    const profile = `services.${serviceIndex}.profile` as const;
+    if (!getValues(`${profile}.hasGpu`)) {
+      setValue(`${profile}.hasGpu`, true, { shouldDirty: true });
+    }
+    if ((getValues(`${profile}.gpu`) ?? 0) < 1) {
+      setValue(`${profile}.gpu`, 1, { shouldValidate: true, shouldDirty: true });
+    }
+    if ((getValues(`${profile}.gpuModels`) ?? []).length === 0) {
+      setValue(`${profile}.gpuModels`, [{ ...defaultGpuModel }], { shouldDirty: true });
+    }
+  }, [getValues, serviceIndex, setValue]);
+
+  const setPlacementCapability = useCallback(
+    (enabled: boolean) => {
+      const placementId = getValues(`services.${serviceIndex}.placementId`);
+      const placementIndex = getValues("placements").findIndex(placement => placement.id === placementId);
+      if (placementIndex < 0) return;
+
+      const attributes = getValues(`placements.${placementIndex}.attributes`);
+      const nextAttributes = enabled ? withGpuInterconnectCapability(attributes) : withoutGpuInterconnectCapability(attributes);
+      if (nextAttributes !== attributes) {
+        setValue(`placements.${placementIndex}.attributes`, nextAttributes, { shouldDirty: true });
+      }
+    },
+    [getValues, serviceIndex, setValue]
+  );
+
+  const toggleInterconnect = useCallback(
+    (checked: boolean) => {
+      setValue(`services.${serviceIndex}.profile.interconnect`, checked ? {} : undefined, { shouldDirty: true });
+      if (checked) {
+        enableGpu();
+        setPlacementCapability(true);
+      } else if (!hasOtherInterconnectService(getValues("services"), serviceIndex)) {
+        setPlacementCapability(false);
+      }
+    },
+    [enableGpu, getValues, serviceIndex, setPlacementCapability, setValue]
+  );
+
+  return (
+    <d.CollapsibleCard
+      locked={locked}
+      title="GPU Interconnect"
+      icon={<NetworkIcon className="h-4 w-4" />}
+      infoTooltip={gpuInterconnectTooltip}
+      isToggled={isEnabled}
+      onToggle={toggleInterconnect}
+      toggleAriaLabel="Enable GPU interconnect"
+      toggleDisabled={locked}
+    >
+      {isEnabled ? (
+        <div className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            This service requests a high-bandwidth GPU-to-GPU interconnect; only interconnect-capable providers will bid.
+          </p>
+          {showSingleNodeHint && (
+            <p className="text-sm text-muted-foreground">
+              A GPU interconnect links GPUs across 2+ nodes. Increase the replica count under Runtime for a multi-node workload.
+            </p>
+          )}
+          {gpuMismatch && (
+            <d.Alert variant="warning" className="p-4 text-sm">
+              A GPU interconnect needs GPU resources on this service. Enable the GPU card above so interconnect-capable providers can bid.
+            </d.Alert>
+          )}
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground">GPU interconnect is off.</p>
+      )}
+    </d.CollapsibleCard>
+  );
+};

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/HardwareSection/HardwareSection.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/HardwareSection/HardwareSection.spec.tsx
@@ -9,15 +9,20 @@ describe(HardwareSection.name, () => {
   it("renders each hardware row for the selected service", () => {
     const PresetsCard = vi.fn(() => null);
     const GpuCard = vi.fn(() => null);
+    const GpuInterconnectCard = vi.fn(() => null);
     const ComputeResourcesCard = vi.fn(() => null);
     const PersistentStorageCard = vi.fn(() => null);
     const RamStorageCard = vi.fn(() => null);
     const ConfidentialComputeCard = vi.fn(() => null);
 
-    setup({ serviceIndex: 2, dependencies: { PresetsCard, GpuCard, ComputeResourcesCard, PersistentStorageCard, RamStorageCard, ConfidentialComputeCard } });
+    setup({
+      serviceIndex: 2,
+      dependencies: { PresetsCard, GpuCard, GpuInterconnectCard, ComputeResourcesCard, PersistentStorageCard, RamStorageCard, ConfidentialComputeCard }
+    });
 
     expect(PresetsCard).toHaveBeenCalledWith(expect.objectContaining({ serviceIndex: 2 }), expect.anything());
     expect(GpuCard).toHaveBeenCalledWith(expect.objectContaining({ serviceIndex: 2 }), expect.anything());
+    expect(GpuInterconnectCard).toHaveBeenCalledWith(expect.objectContaining({ serviceIndex: 2 }), expect.anything());
     expect(ComputeResourcesCard).toHaveBeenCalledWith(expect.objectContaining({ serviceIndex: 2 }), expect.anything());
     expect(PersistentStorageCard).toHaveBeenCalledWith(expect.objectContaining({ serviceIndex: 2 }), expect.anything());
     expect(RamStorageCard).toHaveBeenCalledWith(expect.objectContaining({ serviceIndex: 2 }), expect.anything());
@@ -27,17 +32,36 @@ describe(HardwareSection.name, () => {
   it("forwards the locked state to every hardware card", () => {
     const PresetsCard = vi.fn(() => null);
     const GpuCard = vi.fn(() => null);
+    const GpuInterconnectCard = vi.fn(() => null);
     const ComputeResourcesCard = vi.fn(() => null);
     const PersistentStorageCard = vi.fn(() => null);
     const RamStorageCard = vi.fn(() => null);
 
-    setup({ locked: true, dependencies: { PresetsCard, GpuCard, ComputeResourcesCard, PersistentStorageCard, RamStorageCard } });
+    setup({ locked: true, dependencies: { PresetsCard, GpuCard, GpuInterconnectCard, ComputeResourcesCard, PersistentStorageCard, RamStorageCard } });
 
     expect(PresetsCard).toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
     expect(GpuCard).toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
+    expect(GpuInterconnectCard).toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
     expect(ComputeResourcesCard).toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
     expect(PersistentStorageCard).toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
     expect(RamStorageCard).toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
+  });
+
+  it("hides the GPU interconnect card while the ui_gpu_interconnect flag is off", () => {
+    const GpuInterconnectCard = vi.fn(() => null);
+    const useFlag = () => false;
+
+    setup({ dependencies: { GpuInterconnectCard, useFlag } });
+
+    expect(GpuInterconnectCard).not.toHaveBeenCalled();
+  });
+
+  it("gates the GPU interconnect card on the ui_gpu_interconnect flag", () => {
+    const useFlag = vi.fn(() => true);
+
+    setup({ dependencies: { useFlag } });
+
+    expect(useFlag).toHaveBeenCalledWith("ui_gpu_interconnect");
   });
 
   it("passes an isBlockedModel predicate and unlock handler to the GPU cards", () => {
@@ -122,6 +146,7 @@ describe(HardwareSection.name, () => {
   function setup(input: { serviceIndex?: number; locked?: boolean; dependencies?: Partial<typeof DEPENDENCIES> }) {
     const dependencies = MockComponents(DEPENDENCIES, {
       useTrialGate: () => ({ isRestricted: false, isWalletReady: false }),
+      useFlag: () => true,
       ...input.dependencies
     });
     render(<HardwareSection serviceIndex={input.serviceIndex ?? 0} locked={input.locked} dependencies={dependencies} />);

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/HardwareSection/HardwareSection.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/HardwareSection/HardwareSection.tsx
@@ -4,12 +4,14 @@ import { CollapsibleCard } from "@akashnetwork/ui/components";
 import { CpuIcon, PackageOpenIcon } from "lucide-react";
 
 import { AddCreditsSheet } from "@src/components/auth/AddCreditsSheet/AddCreditsSheet";
+import { useFlag } from "@src/hooks/useFlag";
 import { isTrialBlockedGpuSelection, isTrialGpuRestrictionActive } from "@src/utils/deploymentData/v1beta3";
 import { useRevalidateUniqueness } from "../../DeploymentPane/useRevalidateUniqueness/useRevalidateUniqueness";
 import { computeResourcesTooltip, presetsTooltip } from "../cardTooltips";
 import { ComputeResourcesCard } from "../ComputeResourcesCard/ComputeResourcesCard";
 import { ConfidentialComputeCard } from "../ConfidentialComputeCard/ConfidentialComputeCard";
 import { GpuCard } from "../GpuCard/GpuCard";
+import { GpuInterconnectCard } from "../GpuInterconnectCard/GpuInterconnectCard";
 import { PersistentStorageCard } from "../PersistentStorageCard/PersistentStorageCard";
 import { PresetsCard } from "../PresetsCard/PresetsCard";
 import { RamStorageCard } from "../RamStorageCard/RamStorageCard";
@@ -30,11 +32,13 @@ export const DEPENDENCIES = {
   CollapsibleCard,
   PresetsCard,
   GpuCard,
+  GpuInterconnectCard,
   ComputeResourcesCard,
   RamStorageCard,
   PersistentStorageCard,
   ConfidentialComputeCard,
   AddCreditsSheet,
+  useFlag,
   useRevalidateUniqueness,
   useTrialGate
 };
@@ -82,6 +86,8 @@ export const HardwareSection: FC<Props> = ({ serviceIndex, locked = false, depen
         </d.CollapsibleCard>
 
         <d.GpuCard serviceIndex={serviceIndex} locked={locked} isBlockedModel={isBlockedModel} onUnlock={openUnlock} />
+
+        {d.useFlag("ui_gpu_interconnect") && <d.GpuInterconnectCard serviceIndex={serviceIndex} locked={locked} />}
 
         <d.CollapsibleCard locked={locked} title="Compute Resources" icon={<CpuIcon className="h-4 w-4" />} infoTooltip={computeResourcesTooltip}>
           <d.ComputeResourcesCard serviceIndex={serviceIndex} locked={locked} />

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/cardTooltips.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/cardTooltips.tsx
@@ -86,6 +86,15 @@ export const confidentialComputeTooltip = (
   </>
 );
 
+export const gpuInterconnectTooltip = (
+  <>
+    Request a high-bandwidth GPU-to-GPU interconnect (e.g. InfiniBand) between the nodes running this service, for multi-node workloads like NCCL training.
+    <br />
+    <br />
+    Enabling adds a placement capability so only interconnect-capable providers bid on this deployment. It also turns on the GPU card for this service.
+  </>
+);
+
 export const dockerImageTooltip = (
   <>
     Docker image of the container.

--- a/apps/deploy-web/src/types/feature-flags.ts
+++ b/apps/deploy-web/src/types/feature-flags.ts
@@ -8,6 +8,7 @@ export type FeatureFlag =
   | "auto_credit_reload"
   | "ui_sdl_preview_panel"
   | "ui_build_and_deploy"
+  | "ui_gpu_interconnect"
   | "ui_agent_mode_deploy"
   | "hackathons"
   | "ui_top_nav";

--- a/apps/deploy-web/src/utils/sdl/gpuInterconnect.spec.ts
+++ b/apps/deploy-web/src/utils/sdl/gpuInterconnect.spec.ts
@@ -57,6 +57,10 @@ describe(withoutGpuInterconnectCapability.name, () => {
 
     expect(withoutGpuInterconnectCapability(attributes)).toBe(attributes);
   });
+
+  it("preserves undefined instead of allocating an empty array", () => {
+    expect(withoutGpuInterconnectCapability(undefined)).toBeUndefined();
+  });
 });
 
 describe(hasOtherInterconnectService.name, () => {

--- a/apps/deploy-web/src/utils/sdl/gpuInterconnect.spec.ts
+++ b/apps/deploy-web/src/utils/sdl/gpuInterconnect.spec.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import type { PlacementAttributeType, ServiceType } from "@src/types";
+import {
+  GPU_INTERCONNECT_CAPABILITY_KEY,
+  GPU_INTERCONNECT_FABRIC_PREFIX,
+  hasOtherInterconnectService,
+  withGpuInterconnectCapability,
+  withoutGpuInterconnectCapability
+} from "./gpuInterconnect";
+
+describe(withGpuInterconnectCapability.name, () => {
+  it("appends the capability with a generated id when absent", () => {
+    const attributes: PlacementAttributeType[] = [{ id: "r1", key: "region", value: "us-west" }];
+
+    const result = withGpuInterconnectCapability(attributes);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({ id: "r1", key: "region", value: "us-west" });
+    expect(result[1]).toEqual({ id: expect.any(String), key: GPU_INTERCONNECT_CAPABILITY_KEY, value: "true" });
+  });
+
+  it("upserts an existing row to true instead of appending a duplicate", () => {
+    const attributes: PlacementAttributeType[] = [{ id: "c1", key: GPU_INTERCONNECT_CAPABILITY_KEY, value: "false" }];
+
+    const result = withGpuInterconnectCapability(attributes);
+
+    expect(result).toEqual([{ id: "c1", key: GPU_INTERCONNECT_CAPABILITY_KEY, value: "true" }]);
+  });
+
+  it("returns the same reference when the capability is already true", () => {
+    const attributes: PlacementAttributeType[] = [{ id: "c1", key: GPU_INTERCONNECT_CAPABILITY_KEY, value: "true" }];
+
+    expect(withGpuInterconnectCapability(attributes)).toBe(attributes);
+  });
+
+  it("builds the row from undefined attributes", () => {
+    expect(withGpuInterconnectCapability(undefined)).toEqual([{ id: expect.any(String), key: GPU_INTERCONNECT_CAPABILITY_KEY, value: "true" }]);
+  });
+});
+
+describe(withoutGpuInterconnectCapability.name, () => {
+  it("removes the capability and fabric pins while preserving unrelated rows", () => {
+    const attributes: PlacementAttributeType[] = [
+      { id: "r1", key: "region", value: "us-west" },
+      { id: "c1", key: GPU_INTERCONNECT_CAPABILITY_KEY, value: "true" },
+      { id: "f1", key: `${GPU_INTERCONNECT_FABRIC_PREFIX}infiniband`, value: "true" }
+    ];
+
+    const result = withoutGpuInterconnectCapability(attributes);
+
+    expect(result).toEqual([{ id: "r1", key: "region", value: "us-west" }]);
+  });
+
+  it("returns the same reference when there is nothing to remove", () => {
+    const attributes: PlacementAttributeType[] = [{ id: "r1", key: "region", value: "us-west" }];
+
+    expect(withoutGpuInterconnectCapability(attributes)).toBe(attributes);
+  });
+});
+
+describe(hasOtherInterconnectService.name, () => {
+  it("finds a same-placement sibling that opts in", () => {
+    const services = [service("p1"), service("p1", {})];
+
+    expect(hasOtherInterconnectService(services, 0)).toBe(true);
+  });
+
+  it("ignores an opted-in service on a different placement", () => {
+    const services = [service("p1"), service("p2", {})];
+
+    expect(hasOtherInterconnectService(services, 0)).toBe(false);
+  });
+
+  it("ignores the service itself", () => {
+    const services = [service("p1", {})];
+
+    expect(hasOtherInterconnectService(services, 0)).toBe(false);
+  });
+
+  function service(placementId: string, interconnect?: { group?: string }): Pick<ServiceType, "placementId" | "profile"> {
+    return { placementId, profile: { cpu: 0.1, ram: 512, ramUnit: "Mi", storage: [], interconnect } };
+  }
+});

--- a/apps/deploy-web/src/utils/sdl/gpuInterconnect.ts
+++ b/apps/deploy-web/src/utils/sdl/gpuInterconnect.ts
@@ -36,10 +36,12 @@ export function withGpuInterconnectCapability(attributes: PlacementAttributeType
  * fabric pin would over-filter providers on a deployment that no longer requests
  * the interconnect at all.
  */
-export function withoutGpuInterconnectCapability(attributes: PlacementAttributeType[] | undefined): PlacementAttributeType[] {
-  const rows = attributes ?? [];
-  const remaining = rows.filter(attribute => attribute.key !== GPU_INTERCONNECT_CAPABILITY_KEY && !attribute.key.startsWith(GPU_INTERCONNECT_FABRIC_PREFIX));
-  return remaining.length === rows.length ? rows : remaining;
+export function withoutGpuInterconnectCapability(attributes: PlacementAttributeType[] | undefined): PlacementAttributeType[] | undefined {
+  if (!attributes) return attributes;
+  const remaining = attributes.filter(
+    attribute => attribute.key !== GPU_INTERCONNECT_CAPABILITY_KEY && !attribute.key.startsWith(GPU_INTERCONNECT_FABRIC_PREFIX)
+  );
+  return remaining.length === attributes.length ? attributes : remaining;
 }
 
 /** True when any service other than `selfIndex` on the same placement still opts into the interconnect. */

--- a/apps/deploy-web/src/utils/sdl/gpuInterconnect.ts
+++ b/apps/deploy-web/src/utils/sdl/gpuInterconnect.ts
@@ -1,0 +1,49 @@
+import { nanoid } from "nanoid";
+
+import type { PlacementAttributeType, ServiceType } from "@src/types";
+
+/**
+ * GPU interconnect helpers for the deployment builder. Opting a service into
+ * `profile.interconnect` requires the placement attribute
+ * `capabilities/gpu-interconnect: "true"` so only interconnect-capable providers
+ * bid; the helpers below keep that placement row in sync with the services'
+ * opt-ins. Both mutation helpers return the SAME array reference when nothing
+ * changes, so callers can skip dirtying the form on a no-op.
+ */
+
+export const GPU_INTERCONNECT_CAPABILITY_KEY = "capabilities/gpu-interconnect";
+
+/** Prefix of the optional fabric-pin attributes (e.g. `.../fabric/infiniband`) that only make sense alongside the capability itself. */
+export const GPU_INTERCONNECT_FABRIC_PREFIX = "capabilities/gpu-interconnect/fabric/";
+
+/**
+ * Upserts the interconnect capability to `"true"`. An existing row is updated in
+ * place (an imported `"false"` must not survive an explicit opt-in) rather than
+ * appended alongside.
+ */
+export function withGpuInterconnectCapability(attributes: PlacementAttributeType[] | undefined): PlacementAttributeType[] {
+  const rows = attributes ?? [];
+  const existing = rows.find(attribute => attribute.key === GPU_INTERCONNECT_CAPABILITY_KEY);
+  if (existing?.value === "true") return rows;
+  if (existing) {
+    return rows.map(attribute => (attribute === existing ? { ...attribute, value: "true" } : attribute));
+  }
+  return [...rows, { id: nanoid(), key: GPU_INTERCONNECT_CAPABILITY_KEY, value: "true" }];
+}
+
+/**
+ * Removes the interconnect capability along with any fabric pins — an orphaned
+ * fabric pin would over-filter providers on a deployment that no longer requests
+ * the interconnect at all.
+ */
+export function withoutGpuInterconnectCapability(attributes: PlacementAttributeType[] | undefined): PlacementAttributeType[] {
+  const rows = attributes ?? [];
+  const remaining = rows.filter(attribute => attribute.key !== GPU_INTERCONNECT_CAPABILITY_KEY && !attribute.key.startsWith(GPU_INTERCONNECT_FABRIC_PREFIX));
+  return remaining.length === rows.length ? rows : remaining;
+}
+
+/** True when any service other than `selfIndex` on the same placement still opts into the interconnect. */
+export function hasOtherInterconnectService(services: Pick<ServiceType, "placementId" | "profile">[], selfIndex: number): boolean {
+  const placementId = services[selfIndex]?.placementId;
+  return services.some((service, index) => index !== selfIndex && service.placementId === placementId && !!service.profile?.interconnect);
+}


### PR DESCRIPTION
## Why

Closes CON-689

Users running multi-node NCCL workloads (RDMA over InfiniBand/RoCE) currently must hand-edit raw SDL to opt into GPU interconnect. This adds a first-class on/off "GPU Interconnect" card to the hardware section of the new-deployment configure flow, with UX parity to the Confidential Compute card, building on the SDL round-trip merged in #3547 (CON-688) and chain-sdk `1.0.0-alpha.41` (#3545, CON-686).

## What

<img width="411" height="667" alt="image" src="https://github.com/user-attachments/assets/64a3c34b-fb96-4acf-a61e-43c099d9e333" />

<img width="379" height="466" alt="image" src="https://github.com/user-attachments/assets/d2028482-180d-4889-8e37-c2b7f26969a3" />



- New `GpuInterconnectCard` in the configuration pane's hardware section, gated behind the new `ui_gpu_interconnect` feature flag (kill-switch; removal tracked by CON-693).
- Toggling ON sets `profile.interconnect = {}` (implicit "auto" group), enables the GPU card (same side effect as the TEE card's cpu-gpu option), and **upserts** the placement attribute `capabilities/gpu-interconnect: "true"` so only interconnect-capable providers bid — an imported `"false"` row is normalized rather than duplicated.
- Toggling OFF clears the opt-in and removes the placement capability plus any `capabilities/gpu-interconnect/fabric/*` pins, unless another service on the same placement still opts in.
- Non-blocking muted hint when the service runs a single replica (interconnect links GPUs across 2+ nodes); never mutates `count`.
- Warning `Alert` when enabled while the GPU card is off (user can turn GPU back off after enabling — parity with the TEE `gpuMismatch` warning).
- New `utils/sdl/gpuInterconnect.ts` helpers with same-reference no-op semantics so the card only dirties the form on real changes.
- Scope: on/off + implicit group only. Explicit group & fabric selection UI = CON-692; trial restriction = CON-690; deployment-view indicator = CON-691.

**Operational note:** the Unleash flag `ui_gpu_interconnect` must be created in the dashboard before enabling in any environment (locally `NEXT_PUBLIC_UNLEASH_ENABLE_ALL=true` turns it on).

**Accepted limitations** (documented in the card docblock / same class as existing builder behavior):
- Removing an interconnect service without toggling it off first strands the placement capability row (same class as `gpuModels` surviving GPU-off).
- Imported SDL with the capability but no opted-in service mounts the card OFF and leaves the attributes untouched (no mount-time mutation, preserving the #3547 round-trip invariant).

Verified end-to-end on a local run of `/new-deployment/configure` (Playwright): flag-off hides the card; toggle ON produces `interconnect: []` above `vendor` plus the placement capability in the SDL preview and switches the GPU card on; toggle OFF removes both; single-replica hint shows with `count` untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional GPU interconnect setting to deployment hardware configuration.
  * Automatically enables required GPU resources and filters placement options based on provider capabilities.
  * Added guidance, single-node and missing-GPU warnings, sibling-service handling, and support for locked configurations.
  * Added feature-flag support for controlling GPU interconnect visibility.
* **Tests**
  * Added comprehensive coverage for GPU interconnect configuration, placement behavior, warnings, and imported configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->