### PR TITLE
feat(billing): fund draining deployments as soon as credits are added

### DIFF
--- a/apps/api/src/app/providers/jobs.provider.ts
+++ b/apps/api/src/app/providers/jobs.provider.ts
@@ -10,6 +10,7 @@ import { CloseTrialDeploymentHandler } from "../services/close-trial-deployment/
 import { EnableDeploymentAlertHandler } from "../services/enable-deployment-alert/enable-deployment-alert.handler";
 import { FirstPurchaseBonusGrantedHandler } from "../services/first-purchase-bonus-granted/first-purchase-bonus-granted.handler";
 import { FundDeploymentHandler } from "../services/fund-deployment/fund-deployment.handler";
+import { FundDrainingDeploymentsHandler } from "../services/fund-draining-deployments/fund-draining-deployments.handler";
 import { TrialDeploymentLeaseCreatedHandler } from "../services/trial-deployment-lease-created/trial-deployment-lease-created.handler";
 import { TrialStartedHandler } from "../services/trial-started/trial-started.handler";
 
@@ -25,6 +26,7 @@ container.register(APP_INITIALIZER, {
         container.resolve(TrialDeploymentLeaseCreatedHandler),
         container.resolve(EnableDeploymentAlertHandler),
         container.resolve(FundDeploymentHandler),
+        container.resolve(FundDrainingDeploymentsHandler),
         container.resolve(WalletBalanceReloadCheckHandler),
         container.resolve(FirstPurchaseBonusGrantedHandler),
         container.resolve(ActivateTrialHandler)

--- a/apps/api/src/app/services/fund-draining-deployments/fund-draining-deployments.handler.spec.ts
+++ b/apps/api/src/app/services/fund-draining-deployments/fund-draining-deployments.handler.spec.ts
@@ -35,6 +35,12 @@ describe(FundDrainingDeploymentsHandler.name, () => {
     expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "FUND_DRAINING_DEPLOYMENTS_FAILED", error }));
   });
 
+  it("uses the singleton policy so the per-wallet singletonKey serializes same-wallet funding", () => {
+    const { handler } = setup();
+
+    expect(handler.policy).toBe("singleton");
+  });
+
   function setup(params?: { topUpManagedDeploymentsService?: Partial<TopUpManagedDeploymentsService> }) {
     const topUpManagedDeploymentsService = mock<TopUpManagedDeploymentsService>({
       topUpDrainingDeploymentsForOwner: vi.fn().mockResolvedValue(undefined),

--- a/apps/api/src/app/services/fund-draining-deployments/fund-draining-deployments.handler.spec.ts
+++ b/apps/api/src/app/services/fund-draining-deployments/fund-draining-deployments.handler.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { FundDrainingDeploymentsCommand } from "@src/billing/commands/fund-draining-deployments.command";
+import type { JobPayload } from "@src/core";
+import type { CreateLogger } from "@src/core/providers/logging.provider";
+import type { TopUpManagedDeploymentsService } from "@src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service";
+import { FundDrainingDeploymentsHandler } from "./fund-draining-deployments.handler";
+
+describe(FundDrainingDeploymentsHandler.name, () => {
+  const payload: JobPayload<FundDrainingDeploymentsCommand> = {
+    walletId: 1,
+    address: "akash1abc",
+    version: 1
+  };
+
+  it("funds the owner's draining deployments for the payload identifiers", async () => {
+    const { handler, topUpManagedDeploymentsService } = setup();
+
+    await handler.handle(payload);
+
+    expect(topUpManagedDeploymentsService.topUpDrainingDeploymentsForOwner).toHaveBeenCalledWith({
+      walletId: 1,
+      address: "akash1abc"
+    });
+  });
+
+  it("logs and rethrows when the funding service throws so the job can retry", async () => {
+    const error = new Error("deposit failed");
+    const { handler, logger } = setup({
+      topUpManagedDeploymentsService: { topUpDrainingDeploymentsForOwner: vi.fn().mockRejectedValue(error) }
+    });
+
+    await expect(handler.handle(payload)).rejects.toThrow(error);
+    expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "FUND_DRAINING_DEPLOYMENTS_FAILED", error }));
+  });
+
+  function setup(params?: { topUpManagedDeploymentsService?: Partial<TopUpManagedDeploymentsService> }) {
+    const topUpManagedDeploymentsService = mock<TopUpManagedDeploymentsService>({
+      topUpDrainingDeploymentsForOwner: vi.fn().mockResolvedValue(undefined),
+      ...params?.topUpManagedDeploymentsService
+    });
+    const logger = mock<ReturnType<CreateLogger>>();
+    const createLogger: CreateLogger = () => logger;
+
+    const handler = new FundDrainingDeploymentsHandler(topUpManagedDeploymentsService, createLogger);
+
+    return { handler, topUpManagedDeploymentsService, logger };
+  }
+});

--- a/apps/api/src/app/services/fund-draining-deployments/fund-draining-deployments.handler.ts
+++ b/apps/api/src/app/services/fund-draining-deployments/fund-draining-deployments.handler.ts
@@ -11,6 +11,13 @@ export class FundDrainingDeploymentsHandler implements JobHandler<FundDrainingDe
 
   public readonly concurrency = 2;
 
+  /**
+   * With the per-wallet singletonKey on the command, the `singleton` policy keeps two top-ups for the
+   * same wallet from funding its draining deployments concurrently (a plain `standard` queue ignores
+   * singletonKey), while different wallets still run in parallel up to `concurrency`.
+   */
+  public readonly policy = "singleton";
+
   private readonly logger: ReturnType<CreateLogger>;
 
   constructor(

--- a/apps/api/src/app/services/fund-draining-deployments/fund-draining-deployments.handler.ts
+++ b/apps/api/src/app/services/fund-draining-deployments/fund-draining-deployments.handler.ts
@@ -1,0 +1,36 @@
+import { inject, singleton } from "tsyringe";
+
+import { FundDrainingDeploymentsCommand } from "@src/billing/commands/fund-draining-deployments.command";
+import type { JobHandler, JobPayload } from "@src/core";
+import { type CreateLogger, LOGGER_FACTORY } from "@src/core/providers/logging.provider";
+import { TopUpManagedDeploymentsService } from "@src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service";
+
+@singleton()
+export class FundDrainingDeploymentsHandler implements JobHandler<FundDrainingDeploymentsCommand> {
+  public readonly accepts = FundDrainingDeploymentsCommand;
+
+  public readonly concurrency = 2;
+
+  private readonly logger: ReturnType<CreateLogger>;
+
+  constructor(
+    private readonly topUpManagedDeploymentsService: TopUpManagedDeploymentsService,
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
+  ) {
+    this.logger = createLogger({ context: FundDrainingDeploymentsHandler.name });
+  }
+
+  async handle(payload: JobPayload<FundDrainingDeploymentsCommand>): Promise<void> {
+    this.logger.debug({ event: "FUND_DRAINING_DEPLOYMENTS", walletId: payload.walletId, address: payload.address });
+
+    try {
+      await this.topUpManagedDeploymentsService.topUpDrainingDeploymentsForOwner({
+        walletId: payload.walletId,
+        address: payload.address
+      });
+    } catch (error) {
+      this.logger.error({ event: "FUND_DRAINING_DEPLOYMENTS_FAILED", walletId: payload.walletId, address: payload.address, error });
+      throw error;
+    }
+  }
+}

--- a/apps/api/src/billing/commands/fund-draining-deployments.command.ts
+++ b/apps/api/src/billing/commands/fund-draining-deployments.command.ts
@@ -1,0 +1,16 @@
+import type { Job } from "@src/core";
+import { JOB_NAME } from "@src/core";
+
+export class FundDrainingDeploymentsCommand implements Job {
+  static readonly [JOB_NAME] = "FundDrainingDeploymentsCommand";
+
+  public readonly name = FundDrainingDeploymentsCommand[JOB_NAME];
+  public readonly version = 1;
+
+  constructor(
+    public readonly data: {
+      walletId: number;
+      address: string;
+    }
+  ) {}
+}

--- a/apps/api/src/billing/services/refill/refill.service.spec.ts
+++ b/apps/api/src/billing/services/refill/refill.service.spec.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
 
-import { FundDrainingDeploymentsCommand } from "@src/billing/commands/fund-draining-deployments.command";
 import type { BillingConfig } from "@src/billing/providers";
 import type { UserWalletRepository } from "@src/billing/repositories";
 import type { ManagedSignerService, ManagedUserWalletService } from "@src/billing/services";
@@ -9,7 +8,6 @@ import type { BalancesService } from "@src/billing/services/balances/balances.se
 import { RefillService } from "@src/billing/services/refill/refill.service";
 import type { WalletInitializerService } from "@src/billing/services/wallet-initializer/wallet-initializer.service";
 import type { AnalyticsService } from "@src/core/services/analytics/analytics.service";
-import type { DomainEventsService } from "@src/core/services/domain-events/domain-events.service";
 
 import { createInitializedUserWallet, createUserWallet } from "@test/seeders/user-wallet.seeder";
 
@@ -109,8 +107,8 @@ describe(RefillService.name, () => {
       expect(analyticsService.track).toHaveBeenCalledWith(userId, "balance_top_up", expect.objectContaining({ amount_cents: amountUsd, amount_usd: 1 }));
     });
 
-    it("publishes a command to immediately fund the wallet's draining deployments", async () => {
-      const { service, userWalletRepository, managedUserWalletService, balancesService, walletInitializerService, domainEvents } = setup();
+    it("returns the credited wallet identifiers so the caller can fund its draining deployments", async () => {
+      const { service, userWalletRepository, managedUserWalletService, balancesService, walletInitializerService } = setup();
       const existingWallet = createInitializedUserWallet({ userId });
       walletInitializerService.ensureWallet.mockResolvedValue(existingWallet);
       userWalletRepository.claimActivation.mockResolvedValue(undefined);
@@ -118,15 +116,9 @@ describe(RefillService.name, () => {
       balancesService.retrieveDeploymentLimit.mockResolvedValue(5000);
       balancesService.refreshUserWalletLimits.mockResolvedValue();
 
-      await service.topUpWallet(amountUsd, userId);
+      const result = await service.topUpWallet(amountUsd, userId);
 
-      expect(domainEvents.publish).toHaveBeenCalledWith(
-        expect.objectContaining({
-          name: FundDrainingDeploymentsCommand.name,
-          data: { walletId: existingWallet.id, address: existingWallet.address }
-        }),
-        { singletonKey: `${FundDrainingDeploymentsCommand.name}.${existingWallet.id}` }
-      );
+      expect(result).toEqual({ walletId: existingWallet.id, address: existingWallet.address });
     });
 
     function setup() {
@@ -137,7 +129,6 @@ describe(RefillService.name, () => {
       const balancesService = mock<BalancesService>();
       const walletInitializerService = mock<WalletInitializerService>();
       const analyticsService = mock<AnalyticsService>();
-      const domainEvents = mock<DomainEventsService>();
 
       billingConfig.FEE_ALLOWANCE_REFILL_AMOUNT = 1000;
 
@@ -148,8 +139,7 @@ describe(RefillService.name, () => {
         managedSignerService,
         balancesService,
         walletInitializerService,
-        analyticsService,
-        domainEvents
+        analyticsService
       );
 
       return {
@@ -160,8 +150,7 @@ describe(RefillService.name, () => {
         managedSignerService,
         balancesService,
         walletInitializerService,
-        analyticsService,
-        domainEvents
+        analyticsService
       };
     }
   });
@@ -170,7 +159,7 @@ describe(RefillService.name, () => {
     const userId = "test-user-id";
 
     it("reduces wallet balance by the specified amount", async () => {
-      const { service, userWalletRepository, managedUserWalletService, managedSignerService, balancesService, analyticsService, domainEvents } = setup();
+      const { service, userWalletRepository, managedUserWalletService, managedSignerService, balancesService, analyticsService } = setup();
       const existingWallet = createUserWallet({ userId, address: "akash1test..." });
 
       userWalletRepository.findOneBy.mockResolvedValue(existingWallet);
@@ -189,7 +178,6 @@ describe(RefillService.name, () => {
       });
       expect(balancesService.refreshUserWalletLimits).toHaveBeenCalledWith(existingWallet);
       expect(analyticsService.track).toHaveBeenCalledWith(userId, "balance_refund", expect.objectContaining({ amount_cents: 100, amount_usd: 1 }));
-      expect(domainEvents.publish).not.toHaveBeenCalled();
     });
 
     it("attaches payment context to the balance_refund analytics event", async () => {
@@ -263,7 +251,6 @@ describe(RefillService.name, () => {
       const balancesService = mock<BalancesService>();
       const walletInitializerService = mock<WalletInitializerService>();
       const analyticsService = mock<AnalyticsService>();
-      const domainEvents = mock<DomainEventsService>();
 
       billingConfig.FEE_ALLOWANCE_REFILL_AMOUNT = 1000;
 
@@ -274,8 +261,7 @@ describe(RefillService.name, () => {
         managedSignerService,
         balancesService,
         walletInitializerService,
-        analyticsService,
-        domainEvents
+        analyticsService
       );
 
       return {
@@ -286,8 +272,7 @@ describe(RefillService.name, () => {
         managedSignerService,
         balancesService,
         walletInitializerService,
-        analyticsService,
-        domainEvents
+        analyticsService
       };
     }
   });

--- a/apps/api/src/billing/services/refill/refill.service.spec.ts
+++ b/apps/api/src/billing/services/refill/refill.service.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
 
+import { FundDrainingDeploymentsCommand } from "@src/billing/commands/fund-draining-deployments.command";
 import type { BillingConfig } from "@src/billing/providers";
 import type { UserWalletRepository } from "@src/billing/repositories";
 import type { ManagedSignerService, ManagedUserWalletService } from "@src/billing/services";
@@ -8,6 +9,7 @@ import type { BalancesService } from "@src/billing/services/balances/balances.se
 import { RefillService } from "@src/billing/services/refill/refill.service";
 import type { WalletInitializerService } from "@src/billing/services/wallet-initializer/wallet-initializer.service";
 import type { AnalyticsService } from "@src/core/services/analytics/analytics.service";
+import type { DomainEventsService } from "@src/core/services/domain-events/domain-events.service";
 
 import { createInitializedUserWallet, createUserWallet } from "@test/seeders/user-wallet.seeder";
 
@@ -107,6 +109,26 @@ describe(RefillService.name, () => {
       expect(analyticsService.track).toHaveBeenCalledWith(userId, "balance_top_up", expect.objectContaining({ amount_cents: amountUsd, amount_usd: 1 }));
     });
 
+    it("publishes a command to immediately fund the wallet's draining deployments", async () => {
+      const { service, userWalletRepository, managedUserWalletService, balancesService, walletInitializerService, domainEvents } = setup();
+      const existingWallet = createInitializedUserWallet({ userId });
+      walletInitializerService.ensureWallet.mockResolvedValue(existingWallet);
+      userWalletRepository.claimActivation.mockResolvedValue(undefined);
+      managedUserWalletService.authorizeSpending.mockResolvedValue();
+      balancesService.retrieveDeploymentLimit.mockResolvedValue(5000);
+      balancesService.refreshUserWalletLimits.mockResolvedValue();
+
+      await service.topUpWallet(amountUsd, userId);
+
+      expect(domainEvents.publish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: FundDrainingDeploymentsCommand.name,
+          data: { walletId: existingWallet.id, address: existingWallet.address }
+        }),
+        { singletonKey: `${FundDrainingDeploymentsCommand.name}.${existingWallet.id}` }
+      );
+    });
+
     function setup() {
       const billingConfig = mock<BillingConfig>();
       const userWalletRepository = mock<UserWalletRepository>();
@@ -115,6 +137,7 @@ describe(RefillService.name, () => {
       const balancesService = mock<BalancesService>();
       const walletInitializerService = mock<WalletInitializerService>();
       const analyticsService = mock<AnalyticsService>();
+      const domainEvents = mock<DomainEventsService>();
 
       billingConfig.FEE_ALLOWANCE_REFILL_AMOUNT = 1000;
 
@@ -125,7 +148,8 @@ describe(RefillService.name, () => {
         managedSignerService,
         balancesService,
         walletInitializerService,
-        analyticsService
+        analyticsService,
+        domainEvents
       );
 
       return {
@@ -136,7 +160,8 @@ describe(RefillService.name, () => {
         managedSignerService,
         balancesService,
         walletInitializerService,
-        analyticsService
+        analyticsService,
+        domainEvents
       };
     }
   });
@@ -145,7 +170,7 @@ describe(RefillService.name, () => {
     const userId = "test-user-id";
 
     it("reduces wallet balance by the specified amount", async () => {
-      const { service, userWalletRepository, managedUserWalletService, managedSignerService, balancesService, analyticsService } = setup();
+      const { service, userWalletRepository, managedUserWalletService, managedSignerService, balancesService, analyticsService, domainEvents } = setup();
       const existingWallet = createUserWallet({ userId, address: "akash1test..." });
 
       userWalletRepository.findOneBy.mockResolvedValue(existingWallet);
@@ -164,6 +189,7 @@ describe(RefillService.name, () => {
       });
       expect(balancesService.refreshUserWalletLimits).toHaveBeenCalledWith(existingWallet);
       expect(analyticsService.track).toHaveBeenCalledWith(userId, "balance_refund", expect.objectContaining({ amount_cents: 100, amount_usd: 1 }));
+      expect(domainEvents.publish).not.toHaveBeenCalled();
     });
 
     it("attaches payment context to the balance_refund analytics event", async () => {
@@ -237,6 +263,7 @@ describe(RefillService.name, () => {
       const balancesService = mock<BalancesService>();
       const walletInitializerService = mock<WalletInitializerService>();
       const analyticsService = mock<AnalyticsService>();
+      const domainEvents = mock<DomainEventsService>();
 
       billingConfig.FEE_ALLOWANCE_REFILL_AMOUNT = 1000;
 
@@ -247,7 +274,8 @@ describe(RefillService.name, () => {
         managedSignerService,
         balancesService,
         walletInitializerService,
-        analyticsService
+        analyticsService,
+        domainEvents
       );
 
       return {
@@ -258,7 +286,8 @@ describe(RefillService.name, () => {
         managedSignerService,
         balancesService,
         walletInitializerService,
-        analyticsService
+        analyticsService,
+        domainEvents
       };
     }
   });

--- a/apps/api/src/billing/services/refill/refill.service.ts
+++ b/apps/api/src/billing/services/refill/refill.service.ts
@@ -2,6 +2,7 @@ import { createOtelLogger } from "@akashnetwork/logging/otel";
 import { PromisePool } from "@supercharge/promise-pool";
 import { singleton } from "tsyringe";
 
+import { FundDrainingDeploymentsCommand } from "@src/billing/commands/fund-draining-deployments.command";
 import { type BillingConfig, InjectBillingConfig } from "@src/billing/providers";
 import { type StripeTransactionType, type UserWalletOutput, UserWalletRepository } from "@src/billing/repositories";
 import { BalancesService } from "@src/billing/services/balances/balances.service";
@@ -9,6 +10,7 @@ import { ManagedSignerService } from "@src/billing/services/managed-signer/manag
 import { ManagedUserWalletService } from "@src/billing/services/managed-user-wallet/managed-user-wallet.service";
 import { WalletInitializerService } from "@src/billing/services/wallet-initializer/wallet-initializer.service";
 import { AnalyticsService } from "@src/core/services/analytics/analytics.service";
+import { DomainEventsService } from "@src/core/services/domain-events/domain-events.service";
 
 export interface PaymentAnalyticsContext {
   currency?: string;
@@ -31,7 +33,8 @@ export class RefillService {
     private readonly managedSignerService: ManagedSignerService,
     private readonly balancesService: BalancesService,
     private readonly walletInitializerService: WalletInitializerService,
-    private readonly analyticsService: AnalyticsService
+    private readonly analyticsService: AnalyticsService,
+    private readonly domainEvents: DomainEventsService
   ) {}
 
   async refillAllFees() {
@@ -74,6 +77,11 @@ export class RefillService {
     });
 
     await this.balancesService.refreshUserWalletLimits(userWallet, { endTrial: options.endTrial ?? true });
+
+    await this.domainEvents.publish(new FundDrainingDeploymentsCommand({ walletId: userWallet.id, address: userWallet.address! }), {
+      singletonKey: `${FundDrainingDeploymentsCommand.name}.${userWallet.id}`
+    });
+
     this.analyticsService.track(userId, "balance_top_up", {
       amount_cents: amountUsd,
       amount_usd: amountUsd / 100,

--- a/apps/api/src/billing/services/refill/refill.service.ts
+++ b/apps/api/src/billing/services/refill/refill.service.ts
@@ -2,7 +2,6 @@ import { createOtelLogger } from "@akashnetwork/logging/otel";
 import { PromisePool } from "@supercharge/promise-pool";
 import { singleton } from "tsyringe";
 
-import { FundDrainingDeploymentsCommand } from "@src/billing/commands/fund-draining-deployments.command";
 import { type BillingConfig, InjectBillingConfig } from "@src/billing/providers";
 import { type StripeTransactionType, type UserWalletOutput, UserWalletRepository } from "@src/billing/repositories";
 import { BalancesService } from "@src/billing/services/balances/balances.service";
@@ -10,7 +9,6 @@ import { ManagedSignerService } from "@src/billing/services/managed-signer/manag
 import { ManagedUserWalletService } from "@src/billing/services/managed-user-wallet/managed-user-wallet.service";
 import { WalletInitializerService } from "@src/billing/services/wallet-initializer/wallet-initializer.service";
 import { AnalyticsService } from "@src/core/services/analytics/analytics.service";
-import { DomainEventsService } from "@src/core/services/domain-events/domain-events.service";
 
 export interface PaymentAnalyticsContext {
   currency?: string;
@@ -20,6 +18,12 @@ export interface PaymentAnalyticsContext {
   source?: StripeTransactionType;
   /** First-purchase bonus included in the topped-up amount, in cents. */
   bonusAmountCents?: number;
+}
+
+/** Identifiers of the wallet a top-up credited, so callers can fund its draining deployments once the credit has committed. */
+export interface ToppedUpWallet {
+  walletId: number;
+  address: string;
 }
 
 @singleton()
@@ -33,8 +37,7 @@ export class RefillService {
     private readonly managedSignerService: ManagedSignerService,
     private readonly balancesService: BalancesService,
     private readonly walletInitializerService: WalletInitializerService,
-    private readonly analyticsService: AnalyticsService,
-    private readonly domainEvents: DomainEventsService
+    private readonly analyticsService: AnalyticsService
   ) {}
 
   async refillAllFees() {
@@ -64,8 +67,13 @@ export class RefillService {
    * @param amountUsd - The amount in USD *cents* to top up the wallet with (e.g. 10000 = $100)
    * @param userId - The ID of the user to top up the wallet for
    * @param options.payment - Payment context attached to the `balance_top_up` analytics event
+   * @returns The credited wallet's identifiers, so the caller can fund its draining deployments after the credit commits.
    */
-  async topUpWallet(amountUsd: number, userId: UserWalletOutput["userId"], options: { endTrial?: boolean; payment?: PaymentAnalyticsContext } = {}) {
+  async topUpWallet(
+    amountUsd: number,
+    userId: UserWalletOutput["userId"],
+    options: { endTrial?: boolean; payment?: PaymentAnalyticsContext } = {}
+  ): Promise<ToppedUpWallet> {
     const userWallet = await this.ensureActivatedWallet(userId);
     const currentLimit = await this.balancesService.retrieveDeploymentLimit(userWallet);
 
@@ -78,10 +86,6 @@ export class RefillService {
 
     await this.balancesService.refreshUserWalletLimits(userWallet, { endTrial: options.endTrial ?? true });
 
-    await this.domainEvents.publish(new FundDrainingDeploymentsCommand({ walletId: userWallet.id, address: userWallet.address! }), {
-      singletonKey: `${FundDrainingDeploymentsCommand.name}.${userWallet.id}`
-    });
-
     this.analyticsService.track(userId, "balance_top_up", {
       amount_cents: amountUsd,
       amount_usd: amountUsd / 100,
@@ -93,6 +97,8 @@ export class RefillService {
       bonus_amount_cents: options.payment?.bonusAmountCents
     });
     this.logger.debug({ event: "WALLET_TOP_UP", userWallet, limits });
+
+    return { walletId: userWallet.id, address: userWallet.address! };
   }
 
   /**

--- a/apps/api/src/billing/services/stripe-transaction/stripe-transaction.service.integration.ts
+++ b/apps/api/src/billing/services/stripe-transaction/stripe-transaction.service.integration.ts
@@ -4,9 +4,11 @@ import Stripe from "stripe";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
+import { FundDrainingDeploymentsCommand } from "@src/billing/commands/fund-draining-deployments.command";
 import type { StripeTransactionRepository } from "@src/billing/repositories";
 import type { FirstPurchaseBonusService } from "@src/billing/services/first-purchase-bonus/first-purchase-bonus.service";
 import type { RefillService } from "@src/billing/services/refill/refill.service";
+import type { DomainEventsService } from "@src/core/services/domain-events/domain-events.service";
 import type { TimerService } from "@src/core/services/timer/timer.service";
 import type { UserRepository } from "@src/user/repositories/user/user.repository";
 import { StripeTransactionService } from "./stripe-transaction.service";
@@ -23,7 +25,7 @@ import { createTestUser } from "@test/seeders/user-test.seeder";
 describe(StripeTransactionService.name, () => {
   describe("settlePaymentIntent", () => {
     it("tops up wallet and updates transaction on successful payment", async () => {
-      const { service, userRepository, stripeTransactionRepository, refillService, stripe } = setup();
+      const { service, userRepository, stripeTransactionRepository, refillService, stripe, domainEventsService, toppedUpWallet } = setup();
       const mockUser = createTestUser();
       const chargeId = "ch_123";
       const paymentIntentId = "pi_123";
@@ -33,7 +35,6 @@ describe(StripeTransactionService.name, () => {
       userRepository.findOneBy.mockResolvedValue(mockUser);
       stripeTransactionRepository.findById.mockResolvedValue(internalTransaction);
       stripeTransactionRepository.findOneByAndLock.mockResolvedValue(internalTransaction);
-      refillService.topUpWallet.mockResolvedValue();
       vi.spyOn(stripe.charges, "retrieve").mockResolvedValue(
         mock<Stripe.Response<Stripe.Charge>>({
           id: chargeId,
@@ -75,6 +76,9 @@ describe(StripeTransactionService.name, () => {
           source: "payment_intent"
         }
       });
+      expect(domainEventsService.publish).toHaveBeenCalledWith(expect.objectContaining({ name: FundDrainingDeploymentsCommand.name, data: toppedUpWallet }), {
+        singletonKey: `${FundDrainingDeploymentsCommand.name}.${toppedUpWallet.walletId}`
+      });
     });
 
     it("returns early when customer ID is missing", async () => {
@@ -99,7 +103,7 @@ describe(StripeTransactionService.name, () => {
     });
 
     it("returns early when payment was already processed (idempotency)", async () => {
-      const { service, userRepository, stripeTransactionRepository, refillService } = setup();
+      const { service, userRepository, stripeTransactionRepository, refillService, domainEventsService } = setup();
       const mockUser = createTestUser();
       const internalTransaction = generateDatabaseStripeTransaction({ id: "tx-123", status: "succeeded" });
 
@@ -119,6 +123,7 @@ describe(StripeTransactionService.name, () => {
       expect(stripeTransactionRepository.findById).toHaveBeenCalledWith(internalTransaction.id);
       expect(refillService.topUpWallet).not.toHaveBeenCalled();
       expect(stripeTransactionRepository.updateById).not.toHaveBeenCalled();
+      expect(domainEventsService.publish).not.toHaveBeenCalled();
     });
 
     it("skips a payment-method validation intent without touching the transaction", async () => {
@@ -259,7 +264,6 @@ describe(StripeTransactionService.name, () => {
       userRepository.findOneBy.mockResolvedValue(mockUser);
       stripeTransactionRepository.findByInvoiceId.mockResolvedValue(internalTransaction);
       stripeTransactionRepository.findOneByAndLock.mockResolvedValue(internalTransaction);
-      refillService.topUpWallet.mockResolvedValue();
       vi.spyOn(stripe.charges, "retrieve").mockResolvedValue(
         mock<Stripe.Response<Stripe.Charge>>({
           id: chargeId,
@@ -362,7 +366,6 @@ describe(StripeTransactionService.name, () => {
       userRepository.findOneBy.mockResolvedValue(mockUser);
       stripeTransactionRepository.findByInvoiceId.mockResolvedValue(internalTransaction);
       stripeTransactionRepository.findOneByAndLock.mockResolvedValue(internalTransaction);
-      refillService.topUpWallet.mockResolvedValue();
 
       await service.settleInvoice(createInvoicePaymentSucceededEvent({ id: "in_123", customer: mockUser.stripeCustomerId, amount_paid: 0 }));
 
@@ -403,7 +406,6 @@ describe(StripeTransactionService.name, () => {
       userRepository.findOneBy.mockResolvedValue(mockUser);
       stripeTransactionRepository.findByInvoiceId.mockResolvedValue(transaction);
       stripeTransactionRepository.findOneByAndLock.mockResolvedValue(transaction);
-      refillService.topUpWallet.mockResolvedValue();
 
       await service.settleInvoice(createInvoicePaidEvent({ id: invoiceId, customer: mockUser.stripeCustomerId, amount_paid: amount }));
 
@@ -422,7 +424,7 @@ describe(StripeTransactionService.name, () => {
     });
 
     it("credits only once when invoice.paid and invoice.payment_succeeded both fire for the same manual_credit invoice", async () => {
-      const { service, userRepository, stripeTransactionRepository, refillService } = setup();
+      const { service, userRepository, stripeTransactionRepository, refillService, domainEventsService } = setup();
       const mockUser = createTestUser();
       const invoiceId = "in_manual_dual";
       const amount = 50000;
@@ -438,13 +440,13 @@ describe(StripeTransactionService.name, () => {
       userRepository.findOneBy.mockResolvedValue(mockUser);
       stripeTransactionRepository.findByInvoiceId.mockResolvedValue(pendingTransaction);
       stripeTransactionRepository.findOneByAndLock.mockResolvedValueOnce(pendingTransaction).mockResolvedValueOnce(succeededTransaction);
-      refillService.topUpWallet.mockResolvedValue();
 
       const invoice = { id: invoiceId, customer: mockUser.stripeCustomerId, amount_paid: amount };
       await service.settleInvoice(createInvoicePaidEvent(invoice));
       await service.settleInvoice(createInvoicePaymentSucceededEvent(invoice));
 
       expect(refillService.topUpWallet).toHaveBeenCalledTimes(1);
+      expect(domainEventsService.publish).toHaveBeenCalledTimes(1);
       expect(refillService.topUpWallet).toHaveBeenCalledWith(amount, mockUser.id, {
         endTrial: false,
         payment: {
@@ -646,6 +648,10 @@ describe(StripeTransactionService.name, () => {
     const firstPurchaseBonusService = mock<FirstPurchaseBonusService>();
     firstPurchaseBonusService.getEligibleBonusAmount.mockResolvedValue(0);
     const userRepository = mock<UserRepository>();
+    const domainEventsService = mock<DomainEventsService>();
+
+    const toppedUpWallet = { walletId: 42, address: "akash1toppedupwallet" };
+    refillService.topUpWallet.mockResolvedValue(toppedUpWallet);
 
     const stripe = new Stripe(`sk_test_${faker.string.alphanumeric(32)}`, { apiVersion: "2025-10-29.clover", httpClient: Stripe.createFetchHttpClient() });
 
@@ -656,10 +662,11 @@ describe(StripeTransactionService.name, () => {
       firstPurchaseBonusService,
       mock<TimerService>(),
       userRepository,
+      domainEventsService,
       () => mock<LoggerService>()
     );
 
-    return { service, stripe, stripeTransactionRepository, refillService, firstPurchaseBonusService, userRepository };
+    return { service, stripe, stripeTransactionRepository, refillService, firstPurchaseBonusService, userRepository, domainEventsService, toppedUpWallet };
   }
 
   function createPaymentIntentSucceededEvent(paymentIntent: Partial<Stripe.PaymentIntent>): Stripe.PaymentIntentSucceededEvent {

--- a/apps/api/src/billing/services/stripe-transaction/stripe-transaction.service.spec.ts
+++ b/apps/api/src/billing/services/stripe-transaction/stripe-transaction.service.spec.ts
@@ -8,6 +8,7 @@ import type { StripeTransactionRepository } from "@src/billing/repositories";
 import type { FirstPurchaseBonusService } from "@src/billing/services/first-purchase-bonus/first-purchase-bonus.service";
 import type { RefillService } from "@src/billing/services/refill/refill.service";
 import { IDEMPOTENCY_KEY_MISMATCH_ERROR_MESSAGE, PAYMENT_IN_PROGRESS_ERROR_MESSAGE } from "@src/billing/services/stripe-error/stripe-error.service";
+import type { DomainEventsService } from "@src/core/services/domain-events/domain-events.service";
 import type { TimerService } from "@src/core/services/timer/timer.service";
 import type { UserRepository } from "@src/user/repositories/user/user.repository";
 import { StripeTransactionService } from "./stripe-transaction.service";
@@ -465,6 +466,7 @@ describe(StripeTransactionService.name, () => {
       mock<FirstPurchaseBonusService>(),
       timerService,
       mock<UserRepository>(),
+      mock<DomainEventsService>(),
       () => mock<LoggerService>()
     );
 

--- a/apps/api/src/billing/services/stripe-transaction/stripe-transaction.service.ts
+++ b/apps/api/src/billing/services/stripe-transaction/stripe-transaction.service.ts
@@ -5,6 +5,7 @@ import createError from "http-errors";
 import Stripe from "stripe";
 import { inject, singleton } from "tsyringe";
 
+import { FundDrainingDeploymentsCommand } from "@src/billing/commands/fund-draining-deployments.command";
 import { PaymentIntentResult } from "@src/billing/http-schemas/stripe.schema";
 import { STRIPE_CLIENT } from "@src/billing/providers/stripe-client.provider";
 import {
@@ -15,10 +16,11 @@ import {
   TRIAL_PRESERVING_TRANSACTION_TYPES
 } from "@src/billing/repositories";
 import { FirstPurchaseBonusService } from "@src/billing/services/first-purchase-bonus/first-purchase-bonus.service";
-import { RefillService } from "@src/billing/services/refill/refill.service";
+import { RefillService, type ToppedUpWallet } from "@src/billing/services/refill/refill.service";
 import { STRIPE_CURRENCY } from "@src/billing/services/stripe/stripe.service";
 import { IDEMPOTENCY_KEY_MISMATCH_ERROR_MESSAGE, PAYMENT_IN_PROGRESS_ERROR_MESSAGE } from "@src/billing/services/stripe-error/stripe-error.service";
 import { type CreateLogger, LOGGER_FACTORY, WithTransaction } from "@src/core";
+import { DomainEventsService } from "@src/core/services/domain-events/domain-events.service";
 import { TimerService } from "@src/core/services/timer/timer.service";
 import { UserRepository } from "@src/user/repositories/user/user.repository";
 
@@ -60,6 +62,7 @@ export class StripeTransactionService {
     private readonly firstPurchaseBonusService: FirstPurchaseBonusService,
     private readonly timerService: TimerService,
     private readonly userRepository: UserRepository,
+    private readonly domainEventsService: DomainEventsService,
     @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
     this.loggerService = createLogger({ context: StripeTransactionService.name });
@@ -414,7 +417,7 @@ export class StripeTransactionService {
     userId: string;
     eventDescription: string;
     endTrial?: boolean;
-  }): Promise<number> {
+  }): Promise<{ bonusAmount: number; toppedUpWallet?: ToppedUpWallet }> {
     const transaction = await this.stripeTransactionRepository.findOneByAndLock({ id: params.transactionId });
 
     if (!transaction) {
@@ -423,7 +426,7 @@ export class StripeTransactionService {
         transactionId: params.transactionId,
         description: params.eventDescription
       });
-      return 0;
+      return { bonusAmount: 0 };
     }
 
     if (transaction.status === "succeeded") {
@@ -432,7 +435,7 @@ export class StripeTransactionService {
         transactionId: params.transactionId,
         description: params.eventDescription
       });
-      return 0;
+      return { bonusAmount: 0 };
     }
 
     const bonusAmount = await this.firstPurchaseBonusService.getEligibleBonusAmount(transaction, params.paymentAmount);
@@ -449,7 +452,7 @@ export class StripeTransactionService {
     });
 
     // Single combined top-up: two calls would double chain fees and race on retrieveDeploymentLimit.
-    await this.refillService.topUpWallet(params.paymentAmount + bonusAmount, params.userId, {
+    const toppedUpWallet = await this.refillService.topUpWallet(params.paymentAmount + bonusAmount, params.userId, {
       endTrial: params.endTrial,
       payment: {
         currency: transaction.currency,
@@ -472,7 +475,7 @@ export class StripeTransactionService {
       });
     }
 
-    return bonusAmount;
+    return { bonusAmount, toppedUpWallet };
   }
 
   async settlePaymentIntent(event: Stripe.PaymentIntentSucceededEvent): Promise<FirstPurchaseBonusGrant | undefined> {
@@ -553,9 +556,10 @@ export class StripeTransactionService {
 
   /**
    * Credits the wallet for a settled Stripe charge: resolves the owning user, enriches the row with the
-   * charge's card details, and records the succeeded transaction. Returns the first-purchase bonus grant
-   * (if any) so the caller can publish the domain event after this commits — publishing it here would risk
-   * firing on a rolled-back grant.
+   * charge's card details, and records the succeeded transaction. Once that transaction has committed it
+   * publishes the draining-deployment funding command and returns the first-purchase bonus grant (if any)
+   * for the caller to publish. Both run post-commit so a rolled-back credit can neither fund deployments
+   * nor send a bonus email.
    */
   async #settleFromWebhook(params: {
     customerId: string | null;
@@ -604,7 +608,7 @@ export class StripeTransactionService {
       }
     }
 
-    const bonusAmountCents = await this.settleSucceededTransaction({
+    const settlement = await this.settleSucceededTransaction({
       transactionId: params.transaction.id,
       chargeId: params.chargeId,
       paymentMethodType: params.paymentMethodType,
@@ -618,7 +622,14 @@ export class StripeTransactionService {
       endTrial: params.endTrial
     });
 
-    return bonusAmountCents > 0 ? { userId: user.id, bonusAmountCents, paidAmountCents: params.paymentAmount } : undefined;
+    // Published after settleSucceededTransaction has committed so a rolled-back credit never funds deployments.
+    if (settlement.toppedUpWallet) {
+      await this.domainEventsService.publish(new FundDrainingDeploymentsCommand(settlement.toppedUpWallet), {
+        singletonKey: `${FundDrainingDeploymentsCommand.name}.${settlement.toppedUpWallet.walletId}`
+      });
+    }
+
+    return settlement.bonusAmount > 0 ? { userId: user.id, bonusAmountCents: settlement.bonusAmount, paidAmountCents: params.paymentAmount } : undefined;
   }
 
   @WithTransaction()

--- a/apps/api/src/deployment/services/cached-balance/cached-balance.service.spec.ts
+++ b/apps/api/src/deployment/services/cached-balance/cached-balance.service.spec.ts
@@ -87,6 +87,23 @@ describe(CachedBalanceService.name, () => {
     });
   });
 
+  describe("getFresh", () => {
+    const address = createAkashAddress();
+
+    it("fetches a fresh, independent balance on every call, bypassing the memo used by get", async () => {
+      const { service, balancesService } = setup();
+      balancesService.getFreshLimits.mockResolvedValue({ deployment: 1000, fee: 100 });
+
+      const first = await service.getFresh(address);
+      const second = await service.getFresh(address);
+
+      expect(balancesService.getFreshLimits).toHaveBeenCalledTimes(2);
+      expect(first).not.toBe(second);
+      expect(first.reserveSufficientAmount(700)).toBe(700);
+      expect(second.reserveSufficientAmount(1000)).toBe(1000);
+    });
+  });
+
   function setup() {
     const balancesService = {
       getFreshLimits: vi.fn()

--- a/apps/api/src/deployment/services/cached-balance/cached-balance.service.ts
+++ b/apps/api/src/deployment/services/cached-balance/cached-balance.service.ts
@@ -21,13 +21,21 @@ export class CachedBalance {
 
 @singleton()
 export class CachedBalanceService {
-  public get = memoizeAsync(
-    async (address: string) => {
-      const limits = await this.balancesService.getFreshLimits({ address });
-      return new CachedBalance(limits.deployment);
-    },
-    { cacheItemLimit: 10_000 }
-  );
+  public get = memoizeAsync((address: string) => this.buildForAddress(address), { cacheItemLimit: 10_000 });
 
   constructor(private readonly balancesService: BalancesService) {}
+
+  /**
+   * Reads a fresh balance bypassing the per-address memo. The memo is keyed for
+   * the process lifetime, which suits the short-lived top-up cron but would serve
+   * stale balances to the long-running background worker across credit landings.
+   */
+  public getFresh(address: string): Promise<CachedBalance> {
+    return this.buildForAddress(address);
+  }
+
+  private async buildForAddress(address: string): Promise<CachedBalance> {
+    const limits = await this.balancesService.getFreshLimits({ address });
+    return new CachedBalance(limits.deployment);
+  }
 }

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
@@ -21,7 +21,7 @@ import { DrainingDeploymentService } from "./draining-deployment.service";
 
 import { mockConfigService } from "@test/mocks/config-service.mock";
 import { createAkashAddress } from "@test/seeders";
-import { createManyAutoTopUpDeployments } from "@test/seeders/auto-top-up-deployment.seeder";
+import { createAutoTopUpDeployment, createManyAutoTopUpDeployments } from "@test/seeders/auto-top-up-deployment.seeder";
 import { createDrainingDeployment } from "@test/seeders/draining-deployment.seeder";
 import { createUserWallet } from "@test/seeders/user-wallet.seeder";
 
@@ -105,6 +105,63 @@ describe(DrainingDeploymentService.name, () => {
           })
         );
       });
+    });
+  });
+
+  describe("findDrainingDeploymentsForOwner", () => {
+    it("returns the owner's active draining deployments enriched with block rate and predicted close height", async () => {
+      const { service, deploymentSettingRepository } = setup();
+      const address = createAkashAddress();
+      const settings = [createAutoTopUpDeployment({ address, dseq: "1001" }), createAutoTopUpDeployment({ address, dseq: "1002" })];
+      const leases = settings.map(setting =>
+        createDrainingDeployment({ dseq: Number(setting.dseq), owner: address, blockRate: 60, predictedClosedHeight: 1000500 })
+      );
+
+      deploymentSettingRepository.findAutoTopUpDeploymentsByOwner.mockResolvedValue(settings);
+      vi.spyOn(service, "findLeases").mockResolvedValue(leases);
+
+      const result = await service.findDrainingDeploymentsForOwner(address);
+
+      expect(deploymentSettingRepository.findAutoTopUpDeploymentsByOwner).toHaveBeenCalledWith(address);
+      expect(result).toHaveLength(2);
+      expect(result).toEqual(
+        expect.arrayContaining(settings.map(setting => expect.objectContaining({ dseq: setting.dseq, address, blockRate: 60, predictedClosedHeight: 1000500 })))
+      );
+    });
+
+    it("marks closed deployments as closed and excludes them from the result", async () => {
+      const { service, deploymentSettingRepository, currentHeight } = setup();
+      const address = createAkashAddress();
+      const activeSetting = createAutoTopUpDeployment({ address, dseq: "2001" });
+      const closedSetting = createAutoTopUpDeployment({ address, dseq: "2002" });
+
+      deploymentSettingRepository.findAutoTopUpDeploymentsByOwner.mockResolvedValue([activeSetting, closedSetting]);
+      vi.spyOn(service, "findLeases").mockResolvedValue([
+        createDrainingDeployment({ dseq: Number(activeSetting.dseq), owner: address, predictedClosedHeight: currentHeight + 500 }),
+        createDrainingDeployment({
+          dseq: Number(closedSetting.dseq),
+          owner: address,
+          predictedClosedHeight: currentHeight + 500,
+          closedHeight: currentHeight - 100
+        })
+      ]);
+
+      const result = await service.findDrainingDeploymentsForOwner(address);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].dseq).toBe(activeSetting.dseq);
+      expect(deploymentSettingRepository.updateManyById).toHaveBeenCalledWith([closedSetting.id], { closed: true });
+    });
+
+    it("returns an empty array without querying leases when the owner has no auto-top-up deployments", async () => {
+      const { service, deploymentSettingRepository } = setup();
+      const findLeasesSpy = vi.spyOn(service, "findLeases");
+      deploymentSettingRepository.findAutoTopUpDeploymentsByOwner.mockResolvedValue([]);
+
+      const result = await service.findDrainingDeploymentsForOwner(createAkashAddress());
+
+      expect(result).toEqual([]);
+      expect(findLeasesSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
@@ -41,51 +41,79 @@ export class DrainingDeploymentService {
    * @yields Object with owner address and array of draining deployments
    */
   async *findDrainingDeploymentsByOwner(): AsyncGenerator<{ address: string; walletId: number; deployments: DrainingDeployment[] }> {
-    const currentHeight = await this.blockHttpService.getCurrentHeight();
-    const expectedClosureHeight = Math.floor(currentHeight + averageBlockCountInAnHour * this.config.get("AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H"));
+    const expectedClosureHeight = await this.#getExpectedClosureHeight();
 
     for await (const { address, walletId, deploymentSettings } of this.deploymentSettingRepository.findAutoTopUpDeploymentsByOwnerIteratively()) {
-      if (deploymentSettings.length === 0) {
-        continue;
-      }
+      const deployments = await this.#resolveActiveDrainingDeployments(deploymentSettings, address, expectedClosureHeight);
 
-      const dseqs = deploymentSettings.map(deployment => deployment.dseq);
-      const drainingDeployments = await this.findLeases(expectedClosureHeight, address, dseqs);
-
-      if (drainingDeployments.length) {
-        const byDseqOwner = keyBy(drainingDeployments, "dseq");
-        const [active, missingIds] = deploymentSettings.reduce<[DrainingDeployment[], string[]]>(
-          (acc, deploymentSetting) => {
-            const deployment = byDseqOwner[Number(deploymentSetting.dseq)];
-
-            if (!deployment) {
-              return acc;
-            }
-
-            if (deployment.closedHeight) {
-              acc[1].push(deploymentSetting.id);
-            } else {
-              acc[0].push({
-                ...deploymentSetting,
-                predictedClosedHeight: deployment.predictedClosedHeight,
-                blockRate: deployment.blockRate
-              });
-            }
-            return acc;
-          },
-          [[], []]
-        );
-
-        if (missingIds.length) {
-          await this.deploymentSettingRepository.updateManyById(missingIds, { closed: true });
-          this.instrumentation.recordDeploymentsMarkedClosed(missingIds.length);
-        }
-
-        if (active.length) {
-          yield { address, walletId, deployments: active };
-        }
+      if (deployments.length) {
+        yield { address, walletId, deployments };
       }
     }
+  }
+
+  /**
+   * Finds the active draining deployments for a single owner, applying the same
+   * look-ahead window, auto-top-up gate, and closed-marking as the cron sweep.
+   * Backs the event-driven immediate funding triggered when credits land.
+   */
+  async findDrainingDeploymentsForOwner(address: string): Promise<DrainingDeployment[]> {
+    const deploymentSettings = await this.deploymentSettingRepository.findAutoTopUpDeploymentsByOwner(address);
+    const expectedClosureHeight = await this.#getExpectedClosureHeight();
+
+    return this.#resolveActiveDrainingDeployments(deploymentSettings, address, expectedClosureHeight);
+  }
+
+  async #getExpectedClosureHeight(): Promise<number> {
+    const currentHeight = await this.blockHttpService.getCurrentHeight();
+    return Math.floor(currentHeight + averageBlockCountInAnHour * this.config.get("AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H"));
+  }
+
+  async #resolveActiveDrainingDeployments(
+    deploymentSettings: AutoTopUpDeployment[],
+    address: string,
+    expectedClosureHeight: number
+  ): Promise<DrainingDeployment[]> {
+    if (deploymentSettings.length === 0) {
+      return [];
+    }
+
+    const dseqs = deploymentSettings.map(deployment => deployment.dseq);
+    const drainingDeployments = await this.findLeases(expectedClosureHeight, address, dseqs);
+
+    if (!drainingDeployments.length) {
+      return [];
+    }
+
+    const byDseqOwner = keyBy(drainingDeployments, "dseq");
+    const [active, missingIds] = deploymentSettings.reduce<[DrainingDeployment[], string[]]>(
+      (acc, deploymentSetting) => {
+        const deployment = byDseqOwner[Number(deploymentSetting.dseq)];
+
+        if (!deployment) {
+          return acc;
+        }
+
+        if (deployment.closedHeight) {
+          acc[1].push(deploymentSetting.id);
+        } else {
+          acc[0].push({
+            ...deploymentSetting,
+            predictedClosedHeight: deployment.predictedClosedHeight,
+            blockRate: deployment.blockRate
+          });
+        }
+        return acc;
+      },
+      [[], []]
+    );
+
+    if (missingIds.length) {
+      await this.deploymentSettingRepository.updateManyById(missingIds, { closed: true });
+      this.instrumentation.recordDeploymentsMarkedClosed(missingIds.length);
+    }
+
+    return active;
   }
 
   /**

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
@@ -539,6 +539,65 @@ describe(TopUpManagedDeploymentsService.name, () => {
     });
   });
 
+  describe("topUpDrainingDeploymentsForOwner", () => {
+    it("funds the owner's draining deployments in a single tx and schedules a wallet reload", async () => {
+      const { service, drainingDeploymentService, cachedBalanceService, managedSignerService, walletReloadService } = setup();
+      const owner = createAkashAddress();
+      const walletId = faker.number.int({ min: 1000000, max: 9999999 });
+      const sufficientAmount = faker.number.int({ min: 1000000, max: 2000000 });
+
+      drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([createDrainingFor(owner, walletId), createDrainingFor(owner, walletId)]);
+      drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(faker.number.int({ min: 3500000, max: 4000000 }));
+      cachedBalanceService.getFresh.mockResolvedValue(createMockCachedBalance(() => sufficientAmount));
+
+      await service.topUpDrainingDeploymentsForOwner({ walletId, address: owner });
+
+      expect(drainingDeploymentService.findDrainingDeploymentsForOwner).toHaveBeenCalledWith(owner);
+      expect(managedSignerService.executeDerivedTx).toHaveBeenCalledTimes(1);
+      expect(managedSignerService.executeDerivedTx).toHaveBeenCalledWith(walletId, [
+        expect.objectContaining({ typeUrl: "/akash.escrow.v1.MsgAccountDeposit" }),
+        expect.objectContaining({ typeUrl: "/akash.escrow.v1.MsgAccountDeposit" })
+      ]);
+      expect(walletReloadService.scheduleImmediate).toHaveBeenCalledWith({ walletId });
+    });
+
+    it("reads a fresh balance rather than the memoized one so the long-running worker never funds from a stale balance", async () => {
+      const { service, drainingDeploymentService, cachedBalanceService } = setup();
+      const owner = createAkashAddress();
+      const walletId = faker.number.int({ min: 1000000, max: 9999999 });
+
+      drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([createDrainingFor(owner, walletId)]);
+      drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(1000000);
+      cachedBalanceService.getFresh.mockResolvedValue(createMockCachedBalance(() => 500000));
+
+      await service.topUpDrainingDeploymentsForOwner({ walletId, address: owner });
+
+      expect(cachedBalanceService.getFresh).toHaveBeenCalledWith(owner);
+      expect(cachedBalanceService.get).not.toHaveBeenCalled();
+    });
+
+    it("does nothing when the owner has no draining deployments", async () => {
+      const { service, drainingDeploymentService, cachedBalanceService, managedSignerService, walletReloadService } = setup();
+
+      drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([]);
+
+      await service.topUpDrainingDeploymentsForOwner({ walletId: 1, address: createAkashAddress() });
+
+      expect(cachedBalanceService.getFresh).not.toHaveBeenCalled();
+      expect(managedSignerService.executeDerivedTx).not.toHaveBeenCalled();
+      expect(walletReloadService.scheduleImmediate).not.toHaveBeenCalled();
+    });
+
+    function createDrainingFor(owner: string, walletId: number, predictedClosedHeight = CURRENT_BLOCK_HEIGHT + 1500): DrainingDeployment {
+      const setting = createAutoTopUpDeployment({ address: owner, walletId });
+      return {
+        ...setting,
+        ...createDrainingDeployment({ dseq: Number(setting.dseq), owner, predictedClosedHeight, denom: DEPLOYMENT_GRANT_DENOM }),
+        dseq: setting.dseq
+      } as DrainingDeployment;
+    }
+  });
+
   function setup(input?: { currentBlockHeight?: number; feeAllowance?: number }) {
     const currentBlockHeight = input?.currentBlockHeight ?? CURRENT_BLOCK_HEIGHT;
     const feeAllowance = input?.feeAllowance ?? SUFFICIENT_FEE_ALLOWANCE;

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
@@ -11,7 +11,7 @@ import { BlockHttpService } from "@src/chain/services/block-http/block-http.serv
 import type { DryRunOptions } from "@src/core/types/console";
 import { DrainingDeployment } from "@src/deployment/services/draining-deployment/draining-deployment.service";
 import { DrainingDeploymentService } from "@src/deployment/services/draining-deployment/draining-deployment.service";
-import { CachedBalanceService } from "../cached-balance/cached-balance.service";
+import { CachedBalance, CachedBalanceService } from "../cached-balance/cached-balance.service";
 import { TopUpManagedDeploymentsInstrumentationService } from "./top-up-managed-deployments-instrumentation.service";
 
 type CollectedMessage = {
@@ -39,20 +39,10 @@ export class TopUpManagedDeploymentsService {
     const errors: unknown[] = [];
 
     try {
-      for await (const { address, walletId, deployments } of this.drainingDeploymentService.findDrainingDeploymentsByOwner()) {
+      for await (const owner of this.drainingDeploymentService.findDrainingDeploymentsByOwner()) {
         try {
-          const messageInputs = await this.collectMessages(deployments);
-          if (messageInputs.length) {
-            await this.topUpForOwner(address, messageInputs, options);
-            if (!options.dryRun) {
-              await this.walletReloadService.scheduleImmediate({ walletId });
-            }
-          } else {
-            this.instrumentation.recordSkipped({
-              owner: address,
-              deploymentCount: deployments.length
-            });
-          }
+          const balance = await this.cachedBalanceService.get(owner.address);
+          await this.#fundOwnerDeployments(owner, options, balance);
         } catch (error: unknown) {
           errors.push(error);
         }
@@ -67,7 +57,42 @@ export class TopUpManagedDeploymentsService {
     return errors.length > 0 ? Err(errors) : Ok(undefined);
   }
 
-  private async collectMessages(deployments: DrainingDeployment[]): Promise<CollectedMessage[]> {
+  /**
+   * Funds a single owner's draining deployments immediately, reusing the cron's
+   * per-owner path. Triggered off-cron the moment credits land so a deployment
+   * about to drain does not wait up to an hour for the next scheduled pass.
+   */
+  async topUpDrainingDeploymentsForOwner({ walletId, address }: { walletId: number; address: string }): Promise<void> {
+    const deployments = await this.drainingDeploymentService.findDrainingDeploymentsForOwner(address);
+
+    if (!deployments.length) {
+      return;
+    }
+
+    const balance = await this.cachedBalanceService.getFresh(address);
+    await this.#fundOwnerDeployments({ address, walletId, deployments }, { dryRun: false }, balance);
+  }
+
+  async #fundOwnerDeployments(
+    { address, walletId, deployments }: { address: string; walletId: number; deployments: DrainingDeployment[] },
+    options: DryRunOptions,
+    balance: CachedBalance
+  ): Promise<void> {
+    const messageInputs = await this.collectMessages(deployments, balance);
+
+    if (!messageInputs.length) {
+      this.instrumentation.recordSkipped({ owner: address, deploymentCount: deployments.length });
+      return;
+    }
+
+    await this.topUpForOwner(address, messageInputs, options);
+
+    if (!options.dryRun) {
+      await this.walletReloadService.scheduleImmediate({ walletId });
+    }
+  }
+
+  private async collectMessages(deployments: DrainingDeployment[], balance: CachedBalance): Promise<CollectedMessage[]> {
     const denom = this.billingConfig.get("DEPLOYMENT_GRANT_DENOM");
 
     const messageInputs = await Promise.all(
@@ -75,12 +100,7 @@ export class TopUpManagedDeploymentsService {
         this.instrumentation.recordDeploymentPreparation(deployment.address, deployment.predictedClosedHeight);
 
         try {
-          const { address } = deployment;
-
-          const [balance, desiredAmount] = await Promise.all([
-            this.cachedBalanceService.get(address),
-            this.drainingDeploymentService.calculateTopUpAmount(deployment)
-          ]);
+          const desiredAmount = await this.drainingDeploymentService.calculateTopUpAmount(deployment);
           if (desiredAmount <= 0) {
             this.instrumentation.recordInvalidDepositAmount({
               desiredAmount,

--- a/apps/api/test/functional/stripe-webhook.spec.ts
+++ b/apps/api/test/functional/stripe-webhook.spec.ts
@@ -813,13 +813,14 @@ describe("Stripe webhook", () => {
 
     vi.spyOn(refillService, "topUpWallet").mockImplementation(async (amountUsd, userId, options) => {
       const wallet = await userWalletRepository.findOneBy({ userId });
-      if (!wallet) return;
+      if (!wallet) throw new Error(`No wallet found for user ${userId}`);
       // Mirror the real service: only graduate the trial when endTrial is not explicitly false
       const endTrial = options?.endTrial ?? true;
       await userWalletRepository.updateById(wallet.id, {
         deploymentAllowance: wallet.deploymentAllowance + amountUsd * 10000,
         ...(endTrial ? { isTrialing: false } : {})
       });
+      return { walletId: wallet.id, address: wallet.address! };
     });
 
     vi.spyOn(refillService, "reduceWalletBalance").mockImplementation(async (amountUsd, userId) => {


### PR DESCRIPTION
## Why

Fixes CON-761

When a wallet has no credits, the hourly top-up pass skips its draining deployments. If the user then buys credits, nothing funds those deployments until the next hourly pass, so a deployment with under an hour of runway can be closed by the provider minutes after the user paid to keep it alive. Auto-reload users rarely reach this state; manually-paying users are the exposed group.

## What

When credits land on a managed wallet (card purchase, auto-reload charge, admin manual credit, or coupon), the webhook settlement publishes a `FundDrainingDeploymentsCommand` once the crediting transaction commits. A background handler funds that account's draining deployments right away, reusing the per-owner path the hourly cron already runs. This is the same event-driven shape as CON-735 (fund on lease start).

- The command is published from `StripeTransactionService.#settleFromWebhook` **after** the crediting `@WithTransaction` commits (mirroring the after-commit `FirstPurchaseBonusGranted` publish); `RefillService.topUpWallet` returns the credited wallet instead of publishing. Publishing inside that transaction let a failed enqueue abort payment settlement and double-credit on the Stripe webhook retry, so it now runs post-commit. Enqueue errors are still swallowed and the hourly cron stays the safety net.
- `TopUpManagedDeploymentsService.topUpDrainingDeploymentsForOwner` funds one owner's draining deployments. The cron loop body is extracted into a shared private method so both paths behave identically (auto-top-up gate, partial-balance clamp, wallet-reload follow-up).
- `DrainingDeploymentService.findDrainingDeploymentsForOwner` returns a single owner's active draining deployments using the same look-ahead window and closed-marking as the cron sweep.
- `CachedBalanceService.getFresh` reads a fresh balance for the immediate path. The existing `get` memoizes per address for the process lifetime, which suits the short-lived cron CLI but would serve stale balances to the long-running background worker across successive credit landings.

Acceptance criteria are covered by the reused logic: auto-top-up-disabled deployments are excluded by the existing SQL gate, partial coverage falls out of `reserveSufficientAmount`, and trials keep the cron's existing clamped behavior (a purchase ends the trial anyway).

No new env vars, migrations, or breaking contract changes.

### Tests

Full `apps/api` unit suite passes. New coverage: the post-commit funding publish and its non-publish on an idempotent replay (stripe-transaction integration), the handler's `singleton` policy, handler delegation and retry, the per-owner draining query (active, closed-marking, empty), the immediate funding path (single tx, fresh balance, no-op when nothing drains), and `getFresh`.



## Follow-ups

Refs CON-837. Same-wallet immediate funding is now serialized by the handler's `singleton` queue policy, so two top-ups for one wallet cannot fund it concurrently. The rest stays deferred: a bounded duplicate-deposit race when immediate funding overlaps the hourly cron (which does not go through the queue) or when a job retries after its deposit already landed on-chain, plus concurrency-safe instrumentation for the immediate path. These only over-fund the user's own escrow from their own authorized limit, and self-correct when the deployment closes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic funding for draining deployments after successful wallet top-ups.
  * Added owner-specific processing that groups eligible deployments into a single transaction.
  * Added fresh balance retrieval for funding decisions based on current limits.
  * Added background processing with controlled concurrency and wallet reload scheduling.

* **Bug Fixes**
  * Improved handling of closed or inactive deployments.
  * Prevented duplicate funding triggered by repeated payment settlement.

* **Tests**
  * Expanded coverage for funding, balance refreshes, deployment filtering, and no-op scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

