### PR TITLE
refactor(deployment): remove the ui_gpu_interconnect feature flag

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/HardwareSection/HardwareSection.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/HardwareSection/HardwareSection.spec.tsx
@@ -47,23 +47,6 @@ describe(HardwareSection.name, () => {
     expect(RamStorageCard).toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
   });
 
-  it("hides the GPU interconnect card while the ui_gpu_interconnect flag is off", () => {
-    const GpuInterconnectCard = vi.fn(() => null);
-    const useFlag = () => false;
-
-    setup({ dependencies: { GpuInterconnectCard, useFlag } });
-
-    expect(GpuInterconnectCard).not.toHaveBeenCalled();
-  });
-
-  it("gates the GPU interconnect card on the ui_gpu_interconnect flag", () => {
-    const useFlag = vi.fn(() => true);
-
-    setup({ dependencies: { useFlag } });
-
-    expect(useFlag).toHaveBeenCalledWith("ui_gpu_interconnect");
-  });
-
   it("passes an isBlockedModel predicate and unlock handler to the GPU cards", () => {
     const PresetsCard = vi.fn(() => null);
     const GpuCard = vi.fn(() => null);
@@ -173,7 +156,6 @@ describe(HardwareSection.name, () => {
   function setup(input: { serviceIndex?: number; locked?: boolean; dependencies?: Partial<typeof DEPENDENCIES> }) {
     const dependencies = MockComponents(DEPENDENCIES, {
       useTrialGate: () => ({ isRestricted: false, isWalletReady: false }),
-      useFlag: () => true,
       ...input.dependencies
     });
     render(<HardwareSection serviceIndex={input.serviceIndex ?? 0} locked={input.locked} dependencies={dependencies} />);

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/HardwareSection/HardwareSection.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/HardwareSection/HardwareSection.tsx
@@ -4,7 +4,6 @@ import { CollapsibleCard } from "@akashnetwork/ui/components";
 import { CpuIcon, PackageOpenIcon } from "lucide-react";
 
 import { AddCreditsSheet } from "@src/components/auth/AddCreditsSheet/AddCreditsSheet";
-import { useFlag } from "@src/hooks/useFlag";
 import { isTrialBlockedGpuSelection, isTrialGpuRestrictionActive } from "@src/utils/deploymentData/v1beta3";
 import { useRevalidateUniqueness } from "../../DeploymentPane/useRevalidateUniqueness/useRevalidateUniqueness";
 import { computeResourcesTooltip, presetsTooltip } from "../cardTooltips";
@@ -38,7 +37,6 @@ export const DEPENDENCIES = {
   PersistentStorageCard,
   ConfidentialComputeCard,
   AddCreditsSheet,
-  useFlag,
   useRevalidateUniqueness,
   useTrialGate
 };
@@ -87,14 +85,12 @@ export const HardwareSection: FC<Props> = ({ serviceIndex, locked = false, depen
 
         <d.GpuCard serviceIndex={serviceIndex} locked={locked} isBlockedModel={isBlockedModel} onUnlock={openUnlock} />
 
-        {d.useFlag("ui_gpu_interconnect") && (
-          <d.GpuInterconnectCard
-            serviceIndex={serviceIndex}
-            locked={locked}
-            isTrialBlocked={isRestricted && !locked && isTrialGpuRestrictionActive()}
-            onUnlock={openUnlock}
-          />
-        )}
+        <d.GpuInterconnectCard
+          serviceIndex={serviceIndex}
+          locked={locked}
+          isTrialBlocked={isRestricted && !locked && isTrialGpuRestrictionActive()}
+          onUnlock={openUnlock}
+        />
 
         <d.CollapsibleCard locked={locked} title="Compute Resources" icon={<CpuIcon className="h-4 w-4" />} infoTooltip={computeResourcesTooltip}>
           <d.ComputeResourcesCard serviceIndex={serviceIndex} locked={locked} />

--- a/apps/deploy-web/src/types/feature-flags.ts
+++ b/apps/deploy-web/src/types/feature-flags.ts
@@ -9,6 +9,5 @@ export type FeatureFlag =
   | "auto_reload_fixed_threshold"
   | "ui_sdl_preview_panel"
   | "ui_build_and_deploy"
-  | "ui_gpu_interconnect"
   | "ui_agent_mode_deploy"
   | "hackathons";


### PR DESCRIPTION
## Why

The GPU interconnect toggle shipped behind the `ui_gpu_interconnect` feature flag as a launch safeguard. Interconnect is stable now, so the flag and the dead code guarding it can go, which trims the configuration surface.

Closes CON-693

## What

- Dropped `ui_gpu_interconnect` from the `FeatureFlag` union.
- Un-gated `GpuInterconnectCard` in `HardwareSection` so it always renders in the configure flow — removed the `useFlag` call, its import, and its `DEPENDENCIES` entry.
- Deleted the two flag-specific tests and the `useFlag` mock default in `HardwareSection.spec.tsx`. The remaining interconnect tests keep passing because the card now renders unconditionally.

The interconnect feature itself — the card, SDL generation/import, and trial gating — is unchanged.

### Behavior note for reviewers

Despite the "kill-switch" wording, the flag was actually opt-in: the code was `useFlag("ui_gpu_interconnect") && <GpuInterconnectCard/>`, so the card showed only while the flag was ON. If the flag is currently off in prod Unleash, merging this exposes the card to everyone; if it's already on, this is pure cleanup. Either way it matches the intent (the toggle is now available without a flag).

**Post-merge:** delete the now-orphaned `ui_gpu_interconnect` toggle in the Unleash dashboard so it doesn't linger server-side.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GPU interconnect configuration is now available directly in the hardware configuration section.
  * Trial restrictions and unlock handling remain in place.

* **Tests**
  * Updated hardware configuration coverage to reflect the always-available GPU interconnect option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->