### PR TITLE
test(notification-channel): align channels e2e with alerts settings tabs

### DIFF
--- a/apps/deploy-web/tests/ui/managed-wallet-notification-channels.spec.ts
+++ b/apps/deploy-web/tests/ui/managed-wallet-notification-channels.spec.ts
@@ -18,20 +18,20 @@ test.describe("Managed wallet notification channels", () => {
       await appNav.openAlerts();
       await alertsPage.waitForPage();
       await alertsPage.openNotificationChannelsTab();
-      await page.waitForURL(/\/alerts\/notification-channels$/);
     });
 
     await test.step("create notification channel", async () => {
       await notificationChannelsPage.openCreate();
       await notificationChannelsPage.fillForm({ name: channelName, emails: channelEmail });
       await notificationChannelsPage.submitForm();
-      await page.waitForURL(/\/alerts\/notification-channels$/, { timeout: 10_000 });
+      await page.waitForURL(/\/alerts\/?$/, { timeout: 10_000 });
       const notification = page.getByRole("alert").filter({ hasText: "Notification channel created" });
       await expect(notification).toBeVisible({ timeout: 10_000 });
       await notification.getByRole("button").click();
     });
 
     await test.step("verify channel appears in list", async () => {
+      await alertsPage.openNotificationChannelsTab();
       const row = notificationChannelsPage.getChannelRow(channelName);
 
       await expect(async () => {

--- a/apps/deploy-web/tests/ui/pages/AlertsPage.ts
+++ b/apps/deploy-web/tests/ui/pages/AlertsPage.ts
@@ -12,8 +12,9 @@ export class AlertsPage {
   }
 
   async openNotificationChannelsTab() {
-    await this.page.getByRole("tab", { name: /notification channels/i }).click();
-    await this.page.getByRole("tab", { name: /notification channels/i, selected: true }).waitFor();
+    const tab = this.page.getByRole("tab", { name: /notification channels/i });
+    await tab.click();
+    await tab.and(this.page.getByRole("tab", { selected: true })).waitFor();
   }
 
   getAlertRow(index: number) {

--- a/apps/deploy-web/tests/ui/pages/AlertsPage.ts
+++ b/apps/deploy-web/tests/ui/pages/AlertsPage.ts
@@ -13,6 +13,7 @@ export class AlertsPage {
 
   async openNotificationChannelsTab() {
     await this.page.getByRole("tab", { name: /notification channels/i }).click();
+    await this.page.getByRole("tab", { name: /notification channels/i, selected: true }).waitFor();
   }
 
   getAlertRow(index: number) {


### PR DESCRIPTION
## Why

The beta e2e gate for console-web v3.164.0 failed on `managed-wallet-notification-channels.spec.ts` ([run](https://github.com/akash-network/console/actions/runs/31714501725)). #3583 folded Notification Channels into the Alerts page as local tabs: switching tabs no longer changes the URL, `/alerts/notification-channels` now redirects to `/alerts`, and saving a new channel navigates back to `/alerts` with the default Alerts tab selected. The spec still waited on the old URLs, so it timed out. Beta itself is healthy; only the spec was stale.

Part of CON-733.

## What

- `AlertsPage.openNotificationChannelsTab()` waits for the tab to become selected instead of relying on a URL change
- After saving a channel, the spec waits for `/alerts`, where the app actually lands
- The list verification step re-opens the Notification Channels tab, since the page comes back on the default Alerts tab

Beta e2e checks out the release tag, so this takes effect starting with the next console-web release; the failed v3.164.0 run cannot be re-greened by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated notification channel flow coverage to reflect the redirect to the Alerts page after creation.
  * Added verification that the Notification Channels tab is selected before checking the created channel.
  * Improved test stability by waiting for the tab selection to complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->