### PR TITLE
fix(billing): derive history pagination from totalCount

### DIFF
--- a/apps/deploy-web/src/components/billing-usage/BillingContainer/BillingContainer.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/BillingContainer/BillingContainer.spec.tsx
@@ -16,8 +16,6 @@ describe(BillingContainer.name, () => {
     const { data, child } = await setup();
     expect(child.data).toEqual(data?.transactions);
     expect(child.totalCount).toBe(data?.totalCount);
-    expect(child.hasMore).toBe(data?.hasMore);
-    expect(child.hasPrevious).toBe(false);
   });
 
   it("passes through loading and error flags", async () => {
@@ -36,7 +34,6 @@ describe(BillingContainer.name, () => {
     const { child } = await setup({ data: undefined });
     expect(child.data).toEqual([]);
     expect(child.totalCount).toBe(0);
-    expect(child.hasMore).toBe(false);
   });
 
   it("calls onPaginationChange", async () => {

--- a/apps/deploy-web/src/components/billing-usage/BillingContainer/BillingContainer.tsx
+++ b/apps/deploy-web/src/components/billing-usage/BillingContainer/BillingContainer.tsx
@@ -16,8 +16,6 @@ const DEPENDENCIES = {
 
 export type ChildrenProps = {
   data: BillingTransaction[];
-  hasMore: boolean;
-  hasPrevious: boolean;
   isLoading: boolean;
   isFetching: boolean;
   isError: boolean;
@@ -103,8 +101,6 @@ export const BillingContainer: React.FC<BillingContainerProps> = ({ children, de
     <>
       {children({
         data: data?.transactions || [],
-        hasMore: data?.hasMore || false,
-        hasPrevious: pagination.pageIndex > 0,
         onExport: exportCsv,
         onPaginationChange: handlePaginationChange,
         totalCount: data?.totalCount || 0,

--- a/apps/deploy-web/src/components/billing-usage/BillingView/BillingView.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/BillingView/BillingView.spec.tsx
@@ -121,11 +121,31 @@ describe(BillingView.name, () => {
 
   it("calls onPaginationChange when clicking next/prev", () => {
     const onPaginationChange = vi.fn();
-    setup({ onPaginationChange, hasMore: true, hasPrevious: true, pagination: { pageIndex: 1, pageSize: 10 } });
+    setup({ onPaginationChange, totalCount: 30, pagination: { pageIndex: 1, pageSize: 10 } });
     fireEvent.click(screen.getByText("Previous"));
     expect(onPaginationChange).toHaveBeenCalledWith({ pageIndex: 0, pageSize: 10 });
     fireEvent.click(screen.getByText("Next"));
     expect(onPaginationChange).toHaveBeenCalledWith({ pageIndex: 2, pageSize: 10 });
+  });
+
+  it("derives one page per pageSize chunk of totalCount", () => {
+    setup({ totalCount: 35, pagination: { pageIndex: 0, pageSize: 10 } });
+    expect(screen.getByRole("button", { name: "1" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "4" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "5" })).not.toBeInTheDocument();
+  });
+
+  it("navigates to the clicked page number", () => {
+    const onPaginationChange = vi.fn();
+    setup({ onPaginationChange, totalCount: 35, pagination: { pageIndex: 0, pageSize: 10 } });
+    fireEvent.click(screen.getByRole("button", { name: "3" }));
+    expect(onPaginationChange).toHaveBeenCalledWith({ pageIndex: 2, pageSize: 10 });
+  });
+
+  it("does not render a phantom page beyond totalCount", () => {
+    setup({ totalCount: 15, pagination: { pageIndex: 0, pageSize: 10 } });
+    expect(screen.getByRole("button", { name: "2" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "3" })).not.toBeInTheDocument();
   });
 
   it("disables export button when no data", () => {
@@ -191,14 +211,23 @@ describe(BillingView.name, () => {
 
     const defaultComponents: NonNullable<BillingViewProps["components"]> = {
       FormattedNumber: ({ value }) => <span>{value.toFixed(2)}</span>,
-      PaginationSizeSelector: ({ pageSize, setPageSize }) => (
-        <select value={pageSize} onChange={e => setPageSize?.(parseInt(e.target.value, 10))} role="combobox">
-          {[10, 20, 50].map(size => (
-            <option key={size} value={size}>
-              {size}
-            </option>
+      CustomPagination: ({ totalPageCount, pageIndex, pageSize, setPageIndex, setPageSize }) => (
+        <div>
+          <select value={pageSize} onChange={e => setPageSize(parseInt(e.target.value, 10))} role="combobox">
+            {[10, 20, 50].map(size => (
+              <option key={size} value={size}>
+                {size}
+              </option>
+            ))}
+          </select>
+          <button onClick={() => setPageIndex(pageIndex - 1)}>Previous</button>
+          {Array.from({ length: totalPageCount }, (_, page) => (
+            <button key={page} onClick={() => setPageIndex(page)}>
+              {page + 1}
+            </button>
           ))}
-        </select>
+          <button onClick={() => setPageIndex(pageIndex + 1)}>Next</button>
+        </div>
       ),
       DateRangePicker: ({ date = props.dateRange, onChange }) => (
         <div>
@@ -224,8 +253,6 @@ describe(BillingView.name, () => {
 
     const defaultProps: React.ComponentProps<typeof BillingView> = {
       data: props.data ?? defaultData,
-      hasMore: false,
-      hasPrevious: false,
       isLoading: false,
       isFetching: false,
       isError: false,

--- a/apps/deploy-web/src/components/billing-usage/BillingView/BillingView.tsx
+++ b/apps/deploy-web/src/components/billing-usage/BillingView/BillingView.tsx
@@ -8,16 +8,9 @@ import {
   Card,
   CardContent,
   CardHeader,
+  CustomPagination,
   DateRangePicker,
   Label,
-  Pagination,
-  PaginationContent,
-  PaginationEllipsis,
-  PaginationItem,
-  PaginationLink,
-  PaginationNext,
-  PaginationPrevious,
-  PaginationSizeSelector,
   Skeleton,
   Table,
   TableBody,
@@ -39,7 +32,7 @@ import { capitalizeFirstLetter } from "@src/utils/stringUtils";
 export const COMPONENTS = {
   FormattedNumber,
   DateRangePicker,
-  PaginationSizeSelector
+  CustomPagination
 };
 
 const TRANSACTION_TYPE_LABELS: Record<BillingTransaction["type"], string> = {
@@ -72,8 +65,6 @@ const COLUMN_CLASSES = ["w-28 px-4 py-2", "w-36 px-4 py-2", "w-32 px-4 py-2", "w
 
 export type BillingViewProps = {
   data: BillingTransaction[];
-  hasMore: boolean;
-  hasPrevious: boolean;
   isLoading: boolean;
   isFetching: boolean;
   isError: boolean;
@@ -89,8 +80,6 @@ export type BillingViewProps = {
 
 export const BillingView: React.FC<BillingViewProps> = ({
   data,
-  hasMore,
-  hasPrevious,
   isLoading,
   isFetching,
   errorMessage,
@@ -98,9 +87,10 @@ export const BillingView: React.FC<BillingViewProps> = ({
   onExport,
   onPaginationChange,
   pagination,
+  totalCount,
   dateRange,
   onDateRangeChange,
-  components: { FormattedNumber, DateRangePicker, PaginationSizeSelector } = COMPONENTS
+  components: { FormattedNumber, DateRangePicker, CustomPagination } = COMPONENTS
 }) => {
   const oneYearAgo = startOfDay(subYears(new Date(), 1));
   const columnHelper = createColumnHelper<BillingTransaction>();
@@ -283,100 +273,15 @@ export const BillingView: React.FC<BillingViewProps> = ({
               </Table>
             </div>
 
-            <Pagination className="flex flex-col justify-start gap-2 pt-2 sm:flex-row sm:items-center sm:gap-0 sm:pt-6">
-              <PaginationSizeSelector
+            <div className="flex items-center justify-center pt-2 sm:pt-6">
+              <CustomPagination
+                totalPageCount={Math.max(1, Math.ceil(totalCount / pagination.pageSize))}
+                pageIndex={pagination.pageIndex}
                 pageSize={pagination.pageSize}
-                setPageSize={pageSize => {
-                  onPaginationChange({
-                    pageIndex: 0,
-                    pageSize
-                  });
-                }}
+                setPageIndex={pageIndex => onPaginationChange({ pageIndex, pageSize: pagination.pageSize })}
+                setPageSize={pageSize => onPaginationChange({ pageIndex: 0, pageSize })}
               />
-
-              <PaginationContent className="flex items-center space-x-1">
-                <PaginationItem className="hidden sm:list-item">
-                  <PaginationPrevious
-                    onClick={() =>
-                      onPaginationChange({
-                        pageIndex: Math.max(0, pagination.pageIndex - 1),
-                        pageSize: pagination.pageSize
-                      })
-                    }
-                    disabled={!hasPrevious || isFetching}
-                    className="h-8 px-2 text-sm text-neutral-500 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-300 [&_span]:hidden sm:[&_span]:inline-block"
-                  />
-                </PaginationItem>
-
-                {hasPrevious && (
-                  <PaginationItem>
-                    <PaginationLink
-                      className="text-neutral-500 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-300"
-                      disabled={isFetching}
-                      onClick={() =>
-                        onPaginationChange({
-                          pageIndex: pagination.pageIndex - 1,
-                          pageSize: pagination.pageSize
-                        })
-                      }
-                    >
-                      {pagination.pageIndex}
-                    </PaginationLink>
-                  </PaginationItem>
-                )}
-
-                <PaginationItem>
-                  <PaginationLink disabled className="text-neutral-500 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-300">
-                    {pagination.pageIndex + 1}
-                  </PaginationLink>
-                </PaginationItem>
-
-                {hasMore && (
-                  <PaginationItem>
-                    <PaginationLink
-                      className="text-neutral-500 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-300"
-                      disabled={isFetching}
-                      onClick={() =>
-                        onPaginationChange({
-                          pageIndex: pagination.pageIndex + 1,
-                          pageSize: pagination.pageSize
-                        })
-                      }
-                    >
-                      {pagination.pageIndex + 2}
-                    </PaginationLink>
-                  </PaginationItem>
-                )}
-
-                {pagination.pageIndex === 0 && hasMore && (
-                  <>
-                    <PaginationItem>
-                      <PaginationLink
-                        className="text-neutral-500 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-300"
-                        disabled={isFetching}
-                        onClick={() =>
-                          onPaginationChange({
-                            pageIndex: 2,
-                            pageSize: pagination.pageSize
-                          })
-                        }
-                      >
-                        3
-                      </PaginationLink>
-                    </PaginationItem>
-                    <PaginationEllipsis className="text-neutral-500 dark:text-neutral-400" />
-                  </>
-                )}
-
-                <PaginationItem className="hidden sm:list-item">
-                  <PaginationNext
-                    onClick={() => onPaginationChange({ pageIndex: pagination.pageIndex + 1, pageSize: pagination.pageSize })}
-                    disabled={!hasMore || isFetching}
-                    className="h-8 px-2 text-sm text-neutral-500 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-300 [&_span]:hidden sm:[&_span]:inline-block"
-                  />
-                </PaginationItem>
-              </PaginationContent>
-            </Pagination>
+            </div>
           </div>
         )}
       </CardContent>


### PR DESCRIPTION
## Why

The billing **History** table pagination was broken in production. On load an account with ~2 pages of transactions showed ~4 pages; clicking page 2 collapsed the count to 2; clicking the phantom page 3/4 loaded an empty table.

The view fabricated its page numbers from the `hasMore` flag plus a hardcoded "render a literal page 3 + ellipsis while on the first page" block, and never used the stable `totalCount` the container (and backend `COUNT(*)`) already provided. So:

- **Page 1** (`pageIndex 0`): rendered `1`, `2` (because `hasMore`), then the hardcoded `3` + `…` + Next → looked like ~4 pages.
- **Click page 2**: backend `hasMore` is now `false` and the first-page block is gone → collapsed to `1`, `2`.
- **Click the phantom `3` / Next**: jumped to an offset past `totalCount` → empty "No billing history found".

## What

- Replaced the hand-rolled pagination in `BillingView` with the shared `CustomPagination` component already used by the alerts/providers/deployments tables, driven by `Math.ceil(totalCount / pageSize)`.
- Dropped the now-dead `hasMore`/`hasPrevious` props from `BillingView` and `BillingContainer`.
- Updated the `BillingView`/`BillingContainer` specs and added regression cases: 15 rows → exactly 2 pages (no phantom page 3), 35 rows → 4 pages, clicking page 3 navigates to `pageIndex: 2`.

Minor UX change: page buttons no longer disable during a background refetch (`CustomPagination` has no fetching state, consistent with the other tables; `keepPreviousData` keeps rows visible meanwhile).

**Verification:** `npm run test:unit -- BillingView BillingContainer` (32 passed), `npm run lint -- --quiet` clean, `npx tsc --noEmit` no new errors in the changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added numbered pagination for billing usage views.
  * Added previous/next navigation and page-size selection.
  * Pagination now accurately reflects available pages and resets when the page size changes.

* **Tests**
  * Expanded coverage for page navigation, total-page calculations, page-size changes, and preventing empty phantom pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->