### PR TITLE
fix(network): migrate governance proposal queries to gov v1 endpoints

### DIFF
--- a/apps/api/src/proposal/services/proposal/proposal.service.ts
+++ b/apps/api/src/proposal/services/proposal/proposal.service.ts
@@ -62,7 +62,7 @@ export class ProposalService {
         votingEndTime: proposalFromCosmos.voting_end_time ?? UNSET_TIMESTAMP,
         totalDeposit: parseInt(proposalFromCosmos.total_deposit[0]?.amount || "0"),
         tally: { ...tally, total: tally.yes + tally.abstain + tally.no + tally.noWithVeto },
-        paramChanges: proposalFromCosmos.messages
+        paramChanges: (proposalFromCosmos.messages ?? [])
           .filter(message => message["@type"] === MSG_EXEC_LEGACY_CONTENT_TYPE)
           .flatMap(message => message.content?.changes ?? [])
           .map(change => ({

--- a/apps/api/src/proposal/services/proposal/proposal.service.ts
+++ b/apps/api/src/proposal/services/proposal/proposal.service.ts
@@ -4,6 +4,10 @@ import { singleton } from "tsyringe";
 
 import { GetProposalByIdResponse, GetProposalListResponse } from "@src/proposal/http-schemas/proposal.schema";
 
+/** gov v1 renders unset voting times as null; the retired v1beta1 endpoint emitted this zero value, which the public API contract keeps. */
+const UNSET_TIMESTAMP = "0001-01-01T00:00:00Z";
+const MSG_EXEC_LEGACY_CONTENT_TYPE = "/cosmos.gov.v1.MsgExecLegacyContent";
+
 @singleton()
 export class ProposalService {
   constructor(private readonly cosmosHttpService: CosmosHttpService) {}
@@ -11,12 +15,12 @@ export class ProposalService {
   async getProposals(): Promise<GetProposalListResponse> {
     const proposalsFromCosmos = await this.cosmosHttpService.getProposals();
     const proposals = proposalsFromCosmos.map(x => ({
-      id: parseInt(x.proposal_id),
-      title: x.content.title,
+      id: parseInt(x.id),
+      title: x.title,
       status: x.status,
       submitTime: x.submit_time,
-      votingStartTime: x.voting_start_time,
-      votingEndTime: x.voting_end_time,
+      votingStartTime: x.voting_start_time ?? UNSET_TIMESTAMP,
+      votingEndTime: x.voting_end_time ?? UNSET_TIMESTAMP,
       totalDeposit: parseInt(x.total_deposit[0]?.amount || "0")
     }));
 
@@ -34,35 +38,38 @@ export class ProposalService {
         const tallyFromCosmos = await this.cosmosHttpService.getProposalTally(id);
 
         tally = {
-          yes: parseInt(tallyFromCosmos.yes) || 0,
-          abstain: parseInt(tallyFromCosmos.abstain) || 0,
-          no: parseInt(tallyFromCosmos.no) || 0,
-          noWithVeto: parseInt(tallyFromCosmos.no_with_veto) || 0
+          yes: parseInt(tallyFromCosmos.yes_count) || 0,
+          abstain: parseInt(tallyFromCosmos.abstain_count) || 0,
+          no: parseInt(tallyFromCosmos.no_count) || 0,
+          noWithVeto: parseInt(tallyFromCosmos.no_with_veto_count) || 0
         };
       } else {
         tally = {
-          yes: parseInt(proposalFromCosmos.final_tally_result?.yes || "0") || 0,
-          abstain: parseInt(proposalFromCosmos.final_tally_result?.abstain || "0") || 0,
-          no: parseInt(proposalFromCosmos.final_tally_result?.no || "0") || 0,
-          noWithVeto: parseInt(proposalFromCosmos.final_tally_result?.no_with_veto || "0") || 0
+          yes: parseInt(proposalFromCosmos.final_tally_result?.yes_count || "0") || 0,
+          abstain: parseInt(proposalFromCosmos.final_tally_result?.abstain_count || "0") || 0,
+          no: parseInt(proposalFromCosmos.final_tally_result?.no_count || "0") || 0,
+          noWithVeto: parseInt(proposalFromCosmos.final_tally_result?.no_with_veto_count || "0") || 0
         };
       }
 
       return {
-        id: parseInt(proposalFromCosmos.proposal_id),
-        title: proposalFromCosmos.content.title,
-        description: proposalFromCosmos.content.description,
+        id: parseInt(proposalFromCosmos.id),
+        title: proposalFromCosmos.title,
+        description: proposalFromCosmos.summary,
         status: proposalFromCosmos.status,
         submitTime: proposalFromCosmos.submit_time,
-        votingStartTime: proposalFromCosmos.voting_start_time,
-        votingEndTime: proposalFromCosmos.voting_end_time,
+        votingStartTime: proposalFromCosmos.voting_start_time ?? UNSET_TIMESTAMP,
+        votingEndTime: proposalFromCosmos.voting_end_time ?? UNSET_TIMESTAMP,
         totalDeposit: parseInt(proposalFromCosmos.total_deposit[0]?.amount || "0"),
         tally: { ...tally, total: tally.yes + tally.abstain + tally.no + tally.noWithVeto },
-        paramChanges: (proposalFromCosmos.content.changes || []).map(change => ({
-          subspace: change.subspace,
-          key: change.key,
-          value: JSON.parse(change.value)
-        }))
+        paramChanges: proposalFromCosmos.messages
+          .filter(message => message["@type"] === MSG_EXEC_LEGACY_CONTENT_TYPE)
+          .flatMap(message => message.content?.changes ?? [])
+          .map(change => ({
+            subspace: change.subspace,
+            key: change.key,
+            value: JSON.parse(change.value)
+          }))
       };
     } catch (err) {
       if (axios.isAxiosError(err) && err.response?.status === 404) {

--- a/apps/api/src/proposal/services/proposal/proposal.service.ts
+++ b/apps/api/src/proposal/services/proposal/proposal.service.ts
@@ -21,7 +21,7 @@ export class ProposalService {
       submitTime: x.submit_time,
       votingStartTime: x.voting_start_time ?? UNSET_TIMESTAMP,
       votingEndTime: x.voting_end_time ?? UNSET_TIMESTAMP,
-      totalDeposit: parseInt(x.total_deposit[0]?.amount || "0")
+      totalDeposit: parseInt(x.total_deposit?.[0]?.amount || "0")
     }));
 
     const sortedProposals = proposals.sort((a, b) => b.id - a.id);
@@ -60,7 +60,7 @@ export class ProposalService {
         submitTime: proposalFromCosmos.submit_time,
         votingStartTime: proposalFromCosmos.voting_start_time ?? UNSET_TIMESTAMP,
         votingEndTime: proposalFromCosmos.voting_end_time ?? UNSET_TIMESTAMP,
-        totalDeposit: parseInt(proposalFromCosmos.total_deposit[0]?.amount || "0"),
+        totalDeposit: parseInt(proposalFromCosmos.total_deposit?.[0]?.amount || "0"),
         tally: { ...tally, total: tally.yes + tally.abstain + tally.no + tally.noWithVeto },
         paramChanges: (proposalFromCosmos.messages ?? [])
           .filter(message => message["@type"] === MSG_EXEC_LEGACY_CONTENT_TYPE)

--- a/apps/api/test/functional/proposals.spec.ts
+++ b/apps/api/test/functional/proposals.spec.ts
@@ -21,6 +21,15 @@ describe("Proposals", () => {
       expect(response.status).toBe(200);
       expect(data).toEqual([
         {
+          id: 4,
+          title: "PIP Spot and Reservation Revenue Share Proposal",
+          status: "PROPOSAL_STATUS_DEPOSIT_PERIOD",
+          submitTime: "2023-08-05T10:00:00.000000000Z",
+          votingStartTime: "0001-01-01T00:00:00Z",
+          votingEndTime: "0001-01-01T00:00:00Z",
+          totalDeposit: 500000000
+        },
+        {
           id: 3,
           title: "Enable axlUSDC for deployments",
           status: "PROPOSAL_STATUS_PASSED",
@@ -31,8 +40,8 @@ describe("Proposals", () => {
         },
         {
           id: 2,
-          title: "v0.24.0",
-          status: "PROPOSAL_STATUS_PASSED",
+          title: "Akash Inflation & Community Pool Update",
+          status: "PROPOSAL_STATUS_VOTING_PERIOD",
           submitTime: "2023-08-04T09:33:52.911650830Z",
           votingStartTime: "2023-08-04T09:34:14.957738073Z",
           votingEndTime: "2023-08-04T09:44:14.957738073Z",
@@ -52,7 +61,7 @@ describe("Proposals", () => {
   });
 
   describe("GET /v1/proposals/{id}", () => {
-    it("resolves a proposal", async () => {
+    it("resolves a proposal in voting period with tally from the live tally endpoint", async () => {
       setup();
 
       const response = await app.request("/v1/proposals/2");
@@ -61,8 +70,8 @@ describe("Proposals", () => {
       expect(response.status).toBe(200);
       expect(data).toEqual({
         id: 2,
-        title: "v0.24.0",
-        description: "SW upgrade proposal for v0.24.0",
+        title: "Akash Inflation & Community Pool Update",
+        description: "Reduce inflation and fund community pool",
         status: "PROPOSAL_STATUS_VOTING_PERIOD",
         submitTime: "2023-08-04T09:33:52.911650830Z",
         votingStartTime: "2023-08-04T09:34:14.957738073Z",
@@ -74,6 +83,89 @@ describe("Proposals", () => {
           no: 0,
           noWithVeto: 0,
           total: 3000002000000
+        },
+        paramChanges: []
+      });
+    });
+
+    it("resolves a closed legacy proposal with param changes and tally from the final tally result", async () => {
+      setup();
+
+      const response = await app.request("/v1/proposals/3");
+      const data = (await response.json()) as GetProposalByIdResponse;
+
+      expect(response.status).toBe(200);
+      expect(data).toEqual({
+        id: 3,
+        title: "Enable axlUSDC for deployments",
+        description: "Enable axlUSDC for deployments",
+        status: "PROPOSAL_STATUS_PASSED",
+        submitTime: "2023-08-04T11:23:30.716939528Z",
+        votingStartTime: "2023-08-04T11:23:30.716939528Z",
+        votingEndTime: "2023-08-04T11:33:30.716939528Z",
+        totalDeposit: 1010000000,
+        tally: {
+          yes: 3000002000000,
+          abstain: 1000000,
+          no: 2000000,
+          noWithVeto: 0,
+          total: 3000005000000
+        },
+        paramChanges: [
+          {
+            subspace: "take",
+            key: "DenomTakeRates",
+            value: [
+              {
+                denom: "uakt",
+                rate: 0
+              },
+              {
+                denom: "ibc/028CD1864059EEFB48A6048376165318E3E82C234390AE5A6D7B22001725B06E",
+                rate: 20
+              }
+            ]
+          },
+          {
+            subspace: "deployment",
+            key: "MinDeposits",
+            value: [
+              {
+                denom: "uakt",
+                amount: "5000000"
+              },
+              {
+                denom: "ibc/028CD1864059EEFB48A6048376165318E3E82C234390AE5A6D7B22001725B06E",
+                amount: "5000000"
+              }
+            ]
+          }
+        ]
+      });
+    });
+
+    it("resolves a proposal without messages and voting times", async () => {
+      setup();
+
+      const response = await app.request("/v1/proposals/4");
+      const data = (await response.json()) as GetProposalByIdResponse;
+
+      expect(response.status).toBe(200);
+      expect(data).toEqual({
+        id: 4,
+        title: "PIP Spot and Reservation Revenue Share Proposal",
+        description: "Signaling proposal for PIP revenue share",
+        status: "PROPOSAL_STATUS_DEPOSIT_PERIOD",
+        submitTime: "2023-08-05T10:00:00.000000000Z",
+        votingStartTime: "0001-01-01T00:00:00Z",
+        votingEndTime: "0001-01-01T00:00:00Z",
+        totalDeposit: 500000000,
+        tally: {
+          yes: 0,
+          abstain: 0,
+          no: 0,
+          noWithVeto: 0,
+          total: 0
         },
         paramChanges: []
       });
@@ -96,184 +188,217 @@ describe("Proposals", () => {
     });
   });
 
+  const GOV_AUTHORITY = "akash10d07y265gmmuvt4z0w9aw880jnsr700jhe7z0f";
+
+  const softwareUpgradeProposal = {
+    id: "1",
+    messages: [
+      {
+        "@type": "/cosmos.upgrade.v1beta1.MsgSoftwareUpgrade",
+        authority: GOV_AUTHORITY,
+        plan: {
+          name: "v0.24.0",
+          time: "0001-01-01T00:00:00Z",
+          height: "249633",
+          info: "https://raw.githubusercontent.com/akash-network/net/main/sandbox/upgrades/v0.24.0/info.json",
+          upgraded_client_state: null
+        }
+      }
+    ],
+    status: "PROPOSAL_STATUS_FAILED",
+    final_tally_result: {
+      yes_count: "3000002000000",
+      abstain_count: "0",
+      no_count: "0",
+      no_with_veto_count: "0"
+    },
+    submit_time: "2023-08-04T09:22:37.090076750Z",
+    deposit_end_time: "2023-08-04T09:32:37.090076750Z",
+    total_deposit: [
+      {
+        denom: "uakt",
+        amount: "10000000"
+      }
+    ],
+    voting_start_time: "2023-08-04T09:22:53.568959577Z",
+    voting_end_time: "2023-08-04T09:32:53.568959577Z",
+    metadata: "",
+    title: "v0.24.0",
+    summary: "SW upgrade proposal for v0.24.0",
+    proposer: GOV_AUTHORITY
+  };
+
+  const multiMessageProposal = {
+    id: "2",
+    messages: [
+      {
+        "@type": "/cosmos.mint.v1beta1.MsgUpdateParams",
+        authority: GOV_AUTHORITY,
+        params: {
+          inflation_max: "0.13",
+          inflation_min: "0.09"
+        }
+      },
+      {
+        "@type": "/cosmos.distribution.v1beta1.MsgCommunityPoolSpend",
+        authority: GOV_AUTHORITY,
+        recipient: GOV_AUTHORITY,
+        amount: [
+          {
+            denom: "uakt",
+            amount: "5023590000"
+          }
+        ]
+      }
+    ],
+    status: "PROPOSAL_STATUS_VOTING_PERIOD",
+    final_tally_result: {
+      yes_count: "0",
+      abstain_count: "0",
+      no_count: "0",
+      no_with_veto_count: "0"
+    },
+    submit_time: "2023-08-04T09:33:52.911650830Z",
+    deposit_end_time: "2023-08-04T09:43:52.911650830Z",
+    total_deposit: [
+      {
+        denom: "uakt",
+        amount: "10000000"
+      }
+    ],
+    voting_start_time: "2023-08-04T09:34:14.957738073Z",
+    voting_end_time: "2023-08-04T09:44:14.957738073Z",
+    metadata: "",
+    title: "Akash Inflation & Community Pool Update",
+    summary: "Reduce inflation and fund community pool",
+    proposer: GOV_AUTHORITY
+  };
+
+  const legacyParamChangeProposal = {
+    id: "3",
+    messages: [
+      {
+        "@type": "/cosmos.gov.v1.MsgExecLegacyContent",
+        authority: GOV_AUTHORITY,
+        content: {
+          "@type": "/cosmos.params.v1beta1.ParameterChangeProposal",
+          title: "Enable axlUSDC for deployments",
+          description: "Enable axlUSDC for deployments",
+          changes: [
+            {
+              subspace: "take",
+              key: "DenomTakeRates",
+              value: JSON.stringify([
+                {
+                  denom: "uakt",
+                  rate: 0
+                },
+                {
+                  denom: "ibc/028CD1864059EEFB48A6048376165318E3E82C234390AE5A6D7B22001725B06E",
+                  rate: 20
+                }
+              ])
+            },
+            {
+              subspace: "deployment",
+              key: "MinDeposits",
+              value: JSON.stringify([
+                {
+                  denom: "uakt",
+                  amount: "5000000"
+                },
+                {
+                  denom: "ibc/028CD1864059EEFB48A6048376165318E3E82C234390AE5A6D7B22001725B06E",
+                  amount: "5000000"
+                }
+              ])
+            }
+          ]
+        }
+      }
+    ],
+    status: "PROPOSAL_STATUS_PASSED",
+    final_tally_result: {
+      yes_count: "3000002000000",
+      abstain_count: "1000000",
+      no_count: "2000000",
+      no_with_veto_count: "0"
+    },
+    submit_time: "2023-08-04T11:23:30.716939528Z",
+    deposit_end_time: "2023-08-04T11:33:30.716939528Z",
+    total_deposit: [
+      {
+        denom: "uakt",
+        amount: "1010000000"
+      }
+    ],
+    voting_start_time: "2023-08-04T11:23:30.716939528Z",
+    voting_end_time: "2023-08-04T11:33:30.716939528Z",
+    metadata: "",
+    title: "Enable axlUSDC for deployments",
+    summary: "Enable axlUSDC for deployments",
+    proposer: GOV_AUTHORITY
+  };
+
+  const emptyMessagesProposal = {
+    id: "4",
+    messages: [],
+    status: "PROPOSAL_STATUS_DEPOSIT_PERIOD",
+    final_tally_result: {
+      yes_count: "0",
+      abstain_count: "0",
+      no_count: "0",
+      no_with_veto_count: "0"
+    },
+    submit_time: "2023-08-05T10:00:00.000000000Z",
+    deposit_end_time: "2023-08-19T10:00:00.000000000Z",
+    total_deposit: [
+      {
+        denom: "uakt",
+        amount: "500000000"
+      }
+    ],
+    voting_start_time: null,
+    voting_end_time: null,
+    metadata: "",
+    title: "PIP Spot and Reservation Revenue Share Proposal",
+    summary: "Signaling proposal for PIP revenue share",
+    proposer: GOV_AUTHORITY
+  };
+
   const setup = () => {
     nock(container.resolve(CORE_CONFIG).REST_API_NODE_URL)
       .persist()
-      .get("/cosmos/gov/v1beta1/proposals?pagination.limit=1000")
+      .get("/cosmos/gov/v1/proposals?pagination.limit=1000")
       .reply(200, {
-        proposals: [
-          {
-            proposal_id: "1",
-            content: {
-              "@type": "/cosmos.upgrade.v1beta1.SoftwareUpgradeProposal",
-              title: "v0.24.0",
-              description: "SW upgrade proposal for v0.24.0",
-              plan: {
-                name: "v0.24.0",
-                time: "0001-01-01T00:00:00Z",
-                height: "249633",
-                info: "https://raw.githubusercontent.com/akash-network/net/main/sandbox/upgrades/v0.24.0/info.json",
-                upgraded_client_state: null
-              }
-            },
-            status: "PROPOSAL_STATUS_FAILED",
-            final_tally_result: {
-              yes: "3000002000000",
-              abstain: "0",
-              no: "0",
-              no_with_veto: "0"
-            },
-            submit_time: "2023-08-04T09:22:37.090076750Z",
-            deposit_end_time: "2023-08-04T09:32:37.090076750Z",
-            total_deposit: [
-              {
-                denom: "uakt",
-                amount: "10000000"
-              }
-            ],
-            voting_start_time: "2023-08-04T09:22:53.568959577Z",
-            voting_end_time: "2023-08-04T09:32:53.568959577Z"
-          },
-          {
-            proposal_id: "2",
-            content: {
-              "@type": "/cosmos.upgrade.v1beta1.SoftwareUpgradeProposal",
-              title: "v0.24.0",
-              description: "SW upgrade proposal for v0.24.0",
-              plan: {
-                name: "v0.24.0",
-                time: "0001-01-01T00:00:00Z",
-                height: "249826",
-                info: "https://raw.githubusercontent.com/akash-network/net/main/sandbox/upgrades/v0.24.0/info.json",
-                upgraded_client_state: null
-              }
-            },
-            status: "PROPOSAL_STATUS_PASSED",
-            final_tally_result: {
-              yes: "3000002000000",
-              abstain: "0",
-              no: "0",
-              no_with_veto: "0"
-            },
-            submit_time: "2023-08-04T09:33:52.911650830Z",
-            deposit_end_time: "2023-08-04T09:43:52.911650830Z",
-            total_deposit: [
-              {
-                denom: "uakt",
-                amount: "10000000"
-              }
-            ],
-            voting_start_time: "2023-08-04T09:34:14.957738073Z",
-            voting_end_time: "2023-08-04T09:44:14.957738073Z"
-          },
-          {
-            proposal_id: "3",
-            content: {
-              "@type": "/cosmos.params.v1beta1.ParameterChangeProposal",
-              title: "Enable axlUSDC for deployments",
-              description: "Enable axlUSDC for deployments",
-              changes: [
-                {
-                  subspace: "take",
-                  key: "DenomTakeRates",
-                  value: JSON.stringify([
-                    {
-                      denom: "uakt",
-                      rate: 0
-                    },
-                    {
-                      denom: "ibc/028CD1864059EEFB48A6048376165318E3E82C234390AE5A6D7B22001725B06E",
-                      rate: 20
-                    }
-                  ])
-                },
-                {
-                  subspace: "deployment",
-                  key: "MinDeposits",
-                  value: JSON.stringify([
-                    {
-                      denom: "uakt",
-                      amount: "5000000"
-                    },
-                    {
-                      denom: "ibc/028CD1864059EEFB48A6048376165318E3E82C234390AE5A6D7B22001725B06E",
-                      amount: "5000000"
-                    }
-                  ])
-                }
-              ]
-            },
-            status: "PROPOSAL_STATUS_PASSED",
-            final_tally_result: {
-              yes: "3000002000000",
-              abstain: "0",
-              no: "0",
-              no_with_veto: "0"
-            },
-            submit_time: "2023-08-04T11:23:30.716939528Z",
-            deposit_end_time: "2023-08-04T11:33:30.716939528Z",
-            total_deposit: [
-              {
-                denom: "uakt",
-                amount: "1010000000"
-              }
-            ],
-            voting_start_time: "2023-08-04T11:23:30.716939528Z",
-            voting_end_time: "2023-08-04T11:33:30.716939528Z"
-          }
-        ]
-      });
-
-    nock(container.resolve(CORE_CONFIG).REST_API_NODE_URL)
-      .persist()
-      .get("/cosmos/gov/v1beta1/proposals/2")
-      .reply(200, {
-        proposal: {
-          proposal_id: "2",
-          content: {
-            "@type": "/cosmos.upgrade.v1beta1.SoftwareUpgradeProposal",
-            title: "v0.24.0",
-            description: "SW upgrade proposal for v0.24.0",
-            plan: {
-              name: "v0.24.0",
-              time: "0001-01-01T00:00:00Z",
-              height: "249826",
-              info: "https://raw.githubusercontent.com/akash-network/net/main/sandbox/upgrades/v0.24.0/info.json",
-              upgraded_client_state: null
-            }
-          },
-          status: "PROPOSAL_STATUS_VOTING_PERIOD",
-          final_tally_result: {
-            yes: "0",
-            abstain: "0",
-            no: "0",
-            no_with_veto: "0"
-          },
-          submit_time: "2023-08-04T09:33:52.911650830Z",
-          deposit_end_time: "2023-08-04T09:43:52.911650830Z",
-          total_deposit: [
-            {
-              denom: "uakt",
-              amount: "10000000"
-            }
-          ],
-          voting_start_time: "2023-08-04T09:34:14.957738073Z",
-          voting_end_time: "2023-08-04T09:44:14.957738073Z"
+        proposals: [softwareUpgradeProposal, multiMessageProposal, legacyParamChangeProposal, emptyMessagesProposal],
+        pagination: {
+          next_key: null,
+          total: "4"
         }
       });
 
+    nock(container.resolve(CORE_CONFIG).REST_API_NODE_URL).persist().get("/cosmos/gov/v1/proposals/2").reply(200, { proposal: multiMessageProposal });
+
     nock(container.resolve(CORE_CONFIG).REST_API_NODE_URL)
       .persist()
-      .get("/cosmos/gov/v1beta1/proposals/2/tally")
+      .get("/cosmos/gov/v1/proposals/2/tally")
       .reply(200, {
         tally: {
-          yes: "3000002000000",
-          abstain: "0",
-          no: "0",
-          no_with_veto: "0"
+          yes_count: "3000002000000",
+          abstain_count: "0",
+          no_count: "0",
+          no_with_veto_count: "0"
         }
       });
 
-    nock(container.resolve(CORE_CONFIG).REST_API_NODE_URL).persist().get("/cosmos/gov/v1beta1/proposals/999").reply(404);
+    nock(container.resolve(CORE_CONFIG).REST_API_NODE_URL).persist().get("/cosmos/gov/v1/proposals/3").reply(200, { proposal: legacyParamChangeProposal });
+
+    nock(container.resolve(CORE_CONFIG).REST_API_NODE_URL).persist().get("/cosmos/gov/v1/proposals/4").reply(200, { proposal: emptyMessagesProposal });
+
+    nock(container.resolve(CORE_CONFIG).REST_API_NODE_URL)
+      .persist()
+      .get("/cosmos/gov/v1/proposals/999")
+      .reply(404, { code: 5, message: "proposal 999 doesn't exist", details: [] });
   };
 });

--- a/apps/api/test/functional/proposals.spec.ts
+++ b/apps/api/test/functional/proposals.spec.ts
@@ -340,9 +340,9 @@ describe("Proposals", () => {
     proposer: GOV_AUTHORITY
   };
 
-  const emptyMessagesProposal = {
+  /** protojson omits empty repeated fields, so a zero-message proposal arrives without a `messages` key. */
+  const omittedMessagesProposal = {
     id: "4",
-    messages: [],
     status: "PROPOSAL_STATUS_DEPOSIT_PERIOD",
     final_tally_result: {
       yes_count: "0",
@@ -371,7 +371,7 @@ describe("Proposals", () => {
       .persist()
       .get("/cosmos/gov/v1/proposals?pagination.limit=1000")
       .reply(200, {
-        proposals: [softwareUpgradeProposal, multiMessageProposal, legacyParamChangeProposal, emptyMessagesProposal],
+        proposals: [softwareUpgradeProposal, multiMessageProposal, legacyParamChangeProposal, omittedMessagesProposal],
         pagination: {
           next_key: null,
           total: "4"
@@ -394,7 +394,7 @@ describe("Proposals", () => {
 
     nock(container.resolve(CORE_CONFIG).REST_API_NODE_URL).persist().get("/cosmos/gov/v1/proposals/3").reply(200, { proposal: legacyParamChangeProposal });
 
-    nock(container.resolve(CORE_CONFIG).REST_API_NODE_URL).persist().get("/cosmos/gov/v1/proposals/4").reply(200, { proposal: emptyMessagesProposal });
+    nock(container.resolve(CORE_CONFIG).REST_API_NODE_URL).persist().get("/cosmos/gov/v1/proposals/4").reply(200, { proposal: omittedMessagesProposal });
 
     nock(container.resolve(CORE_CONFIG).REST_API_NODE_URL)
       .persist()

--- a/apps/api/test/functional/proposals.spec.ts
+++ b/apps/api/test/functional/proposals.spec.ts
@@ -27,7 +27,7 @@ describe("Proposals", () => {
           submitTime: "2023-08-05T10:00:00.000000000Z",
           votingStartTime: "0001-01-01T00:00:00Z",
           votingEndTime: "0001-01-01T00:00:00Z",
-          totalDeposit: 500000000
+          totalDeposit: 0
         },
         {
           id: 3,
@@ -144,7 +144,7 @@ describe("Proposals", () => {
       });
     });
 
-    it("resolves a proposal without messages and voting times", async () => {
+    it("resolves a proposal without messages, deposit and voting times", async () => {
       setup();
 
       const response = await app.request("/v1/proposals/4");
@@ -159,7 +159,7 @@ describe("Proposals", () => {
         submitTime: "2023-08-05T10:00:00.000000000Z",
         votingStartTime: "0001-01-01T00:00:00Z",
         votingEndTime: "0001-01-01T00:00:00Z",
-        totalDeposit: 500000000,
+        totalDeposit: 0,
         tally: {
           yes: 0,
           abstain: 0,
@@ -340,8 +340,8 @@ describe("Proposals", () => {
     proposer: GOV_AUTHORITY
   };
 
-  /** protojson omits empty repeated fields, so a zero-message proposal arrives without a `messages` key. */
-  const omittedMessagesProposal = {
+  /** protojson omits empty repeated fields, so a zero-message zero-deposit proposal arrives without `messages` and `total_deposit` keys. */
+  const omittedRepeatedFieldsProposal = {
     id: "4",
     status: "PROPOSAL_STATUS_DEPOSIT_PERIOD",
     final_tally_result: {
@@ -352,12 +352,6 @@ describe("Proposals", () => {
     },
     submit_time: "2023-08-05T10:00:00.000000000Z",
     deposit_end_time: "2023-08-19T10:00:00.000000000Z",
-    total_deposit: [
-      {
-        denom: "uakt",
-        amount: "500000000"
-      }
-    ],
     voting_start_time: null,
     voting_end_time: null,
     metadata: "",
@@ -371,7 +365,7 @@ describe("Proposals", () => {
       .persist()
       .get("/cosmos/gov/v1/proposals?pagination.limit=1000")
       .reply(200, {
-        proposals: [softwareUpgradeProposal, multiMessageProposal, legacyParamChangeProposal, omittedMessagesProposal],
+        proposals: [softwareUpgradeProposal, multiMessageProposal, legacyParamChangeProposal, omittedRepeatedFieldsProposal],
         pagination: {
           next_key: null,
           total: "4"
@@ -394,7 +388,7 @@ describe("Proposals", () => {
 
     nock(container.resolve(CORE_CONFIG).REST_API_NODE_URL).persist().get("/cosmos/gov/v1/proposals/3").reply(200, { proposal: legacyParamChangeProposal });
 
-    nock(container.resolve(CORE_CONFIG).REST_API_NODE_URL).persist().get("/cosmos/gov/v1/proposals/4").reply(200, { proposal: omittedMessagesProposal });
+    nock(container.resolve(CORE_CONFIG).REST_API_NODE_URL).persist().get("/cosmos/gov/v1/proposals/4").reply(200, { proposal: omittedRepeatedFieldsProposal });
 
     nock(container.resolve(CORE_CONFIG).REST_API_NODE_URL)
       .persist()

--- a/packages/http-sdk/src/cosmos/cosmos-http.service.spec.ts
+++ b/packages/http-sdk/src/cosmos/cosmos-http.service.spec.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { HttpClient } from "../utils/httpClient";
+import { CosmosHttpService } from "./cosmos-http.service";
+import type { CosmosGovProposal, CosmosGovTallyResult } from "./types";
+
+describe(CosmosHttpService.name, () => {
+  describe("getProposals", () => {
+    it("requests gov v1 proposals and returns them", async () => {
+      const { service, httpClient, proposal } = setup();
+      httpClient.get.mockResolvedValue({
+        data: { proposals: [proposal], pagination: { next_key: null, total: "1" } }
+      });
+
+      const result = await service.getProposals();
+
+      expect(httpClient.get).toHaveBeenCalledWith("/cosmos/gov/v1/proposals?pagination.limit=1000");
+      expect(result).toEqual([proposal]);
+    });
+  });
+
+  describe("getProposal", () => {
+    it("requests a gov v1 proposal by id and returns it", async () => {
+      const { service, httpClient, proposal } = setup();
+      httpClient.get.mockResolvedValue({ data: { proposal } });
+
+      const result = await service.getProposal(42);
+
+      expect(httpClient.get).toHaveBeenCalledWith("/cosmos/gov/v1/proposals/42");
+      expect(result).toEqual(proposal);
+    });
+  });
+
+  describe("getProposalTally", () => {
+    it("requests a gov v1 proposal tally by id and returns it", async () => {
+      const { service, httpClient, tally } = setup();
+      httpClient.get.mockResolvedValue({ data: { tally } });
+
+      const result = await service.getProposalTally(42);
+
+      expect(httpClient.get).toHaveBeenCalledWith("/cosmos/gov/v1/proposals/42/tally");
+      expect(result).toEqual(tally);
+    });
+  });
+
+  function setup() {
+    const tally: CosmosGovTallyResult = {
+      yes_count: "100",
+      abstain_count: "1",
+      no_count: "2",
+      no_with_veto_count: "0"
+    };
+    const proposal: CosmosGovProposal = {
+      id: "42",
+      messages: [],
+      status: "PROPOSAL_STATUS_PASSED",
+      final_tally_result: tally,
+      submit_time: "2026-05-01T00:00:00Z",
+      deposit_end_time: "2026-05-15T00:00:00Z",
+      total_deposit: [{ denom: "uakt", amount: "1000000000" }],
+      voting_start_time: "2026-05-01T00:00:00Z",
+      voting_end_time: "2026-05-08T00:00:00Z",
+      metadata: "",
+      title: "Test proposal",
+      summary: "Test proposal summary",
+      proposer: "akash1proposer"
+    };
+    const httpClient = mock<HttpClient>();
+    const service = new CosmosHttpService(httpClient);
+    return { service, httpClient, proposal, tally };
+  }
+});

--- a/packages/http-sdk/src/cosmos/cosmos-http.service.ts
+++ b/packages/http-sdk/src/cosmos/cosmos-http.service.ts
@@ -90,19 +90,19 @@ export class CosmosHttpService {
   }
 
   async getProposals(): Promise<CosmosGovProposalsResponse["proposals"]> {
-    const { proposals } = extractData(await this.httpClient.get<CosmosGovProposalsResponse>(`/cosmos/gov/v1beta1/proposals?pagination.limit=1000`));
+    const { proposals } = extractData(await this.httpClient.get<CosmosGovProposalsResponse>(`/cosmos/gov/v1/proposals?pagination.limit=1000`));
 
     return proposals;
   }
 
   async getProposal(id: number): Promise<CosmosGovProposalResponse["proposal"]> {
-    const { proposal } = extractData(await this.httpClient.get<CosmosGovProposalResponse>(`/cosmos/gov/v1beta1/proposals/${id}`));
+    const { proposal } = extractData(await this.httpClient.get<CosmosGovProposalResponse>(`/cosmos/gov/v1/proposals/${id}`));
 
     return proposal;
   }
 
   async getProposalTally(id: number): Promise<RestGovProposalsTallyResponse["tally"]> {
-    const { tally } = extractData(await this.httpClient.get<RestGovProposalsTallyResponse>(`/cosmos/gov/v1beta1/proposals/${id}/tally`));
+    const { tally } = extractData(await this.httpClient.get<RestGovProposalsTallyResponse>(`/cosmos/gov/v1/proposals/${id}/tally`));
 
     return tally;
   }

--- a/packages/http-sdk/src/cosmos/types.ts
+++ b/packages/http-sdk/src/cosmos/types.ts
@@ -169,7 +169,8 @@ export type CosmosGovTallyResult = {
 
 export type CosmosGovProposal = {
   id: string;
-  messages: CosmosGovProposalMessage[];
+  /** protojson omits empty repeated fields, so zero-message proposals may lack this key entirely. */
+  messages?: CosmosGovProposalMessage[];
   status: string;
   final_tally_result?: CosmosGovTallyResult;
   submit_time: string;

--- a/packages/http-sdk/src/cosmos/types.ts
+++ b/packages/http-sdk/src/cosmos/types.ts
@@ -146,35 +146,48 @@ export type CosmosDistributionValidatorsCommissionResponse = {
   };
 };
 
-export type CosmosGovProposalsResponse = {
-  proposals: {
-    proposal_id: string;
-    content: {
-      "@type": string;
-      title: string;
-      description: string;
-      changes: {
-        subspace: string;
-        key: string;
-        value: string;
-      }[];
-    };
-    status: string;
-    final_tally_result: {
-      yes: string;
-      abstain: string;
-      no: string;
-      no_with_veto: string;
-    };
-    submit_time: string;
-    deposit_end_time: string;
-    total_deposit: {
-      denom: string;
-      amount: string;
+export type CosmosGovProposalMessage = {
+  "@type": string;
+  content?: {
+    "@type": string;
+    title?: string;
+    description?: string;
+    changes?: {
+      subspace: string;
+      key: string;
+      value: string;
     }[];
-    voting_start_time: string;
-    voting_end_time: string;
+  };
+};
+
+export type CosmosGovTallyResult = {
+  yes_count: string;
+  abstain_count: string;
+  no_count: string;
+  no_with_veto_count: string;
+};
+
+export type CosmosGovProposal = {
+  id: string;
+  messages: CosmosGovProposalMessage[];
+  status: string;
+  final_tally_result?: CosmosGovTallyResult;
+  submit_time: string;
+  deposit_end_time: string;
+  total_deposit: {
+    denom: string;
+    amount: string;
   }[];
+  voting_start_time: string | null;
+  voting_end_time: string | null;
+  metadata: string;
+  title: string;
+  summary: string;
+  proposer: string;
+};
+
+export type CosmosGovProposalsResponse = {
+  proposals: CosmosGovProposal[];
   pagination: {
     next_key: string | null;
     total: string;
@@ -182,41 +195,9 @@ export type CosmosGovProposalsResponse = {
 };
 
 export type CosmosGovProposalResponse = {
-  proposal: {
-    proposal_id: string;
-    content: {
-      "@type": string;
-      title: string;
-      description: string;
-      changes: {
-        subspace: string;
-        key: string;
-        value: string;
-      }[];
-    };
-    status: string;
-    final_tally_result?: {
-      yes: string;
-      abstain: string;
-      no: string;
-      no_with_veto: string;
-    };
-    submit_time: string;
-    deposit_end_time: string;
-    total_deposit: {
-      denom: string;
-      amount: string;
-    }[];
-    voting_start_time: string;
-    voting_end_time: string;
-  };
+  proposal: CosmosGovProposal;
 };
 
 export type RestGovProposalsTallyResponse = {
-  tally: {
-    yes: string;
-    abstain: string;
-    no: string;
-    no_with_veto: string;
-  };
+  tally: CosmosGovTallyResult;
 };

--- a/packages/http-sdk/src/cosmos/types.ts
+++ b/packages/http-sdk/src/cosmos/types.ts
@@ -175,7 +175,8 @@ export type CosmosGovProposal = {
   final_tally_result?: CosmosGovTallyResult;
   submit_time: string;
   deposit_end_time: string;
-  total_deposit: {
+  /** protojson omits empty repeated fields, so zero-deposit proposals may lack this key entirely. */
+  total_deposit?: {
     denom: string;
     amount: string;
   }[];


### PR DESCRIPTION
## Why

Production `GET /v1/proposals` (and `GET /v1/proposals/{id}` for some ids) returns 500. The upstream chain REST node rejects the legacy governance endpoint with:

> `codespace sdk code 29: invalid type: can't convert a gov/v1 Proposal to gov/v1beta1 Proposal when amount of proposal messages not exactly one`

On-chain proposals **#322 (2 messages)** and **#329 (0 messages)** cannot be represented in the legacy gov v1beta1 shape, so the node 500s the entire `/cosmos/gov/v1beta1/proposals` list response (reproduced live against `api.akashnet.net`). As a side effect, the shared chain HTTP client retries 5xx GETs 3×, so every console request was also tripling load on the failing upstream endpoint.

## What

Migrate the three governance queries in `CosmosHttpService` from `/cosmos/gov/v1beta1/*` to `/cosmos/gov/v1/*` and adapt to the v1 response shape:

- `packages/http-sdk`: rewrite the gov response types to the v1 shape (`id`, `messages[]`, top-level `title`/`summary`, `*_count` tally fields, nullable voting timestamps). Type names are unchanged; note the shapes are breaking for external consumers of these exported types — though the old shapes described an endpoint that now 500s.
- `apps/api` `ProposalService`: map `title`/`summary` from the v1 top-level fields, tally from `*_count` fields, extract `paramChanges` from `MsgExecLegacyContent` messages (multi-/zero-message proposals yield `[]`), and coalesce null voting timestamps to `0001-01-01T00:00:00Z` — exactly what the v1beta1 endpoint emitted for unset times.
- **The public `/v1/proposals` response contract is unchanged** (zod schemas and generated `console-api-types` untouched).
- Functional spec fixtures rewritten to the v1 shape, adding regression coverage for the two prod-breaking shapes (zero-message proposal with null voting times, multi-message proposal) and for the legacy param-change + final-tally path.

Verified end-to-end by booting the built API locally against the live mainnet node: `/v1/proposals` returns 200 with all 161 proposals (currently 500 in prod), `/v1/proposals/322` and `/v1/proposals/329` return 200, legacy param-change proposals still surface parsed `paramChanges`, and unknown ids still 404.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated governance proposal retrieval to use the current Cosmos Gov v1 API.
  * Corrected proposal details, voting periods, tallies, and parameter-change decoding.
  * Added handling for proposals without messages and unset voting or tally values.

* **Tests**
  * Expanded coverage for proposal lists, details, tallies, and multiple proposal types.
  * Added validation for unknown proposals and current API response formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->