### PR TITLE
feat(indexer): incremental network state and daily rollup aggregates

### DIFF
--- a/apps/chain-indexer/drizzle/0009_loud_blue_marvel.sql
+++ b/apps/chain-indexer/drizzle/0009_loud_blue_marvel.sql
@@ -1,0 +1,49 @@
+CREATE TABLE "akash"."daily_prices" (
+	"date" date NOT NULL,
+	"denom" text NOT NULL,
+	"price" numeric(38, 18) NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "daily_prices_date_denom_pk" PRIMARY KEY("date","denom")
+);
+--> statement-breakpoint
+CREATE TABLE "akash"."network_rollups" (
+	"date" date PRIMARY KEY NOT NULL,
+	"close_height" bigint NOT NULL,
+	"close_at" timestamp with time zone NOT NULL,
+	"active_lease_count" integer NOT NULL,
+	"total_lease_count" bigint NOT NULL,
+	"daily_lease_count" integer NOT NULL,
+	"active_provider_count" integer NOT NULL,
+	"active_cpu_units" bigint NOT NULL,
+	"active_gpu_units" bigint NOT NULL,
+	"active_memory_bytes" bigint NOT NULL,
+	"active_ephemeral_storage_bytes" bigint NOT NULL,
+	"active_persistent_storage_bytes" bigint NOT NULL,
+	"total_uakt_spent" numeric(38, 18) NOT NULL,
+	"total_uusdc_spent" numeric(38, 18) NOT NULL,
+	"total_uact_spent" numeric(38, 18) NOT NULL,
+	"daily_uakt_spent" numeric(38, 18) NOT NULL,
+	"daily_uusdc_spent" numeric(38, 18) NOT NULL,
+	"daily_uact_spent" numeric(38, 18) NOT NULL,
+	"daily_usd_spent" numeric(38, 18),
+	"akt_price_used" numeric(38, 18),
+	"usd_computed_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE TABLE "akash"."network_state" (
+	"id" integer PRIMARY KEY NOT NULL,
+	"last_aggregated_height" bigint NOT NULL,
+	"last_aggregated_at" timestamp with time zone NOT NULL,
+	"active_lease_count" integer DEFAULT 0 NOT NULL,
+	"total_lease_count" bigint DEFAULT 0 NOT NULL,
+	"active_provider_count" integer DEFAULT 0 NOT NULL,
+	"active_cpu_units" bigint DEFAULT 0 NOT NULL,
+	"active_gpu_units" bigint DEFAULT 0 NOT NULL,
+	"active_memory_bytes" bigint DEFAULT 0 NOT NULL,
+	"active_ephemeral_storage_bytes" bigint DEFAULT 0 NOT NULL,
+	"active_persistent_storage_bytes" bigint DEFAULT 0 NOT NULL,
+	"total_uakt_spent" numeric(38, 18) DEFAULT '0' NOT NULL,
+	"total_uusdc_spent" numeric(38, 18) DEFAULT '0' NOT NULL,
+	"total_uact_spent" numeric(38, 18) DEFAULT '0' NOT NULL,
+	CONSTRAINT "network_state_singleton_check" CHECK ("akash"."network_state"."id" = 1)
+);

--- a/apps/chain-indexer/drizzle/meta/0009_snapshot.json
+++ b/apps/chain-indexer/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,3057 @@
+{
+  "id": "080d0308-11dd-4220-855e-30746d3813e4",
+  "prevId": "2c31f1a9-1835-449a-899e-f6eaa1ebec5b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "cosmos.account_balances": {
+      "name": "account_balances",
+      "schema": "cosmos",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "denom": {
+          "name": "denom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(38, 0)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_balances_account_id_accounts_id_fk": {
+          "name": "account_balances_account_id_accounts_id_fk",
+          "tableFrom": "account_balances",
+          "tableTo": "accounts",
+          "schemaTo": "cosmos",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_balances_account_id_denom_pk": {
+          "name": "account_balances_account_id_denom_pk",
+          "columns": [
+            "account_id",
+            "denom"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "cosmos.account_txs": {
+      "name": "account_txs",
+      "schema": "cosmos",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tx_index": {
+          "name": "tx_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "account_tx_role",
+          "typeSchema": "cosmos",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_txs_account_id_accounts_id_fk": {
+          "name": "account_txs_account_id_accounts_id_fk",
+          "tableFrom": "account_txs",
+          "tableTo": "accounts",
+          "schemaTo": "cosmos",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_txs_account_id_height_tx_index_role_pk": {
+          "name": "account_txs_account_id_height_tx_index_role_pk",
+          "columns": [
+            "account_id",
+            "height",
+            "tx_index",
+            "role"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "cosmos.accounts": {
+      "name": "accounts",
+      "schema": "cosmos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_number": {
+          "name": "account_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_module_account": {
+          "name": "is_module_account",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "accounts_address_idx": {
+          "name": "accounts_address_idx",
+          "columns": [
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "cosmos.balance_changes": {
+      "name": "balance_changes",
+      "schema": "cosmos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "denom": {
+          "name": "denom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delta": {
+          "name": "delta",
+          "type": "numeric(38, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_after": {
+          "name": "balance_after",
+          "type": "numeric(38, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "balance_change_reason",
+          "typeSchema": "cosmos",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tx_index": {
+          "name": "tx_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_index": {
+          "name": "event_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counterparty_account_id": {
+          "name": "counterparty_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "balance_changes_account_denom_height_idx": {
+          "name": "balance_changes_account_denom_height_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "denom",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "height",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "balance_changes_height_event_index_idx": {
+          "name": "balance_changes_height_event_index_idx",
+          "columns": [
+            {
+              "expression": "height",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "balance_changes_account_id_accounts_id_fk": {
+          "name": "balance_changes_account_id_accounts_id_fk",
+          "tableFrom": "balance_changes",
+          "tableTo": "accounts",
+          "schemaTo": "cosmos",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "balance_changes_counterparty_account_id_accounts_id_fk": {
+          "name": "balance_changes_counterparty_account_id_accounts_id_fk",
+          "tableFrom": "balance_changes",
+          "tableTo": "accounts",
+          "schemaTo": "cosmos",
+          "columnsFrom": [
+            "counterparty_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "akash.bids": {
+      "name": "bids",
+      "schema": "akash",
+      "columns": {
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gseq": {
+          "name": "gseq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oseq": {
+          "name": "oseq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bseq": {
+          "name": "bseq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "denom": {
+          "name": "denom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "bid_state",
+          "typeSchema": "akash",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_height": {
+          "name": "created_height",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closed_height": {
+          "name": "closed_height",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bids_deployment_id_deployments_id_fk": {
+          "name": "bids_deployment_id_deployments_id_fk",
+          "tableFrom": "bids",
+          "tableTo": "deployments",
+          "schemaTo": "akash",
+          "columnsFrom": [
+            "deployment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bids_provider_account_id_accounts_id_fk": {
+          "name": "bids_provider_account_id_accounts_id_fk",
+          "tableFrom": "bids",
+          "tableTo": "accounts",
+          "schemaTo": "cosmos",
+          "columnsFrom": [
+            "provider_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bids_deployment_id_gseq_oseq_bseq_provider_account_id_pk": {
+          "name": "bids_deployment_id_gseq_oseq_bseq_provider_account_id_pk",
+          "columns": [
+            "deployment_id",
+            "gseq",
+            "oseq",
+            "bseq",
+            "provider_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "cosmos.blocks": {
+      "name": "blocks",
+      "schema": "cosmos",
+      "columns": {
+        "height": {
+          "name": "height",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "datetime": {
+          "name": "datetime",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_hash": {
+          "name": "parent_hash",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposer_address": {
+          "name": "proposer_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tx_count": {
+          "name": "tx_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "akash.bme_canceled_records": {
+      "name": "bme_canceled_records",
+      "schema": "akash",
+      "columns": {
+        "denom": {
+          "name": "denom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_denom": {
+          "name": "to_denom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_height": {
+          "name": "record_height",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tx_index": {
+          "name": "tx_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_reason": {
+          "name": "cancel_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_account_id": {
+          "name": "owner_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_account_id": {
+          "name": "to_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "coins_to_burn_denom": {
+          "name": "coins_to_burn_denom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coins_to_burn_amount": {
+          "name": "coins_to_burn_amount",
+          "type": "numeric(38, 0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denom_to_mint": {
+          "name": "denom_to_mint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "bme_canceled_records_height_idx": {
+          "name": "bme_canceled_records_height_idx",
+          "columns": [
+            {
+              "expression": "height",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bme_canceled_records_owner_account_id_accounts_id_fk": {
+          "name": "bme_canceled_records_owner_account_id_accounts_id_fk",
+          "tableFrom": "bme_canceled_records",
+          "tableTo": "accounts",
+          "schemaTo": "cosmos",
+          "columnsFrom": [
+            "owner_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bme_canceled_records_to_account_id_accounts_id_fk": {
+          "name": "bme_canceled_records_to_account_id_accounts_id_fk",
+          "tableFrom": "bme_canceled_records",
+          "tableTo": "accounts",
+          "schemaTo": "cosmos",
+          "columnsFrom": [
+            "to_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bme_canceled_records_record_height_sequence_denom_to_denom_source_pk": {
+          "name": "bme_canceled_records_record_height_sequence_denom_to_denom_source_pk",
+          "columns": [
+            "record_height",
+            "sequence",
+            "denom",
+            "to_denom",
+            "source"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "akash.bme_ledger_records": {
+      "name": "bme_ledger_records",
+      "schema": "akash",
+      "columns": {
+        "denom": {
+          "name": "denom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_denom": {
+          "name": "to_denom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_height": {
+          "name": "record_height",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tx_index": {
+          "name": "tx_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "burned_from_account_id": {
+          "name": "burned_from_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "minted_to_account_id": {
+          "name": "minted_to_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "burned_denom": {
+          "name": "burned_denom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "burned_amount": {
+          "name": "burned_amount",
+          "type": "numeric(38, 0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "burned_price": {
+          "name": "burned_price",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "minted_denom": {
+          "name": "minted_denom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "minted_amount": {
+          "name": "minted_amount",
+          "type": "numeric(38, 0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "minted_price": {
+          "name": "minted_price",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spread_denom": {
+          "name": "spread_denom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spread_amount": {
+          "name": "spread_amount",
+          "type": "numeric(38, 0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remint_credit_issued_amount": {
+          "name": "remint_credit_issued_amount",
+          "type": "numeric(38, 0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remint_credit_accrued_amount": {
+          "name": "remint_credit_accrued_amount",
+          "type": "numeric(38, 0)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "bme_ledger_records_height_idx": {
+          "name": "bme_ledger_records_height_idx",
+          "columns": [
+            {
+              "expression": "height",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bme_ledger_records_burned_denom_height_idx": {
+          "name": "bme_ledger_records_burned_denom_height_idx",
+          "columns": [
+            {
+              "expression": "burned_denom",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "height",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bme_ledger_records_minted_denom_height_idx": {
+          "name": "bme_ledger_records_minted_denom_height_idx",
+          "columns": [
+            {
+              "expression": "minted_denom",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "height",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bme_ledger_records_burned_from_account_id_accounts_id_fk": {
+          "name": "bme_ledger_records_burned_from_account_id_accounts_id_fk",
+          "tableFrom": "bme_ledger_records",
+          "tableTo": "accounts",
+          "schemaTo": "cosmos",
+          "columnsFrom": [
+            "burned_from_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bme_ledger_records_minted_to_account_id_accounts_id_fk": {
+          "name": "bme_ledger_records_minted_to_account_id_accounts_id_fk",
+          "tableFrom": "bme_ledger_records",
+          "tableTo": "accounts",
+          "schemaTo": "cosmos",
+          "columnsFrom": [
+            "minted_to_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bme_ledger_records_record_height_sequence_denom_to_denom_source_pk": {
+          "name": "bme_ledger_records_record_height_sequence_denom_to_denom_source_pk",
+          "columns": [
+            "record_height",
+            "sequence",
+            "denom",
+            "to_denom",
+            "source"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "akash.bme_status_changes": {
+      "name": "bme_status_changes",
+      "schema": "akash",
+      "columns": {
+        "height": {
+          "name": "height",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_status": {
+          "name": "previous_status",
+          "type": "bme_mint_status",
+          "typeSchema": "akash",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "new_status": {
+          "name": "new_status",
+          "type": "bme_mint_status",
+          "typeSchema": "akash",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collateral_ratio": {
+          "name": "collateral_ratio",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "bme_status_changes_height_ordinal_pk": {
+          "name": "bme_status_changes_height_ordinal_pk",
+          "columns": [
+            "height",
+            "ordinal"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "akash.daily_prices": {
+      "name": "daily_prices",
+      "schema": "akash",
+      "columns": {
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "denom": {
+          "name": "denom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "daily_prices_date_denom_pk": {
+          "name": "daily_prices_date_denom_pk",
+          "columns": [
+            "date",
+            "denom"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "cosmos.delegations": {
+      "name": "delegations",
+      "schema": "cosmos",
+      "columns": {
+        "delegator_account_id": {
+          "name": "delegator_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "validator_operator_address": {
+          "name": "validator_operator_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shares": {
+          "name": "shares",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "delegations_delegator_account_id_accounts_id_fk": {
+          "name": "delegations_delegator_account_id_accounts_id_fk",
+          "tableFrom": "delegations",
+          "tableTo": "accounts",
+          "schemaTo": "cosmos",
+          "columnsFrom": [
+            "delegator_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "delegations_delegator_account_id_validator_operator_address_pk": {
+          "name": "delegations_delegator_account_id_validator_operator_address_pk",
+          "columns": [
+            "delegator_account_id",
+            "validator_operator_address"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "akash.deployment_events": {
+      "name": "deployment_events",
+      "schema": "akash",
+      "columns": {
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tx_index": {
+          "name": "tx_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "msg_index": {
+          "name": "msg_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "deployment_event_type",
+          "typeSchema": "akash",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "deployment_events_deployment_id_deployments_id_fk": {
+          "name": "deployment_events_deployment_id_deployments_id_fk",
+          "tableFrom": "deployment_events",
+          "tableTo": "deployments",
+          "schemaTo": "akash",
+          "columnsFrom": [
+            "deployment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "deployment_events_deployment_id_height_ordinal_pk": {
+          "name": "deployment_events_deployment_id_height_ordinal_pk",
+          "columns": [
+            "deployment_id",
+            "height",
+            "ordinal"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "akash.deployment_group_resources": {
+      "name": "deployment_group_resources",
+      "schema": "akash",
+      "columns": {
+        "deployment_group_id": {
+          "name": "deployment_group_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idx": {
+          "name": "idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cpu_units": {
+          "name": "cpu_units",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gpu_units": {
+          "name": "gpu_units",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gpu_vendor": {
+          "name": "gpu_vendor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gpu_model": {
+          "name": "gpu_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_bytes": {
+          "name": "memory_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ephemeral_storage_bytes": {
+          "name": "ephemeral_storage_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persistent_storage_bytes": {
+          "name": "persistent_storage_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_denom": {
+          "name": "price_denom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "deployment_group_resources_deployment_group_id_deployment_groups_id_fk": {
+          "name": "deployment_group_resources_deployment_group_id_deployment_groups_id_fk",
+          "tableFrom": "deployment_group_resources",
+          "tableTo": "deployment_groups",
+          "schemaTo": "akash",
+          "columnsFrom": [
+            "deployment_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "deployment_group_resources_deployment_group_id_idx_pk": {
+          "name": "deployment_group_resources_deployment_group_id_idx_pk",
+          "columns": [
+            "deployment_group_id",
+            "idx"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "akash.deployment_groups": {
+      "name": "deployment_groups",
+      "schema": "akash",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gseq": {
+          "name": "gseq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "group_state",
+          "typeSchema": "akash",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "closed_height": {
+          "name": "closed_height",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "deployment_groups_deployment_gseq_idx": {
+          "name": "deployment_groups_deployment_gseq_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "gseq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_groups_deployment_id_deployments_id_fk": {
+          "name": "deployment_groups_deployment_id_deployments_id_fk",
+          "tableFrom": "deployment_groups",
+          "tableTo": "deployments",
+          "schemaTo": "akash",
+          "columnsFrom": [
+            "deployment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "akash.deployments": {
+      "name": "deployments",
+      "schema": "akash",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_account_id": {
+          "name": "owner_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dseq": {
+          "name": "dseq",
+          "type": "numeric(20, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "denom": {
+          "name": "denom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deposit": {
+          "name": "deposit",
+          "type": "numeric(38, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "withdrawn_amount": {
+          "name": "withdrawn_amount",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_rate": {
+          "name": "block_rate",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "last_withdraw_height": {
+          "name": "last_withdraw_height",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_processed_height": {
+          "name": "last_processed_height",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_height": {
+          "name": "created_height",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closed_height": {
+          "name": "closed_height",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "close_reason": {
+          "name": "close_reason",
+          "type": "deployment_close_reason",
+          "typeSchema": "akash",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpu_units": {
+          "name": "cpu_units",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gpu_units": {
+          "name": "gpu_units",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_bytes": {
+          "name": "memory_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ephemeral_storage_bytes": {
+          "name": "ephemeral_storage_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persistent_storage_bytes": {
+          "name": "persistent_storage_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "deployments_owner_dseq_idx": {
+          "name": "deployments_owner_dseq_idx",
+          "columns": [
+            {
+              "expression": "owner_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dseq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployments_owner_created_idx": {
+          "name": "deployments_owner_created_idx",
+          "columns": [
+            {
+              "expression": "owner_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_height",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployments_open_idx": {
+          "name": "deployments_open_idx",
+          "columns": [
+            {
+              "expression": "created_height",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"akash\".\"deployments\".\"closed_height\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployments_owner_account_id_accounts_id_fk": {
+          "name": "deployments_owner_account_id_accounts_id_fk",
+          "tableFrom": "deployments",
+          "tableTo": "accounts",
+          "schemaTo": "cosmos",
+          "columnsFrom": [
+            "owner_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.indexer_state": {
+      "name": "indexer_state",
+      "schema": "",
+      "columns": {
+        "stream": {
+          "name": "stream",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_height": {
+          "name": "last_height",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "akash.leases": {
+      "name": "leases",
+      "schema": "akash",
+      "columns": {
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_group_id": {
+          "name": "deployment_group_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gseq": {
+          "name": "gseq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oseq": {
+          "name": "oseq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bseq": {
+          "name": "bseq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "denom": {
+          "name": "denom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "withdrawn_amount": {
+          "name": "withdrawn_amount",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "predicted_closed_height": {
+          "name": "predicted_closed_height",
+          "type": "numeric(30, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_height": {
+          "name": "created_height",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closed_height": {
+          "name": "closed_height",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpu_units": {
+          "name": "cpu_units",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gpu_units": {
+          "name": "gpu_units",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_bytes": {
+          "name": "memory_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ephemeral_storage_bytes": {
+          "name": "ephemeral_storage_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persistent_storage_bytes": {
+          "name": "persistent_storage_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "leases_provider_idx": {
+          "name": "leases_provider_idx",
+          "columns": [
+            {
+              "expression": "provider_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "closed_height",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_height",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "leases_open_idx": {
+          "name": "leases_open_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"akash\".\"leases\".\"closed_height\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "leases_deployment_id_deployments_id_fk": {
+          "name": "leases_deployment_id_deployments_id_fk",
+          "tableFrom": "leases",
+          "tableTo": "deployments",
+          "schemaTo": "akash",
+          "columnsFrom": [
+            "deployment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "leases_deployment_group_id_deployment_groups_id_fk": {
+          "name": "leases_deployment_group_id_deployment_groups_id_fk",
+          "tableFrom": "leases",
+          "tableTo": "deployment_groups",
+          "schemaTo": "akash",
+          "columnsFrom": [
+            "deployment_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "leases_provider_account_id_accounts_id_fk": {
+          "name": "leases_provider_account_id_accounts_id_fk",
+          "tableFrom": "leases",
+          "tableTo": "accounts",
+          "schemaTo": "cosmos",
+          "columnsFrom": [
+            "provider_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "leases_deployment_id_gseq_oseq_bseq_provider_account_id_pk": {
+          "name": "leases_deployment_id_gseq_oseq_bseq_provider_account_id_pk",
+          "columns": [
+            "deployment_id",
+            "gseq",
+            "oseq",
+            "bseq",
+            "provider_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "cosmos.message_dead_letters": {
+      "name": "message_dead_letters",
+      "schema": "cosmos",
+      "columns": {
+        "height": {
+          "name": "height",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tx_index": {
+          "name": "tx_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw": {
+          "name": "raw",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "message_dead_letters_type_id_idx": {
+          "name": "message_dead_letters_type_id_idx",
+          "columns": [
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_dead_letters_type_id_message_types_id_fk": {
+          "name": "message_dead_letters_type_id_message_types_id_fk",
+          "tableFrom": "message_dead_letters",
+          "tableTo": "message_types",
+          "schemaTo": "cosmos",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "message_dead_letters_height_tx_index_index_pk": {
+          "name": "message_dead_letters_height_tx_index_index_pk",
+          "columns": [
+            "height",
+            "tx_index",
+            "index"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "cosmos.message_types": {
+      "name": "message_types",
+      "schema": "cosmos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "message_types_type_idx": {
+          "name": "message_types_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "cosmos.messages": {
+      "name": "messages",
+      "schema": "cosmos",
+      "columns": {
+        "height": {
+          "name": "height",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tx_index": {
+          "name": "tx_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "messages_type_id_idx": {
+          "name": "messages_type_id_idx",
+          "columns": [
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_type_id_message_types_id_fk": {
+          "name": "messages_type_id_message_types_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "message_types",
+          "schemaTo": "cosmos",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "messages_height_tx_index_index_pk": {
+          "name": "messages_height_tx_index_index_pk",
+          "columns": [
+            "height",
+            "tx_index",
+            "index"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "akash.network_rollups": {
+      "name": "network_rollups",
+      "schema": "akash",
+      "columns": {
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "close_height": {
+          "name": "close_height",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "close_at": {
+          "name": "close_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_lease_count": {
+          "name": "active_lease_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_lease_count": {
+          "name": "total_lease_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "daily_lease_count": {
+          "name": "daily_lease_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_provider_count": {
+          "name": "active_provider_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_cpu_units": {
+          "name": "active_cpu_units",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_gpu_units": {
+          "name": "active_gpu_units",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_memory_bytes": {
+          "name": "active_memory_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_ephemeral_storage_bytes": {
+          "name": "active_ephemeral_storage_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_persistent_storage_bytes": {
+          "name": "active_persistent_storage_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_uakt_spent": {
+          "name": "total_uakt_spent",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_uusdc_spent": {
+          "name": "total_uusdc_spent",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_uact_spent": {
+          "name": "total_uact_spent",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "daily_uakt_spent": {
+          "name": "daily_uakt_spent",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "daily_uusdc_spent": {
+          "name": "daily_uusdc_spent",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "daily_uact_spent": {
+          "name": "daily_uact_spent",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "daily_usd_spent": {
+          "name": "daily_usd_spent",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "akt_price_used": {
+          "name": "akt_price_used",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usd_computed_at": {
+          "name": "usd_computed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "akash.network_state": {
+      "name": "network_state",
+      "schema": "akash",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_aggregated_height": {
+          "name": "last_aggregated_height",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_aggregated_at": {
+          "name": "last_aggregated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_lease_count": {
+          "name": "active_lease_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_lease_count": {
+          "name": "total_lease_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "active_provider_count": {
+          "name": "active_provider_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "active_cpu_units": {
+          "name": "active_cpu_units",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "active_gpu_units": {
+          "name": "active_gpu_units",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "active_memory_bytes": {
+          "name": "active_memory_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "active_ephemeral_storage_bytes": {
+          "name": "active_ephemeral_storage_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "active_persistent_storage_bytes": {
+          "name": "active_persistent_storage_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_uakt_spent": {
+          "name": "total_uakt_spent",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total_uusdc_spent": {
+          "name": "total_uusdc_spent",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total_uact_spent": {
+          "name": "total_uact_spent",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "network_state_singleton_check": {
+          "name": "network_state_singleton_check",
+          "value": "\"akash\".\"network_state\".\"id\" = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "cosmos.proposal_deposits": {
+      "name": "proposal_deposits",
+      "schema": "cosmos",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depositor_account_id": {
+          "name": "depositor_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "proposal_deposits_depositor_account_id_accounts_id_fk": {
+          "name": "proposal_deposits_depositor_account_id_accounts_id_fk",
+          "tableFrom": "proposal_deposits",
+          "tableTo": "accounts",
+          "schemaTo": "cosmos",
+          "columnsFrom": [
+            "depositor_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "proposal_deposits_proposal_id_depositor_account_id_height_pk": {
+          "name": "proposal_deposits_proposal_id_depositor_account_id_height_pk",
+          "columns": [
+            "proposal_id",
+            "depositor_account_id",
+            "height"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "cosmos.proposal_votes": {
+      "name": "proposal_votes",
+      "schema": "cosmos",
+      "columns": {
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_account_id": {
+          "name": "voter_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "proposal_votes_voter_account_id_accounts_id_fk": {
+          "name": "proposal_votes_voter_account_id_accounts_id_fk",
+          "tableFrom": "proposal_votes",
+          "tableTo": "accounts",
+          "schemaTo": "cosmos",
+          "columnsFrom": [
+            "voter_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "proposal_votes_proposal_id_voter_account_id_pk": {
+          "name": "proposal_votes_proposal_id_voter_account_id_pk",
+          "columns": [
+            "proposal_id",
+            "voter_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "cosmos.proposals": {
+      "name": "proposals",
+      "schema": "cosmos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "proposer_account_id": {
+          "name": "proposer_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "messages": {
+          "name": "messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "proposal_status",
+          "typeSchema": "cosmos",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submit_time": {
+          "name": "submit_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deposit_end_time": {
+          "name": "deposit_end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voting_start_time": {
+          "name": "voting_start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voting_end_time": {
+          "name": "voting_end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_deposit": {
+          "name": "total_deposit",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "final_tally_yes": {
+          "name": "final_tally_yes",
+          "type": "numeric(38, 0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "final_tally_abstain": {
+          "name": "final_tally_abstain",
+          "type": "numeric(38, 0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "final_tally_no": {
+          "name": "final_tally_no",
+          "type": "numeric(38, 0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "final_tally_no_with_veto": {
+          "name": "final_tally_no_with_veto",
+          "type": "numeric(38, 0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submit_height": {
+          "name": "submit_height",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "proposals_proposer_account_id_accounts_id_fk": {
+          "name": "proposals_proposer_account_id_accounts_id_fk",
+          "tableFrom": "proposals",
+          "tableTo": "accounts",
+          "schemaTo": "cosmos",
+          "columnsFrom": [
+            "proposer_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "akash.provider_audit_signatures": {
+      "name": "provider_audit_signatures",
+      "schema": "akash",
+      "columns": {
+        "owner_account_id": {
+          "name": "owner_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auditor_account_id": {
+          "name": "auditor_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "provider_audit_signatures_owner_account_id_accounts_id_fk": {
+          "name": "provider_audit_signatures_owner_account_id_accounts_id_fk",
+          "tableFrom": "provider_audit_signatures",
+          "tableTo": "accounts",
+          "schemaTo": "cosmos",
+          "columnsFrom": [
+            "owner_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "provider_audit_signatures_auditor_account_id_accounts_id_fk": {
+          "name": "provider_audit_signatures_auditor_account_id_accounts_id_fk",
+          "tableFrom": "provider_audit_signatures",
+          "tableTo": "accounts",
+          "schemaTo": "cosmos",
+          "columnsFrom": [
+            "auditor_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "provider_audit_signatures_owner_account_id_auditor_account_id_key_pk": {
+          "name": "provider_audit_signatures_owner_account_id_auditor_account_id_key_pk",
+          "columns": [
+            "owner_account_id",
+            "auditor_account_id",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "akash.providers": {
+      "name": "providers",
+      "schema": "akash",
+      "columns": {
+        "owner_account_id": {
+          "name": "owner_account_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "host_uri": {
+          "name": "host_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_processed_height": {
+          "name": "last_processed_height",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_height": {
+          "name": "created_height",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_height": {
+          "name": "updated_height",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_height": {
+          "name": "deleted_height",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "providers_owner_account_id_accounts_id_fk": {
+          "name": "providers_owner_account_id_accounts_id_fk",
+          "tableFrom": "providers",
+          "tableTo": "accounts",
+          "schemaTo": "cosmos",
+          "columnsFrom": [
+            "owner_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "cosmos.transactions": {
+      "name": "transactions",
+      "schema": "cosmos",
+      "columns": {
+        "height": {
+          "name": "height",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gas_used": {
+          "name": "gas_used",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gas_wanted": {
+          "name": "gas_wanted",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee": {
+          "name": "fee",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "transactions_hash_idx": {
+          "name": "transactions_hash_idx",
+          "columns": [
+            {
+              "expression": "hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "transactions_height_index_pk": {
+          "name": "transactions_height_index_pk",
+          "columns": [
+            "height",
+            "index"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "cosmos.unbonding_delegations": {
+      "name": "unbonding_delegations",
+      "schema": "cosmos",
+      "columns": {
+        "delegator_account_id": {
+          "name": "delegator_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "validator_operator_address": {
+          "name": "validator_operator_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creation_height": {
+          "name": "creation_height",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completion_time": {
+          "name": "completion_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initial_balance": {
+          "name": "initial_balance",
+          "type": "numeric(38, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "numeric(38, 0)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "unbonding_delegations_delegator_account_id_accounts_id_fk": {
+          "name": "unbonding_delegations_delegator_account_id_accounts_id_fk",
+          "tableFrom": "unbonding_delegations",
+          "tableTo": "accounts",
+          "schemaTo": "cosmos",
+          "columnsFrom": [
+            "delegator_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "unbonding_delegations_delegator_account_id_validator_operator_address_creation_height_pk": {
+          "name": "unbonding_delegations_delegator_account_id_validator_operator_address_creation_height_pk",
+          "columns": [
+            "delegator_account_id",
+            "validator_operator_address",
+            "creation_height"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "cosmos.validators": {
+      "name": "validators",
+      "schema": "cosmos",
+      "columns": {
+        "operator_address": {
+          "name": "operator_address",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_address": {
+          "name": "account_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hex_address": {
+          "name": "hex_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moniker": {
+          "name": "moniker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity": {
+          "name": "identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "security_contact": {
+          "name": "security_contact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commission_rate": {
+          "name": "commission_rate",
+          "type": "numeric(20, 18)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commission_max_rate": {
+          "name": "commission_max_rate",
+          "type": "numeric(20, 18)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commission_max_change_rate": {
+          "name": "commission_max_change_rate",
+          "type": "numeric(20, 18)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_self_delegation": {
+          "name": "min_self_delegation",
+          "type": "numeric(38, 0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jailed": {
+          "name": "jailed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "validator_status",
+          "typeSchema": "cosmos",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "numeric(38, 0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delegator_shares": {
+          "name": "delegator_shares",
+          "type": "numeric(38, 18)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unbonding_height": {
+          "name": "unbonding_height",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unbonding_time": {
+          "name": "unbonding_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "cosmos.account_tx_role": {
+      "name": "account_tx_role",
+      "schema": "cosmos",
+      "values": [
+        "signer",
+        "sender",
+        "receiver"
+      ]
+    },
+    "cosmos.balance_change_reason": {
+      "name": "balance_change_reason",
+      "schema": "cosmos",
+      "values": [
+        "genesis",
+        "transfer",
+        "fee",
+        "reward",
+        "commission",
+        "slash",
+        "gov",
+        "ibc",
+        "escrow",
+        "bme",
+        "mint",
+        "burn",
+        "staking"
+      ]
+    },
+    "akash.bid_state": {
+      "name": "bid_state",
+      "schema": "akash",
+      "values": [
+        "open",
+        "active",
+        "closed"
+      ]
+    },
+    "akash.bme_mint_status": {
+      "name": "bme_mint_status",
+      "schema": "akash",
+      "values": [
+        "mint_status_unspecified",
+        "mint_status_healthy",
+        "mint_status_warning",
+        "mint_status_halt_cr",
+        "mint_status_halt_oracle"
+      ]
+    },
+    "akash.deployment_close_reason": {
+      "name": "deployment_close_reason",
+      "schema": "akash",
+      "values": [
+        "close_message",
+        "overdrawn",
+        "close_event"
+      ]
+    },
+    "akash.deployment_event_type": {
+      "name": "deployment_event_type",
+      "schema": "akash",
+      "values": [
+        "created",
+        "deposited",
+        "updated",
+        "closed",
+        "group_closed",
+        "group_paused",
+        "group_started",
+        "bid_created",
+        "bid_closed",
+        "lease_created",
+        "lease_closed",
+        "lease_withdrawn"
+      ]
+    },
+    "akash.group_state": {
+      "name": "group_state",
+      "schema": "akash",
+      "values": [
+        "open",
+        "paused",
+        "closed"
+      ]
+    },
+    "cosmos.proposal_status": {
+      "name": "proposal_status",
+      "schema": "cosmos",
+      "values": [
+        "deposit_period",
+        "voting_period",
+        "passed",
+        "rejected",
+        "failed"
+      ]
+    },
+    "cosmos.validator_status": {
+      "name": "validator_status",
+      "schema": "cosmos",
+      "values": [
+        "unbonded",
+        "unbonding",
+        "bonded"
+      ]
+    },
+    "cosmos.vote_option": {
+      "name": "vote_option",
+      "schema": "cosmos",
+      "values": [
+        "yes",
+        "abstain",
+        "no",
+        "no_with_veto"
+      ]
+    }
+  },
+  "schemas": {
+    "akash": "akash",
+    "cosmos": "cosmos"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/chain-indexer/drizzle/meta/_journal.json
+++ b/apps/chain-indexer/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1786949585273,
       "tag": "0008_good_galactus",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1786993129072,
+      "tag": "0009_loud_blue_marvel",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/chain-indexer/package.json
+++ b/apps/chain-indexer/package.json
@@ -12,6 +12,7 @@
     "format": "prettier --write ./*.{ts,js,json} **/*.{ts,js,json}",
     "lint": "eslint .",
     "migration:gen": "drizzle-kit generate",
+    "network:recompute-usd": "npm run build && node --enable-source-maps ./dist/recompute-usd.js",
     "prod": "node --enable-source-maps --require ./dist/instrumentation.js ./dist/server.js",
     "reconcile": "npm run build && node --enable-source-maps ./dist/reconcile.js",
     "start": "tsup --watch",

--- a/apps/chain-indexer/src/akash/akash-writer.service.spec.ts
+++ b/apps/chain-indexer/src/akash/akash-writer.service.spec.ts
@@ -5,6 +5,7 @@ import { mock } from "vitest-mock-extended";
 
 import type { AkashBlockChanges, AkashChangeBody } from "@src/akash/akash-changes";
 import { AkashWriter } from "@src/akash/akash-writer.service";
+import { decFromInt } from "@src/akash/dec";
 import { Bids, DeploymentEvents, DeploymentGroupResources, DeploymentGroups, Deployments, Leases } from "@src/db/schema";
 import type { ChainTransaction } from "@src/providers/db.provider";
 import type { LoggerService } from "@src/providers/logging.provider";
@@ -23,16 +24,17 @@ describe(AkashWriter.name, () => {
   it("does nothing for blocks without akash changes", async () => {
     const { writer, tx, inserts, selects } = setup();
 
-    await writer.write(tx, [block(100, [])], ACCOUNT_IDS);
+    const { networkDeltas } = await writer.write(tx, [block(100, [])], ACCOUNT_IDS);
 
     expect(inserts).toEqual([]);
     expect(selects).toEqual([]);
+    expect(networkDeltas).toEqual([]);
   });
 
   it("persists a full lifecycle batch as one consistent set of rows", async () => {
     const { writer, tx, inserts, upserts } = setup();
 
-    await writer.write(
+    const { networkDeltas } = await writer.write(
       tx,
       [block(100, [create(), bidCreated("10")]), block(110, [{ kind: "leaseCreated", key: LEASE_KEY }]), block(200, [{ kind: "deploymentClosed", key: KEY }])],
       ACCOUNT_IDS
@@ -83,6 +85,11 @@ describe(AkashWriter.name, () => {
 
     const deploymentUpsert = upserts.find(upsert => upsert.table === Deployments);
     expect(whereSql(deploymentUpsert?.config.setWhere as SQL)).toContain('excluded.last_processed_height >= "akash"."deployments"."last_processed_height"');
+
+    expect(networkDeltas).toEqual([
+      expect.objectContaining({ height: 110, leasesCreated: 1, activeLeaseDelta: 1, cpuUnitsDelta: 2000, earnedDeltaByDenom: new Map() }),
+      expect.objectContaining({ height: 200, activeLeaseDelta: -1, cpuUnitsDelta: -2000, earnedDeltaByDenom: new Map([["uakt", decFromInt(900)]]) })
+    ]);
   });
 
   it("skips flushing entirely when every block is at or below the stored watermark", async () => {
@@ -90,15 +97,16 @@ describe(AkashWriter.name, () => {
       deployments: [deploymentRow({ lastProcessedHeight: 500 })]
     });
 
-    await writer.write(tx, [block(400, [{ kind: "deploymentDeposited", key: KEY, amount: "10", depositor: null }])], ACCOUNT_IDS);
+    const { networkDeltas } = await writer.write(tx, [block(400, [{ kind: "deploymentDeposited", key: KEY, amount: "10", depositor: null }])], ACCOUNT_IDS);
 
     expect(inserts).toEqual([]);
+    expect(networkDeltas).toEqual([]);
   });
 
   it("ignores provider changes entirely", async () => {
     const { writer, tx, inserts, selects, logger } = setup();
 
-    await writer.write(
+    const { networkDeltas } = await writer.write(
       tx,
       [block(100, [{ kind: "providerCreated", owner: OWNER, hostUri: "https://x", email: null, website: null, attributes: [] }])],
       ACCOUNT_IDS
@@ -106,6 +114,7 @@ describe(AkashWriter.name, () => {
 
     expect(inserts).toEqual([]);
     expect(selects).toEqual([]);
+    expect(networkDeltas).toEqual([]);
     expect(logger.warn).not.toHaveBeenCalled();
   });
 

--- a/apps/chain-indexer/src/akash/akash-writer.service.ts
+++ b/apps/chain-indexer/src/akash/akash-writer.service.ts
@@ -7,6 +7,8 @@ import { isProviderChange } from "@src/akash/akash-changes";
 import { decFromString, decToString } from "@src/akash/dec";
 import type { BidStateValue, DeploymentAggState, GroupStateValue, ReducerWarning } from "@src/akash/deployment-reducer";
 import { applyBlockChanges, stateKey } from "@src/akash/deployment-reducer";
+import type { NetworkBlockDelta } from "@src/akash/network-delta";
+import { diffNetworkDelta, isEmptyNetworkDelta, snapshotNetworkState } from "@src/akash/network-delta";
 import { sumLeaseRate } from "@src/akash/settlement";
 import { insertChunked } from "@src/db/insert-chunked";
 import { Accounts, Bids, DeploymentEvents, DeploymentGroupResources, DeploymentGroups, Deployments, Leases } from "@src/db/schema";
@@ -37,24 +39,33 @@ export class AkashWriter {
     this.#logger.setContext("AKASH_WRITER");
   }
 
-  async write(tx: ChainTransaction, blocks: AkashBlockChanges[], accountIds: Map<string, number>): Promise<void> {
+  async write(tx: ChainTransaction, blocks: AkashBlockChanges[], accountIds: Map<string, number>): Promise<{ networkDeltas: NetworkBlockDelta[] }> {
     const withChanges = blocks.filter(block => block.changes.length > 0);
     if (withChanges.length === 0) {
-      return;
+      return { networkDeltas: [] };
     }
 
     const keyed = this.#collectKeys(withChanges, accountIds);
     if (keyed.length === 0) {
-      return;
+      return { networkDeltas: [] };
     }
     const { states, deploymentIds, groupIds, loadedAddressIds } = await this.#loadStates(tx, keyed);
 
-    const warnings = withChanges.flatMap(block => applyBlockChanges(states, block));
+    const warnings: ReducerWarning[] = [];
+    const networkDeltas: NetworkBlockDelta[] = [];
+    for (const block of withChanges) {
+      const before = snapshotNetworkState(states, block);
+      warnings.push(...applyBlockChanges(states, block));
+      const delta = diffNetworkDelta(before, states, block);
+      if (!isEmptyNetworkDelta(delta)) {
+        networkDeltas.push(delta);
+      }
+    }
     this.#logWarnings(warnings);
 
     const touched = [...states.values()].filter(state => state.touched);
     if (touched.length === 0) {
-      return;
+      return { networkDeltas };
     }
 
     /** Providers of bids and leases loaded from prior batches aren't in this batch's interned map, so their ids come from the loaded rows. */
@@ -66,6 +77,8 @@ export class AkashWriter {
     await this.#flushBids(tx, touched, addressIds, deploymentIds);
     await this.#flushLeases(tx, touched, addressIds, deploymentIds, groupIds);
     await this.#flushEvents(tx, touched, deploymentIds);
+
+    return { networkDeltas };
   }
 
   /** Deterministic (ownerAccountId, dseq) order for both the row locks and the flush statements, so concurrent writers cannot deadlock. */

--- a/apps/chain-indexer/src/akash/network-delta.spec.ts
+++ b/apps/chain-indexer/src/akash/network-delta.spec.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from "vitest";
+
+import type { AkashBlockChanges, AkashChangeBody, NormalizedGroup } from "@src/akash/akash-changes";
+import { decFromInt } from "@src/akash/dec";
+import type { DeploymentAggState } from "@src/akash/deployment-reducer";
+import { applyBlockChanges } from "@src/akash/deployment-reducer";
+import type { NetworkBlockDelta } from "@src/akash/network-delta";
+import { diffNetworkDelta, isEmptyNetworkDelta, snapshotNetworkState } from "@src/akash/network-delta";
+
+const OWNER = "akash1owner";
+const PROVIDER = "akash1prov";
+const KEY = { owner: OWNER, dseq: "42" };
+const LEASE_KEY = { ...KEY, gseq: 1, oseq: 1, bseq: 0, provider: PROVIDER };
+const BLOCK_TIME = new Date("2026-08-13T00:00:00Z");
+
+describe("networkDelta", () => {
+  it("counts a created lease with its own group's resource totals", () => {
+    const { states, fold } = setup();
+    fold(block(100, [create({ groups: twoGroups() }), bidCreated("10")]));
+
+    const delta = fold(block(110, [leaseCreated()]));
+
+    expect(delta).toEqual<NetworkBlockDelta>({
+      height: 110,
+      leasesCreated: 1,
+      activeLeaseDelta: 1,
+      cpuUnitsDelta: 1000 * 2,
+      gpuUnitsDelta: 0 * 2,
+      memoryBytesDelta: 1024 * 2,
+      ephemeralStorageBytesDelta: 100 * 2,
+      persistentStorageBytesDelta: 50 * 2,
+      earnedDeltaByDenom: new Map()
+    });
+    expect(states.size).toBe(1);
+  });
+
+  it("removes resources and recognizes settled earnings when a lease closes", () => {
+    const { fold } = setup();
+    fold(block(100, [create({}), bidCreated("10")]));
+    fold(block(110, [leaseCreated()]));
+
+    const delta = fold(block(120, [{ kind: "leaseClosed", key: LEASE_KEY }]));
+
+    expect(delta.leasesCreated).toBe(0);
+    expect(delta.activeLeaseDelta).toBe(-1);
+    expect(delta.cpuUnitsDelta).toBe(-2000);
+    expect(delta.earnedDeltaByDenom).toEqual(new Map([["uakt", decFromInt(10 * 10)]]));
+  });
+
+  it("nets out resources but still counts the creation when a lease opens and closes in one block", () => {
+    const { fold } = setup();
+    fold(block(100, [create({}), bidCreated("10")]));
+
+    const delta = fold(block(110, [leaseCreated(), { kind: "leaseClosed", key: LEASE_KEY }]));
+
+    expect(delta.leasesCreated).toBe(1);
+    expect(delta.activeLeaseDelta).toBe(0);
+    expect(delta.cpuUnitsDelta).toBe(0);
+    expect(delta.gpuUnitsDelta).toBe(0);
+  });
+
+  it("recognizes accrued earnings on withdrawal without touching resources", () => {
+    const { fold } = setup();
+    fold(block(100, [create({}), bidCreated("10")]));
+    fold(block(110, [leaseCreated()]));
+
+    const delta = fold(block(150, [{ kind: "leaseWithdrawn", key: LEASE_KEY }]));
+
+    expect(delta.activeLeaseDelta).toBe(0);
+    expect(delta.cpuUnitsDelta).toBe(0);
+    expect(delta.earnedDeltaByDenom).toEqual(new Map([["uakt", decFromInt(40 * 10)]]));
+  });
+
+  it("excludes the close-time fractional refund from earnings", () => {
+    const { fold } = setup();
+    fold(block(100, [create({ deposit: "500000" }), bidCreated("2.349334")]));
+    fold(block(110, [leaseCreated()]));
+
+    const delta = fold(block(122, [{ kind: "leaseClosed", key: LEASE_KEY }]));
+
+    expect(delta.earnedDeltaByDenom).toEqual(new Map([["uakt", decFromInt(28)]]));
+  });
+
+  it("keeps earnings of concurrent deployments separate per denom", () => {
+    const { fold } = setup();
+    const usdcKey = { owner: OWNER, dseq: "43" };
+    const usdcLeaseKey = { ...usdcKey, gseq: 1, oseq: 1, bseq: 0, provider: PROVIDER };
+    fold(
+      block(100, [
+        create({}),
+        bidCreated("10"),
+        { ...create({ denom: "ibc/170C677610AC31DF0904FFE09CD3B5C657492170E7E52372E48756B71E56F2F1" }), key: usdcKey },
+        { kind: "bidCreated", key: usdcLeaseKey, price: "5", priceDenom: "uusdc" }
+      ])
+    );
+    fold(block(110, [leaseCreated(), { kind: "leaseCreated", key: usdcLeaseKey }]));
+
+    const delta = fold(
+      block(120, [
+        { kind: "leaseWithdrawn", key: LEASE_KEY },
+        { kind: "leaseWithdrawn", key: usdcLeaseKey }
+      ])
+    );
+
+    expect(delta.earnedDeltaByDenom).toEqual(
+      new Map([
+        ["uakt", decFromInt(100)],
+        ["uusdc", decFromInt(50)]
+      ])
+    );
+  });
+
+  it("produces an empty delta for a provider-only block", () => {
+    const { states } = setup();
+
+    const before = snapshotNetworkState(states, block(100, [{ kind: "providerDeleted", owner: OWNER }]));
+    applyBlockChanges(states, block(100, [{ kind: "providerDeleted", owner: OWNER }]));
+    const delta = diffNetworkDelta(before, states, block(100, []));
+
+    expect(before.size).toBe(0);
+    expect(isEmptyNetworkDelta(delta)).toBe(true);
+  });
+
+  it("produces an empty delta when the watermark skips a replayed block", () => {
+    const { fold } = setup();
+    fold(block(100, [create({}), bidCreated("10")]));
+    fold(block(110, [leaseCreated()]));
+
+    const delta = fold(block(110, [leaseCreated()]));
+
+    expect(isEmptyNetworkDelta(delta)).toBe(true);
+  });
+
+  function setup() {
+    const states = new Map<string, DeploymentAggState>();
+    const fold = (blockChanges: AkashBlockChanges): NetworkBlockDelta => {
+      const before = snapshotNetworkState(states, blockChanges);
+      applyBlockChanges(states, blockChanges);
+      return diffNetworkDelta(before, states, blockChanges);
+    };
+    return { states, fold };
+  }
+
+  function block(height: number, bodies: AkashChangeBody[]): AkashBlockChanges {
+    return {
+      height,
+      datetime: BLOCK_TIME,
+      changes: bodies.map((body, index) => ({ ...body, txIndex: 0, msgIndex: index }))
+    };
+  }
+
+  function create(input: { deposit?: string; denom?: string; groups?: NormalizedGroup[] }): AkashChangeBody {
+    return {
+      kind: "deploymentCreated",
+      key: KEY,
+      denom: input.denom ?? "uakt",
+      deposit: input.deposit ?? "5000000",
+      depositor: null,
+      groups: input.groups ?? [group(1, { cpuUnits: 1000, count: 2 })]
+    };
+  }
+
+  function bidCreated(price: string): AkashChangeBody {
+    return { kind: "bidCreated", key: LEASE_KEY, price, priceDenom: "uakt" };
+  }
+
+  function leaseCreated(): AkashChangeBody {
+    return { kind: "leaseCreated", key: LEASE_KEY };
+  }
+
+  function twoGroups(): NormalizedGroup[] {
+    return [
+      group(1, { cpuUnits: 1000, gpuUnits: 0, memoryBytes: 1024, ephemeralStorageBytes: 100, persistentStorageBytes: 50, count: 2 }),
+      group(2, { cpuUnits: 500, gpuUnits: 1, memoryBytes: 2048, ephemeralStorageBytes: 200, persistentStorageBytes: 0, count: 3 })
+    ];
+  }
+
+  function group(gseq: number, resource: Partial<NormalizedGroup["resources"][number]>): NormalizedGroup {
+    return {
+      gseq,
+      resources: [
+        {
+          count: 1,
+          cpuUnits: 0,
+          gpuUnits: 0,
+          gpuVendor: null,
+          gpuModel: null,
+          memoryBytes: 0,
+          ephemeralStorageBytes: 0,
+          persistentStorageBytes: 0,
+          price: "1",
+          priceDenom: "uakt",
+          ...resource
+        }
+      ]
+    };
+  }
+});

--- a/apps/chain-indexer/src/akash/network-delta.ts
+++ b/apps/chain-indexer/src/akash/network-delta.ts
@@ -1,0 +1,146 @@
+import type { AkashBlockChanges } from "@src/akash/akash-changes";
+import { isProviderChange } from "@src/akash/akash-changes";
+import type { DeploymentAggState } from "@src/akash/deployment-reducer";
+import { stateKey } from "@src/akash/deployment-reducer";
+
+/**
+ * One block's contribution to the network aggregates, measured as the change in the deployment
+ * states across the reducer fold. `earnedDeltaByDenom` holds 18-decimal Dec atomics of the change
+ * in cumulative provider earnings — Σ(withdrawn + balance) over leases — which is settlement-exact
+ * and excludes the close-time fractional refund to the owner by construction.
+ */
+export interface NetworkBlockDelta {
+  height: number;
+  leasesCreated: number;
+  activeLeaseDelta: number;
+  cpuUnitsDelta: number;
+  gpuUnitsDelta: number;
+  memoryBytesDelta: number;
+  ephemeralStorageBytesDelta: number;
+  persistentStorageBytesDelta: number;
+  earnedDeltaByDenom: Map<string, bigint>;
+}
+
+export interface DeploymentNetworkSnapshot {
+  leaseCount: number;
+  activeLeaseCount: number;
+  cpuUnits: number;
+  gpuUnits: number;
+  memoryBytes: number;
+  ephemeralStorageBytes: number;
+  persistentStorageBytes: number;
+  earnedByDenom: Map<string, bigint>;
+}
+
+/**
+ * Captures the pre-apply aggregate contribution of every deployment the block's changes reference.
+ * A deployment the reducer has not loaded (it is created by this block) snapshots as empty, so its
+ * whole post-apply state counts as delta.
+ */
+export function snapshotNetworkState(states: Map<string, DeploymentAggState>, block: AkashBlockChanges): Map<string, DeploymentNetworkSnapshot> {
+  const snapshots = new Map<string, DeploymentNetworkSnapshot>();
+  for (const change of block.changes) {
+    if (isProviderChange(change)) {
+      continue;
+    }
+    const key = stateKey(change.key);
+    if (!snapshots.has(key)) {
+      snapshots.set(key, summarizeDeployment(states.get(key)));
+    }
+  }
+  return snapshots;
+}
+
+export function diffNetworkDelta(
+  before: Map<string, DeploymentNetworkSnapshot>,
+  states: Map<string, DeploymentAggState>,
+  block: AkashBlockChanges
+): NetworkBlockDelta {
+  const delta: NetworkBlockDelta = {
+    height: block.height,
+    leasesCreated: 0,
+    activeLeaseDelta: 0,
+    cpuUnitsDelta: 0,
+    gpuUnitsDelta: 0,
+    memoryBytesDelta: 0,
+    ephemeralStorageBytesDelta: 0,
+    persistentStorageBytesDelta: 0,
+    earnedDeltaByDenom: new Map()
+  };
+
+  for (const [key, prior] of before) {
+    const current = summarizeDeployment(states.get(key));
+    delta.leasesCreated += current.leaseCount - prior.leaseCount;
+    delta.activeLeaseDelta += current.activeLeaseCount - prior.activeLeaseCount;
+    delta.cpuUnitsDelta += current.cpuUnits - prior.cpuUnits;
+    delta.gpuUnitsDelta += current.gpuUnits - prior.gpuUnits;
+    delta.memoryBytesDelta += current.memoryBytes - prior.memoryBytes;
+    delta.ephemeralStorageBytesDelta += current.ephemeralStorageBytes - prior.ephemeralStorageBytes;
+    delta.persistentStorageBytesDelta += current.persistentStorageBytes - prior.persistentStorageBytes;
+    accumulateEarnedDelta(delta.earnedDeltaByDenom, current.earnedByDenom, prior.earnedByDenom);
+  }
+
+  return delta;
+}
+
+export function isEmptyNetworkDelta(delta: NetworkBlockDelta): boolean {
+  return (
+    delta.leasesCreated === 0 &&
+    delta.activeLeaseDelta === 0 &&
+    delta.cpuUnitsDelta === 0 &&
+    delta.gpuUnitsDelta === 0 &&
+    delta.memoryBytesDelta === 0 &&
+    delta.ephemeralStorageBytesDelta === 0 &&
+    delta.persistentStorageBytesDelta === 0 &&
+    delta.earnedDeltaByDenom.size === 0
+  );
+}
+
+function summarizeDeployment(state: DeploymentAggState | undefined): DeploymentNetworkSnapshot {
+  const snapshot: DeploymentNetworkSnapshot = {
+    leaseCount: 0,
+    activeLeaseCount: 0,
+    cpuUnits: 0,
+    gpuUnits: 0,
+    memoryBytes: 0,
+    ephemeralStorageBytes: 0,
+    persistentStorageBytes: 0,
+    earnedByDenom: new Map()
+  };
+  if (!state) {
+    return snapshot;
+  }
+
+  snapshot.leaseCount = state.leases.length;
+  for (const lease of state.leases) {
+    const earned = lease.withdrawn + lease.balance;
+    if (earned !== 0n) {
+      snapshot.earnedByDenom.set(lease.denom, (snapshot.earnedByDenom.get(lease.denom) ?? 0n) + earned);
+    }
+    if (lease.closedHeight !== null) {
+      continue;
+    }
+    snapshot.activeLeaseCount += 1;
+    snapshot.cpuUnits += lease.cpuUnits;
+    snapshot.gpuUnits += lease.gpuUnits;
+    snapshot.memoryBytes += lease.memoryBytes;
+    snapshot.ephemeralStorageBytes += lease.ephemeralStorageBytes;
+    snapshot.persistentStorageBytes += lease.persistentStorageBytes;
+  }
+  return snapshot;
+}
+
+function accumulateEarnedDelta(target: Map<string, bigint>, current: Map<string, bigint>, prior: Map<string, bigint>): void {
+  for (const denom of new Set([...current.keys(), ...prior.keys()])) {
+    const change = (current.get(denom) ?? 0n) - (prior.get(denom) ?? 0n);
+    if (change === 0n) {
+      continue;
+    }
+    const next = (target.get(denom) ?? 0n) + change;
+    if (next === 0n) {
+      target.delete(denom);
+    } else {
+      target.set(denom, next);
+    }
+  }
+}

--- a/apps/chain-indexer/src/db/schema.ts
+++ b/apps/chain-indexer/src/db/schema.ts
@@ -3,6 +3,8 @@ import {
   bigint,
   bigserial,
   boolean,
+  check,
+  date,
   index,
   integer,
   jsonb,
@@ -644,4 +646,80 @@ export const BmeCanceledRecords = akashSchema.table(
     denomToMint: text("denom_to_mint").notNull()
   },
   t => [primaryKey({ columns: [t.recordHeight, t.sequence, t.denom, t.toDenom, t.source] }), index("bme_canceled_records_height_idx").on(t.height)]
+);
+
+/**
+ * Singleton current network state, maintained incrementally inside the per-block transaction so
+ * dashboards read one row instead of scanning leases. `last_aggregated_height` is the replay
+ * watermark: blocks at or below it are duplicates and must not be re-applied. Spend totals are
+ * settlement-exact cumulative provider earnings — Σ(withdrawn + balance) over all leases per denom —
+ * not the legacy rate×blocks estimate, so they reconcile exactly against `akash.leases`.
+ */
+export const NetworkState = akashSchema.table(
+  "network_state",
+  {
+    id: integer("id").primaryKey(),
+    lastAggregatedHeight: bigint("last_aggregated_height", { mode: "number" }).notNull(),
+    lastAggregatedAt: timestamp("last_aggregated_at", { withTimezone: true }).notNull(),
+    activeLeaseCount: integer("active_lease_count").notNull().default(0),
+    totalLeaseCount: bigint("total_lease_count", { mode: "number" }).notNull().default(0),
+    activeProviderCount: integer("active_provider_count").notNull().default(0),
+    activeCpuUnits: bigint("active_cpu_units", { mode: "number" }).notNull().default(0),
+    activeGpuUnits: bigint("active_gpu_units", { mode: "number" }).notNull().default(0),
+    activeMemoryBytes: bigint("active_memory_bytes", { mode: "number" }).notNull().default(0),
+    activeEphemeralStorageBytes: bigint("active_ephemeral_storage_bytes", { mode: "number" }).notNull().default(0),
+    activePersistentStorageBytes: bigint("active_persistent_storage_bytes", { mode: "number" }).notNull().default(0),
+    totalUaktSpent: numeric("total_uakt_spent", { precision: 38, scale: 18 }).notNull().default("0"),
+    totalUusdcSpent: numeric("total_uusdc_spent", { precision: 38, scale: 18 }).notNull().default("0"),
+    totalUactSpent: numeric("total_uact_spent", { precision: 38, scale: 18 }).notNull().default("0")
+  },
+  t => [check("network_state_singleton_check", sql`${t.id} = 1`)]
+);
+
+/**
+ * Append-only daily network rollup, one row per UTC day that had blocks, written atomically with the
+ * first block of the following day. Rows carry both close-of-day cumulatives and per-day deltas in
+ * native denoms; `daily_usd_spent` is filled at day close (or restated later) from `daily_prices`,
+ * with `akt_price_used` marking which price the USD was computed with — a price restatement therefore
+ * updates exactly the affected day's row. Cumulative USD is deliberately not stored: it is a window
+ * SUM over this table on read, so restatements never cascade.
+ */
+export const NetworkRollups = akashSchema.table("network_rollups", {
+  date: date("date", { mode: "string" }).primaryKey(),
+  closeHeight: bigint("close_height", { mode: "number" }).notNull(),
+  closeAt: timestamp("close_at", { withTimezone: true }).notNull(),
+  activeLeaseCount: integer("active_lease_count").notNull(),
+  totalLeaseCount: bigint("total_lease_count", { mode: "number" }).notNull(),
+  dailyLeaseCount: integer("daily_lease_count").notNull(),
+  activeProviderCount: integer("active_provider_count").notNull(),
+  activeCpuUnits: bigint("active_cpu_units", { mode: "number" }).notNull(),
+  activeGpuUnits: bigint("active_gpu_units", { mode: "number" }).notNull(),
+  activeMemoryBytes: bigint("active_memory_bytes", { mode: "number" }).notNull(),
+  activeEphemeralStorageBytes: bigint("active_ephemeral_storage_bytes", { mode: "number" }).notNull(),
+  activePersistentStorageBytes: bigint("active_persistent_storage_bytes", { mode: "number" }).notNull(),
+  totalUaktSpent: numeric("total_uakt_spent", { precision: 38, scale: 18 }).notNull(),
+  totalUusdcSpent: numeric("total_uusdc_spent", { precision: 38, scale: 18 }).notNull(),
+  totalUactSpent: numeric("total_uact_spent", { precision: 38, scale: 18 }).notNull(),
+  dailyUaktSpent: numeric("daily_uakt_spent", { precision: 38, scale: 18 }).notNull(),
+  dailyUusdcSpent: numeric("daily_uusdc_spent", { precision: 38, scale: 18 }).notNull(),
+  dailyUactSpent: numeric("daily_uact_spent", { precision: 38, scale: 18 }).notNull(),
+  dailyUsdSpent: numeric("daily_usd_spent", { precision: 38, scale: 18 }),
+  aktPriceUsed: numeric("akt_price_used", { precision: 38, scale: 18 }),
+  usdComputedAt: timestamp("usd_computed_at", { withTimezone: true })
+});
+
+/**
+ * Daily close prices in USD per whole token, populated by the jobs role (CON-807). Rollup USD values
+ * are recomputed for exactly the days whose price differs from the `akt_price_used` they were
+ * computed with, so this table is the single source of truth for restatements.
+ */
+export const DailyPrices = akashSchema.table(
+  "daily_prices",
+  {
+    date: date("date", { mode: "string" }).notNull(),
+    denom: text("denom").notNull(),
+    price: numeric("price", { precision: 38, scale: 18 }).notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow()
+  },
+  t => [primaryKey({ columns: [t.date, t.denom] })]
 );

--- a/apps/chain-indexer/src/network/day-close-usd.service.spec.ts
+++ b/apps/chain-indexer/src/network/day-close-usd.service.spec.ts
@@ -1,0 +1,85 @@
+import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import { DailyPrices } from "@src/db/schema";
+import { DayCloseUsdService } from "@src/network/day-close-usd.service";
+import type { ChainDatabase } from "@src/providers/db.provider";
+import type { LoggerService } from "@src/providers/logging.provider";
+
+describe(DayCloseUsdService.name, () => {
+  it("updates only rollups whose stored price differs from the daily price", async () => {
+    const { service, executor, captured } = setup({ updatedRows: [{ date: "2026-08-14" }, { date: "2026-08-13" }] });
+
+    const dates = await service.recompute(executor);
+
+    expect(dates).toEqual(["2026-08-13", "2026-08-14"]);
+    expect(captured.from).toBe(DailyPrices);
+    expect(renderSql(captured.where as SQL)).toContain('"akash"."daily_prices"."denom" = ');
+    expect(renderSql(captured.where as SQL)).toContain('"akash"."daily_prices"."date" = "akash"."network_rollups"."date"');
+    expect(renderSql(captured.where as SQL)).toContain('"akash"."network_rollups"."akt_price_used" IS DISTINCT FROM "akash"."daily_prices"."price"');
+  });
+
+  it("converts micro-denom daily spend into whole USD at the day price", async () => {
+    const { service, executor, captured } = setup({});
+
+    await service.recompute(executor);
+
+    const set = captured.set as Record<string, unknown>;
+    expect(renderSql(set.dailyUsdSpent as SQL)).toBe(
+      '"akash"."network_rollups"."daily_uakt_spent" / 1000000::numeric * "akash"."daily_prices"."price" + ("akash"."network_rollups"."daily_uusdc_spent" + "akash"."network_rollups"."daily_uact_spent") / 1000000::numeric'
+    );
+    expect(renderSql(set.aktPriceUsed as SQL)).toBe('"akash"."daily_prices"."price"');
+    expect(set.usdComputedAt).toBeInstanceOf(Date);
+  });
+
+  it("scopes the restatement to a single day when a date is given", async () => {
+    const { service, executor, captured } = setup({ updatedRows: [{ date: "2026-08-13" }] });
+
+    const dates = await service.recompute(executor, "2026-08-13");
+
+    expect(dates).toEqual(["2026-08-13"]);
+    expect(renderSql(captured.where as SQL)).toContain('"akash"."network_rollups"."date" = ');
+  });
+
+  it("logs nothing when no day needed restating", async () => {
+    const { service, executor, logger } = setup({ updatedRows: [] });
+
+    const dates = await service.recompute(executor);
+
+    expect(dates).toEqual([]);
+    expect(logger.info).not.toHaveBeenCalled();
+  });
+
+  function setup(input: { updatedRows?: { date: string }[] }) {
+    const captured: { set?: unknown; from?: unknown; where?: unknown } = {};
+
+    const executor = {
+      update: () => ({
+        set: (values: unknown) => {
+          captured.set = values;
+          return {
+            from: (table: unknown) => {
+              captured.from = table;
+              return {
+                where: (condition: unknown) => {
+                  captured.where = condition;
+                  return { returning: () => Promise.resolve(input.updatedRows ?? []) };
+                }
+              };
+            }
+          };
+        }
+      })
+    };
+
+    const logger = mock<LoggerService>();
+    const service = new DayCloseUsdService(logger);
+    return { service, executor: executor as unknown as ChainDatabase, captured, logger };
+  }
+
+  function renderSql(fragment: SQL): string {
+    return new PgDialect().sqlToQuery(fragment).sql;
+  }
+});

--- a/apps/chain-indexer/src/network/day-close-usd.service.ts
+++ b/apps/chain-indexer/src/network/day-close-usd.service.ts
@@ -1,0 +1,50 @@
+import { and, eq, sql } from "drizzle-orm";
+import { inject, singleton } from "tsyringe";
+
+import { DailyPrices, NetworkRollups } from "@src/db/schema";
+import type { ChainDatabase, ChainTransaction } from "@src/providers/db.provider";
+import { LoggerService } from "@src/providers/logging.provider";
+
+const MICRO_UNITS_PER_TOKEN = sql`1000000::numeric`;
+
+/**
+ * Fills or restates `daily_usd_spent` on the network rollups from `daily_prices`, touching only the
+ * days whose stored `akt_price_used` differs from the current price — so a restatement updates
+ * exactly one row per affected day and a rerun is a no-op. uusdc and uact are stablecoins pegged
+ * 1 USD per whole token, mirroring the legacy USD computation; uakt converts at the day's close price.
+ */
+@singleton()
+export class DayCloseUsdService {
+  readonly #logger: LoggerService;
+
+  constructor(@inject(LoggerService) logger: LoggerService) {
+    this.#logger = logger;
+    this.#logger.setContext("DAY_CLOSE_USD");
+  }
+
+  async recompute(executor: ChainDatabase | ChainTransaction, date?: string): Promise<string[]> {
+    const updated = await executor
+      .update(NetworkRollups)
+      .set({
+        dailyUsdSpent: sql`${NetworkRollups.dailyUaktSpent} / ${MICRO_UNITS_PER_TOKEN} * ${DailyPrices.price} + (${NetworkRollups.dailyUusdcSpent} + ${NetworkRollups.dailyUactSpent}) / ${MICRO_UNITS_PER_TOKEN}`,
+        aktPriceUsed: sql`${DailyPrices.price}`,
+        usdComputedAt: new Date()
+      })
+      .from(DailyPrices)
+      .where(
+        and(
+          eq(DailyPrices.denom, "uakt"),
+          eq(DailyPrices.date, NetworkRollups.date),
+          sql`${NetworkRollups.aktPriceUsed} IS DISTINCT FROM ${DailyPrices.price}`,
+          date === undefined ? undefined : eq(NetworkRollups.date, date)
+        )
+      )
+      .returning({ date: NetworkRollups.date });
+
+    const dates = updated.map(row => row.date).sort();
+    if (dates.length > 0) {
+      this.#logger.info({ event: "DAILY_USD_RESTATED", count: dates.length, dates });
+    }
+    return dates;
+  }
+}

--- a/apps/chain-indexer/src/network/network-stats-writer.service.spec.ts
+++ b/apps/chain-indexer/src/network/network-stats-writer.service.spec.ts
@@ -1,0 +1,305 @@
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import { decFromInt, decToString } from "@src/akash/dec";
+import type { NetworkBlockDelta } from "@src/akash/network-delta";
+import { NetworkRollups, NetworkState } from "@src/db/schema";
+import type { DayCloseUsdService } from "@src/network/day-close-usd.service";
+import { NetworkStatsWriter } from "@src/network/network-stats-writer.service";
+import type { ChainTransaction } from "@src/providers/db.provider";
+import type { LoggerService } from "@src/providers/logging.provider";
+
+describe(NetworkStatsWriter.name, () => {
+  it("lazily initializes the singleton row with the watermark just below the first block", async () => {
+    const { writer, tx, inserts, updates } = setup();
+
+    await writer.write(tx, [block(100, "2026-08-13T10:00:00Z")], []);
+
+    expect(rowsFor(inserts, NetworkState)).toEqual([
+      expect.objectContaining({ id: 1, lastAggregatedHeight: 99, lastAggregatedAt: new Date("2026-08-13T10:00:00Z") })
+    ]);
+    expect(updates).toEqual([
+      expect.objectContaining({ lastAggregatedHeight: 100, lastAggregatedAt: new Date("2026-08-13T10:00:00Z"), activeProviderCount: 5 })
+    ]);
+  });
+
+  it("applies block deltas onto the running state", async () => {
+    const { writer, tx, updates } = setup({ stateRow: stateRow({ lastAggregatedHeight: 100 }) });
+
+    await writer.write(
+      tx,
+      [block(101, "2026-08-13T10:00:00Z")],
+      [
+        delta(101, {
+          leasesCreated: 2,
+          activeLeaseDelta: 1,
+          cpuUnitsDelta: 2000,
+          gpuUnitsDelta: 1,
+          memoryBytesDelta: 1024,
+          ephemeralStorageBytesDelta: 100,
+          persistentStorageBytesDelta: 50,
+          earnedDeltaByDenom: new Map([
+            ["uakt", decFromInt(900)],
+            ["uusdc", decFromInt(30)]
+          ])
+        })
+      ]
+    );
+
+    expect(updates).toEqual([
+      {
+        lastAggregatedHeight: 101,
+        lastAggregatedAt: new Date("2026-08-13T10:00:00Z"),
+        activeLeaseCount: 4,
+        totalLeaseCount: 12,
+        activeProviderCount: 5,
+        activeCpuUnits: 12000,
+        activeGpuUnits: 3,
+        activeMemoryBytes: 11024,
+        activeEphemeralStorageBytes: 1100,
+        activePersistentStorageBytes: 1050,
+        totalUaktSpent: decToString(decFromInt(1900)),
+        totalUusdcSpent: decToString(decFromInt(30)),
+        totalUactSpent: decToString(0n)
+      }
+    ]);
+  });
+
+  it("warns and drops earnings in an unknown denom", async () => {
+    const { writer, tx, updates, logger } = setup({ stateRow: stateRow({ lastAggregatedHeight: 100 }) });
+
+    await writer.write(tx, [block(101, "2026-08-13T10:00:00Z")], [delta(101, { earnedDeltaByDenom: new Map([["ibc/deadbeef", decFromInt(5)]]) })]);
+
+    expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "NETWORK_STATS_UNKNOWN_SPEND_DENOM", denom: "ibc/deadbeef" }));
+    expect(updates[0]).toMatchObject({ totalUaktSpent: decToString(decFromInt(1000)) });
+  });
+
+  it("closes the previous day when a batch crosses a UTC boundary", async () => {
+    const { writer, tx, inserts, dayCloseUsd } = setup({ stateRow: stateRow({ lastAggregatedHeight: 100 }), providerCounts: [4, 5] });
+
+    await writer.write(
+      tx,
+      [block(101, "2026-08-13T23:59:55Z"), block(102, "2026-08-14T00:00:05Z")],
+      [delta(101, { leasesCreated: 1, activeLeaseDelta: 1, earnedDeltaByDenom: new Map([["uakt", decFromInt(100)]]) })]
+    );
+
+    expect(rowsFor(inserts, NetworkRollups)).toEqual([
+      {
+        date: "2026-08-13",
+        closeHeight: 101,
+        closeAt: new Date("2026-08-13T23:59:55Z"),
+        activeLeaseCount: 4,
+        totalLeaseCount: 11,
+        dailyLeaseCount: 11,
+        activeProviderCount: 4,
+        activeCpuUnits: 10000,
+        activeGpuUnits: 2,
+        activeMemoryBytes: 10000,
+        activeEphemeralStorageBytes: 1000,
+        activePersistentStorageBytes: 1000,
+        totalUaktSpent: decToString(decFromInt(1100)),
+        totalUusdcSpent: decToString(0n),
+        totalUactSpent: decToString(0n),
+        dailyUaktSpent: decToString(decFromInt(1100)),
+        dailyUusdcSpent: decToString(0n),
+        dailyUactSpent: decToString(0n)
+      }
+    ]);
+    expect(dayCloseUsd.recompute).toHaveBeenCalledWith(tx, "2026-08-13");
+  });
+
+  it("closes a day whose last block belongs to a previous batch", async () => {
+    const { writer, tx, inserts } = setup({
+      stateRow: stateRow({ lastAggregatedHeight: 100, lastAggregatedAt: new Date("2026-08-13T23:59:55Z") })
+    });
+
+    await writer.write(tx, [block(101, "2026-08-14T00:00:05Z")], []);
+
+    expect(rowsFor(inserts, NetworkRollups)).toEqual([
+      expect.objectContaining({ date: "2026-08-13", closeHeight: 100, closeAt: new Date("2026-08-13T23:59:55Z") })
+    ]);
+  });
+
+  it("computes daily deltas against the previous rollup row", async () => {
+    const { writer, tx, inserts } = setup({
+      stateRow: stateRow({ lastAggregatedHeight: 100, lastAggregatedAt: new Date("2026-08-13T23:59:55Z") }),
+      rollups: [rollupRow({ date: "2026-08-12", totalLeaseCount: 8, totalUaktSpent: decToString(decFromInt(400)) })]
+    });
+
+    await writer.write(tx, [block(101, "2026-08-14T00:00:05Z")], []);
+
+    expect(rowsFor(inserts, NetworkRollups)).toEqual([
+      expect.objectContaining({
+        date: "2026-08-13",
+        dailyLeaseCount: 2,
+        dailyUaktSpent: decToString(decFromInt(600)),
+        totalUaktSpent: decToString(decFromInt(1000))
+      })
+    ]);
+  });
+
+  it("closes each crossed day once and only for days that had blocks", async () => {
+    const { writer, tx, inserts } = setup({ stateRow: stateRow({ lastAggregatedHeight: 100 }), providerCounts: [5, 5, 5] });
+
+    await writer.write(tx, [block(101, "2026-08-13T23:59:55Z"), block(102, "2026-08-16T00:00:05Z"), block(103, "2026-08-17T00:00:05Z")], []);
+
+    expect(rowsFor(inserts, NetworkRollups).map(row => [row.date, row.closeHeight])).toEqual([
+      ["2026-08-13", 101],
+      ["2026-08-16", 102]
+    ]);
+  });
+
+  it("does nothing beyond locking when every block is at or below the watermark", async () => {
+    const { writer, tx, inserts, updates, dayCloseUsd } = setup({ stateRow: stateRow({ lastAggregatedHeight: 200 }) });
+
+    await writer.write(tx, [block(101, "2026-08-14T10:00:00Z")], [delta(101, { activeLeaseDelta: 1 })]);
+
+    expect(rowsFor(inserts, NetworkRollups)).toEqual([]);
+    expect(updates).toEqual([]);
+    expect(dayCloseUsd.recompute).not.toHaveBeenCalled();
+  });
+
+  function setup(input?: { stateRow?: Record<string, unknown>; rollups?: Record<string, unknown>[]; providerCounts?: number[] }) {
+    const inserts: { table: unknown; rows: Record<string, unknown>[] }[] = [];
+    const updates: Record<string, unknown>[] = [];
+    const stateRows: Record<string, unknown>[] = input?.stateRow ? [input.stateRow] : [];
+    const rollupRows: Record<string, unknown>[] = [...(input?.rollups ?? [])];
+    const providerCounts = [...(input?.providerCounts ?? [])];
+
+    const rowsFromTable = (table: unknown) => {
+      if (table === NetworkState) {
+        return stateRows;
+      }
+      if (table === NetworkRollups) {
+        return [...rollupRows].sort((a, b) => String(b.date).localeCompare(String(a.date)));
+      }
+      return [{ value: providerCounts.shift() ?? 5 }];
+    };
+
+    const selectChain = (table: unknown) => {
+      const chain = {
+        where: () => chain,
+        orderBy: () => chain,
+        limit: () => chain,
+        for: () => chain,
+        then: (resolve: (rows: unknown[]) => unknown, reject?: (error: unknown) => unknown) => Promise.resolve(rowsFromTable(table)).then(resolve, reject)
+      };
+      return chain;
+    };
+
+    const tx = {
+      insert: (table: unknown) => ({
+        values: (rows: Record<string, unknown> | Record<string, unknown>[]) => {
+          const rowArray = Array.isArray(rows) ? rows : [rows];
+          inserts.push({ table, rows: rowArray });
+          if (table === NetworkState && stateRows.length === 0) {
+            stateRows.push({ ...emptyStateRow(), ...rowArray[0] });
+          }
+          if (table === NetworkRollups) {
+            rollupRows.push(...rowArray);
+          }
+          return { onConflictDoNothing: () => Promise.resolve() };
+        }
+      }),
+      select: () => ({ from: (table: unknown) => selectChain(table) }),
+      update: (table: unknown) => ({
+        set: (values: Record<string, unknown>) => {
+          void table;
+          updates.push(values);
+          return { where: () => Promise.resolve() };
+        }
+      })
+    };
+
+    const dayCloseUsd = mock<DayCloseUsdService>();
+    const logger = mock<LoggerService>();
+    const writer = new NetworkStatsWriter(dayCloseUsd, logger);
+    return { writer, tx: tx as unknown as ChainTransaction, inserts, updates, dayCloseUsd, logger };
+  }
+
+  function block(height: number, datetime: string) {
+    return { height, datetime: new Date(datetime) };
+  }
+
+  function delta(height: number, overrides: Partial<NetworkBlockDelta>): NetworkBlockDelta {
+    return {
+      height,
+      leasesCreated: 0,
+      activeLeaseDelta: 0,
+      cpuUnitsDelta: 0,
+      gpuUnitsDelta: 0,
+      memoryBytesDelta: 0,
+      ephemeralStorageBytesDelta: 0,
+      persistentStorageBytesDelta: 0,
+      earnedDeltaByDenom: new Map(),
+      ...overrides
+    };
+  }
+
+  function stateRow(overrides: Record<string, unknown>) {
+    return {
+      id: 1,
+      lastAggregatedHeight: 100,
+      lastAggregatedAt: new Date("2026-08-13T09:00:00Z"),
+      activeLeaseCount: 3,
+      totalLeaseCount: 10,
+      activeProviderCount: 5,
+      activeCpuUnits: 10000,
+      activeGpuUnits: 2,
+      activeMemoryBytes: 10000,
+      activeEphemeralStorageBytes: 1000,
+      activePersistentStorageBytes: 1000,
+      totalUaktSpent: decToString(decFromInt(1000)),
+      totalUusdcSpent: decToString(0n),
+      totalUactSpent: decToString(0n),
+      ...overrides
+    };
+  }
+
+  function rollupRow(overrides: Record<string, unknown>) {
+    return {
+      date: "2026-08-12",
+      closeHeight: 90,
+      closeAt: new Date("2026-08-12T23:59:00Z"),
+      activeLeaseCount: 2,
+      totalLeaseCount: 8,
+      dailyLeaseCount: 8,
+      activeProviderCount: 4,
+      activeCpuUnits: 8000,
+      activeGpuUnits: 1,
+      activeMemoryBytes: 8000,
+      activeEphemeralStorageBytes: 800,
+      activePersistentStorageBytes: 800,
+      totalUaktSpent: decToString(decFromInt(400)),
+      totalUusdcSpent: decToString(0n),
+      totalUactSpent: decToString(0n),
+      dailyUaktSpent: decToString(decFromInt(400)),
+      dailyUusdcSpent: decToString(0n),
+      dailyUactSpent: decToString(0n),
+      dailyUsdSpent: null,
+      aktPriceUsed: null,
+      usdComputedAt: null,
+      ...overrides
+    };
+  }
+
+  function emptyStateRow() {
+    return {
+      activeLeaseCount: 0,
+      totalLeaseCount: 0,
+      activeProviderCount: 0,
+      activeCpuUnits: 0,
+      activeGpuUnits: 0,
+      activeMemoryBytes: 0,
+      activeEphemeralStorageBytes: 0,
+      activePersistentStorageBytes: 0,
+      totalUaktSpent: "0",
+      totalUusdcSpent: "0",
+      totalUactSpent: "0"
+    };
+  }
+
+  function rowsFor(inserts: { table: unknown; rows: Record<string, unknown>[] }[], table: unknown): Record<string, unknown>[] {
+    return inserts.filter(insert => insert.table === table).flatMap(insert => insert.rows);
+  }
+});

--- a/apps/chain-indexer/src/network/network-stats-writer.service.ts
+++ b/apps/chain-indexer/src/network/network-stats-writer.service.ts
@@ -1,0 +1,208 @@
+import { and, count, desc, eq, isNull, lte } from "drizzle-orm";
+import { inject, singleton } from "tsyringe";
+
+import { decFromString, decToString } from "@src/akash/dec";
+import type { NetworkBlockDelta } from "@src/akash/network-delta";
+import { NetworkRollups, NetworkState, Providers } from "@src/db/schema";
+import { DayCloseUsdService } from "@src/network/day-close-usd.service";
+import type { ChainTransaction } from "@src/providers/db.provider";
+import { LoggerService } from "@src/providers/logging.provider";
+
+export interface NetworkBlockRef {
+  height: number;
+  datetime: Date;
+}
+
+interface RunningNetworkState {
+  lastAggregatedHeight: number;
+  lastAggregatedAt: Date;
+  activeLeaseCount: number;
+  totalLeaseCount: number;
+  activeProviderCount: number;
+  activeCpuUnits: number;
+  activeGpuUnits: number;
+  activeMemoryBytes: number;
+  activeEphemeralStorageBytes: number;
+  activePersistentStorageBytes: number;
+  totalUaktSpent: bigint;
+  totalUusdcSpent: bigint;
+  totalUactSpent: bigint;
+}
+
+const SINGLETON_ID = 1;
+
+const SPENT_FIELD_BY_DENOM = {
+  uakt: "totalUaktSpent",
+  uusdc: "totalUusdcSpent",
+  uact: "totalUactSpent"
+} as const;
+
+function utcDay(datetime: Date): string {
+  return datetime.toISOString().slice(0, 10);
+}
+
+/**
+ * Maintains the singleton current-network-state row and the append-only daily rollups inside the
+ * block transaction, from the per-block deltas the akash writer measured across its reducer fold.
+ * The row is locked FOR UPDATE and `last_aggregated_height` is the replay watermark, so duplicate
+ * commits and overlapping writers fold each block exactly once. A UTC day is closed atomically with
+ * the first block of the following day; the closed day's USD is filled immediately when its price is
+ * already known (backfill), and otherwise later by the price job via DayCloseUsdService.
+ */
+@singleton()
+export class NetworkStatsWriter {
+  readonly #dayCloseUsd: DayCloseUsdService;
+  readonly #logger: LoggerService;
+
+  constructor(@inject(DayCloseUsdService) dayCloseUsd: DayCloseUsdService, @inject(LoggerService) logger: LoggerService) {
+    this.#dayCloseUsd = dayCloseUsd;
+    this.#logger = logger;
+    this.#logger.setContext("NETWORK_STATS");
+  }
+
+  async write(tx: ChainTransaction, blocks: NetworkBlockRef[], deltas: NetworkBlockDelta[]): Promise<void> {
+    if (blocks.length === 0) {
+      return;
+    }
+
+    await this.#ensureStateRow(tx, blocks[0]);
+    const state = await this.#lockState(tx);
+    const deltaByHeight = new Map(deltas.map(delta => [delta.height, delta]));
+
+    let aggregated = false;
+    for (const block of blocks) {
+      if (block.height <= state.lastAggregatedHeight) {
+        continue;
+      }
+      if (utcDay(block.datetime) > utcDay(state.lastAggregatedAt)) {
+        await this.#closeDay(tx, state);
+      }
+      const delta = deltaByHeight.get(block.height);
+      if (delta) {
+        this.#applyDelta(state, delta);
+      }
+      state.lastAggregatedHeight = block.height;
+      state.lastAggregatedAt = block.datetime;
+      aggregated = true;
+    }
+
+    if (!aggregated) {
+      return;
+    }
+
+    state.activeProviderCount = await this.#countProviders(tx);
+    await this.#flushState(tx, state);
+  }
+
+  async #ensureStateRow(tx: ChainTransaction, firstBlock: NetworkBlockRef): Promise<void> {
+    await tx
+      .insert(NetworkState)
+      .values({ id: SINGLETON_ID, lastAggregatedHeight: firstBlock.height - 1, lastAggregatedAt: firstBlock.datetime })
+      .onConflictDoNothing();
+  }
+
+  async #lockState(tx: ChainTransaction): Promise<RunningNetworkState> {
+    const [row] = await tx.select().from(NetworkState).where(eq(NetworkState.id, SINGLETON_ID)).for("update");
+    return {
+      lastAggregatedHeight: row.lastAggregatedHeight,
+      lastAggregatedAt: row.lastAggregatedAt,
+      activeLeaseCount: row.activeLeaseCount,
+      totalLeaseCount: row.totalLeaseCount,
+      activeProviderCount: row.activeProviderCount,
+      activeCpuUnits: row.activeCpuUnits,
+      activeGpuUnits: row.activeGpuUnits,
+      activeMemoryBytes: row.activeMemoryBytes,
+      activeEphemeralStorageBytes: row.activeEphemeralStorageBytes,
+      activePersistentStorageBytes: row.activePersistentStorageBytes,
+      totalUaktSpent: decFromString(row.totalUaktSpent),
+      totalUusdcSpent: decFromString(row.totalUusdcSpent),
+      totalUactSpent: decFromString(row.totalUactSpent)
+    };
+  }
+
+  #applyDelta(state: RunningNetworkState, delta: NetworkBlockDelta): void {
+    state.activeLeaseCount += delta.activeLeaseDelta;
+    state.totalLeaseCount += delta.leasesCreated;
+    state.activeCpuUnits += delta.cpuUnitsDelta;
+    state.activeGpuUnits += delta.gpuUnitsDelta;
+    state.activeMemoryBytes += delta.memoryBytesDelta;
+    state.activeEphemeralStorageBytes += delta.ephemeralStorageBytesDelta;
+    state.activePersistentStorageBytes += delta.persistentStorageBytesDelta;
+
+    for (const [denom, earned] of delta.earnedDeltaByDenom) {
+      const field = SPENT_FIELD_BY_DENOM[denom as keyof typeof SPENT_FIELD_BY_DENOM];
+      if (!field) {
+        this.#logger.warn({ event: "NETWORK_STATS_UNKNOWN_SPEND_DENOM", denom, height: delta.height, earned: decToString(earned) });
+        continue;
+      }
+      state[field] += earned;
+    }
+  }
+
+  /** The closing day's snapshot is the state as of the last aggregated block, which may belong to a previous batch. */
+  async #closeDay(tx: ChainTransaction, state: RunningNetworkState): Promise<void> {
+    const date = utcDay(state.lastAggregatedAt);
+    const [previous] = await tx.select().from(NetworkRollups).orderBy(desc(NetworkRollups.date)).limit(1);
+    const previousTotals = {
+      totalLeaseCount: previous?.totalLeaseCount ?? 0,
+      totalUaktSpent: previous ? decFromString(previous.totalUaktSpent) : 0n,
+      totalUusdcSpent: previous ? decFromString(previous.totalUusdcSpent) : 0n,
+      totalUactSpent: previous ? decFromString(previous.totalUactSpent) : 0n
+    };
+
+    await tx
+      .insert(NetworkRollups)
+      .values({
+        date,
+        closeHeight: state.lastAggregatedHeight,
+        closeAt: state.lastAggregatedAt,
+        activeLeaseCount: state.activeLeaseCount,
+        totalLeaseCount: state.totalLeaseCount,
+        dailyLeaseCount: state.totalLeaseCount - previousTotals.totalLeaseCount,
+        activeProviderCount: await this.#countProviders(tx, state.lastAggregatedHeight),
+        activeCpuUnits: state.activeCpuUnits,
+        activeGpuUnits: state.activeGpuUnits,
+        activeMemoryBytes: state.activeMemoryBytes,
+        activeEphemeralStorageBytes: state.activeEphemeralStorageBytes,
+        activePersistentStorageBytes: state.activePersistentStorageBytes,
+        totalUaktSpent: decToString(state.totalUaktSpent),
+        totalUusdcSpent: decToString(state.totalUusdcSpent),
+        totalUactSpent: decToString(state.totalUactSpent),
+        dailyUaktSpent: decToString(state.totalUaktSpent - previousTotals.totalUaktSpent),
+        dailyUusdcSpent: decToString(state.totalUusdcSpent - previousTotals.totalUusdcSpent),
+        dailyUactSpent: decToString(state.totalUactSpent - previousTotals.totalUactSpent)
+      })
+      .onConflictDoNothing();
+
+    await this.#dayCloseUsd.recompute(tx, date);
+  }
+
+  async #countProviders(tx: ChainTransaction, atHeight?: number): Promise<number> {
+    const [row] = await tx
+      .select({ value: count() })
+      .from(Providers)
+      .where(atHeight === undefined ? isNull(Providers.deletedHeight) : and(isNull(Providers.deletedHeight), lte(Providers.createdHeight, atHeight)));
+    return row.value;
+  }
+
+  async #flushState(tx: ChainTransaction, state: RunningNetworkState): Promise<void> {
+    await tx
+      .update(NetworkState)
+      .set({
+        lastAggregatedHeight: state.lastAggregatedHeight,
+        lastAggregatedAt: state.lastAggregatedAt,
+        activeLeaseCount: state.activeLeaseCount,
+        totalLeaseCount: state.totalLeaseCount,
+        activeProviderCount: state.activeProviderCount,
+        activeCpuUnits: state.activeCpuUnits,
+        activeGpuUnits: state.activeGpuUnits,
+        activeMemoryBytes: state.activeMemoryBytes,
+        activeEphemeralStorageBytes: state.activeEphemeralStorageBytes,
+        activePersistentStorageBytes: state.activePersistentStorageBytes,
+        totalUaktSpent: decToString(state.totalUaktSpent),
+        totalUusdcSpent: decToString(state.totalUusdcSpent),
+        totalUactSpent: decToString(state.totalUactSpent)
+      })
+      .where(eq(NetworkState.id, SINGLETON_ID));
+  }
+}

--- a/apps/chain-indexer/src/network/recompute-usd.ts
+++ b/apps/chain-indexer/src/network/recompute-usd.ts
@@ -1,0 +1,37 @@
+import "@src/providers";
+
+import { createOtelLogger } from "@akashnetwork/logging/otel";
+import { container } from "tsyringe";
+
+import { envSchema } from "@src/config/env.config";
+import { PgClientService } from "@src/db/pg-client.service";
+import { DayCloseUsdService } from "@src/network/day-close-usd.service";
+import { CHAIN_DB } from "@src/providers/db.provider";
+
+/**
+ * One-shot USD restatement entrypoint (`npm run network:recompute-usd`): recomputes `daily_usd_spent`
+ * for every rollup day whose stored price differs from `daily_prices`, touching one row per affected
+ * day. Exits 0 on success (including nothing to restate), non-zero on failure.
+ */
+async function main(): Promise<void> {
+  const logger = createOtelLogger({ context: "RECOMPUTE_USD_CLI" });
+
+  const parsed = envSchema.safeParse(process.env);
+  if (!parsed.success) {
+    logger.error({ event: "CONFIG_INVALID", issues: parsed.error.issues.map(issue => ({ path: issue.path.join(".") || "(root)", message: issue.message })) });
+    process.exitCode = 1;
+    return;
+  }
+
+  try {
+    const dates = await container.resolve(DayCloseUsdService).recompute(container.resolve(CHAIN_DB));
+    logger.info({ event: "RECOMPUTE_USD_DONE", count: dates.length });
+  } catch (error) {
+    logger.error({ event: "RECOMPUTE_USD_FATAL", error });
+    process.exitCode = 1;
+  } finally {
+    await container.resolve(PgClientService).dispose();
+  }
+}
+
+void main();

--- a/apps/chain-indexer/src/pipeline/block-committer.service.spec.ts
+++ b/apps/chain-indexer/src/pipeline/block-committer.service.spec.ts
@@ -4,10 +4,12 @@ import { describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { AkashWriter } from "@src/akash/akash-writer.service";
+import type { NetworkBlockDelta } from "@src/akash/network-delta";
 import type { ProviderWriter } from "@src/akash/provider-writer.service";
 import type { BmeWriter } from "@src/bme/bme-writer.service";
 import { AccountTxs, Blocks, IndexerState, MessageDeadLetters, Messages, MessageTypes } from "@src/db/schema";
 import type { GovWriter } from "@src/gov/gov-writer.service";
+import type { NetworkStatsWriter } from "@src/network/network-stats-writer.service";
 import type { AccountInterner } from "@src/pipeline/balance/account-interner.service";
 import type { BalanceWriter } from "@src/pipeline/balance/balance-writer.service";
 import { BlockCommitterService } from "@src/pipeline/block-committer.service";
@@ -298,6 +300,17 @@ describe(BlockCommitterService.name, () => {
       expect(accountIds.get("akash1bmeburner")).toBeDefined();
       expect(accountIds.get("akash1bmeminter")).toBeDefined();
     });
+
+    it("hands the network stats writer the batch blocks and the akash writer's deltas", async () => {
+      const { committer, akashWriter, networkStatsWriter } = setup({ selectResults: [[{ id: 7, type: MSG_SEND }]] });
+      const deltas = [mock<NetworkBlockDelta>({ height: 10 })];
+      akashWriter.write.mockResolvedValue({ networkDeltas: deltas });
+
+      const block = buildBlock([MSG_SEND], 10);
+      await committer.commit(block);
+
+      expect(networkStatsWriter.write).toHaveBeenCalledWith(expect.anything(), [block], deltas);
+    });
   });
 
   function setup(input?: {
@@ -350,8 +363,10 @@ describe(BlockCommitterService.name, () => {
 
     const govWriter = mock<GovWriter>();
     const akashWriter = mock<AkashWriter>();
+    akashWriter.write.mockResolvedValue({ networkDeltas: [] });
     const providerWriter = mock<ProviderWriter>();
     const bmeWriter = mock<BmeWriter>();
+    const networkStatsWriter = mock<NetworkStatsWriter>();
     const logger = mock<LoggerService>();
     const committer = new BlockCommitterService(
       dbFake as unknown as ChainDatabase,
@@ -361,9 +376,23 @@ describe(BlockCommitterService.name, () => {
       akashWriter,
       providerWriter,
       bmeWriter,
+      networkStatsWriter,
       logger
     );
-    return { committer, insertedRows, conflictUpdates, deletions, interner, balanceWriter, govWriter, akashWriter, providerWriter, bmeWriter, logger };
+    return {
+      committer,
+      insertedRows,
+      conflictUpdates,
+      deletions,
+      interner,
+      balanceWriter,
+      govWriter,
+      akashWriter,
+      providerWriter,
+      bmeWriter,
+      networkStatsWriter,
+      logger
+    };
   }
 
   function buildBlock(

--- a/apps/chain-indexer/src/pipeline/block-committer.service.ts
+++ b/apps/chain-indexer/src/pipeline/block-committer.service.ts
@@ -15,6 +15,7 @@ import { insertChunked } from "@src/db/insert-chunked";
 import { AccountTxs, Blocks, IndexerState, MessageDeadLetters, Messages, MessageTypes, Transactions } from "@src/db/schema";
 import { sqlExcluded } from "@src/db/sql-excluded";
 import { GovWriter } from "@src/gov/gov-writer.service";
+import { NetworkStatsWriter } from "@src/network/network-stats-writer.service";
 import { AccountInterner, requireAccountId } from "@src/pipeline/balance/account-interner.service";
 import type { DerivedAccountTx } from "@src/pipeline/balance/account-tx-deriver";
 import { deriveAccountTxs } from "@src/pipeline/balance/account-tx-deriver";
@@ -53,6 +54,7 @@ export class BlockCommitterService {
   readonly #akashWriter: AkashWriter;
   readonly #providerWriter: ProviderWriter;
   readonly #bmeWriter: BmeWriter;
+  readonly #networkStatsWriter: NetworkStatsWriter;
   readonly #logger: LoggerService;
   readonly #moduleRegistry = buildModuleAddressRegistry();
   readonly #typeIds = new Map<string, number>();
@@ -65,6 +67,7 @@ export class BlockCommitterService {
     @inject(AkashWriter) akashWriter: AkashWriter,
     @inject(ProviderWriter) providerWriter: ProviderWriter,
     @inject(BmeWriter) bmeWriter: BmeWriter,
+    @inject(NetworkStatsWriter) networkStatsWriter: NetworkStatsWriter,
     @inject(LoggerService) logger: LoggerService
   ) {
     this.#db = db;
@@ -74,6 +77,7 @@ export class BlockCommitterService {
     this.#akashWriter = akashWriter;
     this.#providerWriter = providerWriter;
     this.#bmeWriter = bmeWriter;
+    this.#networkStatsWriter = networkStatsWriter;
     this.#logger = logger;
     this.#logger.setContext("COMMITTER");
   }
@@ -158,9 +162,10 @@ export class BlockCommitterService {
       await this.#balanceWriter.write(tx, balanceIntents);
       await insertChunked(tx, AccountTxs, accountTxRows);
       await this.#govWriter.writeForBlocks(tx, blocks, accountIds);
-      await this.#akashWriter.write(tx, akashChanges, accountIds);
+      const { networkDeltas } = await this.#akashWriter.write(tx, akashChanges, accountIds);
       await this.#providerWriter.write(tx, akashChanges, accountIds);
       await this.#bmeWriter.write(tx, bmeChanges, accountIds);
+      await this.#networkStatsWriter.write(tx, blocks, networkDeltas);
 
       await tx
         .insert(IndexerState)

--- a/apps/chain-indexer/src/reconcile/network-stats-reconciler.spec.ts
+++ b/apps/chain-indexer/src/reconcile/network-stats-reconciler.spec.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import { IndexerState, Leases, NetworkRollups, NetworkState } from "@src/db/schema";
+import type { ChainDatabase } from "@src/providers/db.provider";
+import type { LoggerService } from "@src/providers/logging.provider";
+import { NetworkStatsReconciler } from "@src/reconcile/network-stats-reconciler";
+
+describe(NetworkStatsReconciler.name, () => {
+  it("returns true when the state row matches the recomputation from leases", async () => {
+    const { service, logger } = setup({});
+
+    await expect(service.reconcile()).resolves.toBe(true);
+
+    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "NETWORK_RECONCILE_OK", mismatches: 0 }));
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it("treats differently formatted but equal numerics as matching", async () => {
+    const { service } = setup({
+      stateRow: stateRow({ totalUaktSpent: "1000.000000000000000000" }),
+      spendRows: [{ denom: "uakt", earned: "1000" }]
+    });
+
+    await expect(service.reconcile()).resolves.toBe(true);
+  });
+
+  it("reports a lease count drift on the current state", async () => {
+    const { service, logger } = setup({ leaseAggregates: [leaseAggregates({ activeLeaseCount: 4 })] });
+
+    await expect(service.reconcile()).resolves.toBe(false);
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ event: "NETWORK_RECONCILE_MISMATCH", scope: "network_state", field: "activeLeaseCount", expected: "4", actual: "3" })
+    );
+  });
+
+  it("reports a settlement-exact spend drift per denom", async () => {
+    const { service, logger } = setup({ spendRows: [{ denom: "uakt", earned: "999" }] });
+
+    await expect(service.reconcile()).resolves.toBe(false);
+
+    expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "NETWORK_RECONCILE_MISMATCH", field: "total_uakt_spent" }));
+  });
+
+  it("reports a provider count drift", async () => {
+    const { service, logger } = setup({ providerCount: 7 });
+
+    await expect(service.reconcile()).resolves.toBe(false);
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ event: "NETWORK_RECONCILE_MISMATCH", field: "activeProviderCount", expected: "7", actual: "5" })
+    );
+  });
+
+  it("reports a watermark lagging the sync checkpoint", async () => {
+    const { service, logger } = setup({ checkpoint: 250 });
+
+    await expect(service.reconcile()).resolves.toBe(false);
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ event: "NETWORK_RECONCILE_MISMATCH", field: "lastAggregatedHeight", expected: "250", actual: "100" })
+    );
+  });
+
+  it("re-derives sampled rollup rows at their close height", async () => {
+    const { service, logger } = setup({
+      rollups: [rollupRow({ date: "2026-08-13", activeGpuUnits: 9 })],
+      leaseAggregates: [leaseAggregates({}), leaseAggregates({ activeGpuUnits: 2 })]
+    });
+
+    await expect(service.reconcile()).resolves.toBe(false);
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ event: "NETWORK_RECONCILE_MISMATCH", scope: "network_rollups:2026-08-13", field: "activeGpuUnits", expected: "2", actual: "9" })
+    );
+  });
+
+  it("passes on an empty database with no state row", async () => {
+    const { service, logger } = setup({ stateRow: null, leaseAggregates: [leaseAggregates({ activeLeaseCount: 0, totalLeaseCount: 0 })] });
+
+    await expect(service.reconcile()).resolves.toBe(true);
+
+    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "NETWORK_RECONCILE_EMPTY" }));
+  });
+
+  it("fails when leases exist but the state row is missing", async () => {
+    const { service, logger } = setup({ stateRow: null });
+
+    await expect(service.reconcile()).resolves.toBe(false);
+
+    expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "NETWORK_RECONCILE_NO_STATE" }));
+  });
+
+  function setup(input: {
+    stateRow?: Record<string, unknown> | null;
+    leaseAggregates?: Record<string, unknown>[];
+    spendRows?: { denom: string; earned: string }[];
+    providerCount?: number;
+    checkpoint?: number;
+    rollups?: Record<string, unknown>[];
+  }) {
+    const leaseAggQueue = [...(input.leaseAggregates ?? [leaseAggregates({})])];
+
+    const resolveRows = (table: unknown, grouped: boolean): unknown[] => {
+      if (table === NetworkState) {
+        return input.stateRow === null ? [] : [input.stateRow ?? stateRow({})];
+      }
+      if (table === IndexerState) {
+        return [{ stream: "sync", lastHeight: input.checkpoint ?? 100 }];
+      }
+      if (table === NetworkRollups) {
+        return input.rollups ?? [];
+      }
+      if (table === Leases && grouped) {
+        return input.spendRows ?? [{ denom: "uakt", earned: "1000.000000000000000000" }];
+      }
+      if (table === Leases) {
+        return [leaseAggQueue.shift() ?? leaseAggregates({})];
+      }
+      return [{ value: input.providerCount ?? 5 }];
+    };
+
+    const makeChain = (table: unknown) => {
+      let grouped = false;
+      const chain = {
+        where: () => chain,
+        orderBy: () => chain,
+        limit: () => chain,
+        groupBy: () => {
+          grouped = true;
+          return chain;
+        },
+        then: (resolve: (rows: unknown[]) => unknown, reject?: (error: unknown) => unknown) =>
+          Promise.resolve(resolveRows(table, grouped)).then(resolve, reject)
+      };
+      return chain;
+    };
+
+    const tx = { select: () => ({ from: (table: unknown) => makeChain(table) }) };
+    const dbFake = { transaction: async (callback: (transaction: unknown) => unknown) => callback(tx) };
+
+    const logger = mock<LoggerService>();
+    const service = new NetworkStatsReconciler(dbFake as unknown as ChainDatabase, logger);
+    return { service, logger };
+  }
+
+  function stateRow(overrides: Record<string, unknown>) {
+    return {
+      id: 1,
+      lastAggregatedHeight: 100,
+      lastAggregatedAt: new Date("2026-08-13T10:00:00Z"),
+      activeLeaseCount: 3,
+      totalLeaseCount: 10,
+      activeProviderCount: 5,
+      activeCpuUnits: 10000,
+      activeGpuUnits: 2,
+      activeMemoryBytes: 10000,
+      activeEphemeralStorageBytes: 1000,
+      activePersistentStorageBytes: 1000,
+      totalUaktSpent: "1000.000000000000000000",
+      totalUusdcSpent: "0.000000000000000000",
+      totalUactSpent: "0.000000000000000000",
+      ...overrides
+    };
+  }
+
+  function leaseAggregates(overrides: Record<string, unknown>) {
+    return {
+      activeLeaseCount: 3,
+      totalLeaseCount: 10,
+      activeCpuUnits: 10000,
+      activeGpuUnits: 2,
+      activeMemoryBytes: 10000,
+      activeEphemeralStorageBytes: 1000,
+      activePersistentStorageBytes: 1000,
+      ...overrides
+    };
+  }
+
+  function rollupRow(overrides: Record<string, unknown>) {
+    return {
+      date: "2026-08-13",
+      closeHeight: 90,
+      closeAt: new Date("2026-08-13T23:59:00Z"),
+      activeLeaseCount: 3,
+      totalLeaseCount: 10,
+      dailyLeaseCount: 2,
+      activeProviderCount: 5,
+      activeCpuUnits: 10000,
+      activeGpuUnits: 2,
+      activeMemoryBytes: 10000,
+      activeEphemeralStorageBytes: 1000,
+      activePersistentStorageBytes: 1000,
+      totalUaktSpent: "1000.000000000000000000",
+      totalUusdcSpent: "0.000000000000000000",
+      totalUactSpent: "0.000000000000000000",
+      dailyUaktSpent: "1000.000000000000000000",
+      dailyUusdcSpent: "0.000000000000000000",
+      dailyUactSpent: "0.000000000000000000",
+      dailyUsdSpent: null,
+      aktPriceUsed: null,
+      usdComputedAt: null,
+      ...overrides
+    };
+  }
+});

--- a/apps/chain-indexer/src/reconcile/network-stats-reconciler.ts
+++ b/apps/chain-indexer/src/reconcile/network-stats-reconciler.ts
@@ -1,0 +1,174 @@
+import { desc, eq, isNull, sql } from "drizzle-orm";
+import { inject, singleton } from "tsyringe";
+
+import { decFromString } from "@src/akash/dec";
+import { IndexerState, Leases, NetworkRollups, NetworkState, Providers } from "@src/db/schema";
+import { SYNC_STREAM } from "@src/pipeline/block-committer.service";
+import type { ChainDatabase, ChainTransaction } from "@src/providers/db.provider";
+import { CHAIN_DB } from "@src/providers/db.provider";
+import { LoggerService } from "@src/providers/logging.provider";
+
+const DEFAULT_ROLLUP_SAMPLE_SIZE = 5;
+
+const TRACKED_SPEND_DENOMS = ["uakt", "uusdc", "uact"] as const;
+
+interface LeaseAggregates {
+  activeLeaseCount: number;
+  totalLeaseCount: number;
+  activeCpuUnits: number;
+  activeGpuUnits: number;
+  activeMemoryBytes: number;
+  activeEphemeralStorageBytes: number;
+  activePersistentStorageBytes: number;
+}
+
+interface Mismatch {
+  scope: string;
+  field: string;
+  expected: string;
+  actual: string;
+}
+
+/**
+ * Proves the incremental network aggregates match a manual recomputation from the leases table,
+ * inside one REPEATABLE READ snapshot so the comparison cannot straddle a commit. The current
+ * `network_state` row is checked in full — counts, active resources, provider count, watermark vs
+ * the sync checkpoint, and settlement-exact spend (Σ withdrawn + balance per denom). Sampled rollup
+ * rows are re-derived at their `close_height` from lease created/closed heights; historical spend
+ * and provider counts are not re-derivable from current rows and are covered by the current-state
+ * checks instead.
+ */
+@singleton()
+export class NetworkStatsReconciler {
+  readonly #db: ChainDatabase;
+  readonly #logger: LoggerService;
+
+  constructor(@inject(CHAIN_DB) db: ChainDatabase, @inject(LoggerService) logger: LoggerService) {
+    this.#db = db;
+    this.#logger = logger;
+    this.#logger.setContext("NETWORK_RECONCILE");
+  }
+
+  async reconcile({ rollupSampleSize = DEFAULT_ROLLUP_SAMPLE_SIZE }: { rollupSampleSize?: number } = {}): Promise<boolean> {
+    const mismatches = await this.#db.transaction(async tx => this.#collectMismatches(tx, rollupSampleSize), {
+      isolationLevel: "repeatable read",
+      accessMode: "read only"
+    });
+
+    if (mismatches === undefined) {
+      return false;
+    }
+
+    for (const mismatch of mismatches) {
+      this.#logger.error({ event: "NETWORK_RECONCILE_MISMATCH", ...mismatch });
+    }
+    const ok = mismatches.length === 0;
+    this.#logger[ok ? "info" : "error"]({ event: ok ? "NETWORK_RECONCILE_OK" : "NETWORK_RECONCILE_FAILED", mismatches: mismatches.length });
+    return ok;
+  }
+
+  async #collectMismatches(tx: ChainTransaction, rollupSampleSize: number): Promise<Mismatch[] | undefined> {
+    const [state] = await tx.select().from(NetworkState);
+    if (!state) {
+      const { totalLeaseCount } = await this.#leaseAggregates(tx);
+      if (totalLeaseCount === 0) {
+        this.#logger.info({ event: "NETWORK_RECONCILE_EMPTY" });
+        return [];
+      }
+      this.#logger.error({ event: "NETWORK_RECONCILE_NO_STATE", totalLeaseCount });
+      return undefined;
+    }
+
+    return [...(await this.#checkCurrentState(tx, state)), ...(await this.#checkSpends(tx, state)), ...(await this.#checkRollups(tx, rollupSampleSize))];
+  }
+
+  async #checkCurrentState(tx: ChainTransaction, state: typeof NetworkState.$inferSelect): Promise<Mismatch[]> {
+    const mismatches: Mismatch[] = [];
+    const recomputed = await this.#leaseAggregates(tx);
+
+    for (const field of Object.keys(recomputed) as (keyof LeaseAggregates)[]) {
+      if (state[field] !== recomputed[field]) {
+        mismatches.push({ scope: "network_state", field, expected: String(recomputed[field]), actual: String(state[field]) });
+      }
+    }
+
+    const [providerRow] = await tx
+      .select({ value: sql<number>`COUNT(*)`.mapWith(Number) })
+      .from(Providers)
+      .where(isNull(Providers.deletedHeight));
+    if (state.activeProviderCount !== providerRow.value) {
+      mismatches.push({ scope: "network_state", field: "activeProviderCount", expected: String(providerRow.value), actual: String(state.activeProviderCount) });
+    }
+
+    const [checkpoint] = await tx.select().from(IndexerState).where(eq(IndexerState.stream, SYNC_STREAM));
+    if (checkpoint && checkpoint.lastHeight !== state.lastAggregatedHeight) {
+      mismatches.push({
+        scope: "network_state",
+        field: "lastAggregatedHeight",
+        expected: String(checkpoint.lastHeight),
+        actual: String(state.lastAggregatedHeight)
+      });
+    }
+
+    return mismatches;
+  }
+
+  async #checkSpends(tx: ChainTransaction, state: typeof NetworkState.$inferSelect): Promise<Mismatch[]> {
+    const rows = await tx
+      .select({ denom: Leases.denom, earned: sql<string>`SUM(${Leases.withdrawnAmount} + ${Leases.balance})` })
+      .from(Leases)
+      .groupBy(Leases.denom);
+    const earnedByDenom = new Map(rows.map(row => [row.denom, decFromString(row.earned)]));
+
+    const stateByDenom = {
+      uakt: decFromString(state.totalUaktSpent),
+      uusdc: decFromString(state.totalUusdcSpent),
+      uact: decFromString(state.totalUactSpent)
+    };
+
+    const mismatches: Mismatch[] = [];
+    for (const denom of TRACKED_SPEND_DENOMS) {
+      const expected = earnedByDenom.get(denom) ?? 0n;
+      if (stateByDenom[denom] !== expected) {
+        mismatches.push({ scope: "network_state", field: `total_${denom}_spent`, expected: expected.toString(), actual: stateByDenom[denom].toString() });
+      }
+    }
+    return mismatches;
+  }
+
+  async #checkRollups(tx: ChainTransaction, rollupSampleSize: number): Promise<Mismatch[]> {
+    const rollups = await tx.select().from(NetworkRollups).orderBy(desc(NetworkRollups.date)).limit(rollupSampleSize);
+
+    const mismatches: Mismatch[] = [];
+    for (const rollup of rollups) {
+      const recomputed = await this.#leaseAggregates(tx, rollup.closeHeight);
+      for (const field of Object.keys(recomputed) as (keyof LeaseAggregates)[]) {
+        if (rollup[field] !== recomputed[field]) {
+          mismatches.push({ scope: `network_rollups:${rollup.date}`, field, expected: String(recomputed[field]), actual: String(rollup[field]) });
+        }
+      }
+    }
+    return mismatches;
+  }
+
+  async #leaseAggregates(tx: ChainTransaction, atHeight?: number): Promise<LeaseAggregates> {
+    const active =
+      atHeight === undefined
+        ? sql`${Leases.closedHeight} IS NULL`
+        : sql`${Leases.createdHeight} <= ${atHeight} AND (${Leases.closedHeight} IS NULL OR ${Leases.closedHeight} > ${atHeight})`;
+    const created = atHeight === undefined ? sql`TRUE` : sql`${Leases.createdHeight} <= ${atHeight}`;
+
+    const [row] = await tx
+      .select({
+        activeLeaseCount: sql<number>`COUNT(*) FILTER (WHERE ${active})`.mapWith(Number),
+        totalLeaseCount: sql<number>`COUNT(*) FILTER (WHERE ${created})`.mapWith(Number),
+        activeCpuUnits: sql<number>`COALESCE(SUM(${Leases.cpuUnits}) FILTER (WHERE ${active}), 0)`.mapWith(Number),
+        activeGpuUnits: sql<number>`COALESCE(SUM(${Leases.gpuUnits}) FILTER (WHERE ${active}), 0)`.mapWith(Number),
+        activeMemoryBytes: sql<number>`COALESCE(SUM(${Leases.memoryBytes}) FILTER (WHERE ${active}), 0)`.mapWith(Number),
+        activeEphemeralStorageBytes: sql<number>`COALESCE(SUM(${Leases.ephemeralStorageBytes}) FILTER (WHERE ${active}), 0)`.mapWith(Number),
+        activePersistentStorageBytes: sql<number>`COALESCE(SUM(${Leases.persistentStorageBytes}) FILTER (WHERE ${active}), 0)`.mapWith(Number)
+      })
+      .from(Leases);
+    return row;
+  }
+}

--- a/apps/chain-indexer/src/reconcile/reconcile.ts
+++ b/apps/chain-indexer/src/reconcile/reconcile.ts
@@ -5,11 +5,13 @@ import { container } from "tsyringe";
 
 import { envSchema } from "@src/config/env.config";
 import { PgClientService } from "@src/db/pg-client.service";
+import { NetworkStatsReconciler } from "@src/reconcile/network-stats-reconciler";
 import { ReconcileService } from "@src/reconcile/reconcile.service";
 
 /**
  * One-shot reconciliation entrypoint (`npm run reconcile`): exits 0 when the ledger matches the chain at the
- * sync checkpoint height, non-zero on any mismatch or misconfiguration, so it can gate a deploy.
+ * sync checkpoint height and the network aggregates match their recomputation from the leases table,
+ * non-zero on any mismatch or misconfiguration, so it can gate a deploy.
  */
 async function main(): Promise<void> {
   const logger = createOtelLogger({ context: "RECONCILE_CLI" });
@@ -24,8 +26,9 @@ async function main(): Promise<void> {
   const sampleSize = parsed.data.RECONCILE_SAMPLE_SIZE;
 
   try {
-    const ok = await container.resolve(ReconcileService).reconcile(sampleSize === undefined ? {} : { sampleSize });
-    process.exitCode = ok ? 0 : 1;
+    const bankOk = await container.resolve(ReconcileService).reconcile(sampleSize === undefined ? {} : { sampleSize });
+    const networkOk = await container.resolve(NetworkStatsReconciler).reconcile();
+    process.exitCode = bankOk && networkOk ? 0 : 1;
   } catch (error) {
     logger.error({ event: "RECONCILE_FATAL", error });
     process.exitCode = 1;

--- a/apps/chain-indexer/tsup.config.ts
+++ b/apps/chain-indexer/tsup.config.ts
@@ -14,6 +14,7 @@ export default defineConfig(async overrideOptions =>
     entry: {
       server: "./src/server.ts",
       reconcile: "./src/reconcile/reconcile.ts",
+      "recompute-usd": "./src/network/recompute-usd.ts",
       instrumentation: fileURLToPath(import.meta.resolve("@akashnetwork/instrumentation/register"))
     },
     target: tsconfig.compilerOptions.target,


### PR DESCRIPTION
## Why

The legacy indexer recomputes network stats in memory on every block and writes them onto every block row. When a day's AKT price is restated, `usdSpendingTracker` then rewrites `totalUUsdSpent` on every block row from that day to the tip. Dashboard endpoints pay for this with 5 to 33 second responses.

Closes CON-814

## What

Network aggregates maintained incrementally inside the per-block transaction, in three new tables:

- `akash.network_state`: one row holding the current active lease count, all-time lease count, active provider count, active resource totals (including the on-chain leased GPU count), and cumulative spend per denom. `last_aggregated_height` is the replay watermark; the row is locked `FOR UPDATE` so duplicate commits and overlapping writers fold each block exactly once.
- `akash.network_rollups`: one append-only row per UTC day, written atomically with the first block of the following day. Each row carries the close-of-day snapshot, per-day deltas in native denoms, and a nullable `daily_usd_spent` with the `akt_price_used` it was computed from. Cumulative USD is deliberately not stored: it is a window `SUM` over the same table on read, so a restatement never cascades.
- `akash.daily_prices`: daily close prices, to be populated by the jobs role (CON-807). Until then USD columns stay null.

How the numbers flow: `AkashWriter` now snapshots the deployment states it loads before folding each block through the reducer and diffs after, returning one `NetworkBlockDelta` per block (lease opens/closes with resource totals, and the change in earned value per denom). This catches every close path, including overdraw closes inside settlement, without instrumenting each handler. `NetworkStatsWriter` applies the deltas in the same transaction, after the other writers and before the checkpoint advance.

**Spend is settlement-exact, not the legacy rate estimate.** Cumulative spend per denom is defined as provider earnings, `SUM(withdrawn_amount + balance)` over leases. This reconciles exactly against the leases table and avoids the legacy overstatement for depleted-but-unsettled deployments (the `predictedClosedHeight` workaround). The trade-off: daily series are lumpier than legacy, because a deployment that sits untouched recognizes its accrual on the day it is next settled. Totals are exact. If a smooth estimated series turns out to be needed, an `active_block_rate` column can be added later without reshaping the tables.

A price restatement updates exactly one row per affected day: `DayCloseUsdService` runs a single `UPDATE ... FROM akash.daily_prices WHERE akt_price_used IS DISTINCT FROM price`, invocable in-pipeline at day close, from the new `npm run network:recompute-usd` CLI, or by the future price job. `NetworkStatsReconciler` recomputes the state row and sampled rollup rows from the leases table inside one repeatable-read snapshot and now runs as part of `npm run reconcile`.

### Verification (sandbox, blocks 4,844,900 to 4,852,400)

The range spans the 2026-08-16/17 UTC boundary and real deployment and lease activity.

- `network_state` matched the manual SQL recompute field for field: 1 active lease, 10 all-time, 500 mCPU, 512Mi memory and ephemeral storage, 38,999 uact earned. `npm run reconcile` logged `NETWORK_RECONCILE_OK` with 0 mismatches.
- The 2026-08-16 rollup closed at height 4,849,957, which an independent binary search over RPC block timestamps confirmed as the last block of that day. Re-deriving its counts at `close_height` matched.
- Inserting a `daily_prices` row and running `network:recompute-usd` updated exactly that one rollup row (10,611 uact micro units filled in as $0.010611); restating the price to a new value updated the same single row again, and a second run was a no-op (count 0). No block rows are touched because none exist in this design.
- The daily series and cumulative USD come from one `SELECT ... SUM(daily_usd_spent) OVER (ORDER BY date) FROM akash.network_rollups`.

### Notes

- Aggregates cover ranges indexed after this lands. The state row lazy-inits at the first committed block, so the normal backfill-from-genesis path yields full history, same as the other akash tables.
- Days with zero blocks get no rollup row; consumers must tolerate gaps, as they did with legacy `Day` rows.
- GPU breakdown and per-provider daily stats are out of scope here; they move to `apps/provider-inventory` per the issue.
