### PR TITLE
feat(deployment): move the reclamation banner and show reclaiming badges

### DIFF
--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.spec.tsx
@@ -24,6 +24,17 @@ describe("DeploymentDetail", () => {
     expect(screen.getByText("placements")).toBeInTheDocument();
   });
 
+  it("renders the reclamation banner between the detail header and the tabs", () => {
+    setup();
+
+    const header = screen.getByText("detail-header");
+    const banner = screen.getByText("reclamation-banner");
+    const tabList = screen.getByRole("tablist");
+
+    expect(isRenderedBefore(header, banner)).toBe(true);
+    expect(isRenderedBefore(banner, tabList)).toBe(true);
+  });
+
   it("tracks a navigate_tab analytics event when switching tabs", async () => {
     const { analyticsService } = setup();
 
@@ -94,6 +105,10 @@ describe("DeploymentDetail", () => {
     expect(ManifestUpdate.mock.calls[0][0].onRedeploy).toBeUndefined();
   });
 
+  function isRenderedBefore(earlier: Element, later: Element) {
+    return Boolean(earlier.compareDocumentPosition(later) & Node.DOCUMENT_POSITION_FOLLOWING);
+  }
+
   function setup(input?: {
     deployment?: DeploymentDto | null;
     leases?: LeaseDto[] | null;
@@ -131,6 +146,8 @@ describe("DeploymentDetail", () => {
     const redeploy = vi.fn();
     const useRedeploy: typeof DEPENDENCIES.useRedeploy = () => redeploy;
 
+    const DeploymentDetailHeader = vi.fn(() => <div>detail-header</div>);
+    const ReclamationBanner = vi.fn(() => <div>reclamation-banner</div>);
     const DeploymentPlacements = vi.fn(() => <div>placements</div>);
     const DeploymentLogs = vi.fn(() => <div>logs</div>);
     const DeploymentLeaseShell = vi.fn(() => <div>shell</div>);
@@ -154,6 +171,8 @@ describe("DeploymentDetail", () => {
           useDeploymentDetail,
           useDeploymentLeaseList,
           useProviderList,
+          DeploymentDetailHeader,
+          ReclamationBanner,
           DeploymentPlacements,
           DeploymentLogs,
           DeploymentLeaseShell,

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.tsx
@@ -165,9 +165,9 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = ({ dseq, dependencies
       {deployment && isLeasesLoaded && (
         <>
           <div className={CAPPED_CONTENT}>
-            <d.ReclamationBanner leases={leases} dseq={dseq} />
-
             <d.DeploymentDetailHeader deployment={deployment} leases={leases} providers={providers || []} />
+
+            <d.ReclamationBanner leases={leases} dseq={dseq} className="mb-6" />
           </div>
 
           <Tabs value={activeTab} onValueChange={value => changeTab(value as Tab)} className="flex flex-1 flex-col">

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.spec.tsx
@@ -55,11 +55,12 @@ describe(PlacementCard.name, () => {
     expect(PlacementServiceRow).toHaveBeenCalledTimes(2);
   });
 
-  it("shows the reclamation card when the lease has been reclaimed", () => {
+  it("shows the reclamation card and no reclaiming badge when the lease has been reclaimed", () => {
     const ReclamationCard = vi.fn(() => <div>reclamation</div>);
     setup({ lease: buildLease({ state: "closed", groupState: "paused" }), leaseStatus: null, dependencies: { ReclamationCard } });
 
     expect(screen.getByText("reclamation")).toBeInTheDocument();
+    expect(screen.queryByText("Reclaiming")).not.toBeInTheDocument();
   });
 
   it("shows a reclaiming status while the lease is in the reclamation grace period", () => {

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.spec.tsx
@@ -62,6 +62,18 @@ describe(PlacementCard.name, () => {
     expect(screen.getByText("reclamation")).toBeInTheDocument();
   });
 
+  it("shows a reclaiming status while the lease is in the reclamation grace period", () => {
+    setup({ lease: buildLease({ state: "reclaiming" }) });
+
+    expect(screen.getByText("Reclaiming")).toBeInTheDocument();
+  });
+
+  it("does not show a reclaiming status for an active lease", () => {
+    setup();
+
+    expect(screen.queryByText("Reclaiming")).not.toBeInTheDocument();
+  });
+
   function buildLease(input?: { groupName?: string; state?: string; groupState?: string }) {
     return mock<LeaseDto>({
       id: "1",

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.tsx
@@ -10,11 +10,12 @@ import { getGroupTeeType } from "@src/utils/confidentialCompute";
 import { isLeaseLive } from "@src/utils/leaseUtils";
 import { roundDecimal } from "@src/utils/mathHelpers";
 import { providerDisplayName } from "@src/utils/providerUtils";
-import { isProviderReclaimed } from "@src/utils/reclamationUtils";
+import { isProviderReclaimed, isReclaiming } from "@src/utils/reclamationUtils";
 import { bytesToShrink } from "@src/utils/unitUtils";
 import { ConfidentialComputeResources } from "../../ConfidentialComputeResources";
 import { DownloadAttestationEvidence } from "../../DownloadAttestationEvidence";
 import { ReclamationCard } from "../../ReclamationCard/ReclamationCard";
+import { StatusBadge } from "../DeploymentStatusBadge";
 import type { ManifestServiceDetail } from "./placementModel";
 import { getPlacementGpuModels, getPlacementName, getProviderRegion } from "./placementModel";
 import { PlacementServiceRow } from "./PlacementServiceRow";
@@ -68,7 +69,10 @@ export const PlacementCard: FC<PlacementCardProps> = ({
     <div className="rounded-xl border bg-card">
       <div className="flex flex-col gap-6 border-b p-6 lg:flex-row lg:items-start lg:justify-between">
         <div className="space-y-4">
-          <h3 className="text-2xl font-medium tracking-tight">{name}</h3>
+          <div className="flex flex-wrap items-center gap-3">
+            <h3 className="text-2xl font-medium tracking-tight">{name}</h3>
+            {isReclaiming(lease) && <StatusBadge label="Reclaiming" tone="warning" />}
+          </div>
           {(region || providerName) && (
             <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
               {region && (

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentStatusBadge.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentStatusBadge.tsx
@@ -6,7 +6,7 @@ import type { LeaseDto } from "@src/types/deployment";
 import { isLeaseLive } from "@src/utils/leaseUtils";
 import { classifyLeaseCloseReason, getClosedLeaseLabel, isProviderReclaimed } from "@src/utils/reclamationUtils";
 
-type StatusTone = "running" | "pending" | "warning" | "closed";
+export type StatusTone = "running" | "pending" | "warning" | "closed";
 
 const STATUS_LABELS: Record<string, string> = {
   active: "Running",
@@ -66,16 +66,24 @@ function selectLeaseToReportOn(leases: LeaseDto[]): LeaseDto {
   return closedByProvider ?? leases[0];
 }
 
+export interface StatusBadgeProps {
+  label: string;
+  tone: StatusTone;
+  className?: string;
+}
+
+export const StatusBadge: FC<StatusBadgeProps> = ({ label, tone, className }) => (
+  <span className={cn("inline-flex items-center gap-2 rounded-full px-2.5 py-1 text-xs font-medium", BADGE_TONE_CLASS[tone], className)}>
+    <span className="relative flex h-2 w-2">
+      {tone === "running" && <span className={cn("absolute inline-flex h-full w-full animate-ping rounded-full opacity-75", DOT_TONE_CLASS[tone])} />}
+      <span className={cn("relative inline-flex h-2 w-2 rounded-full", DOT_TONE_CLASS[tone])} />
+    </span>
+    {label}
+  </span>
+);
+
 export const DeploymentStatusBadge: FC<DeploymentStatusBadgeProps> = ({ state, leases, className }) => {
   const { label, tone } = getDeploymentStatus(state, leases);
 
-  return (
-    <span className={cn("inline-flex items-center gap-2 rounded-full px-2.5 py-1 text-xs font-medium", BADGE_TONE_CLASS[tone], className)}>
-      <span className="relative flex h-2 w-2">
-        {tone === "running" && <span className={cn("absolute inline-flex h-full w-full animate-ping rounded-full opacity-75", DOT_TONE_CLASS[tone])} />}
-        <span className={cn("relative inline-flex h-2 w-2 rounded-full", DOT_TONE_CLASS[tone])} />
-      </span>
-      {label}
-    </span>
-  );
+  return <StatusBadge label={label} tone={tone} className={className} />;
 };

--- a/apps/deploy-web/src/components/deployments/DeploymentDetailLegacy.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetailLegacy.tsx
@@ -235,7 +235,7 @@ export const DeploymentDetailLegacy: FC<DeploymentDetailLegacyProps> = ({ dseq }
 
       {deployment && isLeasesLoaded && (
         <>
-          <ReclamationBanner leases={leases} dseq={dseq} />
+          <ReclamationBanner leases={leases} dseq={dseq} className="mt-4" />
 
           <DeploymentSubHeader deployment={deployment} leases={leases} teeTypes={declaredTeeTypes} interconnect={declaredInterconnect} />
 

--- a/apps/deploy-web/src/components/deployments/LeaseRow.tsx
+++ b/apps/deploy-web/src/components/deployments/LeaseRow.tsx
@@ -36,6 +36,7 @@ import { sshVmImages } from "@src/utils/sdl/data";
 import { CopyTextToClipboardButton } from "../shared/CopyTextToClipboardButton";
 import { ManifestErrorSnackbar } from "../shared/ManifestErrorSnackbar/ManifestErrorSnackbar";
 import { ProviderName } from "../shared/ProviderName";
+import { ReclaimingBadge } from "./ReclaimingBadge/ReclaimingBadge";
 import { ReclamationCard } from "./ReclamationCard/ReclamationCard";
 import { ConfidentialComputeResources } from "./ConfidentialComputeResources";
 import { DownloadAttestationEvidence } from "./DownloadAttestationEvidence";
@@ -181,6 +182,7 @@ export const LeaseRow = React.forwardRef<AcceptRefType, Props>(
             <div className="inline-flex items-center text-xs text-muted-foreground">
               <span aria-label={`Lease ${index} state`}>{lease.state}</span>
               <StatusPill state={lease.state} size="small" />
+              <ReclaimingBadge lease={lease} className="ml-2" />
 
               <span className="ml-6 text-muted-foreground">GSEQ:</span>
               <span className="ml-1">{lease.gseq}</span>

--- a/apps/deploy-web/src/components/deployments/ReclaimingBadge/ReclaimingBadge.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ReclaimingBadge/ReclaimingBadge.spec.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { ReclaimingBadge } from "./ReclaimingBadge";
+
+import { render, screen } from "@testing-library/react";
+
+describe(ReclaimingBadge.name, () => {
+  it("shows the reclaiming status for a lease in the reclamation grace period", () => {
+    setup({ state: "reclaiming" });
+
+    expect(screen.getByText("Reclaiming")).toBeInTheDocument();
+  });
+
+  it("renders nothing for a lease that is not reclaiming", () => {
+    setup({ state: "active" });
+
+    expect(screen.queryByText("Reclaiming")).not.toBeInTheDocument();
+  });
+
+  function setup(input: { state: string }) {
+    return render(<ReclaimingBadge lease={{ state: input.state }} />);
+  }
+});

--- a/apps/deploy-web/src/components/deployments/ReclaimingBadge/ReclaimingBadge.tsx
+++ b/apps/deploy-web/src/components/deployments/ReclaimingBadge/ReclaimingBadge.tsx
@@ -1,0 +1,22 @@
+"use client";
+import type { FC } from "react";
+import { Badge } from "@akashnetwork/ui/components";
+import { cn } from "@akashnetwork/ui/utils";
+
+import type { LeaseDto } from "@src/types/deployment";
+import { isReclaiming } from "@src/utils/reclamationUtils";
+
+type Props = {
+  lease: Pick<LeaseDto, "state">;
+  className?: string;
+};
+
+export const ReclaimingBadge: FC<Props> = ({ lease, className }) => {
+  if (!isReclaiming(lease)) return null;
+
+  return (
+    <Badge variant="outline" className={cn("whitespace-nowrap border-amber-500 text-xs text-amber-600", className)}>
+      Reclaiming
+    </Badge>
+  );
+};

--- a/apps/deploy-web/src/components/deployments/ReclamationBanner/ReclamationBanner.tsx
+++ b/apps/deploy-web/src/components/deployments/ReclamationBanner/ReclamationBanner.tsx
@@ -14,6 +14,7 @@ export const DEPENDENCIES = { useLocalNotes, useRedeploy };
 type Props = {
   leases: LeaseDto[] | undefined | null;
   dseq: string;
+  className?: string;
   dependencies?: typeof DEPENDENCIES;
 };
 
@@ -22,7 +23,7 @@ type Props = {
  * Reclamation is terminal — it can't be cancelled — so the call to action is to redeploy elsewhere
  * before the grace-period deadline. The terminal (already-closed) case is handled by ReclamationCard.
  */
-export const ReclamationBanner: React.FunctionComponent<Props> = ({ leases, dseq, dependencies = DEPENDENCIES }) => {
+export const ReclamationBanner: React.FunctionComponent<Props> = ({ leases, dseq, className, dependencies = DEPENDENCIES }) => {
   const { getDeploymentData } = dependencies.useLocalNotes();
   const redeploy = dependencies.useRedeploy();
   const deploymentData = getDeploymentData(dseq);
@@ -40,7 +41,7 @@ export const ReclamationBanner: React.FunctionComponent<Props> = ({ leases, dseq
   if (reclaimingLeases.length === 0) return null;
 
   return (
-    <Alert variant="warning" className="mt-4">
+    <Alert variant="warning" className={className}>
       <WarningTriangle className="h-4 w-4" />
       <AlertTitle>This deployment is being reclaimed</AlertTitle>
       <AlertDescription>


### PR DESCRIPTION
## Why

Two reclamation follow-ups from designer review of the redesigned deployment detail page:

- The "being reclaimed" banner renders above the page header, so the alert displaces the deployment name and status. Design wants it between the header and the tab bar.
- During the reclamation grace period nothing at placement level says so. The redesigned placement card renders no state at all and its services still read "Running", which is technically true (the workload stays up until the deadline) but hides the one thing worth knowing. The legacy page is barely better: the lease row prints the raw lowercase `reclaiming` state string. The deployment list already shows a styled amber "Reclaiming" badge, so the detail pages were the inconsistent ones.

Part of CON-821

## What

The banner move only touches the redesigned page. `ReclamationBanner` loses its hardcoded `mt-4` and takes a `className` prop instead, so each page owns the spacing: the redesigned page renders it after `DeploymentDetailHeader` with `mb-6` (the header's own `py-6` covers the top), and the legacy page passes `mt-4` to stay pixel identical. The banner still returns `null` when nothing is reclaiming, so the normal layout is unchanged.

For the per-placement status, both pages get an amber "Reclaiming" badge while `lease.state === "reclaiming"`:

- The redesigned `PlacementCard` shows a warning-tone pill next to the placement name. The pill is `StatusBadge`, extracted from `DeploymentStatusBadge` so both share one visual source; `DeploymentStatusBadge` is now a thin wrapper around it.
- The legacy `LeaseRow` renders the same outline badge the deployment list uses in `LeaseChip`, pulled into a small `ReclaimingBadge` component. This one is visible on the live page today, unlike the rest of the PR, which sits behind `deployment_detail_redesign`.

The badge and the terminal `ReclamationCard` cannot show together: `isProviderReclaimed` returns `false` while the lease state is `reclaiming`, so the card takes over exactly when the badge stops.

One deliberate non-change: `LeaseChip` keeps its inline copy of the badge instead of switching to `ReclaimingBadge`. It has no spec, and swapping it is churn in a legacy file for zero behavior change. Happy to fold it in if preferred.

Tests: a DOM-order spec pins the header, banner, tabs sequence (the page spec's stubs previously rendered nothing, so nothing guarded the position), `PlacementCard` gets reclaiming and active cases, and `ReclaimingBadge` has its own spec.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clear “Reclaiming” badges to deployment placements and lease rows when leases are being reclaimed.
  * Reclaiming indicators use warning styling for improved visibility.
* **Improvements**
  * Repositioned the reclamation banner between the deployment header and navigation tabs.
  * Improved spacing around reclamation messaging across deployment detail views.
* **Tests**
  * Added coverage to verify reclaiming badges and banner placement appear correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->