### PR TITLE
fix(alert): make wallet-balance alert edits savable and fix channel edit back-nav

### DIFF
--- a/apps/deploy-web/src/components/alerts/EditNotificationChannelPage.spec.tsx
+++ b/apps/deploy-web/src/components/alerts/EditNotificationChannelPage.spec.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { DEPENDENCIES, EditNotificationChannelPage } from "./EditNotificationChannelPage";
+
+import { render, screen } from "@testing-library/react";
+import { buildNotificationChannel } from "@tests/seeders/notificationChannel";
+import { MockComponents } from "@tests/unit/mocks";
+
+describe(EditNotificationChannelPage.name, () => {
+  it("points the header back arrow at the alerts page", () => {
+    setup();
+
+    expect(screen.getByRole("link")).toHaveAttribute("href", "/alerts");
+  });
+
+  function setup() {
+    const notificationChannel = buildNotificationChannel();
+    const dependencies = MockComponents(DEPENDENCIES, {
+      useBackNav: () => vi.fn(),
+      useNavigationGuard: () => ({ toggle: vi.fn() }),
+      NotificationChannelEditContainer: () => <div data-testid="notification-channel-edit-container" />
+    });
+
+    render(<EditNotificationChannelPage notificationChannel={notificationChannel} dependencies={dependencies} />);
+
+    return { notificationChannel };
+  }
+});

--- a/apps/deploy-web/src/components/alerts/EditNotificationChannelPage.tsx
+++ b/apps/deploy-web/src/components/alerts/EditNotificationChannelPage.tsx
@@ -12,30 +12,33 @@ import { useBackNav } from "@src/hooks/useBackNav";
 import { useNavigationGuard } from "@src/hooks/useNavigationGuard/useNavigationGuard";
 import { UrlService } from "@src/utils/urlUtils";
 
+export const DEPENDENCIES = { Layout, NotificationChannelEditContainer, NotificationChannelForm, useBackNav, useNavigationGuard };
+
 type Props = {
   notificationChannel: components["schemas"]["NotificationChannelOutput"]["data"];
+  dependencies?: typeof DEPENDENCIES;
 };
 
-export const EditNotificationChannelPage: React.FunctionComponent<Props> = ({ notificationChannel }: Props) => {
-  const goBack = useBackNav(UrlService.alerts());
-  const navGuard = useNavigationGuard();
+export const EditNotificationChannelPage: React.FunctionComponent<Props> = ({ notificationChannel, dependencies: d = DEPENDENCIES }: Props) => {
+  const goBack = d.useBackNav(UrlService.alerts());
+  const navGuard = d.useNavigationGuard();
   const saveNavStateAndGoBack = useCallback(() => {
     navGuard.toggle({ hasChanges: false });
     goBack();
   }, [goBack, navGuard]);
 
   return (
-    <Layout containerClassName="flex h-full flex-col">
+    <d.Layout containerClassName="flex h-full flex-col">
       <NextSeo title="Edit Notification Channel" />
       <div className="flex flex-wrap items-center px-6 py-6">
-        <Link href="." type="button" className="p-2">
+        <Link href={UrlService.alerts()} type="button" className="p-2">
           <NavArrowLeft />
         </Link>
         <Title>Edit Notification Channel</Title>
       </div>
-      <NotificationChannelEditContainer id={notificationChannel.id} onEditSuccess={saveNavStateAndGoBack}>
+      <d.NotificationChannelEditContainer id={notificationChannel.id} onEditSuccess={saveNavStateAndGoBack}>
         {props => (
-          <NotificationChannelForm
+          <d.NotificationChannelForm
             initialValues={{
               name: notificationChannel.name,
               emails: notificationChannel.config.addresses
@@ -46,7 +49,7 @@ export const EditNotificationChannelPage: React.FunctionComponent<Props> = ({ no
             onStateChange={navGuard.toggle}
           />
         )}
-      </NotificationChannelEditContainer>
-    </Layout>
+      </d.NotificationChannelEditContainer>
+    </d.Layout>
   );
 };

--- a/apps/notifications/src/interfaces/rest/controllers/alert/alert.controller.spec.ts
+++ b/apps/notifications/src/interfaces/rest/controllers/alert/alert.controller.spec.ts
@@ -17,6 +17,7 @@ import { AlertController } from "./alert.controller";
 
 import { MockProvider } from "@test/mocks/provider.mock";
 import { generateGeneralAlert } from "@test/seeders/general-alert.seeder";
+import { generateWalletBalanceAlert } from "@test/seeders/wallet-balance-alert.seeder";
 
 describe(AlertController.name, () => {
   describe("createAlert", () => {
@@ -90,6 +91,33 @@ describe(AlertController.name, () => {
       await expect(controller.updateAlert(id, { data: input })).rejects.toThrow("Notification channel not found");
       expect(notificationChannelRepository.findById).toHaveBeenCalledWith(input.notificationChannelId);
       expect(alertRepository.updateById).not.toHaveBeenCalled();
+    });
+
+    it("throws BadRequestException and does not update a balance alert with non-balance conditions", async () => {
+      const { controller, alertRepository } = await setup();
+
+      const id = faker.string.uuid();
+      alertRepository.findOneById.mockResolvedValue(generateWalletBalanceAlert({ id }));
+
+      await expect(controller.updateAlert(id, { data: { conditions: { operator: "eq", field: "foo", value: "bar" } } })).rejects.toThrow(
+        "Conditions must match the balance alert shape"
+      );
+      expect(alertRepository.updateById).not.toHaveBeenCalled();
+    });
+
+    it("updates a balance alert when the conditions match the balance shape", async () => {
+      const { controller, alertRepository } = await setup();
+
+      const id = faker.string.uuid();
+      const output = generateWalletBalanceAlert({ id });
+      alertRepository.findOneById.mockResolvedValue(output);
+      alertRepository.updateById.mockResolvedValue(output);
+
+      const conditions = { operator: "lt" as const, field: "balance" as const, value: 100 };
+      const result = await controller.updateAlert(id, { data: { conditions } });
+
+      expect(alertRepository.updateById).toHaveBeenCalledWith(id, { conditions });
+      expect(result).toEqual(Ok({ data: output }));
     });
   });
 

--- a/apps/notifications/src/interfaces/rest/controllers/alert/alert.controller.spec.ts
+++ b/apps/notifications/src/interfaces/rest/controllers/alert/alert.controller.spec.ts
@@ -5,10 +5,13 @@ import { Test } from "@nestjs/testing";
 import { Ok } from "ts-results";
 import { describe, expect, it } from "vitest";
 import type { MockProxy } from "vitest-mock-extended";
+import { mock } from "vitest-mock-extended";
 
 import { LoggerService } from "@src/common/services/logger/logger.service";
 import { AuthService } from "@src/interfaces/rest/services/auth/auth.service";
 import { AlertRepository } from "@src/modules/alert/repositories/alert/alert.repository";
+import type { NotificationChannelOutput } from "@src/modules/notifications/repositories/notification-channel/notification-channel.repository";
+import { NotificationChannelRepository } from "@src/modules/notifications/repositories/notification-channel/notification-channel.repository";
 import { chainMessageCreateInputSchema } from "../../http-schemas/alert.http-schema";
 import { AlertController } from "./alert.controller";
 
@@ -32,6 +35,17 @@ describe(AlertController.name, () => {
         userId
       });
       expect(result).toEqual(Ok({ data: output }));
+    });
+
+    it("throws NotFoundException and does not create when the notification channel is not owned by the user", async () => {
+      const { controller, alertRepository, notificationChannelRepository } = await setup();
+
+      const input = generateMock(chainMessageCreateInputSchema);
+      notificationChannelRepository.findById.mockResolvedValue(undefined);
+
+      await expect(controller.createAlert({ data: input })).rejects.toThrow("Notification channel not found");
+      expect(notificationChannelRepository.findById).toHaveBeenCalledWith(input.notificationChannelId);
+      expect(alertRepository.create).not.toHaveBeenCalled();
     });
   });
 
@@ -64,6 +78,18 @@ describe(AlertController.name, () => {
         val: expect.objectContaining({ message: "Alert not found" })
       });
       expect(alertRepository.updateById).toHaveBeenCalledWith(id, input);
+    });
+
+    it("throws NotFoundException and does not update when the notification channel is not owned by the user", async () => {
+      const { controller, alertRepository, notificationChannelRepository } = await setup();
+
+      const id = faker.string.uuid();
+      const input = generateMock(chainMessageCreateInputSchema);
+      notificationChannelRepository.findById.mockResolvedValue(undefined);
+
+      await expect(controller.updateAlert(id, { data: input })).rejects.toThrow("Notification channel not found");
+      expect(notificationChannelRepository.findById).toHaveBeenCalledWith(input.notificationChannelId);
+      expect(alertRepository.updateById).not.toHaveBeenCalled();
     });
   });
 
@@ -130,6 +156,7 @@ describe(AlertController.name, () => {
   async function setup(): Promise<{
     controller: AlertController;
     alertRepository: MockProxy<AlertRepository>;
+    notificationChannelRepository: MockProxy<NotificationChannelRepository>;
     userId: string;
   }> {
     const userId = faker.string.uuid();
@@ -143,6 +170,7 @@ describe(AlertController.name, () => {
           }
         },
         MockProvider(AlertRepository),
+        MockProvider(NotificationChannelRepository),
         MockProvider(LoggerService)
       ]
     }).compile();
@@ -150,10 +178,15 @@ describe(AlertController.name, () => {
     const alertRepository = module.get<MockProxy<AlertRepository>>(AlertRepository);
     alertRepository.accessibleBy.mockReturnValue(alertRepository);
 
+    const notificationChannelRepository = module.get<MockProxy<NotificationChannelRepository>>(NotificationChannelRepository);
+    notificationChannelRepository.accessibleBy.mockReturnValue(notificationChannelRepository);
+    notificationChannelRepository.findById.mockResolvedValue(mock<NotificationChannelOutput>());
+
     return {
       controller: module.get(AlertController),
       userId,
-      alertRepository
+      alertRepository,
+      notificationChannelRepository
     };
   }
 });

--- a/apps/notifications/src/interfaces/rest/controllers/alert/alert.controller.ts
+++ b/apps/notifications/src/interfaces/rest/controllers/alert/alert.controller.ts
@@ -9,6 +9,7 @@ import { AlertCreateInput, AlertListOutputResponse, AlertOutputResponse, AlertPa
 import { AuthService } from "@src/interfaces/rest/services/auth/auth.service";
 import { toPaginatedQuery } from "@src/lib/http-schema/http-schema";
 import { AlertOutput, AlertRepository } from "@src/modules/alert/repositories/alert/alert.repository";
+import { balanceConditionsSchema } from "@src/modules/alert/repositories/alert/alert-json-fields.schema";
 import { NotificationChannelRepository } from "@src/modules/notifications/repositories/notification-channel/notification-channel.repository";
 
 class AlertListQuery extends createZodDto(
@@ -94,6 +95,10 @@ export class AlertController {
       await this.assertOwnsNotificationChannel(data.notificationChannelId);
     }
 
+    if (data.conditions) {
+      await this.assertConditionsMatchAlertType(id, data.conditions);
+    }
+
     const alert = await this.alertRepository.accessibleBy(this.authService.ability, "update").updateById(id, data);
     return this.toResponse(alert);
   }
@@ -105,6 +110,15 @@ export class AlertController {
   async deleteAlert(@Param("id") id: string): Promise<Result<AlertOutputResponse, NotFoundException>> {
     const alert = await this.alertRepository.accessibleBy(this.authService.ability, "delete").deleteOneById(id);
     return this.toResponse(alert);
+  }
+
+  private async assertConditionsMatchAlertType(id: string, conditions: NonNullable<AlertPatchInput["data"]["conditions"]>): Promise<void> {
+    const alert = await this.alertRepository.accessibleBy(this.authService.ability, "read").findOneById(id);
+    const requiresBalanceConditions = alert?.type === "WALLET_BALANCE" || alert?.type === "DEPLOYMENT_BALANCE";
+
+    if (requiresBalanceConditions && !balanceConditionsSchema.safeParse(conditions).success) {
+      throw new BadRequestException("Conditions must match the balance alert shape");
+    }
   }
 
   private async assertOwnsNotificationChannel(notificationChannelId: string): Promise<void> {

--- a/apps/notifications/src/interfaces/rest/controllers/alert/alert.controller.ts
+++ b/apps/notifications/src/interfaces/rest/controllers/alert/alert.controller.ts
@@ -9,6 +9,7 @@ import { AlertCreateInput, AlertListOutputResponse, AlertOutputResponse, AlertPa
 import { AuthService } from "@src/interfaces/rest/services/auth/auth.service";
 import { toPaginatedQuery } from "@src/lib/http-schema/http-schema";
 import { AlertOutput, AlertRepository } from "@src/modules/alert/repositories/alert/alert.repository";
+import { NotificationChannelRepository } from "@src/modules/notifications/repositories/notification-channel/notification-channel.repository";
 
 class AlertListQuery extends createZodDto(
   toPaginatedQuery({
@@ -24,6 +25,7 @@ class AlertListQuery extends createZodDto(
 export class AlertController {
   constructor(
     private readonly alertRepository: AlertRepository,
+    private readonly notificationChannelRepository: NotificationChannelRepository,
     private readonly authService: AuthService
   ) {}
 
@@ -32,6 +34,8 @@ export class AlertController {
     201: { schema: AlertOutputResponse, description: "Returns the created alert" }
   })
   async createAlert(@Body() { data }: AlertCreateInput): Promise<Result<AlertOutputResponse, unknown>> {
+    await this.assertOwnsNotificationChannel(data.notificationChannelId);
+
     return Ok({
       data: await this.alertRepository.accessibleBy(this.authService.ability, "create").create({
         ...data,
@@ -86,6 +90,10 @@ export class AlertController {
     200: { schema: AlertOutputResponse, description: "Returns the updated alert" }
   })
   async updateAlert(@Param("id") id: string, @Body() { data }: AlertPatchInput): Promise<Result<AlertOutputResponse, NotFoundException | BadRequestException>> {
+    if (data.notificationChannelId) {
+      await this.assertOwnsNotificationChannel(data.notificationChannelId);
+    }
+
     const alert = await this.alertRepository.accessibleBy(this.authService.ability, "update").updateById(id, data);
     return this.toResponse(alert);
   }
@@ -97,6 +105,14 @@ export class AlertController {
   async deleteAlert(@Param("id") id: string): Promise<Result<AlertOutputResponse, NotFoundException>> {
     const alert = await this.alertRepository.accessibleBy(this.authService.ability, "delete").deleteOneById(id);
     return this.toResponse(alert);
+  }
+
+  private async assertOwnsNotificationChannel(notificationChannelId: string): Promise<void> {
+    const channel = await this.notificationChannelRepository.accessibleBy(this.authService.ability, "read").findById(notificationChannelId);
+
+    if (!channel) {
+      throw new NotFoundException("Notification channel not found");
+    }
   }
 
   private toResponse(alert: AlertOutput | undefined): Result<AlertOutputResponse, NotFoundException> {

--- a/apps/notifications/src/interfaces/rest/interceptors/auth/auth.interceptor.ts
+++ b/apps/notifications/src/interfaces/rest/interceptors/auth/auth.interceptor.ts
@@ -26,7 +26,7 @@ export class AuthInterceptor implements NestInterceptor {
     request.ability = defineAbility(can => {
       can("manage", "NotificationChannel", { userId });
       can(["create", "read", "delete"], "Alert", { userId });
-      can("update", "Alert", ["enabled"], { userId });
+      can("update", "Alert", ["enabled", "name", "notificationChannelId", "conditions"], { userId });
       can("manage", "DeploymentAlert", { userId });
     });
 

--- a/apps/notifications/test/functional/alert-crud.spec.ts
+++ b/apps/notifications/test/functional/alert-crud.spec.ts
@@ -27,10 +27,11 @@ describe("Alerts CRUD", () => {
   it("should perform all CRUD operations against raw alerts", async () => {
     // NOTE: change this when there's a role that can create alerts
     const HAS_ROLE_TO_CREATE_ALERTS = false;
-    const { app, userId, notificationChannelId, otherNotificationChannelId } = await setup();
+    const { app, userId, notificationChannelId, otherNotificationChannelId, foreignNotificationChannelId } = await setup();
 
     const alert = HAS_ROLE_TO_CREATE_ALERTS ? await shouldCreate(userId, notificationChannelId, app) : await prepareAlert(userId, notificationChannelId, app);
     await shouldUpdate(alert, otherNotificationChannelId, app);
+    await shouldRejectForeignNotificationChannel(alert, foreignNotificationChannelId, app);
     await shouldRead(alert, app);
     await shouldDelete(alert, app);
 
@@ -93,6 +94,18 @@ describe("Alerts CRUD", () => {
     expect(res.body.data).toMatchObject(update);
   }
 
+  async function shouldRejectForeignNotificationChannel(alert: AlertOutputMeta, foreignNotificationChannelId: string, app: INestApplication) {
+    const res = await request(app.getHttpServer())
+      .patch(`/v1/alerts/${alert.id}`)
+      .set("x-user-id", alert.userId)
+      .send({ data: { notificationChannelId: foreignNotificationChannelId } });
+
+    expect(res.status).toBe(404);
+
+    const getRes = await request(app.getHttpServer()).get(`/v1/alerts/${alert.id}`).set("x-user-id", alert.userId);
+    expect(getRes.body.data.notificationChannelId).not.toBe(foreignNotificationChannelId);
+  }
+
   async function shouldRead(alert: AlertOutputMeta, app: INestApplication) {
     const res = await request(app.getHttpServer()).get(`/v1/alerts/${alert.id}`).set("x-user-id", alert.userId);
 
@@ -114,6 +127,7 @@ describe("Alerts CRUD", () => {
     app: INestApplication;
     notificationChannelId: string;
     otherNotificationChannelId: string;
+    foreignNotificationChannelId: string;
     userId: string;
   }> {
     @Module({
@@ -133,12 +147,19 @@ describe("Alerts CRUD", () => {
     await app.init();
 
     const userId = faker.string.uuid();
+    const foreignUserId = faker.string.uuid();
     const db = module.get<NodePgDatabase<typeof alertSchema & { NotificationChannel: typeof NotificationChannel }>>(DRIZZLE_PROVIDER_TOKEN);
-    const [notificationChannel, otherNotificationChannel] = await db
+    const [notificationChannel, otherNotificationChannel, foreignNotificationChannel] = await db
       .insert(NotificationChannel)
-      .values([generateNotificationChannel({ userId }), generateNotificationChannel({ userId })])
+      .values([generateNotificationChannel({ userId }), generateNotificationChannel({ userId }), generateNotificationChannel({ userId: foreignUserId })])
       .returning();
 
-    return { app, notificationChannelId: notificationChannel.id, otherNotificationChannelId: otherNotificationChannel.id, userId };
+    return {
+      app,
+      notificationChannelId: notificationChannel.id,
+      otherNotificationChannelId: otherNotificationChannel.id,
+      foreignNotificationChannelId: foreignNotificationChannel.id,
+      userId
+    };
   }
 });

--- a/apps/notifications/test/functional/alert-crud.spec.ts
+++ b/apps/notifications/test/functional/alert-crud.spec.ts
@@ -156,7 +156,11 @@ describe("Alerts CRUD", () => {
     const db = module.get<NodePgDatabase<typeof alertSchema & { NotificationChannel: typeof NotificationChannel }>>(DRIZZLE_PROVIDER_TOKEN);
     const [notificationChannel, otherNotificationChannel, foreignNotificationChannel] = await db
       .insert(NotificationChannel)
-      .values([generateNotificationChannel({ userId }), generateNotificationChannel({ userId }), generateNotificationChannel({ userId: foreignUserId })])
+      .values([
+        generateNotificationChannel({ userId, isDefault: false }),
+        generateNotificationChannel({ userId, isDefault: false }),
+        generateNotificationChannel({ userId: foreignUserId, isDefault: false })
+      ])
       .returning();
 
     return {

--- a/apps/notifications/test/functional/alert-crud.spec.ts
+++ b/apps/notifications/test/functional/alert-crud.spec.ts
@@ -27,10 +27,10 @@ describe("Alerts CRUD", () => {
   it("should perform all CRUD operations against raw alerts", async () => {
     // NOTE: change this when there's a role that can create alerts
     const HAS_ROLE_TO_CREATE_ALERTS = false;
-    const { app, userId, notificationChannelId } = await setup();
+    const { app, userId, notificationChannelId, otherNotificationChannelId } = await setup();
 
     const alert = HAS_ROLE_TO_CREATE_ALERTS ? await shouldCreate(userId, notificationChannelId, app) : await prepareAlert(userId, notificationChannelId, app);
-    await shouldUpdate(alert, app);
+    await shouldUpdate(alert, otherNotificationChannelId, app);
     await shouldRead(alert, app);
     await shouldDelete(alert, app);
 
@@ -79,14 +79,18 @@ describe("Alerts CRUD", () => {
     };
   }
 
-  async function shouldUpdate(alert: AlertOutputMeta, app: INestApplication) {
-    const res = await request(app.getHttpServer())
-      .patch(`/v1/alerts/${alert.id}`)
-      .set("x-user-id", alert.userId)
-      .send({ data: { enabled: false } });
+  async function shouldUpdate(alert: AlertOutputMeta, otherNotificationChannelId: string, app: INestApplication) {
+    const update = {
+      name: "Updated alert name",
+      notificationChannelId: otherNotificationChannelId,
+      conditions: { operator: "lt" as const, field: "balance", value: 100 },
+      enabled: false
+    };
+
+    const res = await request(app.getHttpServer()).patch(`/v1/alerts/${alert.id}`).set("x-user-id", alert.userId).send({ data: update });
 
     expect(res.status).toBe(200);
-    expect(res.body.data.enabled).toBe(false);
+    expect(res.body.data).toMatchObject(update);
   }
 
   async function shouldRead(alert: AlertOutputMeta, app: INestApplication) {
@@ -109,6 +113,7 @@ describe("Alerts CRUD", () => {
   async function setup(): Promise<{
     app: INestApplication;
     notificationChannelId: string;
+    otherNotificationChannelId: string;
     userId: string;
   }> {
     @Module({
@@ -129,11 +134,11 @@ describe("Alerts CRUD", () => {
 
     const userId = faker.string.uuid();
     const db = module.get<NodePgDatabase<typeof alertSchema & { NotificationChannel: typeof NotificationChannel }>>(DRIZZLE_PROVIDER_TOKEN);
-    const [notificationChannel] = await db
+    const [notificationChannel, otherNotificationChannel] = await db
       .insert(NotificationChannel)
-      .values([generateNotificationChannel({ userId })])
+      .values([generateNotificationChannel({ userId }), generateNotificationChannel({ userId })])
       .returning();
 
-    return { app, notificationChannelId: notificationChannel.id, userId };
+    return { app, notificationChannelId: notificationChannel.id, otherNotificationChannelId: otherNotificationChannel.id, userId };
   }
 });

--- a/apps/notifications/test/functional/alert-crud.spec.ts
+++ b/apps/notifications/test/functional/alert-crud.spec.ts
@@ -31,7 +31,7 @@ describe("Alerts CRUD", () => {
 
     const alert = HAS_ROLE_TO_CREATE_ALERTS ? await shouldCreate(userId, notificationChannelId, app) : await prepareAlert(userId, notificationChannelId, app);
     await shouldUpdate(alert, otherNotificationChannelId, app);
-    await shouldRejectForeignNotificationChannel(alert, foreignNotificationChannelId, app);
+    await shouldRejectForeignNotificationChannel(alert, otherNotificationChannelId, foreignNotificationChannelId, app);
     await shouldRead(alert, app);
     await shouldDelete(alert, app);
 
@@ -94,7 +94,12 @@ describe("Alerts CRUD", () => {
     expect(res.body.data).toMatchObject(update);
   }
 
-  async function shouldRejectForeignNotificationChannel(alert: AlertOutputMeta, foreignNotificationChannelId: string, app: INestApplication) {
+  async function shouldRejectForeignNotificationChannel(
+    alert: AlertOutputMeta,
+    otherNotificationChannelId: string,
+    foreignNotificationChannelId: string,
+    app: INestApplication
+  ) {
     const res = await request(app.getHttpServer())
       .patch(`/v1/alerts/${alert.id}`)
       .set("x-user-id", alert.userId)
@@ -103,7 +108,7 @@ describe("Alerts CRUD", () => {
     expect(res.status).toBe(404);
 
     const getRes = await request(app.getHttpServer()).get(`/v1/alerts/${alert.id}`).set("x-user-id", alert.userId);
-    expect(getRes.body.data.notificationChannelId).not.toBe(foreignNotificationChannelId);
+    expect(getRes.body.data.notificationChannelId).toBe(otherNotificationChannelId);
   }
 
   async function shouldRead(alert: AlertOutputMeta, app: INestApplication) {


### PR DESCRIPTION
## Why

Two bugs surfaced while using the new wallet-balance alert edit UI (#3608):

- **Saving an edited alert failed** with "Failed to save alert...". The notifications update ability only granted the `enabled` field, so any change to name, threshold, or channel tripped the repository's permitted-fields check and returned a 403.
- **The Edit Notification Channel back arrow led nowhere.** It used a relative `Link href="."` that resolved to `/alerts/notification-channels`, a route that now only redirects since the settings-sidebar restructure (#3583).

While fixing the first bug, a commit security review flagged that `notificationChannelId` was writable without any ownership check (the create path had the same gap), so this PR also closes that cross-tenant hole.

## What

- **Alert update ability:** grant the fields the edit form actually owns (`name`, `notificationChannelId`, `conditions`) alongside `enabled`. `params` (owner/denom) stay read-only.
- **Back arrow:** point the notification-channel edit arrow at `UrlService.alerts()`, matching the alert edit page. Added a `DEPENDENCIES` export so the page is unit-testable.
- **Channel-ownership hardening:** on both alert create and update, verify the referenced notification channel is readable by the requesting user, rejecting with 404 otherwise.

### Tests
- Extended the `alert-crud` functional test to update `name`/`notificationChannelId`/`conditions` (fails on the old 403, passes now) and to reject a cross-tenant channel.
- Added controller unit tests for the ownership rejection on create and update.
- Added an `EditNotificationChannelPage` spec asserting the back link targets `/alerts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Alert creation and updates now verify that the selected notification channel is accessible.
  * Attempts to use an unavailable channel return a not-found error without changing the alert.
  * Alert updates can modify the name, enabled status, conditions, and notification channel.
  * Invalid balance-alert conditions are rejected with a clear validation error.
  * The notification channel edit page now returns to the alerts page when using the back arrow.

* **Tests**
  * Added coverage for channel validation, multi-field updates, condition validation, and navigation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->