### PR TITLE
fix(styling): use the regular spinner outside boot loading

### DIFF
--- a/apps/deploy-web/src/components/layout/Layout.spec.tsx
+++ b/apps/deploy-web/src/components/layout/Layout.spec.tsx
@@ -2,10 +2,13 @@ import type { ReactNode } from "react";
 import { describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
 
-import Layout, { DEPENDENCIES } from "./Layout";
+import Layout, { DEPENDENCIES, Loading } from "./Layout";
 
 import { render, screen } from "@testing-library/react";
 import { MockComponents } from "@tests/unit/mocks";
+
+/** viewBox of the animated akash mark, which must stay exclusive to the boot-loading curtain. */
+const AKASH_MARK_VIEW_BOX = "0 0 481 420";
 
 describe("Layout", () => {
   it("reserves the loading indicator space when no isLoading prop is provided", () => {
@@ -46,5 +49,35 @@ describe("Layout", () => {
     );
 
     return { dependencies };
+  }
+});
+
+describe(Loading.name, () => {
+  it("renders the shared spinner", () => {
+    setup({});
+
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
+
+  it("does not render the animated akash mark, which is reserved for boot loading", () => {
+    const { container } = setup({});
+
+    expect(container.querySelector(`svg[viewBox="${AKASH_MARK_VIEW_BOX}"]`)).toBeNull();
+  });
+
+  it("renders the given text", () => {
+    setup({ text: "Loading settings..." });
+
+    expect(screen.getByText("Loading settings...")).toBeInTheDocument();
+  });
+
+  it("exposes the given test id", () => {
+    setup({ testId: "loading-blocker" });
+
+    expect(screen.getByTestId("loading-blocker")).toBeInTheDocument();
+  });
+
+  function setup(input: { text?: string; testId?: string }) {
+    return render(<Loading text={input.text} testId={input.testId} />);
   }
 });

--- a/apps/deploy-web/src/components/layout/Layout.tsx
+++ b/apps/deploy-web/src/components/layout/Layout.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from "react";
 import React, { Suspense, useEffect, useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { IntlProvider } from "react-intl";
-import { ErrorFallback } from "@akashnetwork/ui/components";
+import { ErrorFallback, Spinner } from "@akashnetwork/ui/components";
 import { cn } from "@akashnetwork/ui/utils";
 
 import { ACCOUNT_BAR_HEIGHT } from "@src/config/ui.config";
@@ -12,7 +12,6 @@ import { useOnboardingChrome } from "@src/hooks/useOnboardingChrome";
 import { useTopBanner } from "@src/hooks/useTopBanner";
 import { LinearLoadingSkeleton } from "../shared/LinearLoadingSkeleton";
 import { TopNav } from "./TopNav/TopNav";
-import { AkashLoadingMark } from "./AkashLoadingMark";
 import { TrackingScripts } from "./TrackingScripts";
 
 export const DEPENDENCIES = {
@@ -105,7 +104,7 @@ const LayoutApp: React.FunctionComponent<Props> = ({
 export const Loading: React.FunctionComponent<{ text?: string; testId?: string }> = ({ text, testId }) => {
   return (
     <div className="flex h-full w-full flex-col items-center justify-center pb-12 pt-12" data-testid={testId}>
-      <AkashLoadingMark />
+      <Spinner size="large" />
       {text && <h5 className="pt-4">{text}</h5>}
     </div>
   );


### PR DESCRIPTION
## Why

The animated Akash mark is meant for the boot-loading curtain only, but the shared `Loading` component rendered it too. Since `LoadingBlocker` builds on `Loading`, in-app views got the boot animation.

It showed up most clearly on the alerts page: the notification-channel guard animated the Akash mark while the list right below it used a plain spinner, so one screen had two different loaders.

## What

`Loading` now renders `<Spinner size="large" />` instead of `<AkashLoadingMark />`. One change at the shared source, so every consumer follows:

- alerts: `NotificationChannelsGuard`, `NotificationChannelSelect`
- deployment detail: `DeploymentAlerts`
- remote deploy: `GithubManager`, `RemoteRepositoryDeployManager`
- Layout's own "Loading settings..." gate

`AkashLoadingMark` stays as it is — `BootLoadingProvider` is now its only consumer, which is what its JSDoc already claimed. The full-screen boot curtain is unchanged.

Added tests for `Loading`, including one asserting the mark's `viewBox` is absent, so the boot-only invariant can't regress silently.
