### PR TITLE
feat(onboarding): track choose-provider click in auto-deploy flow

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/AutoDeployFlow/AutoDeployFlow.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/AutoDeployFlow/AutoDeployFlow.spec.tsx
@@ -73,6 +73,15 @@ describe(AutoDeployFlow.name, () => {
     expect(setBidStrategy).toHaveBeenCalledWith("select");
   });
 
+  it("tracks the choose-provider click with the template name when the user switches to manual selection", () => {
+    const flow = mock<DeploymentFlow>({ actions: mock<DeploymentFlow["actions"]>({ setBidStrategy: vi.fn() }) });
+    const { sceneProps, analyticsService } = setup({ flow, templateName: "my-app" });
+
+    sceneProps().onChooseProvider?.();
+
+    expect(analyticsService.track).toHaveBeenCalledWith("onboarding_choose_provider_click", { category: "onboarding", templateName: "my-app" });
+  });
+
   it("opens the configured contact-support URL when the scene requests support", () => {
     const open = vi.spyOn(window, "open").mockImplementation(() => null);
     const { sceneProps } = setup({ contactSupportUrl: "https://support.example" });
@@ -112,9 +121,11 @@ describe(AutoDeployFlow.name, () => {
   ) {
     const PhasedDeployProgressScene = input.dependencies?.PhasedDeployProgressScene ?? vi.fn(ComponentMock);
     const useAutoDeploymentFlow: typeof DEPENDENCIES.useAutoDeploymentFlow = input.useAutoDeploymentFlow ?? (() => buildAutopilot(input.autopilot));
+    const analyticsService = mock<ReturnType<typeof DEPENDENCIES.useServices>["analyticsService"]>();
     const useServices: typeof DEPENDENCIES.useServices = () =>
       mock<ReturnType<typeof DEPENDENCIES.useServices>>({
-        publicConfig: { NEXT_PUBLIC_CONTACT_SUPPORT_URL: input.contactSupportUrl ?? CONTACT_SUPPORT_URL }
+        publicConfig: { NEXT_PUBLIC_CONTACT_SUPPORT_URL: input.contactSupportUrl ?? CONTACT_SUPPORT_URL },
+        analyticsService
       });
 
     render(
@@ -133,6 +144,6 @@ describe(AutoDeployFlow.name, () => {
       />
     );
 
-    return { sceneProps: () => (PhasedDeployProgressScene as ReturnType<typeof vi.fn>).mock.calls[0][0] as SceneProps };
+    return { analyticsService, sceneProps: () => (PhasedDeployProgressScene as ReturnType<typeof vi.fn>).mock.calls[0][0] as SceneProps };
   }
 });

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/AutoDeployFlow/AutoDeployFlow.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/AutoDeployFlow/AutoDeployFlow.tsx
@@ -41,7 +41,7 @@ type Props = {
  * by that flow's built-in redirect.
  */
 export const AutoDeployFlow: FC<Props> = ({ templateName, sdl, resume, flow, dependencies: d = DEPENDENCIES }) => {
-  const { publicConfig } = d.useServices();
+  const { publicConfig, analyticsService } = d.useServices();
   const { state, progressPercent, phases, matchedProviderAddress, tryAgain, stopAutopilot } = d.useAutoDeploymentFlow({
     sdl,
     resumeLeases: resume.activeLeases,
@@ -61,6 +61,7 @@ export const AutoDeployFlow: FC<Props> = ({ templateName, sdl, resume, flow, dep
           window.open(publicConfig.NEXT_PUBLIC_CONTACT_SUPPORT_URL, "_blank", "noopener,noreferrer");
         }}
         onChooseProvider={() => {
+          analyticsService.track("onboarding_choose_provider_click", { category: "onboarding", templateName });
           // Halt the autopilot before flipping to manual: the bid-strategy change only unmounts this flow once the URL
           // propagates, so stopping here keeps the autopilot from leasing the shared deployment during that window.
           stopAutopilot();

--- a/apps/deploy-web/src/services/analytics/analytics.service.ts
+++ b/apps/deploy-web/src/services/analytics/analytics.service.ts
@@ -111,6 +111,7 @@ export type AnalyticsEvent =
   | "log_collector_disabled"
   | "log_collector_deployed"
   | "onboarding_deploy_click"
+  | "onboarding_choose_provider_click"
   | "onboarding_skipped"
   | "add_credits_opened"
   | "add_credits_amount_selected"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added analytics tracking when users choose a deployment provider during onboarding.
  * Events include the onboarding category and selected template for improved reporting.

* **Tests**
  * Added coverage to verify provider-selection analytics are recorded correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->