### PR TITLE
fix(deployment): reduce auto top-up escrow deposit sizing from 48h to 24h

### DIFF
--- a/apps/api/src/deployment/config/env.config.ts
+++ b/apps/api/src/deployment/config/env.config.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 export const envSchema = z.object({
   AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H: z.number({ coerce: true }).optional().default(24),
-  AUTO_TOP_UP_AMOUNT_IN_H: z.number({ coerce: true }).optional().default(48),
+  AUTO_TOP_UP_AMOUNT_IN_H: z.number({ coerce: true }).optional().default(24),
   PROVIDER_PROXY_URL: z.string().url(),
   GPU_BOT_WALLET_MNEMONIC: z.string().optional()
 });


### PR DESCRIPTION
## Why

The hourly auto top-up adds a flat `AUTO_TOP_UP_AMOUNT_IN_H` (48h) worth of a deployment's cost on top of whatever it already holds, and it triggers while the deployment can still hold up to 24h of runway. Expensive deployments therefore hold up to ~72h of cost, and a single funding event moves 48h of burn at once: a $5/h deployment pulls $240 per deposit and holds up to ~$360 in escrow. That lump drains the Available balance in one shot, chains consecutive auto-reload card charges for anything burning more than ~$2/h against the $100 default reload amount, and widens the insufficient-balance window for new deployment creation (CON-512).

Halving the flat amount to 24h halves each draw and the average locked escrow without shortening the buffer against a broken top-up job: time to first customer impact is set by the separate 24h look-ahead trigger (`AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H`), not by the deposit size. First closures after a dead cron still start ~24h in; only the tail of the fleet drains sooner (~48h instead of ~72h).

Related to CON-791: to-target sizing remains the proper fix. A flat 24h add at the 24h trigger is roughly equivalent to CON-791's 48h target in steady state, so this value should be revisited when that lands.

## What

- Lower the `AUTO_TOP_UP_AMOUNT_IN_H` zod default from 48 to 24. This sizes the hourly escrow top-up, the initial funding at lease start, and the `estimatedTopUpAmount` value shown in the UI.
- Deposits become roughly daily per deployment instead of every ~2 days; messages stay batched into one tx per owner, so master-wallet fee spend for this job roughly doubles.
- Still env-overridable: setting `AUTO_TOP_UP_AMOUNT_IN_H=48` is an instant rollback with no deploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Reduced the default automatic top-up interval from 48 hours to 24 hours.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->