### PR TITLE
fix(deployment): fetch only live leases on the homepage

### DIFF
--- a/apps/deploy-web/src/components/home/HomeContainer.spec.tsx
+++ b/apps/deploy-web/src/components/home/HomeContainer.spec.tsx
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { DeploymentDto, LeaseDto } from "@src/types/deployment";
+import type { ApiProviderList } from "@src/types/provider";
+import { LIVE_LEASE_STATES } from "@src/utils/leaseUtils";
+import { DEPENDENCIES, HomeContainer } from "./HomeContainer";
+
+import { render } from "@testing-library/react";
+import { MockComponents } from "@tests/unit/mocks";
+
+describe(HomeContainer.name, () => {
+  it("requests only live leases instead of the full lease history", () => {
+    const { useAllLeases } = setup({ address: "akash1owner" });
+
+    expect(useAllLeases).toHaveBeenCalledWith("akash1owner", expect.objectContaining({ state: LIVE_LEASE_STATES }));
+  });
+
+  it("requests only active deployments for the account aggregates", () => {
+    const { useDeploymentList } = setup({ address: "akash1owner" });
+
+    expect(useDeploymentList).toHaveBeenCalledWith("akash1owner", expect.objectContaining({ enabled: false }), "active");
+  });
+
+  it("passes the fetched leases and providers to YourAccount once settings are initialised", () => {
+    const leases = [mock<LeaseDto>({ dseq: "1", state: "active" })];
+    const providers = [mock<ApiProviderList>({ owner: "provider1" })];
+    const { YourAccount } = setup({ address: "akash1owner", leases, providers });
+
+    expect(YourAccount).toHaveBeenCalledWith(expect.objectContaining({ leases, providers }), expect.anything());
+  });
+
+  it("does not render YourAccount when no wallet is connected", () => {
+    const { YourAccount } = setup({ address: "" });
+
+    expect(YourAccount).not.toHaveBeenCalled();
+  });
+
+  function setup(
+    input: {
+      address?: string;
+      isSettingsInit?: boolean;
+      leases?: LeaseDto[] | null;
+      providers?: ApiProviderList[];
+      deployments?: DeploymentDto[];
+    } = {}
+  ) {
+    const deployments = input.deployments ?? [];
+    const leases = input.leases ?? [];
+    const providers = input.providers ?? [];
+    const refetchDeployments = vi.fn();
+    const refetchLeases = vi.fn();
+    const getDeploymentName = () => null;
+
+    const useWallet: typeof DEPENDENCIES.useWallet = () => mock<ReturnType<typeof DEPENDENCIES.useWallet>>({ address: input.address ?? "" });
+    const useLocalNotes: typeof DEPENDENCIES.useLocalNotes = () => mock<ReturnType<typeof DEPENDENCIES.useLocalNotes>>({ getDeploymentName });
+    const useSettings: typeof DEPENDENCIES.useSettings = () =>
+      mock<ReturnType<typeof DEPENDENCIES.useSettings>>({
+        isSettingsInit: input.isSettingsInit ?? true,
+        settings: mock<ReturnType<typeof DEPENDENCIES.useSettings>["settings"]>({ apiEndpoint: "http://localhost" })
+      });
+    const useWalletBalance: typeof DEPENDENCIES.useWalletBalance = () =>
+      mock<ReturnType<typeof DEPENDENCIES.useWalletBalance>>({ balance: null, isLoading: false });
+    const useProviderList = vi.fn<typeof DEPENDENCIES.useProviderList>(() =>
+      Object.assign(mock<ReturnType<typeof DEPENDENCIES.useProviderList>>(), { data: providers, isFetching: false })
+    );
+    const useDeploymentList = vi.fn<typeof DEPENDENCIES.useDeploymentList>(() =>
+      Object.assign(mock<ReturnType<typeof DEPENDENCIES.useDeploymentList>>(), { data: deployments, isFetching: false, refetch: refetchDeployments })
+    );
+    const useAllLeases = vi.fn<typeof DEPENDENCIES.useAllLeases>(() =>
+      Object.assign(mock<ReturnType<typeof DEPENDENCIES.useAllLeases>>(), { data: leases, isFetching: false, refetch: refetchLeases })
+    );
+    const YourAccount = vi.fn(() => <div>your account</div>);
+
+    render(
+      <HomeContainer
+        dependencies={MockComponents(DEPENDENCIES, {
+          useWallet,
+          useLocalNotes,
+          useSettings,
+          useWalletBalance,
+          useProviderList,
+          useDeploymentList,
+          useAllLeases,
+          YourAccount
+        })}
+      />
+    );
+
+    return { useAllLeases, useDeploymentList, useProviderList, YourAccount };
+  }
+});

--- a/apps/deploy-web/src/components/home/HomeContainer.spec.tsx
+++ b/apps/deploy-web/src/components/home/HomeContainer.spec.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
-import type { DeploymentDto, LeaseDto } from "@src/types/deployment";
+import type { LeaseDto } from "@src/types/deployment";
 import type { ApiProviderList } from "@src/types/provider";
 import { LIVE_LEASE_STATES } from "@src/utils/leaseUtils";
 import { DEPENDENCIES, HomeContainer } from "./HomeContainer";
@@ -36,40 +36,21 @@ describe(HomeContainer.name, () => {
     expect(YourAccount).not.toHaveBeenCalled();
   });
 
-  function setup(
-    input: {
-      address?: string;
-      isSettingsInit?: boolean;
-      leases?: LeaseDto[] | null;
-      providers?: ApiProviderList[];
-      deployments?: DeploymentDto[];
-    } = {}
-  ) {
-    const deployments = input.deployments ?? [];
-    const leases = input.leases ?? [];
-    const providers = input.providers ?? [];
-    const refetchDeployments = vi.fn();
-    const refetchLeases = vi.fn();
+  function setup(input: { address?: string; leases?: LeaseDto[]; providers?: ApiProviderList[] } = {}) {
     const getDeploymentName = () => null;
 
     const useWallet: typeof DEPENDENCIES.useWallet = () => mock<ReturnType<typeof DEPENDENCIES.useWallet>>({ address: input.address ?? "" });
     const useLocalNotes: typeof DEPENDENCIES.useLocalNotes = () => mock<ReturnType<typeof DEPENDENCIES.useLocalNotes>>({ getDeploymentName });
     const useSettings: typeof DEPENDENCIES.useSettings = () =>
       mock<ReturnType<typeof DEPENDENCIES.useSettings>>({
-        isSettingsInit: input.isSettingsInit ?? true,
+        isSettingsInit: true,
         settings: mock<ReturnType<typeof DEPENDENCIES.useSettings>["settings"]>({ apiEndpoint: "http://localhost" })
       });
     const useWalletBalance: typeof DEPENDENCIES.useWalletBalance = () =>
       mock<ReturnType<typeof DEPENDENCIES.useWalletBalance>>({ balance: null, isLoading: false });
-    const useProviderList = vi.fn<typeof DEPENDENCIES.useProviderList>(() =>
-      Object.assign(mock<ReturnType<typeof DEPENDENCIES.useProviderList>>(), { data: providers, isFetching: false })
-    );
-    const useDeploymentList = vi.fn<typeof DEPENDENCIES.useDeploymentList>(() =>
-      Object.assign(mock<ReturnType<typeof DEPENDENCIES.useDeploymentList>>(), { data: deployments, isFetching: false, refetch: refetchDeployments })
-    );
-    const useAllLeases = vi.fn<typeof DEPENDENCIES.useAllLeases>(() =>
-      Object.assign(mock<ReturnType<typeof DEPENDENCIES.useAllLeases>>(), { data: leases, isFetching: false, refetch: refetchLeases })
-    );
+    const useProviderList = mockQueryHook<typeof DEPENDENCIES.useProviderList>(input.providers ?? []);
+    const useDeploymentList = mockQueryHook<typeof DEPENDENCIES.useDeploymentList>([]);
+    const useAllLeases = mockQueryHook<typeof DEPENDENCIES.useAllLeases>(input.leases ?? []);
     const YourAccount = vi.fn(() => <div>your account</div>);
 
     render(
@@ -87,6 +68,12 @@ describe(HomeContainer.name, () => {
       />
     );
 
-    return { useAllLeases, useDeploymentList, useProviderList, YourAccount };
+    return { useAllLeases, useDeploymentList, YourAccount };
+  }
+
+  /** Returns the same result object on every render so `data`/`refetch` refs stay stable for the component's effect deps. */
+  function mockQueryHook<THook extends (...args: never[]) => { data: unknown }>(data: ReturnType<THook>["data"]) {
+    const result = Object.assign(mock<ReturnType<THook>>(), { data, isFetching: false, refetch: vi.fn() });
+    return vi.fn(() => result);
   }
 });

--- a/apps/deploy-web/src/components/home/HomeContainer.tsx
+++ b/apps/deploy-web/src/components/home/HomeContainer.tsx
@@ -11,6 +11,7 @@ import { useDeploymentList } from "@src/queries/useDeploymentQuery";
 import { useAllLeases } from "@src/queries/useLeaseQuery";
 import { useProviderList } from "@src/queries/useProvidersQuery";
 import type { DeploymentDto } from "@src/types/deployment";
+import { LIVE_LEASE_STATES } from "@src/utils/leaseUtils";
 import Layout from "../layout/Layout";
 import { WelcomePanel } from "./WelcomePanel";
 
@@ -18,7 +19,26 @@ const YourAccount = dynamic(() => import("./YourAccount/YourAccount").then(m => 
   ssr: false
 });
 
-export function HomeContainer() {
+export const DEPENDENCIES = {
+  useWallet,
+  useLocalNotes,
+  useSettings,
+  useWalletBalance,
+  useProviderList,
+  useDeploymentList,
+  useAllLeases,
+  Layout,
+  WelcomePanel,
+  YourAccount
+};
+
+type Props = {
+  dependencies?: typeof DEPENDENCIES;
+};
+
+export function HomeContainer({ dependencies = DEPENDENCIES }: Props) {
+  const { useWallet, useLocalNotes, useSettings, useWalletBalance, useProviderList, useDeploymentList, useAllLeases, Layout, WelcomePanel, YourAccount } =
+    dependencies;
   const { address } = useWallet();
   const [activeDeployments, setActiveDeployments] = useState<DeploymentDto[]>([]);
   const { getDeploymentName } = useLocalNotes();
@@ -43,7 +63,7 @@ export function HomeContainer() {
   const { apiEndpoint } = settings;
   const { balance: walletBalance, isLoading: isLoadingBalances } = useWalletBalance();
   const { data: providers, isFetching: isLoadingProviders } = useProviderList();
-  const { data: leases, isFetching: isLoadingLeases, refetch: getLeases } = useAllLeases(address, { enabled: false });
+  const { data: leases, isFetching: isLoadingLeases, refetch: getLeases } = useAllLeases(address, { enabled: false, state: LIVE_LEASE_STATES });
 
   useEffect(() => {
     if (address && isSettingsInit) {

--- a/apps/deploy-web/src/components/home/HomeContainer.tsx
+++ b/apps/deploy-web/src/components/home/HomeContainer.tsx
@@ -36,17 +36,15 @@ type Props = {
   dependencies?: typeof DEPENDENCIES;
 };
 
-export function HomeContainer({ dependencies = DEPENDENCIES }: Props) {
-  const { useWallet, useLocalNotes, useSettings, useWalletBalance, useProviderList, useDeploymentList, useAllLeases, Layout, WelcomePanel, YourAccount } =
-    dependencies;
-  const { address } = useWallet();
+export function HomeContainer({ dependencies: d = DEPENDENCIES }: Props) {
+  const { address } = d.useWallet();
   const [activeDeployments, setActiveDeployments] = useState<DeploymentDto[]>([]);
-  const { getDeploymentName } = useLocalNotes();
+  const { getDeploymentName } = d.useLocalNotes();
   const {
     data: deployments,
     isFetching: isLoadingDeployments,
     refetch: getDeployments
-  } = useDeploymentList(
+  } = d.useDeploymentList(
     address,
     {
       enabled: false
@@ -59,11 +57,11 @@ export function HomeContainer({ dependencies = DEPENDENCIES }: Props) {
     }
   }, [deployments, getDeploymentName]);
 
-  const { settings, isSettingsInit } = useSettings();
+  const { settings, isSettingsInit } = d.useSettings();
   const { apiEndpoint } = settings;
-  const { balance: walletBalance, isLoading: isLoadingBalances } = useWalletBalance();
-  const { data: providers, isFetching: isLoadingProviders } = useProviderList();
-  const { data: leases, isFetching: isLoadingLeases, refetch: getLeases } = useAllLeases(address, { enabled: false, state: LIVE_LEASE_STATES });
+  const { balance: walletBalance, isLoading: isLoadingBalances } = d.useWalletBalance();
+  const { data: providers, isFetching: isLoadingProviders } = d.useProviderList();
+  const { data: leases, isFetching: isLoadingLeases, refetch: getLeases } = d.useAllLeases(address, { enabled: false, state: LIVE_LEASE_STATES });
 
   useEffect(() => {
     if (address && isSettingsInit) {
@@ -80,16 +78,16 @@ export function HomeContainer({ dependencies = DEPENDENCIES }: Props) {
   }, [isSettingsInit, getDeployments, apiEndpoint, address]);
 
   return (
-    <Layout
+    <d.Layout
       containerClassName="flex h-full flex-col justify-between"
       isLoading={isLoadingDeployments || isLoadingBalances || isLoadingProviders || isLoadingLeases}
     >
       <div>
         <div className="mb-6">
-          <WelcomePanel />
+          <d.WelcomePanel />
         </div>
         {isSettingsInit && !!address && (
-          <YourAccount
+          <d.YourAccount
             isLoadingBalances={isLoadingBalances}
             walletBalance={walletBalance}
             activeDeployments={activeDeployments}
@@ -98,6 +96,6 @@ export function HomeContainer({ dependencies = DEPENDENCIES }: Props) {
           />
         )}
       </div>
-    </Layout>
+    </d.Layout>
   );
 }


### PR DESCRIPTION
## Why

The homepage ("Your Account") only ever uses live leases — the spend figures and the "providers in use" list both filter with `isLeaseLive` before doing anything. But `HomeContainer` called `useAllLeases` with **no state filter**, so `loadWithPagination` walked the owner's entire lease history at 1000 per page and then threw the closed ones away on the client. For long-lived accounts that's a large, slow request for data that never renders.

This mirrors the deployment-list optimization (#3596) and the billing spend fix (#3599), finishing the last unfiltered query on the homepage.

## What

- `HomeContainer` now requests `useAllLeases(address, { enabled: false, state: LIVE_LEASE_STATES })` (`active` + `reclaiming`) instead of the full history. `YourAccount` already filters to live leases, so the UI is unchanged.
- The query key now matches the billing overview's live-lease key, so the homepage and billing **share one cached fetch** instead of issuing two different owner-wide requests.
- Made `HomeContainer` dependency-injectable (`DEPENDENCIES` export + `dependencies` prop), following the `DeploymentList` pattern, and added `HomeContainer.spec.tsx` covering the request shapes (live leases, active deployments) and the `YourAccount` render gate.

The other homepage queries were already narrowed: the deployment list requests `active` (#3596), `getBalances` fetches active-only deployments for escrow, and the provider list is a necessary network-wide lookup used to resolve provider names.

### Out of scope / follow-up

The same unfiltered `useAllLeases(address)` call still exists on the provider pages (`ProviderList`, `ProviderDetail`, `ProviderRawData`, `LeaseListContainer`), which may legitimately need closed leases. Left untouched here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the home page to display only currently live leases.
  * Improved active deployment filtering for more accurate results.
  * Ensured lease and provider information is displayed consistently after data is fetched.
  * Prevented account-related content from appearing when no wallet is connected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->