### PR TITLE
feat(billing): disable auto top-up when the default payment method is removed

### DIFF
--- a/apps/api/src/billing/controllers/stripe/stripe.controller.spec.ts
+++ b/apps/api/src/billing/controllers/stripe/stripe.controller.spec.ts
@@ -18,6 +18,7 @@ import type { StripeTransactionService } from "@src/billing/services/stripe-tran
 import type { TopUpService } from "@src/billing/services/top-up/top-up.service";
 import type { TransactionReportingService } from "@src/billing/services/transaction-reporting/transaction-reporting.service";
 import type { TrialActivationJobService } from "@src/billing/services/trial-activation-job/trial-activation-job.service";
+import type { WalletSettingService } from "@src/billing/services/wallet-settings/wallet-settings.service";
 import { StripeController } from "./stripe.controller";
 
 import { generateDatabaseStripeTransaction } from "@test/seeders/database-stripe-transaction.seeder";
@@ -197,35 +198,51 @@ describe(StripeController.name, () => {
   });
 
   describe("removePaymentMethod", () => {
-    it("detaches the payment method after asserting it is removable", async () => {
-      const { controller, stripe, paymentMethodService, userWalletRepository, user } = setup();
+    it("disables auto reload after detaching when the removed method is the default", async () => {
+      const { controller, stripe, paymentMethodService, walletSettingService, user } = setup();
       const paymentMethodId = faker.string.uuid();
       stripe.retrievePaymentMethod.mockResolvedValue(mock<Stripe.Response<Stripe.PaymentMethod>>({ customer: user.stripeCustomerId }));
+      paymentMethodService.isDefaultPaymentMethod.mockResolvedValue(true);
 
       await controller.removePaymentMethod(paymentMethodId);
 
-      expect(paymentMethodService.assertRemovable).toHaveBeenCalledWith(paymentMethodId, user.id);
+      expect(paymentMethodService.isDefaultPaymentMethod).toHaveBeenCalledWith(paymentMethodId, user.id);
       expect(stripe.detachPaymentMethod).toHaveBeenCalledWith(paymentMethodId);
-      expect(userWalletRepository.findOneByUserId).not.toHaveBeenCalled();
+      expect(walletSettingService.disableAutoReload).toHaveBeenCalledWith(user.id);
+      expect(stripe.detachPaymentMethod.mock.invocationCallOrder[0]).toBeLessThan(walletSettingService.disableAutoReload.mock.invocationCallOrder[0]);
+    });
+
+    it("does not disable auto reload when the removed method is not the default", async () => {
+      const { controller, stripe, paymentMethodService, walletSettingService, user } = setup();
+      const paymentMethodId = faker.string.uuid();
+      stripe.retrievePaymentMethod.mockResolvedValue(mock<Stripe.Response<Stripe.PaymentMethod>>({ customer: user.stripeCustomerId }));
+      paymentMethodService.isDefaultPaymentMethod.mockResolvedValue(false);
+
+      await controller.removePaymentMethod(paymentMethodId);
+
+      expect(stripe.detachPaymentMethod).toHaveBeenCalledWith(paymentMethodId);
+      expect(walletSettingService.disableAutoReload).not.toHaveBeenCalled();
     });
 
     it("rejects when the payment method does not belong to the user", async () => {
-      const { controller, stripe } = setup();
+      const { controller, stripe, walletSettingService } = setup();
       const paymentMethodId = faker.string.uuid();
       stripe.retrievePaymentMethod.mockResolvedValue(mock<Stripe.Response<Stripe.PaymentMethod>>({ customer: "cus_someoneelse" }));
 
       await expect(controller.removePaymentMethod(paymentMethodId)).rejects.toMatchObject({ status: 403 });
       expect(stripe.detachPaymentMethod).not.toHaveBeenCalled();
+      expect(walletSettingService.disableAutoReload).not.toHaveBeenCalled();
     });
 
-    it("does not detach when the payment method is not removable", async () => {
-      const { controller, stripe, paymentMethodService, user } = setup();
+    it("does not disable auto reload when the detach fails", async () => {
+      const { controller, stripe, paymentMethodService, walletSettingService, user } = setup();
       const paymentMethodId = faker.string.uuid();
       stripe.retrievePaymentMethod.mockResolvedValue(mock<Stripe.Response<Stripe.PaymentMethod>>({ customer: user.stripeCustomerId }));
-      paymentMethodService.assertRemovable.mockRejectedValue(createError(409, "Cannot remove the default payment method while auto reload is enabled"));
+      paymentMethodService.isDefaultPaymentMethod.mockResolvedValue(true);
+      stripe.detachPaymentMethod.mockRejectedValue(new Error("detach failed"));
 
-      await expect(controller.removePaymentMethod(paymentMethodId)).rejects.toMatchObject({ status: 409 });
-      expect(stripe.detachPaymentMethod).not.toHaveBeenCalled();
+      await expect(controller.removePaymentMethod(paymentMethodId)).rejects.toThrow("detach failed");
+      expect(walletSettingService.disableAutoReload).not.toHaveBeenCalled();
     });
   });
 
@@ -330,6 +347,7 @@ describe(StripeController.name, () => {
     const userWalletRepository = mock<UserWalletRepository>();
     const trialActivationJobService = mock<TrialActivationJobService>();
     const transactionReporting = mock<TransactionReportingService>();
+    const walletSettingService = mock<WalletSettingService>();
     const controller = new StripeController(
       stripe,
       stripeTransaction,
@@ -341,7 +359,8 @@ describe(StripeController.name, () => {
       transactionReporting,
       paymentMethodService,
       couponRedemptionService,
-      customerService
+      customerService,
+      walletSettingService
     );
     container.register(AuthService, { useValue: authService });
 
@@ -357,6 +376,7 @@ describe(StripeController.name, () => {
       stripeErrorService,
       userWalletRepository,
       trialActivationJobService,
+      walletSettingService,
       user
     };
   }

--- a/apps/api/src/billing/controllers/stripe/stripe.controller.spec.ts
+++ b/apps/api/src/billing/controllers/stripe/stripe.controller.spec.ts
@@ -19,6 +19,7 @@ import type { TopUpService } from "@src/billing/services/top-up/top-up.service";
 import type { TransactionReportingService } from "@src/billing/services/transaction-reporting/transaction-reporting.service";
 import type { TrialActivationJobService } from "@src/billing/services/trial-activation-job/trial-activation-job.service";
 import type { WalletSettingService } from "@src/billing/services/wallet-settings/wallet-settings.service";
+import type { LoggerService } from "@src/core/providers/logging.provider";
 import { StripeController } from "./stripe.controller";
 
 import { generateDatabaseStripeTransaction } from "@test/seeders/database-stripe-transaction.seeder";
@@ -244,6 +245,19 @@ describe(StripeController.name, () => {
       await expect(controller.removePaymentMethod(paymentMethodId)).rejects.toThrow("detach failed");
       expect(walletSettingService.disableAutoReload).not.toHaveBeenCalled();
     });
+
+    it("does not fail the request when disabling auto reload throws after detaching the default method", async () => {
+      const { controller, stripe, paymentMethodService, walletSettingService, logger, user } = setup();
+      const paymentMethodId = faker.string.uuid();
+      stripe.retrievePaymentMethod.mockResolvedValue(mock<Stripe.Response<Stripe.PaymentMethod>>({ customer: user.stripeCustomerId }));
+      paymentMethodService.isDefaultPaymentMethod.mockResolvedValue(true);
+      walletSettingService.disableAutoReload.mockRejectedValue(new Error("db down"));
+
+      await expect(controller.removePaymentMethod(paymentMethodId)).resolves.toBeUndefined();
+
+      expect(stripe.detachPaymentMethod).toHaveBeenCalledWith(paymentMethodId);
+      expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "AUTO_RELOAD_DISABLE_AFTER_REMOVAL_FAILED", userId: user.id }));
+    });
   });
 
   describe("getDefaultPaymentMethod", () => {
@@ -348,6 +362,7 @@ describe(StripeController.name, () => {
     const trialActivationJobService = mock<TrialActivationJobService>();
     const transactionReporting = mock<TransactionReportingService>();
     const walletSettingService = mock<WalletSettingService>();
+    const logger = mock<LoggerService>();
     const controller = new StripeController(
       stripe,
       stripeTransaction,
@@ -360,7 +375,8 @@ describe(StripeController.name, () => {
       paymentMethodService,
       couponRedemptionService,
       customerService,
-      walletSettingService
+      walletSettingService,
+      logger
     );
     container.register(AuthService, { useValue: authService });
 
@@ -377,6 +393,7 @@ describe(StripeController.name, () => {
       userWalletRepository,
       trialActivationJobService,
       walletSettingService,
+      logger,
       user
     };
   }

--- a/apps/api/src/billing/controllers/stripe/stripe.controller.ts
+++ b/apps/api/src/billing/controllers/stripe/stripe.controller.ts
@@ -30,6 +30,7 @@ import { StripeTransactionService } from "@src/billing/services/stripe-transacti
 import { TopUpService } from "@src/billing/services/top-up/top-up.service";
 import { TransactionReportingService } from "@src/billing/services/transaction-reporting/transaction-reporting.service";
 import { TrialActivationJobService } from "@src/billing/services/trial-activation-job/trial-activation-job.service";
+import { WalletSettingService } from "@src/billing/services/wallet-settings/wallet-settings.service";
 @singleton()
 export class StripeController {
   constructor(
@@ -43,7 +44,8 @@ export class StripeController {
     private readonly transactionReporting: TransactionReportingService,
     private readonly paymentMethodService: PaymentMethodService,
     private readonly couponRedemptionService: CouponRedemptionService,
-    private readonly customerService: CustomerService
+    private readonly customerService: CustomerService,
+    private readonly walletSettingService: WalletSettingService
   ) {}
 
   @Protected([{ action: "read", subject: "StripePayment" }])
@@ -176,9 +178,13 @@ export class StripeController {
       const customerId = typeof paymentMethod.customer === "string" ? paymentMethod.customer : paymentMethod.customer?.id;
       assert(customerId === currentUser.stripeCustomerId, 403, "Payment method does not belong to the user");
 
-      await this.paymentMethodService.assertRemovable(paymentMethodId, currentUser.id);
+      const wasDefault = await this.paymentMethodService.isDefaultPaymentMethod(paymentMethodId, currentUser.id);
 
       await this.stripe.detachPaymentMethod(paymentMethodId);
+
+      if (wasDefault) {
+        await this.walletSettingService.disableAutoReload(currentUser.id);
+      }
     } catch (error: unknown) {
       if (this.stripeErrorService.isKnownError(error, "payment")) {
         throw this.stripeErrorService.toAppError(error, "payment");

--- a/apps/api/src/billing/controllers/stripe/stripe.controller.ts
+++ b/apps/api/src/billing/controllers/stripe/stripe.controller.ts
@@ -31,6 +31,8 @@ import { TopUpService } from "@src/billing/services/top-up/top-up.service";
 import { TransactionReportingService } from "@src/billing/services/transaction-reporting/transaction-reporting.service";
 import { TrialActivationJobService } from "@src/billing/services/trial-activation-job/trial-activation-job.service";
 import { WalletSettingService } from "@src/billing/services/wallet-settings/wallet-settings.service";
+import { LoggerService } from "@src/core/providers/logging.provider";
+
 @singleton()
 export class StripeController {
   constructor(
@@ -45,8 +47,11 @@ export class StripeController {
     private readonly paymentMethodService: PaymentMethodService,
     private readonly couponRedemptionService: CouponRedemptionService,
     private readonly customerService: CustomerService,
-    private readonly walletSettingService: WalletSettingService
-  ) {}
+    private readonly walletSettingService: WalletSettingService,
+    private readonly logger: LoggerService
+  ) {
+    this.logger.setContext(StripeController.name);
+  }
 
   @Protected([{ action: "read", subject: "StripePayment" }])
   async findPrices(): Promise<StripePricesOutputResponse> {
@@ -183,7 +188,7 @@ export class StripeController {
       await this.stripe.detachPaymentMethod(paymentMethodId);
 
       if (wasDefault) {
-        await this.walletSettingService.disableAutoReload(currentUser.id);
+        await this.#disableAutoReloadAfterDefaultRemoval(currentUser.id);
       }
     } catch (error: unknown) {
       if (this.stripeErrorService.isKnownError(error, "payment")) {
@@ -191,6 +196,19 @@ export class StripeController {
       }
 
       throw error;
+    }
+  }
+
+  /**
+   * The Stripe detach already succeeded and can't be replayed (a retry 403s on the now customer-less
+   * method), so a failed auto reload disable must not fail the request. The stale "enabled with no
+   * default card" state self-heals on the next default payment method read.
+   */
+  async #disableAutoReloadAfterDefaultRemoval(userId: string): Promise<void> {
+    try {
+      await this.walletSettingService.disableAutoReload(userId);
+    } catch (error) {
+      this.logger.error({ event: "AUTO_RELOAD_DISABLE_AFTER_REMOVAL_FAILED", userId, error });
     }
   }
 

--- a/apps/api/src/billing/services/payment-method/payment-method.service.integration.ts
+++ b/apps/api/src/billing/services/payment-method/payment-method.service.integration.ts
@@ -5,7 +5,7 @@ import Stripe from "stripe";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
-import type { PaymentMethodRepository, WalletSettingRepository } from "@src/billing/repositories";
+import type { PaymentMethodRepository } from "@src/billing/repositories";
 import type { PayingUser } from "@src/billing/services/paying-user/paying-user";
 import type { UserRepository } from "@src/user/repositories/user/user.repository";
 import { PaymentMethodService } from "./payment-method.service";
@@ -244,13 +244,12 @@ describe(PaymentMethodService.name, () => {
     const paymentMethodRepository = mock<PaymentMethodRepository>();
     paymentMethodRepository.accessibleBy.mockReturnValue(paymentMethodRepository);
     const userRepository = mock<UserRepository>();
-    const walletSettingRepository = mock<WalletSettingRepository>();
 
     const stripe = new Stripe(`sk_test_${faker.string.alphanumeric(32)}`, { apiVersion: "2025-10-29.clover", httpClient: Stripe.createFetchHttpClient() });
 
-    const service = new PaymentMethodService(stripe, paymentMethodRepository, userRepository, walletSettingRepository, () => mock<LoggerService>());
+    const service = new PaymentMethodService(stripe, paymentMethodRepository, userRepository, () => mock<LoggerService>());
 
-    return { service, stripe, paymentMethodRepository, userRepository, walletSettingRepository };
+    return { service, stripe, paymentMethodRepository, userRepository };
   }
 
   function createPaymentMethodAttachedEvent(params: { id: string; customer: string | null; fingerprint?: string }): Stripe.PaymentMethodAttachedEvent {

--- a/apps/api/src/billing/services/payment-method/payment-method.service.spec.ts
+++ b/apps/api/src/billing/services/payment-method/payment-method.service.spec.ts
@@ -5,7 +5,7 @@ import Stripe from "stripe";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
-import type { PaymentMethodRepository, WalletSettingOutput, WalletSettingRepository } from "@src/billing/repositories";
+import type { PaymentMethodRepository } from "@src/billing/repositories";
 import type { PayingUser } from "@src/billing/services/paying-user/paying-user";
 import type { UserOutput, UserRepository } from "@src/user/repositories/user/user.repository";
 import { PaymentMethodService } from "./payment-method.service";
@@ -289,37 +289,27 @@ describe(PaymentMethodService.name, () => {
     });
   });
 
-  describe("assertRemovable", () => {
-    it("throws 409 when removing the default method while auto reload is enabled", async () => {
-      const { service, paymentMethodRepository, walletSettingRepository } = setup();
+  describe("isDefaultPaymentMethod", () => {
+    it("returns true when the local record is the default", async () => {
+      const { service, paymentMethodRepository } = setup();
       paymentMethodRepository.findOneBy.mockResolvedValue(generateDatabasePaymentMethod({ paymentMethodId: "pm_1", isDefault: true }));
-      walletSettingRepository.findByUserId.mockResolvedValue(mock<WalletSettingOutput>({ autoReloadEnabled: true }));
 
-      await expect(service.assertRemovable("pm_1", "user_1")).rejects.toMatchObject({ status: 409 });
+      expect(await service.isDefaultPaymentMethod("pm_1", "user_1")).toBe(true);
+      expect(paymentMethodRepository.findOneBy).toHaveBeenCalledWith({ userId: "user_1", paymentMethodId: "pm_1" });
     });
 
-    it("resolves when removing the default method while auto reload is disabled", async () => {
-      const { service, paymentMethodRepository, walletSettingRepository } = setup();
-      paymentMethodRepository.findOneBy.mockResolvedValue(generateDatabasePaymentMethod({ paymentMethodId: "pm_1", isDefault: true }));
-      walletSettingRepository.findByUserId.mockResolvedValue(mock<WalletSettingOutput>({ autoReloadEnabled: false }));
-
-      await expect(service.assertRemovable("pm_1", "user_1")).resolves.toBeUndefined();
-    });
-
-    it("resolves for a non-default method even when auto reload is enabled", async () => {
-      const { service, paymentMethodRepository, walletSettingRepository } = setup();
+    it("returns false when the local record is not the default", async () => {
+      const { service, paymentMethodRepository } = setup();
       paymentMethodRepository.findOneBy.mockResolvedValue(generateDatabasePaymentMethod({ paymentMethodId: "pm_1", isDefault: false }));
 
-      await expect(service.assertRemovable("pm_1", "user_1")).resolves.toBeUndefined();
-      expect(walletSettingRepository.findByUserId).not.toHaveBeenCalled();
+      expect(await service.isDefaultPaymentMethod("pm_1", "user_1")).toBe(false);
     });
 
-    it("resolves when the default method has no wallet settings row", async () => {
-      const { service, paymentMethodRepository, walletSettingRepository } = setup();
-      paymentMethodRepository.findOneBy.mockResolvedValue(generateDatabasePaymentMethod({ paymentMethodId: "pm_1", isDefault: true }));
-      walletSettingRepository.findByUserId.mockResolvedValue(undefined);
+    it("returns false when there is no local record", async () => {
+      const { service, paymentMethodRepository } = setup();
+      paymentMethodRepository.findOneBy.mockResolvedValue(undefined);
 
-      await expect(service.assertRemovable("pm_1", "user_1")).resolves.toBeUndefined();
+      expect(await service.isDefaultPaymentMethod("pm_1", "user_1")).toBe(false);
     });
   });
 
@@ -414,13 +404,12 @@ describe(PaymentMethodService.name, () => {
     const paymentMethodRepository = mock<PaymentMethodRepository>();
     paymentMethodRepository.accessibleBy.mockReturnValue(paymentMethodRepository);
     const userRepository = mock<UserRepository>();
-    const walletSettingRepository = mock<WalletSettingRepository>();
     const logger = mock<LoggerService>();
 
     const stripe = new Stripe(`sk_test_${faker.string.alphanumeric(32)}`, { apiVersion: "2025-10-29.clover", httpClient: Stripe.createFetchHttpClient() });
 
-    const service = new PaymentMethodService(stripe, paymentMethodRepository, userRepository, walletSettingRepository, () => logger);
+    const service = new PaymentMethodService(stripe, paymentMethodRepository, userRepository, () => logger);
 
-    return { service, stripe, paymentMethodRepository, userRepository, walletSettingRepository, logger };
+    return { service, stripe, paymentMethodRepository, userRepository, logger };
   }
 });

--- a/apps/api/src/billing/services/payment-method/payment-method.service.ts
+++ b/apps/api/src/billing/services/payment-method/payment-method.service.ts
@@ -7,7 +7,7 @@ import { inject, singleton } from "tsyringe";
 
 import { extractFingerprint } from "@src/billing/lib/payment-method/extract-fingerprint";
 import { STRIPE_CLIENT } from "@src/billing/providers/stripe-client.provider";
-import { type PaymentMethodOutput, PaymentMethodRepository, WalletSettingRepository } from "@src/billing/repositories";
+import { type PaymentMethodOutput, PaymentMethodRepository } from "@src/billing/repositories";
 import { type CreateLogger, LOGGER_FACTORY, WithTransaction } from "@src/core";
 import { type UserOutput, UserRepository } from "@src/user/repositories/user/user.repository";
 import { assertIsPayingUser, type PayingUser } from "../paying-user/paying-user";
@@ -22,7 +22,6 @@ export class PaymentMethodService {
     @inject(STRIPE_CLIENT) private readonly stripe: Stripe,
     private readonly paymentMethodRepository: PaymentMethodRepository,
     private readonly userRepository: UserRepository,
-    private readonly walletSettingRepository: WalletSettingRepository,
     @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
     this.loggerService = createLogger({ context: PaymentMethodService.name });
@@ -249,16 +248,10 @@ export class PaymentMethodService {
     }
   }
 
-  async assertRemovable(paymentMethodId: string, userId: string): Promise<void> {
+  async isDefaultPaymentMethod(paymentMethodId: string, userId: string): Promise<boolean> {
     const local = await this.paymentMethodRepository.findOneBy({ userId, paymentMethodId });
 
-    if (!local?.isDefault) {
-      return;
-    }
-
-    const settings = await this.walletSettingRepository.findByUserId(userId);
-
-    assert(!settings?.autoReloadEnabled, 409, "Cannot remove the default payment method while auto reload is enabled");
+    return !!local?.isDefault;
   }
 
   async hasPaymentMethod(paymentMethodId: string, user: UserOutput): Promise<boolean> {

--- a/apps/api/src/billing/services/wallet-settings/wallet-settings.service.integration.ts
+++ b/apps/api/src/billing/services/wallet-settings/wallet-settings.service.integration.ts
@@ -9,6 +9,7 @@ import type { UserWalletRepository, WalletSettingRepository } from "@src/billing
 import type { PaymentMethodService } from "@src/billing/services/payment-method/payment-method.service";
 import { type PaymentMethod } from "@src/billing/services/payment-method/payment-method.service";
 import type { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
+import type { LoggerService } from "@src/core/providers/logging.provider";
 import type { UserRepository } from "@src/user/repositories";
 import { WalletSettingService } from "./wallet-settings.service";
 
@@ -171,6 +172,39 @@ describe(WalletSettingService.name, () => {
     });
   });
 
+  describe("disableAutoReload", () => {
+    it("disables auto reload and cancels the pending reload job", async () => {
+      const { user, walletSettingRepository, walletReloadJobService, service } = setup();
+      const enabledSetting = generateWalletSetting({ userId: user.id, autoReloadEnabled: true });
+      walletSettingRepository.findByUserId.mockResolvedValue(enabledSetting);
+
+      await service.disableAutoReload(user.id);
+
+      expect(walletSettingRepository.updateById).toHaveBeenCalledWith(enabledSetting.id, { autoReloadEnabled: false });
+      expect(walletReloadJobService.cancelCreatedByUserId).toHaveBeenCalledWith(user.id);
+    });
+
+    it("does nothing when auto reload is already disabled", async () => {
+      const { user, walletSettingRepository, walletReloadJobService, service } = setup();
+      walletSettingRepository.findByUserId.mockResolvedValue(generateWalletSetting({ userId: user.id, autoReloadEnabled: false }));
+
+      await service.disableAutoReload(user.id);
+
+      expect(walletSettingRepository.updateById).not.toHaveBeenCalled();
+      expect(walletReloadJobService.cancelCreatedByUserId).not.toHaveBeenCalled();
+    });
+
+    it("does nothing when the user has no wallet settings", async () => {
+      const { user, walletSettingRepository, walletReloadJobService, service } = setup();
+      walletSettingRepository.findByUserId.mockResolvedValue(undefined);
+
+      await service.disableAutoReload(user.id);
+
+      expect(walletSettingRepository.updateById).not.toHaveBeenCalled();
+      expect(walletReloadJobService.cancelCreatedByUserId).not.toHaveBeenCalled();
+    });
+  });
+
   function setup() {
     const user = createUser();
     const userWithStripe = { ...user, stripeCustomerId: faker.string.uuid() };
@@ -196,13 +230,15 @@ describe(WalletSettingService.name, () => {
     const walletReloadJobService = mock<WalletReloadJobService>({
       scheduleForWalletSetting: vi.fn().mockResolvedValue(jobId)
     });
+    const logger = mock<LoggerService>();
     const service = new WalletSettingService(
       walletSettingRepository,
       userWalletRepository,
       userRepository,
       paymentMethodService,
       authService,
-      walletReloadJobService
+      walletReloadJobService,
+      logger
     );
 
     return {

--- a/apps/api/src/billing/services/wallet-settings/wallet-settings.service.ts
+++ b/apps/api/src/billing/services/wallet-settings/wallet-settings.service.ts
@@ -6,6 +6,7 @@ import { UserWalletRepository, type WalletSettingOutput, WalletSettingRepository
 import { PaymentMethodService } from "@src/billing/services/payment-method/payment-method.service";
 import { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
 import { WithTransaction } from "@src/core";
+import { LoggerService } from "@src/core/providers/logging.provider";
 import { isUniqueViolation } from "@src/core/repositories/base.repository";
 import { UserOutput, UserRepository } from "@src/user/repositories";
 
@@ -23,8 +24,11 @@ export class WalletSettingService {
     private readonly userRepository: UserRepository,
     private readonly paymentMethodService: PaymentMethodService,
     private readonly authService: AuthService,
-    private readonly walletReloadJobService: WalletReloadJobService
-  ) {}
+    private readonly walletReloadJobService: WalletReloadJobService,
+    private readonly logger: LoggerService
+  ) {
+    this.logger.setContext(WalletSettingService.name);
+  }
 
   async getWalletSetting(userId: string): Promise<WalletSettingOutput | undefined> {
     const { ability } = this.authService;
@@ -43,6 +47,19 @@ export class WalletSettingService {
     await this.#arrangeSchedule(mutationResult.prev, mutationResult.next);
 
     return mutationResult.next!;
+  }
+
+  async disableAutoReload(userId: UserOutput["id"]): Promise<void> {
+    const { ability } = this.authService;
+    const setting = await this.walletSettingRepository.accessibleBy(ability, "read").findByUserId(userId);
+
+    if (!setting?.autoReloadEnabled) {
+      return;
+    }
+
+    await this.walletSettingRepository.accessibleBy(ability, "update").updateById(setting.id, { autoReloadEnabled: false });
+    await this.walletReloadJobService.cancelCreatedByUserId(userId);
+    this.logger.info({ event: "AUTO_RELOAD_DISABLED", reason: "DEFAULT_PAYMENT_METHOD_REMOVED", userId });
   }
 
   async #update(userId: UserOutput["id"], settings: WalletSettingInput): Promise<{ prev?: WalletSettingOutput; next?: WalletSettingOutput }> {

--- a/apps/deploy-web/src/components/billing-usage/PaymentMethodsContainer/PaymentMethodsContainer.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/PaymentMethodsContainer/PaymentMethodsContainer.spec.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import type { PaymentMethod, SetupIntentResponse } from "@akashnetwork/http-sdk";
+import type { usePopup } from "@akashnetwork/ui/context";
 import { describe, expect, it, type MockedFunction, vi } from "vitest";
 
 import type { usePaymentMethodsQuery, usePaymentMutations, useRefreshPaymentMethods, useSetupIntentMutation, useWalletSettingsQuery } from "@src/queries";
@@ -36,13 +37,22 @@ describe(PaymentMethodsContainer.name, () => {
     expect(mockSetPaymentMethodAsDefault.mutate).toHaveBeenCalledWith(paymentMethodId);
   });
 
-  it("calls removePaymentMethod mutation when onRemovePaymentMethod is invoked", async () => {
+  it("calls removePaymentMethod mutation when the removal is confirmed", async () => {
     const { child, mockRemovePaymentMethod } = await setup();
     const paymentMethodId = "pm_123456";
 
-    child.onRemovePaymentMethod(paymentMethodId);
+    await child.onRemovePaymentMethod(paymentMethodId);
 
     expect(mockRemovePaymentMethod.mutate).toHaveBeenCalledWith(paymentMethodId);
+  });
+
+  it("does not remove the payment method when the confirmation is cancelled", async () => {
+    const { child, mockRemovePaymentMethod, mockConfirm } = await setup({ confirmResult: false });
+
+    await child.onRemovePaymentMethod("pm_123456");
+
+    expect(mockConfirm).toHaveBeenCalled();
+    expect(mockRemovePaymentMethod.mutate).not.toHaveBeenCalled();
   });
 
   it("initializes showAddPaymentMethod as false", async () => {
@@ -149,24 +159,49 @@ describe(PaymentMethodsContainer.name, () => {
     expect(child.isInProgress).toBe(true);
   });
 
-  it("passes isAutoReloadEnabled as false when wallet settings have auto-reload disabled", async () => {
-    const { child } = await setup({ autoReloadEnabled: false });
-    expect(child.isAutoReloadEnabled).toBe(false);
+  it("warns that auto top-up turns off when removing the default payment method while auto reload is enabled", async () => {
+    const { child, mockConfirm, mockRemovePaymentMethod } = await setup({
+      paymentMethods: [createMockPaymentMethod({ id: "pm_default", isDefault: true })],
+      autoReloadEnabled: true
+    });
+
+    await child.onRemovePaymentMethod("pm_default");
+
+    expect(mockConfirm).toHaveBeenCalledWith(expect.objectContaining({ title: "Remove default payment method?" }));
+    expect(mockRemovePaymentMethod.mutate).toHaveBeenCalledWith("pm_default");
   });
 
-  it("passes isAutoReloadEnabled as true when wallet settings have auto-reload enabled", async () => {
-    const { child } = await setup({ autoReloadEnabled: true });
-    expect(child.isAutoReloadEnabled).toBe(true);
+  it("shows the plain removal confirmation for a non-default payment method while auto reload is enabled", async () => {
+    const { child, mockConfirm } = await setup({
+      paymentMethods: [createMockPaymentMethod({ id: "pm_other", isDefault: false })],
+      autoReloadEnabled: true
+    });
+
+    await child.onRemovePaymentMethod("pm_other");
+
+    expect(mockConfirm).toHaveBeenCalledWith(expect.objectContaining({ title: "Remove payment method?" }));
   });
 
-  it("passes isAutoReloadEnabled as false when wallet settings data is undefined and not loading", async () => {
-    const { child } = await setup();
-    expect(child.isAutoReloadEnabled).toBe(false);
+  it("shows the plain removal confirmation for the default payment method when auto reload is disabled", async () => {
+    const { child, mockConfirm } = await setup({
+      paymentMethods: [createMockPaymentMethod({ id: "pm_default", isDefault: true })],
+      autoReloadEnabled: false
+    });
+
+    await child.onRemovePaymentMethod("pm_default");
+
+    expect(mockConfirm).toHaveBeenCalledWith(expect.objectContaining({ title: "Remove payment method?" }));
   });
 
-  it("passes isAutoReloadEnabled as true when wallet settings are still loading", async () => {
-    const { child } = await setup({ isWalletSettingsLoading: true });
-    expect(child.isAutoReloadEnabled).toBe(true);
+  it("warns about auto top-up for the default payment method while wallet settings are still loading", async () => {
+    const { child, mockConfirm } = await setup({
+      paymentMethods: [createMockPaymentMethod({ id: "pm_default", isDefault: true })],
+      isWalletSettingsLoading: true
+    });
+
+    await child.onRemovePaymentMethod("pm_default");
+
+    expect(mockConfirm).toHaveBeenCalledWith(expect.objectContaining({ title: "Remove default payment method?" }));
   });
 
   async function setup(
@@ -179,6 +214,7 @@ describe(PaymentMethodsContainer.name, () => {
       setupIntent: SetupIntentResponse;
       autoReloadEnabled: boolean;
       isWalletSettingsLoading: boolean;
+      confirmResult: boolean;
     }> = {}
   ) {
     const useDefaultPaymentMethods = !Object.prototype.hasOwnProperty.call(overrides, "paymentMethods");
@@ -229,12 +265,16 @@ describe(PaymentMethodsContainer.name, () => {
       isLoading: overrides.isWalletSettingsLoading ?? false
     })) as unknown as MockedFunction<typeof useWalletSettingsQuery>;
 
+    const mockConfirm = vi.fn().mockResolvedValue(overrides.confirmResult ?? true);
+    const mockedUsePopup = vi.fn(() => ({ confirm: mockConfirm })) as unknown as MockedFunction<typeof usePopup>;
+
     const dependencies = {
       usePaymentMethodsQuery: mockedUsePaymentMethodsQuery,
       usePaymentMutations: mockedUsePaymentMutations,
       useRefreshPaymentMethods: mockedUseRefreshPaymentMethods,
       useSetupIntentMutation: mockedUseSetupIntentMutation,
-      useWalletSettingsQuery: mockedUseWalletSettingsQuery
+      useWalletSettingsQuery: mockedUseWalletSettingsQuery,
+      usePopup: mockedUsePopup
     };
 
     const childCapturer = createContainerTestingChildCapturer<PaymentMethodsViewProps>();
@@ -251,7 +291,8 @@ describe(PaymentMethodsContainer.name, () => {
       mockSetPaymentMethodAsDefault,
       mockRemovePaymentMethod,
       mockCreateSetupIntent,
-      mockResetSetupIntent
+      mockResetSetupIntent,
+      mockConfirm
     };
   }
 });

--- a/apps/deploy-web/src/components/billing-usage/PaymentMethodsContainer/PaymentMethodsContainer.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/PaymentMethodsContainer/PaymentMethodsContainer.spec.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import type { PaymentMethod, SetupIntentResponse } from "@akashnetwork/http-sdk";
 import type { usePopup } from "@akashnetwork/ui/context";
 import { describe, expect, it, type MockedFunction, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
 
 import type { usePaymentMethodsQuery, usePaymentMutations, useRefreshPaymentMethods, useSetupIntentMutation, useWalletSettingsQuery } from "@src/queries";
 import type { PaymentMethodsViewProps } from "../PaymentMethodsView/PaymentMethodsView";
@@ -266,7 +267,7 @@ describe(PaymentMethodsContainer.name, () => {
     })) as unknown as MockedFunction<typeof useWalletSettingsQuery>;
 
     const mockConfirm = vi.fn().mockResolvedValue(overrides.confirmResult ?? true);
-    const mockedUsePopup = vi.fn(() => ({ confirm: mockConfirm })) as unknown as MockedFunction<typeof usePopup>;
+    const mockedUsePopup: typeof usePopup = () => mock<ReturnType<typeof usePopup>>({ confirm: mockConfirm });
 
     const dependencies = {
       usePaymentMethodsQuery: mockedUsePaymentMethodsQuery,

--- a/apps/deploy-web/src/components/billing-usage/PaymentMethodsContainer/PaymentMethodsContainer.tsx
+++ b/apps/deploy-web/src/components/billing-usage/PaymentMethodsContainer/PaymentMethodsContainer.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useState } from "react";
+import { usePopup } from "@akashnetwork/ui/context";
 
 import { usePaymentMethodsQuery, usePaymentMutations, useRefreshPaymentMethods, useSetupIntentMutation, useWalletSettingsQuery } from "@src/queries";
 import type { PaymentMethodsViewProps } from "../PaymentMethodsView/PaymentMethodsView";
@@ -8,7 +9,8 @@ const DEPENDENCIES = {
   usePaymentMutations,
   useRefreshPaymentMethods,
   useSetupIntentMutation,
-  useWalletSettingsQuery
+  useWalletSettingsQuery,
+  usePopup
 };
 
 type PaymentMethodsContainerProps = {
@@ -22,6 +24,7 @@ export const PaymentMethodsContainer: React.FC<PaymentMethodsContainerProps> = (
   const isAutoReloadEnabled = walletSettings?.autoReloadEnabled ?? isWalletSettingsLoading;
   const paymentMutations = d.usePaymentMutations();
   const refreshPaymentMethods = d.useRefreshPaymentMethods();
+  const { confirm } = d.usePopup();
   const { data: setupIntent, mutate: createSetupIntent, reset: resetSetupIntent } = d.useSetupIntentMutation();
   const [showAddPaymentMethod, setShowAddPaymentMethod] = useState(false);
 
@@ -33,10 +36,30 @@ export const PaymentMethodsContainer: React.FC<PaymentMethodsContainerProps> = (
   );
 
   const onRemovePaymentMethod = useCallback(
-    (id: string) => {
+    async (id: string) => {
+      const paymentMethod = paymentMethods.find(method => method.id === id);
+      const willDisableAutoTopUp = !!paymentMethod?.isDefault && isAutoReloadEnabled;
+
+      const isConfirmed = await confirm(
+        willDisableAutoTopUp
+          ? {
+              title: "Remove default payment method?",
+              message:
+                "Removing it will turn off Auto Top-Up. Your deployments may stop if your credit balance runs out, and no automatic charges will be made. You can turn Auto Top-Up back on after setting another card as default."
+            }
+          : {
+              title: "Remove payment method?",
+              message: "This payment method will be removed from your account."
+            }
+      );
+
+      if (!isConfirmed) {
+        return;
+      }
+
       paymentMutations.removePaymentMethod.mutate(id);
     },
-    [paymentMutations.removePaymentMethod]
+    [confirm, paymentMethods, isAutoReloadEnabled, paymentMutations.removePaymentMethod]
   );
 
   const onAddCardSuccess = async () => {
@@ -68,8 +91,7 @@ export const PaymentMethodsContainer: React.FC<PaymentMethodsContainerProps> = (
         setShowAddPaymentMethod,
         setupIntent,
         onAddCardSuccess,
-        isInProgress,
-        isAutoReloadEnabled
+        isInProgress
       })}
     </>
   );

--- a/apps/deploy-web/src/components/billing-usage/PaymentMethodsView/PaymentMethodsRow.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/PaymentMethodsView/PaymentMethodsRow.spec.tsx
@@ -232,20 +232,10 @@ describe(PaymentMethodsRow.name, () => {
       expect(mockOnSetPaymentMethodAsDefault).toHaveBeenCalledWith("pm_sole");
     });
 
-    it("hides 'Remove' for default payment method when auto-reload is enabled", () => {
-      setup({
-        paymentMethod: createMockPaymentMethod({ isDefault: true }),
-        isAutoReloadEnabled: true
-      });
-
-      expect(screen.queryByRole("button")).not.toBeInTheDocument();
-    });
-
-    it("shows 'Remove' for non-default payment method when auto-reload is enabled", async () => {
+    it("calls onRemovePaymentMethod for the default payment method", async () => {
       const user = userEvent.setup();
-      setup({
-        paymentMethod: createMockPaymentMethod({ isDefault: false }),
-        isAutoReloadEnabled: true
+      const { mockOnRemovePaymentMethod } = setup({
+        paymentMethod: createMockPaymentMethod({ id: "pm_default", isDefault: true })
       });
 
       const button = screen.getByRole("button");
@@ -254,6 +244,10 @@ describe(PaymentMethodsRow.name, () => {
       await vi.waitFor(() => {
         expect(screen.getByText("Remove")).toBeInTheDocument();
       });
+
+      await user.click(screen.getByText("Remove"));
+
+      expect(mockOnRemovePaymentMethod).toHaveBeenCalledWith("pm_default");
     });
   });
 
@@ -440,7 +434,6 @@ describe(PaymentMethodsRow.name, () => {
                 })}
                 onSetPaymentMethodAsDefault={vi.fn()}
                 onRemovePaymentMethod={vi.fn()}
-                isAutoReloadEnabled={false}
                 dependencies={mockDependencies}
               />
             </tbody>
@@ -471,7 +464,6 @@ function setup(
     paymentMethod?: PaymentMethod;
     onSetPaymentMethodAsDefault?: Mock;
     onRemovePaymentMethod?: Mock;
-    isAutoReloadEnabled?: boolean;
     dependencies?: typeof mockDependencies;
   } = {}
 ) {
@@ -479,7 +471,6 @@ function setup(
     paymentMethod: createMockPaymentMethod(),
     onSetPaymentMethodAsDefault: vi.fn(),
     onRemovePaymentMethod: vi.fn(),
-    isAutoReloadEnabled: false,
     dependencies: mockDependencies
   };
 

--- a/apps/deploy-web/src/components/billing-usage/PaymentMethodsView/PaymentMethodsRow.tsx
+++ b/apps/deploy-web/src/components/billing-usage/PaymentMethodsView/PaymentMethodsRow.tsx
@@ -22,7 +22,6 @@ export type PaymentMethodsRowProps = {
   paymentMethod: PaymentMethod;
   onSetPaymentMethodAsDefault: (id: string) => void;
   onRemovePaymentMethod: (id: string) => void;
-  isAutoReloadEnabled: boolean;
   dependencies?: typeof DEPENDENCIES;
 };
 
@@ -30,7 +29,6 @@ export const PaymentMethodsRow: React.FC<PaymentMethodsRowProps> = ({
   paymentMethod,
   onSetPaymentMethodAsDefault,
   onRemovePaymentMethod,
-  isAutoReloadEnabled,
   dependencies: d = DEPENDENCIES
 }) => {
   const [open, setOpen] = useState(false);
@@ -97,9 +95,6 @@ export const PaymentMethodsRow: React.FC<PaymentMethodsRowProps> = ({
   }, [onRemovePaymentMethod, paymentMethod.id]);
 
   const canSetAsDefault = !paymentMethod.isDefault;
-  const isDefaultBlockedByAutoReload = paymentMethod.isDefault && isAutoReloadEnabled;
-  const canRemove = !isDefaultBlockedByAutoReload;
-  const showActions = canSetAsDefault || canRemove;
 
   return (
     <d.TableRow className="flex border-0 py-2 hover:bg-transparent">
@@ -107,39 +102,35 @@ export const PaymentMethodsRow: React.FC<PaymentMethodsRowProps> = ({
         {paymentMethodLabel} {defaultBadge}
       </d.TableCell>
       {validUntilContent && <d.TableCell className="flex flex-grow items-center justify-end">Valid until {validUntilContent}</d.TableCell>}
-      {showActions && (
-        <d.TableCell className="min-h-[72px] min-w-[72px]">
-          <d.DropdownMenu modal={false} open={open}>
-            <d.DropdownMenuTrigger asChild>
-              <d.Button onClick={openMenu} size="icon" variant="ghost" className="rounded-full">
-                <MoreHoriz />
-              </d.Button>
-            </d.DropdownMenuTrigger>
-            <d.DropdownMenuContent
-              align="end"
-              onMouseLeave={() => setOpen(false)}
-              onClick={e => {
-                e.stopPropagation();
-              }}
-            >
-              <d.ClickAwayListener onClickAway={() => setOpen(false)}>
-                <div>
-                  {canSetAsDefault && (
-                    <d.CustomDropdownLinkItem onClick={setPaymentAsDefault} icon={<CheckCircle fontSize="small" />}>
-                      Set as default
-                    </d.CustomDropdownLinkItem>
-                  )}
-                  {canRemove && (
-                    <d.CustomDropdownLinkItem onClick={removePaymentMethod} icon={<Trash fontSize="small" />}>
-                      Remove
-                    </d.CustomDropdownLinkItem>
-                  )}
-                </div>
-              </d.ClickAwayListener>
-            </d.DropdownMenuContent>
-          </d.DropdownMenu>
-        </d.TableCell>
-      )}
+      <d.TableCell className="min-h-[72px] min-w-[72px]">
+        <d.DropdownMenu modal={false} open={open}>
+          <d.DropdownMenuTrigger asChild>
+            <d.Button onClick={openMenu} size="icon" variant="ghost" className="rounded-full">
+              <MoreHoriz />
+            </d.Button>
+          </d.DropdownMenuTrigger>
+          <d.DropdownMenuContent
+            align="end"
+            onMouseLeave={() => setOpen(false)}
+            onClick={e => {
+              e.stopPropagation();
+            }}
+          >
+            <d.ClickAwayListener onClickAway={() => setOpen(false)}>
+              <div>
+                {canSetAsDefault && (
+                  <d.CustomDropdownLinkItem onClick={setPaymentAsDefault} icon={<CheckCircle fontSize="small" />}>
+                    Set as default
+                  </d.CustomDropdownLinkItem>
+                )}
+                <d.CustomDropdownLinkItem onClick={removePaymentMethod} icon={<Trash fontSize="small" />}>
+                  Remove
+                </d.CustomDropdownLinkItem>
+              </div>
+            </d.ClickAwayListener>
+          </d.DropdownMenuContent>
+        </d.DropdownMenu>
+      </d.TableCell>
     </d.TableRow>
   );
 };

--- a/apps/deploy-web/src/components/billing-usage/PaymentMethodsView/PaymentMethodsView.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/PaymentMethodsView/PaymentMethodsView.spec.tsx
@@ -18,8 +18,8 @@ const mockUseTheme = vi.fn(() => ({
   systemTheme: "light" as "light" | "dark" | undefined
 }));
 
-const MockPaymentMethodsRow = ({ paymentMethod, onSetPaymentMethodAsDefault, onRemovePaymentMethod, isAutoReloadEnabled }: PaymentMethodsRowProps) => (
-  <tr data-testid={`payment-method-row-${paymentMethod.id}`} data-auto-reload={isAutoReloadEnabled}>
+const MockPaymentMethodsRow = ({ paymentMethod, onSetPaymentMethodAsDefault, onRemovePaymentMethod }: PaymentMethodsRowProps) => (
+  <tr data-testid={`payment-method-row-${paymentMethod.id}`}>
     <td>
       <span>{paymentMethod.card?.last4}</span>
       <button onClick={() => onSetPaymentMethodAsDefault(paymentMethod.id)}>Set as Default</button>
@@ -405,7 +405,6 @@ function setup(
     setupIntent?: SetupIntentResponse;
     onAddCardSuccess?: Mock;
     isInProgress?: boolean;
-    isAutoReloadEnabled?: boolean;
     dependencies?: typeof DEPENDENCIES;
   } = {}
 ) {
@@ -420,7 +419,6 @@ function setup(
     setupIntent: undefined,
     onAddCardSuccess: vi.fn(),
     isInProgress: false,
-    isAutoReloadEnabled: false,
     dependencies: mockDependencies
   };
 

--- a/apps/deploy-web/src/components/billing-usage/PaymentMethodsView/PaymentMethodsView.tsx
+++ b/apps/deploy-web/src/components/billing-usage/PaymentMethodsView/PaymentMethodsView.tsx
@@ -26,7 +26,7 @@ export const DEPENDENCIES = {
 export type PaymentMethodsViewProps = {
   data: PaymentMethod[];
   onSetPaymentMethodAsDefault: (id: string) => void;
-  onRemovePaymentMethod: (id: string) => void;
+  onRemovePaymentMethod: (id: string) => Promise<void> | void;
   onAddPaymentMethod: () => void;
   isLoadingPaymentMethods: boolean;
   showAddPaymentMethod: boolean;
@@ -34,7 +34,6 @@ export type PaymentMethodsViewProps = {
   setupIntent: SetupIntentResponse | undefined;
   onAddCardSuccess: () => void;
   isInProgress: boolean;
-  isAutoReloadEnabled: boolean;
   dependencies?: typeof DEPENDENCIES;
 };
 
@@ -49,7 +48,6 @@ export const PaymentMethodsView: React.FC<PaymentMethodsViewProps> = ({
   setupIntent,
   onAddCardSuccess,
   isInProgress,
-  isAutoReloadEnabled,
   dependencies: d = DEPENDENCIES
 }) => {
   const { resolvedTheme } = d.useTheme();
@@ -83,7 +81,6 @@ export const PaymentMethodsView: React.FC<PaymentMethodsViewProps> = ({
                       paymentMethod={paymentMethod}
                       onSetPaymentMethodAsDefault={onSetPaymentMethodAsDefault}
                       onRemovePaymentMethod={onRemovePaymentMethod}
-                      isAutoReloadEnabled={isAutoReloadEnabled}
                     />
                   ))}
                 </d.TableBody>

--- a/apps/deploy-web/src/queries/usePaymentQueries.spec.tsx
+++ b/apps/deploy-web/src/queries/usePaymentQueries.spec.tsx
@@ -229,12 +229,12 @@ describe("usePaymentQueries", () => {
       });
     });
 
-    it("removes payment method and invalidates the methods and default queries", async () => {
+    it("removes payment method and invalidates the methods, default and wallet settings queries", async () => {
       const mockRemovedPaymentMethod = createMockRemovedPaymentMethod();
       const stripeService = mock<StripeService>({
         removePaymentMethod: vi.fn().mockResolvedValue(mockRemovedPaymentMethod)
       });
-      const api = createProxy({ v1: { getDefaultPaymentMethod: vi.fn() } }) as unknown as ApiService;
+      const api = createProxy({ v1: { getDefaultPaymentMethod: vi.fn(), getWalletSettings: vi.fn() } }) as unknown as ApiService;
       const { result, queryClient } = setupQueryWithClient(() => usePaymentMutations(), {
         services: { stripe: () => stripeService, api: () => api }
       });
@@ -249,6 +249,7 @@ describe("usePaymentQueries", () => {
         expect(stripeService.removePaymentMethod).toHaveBeenCalledWith(mockRemovedPaymentMethod.id);
         expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: QueryKeys.getPaymentMethodsKey() });
         expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: api.v1.getDefaultPaymentMethod.getKey() });
+        expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: api.v1.getWalletSettings.getKey() });
       });
     });
 

--- a/apps/deploy-web/src/queries/usePaymentQueries.ts
+++ b/apps/deploy-web/src/queries/usePaymentQueries.ts
@@ -149,6 +149,7 @@ export const usePaymentMutations = () => {
     },
     onSuccess: () => {
       refreshPaymentMethods();
+      queryClient.invalidateQueries({ queryKey: api.v1.getWalletSettings.getKey() });
     }
   });
 


### PR DESCRIPTION
## Why

With a single default card and auto top-up enabled, the Payment Methods tab is a dead end: the row's actions menu is hidden entirely, so the card can never be removed. #3559 hardened that same rule server-side with a 409 on `DELETE /v1/stripe/payment-methods/{id}`.

Product decision (Maxime): removal must always be possible. Deleting the default payment method should instead automatically turn off auto top-up, since there is no card left to charge (no auto-promotion of another card).

Stacked on #3559 (`fix/billing-default-payment-method-sync`), which owns the guard this PR replaces. Retarget to `main` after it merges.

## What

**API**

- `StripeController.removePaymentMethod` reads whether the card is the local default before detaching, then calls the new `WalletSettingService.disableAutoReload(userId)` after a default-card detach. The 409 guard (`PaymentMethodService.assertRemovable`) is removed along with the `WalletSettingRepository` dependency it pulled into `PaymentMethodService`; a simple `isDefaultPaymentMethod` read replaces it.
- `WalletSettingService.disableAutoReload` is idempotent: no-ops when the settings row is absent or already disabled, flips `autoReloadEnabled` to false, cancels the pending `WalletBalanceReloadCheck` pg-boss job, and logs an `AUTO_RELOAD_DISABLED` event.
- No endpoint shape changes (DELETE stays 204), so no OpenAPI/`console-api-types` regeneration.

**deploy-web**

- `PaymentMethodsRow` always renders the actions menu and the Remove item; `isAutoReloadEnabled` prop dropped from Row/View.
- `PaymentMethodsContainer` confirms every removal via `usePopup().confirm`. When the target is the default card and auto top-up is on, the copy warns that removing it turns Auto Top-Up off; otherwise a plain confirmation shows.
- `removePaymentMethod` mutation additionally invalidates the wallet-settings query so the Auto Top-Up switch in `AccountOverview` flips off immediately after the deletion.

**Verification** (stacked PRs against a non-main base skip the validate CI matrix, so ran locally):

- `apps/api`: unit + functional + integration suites pass; the only failures are the pre-existing `user.repository`/`api-key.repository` throttle flakes that fail identically on the base commit. Lint `--quiet` clean, tsc error count unchanged vs base (40 = 40).
- `apps/deploy-web`: full unit suite passes (2989 passed, 5 skipped). Lint `--quiet` clean, tsc error count unchanged vs base (180 = 180).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added confirmation before removing a payment method.
  * Removing the default payment method warns that Auto Top-Up will be disabled.
  * Default payment methods can now be removed; Auto Top-Up is disabled automatically afterward.
  * Payment and wallet settings refresh after removal.

* **Bug Fixes**
  * Auto Top-Up cleanup failures no longer prevent successful payment-method removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->