### PR TITLE
fix(billing): sync default payment method so the first card becomes default

### DIFF
--- a/apps/api/src/billing/controllers/stripe/stripe.controller.spec.ts
+++ b/apps/api/src/billing/controllers/stripe/stripe.controller.spec.ts
@@ -197,13 +197,14 @@ describe(StripeController.name, () => {
   });
 
   describe("removePaymentMethod", () => {
-    it("detaches the payment method without checking trial status", async () => {
-      const { controller, stripe, userWalletRepository, user } = setup();
+    it("detaches the payment method after asserting it is removable", async () => {
+      const { controller, stripe, paymentMethodService, userWalletRepository, user } = setup();
       const paymentMethodId = faker.string.uuid();
       stripe.retrievePaymentMethod.mockResolvedValue(mock<Stripe.Response<Stripe.PaymentMethod>>({ customer: user.stripeCustomerId }));
 
       await controller.removePaymentMethod(paymentMethodId);
 
+      expect(paymentMethodService.assertRemovable).toHaveBeenCalledWith(paymentMethodId, user.id);
       expect(stripe.detachPaymentMethod).toHaveBeenCalledWith(paymentMethodId);
       expect(userWalletRepository.findOneByUserId).not.toHaveBeenCalled();
     });
@@ -214,6 +215,16 @@ describe(StripeController.name, () => {
       stripe.retrievePaymentMethod.mockResolvedValue(mock<Stripe.Response<Stripe.PaymentMethod>>({ customer: "cus_someoneelse" }));
 
       await expect(controller.removePaymentMethod(paymentMethodId)).rejects.toMatchObject({ status: 403 });
+      expect(stripe.detachPaymentMethod).not.toHaveBeenCalled();
+    });
+
+    it("does not detach when the payment method is not removable", async () => {
+      const { controller, stripe, paymentMethodService, user } = setup();
+      const paymentMethodId = faker.string.uuid();
+      stripe.retrievePaymentMethod.mockResolvedValue(mock<Stripe.Response<Stripe.PaymentMethod>>({ customer: user.stripeCustomerId }));
+      paymentMethodService.assertRemovable.mockRejectedValue(createError(409, "Cannot remove the default payment method while auto reload is enabled"));
+
+      await expect(controller.removePaymentMethod(paymentMethodId)).rejects.toMatchObject({ status: 409 });
       expect(stripe.detachPaymentMethod).not.toHaveBeenCalled();
     });
   });

--- a/apps/api/src/billing/controllers/stripe/stripe.controller.spec.ts
+++ b/apps/api/src/billing/controllers/stripe/stripe.controller.spec.ts
@@ -281,12 +281,13 @@ describe(StripeController.name, () => {
 
   describe("getPaymentMethods", () => {
     it("returns the current user's payment methods", async () => {
-      const { controller, paymentMethodService } = setup();
+      const { controller, authService, paymentMethodService } = setup();
       const methods = [mock<PaymentMethod>({ id: "pm_1", isDefault: true })];
       paymentMethodService.getPaymentMethods.mockResolvedValue(methods);
 
       const result = await controller.getPaymentMethods();
 
+      expect(paymentMethodService.getPaymentMethods).toHaveBeenCalledWith(authService.getCurrentPayingUser(), authService.ability);
       expect(result).toEqual({ data: methods });
     });
 

--- a/apps/api/src/billing/controllers/stripe/stripe.controller.ts
+++ b/apps/api/src/billing/controllers/stripe/stripe.controller.ts
@@ -176,6 +176,8 @@ export class StripeController {
       const customerId = typeof paymentMethod.customer === "string" ? paymentMethod.customer : paymentMethod.customer?.id;
       assert(customerId === currentUser.stripeCustomerId, 403, "Payment method does not belong to the user");
 
+      await this.paymentMethodService.assertRemovable(paymentMethodId, currentUser.id);
+
       await this.stripe.detachPaymentMethod(paymentMethodId);
     } catch (error: unknown) {
       if (this.stripeErrorService.isKnownError(error, "payment")) {

--- a/apps/api/src/billing/controllers/stripe/stripe.controller.ts
+++ b/apps/api/src/billing/controllers/stripe/stripe.controller.ts
@@ -95,7 +95,7 @@ export class StripeController {
     const currentUser = this.authService.getCurrentPayingUser({ strict: false });
 
     if (currentUser) {
-      const paymentMethods = await this.paymentMethodService.getPaymentMethods(currentUser.id, currentUser.stripeCustomerId, this.authService.ability);
+      const paymentMethods = await this.paymentMethodService.getPaymentMethods(currentUser, this.authService.ability);
       return { data: paymentMethods };
     }
 

--- a/apps/api/src/billing/services/payment-method/payment-method.service.integration.ts
+++ b/apps/api/src/billing/services/payment-method/payment-method.service.integration.ts
@@ -23,6 +23,54 @@ const ability = createMongoAbility([{ action: "manage", subject: "all" }]);
 const asPaymentMethodResponse = (paymentMethod: Stripe.PaymentMethod) => paymentMethod as unknown as Stripe.Response<Stripe.PaymentMethod>;
 
 describe(PaymentMethodService.name, () => {
+  describe("getPaymentMethods", () => {
+    const payingUser = () => mock<PayingUser>({ id: "user_1", stripeCustomerId: "cus_1" });
+    const listResponse = (data: Stripe.PaymentMethod[]) => ({ data, has_more: false }) as unknown as Stripe.Response<Stripe.ApiList<Stripe.PaymentMethod>>;
+
+    it("repairs an unsynced remote method by syncing it and pushing the Stripe default", async () => {
+      const { service, stripe, paymentMethodRepository } = setup();
+      const remote = generatePaymentMethod({ id: "pm_1", card: { fingerprint: "fp_1" } });
+      const healed = { ...generateDatabasePaymentMethod({ paymentMethodId: "pm_1", fingerprint: "fp_1" }), isDefault: true };
+      vi.spyOn(stripe.paymentMethods, "list").mockResolvedValue(listResponse([remote]));
+      paymentMethodRepository.findByUserId.mockResolvedValueOnce([]).mockResolvedValueOnce([healed]);
+      paymentMethodRepository.upsert.mockResolvedValue({ paymentMethod: healed, isNew: true });
+      const update = vi.spyOn(stripe.customers, "update").mockResolvedValue(mock<Stripe.Response<Stripe.Customer>>());
+
+      const result = await service.getPaymentMethods(payingUser(), ability);
+
+      expect(paymentMethodRepository.upsert).toHaveBeenCalledWith({ userId: "user_1", fingerprint: "fp_1", paymentMethodId: "pm_1" });
+      expect(update).toHaveBeenCalledWith("cus_1", { invoice_settings: { default_payment_method: "pm_1" } }, { timeout: 3_000 });
+      expect(result).toEqual([{ ...remote, validated: false, isDefault: true }]);
+    });
+
+    it("repairs multiple unsynced remote methods oldest first", async () => {
+      const { service, stripe, paymentMethodRepository } = setup();
+      const older = generatePaymentMethod({ id: "pm_old", created: 100, card: { fingerprint: "fp_old" } });
+      const newer = generatePaymentMethod({ id: "pm_new", created: 200, card: { fingerprint: "fp_new" } });
+      vi.spyOn(stripe.paymentMethods, "list").mockResolvedValue(listResponse([newer, older]));
+      paymentMethodRepository.findByUserId.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+      paymentMethodRepository.upsert.mockResolvedValue({ paymentMethod: generateDatabasePaymentMethod({ paymentMethodId: "pm_old" }), isNew: true });
+      vi.spyOn(stripe.customers, "update").mockResolvedValue(mock<Stripe.Response<Stripe.Customer>>());
+
+      await service.getPaymentMethods(payingUser(), ability);
+
+      expect(paymentMethodRepository.upsert).toHaveBeenNthCalledWith(1, { userId: "user_1", fingerprint: "fp_old", paymentMethodId: "pm_old" });
+      expect(paymentMethodRepository.upsert).toHaveBeenNthCalledWith(2, { userId: "user_1", fingerprint: "fp_new", paymentMethodId: "pm_new" });
+    });
+
+    it("returns the merged list when a repair fails", async () => {
+      const { service, stripe, paymentMethodRepository } = setup();
+      const remote = generatePaymentMethod({ id: "pm_1", card: { fingerprint: "fp_1" } });
+      vi.spyOn(stripe.paymentMethods, "list").mockResolvedValue(listResponse([remote]));
+      paymentMethodRepository.findByUserId.mockResolvedValue([]);
+      paymentMethodRepository.upsert.mockRejectedValue(new Error("db unavailable"));
+
+      const result = await service.getPaymentMethods(payingUser(), ability);
+
+      expect(result).toEqual([{ ...remote, validated: false, isDefault: false }]);
+    });
+  });
+
   describe("markPaymentMethodAsDefault", () => {
     it("sets an already-synced method as default locally and on Stripe", async () => {
       const { service, stripe, paymentMethodRepository } = setup();

--- a/apps/api/src/billing/services/payment-method/payment-method.service.integration.ts
+++ b/apps/api/src/billing/services/payment-method/payment-method.service.integration.ts
@@ -5,7 +5,7 @@ import Stripe from "stripe";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
-import type { PaymentMethodRepository } from "@src/billing/repositories";
+import type { PaymentMethodRepository, WalletSettingRepository } from "@src/billing/repositories";
 import type { PayingUser } from "@src/billing/services/paying-user/paying-user";
 import type { UserRepository } from "@src/user/repositories/user/user.repository";
 import { PaymentMethodService } from "./payment-method.service";
@@ -244,12 +244,13 @@ describe(PaymentMethodService.name, () => {
     const paymentMethodRepository = mock<PaymentMethodRepository>();
     paymentMethodRepository.accessibleBy.mockReturnValue(paymentMethodRepository);
     const userRepository = mock<UserRepository>();
+    const walletSettingRepository = mock<WalletSettingRepository>();
 
     const stripe = new Stripe(`sk_test_${faker.string.alphanumeric(32)}`, { apiVersion: "2025-10-29.clover", httpClient: Stripe.createFetchHttpClient() });
 
-    const service = new PaymentMethodService(stripe, paymentMethodRepository, userRepository, () => mock<LoggerService>());
+    const service = new PaymentMethodService(stripe, paymentMethodRepository, userRepository, walletSettingRepository, () => mock<LoggerService>());
 
-    return { service, stripe, paymentMethodRepository, userRepository };
+    return { service, stripe, paymentMethodRepository, userRepository, walletSettingRepository };
   }
 
   function createPaymentMethodAttachedEvent(params: { id: string; customer: string | null; fingerprint?: string }): Stripe.PaymentMethodAttachedEvent {

--- a/apps/api/src/billing/services/payment-method/payment-method.service.spec.ts
+++ b/apps/api/src/billing/services/payment-method/payment-method.service.spec.ts
@@ -5,7 +5,7 @@ import Stripe from "stripe";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
-import type { PaymentMethodRepository } from "@src/billing/repositories";
+import type { PaymentMethodRepository, WalletSettingOutput, WalletSettingRepository } from "@src/billing/repositories";
 import type { PayingUser } from "@src/billing/services/paying-user/paying-user";
 import type { UserOutput, UserRepository } from "@src/user/repositories/user/user.repository";
 import { PaymentMethodService } from "./payment-method.service";
@@ -233,6 +233,40 @@ describe(PaymentMethodService.name, () => {
     });
   });
 
+  describe("assertRemovable", () => {
+    it("throws 409 when removing the default method while auto reload is enabled", async () => {
+      const { service, paymentMethodRepository, walletSettingRepository } = setup();
+      paymentMethodRepository.findOneBy.mockResolvedValue(generateDatabasePaymentMethod({ paymentMethodId: "pm_1", isDefault: true }));
+      walletSettingRepository.findByUserId.mockResolvedValue(mock<WalletSettingOutput>({ autoReloadEnabled: true }));
+
+      await expect(service.assertRemovable("pm_1", "user_1")).rejects.toMatchObject({ status: 409 });
+    });
+
+    it("resolves when removing the default method while auto reload is disabled", async () => {
+      const { service, paymentMethodRepository, walletSettingRepository } = setup();
+      paymentMethodRepository.findOneBy.mockResolvedValue(generateDatabasePaymentMethod({ paymentMethodId: "pm_1", isDefault: true }));
+      walletSettingRepository.findByUserId.mockResolvedValue(mock<WalletSettingOutput>({ autoReloadEnabled: false }));
+
+      await expect(service.assertRemovable("pm_1", "user_1")).resolves.toBeUndefined();
+    });
+
+    it("resolves for a non-default method even when auto reload is enabled", async () => {
+      const { service, paymentMethodRepository, walletSettingRepository } = setup();
+      paymentMethodRepository.findOneBy.mockResolvedValue(generateDatabasePaymentMethod({ paymentMethodId: "pm_1", isDefault: false }));
+
+      await expect(service.assertRemovable("pm_1", "user_1")).resolves.toBeUndefined();
+      expect(walletSettingRepository.findByUserId).not.toHaveBeenCalled();
+    });
+
+    it("resolves when the default method has no wallet settings row", async () => {
+      const { service, paymentMethodRepository, walletSettingRepository } = setup();
+      paymentMethodRepository.findOneBy.mockResolvedValue(generateDatabasePaymentMethod({ paymentMethodId: "pm_1", isDefault: true }));
+      walletSettingRepository.findByUserId.mockResolvedValue(undefined);
+
+      await expect(service.assertRemovable("pm_1", "user_1")).resolves.toBeUndefined();
+    });
+  });
+
   describe("validatePaymentMethodAfter3DS", () => {
     const CUSTOMER_ID = "cus_123";
     const PAYMENT_METHOD_ID = "pm_123";
@@ -324,11 +358,12 @@ describe(PaymentMethodService.name, () => {
     const paymentMethodRepository = mock<PaymentMethodRepository>();
     paymentMethodRepository.accessibleBy.mockReturnValue(paymentMethodRepository);
     const userRepository = mock<UserRepository>();
+    const walletSettingRepository = mock<WalletSettingRepository>();
 
     const stripe = new Stripe(`sk_test_${faker.string.alphanumeric(32)}`, { apiVersion: "2025-10-29.clover", httpClient: Stripe.createFetchHttpClient() });
 
-    const service = new PaymentMethodService(stripe, paymentMethodRepository, userRepository, () => mock<LoggerService>());
+    const service = new PaymentMethodService(stripe, paymentMethodRepository, userRepository, walletSettingRepository, () => mock<LoggerService>());
 
-    return { service, stripe, paymentMethodRepository, userRepository };
+    return { service, stripe, paymentMethodRepository, userRepository, walletSettingRepository };
   }
 });

--- a/apps/api/src/billing/services/payment-method/payment-method.service.spec.ts
+++ b/apps/api/src/billing/services/payment-method/payment-method.service.spec.ts
@@ -19,20 +19,76 @@ const asResponse = <T>(value: T) => value as unknown as Stripe.Response<T>;
 
 describe(PaymentMethodService.name, () => {
   describe("getPaymentMethods", () => {
+    const payingUser = () => mock<PayingUser>({ id: TEST_CONSTANTS.USER_ID, stripeCustomerId: TEST_CONSTANTS.CUSTOMER_ID });
+
     it("returns remote methods merged with local validated/default flags, newest first", async () => {
       const { service, stripe, paymentMethodRepository } = setup();
       const newer = generatePaymentMethod({ id: TEST_CONSTANTS.PAYMENT_METHOD_ID, created: 1757992768, card: { fingerprint: "fp_a" } });
       const older = generatePaymentMethod({ id: "pm_456", created: 1757991776, card: { fingerprint: "fp_b" } });
-      vi.spyOn(stripe.paymentMethods, "list").mockResolvedValue({ data: [older, newer] } as unknown as Stripe.Response<Stripe.ApiList<Stripe.PaymentMethod>>);
-      paymentMethodRepository.findByUserId.mockResolvedValue([]);
+      vi.spyOn(stripe.paymentMethods, "list").mockResolvedValue({
+        data: [older, newer],
+        has_more: false
+      } as unknown as Stripe.Response<Stripe.ApiList<Stripe.PaymentMethod>>);
+      paymentMethodRepository.findByUserId.mockResolvedValue([
+        generateDatabasePaymentMethod({ paymentMethodId: newer.id, fingerprint: "fp_a", isDefault: true, isValidated: true }),
+        generateDatabasePaymentMethod({ paymentMethodId: older.id, fingerprint: "fp_b" })
+      ]);
 
-      const result = await service.getPaymentMethods(TEST_CONSTANTS.USER_ID, TEST_CONSTANTS.CUSTOMER_ID, ability);
+      const result = await service.getPaymentMethods(payingUser(), ability);
 
       expect(stripe.paymentMethods.list).toHaveBeenCalledWith({ customer: TEST_CONSTANTS.CUSTOMER_ID });
+      expect(paymentMethodRepository.deleteByFingerprint).not.toHaveBeenCalled();
       expect(result).toEqual([
-        { ...newer, validated: false, isDefault: false },
+        { ...newer, validated: true, isDefault: true },
         { ...older, validated: false, isDefault: false }
       ]);
+    });
+
+    it("warns without repairing when an unsynced remote method has no fingerprint", async () => {
+      const { service, stripe, paymentMethodRepository } = setup();
+      const unfingerprintable = generatePaymentMethod({ type: "us_bank_account", card: null } as unknown as Parameters<typeof generatePaymentMethod>[0]);
+      vi.spyOn(stripe.paymentMethods, "list").mockResolvedValue({
+        data: [unfingerprintable],
+        has_more: false
+      } as unknown as Stripe.Response<Stripe.ApiList<Stripe.PaymentMethod>>);
+      paymentMethodRepository.findByUserId.mockResolvedValue([]);
+
+      const result = await service.getPaymentMethods(payingUser(), ability);
+
+      expect(paymentMethodRepository.deleteByFingerprint).not.toHaveBeenCalled();
+      expect(result).toEqual([{ ...unfingerprintable, validated: false, isDefault: false }]);
+    });
+
+    it("removes stale local rows absent from Stripe when the list is complete", async () => {
+      const { service, stripe, paymentMethodRepository } = setup();
+      const stale = generateDatabasePaymentMethod({ paymentMethodId: "pm_stale", fingerprint: "fp_stale" });
+      vi.spyOn(stripe.paymentMethods, "list").mockResolvedValue({
+        data: [],
+        has_more: false
+      } as unknown as Stripe.Response<Stripe.ApiList<Stripe.PaymentMethod>>);
+      paymentMethodRepository.findByUserId.mockResolvedValueOnce([stale]).mockResolvedValueOnce([]);
+
+      const result = await service.getPaymentMethods(payingUser(), ability);
+
+      expect(paymentMethodRepository.deleteByFingerprint).toHaveBeenCalledWith("fp_stale", "pm_stale", TEST_CONSTANTS.USER_ID);
+      expect(result).toEqual([]);
+    });
+
+    it("keeps local rows absent from a truncated Stripe list", async () => {
+      const { service, stripe, paymentMethodRepository } = setup();
+      const onPage = generatePaymentMethod({ id: "pm_on_page", card: { fingerprint: "fp_on_page" } });
+      const local = generateDatabasePaymentMethod({ paymentMethodId: onPage.id, fingerprint: "fp_on_page" });
+      const offPage = generateDatabasePaymentMethod({ paymentMethodId: "pm_off_page", fingerprint: "fp_off_page" });
+      vi.spyOn(stripe.paymentMethods, "list").mockResolvedValue({
+        data: [onPage],
+        has_more: true
+      } as unknown as Stripe.Response<Stripe.ApiList<Stripe.PaymentMethod>>);
+      paymentMethodRepository.findByUserId.mockResolvedValue([local, offPage]);
+
+      const result = await service.getPaymentMethods(payingUser(), ability);
+
+      expect(paymentMethodRepository.deleteByFingerprint).not.toHaveBeenCalled();
+      expect(result).toEqual([{ ...onPage, validated: false, isDefault: false }]);
     });
   });
 

--- a/apps/api/src/billing/services/payment-method/payment-method.service.spec.ts
+++ b/apps/api/src/billing/services/payment-method/payment-method.service.spec.ts
@@ -90,6 +90,39 @@ describe(PaymentMethodService.name, () => {
       expect(paymentMethodRepository.deleteByFingerprint).not.toHaveBeenCalled();
       expect(result).toEqual([{ ...onPage, validated: false, isDefault: false }]);
     });
+
+    it("reports only the successfully repaired ids when one repair throws", async () => {
+      const { service, stripe, paymentMethodRepository, logger } = setup();
+      const older = generatePaymentMethod({ id: "pm_older", created: 1, card: { fingerprint: "fp_older" } });
+      const newer = generatePaymentMethod({ id: "pm_newer", created: 2, card: { fingerprint: "fp_newer" } });
+      vi.spyOn(stripe.paymentMethods, "list").mockResolvedValue({
+        data: [older, newer],
+        has_more: false
+      } as unknown as Stripe.Response<Stripe.ApiList<Stripe.PaymentMethod>>);
+      paymentMethodRepository.findByUserId.mockResolvedValue([]);
+      vi.spyOn(service, "syncAttached").mockResolvedValueOnce({ isNew: true, isDefault: true }).mockRejectedValueOnce(new Error("db unavailable"));
+
+      await service.getPaymentMethods(payingUser(), ability);
+
+      expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "PAYMENT_METHOD_READ_REPAIRED", paymentMethodIds: ["pm_older"] }));
+      expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "PAYMENT_METHOD_READ_REPAIR_FAILED", paymentMethodId: "pm_newer" }));
+    });
+
+    it("does not fail the read when removing a stale local row throws", async () => {
+      const { service, stripe, paymentMethodRepository, logger } = setup();
+      const stale = generateDatabasePaymentMethod({ paymentMethodId: "pm_stale", fingerprint: "fp_stale" });
+      vi.spyOn(stripe.paymentMethods, "list").mockResolvedValue({
+        data: [],
+        has_more: false
+      } as unknown as Stripe.Response<Stripe.ApiList<Stripe.PaymentMethod>>);
+      paymentMethodRepository.findByUserId.mockResolvedValue([stale]);
+      paymentMethodRepository.deleteByFingerprint.mockRejectedValue(new Error("db unavailable"));
+
+      const result = await service.getPaymentMethods(payingUser(), ability);
+
+      expect(result).toEqual([]);
+      expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "PAYMENT_METHOD_STALE_REMOVE_FAILED", paymentMethodId: "pm_stale" }));
+    });
   });
 
   describe("getDefaultPaymentMethod", () => {
@@ -125,11 +158,12 @@ describe(PaymentMethodService.name, () => {
         invoice_settings: { default_payment_method: null }
       } as unknown as Stripe.Response<Stripe.Customer>);
       paymentMethodRepository.findDefaultByUserId.mockResolvedValue(local);
-      vi.spyOn(stripe.paymentMethods, "retrieve").mockResolvedValue(asResponse(remotePaymentMethod));
+      const retrieve = vi.spyOn(stripe.paymentMethods, "retrieve").mockResolvedValue(asResponse(remotePaymentMethod));
       const update = vi.spyOn(stripe.customers, "update").mockResolvedValue(mock<Stripe.Response<Stripe.Customer>>());
 
       const result = await service.getDefaultPaymentMethod(mock<PayingUser>({ id: "user_1", stripeCustomerId: "cus_1" }), ability);
 
+      expect(retrieve).toHaveBeenCalledWith("pm_1", undefined, { timeout: 3_000 });
       expect(update).toHaveBeenCalledWith("cus_1", { invoice_settings: { default_payment_method: "pm_1" } }, { timeout: 3_000 });
       expect(result).toEqual({ ...remotePaymentMethod, validated: local.isValidated, isDefault: local.isDefault });
     });
@@ -185,6 +219,28 @@ describe(PaymentMethodService.name, () => {
 
       expect(paymentMethodRepository.deleteByFingerprint).toHaveBeenCalledWith("fp_1", "pm_1", "user_1");
       expect(result).toBeUndefined();
+    });
+
+    it("returns undefined without throwing when removing the stale local default fails", async () => {
+      const { service, stripe, paymentMethodRepository, logger } = setup();
+      const local = generateDatabasePaymentMethod({ paymentMethodId: "pm_1", fingerprint: "fp_1" });
+      vi.spyOn(stripe.customers, "retrieve").mockResolvedValue({
+        invoice_settings: { default_payment_method: null }
+      } as unknown as Stripe.Response<Stripe.Customer>);
+      paymentMethodRepository.findDefaultByUserId.mockResolvedValue(local);
+      vi.spyOn(stripe.paymentMethods, "retrieve").mockRejectedValue(
+        new Stripe.errors.StripeInvalidRequestError({
+          type: "invalid_request_error",
+          code: "resource_missing",
+          message: "No such PaymentMethod"
+        } as Stripe.StripeRawError)
+      );
+      paymentMethodRepository.deleteByFingerprint.mockRejectedValue(new Error("db unavailable"));
+
+      const result = await service.getDefaultPaymentMethod(mock<PayingUser>({ id: "user_1", stripeCustomerId: "cus_1" }), ability);
+
+      expect(result).toBeUndefined();
+      expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "DEFAULT_PAYMENT_METHOD_STALE_REMOVE_FAILED", paymentMethodId: "pm_1" }));
     });
 
     it("returns undefined without removing the local default when the Stripe push fails", async () => {
@@ -359,11 +415,12 @@ describe(PaymentMethodService.name, () => {
     paymentMethodRepository.accessibleBy.mockReturnValue(paymentMethodRepository);
     const userRepository = mock<UserRepository>();
     const walletSettingRepository = mock<WalletSettingRepository>();
+    const logger = mock<LoggerService>();
 
     const stripe = new Stripe(`sk_test_${faker.string.alphanumeric(32)}`, { apiVersion: "2025-10-29.clover", httpClient: Stripe.createFetchHttpClient() });
 
-    const service = new PaymentMethodService(stripe, paymentMethodRepository, userRepository, walletSettingRepository, () => mock<LoggerService>());
+    const service = new PaymentMethodService(stripe, paymentMethodRepository, userRepository, walletSettingRepository, () => logger);
 
-    return { service, stripe, paymentMethodRepository, userRepository, walletSettingRepository };
+    return { service, stripe, paymentMethodRepository, userRepository, walletSettingRepository, logger };
   }
 });

--- a/apps/api/src/billing/services/payment-method/payment-method.service.spec.ts
+++ b/apps/api/src/billing/services/payment-method/payment-method.service.spec.ts
@@ -116,6 +116,92 @@ describe(PaymentMethodService.name, () => {
 
       expect(await service.getDefaultPaymentMethod(mock<PayingUser>({ id: "user_1", stripeCustomerId: "cus_1" }), ability)).toBeUndefined();
     });
+
+    it("re-pushes the local default to Stripe when the remote default is missing", async () => {
+      const { service, stripe, paymentMethodRepository } = setup();
+      const local = generateDatabasePaymentMethod({ paymentMethodId: "pm_1", fingerprint: "fp_1" });
+      const remotePaymentMethod = generatePaymentMethod({ id: "pm_1", customer: "cus_1" });
+      vi.spyOn(stripe.customers, "retrieve").mockResolvedValue({
+        invoice_settings: { default_payment_method: null }
+      } as unknown as Stripe.Response<Stripe.Customer>);
+      paymentMethodRepository.findDefaultByUserId.mockResolvedValue(local);
+      vi.spyOn(stripe.paymentMethods, "retrieve").mockResolvedValue(asResponse(remotePaymentMethod));
+      const update = vi.spyOn(stripe.customers, "update").mockResolvedValue(mock<Stripe.Response<Stripe.Customer>>());
+
+      const result = await service.getDefaultPaymentMethod(mock<PayingUser>({ id: "user_1", stripeCustomerId: "cus_1" }), ability);
+
+      expect(update).toHaveBeenCalledWith("cus_1", { invoice_settings: { default_payment_method: "pm_1" } }, { timeout: 3_000 });
+      expect(result).toEqual({ ...remotePaymentMethod, validated: local.isValidated, isDefault: local.isDefault });
+    });
+
+    it("realigns Stripe to the local default when the remote default is a different method", async () => {
+      const { service, stripe, paymentMethodRepository } = setup();
+      const local = generateDatabasePaymentMethod({ paymentMethodId: "pm_1", fingerprint: "fp_1" });
+      const remotePaymentMethod = generatePaymentMethod({ id: "pm_1", customer: "cus_1" });
+      vi.spyOn(stripe.customers, "retrieve").mockResolvedValue({
+        invoice_settings: { default_payment_method: generatePaymentMethod({ id: "pm_other" }) }
+      } as unknown as Stripe.Response<Stripe.Customer>);
+      paymentMethodRepository.findDefaultByUserId.mockResolvedValue(local);
+      vi.spyOn(stripe.paymentMethods, "retrieve").mockResolvedValue(asResponse(remotePaymentMethod));
+      const update = vi.spyOn(stripe.customers, "update").mockResolvedValue(mock<Stripe.Response<Stripe.Customer>>());
+
+      const result = await service.getDefaultPaymentMethod(mock<PayingUser>({ id: "user_1", stripeCustomerId: "cus_1" }), ability);
+
+      expect(update).toHaveBeenCalledWith("cus_1", { invoice_settings: { default_payment_method: "pm_1" } }, { timeout: 3_000 });
+      expect(result).toEqual({ ...remotePaymentMethod, validated: local.isValidated, isDefault: local.isDefault });
+    });
+
+    it("removes the stale local default and returns undefined when the card is detached", async () => {
+      const { service, stripe, paymentMethodRepository } = setup();
+      const local = generateDatabasePaymentMethod({ paymentMethodId: "pm_1", fingerprint: "fp_1" });
+      vi.spyOn(stripe.customers, "retrieve").mockResolvedValue({
+        invoice_settings: { default_payment_method: null }
+      } as unknown as Stripe.Response<Stripe.Customer>);
+      paymentMethodRepository.findDefaultByUserId.mockResolvedValue(local);
+      vi.spyOn(stripe.paymentMethods, "retrieve").mockResolvedValue(asResponse(generatePaymentMethod({ id: "pm_1", customer: null })));
+
+      const result = await service.getDefaultPaymentMethod(mock<PayingUser>({ id: "user_1", stripeCustomerId: "cus_1" }), ability);
+
+      expect(paymentMethodRepository.deleteByFingerprint).toHaveBeenCalledWith("fp_1", "pm_1", "user_1");
+      expect(result).toBeUndefined();
+    });
+
+    it("removes the stale local default and returns undefined when Stripe reports the card is missing", async () => {
+      const { service, stripe, paymentMethodRepository } = setup();
+      const local = generateDatabasePaymentMethod({ paymentMethodId: "pm_1", fingerprint: "fp_1" });
+      vi.spyOn(stripe.customers, "retrieve").mockResolvedValue({
+        invoice_settings: { default_payment_method: null }
+      } as unknown as Stripe.Response<Stripe.Customer>);
+      paymentMethodRepository.findDefaultByUserId.mockResolvedValue(local);
+      vi.spyOn(stripe.paymentMethods, "retrieve").mockRejectedValue(
+        new Stripe.errors.StripeInvalidRequestError({
+          type: "invalid_request_error",
+          code: "resource_missing",
+          message: "No such PaymentMethod"
+        } as Stripe.StripeRawError)
+      );
+
+      const result = await service.getDefaultPaymentMethod(mock<PayingUser>({ id: "user_1", stripeCustomerId: "cus_1" }), ability);
+
+      expect(paymentMethodRepository.deleteByFingerprint).toHaveBeenCalledWith("fp_1", "pm_1", "user_1");
+      expect(result).toBeUndefined();
+    });
+
+    it("returns undefined without removing the local default when the Stripe push fails", async () => {
+      const { service, stripe, paymentMethodRepository } = setup();
+      const local = generateDatabasePaymentMethod({ paymentMethodId: "pm_1", fingerprint: "fp_1" });
+      vi.spyOn(stripe.customers, "retrieve").mockResolvedValue({
+        invoice_settings: { default_payment_method: null }
+      } as unknown as Stripe.Response<Stripe.Customer>);
+      paymentMethodRepository.findDefaultByUserId.mockResolvedValue(local);
+      vi.spyOn(stripe.paymentMethods, "retrieve").mockResolvedValue(asResponse(generatePaymentMethod({ id: "pm_1", customer: "cus_1" })));
+      vi.spyOn(stripe.customers, "update").mockRejectedValue(new Error("stripe unavailable"));
+
+      const result = await service.getDefaultPaymentMethod(mock<PayingUser>({ id: "user_1", stripeCustomerId: "cus_1" }), ability);
+
+      expect(paymentMethodRepository.deleteByFingerprint).not.toHaveBeenCalled();
+      expect(result).toBeUndefined();
+    });
   });
 
   describe("hasPaymentMethod", () => {

--- a/apps/api/src/billing/services/payment-method/payment-method.service.ts
+++ b/apps/api/src/billing/services/payment-method/payment-method.service.ts
@@ -162,14 +162,66 @@ export class PaymentMethodService {
 
     const remote = customer.invoice_settings.default_payment_method;
 
-    if (typeof remote === "object" && remote && local) {
+    if (typeof remote === "object" && remote && local && remote.id === local.paymentMethodId) {
       return { ...remote, validated: local.isValidated, isDefault: local.isDefault };
-    } else {
-      this.loggerService.warn({
-        event: "STRIPE_PAYMENT_METHOD_OUT_OF_SYNC",
+    }
+
+    if (local) {
+      return this.#healDefaultPaymentMethodDrift(user, local);
+    }
+
+    this.loggerService.warn({
+      event: "STRIPE_PAYMENT_METHOD_OUT_OF_SYNC",
+      userId: user.id,
+      remoteId: typeof remote === "string" ? remote : remote?.id
+    });
+  }
+
+  /**
+   * The local default is the source of truth. When Stripe's default is missing or points elsewhere,
+   * re-push the local default to Stripe. If the card is gone from Stripe (detached or deleted), the
+   * local row is stale, so drop it. Never throws: this runs inside the reload charging job and the
+   * wallet-settings enable validation, where a Stripe hiccup must not fail the whole operation.
+   */
+  async #healDefaultPaymentMethodDrift(user: PayingUser, local: PaymentMethodOutput): Promise<PaymentMethod | undefined> {
+    try {
+      const remotePaymentMethod = await this.stripe.paymentMethods.retrieve(local.paymentMethodId);
+      const customerId = typeof remotePaymentMethod.customer === "string" ? remotePaymentMethod.customer : remotePaymentMethod.customer?.id;
+
+      if (customerId !== user.stripeCustomerId) {
+        await this.paymentMethodRepository.deleteByFingerprint(local.fingerprint, local.paymentMethodId, user.id);
+        this.loggerService.warn({
+          event: "DEFAULT_PAYMENT_METHOD_STALE_REMOVED",
+          userId: user.id,
+          paymentMethodId: local.paymentMethodId
+        });
+        return;
+      }
+
+      await this.markRemotePaymentMethodAsDefault(local.paymentMethodId, user);
+      this.loggerService.info({
+        event: "DEFAULT_PAYMENT_METHOD_DRIFT_HEALED",
         userId: user.id,
-        remoteId: typeof remote === "string" ? remote : remote?.id,
-        localId: local?.paymentMethodId
+        paymentMethodId: local.paymentMethodId
+      });
+
+      return { ...remotePaymentMethod, validated: local.isValidated, isDefault: local.isDefault };
+    } catch (error) {
+      if (error instanceof Stripe.errors.StripeInvalidRequestError && error.code === "resource_missing") {
+        await this.paymentMethodRepository.deleteByFingerprint(local.fingerprint, local.paymentMethodId, user.id);
+        this.loggerService.warn({
+          event: "DEFAULT_PAYMENT_METHOD_STALE_REMOVED",
+          userId: user.id,
+          paymentMethodId: local.paymentMethodId
+        });
+        return;
+      }
+
+      this.loggerService.warn({
+        event: "DEFAULT_PAYMENT_METHOD_HEAL_FAILED",
+        userId: user.id,
+        paymentMethodId: local.paymentMethodId,
+        error
       });
     }
   }

--- a/apps/api/src/billing/services/payment-method/payment-method.service.ts
+++ b/apps/api/src/billing/services/payment-method/payment-method.service.ts
@@ -96,17 +96,31 @@ export class PaymentMethodService {
       return false;
     }
 
+    const removedIds: string[] = [];
+
     for (const local of stale) {
-      await this.paymentMethodRepository.deleteByFingerprint(local.fingerprint, local.paymentMethodId, userId);
+      try {
+        await this.paymentMethodRepository.deleteByFingerprint(local.fingerprint, local.paymentMethodId, userId);
+        removedIds.push(local.paymentMethodId);
+      } catch (error) {
+        this.loggerService.error({
+          event: "PAYMENT_METHOD_STALE_REMOVE_FAILED",
+          userId,
+          paymentMethodId: local.paymentMethodId,
+          error
+        });
+      }
     }
 
-    this.loggerService.info({
-      event: "PAYMENT_METHOD_STALE_REMOVED",
-      userId,
-      paymentMethodIds: stale.map(local => local.paymentMethodId)
-    });
+    if (removedIds.length) {
+      this.loggerService.info({
+        event: "PAYMENT_METHOD_STALE_REMOVED",
+        userId,
+        paymentMethodIds: removedIds
+      });
+    }
 
-    return true;
+    return removedIds.length > 0;
   }
 
   /**
@@ -124,12 +138,12 @@ export class PaymentMethodService {
       return false;
     }
 
-    let repaired = false;
+    const repairedIds: string[] = [];
 
     for (const remote of unsynced) {
       try {
         await this.syncAttached({ user, paymentMethod: remote });
-        repaired = true;
+        repairedIds.push(remote.id);
       } catch (error) {
         this.loggerService.error({
           event: "PAYMENT_METHOD_READ_REPAIR_FAILED",
@@ -140,15 +154,15 @@ export class PaymentMethodService {
       }
     }
 
-    if (repaired) {
+    if (repairedIds.length) {
       this.loggerService.info({
         event: "PAYMENT_METHOD_READ_REPAIRED",
         userId: user.id,
-        paymentMethodIds: unsynced.map(remote => remote.id)
+        paymentMethodIds: repairedIds
       });
     }
 
-    return repaired;
+    return repairedIds.length > 0;
   }
 
   async getDefaultPaymentMethod(user: PayingUser, ability: AnyAbility): Promise<PaymentMethod | undefined> {
@@ -186,16 +200,11 @@ export class PaymentMethodService {
    */
   async #healDefaultPaymentMethodDrift(user: PayingUser, local: PaymentMethodOutput): Promise<PaymentMethod | undefined> {
     try {
-      const remotePaymentMethod = await this.stripe.paymentMethods.retrieve(local.paymentMethodId);
+      const remotePaymentMethod = await this.stripe.paymentMethods.retrieve(local.paymentMethodId, undefined, { timeout: 3_000 });
       const customerId = typeof remotePaymentMethod.customer === "string" ? remotePaymentMethod.customer : remotePaymentMethod.customer?.id;
 
       if (customerId !== user.stripeCustomerId) {
-        await this.paymentMethodRepository.deleteByFingerprint(local.fingerprint, local.paymentMethodId, user.id);
-        this.loggerService.warn({
-          event: "DEFAULT_PAYMENT_METHOD_STALE_REMOVED",
-          userId: user.id,
-          paymentMethodId: local.paymentMethodId
-        });
+        await this.#removeStaleDefaultPaymentMethod(user, local);
         return;
       }
 
@@ -209,17 +218,30 @@ export class PaymentMethodService {
       return { ...remotePaymentMethod, validated: local.isValidated, isDefault: local.isDefault };
     } catch (error) {
       if (error instanceof Stripe.errors.StripeInvalidRequestError && error.code === "resource_missing") {
-        await this.paymentMethodRepository.deleteByFingerprint(local.fingerprint, local.paymentMethodId, user.id);
-        this.loggerService.warn({
-          event: "DEFAULT_PAYMENT_METHOD_STALE_REMOVED",
-          userId: user.id,
-          paymentMethodId: local.paymentMethodId
-        });
+        await this.#removeStaleDefaultPaymentMethod(user, local);
         return;
       }
 
       this.loggerService.warn({
         event: "DEFAULT_PAYMENT_METHOD_HEAL_FAILED",
+        userId: user.id,
+        paymentMethodId: local.paymentMethodId,
+        error
+      });
+    }
+  }
+
+  async #removeStaleDefaultPaymentMethod(user: PayingUser, local: PaymentMethodOutput): Promise<void> {
+    try {
+      await this.paymentMethodRepository.deleteByFingerprint(local.fingerprint, local.paymentMethodId, user.id);
+      this.loggerService.warn({
+        event: "DEFAULT_PAYMENT_METHOD_STALE_REMOVED",
+        userId: user.id,
+        paymentMethodId: local.paymentMethodId
+      });
+    } catch (error) {
+      this.loggerService.warn({
+        event: "DEFAULT_PAYMENT_METHOD_STALE_REMOVE_FAILED",
         userId: user.id,
         paymentMethodId: local.paymentMethodId,
         error

--- a/apps/api/src/billing/services/payment-method/payment-method.service.ts
+++ b/apps/api/src/billing/services/payment-method/payment-method.service.ts
@@ -1,14 +1,13 @@
 import type { LoggerService } from "@akashnetwork/logging";
 import type { AnyAbility } from "@casl/ability";
 import assert from "http-assert";
-import difference from "lodash/difference";
 import keyBy from "lodash/keyBy";
 import Stripe from "stripe";
 import { inject, singleton } from "tsyringe";
 
 import { extractFingerprint } from "@src/billing/lib/payment-method/extract-fingerprint";
 import { STRIPE_CLIENT } from "@src/billing/providers/stripe-client.provider";
-import { PaymentMethodRepository } from "@src/billing/repositories";
+import { type PaymentMethodOutput, PaymentMethodRepository } from "@src/billing/repositories";
 import { type CreateLogger, LOGGER_FACTORY, WithTransaction } from "@src/core";
 import { type UserOutput, UserRepository } from "@src/user/repositories/user/user.repository";
 import { assertIsPayingUser, type PayingUser } from "../paying-user/paying-user";
@@ -28,37 +27,127 @@ export class PaymentMethodService {
     this.loggerService = createLogger({ context: PaymentMethodService.name });
   }
 
-  async getPaymentMethods(userId: string, customerId: string, ability: AnyAbility): Promise<PaymentMethod[]> {
+  async getPaymentMethods(user: PayingUser, ability: AnyAbility): Promise<PaymentMethod[]> {
     const [remotes, locals] = await Promise.all([
-      this.stripe.paymentMethods.list({ customer: customerId }),
-      this.paymentMethodRepository.accessibleBy(ability, "read").findByUserId(userId)
+      this.stripe.paymentMethods.list({ customer: user.stripeCustomerId }),
+      this.paymentMethodRepository.accessibleBy(ability, "read").findByUserId(user.id)
     ]);
 
-    const localById = keyBy(locals, "paymentMethodId");
-    const remoteIds: string[] = [];
+    const reconciledLocals = await this.#reconcilePaymentMethods({ user, ability, remotes, locals });
+    const localById = keyBy(reconciledLocals, "paymentMethodId");
 
     const merged = remotes.data
-      .map(remote => {
-        remoteIds.push(remote.id);
-        return {
-          ...remote,
-          validated: !!localById[remote.id]?.isValidated,
-          isDefault: !!localById[remote.id]?.isDefault
-        };
-      })
+      .map(remote => ({
+        ...remote,
+        validated: !!localById[remote.id]?.isValidated,
+        isDefault: !!localById[remote.id]?.isDefault
+      }))
       .sort((a, b) => b.created - a.created);
 
-    const outOfSyncIds = difference(remoteIds, Object.keys(localById));
+    const unsyncableIds = remotes.data.filter(remote => !localById[remote.id] && !extractFingerprint(remote)).map(remote => remote.id);
 
-    if (outOfSyncIds.length) {
+    if (unsyncableIds.length) {
       this.loggerService.warn({
         event: "STRIPE_PAYMENT_METHOD_OUT_OF_SYNC",
-        userId,
-        outOfSyncIds
+        userId: user.id,
+        outOfSyncIds: unsyncableIds
       });
     }
 
     return merged;
+  }
+
+  async #reconcilePaymentMethods(params: {
+    user: PayingUser;
+    ability: AnyAbility;
+    remotes: Stripe.ApiList<Stripe.PaymentMethod>;
+    locals: PaymentMethodOutput[];
+  }): Promise<PaymentMethodOutput[]> {
+    const { user, ability, remotes, locals } = params;
+    const remoteIds = new Set(remotes.data.map(remote => remote.id));
+
+    const staleRemoved = await this.#removeStaleLocalPaymentMethods({ userId: user.id, locals, remoteIds, hasMore: remotes.has_more });
+    const repaired = await this.#repairUnsyncedRemotePaymentMethods({ user, remotes: remotes.data, locals });
+
+    if (!staleRemoved && !repaired) {
+      return locals;
+    }
+
+    return this.paymentMethodRepository.accessibleBy(ability, "read").findByUserId(user.id);
+  }
+
+  /**
+   * Deletes local rows whose payment method is absent from Stripe, e.g. left over from a missed
+   * payment_method.detached webhook. Stale rows inflate countByUserId and break first-card default
+   * detection on the next add. Guarded on !hasMore because Stripe pages the list at 10: against a
+   * truncated page a still-attached method would be wrongly deleted.
+   */
+  async #removeStaleLocalPaymentMethods(params: { userId: string; locals: PaymentMethodOutput[]; remoteIds: Set<string>; hasMore: boolean }): Promise<boolean> {
+    const { userId, locals, remoteIds, hasMore } = params;
+
+    if (hasMore) {
+      return false;
+    }
+
+    const stale = locals.filter(local => !remoteIds.has(local.paymentMethodId));
+
+    if (!stale.length) {
+      return false;
+    }
+
+    for (const local of stale) {
+      await this.paymentMethodRepository.deleteByFingerprint(local.fingerprint, local.paymentMethodId, userId);
+    }
+
+    this.loggerService.info({
+      event: "PAYMENT_METHOD_STALE_REMOVED",
+      userId,
+      paymentMethodIds: stale.map(local => local.paymentMethodId)
+    });
+
+    return true;
+  }
+
+  /**
+   * Creates the missing local row for remote methods that never got one, e.g. a missed
+   * payment_method.attached webhook (always the case in local dev). syncAttached is idempotent and
+   * pushes the Stripe default for a first card, so this heals the sync on read. Oldest first so the
+   * genuine first card wins the default. Never lets a single failure fail the whole read.
+   */
+  async #repairUnsyncedRemotePaymentMethods(params: { user: PayingUser; remotes: Stripe.PaymentMethod[]; locals: PaymentMethodOutput[] }): Promise<boolean> {
+    const { user, remotes, locals } = params;
+    const localIds = new Set(locals.map(local => local.paymentMethodId));
+    const unsynced = remotes.filter(remote => !localIds.has(remote.id) && extractFingerprint(remote)).sort((a, b) => a.created - b.created);
+
+    if (!unsynced.length) {
+      return false;
+    }
+
+    let repaired = false;
+
+    for (const remote of unsynced) {
+      try {
+        await this.syncAttached({ user, paymentMethod: remote });
+        repaired = true;
+      } catch (error) {
+        this.loggerService.error({
+          event: "PAYMENT_METHOD_READ_REPAIR_FAILED",
+          userId: user.id,
+          paymentMethodId: remote.id,
+          error
+        });
+      }
+    }
+
+    if (repaired) {
+      this.loggerService.info({
+        event: "PAYMENT_METHOD_READ_REPAIRED",
+        userId: user.id,
+        paymentMethodIds: unsynced.map(remote => remote.id)
+      });
+    }
+
+    return repaired;
   }
 
   async getDefaultPaymentMethod(user: PayingUser, ability: AnyAbility): Promise<PaymentMethod | undefined> {

--- a/apps/api/src/billing/services/payment-method/payment-method.service.ts
+++ b/apps/api/src/billing/services/payment-method/payment-method.service.ts
@@ -7,7 +7,7 @@ import { inject, singleton } from "tsyringe";
 
 import { extractFingerprint } from "@src/billing/lib/payment-method/extract-fingerprint";
 import { STRIPE_CLIENT } from "@src/billing/providers/stripe-client.provider";
-import { type PaymentMethodOutput, PaymentMethodRepository } from "@src/billing/repositories";
+import { type PaymentMethodOutput, PaymentMethodRepository, WalletSettingRepository } from "@src/billing/repositories";
 import { type CreateLogger, LOGGER_FACTORY, WithTransaction } from "@src/core";
 import { type UserOutput, UserRepository } from "@src/user/repositories/user/user.repository";
 import { assertIsPayingUser, type PayingUser } from "../paying-user/paying-user";
@@ -22,6 +22,7 @@ export class PaymentMethodService {
     @inject(STRIPE_CLIENT) private readonly stripe: Stripe,
     private readonly paymentMethodRepository: PaymentMethodRepository,
     private readonly userRepository: UserRepository,
+    private readonly walletSettingRepository: WalletSettingRepository,
     @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
     this.loggerService = createLogger({ context: PaymentMethodService.name });
@@ -224,6 +225,18 @@ export class PaymentMethodService {
         error
       });
     }
+  }
+
+  async assertRemovable(paymentMethodId: string, userId: string): Promise<void> {
+    const local = await this.paymentMethodRepository.findOneBy({ userId, paymentMethodId });
+
+    if (!local?.isDefault) {
+      return;
+    }
+
+    const settings = await this.walletSettingRepository.findByUserId(userId);
+
+    assert(!settings?.autoReloadEnabled, 409, "Cannot remove the default payment method while auto reload is enabled");
   }
 
   async hasPaymentMethod(paymentMethodId: string, user: UserOutput): Promise<boolean> {

--- a/apps/deploy-web/src/components/billing-usage/AddCreditsForm/AddCreditsForm.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AddCreditsForm/AddCreditsForm.spec.tsx
@@ -5,7 +5,6 @@ import { mock } from "vitest-mock-extended";
 
 import { getPaymentMethodDisplay } from "@src/components/shared/PaymentMethodCard/PaymentMethodCard";
 import type { WalletBalance } from "@src/hooks/useWalletBalance";
-import { QueryKeys } from "@src/queries";
 import type { AnalyticsService } from "@src/services/analytics/analytics.service";
 import { handleStripeError } from "@src/utils/stripeErrorHandler";
 import { AddCreditsAmountFields } from "../AddCreditsAmountFields/AddCreditsAmountFields";
@@ -489,8 +488,8 @@ describe(AddCreditsForm.name, () => {
     expect(confirmPayment).toHaveBeenLastCalledWith({ userId: "user_1", paymentMethodId: "pm_new", amount: 100, idempotencyKey: expect.any(String) });
   });
 
-  it("invalidates the payment methods query when a new-card charge fails", async () => {
-    const invalidateQueries = vi.fn();
+  it("refreshes the payment methods when a new-card charge fails", async () => {
+    const refreshPaymentMethods = vi.fn().mockResolvedValue(undefined);
     const confirmPayment = vi.fn().mockRejectedValue(new Error("declined"));
     const addPaymentMethod = vi.fn().mockResolvedValue({ paymentMethodId: "pm_new" });
     const { Mock: AddCreditsNewPaymentMethodFields } = makePaymentMethodFieldsMock(addPaymentMethod);
@@ -499,7 +498,7 @@ describe(AddCreditsForm.name, () => {
       status: "success",
       clientSecret: "seti_secret",
       confirmPayment,
-      invalidateQueries,
+      refreshPaymentMethods,
       dependencies: { AddCreditsNewPaymentMethodFields }
     });
 
@@ -509,7 +508,7 @@ describe(AddCreditsForm.name, () => {
       fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
     });
 
-    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: QueryKeys.getPaymentMethodsKey() });
+    expect(refreshPaymentMethods).toHaveBeenCalled();
   });
 
   it("recreates the setup intent when 'Add new payment method' is re-selected after a card was confirmed", async () => {
@@ -945,7 +944,7 @@ describe(AddCreditsForm.name, () => {
     clientSecret?: string;
     mutate?: ReturnType<typeof DEPENDENCIES.useSetupIntentMutation>["mutate"];
     reset?: ReturnType<typeof DEPENDENCIES.useSetupIntentMutation>["reset"];
-    invalidateQueries?: ReturnType<typeof DEPENDENCIES.useQueryClient>["invalidateQueries"];
+    refreshPaymentMethods?: ReturnType<typeof DEPENDENCIES.useRefreshPaymentMethods>;
     getCustomerTransactions?: ReturnType<typeof DEPENDENCIES.useServices>["stripe"]["getCustomerTransactions"];
     topUpMinAmountUsd?: number;
     confirmPayment?: ReturnType<typeof DEPENDENCIES.usePaymentMutations>["confirmPayment"]["mutateAsync"];
@@ -1002,10 +1001,8 @@ describe(AddCreditsForm.name, () => {
         balance: input.walletBalanceUsd != null ? mock<WalletBalance>({ totalUsd: input.walletBalanceUsd }) : null
       });
 
-    const useQueryClient: typeof DEPENDENCIES.useQueryClient = () =>
-      mock<ReturnType<typeof DEPENDENCIES.useQueryClient>>({
-        invalidateQueries: input.invalidateQueries ?? vi.fn()
-      });
+    const refreshPaymentMethods = input.refreshPaymentMethods ?? vi.fn().mockResolvedValue(undefined);
+    const useRefreshPaymentMethods: typeof DEPENDENCIES.useRefreshPaymentMethods = () => refreshPaymentMethods;
 
     const useServices: typeof DEPENDENCIES.useServices = () =>
       mock<ReturnType<typeof DEPENDENCIES.useServices>>({
@@ -1054,7 +1051,7 @@ describe(AddCreditsForm.name, () => {
           usePaymentMethodsQuery,
           usePaymentMutations,
           usePaymentPolling,
-          useQueryClient,
+          useRefreshPaymentMethods,
           useServices,
           useWallet,
           useWalletBalance,

--- a/apps/deploy-web/src/components/billing-usage/AddCreditsForm/AddCreditsForm.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AddCreditsForm/AddCreditsForm.tsx
@@ -14,7 +14,6 @@ import {
   SelectValue,
   Skeleton
 } from "@akashnetwork/ui/components";
-import { useQueryClient } from "@tanstack/react-query";
 
 import type { AddCreditsAmountValue } from "@src/components/billing-usage/AddCreditsAmountFields/AddCreditsAmountFields";
 import { AddCreditsAmountFields } from "@src/components/billing-usage/AddCreditsAmountFields/AddCreditsAmountFields";
@@ -29,7 +28,7 @@ import { useWallet } from "@src/context/WalletProvider";
 import { use3DSecure } from "@src/hooks/use3DSecure";
 import { useUser } from "@src/hooks/useUser";
 import { useWalletBalance } from "@src/hooks/useWalletBalance";
-import { QueryKeys, usePaymentMethodsQuery, usePaymentMutations, useSetupIntentMutation } from "@src/queries";
+import { usePaymentMethodsQuery, usePaymentMutations, useRefreshPaymentMethods, useSetupIntentMutation } from "@src/queries";
 import { handleStripeError } from "@src/utils/stripeErrorHandler";
 import { useTopUpAttemptKey } from "./useTopUpAttemptKey/useTopUpAttemptKey";
 
@@ -52,7 +51,7 @@ export const DEPENDENCIES = {
   usePaymentMethodsQuery,
   usePaymentMutations,
   usePaymentPolling,
-  useQueryClient,
+  useRefreshPaymentMethods,
   useServices,
   useWallet,
   useWalletBalance,
@@ -104,7 +103,7 @@ export function AddCreditsForm({ onDone, onProcessingChange, dependencies: d = D
   const { stripe, analyticsService } = d.useServices();
   const { isTrialing, topUpMinAmountUsd } = d.useWallet();
   const { balance } = d.useWalletBalance();
-  const queryClient = d.useQueryClient();
+  const refreshPaymentMethods = d.useRefreshPaymentMethods();
   const { data: paymentMethods, isLoading: isLoadingMethods, isError: isMethodsError } = d.usePaymentMethodsQuery();
   const {
     confirmPayment: { mutateAsync: confirmPayment }
@@ -205,10 +204,10 @@ export function AddCreditsForm({ onDone, onProcessingChange, dependencies: d = D
 
       if (confirmedNewCardRef.current) {
         // confirmSetup already saved the card even though the charge failed; surface it in the saved-methods list.
-        queryClient.invalidateQueries({ queryKey: QueryKeys.getPaymentMethodsKey() });
+        refreshPaymentMethods();
       }
     },
-    [queryClient]
+    [refreshPaymentMethods]
   );
 
   const threeDSecure = d.use3DSecure({

--- a/apps/deploy-web/src/components/billing-usage/PaymentMethodsContainer/PaymentMethodsContainer.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/PaymentMethodsContainer/PaymentMethodsContainer.spec.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import type { PaymentMethod, SetupIntentResponse } from "@akashnetwork/http-sdk";
 import { describe, expect, it, type MockedFunction, vi } from "vitest";
 
-import type { usePaymentMethodsQuery, usePaymentMutations, useSetupIntentMutation, useWalletSettingsQuery } from "@src/queries";
+import type { usePaymentMethodsQuery, usePaymentMutations, useRefreshPaymentMethods, useSetupIntentMutation, useWalletSettingsQuery } from "@src/queries";
 import type { PaymentMethodsViewProps } from "../PaymentMethodsView/PaymentMethodsView";
 import { PaymentMethodsContainer } from "./PaymentMethodsContainer";
 
@@ -72,12 +72,11 @@ describe(PaymentMethodsContainer.name, () => {
     expect(child.setupIntent).toEqual(setupIntent);
   });
 
-  it("sets showAddPaymentMethod to false and refetches payment methods when onAddCardSuccess is called", async () => {
-    const { childCapturer, mockRefetchPaymentMethods } = await setup();
+  it("sets showAddPaymentMethod to false and refreshes payment methods when onAddCardSuccess is called", async () => {
+    const { childCapturer, mockRefreshPaymentMethods } = await setup();
 
     let child = await childCapturer.awaitChild(() => true);
 
-    // First, open the add payment method dialog
     await act(async () => {
       child.onAddPaymentMethod();
     });
@@ -85,7 +84,6 @@ describe(PaymentMethodsContainer.name, () => {
     child = await childCapturer.awaitChild(c => c.showAddPaymentMethod === true);
     expect(child.showAddPaymentMethod).toBe(true);
 
-    // Then call onAddCardSuccess
     await act(async () => {
       await child.onAddCardSuccess();
     });
@@ -93,7 +91,7 @@ describe(PaymentMethodsContainer.name, () => {
     child = await childCapturer.awaitChild(c => c.showAddPaymentMethod === false);
 
     expect(child.showAddPaymentMethod).toBe(false);
-    expect(mockRefetchPaymentMethods).toHaveBeenCalled();
+    expect(mockRefreshPaymentMethods).toHaveBeenCalled();
   });
 
   it("allows setShowAddPaymentMethod to update state", async () => {
@@ -191,7 +189,7 @@ describe(PaymentMethodsContainer.name, () => {
     const isRemovePaymentMethodPending = overrides.isRemovePaymentMethodPending ?? false;
     const setupIntent = overrides.setupIntent;
 
-    const mockRefetchPaymentMethods = vi.fn();
+    const mockRefreshPaymentMethods = vi.fn().mockResolvedValue(undefined);
     const mockSetPaymentMethodAsDefault = {
       mutate: vi.fn(),
       isPending: isSetPaymentMethodAsDefaultPending
@@ -206,14 +204,15 @@ describe(PaymentMethodsContainer.name, () => {
     const mockedUsePaymentMethodsQuery = vi.fn(() => ({
       data: paymentMethods,
       isLoading: isLoadingPaymentMethods,
-      isRefetching: isRefetchingPaymentMethods,
-      refetch: mockRefetchPaymentMethods
+      isRefetching: isRefetchingPaymentMethods
     })) as unknown as MockedFunction<typeof usePaymentMethodsQuery>;
 
     const mockedUsePaymentMutations = vi.fn(() => ({
       setPaymentMethodAsDefault: mockSetPaymentMethodAsDefault,
       removePaymentMethod: mockRemovePaymentMethod
     })) as unknown as MockedFunction<typeof usePaymentMutations>;
+
+    const mockedUseRefreshPaymentMethods = vi.fn(() => mockRefreshPaymentMethods) as unknown as MockedFunction<typeof useRefreshPaymentMethods>;
 
     const mockedUseSetupIntentMutation = vi.fn(() => ({
       data: setupIntent,
@@ -233,6 +232,7 @@ describe(PaymentMethodsContainer.name, () => {
     const dependencies = {
       usePaymentMethodsQuery: mockedUsePaymentMethodsQuery,
       usePaymentMutations: mockedUsePaymentMutations,
+      useRefreshPaymentMethods: mockedUseRefreshPaymentMethods,
       useSetupIntentMutation: mockedUseSetupIntentMutation,
       useWalletSettingsQuery: mockedUseWalletSettingsQuery
     };
@@ -247,7 +247,7 @@ describe(PaymentMethodsContainer.name, () => {
       paymentMethods,
       child,
       childCapturer,
-      mockRefetchPaymentMethods,
+      mockRefreshPaymentMethods,
       mockSetPaymentMethodAsDefault,
       mockRemovePaymentMethod,
       mockCreateSetupIntent,

--- a/apps/deploy-web/src/components/billing-usage/PaymentMethodsContainer/PaymentMethodsContainer.tsx
+++ b/apps/deploy-web/src/components/billing-usage/PaymentMethodsContainer/PaymentMethodsContainer.tsx
@@ -1,11 +1,12 @@
 import React, { useCallback, useState } from "react";
 
-import { usePaymentMethodsQuery, usePaymentMutations, useSetupIntentMutation, useWalletSettingsQuery } from "@src/queries";
+import { usePaymentMethodsQuery, usePaymentMutations, useRefreshPaymentMethods, useSetupIntentMutation, useWalletSettingsQuery } from "@src/queries";
 import type { PaymentMethodsViewProps } from "../PaymentMethodsView/PaymentMethodsView";
 
 const DEPENDENCIES = {
   usePaymentMethodsQuery,
   usePaymentMutations,
+  useRefreshPaymentMethods,
   useSetupIntentMutation,
   useWalletSettingsQuery
 };
@@ -16,15 +17,11 @@ type PaymentMethodsContainerProps = {
 };
 
 export const PaymentMethodsContainer: React.FC<PaymentMethodsContainerProps> = ({ children, dependencies: d = DEPENDENCIES }) => {
-  const {
-    data: paymentMethods = [],
-    isLoading: isLoadingPaymentMethods,
-    refetch: refetchPaymentMethods,
-    isRefetching: isRefetchingPaymentMethods
-  } = d.usePaymentMethodsQuery();
+  const { data: paymentMethods = [], isLoading: isLoadingPaymentMethods, isRefetching: isRefetchingPaymentMethods } = d.usePaymentMethodsQuery();
   const { data: walletSettings, isLoading: isWalletSettingsLoading } = d.useWalletSettingsQuery();
   const isAutoReloadEnabled = walletSettings?.autoReloadEnabled ?? isWalletSettingsLoading;
   const paymentMutations = d.usePaymentMutations();
+  const refreshPaymentMethods = d.useRefreshPaymentMethods();
   const { data: setupIntent, mutate: createSetupIntent, reset: resetSetupIntent } = d.useSetupIntentMutation();
   const [showAddPaymentMethod, setShowAddPaymentMethod] = useState(false);
 
@@ -44,7 +41,7 @@ export const PaymentMethodsContainer: React.FC<PaymentMethodsContainerProps> = (
 
   const onAddCardSuccess = async () => {
     setShowAddPaymentMethod(false);
-    refetchPaymentMethods();
+    await refreshPaymentMethods();
   };
 
   const onAddPaymentMethod = useCallback(() => {

--- a/apps/deploy-web/src/components/billing-usage/PaymentMethodsView/PaymentMethodsRow.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/PaymentMethodsView/PaymentMethodsRow.spec.tsx
@@ -142,7 +142,7 @@ describe(PaymentMethodsRow.name, () => {
       expect(screen.queryByText("Default")).not.toBeInTheDocument();
     });
 
-    it("renders dropdown menu button when hasOtherPaymentMethods is true and payment method is not default", () => {
+    it("renders dropdown menu button when payment method is not default", () => {
       setup({
         paymentMethod: createMockPaymentMethod({
           isDefault: false
@@ -151,14 +151,6 @@ describe(PaymentMethodsRow.name, () => {
 
       const button = screen.getByRole("button");
       expect(button).toBeInTheDocument();
-    });
-
-    it("renders dropdown menu button for the only payment method", () => {
-      setup({
-        hasOtherPaymentMethods: false
-      });
-
-      expect(screen.getByRole("button")).toBeInTheDocument();
     });
 
     it("renders dropdown menu button for default payment method", () => {
@@ -210,8 +202,7 @@ describe(PaymentMethodsRow.name, () => {
     it("shows only 'Remove' for default payment method", async () => {
       const user = userEvent.setup();
       setup({
-        paymentMethod: createMockPaymentMethod({ isDefault: true }),
-        hasOtherPaymentMethods: true
+        paymentMethod: createMockPaymentMethod({ isDefault: true })
       });
 
       const button = screen.getByRole("button");
@@ -223,26 +214,27 @@ describe(PaymentMethodsRow.name, () => {
       });
     });
 
-    it("shows only 'Remove' for the only payment method", async () => {
+    it("shows 'Set as default' for a sole non-default payment method", async () => {
       const user = userEvent.setup();
-      setup({
-        paymentMethod: createMockPaymentMethod({ isDefault: true }),
-        hasOtherPaymentMethods: false
+      const { mockOnSetPaymentMethodAsDefault } = setup({
+        paymentMethod: createMockPaymentMethod({ id: "pm_sole", isDefault: false })
       });
 
       const button = screen.getByRole("button");
       await user.click(button);
 
       await vi.waitFor(() => {
-        expect(screen.queryByText("Set as default")).not.toBeInTheDocument();
-        expect(screen.getByText("Remove")).toBeInTheDocument();
+        expect(screen.getByText("Set as default")).toBeInTheDocument();
       });
+
+      await user.click(screen.getByText("Set as default"));
+
+      expect(mockOnSetPaymentMethodAsDefault).toHaveBeenCalledWith("pm_sole");
     });
 
     it("hides 'Remove' for default payment method when auto-reload is enabled", () => {
       setup({
         paymentMethod: createMockPaymentMethod({ isDefault: true }),
-        hasOtherPaymentMethods: true,
         isAutoReloadEnabled: true
       });
 
@@ -253,7 +245,6 @@ describe(PaymentMethodsRow.name, () => {
       const user = userEvent.setup();
       setup({
         paymentMethod: createMockPaymentMethod({ isDefault: false }),
-        hasOtherPaymentMethods: true,
         isAutoReloadEnabled: true
       });
 
@@ -449,7 +440,6 @@ describe(PaymentMethodsRow.name, () => {
                 })}
                 onSetPaymentMethodAsDefault={vi.fn()}
                 onRemovePaymentMethod={vi.fn()}
-                hasOtherPaymentMethods={true}
                 isAutoReloadEnabled={false}
                 dependencies={mockDependencies}
               />
@@ -481,7 +471,6 @@ function setup(
     paymentMethod?: PaymentMethod;
     onSetPaymentMethodAsDefault?: Mock;
     onRemovePaymentMethod?: Mock;
-    hasOtherPaymentMethods?: boolean;
     isAutoReloadEnabled?: boolean;
     dependencies?: typeof mockDependencies;
   } = {}
@@ -490,7 +479,6 @@ function setup(
     paymentMethod: createMockPaymentMethod(),
     onSetPaymentMethodAsDefault: vi.fn(),
     onRemovePaymentMethod: vi.fn(),
-    hasOtherPaymentMethods: true,
     isAutoReloadEnabled: false,
     dependencies: mockDependencies
   };

--- a/apps/deploy-web/src/components/billing-usage/PaymentMethodsView/PaymentMethodsRow.tsx
+++ b/apps/deploy-web/src/components/billing-usage/PaymentMethodsView/PaymentMethodsRow.tsx
@@ -22,7 +22,6 @@ export type PaymentMethodsRowProps = {
   paymentMethod: PaymentMethod;
   onSetPaymentMethodAsDefault: (id: string) => void;
   onRemovePaymentMethod: (id: string) => void;
-  hasOtherPaymentMethods: boolean;
   isAutoReloadEnabled: boolean;
   dependencies?: typeof DEPENDENCIES;
 };
@@ -31,7 +30,6 @@ export const PaymentMethodsRow: React.FC<PaymentMethodsRowProps> = ({
   paymentMethod,
   onSetPaymentMethodAsDefault,
   onRemovePaymentMethod,
-  hasOtherPaymentMethods,
   isAutoReloadEnabled,
   dependencies: d = DEPENDENCIES
 }) => {
@@ -98,7 +96,7 @@ export const PaymentMethodsRow: React.FC<PaymentMethodsRowProps> = ({
     closeMenu();
   }, [onRemovePaymentMethod, paymentMethod.id]);
 
-  const canSetAsDefault = !paymentMethod.isDefault && hasOtherPaymentMethods;
+  const canSetAsDefault = !paymentMethod.isDefault;
   const isDefaultBlockedByAutoReload = paymentMethod.isDefault && isAutoReloadEnabled;
   const canRemove = !isDefaultBlockedByAutoReload;
   const showActions = canSetAsDefault || canRemove;

--- a/apps/deploy-web/src/components/billing-usage/PaymentMethodsView/PaymentMethodsView.tsx
+++ b/apps/deploy-web/src/components/billing-usage/PaymentMethodsView/PaymentMethodsView.tsx
@@ -83,7 +83,6 @@ export const PaymentMethodsView: React.FC<PaymentMethodsViewProps> = ({
                       paymentMethod={paymentMethod}
                       onSetPaymentMethodAsDefault={onSetPaymentMethodAsDefault}
                       onRemovePaymentMethod={onRemovePaymentMethod}
-                      hasOtherPaymentMethods={data.length > 1}
                       isAutoReloadEnabled={isAutoReloadEnabled}
                     />
                   ))}

--- a/apps/deploy-web/src/queries/usePaymentQueries.spec.tsx
+++ b/apps/deploy-web/src/queries/usePaymentQueries.spec.tsx
@@ -134,12 +134,12 @@ describe("usePaymentQueries", () => {
   });
 
   describe("usePaymentMutations", () => {
-    it("invalidates both payment methods and transactions after a settled payment", async () => {
+    it("invalidates transactions, payment methods, and the default method after a settled payment", async () => {
       const mockPaymentResponse = createMockPaymentResponse({ requiresAction: false });
       const stripeService = mock<StripeService>({
         confirmPayment: vi.fn().mockResolvedValue(mockPaymentResponse)
       });
-      const api = createProxy({ v1: { listStripeTransactions: vi.fn() } }) as unknown as ApiService;
+      const api = createProxy({ v1: { listStripeTransactions: vi.fn(), getDefaultPaymentMethod: vi.fn() } }) as unknown as ApiService;
       const { result, queryClient } = setupQueryWithClient(() => usePaymentMutations(), {
         services: { stripe: () => stripeService, api: () => api }
       });
@@ -156,8 +156,9 @@ describe("usePaymentQueries", () => {
 
       await vi.waitFor(() => {
         expect(stripeService.confirmPayment).toHaveBeenCalled();
-        expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: QueryKeys.getPaymentMethodsKey() });
         expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: api.v1.listStripeTransactions.getKey() });
+        expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: QueryKeys.getPaymentMethodsKey() });
+        expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: api.v1.getDefaultPaymentMethod.getKey() });
       });
     });
 
@@ -228,13 +229,14 @@ describe("usePaymentQueries", () => {
       });
     });
 
-    it("removes payment method and invalidate methods", async () => {
+    it("removes payment method and invalidates the methods and default queries", async () => {
       const mockRemovedPaymentMethod = createMockRemovedPaymentMethod();
       const stripeService = mock<StripeService>({
         removePaymentMethod: vi.fn().mockResolvedValue(mockRemovedPaymentMethod)
       });
+      const api = createProxy({ v1: { getDefaultPaymentMethod: vi.fn() } }) as unknown as ApiService;
       const { result, queryClient } = setupQueryWithClient(() => usePaymentMutations(), {
-        services: { stripe: () => stripeService }
+        services: { stripe: () => stripeService, api: () => api }
       });
 
       const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries");
@@ -245,17 +247,19 @@ describe("usePaymentQueries", () => {
 
       await vi.waitFor(() => {
         expect(stripeService.removePaymentMethod).toHaveBeenCalledWith(mockRemovedPaymentMethod.id);
-        expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: ["PAYMENT_METHODS"] });
+        expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: QueryKeys.getPaymentMethodsKey() });
+        expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: api.v1.getDefaultPaymentMethod.getKey() });
       });
     });
 
-    it("validates payment method after 3DS and invalidates queries", async () => {
+    it("validates payment method after 3DS and invalidates the methods and default queries", async () => {
       const mockValidationResponse = { success: true };
       const stripeService = mock<StripeService>({
         validatePaymentMethodAfter3DS: vi.fn().mockResolvedValue(mockValidationResponse)
       });
+      const api = createProxy({ v1: { getDefaultPaymentMethod: vi.fn() } }) as unknown as ApiService;
       const { result, queryClient } = setupQueryWithClient(() => usePaymentMutations(), {
-        services: { stripe: () => stripeService }
+        services: { stripe: () => stripeService, api: () => api }
       });
 
       const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries");
@@ -272,11 +276,12 @@ describe("usePaymentQueries", () => {
           paymentMethodId: "pm_123",
           paymentIntentId: "pi_123"
         });
-        expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: ["PAYMENT_METHODS"] });
+        expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: QueryKeys.getPaymentMethodsKey() });
+        expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: api.v1.getDefaultPaymentMethod.getKey() });
       });
     });
 
-    it("sets payment method as default and invalidates queries", async () => {
+    it("sets payment method as default and invalidates the methods query before the default query", async () => {
       const mockPaymentMethod = createMockPaymentMethod({ isDefault: true });
       const stripeService = mock<StripeService>({
         setPaymentMethodAsDefault: vi.fn().mockResolvedValue(mockPaymentMethod)
@@ -294,8 +299,8 @@ describe("usePaymentQueries", () => {
 
       await vi.waitFor(() => {
         expect(stripeService.setPaymentMethodAsDefault).toHaveBeenCalledWith({ id: "pm_123" });
-        expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: ["PAYMENT_METHODS"] });
-        expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: api.v1.getDefaultPaymentMethod.getKey() });
+        expect(invalidateQueriesSpy).toHaveBeenNthCalledWith(1, { queryKey: QueryKeys.getPaymentMethodsKey() });
+        expect(invalidateQueriesSpy).toHaveBeenNthCalledWith(2, { queryKey: api.v1.getDefaultPaymentMethod.getKey() });
       });
     });
   });

--- a/apps/deploy-web/src/queries/usePaymentQueries.spec.tsx
+++ b/apps/deploy-web/src/queries/usePaymentQueries.spec.tsx
@@ -281,7 +281,7 @@ describe("usePaymentQueries", () => {
       });
     });
 
-    it("sets payment method as default and invalidates the methods query before the default query", async () => {
+    it("waits for the methods invalidation to settle before invalidating the default query", async () => {
       const mockPaymentMethod = createMockPaymentMethod({ isDefault: true });
       const stripeService = mock<StripeService>({
         setPaymentMethodAsDefault: vi.fn().mockResolvedValue(mockPaymentMethod)
@@ -291,15 +291,27 @@ describe("usePaymentQueries", () => {
         services: { stripe: () => stripeService, api: () => api }
       });
 
-      const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries");
+      let resolveMethodsInvalidation!: () => void;
+      const methodsInvalidation = new Promise<void>(resolve => {
+        resolveMethodsInvalidation = resolve;
+      });
+      const invalidateQueriesSpy = vi
+        .spyOn(queryClient, "invalidateQueries")
+        .mockImplementationOnce(() => methodsInvalidation)
+        .mockResolvedValue(undefined);
 
       await act(async () => {
         await result.current.setPaymentMethodAsDefault.mutateAsync("pm_123");
       });
 
       await vi.waitFor(() => {
-        expect(stripeService.setPaymentMethodAsDefault).toHaveBeenCalledWith({ id: "pm_123" });
         expect(invalidateQueriesSpy).toHaveBeenNthCalledWith(1, { queryKey: QueryKeys.getPaymentMethodsKey() });
+      });
+      expect(invalidateQueriesSpy).toHaveBeenCalledTimes(1);
+
+      resolveMethodsInvalidation();
+
+      await vi.waitFor(() => {
         expect(invalidateQueriesSpy).toHaveBeenNthCalledWith(2, { queryKey: api.v1.getDefaultPaymentMethod.getKey() });
       });
     });

--- a/apps/deploy-web/src/queries/usePaymentQueries.ts
+++ b/apps/deploy-web/src/queries/usePaymentQueries.ts
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import type { paths } from "@akashnetwork/console-api-types";
 import type {
   ApplyCouponParams,
@@ -81,9 +82,26 @@ export const useSetupIntentMutation = () => {
   });
 };
 
+/**
+ * Refreshes the payment-methods list, then the default-payment-method query. The order is load
+ * bearing: the awaited list refetch resolves only after the server-side read-repair in
+ * getPaymentMethods has committed, so the following default fetch observes the healed state rather
+ * than the stale drift it was about to repair.
+ */
+export const useRefreshPaymentMethods = () => {
+  const { api } = useServices();
+  const queryClient = useQueryClient();
+
+  return useCallback(async () => {
+    await queryClient.invalidateQueries({ queryKey: QueryKeys.getPaymentMethodsKey() });
+    await queryClient.invalidateQueries({ queryKey: api.v1.getDefaultPaymentMethod.getKey() });
+  }, [api, queryClient]);
+};
+
 export const usePaymentMutations = () => {
   const { stripe, api } = useServices();
   const queryClient = useQueryClient();
+  const refreshPaymentMethods = useRefreshPaymentMethods();
 
   const confirmPayment = useMutation({
     ...walletProvisioningRetry,
@@ -99,7 +117,7 @@ export const usePaymentMutations = () => {
       queryClient.invalidateQueries({ queryKey: api.v1.listStripeTransactions.getKey() });
 
       if (!response.requiresAction) {
-        queryClient.invalidateQueries({ queryKey: QueryKeys.getPaymentMethodsKey() });
+        refreshPaymentMethods();
       }
     }
   });
@@ -112,8 +130,7 @@ export const usePaymentMutations = () => {
       });
     },
     onSuccess: () => {
-      // Invalidate payment methods after 3DS validation
-      queryClient.invalidateQueries({ queryKey: QueryKeys.getPaymentMethodsKey() });
+      refreshPaymentMethods();
     }
   });
 
@@ -131,8 +148,7 @@ export const usePaymentMutations = () => {
       return response;
     },
     onSuccess: () => {
-      // Invalidate payment methods after removal
-      queryClient.invalidateQueries({ queryKey: QueryKeys.getPaymentMethodsKey() });
+      refreshPaymentMethods();
     }
   });
 
@@ -142,8 +158,7 @@ export const usePaymentMutations = () => {
       return response;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: QueryKeys.getPaymentMethodsKey() });
-      queryClient.invalidateQueries({ queryKey: api.v1.getDefaultPaymentMethod.getKey() });
+      refreshPaymentMethods();
     }
   });
 


### PR DESCRIPTION
## Why

Adding the first payment method left the user stranded with no default payment method: no Default badge, no "Set as default" option on a sole card, and auto top-up could not be enabled (both the UI gate and the wallet-settings enable validation require a default).

Root cause: `isDefault` is stored only in the local `payment_methods` row, and that row is created only by the asynchronous `payment_method.attached` webhook (via `syncAttached`/`upsert`). The webhook lags the frontend's immediate post-add refetch by about a second, so the first read after adding a card finds it in Stripe with no local row and no default. The row lands a moment later, but the UI has already shown the stranded state, and enabling auto top-up in that window fails. The webhook's push of Stripe's `invoice_settings.default_payment_method` is also best-effort with the error swallowed, so a transient failure leaves the local row marked default while Stripe has none, which is durable drift. The old `getDefaultPaymentMethod` required the Stripe side and the DB side to agree, so once drift happened there was no recovery path, and the ellipsis menu hid "Set as default" for a sole card.

This bug predates the fixed-threshold auto top-up work and exists on `main`.

## What

Five focused commits, one concern each:

1. **Read-repair reconciliation in `getPaymentMethods`** (root cause). On read, cards present in Stripe but missing a local row are healed via the idempotent `syncAttached` (oldest first, so the genuine first card wins the default), and local rows absent from a complete Stripe list are cleaned up. The stale-cleanup is guarded on `!has_more` so a truncated Stripe page can never delete a still-attached method. Each heal is best-effort: a failure logs and continues, the GET never 500s.

2. **Drift self-heal in `getDefaultPaymentMethod`**. The local default is the source of truth. When Stripe's default is missing or points elsewhere, the local default is re-pushed to Stripe; when the card is gone from Stripe (detached or deleted), the stale local row is dropped. This never throws, since it also runs inside the reload charging job and the wallet-settings enable validation.

3. **UI escape hatch**. Any non-default card can now be promoted; the old `hasOtherPaymentMethods` gate that hid "Set as default" for a sole card is removed. The backend already supported sole-card promotion.

4. **Frontend cache correctness**. New `useRefreshPaymentMethods` hook invalidates the payment-methods list first, then the default-method query. The ordering is load bearing: the awaited list refetch resolves only after the server-side read-repair has committed, so the default fetch observes the healed state. Wired into add, remove, 3DS, confirm, and set-default flows.

5. **Backend guard**. Detaching the default payment method while auto reload is enabled now returns 409 (server-side, not just UI). `PaymentMethodService` gains a `WalletSettingRepository` dependency (the repository, not `WalletSettingService`, which already depends on `PaymentMethodService`, to avoid a cycle).

The "first card = default" policy stays in exactly one place (`PaymentMethodRepository.upsert`); the frontend does not duplicate it.

### Behavior change to flag

Users currently stuck in the drift trap who had enabled auto top-up will silently resume being charged once commit 2 ships, because their local default will heal and become chargeable again. This is the intended recovery, called out here for visibility.

### Out of scope

- No auto-promotion of another card when the default is removed (manual "Set as default" is now always available).
- Reverse drift (Stripe default set, no local row) stays warn-only: the reload job runs with a read-only ability and must not silently adopt a charge target the user never confirmed. The read-repair creates the local row on the next list read anyway.

## Verification

- API unit (1286), API integration for payment methods (16), and API stripe functional tests (18, confirming the new DI dependency bootstraps) pass.
- deploy-web unit suite passes (2989 passed, 5 skipped).
- Lint `--quiet` clean and no new type errors in the touched files for both apps.
- Manual browser + Stripe test-dashboard walkthrough (add `4242 4242 4242 4242` with no webhook forwarding, verify Default badge, DB `is_default`, Stripe `invoice_settings.default_payment_method`, drift heal, remove/re-add, second-card 409 guard) is left to run locally, since it needs live Stripe test credentials and a browser session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Payment methods now automatically synchronize with the payment provider, repairing missing or outdated records.
  * Added safeguards preventing removal of the default payment method when automatic reload is enabled.
  * Users can set a payment method as default even when it is the only available method.
  * Payment method lists refresh consistently after billing actions and payment failures.

* **Bug Fixes**
  * Improved handling of stale, missing, or unsynchronized payment methods and default-payment settings.
  * Prevented unauthorized or invalid payment method removals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
