### PR TITLE
fix(alert): stop false unsaved-changes prompt when closing a deployment

### DIFF
--- a/apps/deploy-web/src/components/alerts/DeploymentAlertsContainer/DeploymentAlertsContainer.tsx
+++ b/apps/deploy-web/src/components/alerts/DeploymentAlertsContainer/DeploymentAlertsContainer.tsx
@@ -35,6 +35,7 @@ export type ChildrenProps = {
   data?: DeploymentAlertsOutput;
   upsert: (input: ContainerInput) => Promise<DeploymentAlertsOutput | undefined>;
   isLoading: boolean;
+  isSaving: boolean;
   isFetched: boolean;
   isError: boolean;
   maxBalanceThreshold: number;
@@ -122,6 +123,7 @@ export const DeploymentAlertsContainer: FC<Props> = ({ children, deployment }) =
         data: output,
         upsert,
         isLoading,
+        isSaving: mutation.isPending,
         isFetched,
         isError,
         maxBalanceThreshold

--- a/apps/deploy-web/src/components/deployments/DeploymentAlerts/DeploymentAlerts.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentAlerts/DeploymentAlerts.spec.tsx
@@ -63,6 +63,22 @@ describe("DeploymentAlerts", () => {
     });
   });
 
+  it("saves an unrelated edit after the escrow balance drops below the mounted threshold", async () => {
+    const { componentProps, rerender } = setup({ data: undefined, maxBalanceThreshold: 1000 });
+
+    rerender({ maxBalanceThreshold: 100 });
+
+    fireEvent.click(screen.getByLabelText("Enabled", { selector: '[name="deploymentClosed.enabled"]' }));
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+    });
+
+    expect(componentProps.upsert).toHaveBeenCalledWith({
+      alerts: { deploymentClosed: expect.objectContaining({ enabled: true }) }
+    });
+  });
+
   it("does not flag unsaved changes when the escrow balance drops on close", () => {
     const { componentProps, rerender } = setup({ data: undefined, maxBalanceThreshold: 1000 });
 

--- a/apps/deploy-web/src/components/deployments/DeploymentAlerts/DeploymentAlerts.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentAlerts/DeploymentAlerts.spec.tsx
@@ -132,6 +132,19 @@ describe("DeploymentAlerts", () => {
     expect((screen.getByRole("button", { name: /save changes/i }) as HTMLButtonElement).disabled).toBe(true);
   });
 
+  it("blocks saving an enabled balance alert with no notification channel", async () => {
+    const { componentProps } = setup({ data: undefined });
+
+    fireEvent.click(screen.getByLabelText("Enabled", { selector: '[name="deploymentBalance.enabled"]' }));
+    fireEvent.change(screen.getByRole("combobox", { name: /escrow balance notification channel/i }), { target: { value: "" } });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+    });
+
+    expect(componentProps.upsert).not.toHaveBeenCalled();
+  });
+
   function setup(input: { data?: ChildrenProps["data"]; maxBalanceThreshold?: number; disabled?: boolean; isSaving?: boolean } = {}) {
     const channel1Id = faker.string.uuid();
     const channel2Id = faker.string.uuid();
@@ -156,6 +169,7 @@ describe("DeploymentAlerts", () => {
           <div>
             <input type="checkbox" {...register("deploymentBalance.enabled")} aria-label="Enabled" disabled={disabled} />
             <select {...register("deploymentBalance.notificationChannelId")} aria-label="Escrow Balance Notification Channel" disabled={disabled}>
+              <option value="">None</option>
               <option value={channel1Id}>Channel 1</option>
               <option value={channel2Id}>Channel 2</option>
             </select>

--- a/apps/deploy-web/src/components/deployments/DeploymentAlerts/DeploymentAlerts.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentAlerts/DeploymentAlerts.spec.tsx
@@ -79,6 +79,22 @@ describe("DeploymentAlerts", () => {
     });
   });
 
+  it("saves an unrelated edit when a saved threshold now exceeds the dropped balance", async () => {
+    const { componentProps, rerender } = setup({ maxBalanceThreshold: 1000 });
+
+    rerender({ maxBalanceThreshold: 50 });
+
+    fireEvent.click(screen.getByLabelText("Enabled", { selector: '[name="deploymentClosed.enabled"]' }));
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+    });
+
+    expect(componentProps.upsert).toHaveBeenCalledWith({
+      alerts: { deploymentClosed: expect.objectContaining({ enabled: false }) }
+    });
+  });
+
   it("does not flag unsaved changes when the escrow balance drops on close", () => {
     const { componentProps, rerender } = setup({ data: undefined, maxBalanceThreshold: 1000 });
 

--- a/apps/deploy-web/src/components/deployments/DeploymentAlerts/DeploymentAlerts.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentAlerts/DeploymentAlerts.spec.tsx
@@ -92,7 +92,15 @@ describe("DeploymentAlerts", () => {
     expect((screen.getByRole("button", { name: /save changes/i }) as HTMLButtonElement).disabled).toBe(false);
   });
 
-  function setup(input: { data?: ChildrenProps["data"]; maxBalanceThreshold?: number; disabled?: boolean } = {}) {
+  it("disables the save button while a save is in flight", () => {
+    setup({ isSaving: true });
+
+    fireEvent.click(screen.getByLabelText("Enabled", { selector: '[name="deploymentBalance.enabled"]' }));
+
+    expect((screen.getByRole("button", { name: /save changes/i }) as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  function setup(input: { data?: ChildrenProps["data"]; maxBalanceThreshold?: number; disabled?: boolean; isSaving?: boolean } = {}) {
     const channel1Id = faker.string.uuid();
     const channel2Id = faker.string.uuid();
 
@@ -131,6 +139,7 @@ describe("DeploymentAlerts", () => {
       notificationChannels: [buildNotificationChannel({ id: channel1Id }), buildNotificationChannel({ id: channel2Id })],
       upsert: vi.fn(),
       disabled: input.disabled,
+      isSaving: input.isSaving ?? false,
       data:
         "data" in input
           ? input.data

--- a/apps/deploy-web/src/components/deployments/DeploymentAlerts/DeploymentAlerts.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentAlerts/DeploymentAlerts.spec.tsx
@@ -47,6 +47,22 @@ describe("DeploymentAlerts", () => {
     });
   });
 
+  it("only persists the edited section when the escrow balance has drifted", async () => {
+    const { componentProps, rerender } = setup({ data: undefined, maxBalanceThreshold: 1000 });
+
+    rerender({ maxBalanceThreshold: 500 });
+
+    fireEvent.click(screen.getByLabelText("Enabled", { selector: '[name="deploymentClosed.enabled"]' }));
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+    });
+
+    expect(componentProps.upsert).toHaveBeenCalledWith({
+      alerts: { deploymentClosed: expect.objectContaining({ enabled: true }) }
+    });
+  });
+
   it("does not flag unsaved changes when the escrow balance drops on close", () => {
     const { componentProps, rerender } = setup({ data: undefined, maxBalanceThreshold: 1000 });
 

--- a/apps/deploy-web/src/components/deployments/DeploymentAlerts/DeploymentAlerts.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentAlerts/DeploymentAlerts.spec.tsx
@@ -47,7 +47,36 @@ describe("DeploymentAlerts", () => {
     });
   });
 
-  function setup() {
+  it("does not flag unsaved changes when the escrow balance drops on close", () => {
+    const { componentProps, rerender } = setup({ data: undefined, maxBalanceThreshold: 1000 });
+
+    rerender({ maxBalanceThreshold: 0, disabled: true });
+
+    expect(componentProps.onStateChange).not.toHaveBeenCalledWith({ hasChanges: true });
+  });
+
+  it("stops flagging unsaved changes once the deployment is closed", () => {
+    const { componentProps, rerender } = setup({ data: undefined });
+
+    fireEvent.click(screen.getByLabelText("Enabled", { selector: '[name="deploymentBalance.enabled"]' }));
+    expect(componentProps.onStateChange).toHaveBeenCalledWith({ hasChanges: true });
+
+    rerender({ disabled: true });
+
+    expect(componentProps.onStateChange).toHaveBeenLastCalledWith({ hasChanges: false });
+  });
+
+  it("keeps the save button disabled until a field changes", () => {
+    setup();
+
+    expect((screen.getByRole("button", { name: /save changes/i }) as HTMLButtonElement).disabled).toBe(true);
+
+    fireEvent.click(screen.getByLabelText("Enabled", { selector: '[name="deploymentBalance.enabled"]' }));
+
+    expect((screen.getByRole("button", { name: /save changes/i }) as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  function setup(input: { data?: ChildrenProps["data"]; maxBalanceThreshold?: number; disabled?: boolean } = {}) {
     const channel1Id = faker.string.uuid();
     const channel2Id = faker.string.uuid();
 
@@ -81,34 +110,48 @@ describe("DeploymentAlerts", () => {
     };
 
     const componentProps: Omit<ChildrenProps & DeploymentAlertsViewProps, "deployment"> = {
-      maxBalanceThreshold: 1000,
+      maxBalanceThreshold: input.maxBalanceThreshold ?? 1000,
       onStateChange: vi.fn(),
       notificationChannels: [buildNotificationChannel({ id: channel1Id }), buildNotificationChannel({ id: channel2Id })],
       upsert: vi.fn(),
-      data: buildDeploymentAlert({
-        alerts: {
-          deploymentBalance: {
-            id: faker.string.uuid(),
-            status: "NORMAL",
-            notificationChannelId: channel1Id,
-            threshold: 100,
-            enabled: true
-          },
-          deploymentClosed: {
-            id: faker.string.uuid(),
-            status: "NORMAL",
-            notificationChannelId: channel2Id,
-            enabled: true
-          }
-        }
-      }),
+      disabled: input.disabled,
+      data:
+        "data" in input
+          ? input.data
+          : buildDeploymentAlert({
+              alerts: {
+                deploymentBalance: {
+                  id: faker.string.uuid(),
+                  status: "NORMAL",
+                  notificationChannelId: channel1Id,
+                  threshold: 100,
+                  enabled: true
+                },
+                deploymentClosed: {
+                  id: faker.string.uuid(),
+                  status: "NORMAL",
+                  notificationChannelId: channel2Id,
+                  enabled: true
+                }
+              }
+            }),
       isFetched: true,
       isLoading: false,
       isError: false
     };
 
-    render(<DeploymentAlertsView {...componentProps} dependencies={DEPENDENCIES} />);
+    const view = render(<DeploymentAlertsView {...componentProps} dependencies={DEPENDENCIES} />);
 
-    return { componentProps };
+    const rerender = (next: { maxBalanceThreshold?: number; disabled?: boolean }) =>
+      view.rerender(
+        <DeploymentAlertsView
+          {...componentProps}
+          maxBalanceThreshold={next.maxBalanceThreshold ?? componentProps.maxBalanceThreshold}
+          disabled={next.disabled ?? componentProps.disabled}
+          dependencies={DEPENDENCIES}
+        />
+      );
+
+    return { componentProps, rerender };
   }
 });

--- a/apps/deploy-web/src/components/deployments/DeploymentAlerts/DeploymentAlerts.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentAlerts/DeploymentAlerts.spec.tsx
@@ -145,6 +145,22 @@ describe("DeploymentAlerts", () => {
     expect(componentProps.upsert).not.toHaveBeenCalled();
   });
 
+  it("saves a balance-alert toggle without re-validating an untouched stale threshold", async () => {
+    const { componentProps, rerender } = setup({ maxBalanceThreshold: 1000 });
+
+    rerender({ maxBalanceThreshold: 50 });
+
+    fireEvent.click(screen.getByLabelText("Enabled", { selector: '[name="deploymentBalance.enabled"]' }));
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+    });
+
+    expect(componentProps.upsert).toHaveBeenCalledWith({
+      alerts: { deploymentBalance: expect.objectContaining({ enabled: false, threshold: 100 }) }
+    });
+  });
+
   function setup(input: { data?: ChildrenProps["data"]; maxBalanceThreshold?: number; disabled?: boolean; isSaving?: boolean } = {}) {
     const channel1Id = faker.string.uuid();
     const channel2Id = faker.string.uuid();

--- a/apps/deploy-web/src/components/deployments/DeploymentAlerts/DeploymentAlerts.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentAlerts/DeploymentAlerts.tsx
@@ -73,12 +73,12 @@ export const DeploymentAlertsView: FC<ChildrenProps & Props> = ({
   dependencies: d = DEPENDENCIES
 }) => {
   const isDeploymentClosedEnabled = d.useFlag("ui_deployment_closed_alert");
-  const isBalanceSectionDirty = useRef(false);
+  const isThresholdDirty = useRef(false);
   const strictSchema = useMemo(() => {
     return schema.extend({
       deploymentBalance: schema.shape.deploymentBalance.extend({
         threshold: schema.shape.deploymentBalance.shape.threshold.refine(
-          value => !isBalanceSectionDirty.current || value <= maxBalanceThreshold,
+          value => !isThresholdDirty.current || value <= maxBalanceThreshold,
           "Threshold must be less than or equal to the current balance"
         )
       })
@@ -118,8 +118,8 @@ export const DeploymentAlertsView: FC<ChildrenProps & Props> = ({
   const { isDirty, dirtyFields } = form.formState;
 
   useEffect(() => {
-    isBalanceSectionDirty.current = !!dirtyFields.deploymentBalance;
-  }, [dirtyFields.deploymentBalance]);
+    isThresholdDirty.current = !!dirtyFields.deploymentBalance?.threshold;
+  }, [dirtyFields.deploymentBalance?.threshold]);
 
   useEffect(() => {
     onStateChange?.({ hasChanges: !disabled && isDirty });

--- a/apps/deploy-web/src/components/deployments/DeploymentAlerts/DeploymentAlerts.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentAlerts/DeploymentAlerts.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type FC, useCallback, useEffect, useMemo, useState } from "react";
+import { type FC, useCallback, useEffect, useMemo } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { LoadingButton } from "@akashnetwork/ui/components";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -111,22 +111,14 @@ export const DeploymentAlertsView: FC<ChildrenProps & Props> = ({
     resolver: zodResolver(strictSchema)
   });
 
-  const [hasChanges, setHasChanges] = useState(false);
-  const values = form.watch();
+  const { isDirty } = form.formState;
 
   useEffect(() => {
-    if (!onStateChange) {
-      return;
-    }
-    const hasChangesNext = !isEqual(providedValues, values);
-    if (hasChanges !== hasChangesNext) {
-      setHasChanges(hasChangesNext);
-      onStateChange({ hasChanges: hasChangesNext });
-    }
-  }, [providedValues, onStateChange, values, hasChanges]);
+    onStateChange?.({ hasChanges: !disabled && isDirty });
+  }, [isDirty, disabled, onStateChange]);
 
   const submit = useCallback(async () => {
-    const { deploymentBalance, deploymentClosed } = values;
+    const { deploymentBalance, deploymentClosed } = form.getValues();
     const payload: Partial<FullAlertsInput> = {};
 
     if (!isEqual(providedValues.deploymentBalance, deploymentBalance)) {
@@ -141,7 +133,7 @@ export const DeploymentAlertsView: FC<ChildrenProps & Props> = ({
     if (nextValues) {
       form.reset(assignDefaults(nextValues.alerts));
     }
-  }, [values, providedValues.deploymentBalance, providedValues.deploymentClosed, upsert, form, assignDefaults]);
+  }, [providedValues.deploymentBalance, providedValues.deploymentClosed, upsert, form, assignDefaults]);
 
   return (
     <FormProvider {...form}>
@@ -149,7 +141,7 @@ export const DeploymentAlertsView: FC<ChildrenProps & Props> = ({
         <div className="my-6 flex items-center text-xl font-semibold">
           <h3 className="mr-6">Configure Alerts</h3>
           {!disabled && (
-            <LoadingButton type="submit" loading={isLoading} disabled={!hasChanges} size="sm">
+            <LoadingButton type="submit" loading={isLoading} disabled={!isDirty} size="sm">
               Save Changes
             </LoadingButton>
           )}

--- a/apps/deploy-web/src/components/deployments/DeploymentAlerts/DeploymentAlerts.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentAlerts/DeploymentAlerts.tsx
@@ -117,6 +117,13 @@ export const DeploymentAlertsView: FC<ChildrenProps & Props> = ({
     onStateChange?.({ hasChanges: !disabled && isDirty });
   }, [isDirty, disabled, onStateChange]);
 
+  useEffect(() => {
+    if (!dirtyFields.deploymentBalance?.threshold) {
+      form.resetField("deploymentBalance.threshold", { defaultValue: providedValues.deploymentBalance.threshold });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [providedValues.deploymentBalance.threshold]);
+
   const submit = useCallback(async () => {
     const { deploymentBalance, deploymentClosed } = form.getValues();
     const payload: Partial<FullAlertsInput> = {};

--- a/apps/deploy-web/src/components/deployments/DeploymentAlerts/DeploymentAlerts.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentAlerts/DeploymentAlerts.tsx
@@ -76,11 +76,11 @@ export const DeploymentAlertsView: FC<ChildrenProps & Props> = ({
   const isBalanceSectionDirty = useRef(false);
   const strictSchema = useMemo(() => {
     return schema.extend({
-      deploymentBalance: z.object({
-        threshold: z
-          .number()
-          .min(0, "Threshold must be greater than 0")
-          .refine(value => !isBalanceSectionDirty.current || value <= maxBalanceThreshold, "Threshold must be less than or equal to the current balance")
+      deploymentBalance: schema.shape.deploymentBalance.extend({
+        threshold: schema.shape.deploymentBalance.shape.threshold.refine(
+          value => !isBalanceSectionDirty.current || value <= maxBalanceThreshold,
+          "Threshold must be less than or equal to the current balance"
+        )
       })
     });
   }, [maxBalanceThreshold]);

--- a/apps/deploy-web/src/components/deployments/DeploymentAlerts/DeploymentAlerts.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentAlerts/DeploymentAlerts.tsx
@@ -63,6 +63,7 @@ const DEFAULT_VALUES = {
 
 export const DeploymentAlertsView: FC<ChildrenProps & Props> = ({
   isLoading,
+  isSaving,
   data,
   upsert,
   maxBalanceThreshold,
@@ -140,7 +141,7 @@ export const DeploymentAlertsView: FC<ChildrenProps & Props> = ({
         <div className="my-6 flex items-center text-xl font-semibold">
           <h3 className="mr-6">Configure Alerts</h3>
           {!disabled && (
-            <LoadingButton type="submit" loading={isLoading} disabled={!isDirty} size="sm">
+            <LoadingButton type="submit" loading={isSaving} disabled={!isDirty || isSaving} size="sm">
               Save Changes
             </LoadingButton>
           )}

--- a/apps/deploy-web/src/components/deployments/DeploymentAlerts/DeploymentAlerts.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentAlerts/DeploymentAlerts.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type FC, useCallback, useEffect, useMemo } from "react";
+import { type FC, useCallback, useEffect, useMemo, useRef } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { LoadingButton } from "@akashnetwork/ui/components";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -73,10 +73,14 @@ export const DeploymentAlertsView: FC<ChildrenProps & Props> = ({
   dependencies: d = DEPENDENCIES
 }) => {
   const isDeploymentClosedEnabled = d.useFlag("ui_deployment_closed_alert");
+  const isBalanceSectionDirty = useRef(false);
   const strictSchema = useMemo(() => {
     return schema.extend({
       deploymentBalance: z.object({
-        threshold: z.number().max(maxBalanceThreshold, "Threshold must be less than or equal to the current balance").min(0, "Threshold must be greater than 0")
+        threshold: z
+          .number()
+          .min(0, "Threshold must be greater than 0")
+          .refine(value => !isBalanceSectionDirty.current || value <= maxBalanceThreshold, "Threshold must be less than or equal to the current balance")
       })
     });
   }, [maxBalanceThreshold]);
@@ -114,15 +118,12 @@ export const DeploymentAlertsView: FC<ChildrenProps & Props> = ({
   const { isDirty, dirtyFields } = form.formState;
 
   useEffect(() => {
-    onStateChange?.({ hasChanges: !disabled && isDirty });
-  }, [isDirty, disabled, onStateChange]);
+    isBalanceSectionDirty.current = !!dirtyFields.deploymentBalance;
+  }, [dirtyFields.deploymentBalance]);
 
   useEffect(() => {
-    if (!dirtyFields.deploymentBalance?.threshold) {
-      form.resetField("deploymentBalance.threshold", { defaultValue: providedValues.deploymentBalance.threshold });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [providedValues.deploymentBalance.threshold]);
+    onStateChange?.({ hasChanges: !disabled && isDirty });
+  }, [isDirty, disabled, onStateChange]);
 
   const submit = useCallback(async () => {
     const { deploymentBalance, deploymentClosed } = form.getValues();

--- a/apps/deploy-web/src/components/deployments/DeploymentAlerts/DeploymentAlerts.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentAlerts/DeploymentAlerts.tsx
@@ -5,7 +5,6 @@ import { FormProvider, useForm } from "react-hook-form";
 import { LoadingButton } from "@akashnetwork/ui/components";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { merge } from "lodash";
-import isEqual from "lodash/isEqual";
 import { z } from "zod";
 
 import type {
@@ -111,7 +110,7 @@ export const DeploymentAlertsView: FC<ChildrenProps & Props> = ({
     resolver: zodResolver(strictSchema)
   });
 
-  const { isDirty } = form.formState;
+  const { isDirty, dirtyFields } = form.formState;
 
   useEffect(() => {
     onStateChange?.({ hasChanges: !disabled && isDirty });
@@ -121,11 +120,11 @@ export const DeploymentAlertsView: FC<ChildrenProps & Props> = ({
     const { deploymentBalance, deploymentClosed } = form.getValues();
     const payload: Partial<FullAlertsInput> = {};
 
-    if (!isEqual(providedValues.deploymentBalance, deploymentBalance)) {
+    if (dirtyFields.deploymentBalance) {
       payload.deploymentBalance = deploymentBalance;
     }
 
-    if (!isEqual(providedValues.deploymentClosed, deploymentClosed)) {
+    if (dirtyFields.deploymentClosed) {
       payload.deploymentClosed = deploymentClosed;
     }
 
@@ -133,7 +132,7 @@ export const DeploymentAlertsView: FC<ChildrenProps & Props> = ({
     if (nextValues) {
       form.reset(assignDefaults(nextValues.alerts));
     }
-  }, [providedValues.deploymentBalance, providedValues.deploymentClosed, upsert, form, assignDefaults]);
+  }, [dirtyFields.deploymentBalance, dirtyFields.deploymentClosed, form, upsert, assignDefaults]);
 
   return (
     <FormProvider {...form}>

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail.tsx
@@ -20,7 +20,6 @@ import { useDeclaredTeeTypes } from "@src/hooks/useDeclaredTeeTypes";
 import { useFlag } from "@src/hooks/useFlag";
 import { useNavigationGuard } from "@src/hooks/useNavigationGuard/useNavigationGuard";
 import { useUser } from "@src/hooks/useUser";
-import { useWhen } from "@src/hooks/useWhen";
 import { useDeploymentDetail } from "@src/queries/useDeploymentQuery";
 import { useDeploymentLeaseList } from "@src/queries/useLeaseQuery";
 import { useProviderList } from "@src/queries/useProvidersQuery";
@@ -212,10 +211,6 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = ({ dseq }) => {
     enabled: isAlertsEnabled && !!badgedTabs.ALERTS,
     message: "You have unsaved alert configuration changes that will be lost. Would you like to continue?",
     skipWhen: params => params.to.startsWith(`/deployments/${dseq}`)
-  });
-
-  useWhen(deployment?.state !== "active", () => {
-    setBadgedTabs({});
   });
 
   return (


### PR DESCRIPTION
## Why

Closing a deployment showed a red "modified" dot on the Alerts tab and popped a "You have unsaved alert configuration changes that will be lost" dialog on navigation, even when the user never touched any alert setting.

Root cause: the alerts form computed its dirty state by comparing the live form values against a baseline (`providedValues`) that is recomputed from `deployment.escrowBalance` (it seeds the default balance threshold via `maxBalanceThreshold`). Closing a deployment refetches the deployment and drops the escrow balance, so the baseline shifted while the form values stayed pinned at mount, flipping the comparison to "changed" with zero user interaction. The earlier `useWhen(state !== "active", ...)` band-aid only partially masked this and lost a race.

## What

- `DeploymentAlerts.tsx`: use react-hook-form's own `formState.isDirty` (compared against the mount / last-saved baseline) instead of the hand-rolled `!isEqual(providedValues, values)`, and report `hasChanges: !disabled && isDirty` so a closed deployment never badges the tab or arms the navigation guard. The Save button now keys off `isDirty`.
- `DeploymentDetail.tsx`: remove the now-redundant racy `useWhen` band-aid (and its unused import).
- Tests: added a regression test (escrow drop on close no longer reports changes), a suppression test (closing clears a prior unsaved edit), and a Save-enablement test. The two regression tests were confirmed to fail on the pre-fix code.

An **active** deployment with genuine unsaved edits still badges the tab and still prompts on navigation, so the feature is preserved.

Verification: `test:unit` 4/4 green, `lint --quiet` clean, `tsc --noEmit` shows 0 new errors vs the `origin/main` baseline (180 == 180).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment alert settings so only modified sections are saved.
  * Prevented disabled alerts from incorrectly showing unsaved changes.
  * Updated threshold validation to apply appropriately when balance settings are edited.
  * Prevented saving when no notification channel is selected.
  * Corrected Save button behavior to reflect edits and saving progress.
  * Improved alert state handling when thresholds or deployment status change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->