### PR TITLE
chore(ci): bound the deploy test job and its apt install

### DIFF
--- a/.github/actions/console-web-ui-testing/action.yml
+++ b/.github/actions/console-web-ui-testing/action.yml
@@ -49,10 +49,16 @@ runs:
     - uses: ./.github/actions/setup-app-deps
       with:
         app: deploy-web
+    # The runner's local Azure package mirror drops out periodically. apt sets no network timeout of its own,
+    # so it exhausts its retries there, fails over to archive.ubuntu.com and then blocks forever on a dead
+    # connection: on 2026-08-19 this step ran 82 minutes before being killed by hand, against a healthy 12s.
+    # `timeout` has to do the bounding because composite action steps don't accept `timeout-minutes`.
     - name: Install Playwright Dependencies
       shell: bash
       working-directory: apps/deploy-web
-      run: npx playwright install-deps chromium
+      run: |
+        printf 'Acquire::http::Timeout "30";\nAcquire::https::Timeout "30";\nAcquire::Retries "2";\n' | sudo tee /etc/apt/apt.conf.d/99-e2e-timeouts.conf > /dev/null
+        timeout 5m npx playwright install-deps chromium
     - name: Install Playwright Browsers
       shell: bash
       working-directory: apps/deploy-web

--- a/.github/actions/console-web-ui-testing/action.yml
+++ b/.github/actions/console-web-ui-testing/action.yml
@@ -89,13 +89,13 @@ runs:
         retention-days: 5
 
     - uses: ./.github/actions/slack-tests-failed-notification
-      if: ${{ !cancelled() && steps.e2e-tests.outcome == 'failure' }}
+      if: ${{ !cancelled() && steps.e2e-tests.outcome != 'success' }}
       with:
         ref: ${{ inputs.ref }}
         url: ${{ inputs.url }}
         gh-user-to-slack-user: ${{ inputs.gh-user-to-slack-user }}
         slack-webhook-url: ${{ inputs.slack-webhook-url }}
-        message-title: "Console web UI tests failed on beta"
+        message-title: ${{ steps.e2e-tests.outcome == 'failure' && 'Console web UI tests failed on beta' || 'Console web UI tests did not run on beta' }}
 
     - name: Summarize Test Results
       if: ${{ !cancelled() }}
@@ -108,5 +108,11 @@ runs:
         prefix=":white_check_mark: Passed"
         if [ "${STEPS_E2E_TESTS_OUTCOME}" == "failure" ]; then
           prefix=":x: Failed"
+        elif [ "${STEPS_E2E_TESTS_OUTCOME}" != "success" ]; then
+          prefix=":x: Did not run"
         fi
-        echo "${prefix}, [download tests report](${STEPS_PLAYWRIGHT_REPORT_OUTPUTS_ARTIFACT_URL})" >> $GITHUB_STEP_SUMMARY
+        line="${prefix}"
+        if [ -n "${STEPS_PLAYWRIGHT_REPORT_OUTPUTS_ARTIFACT_URL}" ]; then
+          line="${line}, [download tests report](${STEPS_PLAYWRIGHT_REPORT_OUTPUTS_ARTIFACT_URL})"
+        fi
+        echo "${line}" >> $GITHUB_STEP_SUMMARY

--- a/.github/actions/console-web-ui-testing/action.yml
+++ b/.github/actions/console-web-ui-testing/action.yml
@@ -96,6 +96,7 @@ runs:
         gh-user-to-slack-user: ${{ inputs.gh-user-to-slack-user }}
         slack-webhook-url: ${{ inputs.slack-webhook-url }}
         message-title: ${{ steps.e2e-tests.outcome == 'failure' && 'Console web UI tests failed on beta' || 'Console web UI tests did not run on beta' }}
+        tests-ran: ${{ steps.e2e-tests.outcome == 'failure' }}
 
     - name: Summarize Test Results
       if: ${{ !cancelled() }}

--- a/.github/actions/slack-tests-failed-notification/action.yml
+++ b/.github/actions/slack-tests-failed-notification/action.yml
@@ -19,6 +19,10 @@ inputs:
     description: Title of the message
     required: false
     default: "E2E tests failed"
+  tests-ran:
+    description: Whether the tests executed. When false the message points at the setup failure instead of blaming the change under test.
+    required: false
+    default: "true"
 
 runs:
   using: "composite"
@@ -43,7 +47,7 @@ runs:
 
                   Hey ${{ steps.associated-pr.outputs.slack-user != '' && format('<@{0}>', steps.associated-pr.outputs.slack-user) || steps.associated-pr.outputs.author }},
 
-                  Tests failed on <${{ inputs.url }}|${{ inputs.url }}> likely related to changes in this PR:
+                  ${{ inputs.tests-ran == 'true' && format('Tests failed on <{0}|{0}> likely related to changes in this PR:', inputs.url) || format('The setup failed on <{0}|{0}> before any test ran, so this is likely infrastructure rather than the change under test:', inputs.url) }}
                   <${{ github.server_url }}/${{ github.repository }}/pull/${{ steps.associated-pr.outputs.number }}|${{ steps.associated-pr.outputs.title }}>
 
-                  Please review the test report available in <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|the workflow> artifacts and resolve the issue.
+                  ${{ inputs.tests-ran == 'true' && format('Please review the test report available in <{0}/{1}/actions/runs/{2}|the workflow> artifacts and resolve the issue.', github.server_url, github.repository, github.run_id) || format('Check <{0}/{1}/actions/runs/{2}|the workflow run> for the failing setup step.', github.server_url, github.repository, github.run_id) }}

--- a/.github/workflows/reusable-deploy-test.yml
+++ b/.github/workflows/reusable-deploy-test.yml
@@ -31,6 +31,10 @@ jobs:
   test:
     name: Test ${{ inputs.environment }}
     runs-on: ubuntu-latest
+    # Backstop for hangs the test tooling can't cut off itself, replacing GitHub's 6h default. Sits just above
+    # the longest run any suite here can legitimately produce: console-web's Playwright globalTimeout of 60m
+    # plus dependency setup and report upload. A healthy console-web run is ~10m.
+    timeout-minutes: 75
     env:
       BASE_URL: ${{ inputs.environment == 'staging' && vars.CONSOLE_WEB_BETA_URL || vars.CONSOLE_WEB_URL }}
     steps:


### PR DESCRIPTION
## Why

The beta e2e job for console-web v3.166.0 sat for 82 minutes before it was cancelled by hand ([run 32238099439](https://github.com/akash-network/console/actions/runs/32238099439)). `Test beta` never passed, so `auto-approve-decision` failed and the prod promotion never ran.

It was stuck in `npx playwright install-deps chromium`. The runner's local Azure package mirror was down, so apt burned its retries there, failed over to archive.ubuntu.com, then blocked on a connection it never times out:

```
Ign:2 http://azure.archive.ubuntu.com/ubuntu noble InRelease      (x4)
Hit:2 https://archive.ubuntu.com/ubuntu noble InRelease
Get:5 https://archive.ubuntu.com/ubuntu noble-security InRelease [126 kB]
##[error]The operation was canceled.
```

The tests never started. Nothing was going to stop it either: the job carries no `timeout-minutes`, so GitHub's 6h default applied.

## What

Two bounds. Neither changes anything on a healthy run.

- `timeout-minutes: 75` on the `test` job in `reusable-deploy-test.yml`. That clears the longest run any suite here can legitimately produce: console-web's Playwright `globalTimeout` is 60m, plus dependency setup and report upload. A healthy console-web run is about 10m.
- `timeout 5m` around the apt install, plus `Acquire::*::Timeout` and `Acquire::Retries` so apt gives up instead of hanging. That step takes 12s when the mirror is healthy. Composite action steps don't accept `timeout-minutes`, so the bound has to come from `timeout`.

Two things deliberately left alone: Playwright's 60m `globalTimeout` is loose against a suite that finishes in 9m, and a mirror outage now fails the deploy outright instead of retrying. Both seemed worth their own decision rather than folding into this fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Reliability Improvements**
  - Improved automated browser test setup with network retries and a five-minute installation limit.
  - Added a 75-minute maximum runtime for deployment tests to prevent jobs from hanging indefinitely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->