### PR TITLE
fix(deployment): prevent duplicate auto-funding of draining deployments under concurrency

### DIFF
--- a/apps/api/drizzle/0036_mushy_malcolm_colcord.sql
+++ b/apps/api/drizzle/0036_mushy_malcolm_colcord.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "deployment_settings" ADD COLUMN "last_funded_at" timestamp;

--- a/apps/api/drizzle/meta/0036_snapshot.json
+++ b/apps/api/drizzle/meta/0036_snapshot.json
@@ -1,0 +1,1387 @@
+{
+  "id": "5fd12801-28eb-47e9-93d8-4f2bc2572a38",
+  "prevId": "c956c0bc-db50-48a0-970c-7a2e9f1630d9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.user_wallets": {
+      "name": "user_wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_allowance": {
+          "name": "deployment_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "fee_allowance": {
+          "name": "fee_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "trial": {
+          "name": "trial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_wallets_user_id_userSetting_id_fk": {
+          "name": "user_wallets_user_id_userSetting_id_fk",
+          "tableFrom": "user_wallets",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_wallets_user_id_unique": {
+          "name": "user_wallets_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "user_wallets_address_unique": {
+          "name": "user_wallets_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_methods": {
+      "name": "payment_methods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_method_id": {
+          "name": "payment_method_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_validated": {
+          "name": "is_validated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payment_methods_fingerprint_payment_method_id_unique": {
+          "name": "payment_methods_fingerprint_payment_method_id_unique",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_default_unique": {
+          "name": "payment_methods_user_id_is_default_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"payment_methods\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_fingerprint_idx": {
+          "name": "payment_methods_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_idx": {
+          "name": "payment_methods_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_validated_idx": {
+          "name": "payment_methods_user_id_is_validated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_validated",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_fingerprint_payment_method_id_idx": {
+          "name": "payment_methods_user_id_fingerprint_payment_method_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_methods_user_id_userSetting_id_fk": {
+          "name": "payment_methods_user_id_userSetting_id_fk",
+          "tableFrom": "payment_methods",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_transactions": {
+      "name": "stripe_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "stripe_transaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "stripe_transaction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created'"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_refunded": {
+          "name": "amount_refunded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bonus_amount": {
+          "name": "bonus_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_charge_id": {
+          "name": "stripe_charge_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_coupon_id": {
+          "name": "stripe_coupon_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_promotion_code_id": {
+          "name": "stripe_promotion_code_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_idempotency_key": {
+          "name": "stripe_idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method_type": {
+          "name": "payment_method_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_brand": {
+          "name": "card_brand",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_last4": {
+          "name": "card_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_url": {
+          "name": "receipt_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_transactions_stripe_invoice_id_unique": {
+          "name": "stripe_transactions_stripe_invoice_id_unique",
+          "columns": [
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stripe_transactions\".\"stripe_invoice_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_idempotency_key_unique": {
+          "name": "stripe_transactions_stripe_idempotency_key_unique",
+          "columns": [
+            {
+              "expression": "stripe_idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stripe_transactions\".\"stripe_idempotency_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_user_id_idx": {
+          "name": "stripe_transactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_payment_intent_id_idx": {
+          "name": "stripe_transactions_stripe_payment_intent_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_payment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_charge_id_idx": {
+          "name": "stripe_transactions_stripe_charge_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_coupon_id_idx": {
+          "name": "stripe_transactions_stripe_coupon_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_coupon_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_promotion_code_id_idx": {
+          "name": "stripe_transactions_stripe_promotion_code_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_promotion_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_status_idx": {
+          "name": "stripe_transactions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_created_at_idx": {
+          "name": "stripe_transactions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_user_id_created_at_idx": {
+          "name": "stripe_transactions_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_transactions_user_id_userSetting_id_fk": {
+          "name": "stripe_transactions_user_id_userSetting_id_fk",
+          "tableFrom": "stripe_transactions",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_settings": {
+      "name": "wallet_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_reload_enabled": {
+          "name": "auto_reload_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_reload_threshold": {
+          "name": "auto_reload_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2000
+        },
+        "auto_reload_amount": {
+          "name": "auto_reload_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10000
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_settings_user_id_idx": {
+          "name": "wallet_settings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_settings_wallet_id_user_wallets_id_fk": {
+          "name": "wallet_settings_wallet_id_user_wallets_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "user_wallets",
+          "columnsFrom": [
+            "wallet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wallet_settings_user_id_userSetting_id_fk": {
+          "name": "wallet_settings_user_id_userSetting_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallet_settings_wallet_id_unique": {
+          "name": "wallet_settings_wallet_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wallet_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.userSetting": {
+      "name": "userSetting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscribedToNewsletter": {
+          "name": "subscribedToNewsletter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "youtubeUsername": {
+          "name": "youtubeUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitterUsername": {
+          "name": "twitterUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "githubUsername": {
+          "name": "githubUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_ip": {
+          "name": "last_ip",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_user_agent": {
+          "name": "last_user_agent",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fingerprint": {
+          "name": "last_fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboardingSkippedAt": {
+          "name": "onboardingSkippedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "userSetting_userId_unique": {
+          "name": "userSetting_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        },
+        "userSetting_username_unique": {
+          "name": "userSetting_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.template": {
+      "name": "template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "copiedFromId": {
+          "name": "copiedFromId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cpu": {
+          "name": "cpu",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ram": {
+          "name": "ram",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage": {
+          "name": "storage",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sdl": {
+          "name": "sdl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "template_userId_idx": {
+          "name": "template_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.templateFavorite": {
+      "name": "templateFavorite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "templateId": {
+          "name": "templateId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addedDate": {
+          "name": "addedDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "templateFavorite_userId_templateId_unique": {
+          "name": "templateFavorite_userId_templateId_unique",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "templateId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "templateFavorite_templateId_template_id_fk": {
+          "name": "templateFavorite_templateId_template_id_fk",
+          "tableFrom": "templateFavorite",
+          "tableTo": "template",
+          "columnsFrom": [
+            "templateId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_settings": {
+      "name": "deployment_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dseq": {
+          "name": "dseq",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_top_up_enabled": {
+          "name": "auto_top_up_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "closed": {
+          "name": "closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_funded_at": {
+          "name": "last_funded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "id_auto_top_up_enabled_closed_idx": {
+          "name": "id_auto_top_up_enabled_closed_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auto_top_up_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "closed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_settings_user_id_userSetting_id_fk": {
+          "name": "deployment_settings_user_id_userSetting_id_fk",
+          "tableFrom": "deployment_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dseq_user_id_idx": {
+          "name": "dseq_user_id_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "dseq",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_key": {
+          "name": "hashed_key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_format": {
+          "name": "key_format",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_user_id_userSetting_id_fk": {
+          "name": "api_keys_user_id_userSetting_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_hashed_key_unique": {
+          "name": "api_keys_hashed_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hashed_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_verification_codes": {
+      "name": "email_verification_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_verification_codes_user_id_idx": {
+          "name": "email_verification_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_verification_codes_user_id_userSetting_id_fk": {
+          "name": "email_verification_codes_user_id_userSetting_id_fk",
+          "tableFrom": "email_verification_codes",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.stripe_transaction_status": {
+      "name": "stripe_transaction_status",
+      "schema": "public",
+      "values": [
+        "created",
+        "pending",
+        "requires_action",
+        "succeeded",
+        "failed",
+        "refunded",
+        "canceled"
+      ]
+    },
+    "public.stripe_transaction_type": {
+      "name": "stripe_transaction_type",
+      "schema": "public",
+      "values": [
+        "payment_intent",
+        "coupon_claim",
+        "manual_credit"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -253,6 +253,13 @@
       "when": 1785917316638,
       "tag": "0035_cheerful_electro",
       "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "7",
+      "when": 1787086974003,
+      "tag": "0036_mushy_malcolm_colcord",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/deployment/config/env.config.ts
+++ b/apps/api/src/deployment/config/env.config.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 export const envSchema = z.object({
   AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H: z.number({ coerce: true }).optional().default(24),
   AUTO_TOP_UP_AMOUNT_IN_H: z.number({ coerce: true }).optional().default(48),
+  AUTO_TOP_UP_DEDUP_COOLDOWN_IN_MIN: z.number({ coerce: true }).positive().optional().default(60),
   PROVIDER_PROXY_URL: z.string().url(),
   GPU_BOT_WALLET_MNEMONIC: z.string().optional()
 });

--- a/apps/api/src/deployment/controllers/deployment-setting/deployment-setting.controller.spec.ts
+++ b/apps/api/src/deployment/controllers/deployment-setting/deployment-setting.controller.spec.ts
@@ -114,7 +114,6 @@ describe(DeploymentSettingController.name, () => {
       dseq: faker.string.numeric(6),
       autoTopUpEnabled: faker.datatype.boolean(),
       closed: false,
-      lastFundedAt: null,
       estimatedTopUpAmount: faker.number.float({ min: 0, max: 100 }),
       topUpFrequencyMs: faker.number.int({ min: 1000, max: 100000 }),
       createdAt: faker.date.recent().toISOString(),

--- a/apps/api/src/deployment/controllers/deployment-setting/deployment-setting.controller.spec.ts
+++ b/apps/api/src/deployment/controllers/deployment-setting/deployment-setting.controller.spec.ts
@@ -114,6 +114,7 @@ describe(DeploymentSettingController.name, () => {
       dseq: faker.string.numeric(6),
       autoTopUpEnabled: faker.datatype.boolean(),
       closed: false,
+      lastFundedAt: null,
       estimatedTopUpAmount: faker.number.float({ min: 0, max: 100 }),
       topUpFrequencyMs: faker.number.int({ min: 1000, max: 100000 }),
       createdAt: faker.date.recent().toISOString(),

--- a/apps/api/src/deployment/model-schemas/deployment-setting/deployment-setting.schema.ts
+++ b/apps/api/src/deployment/model-schemas/deployment-setting/deployment-setting.schema.ts
@@ -16,6 +16,7 @@ export const DeploymentSettings = pgTable(
     dseq: varchar("dseq").notNull(),
     autoTopUpEnabled: boolean("auto_top_up_enabled").notNull().default(false),
     closed: boolean("closed").notNull().default(false),
+    lastFundedAt: timestamp("last_funded_at"),
     createdAt: timestamp("created_at").defaultNow(),
     updatedAt: timestamp("updated_at").defaultNow()
   },

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
@@ -1,0 +1,94 @@
+import { faker } from "@faker-js/faker";
+import { eq, sql } from "drizzle-orm";
+import { container } from "tsyringe";
+import { describe, expect, it } from "vitest";
+
+import type { ApiPgDatabase } from "@src/core";
+import { POSTGRES_DB, resolveTable } from "@src/core";
+import { UserRepository } from "@src/user/repositories";
+import { DeploymentSettingRepository } from "./deployment-setting.repository";
+
+const COOLDOWN_MINUTES = 60;
+
+describe(DeploymentSettingRepository.name, () => {
+  describe("claimForFunding", () => {
+    it("awards a claim to exactly one caller across concurrent attempts", async () => {
+      const { deploymentSettingRepository, settingId } = await setup();
+
+      const results = await Promise.all(Array.from({ length: 5 }, () => deploymentSettingRepository.claimForFunding([settingId], COOLDOWN_MINUTES)));
+
+      const winners = results.filter(claimed => claimed.includes(settingId));
+      expect(winners).toHaveLength(1);
+    });
+
+    it("does not re-claim a deployment funded within the cooldown", async () => {
+      const { deploymentSettingRepository, settingId } = await setup();
+
+      const first = await deploymentSettingRepository.claimForFunding([settingId], COOLDOWN_MINUTES);
+      const second = await deploymentSettingRepository.claimForFunding([settingId], COOLDOWN_MINUTES);
+
+      expect(first).toEqual([settingId]);
+      expect(second).toEqual([]);
+    });
+
+    it("claims again once the cooldown has elapsed", async () => {
+      const { deploymentSettingRepository, settingId, backdateLastFundedAt } = await setup();
+
+      await deploymentSettingRepository.claimForFunding([settingId], COOLDOWN_MINUTES);
+      await backdateLastFundedAt(settingId, COOLDOWN_MINUTES + 1);
+      const afterCooldown = await deploymentSettingRepository.claimForFunding([settingId], COOLDOWN_MINUTES);
+
+      expect(afterCooldown).toEqual([settingId]);
+    });
+
+    it("returns only the ids still outside the cooldown when a batch mixes fresh and recently funded", async () => {
+      const { deploymentSettingRepository, settingId, createSetting } = await setup();
+      const freshId = await createSetting();
+
+      await deploymentSettingRepository.claimForFunding([settingId], COOLDOWN_MINUTES);
+      const claimed = await deploymentSettingRepository.claimForFunding([settingId, freshId], COOLDOWN_MINUTES);
+
+      expect(claimed).toEqual([freshId]);
+    });
+  });
+
+  describe("releaseFundingClaim", () => {
+    it("makes a claimed deployment immediately claimable again", async () => {
+      const { deploymentSettingRepository, settingId } = await setup();
+
+      await deploymentSettingRepository.claimForFunding([settingId], COOLDOWN_MINUTES);
+      await deploymentSettingRepository.releaseFundingClaim([settingId]);
+      const afterRelease = await deploymentSettingRepository.claimForFunding([settingId], COOLDOWN_MINUTES);
+
+      expect(afterRelease).toEqual([settingId]);
+    });
+  });
+
+  async function setup() {
+    const userRepository = container.resolve(UserRepository);
+    const deploymentSettingRepository = container.resolve(DeploymentSettingRepository);
+    const db = container.resolve<ApiPgDatabase>(POSTGRES_DB);
+    const deploymentSettingsTable = resolveTable("DeploymentSettings");
+    const user = await userRepository.create({ userId: faker.string.uuid() });
+
+    async function createSetting() {
+      const setting = await deploymentSettingRepository.create({
+        userId: user.id,
+        dseq: faker.number.int({ min: 100000, max: 999999 }).toString(),
+        autoTopUpEnabled: true
+      });
+      return setting.id;
+    }
+
+    async function backdateLastFundedAt(id: string, minutesAgo: number) {
+      await db
+        .update(deploymentSettingsTable)
+        .set({ lastFundedAt: sql`now() - (${minutesAgo} * interval '1 minute')` })
+        .where(eq(deploymentSettingsTable.id, id));
+    }
+
+    const settingId = await createSetting();
+
+    return { userRepository, deploymentSettingRepository, user, settingId, createSetting, backdateLastFundedAt };
+  }
+});

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
@@ -17,7 +17,7 @@ describe(DeploymentSettingRepository.name, () => {
 
       const results = await Promise.all(Array.from({ length: 5 }, () => deploymentSettingRepository.claimForFunding([settingId], COOLDOWN_MINUTES)));
 
-      const winners = results.filter(claimed => claimed.includes(settingId));
+      const winners = results.filter(claims => claims.some(claim => claim.id === settingId));
       expect(winners).toHaveLength(1);
     });
 
@@ -27,7 +27,7 @@ describe(DeploymentSettingRepository.name, () => {
       const first = await deploymentSettingRepository.claimForFunding([settingId], COOLDOWN_MINUTES);
       const second = await deploymentSettingRepository.claimForFunding([settingId], COOLDOWN_MINUTES);
 
-      expect(first).toEqual([settingId]);
+      expect(first).toEqual([{ id: settingId, claimedAt: expect.any(String) }]);
       expect(second).toEqual([]);
     });
 
@@ -38,7 +38,7 @@ describe(DeploymentSettingRepository.name, () => {
       await backdateLastFundedAt(settingId, COOLDOWN_MINUTES + 1);
       const afterCooldown = await deploymentSettingRepository.claimForFunding([settingId], COOLDOWN_MINUTES);
 
-      expect(afterCooldown).toEqual([settingId]);
+      expect(afterCooldown).toEqual([{ id: settingId, claimedAt: expect.any(String) }]);
     });
 
     it("returns only the ids still outside the cooldown when a batch mixes fresh and recently funded", async () => {
@@ -48,7 +48,7 @@ describe(DeploymentSettingRepository.name, () => {
       await deploymentSettingRepository.claimForFunding([settingId], COOLDOWN_MINUTES);
       const claimed = await deploymentSettingRepository.claimForFunding([settingId, freshId], COOLDOWN_MINUTES);
 
-      expect(claimed).toEqual([freshId]);
+      expect(claimed).toEqual([{ id: freshId, claimedAt: expect.any(String) }]);
     });
   });
 
@@ -56,11 +56,27 @@ describe(DeploymentSettingRepository.name, () => {
     it("makes a claimed deployment immediately claimable again", async () => {
       const { deploymentSettingRepository, settingId } = await setup();
 
-      await deploymentSettingRepository.claimForFunding([settingId], COOLDOWN_MINUTES);
-      await deploymentSettingRepository.releaseFundingClaim([settingId]);
+      const claims = await deploymentSettingRepository.claimForFunding([settingId], COOLDOWN_MINUTES);
+      await deploymentSettingRepository.releaseFundingClaim(claims);
       const afterRelease = await deploymentSettingRepository.claimForFunding([settingId], COOLDOWN_MINUTES);
 
-      expect(afterRelease).toEqual([settingId]);
+      expect(afterRelease).toEqual([{ id: settingId, claimedAt: expect.any(String) }]);
+    });
+
+    it("leaves a newer claim in place when the caller whose claim aged out releases late", async () => {
+      const { deploymentSettingRepository, settingId } = await setup();
+      const NO_COOLDOWN = 0;
+
+      const agedOutClaim = await deploymentSettingRepository.claimForFunding([settingId], COOLDOWN_MINUTES);
+      const newerClaim = await deploymentSettingRepository.claimForFunding([settingId], NO_COOLDOWN);
+      await deploymentSettingRepository.releaseFundingClaim(agedOutClaim);
+
+      expect(newerClaim).toHaveLength(1);
+      expect(await deploymentSettingRepository.claimForFunding([settingId], COOLDOWN_MINUTES)).toEqual([]);
+
+      await deploymentSettingRepository.releaseFundingClaim(newerClaim);
+
+      expect(await deploymentSettingRepository.claimForFunding([settingId], COOLDOWN_MINUTES)).toEqual([{ id: settingId, claimedAt: expect.any(String) }]);
     });
   });
 

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, isNotNull, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, isNotNull, isNull, lt, or, sql } from "drizzle-orm";
 import { singleton } from "tsyringe";
 
 import { UserWallets, WalletSetting } from "@src/billing/model-schemas";
@@ -95,6 +95,46 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
       .orderBy(desc(this.table.id));
 
     return deployments as AutoTopUpDeployment[];
+  }
+
+  /**
+   * Atomically claims deployments for auto-funding, returning only the ids this caller won.
+   * A deployment is claimable when it has never been funded or its last funding is older than
+   * the cooldown. Concurrent callers (hourly cron, immediate job, a retry) racing for the same
+   * id resolve to a single winner via the row-lock re-check, so each is funded at most once per
+   * cooldown. Ids are sorted so overlapping batches lock rows in the same order.
+   */
+  async claimForFunding(ids: string[], cooldownMinutes: number): Promise<string[]> {
+    if (!ids.length) {
+      return [];
+    }
+
+    const orderedIds = [...ids].sort();
+
+    const claimed = await this.cursor
+      .update(this.table)
+      .set({ lastFundedAt: sql`now()`, updatedAt: sql`now()` })
+      .where(
+        and(
+          inArray(this.table.id, orderedIds),
+          or(isNull(this.table.lastFundedAt), lt(this.table.lastFundedAt, sql`now() - (${cooldownMinutes} * interval '1 minute')`))
+        )
+      )
+      .returning({ id: this.table.id });
+
+    return claimed.map(row => row.id);
+  }
+
+  /** Releases a funding claim so the next pass can retry, used when the deposit did not land. */
+  async releaseFundingClaim(ids: string[]): Promise<void> {
+    if (!ids.length) {
+      return;
+    }
+
+    await this.cursor
+      .update(this.table)
+      .set({ lastFundedAt: null, updatedAt: sql`now()` })
+      .where(inArray(this.table.id, ids));
   }
 
   protected toInput(payload: Partial<DeploymentSettingsInput>): Partial<DeploymentSettingsInput> {

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -15,6 +15,12 @@ export type DeploymentSettingsOutput = Omit<DeploymentSettingsDbOutput, "created
   updatedAt: string;
 };
 
+/** A won auto-funding claim: the deployment setting id and the exact marker the claim wrote. */
+export type FundingClaim = {
+  id: string;
+  claimedAt: string;
+};
+
 export type AutoTopUpDeployment = {
   id: string;
   walletId: number;
@@ -98,13 +104,14 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
   }
 
   /**
-   * Atomically claims deployments for auto-funding, returning only the ids this caller won.
+   * Atomically claims deployments for auto-funding, returning only the claims this caller won.
    * A deployment is claimable when it has never been funded or its last funding is older than
    * the cooldown. Concurrent callers (hourly cron, immediate job, a retry) racing for the same
    * id resolve to a single winner via the row-lock re-check, so each is funded at most once per
-   * cooldown. Ids are sorted so overlapping batches lock rows in the same order.
+   * cooldown. Ids are sorted so overlapping batches lock rows in the same order. The claim marker
+   * comes back as text to keep full microsecond precision, which `releaseFundingClaim` matches on.
    */
-  async claimForFunding(ids: string[], cooldownMinutes: number): Promise<string[]> {
+  async claimForFunding(ids: string[], cooldownMinutes: number): Promise<FundingClaim[]> {
     if (!ids.length) {
       return [];
     }
@@ -120,21 +127,25 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
           or(isNull(this.table.lastFundedAt), lt(this.table.lastFundedAt, sql`now() - (${cooldownMinutes} * interval '1 minute')`))
         )
       )
-      .returning({ id: this.table.id });
+      .returning({ id: this.table.id, claimedAt: sql<string>`${this.table.lastFundedAt}::text` });
 
-    return claimed.map(row => row.id);
+    return claimed;
   }
 
-  /** Releases a funding claim so the next pass can retry, used when the deposit did not land. */
-  async releaseFundingClaim(ids: string[]): Promise<void> {
-    if (!ids.length) {
+  /**
+   * Releases a funding claim so the next pass can retry, used when the deposit did not land. Each
+   * release is scoped to the exact marker its claim wrote, so a caller whose claim already aged out
+   * of the cooldown and was re-taken by another pass cannot clear that newer claim.
+   */
+  async releaseFundingClaim(claims: FundingClaim[]): Promise<void> {
+    if (!claims.length) {
       return;
     }
 
     await this.cursor
       .update(this.table)
       .set({ lastFundedAt: null, updatedAt: sql`now()` })
-      .where(inArray(this.table.id, ids));
+      .where(or(...claims.map(claim => and(eq(this.table.id, claim.id), eq(this.table.lastFundedAt, sql`${claim.claimedAt}::timestamp`)))));
   }
 
   protected toInput(payload: Partial<DeploymentSettingsInput>): Partial<DeploymentSettingsInput> {

--- a/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.spec.ts
@@ -139,6 +139,7 @@ describe(DeploymentSettingService.name, () => {
       dseq: faker.string.numeric(6),
       autoTopUpEnabled: false,
       closed: false,
+      lastFundedAt: null,
       createdAt: faker.date.past().toISOString(),
       updatedAt: faker.date.past().toISOString(),
       ...overrides

--- a/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.ts
+++ b/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.ts
@@ -17,7 +17,7 @@ import { DeploymentConfigService } from "../deployment-config/deployment-config.
 import { DrainingDeploymentService } from "../draining-deployment/draining-deployment.service";
 import { TopUpManagedDeploymentsInstrumentationService } from "../top-up-managed-deployments/top-up-managed-deployments-instrumentation.service";
 
-type DeploymentSettingWithEstimatedTopUpAmount = DeploymentSettingsOutput & { estimatedTopUpAmount: number; topUpFrequencyMs: number };
+type DeploymentSettingWithEstimatedTopUpAmount = Omit<DeploymentSettingsOutput, "lastFundedAt"> & { estimatedTopUpAmount: number; topUpFrequencyMs: number };
 
 @singleton()
 export class DeploymentSettingService {
@@ -89,6 +89,7 @@ export class DeploymentSettingService {
     }
   }
 
+  /** `lastFundedAt` is the auto-funding claim marker and stays out of the API payload. */
   async withEstimatedTopUpAmount(params: DeploymentSettingsOutput): Promise<DeploymentSettingWithEstimatedTopUpAmount>;
   async withEstimatedTopUpAmount(params: undefined): Promise<undefined>;
   async withEstimatedTopUpAmount(params?: DeploymentSettingsOutput): Promise<DeploymentSettingWithEstimatedTopUpAmount | undefined> {
@@ -96,20 +97,22 @@ export class DeploymentSettingService {
       return undefined;
     }
 
-    if (!params.autoTopUpEnabled) {
-      return { ...params, estimatedTopUpAmount: 0, topUpFrequencyMs: this.topUpFrequencyMs };
+    const { lastFundedAt, ...setting } = params;
+
+    if (!setting.autoTopUpEnabled) {
+      return { ...setting, estimatedTopUpAmount: 0, topUpFrequencyMs: this.topUpFrequencyMs };
     }
 
-    const estimatedTopUpAmount = await this.drainingDeploymentService.calculateTopUpAmountForDseqAndUserId(params.dseq, params.userId);
+    const estimatedTopUpAmount = await this.drainingDeploymentService.calculateTopUpAmountForDseqAndUserId(setting.dseq, setting.userId);
     if (estimatedTopUpAmount < 0) {
       this.logger.warn({
         event: "ESTIMATED_TOP_UP_AMOUNT_NEGATIVE",
         estimatedTopUpAmount,
-        dseq: params.dseq,
-        userId: params.userId
+        dseq: setting.dseq,
+        userId: setting.userId
       });
     }
 
-    return { ...params, estimatedTopUpAmount, topUpFrequencyMs: this.topUpFrequencyMs };
+    return { ...setting, estimatedTopUpAmount, topUpFrequencyMs: this.topUpFrequencyMs };
   }
 }

--- a/apps/api/src/deployment/services/top-up-managed-deployments/deployment-top-up-instrumentation.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/deployment-top-up-instrumentation.ts
@@ -17,5 +17,6 @@ export interface DeploymentTopUpInstrumentation {
   recordDeposit(details: { owner: string; items: FundingMessageItem[] }): void;
   recordChainTxError(details: { owner: string; items: FundingMessageItem[]; error: unknown }): void;
   recordMasterWalletInsufficientFundsError(details: { owner: string; items: FundingMessageItem[]; error: unknown }): void;
+  recordClaimReleaseError(details: { owner: string; deploymentIds: string[]; error: unknown }): void;
   recordDeploymentsMarkedClosed(count: number): void;
 }

--- a/apps/api/src/deployment/services/top-up-managed-deployments/fund-draining-deployments-instrumentation.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/fund-draining-deployments-instrumentation.service.spec.ts
@@ -153,6 +153,20 @@ describe(FundDrainingDeploymentsInstrumentationService.name, () => {
     });
   });
 
+  describe("recordClaimReleaseError", () => {
+    it("increments the claim-release error counter and logs the error", () => {
+      const { service, claimReleaseErrors } = setup();
+      const error = new Error("connection terminated");
+
+      service.recordClaimReleaseError({ owner: "akash1owner", deploymentIds: ["setting-1"], error });
+
+      expect(claimReleaseErrors.add).toHaveBeenCalledWith(1);
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ event: "FUND_DRAINING_CLAIM_RELEASE_ERROR", owner: "akash1owner", deploymentIds: ["setting-1"], error })
+      );
+    });
+  });
+
   describe("recordDeploymentsMarkedClosed", () => {
     it("increments the marked-closed counter by the given count", () => {
       const { service, deploymentsMarkedClosed } = setup();
@@ -255,6 +269,7 @@ describe(FundDrainingDeploymentsInstrumentationService.name, () => {
       chainTxErrors: counters["fund_draining_deployments_chain_tx_errors_total"],
       masterWalletInsufficientFunds: counters["fund_draining_deployments_master_wallet_insufficient_funds_total"],
       deploymentsMarkedClosed: counters["fund_draining_deployments_deployments_marked_closed_total"],
+      claimReleaseErrors: counters["fund_draining_deployments_claim_release_errors_total"],
       jobDuration: histograms["fund_draining_deployments_job_duration_ms"],
       depositAmount: histograms["fund_draining_deployments_deposit_amount"]
     };

--- a/apps/api/src/deployment/services/top-up-managed-deployments/fund-draining-deployments-instrumentation.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/fund-draining-deployments-instrumentation.service.ts
@@ -42,6 +42,7 @@ export class FundDrainingDeploymentsInstrumentationService implements Deployment
   private readonly chainTxErrors: Counter;
   private readonly masterWalletInsufficientFunds: Counter;
   private readonly deploymentsMarkedClosed: Counter;
+  private readonly claimReleaseErrors: Counter;
 
   private readonly logger = createOtelLogger({ context: "FundDrainingDeploymentsService" });
 
@@ -92,6 +93,10 @@ export class FundDrainingDeploymentsInstrumentationService implements Deployment
 
     this.deploymentsMarkedClosed = this.metricsService.createCounter(this.meter, "fund_draining_deployments_deployments_marked_closed_total", {
       description: "Total number of deployments marked as closed while resolving immediate funding candidates"
+    });
+
+    this.claimReleaseErrors = this.metricsService.createCounter(this.meter, "fund_draining_deployments_claim_release_errors_total", {
+      description: "Total number of failed attempts to release an immediate funding claim after a deposit did not land"
     });
   }
 
@@ -166,6 +171,16 @@ export class FundDrainingDeploymentsInstrumentationService implements Deployment
       event: "FUND_DRAINING_MASTER_WALLET_INSUFFICIENT_FUNDS",
       owner,
       deposits: this.serializeDeposits(items),
+      error
+    });
+  }
+
+  recordClaimReleaseError({ owner, deploymentIds, error }: { owner: string; deploymentIds: string[]; error: unknown }): void {
+    this.claimReleaseErrors.add(1);
+    this.emitLog("error", {
+      event: "FUND_DRAINING_CLAIM_RELEASE_ERROR",
+      owner,
+      deploymentIds,
       error
     });
   }

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.spec.ts
@@ -161,6 +161,24 @@ describe(TopUpManagedDeploymentsInstrumentationService.name, () => {
     });
   });
 
+  describe("recordClaimReleaseError", () => {
+    it("logs the deployments whose funding claim could not be released", () => {
+      const { service, logger } = setup();
+      service.start(100, { dryRun: false });
+
+      service.recordClaimReleaseError({ owner: "akash1owner", deploymentIds: ["setting-1"], error: new Error("connection terminated") });
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: "TOP_UP_CLAIM_RELEASE_ERROR",
+          owner: "akash1owner",
+          deploymentIds: ["setting-1"],
+          message: "connection terminated"
+        })
+      );
+    });
+  });
+
   describe("execWhenEnabled", () => {
     it("does not emit metrics in dry run mode", () => {
       const { service, summarizer } = setup();

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.ts
@@ -259,6 +259,15 @@ export class TopUpManagedDeploymentsInstrumentationService implements Deployment
     });
   }
 
+  recordClaimReleaseError({ error, ...details }: { owner: string; deploymentIds: string[]; error: unknown }): void {
+    this.logger.error({
+      event: "TOP_UP_CLAIM_RELEASE_ERROR",
+      ...details,
+      ...this.serializeError(error),
+      dryRun: this.options?.dryRun
+    });
+  }
+
   private serializeError(error: unknown): { message: string; stack?: string; data?: unknown } {
     if (error instanceof Error) {
       return {

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.integration.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.integration.ts
@@ -200,6 +200,76 @@ describe(TopUpManagedDeploymentsService.name, () => {
     });
   });
 
+  describe("topUpDrainingDeploymentsForOwner", () => {
+    // Two funding passes for the same wallet run at once (immediate funding overlapping the
+    // hourly cron, or two credit top-ups in quick succession). The DB claim must award each
+    // deployment to a single pass so neither draining deployment is deposited into twice.
+    it("funds each draining deployment at most once when the same wallet is funded concurrently", async () => {
+      const { topUpService, executeDerivedTx, createUserWithWallet, createDeploymentSetting, mockLeasesForOwner, mockDeploymentsForOwner, stubGetFreshLimits } =
+        await setup();
+      const { user, wallet, address } = await createUserWithWallet();
+      const dseqA = "800001";
+      const dseqB = "800002";
+
+      await createDeploymentSetting(user.id, dseqA);
+      await createDeploymentSetting(user.id, dseqB);
+
+      mockLeasesForOwner(address, [createActiveLease(address, dseqA), createActiveLease(address, dseqB)], { persist: true });
+      mockDeploymentsForOwner(address, [createActiveDeployment(address, dseqA), createActiveDeployment(address, dseqB)], { persist: true });
+      stubGetFreshLimits({ [address]: 10000000 });
+
+      await Promise.all([
+        topUpService.topUpDrainingDeploymentsForOwner({ walletId: wallet.id, address }),
+        topUpService.topUpDrainingDeploymentsForOwner({ walletId: wallet.id, address })
+      ]);
+
+      const depositedXids = executeDerivedTx.mock.calls.flatMap(([, messages]) => messages.map(message => message.value.id.xid as string));
+      expect(depositedXids.filter(xid => xid.includes(`/${dseqA}`))).toHaveLength(1);
+      expect(depositedXids.filter(xid => xid.includes(`/${dseqB}`))).toHaveLength(1);
+    });
+
+    // A second funding pass for the same wallet arrives while the first funding is still within
+    // the cooldown (a retry after the deposit already landed, or another credit top-up). The
+    // claim marker persists across passes, so the deployment is not funded a second time.
+    it("does not fund again within the cooldown after a successful funding", async () => {
+      const { topUpService, executeDerivedTx, createUserWithWallet, createDeploymentSetting, mockLeasesForOwner, mockDeploymentsForOwner, stubGetFreshLimits } =
+        await setup();
+      const { user, wallet, address } = await createUserWithWallet();
+      const dseq = "810001";
+
+      await createDeploymentSetting(user.id, dseq);
+      mockLeasesForOwner(address, [createActiveLease(address, dseq)], { persist: true });
+      mockDeploymentsForOwner(address, [createActiveDeployment(address, dseq)], { persist: true });
+      stubGetFreshLimits({ [address]: 10000000 });
+
+      await topUpService.topUpDrainingDeploymentsForOwner({ walletId: wallet.id, address });
+      await topUpService.topUpDrainingDeploymentsForOwner({ walletId: wallet.id, address });
+
+      expect(executeDerivedTx).toHaveBeenCalledOnce();
+    });
+
+    // The first deposit lands on-chain with a non-OK code (nothing was funded), so its claim is
+    // released and the next pass re-funds the still-draining deployment.
+    it("releases the claim after a failed deposit so the next pass funds it", async () => {
+      const { topUpService, executeDerivedTx, createUserWithWallet, createDeploymentSetting, mockLeasesForOwner, mockDeploymentsForOwner, stubGetFreshLimits } =
+        await setup();
+      const { user, wallet, address } = await createUserWithWallet();
+      const dseq = "820001";
+
+      await createDeploymentSetting(user.id, dseq);
+      mockLeasesForOwner(address, [createActiveLease(address, dseq)], { persist: true });
+      mockDeploymentsForOwner(address, [createActiveDeployment(address, dseq)], { persist: true });
+      stubGetFreshLimits({ [address]: 10000000 });
+
+      executeDerivedTx.mockResolvedValueOnce({ code: 11, hash: "FAILHASH", rawLog: "out of gas" });
+
+      await topUpService.topUpDrainingDeploymentsForOwner({ walletId: wallet.id, address });
+      await topUpService.topUpDrainingDeploymentsForOwner({ walletId: wallet.id, address });
+
+      expect(executeDerivedTx).toHaveBeenCalledTimes(2);
+    });
+  });
+
   function createActiveLease(owner: string, dseq: string) {
     return createLeaseApiResponse({
       owner,
@@ -305,15 +375,19 @@ describe(TopUpManagedDeploymentsService.name, () => {
       return results[0];
     }
 
-    function mockLeasesForOwner(owner: string, leases: ReturnType<typeof createLeaseApiResponse>[]) {
-      nock(apiNodeUrl)
+    function mockLeasesForOwner(owner: string, leases: ReturnType<typeof createLeaseApiResponse>[], options?: { persist?: boolean }) {
+      const scope = nock(apiNodeUrl);
+      if (options?.persist) scope.persist();
+      scope
         .get("/akash/market/v1beta5/leases/list")
         .query(query => query["filters.owner"] === owner)
         .reply(200, { leases, pagination: { next_key: null, total: String(leases.length) } });
     }
 
-    function mockDeploymentsForOwner(owner: string, deployments: ReturnType<typeof createDeploymentInfoSeed>[]) {
-      nock(apiNodeUrl)
+    function mockDeploymentsForOwner(owner: string, deployments: ReturnType<typeof createDeploymentInfoSeed>[], options?: { persist?: boolean }) {
+      const scope = nock(apiNodeUrl);
+      if (options?.persist) scope.persist();
+      scope
         .get("/akash/deployment/v1beta4/deployments/list")
         .query(query => String(query["filters.owner"]) === owner)
         .reply(200, { deployments, pagination: { next_key: null, total: String(deployments.length) } });

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.integration.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.integration.ts
@@ -201,10 +201,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
   });
 
   describe("topUpDrainingDeploymentsForOwner", () => {
-    // Two funding passes for the same wallet run at once (immediate funding overlapping the
-    // hourly cron, or two credit top-ups in quick succession). The DB claim must award each
-    // deployment to a single pass so neither draining deployment is deposited into twice.
-    it("funds each draining deployment at most once when the same wallet is funded concurrently", async () => {
+    it("funds each draining deployment at most once when two passes for the same wallet run at once", async () => {
       const { topUpService, executeDerivedTx, createUserWithWallet, createDeploymentSetting, mockLeasesForOwner, mockDeploymentsForOwner, stubGetFreshLimits } =
         await setup();
       const { user, wallet, address } = await createUserWithWallet();
@@ -228,10 +225,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
       expect(depositedXids.filter(xid => xid.includes(`/${dseqB}`))).toHaveLength(1);
     });
 
-    // A second funding pass for the same wallet arrives while the first funding is still within
-    // the cooldown (a retry after the deposit already landed, or another credit top-up). The
-    // claim marker persists across passes, so the deployment is not funded a second time.
-    it("does not fund again within the cooldown after a successful funding", async () => {
+    it("does not fund again when a later pass arrives within the cooldown of a successful funding", async () => {
       const { topUpService, executeDerivedTx, createUserWithWallet, createDeploymentSetting, mockLeasesForOwner, mockDeploymentsForOwner, stubGetFreshLimits } =
         await setup();
       const { user, wallet, address } = await createUserWithWallet();
@@ -248,9 +242,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
       expect(executeDerivedTx).toHaveBeenCalledOnce();
     });
 
-    // The first deposit lands on-chain with a non-OK code (nothing was funded), so its claim is
-    // released and the next pass re-funds the still-draining deployment.
-    it("releases the claim after a failed deposit so the next pass funds it", async () => {
+    it("releases the claim of a deposit that landed with a non-OK code so the next pass funds it", async () => {
       const { topUpService, executeDerivedTx, createUserWithWallet, createDeploymentSetting, mockLeasesForOwner, mockDeploymentsForOwner, stubGetFreshLimits } =
         await setup();
       const { user, wallet, address } = await createUserWithWallet();

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
@@ -12,6 +12,8 @@ import type { ChainErrorService } from "@src/billing/services/chain-error/chain-
 import type { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
 import type { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
 import type { BlockHttpService } from "@src/chain/services/block-http/block-http.service";
+import type { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import type { DeploymentConfigService } from "@src/deployment/services/deployment-config/deployment-config.service";
 import type { DrainingDeployment, DrainingDeploymentService } from "@src/deployment/services/draining-deployment/draining-deployment.service";
 import { mockConfigService } from "../../../../test/mocks/config-service.mock";
 import type { CachedBalance, CachedBalanceService } from "../cached-balance/cached-balance.service";
@@ -184,7 +186,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
     });
 
     it("should not execute transactions in dry run mode", async () => {
-      const { service, drainingDeploymentService, cachedBalanceService, managedSignerService, walletReloadService } = setup();
+      const { service, drainingDeploymentService, cachedBalanceService, managedSignerService, walletReloadService, deploymentSettingRepository } = setup();
       const deployments = createManyAutoTopUpDeployments(2);
       const predictedClosedHeight = CURRENT_BLOCK_HEIGHT + 1500;
 
@@ -221,6 +223,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
 
       expect(managedSignerService.executeDerivedTx).not.toHaveBeenCalled();
       expect(walletReloadService.scheduleImmediate).not.toHaveBeenCalled();
+      expect(deploymentSettingRepository.claimForFunding).not.toHaveBeenCalled();
     });
 
     it("should not execute transactions if no draining deployments", async () => {
@@ -667,6 +670,124 @@ describe(TopUpManagedDeploymentsService.name, () => {
       expect(instrumentation.recordChainTxError).not.toHaveBeenCalled();
     });
 
+    it("claims deployments with the configured cooldown and funds only the ones this pass wins", async () => {
+      const { service, drainingDeploymentService, cachedBalanceService, managedSignerService, deploymentSettingRepository } = setup();
+      const owner = createAkashAddress();
+      const walletId = faker.number.int({ min: 1000000, max: 9999999 });
+      const won = createDrainingFor(owner, walletId);
+      const claimedByAnotherPass = createDrainingFor(owner, walletId);
+
+      drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([won, claimedByAnotherPass]);
+      drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(1000000);
+      cachedBalanceService.getFresh.mockResolvedValue(createMockCachedBalance(() => 1000000));
+      deploymentSettingRepository.claimForFunding.mockResolvedValue([won.id]);
+
+      await service.topUpDrainingDeploymentsForOwner({ walletId, address: owner });
+
+      expect(deploymentSettingRepository.claimForFunding).toHaveBeenCalledWith(expect.arrayContaining([won.id, claimedByAnotherPass.id]), 60);
+      expect(managedSignerService.executeDerivedTx).toHaveBeenCalledWith(walletId, [
+        expect.objectContaining({ value: expect.objectContaining({ id: expect.objectContaining({ xid: expect.stringContaining(`/${won.dseq}`) }) }) })
+      ]);
+    });
+
+    it("funds nothing and records a skip when another pass already claimed every deployment", async () => {
+      const {
+        service,
+        drainingDeploymentService,
+        cachedBalanceService,
+        managedSignerService,
+        walletReloadService,
+        deploymentSettingRepository,
+        fundDrainingInstrumentation
+      } = setup();
+      const owner = createAkashAddress();
+      const walletId = faker.number.int({ min: 1000000, max: 9999999 });
+
+      drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([createDrainingFor(owner, walletId)]);
+      drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(1000000);
+      cachedBalanceService.getFresh.mockResolvedValue(createMockCachedBalance(() => 1000000));
+      deploymentSettingRepository.claimForFunding.mockResolvedValue([]);
+
+      await service.topUpDrainingDeploymentsForOwner({ walletId, address: owner });
+
+      expect(managedSignerService.executeDerivedTx).not.toHaveBeenCalled();
+      expect(walletReloadService.scheduleImmediate).not.toHaveBeenCalled();
+      expect(fundDrainingInstrumentation.recordSkipped).toHaveBeenCalledWith(expect.objectContaining({ owner }));
+    });
+
+    it("keeps the claim when the deposit succeeds", async () => {
+      const { service, drainingDeploymentService, cachedBalanceService, deploymentSettingRepository, fundDrainingInstrumentation } = setup();
+      const owner = createAkashAddress();
+      const walletId = faker.number.int({ min: 1000000, max: 9999999 });
+      const deployment = createDrainingFor(owner, walletId);
+
+      drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([deployment]);
+      drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(1000000);
+      cachedBalanceService.getFresh.mockResolvedValue(createMockCachedBalance(() => 1000000));
+      deploymentSettingRepository.claimForFunding.mockResolvedValue([deployment.id]);
+
+      await service.topUpDrainingDeploymentsForOwner({ walletId, address: owner });
+
+      expect(fundDrainingInstrumentation.recordDeposit).toHaveBeenCalledWith(expect.objectContaining({ owner }));
+      expect(deploymentSettingRepository.releaseFundingClaim).not.toHaveBeenCalled();
+    });
+
+    it("releases the claim and does not record a deposit when the tx lands with a non-OK code", async () => {
+      const { service, drainingDeploymentService, cachedBalanceService, managedSignerService, deploymentSettingRepository, fundDrainingInstrumentation } =
+        setup();
+      const owner = createAkashAddress();
+      const walletId = faker.number.int({ min: 1000000, max: 9999999 });
+      const deployment = createDrainingFor(owner, walletId);
+
+      drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([deployment]);
+      drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(1000000);
+      cachedBalanceService.getFresh.mockResolvedValue(createMockCachedBalance(() => 1000000));
+      deploymentSettingRepository.claimForFunding.mockResolvedValue([deployment.id]);
+      managedSignerService.executeDerivedTx.mockResolvedValue(mock<IndexedTx>({ code: 11, hash: "tx-hash", rawLog: "out of gas" }));
+
+      await service.topUpDrainingDeploymentsForOwner({ walletId, address: owner });
+
+      expect(deploymentSettingRepository.releaseFundingClaim).toHaveBeenCalledWith([deployment.id]);
+      expect(fundDrainingInstrumentation.recordChainTxError).toHaveBeenCalledWith(expect.objectContaining({ owner }));
+      expect(fundDrainingInstrumentation.recordDeposit).not.toHaveBeenCalled();
+    });
+
+    it("releases the claim when the deposit throws so the next pass can retry", async () => {
+      const { service, drainingDeploymentService, cachedBalanceService, managedSignerService, chainErrorService, deploymentSettingRepository } = setup();
+      const owner = createAkashAddress();
+      const walletId = faker.number.int({ min: 1000000, max: 9999999 });
+      const deployment = createDrainingFor(owner, walletId);
+
+      drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([deployment]);
+      drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(1000000);
+      cachedBalanceService.getFresh.mockResolvedValue(createMockCachedBalance(() => 1000000));
+      deploymentSettingRepository.claimForFunding.mockResolvedValue([deployment.id]);
+      managedSignerService.executeDerivedTx.mockRejectedValue(new Error("broadcast timed out"));
+      chainErrorService.isMasterWalletInsufficientFundsError.mockResolvedValue(false);
+
+      await service.topUpDrainingDeploymentsForOwner({ walletId, address: owner });
+
+      expect(deploymentSettingRepository.releaseFundingClaim).toHaveBeenCalledWith([deployment.id]);
+    });
+
+    it("releases the claim before rethrowing a master-wallet insufficient-funds failure", async () => {
+      const { service, drainingDeploymentService, cachedBalanceService, managedSignerService, chainErrorService, deploymentSettingRepository } = setup();
+      const owner = createAkashAddress();
+      const walletId = faker.number.int({ min: 1000000, max: 9999999 });
+      const deployment = createDrainingFor(owner, walletId);
+
+      drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([deployment]);
+      drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(1000000);
+      cachedBalanceService.getFresh.mockResolvedValue(createMockCachedBalance(() => 1000000));
+      deploymentSettingRepository.claimForFunding.mockResolvedValue([deployment.id]);
+      managedSignerService.executeDerivedTx.mockRejectedValue(new Error("insufficient funds"));
+      chainErrorService.isMasterWalletInsufficientFundsError.mockResolvedValue(true);
+
+      await expect(service.topUpDrainingDeploymentsForOwner({ walletId, address: owner })).rejects.toThrow("insufficient funds");
+
+      expect(deploymentSettingRepository.releaseFundingClaim).toHaveBeenCalledWith([deployment.id]);
+    });
+
     function createDrainingFor(owner: string, walletId: number, predictedClosedHeight = CURRENT_BLOCK_HEIGHT + 1500): DrainingDeployment {
       const setting = createAutoTopUpDeployment({ address: owner, walletId });
       return {
@@ -683,6 +804,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
 
     const managedSignerService = mock<ManagedSignerService>();
     managedSignerService.ensureFeeGrants.mockResolvedValue(feeAllowance);
+    managedSignerService.executeDerivedTx.mockResolvedValue(mock<IndexedTx>({ code: 0, hash: "tx-hash", rawLog: "success" }));
     const billingConfig = mockConfigService<BillingConfigService>({
       DEPLOYMENT_GRANT_DENOM,
       USDC_IBC_DENOMS: {
@@ -700,6 +822,9 @@ describe(TopUpManagedDeploymentsService.name, () => {
     const instrumentation = mock<TopUpManagedDeploymentsInstrumentationService>();
     const fundDrainingInstrumentation = mock<FundDrainingDeploymentsInstrumentationService>();
     const walletReloadService = mock<WalletReloadJobService>();
+    const deploymentSettingRepository = mock<DeploymentSettingRepository>();
+    deploymentSettingRepository.claimForFunding.mockImplementation(async (ids: string[]) => ids);
+    const deploymentConfig = mockConfigService<DeploymentConfigService>({ AUTO_TOP_UP_DEDUP_COOLDOWN_IN_MIN: 60 });
 
     const service = new TopUpManagedDeploymentsService(
       managedSignerService,
@@ -711,7 +836,9 @@ describe(TopUpManagedDeploymentsService.name, () => {
       chainErrorService,
       instrumentation,
       fundDrainingInstrumentation,
-      walletReloadService
+      walletReloadService,
+      deploymentSettingRepository,
+      deploymentConfig
     );
 
     return {
@@ -725,7 +852,9 @@ describe(TopUpManagedDeploymentsService.name, () => {
       chainErrorService,
       instrumentation,
       fundDrainingInstrumentation,
-      walletReloadService
+      walletReloadService,
+      deploymentSettingRepository,
+      deploymentConfig
     };
   }
 });

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
@@ -676,10 +676,11 @@ describe(TopUpManagedDeploymentsService.name, () => {
       const walletId = faker.number.int({ min: 1000000, max: 9999999 });
       const won = createDrainingFor(owner, walletId);
       const claimedByAnotherPass = createDrainingFor(owner, walletId);
+      const balance = createMockCachedBalance(() => 1000000);
 
       drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([won, claimedByAnotherPass]);
       drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(1000000);
-      cachedBalanceService.getFresh.mockResolvedValue(createMockCachedBalance(() => 1000000));
+      cachedBalanceService.getFresh.mockResolvedValue(balance);
       deploymentSettingRepository.claimForFunding.mockResolvedValue([won.id]);
 
       await service.topUpDrainingDeploymentsForOwner({ walletId, address: owner });
@@ -688,6 +689,75 @@ describe(TopUpManagedDeploymentsService.name, () => {
       expect(managedSignerService.executeDerivedTx).toHaveBeenCalledWith(walletId, [
         expect.objectContaining({ value: expect.objectContaining({ id: expect.objectContaining({ xid: expect.stringContaining(`/${won.dseq}`) }) }) })
       ]);
+      expect(balance.reserveSufficientAmount).toHaveBeenCalledOnce();
+    });
+
+    it("releases the claim of a deployment that produced no deposit message", async () => {
+      const { service, drainingDeploymentService, cachedBalanceService, managedSignerService, deploymentSettingRepository } = setup();
+      const owner = createAkashAddress();
+      const walletId = faker.number.int({ min: 1000000, max: 9999999 });
+      const withoutRunwayToBuy = createDrainingFor(owner, walletId);
+      const fundable = createDrainingFor(owner, walletId);
+
+      drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([withoutRunwayToBuy, fundable]);
+      drainingDeploymentService.calculateTopUpAmount.mockResolvedValueOnce(0).mockResolvedValue(1000000);
+      cachedBalanceService.getFresh.mockResolvedValue(createMockCachedBalance(() => 1000000));
+
+      await service.topUpDrainingDeploymentsForOwner({ walletId, address: owner });
+
+      expect(deploymentSettingRepository.releaseFundingClaim).toHaveBeenCalledWith([withoutRunwayToBuy.id]);
+      expect(managedSignerService.executeDerivedTx).toHaveBeenCalledWith(walletId, [
+        expect.objectContaining({ value: expect.objectContaining({ id: expect.objectContaining({ xid: expect.stringContaining(`/${fundable.dseq}`) }) }) })
+      ]);
+    });
+
+    it("keeps the claim of a landed deposit when recording it throws", async () => {
+      const { service, drainingDeploymentService, cachedBalanceService, deploymentSettingRepository, fundDrainingInstrumentation } = setup();
+      const owner = createAkashAddress();
+      const walletId = faker.number.int({ min: 1000000, max: 9999999 });
+      const deployment = createDrainingFor(owner, walletId);
+
+      drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([deployment]);
+      drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(1000000);
+      cachedBalanceService.getFresh.mockResolvedValue(createMockCachedBalance(() => 1000000));
+      deploymentSettingRepository.claimForFunding.mockResolvedValue([deployment.id]);
+      fundDrainingInstrumentation.recordDeposit.mockImplementation(() => {
+        throw new Error("otel exporter down");
+      });
+
+      await service.topUpDrainingDeploymentsForOwner({ walletId, address: owner });
+
+      expect(deploymentSettingRepository.releaseFundingClaim).not.toHaveBeenCalled();
+    });
+
+    it("reports a failed claim release without masking the chain error that caused it", async () => {
+      const {
+        service,
+        drainingDeploymentService,
+        cachedBalanceService,
+        managedSignerService,
+        chainErrorService,
+        deploymentSettingRepository,
+        fundDrainingInstrumentation
+      } = setup();
+      const owner = createAkashAddress();
+      const walletId = faker.number.int({ min: 1000000, max: 9999999 });
+      const deployment = createDrainingFor(owner, walletId);
+      const releaseError = new Error("connection terminated");
+
+      drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([deployment]);
+      drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(1000000);
+      cachedBalanceService.getFresh.mockResolvedValue(createMockCachedBalance(() => 1000000));
+      deploymentSettingRepository.claimForFunding.mockResolvedValue([deployment.id]);
+      deploymentSettingRepository.releaseFundingClaim.mockRejectedValue(releaseError);
+      managedSignerService.executeDerivedTx.mockRejectedValue(new Error("insufficient funds"));
+      chainErrorService.isMasterWalletInsufficientFundsError.mockResolvedValue(true);
+
+      await expect(service.topUpDrainingDeploymentsForOwner({ walletId, address: owner })).rejects.toThrow("insufficient funds");
+
+      expect(fundDrainingInstrumentation.recordClaimReleaseError).toHaveBeenCalledWith(
+        expect.objectContaining({ owner, deploymentIds: [deployment.id], error: releaseError })
+      );
     });
 
     it("funds nothing and records a skip when another pass already claimed every deployment", async () => {
@@ -824,6 +894,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
     const walletReloadService = mock<WalletReloadJobService>();
     const deploymentSettingRepository = mock<DeploymentSettingRepository>();
     deploymentSettingRepository.claimForFunding.mockImplementation(async (ids: string[]) => ids);
+    deploymentSettingRepository.releaseFundingClaim.mockResolvedValue(undefined);
     const deploymentConfig = mockConfigService<DeploymentConfigService>({ AUTO_TOP_UP_DEDUP_COOLDOWN_IN_MIN: 60 });
 
     const service = new TopUpManagedDeploymentsService(

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
@@ -28,7 +28,12 @@ import { createDrainingDeployment } from "@test/seeders/draining-deployment.seed
 describe(TopUpManagedDeploymentsService.name, () => {
   const DEPLOYMENT_GRANT_DENOM = "ibc/170C677610AC31DF0904FFE09CD3B5C657492170E7E52372E48756B71E56F2F1";
   const CURRENT_BLOCK_HEIGHT = 7481457;
+  const CLAIMED_AT = "2026-08-19 06:24:27.123456";
   const SUFFICIENT_FEE_ALLOWANCE = 100001;
+
+  function createFundingClaim(id: string) {
+    return { id, claimedAt: CLAIMED_AT };
+  }
 
   function createMockCachedBalance(reserveSufficientAmount: (desiredAmount: number) => number) {
     const balance = mock<CachedBalance>();
@@ -681,7 +686,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
       drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([won, claimedByAnotherPass]);
       drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(1000000);
       cachedBalanceService.getFresh.mockResolvedValue(balance);
-      deploymentSettingRepository.claimForFunding.mockResolvedValue([won.id]);
+      deploymentSettingRepository.claimForFunding.mockResolvedValue([createFundingClaim(won.id)]);
 
       await service.topUpDrainingDeploymentsForOwner({ walletId, address: owner });
 
@@ -705,7 +710,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
 
       await service.topUpDrainingDeploymentsForOwner({ walletId, address: owner });
 
-      expect(deploymentSettingRepository.releaseFundingClaim).toHaveBeenCalledWith([withoutRunwayToBuy.id]);
+      expect(deploymentSettingRepository.releaseFundingClaim).toHaveBeenCalledWith([createFundingClaim(withoutRunwayToBuy.id)]);
       expect(managedSignerService.executeDerivedTx).toHaveBeenCalledWith(walletId, [
         expect.objectContaining({ value: expect.objectContaining({ id: expect.objectContaining({ xid: expect.stringContaining(`/${fundable.dseq}`) }) }) })
       ]);
@@ -720,7 +725,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
       drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([deployment]);
       drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(1000000);
       cachedBalanceService.getFresh.mockResolvedValue(createMockCachedBalance(() => 1000000));
-      deploymentSettingRepository.claimForFunding.mockResolvedValue([deployment.id]);
+      deploymentSettingRepository.claimForFunding.mockResolvedValue([createFundingClaim(deployment.id)]);
       fundDrainingInstrumentation.recordDeposit.mockImplementation(() => {
         throw new Error("otel exporter down");
       });
@@ -748,7 +753,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
       drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([deployment]);
       drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(1000000);
       cachedBalanceService.getFresh.mockResolvedValue(createMockCachedBalance(() => 1000000));
-      deploymentSettingRepository.claimForFunding.mockResolvedValue([deployment.id]);
+      deploymentSettingRepository.claimForFunding.mockResolvedValue([createFundingClaim(deployment.id)]);
       deploymentSettingRepository.releaseFundingClaim.mockRejectedValue(releaseError);
       managedSignerService.executeDerivedTx.mockRejectedValue(new Error("insufficient funds"));
       chainErrorService.isMasterWalletInsufficientFundsError.mockResolvedValue(true);
@@ -794,7 +799,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
       drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([deployment]);
       drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(1000000);
       cachedBalanceService.getFresh.mockResolvedValue(createMockCachedBalance(() => 1000000));
-      deploymentSettingRepository.claimForFunding.mockResolvedValue([deployment.id]);
+      deploymentSettingRepository.claimForFunding.mockResolvedValue([createFundingClaim(deployment.id)]);
 
       await service.topUpDrainingDeploymentsForOwner({ walletId, address: owner });
 
@@ -812,12 +817,12 @@ describe(TopUpManagedDeploymentsService.name, () => {
       drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([deployment]);
       drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(1000000);
       cachedBalanceService.getFresh.mockResolvedValue(createMockCachedBalance(() => 1000000));
-      deploymentSettingRepository.claimForFunding.mockResolvedValue([deployment.id]);
+      deploymentSettingRepository.claimForFunding.mockResolvedValue([createFundingClaim(deployment.id)]);
       managedSignerService.executeDerivedTx.mockResolvedValue(mock<IndexedTx>({ code: 11, hash: "tx-hash", rawLog: "out of gas" }));
 
       await service.topUpDrainingDeploymentsForOwner({ walletId, address: owner });
 
-      expect(deploymentSettingRepository.releaseFundingClaim).toHaveBeenCalledWith([deployment.id]);
+      expect(deploymentSettingRepository.releaseFundingClaim).toHaveBeenCalledWith([createFundingClaim(deployment.id)]);
       expect(fundDrainingInstrumentation.recordChainTxError).toHaveBeenCalledWith(expect.objectContaining({ owner }));
       expect(fundDrainingInstrumentation.recordDeposit).not.toHaveBeenCalled();
     });
@@ -831,13 +836,13 @@ describe(TopUpManagedDeploymentsService.name, () => {
       drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([deployment]);
       drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(1000000);
       cachedBalanceService.getFresh.mockResolvedValue(createMockCachedBalance(() => 1000000));
-      deploymentSettingRepository.claimForFunding.mockResolvedValue([deployment.id]);
+      deploymentSettingRepository.claimForFunding.mockResolvedValue([createFundingClaim(deployment.id)]);
       managedSignerService.executeDerivedTx.mockRejectedValue(new Error("broadcast timed out"));
       chainErrorService.isMasterWalletInsufficientFundsError.mockResolvedValue(false);
 
       await service.topUpDrainingDeploymentsForOwner({ walletId, address: owner });
 
-      expect(deploymentSettingRepository.releaseFundingClaim).toHaveBeenCalledWith([deployment.id]);
+      expect(deploymentSettingRepository.releaseFundingClaim).toHaveBeenCalledWith([createFundingClaim(deployment.id)]);
     });
 
     it("releases the claim before rethrowing a master-wallet insufficient-funds failure", async () => {
@@ -849,13 +854,13 @@ describe(TopUpManagedDeploymentsService.name, () => {
       drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([deployment]);
       drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(1000000);
       cachedBalanceService.getFresh.mockResolvedValue(createMockCachedBalance(() => 1000000));
-      deploymentSettingRepository.claimForFunding.mockResolvedValue([deployment.id]);
+      deploymentSettingRepository.claimForFunding.mockResolvedValue([createFundingClaim(deployment.id)]);
       managedSignerService.executeDerivedTx.mockRejectedValue(new Error("insufficient funds"));
       chainErrorService.isMasterWalletInsufficientFundsError.mockResolvedValue(true);
 
       await expect(service.topUpDrainingDeploymentsForOwner({ walletId, address: owner })).rejects.toThrow("insufficient funds");
 
-      expect(deploymentSettingRepository.releaseFundingClaim).toHaveBeenCalledWith([deployment.id]);
+      expect(deploymentSettingRepository.releaseFundingClaim).toHaveBeenCalledWith([createFundingClaim(deployment.id)]);
     });
 
     function createDrainingFor(owner: string, walletId: number, predictedClosedHeight = CURRENT_BLOCK_HEIGHT + 1500): DrainingDeployment {
@@ -893,7 +898,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
     const fundDrainingInstrumentation = mock<FundDrainingDeploymentsInstrumentationService>();
     const walletReloadService = mock<WalletReloadJobService>();
     const deploymentSettingRepository = mock<DeploymentSettingRepository>();
-    deploymentSettingRepository.claimForFunding.mockImplementation(async (ids: string[]) => ids);
+    deploymentSettingRepository.claimForFunding.mockImplementation(async (ids: string[]) => ids.map(createFundingClaim));
     deploymentSettingRepository.releaseFundingClaim.mockResolvedValue(undefined);
     const deploymentConfig = mockConfigService<DeploymentConfigService>({ AUTO_TOP_UP_DEDUP_COOLDOWN_IN_MIN: 60 });
 

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
@@ -88,49 +88,95 @@ export class TopUpManagedDeploymentsService {
     balance: CachedBalance,
     instrumentation: DeploymentTopUpInstrumentation
   ): Promise<void> {
-    const messageInputs = await this.collectMessages(deployments, balance, instrumentation);
+    if (options.dryRun) {
+      const messageInputs = await this.collectMessages(deployments, balance, instrumentation);
+
+      if (!messageInputs.length) {
+        instrumentation.recordSkipped({ owner: address, deploymentCount: deployments.length });
+        return;
+      }
+
+      await this.topUpForOwner(address, messageInputs, options, instrumentation);
+      return;
+    }
+
+    const claimedDeployments = await this.#claimForFunding(deployments);
+
+    if (!claimedDeployments.length) {
+      instrumentation.recordSkipped({ owner: address, deploymentCount: deployments.length });
+      return;
+    }
+
+    const messageInputs = await this.collectMessages(claimedDeployments, balance, instrumentation);
+    await this.#releaseClaimsWithoutMessage(address, claimedDeployments, messageInputs, instrumentation);
 
     if (!messageInputs.length) {
       instrumentation.recordSkipped({ owner: address, deploymentCount: deployments.length });
       return;
     }
 
-    if (options.dryRun) {
-      await this.topUpForOwner(address, messageInputs, options, instrumentation);
-      return;
-    }
-
-    const claimedInputs = await this.#claimForFunding(messageInputs);
-
-    if (!claimedInputs.length) {
-      instrumentation.recordSkipped({ owner: address, deploymentCount: deployments.length });
-      return;
-    }
-
-    const claimedIds = claimedInputs.map(input => input.deployment.id);
     let deposited = false;
 
     try {
-      deposited = await this.topUpForOwner(address, claimedInputs, options, instrumentation);
+      deposited = await this.topUpForOwner(address, messageInputs, options, instrumentation);
     } finally {
       if (!deposited) {
-        await this.deploymentSettingRepository.releaseFundingClaim(claimedIds);
+        await this.#releaseFundingClaim(
+          address,
+          messageInputs.map(input => input.deployment.id),
+          instrumentation
+        );
       }
     }
 
     await this.walletReloadService.scheduleImmediate({ walletId });
   }
 
-  async #claimForFunding(messageInputs: CollectedMessage[]): Promise<CollectedMessage[]> {
+  /**
+   * Claims before any balance math so a deployment another pass already funded never reserves a
+   * share of the owner's shared allowance: reservations are not refundable, so a loser reserving
+   * first leaves the winners of the same batch to be funded from a short-changed pool.
+   */
+  async #claimForFunding(deployments: DrainingDeployment[]): Promise<DrainingDeployment[]> {
     const cooldownMinutes = this.deploymentConfig.get("AUTO_TOP_UP_DEDUP_COOLDOWN_IN_MIN");
     const claimedIds = new Set(
       await this.deploymentSettingRepository.claimForFunding(
-        messageInputs.map(input => input.deployment.id),
+        deployments.map(deployment => deployment.id),
         cooldownMinutes
       )
     );
 
-    return messageInputs.filter(input => claimedIds.has(input.deployment.id));
+    return deployments.filter(deployment => claimedIds.has(deployment.id));
+  }
+
+  /**
+   * A claimed deployment that yielded no deposit message (non-positive amount, exhausted balance)
+   * gives its claim back immediately, otherwise it sits out the whole cooldown unfunded.
+   */
+  async #releaseClaimsWithoutMessage(
+    owner: string,
+    claimedDeployments: DrainingDeployment[],
+    messageInputs: CollectedMessage[],
+    instrumentation: DeploymentTopUpInstrumentation
+  ): Promise<void> {
+    const messagedIds = new Set(messageInputs.map(input => input.deployment.id));
+    const unmessagedIds = claimedDeployments.filter(deployment => !messagedIds.has(deployment.id)).map(deployment => deployment.id);
+
+    if (!unmessagedIds.length) {
+      return;
+    }
+
+    await this.#releaseFundingClaim(owner, unmessagedIds, instrumentation);
+  }
+
+  /**
+   * A release failure is reported rather than thrown: the release runs in a finally block, where a
+   * rejection would replace the chain error the caller classifies to decide whether to retry.
+   */
+  async #releaseFundingClaim(owner: string, deploymentIds: string[], instrumentation: DeploymentTopUpInstrumentation): Promise<void> {
+    await this.deploymentSettingRepository.releaseFundingClaim(deploymentIds).catch((error: unknown) => {
+      instrumentation.recordClaimReleaseError({ owner, deploymentIds, error });
+    });
   }
 
   private async collectMessages(
@@ -220,9 +266,6 @@ export class TopUpManagedDeploymentsService {
           return false;
         }
       }
-
-      instrumentation.recordDeposit({ owner, items: ownerInputs });
-      return true;
     } catch (error: unknown) {
       instrumentation.recordChainTxError({ owner, items: ownerInputs, error });
 
@@ -232,6 +275,22 @@ export class TopUpManagedDeploymentsService {
       }
 
       return false;
+    }
+
+    this.#recordDeposit(instrumentation, { owner, items: ownerInputs });
+
+    return true;
+  }
+
+  /**
+   * The deposit has already landed on chain by the time it is recorded, so a telemetry failure must
+   * not escape as a failed deposit: that would release the claim and let the next pass deposit again.
+   */
+  #recordDeposit(instrumentation: DeploymentTopUpInstrumentation, details: { owner: string; items: CollectedMessage[] }): void {
+    try {
+      instrumentation.recordDeposit(details);
+    } catch {
+      return;
     }
   }
 }

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
@@ -9,7 +9,7 @@ import { ManagedSignerService } from "@src/billing/services/managed-signer/manag
 import { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
 import { BlockHttpService } from "@src/chain/services/block-http/block-http.service";
 import type { DryRunOptions } from "@src/core/types/console";
-import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import { DeploymentSettingRepository, type FundingClaim } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import { DrainingDeployment } from "@src/deployment/services/draining-deployment/draining-deployment.service";
 import { DrainingDeploymentService } from "@src/deployment/services/draining-deployment/draining-deployment.service";
 import { COSMOS_TX_CODE_OK } from "@src/utils/constants";
@@ -100,15 +100,26 @@ export class TopUpManagedDeploymentsService {
       return;
     }
 
-    const claimedDeployments = await this.#claimForFunding(deployments);
+    const claims = await this.#claimForFunding(deployments);
 
-    if (!claimedDeployments.length) {
+    if (!claims.length) {
       instrumentation.recordSkipped({ owner: address, deploymentCount: deployments.length });
       return;
     }
 
-    const messageInputs = await this.collectMessages(claimedDeployments, balance, instrumentation);
-    await this.#releaseClaimsWithoutMessage(address, claimedDeployments, messageInputs, instrumentation);
+    const claimedIds = new Set(claims.map(claim => claim.id));
+    const messageInputs = await this.collectMessages(
+      deployments.filter(deployment => claimedIds.has(deployment.id)),
+      balance,
+      instrumentation
+    );
+    const preparedIds = new Set(messageInputs.map(input => input.deployment.id));
+
+    await this.#releaseFundingClaims(
+      address,
+      claims.filter(claim => !preparedIds.has(claim.id)),
+      instrumentation
+    );
 
     if (!messageInputs.length) {
       instrumentation.recordSkipped({ owner: address, deploymentCount: deployments.length });
@@ -121,9 +132,9 @@ export class TopUpManagedDeploymentsService {
       deposited = await this.topUpForOwner(address, messageInputs, options, instrumentation);
     } finally {
       if (!deposited) {
-        await this.#releaseFundingClaim(
+        await this.#releaseFundingClaims(
           address,
-          messageInputs.map(input => input.deployment.id),
+          claims.filter(claim => preparedIds.has(claim.id)),
           instrumentation
         );
       }
@@ -137,45 +148,24 @@ export class TopUpManagedDeploymentsService {
    * share of the owner's shared allowance: reservations are not refundable, so a loser reserving
    * first leaves the winners of the same batch to be funded from a short-changed pool.
    */
-  async #claimForFunding(deployments: DrainingDeployment[]): Promise<DrainingDeployment[]> {
-    const cooldownMinutes = this.deploymentConfig.get("AUTO_TOP_UP_DEDUP_COOLDOWN_IN_MIN");
-    const claimedIds = new Set(
-      await this.deploymentSettingRepository.claimForFunding(
-        deployments.map(deployment => deployment.id),
-        cooldownMinutes
-      )
+  async #claimForFunding(deployments: DrainingDeployment[]): Promise<FundingClaim[]> {
+    return await this.deploymentSettingRepository.claimForFunding(
+      deployments.map(deployment => deployment.id),
+      this.deploymentConfig.get("AUTO_TOP_UP_DEDUP_COOLDOWN_IN_MIN")
     );
-
-    return deployments.filter(deployment => claimedIds.has(deployment.id));
-  }
-
-  /**
-   * A claimed deployment that yielded no deposit message (non-positive amount, exhausted balance)
-   * gives its claim back immediately, otherwise it sits out the whole cooldown unfunded.
-   */
-  async #releaseClaimsWithoutMessage(
-    owner: string,
-    claimedDeployments: DrainingDeployment[],
-    messageInputs: CollectedMessage[],
-    instrumentation: DeploymentTopUpInstrumentation
-  ): Promise<void> {
-    const messagedIds = new Set(messageInputs.map(input => input.deployment.id));
-    const unmessagedIds = claimedDeployments.filter(deployment => !messagedIds.has(deployment.id)).map(deployment => deployment.id);
-
-    if (!unmessagedIds.length) {
-      return;
-    }
-
-    await this.#releaseFundingClaim(owner, unmessagedIds, instrumentation);
   }
 
   /**
    * A release failure is reported rather than thrown: the release runs in a finally block, where a
    * rejection would replace the chain error the caller classifies to decide whether to retry.
    */
-  async #releaseFundingClaim(owner: string, deploymentIds: string[], instrumentation: DeploymentTopUpInstrumentation): Promise<void> {
-    await this.deploymentSettingRepository.releaseFundingClaim(deploymentIds).catch((error: unknown) => {
-      instrumentation.recordClaimReleaseError({ owner, deploymentIds, error });
+  async #releaseFundingClaims(owner: string, claims: FundingClaim[], instrumentation: DeploymentTopUpInstrumentation): Promise<void> {
+    if (!claims.length) {
+      return;
+    }
+
+    await this.deploymentSettingRepository.releaseFundingClaim(claims).catch((error: unknown) => {
+      instrumentation.recordClaimReleaseError({ owner, deploymentIds: claims.map(claim => claim.id), error });
     });
   }
 

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
@@ -9,9 +9,12 @@ import { ManagedSignerService } from "@src/billing/services/managed-signer/manag
 import { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
 import { BlockHttpService } from "@src/chain/services/block-http/block-http.service";
 import type { DryRunOptions } from "@src/core/types/console";
+import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import { DrainingDeployment } from "@src/deployment/services/draining-deployment/draining-deployment.service";
 import { DrainingDeploymentService } from "@src/deployment/services/draining-deployment/draining-deployment.service";
+import { COSMOS_TX_CODE_OK } from "@src/utils/constants";
 import { CachedBalance, CachedBalanceService } from "../cached-balance/cached-balance.service";
+import { DeploymentConfigService } from "../deployment-config/deployment-config.service";
 import type { DeploymentTopUpInstrumentation } from "./deployment-top-up-instrumentation";
 import { FundDrainingDeploymentsInstrumentationService } from "./fund-draining-deployments-instrumentation.service";
 import { TopUpManagedDeploymentsInstrumentationService } from "./top-up-managed-deployments-instrumentation.service";
@@ -34,7 +37,9 @@ export class TopUpManagedDeploymentsService {
     private readonly chainErrorService: ChainErrorService,
     private readonly instrumentation: TopUpManagedDeploymentsInstrumentationService,
     private readonly fundDrainingInstrumentation: FundDrainingDeploymentsInstrumentationService,
-    private readonly walletReloadService: WalletReloadJobService
+    private readonly walletReloadService: WalletReloadJobService,
+    private readonly deploymentSettingRepository: DeploymentSettingRepository,
+    private readonly deploymentConfig: DeploymentConfigService
   ) {}
 
   async topUpDeployments(options: DryRunOptions): Promise<Result<void, unknown[]>> {
@@ -90,11 +95,42 @@ export class TopUpManagedDeploymentsService {
       return;
     }
 
-    await this.topUpForOwner(address, messageInputs, options, instrumentation);
-
-    if (!options.dryRun) {
-      await this.walletReloadService.scheduleImmediate({ walletId });
+    if (options.dryRun) {
+      await this.topUpForOwner(address, messageInputs, options, instrumentation);
+      return;
     }
+
+    const claimedInputs = await this.#claimForFunding(messageInputs);
+
+    if (!claimedInputs.length) {
+      instrumentation.recordSkipped({ owner: address, deploymentCount: deployments.length });
+      return;
+    }
+
+    const claimedIds = claimedInputs.map(input => input.deployment.id);
+    let deposited = false;
+
+    try {
+      deposited = await this.topUpForOwner(address, claimedInputs, options, instrumentation);
+    } finally {
+      if (!deposited) {
+        await this.deploymentSettingRepository.releaseFundingClaim(claimedIds);
+      }
+    }
+
+    await this.walletReloadService.scheduleImmediate({ walletId });
+  }
+
+  async #claimForFunding(messageInputs: CollectedMessage[]): Promise<CollectedMessage[]> {
+    const cooldownMinutes = this.deploymentConfig.get("AUTO_TOP_UP_DEDUP_COOLDOWN_IN_MIN");
+    const claimedIds = new Set(
+      await this.deploymentSettingRepository.claimForFunding(
+        messageInputs.map(input => input.deployment.id),
+        cooldownMinutes
+      )
+    );
+
+    return messageInputs.filter(input => claimedIds.has(input.deployment.id));
   }
 
   private async collectMessages(
@@ -148,7 +184,12 @@ export class TopUpManagedDeploymentsService {
     return messageInputs.filter(x => !!x);
   }
 
-  private async topUpForOwner(owner: string, ownerInputs: CollectedMessage[], options: DryRunOptions, instrumentation: DeploymentTopUpInstrumentation) {
+  private async topUpForOwner(
+    owner: string,
+    ownerInputs: CollectedMessage[],
+    options: DryRunOptions,
+    instrumentation: DeploymentTopUpInstrumentation
+  ): Promise<boolean> {
     const walletId = ownerInputs[0].deployment.walletId;
 
     try {
@@ -162,16 +203,26 @@ export class TopUpManagedDeploymentsService {
             items: ownerInputs,
             error: new Error(`Fee grant missing for wallet ${owner}, unable to top up deployments`)
           });
-          return;
+          return false;
         }
 
-        await this.managedSignerService.executeDerivedTx(
+        const tx = await this.managedSignerService.executeDerivedTx(
           walletId,
           ownerInputs.map(i => i.message)
         );
+
+        if (tx.code !== COSMOS_TX_CODE_OK) {
+          instrumentation.recordChainTxError({
+            owner,
+            items: ownerInputs,
+            error: new Error(`Deposit tx ${tx.hash} failed on-chain with code ${tx.code}: ${tx.rawLog}`)
+          });
+          return false;
+        }
       }
 
       instrumentation.recordDeposit({ owner, items: ownerInputs });
+      return true;
     } catch (error: unknown) {
       instrumentation.recordChainTxError({ owner, items: ownerInputs, error });
 
@@ -179,6 +230,8 @@ export class TopUpManagedDeploymentsService {
         instrumentation.recordMasterWalletInsufficientFundsError({ owner, items: ownerInputs, error });
         throw error;
       }
+
+      return false;
     }
   }
 }


### PR DESCRIPTION
## Why

Fixes CON-845

Managed-wallet draining deployments are auto-funded by two paths that do not coordinate: the hourly `top-up-deployments` cron and the immediate on-credit job added in #3590. The cron runs as its own CLI process with no queue, so the immediate job's pg-boss `singleton` policy never serializes against it. On top of that, the top-up amount is a fixed slug of runway, the "still draining" check reads chain state that lags a just-submitted deposit, and nothing records that a deployment was already funded. So when the cron and an immediate job overlap (or a job retries after its deposit already landed, or two credit top-ups arrive close together), each reads the pre-deposit state and each deposits, funding the same deployment more than once for a single top-up event.

The impact is bounded and self-correcting: it over-funds the user's own escrow from their own authorized limit, and the excess returns when the deployment closes. So this is a credit-burn correctness fix, not a solvency or security one. Deferred from #3590 (observability was split into CON-837 / #3607, already merged).

## What

Both funding paths now take a persisted, cooldown-bounded claim on `deployment_settings` before broadcasting, so concurrent passes and retries resolve to a single deposit.

- **`last_funded_at` column** (migration 0036) records when a deployment was last funded, with new repository methods `claimForFunding(ids, cooldownMinutes)` and `releaseFundingClaim(ids)`. The claim is one atomic `UPDATE ... WHERE (last_funded_at IS NULL OR last_funded_at < now() - cooldown) RETURNING`, the same exactly-once pattern as `UserWalletRepository.claimActivation`. Under READ COMMITTED, two concurrent claims for the same id resolve to a single winner via the row-lock re-check.
- **`TopUpManagedDeploymentsService.#fundOwnerDeployments`** claims the deployments it is about to fund before building any deposit message and funds only the ones it wins. Claiming first also keeps a deployment another pass already funded from reserving a share of the owner's allowance, since reservations are not refundable; a claimed deployment that yields no deposit message releases its claim immediately. Both the cron and the immediate job funnel through this one method, and because the funding path runs in autocommit the claim commits immediately, serializing the two processes and any retry through the shared row.
- **Release on failure**: a deposit that does not land releases its claim so the next pass retries promptly, which keeps a near-empty deployment from waiting out the cooldown. This needed a check on the tx result code in `topUpForOwner`, which previously recorded a chain-rejected deposit as a successful one.
- **`AUTO_TOP_UP_DEDUP_COOLDOWN_IN_MIN`** (default 60) bounds how long a claim suppresses re-funding. It is validated positive at startup, because a non-positive cooldown collapses the guard and reopens the race. 60 min sits well above the retry window and well below the ~24h a funded deployment needs before it legitimately drains again (48h of runway bought minus the 24h look-ahead).

At-most-once holds across the two automatic paths and their retries. A user-initiated manual deposit racing an auto-fund is intentionally not gated. One residual remains, called out in the code: a deposit that lands on chain but whose response errors will be released and re-funded. `MsgAccountDeposit` carries no on-chain idempotency, so this cannot be closed without it, and its impact is the same bounded over-funding.

### Migration

`ALTER TABLE deployment_settings ADD COLUMN last_funded_at timestamp` (nullable, no default). This is metadata-only with no table rewrite and no backfill (NULL means never funded), so it runs without blocking. No breaking contract changes and no new required env vars.

### Tests

- Repository integration tests for `claimForFunding` / `releaseFundingClaim`: a single winner across concurrent claims, no re-claim within the cooldown, re-claim once it elapses, and release makes a deployment claimable again.
- Service integration tests: concurrent same-wallet funding deposits into each draining deployment exactly once, a second pass within the cooldown skips, and a failed deposit is retried by the next pass.
- Unit tests for the claim/release orchestration and the tx-code handling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved automatic deployment funding to prevent duplicate top-ups during concurrent processing.
  - Added a configurable cooldown between automatic funding attempts.
  - Funding claims are released when no deposit is created or funding fails, allowing later retries.
  - Claims now protect newer funding attempts from stale releases.
  - Successful funding validates transaction details before recording deposits and reloading wallets.

- **Bug Fixes**
  - Prevented failed or incomplete funding attempts from unnecessarily blocking future top-ups.

- **Monitoring**
  - Added structured reporting for funding-claim release failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
