### PR TITLE
feat(deployment): show a gpu interconnect indicator on deployment views

### DIFF
--- a/apps/deploy-web/src/components/deployments/DeploymentDetail.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail.tsx
@@ -16,6 +16,7 @@ import { DeploymentAlerts } from "@src/components/deployments/DeploymentAlerts/D
 import { useServices } from "@src/context/ServicesProvider";
 import { useSettings } from "@src/context/SettingsProvider";
 import { useWallet } from "@src/context/WalletProvider";
+import { useDeclaredGpuInterconnect } from "@src/hooks/useDeclaredGpuInterconnect";
 import { useDeclaredTeeTypes } from "@src/hooks/useDeclaredTeeTypes";
 import { useFlag } from "@src/hooks/useFlag";
 import { useNavigationGuard } from "@src/hooks/useNavigationGuard/useNavigationGuard";
@@ -111,6 +112,7 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = ({ dseq }) => {
 
   const isActive = deployment?.state === "active" && leases?.some(isLeaseLive);
   const declaredTeeTypes = useDeclaredTeeTypes(deployment);
+  const declaredInterconnect = useDeclaredGpuInterconnect(deployment);
 
   const tabs = useMemo(() => {
     const tabs: { label: string; value: Tab; badged?: boolean }[] = [
@@ -250,7 +252,7 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = ({ dseq }) => {
         <>
           <ReclamationBanner leases={leases} dseq={dseq} />
 
-          <DeploymentSubHeader deployment={deployment} leases={leases} teeTypes={declaredTeeTypes} />
+          <DeploymentSubHeader deployment={deployment} leases={leases} teeTypes={declaredTeeTypes} interconnect={declaredInterconnect} />
 
           <Tabs value={activeTab} onValueChange={value => changeTab(value as Tab)}>
             <TabsList

--- a/apps/deploy-web/src/components/deployments/DeploymentListRow.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentListRow.tsx
@@ -25,6 +25,7 @@ import { useRouter } from "next/navigation";
 import { useLocalNotes } from "@src/components/LocalNoteManager";
 import { useServices } from "@src/context/ServicesProvider";
 import { useWallet } from "@src/context/WalletProvider";
+import { useDeclaredGpuInterconnect } from "@src/hooks/useDeclaredGpuInterconnect";
 import { useDepositDeployment } from "@src/hooks/useDepositDeployment/useDepositDeployment";
 import { useManagedDeploymentConfirm } from "@src/hooks/useManagedDeploymentConfirm";
 import { useProviderCredentials } from "@src/hooks/useProviderCredentials/useProviderCredentials";
@@ -42,6 +43,7 @@ import { UrlService } from "@src/utils/urlUtils";
 import { TrialDeploymentBadge } from "../shared";
 import { CopyTextToClipboardButton } from "../shared/CopyTextToClipboardButton";
 import { CustomDropdownLinkItem } from "../shared/CustomDropdownLinkItem";
+import { GpuInterconnectBadge } from "../shared/GpuInterconnectBadge";
 import { PriceEstimateTooltip } from "../shared/PriceEstimateTooltip";
 import { PricePerTimeUnit } from "../shared/PricePerTimeUnit";
 import { PriceValue } from "../shared/PriceValue";
@@ -81,6 +83,7 @@ export const DeploymentListRow: React.FunctionComponent<Props> = ({ deployment, 
   const reclaimDeadline = reclaimingLease ? getReclamationDeadline(reclaimingLease) : null;
   const closedReasonLabel = closedLease ? getClosedLeaseLabel(closedLease) : null;
   const hasGpu = Boolean(deployment.gpuAmount && deployment.gpuAmount > 0);
+  const interconnect = useDeclaredGpuInterconnect(deployment);
   const timeLeft = getTimeLeft(deploymentCost || 0, deployment.escrowBalance);
   const realTimeLeft = useRealTimeLeft(
     deploymentCost || 0,
@@ -192,6 +195,12 @@ export const DeploymentListRow: React.FunctionComponent<Props> = ({ deployment, 
         </TableCell>
         <TableCell className="max-w-[100px] text-center">
           <DeploymentName deployment={deployment} deploymentServices={leaseStatus?.services} providerHostUri={provider?.hostUri} />
+
+          {interconnect.enabled && (
+            <div className="mt-2 flex justify-center">
+              <GpuInterconnectBadge interconnect={interconnect} compact />
+            </div>
+          )}
 
           {isTrialing && (
             <div className="mt-2">

--- a/apps/deploy-web/src/components/deployments/DeploymentSubHeader.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentSubHeader.tsx
@@ -7,6 +7,7 @@ import { WarningCircle } from "iconoir-react";
 
 import { ConfidentialComputeBadge } from "@src/components/shared/ConfidentialComputeBadge";
 import { CopyTextToClipboardButton } from "@src/components/shared/CopyTextToClipboardButton";
+import { GpuInterconnectBadge } from "@src/components/shared/GpuInterconnectBadge";
 import { LabelValue } from "@src/components/shared/LabelValue";
 import { PricePerTimeUnit } from "@src/components/shared/PricePerTimeUnit";
 import { PriceValue } from "@src/components/shared/PriceValue";
@@ -18,6 +19,7 @@ import { useDeploymentMetrics } from "@src/hooks/useDeploymentMetrics";
 import { useTrialDeploymentTimeRemaining } from "@src/hooks/useTrialDeploymentTimeRemaining";
 import type { DeploymentDto, LeaseDto } from "@src/types/deployment";
 import type { TeeType } from "@src/utils/confidentialCompute";
+import type { DeclaredGpuInterconnect } from "@src/utils/gpuInterconnect";
 import { udenomToDenom } from "@src/utils/mathHelpers";
 import { isLeaseLive } from "@src/utils/reclamationUtils";
 
@@ -25,10 +27,11 @@ type Props = {
   deployment: DeploymentDto;
   leases: LeaseDto[] | undefined | null;
   teeTypes?: TeeType[];
+  interconnect?: DeclaredGpuInterconnect;
   children?: ReactNode;
 };
 
-export const DeploymentSubHeader: React.FunctionComponent<Props> = ({ deployment, leases, teeTypes = [] }) => {
+export const DeploymentSubHeader: React.FunctionComponent<Props> = ({ deployment, leases, teeTypes = [], interconnect = { enabled: false, fabrics: [] } }) => {
   const { deploymentCost, realTimeLeft } = useDeploymentMetrics({ deployment, leases });
   const isActive = deployment.state === "active";
   const hasLeases = !!leases && leases.length > 0;
@@ -104,6 +107,8 @@ export const DeploymentSubHeader: React.FunctionComponent<Props> = ({ deployment
               <StatusPill state={deployment.state} size="small" />
 
               <ConfidentialComputeBadge teeTypes={teeTypes} />
+
+              <GpuInterconnectBadge interconnect={interconnect} />
 
               {isTrialing && <TrialDeploymentBadge createdHeight={deployment.createdAt} />}
             </div>

--- a/apps/deploy-web/src/components/shared/GpuInterconnectBadge.spec.tsx
+++ b/apps/deploy-web/src/components/shared/GpuInterconnectBadge.spec.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { describe, expect, it } from "vitest";
+
+import type { DeclaredGpuInterconnect } from "@src/utils/gpuInterconnect";
+import { DEPENDENCIES, GpuInterconnectBadge } from "./GpuInterconnectBadge";
+
+import { render, screen } from "@testing-library/react";
+import { MockComponents } from "@tests/unit/mocks";
+
+const TitleRenderingTooltip = ({ title, children }: { title: React.ReactNode; children?: React.ReactNode }) => (
+  <>
+    {title}
+    {children}
+  </>
+);
+
+describe(GpuInterconnectBadge.name, () => {
+  it("renders the bare label and explains interconnect when no fabric is pinned", () => {
+    setup({ interconnect: { enabled: true, fabrics: [] }, dependencies: { CustomTooltip: TitleRenderingTooltip } });
+    expect(screen.getByText("GPU Interconnect")).toBeInTheDocument();
+    expect(screen.getByText(/high-bandwidth, low-latency RDMA/i)).toBeInTheDocument();
+    expect(screen.getByText("Fabric: chosen by the provider.")).toBeInTheDocument();
+  });
+
+  it("reflects a single pinned fabric in the label", () => {
+    setup({ interconnect: { enabled: true, fabrics: ["infiniband"] }, dependencies: { CustomTooltip: TitleRenderingTooltip } });
+    expect(screen.getByText("GPU Interconnect (InfiniBand)")).toBeInTheDocument();
+    expect(screen.getByText("Fabric: InfiniBand.")).toBeInTheDocument();
+  });
+
+  it("keeps a bare label and lists multiple pinned fabrics in the tooltip", () => {
+    setup({ interconnect: { enabled: true, fabrics: ["infiniband", "roce"] }, dependencies: { CustomTooltip: TitleRenderingTooltip } });
+    expect(screen.getByText("GPU Interconnect")).toBeInTheDocument();
+    expect(screen.getByText("Fabrics: InfiniBand, RoCE.")).toBeInTheDocument();
+  });
+
+  it("shows a short label in compact mode and the full label in the tooltip", () => {
+    setup({ interconnect: { enabled: true, fabrics: ["infiniband"] }, compact: true, dependencies: { CustomTooltip: TitleRenderingTooltip } });
+    expect(screen.getByText("Interconnect")).toBeInTheDocument();
+    expect(screen.getByText("GPU Interconnect (InfiniBand)")).toBeInTheDocument();
+  });
+
+  it("renders nothing when interconnect is not enabled", () => {
+    setup({ interconnect: { enabled: false, fabrics: [] } });
+    expect(screen.queryByText(/Interconnect/)).not.toBeInTheDocument();
+  });
+
+  function setup(input: { interconnect: DeclaredGpuInterconnect; compact?: boolean; dependencies?: Partial<typeof DEPENDENCIES> }) {
+    return render(
+      <GpuInterconnectBadge interconnect={input.interconnect} compact={input.compact} dependencies={MockComponents(DEPENDENCIES, input.dependencies)} />
+    );
+  }
+});

--- a/apps/deploy-web/src/components/shared/GpuInterconnectBadge.tsx
+++ b/apps/deploy-web/src/components/shared/GpuInterconnectBadge.tsx
@@ -1,0 +1,68 @@
+"use client";
+import * as React from "react";
+import { Badge, CustomTooltip } from "@akashnetwork/ui/components";
+import { cn } from "@akashnetwork/ui/utils";
+import { Info, Waypoints } from "lucide-react";
+
+import type { DeclaredGpuInterconnect } from "@src/utils/gpuInterconnect";
+import { formatGpuInterconnectFabricLabel } from "@src/utils/gpuInterconnect";
+
+export type Props = {
+  interconnect: DeclaredGpuInterconnect;
+  /** Icon-forward chip for the narrow list-row name cell; the full label lives in the tooltip. */
+  compact?: boolean;
+  className?: string;
+  dependencies?: typeof DEPENDENCIES;
+};
+
+export const DEPENDENCIES = {
+  Badge,
+  CustomTooltip
+};
+
+function getFullLabel(fabrics: string[]): string {
+  return fabrics.length === 1 ? `GPU Interconnect (${formatGpuInterconnectFabricLabel(fabrics[0])})` : "GPU Interconnect";
+}
+
+function getFabricSummary(fabrics: string[]): string {
+  if (fabrics.length === 0) return "Fabric: chosen by the provider.";
+  const labels = fabrics.map(formatGpuInterconnectFabricLabel).join(", ");
+  return fabrics.length === 1 ? `Fabric: ${labels}.` : `Fabrics: ${labels}.`;
+}
+
+export function GpuInterconnectBadge({ interconnect, compact = false, className, dependencies: d = DEPENDENCIES }: Props) {
+  if (!interconnect.enabled) return null;
+
+  const fullLabel = getFullLabel(interconnect.fabrics);
+
+  return (
+    <d.CustomTooltip
+      title={
+        <div className="max-w-xs space-y-2 text-sm">
+          {compact && <p>{fullLabel}</p>}
+          <p>
+            One or more services in this deployment use GPU interconnect — high-bandwidth, low-latency RDMA between nodes (over InfiniBand or RoCE) for
+            distributed GPU workloads such as multi-node NCCL training.
+          </p>
+          <p>{getFabricSummary(interconnect.fabrics)}</p>
+        </div>
+      }
+    >
+      <div className="inline-flex items-center gap-1">
+        <d.Badge variant="secondary" className={cn("inline-flex cursor-help items-center gap-1", className)}>
+          {compact ? (
+            <>
+              <Waypoints className="h-3 w-3" />
+              <span>Interconnect</span>
+            </>
+          ) : (
+            <>
+              <span>{fullLabel}</span>
+              <Info className="h-3 w-3" />
+            </>
+          )}
+        </d.Badge>
+      </div>
+    </d.CustomTooltip>
+  );
+}

--- a/apps/deploy-web/src/hooks/useDeclaredGpuInterconnect.spec.ts
+++ b/apps/deploy-web/src/hooks/useDeclaredGpuInterconnect.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { DeploymentDto } from "@src/types/deployment";
+import { useDeclaredGpuInterconnect } from "./useDeclaredGpuInterconnect";
+
+import { renderHook } from "@testing-library/react";
+import { buildRpcDeployment } from "@tests/seeders";
+
+describe(useDeclaredGpuInterconnect.name, () => {
+  it("reports the interconnect opt-in and pinned fabrics from the deployment's on-chain groups", () => {
+    const groups = buildRpcDeployment({
+      groups: [
+        {
+          group_spec: {
+            requirements: {
+              attributes: [
+                { key: "capabilities/gpu-interconnect", value: "true" },
+                { key: "capabilities/gpu-interconnect/fabric/infiniband", value: "true" }
+              ]
+            }
+          }
+        }
+      ]
+    }).groups;
+    const { result } = setup({ deployment: mock<DeploymentDto>({ groups }) });
+    expect(result.current).toEqual({ enabled: true, fabrics: ["infiniband"] });
+  });
+
+  it("returns a disabled result when the deployment is not loaded", () => {
+    const { result } = setup({ deployment: undefined });
+    expect(result.current).toEqual({ enabled: false, fabrics: [] });
+  });
+
+  function setup(input: { deployment: DeploymentDto | undefined }) {
+    return renderHook(() => useDeclaredGpuInterconnect(input.deployment));
+  }
+});

--- a/apps/deploy-web/src/hooks/useDeclaredGpuInterconnect.ts
+++ b/apps/deploy-web/src/hooks/useDeclaredGpuInterconnect.ts
@@ -1,0 +1,10 @@
+import { useMemo } from "react";
+
+import type { DeploymentDto } from "@src/types/deployment";
+import type { DeclaredGpuInterconnect } from "@src/utils/gpuInterconnect";
+import { getDeclaredGpuInterconnect } from "@src/utils/gpuInterconnect";
+
+/** GPU interconnect opt-in (and any pinned fabrics) declared on the deployment's on-chain groups. */
+export function useDeclaredGpuInterconnect(deployment: DeploymentDto | undefined | null): DeclaredGpuInterconnect {
+  return useMemo(() => getDeclaredGpuInterconnect(deployment?.groups), [deployment?.groups]);
+}

--- a/apps/deploy-web/src/utils/gpuInterconnect.spec.ts
+++ b/apps/deploy-web/src/utils/gpuInterconnect.spec.ts
@@ -1,0 +1,109 @@
+import type { QueryInput as DeepPartial } from "@akashnetwork/chain-sdk";
+import { describe, expect, it } from "vitest";
+
+import type { DeploymentGroup } from "@src/types/deployment";
+import { formatGpuInterconnectFabricLabel, getDeclaredGpuInterconnect, getGroupGpuInterconnect } from "./gpuInterconnect";
+
+import { buildRpcDeployment } from "@tests/seeders";
+
+const CAPABILITY_KEY = "capabilities/gpu-interconnect";
+const FABRIC_PREFIX = "capabilities/gpu-interconnect/fabric/";
+
+/** Builds a single on-chain deployment group, seeded with realistic defaults and the given overrides. */
+function buildGroup(spec?: DeepPartial<DeploymentGroup>): DeploymentGroup {
+  return buildRpcDeployment(spec ? { groups: [spec] } : undefined).groups[0];
+}
+
+/** Builds a group whose on-chain placement requirements carry the given attributes. */
+function buildGroupWithAttributes(attributes: { key: string; value: string }[]): DeploymentGroup {
+  return buildGroup({ group_spec: { requirements: { attributes } } });
+}
+
+describe(getGroupGpuInterconnect.name, () => {
+  it("marks a group with the interconnect capability as enabled", () => {
+    const group = buildGroupWithAttributes([{ key: CAPABILITY_KEY, value: "true" }]);
+    expect(getGroupGpuInterconnect(group)).toEqual({ enabled: true, fabric: undefined });
+  });
+
+  it("captures the pinned fabric slug alongside the capability", () => {
+    const group = buildGroupWithAttributes([
+      { key: CAPABILITY_KEY, value: "true" },
+      { key: `${FABRIC_PREFIX}infiniband`, value: "true" }
+    ]);
+    expect(getGroupGpuInterconnect(group)).toEqual({ enabled: true, fabric: "infiniband" });
+  });
+
+  it('treats a non-"true" capability value as not enabled', () => {
+    const group = buildGroupWithAttributes([{ key: CAPABILITY_KEY, value: "false" }]);
+    expect(getGroupGpuInterconnect(group)).toEqual({ enabled: false });
+  });
+
+  it("returns not enabled when the capability attribute is absent", () => {
+    const group = buildGroupWithAttributes([{ key: "region", value: "us-west" }]);
+    expect(getGroupGpuInterconnect(group)).toEqual({ enabled: false });
+  });
+
+  it("ignores an orphaned fabric pin left without the base capability", () => {
+    const group = buildGroupWithAttributes([{ key: `${FABRIC_PREFIX}roce`, value: "true" }]);
+    expect(getGroupGpuInterconnect(group)).toEqual({ enabled: false });
+  });
+
+  it("ignores an empty fabric slug", () => {
+    const group = buildGroupWithAttributes([
+      { key: CAPABILITY_KEY, value: "true" },
+      { key: FABRIC_PREFIX, value: "true" }
+    ]);
+    expect(getGroupGpuInterconnect(group)).toEqual({ enabled: true, fabric: undefined });
+  });
+
+  it("returns not enabled for a missing or malformed group", () => {
+    expect(getGroupGpuInterconnect(undefined)).toEqual({ enabled: false });
+    expect(getGroupGpuInterconnect(null)).toEqual({ enabled: false });
+  });
+});
+
+describe(getDeclaredGpuInterconnect.name, () => {
+  it("returns disabled with no fabrics when the group list is missing", () => {
+    expect(getDeclaredGpuInterconnect(undefined)).toEqual({ enabled: false, fabrics: [] });
+    expect(getDeclaredGpuInterconnect(null)).toEqual({ enabled: false, fabrics: [] });
+  });
+
+  it("returns enabled with no fabrics when a group opts in without pinning a fabric", () => {
+    const groups = [buildGroupWithAttributes([{ key: CAPABILITY_KEY, value: "true" }])];
+    expect(getDeclaredGpuInterconnect(groups)).toEqual({ enabled: true, fabrics: [] });
+  });
+
+  it("collects the distinct pinned fabrics across all enabled groups", () => {
+    const groups = [
+      buildGroupWithAttributes([
+        { key: CAPABILITY_KEY, value: "true" },
+        { key: `${FABRIC_PREFIX}infiniband`, value: "true" }
+      ]),
+      buildGroupWithAttributes([
+        { key: CAPABILITY_KEY, value: "true" },
+        { key: `${FABRIC_PREFIX}roce`, value: "true" }
+      ]),
+      buildGroupWithAttributes([
+        { key: CAPABILITY_KEY, value: "true" },
+        { key: `${FABRIC_PREFIX}infiniband`, value: "true" }
+      ])
+    ];
+    expect(getDeclaredGpuInterconnect(groups)).toEqual({ enabled: true, fabrics: ["infiniband", "roce"] });
+  });
+
+  it("stays enabled when only some groups opt in", () => {
+    const groups = [buildGroupWithAttributes([{ key: "region", value: "us-west" }]), buildGroupWithAttributes([{ key: CAPABILITY_KEY, value: "true" }])];
+    expect(getDeclaredGpuInterconnect(groups)).toEqual({ enabled: true, fabrics: [] });
+  });
+});
+
+describe(formatGpuInterconnectFabricLabel.name, () => {
+  it("maps known fabric slugs to their display names", () => {
+    expect(formatGpuInterconnectFabricLabel("infiniband")).toBe("InfiniBand");
+    expect(formatGpuInterconnectFabricLabel("roce")).toBe("RoCE");
+  });
+
+  it("title-cases an unknown fabric slug", () => {
+    expect(formatGpuInterconnectFabricLabel("custom")).toBe("Custom");
+  });
+});

--- a/apps/deploy-web/src/utils/gpuInterconnect.spec.ts
+++ b/apps/deploy-web/src/utils/gpuInterconnect.spec.ts
@@ -56,6 +56,24 @@ describe(getGroupGpuInterconnect.name, () => {
     expect(getGroupGpuInterconnect(group)).toEqual({ enabled: true, fabric: undefined });
   });
 
+  it("skips an empty fabric suffix and selects a later valid fabric pin", () => {
+    const group = buildGroupWithAttributes([
+      { key: CAPABILITY_KEY, value: "true" },
+      { key: FABRIC_PREFIX, value: "true" },
+      { key: `${FABRIC_PREFIX}infiniband`, value: "true" }
+    ]);
+    expect(getGroupGpuInterconnect(group)).toEqual({ enabled: true, fabric: "infiniband" });
+  });
+
+  it("ignores a non-string attribute key without throwing", () => {
+    const attributes = [
+      { key: CAPABILITY_KEY, value: "true" },
+      { key: 123, value: "true" }
+    ] as unknown as { key: string; value: string }[];
+    const group = buildGroupWithAttributes(attributes);
+    expect(getGroupGpuInterconnect(group)).toEqual({ enabled: true, fabric: undefined });
+  });
+
   it("returns not enabled for a missing or malformed group", () => {
     expect(getGroupGpuInterconnect(undefined)).toEqual({ enabled: false });
     expect(getGroupGpuInterconnect(null)).toEqual({ enabled: false });

--- a/apps/deploy-web/src/utils/gpuInterconnect.ts
+++ b/apps/deploy-web/src/utils/gpuInterconnect.ts
@@ -51,7 +51,13 @@ export function getGroupGpuInterconnect(group: DeploymentGroup | undefined | nul
   const enabled = attributes.some(attribute => attribute?.key === GPU_INTERCONNECT_CAPABILITY_KEY && attribute?.value === ENABLED_VALUE);
   if (!enabled) return { enabled: false };
 
-  const fabricAttribute = attributes.find(attribute => attribute?.key?.startsWith(GPU_INTERCONNECT_FABRIC_PREFIX) && attribute?.value === ENABLED_VALUE);
+  const fabricAttribute = attributes.find(
+    attribute =>
+      typeof attribute?.key === "string" &&
+      attribute.key.startsWith(GPU_INTERCONNECT_FABRIC_PREFIX) &&
+      attribute.key.length > GPU_INTERCONNECT_FABRIC_PREFIX.length &&
+      attribute.value === ENABLED_VALUE
+  );
   const fabric = fabricAttribute?.key.slice(GPU_INTERCONNECT_FABRIC_PREFIX.length) || undefined;
 
   return { enabled: true, fabric };

--- a/apps/deploy-web/src/utils/gpuInterconnect.ts
+++ b/apps/deploy-web/src/utils/gpuInterconnect.ts
@@ -1,0 +1,78 @@
+import type { DeploymentGroup } from "@src/types/deployment";
+import { GPU_INTERCONNECT_CAPABILITY_KEY, GPU_INTERCONNECT_FABRIC_PREFIX } from "@src/utils/sdl/gpuInterconnect";
+
+/**
+ * GPU interconnect helpers for the deployment detail and list views.
+ *
+ * Interconnect is an on-chain group placement requirement: `group_spec.requirements.attributes` carries
+ * `capabilities/gpu-interconnect: "true"` (so only interconnect-capable providers can bid/match) plus an
+ * optional pinned-fabric attribute `capabilities/gpu-interconnect/fabric/<fabric>: "true"`. It is therefore
+ * authoritative and available for every deployment without the stored SDL manifest, mirroring the
+ * Confidential Compute (`tee/type`) read path in `confidentialCompute.ts`.
+ *
+ * This is the read side; the builder-side write helpers in `utils/sdl/gpuInterconnect.ts` operate on
+ * form-state placement attributes instead. (A future dedup with the fabric helpers in PR #3566 is possible
+ * once that lands.)
+ */
+
+export interface DeclaredGpuInterconnect {
+  enabled: boolean;
+  /** Pinned fabric slugs (e.g. "infiniband", "roce"); empty when the provider is left to choose. */
+  fabrics: string[];
+}
+
+const ENABLED_VALUE = "true";
+
+/** Known interconnect fabric display names; unknown slugs fall back to a title-cased slug. */
+const FABRIC_LABELS: Record<string, string> = {
+  infiniband: "InfiniBand",
+  roce: "RoCE"
+};
+
+/** Human-readable label for a pinned fabric slug. */
+export function formatGpuInterconnectFabricLabel(slug: string): string {
+  return FABRIC_LABELS[slug] ?? slug.charAt(0).toUpperCase() + slug.slice(1);
+}
+
+interface GroupGpuInterconnect {
+  enabled: boolean;
+  fabric?: string;
+}
+
+/**
+ * Reads a single group's interconnect opt-in from its on-chain placement requirements. Returns the pinned
+ * fabric only when the base capability is present — an orphaned fabric pin (capability removed but a pin left
+ * behind) is ignored, matching how the builder strips both together. Never throws on missing/malformed input.
+ */
+export function getGroupGpuInterconnect(group: DeploymentGroup | undefined | null): GroupGpuInterconnect {
+  const attributes = group?.group_spec?.requirements?.attributes;
+  if (!Array.isArray(attributes)) return { enabled: false };
+
+  const enabled = attributes.some(attribute => attribute?.key === GPU_INTERCONNECT_CAPABILITY_KEY && attribute?.value === ENABLED_VALUE);
+  if (!enabled) return { enabled: false };
+
+  const fabricAttribute = attributes.find(attribute => attribute?.key?.startsWith(GPU_INTERCONNECT_FABRIC_PREFIX) && attribute?.value === ENABLED_VALUE);
+  const fabric = fabricAttribute?.key.slice(GPU_INTERCONNECT_FABRIC_PREFIX.length) || undefined;
+
+  return { enabled: true, fabric };
+}
+
+/**
+ * Aggregates interconnect across all of a deployment's groups: enabled when any group opts in, with the
+ * distinct set of pinned fabrics in first-seen order. Never throws — a missing or malformed group list yields
+ * a disabled result so the deployment view stays intact.
+ */
+export function getDeclaredGpuInterconnect(groups: DeploymentGroup[] | undefined | null): DeclaredGpuInterconnect {
+  let enabled = false;
+  const fabrics = new Set<string>();
+
+  if (Array.isArray(groups)) {
+    for (const group of groups) {
+      const { enabled: groupEnabled, fabric } = getGroupGpuInterconnect(group);
+      if (groupEnabled) enabled = true;
+      if (fabric) fabrics.add(fabric);
+    }
+  }
+
+  return { enabled, fabrics: [...fabrics] };
+}


### PR DESCRIPTION
## Why

Once a deployment is running, users should be able to see at a glance that GPU interconnect is active — the same way we already surface confidential compute (TEE). This reads from authoritative on-chain deployment data, so no stored SDL is required.

Closes CON-691

## What

Surfaces a **GPU interconnect indicator** on the deployment **detail** and **list** views when the deployment's on-chain group requirements include the interconnect capability, reflecting the pinned fabric when present.

Mirrors the existing Confidential Compute read pattern (pure reader → thin hook → DI-injected badge rendered next to `ConfidentialComputeBadge`):

- **`utils/gpuInterconnect.ts`** — reads the on-chain placement requirement `capabilities/gpu-interconnect: "true"` from `group_spec.requirements.attributes` (the same array the TEE badge reads for `tee/type`) and derives the pinned fabric from any `capabilities/gpu-interconnect/fabric/<fabric>` pin. Reuses the constants already defined in `utils/sdl/gpuInterconnect.ts`; ignores orphan fabric pins; never throws on missing/malformed data.
- **`hooks/useDeclaredGpuInterconnect.ts`** — memoized wrapper over the deployment's groups.
- **`components/shared/GpuInterconnectBadge.tsx`** — one badge, two forms: full-text (`GPU Interconnect (InfiniBand)`) on the detail view, and a compact icon + tooltip chip on the narrow list-row name cell. Fabric shown when pinned (InfiniBand/RoCE), otherwise provider-chosen.

**Behavior**
- A deployment that opted into interconnect shows the indicator on its detail and list views.
- The fabric is reflected when pinned.
- Non-interconnect deployments show nothing.

**Notes**
- Ungated (no feature flag), matching the `ConfidentialComputeBadge` precedent and the authoritative-on-chain rationale — it also catches raw-SDL interconnect deployments.
- No query/DTO changes: both views already carry `groups` through the shared `deploymentToDto` mapper.
- The fabric-write UI (CON-692) isn't on `main` yet, but the reader already handles pinned fabrics produced by a hand-written/raw interconnect SDL.

**Tests**: unit specs for the reader, hook, and badge (all label/fabric/compact/disabled variants, malformed-input safety), driven off realistically seeded on-chain groups.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added GPU interconnect indicators to deployment list rows and detail views.
  - Displays supported interconnect types and selected fabrics through compact badges and tooltips.
  - Handles deployments with unavailable or incomplete interconnect information safely.

- **Tests**
  - Added coverage for interconnect detection, fabric labels, aggregation, malformed data, and badge display states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->