### PR TITLE
feat(billing): sweep master wallet AKT above fee reserve into ACT

### DIFF
--- a/apps/api/src/app/console.ts
+++ b/apps/api/src/app/console.ts
@@ -42,8 +42,8 @@ program
 
 program
   .command("mint-act")
-  .description("Mint ACT from AKT on master wallet to maintain target balance")
-  .option("-d, --dry-run", "Log what would be minted without broadcasting", false)
+  .description("Burn master wallet AKT above the fee reserve into ACT, capped per run")
+  .option("-d, --dry-run", "Log what would be burned without broadcasting", false)
   .action(async (options, command) => {
     await executeCliHandler(command.name(), async () => {
       return container.resolve(MasterWalletMintController).mint(options);

--- a/apps/api/src/billing/config/env.config.spec.ts
+++ b/apps/api/src/billing/config/env.config.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { envSchema } from "./env.config";
+
+describe("envSchema", () => {
+  describe("MASTER_WALLET_AKT_RESERVE", () => {
+    it("rejects a negative value", () => {
+      const result = setup({ MASTER_WALLET_AKT_RESERVE: "-1" });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects a fractional value", () => {
+      const result = setup({ MASTER_WALLET_AKT_RESERVE: "1.5" });
+      expect(result.success).toBe(false);
+    });
+
+    it("accepts a non-negative integer", () => {
+      const result = setup({ MASTER_WALLET_AKT_RESERVE: "2000000000" });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("MASTER_WALLET_MAX_MINT_UAKT", () => {
+    it("rejects a negative value", () => {
+      const result = setup({ MASTER_WALLET_MAX_MINT_UAKT: "-1" });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects a fractional value", () => {
+      const result = setup({ MASTER_WALLET_MAX_MINT_UAKT: "1.5" });
+      expect(result.success).toBe(false);
+    });
+
+    it("accepts a non-negative integer", () => {
+      const result = setup({ MASTER_WALLET_MAX_MINT_UAKT: "5000000000" });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  const validEnv = {
+    NETWORK: "sandbox",
+    RPC_NODE_ENDPOINT: "https://rpc.example.com",
+    TRIAL_DEPLOYMENT_ALLOWANCE_AMOUNT: "1000",
+    TRIAL_FEES_ALLOWANCE_AMOUNT: "1000",
+    DEPLOYMENT_GRANT_DENOM: "uakt",
+    FEE_ALLOWANCE_REFILL_THRESHOLD: "100",
+    FEE_ALLOWANCE_REFILL_AMOUNT: "100",
+    DEPLOYMENT_ALLOWANCE_REFILL_AMOUNT: "100",
+    STRIPE_SECRET_KEY: "sk_test",
+    STRIPE_PRODUCT_ID: "prod_test",
+    STRIPE_WEBHOOK_SECRET: "whsec_test",
+    CONSOLE_WEB_PAYMENT_LINK: "https://pay.example.com",
+    TX_SIGNER_BASE_URL: "https://tx-signer.example.com"
+  };
+
+  function setup(overrides: Record<string, string>) {
+    return envSchema.safeParse({ ...validEnv, ...overrides });
+  }
+});

--- a/apps/api/src/billing/config/env.config.spec.ts
+++ b/apps/api/src/billing/config/env.config.spec.ts
@@ -18,6 +18,11 @@ describe("envSchema", () => {
       const result = setup({ MASTER_WALLET_AKT_RESERVE: "2000000000" });
       expect(result.success).toBe(true);
     });
+
+    it("accepts zero", () => {
+      const result = setup({ MASTER_WALLET_AKT_RESERVE: "0" });
+      expect(result.success).toBe(true);
+    });
   });
 
   describe("MASTER_WALLET_MAX_MINT_UAKT", () => {
@@ -33,6 +38,11 @@ describe("envSchema", () => {
 
     it("accepts a non-negative integer", () => {
       const result = setup({ MASTER_WALLET_MAX_MINT_UAKT: "5000000000" });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts zero", () => {
+      const result = setup({ MASTER_WALLET_MAX_MINT_UAKT: "0" });
       expect(result.success).toBe(true);
     });
   });

--- a/apps/api/src/billing/config/env.config.ts
+++ b/apps/api/src/billing/config/env.config.ts
@@ -51,7 +51,8 @@ export const envSchema = z.object({
     .refine(entries => entries.every(entry => /^[a-z0-9._-]+\/[a-z0-9._-]+$/.test(entry)), {
       message: "MANAGED_WALLET_TRIAL_BLOCKED_GPU_MODELS entries must be in 'vendor/model' format"
     }),
-  MASTER_WALLET_TARGET_ACT_BALANCE: z.number({ coerce: true }).default(10_000_000_000),
+  MASTER_WALLET_AKT_RESERVE: z.number({ coerce: true }).default(2_000_000_000),
+  MASTER_WALLET_MAX_MINT_UAKT: z.number({ coerce: true }).default(5_000_000_000),
   TX_SIGNER_BASE_URL: z.string()
 });
 

--- a/apps/api/src/billing/config/env.config.ts
+++ b/apps/api/src/billing/config/env.config.ts
@@ -51,8 +51,8 @@ export const envSchema = z.object({
     .refine(entries => entries.every(entry => /^[a-z0-9._-]+\/[a-z0-9._-]+$/.test(entry)), {
       message: "MANAGED_WALLET_TRIAL_BLOCKED_GPU_MODELS entries must be in 'vendor/model' format"
     }),
-  MASTER_WALLET_AKT_RESERVE: z.number({ coerce: true }).default(2_000_000_000),
-  MASTER_WALLET_MAX_MINT_UAKT: z.number({ coerce: true }).default(5_000_000_000),
+  MASTER_WALLET_AKT_RESERVE: z.number({ coerce: true }).int().nonnegative().default(2_000_000_000),
+  MASTER_WALLET_MAX_MINT_UAKT: z.number({ coerce: true }).int().nonnegative().default(5_000_000_000),
   TX_SIGNER_BASE_URL: z.string()
 });
 

--- a/apps/api/src/billing/controllers/master-wallet-mint/master-wallet-mint.controller.spec.ts
+++ b/apps/api/src/billing/controllers/master-wallet-mint/master-wallet-mint.controller.spec.ts
@@ -7,14 +7,14 @@ import { MasterWalletMintController } from "./master-wallet-mint.controller";
 
 describe(MasterWalletMintController.name, () => {
   describe("mint", () => {
-    it("should delegate to service and return result", async () => {
+    it("delegates to service and returns result", async () => {
       const { controller, masterWalletMintService } = setup();
-      masterWalletMintService.mintIfNeeded.mockResolvedValue(Ok.EMPTY);
+      masterWalletMintService.mintExcessAkt.mockResolvedValue(Ok.EMPTY);
 
       const result = await controller.mint({ dryRun: false });
 
       expect(result).toEqual(Ok.EMPTY);
-      expect(masterWalletMintService.mintIfNeeded).toHaveBeenCalledWith({ dryRun: false });
+      expect(masterWalletMintService.mintExcessAkt).toHaveBeenCalledWith({ dryRun: false });
     });
   });
 

--- a/apps/api/src/billing/controllers/master-wallet-mint/master-wallet-mint.controller.ts
+++ b/apps/api/src/billing/controllers/master-wallet-mint/master-wallet-mint.controller.ts
@@ -8,6 +8,6 @@ export class MasterWalletMintController {
   constructor(private readonly masterWalletMintService: MasterWalletMintService) {}
 
   async mint(options: DryRunOptions) {
-    return this.masterWalletMintService.mintIfNeeded(options);
+    return this.masterWalletMintService.mintExcessAkt(options);
   }
 }

--- a/apps/api/src/billing/services/master-wallet-mint/master-wallet-mint.service.spec.ts
+++ b/apps/api/src/billing/services/master-wallet-mint/master-wallet-mint.service.spec.ts
@@ -18,228 +18,212 @@ import { createBmeLedgerRecord, createBmeLedgerResponse } from "@test/seeders/bm
 import { createDenomExchangeRate } from "@test/seeders/denom-exchange-rate.seeder";
 
 describe(MasterWalletMintService.name, () => {
-  describe("mintIfNeeded", () => {
-    it("should skip minting when ACT balance exceeds target", async () => {
-      const { service, txManagerService } = setup({
-        targetActBalance: 10_000_000_000,
-        balances: { uact: 15_000_000_000, uakt: 50_000_000_000 }
+  describe("mintExcessAkt", () => {
+    it("skips when a previous mint is still settling", async () => {
+      const { service, chainSdk, txManagerService } = setup({
+        balances: { uact: 5_000_000_000, uakt: 50_000_000_000 }
       });
+      chainSdk.akash.bme.v1.getLedgerRecords.mockResolvedValueOnce(createBmeLedgerResponse({ records: [createBmeLedgerRecord({ status: 1 })] }));
 
-      const result = await service.mintIfNeeded();
+      const result = await service.mintExcessAkt();
 
       expect(result).toEqual(Ok.EMPTY);
+      expect(chainSdk.cosmos.bank.v1beta1.getAllBalances).not.toHaveBeenCalled();
       expect(txManagerService.signAndBroadcastWithFundingWallet).not.toHaveBeenCalled();
     });
 
-    it("should skip minting when ACT balance equals target", async () => {
-      const { service, txManagerService } = setup({
-        targetActBalance: 10_000_000_000,
-        balances: { uact: 10_000_000_000, uakt: 50_000_000_000 }
+    it("warns and skips when AKT balance is below the reserve", async () => {
+      const { service, txManagerService, denomExchangeService } = setup({
+        aktReserve: 2_000_000_000,
+        balances: { uact: 5_000_000_000, uakt: 1_500_000_000 }
       });
 
-      const result = await service.mintIfNeeded();
+      const result = await service.mintExcessAkt();
 
       expect(result).toEqual(Ok.EMPTY);
+      expect(denomExchangeService.getExchangeRateToUSD).not.toHaveBeenCalled();
       expect(txManagerService.signAndBroadcastWithFundingWallet).not.toHaveBeenCalled();
     });
 
-    it("should mint with 5% price slippage margin on AKT to burn", async () => {
-      const { service, masterAddress, chainSdk, rpcMessageService } = setup({
-        targetActBalance: 10_000_000_000,
-        balances: { uact: 5_000_000_000, uakt: 99_999_999_999 },
+    it("skips when AKT balance exactly equals the reserve", async () => {
+      const { service, txManagerService, denomExchangeService } = setup({
+        aktReserve: 2_000_000_000,
+        balances: { uact: 5_000_000_000, uakt: 2_000_000_000 }
+      });
+
+      const result = await service.mintExcessAkt();
+
+      expect(result).toEqual(Ok.EMPTY);
+      expect(denomExchangeService.getExchangeRateToUSD).not.toHaveBeenCalled();
+      expect(txManagerService.signAndBroadcastWithFundingWallet).not.toHaveBeenCalled();
+    });
+
+    it("skips when excess is below the BME minimum mint", async () => {
+      const { service, txManagerService } = setup({
+        aktReserve: 2_000_000_000,
+        balances: { uact: 5_000_000_000, uakt: 2_010_000_000 },
         aktPrice: 0.5
       });
-      mockBalancesOnce(chainSdk, { uact: 10_100_000_000, uakt: 89_499_999_999 });
 
-      const result = await service.mintIfNeeded();
+      const result = await service.mintExcessAkt();
 
       expect(result).toEqual(Ok.EMPTY);
-      // deficit = 10_000_000_000 - 5_000_000_000 = 5_000_000_000 uact
-      // aktToBurn = ceil(5_000_000_000 / 0.5 * 1.05) = 10_500_000_000
+      expect(txManagerService.signAndBroadcastWithFundingWallet).not.toHaveBeenCalled();
+    });
+
+    it("burns the full excess above the reserve when under the per-run cap", async () => {
+      const { service, masterAddress, chainSdk, rpcMessageService } = setup({
+        aktReserve: 2_000_000_000,
+        maxMintUakt: 5_000_000_000,
+        balances: { uact: 5_000_000_000, uakt: 6_000_000_000 },
+        aktPrice: 0.5
+      });
+      mockBalancesOnce(chainSdk, { uact: 7_000_000_000, uakt: 2_000_000_000 });
+
+      const result = await service.mintExcessAkt();
+
+      expect(result).toEqual(Ok.EMPTY);
       expect(rpcMessageService.getMintACTMsg).toHaveBeenCalledWith({
         owner: masterAddress,
-        amount: 10_500_000_000
+        amount: 6_000_000_000 - 2_000_000_000
       });
     });
 
-    it("should fail when AKT balance is insufficient to cover mint", async () => {
-      const { service } = setup({
-        targetActBalance: 10_000_000_000,
-        balances: { uact: 5_000_000_000, uakt: 100 },
+    it("caps the burn at the per-run maximum when excess exceeds it", async () => {
+      const { service, masterAddress, chainSdk, rpcMessageService } = setup({
+        aktReserve: 2_000_000_000,
+        maxMintUakt: 5_000_000_000,
+        balances: { uact: 5_000_000_000, uakt: 50_000_000_000 },
         aktPrice: 0.5
       });
+      mockBalancesOnce(chainSdk, { uact: 8_000_000_000, uakt: 45_000_000_000 });
 
-      const result = await service.mintIfNeeded();
+      const result = await service.mintExcessAkt();
+
+      expect(result).toEqual(Ok.EMPTY);
+      expect(rpcMessageService.getMintACTMsg).toHaveBeenCalledWith({
+        owner: masterAddress,
+        amount: 5_000_000_000
+      });
+    });
+
+    it("falls back to default minimum mint when uact denom is absent from BME params", async () => {
+      const { service, bmeHttpService, chainSdk, rpcMessageService, masterAddress } = setup({
+        aktReserve: 2_000_000_000,
+        balances: { uact: 5_000_000_000, uakt: 2_100_000_000 },
+        aktPrice: 0.5
+      });
+      bmeHttpService.getParams.mockResolvedValue({ params: { min_mint: [{ denom: "uother", amount: "500000" }] } });
+      mockBalancesOnce(chainSdk, { uact: 6_000_000_000, uakt: 2_000_000_000 });
+
+      const result = await service.mintExcessAkt();
+
+      expect(result).toEqual(Ok.EMPTY);
+      expect(rpcMessageService.getMintACTMsg).toHaveBeenCalledWith({
+        owner: masterAddress,
+        amount: 100_000_000
+      });
+    });
+
+    it("fails when AKT price is invalid", async () => {
+      const { service, denomExchangeService } = setup({
+        balances: { uact: 5_000_000_000, uakt: 6_000_000_000 }
+      });
+      denomExchangeService.getExchangeRateToUSD.mockResolvedValue(createDenomExchangeRate({ price: 0 }));
+
+      const result = await service.mintExcessAkt();
 
       expect(result.err).toBe(true);
-      expect(result.val).toContain("Insufficient AKT balance");
+      expect(result.val).toBe("Invalid AKT price: 0");
     });
 
-    it("should wait for ledger settlement before confirming mint", async () => {
-      const { service, chainSdk } = setup({
-        targetActBalance: 10_000_000_000,
-        balances: { uact: 5_000_000_000, uakt: 99_999_999_999 },
+    it("fails when mint transaction returns a non-zero code", async () => {
+      const { service, txManagerService } = setup({
+        balances: { uact: 5_000_000_000, uakt: 6_000_000_000 },
         aktPrice: 0.5
       });
-      mockBalancesOnce(chainSdk, { uact: 10_100_000_000, uakt: 89_799_999_999 });
+      txManagerService.signAndBroadcastWithFundingWallet.mockResolvedValue({ code: 11, hash: "FAIL", rawLog: "insufficient funds" });
+
+      const result = await service.mintExcessAkt();
+
+      expect(result.err).toBe(true);
+      expect(result.val).toBe("Transaction failed with code 11: insufficient funds");
+    });
+
+    it("waits for ledger settlement before confirming mint", async () => {
+      const { service, chainSdk } = setup({
+        balances: { uact: 5_000_000_000, uakt: 6_000_000_000 },
+        aktPrice: 0.5
+      });
+      mockBalancesOnce(chainSdk, { uact: 7_000_000_000, uakt: 2_000_000_000 });
 
       const pendingRecord = createBmeLedgerRecord({ status: 1 });
       chainSdk.akash.bme.v1.getLedgerRecords
+        .mockResolvedValueOnce(createBmeLedgerResponse())
         .mockResolvedValueOnce(createBmeLedgerResponse({ records: [pendingRecord] }))
         .mockResolvedValueOnce(createBmeLedgerResponse());
 
-      const result = await service.mintIfNeeded();
+      const result = await service.mintExcessAkt();
 
       expect(result).toEqual(Ok.EMPTY);
-      expect(chainSdk.akash.bme.v1.getLedgerRecords).toHaveBeenCalledTimes(2);
+      expect(chainSdk.akash.bme.v1.getLedgerRecords).toHaveBeenCalledTimes(3);
     });
 
-    it("should fail when ledger settlement times out", async () => {
+    it("fails when ledger settlement times out", async () => {
       const { service, chainSdk } = setup({
-        targetActBalance: 10_000_000_000,
-        balances: { uact: 5_000_000_000, uakt: 99_999_999_999 },
+        balances: { uact: 5_000_000_000, uakt: 6_000_000_000 },
         aktPrice: 0.5
       });
+      chainSdk.akash.bme.v1.getLedgerRecords.mockResolvedValueOnce(createBmeLedgerResponse());
+      chainSdk.akash.bme.v1.getLedgerRecords.mockResolvedValue(createBmeLedgerResponse({ records: [createBmeLedgerRecord({ status: 1 })] }));
 
-      const pendingRecord = createBmeLedgerRecord({ status: 1 });
-      chainSdk.akash.bme.v1.getLedgerRecords.mockResolvedValue(createBmeLedgerResponse({ records: [pendingRecord] }));
-
-      const result = await service.mintIfNeeded();
+      const result = await service.mintExcessAkt();
 
       expect(result.err).toBe(true);
       expect(result.val).toBe("Ledger polling timed out waiting for mint settlement");
     });
 
-    it("should fail when ACT balance stays below target after retries", async () => {
+    it("keeps polling until ACT balance reaches expected after mint", async () => {
       const { service, chainSdk } = setup({
-        targetActBalance: 10_000_000_000,
-        balances: { uact: 5_000_000_000, uakt: 99_999_999_999 },
+        balances: { uact: 5_000_000_000, uakt: 6_000_000_000 },
+        aktPrice: 0.5
+      });
+      mockBalancesOnce(chainSdk, { uact: 5_000_000_000, uakt: 2_000_000_000 });
+      mockBalancesOnce(chainSdk, { uact: 7_000_000_000, uakt: 2_000_000_000 });
+
+      const result = await service.mintExcessAkt();
+
+      expect(result).toEqual(Ok.EMPTY);
+      expect(chainSdk.cosmos.bank.v1beta1.getAllBalances).toHaveBeenCalledTimes(3);
+    });
+
+    it("fails when ACT balance stays below expected after retries", async () => {
+      const { service, chainSdk } = setup({
+        balances: { uact: 5_000_000_000, uakt: 6_000_000_000 },
         aktPrice: 0.5
       });
       chainSdk.cosmos.bank.v1beta1.getAllBalances.mockResolvedValue(
         createBankBalancesResponse({
           balances: [
             { denom: "uact", amount: String(5_000_000_000) },
-            { denom: "uakt", amount: String(96_123_572) }
+            { denom: "uakt", amount: String(2_000_000_000) }
           ]
         })
       );
 
-      const result = await service.mintIfNeeded();
+      const result = await service.mintExcessAkt();
 
       expect(result.err).toBe(true);
       expect(result.val).toBe("ACT balance still below expected after mint");
     });
 
-    it("should fail when AKT price is invalid", async () => {
-      const { service, denomExchangeService } = setup({
-        targetActBalance: 10_000_000_000,
-        balances: { uact: 5_000_000_000, uakt: 99_999_999_999 }
-      });
-      denomExchangeService.getExchangeRateToUSD.mockResolvedValue(createDenomExchangeRate({ price: 0 }));
-
-      const result = await service.mintIfNeeded();
-
-      expect(result.err).toBe(true);
-      expect(result.val).toBe("Invalid AKT price: 0");
-    });
-
-    it("should fail when mint transaction returns a non-zero code", async () => {
+    it("skips broadcasting when dry-run is enabled", async () => {
       const { service, txManagerService } = setup({
-        targetActBalance: 10_000_000_000,
-        balances: { uact: 5_000_000_000, uakt: 99_999_999_999 },
-        aktPrice: 0.5
-      });
-      txManagerService.signAndBroadcastWithFundingWallet.mockResolvedValue({ code: 11, hash: "FAIL", rawLog: "insufficient funds" });
-
-      const result = await service.mintIfNeeded();
-
-      expect(result.err).toBe(true);
-      expect(result.val).toBe("Transaction failed with code 11: insufficient funds");
-    });
-
-    it("should cap burn amount and scale expected ACT when AKT partially covers the mint", async () => {
-      const { service, chainSdk, rpcMessageService, masterAddress } = setup({
-        targetActBalance: 10_000_000_000,
-        balances: { uact: 5_000_000_000, uakt: 5_200_000_000 },
-        aktPrice: 0.5
-      });
-      mockBalancesOnce(chainSdk, { uact: 7_500_000_000, uakt: 0 });
-
-      const result = await service.mintIfNeeded();
-
-      expect(result).toEqual(Ok.EMPTY);
-      // available = 5_200_000_000 - 100_000_000 reserve = 5_100_000_000 (< 10_500_000_000 requested)
-      // expected ACT = floor(5_100_000_000 * 0.5 / 1.05) = 2_428_571_428
-      // expectedActBalance = 5_000_000_000 + 2_428_571_428 = 7_428_571_428
-      expect(rpcMessageService.getMintACTMsg).toHaveBeenCalledWith({
-        owner: masterAddress,
-        amount: 5_100_000_000
-      });
-    });
-
-    it("should bump mint amount to the BME minimum when deficit is smaller", async () => {
-      const { service, chainSdk, rpcMessageService, masterAddress } = setup({
-        targetActBalance: 10_000_000_000,
-        balances: { uact: 9_999_000_000, uakt: 99_999_999_999 },
-        aktPrice: 0.5
-      });
-      mockBalancesOnce(chainSdk, { uact: 10_009_000_000, uakt: 0 });
-
-      const result = await service.mintIfNeeded();
-
-      expect(result).toEqual(Ok.EMPTY);
-      // deficit = 1_000_000 uact, BME minMintUact = 10_000_000
-      // aktToBurn = ceil(10_000_000 / 0.5 * 1.05) = 21_000_000
-      expect(rpcMessageService.getMintACTMsg).toHaveBeenCalledWith({
-        owner: masterAddress,
-        amount: 21_000_000
-      });
-    });
-
-    it("should fall back to default minimum mint when uact denom is absent from BME params", async () => {
-      const { service, bmeHttpService, chainSdk, rpcMessageService, masterAddress } = setup({
-        targetActBalance: 10_000_000_000,
-        balances: { uact: 9_999_000_000, uakt: 99_999_999_999 },
-        aktPrice: 0.5
-      });
-      bmeHttpService.getParams.mockResolvedValue({ params: { min_mint: [{ denom: "uother", amount: "500000" }] } });
-      mockBalancesOnce(chainSdk, { uact: 10_009_000_000, uakt: 0 });
-
-      const result = await service.mintIfNeeded();
-
-      expect(result).toEqual(Ok.EMPTY);
-      // fallback minMintUact = 10_000_000; aktToBurn = ceil(10_000_000 / 0.5 * 1.05) = 21_000_000
-      expect(rpcMessageService.getMintACTMsg).toHaveBeenCalledWith({
-        owner: masterAddress,
-        amount: 21_000_000
-      });
-    });
-
-    it("should keep polling until ACT balance reaches expected after mint", async () => {
-      const { service, chainSdk } = setup({
-        targetActBalance: 10_000_000_000,
-        balances: { uact: 5_000_000_000, uakt: 99_999_999_999 },
-        aktPrice: 0.5
-      });
-      mockBalancesOnce(chainSdk, { uact: 5_000_000_000, uakt: 89_799_999_999 });
-      mockBalancesOnce(chainSdk, { uact: 10_100_000_000, uakt: 89_799_999_999 });
-
-      const result = await service.mintIfNeeded();
-
-      expect(result).toEqual(Ok.EMPTY);
-      // 1 initial fetch + 2 verification polls
-      expect(chainSdk.cosmos.bank.v1beta1.getAllBalances).toHaveBeenCalledTimes(3);
-    });
-
-    it("should skip broadcasting when dry-run is enabled", async () => {
-      const { service, txManagerService } = setup({
-        targetActBalance: 10_000_000_000,
-        balances: { uact: 5_000_000_000, uakt: 99_999_999_999 },
+        balances: { uact: 5_000_000_000, uakt: 6_000_000_000 },
         aktPrice: 0.5
       });
 
-      const result = await service.mintIfNeeded({ dryRun: true });
+      const result = await service.mintExcessAkt({ dryRun: true });
 
       expect(result).toEqual(Ok.EMPTY);
       expect(txManagerService.signAndBroadcastWithFundingWallet).not.toHaveBeenCalled();
@@ -257,9 +241,10 @@ describe(MasterWalletMintService.name, () => {
     );
   }
 
-  function setup(input: { targetActBalance: number; balances?: { uact: number; uakt: number }; aktPrice?: number }) {
+  function setup(input: { aktReserve?: number; maxMintUakt?: number; balances?: { uact: number; uakt: number }; aktPrice?: number }) {
     const billingConfig = mock<BillingConfigService>();
-    billingConfig.get.calledWith("MASTER_WALLET_TARGET_ACT_BALANCE").mockReturnValue(input.targetActBalance);
+    billingConfig.get.calledWith("MASTER_WALLET_AKT_RESERVE").mockReturnValue(input.aktReserve ?? 2_000_000_000);
+    billingConfig.get.calledWith("MASTER_WALLET_MAX_MINT_UAKT").mockReturnValue(input.maxMintUakt ?? 5_000_000_000);
 
     const masterAddress = createAkashAddress();
     const txManagerService = mock<TxManagerService>();

--- a/apps/api/src/billing/services/master-wallet-mint/master-wallet-mint.service.ts
+++ b/apps/api/src/billing/services/master-wallet-mint/master-wallet-mint.service.ts
@@ -22,7 +22,6 @@ export class MasterWalletMintService {
   private readonly MAX_POLL_ATTEMPTS = 24;
   private readonly BALANCE_CHECK_INTERVAL_MS = 10_000;
   private readonly MAX_BALANCE_CHECK_ATTEMPTS = 18;
-  private readonly AKT_RESERVE_UAKT = 100_000_000;
 
   constructor(
     private readonly billingConfigService: BillingConfigService,
@@ -35,36 +34,65 @@ export class MasterWalletMintService {
   ) {}
 
   /**
-   * Checks the master wallet's ACT balance against the configured target and mints ACT from AKT if below.
-   * Computes AKT to burn using oracle price (with slippage margin), enforces BME minimum mint,
-   * caps to available AKT (minus reserve), broadcasts MsgMintACT, polls for settlement, and verifies post-mint balance.
+   * Burns the master wallet's AKT above the configured fee reserve into ACT, capped per run
+   * so a large backlog drains gradually across cron runs. Skips (without error) while a prior
+   * mint is still settling, when there is no excess, or when the excess is below the BME minimum —
+   * all normal states under a frequent cron. Broadcasts MsgMintACT, polls for settlement, and
+   * verifies the post-mint ACT balance.
    */
-  async mintIfNeeded(options?: DryRunOptions): Promise<Result<void, string>> {
+  async mintExcessAkt(options?: DryRunOptions): Promise<Result<void, string>> {
     const address = await this.txManagerService.getFundingWalletAddress();
-    const balances = await this.fetchWalletBalances(address);
-    const currentUactBalance = this.findBalance(balances, "uact");
-    const deficit = this.billingConfigService.get("MASTER_WALLET_TARGET_ACT_BALANCE") - currentUactBalance;
 
-    if (deficit <= 0) {
-      this.logger.info({ event: "MASTER_WALLET_MINT_SKIPPED", deficit });
+    if (await this.hasPendingSettlement(address)) {
+      this.logger.info({ event: "MASTER_WALLET_MINT_SKIPPED", reason: "previous mint still settling", address });
       return Ok.EMPTY;
     }
 
-    const calculation = await this.calculateAktToBurn(deficit, balances);
+    const balances = await this.fetchWalletBalances(address);
+    const aktBalance = this.findBalance(balances, "uakt");
+    const reserve = this.billingConfigService.get("MASTER_WALLET_AKT_RESERVE");
+
+    if (aktBalance < reserve) {
+      this.logger.warn({ event: "MASTER_WALLET_BALANCE_BELOW_RESERVE", message: "AKT balance is below the fee reserve", aktBalance, reserve });
+      return Ok.EMPTY;
+    }
+
+    const excess = aktBalance - reserve;
+    const aktToBurn = Math.min(excess, this.billingConfigService.get("MASTER_WALLET_MAX_MINT_UAKT"));
+
+    if (aktToBurn <= 0) {
+      this.logger.info({ event: "MASTER_WALLET_MINT_SKIPPED", reason: "no excess AKT", aktBalance, reserve });
+      return Ok.EMPTY;
+    }
+
+    const calculation = await this.calculateExpectedAct(aktToBurn);
 
     if (calculation.err) {
       return calculation;
     }
 
-    const aktToBurn = calculation.val.akt;
-    const expectedActBalance = currentUactBalance + calculation.val.act;
-
-    if (options?.dryRun) {
-      this.logger.info({ event: "MASTER_WALLET_MINT_DRY_RUN", deficit, aktToBurn, expectedActToMint: calculation.val.act, expectedActBalance });
+    if (calculation.val === null) {
       return Ok.EMPTY;
     }
 
+    const expectedActBalance = this.findBalance(balances, "uact") + calculation.val;
+    const remainingBacklog = excess - aktToBurn;
+
+    if (options?.dryRun) {
+      this.logger.info({ event: "MASTER_WALLET_MINT_DRY_RUN", aktToBurn, reserve, remainingBacklog, expectedActToMint: calculation.val, expectedActBalance });
+      return Ok.EMPTY;
+    }
+
+    if (remainingBacklog > 0) {
+      this.logger.info({ event: "MASTER_WALLET_MINT_CAPPED", aktToBurn, remainingBacklog });
+    }
+
     return this.executeMint(address, aktToBurn, expectedActBalance);
+  }
+
+  private async hasPendingSettlement(address: string): Promise<boolean> {
+    const { records } = await this.fetchPendingLedgerRecords(address);
+    return records.length > 0;
   }
 
   private async fetchWalletBalances(address: string): Promise<Balances> {
@@ -73,9 +101,11 @@ export class MasterWalletMintService {
   }
 
   /**
-   * Computes the final AKT amount to burn: applies oracle price with slippage, enforces BME min mint, and caps to available AKT minus reserve.
+   * Computes the slippage-discounted ACT expected from burning the given AKT amount.
+   * Returns Ok(null) when the burn is below the BME minimum mint — a skip, not a failure,
+   * since small excess simply accumulates until a later run clears the floor.
    */
-  private async calculateAktToBurn(actDeficit: number, balances: Balances): Promise<Result<{ akt: number; act: number }, string>> {
+  private async calculateExpectedAct(aktToBurn: number): Promise<Result<number | null, string>> {
     const [{ price }, minMintUact] = await Promise.all([this.denomExchangeService.getExchangeRateToUSD("akt"), this.getMinMintAmount()]);
 
     if (!price || price <= 0) {
@@ -84,18 +114,13 @@ export class MasterWalletMintService {
     }
 
     const minAktToBurn = Math.ceil((minMintUact / price) * this.PRICE_SLIPPAGE_MULTIPLIER);
-    const aktToBurn = Math.ceil((Math.max(actDeficit, minMintUact) / price) * this.PRICE_SLIPPAGE_MULTIPLIER);
 
-    const capped = this.capToAvailableAkt(balances, aktToBurn, minAktToBurn);
-
-    if (capped.err) {
-      return capped;
+    if (aktToBurn < minAktToBurn) {
+      this.logger.info({ event: "MASTER_WALLET_MINT_SKIPPED", reason: "excess below BME minimum mint", aktToBurn, minAktToBurn });
+      return Ok(null);
     }
 
-    return Ok({
-      akt: capped.val,
-      act: Math.floor((capped.val * price) / this.PRICE_SLIPPAGE_MULTIPLIER)
-    });
+    return Ok(Math.floor((aktToBurn * price) / this.PRICE_SLIPPAGE_MULTIPLIER));
   }
 
   private async getMinMintAmount(): Promise<number> {
@@ -112,24 +137,6 @@ export class MasterWalletMintService {
     }
 
     return Number(uactCoin.amount);
-  }
-
-  /** Caps burn amount to available AKT minus reserve (100 AKT). Fails if available can't cover the BME minimum mint. */
-  private capToAvailableAkt(balances: Balances, aktToBurn: number, minAktToBurn: number): Result<number, string> {
-    const aktBalance = this.findBalance(balances, "uakt");
-    const available = aktBalance - this.AKT_RESERVE_UAKT;
-
-    if (available < minAktToBurn) {
-      const message = `Insufficient AKT balance: have ${aktBalance}, need at least ${minAktToBurn + this.AKT_RESERVE_UAKT} (${minAktToBurn} min burn + ${this.AKT_RESERVE_UAKT} reserve)`;
-      this.logger.error({ event: "MASTER_WALLET_MINT_FAILED", message, aktBalance, minAktToBurn, reserve: this.AKT_RESERVE_UAKT });
-      return Err(message);
-    }
-
-    if (available < aktToBurn) {
-      this.logger.warn({ event: "MASTER_WALLET_MINT_CAPPED", message: "Minting less than needed due to AKT balance", requested: aktToBurn, available });
-    }
-
-    return Ok(Math.min(aktToBurn, available));
   }
 
   /**
@@ -156,12 +163,16 @@ export class MasterWalletMintService {
     return this.verifyMintedBalance(address, aktToBurn, expectedActBalance);
   }
 
+  private fetchPendingLedgerRecords(address: string) {
+    return this.chainSdk.akash.bme.v1.getLedgerRecords({
+      filters: { source: address, status: "ledger_record_status_pending" }
+    });
+  }
+
   /** Polls BME ledger until no pending records remain for this address. */
   private async waitForSettlement(address: string): Promise<Result<void, string>> {
     for (let attempt = 0; attempt < this.MAX_POLL_ATTEMPTS; attempt++) {
-      const { records } = await this.chainSdk.akash.bme.v1.getLedgerRecords({
-        filters: { source: address, status: "ledger_record_status_pending" }
-      });
+      const { records } = await this.fetchPendingLedgerRecords(address);
 
       if (records.length === 0) {
         return Ok.EMPTY;


### PR DESCRIPTION
## Why

The daily `mint-act` job currently tops the master wallet up to a 10k ACT target, leaving all remaining AKT idle in the wallet. We want the opposite: keep as little AKT in the master wallet as possible — only a fee reserve — and convert everything else to ACT, including AKT deposited later.

## What

Reworks `MasterWalletMintService` from "fill ACT deficit up to target" to "burn AKT excess above a fee reserve, capped per run":

- New env vars: `MASTER_WALLET_AKT_RESERVE` (default 2,000 AKT — kept for tx fees; this wallet is the fee granter for all managed-wallet txs) and `MASTER_WALLET_MAX_MINT_UAKT` (default 5,000 AKT per run, so a large backlog drains gradually). Removes `MASTER_WALLET_TARGET_ACT_BALANCE` (a stale value in prod env is harmless — the schema is not strict).
- Overlap guard: a run skips while a previous mint still has pending BME ledger records, so frequent cron runs can't double-burn.
- **Behavior change for reviewers**: "insufficient AKT" is no longer an error. No excess, excess below the BME minimum mint, or a still-settling prior mint are info-level skips; balance below the reserve is a warn (`MASTER_WALLET_BALANCE_BELOW_RESERVE`). Only an invalid oracle price and tx/settlement failures remain errors, so a frequent cron doesn't page on healthy no-op states.
- CLI command name stays `mint-act` (existing cron and manual invocation keep working); dry-run unchanged.

### Ops rollout (out of repo)

1. Deploy, then optionally run `mint-act --dry-run` / `mint-act` manually to start the drain.
2. Keep the existing **daily** cron: it drains the backlog at 5k AKT/day until the balance reaches the 2k reserve (visible via `MASTER_WALLET_MINT_SKIPPED` logs).
3. Then repoint the cron to every 5–15 min so newly deposited AKT is minted right away. The cron should be non-overlapping (`concurrencyPolicy: Forbid` / flock).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Master-wallet conversion now processes excess AKT above a configurable reserve.
  - Each run caps the conversion amount and reports any remaining excess.
  - Dry-run mode previews planned conversions accurately.
  - New settings control the AKT reserve and maximum conversion amount.

- **Bug Fixes**
  - Conversion is skipped during pending settlements or below minimum thresholds.
  - Improved handling for unavailable pricing, missing denominations, transaction failures, and ledger delays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->