### PR TITLE
fix(deployment): coerce the provider's null lease-status arrays at the query boundary

### DIFF
--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementServiceRow.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementServiceRow.spec.tsx
@@ -66,6 +66,15 @@ describe(PlacementServiceRow.name, () => {
     expect(screen.getByText("None")).toBeInTheDocument();
   });
 
+  it("shows a None placeholder when the provider reports null endpoint collections", async () => {
+    setup({ uris: null, forwardedPorts: null, ips: null });
+
+    await expandService();
+
+    expect(screen.getByText("Expose Ports")).toBeInTheDocument();
+    expect(screen.getByText("None")).toBeInTheDocument();
+  });
+
   it("shows the Docker image row when an image is known", async () => {
     setup({ detail: { image: "nginx:1.25" } });
 

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementServiceRow.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementServiceRow.tsx
@@ -6,13 +6,12 @@ import { cn } from "@akashnetwork/ui/utils";
 import { Box, Globe, Key, NavArrowDown, NavArrowUp, Terminal } from "iconoir-react";
 
 import { CopyTextToClipboardButton } from "@src/components/shared/CopyTextToClipboardButton";
-import type { LeaseServiceStatus } from "@src/queries/useLeaseQuery";
+import type { ForwardedPort, LeaseServiceStatus, ServiceIp } from "@src/queries/useLeaseQuery";
 import type { LeaseDto } from "@src/types/deployment";
 import type { ManifestEnvVar, ManifestServiceDetail, ManifestServiceResources, ServiceStatusView } from "./placementModel";
 import { getServiceStatus } from "./placementModel";
 import type { PlacementStat } from "./PlacementStats";
 import { PlacementStats } from "./PlacementStats";
-import type { ForwardedPort, ServiceIp } from "./ServiceEndpoints";
 import { EndpointLinks, toForwardedPortLinks, toIpLinks, toUriLinks } from "./ServiceEndpoints";
 
 export interface PlacementServiceRowProps {
@@ -21,9 +20,9 @@ export interface PlacementServiceRowProps {
   leaseState: LeaseDto["state"];
   isReclaimed?: boolean;
   detail?: ManifestServiceDetail;
-  uris?: string[];
-  forwardedPorts?: ForwardedPort[];
-  ips?: ServiceIp[];
+  uris?: string[] | null;
+  forwardedPorts?: ForwardedPort[] | null;
+  ips?: ServiceIp[] | null;
 }
 
 export const PlacementServiceRow: FC<PlacementServiceRowProps> = ({ serviceName, service, leaseState, isReclaimed, detail, uris, forwardedPorts, ips }) => {

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/ServiceEndpoints.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/ServiceEndpoints.spec.tsx
@@ -10,6 +10,11 @@ describe("ServiceEndpoints", () => {
     it("builds an http link and copy value for each URI", () => {
       expect(toUriLinks(["app.example.com"])).toEqual([{ text: "app.example.com", href: "http://app.example.com", copyValue: "app.example.com" }]);
     });
+
+    it("yields no links when the provider reports no URIs", () => {
+      expect(toUriLinks(null)).toEqual([]);
+      expect(toUriLinks(undefined)).toEqual([]);
+    });
   });
 
   describe("toForwardedPortLinks", () => {
@@ -24,6 +29,11 @@ describe("ServiceEndpoints", () => {
         { text: "80:30000", href: undefined, disabled: true }
       ]);
     });
+
+    it("yields no links when the provider reports no forwarded ports", () => {
+      expect(toForwardedPortLinks(null)).toEqual([]);
+      expect(toForwardedPortLinks(undefined)).toEqual([]);
+    });
   });
 
   describe("toIpLinks", () => {
@@ -32,6 +42,11 @@ describe("ServiceEndpoints", () => {
 
       expect(link.href).toBe("http://1.2.3.4:8080");
       expect(link.copyValue).toBe("1.2.3.4:8080");
+    });
+
+    it("yields no links when the provider reports no IPs", () => {
+      expect(toIpLinks(null)).toEqual([]);
+      expect(toIpLinks(undefined)).toEqual([]);
     });
   });
 

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/ServiceEndpoints.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/ServiceEndpoints.tsx
@@ -5,20 +5,7 @@ import { InfoCircle, OpenInWindow } from "iconoir-react";
 import Link from "next/link";
 
 import { CopyTextToClipboardButton } from "@src/components/shared/CopyTextToClipboardButton";
-
-export interface ForwardedPort {
-  host: string;
-  externalPort: number;
-  port: number;
-  available: number;
-}
-
-export interface ServiceIp {
-  IP: string;
-  ExternalPort: number;
-  Port: number;
-  Protocol: string;
-}
+import type { ForwardedPort, ServiceIp } from "@src/queries/useLeaseQuery";
 
 export interface EndpointLink {
   text: string;
@@ -60,20 +47,20 @@ export const EndpointLinks: FC<{ items: EndpointLink[] }> = ({ items }) => (
   </span>
 );
 
-export function toUriLinks(uris: string[] = []): EndpointLink[] {
-  return uris.map(uri => ({ text: uri, href: `http://${uri}`, copyValue: uri }));
+export function toUriLinks(uris?: string[] | null): EndpointLink[] {
+  return (uris ?? []).map(uri => ({ text: uri, href: `http://${uri}`, copyValue: uri }));
 }
 
-export function toForwardedPortLinks(ports: ForwardedPort[] = []): EndpointLink[] {
-  return ports.map(port => ({
+export function toForwardedPortLinks(ports?: ForwardedPort[] | null): EndpointLink[] {
+  return (ports ?? []).map(port => ({
     text: `${port.port}:${port.externalPort}`,
     href: port.host ? `http://${port.host}:${port.externalPort}` : undefined,
     disabled: port.available < 1
   }));
 }
 
-export function toIpLinks(ips: ServiceIp[] = []): EndpointLink[] {
-  return ips.map(ip => ({
+export function toIpLinks(ips?: ServiceIp[] | null): EndpointLink[] {
+  return (ips ?? []).map(ip => ({
     text: `${ip.IP}:${ip.ExternalPort}`,
     href: `http://${ip.IP}:${ip.ExternalPort}`,
     copyValue: `${ip.IP}:${ip.ExternalPort}`,

--- a/apps/deploy-web/src/queries/useLeaseQuery.spec.tsx
+++ b/apps/deploy-web/src/queries/useLeaseQuery.spec.tsx
@@ -14,7 +14,10 @@ import { leaseToDto } from "@src/utils/deploymentDetailUtils";
 import { setupQuery } from "../../tests/unit/query-client";
 import { QueryKeys } from "./queryKeys";
 import {
+  type LeaseServiceStatusResponse,
   type LeaseStatusDto,
+  type LeaseStatusResponse,
+  normalizeLeaseStatus,
   USE_LEASE_STATUS_DEPENDENCIES,
   useAllLeases,
   useDeploymentLeaseList,
@@ -676,6 +679,31 @@ describe("useLeaseQuery", () => {
       expect(receivedServices).not.toHaveProperty("akash-attestation-sidecar");
     });
 
+    it("coerces the provider's null endpoint collections to empty arrays", async () => {
+      const statusWithNulls = {
+        forwarded_ports: { web: null },
+        ips: null,
+        services: { web: { name: "web", available: 1, uris: null } }
+      };
+      const providerProxy = mock<ProviderProxyService>({
+        request: vi.fn().mockResolvedValue({ data: statusWithNulls })
+      });
+      const { result } = setupLeaseStatus({
+        lease: mockLease,
+        services: {
+          providerProxy: () => providerProxy
+        }
+      });
+
+      await vi.waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(result.current.data?.services.web.uris).toEqual([]);
+      expect(result.current.data?.forwarded_ports.web).toEqual([]);
+      expect(result.current.data?.ips).toEqual({});
+    });
+
     function setupLeaseStatus(input?: {
       provider?: ApiProviderList;
       lease?: LeaseDto;
@@ -702,6 +730,63 @@ describe("useLeaseQuery", () => {
           ...input?.services
         }
       });
+    }
+  });
+
+  describe(normalizeLeaseStatus.name, () => {
+    it("keeps the collections a provider already reports as arrays", () => {
+      const status = normalizeLeaseStatus({
+        forwarded_ports: { web: [{ host: "provider.io", externalPort: 30000, port: 80, available: 1 }] },
+        ips: { web: [{ IP: "1.2.3.4", ExternalPort: 8080, Port: 80, Protocol: "TCP" }] },
+        services: { web: buildServiceResponse({ uris: ["app.example.com"] }) }
+      });
+
+      expect(status.services.web.uris).toEqual(["app.example.com"]);
+      expect(status.forwarded_ports.web).toHaveLength(1);
+      expect(status.ips.web).toHaveLength(1);
+    });
+
+    it("coerces a nil-slice null on each collection to an empty array", () => {
+      const status = normalizeLeaseStatus({
+        forwarded_ports: { web: null },
+        ips: { web: null },
+        services: { web: buildServiceResponse({ uris: null }) }
+      });
+
+      expect(status.services.web.uris).toEqual([]);
+      expect(status.forwarded_ports.web).toEqual([]);
+      expect(status.ips.web).toEqual([]);
+    });
+
+    it("coerces a nil-map null on each collection to an empty record", () => {
+      const status = normalizeLeaseStatus({ forwarded_ports: null, ips: null, services: null });
+
+      expect(status.services).toEqual({});
+      expect(status.forwarded_ports).toEqual({});
+      expect(status.ips).toEqual({});
+    });
+
+    it("keeps a service named __proto__ as an own key rather than reassigning the prototype", () => {
+      const services: LeaseStatusResponse["services"] = JSON.parse('{"__proto__":{"name":"__proto__","uris":null}}');
+
+      const status = normalizeLeaseStatus({ forwarded_ports: null, ips: null, services });
+
+      expect(Object.keys(status.services)).toEqual(["__proto__"]);
+    });
+
+    function buildServiceResponse(overrides: Partial<LeaseServiceStatusResponse>): LeaseServiceStatusResponse {
+      return {
+        name: "web",
+        available: 1,
+        total: 1,
+        uris: [],
+        observed_generation: 1,
+        replicas: 1,
+        updated_replicas: 1,
+        ready_replicas: 1,
+        available_replicas: 1,
+        ...overrides
+      };
     }
   });
 });

--- a/apps/deploy-web/src/queries/useLeaseQuery.ts
+++ b/apps/deploy-web/src/queries/useLeaseQuery.ts
@@ -2,6 +2,7 @@ import { isHttpError, type LeaseListParams } from "@akashnetwork/http-sdk";
 import type { UseQueryOptions } from "@tanstack/react-query";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import type { AxiosInstance } from "axios";
+import mapValues from "lodash/mapValues";
 
 import { useServices } from "@src/context/ServicesProvider";
 import { useProviderCredentials } from "@src/hooks/useProviderCredentials/useProviderCredentials";
@@ -124,7 +125,7 @@ export function useLeaseStatus(
       if (!lease || !isLeaseLive(lease) || !providerCredentials.details.usable) return null;
 
       const token = await providerCredentials.ensureToken();
-      const response = await fetchProviderUrl<LeaseStatusDto>(`/lease/${lease.dseq}/${lease.gseq}/${lease.oseq}/status`, {
+      const response = await fetchProviderUrl<LeaseStatusResponse>(`/lease/${lease.dseq}/${lease.gseq}/${lease.oseq}/status`, {
         method: "GET",
         credentials: { type: "jwt", value: token }
       }).catch(error => {
@@ -134,7 +135,7 @@ export function useLeaseStatus(
         throw error;
       });
 
-      return response.data;
+      return response.data ? normalizeLeaseStatus(response.data) : null;
     },
     ...options,
     enabled: options.enabled !== false && providerCredentials.details.usable,
@@ -152,18 +153,53 @@ export const USE_LEASE_STATUS_DEPENDENCIES = {
   useProviderCredentials
 };
 
+export interface ForwardedPort {
+  host: string;
+  externalPort: number;
+  port: number;
+  available: number;
+}
+
+export interface ServiceIp {
+  IP: string;
+  ExternalPort: number;
+  Port: number;
+  Protocol: string;
+}
+
 export interface LeaseStatusDto {
-  forwarded_ports: Record<
-    string,
-    {
-      host: string;
-      externalPort: number;
-      port: number;
-      available: number;
-    }[]
-  >;
-  ips: any;
+  forwarded_ports: Record<string, ForwardedPort[]>;
+  ips: Record<string, ServiceIp[]>;
   services: Record<string, LeaseServiceStatus>;
+}
+
+/**
+ * The provider's lease status as it arrives on the wire. Go marshals a nil slice or map as JSON
+ * `null`, so a service exposing no ingress reports `uris: null`, a lease with no leased IPs reports
+ * `ips: null`, and either map can carry a `null` value for an individual service.
+ */
+export interface LeaseStatusResponse {
+  forwarded_ports: Record<string, ForwardedPort[] | null> | null;
+  ips: Record<string, ServiceIp[] | null> | null;
+  services: Record<string, LeaseServiceStatusResponse> | null;
+}
+
+export interface LeaseServiceStatusResponse extends Omit<LeaseServiceStatus, "uris"> {
+  uris: string[] | null;
+}
+
+/**
+ * Coerces the provider's nil-slice `null`s to empty arrays at the one point its JSON enters the app,
+ * so every consumer can trust a LeaseStatusDto map and its arrays to be present. Runs in the queryFn
+ * rather than in `select` so the coerced value is cached per fetch, letting React Query's structural
+ * sharing keep it referentially stable across the status refetch interval.
+ */
+export function normalizeLeaseStatus(status: LeaseStatusResponse): LeaseStatusDto {
+  return {
+    forwarded_ports: mapValues(status.forwarded_ports ?? {}, ports => ports ?? []),
+    ips: mapValues(status.ips ?? {}, ips => ips ?? []),
+    services: mapValues(status.services ?? {}, service => ({ ...service, uris: service.uris ?? [] }))
+  };
 }
 
 export interface LeaseServiceStatus {


### PR DESCRIPTION
## Why

The redesigned Details tab blanked out with `TypeError: Cannot read properties of null (reading 'map')` for any deployment whose services expose no URIs. A deployment declaring only `RANDOM_PORT` endpoints hits it every time.

Providers marshal Go nil slices as JSON `null`, so such a service arrives as `uris: null`. The endpoint converters guarded with default parameters, which only substitute for `undefined`:

```ts
export function toUriLinks(uris: string[] = []): EndpointLink[] {
  return uris.map(...)   // null.map throws
}
```

Nothing flagged the unsafe `map` because `LeaseStatusDto` claimed `uris` was always `string[]` and typed `ips` as `any`. The rest of the codebase already knew better: `DeploymentDetailHeader` writes `service.uris ?? []`, `DeploymentName` writes `(service.uris || []).map(...)`, and `DeploymentName.spec.tsx` has had a `uris: null` case for a while.

Ref CON-822

## What

Rather than widen `uris`, `forwarded_ports`, and `ips` to `| null` and add a guard at every call site, this normalizes the nulls once in the lease-status `queryFn`. `LeaseStatusDto` is now a type that is actually true instead of one that needs guarding, so no future caller can re-arm the trap.

- `normalizeLeaseStatus` coerces a nil map to `{}` and a nil slice to `[]` for all three collections. `LeaseStatusResponse` describes the wire shape (nullable) and `LeaseStatusDto` describes what consumers get (never null).
- `ForwardedPort` and `ServiceIp` are now declared once in `useLeaseQuery.ts`. `forwarded_ports` previously carried an inline duplicate of the former and `ips` was `any`.
- The three converters and `PlacementServiceRowProps` accept `| null` as defense in depth, so an un-normalized caller degrades to an empty list instead of throwing.
- Normalizing in `queryFn` rather than in `select` keeps the coerced value cached per fetch, so React Query's structural sharing holds the reference stable across the 30s status refetch. That avoids the hand-rolled referential-stability dance `omitAttestationSidecar` needs, and the caller-supplied `select` contract is unchanged.

Forwarded ports and IPs are covered on the same path as URIs, at both the map level and the per-service level. Two smaller things fall out of this:

- `Object.keys(leaseStatus.services)` in `PlacementCard` and `LeaseRow` was unguarded and would have thrown the same way on a nil services map. It can't now.
- `LeaseRow.tsx`, `DeploymentName.tsx`, and `DeploymentDetailHeader.tsx` are untouched and still compile. Their existing guards are redundant after this, but harmless, and leaving them alone keeps this diff off a component with no test coverage.

I swept the rest of the redesigned detail page for the same class of bug and found nothing else. The other provider-proxy consumers on the page (attestation evidence, TEE carve-outs) read chain data or already-guarded arrays. Chain REST goes through grpc-gateway, which emits `[]` for an empty repeated field rather than `null`, which is why this only ever bit the provider path.

### Tests

- `PlacementServiceRow.spec.tsx` renders with `uris`, `forwardedPorts`, and `ips` all null and expects the `None` placeholder. This one reproduced the reported stack trace before the fix.
- `useLeaseQuery.spec.tsx` covers the query boundary end to end plus `normalizeLeaseStatus` directly, including a nil services map and a service named `__proto__`.
- `ServiceEndpoints.spec.tsx` covers each converter with `null` and `undefined`.

### Verification

- 3321 unit tests pass across 348 files.
- `tsc --noEmit` reports the same 88 pre-existing errors before and after, with zero delta and none in the touched files.
- `eslint --quiet` is clean.
- `/deployments/[dseq]/preview` compiles under Turbopack, confirming the new type-only import across the query and component boundary is erased as expected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment details handling when endpoint data is missing or unavailable.
  * Empty URI, forwarded port, and IP collections now display consistently, including a “None” placeholder in expanded placement details.
  * Lease status data is normalized to prevent missing endpoint information from affecting the interface.

* **Tests**
  * Added coverage for null, undefined, and empty endpoint collections, including edge-case service names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->