### PR TITLE
test: resets location state in deploy-web

### DIFF
--- a/apps/deploy-web/tests/unit/setup.ts
+++ b/apps/deploy-web/tests/unit/setup.ts
@@ -51,7 +51,16 @@ beforeAll(() => {
   });
 });
 
+/**
+ * Unit tests share a single jsdom window (`isolate: false` in vitest.config.ts), so a spec that navigates
+ * (e.g. history.replaceState) leaks its URL into every spec that runs after it in the same worker.
+ */
+function restoreInitialLocation() {
+  window.history.replaceState(null, "", "/");
+}
+
 afterEach(() => {
   vi.useRealTimers();
   cleanup();
+  restoreInitialLocation();
 });


### PR DESCRIPTION
## Why

Closes CON-839

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by resetting the simulated browser URL after each test.
  * Ensured timers and the document state continue to be restored during test cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->