### PR TITLE
fix(dx): run reload-job cleanup inside the ambient transaction

### DIFF
--- a/apps/api/src/core/services/job-queue/job-queue.service.spec.ts
+++ b/apps/api/src/core/services/job-queue/job-queue.service.spec.ts
@@ -179,6 +179,33 @@ describe(JobQueueService.name, () => {
     });
   });
 
+  describe("cancelCreatedBy", () => {
+    it("cancels created jobs on the pg-boss connection when no transaction is active", async () => {
+      const { service, pgBoss, txService } = setup();
+      txService.getConnection.mockReturnValue(undefined);
+      const executeSql = vi.fn().mockResolvedValue({ rows: [{ id: "job-1" }] });
+      const getDb = vi.spyOn(pgBoss, "getDb").mockReturnValue({ executeSql });
+
+      await service.cancelCreatedBy({ name: "test-job", singletonKey: "singleton-1" });
+
+      expect(getDb).toHaveBeenCalled();
+      expect(executeSql).toHaveBeenCalledWith(expect.stringContaining("state = 'cancelled'"), ["test-job", "singleton-1"]);
+    });
+
+    it("cancels created jobs on the ambient transaction connection when one is active", async () => {
+      const { service, pgBoss, txService } = setup();
+      const unsafe = vi.fn().mockResolvedValue([{ id: "job-1" }]);
+      const connection = { unsafe } as unknown as Sql;
+      txService.getConnection.mockReturnValue(connection);
+      const getDb = vi.spyOn(pgBoss, "getDb");
+
+      await service.cancelCreatedBy({ name: "test-job", singletonKey: "singleton-1" });
+
+      expect(unsafe).toHaveBeenCalledWith(expect.stringContaining("state = 'cancelled'"), ["test-job", "singleton-1"]);
+      expect(getDb).not.toHaveBeenCalled();
+    });
+  });
+
   describe("complete()", () => {
     it("completes a job and logs completion", async () => {
       const { service, pgBoss, logger } = setup();

--- a/apps/api/src/core/services/job-queue/job-queue.service.ts
+++ b/apps/api/src/core/services/job-queue/job-queue.service.ts
@@ -134,7 +134,8 @@ export class JobQueueService implements Disposable {
   }
 
   async cancelCreatedBy(query: { name: string; singletonKey: string }): Promise<void> {
-    const db = await this.pgBoss.getDb();
+    const connection = this.txService.getConnection();
+    const db = connection ? this.#toTransactionDb(connection) : await this.pgBoss.getDb();
     const schema = this.coreConfig.get("POSTGRES_BACKGROUND_JOBS_SCHEMA");
     const result = (await db.executeSql(
       `


### PR DESCRIPTION
## Why

Fixes CON-798

When a managed wallet's auto top-up settings are saved, the pending balance-reload job was cancelled on pg-boss's own autocommitting connection — outside the `@WithTransaction` that wraps the settings update. If that transaction rolled back, the previously-scheduled reload job stayed cancelled with nothing to reschedule it, silently disabling auto top-up for that user.

Behind the `auto_reload_fixed_threshold` flag (off by default), so there is no current production exposure — this is GA hardening for the fixed-threshold rollout (CON-717). The fix touches shared job-queue infrastructure, so it ships as its own small PR.

## What

- `JobQueueService.cancelCreatedBy` now routes its cancel `UPDATE` through the ambient transaction connection when one is active (mirroring `enqueue`), falling back to pg-boss's connection otherwise — so the reload-job cleanup and re-enqueue commit or roll back atomically with the wallet-settings update.
- The `connection ? … : pgBoss.getDb()` fallback preserves current behavior for every non-transactional caller.
- Unit tests cover both the in-transaction and no-transaction paths.
