### PR TITLE
refactor(observability): isolate immediate funding instrumentation from cron

### DIFF
--- a/apps/api/src/app/services/fund-draining-deployments/fund-draining-deployments.handler.spec.ts
+++ b/apps/api/src/app/services/fund-draining-deployments/fund-draining-deployments.handler.spec.ts
@@ -4,6 +4,7 @@ import { mock } from "vitest-mock-extended";
 import type { FundDrainingDeploymentsCommand } from "@src/billing/commands/fund-draining-deployments.command";
 import type { JobPayload } from "@src/core";
 import type { CreateLogger } from "@src/core/providers/logging.provider";
+import type { FundDrainingDeploymentsInstrumentationService } from "@src/deployment/services/top-up-managed-deployments/fund-draining-deployments-instrumentation.service";
 import type { TopUpManagedDeploymentsService } from "@src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service";
 import { FundDrainingDeploymentsHandler } from "./fund-draining-deployments.handler";
 
@@ -14,8 +15,8 @@ describe(FundDrainingDeploymentsHandler.name, () => {
     version: 1
   };
 
-  it("funds the owner's draining deployments for the payload identifiers", async () => {
-    const { handler, topUpManagedDeploymentsService } = setup();
+  it("funds the owner's draining deployments and records job success", async () => {
+    const { handler, topUpManagedDeploymentsService, instrumentation } = setup();
 
     await handler.handle(payload);
 
@@ -23,16 +24,19 @@ describe(FundDrainingDeploymentsHandler.name, () => {
       walletId: 1,
       address: "akash1abc"
     });
+    expect(instrumentation.recordJobSucceeded).toHaveBeenCalledWith(expect.any(Number));
+    expect(instrumentation.recordJobFailed).not.toHaveBeenCalled();
   });
 
-  it("logs and rethrows when the funding service throws so the job can retry", async () => {
+  it("records the failure and rethrows when funding throws so the job can retry", async () => {
     const error = new Error("deposit failed");
-    const { handler, logger } = setup({
+    const { handler, instrumentation } = setup({
       topUpManagedDeploymentsService: { topUpDrainingDeploymentsForOwner: vi.fn().mockRejectedValue(error) }
     });
 
     await expect(handler.handle(payload)).rejects.toThrow(error);
-    expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "FUND_DRAINING_DEPLOYMENTS_FAILED", error }));
+    expect(instrumentation.recordJobFailed).toHaveBeenCalledWith(expect.any(Number), error);
+    expect(instrumentation.recordJobSucceeded).not.toHaveBeenCalled();
   });
 
   it("uses the singleton policy so the per-wallet singletonKey serializes same-wallet funding", () => {
@@ -46,11 +50,12 @@ describe(FundDrainingDeploymentsHandler.name, () => {
       topUpDrainingDeploymentsForOwner: vi.fn().mockResolvedValue(undefined),
       ...params?.topUpManagedDeploymentsService
     });
+    const instrumentation = mock<FundDrainingDeploymentsInstrumentationService>();
     const logger = mock<ReturnType<CreateLogger>>();
     const createLogger: CreateLogger = () => logger;
 
-    const handler = new FundDrainingDeploymentsHandler(topUpManagedDeploymentsService, createLogger);
+    const handler = new FundDrainingDeploymentsHandler(topUpManagedDeploymentsService, instrumentation, createLogger);
 
-    return { handler, topUpManagedDeploymentsService, logger };
+    return { handler, topUpManagedDeploymentsService, instrumentation, logger };
   }
 });

--- a/apps/api/src/app/services/fund-draining-deployments/fund-draining-deployments.handler.ts
+++ b/apps/api/src/app/services/fund-draining-deployments/fund-draining-deployments.handler.ts
@@ -3,6 +3,7 @@ import { inject, singleton } from "tsyringe";
 import { FundDrainingDeploymentsCommand } from "@src/billing/commands/fund-draining-deployments.command";
 import type { JobHandler, JobPayload } from "@src/core";
 import { type CreateLogger, LOGGER_FACTORY } from "@src/core/providers/logging.provider";
+import { FundDrainingDeploymentsInstrumentationService } from "@src/deployment/services/top-up-managed-deployments/fund-draining-deployments-instrumentation.service";
 import { TopUpManagedDeploymentsService } from "@src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service";
 
 @singleton()
@@ -22,6 +23,7 @@ export class FundDrainingDeploymentsHandler implements JobHandler<FundDrainingDe
 
   constructor(
     private readonly topUpManagedDeploymentsService: TopUpManagedDeploymentsService,
+    private readonly instrumentation: FundDrainingDeploymentsInstrumentationService,
     @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
     this.logger = createLogger({ context: FundDrainingDeploymentsHandler.name });
@@ -30,13 +32,16 @@ export class FundDrainingDeploymentsHandler implements JobHandler<FundDrainingDe
   async handle(payload: JobPayload<FundDrainingDeploymentsCommand>): Promise<void> {
     this.logger.debug({ event: "FUND_DRAINING_DEPLOYMENTS", walletId: payload.walletId, address: payload.address });
 
+    const startTime = Date.now();
+
     try {
       await this.topUpManagedDeploymentsService.topUpDrainingDeploymentsForOwner({
         walletId: payload.walletId,
         address: payload.address
       });
+      this.instrumentation.recordJobSucceeded(Date.now() - startTime);
     } catch (error) {
-      this.logger.error({ event: "FUND_DRAINING_DEPLOYMENTS_FAILED", walletId: payload.walletId, address: payload.address, error });
+      this.instrumentation.recordJobFailed(Date.now() - startTime, error);
       throw error;
     }
   }

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
@@ -16,6 +16,7 @@ import type { DrainingDeploymentOutput, LeaseRepository } from "@src/deployment/
 import { averageBlockCountInAnHour } from "@src/utils/constants";
 import type { DeploymentConfigService } from "../deployment-config/deployment-config.service";
 import type { DrainingDeploymentRpcService } from "../draining-deployment-rpc/draining-deployment-rpc.service";
+import type { DeploymentTopUpInstrumentation } from "../top-up-managed-deployments/deployment-top-up-instrumentation";
 import type { TopUpManagedDeploymentsInstrumentationService } from "../top-up-managed-deployments/top-up-managed-deployments-instrumentation.service";
 import { DrainingDeploymentService } from "./draining-deployment.service";
 
@@ -120,7 +121,7 @@ describe(DrainingDeploymentService.name, () => {
       deploymentSettingRepository.findAutoTopUpDeploymentsByOwner.mockResolvedValue(settings);
       vi.spyOn(service, "findLeases").mockResolvedValue(leases);
 
-      const result = await service.findDrainingDeploymentsForOwner(address);
+      const result = await service.findDrainingDeploymentsForOwner(address, mock<DeploymentTopUpInstrumentation>());
 
       expect(deploymentSettingRepository.findAutoTopUpDeploymentsByOwner).toHaveBeenCalledWith(address);
       expect(result).toHaveLength(2);
@@ -130,7 +131,8 @@ describe(DrainingDeploymentService.name, () => {
     });
 
     it("marks closed deployments as closed and excludes them from the result", async () => {
-      const { service, deploymentSettingRepository, currentHeight } = setup();
+      const { service, deploymentSettingRepository, currentHeight, instrumentation } = setup();
+      const sink = mock<DeploymentTopUpInstrumentation>();
       const address = createAkashAddress();
       const activeSetting = createAutoTopUpDeployment({ address, dseq: "2001" });
       const closedSetting = createAutoTopUpDeployment({ address, dseq: "2002" });
@@ -146,11 +148,13 @@ describe(DrainingDeploymentService.name, () => {
         })
       ]);
 
-      const result = await service.findDrainingDeploymentsForOwner(address);
+      const result = await service.findDrainingDeploymentsForOwner(address, sink);
 
       expect(result).toHaveLength(1);
       expect(result[0].dseq).toBe(activeSetting.dseq);
       expect(deploymentSettingRepository.updateManyById).toHaveBeenCalledWith([closedSetting.id], { closed: true });
+      expect(sink.recordDeploymentsMarkedClosed).toHaveBeenCalledWith(1);
+      expect(instrumentation.recordDeploymentsMarkedClosed).not.toHaveBeenCalled();
     });
 
     it("returns an empty array without querying leases when the owner has no auto-top-up deployments", async () => {
@@ -158,7 +162,7 @@ describe(DrainingDeploymentService.name, () => {
       const findLeasesSpy = vi.spyOn(service, "findLeases");
       deploymentSettingRepository.findAutoTopUpDeploymentsByOwner.mockResolvedValue([]);
 
-      const result = await service.findDrainingDeploymentsForOwner(createAkashAddress());
+      const result = await service.findDrainingDeploymentsForOwner(createAkashAddress(), mock<DeploymentTopUpInstrumentation>());
 
       expect(result).toEqual([]);
       expect(findLeasesSpy).not.toHaveBeenCalled();
@@ -624,7 +628,8 @@ describe(DrainingDeploymentService.name, () => {
       loggerService,
       balancesService,
       config,
-      currentHeight
+      currentHeight,
+      instrumentation
     };
   }
 });

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
@@ -12,6 +12,7 @@ import { DrainingDeployment } from "@src/deployment/types/draining-deployment";
 import { averageBlockCountInAnHour } from "@src/utils/constants";
 import { DeploymentConfigService } from "../deployment-config/deployment-config.service";
 import { DrainingDeploymentRpcService } from "../draining-deployment-rpc/draining-deployment-rpc.service";
+import type { DeploymentTopUpInstrumentation } from "../top-up-managed-deployments/deployment-top-up-instrumentation";
 import { TopUpManagedDeploymentsInstrumentationService } from "../top-up-managed-deployments/top-up-managed-deployments-instrumentation.service";
 
 export type { DrainingDeployment } from "@src/deployment/types/draining-deployment";
@@ -44,7 +45,7 @@ export class DrainingDeploymentService {
     const expectedClosureHeight = await this.#getExpectedClosureHeight();
 
     for await (const { address, walletId, deploymentSettings } of this.deploymentSettingRepository.findAutoTopUpDeploymentsByOwnerIteratively()) {
-      const deployments = await this.#resolveActiveDrainingDeployments(deploymentSettings, address, expectedClosureHeight);
+      const deployments = await this.#resolveActiveDrainingDeployments(deploymentSettings, address, expectedClosureHeight, this.instrumentation);
 
       if (deployments.length) {
         yield { address, walletId, deployments };
@@ -57,11 +58,11 @@ export class DrainingDeploymentService {
    * look-ahead window, auto-top-up gate, and closed-marking as the cron sweep.
    * Backs the event-driven immediate funding triggered when credits land.
    */
-  async findDrainingDeploymentsForOwner(address: string): Promise<DrainingDeployment[]> {
+  async findDrainingDeploymentsForOwner(address: string, instrumentation: DeploymentTopUpInstrumentation): Promise<DrainingDeployment[]> {
     const deploymentSettings = await this.deploymentSettingRepository.findAutoTopUpDeploymentsByOwner(address);
     const expectedClosureHeight = await this.#getExpectedClosureHeight();
 
-    return this.#resolveActiveDrainingDeployments(deploymentSettings, address, expectedClosureHeight);
+    return this.#resolveActiveDrainingDeployments(deploymentSettings, address, expectedClosureHeight, instrumentation);
   }
 
   async #getExpectedClosureHeight(): Promise<number> {
@@ -72,7 +73,8 @@ export class DrainingDeploymentService {
   async #resolveActiveDrainingDeployments(
     deploymentSettings: AutoTopUpDeployment[],
     address: string,
-    expectedClosureHeight: number
+    expectedClosureHeight: number,
+    instrumentation: DeploymentTopUpInstrumentation
   ): Promise<DrainingDeployment[]> {
     if (deploymentSettings.length === 0) {
       return [];
@@ -110,7 +112,7 @@ export class DrainingDeploymentService {
 
     if (missingIds.length) {
       await this.deploymentSettingRepository.updateManyById(missingIds, { closed: true });
-      this.instrumentation.recordDeploymentsMarkedClosed(missingIds.length);
+      instrumentation.recordDeploymentsMarkedClosed(missingIds.length);
     }
 
     return active;

--- a/apps/api/src/deployment/services/top-up-managed-deployments/deployment-top-up-instrumentation.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/deployment-top-up-instrumentation.ts
@@ -1,0 +1,21 @@
+import type { DepositDeploymentMsgOptions } from "@src/billing/services";
+import type { DrainingDeployment } from "@src/deployment/types/draining-deployment";
+
+export type FundingMessageItem = { deployment: DrainingDeployment; input: DepositDeploymentMsgOptions };
+
+/**
+ * Telemetry sink shared by the two deployment top-up paths: the hourly cron and the event-driven
+ * immediate funding that runs when credits land. The cron's summarizer-backed instrumentation and the
+ * stateless per-job instrumentation each implement this, so the shared funding mechanics can report to
+ * whichever instrumentation owns the current run without knowing which meter it feeds.
+ */
+export interface DeploymentTopUpInstrumentation {
+  recordDeploymentPreparation(ownerAddress: string, predictedClosedHeight: number): void;
+  recordInvalidDepositAmount(details: { desiredAmount: number; dseq: string; address: string; blockRate: number }): void;
+  recordMessagePreparationError(details: { deployment: DrainingDeployment; error: unknown }): void;
+  recordSkipped(details: { owner: string; deploymentCount: number }): void;
+  recordDeposit(details: { owner: string; items: FundingMessageItem[] }): void;
+  recordChainTxError(details: { owner: string; items: FundingMessageItem[]; error: unknown }): void;
+  recordMasterWalletInsufficientFundsError(details: { owner: string; items: FundingMessageItem[]; error: unknown }): void;
+  recordDeploymentsMarkedClosed(count: number): void;
+}

--- a/apps/api/src/deployment/services/top-up-managed-deployments/fund-draining-deployments-instrumentation.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/fund-draining-deployments-instrumentation.service.spec.ts
@@ -1,0 +1,262 @@
+const mockLogger = vi.hoisted(() => ({
+  info: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  debug: vi.fn()
+}));
+
+vi.mock("@akashnetwork/logging/otel", () => ({
+  createOtelLogger: () => mockLogger
+}));
+
+import { faker } from "@faker-js/faker";
+import type { Counter, Histogram } from "@opentelemetry/api";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { MetricsService } from "@src/core";
+import type { DrainingDeployment } from "@src/deployment/types/draining-deployment";
+import type { FundingMessageItem } from "./deployment-top-up-instrumentation";
+import { classifyFailure, FundDrainingDeploymentsInstrumentationService } from "./fund-draining-deployments-instrumentation.service";
+
+describe(FundDrainingDeploymentsInstrumentationService.name, () => {
+  describe("recordJobSucceeded", () => {
+    it("increments completions and duration with a success status and logs completion", () => {
+      const { service, jobCompletions, jobDuration } = setup();
+
+      service.recordJobSucceeded(1234);
+
+      expect(jobCompletions.add).toHaveBeenCalledWith(1, { status: "success" });
+      expect(jobDuration.record).toHaveBeenCalledWith(1234, { status: "success" });
+      expect(mockLogger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "FUND_DRAINING_JOB_COMPLETED", status: "success", durationMs: 1234 }));
+    });
+  });
+
+  describe("recordJobFailed", () => {
+    it("marks a master-wallet insufficient-funds failure as retriable", () => {
+      const { service, jobCompletions, jobDuration } = setup();
+      const error = new Error("failed to execute message; message index: 0: insufficient funds");
+
+      service.recordJobFailed(50, error);
+
+      expect(jobCompletions.add).toHaveBeenCalledWith(1, { status: "failure", reason: "master_wallet_insufficient_funds", retriable: true });
+      expect(jobDuration.record).toHaveBeenCalledWith(50, { status: "failure" });
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ event: "FUND_DRAINING_JOB_FAILED", reason: "master_wallet_insufficient_funds", retriable: true, error })
+      );
+    });
+
+    it("marks a generic deposit failure as non-retriable", () => {
+      const { service, jobCompletions } = setup();
+      const error = new Error("Bad status on response: 503");
+
+      service.recordJobFailed(50, error);
+
+      expect(jobCompletions.add).toHaveBeenCalledWith(1, { status: "failure", reason: "deposit_tx_failed", retriable: false });
+    });
+  });
+
+  describe("recordDeposit", () => {
+    it("increments deposits by item count, records each amount under its denom, and logs the deposit", () => {
+      const { service, deposits, depositAmount } = setup();
+      const items = [createFundingItem({ amount: 500000, denom: "uakt", dseq: 1 }), createFundingItem({ amount: 750000, denom: "uakt", dseq: 2 })];
+
+      service.recordDeposit({ owner: "akash1owner", items });
+
+      expect(deposits.add).toHaveBeenCalledWith(2);
+      expect(depositAmount.record).toHaveBeenCalledWith(500000, { denom: "uakt" });
+      expect(depositAmount.record).toHaveBeenCalledWith(750000, { denom: "uakt" });
+      expect(mockLogger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "FUND_DRAINING_DEPOSITED", owner: "akash1owner" }));
+    });
+  });
+
+  describe("recordSkipped", () => {
+    it("increments skips with a nothing_to_fund reason and logs it", () => {
+      const { service, skips } = setup();
+
+      service.recordSkipped({ owner: "akash1owner", deploymentCount: 3 });
+
+      expect(skips.add).toHaveBeenCalledWith(1, { reason: "nothing_to_fund" });
+      expect(mockLogger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "FUND_DRAINING_SKIPPED", owner: "akash1owner", deploymentCount: 3 }));
+    });
+  });
+
+  describe("recordInvalidDepositAmount", () => {
+    it("increments skips with a non_positive_amount reason and warns", () => {
+      const { service, skips } = setup();
+
+      service.recordInvalidDepositAmount({ desiredAmount: 0, dseq: "123", address: "akash1owner", blockRate: 50 });
+
+      expect(skips.add).toHaveBeenCalledWith(1, { reason: "non_positive_amount" });
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "FUND_DRAINING_AMOUNT_NON_POSITIVE", desiredAmount: 0, dseq: "123" }));
+    });
+  });
+
+  describe("recordMessagePreparationError", () => {
+    it("tags an insufficient-balance error and counts auto-reload wallets separately", () => {
+      const { service, messagePreparationErrors, insufficientBalanceWithAutoReload } = setup();
+      const deployment = mock<DrainingDeployment>({ dseq: "123", address: "akash1owner", isWalletAutoTopUpEnabled: true });
+
+      service.recordMessagePreparationError({ deployment, error: new Error("Insufficient balance to cover deposit") });
+
+      expect(messagePreparationErrors.add).toHaveBeenCalledWith(1, { error_type: "insufficient_balance" });
+      expect(insufficientBalanceWithAutoReload.add).toHaveBeenCalledWith(1);
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ event: "FUND_DRAINING_MESSAGE_PREPARATION_ERROR", errorType: "insufficient_balance" })
+      );
+    });
+
+    it("does not count auto-reload when the wallet has auto top-up disabled", () => {
+      const { service, insufficientBalanceWithAutoReload } = setup();
+      const deployment = mock<DrainingDeployment>({ dseq: "123", address: "akash1owner", isWalletAutoTopUpEnabled: false });
+
+      service.recordMessagePreparationError({ deployment, error: new Error("Insufficient balance to cover deposit") });
+
+      expect(insufficientBalanceWithAutoReload.add).not.toHaveBeenCalled();
+    });
+
+    it("tags any other preparation error as unknown and logs an error", () => {
+      const { service, messagePreparationErrors, insufficientBalanceWithAutoReload } = setup();
+      const deployment = mock<DrainingDeployment>({ dseq: "123", address: "akash1owner", isWalletAutoTopUpEnabled: true });
+
+      service.recordMessagePreparationError({ deployment, error: new Error("rpc unavailable") });
+
+      expect(messagePreparationErrors.add).toHaveBeenCalledWith(1, { error_type: "unknown" });
+      expect(insufficientBalanceWithAutoReload.add).not.toHaveBeenCalled();
+      expect(mockLogger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "FUND_DRAINING_MESSAGE_PREPARATION_ERROR", errorType: "unknown" }));
+    });
+  });
+
+  describe("recordChainTxError", () => {
+    it("increments chain tx errors and logs the error", () => {
+      const { service, chainTxErrors } = setup();
+      const error = new Error("broadcast failed");
+
+      service.recordChainTxError({ owner: "akash1owner", items: [createFundingItem()], error });
+
+      expect(chainTxErrors.add).toHaveBeenCalledWith(1);
+      expect(mockLogger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "FUND_DRAINING_CHAIN_TX_ERROR", owner: "akash1owner", error }));
+    });
+  });
+
+  describe("recordMasterWalletInsufficientFundsError", () => {
+    it("increments the master-wallet insufficient-funds counter and logs the error", () => {
+      const { service, masterWalletInsufficientFunds } = setup();
+      const error = new Error("insufficient funds");
+
+      service.recordMasterWalletInsufficientFundsError({ owner: "akash1owner", items: [createFundingItem()], error });
+
+      expect(masterWalletInsufficientFunds.add).toHaveBeenCalledWith(1);
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ event: "FUND_DRAINING_MASTER_WALLET_INSUFFICIENT_FUNDS", owner: "akash1owner", error })
+      );
+    });
+  });
+
+  describe("recordDeploymentsMarkedClosed", () => {
+    it("increments the marked-closed counter by the given count", () => {
+      const { service, deploymentsMarkedClosed } = setup();
+
+      service.recordDeploymentsMarkedClosed(4);
+
+      expect(deploymentsMarkedClosed.add).toHaveBeenCalledWith(4);
+    });
+  });
+
+  describe("recordDeploymentPreparation", () => {
+    it("records no instrument and does not throw on the stateless path", () => {
+      const { service, jobCompletions } = setup();
+
+      expect(() => service.recordDeploymentPreparation("akash1owner", 1000500)).not.toThrow();
+      expect(jobCompletions.add).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the logger throws", () => {
+    it("still records job completion metrics and does not propagate the failure", () => {
+      const { service, jobCompletions, jobDuration } = setup();
+      mockLogger.info.mockImplementationOnce(() => {
+        throw new Error("logger down");
+      });
+
+      expect(() => service.recordJobSucceeded(1234)).not.toThrow();
+      expect(jobCompletions.add).toHaveBeenCalledWith(1, { status: "success" });
+      expect(jobDuration.record).toHaveBeenCalledWith(1234, { status: "success" });
+    });
+
+    it("still records failure metrics and does not propagate the failure", () => {
+      const { service, jobCompletions } = setup();
+      mockLogger.error.mockImplementationOnce(() => {
+        throw new Error("logger down");
+      });
+
+      expect(() => service.recordJobFailed(50, new Error("boom"))).not.toThrow();
+      expect(jobCompletions.add).toHaveBeenCalledWith(1, { status: "failure", reason: "deposit_tx_failed", retriable: false });
+    });
+
+    it("still records skip metrics and does not propagate the failure", () => {
+      const { service, skips } = setup();
+      mockLogger.info.mockImplementationOnce(() => {
+        throw new Error("logger down");
+      });
+
+      expect(() => service.recordSkipped({ owner: "akash1owner", deploymentCount: 1 })).not.toThrow();
+      expect(skips.add).toHaveBeenCalledWith(1, { reason: "nothing_to_fund" });
+    });
+  });
+
+  describe("classifyFailure", () => {
+    it("classifies an insufficient-funds error, case-insensitively", () => {
+      expect(classifyFailure(new Error("Message index 0: Insufficient Funds"))).toBe("master_wallet_insufficient_funds");
+    });
+
+    it("classifies any other error as a deposit tx failure", () => {
+      expect(classifyFailure(new Error(faker.lorem.sentence()))).toBe("deposit_tx_failed");
+    });
+
+    it("classifies a non-error throw as unknown", () => {
+      expect(classifyFailure("boom")).toBe("unknown");
+    });
+  });
+
+  function createFundingItem(input?: { amount?: number; denom?: string; dseq?: number }): FundingMessageItem {
+    return {
+      deployment: mock<DrainingDeployment>(),
+      input: {
+        dseq: input?.dseq ?? faker.number.int({ min: 1, max: 100000 }),
+        amount: input?.amount ?? faker.number.int({ min: 1, max: 1000000 }),
+        denom: input?.denom ?? "uakt",
+        owner: "akash1owner",
+        signer: "akash1owner"
+      }
+    };
+  }
+
+  function setup() {
+    vi.clearAllMocks();
+
+    const counters: Record<string, Counter> = {};
+    const histograms: Record<string, Histogram> = {};
+
+    const metricsService = mock<MetricsService>();
+    metricsService.getMeter.mockReturnValue(mock());
+    metricsService.createCounter.mockImplementation((_meter, name) => (counters[name] = mock<Counter>()));
+    metricsService.createHistogram.mockImplementation((_meter, name) => (histograms[name] = mock<Histogram>()));
+
+    const service = new FundDrainingDeploymentsInstrumentationService(metricsService);
+
+    return {
+      service,
+      jobCompletions: counters["fund_draining_deployments_job_completions_total"],
+      deposits: counters["fund_draining_deployments_deposits_total"],
+      skips: counters["fund_draining_deployments_skips_total"],
+      messagePreparationErrors: counters["fund_draining_deployments_message_preparation_errors_total"],
+      insufficientBalanceWithAutoReload: counters["fund_draining_deployments_insufficient_balance_with_auto_reload_total"],
+      chainTxErrors: counters["fund_draining_deployments_chain_tx_errors_total"],
+      masterWalletInsufficientFunds: counters["fund_draining_deployments_master_wallet_insufficient_funds_total"],
+      deploymentsMarkedClosed: counters["fund_draining_deployments_deployments_marked_closed_total"],
+      jobDuration: histograms["fund_draining_deployments_job_duration_ms"],
+      depositAmount: histograms["fund_draining_deployments_deposit_amount"]
+    };
+  }
+});

--- a/apps/api/src/deployment/services/top-up-managed-deployments/fund-draining-deployments-instrumentation.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/fund-draining-deployments-instrumentation.service.ts
@@ -116,7 +116,7 @@ export class FundDrainingDeploymentsInstrumentationService implements Deployment
     this.emitLog("info", {
       event: "FUND_DRAINING_DEPOSITED",
       owner,
-      deposits: items.map(({ input }) => ({ dseq: input.dseq, amount: input.amount, denom: input.denom }))
+      deposits: this.serializeDeposits(items)
     });
   }
 
@@ -155,7 +155,7 @@ export class FundDrainingDeploymentsInstrumentationService implements Deployment
     this.emitLog("error", {
       event: "FUND_DRAINING_CHAIN_TX_ERROR",
       owner,
-      deposits: items.map(({ input }) => ({ dseq: input.dseq, amount: input.amount, denom: input.denom })),
+      deposits: this.serializeDeposits(items),
       error
     });
   }
@@ -165,7 +165,7 @@ export class FundDrainingDeploymentsInstrumentationService implements Deployment
     this.emitLog("error", {
       event: "FUND_DRAINING_MASTER_WALLET_INSUFFICIENT_FUNDS",
       owner,
-      deposits: items.map(({ input }) => ({ dseq: input.dseq, amount: input.amount, denom: input.denom })),
+      deposits: this.serializeDeposits(items),
       error
     });
   }
@@ -179,6 +179,10 @@ export class FundDrainingDeploymentsInstrumentationService implements Deployment
    * event-driven path has no per-run start height, so there is nothing meaningful to record here.
    */
   recordDeploymentPreparation(_ownerAddress: string, _predictedClosedHeight: number): void {}
+
+  private serializeDeposits(items: FundingMessageItem[]): { dseq: number | string; amount: number; denom: string }[] {
+    return items.map(({ input }) => ({ dseq: input.dseq, amount: input.amount, denom: input.denom }));
+  }
 
   /**
    * Telemetry must never break the funding job. It runs on pg-boss, so a synchronous logger failure

--- a/apps/api/src/deployment/services/top-up-managed-deployments/fund-draining-deployments-instrumentation.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/fund-draining-deployments-instrumentation.service.ts
@@ -1,0 +1,195 @@
+import { createOtelLogger } from "@akashnetwork/logging/otel";
+import type { Counter, Histogram, Meter } from "@opentelemetry/api";
+import { singleton } from "tsyringe";
+
+import { MetricsService } from "@src/core";
+import type { DrainingDeployment } from "@src/deployment/types/draining-deployment";
+import type { DeploymentTopUpInstrumentation, FundingMessageItem } from "./deployment-top-up-instrumentation";
+
+export type FundDrainingFailureReason = "master_wallet_insufficient_funds" | "deposit_tx_failed" | "unknown";
+
+export type FundDrainingSkipReason = "nothing_to_fund" | "non_positive_amount";
+
+export function classifyFailure(error: unknown): FundDrainingFailureReason {
+  if (!(error instanceof Error)) {
+    return "unknown";
+  }
+
+  if (/insufficient funds/i.test(error.message)) {
+    return "master_wallet_insufficient_funds";
+  }
+
+  return "deposit_tx_failed";
+}
+
+/**
+ * Instruments the event-driven immediate funding path (funding a wallet's draining deployments the moment
+ * credits land). Unlike the cron's summarizer-backed instrumentation it is stateless and holds no per-run
+ * state, so the always-on background worker can run several fundings concurrently without co-mingling. It
+ * reports under its own `fund_draining_deployments_*` meter so immediate funding stays distinguishable from
+ * the hourly cron's `auto_top_up_*` series.
+ */
+@singleton()
+export class FundDrainingDeploymentsInstrumentationService implements DeploymentTopUpInstrumentation {
+  private readonly meter: Meter;
+  private readonly jobCompletions: Counter;
+  private readonly jobDuration: Histogram;
+  private readonly deposits: Counter;
+  private readonly depositAmount: Histogram;
+  private readonly skips: Counter;
+  private readonly messagePreparationErrors: Counter;
+  private readonly insufficientBalanceWithAutoReload: Counter;
+  private readonly chainTxErrors: Counter;
+  private readonly masterWalletInsufficientFunds: Counter;
+  private readonly deploymentsMarkedClosed: Counter;
+
+  private readonly logger = createOtelLogger({ context: "FundDrainingDeploymentsService" });
+
+  constructor(private readonly metricsService: MetricsService) {
+    this.meter = this.metricsService.getMeter("fund-draining-deployments", "1.0.0");
+
+    this.jobCompletions = this.metricsService.createCounter(this.meter, "fund_draining_deployments_job_completions_total", {
+      description: "Total number of immediate draining-deployment funding job completions by status"
+    });
+
+    this.jobDuration = this.metricsService.createHistogram(this.meter, "fund_draining_deployments_job_duration_ms", {
+      description: "Duration of immediate draining-deployment funding job execution in milliseconds",
+      unit: "ms"
+    });
+
+    this.deposits = this.metricsService.createCounter(this.meter, "fund_draining_deployments_deposits_total", {
+      description: "Total number of successful immediate draining-deployment deposit transactions"
+    });
+
+    this.depositAmount = this.metricsService.createHistogram(this.meter, "fund_draining_deployments_deposit_amount", {
+      description: "Immediate draining-deployment deposit amounts per deployment",
+      unit: "uakt"
+    });
+
+    this.skips = this.metricsService.createCounter(this.meter, "fund_draining_deployments_skips_total", {
+      description: "Total number of immediate funding deployments skipped without depositing, by reason"
+    });
+
+    this.messagePreparationErrors = this.metricsService.createCounter(this.meter, "fund_draining_deployments_message_preparation_errors_total", {
+      description: "Total number of failed immediate funding message preparation attempts, by error type"
+    });
+
+    this.insufficientBalanceWithAutoReload = this.metricsService.createCounter(
+      this.meter,
+      "fund_draining_deployments_insufficient_balance_with_auto_reload_total",
+      {
+        description: "Total number of immediate funding insufficient balance errors where wallet auto-reload is enabled"
+      }
+    );
+
+    this.chainTxErrors = this.metricsService.createCounter(this.meter, "fund_draining_deployments_chain_tx_errors_total", {
+      description: "Total number of failed immediate funding deposit attempts"
+    });
+
+    this.masterWalletInsufficientFunds = this.metricsService.createCounter(this.meter, "fund_draining_deployments_master_wallet_insufficient_funds_total", {
+      description: "Total number of immediate funding deposits aborted because the master wallet had insufficient funds"
+    });
+
+    this.deploymentsMarkedClosed = this.metricsService.createCounter(this.meter, "fund_draining_deployments_deployments_marked_closed_total", {
+      description: "Total number of deployments marked as closed while resolving immediate funding candidates"
+    });
+  }
+
+  recordJobSucceeded(durationMs: number): void {
+    this.jobCompletions.add(1, { status: "success" });
+    this.jobDuration.record(durationMs, { status: "success" });
+    this.emitLog("info", { event: "FUND_DRAINING_JOB_COMPLETED", durationMs, status: "success" });
+  }
+
+  recordJobFailed(durationMs: number, error: unknown): void {
+    const reason = classifyFailure(error);
+    const retriable = reason === "master_wallet_insufficient_funds";
+
+    this.jobCompletions.add(1, { status: "failure", reason, retriable });
+    this.jobDuration.record(durationMs, { status: "failure" });
+    this.emitLog("error", { event: "FUND_DRAINING_JOB_FAILED", durationMs, reason, retriable, error });
+  }
+
+  recordDeposit({ owner, items }: { owner: string; items: FundingMessageItem[] }): void {
+    this.deposits.add(items.length);
+    items.forEach(({ input }) => this.depositAmount.record(input.amount, { denom: input.denom }));
+    this.emitLog("info", {
+      event: "FUND_DRAINING_DEPOSITED",
+      owner,
+      deposits: items.map(({ input }) => ({ dseq: input.dseq, amount: input.amount, denom: input.denom }))
+    });
+  }
+
+  recordSkipped({ owner, deploymentCount }: { owner: string; deploymentCount: number }): void {
+    this.skips.add(1, { reason: "nothing_to_fund" satisfies FundDrainingSkipReason });
+    this.emitLog("info", { event: "FUND_DRAINING_SKIPPED", owner, deploymentCount });
+  }
+
+  recordInvalidDepositAmount(details: { desiredAmount: number; dseq: string; address: string; blockRate: number }): void {
+    this.skips.add(1, { reason: "non_positive_amount" satisfies FundDrainingSkipReason });
+    this.emitLog("warn", { event: "FUND_DRAINING_AMOUNT_NON_POSITIVE", ...details });
+  }
+
+  recordMessagePreparationError({ deployment, error }: { deployment: DrainingDeployment; error: unknown }): void {
+    const message = error instanceof Error ? error.message : String(error);
+    const isInsufficientBalance = message.startsWith("Insufficient balance");
+    const errorType = isInsufficientBalance ? "insufficient_balance" : "unknown";
+
+    this.messagePreparationErrors.add(1, { error_type: errorType });
+
+    if (isInsufficientBalance && deployment.isWalletAutoTopUpEnabled) {
+      this.insufficientBalanceWithAutoReload.add(1);
+    }
+
+    this.emitLog(isInsufficientBalance ? "warn" : "error", {
+      event: "FUND_DRAINING_MESSAGE_PREPARATION_ERROR",
+      errorType,
+      dseq: deployment.dseq,
+      address: deployment.address,
+      error
+    });
+  }
+
+  recordChainTxError({ owner, items, error }: { owner: string; items: FundingMessageItem[]; error: unknown }): void {
+    this.chainTxErrors.add(1);
+    this.emitLog("error", {
+      event: "FUND_DRAINING_CHAIN_TX_ERROR",
+      owner,
+      deposits: items.map(({ input }) => ({ dseq: input.dseq, amount: input.amount, denom: input.denom })),
+      error
+    });
+  }
+
+  recordMasterWalletInsufficientFundsError({ owner, items, error }: { owner: string; items: FundingMessageItem[]; error: unknown }): void {
+    this.masterWalletInsufficientFunds.add(1);
+    this.emitLog("error", {
+      event: "FUND_DRAINING_MASTER_WALLET_INSUFFICIENT_FUNDS",
+      owner,
+      deposits: items.map(({ input }) => ({ dseq: input.dseq, amount: input.amount, denom: input.denom })),
+      error
+    });
+  }
+
+  recordDeploymentsMarkedClosed(count: number): void {
+    this.deploymentsMarkedClosed.add(count);
+  }
+
+  /**
+   * The cron records blocks-until-predicted-close against a run-scoped start height. The stateless
+   * event-driven path has no per-run start height, so there is nothing meaningful to record here.
+   */
+  recordDeploymentPreparation(_ownerAddress: string, _predictedClosedHeight: number): void {}
+
+  /**
+   * Telemetry must never break the funding job. It runs on pg-boss, so a synchronous logger failure
+   * escaping a record* call would mark an already-completed deposit as failed and trigger a retry.
+   * Metrics are emitted before logging because the OTel spec guarantees instrument writes never throw.
+   */
+  private emitLog(level: "info" | "warn" | "error", payload: Record<string, unknown>): void {
+    try {
+      this.logger[level](payload);
+    } catch {
+      return;
+    }
+  }
+}

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.ts
@@ -6,9 +6,10 @@ import { LoggerService, MetricsService } from "@src/core";
 import type { DryRunOptions } from "@src/core/types/console";
 import { TopUpSummarizer } from "@src/deployment/lib/top-up-summarizer/top-up-summarizer";
 import { DrainingDeployment } from "@src/deployment/types/draining-deployment";
+import type { DeploymentTopUpInstrumentation } from "./deployment-top-up-instrumentation";
 
 @scoped(Lifecycle.ResolutionScoped)
-export class TopUpManagedDeploymentsInstrumentationService {
+export class TopUpManagedDeploymentsInstrumentationService implements DeploymentTopUpInstrumentation {
   private readonly meter: Meter;
   private readonly jobExecutions: Counter;
   private readonly jobDuration: Histogram;

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
@@ -599,13 +599,15 @@ describe(TopUpManagedDeploymentsService.name, () => {
       expect(cachedBalanceService.get).not.toHaveBeenCalled();
     });
 
-    it("does nothing when the owner has no draining deployments", async () => {
-      const { service, drainingDeploymentService, cachedBalanceService, managedSignerService, walletReloadService } = setup();
+    it("records a nothing-to-fund skip and funds nothing when the owner has no draining deployments", async () => {
+      const { service, drainingDeploymentService, cachedBalanceService, managedSignerService, walletReloadService, fundDrainingInstrumentation } = setup();
+      const owner = createAkashAddress();
 
       drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([]);
 
-      await service.topUpDrainingDeploymentsForOwner({ walletId: 1, address: createAkashAddress() });
+      await service.topUpDrainingDeploymentsForOwner({ walletId: 1, address: owner });
 
+      expect(fundDrainingInstrumentation.recordSkipped).toHaveBeenCalledWith({ owner, deploymentCount: 0 });
       expect(cachedBalanceService.getFresh).not.toHaveBeenCalled();
       expect(managedSignerService.executeDerivedTx).not.toHaveBeenCalled();
       expect(walletReloadService.scheduleImmediate).not.toHaveBeenCalled();

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
@@ -15,6 +15,7 @@ import type { BlockHttpService } from "@src/chain/services/block-http/block-http
 import type { DrainingDeployment, DrainingDeploymentService } from "@src/deployment/services/draining-deployment/draining-deployment.service";
 import { mockConfigService } from "../../../../test/mocks/config-service.mock";
 import type { CachedBalance, CachedBalanceService } from "../cached-balance/cached-balance.service";
+import type { FundDrainingDeploymentsInstrumentationService } from "./fund-draining-deployments-instrumentation.service";
 import { TopUpManagedDeploymentsService } from "./top-up-managed-deployments.service";
 import type { TopUpManagedDeploymentsInstrumentationService } from "./top-up-managed-deployments-instrumentation.service";
 
@@ -35,7 +36,15 @@ describe(TopUpManagedDeploymentsService.name, () => {
 
   describe("topUpDeployments", () => {
     it("should top up draining deployments", async () => {
-      const { service, drainingDeploymentService, cachedBalanceService, managedSignerService, instrumentation, walletReloadService } = setup();
+      const {
+        service,
+        drainingDeploymentService,
+        cachedBalanceService,
+        managedSignerService,
+        instrumentation,
+        fundDrainingInstrumentation,
+        walletReloadService
+      } = setup();
       const deployments = createManyAutoTopUpDeployments(2);
       const desiredAmount = faker.number.int({ min: 3500000, max: 4000000 });
       const sufficientAmount = faker.number.int({ min: 1000000, max: 2000000 });
@@ -129,6 +138,8 @@ describe(TopUpManagedDeploymentsService.name, () => {
       deployments.forEach(deployment => {
         expect(walletReloadService.scheduleImmediate).toHaveBeenCalledWith({ walletId: deployment.walletId });
       });
+
+      expect(fundDrainingInstrumentation.recordDeposit).not.toHaveBeenCalled();
     });
 
     it("should handle errors and continue processing", async () => {
@@ -541,7 +552,15 @@ describe(TopUpManagedDeploymentsService.name, () => {
 
   describe("topUpDrainingDeploymentsForOwner", () => {
     it("funds the owner's draining deployments in a single tx and schedules a wallet reload", async () => {
-      const { service, drainingDeploymentService, cachedBalanceService, managedSignerService, walletReloadService } = setup();
+      const {
+        service,
+        drainingDeploymentService,
+        cachedBalanceService,
+        managedSignerService,
+        walletReloadService,
+        fundDrainingInstrumentation,
+        instrumentation
+      } = setup();
       const owner = createAkashAddress();
       const walletId = faker.number.int({ min: 1000000, max: 9999999 });
       const sufficientAmount = faker.number.int({ min: 1000000, max: 2000000 });
@@ -552,13 +571,17 @@ describe(TopUpManagedDeploymentsService.name, () => {
 
       await service.topUpDrainingDeploymentsForOwner({ walletId, address: owner });
 
-      expect(drainingDeploymentService.findDrainingDeploymentsForOwner).toHaveBeenCalledWith(owner);
+      expect(drainingDeploymentService.findDrainingDeploymentsForOwner).toHaveBeenCalledWith(owner, fundDrainingInstrumentation);
       expect(managedSignerService.executeDerivedTx).toHaveBeenCalledTimes(1);
       expect(managedSignerService.executeDerivedTx).toHaveBeenCalledWith(walletId, [
         expect.objectContaining({ typeUrl: "/akash.escrow.v1.MsgAccountDeposit" }),
         expect.objectContaining({ typeUrl: "/akash.escrow.v1.MsgAccountDeposit" })
       ]);
       expect(walletReloadService.scheduleImmediate).toHaveBeenCalledWith({ walletId });
+      expect(fundDrainingInstrumentation.recordDeposit).toHaveBeenCalledWith(expect.objectContaining({ owner }));
+      expect(instrumentation.recordDeposit).not.toHaveBeenCalled();
+      expect(instrumentation.start).not.toHaveBeenCalled();
+      expect(instrumentation.finish).not.toHaveBeenCalled();
     });
 
     it("reads a fresh balance rather than the memoized one so the long-running worker never funds from a stale balance", async () => {
@@ -586,6 +609,33 @@ describe(TopUpManagedDeploymentsService.name, () => {
       expect(cachedBalanceService.getFresh).not.toHaveBeenCalled();
       expect(managedSignerService.executeDerivedTx).not.toHaveBeenCalled();
       expect(walletReloadService.scheduleImmediate).not.toHaveBeenCalled();
+    });
+
+    it("routes a master-wallet insufficient-funds failure to the immediate-funding instrumentation and rethrows", async () => {
+      const {
+        service,
+        drainingDeploymentService,
+        cachedBalanceService,
+        managedSignerService,
+        chainErrorService,
+        fundDrainingInstrumentation,
+        instrumentation
+      } = setup();
+      const owner = createAkashAddress();
+      const walletId = faker.number.int({ min: 1000000, max: 9999999 });
+      const error = new Error("insufficient funds");
+
+      drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([createDrainingFor(owner, walletId)]);
+      drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(1000000);
+      cachedBalanceService.getFresh.mockResolvedValue(createMockCachedBalance(() => 1000000));
+      managedSignerService.executeDerivedTx.mockRejectedValue(error);
+      chainErrorService.isMasterWalletInsufficientFundsError.mockResolvedValue(true);
+
+      await expect(service.topUpDrainingDeploymentsForOwner({ walletId, address: owner })).rejects.toThrow(error);
+
+      expect(fundDrainingInstrumentation.recordChainTxError).toHaveBeenCalledWith(expect.objectContaining({ owner, error }));
+      expect(fundDrainingInstrumentation.recordMasterWalletInsufficientFundsError).toHaveBeenCalledWith(expect.objectContaining({ owner, error }));
+      expect(instrumentation.recordChainTxError).not.toHaveBeenCalled();
     });
 
     function createDrainingFor(owner: string, walletId: number, predictedClosedHeight = CURRENT_BLOCK_HEIGHT + 1500): DrainingDeployment {
@@ -619,6 +669,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
     const chainErrorService = mock<ChainErrorService>();
     chainErrorService.isMasterWalletInsufficientFundsError.mockResolvedValue(false);
     const instrumentation = mock<TopUpManagedDeploymentsInstrumentationService>();
+    const fundDrainingInstrumentation = mock<FundDrainingDeploymentsInstrumentationService>();
     const walletReloadService = mock<WalletReloadJobService>();
 
     const service = new TopUpManagedDeploymentsService(
@@ -630,6 +681,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
       blockHttpService,
       chainErrorService,
       instrumentation,
+      fundDrainingInstrumentation,
       walletReloadService
     );
 
@@ -643,6 +695,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
       blockHttpService,
       chainErrorService,
       instrumentation,
+      fundDrainingInstrumentation,
       walletReloadService
     };
   }

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
@@ -613,6 +613,33 @@ describe(TopUpManagedDeploymentsService.name, () => {
       expect(walletReloadService.scheduleImmediate).not.toHaveBeenCalled();
     });
 
+    it("records a non-positive-amount skip without reporting a false insufficient-balance error", async () => {
+      const { service, drainingDeploymentService, cachedBalanceService, managedSignerService, walletReloadService, fundDrainingInstrumentation } = setup();
+      const owner = createAkashAddress();
+      const walletId = faker.number.int({ min: 1000000, max: 9999999 });
+      const deployment = createDrainingFor(owner, walletId);
+      const balance = createMockCachedBalance(desiredAmount => {
+        if (desiredAmount <= 0) {
+          throw new Error(`Insufficient balance: 1000000 < ${desiredAmount}`);
+        }
+        return desiredAmount;
+      });
+
+      drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([deployment]);
+      drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(0);
+      cachedBalanceService.getFresh.mockResolvedValue(balance);
+
+      await service.topUpDrainingDeploymentsForOwner({ walletId, address: owner });
+
+      expect(fundDrainingInstrumentation.recordInvalidDepositAmount).toHaveBeenCalledWith(
+        expect.objectContaining({ desiredAmount: 0, dseq: deployment.dseq, address: deployment.address })
+      );
+      expect(balance.reserveSufficientAmount).not.toHaveBeenCalled();
+      expect(fundDrainingInstrumentation.recordMessagePreparationError).not.toHaveBeenCalled();
+      expect(managedSignerService.executeDerivedTx).not.toHaveBeenCalled();
+      expect(walletReloadService.scheduleImmediate).not.toHaveBeenCalled();
+    });
+
     it("routes a master-wallet insufficient-funds failure to the immediate-funding instrumentation and rethrows", async () => {
       const {
         service,

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
@@ -12,6 +12,8 @@ import type { DryRunOptions } from "@src/core/types/console";
 import { DrainingDeployment } from "@src/deployment/services/draining-deployment/draining-deployment.service";
 import { DrainingDeploymentService } from "@src/deployment/services/draining-deployment/draining-deployment.service";
 import { CachedBalance, CachedBalanceService } from "../cached-balance/cached-balance.service";
+import type { DeploymentTopUpInstrumentation } from "./deployment-top-up-instrumentation";
+import { FundDrainingDeploymentsInstrumentationService } from "./fund-draining-deployments-instrumentation.service";
 import { TopUpManagedDeploymentsInstrumentationService } from "./top-up-managed-deployments-instrumentation.service";
 
 type CollectedMessage = {
@@ -31,6 +33,7 @@ export class TopUpManagedDeploymentsService {
     private readonly blockHttpService: BlockHttpService,
     private readonly chainErrorService: ChainErrorService,
     private readonly instrumentation: TopUpManagedDeploymentsInstrumentationService,
+    private readonly fundDrainingInstrumentation: FundDrainingDeploymentsInstrumentationService,
     private readonly walletReloadService: WalletReloadJobService
   ) {}
 
@@ -42,7 +45,7 @@ export class TopUpManagedDeploymentsService {
       for await (const owner of this.drainingDeploymentService.findDrainingDeploymentsByOwner()) {
         try {
           const balance = await this.cachedBalanceService.get(owner.address);
-          await this.#fundOwnerDeployments(owner, options, balance);
+          await this.#fundOwnerDeployments(owner, options, balance, this.instrumentation);
         } catch (error: unknown) {
           errors.push(error);
         }
@@ -63,46 +66,51 @@ export class TopUpManagedDeploymentsService {
    * about to drain does not wait up to an hour for the next scheduled pass.
    */
   async topUpDrainingDeploymentsForOwner({ walletId, address }: { walletId: number; address: string }): Promise<void> {
-    const deployments = await this.drainingDeploymentService.findDrainingDeploymentsForOwner(address);
+    const deployments = await this.drainingDeploymentService.findDrainingDeploymentsForOwner(address, this.fundDrainingInstrumentation);
 
     if (!deployments.length) {
       return;
     }
 
     const balance = await this.cachedBalanceService.getFresh(address);
-    await this.#fundOwnerDeployments({ address, walletId, deployments }, { dryRun: false }, balance);
+    await this.#fundOwnerDeployments({ address, walletId, deployments }, { dryRun: false }, balance, this.fundDrainingInstrumentation);
   }
 
   async #fundOwnerDeployments(
     { address, walletId, deployments }: { address: string; walletId: number; deployments: DrainingDeployment[] },
     options: DryRunOptions,
-    balance: CachedBalance
+    balance: CachedBalance,
+    instrumentation: DeploymentTopUpInstrumentation
   ): Promise<void> {
-    const messageInputs = await this.collectMessages(deployments, balance);
+    const messageInputs = await this.collectMessages(deployments, balance, instrumentation);
 
     if (!messageInputs.length) {
-      this.instrumentation.recordSkipped({ owner: address, deploymentCount: deployments.length });
+      instrumentation.recordSkipped({ owner: address, deploymentCount: deployments.length });
       return;
     }
 
-    await this.topUpForOwner(address, messageInputs, options);
+    await this.topUpForOwner(address, messageInputs, options, instrumentation);
 
     if (!options.dryRun) {
       await this.walletReloadService.scheduleImmediate({ walletId });
     }
   }
 
-  private async collectMessages(deployments: DrainingDeployment[], balance: CachedBalance): Promise<CollectedMessage[]> {
+  private async collectMessages(
+    deployments: DrainingDeployment[],
+    balance: CachedBalance,
+    instrumentation: DeploymentTopUpInstrumentation
+  ): Promise<CollectedMessage[]> {
     const denom = this.billingConfig.get("DEPLOYMENT_GRANT_DENOM");
 
     const messageInputs = await Promise.all(
       deployments.map(async deployment => {
-        this.instrumentation.recordDeploymentPreparation(deployment.address, deployment.predictedClosedHeight);
+        instrumentation.recordDeploymentPreparation(deployment.address, deployment.predictedClosedHeight);
 
         try {
           const desiredAmount = await this.drainingDeploymentService.calculateTopUpAmount(deployment);
           if (desiredAmount <= 0) {
-            this.instrumentation.recordInvalidDepositAmount({
+            instrumentation.recordInvalidDepositAmount({
               desiredAmount,
               dseq: deployment.dseq,
               address: deployment.address,
@@ -127,7 +135,7 @@ export class TopUpManagedDeploymentsService {
             deployment
           };
         } catch (error: unknown) {
-          this.instrumentation.recordMessagePreparationError({
+          instrumentation.recordMessagePreparationError({
             deployment,
             error
           });
@@ -138,7 +146,7 @@ export class TopUpManagedDeploymentsService {
     return messageInputs.filter(x => !!x);
   }
 
-  private async topUpForOwner(owner: string, ownerInputs: CollectedMessage[], options: DryRunOptions) {
+  private async topUpForOwner(owner: string, ownerInputs: CollectedMessage[], options: DryRunOptions, instrumentation: DeploymentTopUpInstrumentation) {
     const walletId = ownerInputs[0].deployment.walletId;
 
     try {
@@ -147,7 +155,7 @@ export class TopUpManagedDeploymentsService {
         const feeAllowance = await this.managedSignerService.ensureFeeGrants({ address, isTrialing, createdAt, activatedAt });
 
         if (feeAllowance <= 0) {
-          this.instrumentation.recordChainTxError({
+          instrumentation.recordChainTxError({
             owner,
             items: ownerInputs,
             error: new Error(`Fee grant missing for wallet ${owner}, unable to top up deployments`)
@@ -161,12 +169,12 @@ export class TopUpManagedDeploymentsService {
         );
       }
 
-      this.instrumentation.recordDeposit({ owner, items: ownerInputs });
+      instrumentation.recordDeposit({ owner, items: ownerInputs });
     } catch (error: unknown) {
-      this.instrumentation.recordChainTxError({ owner, items: ownerInputs, error });
+      instrumentation.recordChainTxError({ owner, items: ownerInputs, error });
 
       if (error instanceof Error && (await this.chainErrorService.isMasterWalletInsufficientFundsError(error))) {
-        this.instrumentation.recordMasterWalletInsufficientFundsError({ owner, items: ownerInputs, error });
+        instrumentation.recordMasterWalletInsufficientFundsError({ owner, items: ownerInputs, error });
         throw error;
       }
     }

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
@@ -117,6 +117,7 @@ export class TopUpManagedDeploymentsService {
               address: deployment.address,
               blockRate: deployment.blockRate
             });
+            return;
           }
           const sufficientAmount = balance.reserveSufficientAmount(desiredAmount);
 

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
@@ -69,6 +69,7 @@ export class TopUpManagedDeploymentsService {
     const deployments = await this.drainingDeploymentService.findDrainingDeploymentsForOwner(address, this.fundDrainingInstrumentation);
 
     if (!deployments.length) {
+      this.fundDrainingInstrumentation.recordSkipped({ owner: address, deploymentCount: 0 });
       return;
     }
 


### PR DESCRIPTION
## Why

Closes CON-837

PR #3590 shipped event-driven immediate funding (funding a wallet's draining deployments as soon as credits land) by reusing the hourly top-up cron's internals. That reuse extended to the cron's instrumentation, which was built for a single short-lived CLI run: it is resolution-scoped but pinned to a singleton, so it behaves as one shared, summarizer-backed instance for the whole process.

In the always-on background worker that caused two problems:

- The immediate path emitted its deposits, errors, and skips under the cron's `auto_top_up_*` meter, so immediate funding was indistinguishable from real cron runs in dashboards and alerts. It also never called `start()`/`finish()`, so no job count or duration was recorded.
- It wrote the shared `TopUpSummarizer`, which is never summarized or reset on this path, so state accumulated for the process lifetime and was co-mingled across the concurrent per-wallet jobs the worker runs. The handler's `singleton` policy only serializes same-wallet jobs, so different wallets still run in parallel up to `concurrency`.

## What

Give the immediate funding path its own stateless, concurrency-safe instrumentation, modeled on the existing initial-deployment-funding job:

- New `DeploymentTopUpInstrumentation` interface, implemented by both the cron's existing summarizer-backed service and a new stateless `FundDrainingDeploymentsInstrumentationService` with its own `fund_draining_deployments_*` meter and no per-run state.
- The shared funding methods and the draining-deployment resolver take the instrumentation as a parameter: the cron passes its summarizer-backed service, the immediate path passes the new one. The worker no longer emits under the cron meter or writes the shared summarizer.
- The handler records job success/failure and duration.

Deliberate deltas worth noting:

- The immediate path now records job count and duration (previously never, since `start()`/`finish()` were cron-only).
- `predicted_close_blocks` stays intentionally unrecorded on the immediate path: it needs a run-scoped start height the stateless path has no notion of.
- Master-wallet-insufficient-funds is now a metric in addition to a log.

Out of scope, tracked separately: the bounded duplicate-deposit race when immediate funding overlaps the cron or a job retries after the on-chain deposit. It draws only from the user's own authorized limit and self-corrects when the deployment closes.

No new env vars, migrations, or contract changes.

### Tests

Full `apps/api` unit suite passes (1370). New coverage for the instrumentation service (every record method, the never-throw logger wrapping, and failure classification), plus updated service and handler specs proving the immediate path reports only via the new meter and never touches the cron's `start`/`finish` or summarizer, and that the cron path is unchanged. The top-up integration test passes, confirming the new singleton resolves through the container.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detailed monitoring for direct deployment funding workflows, including job outcomes, deposits, skipped deployments, errors, insufficient funds, and closed deployments.
  * Added failure classification and timing information for funding operations.
  * Ensured monitoring failures do not interrupt funding jobs.
  * Preserved separate monitoring for scheduled and direct funding workflows.

* **Tests**
  * Expanded coverage for successful and failed funding scenarios, error handling, and telemetry recording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->