### PR TITLE
feat(deployment): add flag-gated redesigned deployment detail page

### DIFF
--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.spec.tsx
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { DeploymentDto, LeaseDto } from "@src/types/deployment";
+import type { ApiProviderList } from "@src/types/provider";
+import { DEPENDENCIES, DeploymentDetail } from "./DeploymentDetail";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MockComponents } from "@tests/unit/mocks";
+
+describe("DeploymentDetail", () => {
+  it("renders the tab bar and lease rows when the deployment and leases are loaded", () => {
+    setup();
+
+    expect(screen.getByRole("tab", { name: "Details" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Billing & Notifications" })).toBeInTheDocument();
+    expect(screen.getByText("lease-row")).toBeInTheDocument();
+  });
+
+  it("tracks a navigate_tab analytics event when switching tabs", async () => {
+    const { analyticsService } = setup();
+
+    await userEvent.click(screen.getByRole("tab", { name: "Logs" }));
+
+    expect(analyticsService.track).toHaveBeenCalledWith("navigate_tab", expect.objectContaining({ tab: "LOGS", category: "deployments" }));
+    expect(window.location.search).toBe("?tab=LOGS");
+    expect(screen.getByText("logs")).toBeInTheDocument();
+  });
+
+  it("opens the Settings tab from the ?tab= query param", () => {
+    setup({ tab: "SETTINGS" });
+
+    expect(screen.getByText("manifest-update")).toBeInTheDocument();
+  });
+
+  it("shows an inactive-state note instead of the shell when the deployment has no live lease", () => {
+    setup({ tab: "SHELL", leaseState: "closed" });
+
+    expect(screen.getByText("Available when the deployment is active.")).toBeInTheDocument();
+    expect(screen.queryByText("shell")).not.toBeInTheDocument();
+  });
+
+  it("renders alerts on the Billing tab when alerts are enabled", () => {
+    setup({ tab: "BILLING", alertsEnabled: true });
+
+    expect(screen.getByText("alerts")).toBeInTheDocument();
+  });
+
+  it("shows a coming-soon note on the Billing tab when alerts are disabled", () => {
+    setup({ tab: "BILLING", alertsEnabled: false });
+
+    expect(screen.getByText("Billing & notifications are coming soon.")).toBeInTheDocument();
+  });
+
+  it("shows a not-found message when the deployment does not exist", () => {
+    const error = Object.assign(new Error("Deployment not found"), { response: { data: { message: "Deployment not found" } } });
+    setup({ deployment: null, error });
+
+    expect(screen.getByText(/this deployment does not exist/i)).toBeInTheDocument();
+  });
+
+  it("redirects an in-progress deployment with no lease to the configure flow", () => {
+    const { router } = setup({ leases: [] });
+
+    expect(router.replace).toHaveBeenCalledWith(expect.stringContaining("configure"));
+  });
+
+  function setup(input?: {
+    deployment?: DeploymentDto | null;
+    leases?: LeaseDto[] | null;
+    isLeasesLoaded?: boolean;
+    error?: Error | null;
+    tab?: string;
+    alertsEnabled?: boolean;
+    leaseState?: string;
+  }) {
+    const deployment = input && "deployment" in input ? input.deployment : mock<DeploymentDto>({ dseq: "1786440078202", state: "active", groups: [] });
+    const leases = input && "leases" in input ? input.leases : [mock<LeaseDto>({ id: "1", provider: "akash1provider", state: input?.leaseState ?? "active" })];
+    const providers = [mock<ApiProviderList>({ owner: "akash1provider" })];
+
+    const analyticsService = mock<ReturnType<typeof DEPENDENCIES.useServices>["analyticsService"]>();
+    const router = mock<ReturnType<typeof DEPENDENCIES.useRouter>>();
+
+    const useServices: typeof DEPENDENCIES.useServices = () =>
+      mock<ReturnType<typeof DEPENDENCIES.useServices>>({
+        deploymentLocalStorage: mock<ReturnType<typeof DEPENDENCIES.useServices>["deploymentLocalStorage"]>({ get: () => null }),
+        sdlAnalyzer: mock<ReturnType<typeof DEPENDENCIES.useServices>["sdlAnalyzer"]>({ hasCiCdImage: () => false }),
+        analyticsService
+      });
+    const useWallet: typeof DEPENDENCIES.useWallet = () => mock<ReturnType<typeof DEPENDENCIES.useWallet>>({ address: "akash1test" });
+    const useSettings: typeof DEPENDENCIES.useSettings = () => mock<ReturnType<typeof DEPENDENCIES.useSettings>>({ isSettingsInit: true });
+    const useUser: typeof DEPENDENCIES.useUser = () =>
+      mock<ReturnType<typeof DEPENDENCIES.useUser>>({ user: mock<NonNullable<ReturnType<typeof DEPENDENCIES.useUser>["user"]>>({ userId: "u1" }) });
+    const useFlag: typeof DEPENDENCIES.useFlag = () => input?.alertsEnabled ?? false;
+    const useRouter: typeof DEPENDENCIES.useRouter = () => router;
+    const searchParams = new URLSearchParams(input?.tab ? `tab=${input.tab}` : "");
+    const useSearchParams: typeof DEPENDENCIES.useSearchParams = () => searchParams as unknown as ReturnType<typeof DEPENDENCIES.useSearchParams>;
+    const useDeploymentDetail: typeof DEPENDENCIES.useDeploymentDetail = () =>
+      mock<ReturnType<typeof DEPENDENCIES.useDeploymentDetail>>({ data: deployment, isFetching: false, error: input?.error ?? null });
+    const useDeploymentLeaseList: typeof DEPENDENCIES.useDeploymentLeaseList = () =>
+      mock<ReturnType<typeof DEPENDENCIES.useDeploymentLeaseList>>({ data: leases, isLoading: false, isSuccess: input?.isLeasesLoaded ?? true });
+    const useProviderList: typeof DEPENDENCIES.useProviderList = () =>
+      mock<ReturnType<typeof DEPENDENCIES.useProviderList>>({ data: providers, isFetching: false });
+
+    const LeaseRow = vi.fn(() => <div>lease-row</div>);
+    const DeploymentLogs = vi.fn(() => <div>logs</div>);
+    const DeploymentLeaseShell = vi.fn(() => <div>shell</div>);
+    const ManifestUpdate = vi.fn(() => <div>manifest-update</div>);
+    const DeploymentAlerts = vi.fn(() => <div>alerts</div>);
+
+    render(
+      <DeploymentDetail
+        dseq="1786440078202"
+        dependencies={MockComponents(DEPENDENCIES, {
+          useServices,
+          useWallet,
+          useSettings,
+          useUser,
+          useFlag,
+          useRouter,
+          useSearchParams,
+          useDeploymentDetail,
+          useDeploymentLeaseList,
+          useProviderList,
+          LeaseRow: LeaseRow as unknown as typeof DEPENDENCIES.LeaseRow,
+          DeploymentLogs,
+          DeploymentLeaseShell,
+          ManifestUpdate,
+          DeploymentAlerts
+        })}
+      />
+    );
+
+    return { router, analyticsService };
+  }
+});

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.tsx
@@ -1,0 +1,245 @@
+"use client";
+import type { FC } from "react";
+import { useEffect, useState } from "react";
+import { buttonVariants, Tabs, TabsList, TabsTrigger } from "@akashnetwork/ui/components";
+import { cn } from "@akashnetwork/ui/utils";
+import { ArrowLeft } from "iconoir-react";
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { NextSeo } from "next-seo";
+
+import { createConfigureDraft } from "@src/components/deployments/ConfigureDeployment/useConfigureDraft/useConfigureDraft";
+import { DeploymentAlerts } from "@src/components/deployments/DeploymentAlerts/DeploymentAlerts";
+import { useServices } from "@src/context/ServicesProvider";
+import { useSettings } from "@src/context/SettingsProvider";
+import { useWallet } from "@src/context/WalletProvider";
+import { useFlag } from "@src/hooks/useFlag";
+import { useUser } from "@src/hooks/useUser";
+import { useDeploymentDetail } from "@src/queries/useDeploymentQuery";
+import { useDeploymentLeaseList } from "@src/queries/useLeaseQuery";
+import { useProviderList } from "@src/queries/useProvidersQuery";
+import { extractRepositoryUrl } from "@src/services/remote-deploy/env-var-manager.service";
+import { isLeaseLive } from "@src/utils/reclamationUtils";
+import { UrlService } from "@src/utils/urlUtils";
+import Layout from "../../layout/Layout";
+import { Title } from "../../shared/Title";
+import { DeploymentLeaseShell } from "../DeploymentLeaseShell";
+import { DeploymentLogs } from "../DeploymentLogs";
+import { LeaseRow } from "../LeaseRow";
+import { ManifestUpdate } from "../ManifestUpdate/ManifestUpdate";
+import { ReclamationBanner } from "../ReclamationBanner/ReclamationBanner";
+import { DeploymentDetailHeader } from "./DeploymentDetailHeader";
+
+export const DEPENDENCIES = {
+  useServices,
+  useWallet,
+  useSettings,
+  useUser,
+  useFlag,
+  useRouter,
+  useSearchParams,
+  useDeploymentDetail,
+  useDeploymentLeaseList,
+  useProviderList,
+  NextSeo,
+  Layout,
+  ReclamationBanner,
+  DeploymentDetailHeader,
+  LeaseRow,
+  DeploymentLogs,
+  DeploymentLeaseShell,
+  ManifestUpdate,
+  DeploymentAlerts
+};
+
+const TABS = ["DETAILS", "LOGS", "EVENTS", "SHELL", "SETTINGS", "BILLING"] as const;
+type Tab = (typeof TABS)[number];
+
+const TAB_LABELS: Record<Tab, string> = {
+  DETAILS: "Details",
+  LOGS: "Logs",
+  EVENTS: "Events",
+  SHELL: "Shell",
+  SETTINGS: "Settings",
+  BILLING: "Billing & Notifications"
+};
+
+export interface DeploymentDetailProps {
+  dseq: string;
+  dependencies?: typeof DEPENDENCIES;
+}
+
+export const DeploymentDetail: FC<DeploymentDetailProps> = ({ dseq, dependencies: d = DEPENDENCIES }) => {
+  const { deploymentLocalStorage, sdlAnalyzer, analyticsService } = d.useServices();
+  const router = d.useRouter();
+  const searchParams = d.useSearchParams();
+  const { address } = d.useWallet();
+  const { isSettingsInit } = d.useSettings();
+  const { user } = d.useUser();
+  const isAlertsEnabled = d.useFlag("alerts") && !!user?.userId;
+
+  const [activeTab, setActiveTab] = useState<Tab>("DETAILS");
+  const [editedManifest, setEditedManifest] = useState<string | null>(null);
+  const isRemoteDeploy = sdlAnalyzer.hasCiCdImage(editedManifest);
+  const repo = isRemoteDeploy ? extractRepositoryUrl(editedManifest) : null;
+
+  const { data: deployment, isFetching: isLoadingDeployment, refetch: getDeploymentDetail, error: deploymentError } = d.useDeploymentDetail(address, dseq);
+  const {
+    data: leases,
+    isLoading: isLoadingLeases,
+    refetch: getLeases,
+    isSuccess: isLeasesLoaded
+  } = d.useDeploymentLeaseList(address, deployment, {
+    enabled: deployment?.state === "active",
+    refetchOnWindowFocus: false
+  });
+  const { data: providers, isFetching: isLoadingProviders, refetch: getProviders } = d.useProviderList();
+
+  const deploymentManifest = deployment ? deploymentLocalStorage.get(address, dseq)?.manifest || "" : "";
+  const hasLeases = !!leases && leases.length > 0;
+  const isActive = deployment?.state === "active" && !!leases?.some(isLeaseLive);
+  const isDeploymentNotFound = !!deploymentError && (deploymentError as any).response?.data?.message?.includes("Deployment not found") && !isLoadingDeployment;
+
+  useEffect(() => {
+    if (isSettingsInit) getDeploymentDetail();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isSettingsInit]);
+
+  useEffect(() => {
+    if (deployment) {
+      getLeases();
+      getProviders();
+    }
+  }, [deployment, getLeases, getProviders]);
+
+  useEffect(
+    function redirectWhenInProgressWithoutLease() {
+      if (leases && deployment?.state === "active" && leases.length === 0 && !deployment.groups?.some(g => g.state === "paused")) {
+        const localData = deploymentLocalStorage.get(address, dseq);
+        const draftId = localData?.manifest ? createConfigureDraft(localData.manifest, localData.name) : undefined;
+        router.replace(UrlService.configureDeployment({ dseq, draftId }));
+      }
+    },
+    [address, deployment?.state, deployment?.groups, deploymentLocalStorage, dseq, leases, router]
+  );
+
+  const tabQuery = searchParams?.get("tab");
+  useEffect(() => {
+    if (tabQuery && (TABS as readonly string[]).includes(tabQuery)) {
+      setActiveTab(tabQuery as Tab);
+    }
+  }, [tabQuery]);
+
+  async function loadDeploymentDetail() {
+    if (!isLoadingDeployment) {
+      await getDeploymentDetail();
+      await getLeases();
+    }
+  }
+
+  function changeTab(tab: Tab) {
+    setActiveTab(tab);
+    const url = new URL(window.location.href);
+    url.searchParams.set("tab", tab);
+    window.history.replaceState(window.history.state, "", `${url.pathname}${url.search}`);
+    analyticsService.track("navigate_tab", { category: "deployments", label: `Navigate tab ${tab} in deployment detail`, tab });
+  }
+
+  return (
+    <d.Layout
+      isLoading={isLoadingLeases || isLoadingDeployment || isLoadingProviders}
+      isUsingSettings
+      disableContainer
+      containerClassName="flex min-h-[calc(100dvh_-_var(--app-header-height,57px)_-_4px)] flex-col px-6 pt-4"
+    >
+      <d.NextSeo title={`Deployment detail #${dseq}`} />
+
+      {isDeploymentNotFound && (
+        <div className="mt-8 text-center">
+          <Title className="mb-2">404</Title>
+          <p>This deployment does not exist or it was created using another wallet.</p>
+          <div className="pt-4">
+            <Link href={UrlService.home()} className={cn(buttonVariants({ variant: "default" }), "inline-flex items-center space-x-2")}>
+              <ArrowLeft className="text-sm" />
+              <span>Go to homepage</span>
+            </Link>
+          </div>
+        </div>
+      )}
+
+      {deployment && isLeasesLoaded && (
+        <>
+          <d.ReclamationBanner leases={leases} dseq={dseq} />
+
+          <d.DeploymentDetailHeader deployment={deployment} leases={leases} providers={providers || []} />
+
+          <Tabs value={activeTab} onValueChange={value => changeTab(value as Tab)} className="flex flex-1 flex-col">
+            <div className="-mx-6 border-b border-t">
+              <TabsList className="h-auto w-full justify-start gap-8 rounded-none border-0 bg-transparent px-6 py-0">
+                {TABS.map(tab => (
+                  <TabsTrigger
+                    key={tab}
+                    value={tab}
+                    className="-mb-px whitespace-nowrap rounded-none border-b-2 border-transparent bg-transparent px-1 pb-3 pt-3 text-base font-medium text-muted-foreground shadow-none data-[state=active]:border-foreground data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:shadow-none"
+                  >
+                    {TAB_LABELS[tab]}
+                  </TabsTrigger>
+                ))}
+              </TabsList>
+            </div>
+
+            <div className="-mx-6 flex-1 bg-muted px-6 py-6">
+              {activeTab === "DETAILS" && (
+                <div>
+                  {leases?.map((lease, i) => (
+                    <d.LeaseRow
+                      key={lease.id}
+                      index={i}
+                      lease={lease}
+                      repo={repo}
+                      deploymentManifest={deploymentManifest}
+                      dseq={dseq}
+                      providers={providers || []}
+                      loadDeploymentDetail={loadDeploymentDetail}
+                      isRemoteDeploy={isRemoteDeploy}
+                    />
+                  ))}
+                  {!hasLeases && !isLoadingLeases && !isLoadingDeployment && <>This deployment doesn't have any leases</>}
+                </div>
+              )}
+
+              {activeTab === "LOGS" && (isActive ? <d.DeploymentLogs leases={leases} selectedLogsMode="logs" /> : <TabInactiveState />)}
+              {activeTab === "EVENTS" && (isActive ? <d.DeploymentLogs leases={leases} selectedLogsMode="events" /> : <TabInactiveState />)}
+              {activeTab === "SHELL" && (isActive ? <d.DeploymentLeaseShell leases={leases} /> : <TabInactiveState />)}
+
+              {activeTab === "SETTINGS" && leases && (
+                <d.ManifestUpdate
+                  editedManifest={editedManifest as string}
+                  onManifestChange={setEditedManifest}
+                  isRemoteDeploy={isRemoteDeploy}
+                  deployment={deployment}
+                  leases={leases}
+                  closeManifestEditor={() => {
+                    setActiveTab("DETAILS");
+                    loadDeploymentDetail();
+                  }}
+                />
+              )}
+
+              {activeTab === "BILLING" &&
+                (isAlertsEnabled ? (
+                  <d.DeploymentAlerts deployment={deployment} onStateChange={() => undefined} />
+                ) : (
+                  <TabInactiveState label="Billing & notifications are coming soon." />
+                ))}
+            </div>
+          </Tabs>
+        </>
+      )}
+    </d.Layout>
+  );
+};
+
+const TabInactiveState: FC<{ label?: string }> = ({ label = "Available when the deployment is active." }) => (
+  <div className="py-12 text-center text-sm text-muted-foreground">{label}</div>
+);

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.spec.tsx
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { LeaseServiceStatus, LeaseStatusDto } from "@src/queries/useLeaseQuery";
+import type { DeploymentDto, LeaseDto } from "@src/types/deployment";
+import type { ApiProviderList } from "@src/types/provider";
+import { DEPENDENCIES, DeploymentDetailHeader } from "./DeploymentDetailHeader";
+
+import { render, screen } from "@testing-library/react";
+import { MockComponents } from "@tests/unit/mocks";
+
+describe("DeploymentDetailHeader", () => {
+  it("shows the number of services reported by the lease status", () => {
+    setup({ serviceUris: { web: [], api: [], worker: [] } });
+
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("shows auto top-up as active when enabled for the deployment", () => {
+    setup({ autoTopUpEnabled: true });
+
+    expect(screen.getByText("Active")).toBeInTheDocument();
+  });
+
+  it("shows auto top-up as off when disabled for the deployment", () => {
+    setup({ autoTopUpEnabled: false });
+
+    expect(screen.getByText("Off")).toBeInTheDocument();
+  });
+
+  it("links to the service URI with a Visit action", () => {
+    setup({ serviceUris: { web: ["my-app.akash.app"] } });
+
+    const visit = screen.getByRole("link", { name: "Visit" });
+    expect(visit).toHaveAttribute("href", "http://my-app.akash.app");
+  });
+
+  it("hides the Visit action when the lease has no status yet", () => {
+    setup({ hasLeaseStatus: false });
+
+    expect(screen.queryByRole("link", { name: "Visit" })).not.toBeInTheDocument();
+  });
+
+  function setup(input: { serviceUris?: Record<string, string[]>; autoTopUpEnabled?: boolean; hasLeaseStatus?: boolean }) {
+    const hasLeaseStatus = input.hasLeaseStatus ?? true;
+    let leaseStatus: LeaseStatusDto | null = null;
+    if (hasLeaseStatus) {
+      leaseStatus = mock<LeaseStatusDto>();
+      leaseStatus.forwarded_ports = {};
+      leaseStatus.services = Object.fromEntries(
+        Object.entries(input.serviceUris ?? { web: [] }).map(([name, uris]) => {
+          const service = mock<LeaseServiceStatus>();
+          service.uris = uris;
+          return [name, service];
+        })
+      );
+    }
+
+    const useServices: typeof DEPENDENCIES.useServices = () =>
+      mock<ReturnType<typeof DEPENDENCIES.useServices>>({
+        deploymentLocalStorage: mock<ReturnType<typeof DEPENDENCIES.useServices>["deploymentLocalStorage"]>({ get: () => null })
+      });
+    const useWallet: typeof DEPENDENCIES.useWallet = () => mock<ReturnType<typeof DEPENDENCIES.useWallet>>({ address: "akash1test" });
+    const useWalletBalance: typeof DEPENDENCIES.useWalletBalance = () => mock<ReturnType<typeof DEPENDENCIES.useWalletBalance>>({ balance: null });
+    const useDeploymentSettingQuery: typeof DEPENDENCIES.useDeploymentSettingQuery = () =>
+      mock<ReturnType<typeof DEPENDENCIES.useDeploymentSettingQuery>>({
+        data: mock<NonNullable<ReturnType<typeof DEPENDENCIES.useDeploymentSettingQuery>["data"]>>({ autoTopUpEnabled: input.autoTopUpEnabled ?? false })
+      });
+    const useLeaseStatus: typeof DEPENDENCIES.useLeaseStatus = () => mock<ReturnType<typeof DEPENDENCIES.useLeaseStatus>>({ data: leaseStatus });
+
+    const deployment = mock<DeploymentDto>({
+      dseq: "1786440078202",
+      state: "active",
+      cpuAmount: 2,
+      gpuAmount: 0,
+      memoryAmount: 536870912,
+      storageAmount: 536870912,
+      escrowAccount: mock<DeploymentDto["escrowAccount"]>({ state: mock<DeploymentDto["escrowAccount"]["state"]>({ funds: [] }) })
+    });
+
+    return render(
+      <DeploymentDetailHeader
+        deployment={deployment}
+        leases={[mock<LeaseDto>({ id: "1", provider: "akash1provider", state: "active" })]}
+        providers={[mock<ApiProviderList>({ owner: "akash1provider" })]}
+        dependencies={MockComponents(DEPENDENCIES, {
+          useServices,
+          useWallet,
+          useWalletBalance,
+          useDeploymentSettingQuery,
+          useLeaseStatus
+        })}
+      />
+    );
+  }
+});

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.tsx
@@ -1,0 +1,143 @@
+"use client";
+import type { FC, ReactNode } from "react";
+import { Badge, buttonVariants, Card, CardContent, CustomTooltip } from "@akashnetwork/ui/components";
+import { cn } from "@akashnetwork/ui/utils";
+import { CheckCircle, Globe, InfoCircle, MediaImage } from "iconoir-react";
+import Link from "next/link";
+
+import { PricePerTimeUnit } from "@src/components/shared/PricePerTimeUnit";
+import { StatusPill } from "@src/components/shared/StatusPill";
+import { useServices } from "@src/context/ServicesProvider";
+import { useWallet } from "@src/context/WalletProvider";
+import { useWalletBalance } from "@src/hooks/useWalletBalance";
+import { useDeploymentSettingQuery } from "@src/queries/deploymentSettingsQuery";
+import type { LeaseStatusDto } from "@src/queries/useLeaseQuery";
+import { useLeaseStatus } from "@src/queries/useLeaseQuery";
+import type { DeploymentDto, LeaseDto } from "@src/types/deployment";
+import type { ApiProviderList } from "@src/types/provider";
+import { roundDecimal, udenomToDenom } from "@src/utils/mathHelpers";
+import { hasLiveGpuLease, isLeaseLive } from "@src/utils/reclamationUtils";
+import { bytesToShrink } from "@src/utils/unitUtils";
+
+export const DEPENDENCIES = {
+  useServices,
+  useWallet,
+  useWalletBalance,
+  useDeploymentSettingQuery,
+  useLeaseStatus,
+  CustomTooltip
+};
+
+/** Deployment states map to a user-facing verb; unknown states fall through to the raw value. */
+const STATUS_LABELS: Record<string, string> = {
+  active: "Running",
+  closed: "Closed"
+};
+
+export interface DeploymentDetailHeaderProps {
+  deployment: DeploymentDto;
+  leases: LeaseDto[] | null | undefined;
+  providers: ApiProviderList[];
+  dependencies?: typeof DEPENDENCIES;
+}
+
+export const DeploymentDetailHeader: FC<DeploymentDetailHeaderProps> = ({ deployment, leases, providers, dependencies: d = DEPENDENCIES }) => {
+  const { deploymentLocalStorage } = d.useServices();
+  const { address } = d.useWallet();
+  const deploymentCost = leases?.reduce((sum, lease) => sum + parseFloat(lease.price.amount), 0) ?? 0;
+  const { balance: walletBalance } = d.useWalletBalance();
+  const { data: settings } = d.useDeploymentSettingQuery({ dseq: deployment.dseq });
+
+  const liveLease = leases?.find(isLeaseLive) ?? null;
+  const provider = providers.find(p => p.owner === liveLease?.provider) ?? null;
+  const { data: leaseStatus } = d.useLeaseStatus({ provider, lease: liveLease, enabled: !!provider });
+
+  const name = deploymentLocalStorage.get(address, deployment.dseq)?.name || `Deployment #${deployment.dseq}`;
+  const statusLabel = STATUS_LABELS[deployment.state] ?? deployment.state;
+  const denom = deployment.escrowAccount.state.funds[0]?.denom || "";
+  const hasGpu = hasLiveGpuLease(leases);
+  const servicesCount = leaseStatus ? Object.keys(leaseStatus.services).length : leases?.length ?? 0;
+  const primaryUri = getPrimaryUri(leaseStatus);
+  const memory = bytesToShrink(deployment.memoryAmount);
+  const storage = bytesToShrink(deployment.storageAmount);
+
+  return (
+    <div className="flex flex-col gap-6 py-6 lg:flex-row lg:items-start lg:justify-between">
+      <div className="flex items-start gap-6">
+        <div className="flex h-36 w-56 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-muted text-muted-foreground">
+          <MediaImage className="text-5xl" />
+        </div>
+        <div className="space-y-3">
+          <div className="flex items-center">
+            <StatusPill state={deployment.state} size="small" className={cn("ml-0", { "bg-emerald-500": deployment.state === "active" })} />
+            <span className={cn("ml-2 text-sm font-medium", { "text-emerald-500": deployment.state === "active" })}>{statusLabel}</span>
+          </div>
+          <h1 className="text-3xl font-bold tracking-tight">{name}</h1>
+          {primaryUri && (
+            <div className="flex items-center gap-2">
+              <div className="inline-flex max-w-xs items-center gap-2 rounded-md border px-3 py-2 text-sm">
+                <Globe className="shrink-0 text-xs text-muted-foreground" />
+                <span className="truncate">{primaryUri}</span>
+              </div>
+              <Link href={`http://${primaryUri}`} target="_blank" rel="noreferrer" className={cn(buttonVariants({ variant: "default", size: "sm" }))}>
+                Visit
+              </Link>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <Card className="w-full shrink-0 lg:w-auto">
+        <CardContent className="grid grid-cols-4 gap-x-10 gap-y-5 p-6">
+          <SummaryItem label="TOTAL SERVICES">{servicesCount}</SummaryItem>
+          <SummaryItem label="COST">
+            {deploymentCost ? <PricePerTimeUnit denom={denom} perBlockValue={udenomToDenom(deploymentCost, 10)} showAsHourly={hasGpu} /> : "—"}
+          </SummaryItem>
+          <SummaryItem label="BALANCE">{walletBalance ? `$${walletBalance.totalUsd.toFixed(2)}` : "—"}</SummaryItem>
+          <SummaryItem
+            label={
+              <span className="inline-flex items-center gap-1">
+                AUTO TOP-UP
+                <d.CustomTooltip title="Automatically add credits when your balance gets low to keep your deployments running.">
+                  <InfoCircle width={12} height={12} className="text-muted-foreground" />
+                </d.CustomTooltip>
+              </span>
+            }
+          >
+            {settings?.autoTopUpEnabled ? (
+              <Badge className="gap-1 rounded-md border-transparent bg-blue-500 px-2 py-0.5 text-white hover:bg-blue-500 dark:bg-blue-600 dark:hover:bg-blue-600">
+                <CheckCircle width={12} height={12} />
+                Active
+              </Badge>
+            ) : (
+              <span className="text-muted-foreground">Off</span>
+            )}
+          </SummaryItem>
+          <SummaryItem label="GPU">{deployment.gpuAmount ? deployment.gpuAmount : "—"}</SummaryItem>
+          <SummaryItem label="vCPU">{roundDecimal(deployment.cpuAmount, 2)}</SummaryItem>
+          <SummaryItem label="MEMORY">{`${roundDecimal(memory.value, 2)} ${memory.unit}`}</SummaryItem>
+          <SummaryItem label="STORAGE">{`${roundDecimal(storage.value, 2)} ${storage.unit}`}</SummaryItem>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+const SummaryItem: FC<{ label: ReactNode; children: ReactNode }> = ({ label, children }) => (
+  <div className="space-y-1.5">
+    <div className="whitespace-nowrap text-xs font-medium text-muted-foreground">{label}</div>
+    <div className="whitespace-nowrap text-sm font-medium">{children}</div>
+  </div>
+);
+
+function getPrimaryUri(leaseStatus: LeaseStatusDto | null | undefined): string | undefined {
+  if (!leaseStatus) return undefined;
+
+  const uri = Object.values(leaseStatus.services).flatMap(service => service.uris ?? [])[0];
+  if (uri) return uri;
+
+  const forwarded = Object.values(leaseStatus.forwarded_ports ?? {})
+    .flat()
+    .find(port => port.host);
+  return forwarded ? `${forwarded.host}:${forwarded.externalPort}` : undefined;
+}

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailPreview.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailPreview.spec.tsx
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { DEPENDENCIES, DeploymentDetailPreview } from "./DeploymentDetailPreview";
+
+import { render, screen } from "@testing-library/react";
+import { MockComponents } from "@tests/unit/mocks";
+
+describe("DeploymentDetailPreview", () => {
+  it("renders the deployment detail page when the preview flag is on", () => {
+    const DeploymentDetail = vi.fn((_props: { dseq: string }) => <div>deployment-detail</div>);
+    const { useFlag } = setup({ isPreviewEnabled: true, dependencies: { DeploymentDetail } });
+
+    expect(screen.getByText("deployment-detail")).toBeInTheDocument();
+    expect(useFlag).toHaveBeenCalledWith("deployment_detail_preview");
+    expect(DeploymentDetail.mock.calls[0]?.[0]).toEqual({ dseq: "1786440078202" });
+  });
+
+  it("renders a not-available page when the preview flag is off", () => {
+    setup({ isPreviewEnabled: false });
+
+    expect(screen.getByText("This page is not available.")).toBeInTheDocument();
+    expect(screen.queryByText("deployment-detail")).not.toBeInTheDocument();
+  });
+
+  function setup(input: { isPreviewEnabled: boolean; dependencies?: Partial<typeof DEPENDENCIES> }) {
+    const useFlag = vi.fn(() => input.isPreviewEnabled);
+    const DeploymentDetail = () => <div>deployment-detail</div>;
+
+    return {
+      useFlag,
+      ...render(
+        <DeploymentDetailPreview dseq="1786440078202" dependencies={MockComponents(DEPENDENCIES, { useFlag, DeploymentDetail, ...input.dependencies })} />
+      )
+    };
+  }
+});

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailPreview.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailPreview.tsx
@@ -1,0 +1,41 @@
+"use client";
+import type { FC } from "react";
+
+import { useFlag } from "@src/hooks/useFlag";
+import Layout from "../../layout/Layout";
+import { Title } from "../../shared/Title";
+import { DeploymentDetail } from "./DeploymentDetail";
+
+export const DEPENDENCIES = {
+  useFlag,
+  Layout,
+  DeploymentDetail
+};
+
+export interface DeploymentDetailPreviewProps {
+  dseq: string;
+  dependencies?: typeof DEPENDENCIES;
+}
+
+/**
+ * Development-only mirror of the canonical deployment detail page on a parallel route, so the redesign
+ * can be e2e-tested and demoed while the canonical route keeps serving the legacy page. It renders the very
+ * same {@link DeploymentDetail} the canonical route does; only the gating flag differs. Removed as a whole
+ * (route file + this file) once the redesign is rolled out — no other file changes.
+ */
+export const DeploymentDetailPreview: FC<DeploymentDetailPreviewProps> = ({ dseq, dependencies: d = DEPENDENCIES }) => {
+  const isPreviewEnabled = d.useFlag("deployment_detail_preview");
+
+  if (!isPreviewEnabled) {
+    return (
+      <d.Layout>
+        <div className="mt-8 text-center">
+          <Title className="mb-2">404</Title>
+          <p>This page is not available.</p>
+        </div>
+      </d.Layout>
+    );
+  }
+
+  return <d.DeploymentDetail dseq={dseq} />;
+};

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailRouter.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailRouter.spec.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { DEPENDENCIES, DeploymentDetailRouter } from "./DeploymentDetailRouter";
+
+import { render, screen } from "@testing-library/react";
+import { MockComponents } from "@tests/unit/mocks";
+
+describe("DeploymentDetailRouter", () => {
+  it("renders the redesigned page when the redesign flag is on", () => {
+    setup({ isRedesignEnabled: true });
+
+    expect(screen.getByText("redesigned")).toBeInTheDocument();
+    expect(screen.queryByText("legacy")).not.toBeInTheDocument();
+  });
+
+  it("renders the legacy page when the redesign flag is off", () => {
+    setup({ isRedesignEnabled: false });
+
+    expect(screen.getByText("legacy")).toBeInTheDocument();
+    expect(screen.queryByText("redesigned")).not.toBeInTheDocument();
+  });
+
+  it("passes the dseq through to the rendered page", () => {
+    const DeploymentDetail = vi.fn((_props: { dseq: string }) => <div>redesigned</div>);
+    setup({ isRedesignEnabled: true, dependencies: { DeploymentDetail } });
+
+    expect(DeploymentDetail.mock.calls[0]?.[0]).toEqual({ dseq: "1786440078202" });
+  });
+
+  function setup(input: { isRedesignEnabled: boolean; dependencies?: Partial<typeof DEPENDENCIES> }) {
+    const useFlag: typeof DEPENDENCIES.useFlag = () => input.isRedesignEnabled;
+    const DeploymentDetail = () => <div>redesigned</div>;
+    const DeploymentDetailLegacy = () => <div>legacy</div>;
+
+    return render(
+      <DeploymentDetailRouter
+        dseq="1786440078202"
+        dependencies={MockComponents(DEPENDENCIES, { useFlag, DeploymentDetail, DeploymentDetailLegacy, ...input.dependencies })}
+      />
+    );
+  }
+});

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailRouter.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailRouter.tsx
@@ -1,0 +1,23 @@
+"use client";
+import type { FC } from "react";
+
+import { DeploymentDetailLegacy } from "@src/components/deployments/DeploymentDetailLegacy";
+import { useFlag } from "@src/hooks/useFlag";
+import { DeploymentDetail } from "./DeploymentDetail";
+
+export const DEPENDENCIES = {
+  useFlag,
+  DeploymentDetail,
+  DeploymentDetailLegacy
+};
+
+export interface DeploymentDetailRouterProps {
+  dseq: string;
+  dependencies?: typeof DEPENDENCIES;
+}
+
+export const DeploymentDetailRouter: FC<DeploymentDetailRouterProps> = ({ dseq, dependencies: d = DEPENDENCIES }) => {
+  const isRedesignEnabled = d.useFlag("deployment_detail_redesign");
+
+  return isRedesignEnabled ? <d.DeploymentDetail dseq={dseq} /> : <d.DeploymentDetailLegacy dseq={dseq} />;
+};

--- a/apps/deploy-web/src/components/deployments/DeploymentDetailLegacy.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetailLegacy.tsx
@@ -37,13 +37,13 @@ import { DeploymentLogs } from "./DeploymentLogs";
 import { DeploymentSubHeader } from "./DeploymentSubHeader";
 import { LeaseRow } from "./LeaseRow";
 
-export interface DeploymentDetailProps {
+export interface DeploymentDetailLegacyProps {
   dseq: string;
 }
 
 type Tab = "ALERTS" | "EVENTS" | "LOGS" | "SHELL" | "EDIT" | "LEASES";
 
-export const DeploymentDetail: FC<DeploymentDetailProps> = ({ dseq }) => {
+export const DeploymentDetailLegacy: FC<DeploymentDetailLegacyProps> = ({ dseq }) => {
   const { analyticsService, deploymentLocalStorage, sdlAnalyzer } = useServices();
   const router = useRouter();
 

--- a/apps/deploy-web/src/components/deployments/DeploymentSubHeader.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentSubHeader.tsx
@@ -21,7 +21,7 @@ import type { DeploymentDto, LeaseDto } from "@src/types/deployment";
 import type { TeeType } from "@src/utils/confidentialCompute";
 import type { DeclaredGpuInterconnect } from "@src/utils/gpuInterconnect";
 import { udenomToDenom } from "@src/utils/mathHelpers";
-import { isLeaseLive } from "@src/utils/reclamationUtils";
+import { hasLiveGpuLease, isLeaseLive } from "@src/utils/reclamationUtils";
 
 type Props = {
   deployment: DeploymentDto;
@@ -36,7 +36,7 @@ export const DeploymentSubHeader: React.FunctionComponent<Props> = ({ deployment
   const isActive = deployment.state === "active";
   const hasLeases = !!leases && leases.length > 0;
   const hasActiveLeases = hasLeases && leases.some(isLeaseLive);
-  const hasGpu = leases?.some(l => isLeaseLive(l) && l.gpuAmount && l.gpuAmount > 0);
+  const hasGpu = hasLiveGpuLease(leases);
   const { isTrialing } = useWallet();
   const { publicConfig: appConfig } = useServices();
 

--- a/apps/deploy-web/src/pages/deployments/[dseq]/preview.tsx
+++ b/apps/deploy-web/src/pages/deployments/[dseq]/preview.tsx
@@ -1,12 +1,12 @@
 import { z } from "zod";
 
-import { DeploymentDetailRouter } from "@src/components/deployments/DeploymentDetail/DeploymentDetailRouter";
+import { DeploymentDetailPreview } from "@src/components/deployments/DeploymentDetail/DeploymentDetailPreview";
 import { defineServerSideProps } from "@src/lib/nextjs/defineServerSideProps/defineServerSideProps";
 
-export default DeploymentDetailRouter;
+export default DeploymentDetailPreview;
 
 export const getServerSideProps = defineServerSideProps({
-  route: "/deployments/[dseq]",
+  route: "/deployments/[dseq]/preview",
   schema: z.object({
     params: z.object({
       dseq: z.string().regex(/^\d+$/)

--- a/apps/deploy-web/src/types/feature-flags.ts
+++ b/apps/deploy-web/src/types/feature-flags.ts
@@ -10,4 +10,6 @@ export type FeatureFlag =
   | "ui_sdl_preview_panel"
   | "ui_build_and_deploy"
   | "ui_agent_mode_deploy"
-  | "hackathons";
+  | "hackathons"
+  | "deployment_detail_redesign"
+  | "deployment_detail_preview";

--- a/apps/deploy-web/src/utils/reclamationUtils.spec.ts
+++ b/apps/deploy-web/src/utils/reclamationUtils.spec.ts
@@ -5,6 +5,7 @@ import {
   classifyLeaseCloseReason,
   getLeaseCloseReasonLabel,
   getReclamationDeadline,
+  hasLiveGpuLease,
   isLeaseLive,
   isProviderReclaimed,
   isReclaiming,
@@ -145,11 +146,32 @@ describe("reclamationUtils", () => {
     });
   });
 
+  describe("hasLiveGpuLease", () => {
+    it("is true when a live lease has a GPU", () => {
+      expect(hasLiveGpuLease([createLease({ state: "active", gpuAmount: 1 })])).toBe(true);
+    });
+
+    it("is false when the GPU lease is not live", () => {
+      expect(hasLiveGpuLease([createLease({ state: "closed", gpuAmount: 1 })])).toBe(false);
+    });
+
+    it("is false when no live lease has a GPU", () => {
+      expect(hasLiveGpuLease([createLease({ state: "active", gpuAmount: 0 })])).toBe(false);
+    });
+
+    it("is false for empty or missing leases", () => {
+      expect(hasLiveGpuLease([])).toBe(false);
+      expect(hasLiveGpuLease(null)).toBe(false);
+      expect(hasLiveGpuLease(undefined)).toBe(false);
+    });
+  });
+
   function createLease(
     overrides: {
       state?: string;
       reason?: string;
       groupState?: string;
+      gpuAmount?: number;
       reclamation?: LeaseDto["reclamation"];
     } = {}
   ): LeaseDto {
@@ -163,6 +185,7 @@ describe("reclamationUtils", () => {
       state: overrides.state ?? "active",
       price: { denom: "uakt", amount: "100" },
       cpuAmount: 0,
+      gpuAmount: overrides.gpuAmount,
       memoryAmount: 0,
       storageAmount: 0,
       reason: overrides.reason,

--- a/apps/deploy-web/src/utils/reclamationUtils.ts
+++ b/apps/deploy-web/src/utils/reclamationUtils.ts
@@ -82,6 +82,11 @@ export function isLeaseLive(lease: Pick<LeaseDto, "state">): boolean {
   return lease.state === "active" || lease.state === "reclaiming";
 }
 
+/** Whether any live lease is running on GPU — drives hourly-vs-monthly cost display in the headers. */
+export function hasLiveGpuLease(leases: Pick<LeaseDto, "state" | "gpuAmount">[] | null | undefined): boolean {
+  return !!leases?.some(lease => isLeaseLive(lease) && !!lease.gpuAmount && lease.gpuAmount > 0);
+}
+
 function hasReclamationStarted(lease: Pick<LeaseDto, "reclamation">): boolean {
   const startedAt = lease.reclamation?.startedAt;
   return startedAt !== undefined && Number(startedAt) > 0;

--- a/apps/deploy-web/tests/ui/deployment-detail-preview.spec.ts
+++ b/apps/deploy-web/tests/ui/deployment-detail-preview.spec.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "./fixture/base-test";
+import { testEnvConfig } from "./fixture/test-env.config";
+import { ConfigureDeploymentPage } from "./pages/ConfigureDeploymentPage";
+
+const REDESIGN_TABS = ["Details", "Logs", "Events", "Shell", "Settings", "Billing & Notifications"];
+
+test.describe("Deployment detail redesign preview", () => {
+  test.use({ userType: "existing" });
+
+  test("renders the redesigned header and tabs on the preview route", async ({ page }) => {
+    test.setTimeout(8 * 60 * 1000);
+
+    const configure = new ConfigureDeploymentPage(page);
+    let dseq: string;
+
+    await test.step("deploy a container through the configure flow", async () => {
+      await configure.open();
+      await configure.fillImageName("nginx:latest");
+      await configure.requestQuotes();
+      await page.waitForURL(/\/new-deployment\/configure\/\d+/, { timeout: 180_000 });
+
+      await configure.selectFirstAvailableProvider();
+      await expect(configure.reviewDialog()).toBeVisible({ timeout: 30_000 });
+      await configure.confirmAndDeploy();
+      await page.waitForURL(/\/deployments\/\d+/, { timeout: 180_000 });
+
+      const match = page.url().match(/deployments\/(\d+)/);
+      if (!match) throw new Error(`Could not extract DSEQ from URL: ${page.url()}`);
+      dseq = match[1];
+    });
+
+    await test.step("open the redesigned preview route", async () => {
+      await page.goto(`${testEnvConfig.BASE_URL}/deployments/${dseq!}/preview`);
+      await expect(page).toHaveURL(new RegExp(`/deployments/${dseq!}/preview`));
+    });
+
+    await test.step("renders the summary header and full tab bar", async () => {
+      await expect(page.getByText("TOTAL SERVICES")).toBeVisible({ timeout: 30_000 });
+      await expect(page.getByText("AUTO TOP-UP")).toBeVisible();
+
+      for (const tab of REDESIGN_TABS) {
+        await expect(page.getByRole("tab", { name: tab })).toBeVisible();
+      }
+    });
+
+    await test.step("switches tabs via the tab query param without navigating", async () => {
+      await page.getByRole("tab", { name: "Events" }).click();
+      await expect(page).toHaveURL(new RegExp(`/deployments/${dseq!}/preview\\?tab=EVENTS`));
+    });
+  });
+});


### PR DESCRIPTION
## Why

The deployment detail page opens on a dense grid of text (balance, cost, spent, status, time-left, dseq). The redesign leads with what a user cares about at a glance — is it running, where can I reach it, what does it cost, how much balance is left — and reorganizes the tabs. This PR lays the foundational shell every subsequent tab slice builds on, shipped behind feature flags in parallel with the current page so nothing changes for users until we deliberately roll it over.

Closes CON-821

## What

A redesigned deployment detail page behind two Unleash flags:

- **`deployment_detail_redesign`** — gates the canonical `/deployments/[dseq]` route (redesigned vs legacy page). Off → the current page is byte-for-byte unchanged.
- **`deployment_detail_preview`** — gates a temporary, development-only `/deployments/[dseq]/preview` route that renders the *same* page for e2e and demos, while the canonical route keeps serving the legacy page. Both routes mount the identical `DeploymentDetail` component; removing the preview later is pure file deletion.

The page:

- **Header** — app thumbnail (placeholder for now), running/status state, deployment name, live URL + Visit, and a summary card: total services, cost (hourly for GPU, monthly otherwise), account balance, auto top-up, and aggregate GPU / vCPU / memory / storage.
- **Tabs** — Details · Logs · Events · Shell · Settings · Billing & Notifications. Tab bodies reuse the existing components (lease rows, logs, shell, manifest update, alerts) so nothing regresses. Tabs update the `?tab=` query param via `history.replaceState` — no navigation.
- Full-width layout with the design's `#f5f5f5` content band and underline tabs.
- **Smoke e2e** on the `/preview` route: deploy a container, then assert the redesigned header + full tab bar render and tabs update `?tab=` without navigating.

The old page is renamed to `DeploymentDetailLegacy` so the redesign permanently owns the `DeploymentDetail` name and rollout teardown stays deletion-only (delete the legacy page, the preview route, and the flags).

**Provisional, refined in later slices:** header balance uses the account total; services count and live URL derive from the primary live lease; the thumbnail is a placeholder pending a product decision.

<img width="1488" height="707" alt="image" src="https://github.com/user-attachments/assets/ead59b38-803a-4d03-ab5a-c474d60870b3" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a redesigned deployment details experience with Details, Logs, Events, Shell, Settings, and Billing tabs.
  - Added deployment status, service links, resource and cost metrics, wallet balance, GPU usage, and auto top-up information.
  - Added URL-synchronized tabs, deployment error handling, and clearer inactive-deployment messaging.
  - Added a feature-flagged preview route with validation and fallback to the existing experience.
  - Improved GPU lease status detection.

- **Tests**
  - Added coverage for deployment details, headers, feature-flag routing, preview behavior, lease states, and tab navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->