### PR TITLE
fix(alert): add vertical padding to alerts list status states

### DIFF
--- a/apps/deploy-web/src/components/alerts/AlertsListView/AlertsListView.tsx
+++ b/apps/deploy-web/src/components/alerts/AlertsListView/AlertsListView.tsx
@@ -136,7 +136,7 @@ export const AlertsListView: FC<Props> = ({
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center">
+      <div className="flex items-center justify-center py-12">
         <Spinner size="large" />
       </div>
     );
@@ -144,7 +144,7 @@ export const AlertsListView: FC<Props> = ({
 
   if (isError) {
     return (
-      <div className="flex items-center justify-center">
+      <div className="flex items-center justify-center py-12">
         <p className="text-red-500">Error loading alerts</p>
       </div>
     );
@@ -152,7 +152,7 @@ export const AlertsListView: FC<Props> = ({
 
   if (!data || data.length === 0) {
     return (
-      <div className="flex items-center justify-center">
+      <div className="flex items-center justify-center py-12">
         <p className="text-gray-500">No alerts found</p>
       </div>
     );


### PR DESCRIPTION
## Why

On Settings → Alerts, the "No alerts found" empty state sat cramped right under the tab bar with no vertical breathing room. The loading spinner and error states share the same container, so they had the same issue. This adds padding so those status views read with proper whitespace.

## What

Added `py-12` (48px vertical padding) to the three status containers in `AlertsListView` (loading, error, empty), matching the centered-status-container convention used elsewhere in deploy-web (e.g. `ProviderList`, the "No deployments" card).

Only the Alerts tab is affected; the Notification Channels tab is left unchanged.

Before: "No alerts found" hugged the tabs.
After: ~48px of padding above and below the message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved spacing around loading, error, and empty states in the alerts view for a more consistent and comfortable layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->