### PR TITLE
feat(deployment): add explicit group and fabric controls to gpu interconnect

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/GpuInterconnectCard/GpuInterconnectCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/GpuInterconnectCard/GpuInterconnectCard.spec.tsx
@@ -203,6 +203,105 @@ describe(GpuInterconnectCard.name, () => {
     expect(screen.queryByText(/free trial/i)).not.toBeInTheDocument();
   });
 
+  it("shows an imported explicit group name in the group input", () => {
+    setup({ interconnect: { group: "pair0" } });
+
+    expect(screen.getByLabelText("Interconnect group")).toHaveValue("pair0");
+  });
+
+  it("writes an explicit group as the user types", async () => {
+    const { getValues } = setup({ interconnect: {} });
+
+    await userEvent.type(screen.getByLabelText("Interconnect group"), "pair0");
+
+    expect(getValues().services[0].profile.interconnect).toEqual({ group: "pair0" });
+  });
+
+  it("returns to the implicit group when the name is cleared", async () => {
+    const { getValues } = setup({ interconnect: { group: "pair0" } });
+
+    await userEvent.clear(screen.getByLabelText("Interconnect group"));
+
+    expect(getValues().services[0].profile.interconnect).toEqual({});
+  });
+
+  it("warns that the group name auto is reserved", () => {
+    setup({ interconnect: { group: "auto" } });
+
+    expect(screen.getByText(/reserved for the automatic group/i)).toBeInTheDocument();
+  });
+
+  it("warns when services on the placement mix automatic and named groups", () => {
+    setup({ interconnect: { group: "pair0" }, sibling: "same-placement" });
+
+    expect(screen.getByText(/mix automatic and named interconnect groups/i)).toBeInTheDocument();
+  });
+
+  it("does not warn about mixing when the differently-formed service is on another placement", () => {
+    setup({ interconnect: { group: "pair0" }, sibling: "other-placement" });
+
+    expect(screen.queryByText(/mix automatic and named interconnect groups/i)).not.toBeInTheDocument();
+  });
+
+  it("pins the selected fabric on the placement", async () => {
+    const { getValues } = setup({ interconnect: {}, attributes: [{ id: "c1", key: GPU_INTERCONNECT_CAPABILITY_KEY, value: "true" }] });
+
+    await userEvent.click(screen.getByRole("radio", { name: "InfiniBand" }));
+
+    expect(getValues().placements[0].attributes).toEqual([
+      { id: "c1", key: GPU_INTERCONNECT_CAPABILITY_KEY, value: "true" },
+      { id: expect.any(String), key: `${GPU_INTERCONNECT_FABRIC_PREFIX}infiniband`, value: "true" }
+    ]);
+  });
+
+  it("replaces the pinned fabric when another is selected", async () => {
+    const { getValues } = setup({ interconnect: {}, attributes: [{ id: "f1", key: `${GPU_INTERCONNECT_FABRIC_PREFIX}infiniband`, value: "true" }] });
+
+    await userEvent.click(screen.getByRole("radio", { name: "RoCE" }));
+
+    expect(getValues().placements[0].attributes).toEqual([{ id: expect.any(String), key: `${GPU_INTERCONNECT_FABRIC_PREFIX}roce`, value: "true" }]);
+  });
+
+  it("preselects an imported fabric pin", () => {
+    setup({ interconnect: {}, attributes: [{ id: "f1", key: `${GPU_INTERCONNECT_FABRIC_PREFIX}roce`, value: "true" }] });
+
+    expect(screen.getByRole("radio", { name: "RoCE" })).toBeChecked();
+  });
+
+  it("defaults the fabric to Any when nothing is pinned", () => {
+    setup({ interconnect: {} });
+
+    expect(screen.getByRole("radio", { name: "Any" })).toBeChecked();
+  });
+
+  it("removes the fabric pin when Any is selected", async () => {
+    const { getValues } = setup({
+      interconnect: {},
+      attributes: [
+        { id: "c1", key: GPU_INTERCONNECT_CAPABILITY_KEY, value: "true" },
+        { id: "f1", key: `${GPU_INTERCONNECT_FABRIC_PREFIX}infiniband`, value: "true" }
+      ]
+    });
+
+    await userEvent.click(screen.getByRole("radio", { name: "Any" }));
+
+    expect(getValues().placements[0].attributes).toEqual([{ id: "c1", key: GPU_INTERCONNECT_CAPABILITY_KEY, value: "true" }]);
+  });
+
+  it("disables the advanced controls for a trial-blocked wallet", () => {
+    setup({ isTrialBlocked: true, interconnect: {} });
+
+    expect(screen.getByLabelText("Interconnect group")).toBeDisabled();
+    expect(screen.getByRole("radio", { name: "InfiniBand" })).toBeDisabled();
+  });
+
+  it("disables the advanced controls while the pane is locked", () => {
+    setup({ interconnect: {}, locked: true });
+
+    expect(screen.getByLabelText("Interconnect group")).toBeDisabled();
+    expect(screen.getByRole("radio", { name: "InfiniBand" })).toBeDisabled();
+  });
+
   function setup(input: {
     interconnect?: { group?: string };
     profile?: Partial<ServiceType["profile"]>;

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/GpuInterconnectCard/GpuInterconnectCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/GpuInterconnectCard/GpuInterconnectCard.tsx
@@ -1,20 +1,37 @@
 import type { FC } from "react";
 import { useCallback } from "react";
 import { useFormContext, useWatch } from "react-hook-form";
-import { Alert, CollapsibleCard } from "@akashnetwork/ui/components";
+import { Alert, CollapsibleCard, Input, Label, RadioGroup, RadioGroupItem } from "@akashnetwork/ui/components";
 import { NetworkIcon } from "lucide-react";
 
-import type { SdlBuilderFormValuesType } from "@src/types";
+import type { PlacementAttributeType, SdlBuilderFormValuesType } from "@src/types";
 import { defaultGpuModel } from "@src/utils/sdl/data";
-import { hasOtherInterconnectService, withGpuInterconnectCapability, withoutGpuInterconnectCapability } from "@src/utils/sdl/gpuInterconnect";
+import type { GpuInterconnectFabric } from "@src/utils/sdl/gpuInterconnect";
+import {
+  getGpuInterconnectFabric,
+  hasMixedInterconnectGroupForms,
+  hasOtherInterconnectService,
+  withGpuInterconnectCapability,
+  withGpuInterconnectFabric,
+  withoutGpuInterconnectCapability
+} from "@src/utils/sdl/gpuInterconnect";
 import { gpuInterconnectTooltip } from "../cardTooltips";
 import { UnlockGpusButton } from "../UnlockGpusButton/UnlockGpusButton";
 
-export const DEPENDENCIES = { CollapsibleCard, Alert, UnlockGpusButton };
+export const DEPENDENCIES = { CollapsibleCard, Alert, Input, Label, RadioGroup, RadioGroupItem, UnlockGpusButton };
 
 /** Hover explanation for the trial unlock CTA; mirrors the phrasing of the high-end GPU unlock copy. */
 const INTERCONNECT_UNLOCK_EXPLANATION =
   "GPU interconnect isn't included in your free trial. Add credits to unlock it, along with longer runtimes and the full Console.";
+
+/** "any" = no fabric pin, the provider chooses; the two pinned choices emit a placement capability. */
+type FabricChoice = GpuInterconnectFabric | "any";
+
+const FABRIC_OPTIONS: { value: FabricChoice; label: string; description: string }[] = [
+  { value: "any", label: "Any", description: "Let the provider choose the interconnect fabric." },
+  { value: "infiniband", label: "InfiniBand", description: "Only providers offering an InfiniBand fabric will bid." },
+  { value: "roce", label: "RoCE", description: "Only providers offering an RDMA over Converged Ethernet fabric will bid." }
+];
 
 type Props = {
   serviceIndex: number;
@@ -40,10 +57,14 @@ type Props = {
  * bid. Disabling clears the opt-in and removes the placement capability (plus
  * any fabric pins) unless another service on the same placement still opts in.
  *
- * The card never mutates on mount, preserving the SDL import round-trip: an
- * imported explicit group (`{ group: "x" }`) simply shows as ON, and toggling it
- * off and on collapses it to the implicit `{}` group (explicit group editing is
- * out of scope here, see CON-692).
+ * While enabled, the body offers the advanced controls: an optional explicit
+ * group name (empty = the implicit "auto" group; `auto` itself is reserved and
+ * only warned about here, the SDL validator rejects it with the same guidance)
+ * and a fabric choice that pins `capabilities/gpu-interconnect/fabric/<fabric>`
+ * on the placement — a per-placement setting shared by sibling services, with
+ * "Any" leaving the fabric to the provider.
+ *
+ * The card never mutates on mount, preserving the SDL import round-trip.
  *
  * Trial wallets cannot enable the interconnect (`isTrialBlocked`): the switch is
  * disabled while off and an add-credits CTA is shown; the API enforces the same
@@ -54,10 +75,18 @@ export const GpuInterconnectCard: FC<Props> = ({ serviceIndex, locked = false, i
   const interconnect = useWatch({ control, name: `services.${serviceIndex}.profile.interconnect` });
   const hasGpu = useWatch({ control, name: `services.${serviceIndex}.profile.hasGpu` });
   const count = useWatch({ control, name: `services.${serviceIndex}.count` });
+  const placementId = useWatch({ control, name: `services.${serviceIndex}.placementId` });
   const watchedServices = useWatch({ control, name: "services" });
   const services = Array.isArray(watchedServices) ? (watchedServices as SdlBuilderFormValuesType["services"]) : [];
+  const watchedPlacements = useWatch({ control, name: "placements" });
+  const placements = Array.isArray(watchedPlacements) ? (watchedPlacements as SdlBuilderFormValuesType["placements"]) : [];
 
   const isEnabled = !!interconnect;
+  const controlsDisabled = locked || isTrialBlocked;
+  const fabric = getGpuInterconnectFabric(placements.find(placement => placement.id === placementId)?.attributes);
+
+  const groupIsReserved = interconnect?.group === "auto";
+  const hasMixedForms = isEnabled && hasMixedInterconnectGroupForms(services, serviceIndex);
 
   /**
    * Enabling turns the GPU card on, but the user can still turn GPU back off afterwards — surface the
@@ -86,19 +115,40 @@ export const GpuInterconnectCard: FC<Props> = ({ serviceIndex, locked = false, i
     }
   }, [getValues, serviceIndex, setValue]);
 
-  const setPlacementCapability = useCallback(
-    (enabled: boolean) => {
-      const placementId = getValues(`services.${serviceIndex}.placementId`);
-      const placementIndex = getValues("placements").findIndex(placement => placement.id === placementId);
+  const updatePlacementAttributes = useCallback(
+    (transform: (attributes: PlacementAttributeType[] | undefined) => PlacementAttributeType[] | undefined) => {
+      const currentPlacementId = getValues(`services.${serviceIndex}.placementId`);
+      const placementIndex = getValues("placements").findIndex(placement => placement.id === currentPlacementId);
       if (placementIndex < 0) return;
 
       const attributes = getValues(`placements.${placementIndex}.attributes`);
-      const nextAttributes = enabled ? withGpuInterconnectCapability(attributes) : withoutGpuInterconnectCapability(attributes);
+      const nextAttributes = transform(attributes);
       if (nextAttributes !== attributes) {
         setValue(`placements.${placementIndex}.attributes`, nextAttributes, { shouldDirty: true });
       }
     },
     [getValues, serviceIndex, setValue]
+  );
+
+  const setPlacementCapability = useCallback(
+    (enabled: boolean) => {
+      updatePlacementAttributes(attributes => (enabled ? withGpuInterconnectCapability(attributes) : withoutGpuInterconnectCapability(attributes)));
+    },
+    [updatePlacementAttributes]
+  );
+
+  const setFabric = useCallback(
+    (choice: FabricChoice) => {
+      updatePlacementAttributes(attributes => withGpuInterconnectFabric(attributes, choice === "any" ? undefined : choice));
+    },
+    [updatePlacementAttributes]
+  );
+
+  const setGroup = useCallback(
+    (name: string) => {
+      setValue(`services.${serviceIndex}.profile.interconnect`, name === "" ? {} : { group: name }, { shouldDirty: true });
+    },
+    [serviceIndex, setValue]
   );
 
   const toggleInterconnect = useCallback(
@@ -142,6 +192,58 @@ export const GpuInterconnectCard: FC<Props> = ({ serviceIndex, locked = false, i
                 A GPU interconnect needs GPU resources on this service. Enable the GPU card above so interconnect-capable providers can bid.
               </d.Alert>
             )}
+            <div className="space-y-2">
+              <d.Input
+                id={`interconnect-group-${serviceIndex}`}
+                label="Interconnect group"
+                value={interconnect?.group ?? ""}
+                onChange={event => setGroup(event.target.value)}
+                placeholder="auto"
+                disabled={controlsDisabled}
+              />
+              <p className="text-xs text-muted-foreground">
+                Leave empty for the automatic group. Services that opt in without a name share one group per placement.
+              </p>
+            </div>
+            {groupIsReserved && (
+              <d.Alert variant="warning" className="p-4 text-sm">
+                The group name &quot;auto&quot; is reserved for the automatic group. Leave the field empty instead, or pick a different name.
+              </d.Alert>
+            )}
+            {hasMixedForms && (
+              <d.Alert variant="warning" className="p-4 text-sm">
+                Services on this placement mix automatic and named interconnect groups, which is rejected at deploy time. Use one form for every service on the
+                placement.
+              </d.Alert>
+            )}
+            <div className="space-y-2">
+              <d.Label>Fabric</d.Label>
+              <d.RadioGroup
+                aria-label="Interconnect fabric"
+                value={fabric ?? "any"}
+                onValueChange={value => setFabric(value as FabricChoice)}
+                className="gap-3"
+                disabled={controlsDisabled}
+              >
+                {FABRIC_OPTIONS.map(option => {
+                  const id = `interconnect-fabric-${serviceIndex}-${option.value}`;
+                  return (
+                    <d.Label
+                      key={option.value}
+                      htmlFor={id}
+                      className="flex items-start gap-3 rounded-md border border-zinc-200 p-3 font-normal dark:border-zinc-800"
+                    >
+                      <d.RadioGroupItem id={id} value={option.value} aria-label={option.label} disabled={controlsDisabled} className="mt-0.5" />
+                      <span className="flex flex-col gap-0.5">
+                        <span className="text-sm font-medium">{option.label}</span>
+                        <span className="text-xs text-muted-foreground">{option.description}</span>
+                      </span>
+                    </d.Label>
+                  );
+                })}
+              </d.RadioGroup>
+              <p className="text-xs text-muted-foreground">The fabric applies to the whole placement, including sibling services that opt in.</p>
+            </div>
           </>
         ) : (
           <p className="text-sm text-muted-foreground">GPU interconnect is off.</p>

--- a/apps/deploy-web/src/utils/sdl/gpuInterconnect.spec.ts
+++ b/apps/deploy-web/src/utils/sdl/gpuInterconnect.spec.ts
@@ -2,10 +2,13 @@ import { describe, expect, it } from "vitest";
 
 import type { PlacementAttributeType, ServiceType } from "@src/types";
 import {
+  getGpuInterconnectFabric,
   GPU_INTERCONNECT_CAPABILITY_KEY,
   GPU_INTERCONNECT_FABRIC_PREFIX,
+  hasMixedInterconnectGroupForms,
   hasOtherInterconnectService,
   withGpuInterconnectCapability,
+  withGpuInterconnectFabric,
   withoutGpuInterconnectCapability
 } from "./gpuInterconnect";
 
@@ -63,6 +66,77 @@ describe(withoutGpuInterconnectCapability.name, () => {
   });
 });
 
+describe(getGpuInterconnectFabric.name, () => {
+  it("returns undefined when no fabric is pinned", () => {
+    expect(getGpuInterconnectFabric(undefined)).toBeUndefined();
+    expect(getGpuInterconnectFabric([{ id: "c1", key: GPU_INTERCONNECT_CAPABILITY_KEY, value: "true" }])).toBeUndefined();
+  });
+
+  it("reads a pinned fabric", () => {
+    expect(getGpuInterconnectFabric([{ id: "f1", key: `${GPU_INTERCONNECT_FABRIC_PREFIX}infiniband`, value: "true" }])).toBe("infiniband");
+    expect(getGpuInterconnectFabric([{ id: "f1", key: `${GPU_INTERCONNECT_FABRIC_PREFIX}roce`, value: "true" }])).toBe("roce");
+  });
+
+  it("ignores an unknown fabric suffix", () => {
+    expect(getGpuInterconnectFabric([{ id: "f1", key: `${GPU_INTERCONNECT_FABRIC_PREFIX}omni-path`, value: "true" }])).toBeUndefined();
+  });
+
+  it("ignores a pin that is not set to true", () => {
+    expect(getGpuInterconnectFabric([{ id: "f1", key: `${GPU_INTERCONNECT_FABRIC_PREFIX}infiniband`, value: "false" }])).toBeUndefined();
+  });
+});
+
+describe(withGpuInterconnectFabric.name, () => {
+  it("pins a fabric from undefined attributes", () => {
+    expect(withGpuInterconnectFabric(undefined, "infiniband")).toEqual([
+      { id: expect.any(String), key: `${GPU_INTERCONNECT_FABRIC_PREFIX}infiniband`, value: "true" }
+    ]);
+  });
+
+  it("replaces an existing pin while preserving unrelated rows", () => {
+    const attributes: PlacementAttributeType[] = [
+      { id: "c1", key: GPU_INTERCONNECT_CAPABILITY_KEY, value: "true" },
+      { id: "f1", key: `${GPU_INTERCONNECT_FABRIC_PREFIX}infiniband`, value: "true" }
+    ];
+
+    expect(withGpuInterconnectFabric(attributes, "roce")).toEqual([
+      { id: "c1", key: GPU_INTERCONNECT_CAPABILITY_KEY, value: "true" },
+      { id: expect.any(String), key: `${GPU_INTERCONNECT_FABRIC_PREFIX}roce`, value: "true" }
+    ]);
+  });
+
+  it("removes every pin when the fabric is cleared", () => {
+    const attributes: PlacementAttributeType[] = [
+      { id: "c1", key: GPU_INTERCONNECT_CAPABILITY_KEY, value: "true" },
+      { id: "f1", key: `${GPU_INTERCONNECT_FABRIC_PREFIX}infiniband`, value: "true" },
+      { id: "f2", key: `${GPU_INTERCONNECT_FABRIC_PREFIX}roce`, value: "true" }
+    ];
+
+    expect(withGpuInterconnectFabric(attributes, undefined)).toEqual([{ id: "c1", key: GPU_INTERCONNECT_CAPABILITY_KEY, value: "true" }]);
+  });
+
+  it("returns the same reference when the fabric is already pinned", () => {
+    const attributes: PlacementAttributeType[] = [{ id: "f1", key: `${GPU_INTERCONNECT_FABRIC_PREFIX}roce`, value: "true" }];
+
+    expect(withGpuInterconnectFabric(attributes, "roce")).toBe(attributes);
+  });
+
+  it("returns the same reference when clearing with no pins present", () => {
+    const attributes: PlacementAttributeType[] = [{ id: "r1", key: "region", value: "us-west" }];
+
+    expect(withGpuInterconnectFabric(attributes, undefined)).toBe(attributes);
+    expect(withGpuInterconnectFabric(undefined, undefined)).toBeUndefined();
+  });
+
+  it("normalizes an imported false pin to a single true pin", () => {
+    const attributes: PlacementAttributeType[] = [{ id: "f1", key: `${GPU_INTERCONNECT_FABRIC_PREFIX}infiniband`, value: "false" }];
+
+    expect(withGpuInterconnectFabric(attributes, "infiniband")).toEqual([
+      { id: expect.any(String), key: `${GPU_INTERCONNECT_FABRIC_PREFIX}infiniband`, value: "true" }
+    ]);
+  });
+});
+
 describe(hasOtherInterconnectService.name, () => {
   it("finds a same-placement sibling that opts in", () => {
     const services = [service("p1"), service("p1", {})];
@@ -81,8 +155,41 @@ describe(hasOtherInterconnectService.name, () => {
 
     expect(hasOtherInterconnectService(services, 0)).toBe(false);
   });
-
-  function service(placementId: string, interconnect?: { group?: string }): Pick<ServiceType, "placementId" | "profile"> {
-    return { placementId, profile: { cpu: 0.1, ram: 512, ramUnit: "Mi", storage: [], interconnect } };
-  }
 });
+
+describe(hasMixedInterconnectGroupForms.name, () => {
+  it("is false when the service itself does not opt in", () => {
+    const services = [service("p1"), service("p1", { group: "pair0" })];
+
+    expect(hasMixedInterconnectGroupForms(services, 0)).toBe(false);
+  });
+
+  it("is false when every opted-in service on the placement uses the implicit form", () => {
+    const services = [service("p1", {}), service("p1", {})];
+
+    expect(hasMixedInterconnectGroupForms(services, 0)).toBe(false);
+  });
+
+  it("detects an implicit service next to an explicit same-placement sibling", () => {
+    const services = [service("p1", {}), service("p1", { group: "pair0" })];
+
+    expect(hasMixedInterconnectGroupForms(services, 0)).toBe(true);
+    expect(hasMixedInterconnectGroupForms(services, 1)).toBe(true);
+  });
+
+  it("ignores a differently-formed service on another placement", () => {
+    const services = [service("p1", {}), service("p2", { group: "pair0" })];
+
+    expect(hasMixedInterconnectGroupForms(services, 0)).toBe(false);
+  });
+
+  it("allows two different explicit groups on one placement", () => {
+    const services = [service("p1", { group: "pair0" }), service("p1", { group: "pair1" })];
+
+    expect(hasMixedInterconnectGroupForms(services, 0)).toBe(false);
+  });
+});
+
+function service(placementId: string, interconnect?: { group?: string }): Pick<ServiceType, "placementId" | "profile"> {
+  return { placementId, profile: { cpu: 0.1, ram: 512, ramUnit: "Mi", storage: [], interconnect } };
+}

--- a/apps/deploy-web/src/utils/sdl/gpuInterconnect.ts
+++ b/apps/deploy-web/src/utils/sdl/gpuInterconnect.ts
@@ -16,6 +16,8 @@ export const GPU_INTERCONNECT_CAPABILITY_KEY = "capabilities/gpu-interconnect";
 /** Prefix of the optional fabric-pin attributes (e.g. `.../fabric/infiniband`) that only make sense alongside the capability itself. */
 export const GPU_INTERCONNECT_FABRIC_PREFIX = "capabilities/gpu-interconnect/fabric/";
 
+export type GpuInterconnectFabric = "infiniband" | "roce";
+
 /**
  * Upserts the interconnect capability to `"true"`. An existing row is updated in
  * place (an imported `"false"` must not survive an explicit opt-in) rather than
@@ -44,8 +46,56 @@ export function withoutGpuInterconnectCapability(attributes: PlacementAttributeT
   return remaining.length === attributes.length ? attributes : remaining;
 }
 
+/** The placement's pinned fabric, if any known one is pinned. Extra or unknown pins are ignored rather than surfaced. */
+export function getGpuInterconnectFabric(attributes: PlacementAttributeType[] | undefined): GpuInterconnectFabric | undefined {
+  const pin = attributes?.find(attribute => attribute.key.startsWith(GPU_INTERCONNECT_FABRIC_PREFIX) && attribute.value === "true");
+  const fabric = pin?.key.slice(GPU_INTERCONNECT_FABRIC_PREFIX.length);
+  return fabric === "infiniband" || fabric === "roce" ? fabric : undefined;
+}
+
+/**
+ * Pins the placement to a single fabric, replacing any existing pins, or removes every pin when
+ * `fabric` is undefined (= the provider chooses). Returns the SAME reference on a no-op so callers
+ * can skip dirtying the form.
+ */
+export function withGpuInterconnectFabric(
+  attributes: PlacementAttributeType[] | undefined,
+  fabric: GpuInterconnectFabric | undefined
+): PlacementAttributeType[] | undefined {
+  const rows = attributes ?? [];
+  const pins = rows.filter(attribute => attribute.key.startsWith(GPU_INTERCONNECT_FABRIC_PREFIX));
+  const desiredKey = fabric ? `${GPU_INTERCONNECT_FABRIC_PREFIX}${fabric}` : undefined;
+
+  const alreadyExact = desiredKey ? pins.length === 1 && pins[0].key === desiredKey && pins[0].value === "true" : pins.length === 0;
+  if (alreadyExact) return attributes;
+
+  const withoutPins = rows.filter(attribute => !attribute.key.startsWith(GPU_INTERCONNECT_FABRIC_PREFIX));
+  return desiredKey ? [...withoutPins, { id: nanoid(), key: desiredKey, value: "true" }] : withoutPins;
+}
+
 /** True when any service other than `selfIndex` on the same placement still opts into the interconnect. */
 export function hasOtherInterconnectService(services: Pick<ServiceType, "placementId" | "profile">[], selfIndex: number): boolean {
   const placementId = services[selfIndex]?.placementId;
   return services.some((service, index) => index !== selfIndex && service.placementId === placementId && !!service.profile?.interconnect);
+}
+
+/**
+ * True when this service and another opted-in service on the same placement use different opt-in
+ * forms — implicit (`{}`) vs explicit (`{ group }`). The SDL parser rejects mixing the two forms
+ * within one placement, so the card warns before the deploy-time error. Different explicit names
+ * are fine (they are simply separate groups).
+ */
+export function hasMixedInterconnectGroupForms(services: Pick<ServiceType, "placementId" | "profile">[], selfIndex: number): boolean {
+  const self = services[selfIndex];
+  const selfInterconnect = self?.profile?.interconnect;
+  if (!selfInterconnect) return false;
+
+  const selfIsExplicit = selfInterconnect.group !== undefined;
+  return services.some(
+    (service, index) =>
+      index !== selfIndex &&
+      service.placementId === self.placementId &&
+      !!service.profile?.interconnect &&
+      (service.profile.interconnect.group !== undefined) !== selfIsExplicit
+  );
 }


### PR DESCRIPTION
## Why

Closes CON-692

Power users running multiple independent interconnect groups, or needing a specific fabric (InfiniBand vs RoCE), need finer control than the simple on/off toggle. They can already express this in raw SDL; this brings it into the builder.

Stacked on #3565 (both change `GpuInterconnectCard`); the base is `feat/deployment-gpu-interconnect-trial-gate` and this PR should be rebased onto main once that one merges.

## What


https://github.com/user-attachments/assets/6ef6c8b8-6fd9-4172-a215-c6f73ebf5ff8



- The GPU interconnect card body (while enabled) gains the advanced controls:
  - **Interconnect group** input: empty = the implicit "auto" group (emits `interconnect: []`); a name emits `interconnect: { group: <name> }`. The UI never emits `{ group: "" }`. Typing the reserved name `auto` shows an inline warning (the SDL validator also rejects it server-side with the same guidance).
  - **Fabric** radio (Any / InfiniBand / RoCE): pins `capabilities/gpu-interconnect/fabric/<fabric>: "true"` on the placement via new `withGpuInterconnectFabric` / `getGpuInterconnectFabric` helpers; "Any" removes the pin and leaves the choice to the provider. The pin is per-placement and shared by sibling services (noted in the UI).
  - An inline warning when services on one placement mix implicit and explicit opt-in forms, which the SDL parser rejects at deploy time (new `hasMixedInterconnectGroupForms` helper).
- Both controls are disabled while the pane is locked or the wallet is trial-blocked.
- SDL generation/import already round-trips the group and the fabric pin generically, so the resulting SDL matches the equivalent hand-written configuration (covered by existing `sdlGenerator`/`sdlImport` specs).