### PR TITLE
fix(billing): skip fixed-threshold auto top-up when no active deployments

### DIFF
--- a/apps/api/src/billing/events/wallet-balance-reload-check.ts
+++ b/apps/api/src/billing/events/wallet-balance-reload-check.ts
@@ -10,6 +10,12 @@ export class WalletBalanceReloadCheck implements Job {
   constructor(
     public readonly data: {
       userId: UserOutput["id"];
+      /**
+       * True when scheduled right after deployment activity (scheduleImmediate) rather than by the
+       * periodic sweep. The fixed-threshold handler skips its no-active-deployments guard for these,
+       * since the triggering deployment may not be in the indexer's Deployment table yet.
+       */
+      immediate?: boolean;
     }
   ) {}
 }

--- a/apps/api/src/billing/events/wallet-balance-reload-check.ts
+++ b/apps/api/src/billing/events/wallet-balance-reload-check.ts
@@ -11,11 +11,13 @@ export class WalletBalanceReloadCheck implements Job {
     public readonly data: {
       userId: UserOutput["id"];
       /**
-       * True when scheduled right after deployment activity (scheduleImmediate) rather than by the
-       * periodic sweep. The fixed-threshold handler skips its no-active-deployments guard for these,
-       * since the triggering deployment may not be in the indexer's Deployment table yet.
+       * Set only when the check is scheduled right after a deployment's lease starts. The
+       * fixed-threshold handler skips its no-active-deployments guard for these, since the
+       * just-started deployment may not be in the indexer's Deployment table yet. Every other
+       * scheduler (periodic sweep, settings lazy-create, spend events) leaves it unset so the
+       * guard runs.
        */
-      immediate?: boolean;
+      triggeredByDeployment?: boolean;
     }
   ) {}
 }

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check-instrumentation.service.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check-instrumentation.service.ts
@@ -93,7 +93,7 @@ export class WalletBalanceReloadCheckInstrumentationService {
     });
   }
 
-  recordReloadSkipped(input: ReloadMetricInput & { reason: "zero_cost" | "sufficient_balance" }): void {
+  recordReloadSkipped(input: ReloadMetricInput & { reason: "zero_cost" | "sufficient_balance" | "no_active_deployments" }): void {
     this.reloadsSkipped.add(1, {
       reason: input.reason
     });

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.spec.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.spec.ts
@@ -12,6 +12,7 @@ import type { StripeTransactionService } from "@src/billing/services/stripe-tran
 import type { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
 import type { JobMeta } from "@src/core";
 import type { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
+import type { DeploymentRepository } from "@src/deployment/repositories/deployment/deployment.repository";
 import type { DrainingDeploymentService } from "@src/deployment/services/draining-deployment/draining-deployment.service";
 import type { JobPayload } from "../../../core";
 import { WalletBalanceReloadCheckHandler } from "./wallet-balance-reload-check.handler";
@@ -411,17 +412,38 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       );
     });
 
-    it("reloads even when there are no active deployments", async () => {
-      const { handler, stripeTransactionService, drainingDeploymentService, job, jobMeta } = setup({
+    it("skips the reload when there are no active deployments", async () => {
+      const { handler, stripeTransactionService, instrumentationService, job, jobMeta } = setup({
         fixedThresholdEnabled: true,
         balance: 0,
         autoReloadThresholdUsd: 20,
-        autoReloadAmountUsd: 100
+        autoReloadAmountUsd: 100,
+        activeDeploymentCount: 0
       });
 
       await handler.handle(job, jobMeta);
 
-      expect(drainingDeploymentService.calculateAllDeploymentCostUntilDate).not.toHaveBeenCalled();
+      expect(stripeTransactionService.createPaymentIntent).not.toHaveBeenCalled();
+      expect(instrumentationService.recordReloadSkipped).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reason: "no_active_deployments",
+          logContext: expect.objectContaining({ balance: 0, threshold: 20 })
+        })
+      );
+    });
+
+    it("charges when at or below the threshold and there is at least one active deployment", async () => {
+      const { handler, stripeTransactionService, deploymentRepository, wallet, job, jobMeta } = setup({
+        fixedThresholdEnabled: true,
+        balance: 10,
+        autoReloadThresholdUsd: 20,
+        autoReloadAmountUsd: 100,
+        activeDeploymentCount: 2
+      });
+
+      await handler.handle(job, jobMeta);
+
+      expect(deploymentRepository.countActiveByOwner).toHaveBeenCalledWith(wallet.address);
       expect(stripeTransactionService.createPaymentIntent).toHaveBeenCalledWith(expect.objectContaining({ amount: 100 }));
     });
 
@@ -467,6 +489,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
     autoReloadThresholdUsd?: number;
     autoReloadAmountUsd?: number;
     fixedThresholdEnabled?: boolean;
+    activeDeploymentCount?: number;
     user?: ReturnType<typeof createUser>;
     wallet?: ReturnType<typeof createUserWallet>;
   }) {
@@ -508,6 +531,8 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
     });
     const walletReloadJobService = mock<WalletReloadJobService>();
     const drainingDeploymentService = mock<DrainingDeploymentService>();
+    const deploymentRepository = mock<DeploymentRepository>();
+    deploymentRepository.countActiveByOwner.mockResolvedValue(input?.activeDeploymentCount ?? 1);
     const paymentMethodService = mock<PaymentMethodService>();
     const stripeTransactionService = mock<StripeTransactionService>();
     const instrumentationService = mock<WalletBalanceReloadCheckInstrumentationService>({
@@ -548,6 +573,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       paymentMethodService,
       stripeTransactionService,
       drainingDeploymentService,
+      deploymentRepository,
       instrumentationService,
       featureFlagsService
     );
@@ -558,6 +584,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       balancesService,
       walletReloadJobService,
       drainingDeploymentService,
+      deploymentRepository,
       paymentMethodService,
       stripeTransactionService,
       instrumentationService,

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.spec.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.spec.ts
@@ -432,14 +432,14 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       );
     });
 
-    it("charges on an immediate post-deploy check without consulting the active-deployment count", async () => {
+    it("charges on a deployment-triggered check without consulting the active-deployment count", async () => {
       const { handler, stripeTransactionService, deploymentRepository, job, jobMeta } = setup({
         fixedThresholdEnabled: true,
         balance: 0,
         autoReloadThresholdUsd: 20,
         autoReloadAmountUsd: 100,
         activeDeploymentCount: 0,
-        immediate: true
+        triggeredByDeployment: true
       });
 
       await handler.handle(job, jobMeta);
@@ -506,7 +506,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
     autoReloadAmountUsd?: number;
     fixedThresholdEnabled?: boolean;
     activeDeploymentCount?: number;
-    immediate?: boolean;
+    triggeredByDeployment?: boolean;
     user?: ReturnType<typeof createUser>;
     wallet?: ReturnType<typeof createUserWallet>;
   }) {
@@ -537,7 +537,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
     const job: JobPayload<WalletBalanceReloadCheck> = {
       userId: user.id,
       version: 1,
-      ...(input?.immediate && { immediate: true })
+      ...(input?.triggeredByDeployment && { triggeredByDeployment: true })
     };
     const jobMeta: JobMeta = {
       id: faker.string.uuid()

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.spec.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.spec.ts
@@ -432,6 +432,22 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       );
     });
 
+    it("charges on an immediate post-deploy check without consulting the active-deployment count", async () => {
+      const { handler, stripeTransactionService, deploymentRepository, job, jobMeta } = setup({
+        fixedThresholdEnabled: true,
+        balance: 0,
+        autoReloadThresholdUsd: 20,
+        autoReloadAmountUsd: 100,
+        activeDeploymentCount: 0,
+        immediate: true
+      });
+
+      await handler.handle(job, jobMeta);
+
+      expect(deploymentRepository.countActiveByOwner).not.toHaveBeenCalled();
+      expect(stripeTransactionService.createPaymentIntent).toHaveBeenCalledWith(expect.objectContaining({ amount: 100 }));
+    });
+
     it("charges when at or below the threshold and there is at least one active deployment", async () => {
       const { handler, stripeTransactionService, deploymentRepository, wallet, job, jobMeta } = setup({
         fixedThresholdEnabled: true,
@@ -490,6 +506,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
     autoReloadAmountUsd?: number;
     fixedThresholdEnabled?: boolean;
     activeDeploymentCount?: number;
+    immediate?: boolean;
     user?: ReturnType<typeof createUser>;
     wallet?: ReturnType<typeof createUserWallet>;
   }) {
@@ -519,7 +536,8 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
     };
     const job: JobPayload<WalletBalanceReloadCheck> = {
       userId: user.id,
-      version: 1
+      version: 1,
+      ...(input?.immediate && { immediate: true })
     };
     const jobMeta: JobMeta = {
       id: faker.string.uuid()

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.ts
@@ -16,6 +16,7 @@ import { JobHandler, JobMeta, JobPayload } from "@src/core";
 import { FeatureFlags } from "@src/core/services/feature-flags/feature-flags";
 import { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
 import type { Require } from "@src/core/types/require.type";
+import { DeploymentRepository } from "@src/deployment/repositories/deployment/deployment.repository";
 import { DrainingDeploymentService } from "@src/deployment/services/draining-deployment/draining-deployment.service";
 import { isPayingUser, PayingUser } from "../paying-user/paying-user";
 import { WalletBalanceReloadCheckInstrumentationService } from "./wallet-balance-reload-check-instrumentation.service";
@@ -60,6 +61,7 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
     private readonly paymentMethodService: PaymentMethodService,
     private readonly stripeTransactionService: StripeTransactionService,
     private readonly drainingDeploymentService: DrainingDeploymentService,
+    private readonly deploymentRepository: DeploymentRepository,
     private readonly instrumentationService: WalletBalanceReloadCheckInstrumentationService,
     private readonly featureFlagsService: FeatureFlagsService
   ) {}
@@ -193,6 +195,12 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
 
     if (balance > threshold) {
       this.instrumentationService.recordReloadSkipped({ reason: "sufficient_balance", coverageRatio, logContext: log });
+      return;
+    }
+
+    const activeDeploymentCount = await this.deploymentRepository.countActiveByOwner(resources.wallet.address);
+    if (activeDeploymentCount === 0) {
+      this.instrumentationService.recordReloadSkipped({ reason: "no_active_deployments", coverageRatio, logContext: log });
       return;
     }
 

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.ts
@@ -35,6 +35,7 @@ type Resources = {
   user: PayingUser;
 };
 type AllResources = Resources & { balance: GetBalancesResponseOutput["data"]["total"]; paymentMethod: PaymentMethod };
+type ReloadContext = AllResources & { job: JobMeta; immediate: boolean };
 
 const millisecondsInDay = 24 * millisecondsInHour;
 
@@ -74,7 +75,7 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
       const resourcesResult = await this.#collectResources(payload);
 
       if (resourcesResult.ok) {
-        await this.#tryToReload({ ...resourcesResult.val, job });
+        await this.#tryToReload({ ...resourcesResult.val, job, immediate: payload.immediate ?? false });
         await this.#scheduleNextCheck(resourcesResult.val);
         success = true;
       } else {
@@ -173,7 +174,7 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
     });
   }
 
-  async #tryToReload(resources: AllResources & { job: JobMeta }): Promise<void> {
+  async #tryToReload(resources: ReloadContext): Promise<void> {
     if (this.featureFlagsService.isEnabled(FeatureFlags.AUTO_RELOAD_FIXED_THRESHOLD)) {
       return this.#tryToReloadOnFixedThreshold(resources);
     }
@@ -181,7 +182,7 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
     return this.#tryToReloadOnPredictedSpend(resources);
   }
 
-  async #tryToReloadOnFixedThreshold(resources: AllResources & { job: JobMeta }): Promise<void> {
+  async #tryToReloadOnFixedThreshold(resources: ReloadContext): Promise<void> {
     const { balance } = resources;
     const threshold = centsToUsd(resources.walletSetting.autoReloadThreshold);
     const reloadAmount = Math.max(centsToUsd(resources.walletSetting.autoReloadAmount), STANDARD_TOP_UP_MIN_AMOUNT_USD);
@@ -198,10 +199,12 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
       return;
     }
 
-    const activeDeploymentCount = await this.deploymentRepository.countActiveByOwner(resources.wallet.address);
-    if (activeDeploymentCount === 0) {
-      this.instrumentationService.recordReloadSkipped({ reason: "no_active_deployments", coverageRatio, logContext: log });
-      return;
+    if (!resources.immediate) {
+      const activeDeploymentCount = await this.deploymentRepository.countActiveByOwner(resources.wallet.address);
+      if (activeDeploymentCount === 0) {
+        this.instrumentationService.recordReloadSkipped({ reason: "no_active_deployments", coverageRatio, logContext: log });
+        return;
+      }
     }
 
     try {
@@ -221,7 +224,7 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
     }
   }
 
-  async #tryToReloadOnPredictedSpend(resources: AllResources & { job: JobMeta }): Promise<void> {
+  async #tryToReloadOnPredictedSpend(resources: ReloadContext): Promise<void> {
     const reloadTargetDate = addMilliseconds(new Date(), this.#RELOAD_COVERAGE_PERIOD_IN_MS);
     const costUntilTargetDateInDenom = await this.drainingDeploymentService.calculateAllDeploymentCostUntilDate(resources.wallet.address, reloadTargetDate);
     const costUntilTargetDateInFiat = await this.balancesService.toFiatAmount(costUntilTargetDateInDenom);

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.ts
@@ -35,7 +35,7 @@ type Resources = {
   user: PayingUser;
 };
 type AllResources = Resources & { balance: GetBalancesResponseOutput["data"]["total"]; paymentMethod: PaymentMethod };
-type ReloadContext = AllResources & { job: JobMeta; immediate: boolean };
+type ReloadContext = AllResources & { job: JobMeta; triggeredByDeployment: boolean };
 
 const millisecondsInDay = 24 * millisecondsInHour;
 
@@ -75,7 +75,7 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
       const resourcesResult = await this.#collectResources(payload);
 
       if (resourcesResult.ok) {
-        await this.#tryToReload({ ...resourcesResult.val, job, immediate: payload.immediate ?? false });
+        await this.#tryToReload({ ...resourcesResult.val, job, triggeredByDeployment: payload.triggeredByDeployment ?? false });
         await this.#scheduleNextCheck(resourcesResult.val);
         success = true;
       } else {
@@ -199,7 +199,7 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
       return;
     }
 
-    if (!resources.immediate) {
+    if (!resources.triggeredByDeployment) {
       const activeDeploymentCount = await this.deploymentRepository.countActiveByOwner(resources.wallet.address);
       if (activeDeploymentCount === 0) {
         this.instrumentationService.recordReloadSkipped({ reason: "no_active_deployments", coverageRatio, logContext: log });

--- a/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.spec.ts
+++ b/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.spec.ts
@@ -59,6 +59,8 @@ describe(WalletReloadJobService.name, () => {
           singletonKey: `${WalletBalanceReloadCheck.name}.${walletSetting.userId}`
         })
       );
+      const [immediateJob] = jobQueueService.enqueue.mock.calls[0];
+      expect((immediateJob as WalletBalanceReloadCheck).data).toMatchObject({ userId: walletSetting.userId, immediate: true });
     });
 
     it("looks up the wallet setting by walletId when given a walletId", async () => {
@@ -116,6 +118,8 @@ describe(WalletReloadJobService.name, () => {
           singletonKey: `${WalletBalanceReloadCheck.name}.${walletSetting.userId}`
         })
       );
+      const [scheduledJob] = jobQueueService.enqueue.mock.calls[0];
+      expect((scheduledJob as WalletBalanceReloadCheck).data.immediate).toBeUndefined();
       expect(result).toBe(jobId);
     });
 

--- a/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.spec.ts
+++ b/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.spec.ts
@@ -59,8 +59,21 @@ describe(WalletReloadJobService.name, () => {
           singletonKey: `${WalletBalanceReloadCheck.name}.${walletSetting.userId}`
         })
       );
-      const [immediateJob] = jobQueueService.enqueue.mock.calls[0];
-      expect((immediateJob as WalletBalanceReloadCheck).data).toMatchObject({ userId: walletSetting.userId, immediate: true });
+      const [defaultJob] = jobQueueService.enqueue.mock.calls[0];
+      expect((defaultJob as WalletBalanceReloadCheck).data.triggeredByDeployment).toBeUndefined();
+    });
+
+    it("marks the job as deployment-triggered only when the caller opts in", async () => {
+      const { service, walletSettingRepository, jobQueueService } = setup();
+      const userId = faker.string.uuid();
+      const walletSetting = generateWalletSetting({ autoReloadEnabled: true });
+      walletSettingRepository.findByUserId.mockResolvedValue(walletSetting);
+      jobQueueService.enqueue.mockResolvedValue(faker.string.uuid());
+
+      await service.scheduleImmediate({ userId }, { triggeredByDeployment: true });
+
+      const [job] = jobQueueService.enqueue.mock.calls[0];
+      expect((job as WalletBalanceReloadCheck).data).toMatchObject({ userId: walletSetting.userId, triggeredByDeployment: true });
     });
 
     it("looks up the wallet setting by walletId when given a walletId", async () => {
@@ -119,7 +132,7 @@ describe(WalletReloadJobService.name, () => {
         })
       );
       const [scheduledJob] = jobQueueService.enqueue.mock.calls[0];
-      expect((scheduledJob as WalletBalanceReloadCheck).data.immediate).toBeUndefined();
+      expect((scheduledJob as WalletBalanceReloadCheck).data.triggeredByDeployment).toBeUndefined();
       expect(result).toBe(jobId);
     });
 

--- a/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.ts
+++ b/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.ts
@@ -22,7 +22,7 @@ export class WalletReloadJobService {
         : await this.walletSettingRepository.findOneBy({ walletId: input.walletId });
 
     if (walletSetting?.autoReloadEnabled) {
-      await this.scheduleForWalletSetting(walletSetting, { withCleanup: true });
+      await this.scheduleForWalletSetting(walletSetting, { withCleanup: true, immediate: true });
       return true;
     }
 
@@ -31,7 +31,7 @@ export class WalletReloadJobService {
 
   async scheduleForWalletSetting(
     walletSetting: Pick<WalletSettingOutput, "id" | "userId">,
-    options?: Pick<EnqueueOptions, "startAfter"> & { withCleanup?: boolean }
+    options?: Pick<EnqueueOptions, "startAfter"> & { withCleanup?: boolean; immediate?: boolean }
   ): Promise<string> {
     if (options?.withCleanup) {
       await this.cancelCreatedByUserId(walletSetting.userId);
@@ -39,7 +39,8 @@ export class WalletReloadJobService {
 
     const createdJobId = await this.jobQueueService.enqueue(
       new WalletBalanceReloadCheck({
-        userId: walletSetting.userId
+        userId: walletSetting.userId,
+        ...(options?.immediate && { immediate: true })
       }),
       {
         singletonKey: `${WalletBalanceReloadCheck.name}.${walletSetting.userId}`,

--- a/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.ts
+++ b/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.ts
@@ -15,14 +15,14 @@ export class WalletReloadJobService {
     this.logger.setContext(WalletReloadJobService.name);
   }
 
-  async scheduleImmediate(input: WalletReloadImmediateInput): Promise<boolean> {
+  async scheduleImmediate(input: WalletReloadImmediateInput, options?: { triggeredByDeployment?: boolean }): Promise<boolean> {
     const walletSetting =
       "userId" in input
         ? await this.walletSettingRepository.findByUserId(input.userId)
         : await this.walletSettingRepository.findOneBy({ walletId: input.walletId });
 
     if (walletSetting?.autoReloadEnabled) {
-      await this.scheduleForWalletSetting(walletSetting, { withCleanup: true, immediate: true });
+      await this.scheduleForWalletSetting(walletSetting, { withCleanup: true, triggeredByDeployment: options?.triggeredByDeployment });
       return true;
     }
 
@@ -31,7 +31,7 @@ export class WalletReloadJobService {
 
   async scheduleForWalletSetting(
     walletSetting: Pick<WalletSettingOutput, "id" | "userId">,
-    options?: Pick<EnqueueOptions, "startAfter"> & { withCleanup?: boolean; immediate?: boolean }
+    options?: Pick<EnqueueOptions, "startAfter"> & { withCleanup?: boolean; triggeredByDeployment?: boolean }
   ): Promise<string> {
     if (options?.withCleanup) {
       await this.cancelCreatedByUserId(walletSetting.userId);
@@ -40,7 +40,7 @@ export class WalletReloadJobService {
     const createdJobId = await this.jobQueueService.enqueue(
       new WalletBalanceReloadCheck({
         userId: walletSetting.userId,
-        ...(options?.immediate && { immediate: true })
+        ...(options?.triggeredByDeployment && { triggeredByDeployment: true })
       }),
       {
         singletonKey: `${WalletBalanceReloadCheck.name}.${walletSetting.userId}`,

--- a/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.spec.ts
+++ b/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.spec.ts
@@ -71,7 +71,7 @@ describe(InitialDeploymentFundingService.name, () => {
       signer: "akash1owner"
     });
     expect(managedSignerService.executeDerivedTx).toHaveBeenCalledWith(1, [depositMessage]);
-    expect(walletReloadJobService.scheduleImmediate).toHaveBeenCalledWith({ walletId: 1 });
+    expect(walletReloadJobService.scheduleImmediate).toHaveBeenCalledWith({ walletId: 1 }, { triggeredByDeployment: true });
     expect(instrumentation.recordDeposit).toHaveBeenCalledWith(500000, "uakt", expect.objectContaining({ dseq: "123", address: "akash1owner" }));
   });
 

--- a/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.ts
+++ b/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.ts
@@ -156,7 +156,7 @@ export class InitialDeploymentFundingService {
    */
   private async scheduleWalletReload({ walletId, dseq, address }: { walletId: number; dseq: string; address: string }): Promise<void> {
     try {
-      await this.walletReloadJobService.scheduleImmediate({ walletId });
+      await this.walletReloadJobService.scheduleImmediate({ walletId }, { triggeredByDeployment: true });
     } catch (error) {
       try {
         this.logger.error({ event: "INITIAL_FUNDING_WALLET_RELOAD_SCHEDULE_FAILED", walletId, dseq, address, error });


### PR DESCRIPTION
## Why

Fixes CON-796

The fixed-threshold auto top-up path charged the configured amount whenever the balance was at or below the threshold, even for a wallet with **no active deployments** — dropping the implicit "never charge an idle wallet" guarantee the legacy predicted-spend path has (its projected spend is zero, so it skips). At GA this would produce surprising charges (a user whose deployments have all closed, leaving leftover credit below their threshold), the kind most likely to generate support tickets and chargebacks.

Behind the `auto_reload_fixed_threshold` flag (off by default). Part of the CON-717 GA hardening.

## What

- Guard the fixed-threshold charge on `DeploymentRepository.countActiveByOwner` (active on-chain deployments, `closedHeight = null`), placed after the cheap in-memory balance check so the DB query only runs when a charge is otherwise imminent.
- Skipped checks are recorded with a new `no_active_deployments` reason, consistent with how the predicted-spend path records its skips.
- Creating a deployment already triggers an immediate reload check, so a low-balance user is still topped up the moment they actually deploy — this guard only suppresses charges while nothing is running.
- Tests: skip-when-zero (asserts the new reason and no charge) and charge-when-at-least-one-active-deployment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Wallet balance reloads scheduled immediately after deployment funding are now identified and processed without waiting for deployment indexing.
  - Immediate and standard reloads retain their scheduling context for consistent processing.

- **Bug Fixes**
  - Fixed-threshold reloads are skipped when no active deployments exist, reducing unnecessary reload attempts.
  - Reload activity now records when a reload is skipped because no active deployments are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->