### PR TITLE
feat(deployment): add Settings and Update tabs to the redesigned detail page

### DIFF
--- a/apps/deploy-web/src/components/alerts/AlertsListView/AlertsListView.spec.tsx
+++ b/apps/deploy-web/src/components/alerts/AlertsListView/AlertsListView.spec.tsx
@@ -48,6 +48,22 @@ describe(AlertsListView.name, () => {
     expect(screen.getByText("12345")).toBeInTheDocument();
   });
 
+  it("links the deployment name to the settings tab when the deployment detail redesign is enabled", () => {
+    const mockAlert = buildAlert({ type: "DEPLOYMENT_BALANCE", params: { owner: "owner", dseq: "12345" } });
+
+    setup({ data: [mockAlert], isDeploymentDetailRedesignEnabled: true });
+
+    expect(screen.getByRole("link", { name: mockAlert.deploymentName })).toHaveAttribute("href", UrlService.deploymentDetails("12345", "SETTINGS"));
+  });
+
+  it("links the deployment name to the alerts tab when the deployment detail redesign is disabled", () => {
+    const mockAlert = buildAlert({ type: "DEPLOYMENT_BALANCE", params: { owner: "owner", dseq: "12345" } });
+
+    setup({ data: [mockAlert], isDeploymentDetailRedesignEnabled: false });
+
+    expect(screen.getByRole("link", { name: mockAlert.deploymentName })).toHaveAttribute("href", UrlService.deploymentDetails("12345", "ALERTS"));
+  });
+
   it("renders table with disabled alert without params", () => {
     const mockAlert = buildAlert({
       type: "CHAIN_MESSAGE",
@@ -160,7 +176,11 @@ describe(AlertsListView.name, () => {
     expect(screen.getByRole("navigation")).toBeInTheDocument();
   });
 
-  function setup({ isAlertUpdateEnabled = true, ...props }: Partial<Props> & { isAlertUpdateEnabled?: boolean } = {}) {
+  function setup({
+    isAlertUpdateEnabled = true,
+    isDeploymentDetailRedesignEnabled = false,
+    ...props
+  }: Partial<Props> & { isAlertUpdateEnabled?: boolean; isDeploymentDetailRedesignEnabled?: boolean } = {}) {
     const defaultProps: Props = {
       pagination: {
         page: 1,
@@ -182,6 +202,9 @@ describe(AlertsListView.name, () => {
     const mockUseFlag = vi.fn((flag: string) => {
       if (flag === "notifications_general_alerts_update") {
         return isAlertUpdateEnabled;
+      }
+      if (flag === "deployment_detail_redesign") {
+        return isDeploymentDetailRedesignEnabled;
       }
       return false;
     }) as unknown as typeof useFlag;

--- a/apps/deploy-web/src/components/alerts/AlertsListView/AlertsListView.tsx
+++ b/apps/deploy-web/src/components/alerts/AlertsListView/AlertsListView.tsx
@@ -64,6 +64,8 @@ export const AlertsListView: FC<Props> = ({
   const { confirm } = usePopup();
   const columnHelper = createColumnHelper<Alert>();
   const isAlertUpdateEnabled = d.useFlag("notifications_general_alerts_update");
+  const isDeploymentDetailRedesignEnabled = d.useFlag("deployment_detail_redesign");
+  const deploymentAlertsTab = isDeploymentDetailRedesignEnabled ? "SETTINGS" : "ALERTS";
 
   const extractDseq = useCallback((info: CellContext<Alert, unknown>) => {
     const { params } = info.row.original;
@@ -97,7 +99,7 @@ export const AlertsListView: FC<Props> = ({
       cell: info => {
         const dseq = extractDseq(info);
         return dseq ? (
-          <Link href={UrlService.deploymentDetails(dseq, "SETTINGS")} className="font-bold">
+          <Link href={UrlService.deploymentDetails(dseq, deploymentAlertsTab)} className="font-bold">
             {info.getValue()}
           </Link>
         ) : (

--- a/apps/deploy-web/src/components/alerts/AlertsListView/AlertsListView.tsx
+++ b/apps/deploy-web/src/components/alerts/AlertsListView/AlertsListView.tsx
@@ -97,7 +97,7 @@ export const AlertsListView: FC<Props> = ({
       cell: info => {
         const dseq = extractDseq(info);
         return dseq ? (
-          <Link href={UrlService.deploymentDetails(dseq, "ALERTS")} className="font-bold">
+          <Link href={UrlService.deploymentDetails(dseq, "SETTINGS")} className="font-bold">
             {info.getValue()}
           </Link>
         ) : (

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.spec.tsx
@@ -18,7 +18,9 @@ describe("DeploymentDetail", () => {
     setup();
 
     expect(screen.getByRole("tab", { name: "Details" })).toBeInTheDocument();
-    expect(screen.getByRole("tab", { name: "Billing & Notifications" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Update" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Settings" })).toBeInTheDocument();
+    expect(screen.queryByRole("tab", { name: "Billing & Notifications" })).not.toBeInTheDocument();
     expect(screen.getByText("placements")).toBeInTheDocument();
   });
 
@@ -32,10 +34,17 @@ describe("DeploymentDetail", () => {
     expect(screen.getByText("logs")).toBeInTheDocument();
   });
 
-  it("opens the Settings tab from the ?tab= query param", () => {
-    setup({ tab: "SETTINGS" });
+  it("opens the manifest editor on the Update tab from the ?tab= query param", () => {
+    setup({ tab: "UPDATE" });
 
     expect(screen.getByText("manifest-update")).toBeInTheDocument();
+  });
+
+  it("opens the deployment settings on the Settings tab from the ?tab= query param", () => {
+    setup({ tab: "SETTINGS" });
+
+    expect(screen.getByText("settings")).toBeInTheDocument();
+    expect(screen.queryByText("manifest-update")).not.toBeInTheDocument();
   });
 
   it("shows an inactive-state note instead of the shell when the deployment has no live lease", () => {
@@ -43,18 +52,6 @@ describe("DeploymentDetail", () => {
 
     expect(screen.getByText("Available when the deployment is active.")).toBeInTheDocument();
     expect(screen.queryByText("shell")).not.toBeInTheDocument();
-  });
-
-  it("renders alerts on the Billing tab when the user is signed in", () => {
-    setup({ tab: "BILLING" });
-
-    expect(screen.getByText("alerts")).toBeInTheDocument();
-  });
-
-  it("shows a coming-soon note on the Billing tab when the user is not signed in", () => {
-    setup({ tab: "BILLING", isSignedIn: false });
-
-    expect(screen.getByText("Billing & notifications are coming soon.")).toBeInTheDocument();
   });
 
   it("shows a not-found message when the deployment does not exist", () => {
@@ -76,7 +73,6 @@ describe("DeploymentDetail", () => {
     isLeasesLoaded?: boolean;
     error?: Error | null;
     tab?: string;
-    isSignedIn?: boolean;
     leaseState?: string;
   }) {
     const deployment = input && "deployment" in input ? input.deployment : mock<DeploymentDto>({ dseq: "1786440078202", state: "active", groups: [] });
@@ -94,10 +90,6 @@ describe("DeploymentDetail", () => {
       });
     const useWallet: typeof DEPENDENCIES.useWallet = () => mock<ReturnType<typeof DEPENDENCIES.useWallet>>({ address: "akash1test" });
     const useSettings: typeof DEPENDENCIES.useSettings = () => mock<ReturnType<typeof DEPENDENCIES.useSettings>>({ isSettingsInit: true });
-    const useUser: typeof DEPENDENCIES.useUser = () =>
-      mock<ReturnType<typeof DEPENDENCIES.useUser>>({
-        user: input?.isSignedIn === false ? undefined : mock<NonNullable<ReturnType<typeof DEPENDENCIES.useUser>["user"]>>({ userId: "u1" })
-      });
     const useRouter: typeof DEPENDENCIES.useRouter = () => router;
     const searchParams = new URLSearchParams(input?.tab ? `tab=${input.tab}` : "");
     const useSearchParams: typeof DEPENDENCIES.useSearchParams = () => searchParams as unknown as ReturnType<typeof DEPENDENCIES.useSearchParams>;
@@ -112,7 +104,7 @@ describe("DeploymentDetail", () => {
     const DeploymentLogs = vi.fn(() => <div>logs</div>);
     const DeploymentLeaseShell = vi.fn(() => <div>shell</div>);
     const ManifestUpdate = vi.fn(() => <div>manifest-update</div>);
-    const DeploymentAlerts = vi.fn(() => <div>alerts</div>);
+    const DeploymentSettings = vi.fn(() => <div>settings</div>);
 
     render(
       <DeploymentDetail
@@ -121,7 +113,6 @@ describe("DeploymentDetail", () => {
           useServices,
           useWallet,
           useSettings,
-          useUser,
           useRouter,
           useSearchParams,
           useDeploymentDetail,
@@ -131,7 +122,7 @@ describe("DeploymentDetail", () => {
           DeploymentLogs,
           DeploymentLeaseShell,
           ManifestUpdate,
-          DeploymentAlerts
+          DeploymentSettings
         })}
       />
     );

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.tsx
@@ -9,11 +9,9 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { NextSeo } from "next-seo";
 
 import { createConfigureDraft } from "@src/components/deployments/ConfigureDeployment/useConfigureDraft/useConfigureDraft";
-import { DeploymentAlerts } from "@src/components/deployments/DeploymentAlerts/DeploymentAlerts";
 import { useServices } from "@src/context/ServicesProvider";
 import { useSettings } from "@src/context/SettingsProvider";
 import { useWallet } from "@src/context/WalletProvider";
-import { useUser } from "@src/hooks/useUser";
 import { useDeploymentDetail } from "@src/queries/useDeploymentQuery";
 import { useDeploymentLeaseList } from "@src/queries/useLeaseQuery";
 import { useProviderList } from "@src/queries/useProvidersQuery";
@@ -26,13 +24,13 @@ import { DeploymentLogs } from "../DeploymentLogs";
 import { ManifestUpdate } from "../ManifestUpdate/ManifestUpdate";
 import { ReclamationBanner } from "../ReclamationBanner/ReclamationBanner";
 import { DeploymentPlacements } from "./DeploymentPlacements/DeploymentPlacements";
+import { DeploymentSettings } from "./DeploymentSettings/DeploymentSettings";
 import { DeploymentDetailHeader } from "./DeploymentDetailHeader";
 
 export const DEPENDENCIES = {
   useServices,
   useWallet,
   useSettings,
-  useUser,
   useRouter,
   useSearchParams,
   useDeploymentDetail,
@@ -46,10 +44,10 @@ export const DEPENDENCIES = {
   DeploymentLogs,
   DeploymentLeaseShell,
   ManifestUpdate,
-  DeploymentAlerts
+  DeploymentSettings
 };
 
-const TABS = ["DETAILS", "LOGS", "EVENTS", "SHELL", "SETTINGS", "BILLING"] as const;
+const TABS = ["DETAILS", "LOGS", "EVENTS", "SHELL", "UPDATE", "SETTINGS"] as const;
 type Tab = (typeof TABS)[number];
 
 const TAB_LABELS: Record<Tab, string> = {
@@ -57,8 +55,8 @@ const TAB_LABELS: Record<Tab, string> = {
   LOGS: "Logs",
   EVENTS: "Events",
   SHELL: "Shell",
-  SETTINGS: "Settings",
-  BILLING: "Billing & Notifications"
+  UPDATE: "Update",
+  SETTINGS: "Settings"
 };
 
 export interface DeploymentDetailProps {
@@ -72,8 +70,6 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = ({ dseq, dependencies
   const searchParams = d.useSearchParams();
   const { address } = d.useWallet();
   const { isSettingsInit } = d.useSettings();
-  const { user } = d.useUser();
-  const isAlertsEnabled = !!user?.userId;
 
   const [activeTab, setActiveTab] = useState<Tab>("DETAILS");
   const [editedManifest, setEditedManifest] = useState<string | null>(null);
@@ -198,7 +194,7 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = ({ dseq, dependencies
               {activeTab === "EVENTS" && (isActive ? <d.DeploymentLogs leases={leases} selectedLogsMode="events" /> : <TabInactiveState />)}
               {activeTab === "SHELL" && (isActive ? <d.DeploymentLeaseShell leases={leases} /> : <TabInactiveState />)}
 
-              {activeTab === "SETTINGS" && leases && (
+              {activeTab === "UPDATE" && leases && (
                 <d.ManifestUpdate
                   editedManifest={editedManifest as string}
                   onManifestChange={setEditedManifest}
@@ -212,12 +208,7 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = ({ dseq, dependencies
                 />
               )}
 
-              {activeTab === "BILLING" &&
-                (isAlertsEnabled ? (
-                  <d.DeploymentAlerts deployment={deployment} onStateChange={() => undefined} />
-                ) : (
-                  <TabInactiveState label="Billing & notifications are coming soon." />
-                ))}
+              {activeTab === "SETTINGS" && <d.DeploymentSettings deployment={deployment} leases={leases} onDeploymentChange={loadDeploymentDetail} />}
             </div>
           </Tabs>
         </>

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.spec.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { LeaseServiceStatus, LeaseStatusDto } from "@src/queries/useLeaseQuery";
@@ -7,6 +7,7 @@ import type { ApiProviderList } from "@src/types/provider";
 import { DEPENDENCIES, DeploymentDetailHeader } from "./DeploymentDetailHeader";
 
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MockComponents } from "@tests/unit/mocks";
 
 describe("DeploymentDetailHeader", () => {
@@ -14,6 +15,32 @@ describe("DeploymentDetailHeader", () => {
     setup({ serviceUris: { web: [], api: [], worker: [] } });
 
     expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("shows the deployment name from local notes", () => {
+    setup({ name: "My Storefront" });
+
+    expect(screen.getByText("My Storefront")).toBeInTheDocument();
+  });
+
+  it("falls back to a generated name when none is stored", () => {
+    setup({ name: null });
+
+    expect(screen.getByText("Deployment #1786440078202")).toBeInTheDocument();
+  });
+
+  it("shows the running status badge when the deployment is active", () => {
+    setup({});
+
+    expect(screen.getByText("Running")).toBeInTheDocument();
+  });
+
+  it("opens the rename flow when the edit-name button is clicked", async () => {
+    const { changeDeploymentName } = setup({});
+
+    await userEvent.click(screen.getByRole("button", { name: "Edit deployment name" }));
+
+    expect(changeDeploymentName).toHaveBeenCalledWith("1786440078202");
   });
 
   it("shows auto top-up as active when enabled for the deployment", () => {
@@ -41,7 +68,7 @@ describe("DeploymentDetailHeader", () => {
     expect(screen.queryByRole("link", { name: "Visit" })).not.toBeInTheDocument();
   });
 
-  function setup(input: { serviceUris?: Record<string, string[]>; autoTopUpEnabled?: boolean; hasLeaseStatus?: boolean }) {
+  function setup(input: { serviceUris?: Record<string, string[]>; autoTopUpEnabled?: boolean; hasLeaseStatus?: boolean; name?: string | null }) {
     const hasLeaseStatus = input.hasLeaseStatus ?? true;
     let leaseStatus: LeaseStatusDto | null = null;
     if (hasLeaseStatus) {
@@ -56,11 +83,12 @@ describe("DeploymentDetailHeader", () => {
       );
     }
 
-    const useServices: typeof DEPENDENCIES.useServices = () =>
-      mock<ReturnType<typeof DEPENDENCIES.useServices>>({
-        deploymentLocalStorage: mock<ReturnType<typeof DEPENDENCIES.useServices>["deploymentLocalStorage"]>({ get: () => null })
+    const changeDeploymentName = vi.fn();
+    const useLocalNotes: typeof DEPENDENCIES.useLocalNotes = () =>
+      mock<ReturnType<typeof DEPENDENCIES.useLocalNotes>>({
+        getDeploymentName: () => input.name ?? null,
+        changeDeploymentName
       });
-    const useWallet: typeof DEPENDENCIES.useWallet = () => mock<ReturnType<typeof DEPENDENCIES.useWallet>>({ address: "akash1test" });
     const useWalletBalance: typeof DEPENDENCIES.useWalletBalance = () => mock<ReturnType<typeof DEPENDENCIES.useWalletBalance>>({ balance: null });
     const useDeploymentSettingQuery: typeof DEPENDENCIES.useDeploymentSettingQuery = () =>
       mock<ReturnType<typeof DEPENDENCIES.useDeploymentSettingQuery>>({
@@ -78,19 +106,20 @@ describe("DeploymentDetailHeader", () => {
       escrowAccount: mock<DeploymentDto["escrowAccount"]>({ state: mock<DeploymentDto["escrowAccount"]["state"]>({ funds: [] }) })
     });
 
-    return render(
+    render(
       <DeploymentDetailHeader
         deployment={deployment}
         leases={[mock<LeaseDto>({ id: "1", provider: "akash1provider", state: "active" })]}
         providers={[mock<ApiProviderList>({ owner: "akash1provider" })]}
         dependencies={MockComponents(DEPENDENCIES, {
-          useServices,
-          useWallet,
+          useLocalNotes,
           useWalletBalance,
           useDeploymentSettingQuery,
           useLeaseStatus
         })}
       />
     );
+
+    return { changeDeploymentName };
   }
 });

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.tsx
@@ -13,6 +13,7 @@ import type { LeaseStatusDto } from "@src/queries/useLeaseQuery";
 import { useLeaseStatus } from "@src/queries/useLeaseQuery";
 import type { DeploymentDto, LeaseDto } from "@src/types/deployment";
 import type { ApiProviderList } from "@src/types/provider";
+import { getEscrowDenom } from "@src/utils/deploymentUtils";
 import { hasLiveGpuLease, isLeaseLive } from "@src/utils/leaseUtils";
 import { roundDecimal, udenomToDenom } from "@src/utils/mathHelpers";
 import { bytesToShrink } from "@src/utils/unitUtils";
@@ -44,7 +45,7 @@ export const DeploymentDetailHeader: FC<DeploymentDetailHeaderProps> = ({ deploy
   const { data: leaseStatus } = d.useLeaseStatus({ provider, lease: liveLease, enabled: !!provider });
 
   const name = getDeploymentName(deployment.dseq) || `Deployment #${deployment.dseq}`;
-  const denom = deployment.escrowAccount.state.funds[0]?.denom || "";
+  const denom = getEscrowDenom(deployment);
   const hasGpu = hasLiveGpuLease(leases);
   const servicesCount = leaseStatus ? Object.keys(leaseStatus.services).length : leases?.length ?? 0;
   const primaryUri = getPrimaryUri(leaseStatus);

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.tsx
@@ -1,14 +1,12 @@
 "use client";
 import type { FC, ReactNode } from "react";
-import { Badge, buttonVariants, Card, CardContent, CustomTooltip } from "@akashnetwork/ui/components";
+import { Badge, Button, buttonVariants, Card, CardContent, CustomTooltip } from "@akashnetwork/ui/components";
 import { cn } from "@akashnetwork/ui/utils";
-import { CheckCircle, Globe, InfoCircle, MediaImage } from "iconoir-react";
+import { CheckCircle, EditPencil, Globe, InfoCircle } from "iconoir-react";
 import Link from "next/link";
 
+import { useLocalNotes } from "@src/components/LocalNoteManager";
 import { PricePerTimeUnit } from "@src/components/shared/PricePerTimeUnit";
-import { StatusPill } from "@src/components/shared/StatusPill";
-import { useServices } from "@src/context/ServicesProvider";
-import { useWallet } from "@src/context/WalletProvider";
 import { useWalletBalance } from "@src/hooks/useWalletBalance";
 import { useDeploymentSettingQuery } from "@src/queries/deploymentSettingsQuery";
 import type { LeaseStatusDto } from "@src/queries/useLeaseQuery";
@@ -18,20 +16,14 @@ import type { ApiProviderList } from "@src/types/provider";
 import { hasLiveGpuLease, isLeaseLive } from "@src/utils/leaseUtils";
 import { roundDecimal, udenomToDenom } from "@src/utils/mathHelpers";
 import { bytesToShrink } from "@src/utils/unitUtils";
+import { DeploymentStatusBadge } from "./DeploymentStatusBadge";
 
 export const DEPENDENCIES = {
-  useServices,
-  useWallet,
+  useLocalNotes,
   useWalletBalance,
   useDeploymentSettingQuery,
   useLeaseStatus,
   CustomTooltip
-};
-
-/** Deployment states map to a user-facing verb; unknown states fall through to the raw value. */
-const STATUS_LABELS: Record<string, string> = {
-  active: "Running",
-  closed: "Closed"
 };
 
 export interface DeploymentDetailHeaderProps {
@@ -42,8 +34,7 @@ export interface DeploymentDetailHeaderProps {
 }
 
 export const DeploymentDetailHeader: FC<DeploymentDetailHeaderProps> = ({ deployment, leases, providers, dependencies: d = DEPENDENCIES }) => {
-  const { deploymentLocalStorage } = d.useServices();
-  const { address } = d.useWallet();
+  const { getDeploymentName, changeDeploymentName } = d.useLocalNotes();
   const deploymentCost = leases?.reduce((sum, lease) => sum + parseFloat(lease.price.amount), 0) ?? 0;
   const { balance: walletBalance } = d.useWalletBalance();
   const { data: settings } = d.useDeploymentSettingQuery({ dseq: deployment.dseq });
@@ -52,8 +43,7 @@ export const DeploymentDetailHeader: FC<DeploymentDetailHeaderProps> = ({ deploy
   const provider = providers.find(p => p.owner === liveLease?.provider) ?? null;
   const { data: leaseStatus } = d.useLeaseStatus({ provider, lease: liveLease, enabled: !!provider });
 
-  const name = deploymentLocalStorage.get(address, deployment.dseq)?.name || `Deployment #${deployment.dseq}`;
-  const statusLabel = STATUS_LABELS[deployment.state] ?? deployment.state;
+  const name = getDeploymentName(deployment.dseq) || `Deployment #${deployment.dseq}`;
   const denom = deployment.escrowAccount.state.funds[0]?.denom || "";
   const hasGpu = hasLiveGpuLease(leases);
   const servicesCount = leaseStatus ? Object.keys(leaseStatus.services).length : leases?.length ?? 0;
@@ -63,28 +53,25 @@ export const DeploymentDetailHeader: FC<DeploymentDetailHeaderProps> = ({ deploy
 
   return (
     <div className="flex flex-col gap-6 py-6 lg:flex-row lg:items-start lg:justify-between">
-      <div className="flex items-start gap-6">
-        <div className="flex h-36 w-56 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-muted text-muted-foreground">
-          <MediaImage className="text-5xl" />
-        </div>
-        <div className="space-y-3">
-          <div className="flex items-center">
-            <StatusPill state={deployment.state} size="small" className={cn("ml-0", { "bg-emerald-500": deployment.state === "active" })} />
-            <span className={cn("ml-2 text-sm font-medium", { "text-emerald-500": deployment.state === "active" })}>{statusLabel}</span>
-          </div>
+      <div className="space-y-3">
+        <DeploymentStatusBadge state={deployment.state} />
+        <div className="flex items-center gap-2">
           <h1 className="text-3xl font-bold tracking-tight">{name}</h1>
-          {primaryUri && (
-            <div className="flex items-center gap-2">
-              <div className="inline-flex max-w-xs items-center gap-2 rounded-md border px-3 py-2 text-sm">
-                <Globe className="shrink-0 text-xs text-muted-foreground" />
-                <span className="truncate">{primaryUri}</span>
-              </div>
-              <Link href={`http://${primaryUri}`} target="_blank" rel="noreferrer" className={cn(buttonVariants({ variant: "default", size: "sm" }))}>
-                Visit
-              </Link>
-            </div>
-          )}
+          <Button aria-label="Edit deployment name" variant="ghost" size="icon" onClick={() => changeDeploymentName(deployment.dseq)}>
+            <EditPencil className="text-lg" />
+          </Button>
         </div>
+        {primaryUri && (
+          <div className="flex items-center gap-2">
+            <div className="inline-flex max-w-xs items-center gap-2 rounded-md border px-3 py-2 text-sm">
+              <Globe className="shrink-0 text-xs text-muted-foreground" />
+              <span className="truncate">{primaryUri}</span>
+            </div>
+            <Link href={`http://${primaryUri}`} target="_blank" rel="noreferrer" className={cn(buttonVariants({ variant: "default", size: "sm" }))}>
+              Visit
+            </Link>
+          </div>
+        )}
       </div>
 
       <Card className="w-full shrink-0 lg:w-auto">

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentBillingSection.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentBillingSection.spec.tsx
@@ -32,7 +32,19 @@ describe("DeploymentBillingSection", () => {
     expect(screen.queryByRole("switch")).not.toBeInTheDocument();
   });
 
-  function setup(input: { state?: string; isEnabled?: boolean }) {
+  it("shows the real-time draining escrow balance for an active deployment with live leases", () => {
+    setup({ state: "active", escrowBalance: 2000000, realTimeLeftEscrow: 500000, leases: [mock<LeaseDto>({ id: "1", state: "active" })] });
+
+    expect(screen.getByTestId("current-balance")).toHaveTextContent("0.5");
+  });
+
+  it("shows the settled escrow balance when the deployment has no live leases", () => {
+    setup({ state: "active", escrowBalance: 2000000, realTimeLeftEscrow: 500000, leases: [] });
+
+    expect(screen.getByTestId("current-balance")).toHaveTextContent("2");
+  });
+
+  function setup(input: { state?: string; isEnabled?: boolean; escrowBalance?: number; realTimeLeftEscrow?: number; leases?: LeaseDto[] | null }) {
     const setEnabled = vi.fn();
     const deposit = vi.fn();
     const onFundsChanged = vi.fn();
@@ -41,33 +53,37 @@ describe("DeploymentBillingSection", () => {
     const useServices: typeof DEPENDENCIES.useServices = () => mock<ReturnType<typeof DEPENDENCIES.useServices>>({ analyticsService });
     const useWallet: typeof DEPENDENCIES.useWallet = () => mock<ReturnType<typeof DEPENDENCIES.useWallet>>({ denom: "uakt" });
     const usePricing: typeof DEPENDENCIES.usePricing = () => mock<ReturnType<typeof DEPENDENCIES.usePricing>>({ udenomToUsd: () => 0 });
+    const realTimeLeft: ReturnType<typeof DEPENDENCIES.useAutoTopUp>["realTimeLeft"] =
+      input.realTimeLeftEscrow !== undefined ? { timeLeft: new Date(), escrow: input.realTimeLeftEscrow, amountSpent: 0 } : undefined;
     const useAutoTopUp: typeof DEPENDENCIES.useAutoTopUp = () =>
       mock<ReturnType<typeof DEPENDENCIES.useAutoTopUp>>({
         isEnabled: input.isEnabled ?? false,
         isLoading: false,
         estimatedTopUpAmount: 0,
         topUpFrequencyMs: 0,
+        realTimeLeft,
         setEnabled,
         deposit
       });
     const DeploymentDepositModal = vi.fn(() => <div>deposit-modal</div>);
+    const PriceValue: typeof DEPENDENCIES.PriceValue = ({ value }) => <span data-testid="current-balance">{value}</span>;
 
     const deployment = mock<DeploymentDto>({
       dseq: "1786440078202",
       state: input.state ?? "active",
-      escrowBalance: 1000000,
+      escrowBalance: input.escrowBalance ?? 1000000,
       escrowAccount: mock<DeploymentDto["escrowAccount"]>({
         state: mock<DeploymentDto["escrowAccount"]["state"]>({ funds: [{ denom: "uakt", amount: "1000000" }] })
       })
     });
-    const leases = [mock<LeaseDto>({ id: "1", state: "active" })];
+    const leases = input.leases !== undefined ? input.leases : [mock<LeaseDto>({ id: "1", state: "active" })];
 
     render(
       <DeploymentBillingSection
         deployment={deployment}
         leases={leases}
         onFundsChanged={onFundsChanged}
-        dependencies={MockComponents(DEPENDENCIES, { useServices, useWallet, usePricing, useAutoTopUp, DeploymentDepositModal })}
+        dependencies={MockComponents(DEPENDENCIES, { useServices, useWallet, usePricing, useAutoTopUp, DeploymentDepositModal, PriceValue })}
       />
     );
 

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentBillingSection.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentBillingSection.spec.tsx
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { DeploymentDto, LeaseDto } from "@src/types/deployment";
+import { DEPENDENCIES, DeploymentBillingSection } from "./DeploymentBillingSection";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MockComponents } from "@tests/unit/mocks";
+
+describe("DeploymentBillingSection", () => {
+  it("opens the deposit modal when Add funds is clicked on an active deployment", async () => {
+    setup({ state: "active" });
+
+    await userEvent.click(screen.getByRole("button", { name: "Add funds" }));
+
+    expect(screen.getByText("deposit-modal")).toBeInTheDocument();
+  });
+
+  it("enables auto top-up when the toggle is switched on", async () => {
+    const { setEnabled } = setup({ state: "active", isEnabled: false });
+
+    await userEvent.click(screen.getByRole("switch", { name: "Auto Top-Up" }));
+
+    expect(setEnabled).toHaveBeenCalledWith(true);
+  });
+
+  it("hides Add funds and the auto top-up toggle when the deployment is closed", () => {
+    setup({ state: "closed" });
+
+    expect(screen.queryByRole("button", { name: "Add funds" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("switch")).not.toBeInTheDocument();
+  });
+
+  function setup(input: { state?: string; isEnabled?: boolean }) {
+    const setEnabled = vi.fn();
+    const deposit = vi.fn();
+    const onFundsChanged = vi.fn();
+
+    const analyticsService = mock<ReturnType<typeof DEPENDENCIES.useServices>["analyticsService"]>();
+    const useServices: typeof DEPENDENCIES.useServices = () => mock<ReturnType<typeof DEPENDENCIES.useServices>>({ analyticsService });
+    const useWallet: typeof DEPENDENCIES.useWallet = () => mock<ReturnType<typeof DEPENDENCIES.useWallet>>({ denom: "uakt" });
+    const usePricing: typeof DEPENDENCIES.usePricing = () => mock<ReturnType<typeof DEPENDENCIES.usePricing>>({ udenomToUsd: () => 0 });
+    const useAutoTopUp: typeof DEPENDENCIES.useAutoTopUp = () =>
+      mock<ReturnType<typeof DEPENDENCIES.useAutoTopUp>>({
+        isEnabled: input.isEnabled ?? false,
+        isLoading: false,
+        estimatedTopUpAmount: 0,
+        topUpFrequencyMs: 0,
+        setEnabled,
+        deposit
+      });
+    const DeploymentDepositModal = vi.fn(() => <div>deposit-modal</div>);
+
+    const deployment = mock<DeploymentDto>({
+      dseq: "1786440078202",
+      state: input.state ?? "active",
+      escrowBalance: 1000000,
+      escrowAccount: mock<DeploymentDto["escrowAccount"]>({
+        state: mock<DeploymentDto["escrowAccount"]["state"]>({ funds: [{ denom: "uakt", amount: "1000000" }] })
+      })
+    });
+    const leases = [mock<LeaseDto>({ id: "1", state: "active" })];
+
+    render(
+      <DeploymentBillingSection
+        deployment={deployment}
+        leases={leases}
+        onFundsChanged={onFundsChanged}
+        dependencies={MockComponents(DEPENDENCIES, { useServices, useWallet, usePricing, useAutoTopUp, DeploymentDepositModal })}
+      />
+    );
+
+    return { setEnabled, deposit, onFundsChanged };
+  }
+});

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentBillingSection.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentBillingSection.tsx
@@ -12,6 +12,8 @@ import { useWallet } from "@src/context/WalletProvider";
 import { useAutoTopUp } from "@src/hooks/useAutoTopUp/useAutoTopUp";
 import { usePricing } from "@src/hooks/usePricing/usePricing";
 import type { DeploymentDto, LeaseDto } from "@src/types/deployment";
+import { getEscrowDenom } from "@src/utils/deploymentUtils";
+import { isLeaseLive } from "@src/utils/leaseUtils";
 import { udenomToDenom } from "@src/utils/mathHelpers";
 import { DeploymentDepositModal } from "../../DeploymentDepositModal/DeploymentDepositModal";
 
@@ -38,14 +40,16 @@ export const DeploymentBillingSection: FC<DeploymentBillingSectionProps> = ({ de
   const { udenomToUsd } = d.usePricing();
   const [isDepositing, setIsDepositing] = useState(false);
   const isActive = deployment.state === "active";
-  const escrowDenom = deployment.escrowAccount.state.funds[0]?.denom || "";
+  const hasActiveLeases = !!leases && leases.some(isLeaseLive);
+  const escrowDenom = getEscrowDenom(deployment);
 
   const onDeposited = useCallback(() => {
     analyticsService.track("deployment_deposit", { category: "deployments", label: "Deposit deployment in deployment detail" });
     onFundsChanged();
   }, [analyticsService, onFundsChanged]);
 
-  const { isEnabled, isLoading, estimatedTopUpAmount, topUpFrequencyMs, setEnabled, deposit } = d.useAutoTopUp({ deployment, leases, onDeposited });
+  const { isEnabled, isLoading, estimatedTopUpAmount, topUpFrequencyMs, realTimeLeft, setEnabled, deposit } = d.useAutoTopUp({ deployment, leases, onDeposited });
+  const currentBalance = isActive && hasActiveLeases && realTimeLeft ? realTimeLeft.escrow : deployment.escrowBalance;
 
   const openDepositModal = useCallback(() => {
     setIsDepositing(true);
@@ -66,7 +70,7 @@ export const DeploymentBillingSection: FC<DeploymentBillingSectionProps> = ({ de
         <div className="space-y-1">
           <div className="text-xs uppercase tracking-wide text-muted-foreground">Current balance</div>
           <div className="text-2xl font-bold">
-            <d.PriceValue denom={escrowDenom} value={udenomToDenom(deployment.escrowBalance, 6)} />
+            <d.PriceValue denom={escrowDenom} value={udenomToDenom(currentBalance, 6)} />
           </div>
         </div>
         {isActive && (

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentBillingSection.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentBillingSection.tsx
@@ -1,0 +1,112 @@
+"use client";
+import type { FC } from "react";
+import { useCallback, useState } from "react";
+import { Button, CustomTooltip, Spinner, Switch } from "@akashnetwork/ui/components";
+import formatDuration from "date-fns/formatDuration";
+import intervalToDuration from "date-fns/intervalToDuration";
+import { InfoCircle } from "iconoir-react";
+
+import { PriceValue } from "@src/components/shared/PriceValue";
+import { useServices } from "@src/context/ServicesProvider";
+import { useWallet } from "@src/context/WalletProvider";
+import { useAutoTopUp } from "@src/hooks/useAutoTopUp/useAutoTopUp";
+import { usePricing } from "@src/hooks/usePricing/usePricing";
+import type { DeploymentDto, LeaseDto } from "@src/types/deployment";
+import { udenomToDenom } from "@src/utils/mathHelpers";
+import { DeploymentDepositModal } from "../../DeploymentDepositModal/DeploymentDepositModal";
+
+export const DEPENDENCIES = {
+  useServices,
+  useWallet,
+  usePricing,
+  useAutoTopUp,
+  DeploymentDepositModal,
+  PriceValue,
+  CustomTooltip
+};
+
+export interface DeploymentBillingSectionProps {
+  deployment: DeploymentDto;
+  leases: LeaseDto[] | null | undefined;
+  onFundsChanged: () => void;
+  dependencies?: typeof DEPENDENCIES;
+}
+
+export const DeploymentBillingSection: FC<DeploymentBillingSectionProps> = ({ deployment, leases, onFundsChanged, dependencies: d = DEPENDENCIES }) => {
+  const { analyticsService } = d.useServices();
+  const { denom: walletDenom } = d.useWallet();
+  const { udenomToUsd } = d.usePricing();
+  const [isDepositing, setIsDepositing] = useState(false);
+  const isActive = deployment.state === "active";
+  const escrowDenom = deployment.escrowAccount.state.funds[0]?.denom || "";
+
+  const onDeposited = useCallback(() => {
+    analyticsService.track("deployment_deposit", { category: "deployments", label: "Deposit deployment in deployment detail" });
+    onFundsChanged();
+  }, [analyticsService, onFundsChanged]);
+
+  const { isEnabled, isLoading, estimatedTopUpAmount, topUpFrequencyMs, setEnabled, deposit } = d.useAutoTopUp({ deployment, leases, onDeposited });
+
+  const openDepositModal = useCallback(() => {
+    setIsDepositing(true);
+    analyticsService.track("deposit_deployment_btn_clk", "Amplitude");
+  }, [analyticsService]);
+
+  const submitDeposit = useCallback(
+    (amount: number) => {
+      setIsDepositing(false);
+      deposit(amount);
+    },
+    [deposit]
+  );
+
+  return (
+    <div className="rounded-xl border bg-card p-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div className="space-y-1">
+          <div className="text-xs uppercase tracking-wide text-muted-foreground">Current balance</div>
+          <div className="text-2xl font-bold">
+            <d.PriceValue denom={escrowDenom} value={udenomToDenom(deployment.escrowBalance, 6)} />
+          </div>
+        </div>
+        {isActive && (
+          <Button variant="default" onClick={openDepositModal}>
+            Add funds
+          </Button>
+        )}
+      </div>
+
+      {isActive && (
+        <div className="mt-6 flex items-center justify-between gap-4 border-t pt-6">
+          <div className="space-y-1">
+            <div className="flex items-center gap-2 font-medium">
+              Auto Top-Up
+              <d.CustomTooltip
+                title={
+                  <div className="space-y-2">
+                    <div>
+                      <div>Estimated amount: ${udenomToUsd(estimatedTopUpAmount, walletDenom)}</div>
+                      <div>Check period: {formatDuration(intervalToDuration({ start: 0, end: topUpFrequencyMs }))}</div>
+                    </div>
+                    <div className="text-xs text-muted-foreground">
+                      Auto top-up will only occur if there are insufficient funds to maintain the deployment until the next scheduled check.
+                    </div>
+                  </div>
+                }
+              >
+                <InfoCircle width={14} height={14} className="text-muted-foreground" />
+              </d.CustomTooltip>
+            </div>
+            <p className="text-sm text-muted-foreground">Automatically add funds when your balance gets low to keep this deployment running.</p>
+          </div>
+          <div className="flex items-center gap-2">
+            {isLoading && <Spinner size="small" />}
+            <Switch checked={isEnabled} onCheckedChange={setEnabled} disabled={isLoading} aria-label="Auto Top-Up" />
+          </div>
+        </div>
+      )}
+
+      {isDepositing && <d.DeploymentDepositModal denom={escrowDenom} disableMin onCancel={() => setIsDepositing(false)} onSubmit={submitDeposit} />}
+    </div>
+  );
+};

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentDangerZone.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentDangerZone.spec.tsx
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { DeploymentDto } from "@src/types/deployment";
+import { DEPENDENCIES, DeploymentDangerZone } from "./DeploymentDangerZone";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MockComponents } from "@tests/unit/mocks";
+
+describe("DeploymentDangerZone", () => {
+  it("closes the deployment and notifies the parent on confirmation", async () => {
+    const { onClosed, signAndBroadcastTx, closeDeploymentConfirm } = setup({ confirmed: true, txSucceeds: true });
+
+    await userEvent.click(screen.getByRole("button", { name: "Close deployment" }));
+
+    expect(closeDeploymentConfirm).toHaveBeenCalledWith(["1786440078202"]);
+    await vi.waitFor(() => expect(signAndBroadcastTx).toHaveBeenCalled());
+    expect(onClosed).toHaveBeenCalled();
+  });
+
+  it("does not broadcast when the user cancels the confirmation", async () => {
+    const { onClosed, signAndBroadcastTx } = setup({ confirmed: false });
+
+    await userEvent.click(screen.getByRole("button", { name: "Close deployment" }));
+
+    expect(signAndBroadcastTx).not.toHaveBeenCalled();
+    expect(onClosed).not.toHaveBeenCalled();
+  });
+
+  it("does not notify the parent when the transaction fails", async () => {
+    const { onClosed, signAndBroadcastTx } = setup({ confirmed: true, txSucceeds: false });
+
+    await userEvent.click(screen.getByRole("button", { name: "Close deployment" }));
+
+    await vi.waitFor(() => expect(signAndBroadcastTx).toHaveBeenCalled());
+    expect(onClosed).not.toHaveBeenCalled();
+  });
+
+  function setup(input: { confirmed?: boolean; txSucceeds?: boolean }) {
+    const onClosed = vi.fn();
+    const signAndBroadcastTx = vi.fn().mockResolvedValue(input.txSucceeds ?? true);
+    const closeDeploymentConfirm = vi.fn().mockResolvedValue(input.confirmed ?? true);
+
+    const analyticsService = mock<ReturnType<typeof DEPENDENCIES.useServices>["analyticsService"]>();
+    const useServices: typeof DEPENDENCIES.useServices = () => mock<ReturnType<typeof DEPENDENCIES.useServices>>({ analyticsService });
+    const useWallet: typeof DEPENDENCIES.useWallet = () => mock<ReturnType<typeof DEPENDENCIES.useWallet>>({ address: "akash1test", signAndBroadcastTx });
+    const useManagedDeploymentConfirm: typeof DEPENDENCIES.useManagedDeploymentConfirm = () =>
+      mock<ReturnType<typeof DEPENDENCIES.useManagedDeploymentConfirm>>({ closeDeploymentConfirm });
+
+    const deployment = mock<DeploymentDto>({ dseq: "1786440078202", state: "active" });
+
+    render(
+      <DeploymentDangerZone
+        deployment={deployment}
+        onClosed={onClosed}
+        dependencies={MockComponents(DEPENDENCIES, { useServices, useWallet, useManagedDeploymentConfirm })}
+      />
+    );
+
+    return { onClosed, signAndBroadcastTx, closeDeploymentConfirm };
+  }
+});

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentDangerZone.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentDangerZone.tsx
@@ -1,0 +1,54 @@
+"use client";
+import type { FC } from "react";
+import { useState } from "react";
+import { Button, Spinner } from "@akashnetwork/ui/components";
+
+import { useServices } from "@src/context/ServicesProvider";
+import { useWallet } from "@src/context/WalletProvider";
+import { useManagedDeploymentConfirm } from "@src/hooks/useManagedDeploymentConfirm";
+import type { DeploymentDto } from "@src/types/deployment";
+import { TransactionMessageData } from "@src/utils/TransactionMessageData";
+
+export const DEPENDENCIES = { useServices, useWallet, useManagedDeploymentConfirm };
+
+export interface DeploymentDangerZoneProps {
+  deployment: DeploymentDto;
+  onClosed: () => void;
+  dependencies?: typeof DEPENDENCIES;
+}
+
+export const DeploymentDangerZone: FC<DeploymentDangerZoneProps> = ({ deployment, onClosed, dependencies: d = DEPENDENCIES }) => {
+  const { analyticsService } = d.useServices();
+  const { address, signAndBroadcastTx } = d.useWallet();
+  const { closeDeploymentConfirm } = d.useManagedDeploymentConfirm();
+  const [isClosing, setIsClosing] = useState(false);
+
+  const confirmAndClose = async () => {
+    const isConfirmed = await closeDeploymentConfirm([deployment.dseq]);
+    if (!isConfirmed) return;
+
+    setIsClosing(true);
+    try {
+      const message = TransactionMessageData.getCloseDeploymentMsg(address, deployment.dseq);
+      const response = await signAndBroadcastTx([message]);
+      if (response) {
+        analyticsService.track("close_deployment", { category: "deployments", label: "Close deployment in deployment detail" });
+        onClosed();
+      }
+    } finally {
+      setIsClosing(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-4 rounded-xl border border-destructive/50 bg-card p-6">
+      <div className="space-y-1">
+        <h3 className="font-semibold">Close this deployment</h3>
+        <p className="text-sm text-muted-foreground">Stop all services and permanently tear down this deployment. This action can&apos;t be undone.</p>
+      </div>
+      <Button variant="destructive" onClick={confirmAndClose} disabled={isClosing} aria-label="Close deployment">
+        {isClosing ? <Spinner size="small" /> : "Close deployment"}
+      </Button>
+    </div>
+  );
+};

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentNotificationsSection.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentNotificationsSection.spec.tsx
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { DeploymentDto } from "@src/types/deployment";
+import { DEPENDENCIES, DeploymentNotificationsSection } from "./DeploymentNotificationsSection";
+
+import { render, screen } from "@testing-library/react";
+import { MockComponents } from "@tests/unit/mocks";
+
+describe("DeploymentNotificationsSection", () => {
+  it("renders the alerts form when notifications are enabled", () => {
+    setup({ isEnabled: true });
+
+    expect(screen.getByText("alerts")).toBeInTheDocument();
+  });
+
+  it("shows a sign-in note when notifications are disabled", () => {
+    setup({ isEnabled: false });
+
+    expect(screen.getByText(/sign in to configure notifications/i)).toBeInTheDocument();
+    expect(screen.queryByText("alerts")).not.toBeInTheDocument();
+  });
+
+  function setup(input: { isEnabled: boolean }) {
+    const DeploymentAlerts = vi.fn(() => <div>alerts</div>);
+    const deployment = mock<DeploymentDto>({ dseq: "1786440078202", state: "active" });
+
+    render(
+      <DeploymentNotificationsSection deployment={deployment} isEnabled={input.isEnabled} dependencies={MockComponents(DEPENDENCIES, { DeploymentAlerts })} />
+    );
+  }
+});

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentNotificationsSection.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentNotificationsSection.tsx
@@ -1,0 +1,21 @@
+"use client";
+import type { FC } from "react";
+
+import { DeploymentAlerts } from "@src/components/deployments/DeploymentAlerts/DeploymentAlerts";
+import type { DeploymentDto } from "@src/types/deployment";
+
+export const DEPENDENCIES = { DeploymentAlerts };
+
+export interface DeploymentNotificationsSectionProps {
+  deployment: DeploymentDto;
+  isEnabled: boolean;
+  dependencies?: typeof DEPENDENCIES;
+}
+
+export const DeploymentNotificationsSection: FC<DeploymentNotificationsSectionProps> = ({ deployment, isEnabled, dependencies: d = DEPENDENCIES }) => {
+  if (!isEnabled) {
+    return <div className="rounded-xl border bg-card p-6 text-sm text-muted-foreground">Sign in to configure notifications for this deployment.</div>;
+  }
+
+  return <d.DeploymentAlerts deployment={deployment} onStateChange={() => undefined} />;
+};

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentSettings.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentSettings.spec.tsx
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { DeploymentDto, LeaseDto } from "@src/types/deployment";
+import { DEPENDENCIES, DeploymentSettings } from "./DeploymentSettings";
+
+import { render, screen } from "@testing-library/react";
+import { MockComponents } from "@tests/unit/mocks";
+
+describe("DeploymentSettings", () => {
+  it("renders billing, notifications, and danger zone for an active signed-in deployment", () => {
+    setup({ state: "active", isSignedIn: true });
+
+    expect(screen.getByText("billing-section")).toBeInTheDocument();
+    expect(screen.getByText("notifications:true")).toBeInTheDocument();
+    expect(screen.getByText("danger-zone")).toBeInTheDocument();
+    expect(screen.getByText("Danger Zone")).toBeInTheDocument();
+  });
+
+  it("hides the danger zone when the deployment is closed", () => {
+    setup({ state: "closed", isSignedIn: true });
+
+    expect(screen.queryByText("danger-zone")).not.toBeInTheDocument();
+    expect(screen.queryByText("Danger Zone")).not.toBeInTheDocument();
+  });
+
+  it("disables notifications when the user is not signed in", () => {
+    setup({ state: "active", isSignedIn: false });
+
+    expect(screen.getByText("notifications:false")).toBeInTheDocument();
+  });
+
+  function setup(input: { state?: string; isSignedIn?: boolean }) {
+    const useUser: typeof DEPENDENCIES.useUser = () =>
+      mock<ReturnType<typeof DEPENDENCIES.useUser>>({
+        user: input.isSignedIn ? mock<NonNullable<ReturnType<typeof DEPENDENCIES.useUser>["user"]>>({ userId: "u1" }) : undefined
+      });
+    const DeploymentBillingSection: typeof DEPENDENCIES.DeploymentBillingSection = vi.fn(() => <div>billing-section</div>);
+    const DeploymentNotificationsSection: typeof DEPENDENCIES.DeploymentNotificationsSection = vi.fn(props => (
+      <div>notifications:{String(props.isEnabled)}</div>
+    ));
+    const DeploymentDangerZone: typeof DEPENDENCIES.DeploymentDangerZone = vi.fn(() => <div>danger-zone</div>);
+
+    render(
+      <DeploymentSettings
+        deployment={mock<DeploymentDto>({ dseq: "1786440078202", state: input.state ?? "active" })}
+        leases={[mock<LeaseDto>({ id: "1", state: "active" })]}
+        onDeploymentChange={vi.fn()}
+        dependencies={MockComponents(DEPENDENCIES, { useUser, DeploymentBillingSection, DeploymentNotificationsSection, DeploymentDangerZone })}
+      />
+    );
+  }
+});

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentSettings.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentSettings.tsx
@@ -1,0 +1,54 @@
+"use client";
+import type { FC, ReactNode } from "react";
+import { cn } from "@akashnetwork/ui/utils";
+
+import { useUser } from "@src/hooks/useUser";
+import type { DeploymentDto, LeaseDto } from "@src/types/deployment";
+import { DeploymentBillingSection } from "./DeploymentBillingSection";
+import { DeploymentDangerZone } from "./DeploymentDangerZone";
+import { DeploymentNotificationsSection } from "./DeploymentNotificationsSection";
+
+export const DEPENDENCIES = {
+  useUser,
+  DeploymentBillingSection,
+  DeploymentNotificationsSection,
+  DeploymentDangerZone
+};
+
+export interface DeploymentSettingsProps {
+  deployment: DeploymentDto;
+  leases: LeaseDto[] | null | undefined;
+  onDeploymentChange: () => void;
+  dependencies?: typeof DEPENDENCIES;
+}
+
+export const DeploymentSettings: FC<DeploymentSettingsProps> = ({ deployment, leases, onDeploymentChange, dependencies: d = DEPENDENCIES }) => {
+  const { user } = d.useUser();
+  const isAlertsEnabled = !!user?.userId;
+  const isActive = deployment.state === "active";
+
+  return (
+    <div className="space-y-8">
+      <SettingsSection title="Billing">
+        <d.DeploymentBillingSection deployment={deployment} leases={leases} onFundsChanged={onDeploymentChange} />
+      </SettingsSection>
+
+      <SettingsSection title="Notifications">
+        <d.DeploymentNotificationsSection deployment={deployment} isEnabled={isAlertsEnabled} />
+      </SettingsSection>
+
+      {isActive && (
+        <SettingsSection title="Danger Zone" destructive>
+          <d.DeploymentDangerZone deployment={deployment} onClosed={onDeploymentChange} />
+        </SettingsSection>
+      )}
+    </div>
+  );
+};
+
+const SettingsSection: FC<{ title: string; destructive?: boolean; children: ReactNode }> = ({ title, destructive, children }) => (
+  <section className="space-y-3">
+    <h2 className={cn("text-xs font-medium uppercase tracking-wide", destructive ? "text-destructive" : "text-muted-foreground")}>{title}</h2>
+    {children}
+  </section>
+);

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentStatusBadge.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentStatusBadge.spec.tsx
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { DeploymentStatusBadge } from "./DeploymentStatusBadge";
+
+import { render, screen } from "@testing-library/react";
+
+describe("DeploymentStatusBadge", () => {
+  it("renders 'Running' for the active state", () => {
+    render(<DeploymentStatusBadge state="active" />);
+
+    expect(screen.getByText("Running")).toBeInTheDocument();
+  });
+
+  it("renders 'Closed' for the closed state", () => {
+    render(<DeploymentStatusBadge state="closed" />);
+
+    expect(screen.getByText("Closed")).toBeInTheDocument();
+  });
+
+  it("falls back to the raw state label for unknown states", () => {
+    render(<DeploymentStatusBadge state="paused" />);
+
+    expect(screen.getByText("paused")).toBeInTheDocument();
+  });
+});

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentStatusBadge.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentStatusBadge.tsx
@@ -6,13 +6,11 @@ type StatusTone = "running" | "pending" | "closed";
 
 const STATUS_LABELS: Record<string, string> = {
   active: "Running",
-  reclaiming: "Reclaiming",
   closed: "Closed"
 };
 
 const STATUS_TONES: Record<string, StatusTone> = {
   active: "running",
-  reclaiming: "pending",
   closed: "closed"
 };
 

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentStatusBadge.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentStatusBadge.tsx
@@ -1,0 +1,49 @@
+"use client";
+import type { FC } from "react";
+import { cn } from "@akashnetwork/ui/utils";
+
+type StatusTone = "running" | "pending" | "closed";
+
+const STATUS_LABELS: Record<string, string> = {
+  active: "Running",
+  reclaiming: "Reclaiming",
+  closed: "Closed"
+};
+
+const STATUS_TONES: Record<string, StatusTone> = {
+  active: "running",
+  reclaiming: "pending",
+  closed: "closed"
+};
+
+const BADGE_TONE_CLASS: Record<StatusTone, string> = {
+  running: "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
+  pending: "bg-amber-500/10 text-amber-600 dark:text-amber-400",
+  closed: "bg-destructive/10 text-destructive"
+};
+
+const DOT_TONE_CLASS: Record<StatusTone, string> = {
+  running: "bg-emerald-500",
+  pending: "bg-amber-500",
+  closed: "bg-destructive"
+};
+
+export interface DeploymentStatusBadgeProps {
+  state: string;
+  className?: string;
+}
+
+export const DeploymentStatusBadge: FC<DeploymentStatusBadgeProps> = ({ state, className }) => {
+  const tone = STATUS_TONES[state] ?? "pending";
+  const label = STATUS_LABELS[state] ?? state;
+
+  return (
+    <span className={cn("inline-flex items-center gap-2 rounded-full px-2.5 py-1 text-xs font-medium", BADGE_TONE_CLASS[tone], className)}>
+      <span className="relative flex h-2 w-2">
+        {tone === "running" && <span className={cn("absolute inline-flex h-full w-full animate-ping rounded-full opacity-75", DOT_TONE_CLASS[tone])} />}
+        <span className={cn("relative inline-flex h-2 w-2 rounded-full", DOT_TONE_CLASS[tone])} />
+      </span>
+      {label}
+    </span>
+  );
+};

--- a/apps/deploy-web/src/components/deployments/DeploymentDetailTopBar/DeploymentDetailTopBar.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetailTopBar/DeploymentDetailTopBar.tsx
@@ -25,6 +25,7 @@ import { usePricing } from "@src/hooks/usePricing/usePricing";
 import { useRedeploy } from "@src/hooks/useRedeploy/useRedeploy";
 import { useDeploymentSettingQuery } from "@src/queries/deploymentSettingsQuery";
 import type { DeploymentDto, LeaseDto } from "@src/types/deployment";
+import { getEscrowDenom } from "@src/utils/deploymentUtils";
 import { averageBlockTime } from "@src/utils/priceUtils";
 import { TransactionMessageData } from "@src/utils/TransactionMessageData";
 import { UrlService } from "@src/utils/urlUtils";
@@ -126,7 +127,7 @@ export const DeploymentDetailTopBar: React.FunctionComponent<Props> = ({
 
   const { deposit: depositDeployment } = d.useDepositDeployment({
     dseq: deployment.dseq,
-    denom: deployment.escrowAccount.state.funds[0]?.denom || "",
+    denom: getEscrowDenom(deployment),
     onSuccess: () => {
       loadDeploymentDetail();
       analyticsService.track("deployment_deposit", {
@@ -155,7 +156,7 @@ export const DeploymentDetailTopBar: React.FunctionComponent<Props> = ({
           const secToDepositFor = secTillNextTopUp - secTillClosed;
           const deposit = Math.ceil((deploymentCost * secToDepositFor) / averageBlockTime);
 
-          const convertedDeposit = formatCurrency(udenomToUsd(deposit, deployment.escrowAccount.state.funds[0]?.denom || ""));
+          const convertedDeposit = formatCurrency(udenomToUsd(deposit, getEscrowDenom(deployment)));
           const isConfirmed = await confirm({
             title: "Deposit required",
             message: `To enable auto top-up, please deposit ${convertedDeposit}. This ensures your deployment remains active until the next scheduled check.`
@@ -303,7 +304,7 @@ export const DeploymentDetailTopBar: React.FunctionComponent<Props> = ({
 
       {isDepositingDeployment && (
         <d.DeploymentDepositModal
-          denom={deployment.escrowAccount.state.funds[0]?.denom || ""}
+          denom={getEscrowDenom(deployment)}
           disableMin
           onCancel={() => setIsDepositingDeployment(false)}
           onSubmit={onDeploymentDeposit}

--- a/apps/deploy-web/src/components/deployments/DeploymentListRow.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentListRow.tsx
@@ -34,6 +34,7 @@ import { useRedeploy } from "@src/hooks/useRedeploy/useRedeploy";
 import { useDeploymentLeaseList, useLeaseStatus } from "@src/queries/useLeaseQuery";
 import type { LeaseDto, NamedDeploymentDto } from "@src/types/deployment";
 import type { ApiProviderList } from "@src/types/provider";
+import { getEscrowDenom } from "@src/utils/deploymentUtils";
 import { isLeaseLive } from "@src/utils/leaseUtils";
 import { udenomToDenom } from "@src/utils/mathHelpers";
 import { getTimeLeft } from "@src/utils/priceUtils";
@@ -117,7 +118,7 @@ export const DeploymentListRow: React.FunctionComponent<Props> = ({ deployment, 
 
   const { deposit: depositDeployment } = useDepositDeployment({
     dseq: deployment.dseq,
-    denom: deployment.escrowAccount.state.funds[0]?.denom || "",
+    denom: getEscrowDenom(deployment),
     onSuccess: () => {
       refreshDeployments();
       analyticsService.track("deployment_deposit", {
@@ -217,12 +218,12 @@ export const DeploymentListRow: React.FunctionComponent<Props> = ({ deployment, 
               <div className="flex items-center">
                 <CalendarArrowDown className="mr-2 text-xs" />
                 <PricePerTimeUnit
-                  denom={deployment.escrowAccount.state.funds[0]?.denom || ""}
+                  denom={getEscrowDenom(deployment)}
                   perBlockValue={udenomToDenom(deploymentCost, 10)}
                   className="whitespace-nowrap"
                   showAsHourly={hasGpu}
                 />
-                <PriceEstimateTooltip denom={deployment.escrowAccount.state.funds[0]?.denom || ""} value={deploymentCost} showAsHourly={hasGpu} />
+                <PriceEstimateTooltip denom={getEscrowDenom(deployment)} value={deploymentCost} showAsHourly={hasGpu} />
               </div>
             )}
             {isActive && !!escrowBalanceInDenom && !!escrowBalance && (
@@ -232,13 +233,13 @@ export const DeploymentListRow: React.FunctionComponent<Props> = ({ deployment, 
                     <div className="space-x-2">
                       <span>Balance:</span>
                       <strong>
-                        <PriceValue denom={deployment.escrowAccount.state.funds[0]?.denom || ""} value={escrowBalanceInDenom} />
+                        <PriceValue denom={getEscrowDenom(deployment)} value={escrowBalanceInDenom} />
                       </strong>
                     </div>
                     <div className="space-x-2">
                       <span>Spent:</span>
                       <strong>
-                        <PriceValue denom={deployment.escrowAccount.state.funds[0]?.denom || ""} value={udenomToDenom(amountSpent || 0, 6)} />
+                        <PriceValue denom={getEscrowDenom(deployment)} value={udenomToDenom(amountSpent || 0, 6)} />
                       </strong>
                     </div>
                     <br />
@@ -250,7 +251,7 @@ export const DeploymentListRow: React.FunctionComponent<Props> = ({ deployment, 
               >
                 <div className="inline-flex cursor-help">
                   <Coins className="mr-2 text-xs" />
-                  <PriceValue denom={deployment.escrowAccount.state.funds[0]?.denom || ""} value={escrowBalanceInDenom} />
+                  <PriceValue denom={getEscrowDenom(deployment)} value={escrowBalanceInDenom} />
                 </div>
               </CustomTooltip>
             )}
@@ -366,7 +367,7 @@ export const DeploymentListRow: React.FunctionComponent<Props> = ({ deployment, 
 
       {isActive && isDepositingDeployment && (
         <DeploymentDepositModal
-          denom={deployment.escrowAccount.state.funds[0]?.denom || ""}
+          denom={getEscrowDenom(deployment)}
           disableMin
           onCancel={() => setIsDepositingDeployment(false)}
           onSubmit={onDeploymentDeposit}

--- a/apps/deploy-web/src/components/deployments/DeploymentSubHeader.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentSubHeader.tsx
@@ -19,6 +19,7 @@ import { useDeploymentMetrics } from "@src/hooks/useDeploymentMetrics";
 import { useTrialDeploymentTimeRemaining } from "@src/hooks/useTrialDeploymentTimeRemaining";
 import type { DeploymentDto, LeaseDto } from "@src/types/deployment";
 import type { TeeType } from "@src/utils/confidentialCompute";
+import { getEscrowDenom } from "@src/utils/deploymentUtils";
 import type { DeclaredGpuInterconnect } from "@src/utils/gpuInterconnect";
 import { hasLiveGpuLease, isLeaseLive } from "@src/utils/leaseUtils";
 import { udenomToDenom } from "@src/utils/mathHelpers";
@@ -56,7 +57,7 @@ export const DeploymentSubHeader: React.FunctionComponent<Props> = ({ deployment
           value={
             <div className="flex items-center space-x-2">
               <PriceValue
-                denom={deployment.escrowAccount.state.funds[0]?.denom || ""}
+                denom={getEscrowDenom(deployment)}
                 value={udenomToDenom(isActive && hasActiveLeases && realTimeLeft ? realTimeLeft?.escrow : deployment.escrowBalance, 6)}
               />
 
@@ -75,7 +76,7 @@ export const DeploymentSubHeader: React.FunctionComponent<Props> = ({ deployment
             !!deploymentCost && (
               <div className="flex items-center space-x-2">
                 <PricePerTimeUnit
-                  denom={deployment.escrowAccount.state.funds[0]?.denom || ""}
+                  denom={getEscrowDenom(deployment)}
                   perBlockValue={udenomToDenom(deploymentCost, 10)}
                   showAsHourly={hasGpu}
                 />
@@ -89,7 +90,7 @@ export const DeploymentSubHeader: React.FunctionComponent<Props> = ({ deployment
           value={
             <div className="flex items-center space-x-2">
               <PriceValue
-                denom={deployment.escrowAccount.state.funds[0]?.denom || ""}
+                denom={getEscrowDenom(deployment)}
                 value={udenomToDenom(isActive && hasActiveLeases && realTimeLeft ? realTimeLeft?.amountSpent : parseFloat(deployment.transferred.amount), 6)}
               />
             </div>

--- a/apps/deploy-web/src/hooks/useAutoTopUp/useAutoTopUp.spec.ts
+++ b/apps/deploy-web/src/hooks/useAutoTopUp/useAutoTopUp.spec.ts
@@ -55,6 +55,12 @@ describe(useAutoTopUp.name, () => {
     expect(setAutoTopUpEnabled).toHaveBeenCalledWith(false);
   });
 
+  it("exposes the real-time escrow metrics from useDeploymentMetrics", () => {
+    const { result, realTimeLeft } = setup({ hoursOfRunway: 3 });
+
+    expect(result.current.realTimeLeft).toBe(realTimeLeft);
+  });
+
   function setup(input: { hoursOfRunway?: number; minutesOfRunway?: number; confirmed?: boolean; depositSucceeds?: boolean }) {
     const runwayMs = input.hoursOfRunway != null ? input.hoursOfRunway * 60 * 60 * 1000 : (input.minutesOfRunway ?? 1) * 60 * 1000;
     const timeLeft = new Date(Date.now() + runwayMs);
@@ -65,8 +71,9 @@ describe(useAutoTopUp.name, () => {
 
     const usePopup: typeof DEPENDENCIES.usePopup = () => mock<ReturnType<typeof DEPENDENCIES.usePopup>>({ confirm });
     const useCurrencyFormatter: typeof DEPENDENCIES.useCurrencyFormatter = () => (value: number) => `$${value}`;
+    const realTimeLeft = { timeLeft, escrow: 0, amountSpent: 0 };
     const useDeploymentMetrics: typeof DEPENDENCIES.useDeploymentMetrics = () => ({
-      realTimeLeft: { timeLeft, escrow: 0, amountSpent: 0 },
+      realTimeLeft,
       deploymentCost: 100
     });
     const useDepositDeployment: typeof DEPENDENCIES.useDepositDeployment = () => ({ deposit });
@@ -95,6 +102,6 @@ describe(useAutoTopUp.name, () => {
       })
     );
 
-    return { result, setAutoTopUpEnabled, confirm, deposit };
+    return { result, setAutoTopUpEnabled, confirm, deposit, realTimeLeft };
   }
 });

--- a/apps/deploy-web/src/hooks/useAutoTopUp/useAutoTopUp.spec.ts
+++ b/apps/deploy-web/src/hooks/useAutoTopUp/useAutoTopUp.spec.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { DeploymentDto, LeaseDto } from "@src/types/deployment";
+import type { DEPENDENCIES } from "./useAutoTopUp";
+import { useAutoTopUp } from "./useAutoTopUp";
+
+import { renderHook } from "@testing-library/react";
+
+describe(useAutoTopUp.name, () => {
+  it("enables auto top-up directly when the deployment has enough runway", async () => {
+    const { result, setAutoTopUpEnabled, confirm, deposit } = setup({ hoursOfRunway: 3 });
+
+    await result.current.setEnabled(true);
+
+    expect(confirm).not.toHaveBeenCalled();
+    expect(deposit).not.toHaveBeenCalled();
+    expect(setAutoTopUpEnabled).toHaveBeenCalledWith(true);
+  });
+
+  it("requires a deposit before enabling when runway is shorter than the next check window", async () => {
+    const { result, setAutoTopUpEnabled, confirm, deposit } = setup({ minutesOfRunway: 1, confirmed: true, depositSucceeds: true });
+
+    await result.current.setEnabled(true);
+
+    expect(confirm).toHaveBeenCalled();
+    expect(deposit).toHaveBeenCalled();
+    expect(setAutoTopUpEnabled).toHaveBeenCalledWith(true);
+  });
+
+  it("does not enable when the required deposit is declined", async () => {
+    const { result, setAutoTopUpEnabled, deposit } = setup({ minutesOfRunway: 1, confirmed: false });
+
+    await result.current.setEnabled(true);
+
+    expect(deposit).not.toHaveBeenCalled();
+    expect(setAutoTopUpEnabled).not.toHaveBeenCalled();
+  });
+
+  it("does not enable when the required deposit fails", async () => {
+    const { result, setAutoTopUpEnabled, deposit } = setup({ minutesOfRunway: 1, confirmed: true, depositSucceeds: false });
+
+    await result.current.setEnabled(true);
+
+    expect(deposit).toHaveBeenCalled();
+    expect(setAutoTopUpEnabled).not.toHaveBeenCalled();
+  });
+
+  it("disables auto top-up without requiring a deposit", async () => {
+    const { result, setAutoTopUpEnabled, confirm } = setup({ minutesOfRunway: 1 });
+
+    await result.current.setEnabled(false);
+
+    expect(confirm).not.toHaveBeenCalled();
+    expect(setAutoTopUpEnabled).toHaveBeenCalledWith(false);
+  });
+
+  function setup(input: { hoursOfRunway?: number; minutesOfRunway?: number; confirmed?: boolean; depositSucceeds?: boolean }) {
+    const runwayMs = input.hoursOfRunway != null ? input.hoursOfRunway * 60 * 60 * 1000 : (input.minutesOfRunway ?? 1) * 60 * 1000;
+    const timeLeft = new Date(Date.now() + runwayMs);
+
+    const setAutoTopUpEnabled = vi.fn();
+    const confirm = vi.fn().mockResolvedValue(input.confirmed ?? true);
+    const deposit = vi.fn().mockResolvedValue(input.depositSucceeds ?? true);
+
+    const usePopup: typeof DEPENDENCIES.usePopup = () => mock<ReturnType<typeof DEPENDENCIES.usePopup>>({ confirm });
+    const useCurrencyFormatter: typeof DEPENDENCIES.useCurrencyFormatter = () => (value: number) => `$${value}`;
+    const useDeploymentMetrics: typeof DEPENDENCIES.useDeploymentMetrics = () => ({
+      realTimeLeft: { timeLeft, escrow: 0, amountSpent: 0 },
+      deploymentCost: 100
+    });
+    const useDepositDeployment: typeof DEPENDENCIES.useDepositDeployment = () => ({ deposit });
+    const usePricing: typeof DEPENDENCIES.usePricing = () => mock<ReturnType<typeof DEPENDENCIES.usePricing>>({ udenomToUsd: () => 5 });
+    const useDeploymentSettingQuery: typeof DEPENDENCIES.useDeploymentSettingQuery = () =>
+      mock<ReturnType<typeof DEPENDENCIES.useDeploymentSettingQuery>>({
+        data: mock<NonNullable<ReturnType<typeof DEPENDENCIES.useDeploymentSettingQuery>["data"]>>({ autoTopUpEnabled: false }),
+        setAutoTopUpEnabled,
+        isLoading: false
+      });
+
+    const deployment = mock<DeploymentDto>({
+      dseq: "1786440078202",
+      state: "active",
+      escrowAccount: mock<DeploymentDto["escrowAccount"]>({
+        state: mock<DeploymentDto["escrowAccount"]["state"]>({ funds: [{ denom: "uakt", amount: "1000" }] })
+      })
+    });
+    const leases = [mock<LeaseDto>({ id: "1", state: "active" })];
+
+    const { result } = renderHook(() =>
+      useAutoTopUp({
+        deployment,
+        leases,
+        dependencies: { usePopup, useCurrencyFormatter, useDeploymentMetrics, useDepositDeployment, usePricing, useDeploymentSettingQuery }
+      })
+    );
+
+    return { result, setAutoTopUpEnabled, confirm, deposit };
+  }
+});

--- a/apps/deploy-web/src/hooks/useAutoTopUp/useAutoTopUp.ts
+++ b/apps/deploy-web/src/hooks/useAutoTopUp/useAutoTopUp.ts
@@ -11,6 +11,7 @@ import { useDepositDeployment } from "@src/hooks/useDepositDeployment/useDeposit
 import { usePricing } from "@src/hooks/usePricing/usePricing";
 import { useDeploymentSettingQuery } from "@src/queries/deploymentSettingsQuery";
 import type { DeploymentDto, LeaseDto } from "@src/types/deployment";
+import { getEscrowDenom } from "@src/utils/deploymentUtils";
 import { averageBlockTime } from "@src/utils/priceUtils";
 
 export const DEPENDENCIES = {
@@ -34,6 +35,7 @@ export interface UseAutoTopUpResult {
   isLoading: boolean;
   estimatedTopUpAmount: number;
   topUpFrequencyMs: number;
+  realTimeLeft: ReturnType<typeof useDeploymentMetrics>["realTimeLeft"];
   setEnabled: (enabled: boolean) => Promise<void>;
   deposit: (amountUdenom: number) => Promise<boolean>;
 }
@@ -53,7 +55,7 @@ export function useAutoTopUp({ deployment, leases, onDeposited, dependencies: d 
   const deploymentSetting = d.useDeploymentSettingQuery({ dseq: deployment.dseq });
   const { realTimeLeft, deploymentCost } = d.useDeploymentMetrics({ deployment, leases });
 
-  const escrowDenom = deployment.escrowAccount.state.funds[0]?.denom || "";
+  const escrowDenom = getEscrowDenom(deployment);
   const { deposit } = d.useDepositDeployment({ dseq: deployment.dseq, denom: escrowDenom, onSuccess: onDeposited });
 
   const setEnabled = useCallback(
@@ -87,6 +89,7 @@ export function useAutoTopUp({ deployment, leases, onDeposited, dependencies: d 
     isLoading: deploymentSetting.isLoading,
     estimatedTopUpAmount: deploymentSetting.data?.estimatedTopUpAmount ?? 0,
     topUpFrequencyMs: deploymentSetting.data?.topUpFrequencyMs ?? 0,
+    realTimeLeft,
     setEnabled,
     deposit
   };

--- a/apps/deploy-web/src/hooks/useAutoTopUp/useAutoTopUp.ts
+++ b/apps/deploy-web/src/hooks/useAutoTopUp/useAutoTopUp.ts
@@ -1,0 +1,93 @@
+"use client";
+import { useCallback } from "react";
+import { usePopup } from "@akashnetwork/ui/context";
+import addHours from "date-fns/addHours";
+import differenceInSeconds from "date-fns/differenceInSeconds";
+import startOfHour from "date-fns/startOfHour";
+
+import { useCurrencyFormatter } from "@src/hooks/useCurrencyFormatter/useCurrencyFormatter";
+import { useDeploymentMetrics } from "@src/hooks/useDeploymentMetrics";
+import { useDepositDeployment } from "@src/hooks/useDepositDeployment/useDepositDeployment";
+import { usePricing } from "@src/hooks/usePricing/usePricing";
+import { useDeploymentSettingQuery } from "@src/queries/deploymentSettingsQuery";
+import type { DeploymentDto, LeaseDto } from "@src/types/deployment";
+import { averageBlockTime } from "@src/utils/priceUtils";
+
+export const DEPENDENCIES = {
+  usePopup,
+  useCurrencyFormatter,
+  useDeploymentMetrics,
+  useDepositDeployment,
+  usePricing,
+  useDeploymentSettingQuery
+};
+
+export interface UseAutoTopUpParams {
+  deployment: DeploymentDto;
+  leases: LeaseDto[] | null | undefined;
+  onDeposited?: () => void;
+  dependencies?: typeof DEPENDENCIES;
+}
+
+export interface UseAutoTopUpResult {
+  isEnabled: boolean;
+  isLoading: boolean;
+  estimatedTopUpAmount: number;
+  topUpFrequencyMs: number;
+  setEnabled: (enabled: boolean) => Promise<void>;
+  deposit: (amountUdenom: number) => Promise<boolean>;
+}
+
+/** The scheduled auto top-up job runs every 2 hours on the hour. */
+const TOP_UP_CHECK_ANCHOR_HOURS = 2;
+
+/**
+ * Backs the per-deployment Auto Top-Up toggle and escrow "Add funds" action. Enabling auto top-up
+ * requires the deployment to survive until the next scheduled check; when it wouldn't, the user is
+ * asked to deposit the shortfall first, and the toggle is only flipped once that deposit succeeds.
+ */
+export function useAutoTopUp({ deployment, leases, onDeposited, dependencies: d = DEPENDENCIES }: UseAutoTopUpParams): UseAutoTopUpResult {
+  const { confirm } = d.usePopup();
+  const formatCurrency = d.useCurrencyFormatter();
+  const { udenomToUsd } = d.usePricing();
+  const deploymentSetting = d.useDeploymentSettingQuery({ dseq: deployment.dseq });
+  const { realTimeLeft, deploymentCost } = d.useDeploymentMetrics({ deployment, leases });
+
+  const escrowDenom = deployment.escrowAccount.state.funds[0]?.denom || "";
+  const { deposit } = d.useDepositDeployment({ dseq: deployment.dseq, denom: escrowDenom, onSuccess: onDeposited });
+
+  const setEnabled = useCallback(
+    async (enabled: boolean) => {
+      if (enabled && realTimeLeft?.timeLeft) {
+        const secondsUntilNextTopUp = differenceInSeconds(addHours(startOfHour(new Date()), TOP_UP_CHECK_ANCHOR_HOURS), new Date());
+        const secondsUntilClosed = differenceInSeconds(realTimeLeft.timeLeft, new Date());
+
+        if (secondsUntilClosed < secondsUntilNextTopUp) {
+          const secondsToDepositFor = secondsUntilNextTopUp - secondsUntilClosed;
+          const requiredDeposit = Math.ceil((deploymentCost * secondsToDepositFor) / averageBlockTime);
+
+          const isConfirmed = await confirm({
+            title: "Deposit required",
+            message: `To enable auto top-up, please deposit ${formatCurrency(udenomToUsd(requiredDeposit, escrowDenom))}. This ensures your deployment remains active until the next scheduled check.`
+          });
+          if (!isConfirmed) return;
+
+          const deposited = await deposit(requiredDeposit);
+          if (!deposited) return;
+        }
+      }
+
+      deploymentSetting.setAutoTopUpEnabled(enabled);
+    },
+    [confirm, deploymentCost, deploymentSetting, deposit, escrowDenom, formatCurrency, realTimeLeft?.timeLeft, udenomToUsd]
+  );
+
+  return {
+    isEnabled: deploymentSetting.data?.autoTopUpEnabled ?? false,
+    isLoading: deploymentSetting.isLoading,
+    estimatedTopUpAmount: deploymentSetting.data?.estimatedTopUpAmount ?? 0,
+    topUpFrequencyMs: deploymentSetting.data?.topUpFrequencyMs ?? 0,
+    setEnabled,
+    deposit
+  };
+}

--- a/apps/deploy-web/src/utils/deploymentUtils.spec.ts
+++ b/apps/deploy-web/src/utils/deploymentUtils.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { DeploymentDto } from "@src/types/deployment";
+import { getEscrowDenom } from "./deploymentUtils";
+
+describe(getEscrowDenom.name, () => {
+  it("returns the denom of the first escrow fund", () => {
+    const deployment = mock<DeploymentDto>({
+      escrowAccount: mock<DeploymentDto["escrowAccount"]>({
+        state: mock<DeploymentDto["escrowAccount"]["state"]>({ funds: [{ denom: "uakt", amount: "1000" }] })
+      })
+    });
+
+    expect(getEscrowDenom(deployment)).toBe("uakt");
+  });
+
+  it("returns an empty string when the escrow account has no funds", () => {
+    const deployment = mock<DeploymentDto>({
+      escrowAccount: mock<DeploymentDto["escrowAccount"]>({
+        state: mock<DeploymentDto["escrowAccount"]["state"]>({ funds: [] })
+      })
+    });
+
+    expect(getEscrowDenom(deployment)).toBe("");
+  });
+});

--- a/apps/deploy-web/src/utils/deploymentUtils.ts
+++ b/apps/deploy-web/src/utils/deploymentUtils.ts
@@ -1,4 +1,10 @@
 import type { ExposeType, TemplateCreation } from "@src/types";
+import type { DeploymentDto } from "@src/types/deployment";
+
+/** Denom of the deployment's escrow account, taken from its first fund entry; empty string when the account has no funds. */
+export function getEscrowDenom(deployment: DeploymentDto): string {
+  return deployment.escrowAccount.state.funds[0]?.denom || "";
+}
 
 /**
  * Validate values to change in the template

--- a/apps/deploy-web/tests/ui/actions/deploy.ts
+++ b/apps/deploy-web/tests/ui/actions/deploy.ts
@@ -73,3 +73,18 @@ export async function closeActiveDeployment(page: Page) {
   await page.getByRole("button", { name: /^confirm$/i }).click();
   await expect(actions).toBeHidden({ timeout: 60_000 });
 }
+
+/**
+ * Closes the active deployment from the redesigned detail page, where the close action lives in the Settings
+ * tab's danger zone instead of an actions menu. The danger zone renders only while the deployment is active,
+ * so the button is awaited first; it disappearing once the deployment closes confirms the close.
+ * Used as cleanup by the redesign preview spec so a run leaves no live deployment on the shared account.
+ */
+export async function closeActiveDeploymentFromSettings(page: Page) {
+  await page.getByRole("tab", { name: "Settings" }).click();
+  const close = page.getByRole("button", { name: "Close deployment" });
+  await close.waitFor({ state: "visible", timeout: 120_000 });
+  await close.click();
+  await page.getByRole("button", { name: /^confirm$/i }).click();
+  await expect(close).toBeHidden({ timeout: 60_000 });
+}

--- a/apps/deploy-web/tests/ui/deployment-detail-preview.spec.ts
+++ b/apps/deploy-web/tests/ui/deployment-detail-preview.spec.ts
@@ -1,3 +1,4 @@
+import { closeActiveDeploymentFromSettings } from "./actions/deploy";
 import { expect, test } from "./fixture/base-test";
 import { testEnvConfig } from "./fixture/test-env.config";
 import { ConfigureDeploymentPage } from "./pages/ConfigureDeploymentPage";
@@ -6,6 +7,12 @@ const REDESIGN_TABS = ["Details", "Logs", "Events", "Shell", "Update", "Settings
 
 test.describe("Deployment detail redesign preview", () => {
   test.use({ userType: "existing" });
+
+  test.afterEach(async function closeDeploymentLeftByTest({ page }) {
+    if (/\/deployments\/\d+/.test(new URL(page.url()).pathname)) {
+      await closeActiveDeploymentFromSettings(page);
+    }
+  });
 
   test("renders the redesigned header and tabs on the preview route", async ({ page }) => {
     test.setTimeout(8 * 60 * 1000);

--- a/apps/deploy-web/tests/ui/deployment-detail-preview.spec.ts
+++ b/apps/deploy-web/tests/ui/deployment-detail-preview.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from "./fixture/base-test";
 import { testEnvConfig } from "./fixture/test-env.config";
 import { ConfigureDeploymentPage } from "./pages/ConfigureDeploymentPage";
 
-const REDESIGN_TABS = ["Details", "Logs", "Events", "Shell", "Settings", "Billing & Notifications"];
+const REDESIGN_TABS = ["Details", "Logs", "Events", "Shell", "Update", "Settings"];
 
 test.describe("Deployment detail redesign preview", () => {
   test.use({ userType: "existing" });


### PR DESCRIPTION
## Why

On the redesigned deployment detail page, the SDL editor lived under a "Settings" tab and billing sat in a combined "Billing & Notifications" tab, which isn't where users look for either one. This reorganizes the redesign tabs so editing the SDL and managing a deployment are separate, discoverable places.

Stacked on #3586. Part of CON-821.

## What

All behind the `deployment_detail_redesign` flag, so the legacy page is untouched.

- **Update tab (new):** the SDL editor (`ManifestUpdate`) moves here, off the old Settings tab.
- **Settings tab (new):** consolidates billing (escrow balance with Add funds, per-deployment Auto Top-Up toggle), the existing notification alerts (relocated as-is), and a Close deployment danger zone. The separate "Billing & Notifications" tab is removed.
- **`useAutoTopUp` hook:** extracts the deposit-required-before-enable flow the redesign billing section needs. The legacy top bar keeps its own inline copy on purpose since it's slated for removal, so that duplication is intentional.
- **Header:** drops the picture placeholder, adds an edit-name button, and shows deployment status as a pulsating badge.

"Current balance" on the billing section is the deployment escrow balance, not the wallet balance. The billing section is kept as a self-contained component so the planned escrow-abstraction swap (hide the toggle, redirect to the billing page) is a contained follow-up.

Testing: unit specs for the new Settings sections, the status badge, the header changes, and the `useAutoTopUp` hook.
