### PR TITLE
refactor(indexer): replace js-sha256 with native node:crypto

### DIFF
--- a/apps/indexer/package.json
+++ b/apps/indexer/package.json
@@ -42,7 +42,6 @@
     "dotenv": "^12.0.4",
     "express": "^4.18.1",
     "human-interval": "^2.0.1",
-    "js-sha256": "^0.9.0",
     "level": "^8.0.1",
     "lodash": "^4.17.21",
     "node-gzip": "^1.1.2",

--- a/apps/indexer/src/chain/chainSync.ts
+++ b/apps/indexer/src/chain/chainSync.ts
@@ -6,7 +6,6 @@ import { fromBase64 } from "@cosmjs/encoding";
 import { decodeTxRaw } from "@cosmjs/proto-signing";
 import { asyncify, eachLimit } from "async";
 import { differenceInSeconds, isEqual } from "date-fns";
-import { sha256 } from "js-sha256";
 import { randomUUID } from "node:crypto";
 import { Op } from "sequelize";
 
@@ -16,6 +15,7 @@ import { ExecutionMode, executionMode, isProd, lastBlockToSync } from "@src/shar
 import type { BlockResultType } from "@src/shared/types";
 import { decodeIfBase64 } from "@src/shared/utils/base64";
 import { env } from "@src/shared/utils/env";
+import { getTransactionHash } from "@src/shared/utils/hash";
 import * as benchmark from "../shared/utils/benchmark";
 import {
   blockHeightToKey,
@@ -220,7 +220,7 @@ async function insertBlocks(startHeight: number, endHeight: number) {
 
     for (let txIndex = 0; txIndex < txs.length; ++txIndex) {
       const tx = txs[txIndex];
-      const hash = sha256(Buffer.from(tx, "base64")).toUpperCase();
+      const hash = getTransactionHash(tx);
       const txId = randomUUID();
 
       const decodedTx = decodeTxRaw(fromBase64(tx));

--- a/apps/indexer/src/chain/statsProcessor.ts
+++ b/apps/indexer/src/chain/statsProcessor.ts
@@ -5,7 +5,6 @@ import type { Message as MessageEntity } from "@akashnetwork/database/dbSchemas/
 import { Transaction, TransactionEvent, TransactionEventAttribute } from "@akashnetwork/database/dbSchemas/base";
 import { fromBase64 } from "@cosmjs/encoding";
 import { decodeTxRaw } from "@cosmjs/proto-signing";
-import { sha256 } from "js-sha256";
 import type { Transaction as DbTransaction } from "sequelize";
 import { Op } from "sequelize";
 
@@ -14,6 +13,7 @@ import { sequelize } from "@src/db/dbConnection";
 import { activeIndexers, indexersMsgTypes } from "@src/indexers";
 import { lastBlockToSync } from "@src/shared/constants";
 import * as benchmark from "@src/shared/utils/benchmark";
+import { getTransactionHash } from "@src/shared/utils/hash";
 import { decodeMsg } from "@src/shared/utils/protobuf";
 import { setMissingBlock } from "./chainSync"; // eslint-disable-line import-x/no-cycle
 import { getGenesis } from "./genesisImporter";
@@ -172,7 +172,7 @@ class StatsProcessor {
 
           for (const transaction of block.transactions) {
             const decodeTimer = benchmark.startTimer("decodeTx");
-            const tx = blockData.block.data.txs.find(t => sha256(Buffer.from(t, "base64")).toUpperCase() === transaction.hash);
+            const tx = blockData.block.data.txs.find(t => getTransactionHash(t) === transaction.hash);
             if (!tx) {
               throw new Error(`Transaction ${transaction.hash} not found in block ${block.height}`);
             }

--- a/apps/indexer/src/shared/utils/hash.ts
+++ b/apps/indexer/src/shared/utils/hash.ts
@@ -1,0 +1,6 @@
+import { createHash } from "node:crypto";
+
+/** Derives the uppercase hex transaction hash from a base64-encoded transaction, matching the Tendermint tx hash format. */
+export function getTransactionHash(txBase64: string): string {
+  return createHash("sha256").update(Buffer.from(txBase64, "base64")).digest("hex").toUpperCase();
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2178,7 +2178,6 @@
         "dotenv": "^12.0.4",
         "express": "^4.18.1",
         "human-interval": "^2.0.1",
-        "js-sha256": "^0.9.0",
         "level": "^8.0.1",
         "lodash": "^4.17.21",
         "node-gzip": "^1.1.2",
@@ -31737,10 +31736,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/js-sha256": {
-      "version": "0.9.0",
-      "license": "MIT"
     },
     "node_modules/js-sha3": {
       "version": "0.8.0",


### PR DESCRIPTION
## Why

Closes CON-792

## What

Compute transaction hashes via node:crypto's createHash instead of the js-sha256 package, extracting a shared getTransactionHash helper and dropping the third-party dependency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction hash consistency by standardizing hash calculation across indexing processes.
  * Preserved uppercase hexadecimal formatting for generated transaction hashes.

* **Refactor**
  * Consolidated transaction hash generation into a shared utility.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->