### PR TITLE
fix(deployment): load deployment list one page at a time

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.ts
@@ -420,6 +420,7 @@ export function useDeploymentFlow({ intent }: UseDeploymentFlowInput, dependenci
         queryClient.invalidateQueries({ queryKey: QueryKeys.getLeaseExistenceKey(owner) });
         queryClient.invalidateQueries({ queryKey: QueryKeys.getAllLeasesKey(owner) });
         queryClient.invalidateQueries({ queryKey: QueryKeys.getDeploymentListKey(owner) });
+        queryClient.invalidateQueries({ queryKey: QueryKeys.getDeploymentsPageKeyPrefix(owner) });
         setDeploySucceeded(true);
         redirectTimerRef.current = setTimeout(function redirectToDeployment() {
           router.replace(UrlService.deploymentDetails(activeDseq, "EVENTS", "events"));

--- a/apps/deploy-web/src/components/deployments/DeploymentList.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentList.spec.tsx
@@ -45,6 +45,12 @@ describe(DeploymentList.name, () => {
     expect(screen.getByText("not-selectable")).toBeInTheDocument();
   });
 
+  it("does not force a refetch on initial load since the query is already enabled", () => {
+    const { refetch } = setup({ data: { deployments: [], total: 0 } });
+
+    expect(refetch).not.toHaveBeenCalled();
+  });
+
   it("hides the unfiltered total banner while a search is active", async () => {
     setup({ data: { deployments: [mock<DeploymentDto>({ dseq: "100", state: "active" })], total: 20 } });
 

--- a/apps/deploy-web/src/components/deployments/DeploymentList.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentList.spec.tsx
@@ -21,14 +21,14 @@ describe(DeploymentList.name, () => {
   });
 
   it("renders the onboarding empty state when there are no active deployments", () => {
-    const { NoDeploymentsState } = setup({ data: { deployments: [], total: 0 } });
+    const { NoDeploymentsState } = setup({ data: { deployments: [], hasNextPage: false } });
 
     expect(NoDeploymentsState).toHaveBeenCalledWith(expect.objectContaining({ hasDeployments: false }), expect.anything());
     expect(screen.queryByText("No closed deployments.")).not.toBeInTheDocument();
   });
 
   it("renders a closed-specific empty state on the Closed tab", async () => {
-    setup({ data: { deployments: [], total: 0 } });
+    setup({ data: { deployments: [], hasNextPage: false } });
 
     await userEvent.click(screen.getByRole("tab", { name: "Closed" }));
 
@@ -36,7 +36,7 @@ describe(DeploymentList.name, () => {
   });
 
   it("keeps rows selectable on Active but not on Closed", async () => {
-    setup({ data: { deployments: [mock<DeploymentDto>({ dseq: "100", state: "active" })], total: 3 } });
+    setup({ data: { deployments: [mock<DeploymentDto>({ dseq: "100", state: "active" })], hasNextPage: false } });
 
     expect(screen.getByText("selectable")).toBeInTheDocument();
 
@@ -46,28 +46,53 @@ describe(DeploymentList.name, () => {
   });
 
   it("does not force a refetch on initial load since the query is already enabled", () => {
-    const { refetch } = setup({ data: { deployments: [], total: 0 } });
+    const { refetch } = setup({ data: { deployments: [], hasNextPage: false } });
 
     expect(refetch).not.toHaveBeenCalled();
   });
 
-  it("hides the unfiltered total banner while a search is active", async () => {
-    setup({ data: { deployments: [mock<DeploymentDto>({ dseq: "100", state: "active" })], total: 20 } });
+  it("enables Next when the RPC reports a next_key and keeps Previous disabled on the first page", () => {
+    setup({ data: { deployments: [mock<DeploymentDto>({ dseq: "100", state: "active" })], hasNextPage: true } });
 
-    expect(screen.getByText(/You have/)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Go to next page" })).not.toHaveAttribute("aria-disabled", "true");
+    expect(screen.getByRole("link", { name: "Go to previous page" })).toHaveAttribute("aria-disabled", "true");
+    expect(screen.queryByText(/Page \d+ of \d+/)).not.toBeInTheDocument();
+  });
+
+  it("disables Next on the last page", () => {
+    setup({ data: { deployments: [mock<DeploymentDto>({ dseq: "100", state: "active" })], hasNextPage: false } });
+
+    expect(screen.getByRole("link", { name: "Go to next page" })).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("requests the next offset after Next is clicked", async () => {
+    const { useDeploymentsPage } = setup({
+      data: { deployments: [mock<DeploymentDto>({ dseq: "100", state: "active" })], hasNextPage: true }
+    });
+
+    await userEvent.click(screen.getByRole("link", { name: "Go to next page" }));
+
+    expect(useDeploymentsPage).toHaveBeenLastCalledWith("akash1owner", expect.objectContaining({ skip: 10, limit: 10, state: "active" }), expect.anything());
+    expect(screen.getByRole("link", { name: "Go to previous page" })).not.toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("hides the pager while a search is active", async () => {
+    setup({ data: { deployments: [mock<DeploymentDto>({ dseq: "100", state: "active" })], hasNextPage: true } });
+
+    expect(screen.getByRole("link", { name: "Go to next page" })).toBeInTheDocument();
 
     await userEvent.type(screen.getByRole("textbox"), "1");
 
-    expect(screen.queryByText(/You have/)).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Go to next page" })).not.toBeInTheDocument();
   });
 
   function setup(input: { data?: DeploymentsPage; isFetching?: boolean; isError?: boolean } = {}) {
     const refetch = vi.fn();
 
-    const useDeploymentsPage: typeof DEPENDENCIES.useDeploymentsPage = () => {
+    const useDeploymentsPage = vi.fn<typeof DEPENDENCIES.useDeploymentsPage>(() => {
       const query = mock<ReturnType<typeof DEPENDENCIES.useDeploymentsPage>>();
       return Object.assign(query, { data: input.data, isFetching: input.isFetching ?? false, isError: input.isError ?? false, refetch });
-    };
+    });
 
     const useWallet: typeof DEPENDENCIES.useWallet = () => mock<ReturnType<typeof DEPENDENCIES.useWallet>>({ address: "akash1owner", hasWallet: true });
     const useProviderList: typeof DEPENDENCIES.useProviderList = () => mock<ReturnType<typeof DEPENDENCIES.useProviderList>>({ data: [], isFetching: false });
@@ -105,6 +130,6 @@ describe(DeploymentList.name, () => {
       />
     );
 
-    return { refetch, NoDeploymentsState, DeploymentListRow };
+    return { refetch, NoDeploymentsState, DeploymentListRow, useDeploymentsPage };
   }
 });

--- a/apps/deploy-web/src/components/deployments/DeploymentList.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentList.spec.tsx
@@ -76,22 +76,91 @@ describe(DeploymentList.name, () => {
     expect(screen.getByRole("link", { name: "Go to previous page" })).not.toHaveAttribute("aria-disabled", "true");
   });
 
-  it("hides the pager while a search is active", async () => {
-    setup({ data: { deployments: [mock<DeploymentDto>({ dseq: "100", state: "active" })], hasNextPage: true } });
+  it("does not fetch the full state list until a search is entered", () => {
+    const { useDeploymentList } = setup({ data: { deployments: [mock<DeploymentDto>({ dseq: "100", state: "active" })], hasNextPage: false } });
 
-    expect(screen.getByRole("link", { name: "Go to next page" })).toBeInTheDocument();
-
-    await userEvent.type(screen.getByRole("textbox"), "1");
-
-    expect(screen.queryByRole("link", { name: "Go to next page" })).not.toBeInTheDocument();
+    expect(useDeploymentList).toHaveBeenLastCalledWith("akash1owner", expect.objectContaining({ enabled: false }), "active");
   });
 
-  function setup(input: { data?: DeploymentsPage; isFetching?: boolean; isError?: boolean } = {}) {
+  it("searches the full selected-state list, including deployments not on the current page", async () => {
+    setup({
+      data: { deployments: [mock<DeploymentDto>({ dseq: "100", state: "active" })], hasNextPage: true },
+      list: [mock<DeploymentDto>({ dseq: "100", state: "active" }), mock<DeploymentDto>({ dseq: "999", state: "active" })]
+    });
+
+    expect(screen.queryByText("999")).not.toBeInTheDocument();
+
+    await userEvent.type(screen.getByRole("textbox"), "999");
+
+    expect(screen.getByText("999")).toBeInTheDocument();
+    expect(screen.queryByText("100")).not.toBeInTheDocument();
+  });
+
+  it("matches a local deployment name from the full selected-state list", async () => {
+    setup({
+      data: { deployments: [mock<DeploymentDto>({ dseq: "100", state: "active" })], hasNextPage: false },
+      list: [mock<DeploymentDto>({ dseq: "100", state: "active" }), mock<DeploymentDto>({ dseq: "200", state: "active" })],
+      getDeploymentName: dseq => (String(dseq) === "200" ? "staging-api" : null)
+    });
+
+    await userEvent.type(screen.getByRole("textbox"), "staging");
+
+    expect(screen.getByText("200")).toBeInTheDocument();
+    expect(screen.queryByText("100")).not.toBeInTheDocument();
+  });
+
+  it("scopes the full-list search to the Closed tab when that tab is selected", async () => {
+    const { useDeploymentList } = setup({
+      data: { deployments: [mock<DeploymentDto>({ dseq: "100", state: "active" })], hasNextPage: false },
+      list: [mock<DeploymentDto>({ dseq: "300", state: "closed" })]
+    });
+
+    await userEvent.click(screen.getByRole("tab", { name: "Closed" }));
+    await userEvent.type(screen.getByRole("textbox"), "300");
+
+    expect(useDeploymentList).toHaveBeenLastCalledWith("akash1owner", expect.objectContaining({ enabled: true }), "closed");
+    expect(screen.getByText("300")).toBeInTheDocument();
+  });
+
+  it("paginates filtered search results when they exceed the page size", async () => {
+    const list = Array.from({ length: 11 }, (_, index) => mock<DeploymentDto>({ dseq: `match-${index}`, state: "active" }));
+    setup({
+      data: { deployments: [list[0]], hasNextPage: true },
+      list
+    });
+
+    await userEvent.type(screen.getByRole("textbox"), "match");
+
+    expect(screen.getByText("match-0")).toBeInTheDocument();
+    expect(screen.queryByText("match-10")).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Go to next page" })).not.toHaveAttribute("aria-disabled", "true");
+
+    await userEvent.click(screen.getByRole("link", { name: "Go to next page" }));
+
+    expect(screen.getByText("match-10")).toBeInTheDocument();
+    expect(screen.queryByText("match-0")).not.toBeInTheDocument();
+  });
+
+  function setup(
+    input: {
+      data?: DeploymentsPage;
+      list?: DeploymentDto[];
+      isFetching?: boolean;
+      isError?: boolean;
+      getDeploymentName?: (dseq: string | number | null) => string | null;
+    } = {}
+  ) {
     const refetch = vi.fn();
+    const refetchList = vi.fn();
 
     const useDeploymentsPage = vi.fn<typeof DEPENDENCIES.useDeploymentsPage>(() => {
       const query = mock<ReturnType<typeof DEPENDENCIES.useDeploymentsPage>>();
       return Object.assign(query, { data: input.data, isFetching: input.isFetching ?? false, isError: input.isError ?? false, refetch });
+    });
+
+    const useDeploymentList = vi.fn<typeof DEPENDENCIES.useDeploymentList>(() => {
+      const query = mock<ReturnType<typeof DEPENDENCIES.useDeploymentList>>();
+      return Object.assign(query, { data: input.list, isFetching: false, isError: false, refetch: refetchList });
     });
 
     const useWallet: typeof DEPENDENCIES.useWallet = () => mock<ReturnType<typeof DEPENDENCIES.useWallet>>({ address: "akash1owner", hasWallet: true });
@@ -101,7 +170,10 @@ describe(DeploymentList.name, () => {
         isSettingsInit: true,
         settings: mock<ReturnType<typeof DEPENDENCIES.useSettings>["settings"]>({ apiEndpoint: "http://localhost", isBlockchainDown: false })
       });
-    const useLocalNotes: typeof DEPENDENCIES.useLocalNotes = () => mock<ReturnType<typeof DEPENDENCIES.useLocalNotes>>();
+    const useLocalNotes: typeof DEPENDENCIES.useLocalNotes = () =>
+      mock<ReturnType<typeof DEPENDENCIES.useLocalNotes>>({
+        getDeploymentName: input.getDeploymentName ?? (() => null)
+      });
     const useManagedDeploymentConfirm: typeof DEPENDENCIES.useManagedDeploymentConfirm = () =>
       mock<ReturnType<typeof DEPENDENCIES.useManagedDeploymentConfirm>>();
     const useNewDeploymentUrl: typeof DEPENDENCIES.useNewDeploymentUrl = () => () => "/new-deployment";
@@ -118,6 +190,7 @@ describe(DeploymentList.name, () => {
       <DeploymentList
         dependencies={MockComponents(DEPENDENCIES, {
           useDeploymentsPage,
+          useDeploymentList,
           useWallet,
           useProviderList,
           useSettings,
@@ -130,6 +203,6 @@ describe(DeploymentList.name, () => {
       />
     );
 
-    return { refetch, NoDeploymentsState, DeploymentListRow, useDeploymentsPage };
+    return { refetch, NoDeploymentsState, DeploymentListRow, useDeploymentsPage, useDeploymentList };
   }
 });

--- a/apps/deploy-web/src/components/deployments/DeploymentList.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentList.spec.tsx
@@ -141,26 +141,66 @@ describe(DeploymentList.name, () => {
     expect(screen.queryByText("match-0")).not.toBeInTheDocument();
   });
 
+  it("renders the closed empty state when the search box contains only whitespace", async () => {
+    setup({
+      data: { deployments: [mock<DeploymentDto>({ dseq: "100", state: "active" })], hasNextPage: false },
+      closedData: { deployments: [], hasNextPage: false }
+    });
+
+    await userEvent.type(screen.getByRole("textbox"), " ");
+    await userEvent.click(screen.getByRole("tab", { name: "Closed" }));
+
+    expect(screen.getByText("No closed deployments.")).toBeInTheDocument();
+    expect(screen.queryByText("No deployment found.")).not.toBeInTheDocument();
+  });
+
+  it("renders no deployment found when a search matches nothing", async () => {
+    setup({
+      data: { deployments: [mock<DeploymentDto>({ dseq: "100", state: "active" })], hasNextPage: false },
+      list: []
+    });
+
+    await userEvent.type(screen.getByRole("textbox"), "nomatch");
+
+    expect(screen.getByText("No deployment found.")).toBeInTheDocument();
+    expect(screen.queryByText("Couldn't load deployments.")).not.toBeInTheDocument();
+  });
+
+  it("does not render the search-empty message when the search query fails", async () => {
+    setup({
+      data: { deployments: [mock<DeploymentDto>({ dseq: "100", state: "active" })], hasNextPage: false },
+      isListError: true
+    });
+
+    await userEvent.type(screen.getByRole("textbox"), "foo");
+
+    expect(screen.getByText("Couldn't load deployments.")).toBeInTheDocument();
+    expect(screen.queryByText("No deployment found.")).not.toBeInTheDocument();
+  });
+
   function setup(
     input: {
       data?: DeploymentsPage;
+      closedData?: DeploymentsPage;
       list?: DeploymentDto[];
       isFetching?: boolean;
       isError?: boolean;
+      isListError?: boolean;
       getDeploymentName?: (dseq: string | number | null) => string | null;
     } = {}
   ) {
     const refetch = vi.fn();
     const refetchList = vi.fn();
 
-    const useDeploymentsPage = vi.fn<typeof DEPENDENCIES.useDeploymentsPage>(() => {
+    const useDeploymentsPage = vi.fn<typeof DEPENDENCIES.useDeploymentsPage>((_address, params) => {
       const query = mock<ReturnType<typeof DEPENDENCIES.useDeploymentsPage>>();
-      return Object.assign(query, { data: input.data, isFetching: input.isFetching ?? false, isError: input.isError ?? false, refetch });
+      const data = params.state === "closed" && input.closedData !== undefined ? input.closedData : input.data;
+      return Object.assign(query, { data, isFetching: input.isFetching ?? false, isError: input.isError ?? false, refetch });
     });
 
     const useDeploymentList = vi.fn<typeof DEPENDENCIES.useDeploymentList>(() => {
       const query = mock<ReturnType<typeof DEPENDENCIES.useDeploymentList>>();
-      return Object.assign(query, { data: input.list, isFetching: false, isError: false, refetch: refetchList });
+      return Object.assign(query, { data: input.list, isFetching: false, isError: input.isListError ?? false, refetch: refetchList });
     });
 
     const useWallet: typeof DEPENDENCIES.useWallet = () => mock<ReturnType<typeof DEPENDENCIES.useWallet>>({ address: "akash1owner", hasWallet: true });

--- a/apps/deploy-web/src/components/deployments/DeploymentList.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentList.spec.tsx
@@ -45,6 +45,16 @@ describe(DeploymentList.name, () => {
     expect(screen.getByText("not-selectable")).toBeInTheDocument();
   });
 
+  it("hides the unfiltered total banner while a search is active", async () => {
+    setup({ data: { deployments: [mock<DeploymentDto>({ dseq: "100", state: "active" })], total: 20 } });
+
+    expect(screen.getByText(/You have/)).toBeInTheDocument();
+
+    await userEvent.type(screen.getByRole("textbox"), "1");
+
+    expect(screen.queryByText(/You have/)).not.toBeInTheDocument();
+  });
+
   function setup(input: { data?: DeploymentsPage; isFetching?: boolean; isError?: boolean } = {}) {
     const refetch = vi.fn();
 

--- a/apps/deploy-web/src/components/deployments/DeploymentList.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentList.spec.tsx
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { DeploymentsPage } from "@src/queries/useDeploymentQuery";
+import type { DeploymentDto } from "@src/types/deployment";
+import { DEPENDENCIES, DeploymentList } from "./DeploymentList";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MockComponents } from "@tests/unit/mocks";
+
+describe(DeploymentList.name, () => {
+  it("renders an error state with a retry when the page query fails", async () => {
+    const { refetch } = setup({ isError: true });
+
+    expect(screen.getByText("Couldn't load deployments.")).toBeInTheDocument();
+
+    const callsBeforeRetry = refetch.mock.calls.length;
+    await userEvent.click(screen.getByRole("button", { name: /retry/i }));
+    expect(refetch.mock.calls.length).toBeGreaterThan(callsBeforeRetry);
+  });
+
+  it("renders the onboarding empty state when there are no active deployments", () => {
+    const { NoDeploymentsState } = setup({ data: { deployments: [], total: 0 } });
+
+    expect(NoDeploymentsState).toHaveBeenCalledWith(expect.objectContaining({ hasDeployments: false }), expect.anything());
+    expect(screen.queryByText("No closed deployments.")).not.toBeInTheDocument();
+  });
+
+  it("renders a closed-specific empty state on the Closed tab", async () => {
+    setup({ data: { deployments: [], total: 0 } });
+
+    await userEvent.click(screen.getByRole("tab", { name: "Closed" }));
+
+    expect(screen.getByText("No closed deployments.")).toBeInTheDocument();
+  });
+
+  it("keeps rows selectable on Active but not on Closed", async () => {
+    setup({ data: { deployments: [mock<DeploymentDto>({ dseq: "100", state: "active" })], total: 3 } });
+
+    expect(screen.getByText("selectable")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("tab", { name: "Closed" }));
+
+    expect(screen.getByText("not-selectable")).toBeInTheDocument();
+  });
+
+  function setup(input: { data?: DeploymentsPage; isFetching?: boolean; isError?: boolean } = {}) {
+    const refetch = vi.fn();
+
+    const useDeploymentsPage: typeof DEPENDENCIES.useDeploymentsPage = () => {
+      const query = mock<ReturnType<typeof DEPENDENCIES.useDeploymentsPage>>();
+      return Object.assign(query, { data: input.data, isFetching: input.isFetching ?? false, isError: input.isError ?? false, refetch });
+    };
+
+    const useWallet: typeof DEPENDENCIES.useWallet = () => mock<ReturnType<typeof DEPENDENCIES.useWallet>>({ address: "akash1owner", hasWallet: true });
+    const useProviderList: typeof DEPENDENCIES.useProviderList = () => mock<ReturnType<typeof DEPENDENCIES.useProviderList>>({ data: [], isFetching: false });
+    const useSettings: typeof DEPENDENCIES.useSettings = () =>
+      mock<ReturnType<typeof DEPENDENCIES.useSettings>>({
+        isSettingsInit: true,
+        settings: mock<ReturnType<typeof DEPENDENCIES.useSettings>["settings"]>({ apiEndpoint: "http://localhost", isBlockchainDown: false })
+      });
+    const useLocalNotes: typeof DEPENDENCIES.useLocalNotes = () => mock<ReturnType<typeof DEPENDENCIES.useLocalNotes>>();
+    const useManagedDeploymentConfirm: typeof DEPENDENCIES.useManagedDeploymentConfirm = () =>
+      mock<ReturnType<typeof DEPENDENCIES.useManagedDeploymentConfirm>>();
+    const useNewDeploymentUrl: typeof DEPENDENCIES.useNewDeploymentUrl = () => () => "/new-deployment";
+
+    const NoDeploymentsState = vi.fn(() => <div>onboarding empty state</div>);
+    const DeploymentListRow = vi.fn(({ deployment, isSelectable }: { deployment: DeploymentDto; isSelectable?: boolean }) => (
+      <tr>
+        <td>{deployment.dseq}</td>
+        <td>{isSelectable ? "selectable" : "not-selectable"}</td>
+      </tr>
+    ));
+
+    render(
+      <DeploymentList
+        dependencies={MockComponents(DEPENDENCIES, {
+          useDeploymentsPage,
+          useWallet,
+          useProviderList,
+          useSettings,
+          useLocalNotes,
+          useManagedDeploymentConfirm,
+          useNewDeploymentUrl,
+          NoDeploymentsState,
+          DeploymentListRow
+        })}
+      />
+    );
+
+    return { refetch, NoDeploymentsState, DeploymentListRow };
+  }
+});

--- a/apps/deploy-web/src/components/deployments/DeploymentList.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentList.tsx
@@ -38,7 +38,36 @@ import Layout from "../layout/Layout";
 import { Title } from "../shared/Title";
 import { DeploymentListRow } from "./DeploymentListRow";
 
-export const DeploymentList: React.FunctionComponent = () => {
+export const DEPENDENCIES = {
+  useWallet,
+  useProviderList,
+  useSettings,
+  useLocalNotes,
+  useManagedDeploymentConfirm,
+  useNewDeploymentUrl,
+  useDeploymentsPage,
+  Layout,
+  NoDeploymentsState,
+  DeploymentListRow
+};
+
+type Props = {
+  dependencies?: typeof DEPENDENCIES;
+};
+
+export const DeploymentList: React.FunctionComponent<Props> = ({ dependencies = DEPENDENCIES }) => {
+  const {
+    useWallet,
+    useProviderList,
+    useSettings,
+    useLocalNotes,
+    useManagedDeploymentConfirm,
+    useNewDeploymentUrl,
+    useDeploymentsPage,
+    Layout,
+    NoDeploymentsState,
+    DeploymentListRow
+  } = dependencies;
   const { address, signAndBroadcastTx, hasWallet } = useWallet();
   const { data: providers, isFetching: isLoadingProviders } = useProviderList();
   const { settings, isSettingsInit } = useSettings();

--- a/apps/deploy-web/src/components/deployments/DeploymentList.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentList.tsx
@@ -1,9 +1,8 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   Button,
   buttonVariants,
-  CheckboxWithLabel,
   CustomPagination,
   Input,
   Spinner,
@@ -11,9 +10,13 @@ import {
   TableBody,
   TableHead,
   TableHeader,
-  TableRow
+  TableRow,
+  Tabs,
+  TabsList,
+  TabsTrigger
 } from "@akashnetwork/ui/components";
 import { cn } from "@akashnetwork/ui/utils";
+import { keepPreviousData } from "@tanstack/react-query";
 import { Refresh, Rocket, Xmark } from "iconoir-react";
 import { useAtom } from "jotai";
 import Link from "next/link";
@@ -26,10 +29,10 @@ import { useWallet } from "@src/context/WalletProvider";
 import { useListSelection } from "@src/hooks/useListSelection/useListSelection";
 import { useManagedDeploymentConfirm } from "@src/hooks/useManagedDeploymentConfirm";
 import { useNewDeploymentUrl } from "@src/hooks/useNewDeploymentUrl/useNewDeploymentUrl";
-import { useDeploymentList } from "@src/queries/useDeploymentQuery";
+import { useDeploymentsPage } from "@src/queries/useDeploymentQuery";
 import { useProviderList } from "@src/queries/useProvidersQuery";
 import sdlStore from "@src/store/sdlStore";
-import type { DeploymentDto, NamedDeploymentDto } from "@src/types/deployment";
+import type { DeploymentStatus, NamedDeploymentDto } from "@src/types/deployment";
 import { TransactionMessageData } from "@src/utils/TransactionMessageData";
 import { NoDeploymentsState } from "../home/NoDeploymentsState";
 import Layout from "../layout/Layout";
@@ -39,74 +42,57 @@ import { DeploymentListRow } from "./DeploymentListRow";
 export const DeploymentList: React.FunctionComponent = () => {
   const { address, signAndBroadcastTx, hasWallet } = useWallet();
   const { data: providers, isFetching: isLoadingProviders } = useProviderList();
-  const { data: deployments, isFetching: isLoadingDeployments, refetch: getDeployments } = useDeploymentList(address, { enabled: false });
-  const [pageIndex, setPageIndex] = useState(0);
   const { settings, isSettingsInit } = useSettings();
-  const [search, setSearch] = useState("");
-  const { getDeploymentName } = useLocalNotes();
-  const [filteredDeployments, setFilteredDeployments] = useState<NamedDeploymentDto[] | null>(null);
-  const [isFilteringActive, setIsFilteringActive] = useState(true);
   const { apiEndpoint } = settings;
-  const [pageSize, setPageSize] = useState<number>(10);
-  const orderedDeployments = filteredDeployments
-    ? [...filteredDeployments].sort((a: DeploymentDto, b: DeploymentDto) => (a.createdAt < b.createdAt ? 1 : -1))
-    : [];
-  const start = pageIndex * pageSize;
-  const end = start + pageSize;
-  const currentPageDeployments = orderedDeployments.slice(start, end);
-  const pageCount = Math.ceil(orderedDeployments.length / pageSize);
+  const { getDeploymentName } = useLocalNotes();
+  const [deploymentStatus, setDeploymentStatus] = useState<DeploymentStatus>("active");
+  const [pageIndex, setPageIndex] = useState(0);
+  const [pageSize, setPageSize] = useState(10);
+  const [search, setSearch] = useState("");
   const [, setDeploySdl] = useAtom(sdlStore.deploySdl);
   const { closeDeploymentConfirm } = useManagedDeploymentConfirm();
   const newDeploymentUrl = useNewDeploymentUrl();
 
+  const {
+    data,
+    isFetching: isLoadingDeployments,
+    refetch: getDeployments
+  } = useDeploymentsPage(
+    address,
+    { state: deploymentStatus, skip: pageIndex * pageSize, limit: pageSize, countTotal: true },
+    { enabled: isSettingsInit && !!address, placeholderData: keepPreviousData }
+  );
+
+  const total = data?.total ?? 0;
+  const pageCount = Math.ceil(total / pageSize);
+
+  const pageDeployments = useMemo(() => {
+    const named = (data?.deployments ?? []).map(d => ({ ...d, name: getDeploymentName(d.dseq) })) as NamedDeploymentDto[];
+    if (!search) return named;
+    const query = search.toLowerCase();
+    return named.filter(d => d.name?.toLowerCase().includes(query) || d.dseq?.toLowerCase().includes(query));
+  }, [data?.deployments, search, getDeploymentName]);
+
   const { selectedItemIds, selectItem, clearSelection } = useListSelection<string>({
-    ids: currentPageDeployments.map(deployment => deployment.dseq)
+    ids: pageDeployments.map(deployment => deployment.dseq)
   });
 
   useEffect(() => {
-    if (isSettingsInit) {
+    if (isSettingsInit && address) {
       getDeployments();
     }
-  }, [isSettingsInit, getDeployments, apiEndpoint, address]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [apiEndpoint]);
 
-  useEffect(() => {
-    if (deployments) {
-      let filteredDeployments = deployments.map(d => {
-        const name = getDeploymentName(d.dseq);
-
-        return {
-          ...d,
-          name
-        };
-      }) as NamedDeploymentDto[];
-
-      // Filter for search
-      if (search) {
-        filteredDeployments = filteredDeployments.filter(
-          x => x.name?.toLowerCase().includes(search.toLowerCase()) || x.dseq?.toLowerCase().includes(search.toLowerCase())
-        );
-      }
-
-      if (isFilteringActive) {
-        filteredDeployments = filteredDeployments.filter(d => d.state === "active");
-      }
-
-      setFilteredDeployments(filteredDeployments);
-    }
-  }, [deployments, search, getDeploymentName, isFilteringActive]);
-
-  const handleChangePage = (newPage: number) => {
-    setPageIndex(newPage);
-  };
-
-  const onIsFilteringActiveClick = (value: boolean) => {
+  const onStatusChange = (value: string) => {
+    if (value !== "active" && value !== "closed") return;
+    setDeploymentStatus(value);
     setPageIndex(0);
-    setIsFilteringActive(value);
+    clearSelection();
   };
 
   const onSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const value = event.target.value;
-    setSearch(value);
+    setSearch(event.target.value);
   };
 
   const onCloseSelectedDeployments = async () => {
@@ -137,56 +123,60 @@ export const DeploymentList: React.FunctionComponent = () => {
     setPageIndex(0);
   };
 
+  const isActiveStatus = deploymentStatus === "active";
+  const showEmptyState = total === 0 && !isLoadingDeployments && !search;
+
   return (
     <Layout isLoading={isLoadingDeployments || isLoadingProviders} isUsingSettings>
       <NextSeo title="Deployments" />
-      {deployments && deployments.length > 0 && hasWallet && (
+      {hasWallet && (
         <div className="flex flex-wrap items-center pb-6">
-          <>
-            <Title>Deployments</Title>
+          <Title>Deployments</Title>
 
-            <div className="ml-6">
-              <Button aria-label="back" onClick={() => getDeployments()} size="icon" variant="ghost">
-                <Refresh />
-              </Button>
-            </div>
+          <div className="ml-6">
+            <Button aria-label="refresh" onClick={() => getDeployments()} size="icon" variant="ghost">
+              <Refresh />
+            </Button>
+          </div>
 
-            <div className="ml-6">
-              <div className="flex items-center space-x-2">
-                <CheckboxWithLabel label="Active" checked={isFilteringActive} onCheckedChange={onIsFilteringActiveClick} />
+          <div className="ml-6">
+            <Tabs value={deploymentStatus} onValueChange={onStatusChange}>
+              <TabsList>
+                <TabsTrigger value="active">Active</TabsTrigger>
+                <TabsTrigger value="closed">Closed</TabsTrigger>
+              </TabsList>
+            </Tabs>
+          </div>
+
+          {selectedItemIds.length > 0 && (
+            <>
+              <div className="md:ml-6">
+                <Button onClick={onCloseSelectedDeployments} color="secondary" size="sm">
+                  Close selected ({selectedItemIds.length})
+                </Button>
               </div>
-            </div>
 
-            {selectedItemIds.length > 0 && (
-              <>
-                <div className="md:ml-6">
-                  <Button onClick={onCloseSelectedDeployments} color="secondary" size="sm">
-                    Close selected ({selectedItemIds.length})
-                  </Button>
-                </div>
+              <div className="ml-6">
+                <LinkTo onClick={clearSelection}>Clear</LinkTo>
+              </div>
+            </>
+          )}
 
-                <div className="ml-6">
-                  <LinkTo onClick={clearSelection}>Clear</LinkTo>
-                </div>
-              </>
-            )}
-
-            {(filteredDeployments?.length || 0) > 0 && (
-              <Link
-                href={newDeploymentUrl()}
-                className={cn("ml-auto space-x-2", buttonVariants({ variant: "default", size: "sm" }))}
-                aria-disabled={settings.isBlockchainDown}
-                onClick={onDeployClick}
-              >
-                <Rocket className="rotate-45 text-sm" />
-                <span className="whitespace-nowrap">Deploy</span>
-              </Link>
-            )}
-          </>
+          {total > 0 && (
+            <Link
+              href={newDeploymentUrl()}
+              className={cn("ml-auto space-x-2", buttonVariants({ variant: "default", size: "sm" }))}
+              aria-disabled={settings.isBlockchainDown}
+              onClick={onDeployClick}
+            >
+              <Rocket className="rotate-45 text-sm" />
+              <span className="whitespace-nowrap">Deploy</span>
+            </Link>
+          )}
         </div>
       )}
 
-      {((filteredDeployments?.length || 0) > 0 || !!search) && (
+      {(total > 0 || !!search) && (
         <div className="flex items-center pb-6">
           <div className="flex-grow">
             <Input
@@ -207,27 +197,31 @@ export const DeploymentList: React.FunctionComponent = () => {
         </div>
       )}
 
-      {filteredDeployments?.length === 0 && !isLoadingDeployments && !search && (
-        <NoDeploymentsState onDeployClick={onDeployClick} hasDeployments={Boolean(deployments && deployments.length > 0)} showTemplatesButton />
+      {showEmptyState && isActiveStatus && <NoDeploymentsState onDeployClick={onDeployClick} hasDeployments={false} showTemplatesButton />}
+
+      {showEmptyState && !isActiveStatus && (
+        <div className="py-6">
+          <p>No closed deployments.</p>
+        </div>
       )}
 
-      {(!filteredDeployments || filteredDeployments?.length === 0) && isLoadingDeployments && !search && (
+      {total === 0 && isLoadingDeployments && !search && (
         <div className="flex items-center justify-center p-8">
           <Spinner size="large" />
         </div>
       )}
 
       <div>
-        {orderedDeployments.length > 0 && (
+        {total > 0 && (
           <div className="flex flex-wrap items-center justify-between pb-6">
             <span className="text-xs">
-              You have <strong>{orderedDeployments.length}</strong>
-              {isFilteringActive ? " active" : ""} deployments
+              You have <strong>{total}</strong>
+              {isActiveStatus ? " active" : " closed"} deployments
             </span>
           </div>
         )}
 
-        {currentPageDeployments?.length > 0 && (
+        {pageDeployments.length > 0 && (
           <Table className="min-w-[1024px] table-fixed">
             <colgroup>
               <col width="120" />
@@ -249,7 +243,7 @@ export const DeploymentList: React.FunctionComponent = () => {
             </TableHeader>
 
             <TableBody>
-              {currentPageDeployments.map(deployment => (
+              {pageDeployments.map(deployment => (
                 <DeploymentListRow
                   key={deployment.dseq}
                   deployment={deployment}
@@ -265,21 +259,15 @@ export const DeploymentList: React.FunctionComponent = () => {
         )}
       </div>
 
-      {search && currentPageDeployments.length === 0 && (
+      {search && pageDeployments.length === 0 && (
         <div className="py-6">
           <p>No deployment found.</p>
         </div>
       )}
 
-      {(filteredDeployments?.length || 0) > 0 && (
+      {total > 0 && !search && (
         <div className="flex items-center justify-center py-8">
-          <CustomPagination
-            totalPageCount={pageCount}
-            setPageIndex={handleChangePage}
-            pageIndex={pageIndex}
-            pageSize={pageSize}
-            setPageSize={onPageSizeChange}
-          />
+          <CustomPagination totalPageCount={pageCount} setPageIndex={setPageIndex} pageIndex={pageIndex} pageSize={pageSize} setPageSize={onPageSizeChange} />
         </div>
       )}
     </Layout>

--- a/apps/deploy-web/src/components/deployments/DeploymentList.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentList.tsx
@@ -16,7 +16,6 @@ import {
   TabsTrigger
 } from "@akashnetwork/ui/components";
 import { cn } from "@akashnetwork/ui/utils";
-import { keepPreviousData } from "@tanstack/react-query";
 import { Refresh, Rocket, Xmark } from "iconoir-react";
 import { useAtom } from "jotai";
 import Link from "next/link";
@@ -56,15 +55,22 @@ export const DeploymentList: React.FunctionComponent = () => {
   const {
     data,
     isFetching: isLoadingDeployments,
+    isError,
     refetch: getDeployments
   } = useDeploymentsPage(
     address,
     { state: deploymentStatus, skip: pageIndex * pageSize, limit: pageSize, countTotal: true },
-    { enabled: isSettingsInit && !!address, placeholderData: keepPreviousData }
+    { enabled: isSettingsInit && !!address }
   );
 
   const total = data?.total ?? 0;
   const pageCount = Math.ceil(total / pageSize);
+
+  useEffect(() => {
+    if (pageIndex > 0 && pageIndex > pageCount - 1) {
+      setPageIndex(Math.max(pageCount - 1, 0));
+    }
+  }, [pageCount, pageIndex]);
 
   const pageDeployments = useMemo(() => {
     const named = (data?.deployments ?? []).map(d => ({ ...d, name: getDeploymentName(d.dseq) })) as NamedDeploymentDto[];
@@ -124,7 +130,8 @@ export const DeploymentList: React.FunctionComponent = () => {
   };
 
   const isActiveStatus = deploymentStatus === "active";
-  const showEmptyState = total === 0 && !isLoadingDeployments && !search;
+  const showEmptyState = total === 0 && !isLoadingDeployments && !isError && !search;
+  const showErrorState = isError && total === 0 && !isLoadingDeployments;
 
   return (
     <Layout isLoading={isLoadingDeployments || isLoadingProviders} isUsingSettings>
@@ -197,6 +204,16 @@ export const DeploymentList: React.FunctionComponent = () => {
         </div>
       )}
 
+      {showErrorState && (
+        <div className="flex flex-col items-center justify-center gap-4 py-8">
+          <p className="text-muted-foreground">Couldn't load deployments.</p>
+          <Button variant="outline" size="sm" onClick={() => getDeployments()}>
+            <Refresh className="mr-2 h-4 w-4" />
+            Retry
+          </Button>
+        </div>
+      )}
+
       {showEmptyState && isActiveStatus && <NoDeploymentsState onDeployClick={onDeployClick} hasDeployments={false} showTemplatesButton />}
 
       {showEmptyState && !isActiveStatus && (
@@ -249,7 +266,7 @@ export const DeploymentList: React.FunctionComponent = () => {
                   deployment={deployment}
                   refreshDeployments={getDeployments}
                   providers={providers}
-                  isSelectable
+                  isSelectable={isActiveStatus}
                   onSelectDeployment={selectItem}
                   checked={selectedItemIds.includes(deployment.dseq)}
                 />

--- a/apps/deploy-web/src/components/deployments/DeploymentList.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentList.tsx
@@ -33,7 +33,7 @@ import { useWallet } from "@src/context/WalletProvider";
 import { useListSelection } from "@src/hooks/useListSelection/useListSelection";
 import { useManagedDeploymentConfirm } from "@src/hooks/useManagedDeploymentConfirm";
 import { useNewDeploymentUrl } from "@src/hooks/useNewDeploymentUrl/useNewDeploymentUrl";
-import { useDeploymentsPage } from "@src/queries/useDeploymentQuery";
+import { useDeploymentList, useDeploymentsPage } from "@src/queries/useDeploymentQuery";
 import { useProviderList } from "@src/queries/useProvidersQuery";
 import sdlStore from "@src/store/sdlStore";
 import type { DeploymentStatus, NamedDeploymentDto } from "@src/types/deployment";
@@ -51,6 +51,7 @@ export const DEPENDENCIES = {
   useManagedDeploymentConfirm,
   useNewDeploymentUrl,
   useDeploymentsPage,
+  useDeploymentList,
   Layout,
   NoDeploymentsState,
   DeploymentListRow
@@ -69,6 +70,7 @@ export const DeploymentList: React.FunctionComponent<Props> = ({ dependencies = 
     useManagedDeploymentConfirm,
     useNewDeploymentUrl,
     useDeploymentsPage,
+    useDeploymentList,
     Layout,
     NoDeploymentsState,
     DeploymentListRow
@@ -86,31 +88,52 @@ export const DeploymentList: React.FunctionComponent<Props> = ({ dependencies = 
   const { closeDeploymentConfirm } = useManagedDeploymentConfirm();
   const newDeploymentUrl = useNewDeploymentUrl();
 
-  const {
-    data,
-    isFetching: isLoadingDeployments,
-    isError,
-    refetch: getDeployments
-  } = useDeploymentsPage(address, { state: deploymentStatus, skip: pageIndex * pageSize, limit: pageSize }, { enabled: isSettingsInit && !!address });
+  const isSearching = search.trim().length > 0;
+  const canQuery = isSettingsInit && !!address;
 
-  const hasPageResults = (data?.deployments.length ?? 0) > 0;
-  const hasNextPage = data?.hasNextPage ?? false;
+  const {
+    data: pageData,
+    isFetching: isLoadingPage,
+    isError: isPageError,
+    refetch: refetchPage
+  } = useDeploymentsPage(address, { state: deploymentStatus, skip: pageIndex * pageSize, limit: pageSize }, { enabled: canQuery && !isSearching });
+
+  const {
+    data: listData,
+    isFetching: isLoadingList,
+    isError: isListError,
+    refetch: refetchList
+  } = useDeploymentList(address, { enabled: canQuery && isSearching }, deploymentStatus);
+
+  const isLoadingDeployments = isSearching ? isLoadingList : isLoadingPage;
+  const isError = isSearching ? isListError : isPageError;
+  const getDeployments = isSearching ? refetchList : refetchPage;
+
+  const filteredDeployments = useMemo(() => {
+    const source = isSearching ? listData ?? [] : pageData?.deployments ?? [];
+    const named = source.map(d => ({ ...d, name: getDeploymentName(d.dseq) })) as NamedDeploymentDto[];
+    if (!isSearching) return named;
+    const query = search.trim().toLowerCase();
+    return named.filter(d => d.name?.toLowerCase().includes(query) || d.dseq?.toLowerCase().includes(query));
+  }, [isSearching, listData, pageData?.deployments, search, getDeploymentName]);
+
+  const pageDeployments = useMemo(() => {
+    if (!isSearching) return filteredDeployments;
+    const start = pageIndex * pageSize;
+    return filteredDeployments.slice(start, start + pageSize);
+  }, [filteredDeployments, isSearching, pageIndex, pageSize]);
+
+  const hasPageResults = isSearching ? filteredDeployments.length > 0 : (pageData?.deployments.length ?? 0) > 0;
+  const hasNextPage = isSearching ? (pageIndex + 1) * pageSize < filteredDeployments.length : pageData?.hasNextPage ?? false;
 
   useEffect(
     function goBackFromEmptyPage() {
-      if (pageIndex > 0 && !isLoadingDeployments && !isError && !hasPageResults) {
+      if (pageIndex > 0 && !isLoadingDeployments && !isError && pageDeployments.length === 0 && (hasPageResults || !isSearching)) {
         setPageIndex(current => Math.max(current - 1, 0));
       }
     },
-    [hasPageResults, isLoadingDeployments, isError, pageIndex]
+    [hasPageResults, isLoadingDeployments, isError, pageIndex, pageDeployments.length, isSearching]
   );
-
-  const pageDeployments = useMemo(() => {
-    const named = (data?.deployments ?? []).map(d => ({ ...d, name: getDeploymentName(d.dseq) })) as NamedDeploymentDto[];
-    if (!search) return named;
-    const query = search.toLowerCase();
-    return named.filter(d => d.name?.toLowerCase().includes(query) || d.dseq?.toLowerCase().includes(query));
-  }, [data?.deployments, search, getDeploymentName]);
 
   const { selectedItemIds, selectItem, clearSelection } = useListSelection<string>({
     ids: pageDeployments.map(deployment => deployment.dseq)
@@ -135,6 +158,7 @@ export const DeploymentList: React.FunctionComponent<Props> = ({ dependencies = 
 
   const onSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setSearch(event.target.value);
+    setPageIndex(0);
   };
 
   const onCloseSelectedDeployments = async () => {
@@ -231,7 +255,14 @@ export const DeploymentList: React.FunctionComponent<Props> = ({ dependencies = 
               type="text"
               endIcon={
                 !!search && (
-                  <Button size="icon" variant="text" onClick={() => setSearch("")}>
+                  <Button
+                    size="icon"
+                    variant="text"
+                    onClick={() => {
+                      setSearch("");
+                      setPageIndex(0);
+                    }}
+                  >
                     <Xmark className="text-xs" />
                   </Button>
                 )
@@ -259,7 +290,7 @@ export const DeploymentList: React.FunctionComponent<Props> = ({ dependencies = 
         </div>
       )}
 
-      {!hasPageResults && isLoadingDeployments && !search && (
+      {!hasPageResults && isLoadingDeployments && (
         <div className="flex items-center justify-center p-8">
           <Spinner size="large" />
         </div>
@@ -304,13 +335,13 @@ export const DeploymentList: React.FunctionComponent<Props> = ({ dependencies = 
         )}
       </div>
 
-      {search && pageDeployments.length === 0 && (
+      {isSearching && pageDeployments.length === 0 && !isLoadingDeployments && (
         <div className="py-6">
           <p>No deployment found.</p>
         </div>
       )}
 
-      {hasPageResults && !search && (
+      {hasPageResults && (
         <div className="flex flex-col items-center justify-between px-2 py-8 md:flex-row md:space-x-4">
           <PaginationSizeSelector pageSize={pageSize} setPageSize={onPageSizeChange} />
           <Pagination>

--- a/apps/deploy-web/src/components/deployments/DeploymentList.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentList.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   Button,
   buttonVariants,
@@ -112,12 +112,15 @@ export const DeploymentList: React.FunctionComponent<Props> = ({ dependencies = 
     ids: pageDeployments.map(deployment => deployment.dseq)
   });
 
+  const previousApiEndpointRef = useRef(apiEndpoint);
   useEffect(() => {
-    if (isSettingsInit && address) {
+    const previousApiEndpoint = previousApiEndpointRef.current;
+    previousApiEndpointRef.current = apiEndpoint;
+    const isEndpointSwitch = previousApiEndpoint !== "" && previousApiEndpoint !== apiEndpoint;
+    if (isEndpointSwitch && isSettingsInit && address) {
       getDeployments();
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [apiEndpoint]);
+  }, [apiEndpoint, isSettingsInit, address, getDeployments]);
 
   const onStatusChange = (value: string) => {
     if (value !== "active" && value !== "closed") return;

--- a/apps/deploy-web/src/components/deployments/DeploymentList.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentList.tsx
@@ -3,8 +3,13 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import {
   Button,
   buttonVariants,
-  CustomPagination,
   Input,
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationNext,
+  PaginationPrevious,
+  PaginationSizeSelector,
   Spinner,
   Table,
   TableBody,
@@ -86,20 +91,19 @@ export const DeploymentList: React.FunctionComponent<Props> = ({ dependencies = 
     isFetching: isLoadingDeployments,
     isError,
     refetch: getDeployments
-  } = useDeploymentsPage(
-    address,
-    { state: deploymentStatus, skip: pageIndex * pageSize, limit: pageSize, countTotal: true },
-    { enabled: isSettingsInit && !!address }
+  } = useDeploymentsPage(address, { state: deploymentStatus, skip: pageIndex * pageSize, limit: pageSize }, { enabled: isSettingsInit && !!address });
+
+  const hasPageResults = (data?.deployments.length ?? 0) > 0;
+  const hasNextPage = data?.hasNextPage ?? false;
+
+  useEffect(
+    function goBackFromEmptyPage() {
+      if (pageIndex > 0 && !isLoadingDeployments && !isError && !hasPageResults) {
+        setPageIndex(current => Math.max(current - 1, 0));
+      }
+    },
+    [hasPageResults, isLoadingDeployments, isError, pageIndex]
   );
-
-  const total = data?.total ?? 0;
-  const pageCount = Math.ceil(total / pageSize);
-
-  useEffect(() => {
-    if (pageIndex > 0 && pageIndex > pageCount - 1) {
-      setPageIndex(Math.max(pageCount - 1, 0));
-    }
-  }, [pageCount, pageIndex]);
 
   const pageDeployments = useMemo(() => {
     const named = (data?.deployments ?? []).map(d => ({ ...d, name: getDeploymentName(d.dseq) })) as NamedDeploymentDto[];
@@ -162,8 +166,9 @@ export const DeploymentList: React.FunctionComponent<Props> = ({ dependencies = 
   };
 
   const isActiveStatus = deploymentStatus === "active";
-  const showEmptyState = total === 0 && !isLoadingDeployments && !isError && !search;
-  const showErrorState = isError && total === 0 && !isLoadingDeployments;
+  const hasList = hasPageResults || pageIndex > 0;
+  const showEmptyState = !hasPageResults && pageIndex === 0 && !isLoadingDeployments && !isError && !search;
+  const showErrorState = isError && !hasPageResults && !isLoadingDeployments;
 
   return (
     <Layout isLoading={isLoadingDeployments || isLoadingProviders} isUsingSettings>
@@ -201,7 +206,7 @@ export const DeploymentList: React.FunctionComponent<Props> = ({ dependencies = 
             </>
           )}
 
-          {total > 0 && (
+          {hasList && (
             <Link
               href={newDeploymentUrl()}
               className={cn("ml-auto space-x-2", buttonVariants({ variant: "default", size: "sm" }))}
@@ -215,7 +220,7 @@ export const DeploymentList: React.FunctionComponent<Props> = ({ dependencies = 
         </div>
       )}
 
-      {(total > 0 || !!search) && (
+      {(hasList || !!search) && (
         <div className="flex items-center pb-6">
           <div className="flex-grow">
             <Input
@@ -254,22 +259,13 @@ export const DeploymentList: React.FunctionComponent<Props> = ({ dependencies = 
         </div>
       )}
 
-      {total === 0 && isLoadingDeployments && !search && (
+      {!hasPageResults && isLoadingDeployments && !search && (
         <div className="flex items-center justify-center p-8">
           <Spinner size="large" />
         </div>
       )}
 
       <div>
-        {total > 0 && !search && (
-          <div className="flex flex-wrap items-center justify-between pb-6">
-            <span className="text-xs">
-              You have <strong>{total}</strong>
-              {isActiveStatus ? " active" : " closed"} deployments
-            </span>
-          </div>
-        )}
-
         {pageDeployments.length > 0 && (
           <Table className="min-w-[1024px] table-fixed">
             <colgroup>
@@ -314,9 +310,19 @@ export const DeploymentList: React.FunctionComponent<Props> = ({ dependencies = 
         </div>
       )}
 
-      {total > 0 && !search && (
-        <div className="flex items-center justify-center py-8">
-          <CustomPagination totalPageCount={pageCount} setPageIndex={setPageIndex} pageIndex={pageIndex} pageSize={pageSize} setPageSize={onPageSizeChange} />
+      {hasPageResults && !search && (
+        <div className="flex flex-col items-center justify-between px-2 py-8 md:flex-row md:space-x-4">
+          <PaginationSizeSelector pageSize={pageSize} setPageSize={onPageSizeChange} />
+          <Pagination>
+            <PaginationContent>
+              <PaginationItem>
+                <PaginationPrevious onClick={() => setPageIndex(current => current - 1)} disabled={pageIndex === 0} />
+              </PaginationItem>
+              <PaginationItem>
+                <PaginationNext onClick={() => setPageIndex(current => current + 1)} disabled={!hasNextPage} />
+              </PaginationItem>
+            </PaginationContent>
+          </Pagination>
         </div>
       )}
     </Layout>

--- a/apps/deploy-web/src/components/deployments/DeploymentList.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentList.tsx
@@ -191,7 +191,7 @@ export const DeploymentList: React.FunctionComponent<Props> = ({ dependencies = 
 
   const isActiveStatus = deploymentStatus === "active";
   const hasList = hasPageResults || pageIndex > 0;
-  const showEmptyState = !hasPageResults && pageIndex === 0 && !isLoadingDeployments && !isError && !search;
+  const showEmptyState = !hasPageResults && pageIndex === 0 && !isLoadingDeployments && !isError && !isSearching;
   const showErrorState = isError && !hasPageResults && !isLoadingDeployments;
 
   return (
@@ -335,7 +335,7 @@ export const DeploymentList: React.FunctionComponent<Props> = ({ dependencies = 
         )}
       </div>
 
-      {isSearching && pageDeployments.length === 0 && !isLoadingDeployments && (
+      {isSearching && !isError && pageDeployments.length === 0 && !isLoadingDeployments && (
         <div className="py-6">
           <p>No deployment found.</p>
         </div>

--- a/apps/deploy-web/src/components/deployments/DeploymentList.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentList.tsx
@@ -258,7 +258,7 @@ export const DeploymentList: React.FunctionComponent<Props> = ({ dependencies = 
       )}
 
       <div>
-        {total > 0 && (
+        {total > 0 && !search && (
           <div className="flex flex-wrap items-center justify-between pb-6">
             <span className="text-xs">
               You have <strong>{total}</strong>

--- a/apps/deploy-web/src/components/deployments/DeploymentListRow.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentListRow.tsx
@@ -70,7 +70,7 @@ export const DeploymentListRow: React.FunctionComponent<Props> = ({ deployment, 
   const { changeDeploymentName, getDeploymentData } = useLocalNotes();
   const { address, signAndBroadcastTx, isTrialing } = useWallet();
   const isActive = deployment.state === "active";
-  const { data: filteredLeases, isLoading: isLoadingLeases } = useDeploymentLeaseList(address, deployment, { enabled: !!deployment && isActive });
+  const { data: filteredLeases, isLoading: isLoadingLeases } = useDeploymentLeaseList(address, deployment, { enabled: !!deployment });
   // A reclaiming lease is still running (grace period), so it counts as live for cost/escrow metrics.
   const liveLeases = filteredLeases?.filter(isLeaseLive);
   const hasActiveLeases = !!liveLeases?.length;

--- a/apps/deploy-web/src/components/deployments/DeploymentListRow.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentListRow.tsx
@@ -31,7 +31,7 @@ import { useManagedDeploymentConfirm } from "@src/hooks/useManagedDeploymentConf
 import { useProviderCredentials } from "@src/hooks/useProviderCredentials/useProviderCredentials";
 import { useRealTimeLeft } from "@src/hooks/useRealTimeLeft";
 import { useRedeploy } from "@src/hooks/useRedeploy/useRedeploy";
-import { useAllLeases, useLeaseStatus } from "@src/queries/useLeaseQuery";
+import { useDeploymentLeaseList, useLeaseStatus } from "@src/queries/useLeaseQuery";
 import type { LeaseDto, NamedDeploymentDto } from "@src/types/deployment";
 import type { ApiProviderList } from "@src/types/provider";
 import { udenomToDenom } from "@src/utils/mathHelpers";
@@ -70,8 +70,7 @@ export const DeploymentListRow: React.FunctionComponent<Props> = ({ deployment, 
   const { changeDeploymentName, getDeploymentData } = useLocalNotes();
   const { address, signAndBroadcastTx, isTrialing } = useWallet();
   const isActive = deployment.state === "active";
-  const { data: leases, isLoading: isLoadingLeases } = useAllLeases(address, { enabled: !!deployment && isActive });
-  const filteredLeases = leases?.filter(l => l.dseq === deployment.dseq);
+  const { data: filteredLeases, isLoading: isLoadingLeases } = useDeploymentLeaseList(address, deployment, { enabled: !!deployment && isActive });
   // A reclaiming lease is still running (grace period), so it counts as live for cost/escrow metrics.
   const liveLeases = filteredLeases?.filter(isLeaseLive);
   const hasActiveLeases = !!liveLeases?.length;

--- a/apps/deploy-web/src/components/home/HomeContainer.tsx
+++ b/apps/deploy-web/src/components/home/HomeContainer.tsx
@@ -26,9 +26,13 @@ export function HomeContainer() {
     data: deployments,
     isFetching: isLoadingDeployments,
     refetch: getDeployments
-  } = useDeploymentList(address, {
-    enabled: false
-  });
+  } = useDeploymentList(
+    address,
+    {
+      enabled: false
+    },
+    "active"
+  );
   useEffect(() => {
     if (deployments) {
       setActiveDeployments(

--- a/apps/deploy-web/src/components/home/HomeContainer.tsx
+++ b/apps/deploy-web/src/components/home/HomeContainer.tsx
@@ -35,20 +35,7 @@ export function HomeContainer() {
   );
   useEffect(() => {
     if (deployments) {
-      setActiveDeployments(
-        deployments
-          ? [...deployments]
-              .filter(d => d.state === "active")
-              .map(d => {
-                const name = getDeploymentName(d.dseq);
-
-                return {
-                  ...d,
-                  name
-                };
-              })
-          : []
-      );
+      setActiveDeployments(deployments.map(d => ({ ...d, name: getDeploymentName(d.dseq) })));
     }
   }, [deployments, getDeploymentName]);
 

--- a/apps/deploy-web/src/queries/queryKeys.ts
+++ b/apps/deploy-web/src/queries/queryKeys.ts
@@ -24,12 +24,11 @@ export class QueryKeys {
   static getDeploymentListKey = (address: string, state?: string) => (state ? ["DEPLOYMENT_LIST", address, state] : ["DEPLOYMENT_LIST", address]);
   /** Prefix for every paginated deployment page of an address; use it to invalidate all pages at once. */
   static getDeploymentsPageKeyPrefix = (address: string) => ["DEPLOYMENTS_PAGE", address];
-  static getDeploymentsPageKey = (address: string, state: string, skip: number, limit: number, countTotal?: boolean) => [
+  static getDeploymentsPageKey = (address: string, state: string, skip: number, limit: number) => [
     ...QueryKeys.getDeploymentsPageKeyPrefix(address),
     state,
     skip,
-    limit,
-    countTotal
+    limit
   ];
   static getDeploymentDetailKey = (address: string, dseq?: string) => ["DEPLOYMENT_DETAIL", address, dseq].filter(Boolean);
   static getAllLeasesKey = (address: string) => ["ALL_LEASES", address];

--- a/apps/deploy-web/src/queries/queryKeys.ts
+++ b/apps/deploy-web/src/queries/queryKeys.ts
@@ -24,11 +24,12 @@ export class QueryKeys {
   static getDeploymentListKey = (address: string, state?: string) => ["DEPLOYMENT_LIST", address, state].filter(Boolean);
   /** Prefix for every paginated deployment page of an address; use it to invalidate all pages at once. */
   static getDeploymentsPageKeyPrefix = (address: string) => ["DEPLOYMENTS_PAGE", address];
-  static getDeploymentsPageKey = (address: string, state: string, skip: number, limit: number) => [
+  static getDeploymentsPageKey = (address: string, state: string, skip: number, limit: number, countTotal?: boolean) => [
     ...QueryKeys.getDeploymentsPageKeyPrefix(address),
     state,
     skip,
-    limit
+    limit,
+    countTotal
   ];
   static getDeploymentDetailKey = (address: string, dseq?: string) => ["DEPLOYMENT_DETAIL", address, dseq].filter(Boolean);
   static getAllLeasesKey = (address: string) => ["ALL_LEASES", address];

--- a/apps/deploy-web/src/queries/queryKeys.ts
+++ b/apps/deploy-web/src/queries/queryKeys.ts
@@ -21,7 +21,7 @@ export class QueryKeys {
   static getUserTemplatesKey = (username: string) => ["USER_TEMPLATES", username];
   static getUserFavoriteTemplatesKey = (userId: string) => ["USER_FAVORITES_TEMPLATES", userId];
   // Deploy
-  static getDeploymentListKey = (address: string, state?: string) => ["DEPLOYMENT_LIST", address, state].filter(Boolean);
+  static getDeploymentListKey = (address: string, state?: string) => (state ? ["DEPLOYMENT_LIST", address, state] : ["DEPLOYMENT_LIST", address]);
   /** Prefix for every paginated deployment page of an address; use it to invalidate all pages at once. */
   static getDeploymentsPageKeyPrefix = (address: string) => ["DEPLOYMENTS_PAGE", address];
   static getDeploymentsPageKey = (address: string, state: string, skip: number, limit: number, countTotal?: boolean) => [

--- a/apps/deploy-web/src/queries/queryKeys.ts
+++ b/apps/deploy-web/src/queries/queryKeys.ts
@@ -21,7 +21,15 @@ export class QueryKeys {
   static getUserTemplatesKey = (username: string) => ["USER_TEMPLATES", username];
   static getUserFavoriteTemplatesKey = (userId: string) => ["USER_FAVORITES_TEMPLATES", userId];
   // Deploy
-  static getDeploymentListKey = (address: string) => ["DEPLOYMENT_LIST", address];
+  static getDeploymentListKey = (address: string, state?: string) => ["DEPLOYMENT_LIST", address, state].filter(Boolean);
+  /** Prefix for every paginated deployment page of an address; use it to invalidate all pages at once. */
+  static getDeploymentsPageKeyPrefix = (address: string) => ["DEPLOYMENTS_PAGE", address];
+  static getDeploymentsPageKey = (address: string, state: string, skip: number, limit: number) => [
+    ...QueryKeys.getDeploymentsPageKeyPrefix(address),
+    state,
+    skip,
+    limit
+  ];
   static getDeploymentDetailKey = (address: string, dseq?: string) => ["DEPLOYMENT_DETAIL", address, dseq].filter(Boolean);
   static getAllLeasesKey = (address: string) => ["ALL_LEASES", address];
   /** Extends the all-leases key so prefix-based invalidation after a deploy also refreshes the existence check. */

--- a/apps/deploy-web/src/queries/useDeploymentQuery.spec.tsx
+++ b/apps/deploy-web/src/queries/useDeploymentQuery.spec.tsx
@@ -98,7 +98,7 @@ describe("useDeploymentQuery", () => {
       expect(result.current.data).toBeUndefined();
     });
 
-    it("keys the query by address, state, skip and limit", async () => {
+    it("keys the query by address, state, skip, limit and countTotal", async () => {
       const { result } = setupQuery(
         () => {
           const page = useDeploymentsPage("test-address", { state: "closed", skip: 30, limit: 10, countTotal: true });
@@ -111,7 +111,35 @@ describe("useDeploymentQuery", () => {
       await vi.waitFor(() => expect(result.current.page.isSuccess).toBe(true));
 
       const [query] = result.current.queryClient.getQueryCache().findAll();
-      expect(query.queryKey).toEqual(QueryKeys.getDeploymentsPageKey("test-address", "closed", 30, 10));
+      expect(query.queryKey).toEqual(QueryKeys.getDeploymentsPageKey("test-address", "closed", 30, 10, true));
+    });
+
+    it("keys totals-bearing and totals-free requests separately so one cannot satisfy the other", () => {
+      expect(QueryKeys.getDeploymentsPageKey("test-address", "active", 0, 10, true)).not.toEqual(
+        QueryKeys.getDeploymentsPageKey("test-address", "active", 0, 10, false)
+      );
+    });
+
+    it("drops the previous page when the address changes even if the status is unchanged", async () => {
+      const { chainApiHttpClient, requestCount, resolveNextPage } = buildDeferredClient();
+
+      let address = "address-a";
+      const { result, rerender } = setupQuery(() => useDeploymentsPage(address, { state: "active", skip: 0, limit: 10, countTotal: true }), {
+        services: { chainApiHttpClient: () => chainApiHttpClient }
+      });
+
+      await vi.waitFor(() => expect(requestCount()).toBe(1));
+      resolveNextPage([buildRpcDeployment({ deployment: { id: { owner: "address-a", dseq: "1" }, state: "active" } })], 5);
+      await vi.waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      address = "address-b";
+      rerender();
+
+      await vi.waitFor(() => {
+        expect(requestCount()).toBe(2);
+        expect(result.current.isPlaceholderData).toBe(false);
+      });
+      expect(result.current.data).toBeUndefined();
     });
 
     function buildDeferredClient() {

--- a/apps/deploy-web/src/queries/useDeploymentQuery.spec.tsx
+++ b/apps/deploy-web/src/queries/useDeploymentQuery.spec.tsx
@@ -62,6 +62,42 @@ describe("useDeploymentQuery", () => {
       expect(QueryKeys.getDeploymentsPageKey("test-address", "active", 0, 10).slice(0, prefix.length)).toEqual(prefix);
     });
 
+    it("keeps the previous page while paging within a status but drops it across a status change", async () => {
+      const { chainApiHttpClient, requestCount, resolveNextPage } = buildDeferredClient();
+
+      let params: Parameters<typeof useDeploymentsPage>[1] = { state: "active", skip: 0, limit: 10, countTotal: true };
+      const { result, rerender } = setupQuery(() => useDeploymentsPage("test-address", params), {
+        services: { chainApiHttpClient: () => chainApiHttpClient }
+      });
+
+      const activePage1 = buildRpcDeployment({ deployment: { id: { owner: "test-address", dseq: "100" }, state: "active" } });
+      await vi.waitFor(() => expect(requestCount()).toBe(1));
+      resolveNextPage([activePage1], 20);
+      await vi.waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(result.current.data).toEqual({ deployments: [deploymentToDto(activePage1)], total: 20 });
+
+      params = { state: "active", skip: 10, limit: 10, countTotal: true };
+      rerender();
+      await vi.waitFor(() => {
+        expect(requestCount()).toBe(2);
+        expect(result.current.isPlaceholderData).toBe(true);
+      });
+      expect(result.current.data).toEqual({ deployments: [deploymentToDto(activePage1)], total: 20 });
+
+      const activePage2 = buildRpcDeployment({ deployment: { id: { owner: "test-address", dseq: "200" }, state: "active" } });
+      resolveNextPage([activePage2], 20);
+      await vi.waitFor(() => expect(result.current.isPlaceholderData).toBe(false));
+      expect(result.current.data).toEqual({ deployments: [deploymentToDto(activePage2)], total: 20 });
+
+      params = { state: "closed", skip: 0, limit: 10, countTotal: true };
+      rerender();
+      await vi.waitFor(() => {
+        expect(requestCount()).toBe(3);
+        expect(result.current.isPlaceholderData).toBe(false);
+      });
+      expect(result.current.data).toBeUndefined();
+    });
+
     it("keys the query by address, state, skip and limit", async () => {
       const { result } = setupQuery(
         () => {
@@ -77,6 +113,24 @@ describe("useDeploymentQuery", () => {
       const [query] = result.current.queryClient.getQueryCache().findAll();
       expect(query.queryKey).toEqual(QueryKeys.getDeploymentsPageKey("test-address", "closed", 30, 10));
     });
+
+    function buildDeferredClient() {
+      const resolvers: Array<(value: unknown) => void> = [];
+      let resolvedCount = 0;
+      const chainApiHttpClient = mock<FallbackableHttpClient>({
+        get: vi.fn().mockImplementation(() => new Promise(resolve => resolvers.push(resolve)))
+      } as unknown as FallbackableHttpClient);
+
+      return {
+        chainApiHttpClient,
+        requestCount: () => resolvers.length,
+        resolveNextPage: (deployments: ReturnType<typeof buildRpcDeployment>[], total: number) => {
+          const resolve = resolvers[resolvedCount++];
+          if (!resolve) throw new Error("No pending deployments request to resolve");
+          resolve({ data: { deployments, pagination: { next_key: null, total: String(total) } } });
+        }
+      };
+    }
 
     function buildClient(input: { total: number; deployments?: ReturnType<typeof buildRpcDeployment>[] }) {
       return mock<FallbackableHttpClient>({

--- a/apps/deploy-web/src/queries/useDeploymentQuery.spec.tsx
+++ b/apps/deploy-web/src/queries/useDeploymentQuery.spec.tsx
@@ -179,4 +179,11 @@ describe("useDeploymentQuery", () => {
       return { chainApiHttpClient, result };
     }
   });
+
+  describe(QueryKeys.getDeploymentListKey.name, () => {
+    it("keeps the address segment even when the address is empty and state is omitted", () => {
+      expect(QueryKeys.getDeploymentListKey("", "active")).toEqual(["DEPLOYMENT_LIST", "", "active"]);
+      expect(QueryKeys.getDeploymentListKey("akash1abc")).toEqual(["DEPLOYMENT_LIST", "akash1abc"]);
+    });
+  });
 });

--- a/apps/deploy-web/src/queries/useDeploymentQuery.spec.tsx
+++ b/apps/deploy-web/src/queries/useDeploymentQuery.spec.tsx
@@ -6,7 +6,7 @@ import type { FallbackableHttpClient } from "@src/services/createFallbackableHtt
 import { deploymentToDto } from "@src/utils/deploymentDetailUtils";
 import { setupQuery } from "../../tests/unit/query-client";
 import { QueryKeys } from "./queryKeys";
-import { useDeploymentsPage } from "./useDeploymentQuery";
+import { useDeploymentList, useDeploymentsPage } from "./useDeploymentQuery";
 
 import { buildRpcDeployment } from "@tests/seeders/deployment";
 
@@ -151,9 +151,8 @@ describe("useDeploymentQuery", () => {
     function buildDeferredClient() {
       const resolvers: Array<(value: unknown) => void> = [];
       let resolvedCount = 0;
-      const chainApiHttpClient = mock<FallbackableHttpClient>({
-        get: vi.fn().mockImplementation(() => new Promise(resolve => resolvers.push(resolve)))
-      } as unknown as FallbackableHttpClient);
+      const chainApiHttpClient = mock<FallbackableHttpClient>();
+      chainApiHttpClient.get.mockImplementation(() => new Promise(resolve => resolvers.push(resolve)));
 
       return {
         chainApiHttpClient,
@@ -177,14 +176,14 @@ describe("useDeploymentQuery", () => {
       const pagination =
         input.pagination === undefined ? { next_key: input.nextKey ?? null, total: input.total ?? String(input.deployments?.length ?? 0) } : input.pagination;
 
-      return mock<FallbackableHttpClient>({
-        get: vi.fn().mockResolvedValue({
-          data: {
-            deployments: input.deployments ?? [],
-            pagination
-          }
-        })
-      } as unknown as FallbackableHttpClient);
+      const chainApiHttpClient = mock<FallbackableHttpClient>();
+      chainApiHttpClient.get.mockResolvedValue({
+        data: {
+          deployments: input.deployments ?? [],
+          pagination
+        }
+      });
+      return chainApiHttpClient;
     }
 
     function setup(
@@ -201,6 +200,23 @@ describe("useDeploymentQuery", () => {
       });
       return { chainApiHttpClient, result };
     }
+  });
+
+  describe(useDeploymentList.name, () => {
+    it("requests the full state list newest-first so search matches browse order", async () => {
+      const chainApiHttpClient = mock<FallbackableHttpClient>();
+      chainApiHttpClient.get.mockResolvedValue({
+        data: { deployments: [], pagination: { next_key: null, total: "0" } }
+      });
+
+      const { result } = setupQuery(() => useDeploymentList("test-address", undefined, "active"), {
+        services: { chainApiHttpClient: () => chainApiHttpClient }
+      });
+
+      await vi.waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(chainApiHttpClient.get.mock.calls[0][0]).toContain("pagination.reverse=true");
+    });
   });
 
   describe(QueryKeys.getDeploymentListKey.name, () => {

--- a/apps/deploy-web/src/queries/useDeploymentQuery.spec.tsx
+++ b/apps/deploy-web/src/queries/useDeploymentQuery.spec.tsx
@@ -1,0 +1,100 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { FallbackableHttpClient } from "@src/services/createFallbackableHttpClient/createFallbackableHttpClient";
+import { deploymentToDto } from "@src/utils/deploymentDetailUtils";
+import { setupQuery } from "../../tests/unit/query-client";
+import { QueryKeys } from "./queryKeys";
+import { useDeploymentsPage } from "./useDeploymentQuery";
+
+import { buildRpcDeployment } from "@tests/seeders/deployment";
+
+describe("useDeploymentQuery", () => {
+  describe(useDeploymentsPage.name, () => {
+    it("returns an empty page when address is not provided", async () => {
+      const { result } = setupQuery(() => useDeploymentsPage("", { state: "active", skip: 0, limit: 10, countTotal: true }), {
+        services: { chainApiHttpClient: () => mock<FallbackableHttpClient>() }
+      });
+
+      await vi.waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(result.current.data).toEqual({ deployments: [], total: 0 });
+    });
+
+    it("requests a single page filtered by state with offset pagination and count_total", async () => {
+      const { chainApiHttpClient, result } = setup({ total: 42 });
+
+      await vi.waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      const requestedUrl = chainApiHttpClient.get.mock.calls[0][0] as string;
+      expect(requestedUrl).toContain("filters.owner=test-address");
+      expect(requestedUrl).toContain("filters.state=active");
+      expect(requestedUrl).toContain("pagination.offset=20");
+      expect(requestedUrl).toContain("pagination.limit=10");
+      expect(requestedUrl).toContain("pagination.count_total=true");
+      expect(requestedUrl).toContain("pagination.reverse=true");
+    });
+
+    it("maps deployments to DTOs and exposes the server total", async () => {
+      const deployment = buildRpcDeployment({ deployment: { id: { owner: "test-address" }, state: "active" } });
+      const { result } = setup({ total: 42, deployments: [deployment] });
+
+      await vi.waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(result.current.data).toEqual({
+        deployments: [deploymentToDto(deployment)],
+        total: 42
+      });
+    });
+
+    it("omits count_total and leaves total undefined when countTotal is false", async () => {
+      const { chainApiHttpClient, result } = setup({ total: 42, countTotal: false });
+
+      await vi.waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(chainApiHttpClient.get.mock.calls[0][0]).not.toContain("pagination.count_total");
+      expect(result.current.data?.total).toBeUndefined();
+    });
+
+    it("keys pages under the address prefix so deploy-success invalidation refreshes them", () => {
+      const prefix = QueryKeys.getDeploymentsPageKeyPrefix("test-address");
+
+      expect(QueryKeys.getDeploymentsPageKey("test-address", "active", 0, 10).slice(0, prefix.length)).toEqual(prefix);
+    });
+
+    it("keys the query by address, state, skip and limit", async () => {
+      const { result } = setupQuery(
+        () => {
+          const page = useDeploymentsPage("test-address", { state: "closed", skip: 30, limit: 10, countTotal: true });
+          const queryClient = useQueryClient();
+          return { page, queryClient };
+        },
+        { services: { chainApiHttpClient: () => buildClient({ total: 0 }) } }
+      );
+
+      await vi.waitFor(() => expect(result.current.page.isSuccess).toBe(true));
+
+      const [query] = result.current.queryClient.getQueryCache().findAll();
+      expect(query.queryKey).toEqual(QueryKeys.getDeploymentsPageKey("test-address", "closed", 30, 10));
+    });
+
+    function buildClient(input: { total: number; deployments?: ReturnType<typeof buildRpcDeployment>[] }) {
+      return mock<FallbackableHttpClient>({
+        get: vi.fn().mockResolvedValue({
+          data: {
+            deployments: input.deployments ?? [],
+            pagination: { next_key: null, total: String(input.total) }
+          }
+        })
+      } as unknown as FallbackableHttpClient);
+    }
+
+    function setup(input: { total: number; deployments?: ReturnType<typeof buildRpcDeployment>[]; countTotal?: boolean }) {
+      const chainApiHttpClient = buildClient(input);
+      const { result } = setupQuery(() => useDeploymentsPage("test-address", { state: "active", skip: 20, limit: 10, countTotal: input.countTotal ?? true }), {
+        services: { chainApiHttpClient: () => chainApiHttpClient }
+      });
+      return { chainApiHttpClient, result };
+    }
+  });
+});

--- a/apps/deploy-web/src/queries/useDeploymentQuery.spec.tsx
+++ b/apps/deploy-web/src/queries/useDeploymentQuery.spec.tsx
@@ -13,16 +13,16 @@ import { buildRpcDeployment } from "@tests/seeders/deployment";
 describe("useDeploymentQuery", () => {
   describe(useDeploymentsPage.name, () => {
     it("returns an empty page when address is not provided", async () => {
-      const { result } = setupQuery(() => useDeploymentsPage("", { state: "active", skip: 0, limit: 10, countTotal: true }), {
+      const { result } = setupQuery(() => useDeploymentsPage("", { state: "active", skip: 0, limit: 10 }), {
         services: { chainApiHttpClient: () => mock<FallbackableHttpClient>() }
       });
 
       await vi.waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(result.current.data).toEqual({ deployments: [], total: 0 });
+      expect(result.current.data).toEqual({ deployments: [], hasNextPage: false });
     });
 
-    it("requests a single page filtered by state with offset pagination and count_total", async () => {
-      const { chainApiHttpClient, result } = setup({ total: 42 });
+    it("requests a single page filtered by state with offset pagination and no count_total", async () => {
+      const { chainApiHttpClient, result } = setup();
 
       await vi.waitFor(() => expect(result.current.isSuccess).toBe(true));
 
@@ -31,29 +31,41 @@ describe("useDeploymentQuery", () => {
       expect(requestedUrl).toContain("filters.state=active");
       expect(requestedUrl).toContain("pagination.offset=20");
       expect(requestedUrl).toContain("pagination.limit=10");
-      expect(requestedUrl).toContain("pagination.count_total=true");
       expect(requestedUrl).toContain("pagination.reverse=true");
+      expect(requestedUrl).not.toContain("pagination.count_total");
     });
 
-    it("maps deployments to DTOs and exposes the server total", async () => {
+    it("maps deployments to DTOs and treats a next_key as another page", async () => {
       const deployment = buildRpcDeployment({ deployment: { id: { owner: "test-address" }, state: "active" } });
-      const { result } = setup({ total: 42, deployments: [deployment] });
+      const { result } = setup({ deployments: [deployment], nextKey: "cursor-1" });
 
       await vi.waitFor(() => expect(result.current.isSuccess).toBe(true));
 
       expect(result.current.data).toEqual({
         deployments: [deploymentToDto(deployment)],
-        total: 42
+        hasNextPage: true
       });
     });
 
-    it("omits count_total and leaves total undefined when countTotal is false", async () => {
-      const { chainApiHttpClient, result } = setup({ total: 42, countTotal: false });
+    it("does not treat pagination.total as a real total when next_key is absent", async () => {
+      const deployment = buildRpcDeployment({ deployment: { id: { owner: "test-address" }, state: "active" } });
+      const { result } = setup({ deployments: [deployment], nextKey: null, total: "10" });
 
       await vi.waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-      expect(chainApiHttpClient.get.mock.calls[0][0]).not.toContain("pagination.count_total");
-      expect(result.current.data?.total).toBeUndefined();
+      expect(result.current.data).toEqual({
+        deployments: [deploymentToDto(deployment)],
+        hasNextPage: false
+      });
+      expect(result.current.data).not.toHaveProperty("total");
+    });
+
+    it("treats a missing pagination object as the last page", async () => {
+      const { result } = setup({ pagination: null });
+
+      await vi.waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(result.current.data).toEqual({ deployments: [], hasNextPage: false });
     });
 
     it("keys pages under the address prefix so deploy-success invalidation refreshes them", () => {
@@ -65,31 +77,31 @@ describe("useDeploymentQuery", () => {
     it("keeps the previous page while paging within a status but drops it across a status change", async () => {
       const { chainApiHttpClient, requestCount, resolveNextPage } = buildDeferredClient();
 
-      let params: Parameters<typeof useDeploymentsPage>[1] = { state: "active", skip: 0, limit: 10, countTotal: true };
+      let params: Parameters<typeof useDeploymentsPage>[1] = { state: "active", skip: 0, limit: 10 };
       const { result, rerender } = setupQuery(() => useDeploymentsPage("test-address", params), {
         services: { chainApiHttpClient: () => chainApiHttpClient }
       });
 
       const activePage1 = buildRpcDeployment({ deployment: { id: { owner: "test-address", dseq: "100" }, state: "active" } });
       await vi.waitFor(() => expect(requestCount()).toBe(1));
-      resolveNextPage([activePage1], 20);
+      resolveNextPage([activePage1], "cursor-1");
       await vi.waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(result.current.data).toEqual({ deployments: [deploymentToDto(activePage1)], total: 20 });
+      expect(result.current.data).toEqual({ deployments: [deploymentToDto(activePage1)], hasNextPage: true });
 
-      params = { state: "active", skip: 10, limit: 10, countTotal: true };
+      params = { state: "active", skip: 10, limit: 10 };
       rerender();
       await vi.waitFor(() => {
         expect(requestCount()).toBe(2);
         expect(result.current.isPlaceholderData).toBe(true);
       });
-      expect(result.current.data).toEqual({ deployments: [deploymentToDto(activePage1)], total: 20 });
+      expect(result.current.data).toEqual({ deployments: [deploymentToDto(activePage1)], hasNextPage: true });
 
       const activePage2 = buildRpcDeployment({ deployment: { id: { owner: "test-address", dseq: "200" }, state: "active" } });
-      resolveNextPage([activePage2], 20);
+      resolveNextPage([activePage2], null);
       await vi.waitFor(() => expect(result.current.isPlaceholderData).toBe(false));
-      expect(result.current.data).toEqual({ deployments: [deploymentToDto(activePage2)], total: 20 });
+      expect(result.current.data).toEqual({ deployments: [deploymentToDto(activePage2)], hasNextPage: false });
 
-      params = { state: "closed", skip: 0, limit: 10, countTotal: true };
+      params = { state: "closed", skip: 0, limit: 10 };
       rerender();
       await vi.waitFor(() => {
         expect(requestCount()).toBe(3);
@@ -98,38 +110,32 @@ describe("useDeploymentQuery", () => {
       expect(result.current.data).toBeUndefined();
     });
 
-    it("keys the query by address, state, skip, limit and countTotal", async () => {
+    it("keys the query by address, state, skip and limit", async () => {
       const { result } = setupQuery(
         () => {
-          const page = useDeploymentsPage("test-address", { state: "closed", skip: 30, limit: 10, countTotal: true });
+          const page = useDeploymentsPage("test-address", { state: "closed", skip: 30, limit: 10 });
           const queryClient = useQueryClient();
           return { page, queryClient };
         },
-        { services: { chainApiHttpClient: () => buildClient({ total: 0 }) } }
+        { services: { chainApiHttpClient: () => buildClient() } }
       );
 
       await vi.waitFor(() => expect(result.current.page.isSuccess).toBe(true));
 
       const [query] = result.current.queryClient.getQueryCache().findAll();
-      expect(query.queryKey).toEqual(QueryKeys.getDeploymentsPageKey("test-address", "closed", 30, 10, true));
-    });
-
-    it("keys totals-bearing and totals-free requests separately so one cannot satisfy the other", () => {
-      expect(QueryKeys.getDeploymentsPageKey("test-address", "active", 0, 10, true)).not.toEqual(
-        QueryKeys.getDeploymentsPageKey("test-address", "active", 0, 10, false)
-      );
+      expect(query.queryKey).toEqual(QueryKeys.getDeploymentsPageKey("test-address", "closed", 30, 10));
     });
 
     it("drops the previous page when the address changes even if the status is unchanged", async () => {
       const { chainApiHttpClient, requestCount, resolveNextPage } = buildDeferredClient();
 
       let address = "address-a";
-      const { result, rerender } = setupQuery(() => useDeploymentsPage(address, { state: "active", skip: 0, limit: 10, countTotal: true }), {
+      const { result, rerender } = setupQuery(() => useDeploymentsPage(address, { state: "active", skip: 0, limit: 10 }), {
         services: { chainApiHttpClient: () => chainApiHttpClient }
       });
 
       await vi.waitFor(() => expect(requestCount()).toBe(1));
-      resolveNextPage([buildRpcDeployment({ deployment: { id: { owner: "address-a", dseq: "1" }, state: "active" } })], 5);
+      resolveNextPage([buildRpcDeployment({ deployment: { id: { owner: "address-a", dseq: "1" }, state: "active" } })], null);
       await vi.waitFor(() => expect(result.current.isSuccess).toBe(true));
 
       address = "address-b";
@@ -152,28 +158,45 @@ describe("useDeploymentQuery", () => {
       return {
         chainApiHttpClient,
         requestCount: () => resolvers.length,
-        resolveNextPage: (deployments: ReturnType<typeof buildRpcDeployment>[], total: number) => {
+        resolveNextPage: (deployments: ReturnType<typeof buildRpcDeployment>[], nextKey: string | null) => {
           const resolve = resolvers[resolvedCount++];
           if (!resolve) throw new Error("No pending deployments request to resolve");
-          resolve({ data: { deployments, pagination: { next_key: null, total: String(total) } } });
+          resolve({ data: { deployments, pagination: { next_key: nextKey, total: String(deployments.length) } } });
         }
       };
     }
 
-    function buildClient(input: { total: number; deployments?: ReturnType<typeof buildRpcDeployment>[] }) {
+    function buildClient(
+      input: {
+        deployments?: ReturnType<typeof buildRpcDeployment>[];
+        nextKey?: string | null;
+        total?: string;
+        pagination?: { next_key: string | null; total: string } | null;
+      } = {}
+    ) {
+      const pagination =
+        input.pagination === undefined ? { next_key: input.nextKey ?? null, total: input.total ?? String(input.deployments?.length ?? 0) } : input.pagination;
+
       return mock<FallbackableHttpClient>({
         get: vi.fn().mockResolvedValue({
           data: {
             deployments: input.deployments ?? [],
-            pagination: { next_key: null, total: String(input.total) }
+            pagination
           }
         })
       } as unknown as FallbackableHttpClient);
     }
 
-    function setup(input: { total: number; deployments?: ReturnType<typeof buildRpcDeployment>[]; countTotal?: boolean }) {
+    function setup(
+      input: {
+        deployments?: ReturnType<typeof buildRpcDeployment>[];
+        nextKey?: string | null;
+        total?: string;
+        pagination?: { next_key: string | null; total: string } | null;
+      } = {}
+    ) {
       const chainApiHttpClient = buildClient(input);
-      const { result } = setupQuery(() => useDeploymentsPage("test-address", { state: "active", skip: 20, limit: 10, countTotal: input.countTotal ?? true }), {
+      const { result } = setupQuery(() => useDeploymentsPage("test-address", { state: "active", skip: 20, limit: 10 }), {
         services: { chainApiHttpClient: () => chainApiHttpClient }
       });
       return { chainApiHttpClient, result };

--- a/apps/deploy-web/src/queries/useDeploymentQuery.ts
+++ b/apps/deploy-web/src/queries/useDeploymentQuery.ts
@@ -3,25 +3,59 @@ import { useQuery } from "@tanstack/react-query";
 import type { AxiosInstance } from "axios";
 
 import { useServices } from "@src/context/ServicesProvider";
-import type { DeploymentDto, RpcDeployment } from "@src/types/deployment";
+import type { DeploymentDto, DeploymentStatus, RpcDeployment } from "@src/types/deployment";
 import { ApiUrlService, loadWithPagination } from "@src/utils/apiUtils";
 import { deploymentToDto } from "@src/utils/deploymentDetailUtils";
 import { QueryKeys } from "./queryKeys";
 
-// Deployment list
-async function getDeploymentList(chainApiHttpClient: AxiosInstance, address: string) {
+// Deployment list (fetches every deployment of the given state; used where aggregates need the full set)
+async function getDeploymentList(chainApiHttpClient: AxiosInstance, address: string, state?: DeploymentStatus) {
   if (!address) return [];
 
-  const deployments = await loadWithPagination<RpcDeployment[]>(ApiUrlService.deploymentList("", address), "deployments", 1000, chainApiHttpClient);
+  const deployments = await loadWithPagination<RpcDeployment[]>(ApiUrlService.deploymentList("", address, state), "deployments", 1000, chainApiHttpClient);
 
   return deployments.map(d => deploymentToDto(d));
 }
 
-export function useDeploymentList(address: string, options?: Omit<UseQueryOptions<DeploymentDto[] | null>, "queryKey" | "queryFn">) {
+export function useDeploymentList(address: string, options?: Omit<UseQueryOptions<DeploymentDto[] | null>, "queryKey" | "queryFn">, state?: DeploymentStatus) {
   const { chainApiHttpClient } = useServices();
   return useQuery({
-    queryKey: QueryKeys.getDeploymentListKey(address),
-    queryFn: () => getDeploymentList(chainApiHttpClient, address),
+    queryKey: QueryKeys.getDeploymentListKey(address, state),
+    queryFn: () => getDeploymentList(chainApiHttpClient, address, state),
+    ...options
+  });
+}
+
+export interface DeploymentsPage {
+  deployments: DeploymentDto[];
+  total?: number;
+}
+
+type DeploymentsPageParams = {
+  state: DeploymentStatus;
+  skip: number;
+  limit: number;
+  countTotal?: boolean;
+};
+
+async function getDeploymentsPage(chainApiHttpClient: AxiosInstance, address: string, params: DeploymentsPageParams): Promise<DeploymentsPage> {
+  if (!address) return { deployments: [], total: 0 };
+
+  const { state, skip, limit, countTotal } = params;
+  const response = await chainApiHttpClient.get(ApiUrlService.deploymentsPage("", { owner: address, state, offset: skip, limit, countTotal, reverse: true }));
+  const deployments = (response.data.deployments as RpcDeployment[]).map(d => deploymentToDto(d));
+
+  return {
+    deployments,
+    total: countTotal ? Number(response.data.pagination.total) : undefined
+  };
+}
+
+export function useDeploymentsPage(address: string, params: DeploymentsPageParams, options?: Omit<UseQueryOptions<DeploymentsPage>, "queryKey" | "queryFn">) {
+  const { chainApiHttpClient } = useServices();
+  return useQuery({
+    queryKey: QueryKeys.getDeploymentsPageKey(address, params.state, params.skip, params.limit),
+    queryFn: () => getDeploymentsPage(chainApiHttpClient, address, params),
     ...options
   });
 }

--- a/apps/deploy-web/src/queries/useDeploymentQuery.ts
+++ b/apps/deploy-web/src/queries/useDeploymentQuery.ts
@@ -8,7 +8,7 @@ import { ApiUrlService, loadWithPagination } from "@src/utils/apiUtils";
 import { deploymentToDto } from "@src/utils/deploymentDetailUtils";
 import { QueryKeys } from "./queryKeys";
 
-// Deployment list (fetches every deployment of the given state; used where aggregates need the full set)
+/** Fetches every deployment of the given state; used where aggregates need the full set. */
 async function getDeploymentList(chainApiHttpClient: AxiosInstance, address: string, state?: DeploymentStatus) {
   if (!address) return [];
 

--- a/apps/deploy-web/src/queries/useDeploymentQuery.ts
+++ b/apps/deploy-web/src/queries/useDeploymentQuery.ts
@@ -12,7 +12,12 @@ import { QueryKeys } from "./queryKeys";
 async function getDeploymentList(chainApiHttpClient: AxiosInstance, address: string, state?: DeploymentStatus) {
   if (!address) return [];
 
-  const deployments = await loadWithPagination<RpcDeployment[]>(ApiUrlService.deploymentList("", address, state), "deployments", 1000, chainApiHttpClient);
+  const deployments = await loadWithPagination<RpcDeployment[]>(
+    ApiUrlService.deploymentList("", address, state, true),
+    "deployments",
+    1000,
+    chainApiHttpClient
+  );
 
   return deployments.map(d => deploymentToDto(d));
 }

--- a/apps/deploy-web/src/queries/useDeploymentQuery.ts
+++ b/apps/deploy-web/src/queries/useDeploymentQuery.ts
@@ -26,28 +26,28 @@ export function useDeploymentList(address: string, options?: Omit<UseQueryOption
   });
 }
 
+/** `hasNextPage` comes from RPC `pagination.next_key`. `pagination.total` is the current page size, not the collection size. */
 export interface DeploymentsPage {
   deployments: DeploymentDto[];
-  total?: number;
+  hasNextPage: boolean;
 }
 
 type DeploymentsPageParams = {
   state: DeploymentStatus;
   skip: number;
   limit: number;
-  countTotal?: boolean;
 };
 
 async function getDeploymentsPage(chainApiHttpClient: AxiosInstance, address: string, params: DeploymentsPageParams): Promise<DeploymentsPage> {
-  if (!address) return { deployments: [], total: 0 };
+  if (!address) return { deployments: [], hasNextPage: false };
 
-  const { state, skip, limit, countTotal } = params;
-  const response = await chainApiHttpClient.get(ApiUrlService.deploymentsPage("", { owner: address, state, offset: skip, limit, countTotal, reverse: true }));
+  const { state, skip, limit } = params;
+  const response = await chainApiHttpClient.get(ApiUrlService.deploymentsPage("", { owner: address, state, offset: skip, limit, reverse: true }));
   const deployments = (response.data.deployments as RpcDeployment[]).map(d => deploymentToDto(d));
 
   return {
     deployments,
-    total: countTotal ? Number(response.data.pagination.total) : undefined
+    hasNextPage: Boolean(response.data.pagination?.next_key)
   };
 }
 
@@ -57,8 +57,8 @@ const DEPLOYMENTS_PAGE_STATE_KEY_INDEX = 2;
 
 /**
  * Retains the last page while paging within one account and status, but drops it across an
- * account switch or an Active/Closed switch so the prior view's rows and total never render
- * under the newly selected one while its own data loads.
+ * account switch or an Active/Closed switch so the prior view's rows never render under the
+ * newly selected one while its own data loads.
  */
 function keepPreviousPageOfSameStatus(address: string, state: DeploymentStatus) {
   return (previousData: DeploymentsPage | undefined, previousQuery: { queryKey: QueryKey } | undefined) => {
@@ -72,7 +72,7 @@ function keepPreviousPageOfSameStatus(address: string, state: DeploymentStatus) 
 export function useDeploymentsPage(address: string, params: DeploymentsPageParams, options?: Omit<UseQueryOptions<DeploymentsPage>, "queryKey" | "queryFn">) {
   const { chainApiHttpClient } = useServices();
   return useQuery({
-    queryKey: QueryKeys.getDeploymentsPageKey(address, params.state, params.skip, params.limit, params.countTotal),
+    queryKey: QueryKeys.getDeploymentsPageKey(address, params.state, params.skip, params.limit),
     queryFn: () => getDeploymentsPage(chainApiHttpClient, address, params),
     placeholderData: keepPreviousPageOfSameStatus(address, params.state),
     ...options

--- a/apps/deploy-web/src/queries/useDeploymentQuery.ts
+++ b/apps/deploy-web/src/queries/useDeploymentQuery.ts
@@ -51,11 +51,25 @@ async function getDeploymentsPage(chainApiHttpClient: AxiosInstance, address: st
   };
 }
 
+/** Position of `state` within the tuple returned by {@link QueryKeys.getDeploymentsPageKey}. */
+const DEPLOYMENTS_PAGE_STATE_KEY_INDEX = 2;
+
+/**
+ * Retains the last page while paging within one status, but drops it across an Active/Closed
+ * switch so the prior tab's rows and total never render under the newly selected tab while its
+ * own data loads.
+ */
+function keepPreviousPageOfSameStatus(state: DeploymentStatus) {
+  return (previousData: DeploymentsPage | undefined, previousQuery: { queryKey: QueryKey } | undefined) =>
+    previousQuery?.queryKey[DEPLOYMENTS_PAGE_STATE_KEY_INDEX] === state ? previousData : undefined;
+}
+
 export function useDeploymentsPage(address: string, params: DeploymentsPageParams, options?: Omit<UseQueryOptions<DeploymentsPage>, "queryKey" | "queryFn">) {
   const { chainApiHttpClient } = useServices();
   return useQuery({
     queryKey: QueryKeys.getDeploymentsPageKey(address, params.state, params.skip, params.limit),
     queryFn: () => getDeploymentsPage(chainApiHttpClient, address, params),
+    placeholderData: keepPreviousPageOfSameStatus(params.state),
     ...options
   });
 }

--- a/apps/deploy-web/src/queries/useDeploymentQuery.ts
+++ b/apps/deploy-web/src/queries/useDeploymentQuery.ts
@@ -51,25 +51,30 @@ async function getDeploymentsPage(chainApiHttpClient: AxiosInstance, address: st
   };
 }
 
-/** Position of `state` within the tuple returned by {@link QueryKeys.getDeploymentsPageKey}. */
+/** Positions within the tuple returned by {@link QueryKeys.getDeploymentsPageKey}. */
+const DEPLOYMENTS_PAGE_ADDRESS_KEY_INDEX = 1;
 const DEPLOYMENTS_PAGE_STATE_KEY_INDEX = 2;
 
 /**
- * Retains the last page while paging within one status, but drops it across an Active/Closed
- * switch so the prior tab's rows and total never render under the newly selected tab while its
- * own data loads.
+ * Retains the last page while paging within one account and status, but drops it across an
+ * account switch or an Active/Closed switch so the prior view's rows and total never render
+ * under the newly selected one while its own data loads.
  */
-function keepPreviousPageOfSameStatus(state: DeploymentStatus) {
-  return (previousData: DeploymentsPage | undefined, previousQuery: { queryKey: QueryKey } | undefined) =>
-    previousQuery?.queryKey[DEPLOYMENTS_PAGE_STATE_KEY_INDEX] === state ? previousData : undefined;
+function keepPreviousPageOfSameStatus(address: string, state: DeploymentStatus) {
+  return (previousData: DeploymentsPage | undefined, previousQuery: { queryKey: QueryKey } | undefined) => {
+    if (!previousQuery) return undefined;
+    const sameAccount = previousQuery.queryKey[DEPLOYMENTS_PAGE_ADDRESS_KEY_INDEX] === address;
+    const sameStatus = previousQuery.queryKey[DEPLOYMENTS_PAGE_STATE_KEY_INDEX] === state;
+    return sameAccount && sameStatus ? previousData : undefined;
+  };
 }
 
 export function useDeploymentsPage(address: string, params: DeploymentsPageParams, options?: Omit<UseQueryOptions<DeploymentsPage>, "queryKey" | "queryFn">) {
   const { chainApiHttpClient } = useServices();
   return useQuery({
-    queryKey: QueryKeys.getDeploymentsPageKey(address, params.state, params.skip, params.limit),
+    queryKey: QueryKeys.getDeploymentsPageKey(address, params.state, params.skip, params.limit, params.countTotal),
     queryFn: () => getDeploymentsPage(chainApiHttpClient, address, params),
-    placeholderData: keepPreviousPageOfSameStatus(params.state),
+    placeholderData: keepPreviousPageOfSameStatus(address, params.state),
     ...options
   });
 }

--- a/apps/deploy-web/src/queries/useLeaseQuery.spec.tsx
+++ b/apps/deploy-web/src/queries/useLeaseQuery.spec.tsx
@@ -1,5 +1,5 @@
 import type { LeaseHttpService } from "@akashnetwork/http-sdk";
-import { useQueryClient } from "@tanstack/react-query";
+import { QueryClient, useQueryClient } from "@tanstack/react-query";
 import { AxiosError } from "axios";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
@@ -77,6 +77,16 @@ const mockLeases = [
           amount: "0"
         }
       }
+    }
+  }
+];
+
+const mockClosedLeases = [
+  {
+    ...mockLeases[0],
+    lease: {
+      ...mockLeases[0].lease,
+      state: "closed"
     }
   }
 ];
@@ -204,7 +214,7 @@ describe("useLeaseQuery", () => {
     });
 
     it("keeps a closed deployment's lease list fresh after the first fetch", async () => {
-      const { result, chainApiHttpClient } = setup({ state: "closed" });
+      const { result, chainApiHttpClient } = setup({ state: "closed", leases: mockClosedLeases });
 
       await vi.waitFor(() => {
         expect(result.current.leases.isSuccess).toBe(true);
@@ -232,12 +242,53 @@ describe("useLeaseQuery", () => {
       expect(query?.isStale()).toBe(true);
     });
 
-    function setup(input: { state?: string }) {
+    it("refetches a closed deployment when the cached lease list still looks live", async () => {
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: { retry: false, refetchOnWindowFocus: false, refetchOnReconnect: false }
+        }
+      });
       const chainApiHttpClient = mock<FallbackableHttpClient>();
       chainApiHttpClient.get.mockResolvedValue({
         data: {
           leases: mockLeases,
           pagination: { next_key: null, total: mockLeases.length }
+        }
+      });
+
+      const first = setupQuery(() => useDeploymentLeaseList("test-address", { ...mockDeployment, state: "active" }), {
+        services: {
+          chainApiHttpClient: () => chainApiHttpClient,
+          queryClient: () => queryClient
+        }
+      });
+
+      await vi.waitFor(() => {
+        expect(first.result.current.isSuccess).toBe(true);
+      });
+      expect(chainApiHttpClient.get).toHaveBeenCalledTimes(1);
+      first.unmount();
+
+      const second = setupQuery(() => useDeploymentLeaseList("test-address", { ...mockDeployment, state: "closed" }), {
+        services: {
+          chainApiHttpClient: () => chainApiHttpClient,
+          queryClient: () => queryClient
+        }
+      });
+
+      await vi.waitFor(() => {
+        expect(chainApiHttpClient.get).toHaveBeenCalledTimes(2);
+      });
+      second.unmount();
+    });
+
+    function setup(input: { state?: string; leases?: typeof mockLeases }) {
+      const rpcLeases = input.leases ?? mockLeases;
+      const chainApiHttpClient = mock<FallbackableHttpClient>();
+      chainApiHttpClient.get.mockResolvedValue({
+        data: {
+          leases: rpcLeases,
+          pagination: { next_key: null, total: rpcLeases.length }
         }
       });
       const { result } = setupQuery(

--- a/apps/deploy-web/src/queries/useLeaseQuery.spec.tsx
+++ b/apps/deploy-web/src/queries/useLeaseQuery.spec.tsx
@@ -202,6 +202,59 @@ describe("useLeaseQuery", () => {
       const queriesAfter = result.current.queryClient.getQueryCache().findAll({ queryKey });
       expect(queriesAfter).toHaveLength(0);
     });
+
+    it("keeps a closed deployment's lease list fresh after the first fetch", async () => {
+      const { result, chainApiHttpClient } = setup({ state: "closed" });
+
+      await vi.waitFor(() => {
+        expect(result.current.leases.isSuccess).toBe(true);
+      });
+
+      const query = result.current.queryClient.getQueryCache().find({
+        queryKey: QueryKeys.getLeasesKey("test-address", mockDeployment.dseq)
+      });
+
+      expect(chainApiHttpClient.get).toHaveBeenCalledTimes(1);
+      expect(query?.isStale()).toBe(false);
+    });
+
+    it("treats an active deployment's lease list as immediately stale", async () => {
+      const { result } = setup({ state: "active" });
+
+      await vi.waitFor(() => {
+        expect(result.current.leases.isSuccess).toBe(true);
+      });
+
+      const query = result.current.queryClient.getQueryCache().find({
+        queryKey: QueryKeys.getLeasesKey("test-address", mockDeployment.dseq)
+      });
+
+      expect(query?.isStale()).toBe(true);
+    });
+
+    function setup(input: { state?: string }) {
+      const chainApiHttpClient = mock<FallbackableHttpClient>();
+      chainApiHttpClient.get.mockResolvedValue({
+        data: {
+          leases: mockLeases,
+          pagination: { next_key: null, total: mockLeases.length }
+        }
+      });
+      const { result } = setupQuery(
+        () => {
+          const leases = useDeploymentLeaseList("test-address", { ...mockDeployment, state: input.state });
+          const queryClient = useQueryClient();
+          return { leases, queryClient };
+        },
+        {
+          services: {
+            chainApiHttpClient: () => chainApiHttpClient
+          }
+        }
+      );
+
+      return { result, chainApiHttpClient };
+    }
   });
 
   describe("useAllLeases", () => {

--- a/apps/deploy-web/src/queries/useLeaseQuery.ts
+++ b/apps/deploy-web/src/queries/useLeaseQuery.ts
@@ -14,6 +14,11 @@ import { leaseToDto } from "@src/utils/deploymentDetailUtils";
 import { isLeaseLive } from "@src/utils/reclamationUtils";
 import { QueryKeys } from "./queryKeys";
 
+/** Closed deployments cannot gain or change leases, so a successful list never needs refetching. */
+function closedDeploymentLeaseListStaleTime(state: string | undefined) {
+  return state === "closed" ? Infinity : undefined;
+}
+
 // Leases
 async function getDeploymentLeases(chainApiHttpClient: AxiosInstance, address: string, deployment: Pick<DeploymentDto, "dseq" | "groups">) {
   if (!address) {
@@ -28,7 +33,7 @@ async function getDeploymentLeases(chainApiHttpClient: AxiosInstance, address: s
 
 export function useDeploymentLeaseList(
   address: string,
-  deployment: Pick<DeploymentDto, "dseq" | "groups"> | null | undefined,
+  deployment: (Pick<DeploymentDto, "dseq" | "groups"> & Partial<Pick<DeploymentDto, "state">>) | null | undefined,
   options: Omit<UseQueryOptions<LeaseDto[] | null>, "queryKey" | "queryFn"> = {}
 ) {
   const { chainApiHttpClient } = useServices();
@@ -41,6 +46,7 @@ export function useDeploymentLeaseList(
       if (!deployment) return null;
       return getDeploymentLeases(chainApiHttpClient, address, deployment);
     },
+    staleTime: closedDeploymentLeaseListStaleTime(deployment?.state),
     ...options
   });
 

--- a/apps/deploy-web/src/queries/useLeaseQuery.ts
+++ b/apps/deploy-web/src/queries/useLeaseQuery.ts
@@ -14,9 +14,13 @@ import { leaseToDto } from "@src/utils/deploymentDetailUtils";
 import { isLeaseLive } from "@src/utils/reclamationUtils";
 import { QueryKeys } from "./queryKeys";
 
-/** Closed deployments cannot gain or change leases, so a successful list never needs refetching. */
-function closedDeploymentLeaseListStaleTime(state: string | undefined) {
-  return state === "closed" ? Infinity : undefined;
+/**
+ * Closed deployments cannot gain leases. Infinity only after the fetched list itself
+ * has no live leases, so a leftover Active-tab snapshot is still treated as stale.
+ */
+function closedDeploymentLeaseListStaleTime(state: string | undefined, leases: LeaseDto[] | null | undefined) {
+  if (state !== "closed" || !leases || leases.some(isLeaseLive)) return 0;
+  return Infinity;
 }
 
 // Leases
@@ -46,7 +50,7 @@ export function useDeploymentLeaseList(
       if (!deployment) return null;
       return getDeploymentLeases(chainApiHttpClient, address, deployment);
     },
-    staleTime: closedDeploymentLeaseListStaleTime(deployment?.state),
+    staleTime: query => closedDeploymentLeaseListStaleTime(deployment?.state, query.state.data),
     ...options
   });
 

--- a/apps/deploy-web/src/services/wallet-balances/wallet-balances.service.ts
+++ b/apps/deploy-web/src/services/wallet-balances/wallet-balances.service.ts
@@ -22,7 +22,7 @@ export class WalletBalancesService {
     const [balanceResponse, deploymentGrants, activeDeploymentsResponse] = await Promise.all([
       this.chainApiHttpClient.get<RestApiBalancesResponseType>(ApiUrlService.balance("", address)),
       this.authzHttpService.getAllDepositDeploymentGrants({ grantee: address, limit: 1000 }),
-      loadWithPagination<RpcDeployment[]>(ApiUrlService.deploymentList("", address, true), "deployments", 1000, this.chainApiHttpClient)
+      loadWithPagination<RpcDeployment[]>(ApiUrlService.deploymentList("", address, "active"), "deployments", 1000, this.chainApiHttpClient)
     ]);
 
     const deploymentGrantsPerDenom = deploymentGrants.reduce<Record<string, number>>((acc, grant) => {

--- a/apps/deploy-web/src/types/deployment.ts
+++ b/apps/deploy-web/src/types/deployment.ts
@@ -269,6 +269,8 @@ export interface NamedDeploymentDto extends DeploymentDto {
   name: string;
 }
 
+export type DeploymentStatus = "active" | "closed";
+
 export interface LeaseDto {
   id: string;
   owner: string;

--- a/apps/deploy-web/src/utils/apiUtils.ts
+++ b/apps/deploy-web/src/utils/apiUtils.ts
@@ -5,7 +5,7 @@ import networkStore from "@src/store/networkStore";
 import type { DeploymentStatus } from "@src/types/deployment";
 import { appendSearchParams } from "./urlUtils";
 
-type DeploymentsPageParams = {
+type DeploymentsPageUrlParams = {
   owner: string;
   state: DeploymentStatus;
   offset: number;
@@ -25,7 +25,7 @@ export class ApiUrlService {
    * Single-page deployment listing. Uses offset-based pagination, which the chain only allows
    * alongside a `filters.state`, and only honors `count_total` when an offset is set.
    */
-  static deploymentsPage(apiEndpoint: string, { owner, state, offset, limit, countTotal, reverse }: DeploymentsPageParams) {
+  static deploymentsPage(apiEndpoint: string, { owner, state, offset, limit, countTotal, reverse }: DeploymentsPageUrlParams) {
     let url = `${apiEndpoint}/akash/deployment/${networkStore.deploymentVersion}/deployments/list?filters.owner=${owner}&filters.state=${state}&pagination.offset=${offset}&pagination.limit=${limit}`;
     if (countTotal) url += "&pagination.count_total=true";
     if (reverse) url += "&pagination.reverse=true";

--- a/apps/deploy-web/src/utils/apiUtils.ts
+++ b/apps/deploy-web/src/utils/apiUtils.ts
@@ -10,7 +10,6 @@ type DeploymentsPageUrlParams = {
   state: DeploymentStatus;
   offset: number;
   limit: number;
-  countTotal?: boolean;
   reverse?: boolean;
 };
 
@@ -22,12 +21,12 @@ export class ApiUrlService {
     return `${apiEndpoint}/akash/deployment/${networkStore.deploymentVersion}/deployments/list?filters.owner=${address}${state ? `&filters.state=${state}` : ""}`;
   }
   /**
-   * Single-page deployment listing. Uses offset-based pagination, which the chain only allows
-   * alongside a `filters.state`, and only honors `count_total` when an offset is set.
+   * Single-page deployment listing. Offset pagination requires `filters.state`.
+   * Do not request `count_total`: the RPC reports the current page size, not the collection size.
+   * Callers should use `pagination.next_key` to decide whether another page exists.
    */
-  static deploymentsPage(apiEndpoint: string, { owner, state, offset, limit, countTotal, reverse }: DeploymentsPageUrlParams) {
+  static deploymentsPage(apiEndpoint: string, { owner, state, offset, limit, reverse }: DeploymentsPageUrlParams) {
     let url = `${apiEndpoint}/akash/deployment/${networkStore.deploymentVersion}/deployments/list?filters.owner=${owner}&filters.state=${state}&pagination.offset=${offset}&pagination.limit=${limit}`;
-    if (countTotal) url += "&pagination.count_total=true";
     if (reverse) url += "&pagination.reverse=true";
     return url;
   }

--- a/apps/deploy-web/src/utils/apiUtils.ts
+++ b/apps/deploy-web/src/utils/apiUtils.ts
@@ -2,14 +2,34 @@ import type { AxiosInstance } from "axios";
 
 import { services } from "@src/services/app-di-container/browser-di-container";
 import networkStore from "@src/store/networkStore";
+import type { DeploymentStatus } from "@src/types/deployment";
 import { appendSearchParams } from "./urlUtils";
+
+type DeploymentsPageParams = {
+  owner: string;
+  state: DeploymentStatus;
+  offset: number;
+  limit: number;
+  countTotal?: boolean;
+  reverse?: boolean;
+};
 
 export class ApiUrlService {
   static depositParams(apiEndpoint: string) {
     return `${apiEndpoint}/akash/deployment/${networkStore.deploymentVersion}/params`;
   }
-  static deploymentList(apiEndpoint: string, address: string, isActive?: boolean) {
-    return `${apiEndpoint}/akash/deployment/${networkStore.deploymentVersion}/deployments/list?filters.owner=${address}${isActive ? "&filters.state=active" : ""}`;
+  static deploymentList(apiEndpoint: string, address: string, state?: DeploymentStatus) {
+    return `${apiEndpoint}/akash/deployment/${networkStore.deploymentVersion}/deployments/list?filters.owner=${address}${state ? `&filters.state=${state}` : ""}`;
+  }
+  /**
+   * Single-page deployment listing. Uses offset-based pagination, which the chain only allows
+   * alongside a `filters.state`, and only honors `count_total` when an offset is set.
+   */
+  static deploymentsPage(apiEndpoint: string, { owner, state, offset, limit, countTotal, reverse }: DeploymentsPageParams) {
+    let url = `${apiEndpoint}/akash/deployment/${networkStore.deploymentVersion}/deployments/list?filters.owner=${owner}&filters.state=${state}&pagination.offset=${offset}&pagination.limit=${limit}`;
+    if (countTotal) url += "&pagination.count_total=true";
+    if (reverse) url += "&pagination.reverse=true";
+    return url;
   }
   static deploymentDetail(apiEndpoint: string, address: string, dseq: string) {
     return `${apiEndpoint}/akash/deployment/${networkStore.deploymentVersion}/deployments/info?id.owner=${address}&id.dseq=${dseq}`;

--- a/apps/deploy-web/src/utils/apiUtils.ts
+++ b/apps/deploy-web/src/utils/apiUtils.ts
@@ -17,8 +17,10 @@ export class ApiUrlService {
   static depositParams(apiEndpoint: string) {
     return `${apiEndpoint}/akash/deployment/${networkStore.deploymentVersion}/params`;
   }
-  static deploymentList(apiEndpoint: string, address: string, state?: DeploymentStatus) {
-    return `${apiEndpoint}/akash/deployment/${networkStore.deploymentVersion}/deployments/list?filters.owner=${address}${state ? `&filters.state=${state}` : ""}`;
+  static deploymentList(apiEndpoint: string, address: string, state?: DeploymentStatus, reverse?: boolean) {
+    let url = `${apiEndpoint}/akash/deployment/${networkStore.deploymentVersion}/deployments/list?filters.owner=${address}${state ? `&filters.state=${state}` : ""}`;
+    if (reverse) url += "&pagination.reverse=true";
+    return url;
   }
   /**
    * Single-page deployment listing. Offset pagination requires `filters.state`.


### PR DESCRIPTION
## Why

The deployments page gets very slow for accounts with a lot of deployments. It fetched **every** deployment (active and closed) at `pagination.limit=1000` with `count_total=true` on every page, looping until the whole set was down, then did all the filtering, sorting and pagination client-side just to render 10 rows. For a ~940-deployment account that's a single multi-megabyte response taking 10s+, plus a second owner-wide fetch of the entire lease history behind the list.

## What

Load only the current page, straight from the chain RPC.

- **Server-side pagination.** New `deploymentsPage` URL builder + `useDeploymentsPage` hook use offset-based pagination (which the chain only allows alongside `filters.state`, and which is the only mode that honors `count_total`). The page returns `{ deployments, total }` and feeds the existing `CustomPagination`.
- **Active by default, closed on demand.** The old "Active" checkbox is now an Active/Closed toggle. Offset pagination requires a concrete state, and this also means the common view stops downloading closed deployments entirely.
- **Per-page lease fetches.** Rows moved from the owner-wide `useAllLeases` to the per-dseq `useDeploymentLeaseList`, so lease requests are bounded by page size (≤10) instead of pulling the full lease history.
- **Home stays correct.** `YourAccount` still needs the full active set for its resource aggregates, so Home keeps a full fetch but now requests active-only.

Search is intentionally left as a follow-up: it filters the loaded page for now, and the pager hides while a search is active so the page count can't mislead.

The `countTotal` flag is exposed on the hook on purpose so we can measure whether `count_total` dominates latency on a heavy account and, if so, decouple it (background count) or switch to prev/next cursors without a rewrite.

### Testing

- New `useDeploymentQuery.spec.tsx` covers the request params (offset/state/count_total/reverse), DTO mapping, the server total, the `countTotal: false` path, and the invalidation-prefix contract.
- Full deploy-web unit suite green (3131 passed), `tsc` clean (no new errors), lint clean.

Not yet done and best verified against a real heavy account: the end-to-end network-tab check and the `count_total` on/off latency measurement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added paginated deployment browsing with active and closed status tabs.
  - Added deployment search, result counts, empty states, retry handling, and pagination controls.
  - Only active deployments can be selected for actions.
  - Improved lease loading with more targeted deployment results.

- **Bug Fixes**
  - Deployment lists now refresh automatically after completing a deployment.
  - Active deployment balances are filtered more accurately.

- **Tests**
  - Added coverage for pagination, status filtering, totals, retries, cache invalidation, and selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->