### PR TITLE
feat(billing): store the auto reload mode on the wallet setting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+apps/api/swagger/openapi.json

--- a/apps/api/.prettierignore
+++ b/apps/api/.prettierignore
@@ -1,0 +1,1 @@
+swagger/openapi.json

--- a/apps/api/drizzle/0037_adorable_quasar.sql
+++ b/apps/api/drizzle/0037_adorable_quasar.sql
@@ -1,0 +1,2 @@
+CREATE TYPE "public"."auto_reload_mode" AS ENUM('prediction', 'threshold');--> statement-breakpoint
+ALTER TABLE "wallet_settings" ADD COLUMN "auto_reload_mode" "auto_reload_mode" DEFAULT 'prediction' NOT NULL;

--- a/apps/api/drizzle/meta/0037_snapshot.json
+++ b/apps/api/drizzle/meta/0037_snapshot.json
@@ -1,0 +1,1403 @@
+{
+  "id": "98211468-1ace-4529-ad92-99a14e1fb80a",
+  "prevId": "5fd12801-28eb-47e9-93d8-4f2bc2572a38",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.user_wallets": {
+      "name": "user_wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_allowance": {
+          "name": "deployment_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "fee_allowance": {
+          "name": "fee_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "trial": {
+          "name": "trial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_wallets_user_id_userSetting_id_fk": {
+          "name": "user_wallets_user_id_userSetting_id_fk",
+          "tableFrom": "user_wallets",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_wallets_user_id_unique": {
+          "name": "user_wallets_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "user_wallets_address_unique": {
+          "name": "user_wallets_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_methods": {
+      "name": "payment_methods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_method_id": {
+          "name": "payment_method_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_validated": {
+          "name": "is_validated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payment_methods_fingerprint_payment_method_id_unique": {
+          "name": "payment_methods_fingerprint_payment_method_id_unique",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_default_unique": {
+          "name": "payment_methods_user_id_is_default_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"payment_methods\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_fingerprint_idx": {
+          "name": "payment_methods_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_idx": {
+          "name": "payment_methods_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_validated_idx": {
+          "name": "payment_methods_user_id_is_validated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_validated",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_fingerprint_payment_method_id_idx": {
+          "name": "payment_methods_user_id_fingerprint_payment_method_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_methods_user_id_userSetting_id_fk": {
+          "name": "payment_methods_user_id_userSetting_id_fk",
+          "tableFrom": "payment_methods",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_transactions": {
+      "name": "stripe_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "stripe_transaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "stripe_transaction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created'"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_refunded": {
+          "name": "amount_refunded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bonus_amount": {
+          "name": "bonus_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_charge_id": {
+          "name": "stripe_charge_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_coupon_id": {
+          "name": "stripe_coupon_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_promotion_code_id": {
+          "name": "stripe_promotion_code_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_idempotency_key": {
+          "name": "stripe_idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method_type": {
+          "name": "payment_method_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_brand": {
+          "name": "card_brand",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_last4": {
+          "name": "card_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_url": {
+          "name": "receipt_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_transactions_stripe_invoice_id_unique": {
+          "name": "stripe_transactions_stripe_invoice_id_unique",
+          "columns": [
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stripe_transactions\".\"stripe_invoice_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_idempotency_key_unique": {
+          "name": "stripe_transactions_stripe_idempotency_key_unique",
+          "columns": [
+            {
+              "expression": "stripe_idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stripe_transactions\".\"stripe_idempotency_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_user_id_idx": {
+          "name": "stripe_transactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_payment_intent_id_idx": {
+          "name": "stripe_transactions_stripe_payment_intent_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_payment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_charge_id_idx": {
+          "name": "stripe_transactions_stripe_charge_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_coupon_id_idx": {
+          "name": "stripe_transactions_stripe_coupon_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_coupon_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_promotion_code_id_idx": {
+          "name": "stripe_transactions_stripe_promotion_code_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_promotion_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_status_idx": {
+          "name": "stripe_transactions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_created_at_idx": {
+          "name": "stripe_transactions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_user_id_created_at_idx": {
+          "name": "stripe_transactions_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_transactions_user_id_userSetting_id_fk": {
+          "name": "stripe_transactions_user_id_userSetting_id_fk",
+          "tableFrom": "stripe_transactions",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_settings": {
+      "name": "wallet_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_reload_enabled": {
+          "name": "auto_reload_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_reload_mode": {
+          "name": "auto_reload_mode",
+          "type": "auto_reload_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'prediction'"
+        },
+        "auto_reload_threshold": {
+          "name": "auto_reload_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2000
+        },
+        "auto_reload_amount": {
+          "name": "auto_reload_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10000
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_settings_user_id_idx": {
+          "name": "wallet_settings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_settings_wallet_id_user_wallets_id_fk": {
+          "name": "wallet_settings_wallet_id_user_wallets_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "user_wallets",
+          "columnsFrom": [
+            "wallet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wallet_settings_user_id_userSetting_id_fk": {
+          "name": "wallet_settings_user_id_userSetting_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallet_settings_wallet_id_unique": {
+          "name": "wallet_settings_wallet_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wallet_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.userSetting": {
+      "name": "userSetting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscribedToNewsletter": {
+          "name": "subscribedToNewsletter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "youtubeUsername": {
+          "name": "youtubeUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitterUsername": {
+          "name": "twitterUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "githubUsername": {
+          "name": "githubUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_ip": {
+          "name": "last_ip",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_user_agent": {
+          "name": "last_user_agent",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fingerprint": {
+          "name": "last_fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboardingSkippedAt": {
+          "name": "onboardingSkippedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "userSetting_userId_unique": {
+          "name": "userSetting_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        },
+        "userSetting_username_unique": {
+          "name": "userSetting_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.template": {
+      "name": "template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "copiedFromId": {
+          "name": "copiedFromId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cpu": {
+          "name": "cpu",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ram": {
+          "name": "ram",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage": {
+          "name": "storage",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sdl": {
+          "name": "sdl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "template_userId_idx": {
+          "name": "template_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.templateFavorite": {
+      "name": "templateFavorite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "templateId": {
+          "name": "templateId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addedDate": {
+          "name": "addedDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "templateFavorite_userId_templateId_unique": {
+          "name": "templateFavorite_userId_templateId_unique",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "templateId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "templateFavorite_templateId_template_id_fk": {
+          "name": "templateFavorite_templateId_template_id_fk",
+          "tableFrom": "templateFavorite",
+          "tableTo": "template",
+          "columnsFrom": [
+            "templateId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_settings": {
+      "name": "deployment_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dseq": {
+          "name": "dseq",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_top_up_enabled": {
+          "name": "auto_top_up_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "closed": {
+          "name": "closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_funded_at": {
+          "name": "last_funded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "id_auto_top_up_enabled_closed_idx": {
+          "name": "id_auto_top_up_enabled_closed_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auto_top_up_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "closed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_settings_user_id_userSetting_id_fk": {
+          "name": "deployment_settings_user_id_userSetting_id_fk",
+          "tableFrom": "deployment_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dseq_user_id_idx": {
+          "name": "dseq_user_id_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "dseq",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_key": {
+          "name": "hashed_key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_format": {
+          "name": "key_format",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_user_id_userSetting_id_fk": {
+          "name": "api_keys_user_id_userSetting_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_hashed_key_unique": {
+          "name": "api_keys_hashed_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hashed_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_verification_codes": {
+      "name": "email_verification_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_verification_codes_user_id_idx": {
+          "name": "email_verification_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_verification_codes_user_id_userSetting_id_fk": {
+          "name": "email_verification_codes_user_id_userSetting_id_fk",
+          "tableFrom": "email_verification_codes",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.stripe_transaction_status": {
+      "name": "stripe_transaction_status",
+      "schema": "public",
+      "values": [
+        "created",
+        "pending",
+        "requires_action",
+        "succeeded",
+        "failed",
+        "refunded",
+        "canceled"
+      ]
+    },
+    "public.stripe_transaction_type": {
+      "name": "stripe_transaction_type",
+      "schema": "public",
+      "values": [
+        "payment_intent",
+        "coupon_claim",
+        "manual_credit"
+      ]
+    },
+    "public.auto_reload_mode": {
+      "name": "auto_reload_mode",
+      "schema": "public",
+      "values": [
+        "prediction",
+        "threshold"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -260,6 +260,13 @@
       "when": 1787086974003,
       "tag": "0036_mushy_malcolm_colcord",
       "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "7",
+      "when": 1787235760561,
+      "tag": "0037_adorable_quasar",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -20,7 +20,7 @@
     "lint": "eslint .",
     "migration:gen": "drizzle-kit generate",
     "prod": "node --permission --allow-fs-read=./dist/ --allow-fs-read=./env/ --allow-fs-read=./node_modules/ --allow-fs-read=../../node_modules/ --allow-fs-read=../../packages/env-loader/ --allow-fs-read=./drizzle/ --enable-source-maps --require ./dist/instrumentation.js ./dist/server.js",
-    "sdk:gen:swagger": "rm -rf ./swagger && npm run build:app && NOTIFICATIONS_SWAGGER_PATH=../notifications/swagger/swagger.json POSTGRES_DB_URI=postgres://localhost/unused AMPLITUDE_API_KEY=unused FEATURE_FLAGS_ENABLE_ALL=true INTERFACE=swagger-gen node dist/server.js",
+    "sdk:gen:swagger": "rm -rf ./swagger && npm run build:app && SERVER_ORIGIN=https://console-api-sandbox.akash.network NOTIFICATIONS_SWAGGER_PATH=../notifications/swagger/swagger.json POSTGRES_DB_URI=postgres://localhost/unused AMPLITUDE_API_KEY=unused FEATURE_FLAGS_ENABLE_ALL=true INTERFACE=swagger-gen node dist/server.js",
     "start": "tsup --watch",
     "start:dev": "tsup src/server.ts --watch",
     "test": "vitest run --project=unit --project=functional --project=integration",

--- a/apps/api/src/billing/http-schemas/wallet.schema.ts
+++ b/apps/api/src/billing/http-schemas/wallet.schema.ts
@@ -8,6 +8,8 @@ const AUTO_RELOAD_THRESHOLD_MIN_USD = 5;
 const AUTO_RELOAD_THRESHOLD_MAX_USD = 10_000;
 const AUTO_RELOAD_AMOUNT_MAX_USD = 10_000;
 
+const AutoReloadModeSchema = z.enum(["threshold", "prediction"]);
+
 const WalletOutputSchema = z.object({
   id: z.number().openapi({}),
   userId: z.string().openapi({}),
@@ -25,12 +27,17 @@ export const WalletListResponseOutputSchema = z.object({
 
 export const WalletSettingsOutputSchema = z.object({
   autoReloadEnabled: z.boolean().openapi({}),
+  autoReloadMode: AutoReloadModeSchema.openapi({ description: "Rule used to decide when and how much to top up." }),
   autoReloadThreshold: z.number().openapi({ description: "USD credit balance at or below which an automatic top-up is triggered." }),
   autoReloadAmount: z.number().openapi({ description: "USD amount charged to the default payment method on each automatic top-up." })
 });
 
 export const WalletSettingsInputSchema = z.object({
   autoReloadEnabled: z.boolean().openapi({}),
+  autoReloadMode: AutoReloadModeSchema.optional().openapi({
+    description:
+      "Rule used to decide when and how much to top up: `threshold` charges the fixed amount as soon as the balance reaches the threshold, `prediction` covers the next 7 days of projected spend. Left unchanged when omitted."
+  }),
   autoReloadThreshold: z
     .number()
     .min(AUTO_RELOAD_THRESHOLD_MIN_USD)
@@ -67,3 +74,4 @@ export type WalletListOutputResponse = z.infer<typeof WalletListResponseOutputSc
 export type WalletSettingsResponse = z.infer<typeof WalletSettingsResponseSchema>;
 export type CreateWalletSettingsRequest = z.infer<typeof CreateWalletSettingsRequestSchema>;
 export type UpdateWalletSettingsRequest = z.infer<typeof UpdateWalletSettingsRequestSchema>;
+export type AutoReloadMode = z.infer<typeof AutoReloadModeSchema>;

--- a/apps/api/src/billing/http-schemas/wallet.schema.ts
+++ b/apps/api/src/billing/http-schemas/wallet.schema.ts
@@ -36,7 +36,7 @@ export const WalletSettingsInputSchema = z.object({
   autoReloadEnabled: z.boolean().openapi({}),
   autoReloadMode: AutoReloadModeSchema.optional().openapi({
     description:
-      "Rule used to decide when and how much to top up: `threshold` charges the fixed amount as soon as the balance reaches the threshold, `prediction` covers the next 7 days of projected spend. Left unchanged when omitted."
+      "Rule used to decide when and how much to top up: `threshold` charges the fixed amount as soon as the balance reaches the threshold, `prediction` covers the next 7 days of projected spend. Defaults to `prediction` on create when omitted; left unchanged on update."
   }),
   autoReloadThreshold: z
     .number()

--- a/apps/api/src/billing/model-schemas/wallet-setting/wallet-setting.schema.ts
+++ b/apps/api/src/billing/model-schemas/wallet-setting/wallet-setting.schema.ts
@@ -1,8 +1,10 @@
 import { relations, sql } from "drizzle-orm";
-import { boolean, index, integer, pgTable, timestamp, unique, uuid } from "drizzle-orm/pg-core";
+import { boolean, index, integer, pgEnum, pgTable, timestamp, unique, uuid } from "drizzle-orm/pg-core";
 
 import { UserWallets } from "@src/billing/model-schemas/user-wallet/user-wallet.schema";
 import { Users } from "@src/user/model-schemas";
+
+export const autoReloadModeEnum = pgEnum("auto_reload_mode", ["prediction", "threshold"]);
 
 export const WalletSetting = pgTable(
   "wallet_settings",
@@ -18,6 +20,12 @@ export const WalletSetting = pgTable(
       .references(() => Users.id, { onDelete: "cascade" })
       .notNull(),
     autoReloadEnabled: boolean("auto_reload_enabled").default(false).notNull(),
+    /**
+     * Defaults to the predicted-spend rule so rows that predate this column keep the behavior their owner
+     * signed up for. The product default for a new enablement is "threshold" and is sent explicitly by the
+     * client, never inferred here.
+     */
+    autoReloadMode: autoReloadModeEnum("auto_reload_mode").notNull().default("prediction"),
     autoReloadThreshold: integer("auto_reload_threshold").notNull().default(2000),
     autoReloadAmount: integer("auto_reload_amount").notNull().default(10000),
     createdAt: timestamp("created_at").defaultNow(),

--- a/apps/api/src/billing/services/wallet-balance-reload-check/README.md
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/README.md
@@ -2,14 +2,14 @@
 
 ## Overview
 
-This job worker automatically tops up a user's credit balance when it drops to or below a user-configured threshold. When a user has auto top-up enabled, the handler charges their default payment method a fixed amount as soon as the balance reaches the trigger point.
+This job worker automatically tops up a user's credit balance when auto top-up is enabled. It charges the user's default payment method, and the rule it applies comes from `walletSetting.autoReloadMode` — a per-user column, not a feature flag:
 
-The algorithm is selected by the `auto_reload_fixed_threshold` feature flag:
+- **`threshold`** — fixed threshold/amount, described below. This is what the billing UI offers when a user enables auto top-up.
+- **`prediction`** — predicted-spend, described at the end. Every row created before CON-884 has this mode, so existing users keep the behavior they signed up for until they switch.
 
-- **Flag ON** — fixed threshold/amount (the algorithm described below). This is the target behavior.
-- **Flag OFF** — legacy predicted-spend algorithm (documented at the end; removed once the flag is cleaned up).
+Both modes are supported; neither is scheduled for removal. The `auto_reload_fixed_threshold` flag still exists, but only in `apps/deploy-web`, where it gates whether the mode picker is offered. The handler never reads it: background jobs run without a real Unleash user, so a flag could not express a per-user choice here anyway.
 
-## Fixed-threshold algorithm (primary)
+## Threshold mode
 
 A user configures two values on their wallet settings:
 
@@ -44,7 +44,7 @@ The check is a pure balance comparison. It fires even when the user has no activ
 Checks are **spend-event-driven**, not fixed to a daily cadence. A check is enqueued:
 
 1. When a user enables auto top-up (immediate, prefilled from the settings dialog).
-2. When a user changes their threshold or amount while enabled (immediate — backs the dialog's "top-up runs shortly after saving").
+2. When a user changes their mode, threshold, or amount while enabled (immediate — backs the dialog's "top-up runs shortly after saving").
 3. After every spending broadcast, after initial deployment funding, and after each escrow top-up cycle.
 4. On a self-rescheduled 24h job that acts only as a safety net.
 
@@ -64,7 +64,7 @@ If any validation fails, the handler logs and skips processing (does not throw).
 
 ## Payment intent
 
-The charge uses a job-scoped idempotency key (`WalletBalanceReloadCheck.<jobId>`), `confirm: true`, and `onAmountMismatch: "tolerate"`. Tolerate keeps retries safe when the computed amount differs between attempts — e.g. settings were edited or the feature flag flipped between the original charge and a retry under the reused key.
+The charge uses a job-scoped idempotency key (`WalletBalanceReloadCheck.<jobId>`), `confirm: true`, and `onAmountMismatch: "tolerate"`. Tolerate keeps retries safe when the computed amount differs between attempts — e.g. the user edited their settings or switched modes between the original charge and a retry under the reused key.
 
 ## What happens on failure?
 
@@ -76,11 +76,9 @@ The charge uses a job-scoped idempotency key (`WalletBalanceReloadCheck.<jobId>`
 
 ---
 
-## Legacy predicted-spend algorithm (behind the flag, `auto_reload_fixed_threshold` OFF)
+## Prediction mode
 
-> This section describes the pre-CON-717 behavior. It is retained only while the flag is being rolled out and is removed by the flag-cleanup follow-up.
-
-The legacy path predicts upcoming spend instead of comparing against a fixed threshold:
+This is the pre-CON-717 behavior, kept as a supported mode by CON-884. It predicts upcoming spend instead of comparing against a fixed threshold:
 
 1. **Calculate** the unfunded cost to keep all auto-top-up deployments running for the next 7 days (`RELOAD_COVERAGE_PERIOD_IN_MS`), excluding the portion already covered by escrow.
 2. **Compare** the balance against 25% of that projection (`MIN_COVERAGE_PERCENTAGE`). Reload when `balance < 0.25 * costUntilTargetDate` (~1.75 days of coverage remaining).
@@ -88,4 +86,6 @@ The legacy path predicts upcoming spend instead of comparing against a fixed thr
 4. **Skip** entirely when the projected cost is 0 (no active auto-top-up deployments).
 5. **Schedule** the next check 24 hours out.
 
-Legacy key constants: Check Interval 24h, Reload Coverage Period 7 days, Minimum Coverage Percentage 25%, Minimum Reload $20.
+Key constants: Check Interval 24h, Reload Coverage Period 7 days, Minimum Coverage Percentage 25%, Minimum Reload $20.
+
+Note that `autoReloadThreshold` and `autoReloadAmount` are ignored in this mode — the amounts are derived from projected spend. They stay on the row so that switching to threshold mode and back preserves them.

--- a/apps/api/src/billing/services/wallet-balance-reload-check/README.md
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/README.md
@@ -26,7 +26,9 @@ if (balance <= autoReloadThreshold) {
 
 The comparison is **inclusive**: a balance exactly at the threshold triggers a top-up. The `max(..., $20)` is a defensive clamp — there is no DB CHECK constraint, so the handler guarantees Stripe's minimum even if a smaller amount was somehow persisted.
 
-The check is a pure balance comparison. It fires even when the user has no active deployments, and it does not project future spend. The balance compared is the deployment-grant balance in USD (`getDeploymentBalanceInFiat`) — the same "Available Balance" shown on the billing page.
+The check is a pure balance comparison: it does not project future spend. The balance compared is the deployment-grant balance in USD (`getDeploymentBalanceInFiat`) — the same "Available Balance" shown on the billing page.
+
+One guard sits after the comparison: when the wallet owns no active deployment the charge is skipped (`no_active_deployments`), so leftover credit below the threshold never gets topped up on an idle wallet. Checks enqueued by initial deployment funding (`triggeredByDeployment`) bypass that count, because it reads the indexer-fed `Deployment` table, which lags chain state right after a lease starts.
 
 ### Worked examples (defaults: threshold $20, amount $100)
 
@@ -34,7 +36,8 @@ The check is a pure balance comparison. It fires even when the user has no activ
 | ------- | --------- | ------ | ------- |
 | $20.00  | $20       | $100   | `balance <= threshold` → **charge $100** |
 | $20.01  | $20       | $100   | `balance > threshold` → **skip** |
-| $0.00   | $20       | $100   | **charge $100** (fires with no deployments) |
+| $0.00   | $20       | $100   | **charge $100** (wallet has an active deployment) |
+| $0.00   | $20       | $100   | **skip** `no_active_deployments` (idle wallet, check not deployment-triggered) |
 | $5.00   | $20       | $15\*  | **charge $20** (clamped to the $20 minimum) |
 
 \* An amount below $20 should never persist (zod rejects it on write); the clamp is defensive only.

--- a/apps/api/src/billing/services/wallet-balance-reload-check/README.md
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/README.md
@@ -7,7 +7,7 @@ This job worker automatically tops up a user's credit balance when auto top-up i
 - **`threshold`** — fixed threshold/amount, described below. This is what the billing UI offers when a user enables auto top-up.
 - **`prediction`** — predicted-spend, described at the end. Every row created before CON-884 has this mode, so existing users keep the behavior they signed up for until they switch.
 
-Both modes are supported; neither is scheduled for removal. The `auto_reload_fixed_threshold` flag still exists and stays registered in the API for other callers, but this handler never reads it: background jobs run without a real Unleash user, so a flag could not express a per-user choice here anyway. In `apps/deploy-web` the same flag gates whether the mode picker is offered.
+Both modes are supported; neither is scheduled for removal. The `auto_reload_fixed_threshold` flag decides nothing here: background jobs run without a real Unleash user, so a flag could not express a per-user choice anyway. It has no reader left in `apps/api` and stays in the `FeatureFlags` map only because the default-deposit rollout gates on the same flag. In `apps/deploy-web` it gates whether the mode picker is offered.
 
 ## Threshold mode
 

--- a/apps/api/src/billing/services/wallet-balance-reload-check/README.md
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/README.md
@@ -7,7 +7,7 @@ This job worker automatically tops up a user's credit balance when auto top-up i
 - **`threshold`** — fixed threshold/amount, described below. This is what the billing UI offers when a user enables auto top-up.
 - **`prediction`** — predicted-spend, described at the end. Every row created before CON-884 has this mode, so existing users keep the behavior they signed up for until they switch.
 
-Both modes are supported; neither is scheduled for removal. The `auto_reload_fixed_threshold` flag still exists, but only in `apps/deploy-web`, where it gates whether the mode picker is offered. The handler never reads it: background jobs run without a real Unleash user, so a flag could not express a per-user choice here anyway.
+Both modes are supported; neither is scheduled for removal. The `auto_reload_fixed_threshold` flag still exists and stays registered in the API for other callers, but this handler never reads it: background jobs run without a real Unleash user, so a flag could not express a per-user choice here anyway. In `apps/deploy-web` the same flag gates whether the mode picker is offered.
 
 ## Threshold mode
 

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check-instrumentation.service.spec.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check-instrumentation.service.spec.ts
@@ -20,18 +20,20 @@ import { WalletBalanceReloadCheckInstrumentationService } from "./wallet-balance
 describe(WalletBalanceReloadCheckInstrumentationService.name, () => {
   describe("recordReloadFailed", () => {
     it("logs error with context when reload fails with an Error", () => {
-      const { service } = setup();
+      const { service, counters } = setup();
       const error = new TypeError(faker.lorem.sentence());
       const logContext = {
         walletAddress: faker.string.alphanumeric(44),
         balance: faker.number.float({ min: 0, max: 100 })
       };
 
-      service.recordReloadFailed(error, logContext);
+      service.recordReloadFailed({ mode: "threshold", error, logContext });
 
+      expect(counters.wallet_balance_reload_check_reload_failures_total.add).toHaveBeenCalledWith(1, { mode: "threshold", error_type: "TypeError" });
       expect(mockLogger.error).toHaveBeenCalledWith(
         expect.objectContaining({
           ...logContext,
+          mode: "threshold",
           event: "WALLET_BALANCE_RELOAD_FAILED",
           error
         })
@@ -39,18 +41,20 @@ describe(WalletBalanceReloadCheckInstrumentationService.name, () => {
     });
 
     it("logs error with context when reload fails with a non-Error", () => {
-      const { service } = setup();
+      const { service, counters } = setup();
       const error = faker.lorem.sentence();
       const logContext = {
         walletAddress: faker.string.alphanumeric(44),
         balance: faker.number.float({ min: 0, max: 100 })
       };
 
-      service.recordReloadFailed(error, logContext);
+      service.recordReloadFailed({ mode: "prediction", error, logContext });
 
+      expect(counters.wallet_balance_reload_check_reload_failures_total.add).toHaveBeenCalledWith(1, { mode: "prediction", error_type: "Unknown" });
       expect(mockLogger.error).toHaveBeenCalledWith(
         expect.objectContaining({
           ...logContext,
+          mode: "prediction",
           event: "WALLET_BALANCE_RELOAD_FAILED",
           error
         })

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check-instrumentation.service.spec.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check-instrumentation.service.spec.ts
@@ -59,35 +59,42 @@ describe(WalletBalanceReloadCheckInstrumentationService.name, () => {
   });
 
   describe("recordReloadTriggered", () => {
-    it("records the coverage ratio and projected cost on the legacy path and logs the reload", () => {
-      const { service, histograms } = setup();
+    it("records the coverage ratio and projected cost in prediction mode and logs the reload", () => {
+      const { service, histograms, counters } = setup();
       const logContext = { walletAddress: faker.string.alphanumeric(44), balance: 10 };
 
-      service.recordReloadTriggered({ amount: 40, coverageRatio: 0.2, projectedCost: 50, logContext });
+      service.recordReloadTriggered({ mode: "prediction", amount: 40, coverageRatio: 0.2, projectedCost: 50, logContext });
 
-      expect(histograms.wallet_balance_reload_check_balance_coverage_ratio.record).toHaveBeenCalledWith(0.2);
-      expect(histograms.wallet_balance_reload_check_projected_cost_usd.record).toHaveBeenCalledWith(50);
-      expect(mockLogger.info).toHaveBeenCalledWith(expect.objectContaining({ ...logContext, amount: 40, event: "WALLET_BALANCE_RELOADED" }));
+      expect(counters.wallet_balance_reload_check_reloads_triggered_total.add).toHaveBeenCalledWith(1, { mode: "prediction" });
+      expect(histograms.wallet_balance_reload_check_balance_coverage_ratio.record).toHaveBeenCalledWith(0.2, { mode: "prediction" });
+      expect(histograms.wallet_balance_reload_check_projected_cost_usd.record).toHaveBeenCalledWith(50, { mode: "prediction" });
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.objectContaining({ ...logContext, mode: "prediction", amount: 40, event: "WALLET_BALANCE_RELOADED" })
+      );
     });
 
-    it("omits the projected cost histogram on the fixed-threshold path", () => {
-      const { service, histograms } = setup();
+    it("omits the projected cost histogram in threshold mode", () => {
+      const { service, histograms, counters } = setup();
 
-      service.recordReloadTriggered({ amount: 100, coverageRatio: 0.5, logContext: { threshold: 20 } });
+      service.recordReloadTriggered({ mode: "threshold", amount: 100, coverageRatio: 0.5, logContext: { threshold: 20 } });
 
-      expect(histograms.wallet_balance_reload_check_balance_coverage_ratio.record).toHaveBeenCalledWith(0.5);
+      expect(counters.wallet_balance_reload_check_reloads_triggered_total.add).toHaveBeenCalledWith(1, { mode: "threshold" });
+      expect(histograms.wallet_balance_reload_check_balance_coverage_ratio.record).toHaveBeenCalledWith(0.5, { mode: "threshold" });
       expect(histograms.wallet_balance_reload_check_projected_cost_usd.record).not.toHaveBeenCalled();
     });
   });
 
   describe("recordReloadSkipped", () => {
-    it("increments the skipped counter with the reason and logs the skip", () => {
+    it("increments the skipped counter with the mode and reason and logs the skip", () => {
       const { service, counters } = setup();
 
-      service.recordReloadSkipped({ reason: "sufficient_balance", coverageRatio: 1.5, logContext: { threshold: 20 } });
+      service.recordReloadSkipped({ mode: "threshold", reason: "sufficient_balance", coverageRatio: 1.5, logContext: { threshold: 20 } });
 
-      expect(counters.wallet_balance_reload_check_reloads_skipped_total.add).toHaveBeenCalledWith(1, { reason: "sufficient_balance" });
-      expect(mockLogger.info).toHaveBeenCalledWith(expect.objectContaining({ threshold: 20, event: "WALLET_BALANCE_RELOAD_SKIPPED" }));
+      expect(counters.wallet_balance_reload_check_reloads_skipped_total.add).toHaveBeenCalledWith(1, {
+        mode: "threshold",
+        reason: "sufficient_balance"
+      });
+      expect(mockLogger.info).toHaveBeenCalledWith(expect.objectContaining({ threshold: 20, mode: "threshold", event: "WALLET_BALANCE_RELOAD_SKIPPED" }));
     });
   });
 

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check-instrumentation.service.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check-instrumentation.service.ts
@@ -2,9 +2,11 @@ import { createOtelLogger } from "@akashnetwork/logging/otel";
 import type { Counter, Histogram, Meter } from "@opentelemetry/api";
 import { singleton } from "tsyringe";
 
+import type { WalletSettingOutput } from "@src/billing/repositories";
 import { MetricsService } from "@src/core";
 
 type ReloadMetricInput = {
+  mode: WalletSettingOutput["autoReloadMode"];
   coverageRatio?: number;
   projectedCost?: number;
   logContext: Record<string, unknown>;
@@ -59,11 +61,11 @@ export class WalletBalanceReloadCheckInstrumentationService {
 
     this.balanceCoverageRatio = this.metricsService.createHistogram(this.meter, "wallet_balance_reload_check_balance_coverage_ratio", {
       description:
-        "Ratio of current balance to the reload trigger point (balance / threshold on the fixed-threshold path, balance / costUntilTargetDate on the legacy path)"
+        "Ratio of current balance to the reload trigger point (balance / threshold in threshold mode, balance / costUntilTargetDate in prediction mode)"
     });
 
     this.projectedCost = this.metricsService.createHistogram(this.meter, "wallet_balance_reload_check_projected_cost_usd", {
-      description: "Projected deployment cost until target date in USD (legacy predicted-spend path only)",
+      description: "Projected deployment cost until target date in USD (prediction mode only)",
       unit: "USD"
     });
   }
@@ -84,10 +86,13 @@ export class WalletBalanceReloadCheckInstrumentationService {
   }
 
   recordReloadTriggered(input: ReloadMetricInput & { amount: number }): void {
-    this.reloadsTriggered.add(1);
+    this.reloadsTriggered.add(1, {
+      mode: input.mode
+    });
     this.#recordCoverage(input);
     this.logger.info({
       ...input.logContext,
+      mode: input.mode,
       amount: input.amount,
       event: "WALLET_BALANCE_RELOADED"
     });
@@ -95,21 +100,23 @@ export class WalletBalanceReloadCheckInstrumentationService {
 
   recordReloadSkipped(input: ReloadMetricInput & { reason: "zero_cost" | "sufficient_balance" | "no_active_deployments" }): void {
     this.reloadsSkipped.add(1, {
+      mode: input.mode,
       reason: input.reason
     });
     this.#recordCoverage(input);
     this.logger.info({
       ...input.logContext,
+      mode: input.mode,
       event: "WALLET_BALANCE_RELOAD_SKIPPED"
     });
   }
 
   #recordCoverage(input: ReloadMetricInput): void {
     if (input.coverageRatio !== undefined) {
-      this.balanceCoverageRatio.record(input.coverageRatio);
+      this.balanceCoverageRatio.record(input.coverageRatio, { mode: input.mode });
     }
     if (input.projectedCost !== undefined) {
-      this.projectedCost.record(input.projectedCost);
+      this.projectedCost.record(input.projectedCost, { mode: input.mode });
     }
   }
 

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check-instrumentation.service.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check-instrumentation.service.ts
@@ -120,14 +120,16 @@ export class WalletBalanceReloadCheckInstrumentationService {
     }
   }
 
-  recordReloadFailed(error: unknown, logContext: Record<string, unknown>): void {
+  recordReloadFailed(input: Pick<ReloadMetricInput, "mode" | "logContext"> & { error: unknown }): void {
     this.reloadFailures.add(1, {
-      error_type: error instanceof Error ? error.constructor.name : "Unknown"
+      mode: input.mode,
+      error_type: input.error instanceof Error ? input.error.constructor.name : "Unknown"
     });
     this.logger.error({
-      ...logContext,
+      ...input.logContext,
+      mode: input.mode,
       event: "WALLET_BALANCE_RELOAD_FAILED",
-      error: error
+      error: input.error
     });
   }
 

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.spec.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.spec.ts
@@ -11,7 +11,6 @@ import type { PaymentMethodService } from "@src/billing/services/payment-method/
 import type { StripeTransactionService } from "@src/billing/services/stripe-transaction/stripe-transaction.service";
 import type { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
 import type { JobMeta } from "@src/core";
-import type { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
 import type { DeploymentRepository } from "@src/deployment/repositories/deployment/deployment.repository";
 import type { DrainingDeploymentService } from "@src/deployment/services/draining-deployment/draining-deployment.service";
 import type { JobPayload } from "../../../core";
@@ -79,6 +78,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       });
       expect(instrumentationService.recordReloadTriggered).toHaveBeenCalledWith(
         expect.objectContaining({
+          mode: "prediction",
           amount: expectedReloadAmount,
           projectedCost: costUntilTargetDateInFiat,
           logContext: expect.objectContaining({
@@ -353,10 +353,10 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
     });
   });
 
-  describe("when the fixed-threshold flag is enabled", () => {
+  describe("when the wallet setting is in threshold mode", () => {
     it("charges the configured amount when balance is at or below the threshold", async () => {
       const { handler, stripeTransactionService, drainingDeploymentService, instrumentationService, job, jobMeta } = setup({
-        fixedThresholdEnabled: true,
+        autoReloadMode: "threshold",
         balance: 10,
         autoReloadThresholdUsd: 20,
         autoReloadAmountUsd: 100
@@ -377,6 +377,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       expect(drainingDeploymentService.calculateAllDeploymentCostUntilDate).not.toHaveBeenCalled();
       expect(instrumentationService.recordReloadTriggered).toHaveBeenCalledWith(
         expect.objectContaining({
+          mode: "threshold",
           amount: 100,
           logContext: expect.objectContaining({ balance: 10, threshold: 20, reloadAmount: 100 })
         })
@@ -385,7 +386,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
 
     it("charges when balance equals the threshold", async () => {
       const { handler, stripeTransactionService, job, jobMeta } = setup({
-        fixedThresholdEnabled: true,
+        autoReloadMode: "threshold",
         balance: 20,
         autoReloadThresholdUsd: 20,
         autoReloadAmountUsd: 100
@@ -398,7 +399,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
 
     it("skips when balance is above the threshold", async () => {
       const { handler, stripeTransactionService, instrumentationService, job, jobMeta } = setup({
-        fixedThresholdEnabled: true,
+        autoReloadMode: "threshold",
         balance: 20.01,
         autoReloadThresholdUsd: 20,
         autoReloadAmountUsd: 100
@@ -409,6 +410,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       expect(stripeTransactionService.createPaymentIntent).not.toHaveBeenCalled();
       expect(instrumentationService.recordReloadSkipped).toHaveBeenCalledWith(
         expect.objectContaining({
+          mode: "threshold",
           reason: "sufficient_balance",
           logContext: expect.objectContaining({ balance: 20.01, threshold: 20 })
         })
@@ -417,7 +419,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
 
     it("skips the reload when there are no active deployments", async () => {
       const { handler, stripeTransactionService, instrumentationService, job, jobMeta } = setup({
-        fixedThresholdEnabled: true,
+        autoReloadMode: "threshold",
         balance: 0,
         autoReloadThresholdUsd: 20,
         autoReloadAmountUsd: 100,
@@ -437,7 +439,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
 
     it("charges on a deployment-triggered check without consulting the active-deployment count", async () => {
       const { handler, stripeTransactionService, deploymentRepository, job, jobMeta } = setup({
-        fixedThresholdEnabled: true,
+        autoReloadMode: "threshold",
         balance: 0,
         autoReloadThresholdUsd: 20,
         autoReloadAmountUsd: 100,
@@ -453,7 +455,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
 
     it("charges when at or below the threshold and there is at least one active deployment", async () => {
       const { handler, stripeTransactionService, deploymentRepository, wallet, job, jobMeta } = setup({
-        fixedThresholdEnabled: true,
+        autoReloadMode: "threshold",
         balance: 10,
         autoReloadThresholdUsd: 20,
         autoReloadAmountUsd: 100,
@@ -468,7 +470,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
 
     it("clamps the charge to the $20 minimum when the stored amount is below it", async () => {
       const { handler, stripeTransactionService, job, jobMeta } = setup({
-        fixedThresholdEnabled: true,
+        autoReloadMode: "threshold",
         balance: 5,
         autoReloadThresholdUsd: 20,
         autoReloadAmountUsd: 15
@@ -482,7 +484,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
     it("records the failure and rethrows when the payment intent fails", async () => {
       const error = new Error("Payment failed");
       const { handler, stripeTransactionService, instrumentationService, job, jobMeta } = setup({
-        fixedThresholdEnabled: true,
+        autoReloadMode: "threshold",
         balance: 10,
         autoReloadThresholdUsd: 20,
         autoReloadAmountUsd: 100
@@ -507,7 +509,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
     autoReloadEnabled?: boolean;
     autoReloadThresholdUsd?: number;
     autoReloadAmountUsd?: number;
-    fixedThresholdEnabled?: boolean;
+    autoReloadMode?: "prediction" | "threshold";
     activeDeploymentCount?: number;
     triggeredByDeployment?: boolean;
     user?: ReturnType<typeof createUser>;
@@ -527,6 +529,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       userId: user.id,
       walletId: wallet.id,
       autoReloadEnabled: input?.autoReloadEnabled ?? true,
+      autoReloadMode: input?.autoReloadMode ?? "prediction",
       ...(input?.autoReloadThresholdUsd !== undefined && { autoReloadThreshold: usdToCents(input.autoReloadThresholdUsd) }),
       ...(input?.autoReloadAmountUsd !== undefined && { autoReloadAmount: usdToCents(input.autoReloadAmountUsd) })
     });
@@ -564,9 +567,6 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       recordValidationError: vi.fn(),
       recordSchedulingError: vi.fn()
     });
-    const featureFlagsService = mock<FeatureFlagsService>();
-    featureFlagsService.isEnabled.mockReturnValue(input?.fixedThresholdEnabled ?? false);
-
     const balance = input?.balance ?? 50.0;
     const weeklyCostInDenom = input?.weeklyCostInDenom ?? 50_000_000;
     const weeklyCostInFiat = input?.weeklyCostInFiat ?? 50.0;
@@ -595,8 +595,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       stripeTransactionService,
       drainingDeploymentService,
       deploymentRepository,
-      instrumentationService,
-      featureFlagsService
+      instrumentationService
     );
 
     return {
@@ -609,7 +608,6 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       paymentMethodService,
       stripeTransactionService,
       instrumentationService,
-      featureFlagsService,
       walletSetting,
       walletSettingWithWallet,
       wallet,

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.spec.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.spec.ts
@@ -230,14 +230,15 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
 
       await expect(handler.handle(job, jobMeta)).rejects.toThrow(error);
 
-      expect(instrumentationService.recordReloadFailed).toHaveBeenCalledWith(
+      expect(instrumentationService.recordReloadFailed).toHaveBeenCalledWith({
+        mode: "prediction",
         error,
-        expect.objectContaining({
+        logContext: expect.objectContaining({
           walletAddress: expect.any(String),
           balance,
           costUntilTargetDateInFiat
         })
-      );
+      });
     });
 
     it("logs error and throws when scheduling next check fails", async () => {
@@ -493,10 +494,11 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
 
       await expect(handler.handle(job, jobMeta)).rejects.toThrow(error);
 
-      expect(instrumentationService.recordReloadFailed).toHaveBeenCalledWith(
+      expect(instrumentationService.recordReloadFailed).toHaveBeenCalledWith({
+        mode: "threshold",
         error,
-        expect.objectContaining({ walletAddress: expect.any(String), balance: 10, threshold: 20, reloadAmount: 100 })
-      );
+        logContext: expect.objectContaining({ walletAddress: expect.any(String), balance: 10, threshold: 20, reloadAmount: 100 })
+      });
     });
   });
 

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.ts
@@ -218,7 +218,7 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
       });
       this.instrumentationService.recordReloadTriggered({ mode, amount: reloadAmount, coverageRatio, logContext: log });
     } catch (error) {
-      this.instrumentationService.recordReloadFailed(error, log);
+      this.instrumentationService.recordReloadFailed({ mode, error, logContext: log });
       throw error;
     }
   }
@@ -274,7 +274,7 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
         logContext: log
       });
     } catch (error) {
-      this.instrumentationService.recordReloadFailed(error, log);
+      this.instrumentationService.recordReloadFailed({ mode, error, logContext: log });
       throw error;
     }
   }

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.ts
@@ -13,8 +13,6 @@ import { type PaymentMethod, PaymentMethodService } from "@src/billing/services/
 import { AUTO_RECHARGE_METADATA_KEY, StripeTransactionService } from "@src/billing/services/stripe-transaction/stripe-transaction.service";
 import { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
 import { JobHandler, JobMeta, JobPayload } from "@src/core";
-import { FeatureFlags } from "@src/core/services/feature-flags/feature-flags";
-import { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
 import type { Require } from "@src/core/types/require.type";
 import { DeploymentRepository } from "@src/deployment/repositories/deployment/deployment.repository";
 import { DrainingDeploymentService } from "@src/deployment/services/draining-deployment/draining-deployment.service";
@@ -27,7 +25,7 @@ type ValidationError = {
 };
 
 type InitializedWallet = Require<Pick<UserWalletOutput, "address">, "address">;
-type ActionableWalletSetting = Pick<WalletSettingOutput, "id" | "userId" | "autoReloadThreshold" | "autoReloadAmount">;
+type ActionableWalletSetting = Pick<WalletSettingOutput, "id" | "userId" | "autoReloadMode" | "autoReloadThreshold" | "autoReloadAmount">;
 
 type Resources = {
   walletSetting: ActionableWalletSetting;
@@ -63,8 +61,7 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
     private readonly stripeTransactionService: StripeTransactionService,
     private readonly drainingDeploymentService: DrainingDeploymentService,
     private readonly deploymentRepository: DeploymentRepository,
-    private readonly instrumentationService: WalletBalanceReloadCheckInstrumentationService,
-    private readonly featureFlagsService: FeatureFlagsService
+    private readonly instrumentationService: WalletBalanceReloadCheckInstrumentationService
   ) {}
 
   async handle(payload: JobPayload<WalletBalanceReloadCheck>, job: JobMeta): Promise<void> {
@@ -175,7 +172,7 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
   }
 
   async #tryToReload(resources: ReloadContext): Promise<void> {
-    if (this.featureFlagsService.isEnabled(FeatureFlags.AUTO_RELOAD_FIXED_THRESHOLD)) {
+    if (resources.walletSetting.autoReloadMode === "threshold") {
       return this.#tryToReloadOnFixedThreshold(resources);
     }
 
@@ -184,6 +181,7 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
 
   async #tryToReloadOnFixedThreshold(resources: ReloadContext): Promise<void> {
     const { balance } = resources;
+    const mode = resources.walletSetting.autoReloadMode;
     const threshold = centsToUsd(resources.walletSetting.autoReloadThreshold);
     const reloadAmount = Math.max(centsToUsd(resources.walletSetting.autoReloadAmount), STANDARD_TOP_UP_MIN_AMOUNT_USD);
     const log = {
@@ -195,14 +193,14 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
     const coverageRatio = threshold > 0 ? balance / threshold : undefined;
 
     if (balance > threshold) {
-      this.instrumentationService.recordReloadSkipped({ reason: "sufficient_balance", coverageRatio, logContext: log });
+      this.instrumentationService.recordReloadSkipped({ mode, reason: "sufficient_balance", coverageRatio, logContext: log });
       return;
     }
 
     if (!resources.triggeredByDeployment) {
       const activeDeploymentCount = await this.deploymentRepository.countActiveByOwner(resources.wallet.address);
       if (activeDeploymentCount === 0) {
-        this.instrumentationService.recordReloadSkipped({ reason: "no_active_deployments", coverageRatio, logContext: log });
+        this.instrumentationService.recordReloadSkipped({ mode, reason: "no_active_deployments", coverageRatio, logContext: log });
         return;
       }
     }
@@ -218,7 +216,7 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
         idempotencyKey: `${WalletBalanceReloadCheck.name}.${resources.job.id}`,
         onAmountMismatch: "tolerate"
       });
-      this.instrumentationService.recordReloadTriggered({ amount: reloadAmount, coverageRatio, logContext: log });
+      this.instrumentationService.recordReloadTriggered({ mode, amount: reloadAmount, coverageRatio, logContext: log });
     } catch (error) {
       this.instrumentationService.recordReloadFailed(error, log);
       throw error;
@@ -226,6 +224,7 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
   }
 
   async #tryToReloadOnPredictedSpend(resources: ReloadContext): Promise<void> {
+    const mode = resources.walletSetting.autoReloadMode;
     const reloadTargetDate = addMilliseconds(new Date(), this.#RELOAD_COVERAGE_PERIOD_IN_MS);
     const costUntilTargetDateInDenom = await this.drainingDeploymentService.calculateAllDeploymentCostUntilDate(resources.wallet.address, reloadTargetDate);
     const costUntilTargetDateInFiat = await this.balancesService.toFiatAmount(costUntilTargetDateInDenom);
@@ -239,12 +238,13 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
     const coverageRatio = costUntilTargetDateInFiat > 0 ? resources.balance / costUntilTargetDateInFiat : undefined;
 
     if (costUntilTargetDateInFiat === 0) {
-      this.instrumentationService.recordReloadSkipped({ reason: "zero_cost", coverageRatio, projectedCost: costUntilTargetDateInFiat, logContext: log });
+      this.instrumentationService.recordReloadSkipped({ mode, reason: "zero_cost", coverageRatio, projectedCost: costUntilTargetDateInFiat, logContext: log });
       return;
     }
 
     if (resources.balance >= threshold) {
       this.instrumentationService.recordReloadSkipped({
+        mode,
         reason: "sufficient_balance",
         coverageRatio,
         projectedCost: costUntilTargetDateInFiat,
@@ -267,6 +267,7 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
         onAmountMismatch: "tolerate"
       });
       this.instrumentationService.recordReloadTriggered({
+        mode,
         amount: reloadAmountInFiat,
         coverageRatio,
         projectedCost: costUntilTargetDateInFiat,

--- a/apps/api/src/billing/services/wallet-settings/wallet-settings.service.integration.ts
+++ b/apps/api/src/billing/services/wallet-settings/wallet-settings.service.integration.ts
@@ -175,6 +175,52 @@ describe(WalletSettingService.name, () => {
       expect(walletReloadJobService.scheduleForWalletSetting).not.toHaveBeenCalled();
     });
 
+    it("stores the requested mode on create", async () => {
+      const { user, userWallet, walletSettingRepository, walletReloadJobService, jobId, service } = setup();
+      const newSetting = generateWalletSetting({ userId: user.id, walletId: userWallet.id, autoReloadEnabled: true, autoReloadMode: "threshold" });
+      walletSettingRepository.findByUserId.mockResolvedValue(undefined);
+      walletSettingRepository.create.mockResolvedValue(newSetting);
+      walletReloadJobService.scheduleForWalletSetting.mockResolvedValue(jobId);
+
+      const result = await service.upsertWalletSetting(user.id, { autoReloadEnabled: true, autoReloadMode: "threshold", autoReloadThreshold: 20 });
+
+      expect(walletSettingRepository.create).toHaveBeenCalledWith({
+        userId: user.id,
+        walletId: userWallet.id,
+        autoReloadEnabled: true,
+        autoReloadMode: "threshold",
+        autoReloadThreshold: 2000
+      });
+      expect(result.autoReloadMode).toBe("threshold");
+    });
+
+    it("leaves the stored mode untouched when the update omits it", async () => {
+      const { user, walletSetting, walletSettingRepository, service } = setup();
+      const predictionSetting = { ...walletSetting, autoReloadEnabled: false, autoReloadMode: "prediction" as const };
+      walletSettingRepository.findByUserId.mockResolvedValue(predictionSetting);
+      walletSettingRepository.updateById.mockResolvedValue({ ...predictionSetting, autoReloadEnabled: true } as any);
+
+      const result = await service.upsertWalletSetting(user.id, { autoReloadEnabled: true });
+
+      expect(walletSettingRepository.updateById).toHaveBeenCalledWith(predictionSetting.id, { autoReloadEnabled: true }, { returning: true });
+      expect(result.autoReloadMode).toBe("prediction");
+    });
+
+    it("schedules an immediate check when the mode changes while enabled", async () => {
+      const { user, walletSetting, walletSettingRepository, walletReloadJobService, jobId, service } = setup();
+      const enabledPrev = { ...walletSetting, autoReloadEnabled: true, autoReloadMode: "prediction" as const };
+      const updated = { ...enabledPrev, autoReloadMode: "threshold" as const };
+      walletSettingRepository.findByUserId.mockResolvedValue(enabledPrev);
+      walletSettingRepository.updateById.mockResolvedValue(updated as any);
+      walletReloadJobService.scheduleForWalletSetting.mockResolvedValue(jobId);
+
+      await service.upsertWalletSetting(user.id, { autoReloadMode: "threshold" });
+
+      expect(walletReloadJobService.scheduleForWalletSetting).toHaveBeenCalledWith(expect.objectContaining({ id: updated.id, userId: user.id }), {
+        withCleanup: true
+      });
+    });
+
     it("persists reload amounts as integer cents and returns them in dollars", async () => {
       const { user, walletSetting, walletSettingRepository, walletReloadJobService, jobId, service } = setup();
       const existingSetting = { ...walletSetting, autoReloadEnabled: true };

--- a/apps/api/src/billing/services/wallet-settings/wallet-settings.service.ts
+++ b/apps/api/src/billing/services/wallet-settings/wallet-settings.service.ts
@@ -13,6 +13,7 @@ import { UserOutput, UserRepository } from "@src/user/repositories";
 
 export interface WalletSettingInput {
   autoReloadEnabled?: boolean;
+  autoReloadMode?: WalletSettingOutput["autoReloadMode"];
   autoReloadThreshold?: number;
   autoReloadAmount?: number;
 }
@@ -141,13 +142,15 @@ export class WalletSettingService {
       return;
     }
 
-    if (this.#hasReloadValuesChanged(prev, next)) {
+    if (this.#hasReloadRuleChanged(prev, next)) {
       await this.walletReloadJobService.scheduleForWalletSetting(next, { withCleanup: true });
     }
   }
 
-  #hasReloadValuesChanged(prev: WalletSettingOutput, next: WalletSettingOutput) {
-    return prev.autoReloadThreshold !== next.autoReloadThreshold || prev.autoReloadAmount !== next.autoReloadAmount;
+  #hasReloadRuleChanged(prev: WalletSettingOutput, next: WalletSettingOutput) {
+    return (
+      prev.autoReloadMode !== next.autoReloadMode || prev.autoReloadThreshold !== next.autoReloadThreshold || prev.autoReloadAmount !== next.autoReloadAmount
+    );
   }
 
   #toStoredSettings(settings: WalletSettingInput): WalletSettingInput {

--- a/apps/api/src/core/services/feature-flags/feature-flags.ts
+++ b/apps/api/src/core/services/feature-flags/feature-flags.ts
@@ -2,7 +2,6 @@ export const FeatureFlags = {
   NOTIFICATIONS_ALERT_CREATE: "notifications_general_alerts_create",
   NOTIFICATIONS_ALERT_UPDATE: "notifications_general_alerts_update",
   AUTO_CREDIT_RELOAD: "auto_credit_reload",
-  AUTO_RELOAD_FIXED_THRESHOLD: "auto_reload_fixed_threshold",
   TRIAL_FINGERPRINT_CHECK: "trial_fingerprint_check"
 } as const;
 

--- a/apps/api/src/core/services/feature-flags/feature-flags.ts
+++ b/apps/api/src/core/services/feature-flags/feature-flags.ts
@@ -2,6 +2,7 @@ export const FeatureFlags = {
   NOTIFICATIONS_ALERT_CREATE: "notifications_general_alerts_create",
   NOTIFICATIONS_ALERT_UPDATE: "notifications_general_alerts_update",
   AUTO_CREDIT_RELOAD: "auto_credit_reload",
+  AUTO_RELOAD_FIXED_THRESHOLD: "auto_reload_fixed_threshold",
   TRIAL_FINGERPRINT_CHECK: "trial_fingerprint_check"
 } as const;
 

--- a/apps/api/src/swagger-gen-app.ts
+++ b/apps/api/src/swagger-gen-app.ts
@@ -18,7 +18,7 @@ export async function bootstrap() {
 
     logger.info({ event: "OPENAPI_SPEC_WRITING", path: OUT });
     await mkdir(dirname(OUT), { recursive: true });
-    await writeFile(OUT, JSON.stringify(docs, null, 2), "utf8");
+    await writeFile(OUT, `${JSON.stringify(docs, null, 2)}\n`, "utf8");
     logger.info({ event: "OPENAPI_SPEC_WRITTEN", path: OUT });
 
     process.exit(0);

--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "servers": [
     {
-      "url": "http://localhost:3080"
+      "url": "https://console-api-sandbox.akash.network"
     }
   ],
   "info": {

--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -14,7 +14,9 @@
     "/v1/wallets": {
       "get": {
         "summary": "Get a list of wallets",
-        "tags": ["Wallet"],
+        "tags": [
+          "Wallet"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -74,11 +76,22 @@
                             "type": "string"
                           }
                         },
-                        "required": ["id", "userId", "creditAmount", "address", "denom", "isTrialing", "topUpMinAmountUsd", "createdAt"]
+                        "required": [
+                          "id",
+                          "userId",
+                          "creditAmount",
+                          "address",
+                          "denom",
+                          "isTrialing",
+                          "topUpMinAmountUsd",
+                          "createdAt"
+                        ]
                       }
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -91,7 +104,9 @@
         "summary": "Get wallet settings",
         "operationId": "getWalletSettings",
         "description": "Retrieves the wallet settings for the current user's wallet",
-        "tags": ["WalletSetting"],
+        "tags": [
+          "WalletSetting"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -116,7 +131,10 @@
                         },
                         "autoReloadMode": {
                           "type": "string",
-                          "enum": ["threshold", "prediction"],
+                          "enum": [
+                            "threshold",
+                            "prediction"
+                          ],
                           "description": "Rule used to decide when and how much to top up."
                         },
                         "autoReloadThreshold": {
@@ -128,10 +146,17 @@
                           "description": "USD amount charged to the default payment method on each automatic top-up."
                         }
                       },
-                      "required": ["autoReloadEnabled", "autoReloadMode", "autoReloadThreshold", "autoReloadAmount"]
+                      "required": [
+                        "autoReloadEnabled",
+                        "autoReloadMode",
+                        "autoReloadThreshold",
+                        "autoReloadAmount"
+                      ]
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -145,7 +170,9 @@
         "summary": "Create wallet settings",
         "operationId": "createWalletSettings",
         "description": "Creates wallet settings for a user wallet",
-        "tags": ["WalletSetting"],
+        "tags": [
+          "WalletSetting"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -168,7 +195,10 @@
                       },
                       "autoReloadMode": {
                         "type": "string",
-                        "enum": ["threshold", "prediction"],
+                        "enum": [
+                          "threshold",
+                          "prediction"
+                        ],
                         "description": "Rule used to decide when and how much to top up: `threshold` charges the fixed amount as soon as the balance reaches the threshold, `prediction` covers the next 7 days of projected spend. Left unchanged when omitted."
                       },
                       "autoReloadThreshold": {
@@ -184,10 +214,14 @@
                         "description": "USD amount charged on each automatic top-up (minimum 20, maximum 10000). Defaults are applied on create when omitted."
                       }
                     },
-                    "required": ["autoReloadEnabled"]
+                    "required": [
+                      "autoReloadEnabled"
+                    ]
                   }
                 },
-                "required": ["data"]
+                "required": [
+                  "data"
+                ]
               }
             }
           }
@@ -208,7 +242,10 @@
                         },
                         "autoReloadMode": {
                           "type": "string",
-                          "enum": ["threshold", "prediction"],
+                          "enum": [
+                            "threshold",
+                            "prediction"
+                          ],
                           "description": "Rule used to decide when and how much to top up."
                         },
                         "autoReloadThreshold": {
@@ -220,10 +257,17 @@
                           "description": "USD amount charged to the default payment method on each automatic top-up."
                         }
                       },
-                      "required": ["autoReloadEnabled", "autoReloadMode", "autoReloadThreshold", "autoReloadAmount"]
+                      "required": [
+                        "autoReloadEnabled",
+                        "autoReloadMode",
+                        "autoReloadThreshold",
+                        "autoReloadAmount"
+                      ]
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -237,7 +281,9 @@
         "summary": "Update wallet settings",
         "operationId": "updateWalletSettings",
         "description": "Updates wallet settings for a user wallet",
-        "tags": ["WalletSetting"],
+        "tags": [
+          "WalletSetting"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -260,7 +306,10 @@
                       },
                       "autoReloadMode": {
                         "type": "string",
-                        "enum": ["threshold", "prediction"],
+                        "enum": [
+                          "threshold",
+                          "prediction"
+                        ],
                         "description": "Rule used to decide when and how much to top up: `threshold` charges the fixed amount as soon as the balance reaches the threshold, `prediction` covers the next 7 days of projected spend. Left unchanged when omitted."
                       },
                       "autoReloadThreshold": {
@@ -276,10 +325,14 @@
                         "description": "USD amount charged on each automatic top-up (minimum 20, maximum 10000). Defaults are applied on create when omitted."
                       }
                     },
-                    "required": ["autoReloadEnabled"]
+                    "required": [
+                      "autoReloadEnabled"
+                    ]
                   }
                 },
-                "required": ["data"]
+                "required": [
+                  "data"
+                ]
               }
             }
           }
@@ -300,7 +353,10 @@
                         },
                         "autoReloadMode": {
                           "type": "string",
-                          "enum": ["threshold", "prediction"],
+                          "enum": [
+                            "threshold",
+                            "prediction"
+                          ],
                           "description": "Rule used to decide when and how much to top up."
                         },
                         "autoReloadThreshold": {
@@ -312,10 +368,17 @@
                           "description": "USD amount charged to the default payment method on each automatic top-up."
                         }
                       },
-                      "required": ["autoReloadEnabled", "autoReloadMode", "autoReloadThreshold", "autoReloadAmount"]
+                      "required": [
+                        "autoReloadEnabled",
+                        "autoReloadMode",
+                        "autoReloadThreshold",
+                        "autoReloadAmount"
+                      ]
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -329,7 +392,9 @@
         "summary": "Delete wallet settings",
         "operationId": "deleteWalletSettings",
         "description": "Deletes wallet settings for a user wallet",
-        "tags": ["WalletSetting"],
+        "tags": [
+          "WalletSetting"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -351,7 +416,9 @@
     "/v1/tx": {
       "post": {
         "summary": "Signs a transaction via a user managed wallet",
-        "tags": ["Wallet"],
+        "tags": [
+          "Wallet"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -392,15 +459,23 @@
                               "type": "string"
                             }
                           },
-                          "required": ["typeUrl", "value"]
+                          "required": [
+                            "typeUrl",
+                            "value"
+                          ]
                         },
                         "minItems": 1
                       }
                     },
-                    "required": ["userId", "messages"]
+                    "required": [
+                      "userId",
+                      "messages"
+                    ]
                   }
                 },
-                "required": ["data"]
+                "required": [
+                  "data"
+                ]
               }
             }
           }
@@ -426,10 +501,16 @@
                           "type": "string"
                         }
                       },
-                      "required": ["code", "transactionHash", "rawLog"]
+                      "required": [
+                        "code",
+                        "transactionHash",
+                        "rawLog"
+                      ]
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -440,7 +521,9 @@
     "/v1/stripe-webhook": {
       "post": {
         "summary": "Stripe Webhook Handler",
-        "tags": ["Payment"],
+        "tags": [
+          "Payment"
+        ],
         "security": [],
         "requestBody": {
           "content": {
@@ -467,7 +550,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["error"]
+                  "required": [
+                    "error"
+                  ]
                 }
               }
             }
@@ -480,7 +565,9 @@
         "operationId": "listStripePrices",
         "summary": "Get available Stripe pricing options",
         "description": "Retrieves the list of available pricing options for wallet top-ups, including custom amounts and standard pricing tiers",
-        "tags": ["Payment"],
+        "tags": [
+          "Payment"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -512,11 +599,17 @@
                             "type": "boolean"
                           }
                         },
-                        "required": ["currency", "unitAmount", "isCustom"]
+                        "required": [
+                          "currency",
+                          "unitAmount",
+                          "isCustom"
+                        ]
                       }
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -528,7 +621,9 @@
       "post": {
         "operationId": "applyStripeCoupon",
         "summary": "Apply a coupon to the current user",
-        "tags": ["Payment"],
+        "tags": [
+          "Payment"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -556,10 +651,15 @@
                         "type": "boolean"
                       }
                     },
-                    "required": ["couponId", "userId"]
+                    "required": [
+                      "couponId",
+                      "userId"
+                    ]
                   }
                 },
-                "required": ["data"]
+                "required": [
+                  "data"
+                ]
               }
             }
           }
@@ -603,7 +703,9 @@
                               "nullable": true
                             }
                           },
-                          "required": ["id"]
+                          "required": [
+                            "id"
+                          ]
                         },
                         "amountAdded": {
                           "type": "number"
@@ -613,7 +715,15 @@
                         },
                         "transactionStatus": {
                           "type": "string",
-                          "enum": ["created", "pending", "requires_action", "succeeded", "failed", "refunded", "canceled"]
+                          "enum": [
+                            "created",
+                            "pending",
+                            "requires_action",
+                            "succeeded",
+                            "failed",
+                            "refunded",
+                            "canceled"
+                          ]
                         },
                         "error": {
                           "type": "object",
@@ -628,12 +738,16 @@
                               "type": "string"
                             }
                           },
-                          "required": ["message"]
+                          "required": [
+                            "message"
+                          ]
                         }
                       }
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -646,7 +760,9 @@
         "operationId": "updateStripeCustomerOrganization",
         "summary": "Update customer organization",
         "description": "Updates the organization/business name for the current user's Stripe customer account",
-        "tags": ["Payment"],
+        "tags": [
+          "Payment"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -665,7 +781,9 @@
                     "type": "string"
                   }
                 },
-                "required": ["organization"]
+                "required": [
+                  "organization"
+                ]
               }
             }
           }
@@ -682,7 +800,9 @@
         "operationId": "createSetupIntent",
         "summary": "Create a Stripe SetupIntent for adding a payment method",
         "description": "Creates a Stripe SetupIntent that allows users to securely add payment methods to their account. The SetupIntent provides a client secret that can be used with Stripe's frontend SDKs to collect payment method details.",
-        "tags": ["Payment"],
+        "tags": [
+          "Payment"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -707,10 +827,14 @@
                           "nullable": true
                         }
                       },
-                      "required": ["clientSecret"]
+                      "required": [
+                        "clientSecret"
+                      ]
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -722,7 +846,9 @@
       "post": {
         "operationId": "setDefaultPaymentMethod",
         "summary": "Marks a payment method as the default.",
-        "tags": ["Payment"],
+        "tags": [
+          "Payment"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -744,10 +870,14 @@
                         "type": "string"
                       }
                     },
-                    "required": ["id"]
+                    "required": [
+                      "id"
+                    ]
                   }
                 },
-                "required": ["data"]
+                "required": [
+                  "data"
+                ]
               }
             }
           }
@@ -762,7 +892,9 @@
         "operationId": "getDefaultPaymentMethod",
         "summary": "Get the default payment method for the current user",
         "description": "Retrieves the default payment method associated with the current user's account, including card details, validation status, and billing information.",
-        "tags": ["Payment"],
+        "tags": [
+          "Payment"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -832,7 +964,12 @@
                               }
                             }
                           },
-                          "required": ["brand", "last4", "exp_month", "exp_year"]
+                          "required": [
+                            "brand",
+                            "last4",
+                            "exp_month",
+                            "exp_year"
+                          ]
                         },
                         "link": {
                           "type": "object",
@@ -876,7 +1013,14 @@
                                   "nullable": true
                                 }
                               },
-                              "required": ["city", "country", "line1", "line2", "postal_code", "state"]
+                              "required": [
+                                "city",
+                                "country",
+                                "line1",
+                                "line2",
+                                "postal_code",
+                                "state"
+                              ]
                             },
                             "email": {
                               "type": "string",
@@ -896,10 +1040,15 @@
                           "type": "string"
                         }
                       },
-                      "required": ["type", "id"]
+                      "required": [
+                        "type",
+                        "id"
+                      ]
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -915,7 +1064,9 @@
         "operationId": "listPaymentMethods",
         "summary": "Get all payment methods for the current user",
         "description": "Retrieves all saved payment methods associated with the current user's account, including card details, validation status, and billing information.",
-        "tags": ["Payment"],
+        "tags": [
+          "Payment"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -987,7 +1138,12 @@
                                 }
                               }
                             },
-                            "required": ["brand", "last4", "exp_month", "exp_year"]
+                            "required": [
+                              "brand",
+                              "last4",
+                              "exp_month",
+                              "exp_year"
+                            ]
                           },
                           "link": {
                             "type": "object",
@@ -1031,7 +1187,14 @@
                                     "nullable": true
                                   }
                                 },
-                                "required": ["city", "country", "line1", "line2", "postal_code", "state"]
+                                "required": [
+                                  "city",
+                                  "country",
+                                  "line1",
+                                  "line2",
+                                  "postal_code",
+                                  "state"
+                                ]
                               },
                               "email": {
                                 "type": "string",
@@ -1051,11 +1214,16 @@
                             "type": "string"
                           }
                         },
-                        "required": ["type", "id"]
+                        "required": [
+                          "type",
+                          "id"
+                        ]
                       }
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -1068,7 +1236,9 @@
         "operationId": "deletePaymentMethod",
         "summary": "Remove a payment method",
         "description": "Permanently removes a saved payment method from the user's account. This action cannot be undone.",
-        "tags": ["Payment"],
+        "tags": [
+          "Payment"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -1101,7 +1271,9 @@
         "operationId": "validatePaymentMethod",
         "summary": "Validates a payment method after 3D Secure authentication",
         "description": "Completes the validation process for a payment method that required 3D Secure authentication. This endpoint should be called after the user completes the 3D Secure challenge.",
-        "tags": ["Payment"],
+        "tags": [
+          "Payment"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -1126,10 +1298,15 @@
                         "type": "string"
                       }
                     },
-                    "required": ["paymentMethodId", "paymentIntentId"]
+                    "required": [
+                      "paymentMethodId",
+                      "paymentIntentId"
+                    ]
                   }
                 },
-                "required": ["data"]
+                "required": [
+                  "data"
+                ]
               }
             }
           }
@@ -1146,7 +1323,9 @@
                       "type": "boolean"
                     }
                   },
-                  "required": ["success"]
+                  "required": [
+                    "success"
+                  ]
                 }
               }
             }
@@ -1159,7 +1338,9 @@
         "operationId": "confirmStripeTransaction",
         "summary": "Confirm a payment using a saved payment method",
         "description": "Processes a payment using a previously saved payment method. This endpoint handles wallet top-ups and may require 3D Secure authentication for certain payment methods or amounts.",
-        "tags": ["Payment"],
+        "tags": [
+          "Payment"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -1195,10 +1376,16 @@
                         "format": "uuid"
                       }
                     },
-                    "required": ["userId", "paymentMethodId", "amount"]
+                    "required": [
+                      "userId",
+                      "paymentMethodId",
+                      "amount"
+                    ]
                   }
                 },
-                "required": ["data"]
+                "required": [
+                  "data"
+                ]
               }
             }
           }
@@ -1231,13 +1418,26 @@
                         },
                         "transactionStatus": {
                           "type": "string",
-                          "enum": ["created", "pending", "requires_action", "succeeded", "failed", "refunded", "canceled"]
+                          "enum": [
+                            "created",
+                            "pending",
+                            "requires_action",
+                            "succeeded",
+                            "failed",
+                            "refunded",
+                            "canceled"
+                          ]
                         }
                       },
-                      "required": ["success", "transactionId"]
+                      "required": [
+                        "success",
+                        "transactionId"
+                      ]
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -1269,13 +1469,26 @@
                         },
                         "transactionStatus": {
                           "type": "string",
-                          "enum": ["created", "pending", "requires_action", "succeeded", "failed", "refunded", "canceled"]
+                          "enum": [
+                            "created",
+                            "pending",
+                            "requires_action",
+                            "succeeded",
+                            "failed",
+                            "refunded",
+                            "canceled"
+                          ]
                         }
                       },
-                      "required": ["success", "transactionId"]
+                      "required": [
+                        "success",
+                        "transactionId"
+                      ]
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -1287,7 +1500,9 @@
       "get": {
         "operationId": "listStripeTransactions",
         "summary": "Get transaction history for the current customer",
-        "tags": ["Payment"],
+        "tags": [
+          "Payment"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -1366,7 +1581,11 @@
                               },
                               "type": {
                                 "type": "string",
-                                "enum": ["payment_intent", "coupon_claim", "manual_credit"]
+                                "enum": [
+                                  "payment_intent",
+                                  "coupon_claim",
+                                  "manual_credit"
+                                ]
                               },
                               "amount": {
                                 "type": "number"
@@ -1407,7 +1626,15 @@
                                 "nullable": true
                               }
                             },
-                            "required": ["id", "type", "amount", "amountRefunded", "currency", "status", "created"]
+                            "required": [
+                              "id",
+                              "type",
+                              "amount",
+                              "amountRefunded",
+                              "currency",
+                              "status",
+                              "created"
+                            ]
                           }
                         },
                         "totalCount": {
@@ -1417,10 +1644,16 @@
                           "type": "boolean"
                         }
                       },
-                      "required": ["transactions", "totalCount", "hasMore"]
+                      "required": [
+                        "transactions",
+                        "totalCount",
+                        "hasMore"
+                      ]
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -1432,7 +1665,9 @@
       "get": {
         "operationId": "exportStripeTransactions",
         "summary": "Export transaction history as CSV for the current customer",
-        "tags": ["Payment"],
+        "tags": [
+          "Payment"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -1493,7 +1728,9 @@
     "/v1/usage/history": {
       "get": {
         "summary": "Get historical data of billing and usage for a wallet address.",
-        "tags": ["Billing"],
+        "tags": [
+          "Billing"
+        ],
         "security": [],
         "parameters": [
           {
@@ -1616,7 +1853,9 @@
     "/v1/usage/history/stats": {
       "get": {
         "summary": "Get historical usage stats for a wallet address.",
-        "tags": ["Billing"],
+        "tags": [
+          "Billing"
+        ],
         "security": [],
         "parameters": [
           {
@@ -1681,7 +1920,12 @@
                       "example": 1.5
                     }
                   },
-                  "required": ["totalSpent", "averageSpentPerDay", "totalDeployments", "averageDeploymentsPerDay"]
+                  "required": [
+                    "totalSpent",
+                    "averageSpentPerDay",
+                    "totalDeployments",
+                    "averageDeploymentsPerDay"
+                  ]
                 }
               }
             }
@@ -1695,7 +1939,9 @@
     "/v1/register-user": {
       "post": {
         "summary": "Registers a new user",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "security": [],
         "requestBody": {
           "content": {
@@ -1716,7 +1962,11 @@
                     "type": "boolean"
                   }
                 },
-                "required": ["wantedUsername", "email", "emailVerified"]
+                "required": [
+                  "wantedUsername",
+                  "email",
+                  "emailVerified"
+                ]
               }
             }
           }
@@ -1776,13 +2026,23 @@
                           "format": "date-time"
                         }
                       },
-                      "required": ["id", "userId", "username", "email", "emailVerified", "subscribedToNewsletter"]
+                      "required": [
+                        "id",
+                        "userId",
+                        "username",
+                        "email",
+                        "emailVerified",
+                        "subscribedToNewsletter"
+                      ]
                     },
                     "isNewUser": {
                       "type": "boolean"
                     }
                   },
-                  "required": ["data", "isNewUser"]
+                  "required": [
+                    "data",
+                    "isNewUser"
+                  ]
                 }
               }
             }
@@ -1793,7 +2053,9 @@
     "/v1/user/me": {
       "get": {
         "summary": "Retrieves the logged in user",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -1857,10 +2119,19 @@
                           "format": "date-time"
                         }
                       },
-                      "required": ["id", "userId", "username", "email", "emailVerified", "subscribedToNewsletter"]
+                      "required": [
+                        "id",
+                        "userId",
+                        "username",
+                        "email",
+                        "emailVerified",
+                        "subscribedToNewsletter"
+                      ]
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -1871,7 +2142,9 @@
     "/v1/user/byUsername/{username}": {
       "get": {
         "summary": "Get user by username",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "security": [],
         "parameters": [
           {
@@ -1899,7 +2172,10 @@
                       "nullable": true
                     }
                   },
-                  "required": ["username", "bio"]
+                  "required": [
+                    "username",
+                    "bio"
+                  ]
                 }
               }
             }
@@ -1913,7 +2189,9 @@
     "/v1/user/updateSettings": {
       "put": {
         "summary": "Update user settings",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -1956,7 +2234,9 @@
                     "maxLength": 200
                   }
                 },
-                "required": ["username"]
+                "required": [
+                  "username"
+                ]
               }
             }
           }
@@ -1977,7 +2257,9 @@
     "/v1/user/checkUsernameAvailability/{username}": {
       "get": {
         "summary": "Check if username is available",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "security": [],
         "parameters": [
           {
@@ -2001,7 +2283,9 @@
                       "type": "boolean"
                     }
                   },
-                  "required": ["isAvailable"]
+                  "required": [
+                    "isAvailable"
+                  ]
                 }
               }
             }
@@ -2012,7 +2296,9 @@
     "/v1/user/subscribeToNewsletter": {
       "post": {
         "summary": "Subscribe to newsletter",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -2034,7 +2320,9 @@
     "/v1/user/skipOnboarding": {
       "post": {
         "summary": "Skip onboarding",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -2056,7 +2344,9 @@
     "/v1/user/template/{id}": {
       "get": {
         "summary": "Get template by ID",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "security": [],
         "parameters": [
           {
@@ -2085,7 +2375,9 @@
     "/v1/user/saveTemplate": {
       "post": {
         "summary": "Save template",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -2127,7 +2419,14 @@
                     "maxLength": 2000
                   }
                 },
-                "required": ["sdl", "title", "cpu", "ram", "storage", "isPublic"]
+                "required": [
+                  "sdl",
+                  "title",
+                  "cpu",
+                  "ram",
+                  "storage",
+                  "isPublic"
+                ]
               }
             }
           }
@@ -2148,7 +2447,9 @@
     "/v1/user/saveTemplateDesc": {
       "post": {
         "summary": "Save template description",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -2171,7 +2472,10 @@
                     "type": "string"
                   }
                 },
-                "required": ["id", "description"]
+                "required": [
+                  "id",
+                  "description"
+                ]
               }
             }
           }
@@ -2189,7 +2493,9 @@
     "/v1/user/templates/{username}": {
       "get": {
         "summary": "Get templates by username",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "security": [],
         "parameters": [
           {
@@ -2214,7 +2520,9 @@
     "/v1/user/deleteTemplate/{id}": {
       "delete": {
         "summary": "Delete template",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -2250,7 +2558,9 @@
     "/v1/user/favoriteTemplates": {
       "get": {
         "summary": "Get favorite templates",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -2272,7 +2582,9 @@
     "/v1/user/addFavoriteTemplate/{templateId}": {
       "post": {
         "summary": "Add favorite template",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -2308,7 +2620,9 @@
     "/v1/user/removeFavoriteTemplate/{templateId}": {
       "delete": {
         "summary": "Remove favorite template",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -2344,7 +2658,9 @@
     "/v1/send-verification-email": {
       "post": {
         "summary": "Resends a verification email",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "security": [],
         "requestBody": {
           "required": true,
@@ -2360,10 +2676,14 @@
                         "type": "string"
                       }
                     },
-                    "required": ["userId"]
+                    "required": [
+                      "userId"
+                    ]
                   }
                 },
-                "required": ["data"]
+                "required": [
+                  "data"
+                ]
               }
             }
           }
@@ -2379,7 +2699,9 @@
     "/v1/send-verification-code": {
       "post": {
         "summary": "Sends a verification code to the authenticated user's email",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -2400,10 +2722,14 @@
                           "type": "string"
                         }
                       },
-                      "required": ["codeSentAt"]
+                      "required": [
+                        "codeSentAt"
+                      ]
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -2417,7 +2743,9 @@
     "/v1/auth/signup": {
       "post": {
         "summary": "Creates a new user without sending a verification email",
-        "tags": ["Auth"],
+        "tags": [
+          "Auth"
+        ],
         "security": [],
         "requestBody": {
           "required": true,
@@ -2435,7 +2763,10 @@
                     "minLength": 8
                   }
                 },
-                "required": ["email", "password"]
+                "required": [
+                  "email",
+                  "password"
+                ]
               }
             }
           }
@@ -2450,7 +2781,9 @@
     "/v1/verify-email-code": {
       "post": {
         "summary": "Verifies the email using a 6-digit code",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -2471,10 +2804,14 @@
                         "pattern": "^\\d{6}$"
                       }
                     },
-                    "required": ["code"]
+                    "required": [
+                      "code"
+                    ]
                   }
                 },
-                "required": ["data"]
+                "required": [
+                  "data"
+                ]
               }
             }
           }
@@ -2495,7 +2832,9 @@
     "/v1/verify-email": {
       "post": {
         "summary": "Checks if the email is verified",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "security": [],
         "requestBody": {
           "required": true,
@@ -2512,10 +2851,14 @@
                         "format": "email"
                       }
                     },
-                    "required": ["email"]
+                    "required": [
+                      "email"
+                    ]
                   }
                 },
-                "required": ["data"]
+                "required": [
+                  "data"
+                ]
               }
             }
           }
@@ -2535,10 +2878,14 @@
                           "type": "boolean"
                         }
                       },
-                      "required": ["emailVerified"]
+                      "required": [
+                        "emailVerified"
+                      ]
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -2555,7 +2902,9 @@
     "/v1/deployment-settings/{userId}/{dseq}": {
       "get": {
         "summary": "Get deployment settings by user ID and dseq",
-        "tags": ["Deployment Settings"],
+        "tags": [
+          "Deployment Settings"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -2625,10 +2974,21 @@
                           "format": "date-time"
                         }
                       },
-                      "required": ["id", "userId", "dseq", "autoTopUpEnabled", "estimatedTopUpAmount", "topUpFrequencyMs", "createdAt", "updatedAt"]
+                      "required": [
+                        "id",
+                        "userId",
+                        "dseq",
+                        "autoTopUpEnabled",
+                        "estimatedTopUpAmount",
+                        "topUpFrequencyMs",
+                        "createdAt",
+                        "updatedAt"
+                      ]
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -2644,7 +3004,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["message"]
+                  "required": [
+                    "message"
+                  ]
                 }
               }
             }
@@ -2653,7 +3015,9 @@
       },
       "patch": {
         "summary": "Update deployment settings",
-        "tags": ["Deployment Settings"],
+        "tags": [
+          "Deployment Settings"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -2697,10 +3061,14 @@
                         "description": "Whether auto top-up is enabled for this deployment"
                       }
                     },
-                    "required": ["autoTopUpEnabled"]
+                    "required": [
+                      "autoTopUpEnabled"
+                    ]
                   }
                 },
-                "required": ["data"]
+                "required": [
+                  "data"
+                ]
               }
             }
           }
@@ -2745,10 +3113,21 @@
                           "format": "date-time"
                         }
                       },
-                      "required": ["id", "userId", "dseq", "autoTopUpEnabled", "estimatedTopUpAmount", "topUpFrequencyMs", "createdAt", "updatedAt"]
+                      "required": [
+                        "id",
+                        "userId",
+                        "dseq",
+                        "autoTopUpEnabled",
+                        "estimatedTopUpAmount",
+                        "topUpFrequencyMs",
+                        "createdAt",
+                        "updatedAt"
+                      ]
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -2764,7 +3143,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["message"]
+                  "required": [
+                    "message"
+                  ]
                 }
               }
             }
@@ -2775,7 +3156,9 @@
     "/v1/deployment-settings": {
       "post": {
         "summary": "Create deployment settings",
-        "tags": ["Deployment Settings"],
+        "tags": [
+          "Deployment Settings"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -2808,10 +3191,15 @@
                         "description": "Whether auto top-up is enabled for this deployment"
                       }
                     },
-                    "required": ["userId", "dseq"]
+                    "required": [
+                      "userId",
+                      "dseq"
+                    ]
                   }
                 },
-                "required": ["data"]
+                "required": [
+                  "data"
+                ]
               }
             }
           }
@@ -2856,10 +3244,21 @@
                           "format": "date-time"
                         }
                       },
-                      "required": ["id", "userId", "dseq", "autoTopUpEnabled", "estimatedTopUpAmount", "topUpFrequencyMs", "createdAt", "updatedAt"]
+                      "required": [
+                        "id",
+                        "userId",
+                        "dseq",
+                        "autoTopUpEnabled",
+                        "estimatedTopUpAmount",
+                        "topUpFrequencyMs",
+                        "createdAt",
+                        "updatedAt"
+                      ]
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -2870,7 +3269,9 @@
     "/v2/deployment-settings/{dseq}": {
       "get": {
         "summary": "Get deployment settings by dseq",
-        "tags": ["Deployment Settings"],
+        "tags": [
+          "Deployment Settings"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -2941,10 +3342,21 @@
                           "format": "date-time"
                         }
                       },
-                      "required": ["id", "userId", "dseq", "autoTopUpEnabled", "estimatedTopUpAmount", "topUpFrequencyMs", "createdAt", "updatedAt"]
+                      "required": [
+                        "id",
+                        "userId",
+                        "dseq",
+                        "autoTopUpEnabled",
+                        "estimatedTopUpAmount",
+                        "topUpFrequencyMs",
+                        "createdAt",
+                        "updatedAt"
+                      ]
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -2960,7 +3372,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["message"]
+                  "required": [
+                    "message"
+                  ]
                 }
               }
             }
@@ -2969,7 +3383,9 @@
       },
       "patch": {
         "summary": "Update deployment settings",
-        "tags": ["Deployment Settings"],
+        "tags": [
+          "Deployment Settings"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -3014,10 +3430,14 @@
                         "description": "Whether auto top-up is enabled for this deployment"
                       }
                     },
-                    "required": ["autoTopUpEnabled"]
+                    "required": [
+                      "autoTopUpEnabled"
+                    ]
                   }
                 },
-                "required": ["data"]
+                "required": [
+                  "data"
+                ]
               }
             }
           }
@@ -3062,10 +3482,21 @@
                           "format": "date-time"
                         }
                       },
-                      "required": ["id", "userId", "dseq", "autoTopUpEnabled", "estimatedTopUpAmount", "topUpFrequencyMs", "createdAt", "updatedAt"]
+                      "required": [
+                        "id",
+                        "userId",
+                        "dseq",
+                        "autoTopUpEnabled",
+                        "estimatedTopUpAmount",
+                        "topUpFrequencyMs",
+                        "createdAt",
+                        "updatedAt"
+                      ]
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -3081,7 +3512,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["message"]
+                  "required": [
+                    "message"
+                  ]
                 }
               }
             }
@@ -3092,7 +3525,9 @@
     "/v2/deployment-settings": {
       "post": {
         "summary": "Create deployment settings",
-        "tags": ["Deployment Settings"],
+        "tags": [
+          "Deployment Settings"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -3126,10 +3561,14 @@
                         "description": "User ID. Defaults to the current authenticated user if not provided"
                       }
                     },
-                    "required": ["dseq"]
+                    "required": [
+                      "dseq"
+                    ]
                   }
                 },
-                "required": ["data"]
+                "required": [
+                  "data"
+                ]
               }
             }
           }
@@ -3174,10 +3613,21 @@
                           "format": "date-time"
                         }
                       },
-                      "required": ["id", "userId", "dseq", "autoTopUpEnabled", "estimatedTopUpAmount", "topUpFrequencyMs", "createdAt", "updatedAt"]
+                      "required": [
+                        "id",
+                        "userId",
+                        "dseq",
+                        "autoTopUpEnabled",
+                        "estimatedTopUpAmount",
+                        "topUpFrequencyMs",
+                        "createdAt",
+                        "updatedAt"
+                      ]
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -3189,7 +3639,9 @@
       "get": {
         "summary": "Get a deployment",
         "operationId": "getDeployment",
-        "tags": ["Deployments"],
+        "tags": [
+          "Deployments"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -3236,7 +3688,10 @@
                                   "pattern": "^d+$"
                                 }
                               },
-                              "required": ["owner", "dseq"]
+                              "required": [
+                                "owner",
+                                "dseq"
+                              ]
                             },
                             "state": {
                               "type": "string"
@@ -3248,7 +3703,12 @@
                               "type": "string"
                             }
                           },
-                          "required": ["id", "state", "hash", "created_at"]
+                          "required": [
+                            "id",
+                            "state",
+                            "hash",
+                            "created_at"
+                          ]
                         },
                         "leases": {
                           "type": "array",
@@ -3278,7 +3738,14 @@
                                     "type": "number"
                                   }
                                 },
-                                "required": ["owner", "dseq", "gseq", "oseq", "provider", "bseq"]
+                                "required": [
+                                  "owner",
+                                  "dseq",
+                                  "gseq",
+                                  "oseq",
+                                  "provider",
+                                  "bseq"
+                                ]
                               },
                               "state": {
                                 "type": "string"
@@ -3293,7 +3760,10 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": ["denom", "amount"]
+                                "required": [
+                                  "denom",
+                                  "amount"
+                                ]
                               },
                               "created_at": {
                                 "type": "string"
@@ -3328,7 +3798,10 @@
                                             "type": "number"
                                           }
                                         },
-                                        "required": ["port", "externalPort"]
+                                        "required": [
+                                          "port",
+                                          "externalPort"
+                                        ]
                                       }
                                     }
                                   },
@@ -3352,7 +3825,12 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": ["IP", "Port", "ExternalPort", "Protocol"]
+                                        "required": [
+                                          "IP",
+                                          "Port",
+                                          "ExternalPort",
+                                          "Protocol"
+                                        ]
                                       }
                                     }
                                   },
@@ -3406,10 +3884,21 @@
                                     }
                                   }
                                 },
-                                "required": ["forwarded_ports", "ips", "services"]
+                                "required": [
+                                  "forwarded_ports",
+                                  "ips",
+                                  "services"
+                                ]
                               }
                             },
-                            "required": ["id", "state", "price", "created_at", "closed_on", "status"]
+                            "required": [
+                              "id",
+                              "state",
+                              "price",
+                              "created_at",
+                              "closed_on",
+                              "status"
+                            ]
                           }
                         },
                         "escrow_account": {
@@ -3425,7 +3914,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["scope", "xid"]
+                              "required": [
+                                "scope",
+                                "xid"
+                              ]
                             },
                             "state": {
                               "type": "object",
@@ -3448,7 +3940,10 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": ["denom", "amount"]
+                                    "required": [
+                                      "denom",
+                                      "amount"
+                                    ]
                                   }
                                 },
                                 "settled_at": {
@@ -3466,7 +3961,10 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": ["denom", "amount"]
+                                    "required": [
+                                      "denom",
+                                      "amount"
+                                    ]
                                   }
                                 },
                                 "deposits": {
@@ -3493,23 +3991,47 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": ["denom", "amount"]
+                                        "required": [
+                                          "denom",
+                                          "amount"
+                                        ]
                                       }
                                     },
-                                    "required": ["owner", "height", "source", "balance"]
+                                    "required": [
+                                      "owner",
+                                      "height",
+                                      "source",
+                                      "balance"
+                                    ]
                                   }
                                 }
                               },
-                              "required": ["owner", "state", "transferred", "settled_at", "funds", "deposits"]
+                              "required": [
+                                "owner",
+                                "state",
+                                "transferred",
+                                "settled_at",
+                                "funds",
+                                "deposits"
+                              ]
                             }
                           },
-                          "required": ["id", "state"]
+                          "required": [
+                            "id",
+                            "state"
+                          ]
                         }
                       },
-                      "required": ["deployment", "leases", "escrow_account"]
+                      "required": [
+                        "deployment",
+                        "leases",
+                        "escrow_account"
+                      ]
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -3519,7 +4041,9 @@
       "delete": {
         "summary": "Close a deployment",
         "operationId": "closeDeployment",
-        "tags": ["Deployments"],
+        "tags": [
+          "Deployments"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -3556,10 +4080,14 @@
                           "type": "boolean"
                         }
                       },
-                      "required": ["success"]
+                      "required": [
+                        "success"
+                      ]
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -3569,7 +4097,9 @@
       "put": {
         "summary": "Update a deployment",
         "operationId": "updateDeployment",
-        "tags": ["Deployments"],
+        "tags": [
+          "Deployments"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -3604,10 +4134,14 @@
                         "type": "string"
                       }
                     },
-                    "required": ["sdl"]
+                    "required": [
+                      "sdl"
+                    ]
                   }
                 },
-                "required": ["data"]
+                "required": [
+                  "data"
+                ]
               }
             }
           }
@@ -3637,7 +4171,10 @@
                                   "pattern": "^d+$"
                                 }
                               },
-                              "required": ["owner", "dseq"]
+                              "required": [
+                                "owner",
+                                "dseq"
+                              ]
                             },
                             "state": {
                               "type": "string"
@@ -3649,7 +4186,12 @@
                               "type": "string"
                             }
                           },
-                          "required": ["id", "state", "hash", "created_at"]
+                          "required": [
+                            "id",
+                            "state",
+                            "hash",
+                            "created_at"
+                          ]
                         },
                         "leases": {
                           "type": "array",
@@ -3679,7 +4221,14 @@
                                     "type": "number"
                                   }
                                 },
-                                "required": ["owner", "dseq", "gseq", "oseq", "provider", "bseq"]
+                                "required": [
+                                  "owner",
+                                  "dseq",
+                                  "gseq",
+                                  "oseq",
+                                  "provider",
+                                  "bseq"
+                                ]
                               },
                               "state": {
                                 "type": "string"
@@ -3694,7 +4243,10 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": ["denom", "amount"]
+                                "required": [
+                                  "denom",
+                                  "amount"
+                                ]
                               },
                               "created_at": {
                                 "type": "string"
@@ -3729,7 +4281,10 @@
                                             "type": "number"
                                           }
                                         },
-                                        "required": ["port", "externalPort"]
+                                        "required": [
+                                          "port",
+                                          "externalPort"
+                                        ]
                                       }
                                     }
                                   },
@@ -3753,7 +4308,12 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": ["IP", "Port", "ExternalPort", "Protocol"]
+                                        "required": [
+                                          "IP",
+                                          "Port",
+                                          "ExternalPort",
+                                          "Protocol"
+                                        ]
                                       }
                                     }
                                   },
@@ -3807,10 +4367,21 @@
                                     }
                                   }
                                 },
-                                "required": ["forwarded_ports", "ips", "services"]
+                                "required": [
+                                  "forwarded_ports",
+                                  "ips",
+                                  "services"
+                                ]
                               }
                             },
-                            "required": ["id", "state", "price", "created_at", "closed_on", "status"]
+                            "required": [
+                              "id",
+                              "state",
+                              "price",
+                              "created_at",
+                              "closed_on",
+                              "status"
+                            ]
                           }
                         },
                         "escrow_account": {
@@ -3826,7 +4397,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["scope", "xid"]
+                              "required": [
+                                "scope",
+                                "xid"
+                              ]
                             },
                             "state": {
                               "type": "object",
@@ -3849,7 +4423,10 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": ["denom", "amount"]
+                                    "required": [
+                                      "denom",
+                                      "amount"
+                                    ]
                                   }
                                 },
                                 "settled_at": {
@@ -3867,7 +4444,10 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": ["denom", "amount"]
+                                    "required": [
+                                      "denom",
+                                      "amount"
+                                    ]
                                   }
                                 },
                                 "deposits": {
@@ -3894,23 +4474,47 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": ["denom", "amount"]
+                                        "required": [
+                                          "denom",
+                                          "amount"
+                                        ]
                                       }
                                     },
-                                    "required": ["owner", "height", "source", "balance"]
+                                    "required": [
+                                      "owner",
+                                      "height",
+                                      "source",
+                                      "balance"
+                                    ]
                                   }
                                 }
                               },
-                              "required": ["owner", "state", "transferred", "settled_at", "funds", "deposits"]
+                              "required": [
+                                "owner",
+                                "state",
+                                "transferred",
+                                "settled_at",
+                                "funds",
+                                "deposits"
+                              ]
                             }
                           },
-                          "required": ["id", "state"]
+                          "required": [
+                            "id",
+                            "state"
+                          ]
                         }
                       },
-                      "required": ["deployment", "leases", "escrow_account"]
+                      "required": [
+                        "deployment",
+                        "leases",
+                        "escrow_account"
+                      ]
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -3922,7 +4526,9 @@
       "post": {
         "summary": "Create new deployment",
         "operationId": "createDeployment",
-        "tags": ["Deployments"],
+        "tags": [
+          "Deployments"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -3948,10 +4554,15 @@
                         "description": "Amount to deposit in dollars (e.g. 5.5)"
                       }
                     },
-                    "required": ["sdl", "deposit"]
+                    "required": [
+                      "sdl",
+                      "deposit"
+                    ]
                   }
                 },
-                "required": ["data"]
+                "required": [
+                  "data"
+                ]
               }
             }
           }
@@ -3987,13 +4598,23 @@
                               "type": "string"
                             }
                           },
-                          "required": ["code", "transactionHash", "rawLog"]
+                          "required": [
+                            "code",
+                            "transactionHash",
+                            "rawLog"
+                          ]
                         }
                       },
-                      "required": ["dseq", "manifest", "signTx"]
+                      "required": [
+                        "dseq",
+                        "manifest",
+                        "signTx"
+                      ]
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -4003,7 +4624,9 @@
       "get": {
         "summary": "List deployments with pagination and filtering",
         "operationId": "listDeployments",
-        "tags": ["Deployments"],
+        "tags": [
+          "Deployments"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -4064,7 +4687,10 @@
                                         "pattern": "^d+$"
                                       }
                                     },
-                                    "required": ["owner", "dseq"]
+                                    "required": [
+                                      "owner",
+                                      "dseq"
+                                    ]
                                   },
                                   "state": {
                                     "type": "string"
@@ -4076,7 +4702,12 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": ["id", "state", "hash", "created_at"]
+                                "required": [
+                                  "id",
+                                  "state",
+                                  "hash",
+                                  "created_at"
+                                ]
                               },
                               "leases": {
                                 "type": "array",
@@ -4106,7 +4737,14 @@
                                           "type": "number"
                                         }
                                       },
-                                      "required": ["owner", "dseq", "gseq", "oseq", "provider", "bseq"]
+                                      "required": [
+                                        "owner",
+                                        "dseq",
+                                        "gseq",
+                                        "oseq",
+                                        "provider",
+                                        "bseq"
+                                      ]
                                     },
                                     "state": {
                                       "type": "string"
@@ -4121,7 +4759,10 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": ["denom", "amount"]
+                                      "required": [
+                                        "denom",
+                                        "amount"
+                                      ]
                                     },
                                     "created_at": {
                                       "type": "string"
@@ -4133,7 +4774,13 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["id", "state", "price", "created_at", "closed_on"]
+                                  "required": [
+                                    "id",
+                                    "state",
+                                    "price",
+                                    "created_at",
+                                    "closed_on"
+                                  ]
                                 }
                               },
                               "escrow_account": {
@@ -4149,7 +4796,10 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": ["scope", "xid"]
+                                    "required": [
+                                      "scope",
+                                      "xid"
+                                    ]
                                   },
                                   "state": {
                                     "type": "object",
@@ -4172,7 +4822,10 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": ["denom", "amount"]
+                                          "required": [
+                                            "denom",
+                                            "amount"
+                                          ]
                                         }
                                       },
                                       "settled_at": {
@@ -4190,7 +4843,10 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": ["denom", "amount"]
+                                          "required": [
+                                            "denom",
+                                            "amount"
+                                          ]
                                         }
                                       },
                                       "deposits": {
@@ -4217,20 +4873,42 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "required": ["denom", "amount"]
+                                              "required": [
+                                                "denom",
+                                                "amount"
+                                              ]
                                             }
                                           },
-                                          "required": ["owner", "height", "source", "balance"]
+                                          "required": [
+                                            "owner",
+                                            "height",
+                                            "source",
+                                            "balance"
+                                          ]
                                         }
                                       }
                                     },
-                                    "required": ["owner", "state", "transferred", "settled_at", "funds", "deposits"]
+                                    "required": [
+                                      "owner",
+                                      "state",
+                                      "transferred",
+                                      "settled_at",
+                                      "funds",
+                                      "deposits"
+                                    ]
                                   }
                                 },
-                                "required": ["id", "state"]
+                                "required": [
+                                  "id",
+                                  "state"
+                                ]
                               }
                             },
-                            "required": ["deployment", "leases", "escrow_account"]
+                            "required": [
+                              "deployment",
+                              "leases",
+                              "escrow_account"
+                            ]
                           }
                         },
                         "pagination": {
@@ -4249,13 +4927,23 @@
                               "type": "boolean"
                             }
                           },
-                          "required": ["total", "skip", "limit", "hasMore"]
+                          "required": [
+                            "total",
+                            "skip",
+                            "limit",
+                            "hasMore"
+                          ]
                         }
                       },
-                      "required": ["deployments", "pagination"]
+                      "required": [
+                        "deployments",
+                        "pagination"
+                      ]
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -4267,7 +4955,9 @@
       "post": {
         "summary": "Deposit into a deployment",
         "operationId": "depositDeployment",
-        "tags": ["Deployments"],
+        "tags": [
+          "Deployments"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -4295,10 +4985,15 @@
                         "description": "Amount to deposit in dollars (e.g. 5.5)"
                       }
                     },
-                    "required": ["dseq", "deposit"]
+                    "required": [
+                      "dseq",
+                      "deposit"
+                    ]
                   }
                 },
-                "required": ["data"]
+                "required": [
+                  "data"
+                ]
               }
             }
           }
@@ -4328,7 +5023,10 @@
                                   "pattern": "^d+$"
                                 }
                               },
-                              "required": ["owner", "dseq"]
+                              "required": [
+                                "owner",
+                                "dseq"
+                              ]
                             },
                             "state": {
                               "type": "string"
@@ -4340,7 +5038,12 @@
                               "type": "string"
                             }
                           },
-                          "required": ["id", "state", "hash", "created_at"]
+                          "required": [
+                            "id",
+                            "state",
+                            "hash",
+                            "created_at"
+                          ]
                         },
                         "leases": {
                           "type": "array",
@@ -4370,7 +5073,14 @@
                                     "type": "number"
                                   }
                                 },
-                                "required": ["owner", "dseq", "gseq", "oseq", "provider", "bseq"]
+                                "required": [
+                                  "owner",
+                                  "dseq",
+                                  "gseq",
+                                  "oseq",
+                                  "provider",
+                                  "bseq"
+                                ]
                               },
                               "state": {
                                 "type": "string"
@@ -4385,7 +5095,10 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": ["denom", "amount"]
+                                "required": [
+                                  "denom",
+                                  "amount"
+                                ]
                               },
                               "created_at": {
                                 "type": "string"
@@ -4420,7 +5133,10 @@
                                             "type": "number"
                                           }
                                         },
-                                        "required": ["port", "externalPort"]
+                                        "required": [
+                                          "port",
+                                          "externalPort"
+                                        ]
                                       }
                                     }
                                   },
@@ -4444,7 +5160,12 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": ["IP", "Port", "ExternalPort", "Protocol"]
+                                        "required": [
+                                          "IP",
+                                          "Port",
+                                          "ExternalPort",
+                                          "Protocol"
+                                        ]
                                       }
                                     }
                                   },
@@ -4498,10 +5219,21 @@
                                     }
                                   }
                                 },
-                                "required": ["forwarded_ports", "ips", "services"]
+                                "required": [
+                                  "forwarded_ports",
+                                  "ips",
+                                  "services"
+                                ]
                               }
                             },
-                            "required": ["id", "state", "price", "created_at", "closed_on", "status"]
+                            "required": [
+                              "id",
+                              "state",
+                              "price",
+                              "created_at",
+                              "closed_on",
+                              "status"
+                            ]
                           }
                         },
                         "escrow_account": {
@@ -4517,7 +5249,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["scope", "xid"]
+                              "required": [
+                                "scope",
+                                "xid"
+                              ]
                             },
                             "state": {
                               "type": "object",
@@ -4540,7 +5275,10 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": ["denom", "amount"]
+                                    "required": [
+                                      "denom",
+                                      "amount"
+                                    ]
                                   }
                                 },
                                 "settled_at": {
@@ -4558,7 +5296,10 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": ["denom", "amount"]
+                                    "required": [
+                                      "denom",
+                                      "amount"
+                                    ]
                                   }
                                 },
                                 "deposits": {
@@ -4585,23 +5326,47 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": ["denom", "amount"]
+                                        "required": [
+                                          "denom",
+                                          "amount"
+                                        ]
                                       }
                                     },
-                                    "required": ["owner", "height", "source", "balance"]
+                                    "required": [
+                                      "owner",
+                                      "height",
+                                      "source",
+                                      "balance"
+                                    ]
                                   }
                                 }
                               },
-                              "required": ["owner", "state", "transferred", "settled_at", "funds", "deposits"]
+                              "required": [
+                                "owner",
+                                "state",
+                                "transferred",
+                                "settled_at",
+                                "funds",
+                                "deposits"
+                              ]
                             }
                           },
-                          "required": ["id", "state"]
+                          "required": [
+                            "id",
+                            "state"
+                          ]
                         }
                       },
-                      "required": ["deployment", "leases", "escrow_account"]
+                      "required": [
+                        "deployment",
+                        "leases",
+                        "escrow_account"
+                      ]
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -4612,7 +5377,10 @@
     "/v1/addresses/{address}/deployments/{skip}/{limit}": {
       "get": {
         "summary": "Get a list of deployments by owner address.",
-        "tags": ["Addresses", "Deployments"],
+        "tags": [
+          "Addresses",
+          "Deployments"
+        ],
         "security": [],
         "parameters": [
           {
@@ -4652,7 +5420,10 @@
           {
             "schema": {
               "type": "string",
-              "enum": ["active", "closed"],
+              "enum": [
+                "active",
+                "closed"
+              ],
               "description": "Filter by status",
               "example": "closed"
             },
@@ -4733,7 +5504,10 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["address", "hostUri"]
+                                  "required": [
+                                    "address",
+                                    "hostUri"
+                                  ]
                                 },
                                 "dseq": {
                                   "type": "string",
@@ -4758,18 +5532,42 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["denom", "amount"]
+                                  "required": [
+                                    "denom",
+                                    "amount"
+                                  ]
                                 }
                               },
-                              "required": ["id", "owner", "dseq", "gseq", "oseq", "state", "price"]
+                              "required": [
+                                "id",
+                                "owner",
+                                "dseq",
+                                "gseq",
+                                "oseq",
+                                "state",
+                                "price"
+                              ]
                             }
                           }
                         },
-                        "required": ["owner", "dseq", "status", "createdHeight", "cpuUnits", "gpuUnits", "memoryQuantity", "storageQuantity", "leases"]
+                        "required": [
+                          "owner",
+                          "dseq",
+                          "status",
+                          "createdHeight",
+                          "cpuUnits",
+                          "gpuUnits",
+                          "memoryQuantity",
+                          "storageQuantity",
+                          "leases"
+                        ]
                       }
                     }
                   },
-                  "required": ["count", "results"]
+                  "required": [
+                    "count",
+                    "results"
+                  ]
                 }
               }
             }
@@ -4783,7 +5581,9 @@
     "/v1/deployment/{owner}/{dseq}": {
       "get": {
         "summary": "Get deployment details",
-        "tags": ["Deployments"],
+        "tags": [
+          "Deployments"
+        ],
         "security": [],
         "parameters": [
           {
@@ -4870,11 +5670,19 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["key", "value"]
+                                  "required": [
+                                    "key",
+                                    "value"
+                                  ]
                                 }
                               }
                             },
-                            "required": ["address", "hostUri", "isDeleted", "attributes"]
+                            "required": [
+                              "address",
+                              "hostUri",
+                              "isDeleted",
+                              "attributes"
+                            ]
                           },
                           "status": {
                             "type": "string"
@@ -4895,7 +5703,17 @@
                             "type": "number"
                           }
                         },
-                        "required": ["gseq", "oseq", "provider", "status", "monthlyCostUDenom", "cpuUnits", "gpuUnits", "memoryQuantity", "storageQuantity"]
+                        "required": [
+                          "gseq",
+                          "oseq",
+                          "provider",
+                          "status",
+                          "monthlyCostUDenom",
+                          "cpuUnits",
+                          "gpuUnits",
+                          "memoryQuantity",
+                          "storageQuantity"
+                        ]
                       }
                     },
                     "events": {
@@ -4913,7 +5731,11 @@
                             "type": "string"
                           }
                         },
-                        "required": ["txHash", "date", "type"]
+                        "required": [
+                          "txHash",
+                          "date",
+                          "type"
+                        ]
                       }
                     },
                     "other": {
@@ -4932,7 +5754,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["owner", "dseq"]
+                              "required": [
+                                "owner",
+                                "dseq"
+                              ]
                             },
                             "state": {
                               "type": "string"
@@ -4944,7 +5769,12 @@
                               "type": "string"
                             }
                           },
-                          "required": ["id", "state", "hash", "created_at"]
+                          "required": [
+                            "id",
+                            "state",
+                            "hash",
+                            "created_at"
+                          ]
                         },
                         "groups": {
                           "type": "array",
@@ -4964,7 +5794,11 @@
                                     "type": "number"
                                   }
                                 },
-                                "required": ["owner", "dseq", "gseq"]
+                                "required": [
+                                  "owner",
+                                  "dseq",
+                                  "gseq"
+                                ]
                               },
                               "state": {
                                 "type": "string"
@@ -4994,7 +5828,10 @@
                                             }
                                           }
                                         },
-                                        "required": ["all_of", "any_of"]
+                                        "required": [
+                                          "all_of",
+                                          "any_of"
+                                        ]
                                       },
                                       "attributes": {
                                         "type": "array",
@@ -5008,11 +5845,17 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": ["key", "value"]
+                                          "required": [
+                                            "key",
+                                            "value"
+                                          ]
                                         }
                                       }
                                     },
-                                    "required": ["signed_by", "attributes"]
+                                    "required": [
+                                      "signed_by",
+                                      "attributes"
+                                    ]
                                   },
                                   "resources": {
                                     "type": "array",
@@ -5035,7 +5878,9 @@
                                                       "type": "string"
                                                     }
                                                   },
-                                                  "required": ["val"]
+                                                  "required": [
+                                                    "val"
+                                                  ]
                                                 },
                                                 "attributes": {
                                                   "type": "array",
@@ -5049,11 +5894,17 @@
                                                         "type": "string"
                                                       }
                                                     },
-                                                    "required": ["key", "value"]
+                                                    "required": [
+                                                      "key",
+                                                      "value"
+                                                    ]
                                                   }
                                                 }
                                               },
-                                              "required": ["units", "attributes"]
+                                              "required": [
+                                                "units",
+                                                "attributes"
+                                              ]
                                             },
                                             "memory": {
                                               "type": "object",
@@ -5065,7 +5916,9 @@
                                                       "type": "string"
                                                     }
                                                   },
-                                                  "required": ["val"]
+                                                  "required": [
+                                                    "val"
+                                                  ]
                                                 },
                                                 "attributes": {
                                                   "type": "array",
@@ -5079,11 +5932,17 @@
                                                         "type": "string"
                                                       }
                                                     },
-                                                    "required": ["key", "value"]
+                                                    "required": [
+                                                      "key",
+                                                      "value"
+                                                    ]
                                                   }
                                                 }
                                               },
-                                              "required": ["quantity", "attributes"]
+                                              "required": [
+                                                "quantity",
+                                                "attributes"
+                                              ]
                                             },
                                             "storage": {
                                               "type": "array",
@@ -5100,7 +5959,9 @@
                                                         "type": "string"
                                                       }
                                                     },
-                                                    "required": ["val"]
+                                                    "required": [
+                                                      "val"
+                                                    ]
                                                   },
                                                   "attributes": {
                                                     "type": "array",
@@ -5114,11 +5975,18 @@
                                                           "type": "string"
                                                         }
                                                       },
-                                                      "required": ["key", "value"]
+                                                      "required": [
+                                                        "key",
+                                                        "value"
+                                                      ]
                                                     }
                                                   }
                                                 },
-                                                "required": ["name", "quantity", "attributes"]
+                                                "required": [
+                                                  "name",
+                                                  "quantity",
+                                                  "attributes"
+                                                ]
                                               }
                                             },
                                             "gpu": {
@@ -5131,7 +5999,9 @@
                                                       "type": "string"
                                                     }
                                                   },
-                                                  "required": ["val"]
+                                                  "required": [
+                                                    "val"
+                                                  ]
                                                 },
                                                 "attributes": {
                                                   "type": "array",
@@ -5145,11 +6015,17 @@
                                                         "type": "string"
                                                       }
                                                     },
-                                                    "required": ["key", "value"]
+                                                    "required": [
+                                                      "key",
+                                                      "value"
+                                                    ]
                                                   }
                                                 }
                                               },
-                                              "required": ["units", "attributes"]
+                                              "required": [
+                                                "units",
+                                                "attributes"
+                                              ]
                                             },
                                             "endpoints": {
                                               "type": "array",
@@ -5163,11 +6039,21 @@
                                                     "type": "number"
                                                   }
                                                 },
-                                                "required": ["kind", "sequence_number"]
+                                                "required": [
+                                                  "kind",
+                                                  "sequence_number"
+                                                ]
                                               }
                                             }
                                           },
-                                          "required": ["id", "cpu", "memory", "storage", "gpu", "endpoints"]
+                                          "required": [
+                                            "id",
+                                            "cpu",
+                                            "memory",
+                                            "storage",
+                                            "gpu",
+                                            "endpoints"
+                                          ]
                                         },
                                         "count": {
                                           "type": "number"
@@ -5182,20 +6068,36 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": ["denom", "amount"]
+                                          "required": [
+                                            "denom",
+                                            "amount"
+                                          ]
                                         }
                                       },
-                                      "required": ["resource", "count", "price"]
+                                      "required": [
+                                        "resource",
+                                        "count",
+                                        "price"
+                                      ]
                                     }
                                   }
                                 },
-                                "required": ["name", "requirements", "resources"]
+                                "required": [
+                                  "name",
+                                  "requirements",
+                                  "resources"
+                                ]
                               },
                               "created_at": {
                                 "type": "string"
                               }
                             },
-                            "required": ["id", "state", "group_spec", "created_at"]
+                            "required": [
+                              "id",
+                              "state",
+                              "group_spec",
+                              "created_at"
+                            ]
                           }
                         },
                         "escrow_account": {
@@ -5211,7 +6113,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["scope", "xid"]
+                              "required": [
+                                "scope",
+                                "xid"
+                              ]
                             },
                             "state": {
                               "type": "object",
@@ -5234,7 +6139,10 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": ["denom", "amount"]
+                                    "required": [
+                                      "denom",
+                                      "amount"
+                                    ]
                                   }
                                 },
                                 "settled_at": {
@@ -5252,7 +6160,10 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": ["denom", "amount"]
+                                    "required": [
+                                      "denom",
+                                      "amount"
+                                    ]
                                   }
                                 },
                                 "deposits": {
@@ -5279,23 +6190,55 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": ["denom", "amount"]
+                                        "required": [
+                                          "denom",
+                                          "amount"
+                                        ]
                                       }
                                     },
-                                    "required": ["owner", "height", "source", "balance"]
+                                    "required": [
+                                      "owner",
+                                      "height",
+                                      "source",
+                                      "balance"
+                                    ]
                                   }
                                 }
                               },
-                              "required": ["owner", "state", "transferred", "settled_at", "funds", "deposits"]
+                              "required": [
+                                "owner",
+                                "state",
+                                "transferred",
+                                "settled_at",
+                                "funds",
+                                "deposits"
+                              ]
                             }
                           },
-                          "required": ["id", "state"]
+                          "required": [
+                            "id",
+                            "state"
+                          ]
                         }
                       },
-                      "required": ["deployment", "groups", "escrow_account"]
+                      "required": [
+                        "deployment",
+                        "groups",
+                        "escrow_account"
+                      ]
                     }
                   },
-                  "required": ["owner", "dseq", "balance", "denom", "status", "totalMonthlyCostUDenom", "leases", "events", "other"]
+                  "required": [
+                    "owner",
+                    "dseq",
+                    "balance",
+                    "denom",
+                    "status",
+                    "totalMonthlyCostUDenom",
+                    "leases",
+                    "events",
+                    "other"
+                  ]
                 }
               }
             }
@@ -5312,7 +6255,9 @@
     "/akash/deployment/{version}/deployments/list": {
       "get": {
         "summary": "List deployments (database fallback)",
-        "tags": ["Deployments"],
+        "tags": [
+          "Deployments"
+        ],
         "security": [],
         "parameters": [
           {
@@ -5326,7 +6271,10 @@
           {
             "schema": {
               "type": "string",
-              "enum": ["active", "closed"]
+              "enum": [
+                "active",
+                "closed"
+              ]
             },
             "required": false,
             "name": "filters.state",
@@ -5403,7 +6351,10 @@
                                     "pattern": "^d+$"
                                   }
                                 },
-                                "required": ["owner", "dseq"]
+                                "required": [
+                                  "owner",
+                                  "dseq"
+                                ]
                               },
                               "state": {
                                 "type": "string"
@@ -5415,7 +6366,12 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["id", "state", "hash", "created_at"]
+                            "required": [
+                              "id",
+                              "state",
+                              "hash",
+                              "created_at"
+                            ]
                           },
                           "groups": {
                             "type": "array",
@@ -5436,7 +6392,11 @@
                                       "type": "number"
                                     }
                                   },
-                                  "required": ["owner", "dseq", "gseq"]
+                                  "required": [
+                                    "owner",
+                                    "dseq",
+                                    "gseq"
+                                  ]
                                 },
                                 "state": {
                                   "type": "string"
@@ -5466,7 +6426,10 @@
                                               }
                                             }
                                           },
-                                          "required": ["all_of", "any_of"]
+                                          "required": [
+                                            "all_of",
+                                            "any_of"
+                                          ]
                                         },
                                         "attributes": {
                                           "type": "array",
@@ -5480,11 +6443,17 @@
                                                 "type": "string"
                                               }
                                             },
-                                            "required": ["key", "value"]
+                                            "required": [
+                                              "key",
+                                              "value"
+                                            ]
                                           }
                                         }
                                       },
-                                      "required": ["signed_by", "attributes"]
+                                      "required": [
+                                        "signed_by",
+                                        "attributes"
+                                      ]
                                     },
                                     "resources": {
                                       "type": "array",
@@ -5507,7 +6476,9 @@
                                                         "type": "string"
                                                       }
                                                     },
-                                                    "required": ["val"]
+                                                    "required": [
+                                                      "val"
+                                                    ]
                                                   },
                                                   "attributes": {
                                                     "type": "array",
@@ -5521,11 +6492,17 @@
                                                           "type": "string"
                                                         }
                                                       },
-                                                      "required": ["key", "value"]
+                                                      "required": [
+                                                        "key",
+                                                        "value"
+                                                      ]
                                                     }
                                                   }
                                                 },
-                                                "required": ["units", "attributes"]
+                                                "required": [
+                                                  "units",
+                                                  "attributes"
+                                                ]
                                               },
                                               "memory": {
                                                 "type": "object",
@@ -5537,7 +6514,9 @@
                                                         "type": "string"
                                                       }
                                                     },
-                                                    "required": ["val"]
+                                                    "required": [
+                                                      "val"
+                                                    ]
                                                   },
                                                   "attributes": {
                                                     "type": "array",
@@ -5551,11 +6530,17 @@
                                                           "type": "string"
                                                         }
                                                       },
-                                                      "required": ["key", "value"]
+                                                      "required": [
+                                                        "key",
+                                                        "value"
+                                                      ]
                                                     }
                                                   }
                                                 },
-                                                "required": ["quantity", "attributes"]
+                                                "required": [
+                                                  "quantity",
+                                                  "attributes"
+                                                ]
                                               },
                                               "storage": {
                                                 "type": "array",
@@ -5572,7 +6557,9 @@
                                                           "type": "string"
                                                         }
                                                       },
-                                                      "required": ["val"]
+                                                      "required": [
+                                                        "val"
+                                                      ]
                                                     },
                                                     "attributes": {
                                                       "type": "array",
@@ -5586,11 +6573,18 @@
                                                             "type": "string"
                                                           }
                                                         },
-                                                        "required": ["key", "value"]
+                                                        "required": [
+                                                          "key",
+                                                          "value"
+                                                        ]
                                                       }
                                                     }
                                                   },
-                                                  "required": ["name", "quantity", "attributes"]
+                                                  "required": [
+                                                    "name",
+                                                    "quantity",
+                                                    "attributes"
+                                                  ]
                                                 }
                                               },
                                               "gpu": {
@@ -5603,7 +6597,9 @@
                                                         "type": "string"
                                                       }
                                                     },
-                                                    "required": ["val"]
+                                                    "required": [
+                                                      "val"
+                                                    ]
                                                   },
                                                   "attributes": {
                                                     "type": "array",
@@ -5617,11 +6613,17 @@
                                                           "type": "string"
                                                         }
                                                       },
-                                                      "required": ["key", "value"]
+                                                      "required": [
+                                                        "key",
+                                                        "value"
+                                                      ]
                                                     }
                                                   }
                                                 },
-                                                "required": ["units", "attributes"]
+                                                "required": [
+                                                  "units",
+                                                  "attributes"
+                                                ]
                                               },
                                               "endpoints": {
                                                 "type": "array",
@@ -5635,11 +6637,21 @@
                                                       "type": "number"
                                                     }
                                                   },
-                                                  "required": ["kind", "sequence_number"]
+                                                  "required": [
+                                                    "kind",
+                                                    "sequence_number"
+                                                  ]
                                                 }
                                               }
                                             },
-                                            "required": ["id", "cpu", "memory", "storage", "gpu", "endpoints"]
+                                            "required": [
+                                              "id",
+                                              "cpu",
+                                              "memory",
+                                              "storage",
+                                              "gpu",
+                                              "endpoints"
+                                            ]
                                           },
                                           "count": {
                                             "type": "number"
@@ -5654,20 +6666,36 @@
                                                 "type": "string"
                                               }
                                             },
-                                            "required": ["denom", "amount"]
+                                            "required": [
+                                              "denom",
+                                              "amount"
+                                            ]
                                           }
                                         },
-                                        "required": ["resource", "count", "price"]
+                                        "required": [
+                                          "resource",
+                                          "count",
+                                          "price"
+                                        ]
                                       }
                                     }
                                   },
-                                  "required": ["name", "requirements", "resources"]
+                                  "required": [
+                                    "name",
+                                    "requirements",
+                                    "resources"
+                                  ]
                                 },
                                 "created_at": {
                                   "type": "string"
                                 }
                               },
-                              "required": ["id", "state", "group_spec", "created_at"]
+                              "required": [
+                                "id",
+                                "state",
+                                "group_spec",
+                                "created_at"
+                              ]
                             }
                           },
                           "escrow_account": {
@@ -5683,7 +6711,10 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": ["scope", "xid"]
+                                "required": [
+                                  "scope",
+                                  "xid"
+                                ]
                               },
                               "state": {
                                 "type": "object",
@@ -5706,7 +6737,10 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": ["denom", "amount"]
+                                      "required": [
+                                        "denom",
+                                        "amount"
+                                      ]
                                     }
                                   },
                                   "settled_at": {
@@ -5724,7 +6758,10 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": ["denom", "amount"]
+                                      "required": [
+                                        "denom",
+                                        "amount"
+                                      ]
                                     }
                                   },
                                   "deposits": {
@@ -5751,20 +6788,42 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": ["denom", "amount"]
+                                          "required": [
+                                            "denom",
+                                            "amount"
+                                          ]
                                         }
                                       },
-                                      "required": ["owner", "height", "source", "balance"]
+                                      "required": [
+                                        "owner",
+                                        "height",
+                                        "source",
+                                        "balance"
+                                      ]
                                     }
                                   }
                                 },
-                                "required": ["owner", "state", "transferred", "settled_at", "funds", "deposits"]
+                                "required": [
+                                  "owner",
+                                  "state",
+                                  "transferred",
+                                  "settled_at",
+                                  "funds",
+                                  "deposits"
+                                ]
                               }
                             },
-                            "required": ["id", "state"]
+                            "required": [
+                              "id",
+                              "state"
+                            ]
                           }
                         },
-                        "required": ["deployment", "groups", "escrow_account"]
+                        "required": [
+                          "deployment",
+                          "groups",
+                          "escrow_account"
+                        ]
                       }
                     },
                     "pagination": {
@@ -5778,10 +6837,16 @@
                           "type": "string"
                         }
                       },
-                      "required": ["next_key", "total"]
+                      "required": [
+                        "next_key",
+                        "total"
+                      ]
                     }
                   },
-                  "required": ["deployments", "pagination"]
+                  "required": [
+                    "deployments",
+                    "pagination"
+                  ]
                 }
               }
             }
@@ -5792,7 +6857,9 @@
     "/akash/deployment/{version}/deployments/info": {
       "get": {
         "summary": "Get deployment info (database fallback)",
-        "tags": ["Deployments"],
+        "tags": [
+          "Deployments"
+        ],
         "security": [],
         "parameters": [
           {
@@ -5835,7 +6902,11 @@
                           }
                         }
                       },
-                      "required": ["code", "message", "details"]
+                      "required": [
+                        "code",
+                        "message",
+                        "details"
+                      ]
                     },
                     {
                       "type": "object",
@@ -5854,7 +6925,10 @@
                                   "pattern": "^d+$"
                                 }
                               },
-                              "required": ["owner", "dseq"]
+                              "required": [
+                                "owner",
+                                "dseq"
+                              ]
                             },
                             "state": {
                               "type": "string"
@@ -5866,7 +6940,12 @@
                               "type": "string"
                             }
                           },
-                          "required": ["id", "state", "hash", "created_at"]
+                          "required": [
+                            "id",
+                            "state",
+                            "hash",
+                            "created_at"
+                          ]
                         },
                         "groups": {
                           "type": "array",
@@ -5887,7 +6966,11 @@
                                     "type": "number"
                                   }
                                 },
-                                "required": ["owner", "dseq", "gseq"]
+                                "required": [
+                                  "owner",
+                                  "dseq",
+                                  "gseq"
+                                ]
                               },
                               "state": {
                                 "type": "string"
@@ -5917,7 +7000,10 @@
                                             }
                                           }
                                         },
-                                        "required": ["all_of", "any_of"]
+                                        "required": [
+                                          "all_of",
+                                          "any_of"
+                                        ]
                                       },
                                       "attributes": {
                                         "type": "array",
@@ -5931,11 +7017,17 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": ["key", "value"]
+                                          "required": [
+                                            "key",
+                                            "value"
+                                          ]
                                         }
                                       }
                                     },
-                                    "required": ["signed_by", "attributes"]
+                                    "required": [
+                                      "signed_by",
+                                      "attributes"
+                                    ]
                                   },
                                   "resources": {
                                     "type": "array",
@@ -5958,7 +7050,9 @@
                                                       "type": "string"
                                                     }
                                                   },
-                                                  "required": ["val"]
+                                                  "required": [
+                                                    "val"
+                                                  ]
                                                 },
                                                 "attributes": {
                                                   "type": "array",
@@ -5972,11 +7066,17 @@
                                                         "type": "string"
                                                       }
                                                     },
-                                                    "required": ["key", "value"]
+                                                    "required": [
+                                                      "key",
+                                                      "value"
+                                                    ]
                                                   }
                                                 }
                                               },
-                                              "required": ["units", "attributes"]
+                                              "required": [
+                                                "units",
+                                                "attributes"
+                                              ]
                                             },
                                             "memory": {
                                               "type": "object",
@@ -5988,7 +7088,9 @@
                                                       "type": "string"
                                                     }
                                                   },
-                                                  "required": ["val"]
+                                                  "required": [
+                                                    "val"
+                                                  ]
                                                 },
                                                 "attributes": {
                                                   "type": "array",
@@ -6002,11 +7104,17 @@
                                                         "type": "string"
                                                       }
                                                     },
-                                                    "required": ["key", "value"]
+                                                    "required": [
+                                                      "key",
+                                                      "value"
+                                                    ]
                                                   }
                                                 }
                                               },
-                                              "required": ["quantity", "attributes"]
+                                              "required": [
+                                                "quantity",
+                                                "attributes"
+                                              ]
                                             },
                                             "storage": {
                                               "type": "array",
@@ -6023,7 +7131,9 @@
                                                         "type": "string"
                                                       }
                                                     },
-                                                    "required": ["val"]
+                                                    "required": [
+                                                      "val"
+                                                    ]
                                                   },
                                                   "attributes": {
                                                     "type": "array",
@@ -6037,11 +7147,18 @@
                                                           "type": "string"
                                                         }
                                                       },
-                                                      "required": ["key", "value"]
+                                                      "required": [
+                                                        "key",
+                                                        "value"
+                                                      ]
                                                     }
                                                   }
                                                 },
-                                                "required": ["name", "quantity", "attributes"]
+                                                "required": [
+                                                  "name",
+                                                  "quantity",
+                                                  "attributes"
+                                                ]
                                               }
                                             },
                                             "gpu": {
@@ -6054,7 +7171,9 @@
                                                       "type": "string"
                                                     }
                                                   },
-                                                  "required": ["val"]
+                                                  "required": [
+                                                    "val"
+                                                  ]
                                                 },
                                                 "attributes": {
                                                   "type": "array",
@@ -6068,11 +7187,17 @@
                                                         "type": "string"
                                                       }
                                                     },
-                                                    "required": ["key", "value"]
+                                                    "required": [
+                                                      "key",
+                                                      "value"
+                                                    ]
                                                   }
                                                 }
                                               },
-                                              "required": ["units", "attributes"]
+                                              "required": [
+                                                "units",
+                                                "attributes"
+                                              ]
                                             },
                                             "endpoints": {
                                               "type": "array",
@@ -6086,11 +7211,21 @@
                                                     "type": "number"
                                                   }
                                                 },
-                                                "required": ["kind", "sequence_number"]
+                                                "required": [
+                                                  "kind",
+                                                  "sequence_number"
+                                                ]
                                               }
                                             }
                                           },
-                                          "required": ["id", "cpu", "memory", "storage", "gpu", "endpoints"]
+                                          "required": [
+                                            "id",
+                                            "cpu",
+                                            "memory",
+                                            "storage",
+                                            "gpu",
+                                            "endpoints"
+                                          ]
                                         },
                                         "count": {
                                           "type": "number"
@@ -6105,20 +7240,36 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": ["denom", "amount"]
+                                          "required": [
+                                            "denom",
+                                            "amount"
+                                          ]
                                         }
                                       },
-                                      "required": ["resource", "count", "price"]
+                                      "required": [
+                                        "resource",
+                                        "count",
+                                        "price"
+                                      ]
                                     }
                                   }
                                 },
-                                "required": ["name", "requirements", "resources"]
+                                "required": [
+                                  "name",
+                                  "requirements",
+                                  "resources"
+                                ]
                               },
                               "created_at": {
                                 "type": "string"
                               }
                             },
-                            "required": ["id", "state", "group_spec", "created_at"]
+                            "required": [
+                              "id",
+                              "state",
+                              "group_spec",
+                              "created_at"
+                            ]
                           }
                         },
                         "escrow_account": {
@@ -6134,7 +7285,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["scope", "xid"]
+                              "required": [
+                                "scope",
+                                "xid"
+                              ]
                             },
                             "state": {
                               "type": "object",
@@ -6157,7 +7311,10 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": ["denom", "amount"]
+                                    "required": [
+                                      "denom",
+                                      "amount"
+                                    ]
                                   }
                                 },
                                 "settled_at": {
@@ -6175,7 +7332,10 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": ["denom", "amount"]
+                                    "required": [
+                                      "denom",
+                                      "amount"
+                                    ]
                                   }
                                 },
                                 "deposits": {
@@ -6202,20 +7362,42 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": ["denom", "amount"]
+                                        "required": [
+                                          "denom",
+                                          "amount"
+                                        ]
                                       }
                                     },
-                                    "required": ["owner", "height", "source", "balance"]
+                                    "required": [
+                                      "owner",
+                                      "height",
+                                      "source",
+                                      "balance"
+                                    ]
                                   }
                                 }
                               },
-                              "required": ["owner", "state", "transferred", "settled_at", "funds", "deposits"]
+                              "required": [
+                                "owner",
+                                "state",
+                                "transferred",
+                                "settled_at",
+                                "funds",
+                                "deposits"
+                              ]
                             }
                           },
-                          "required": ["id", "state"]
+                          "required": [
+                            "id",
+                            "state"
+                          ]
                         }
                       },
-                      "required": ["deployment", "groups", "escrow_account"]
+                      "required": [
+                        "deployment",
+                        "groups",
+                        "escrow_account"
+                      ]
                     }
                   ]
                 }
@@ -6231,7 +7413,9 @@
     "/v1/weekly-cost": {
       "get": {
         "summary": "Get weekly deployment cost",
-        "tags": ["Deployments"],
+        "tags": [
+          "Deployments"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -6256,10 +7440,14 @@
                           "description": "Total weekly cost in USD for all deployments with auto top-up enabled"
                         }
                       },
-                      "required": ["weeklyCost"]
+                      "required": [
+                        "weeklyCost"
+                      ]
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -6271,7 +7459,9 @@
       "post": {
         "summary": "Create leases and send manifest",
         "operationId": "createLease",
-        "tags": ["Leases"],
+        "tags": [
+          "Leases"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -6308,11 +7498,19 @@
                           "type": "string"
                         }
                       },
-                      "required": ["dseq", "gseq", "oseq", "provider"]
+                      "required": [
+                        "dseq",
+                        "gseq",
+                        "oseq",
+                        "provider"
+                      ]
                     }
                   }
                 },
-                "required": ["manifest", "leases"]
+                "required": [
+                  "manifest",
+                  "leases"
+                ]
               }
             }
           }
@@ -6342,7 +7540,10 @@
                                   "pattern": "^d+$"
                                 }
                               },
-                              "required": ["owner", "dseq"]
+                              "required": [
+                                "owner",
+                                "dseq"
+                              ]
                             },
                             "state": {
                               "type": "string"
@@ -6354,7 +7555,12 @@
                               "type": "string"
                             }
                           },
-                          "required": ["id", "state", "hash", "created_at"]
+                          "required": [
+                            "id",
+                            "state",
+                            "hash",
+                            "created_at"
+                          ]
                         },
                         "leases": {
                           "type": "array",
@@ -6384,7 +7590,14 @@
                                     "type": "number"
                                   }
                                 },
-                                "required": ["owner", "dseq", "gseq", "oseq", "provider", "bseq"]
+                                "required": [
+                                  "owner",
+                                  "dseq",
+                                  "gseq",
+                                  "oseq",
+                                  "provider",
+                                  "bseq"
+                                ]
                               },
                               "state": {
                                 "type": "string"
@@ -6399,7 +7612,10 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": ["denom", "amount"]
+                                "required": [
+                                  "denom",
+                                  "amount"
+                                ]
                               },
                               "created_at": {
                                 "type": "string"
@@ -6434,7 +7650,10 @@
                                             "type": "number"
                                           }
                                         },
-                                        "required": ["port", "externalPort"]
+                                        "required": [
+                                          "port",
+                                          "externalPort"
+                                        ]
                                       }
                                     }
                                   },
@@ -6458,7 +7677,12 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": ["IP", "Port", "ExternalPort", "Protocol"]
+                                        "required": [
+                                          "IP",
+                                          "Port",
+                                          "ExternalPort",
+                                          "Protocol"
+                                        ]
                                       }
                                     }
                                   },
@@ -6512,10 +7736,21 @@
                                     }
                                   }
                                 },
-                                "required": ["forwarded_ports", "ips", "services"]
+                                "required": [
+                                  "forwarded_ports",
+                                  "ips",
+                                  "services"
+                                ]
                               }
                             },
-                            "required": ["id", "state", "price", "created_at", "closed_on", "status"]
+                            "required": [
+                              "id",
+                              "state",
+                              "price",
+                              "created_at",
+                              "closed_on",
+                              "status"
+                            ]
                           }
                         },
                         "escrow_account": {
@@ -6531,7 +7766,10 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["scope", "xid"]
+                              "required": [
+                                "scope",
+                                "xid"
+                              ]
                             },
                             "state": {
                               "type": "object",
@@ -6554,7 +7792,10 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": ["denom", "amount"]
+                                    "required": [
+                                      "denom",
+                                      "amount"
+                                    ]
                                   }
                                 },
                                 "settled_at": {
@@ -6572,7 +7813,10 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": ["denom", "amount"]
+                                    "required": [
+                                      "denom",
+                                      "amount"
+                                    ]
                                   }
                                 },
                                 "deposits": {
@@ -6599,23 +7843,47 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": ["denom", "amount"]
+                                        "required": [
+                                          "denom",
+                                          "amount"
+                                        ]
                                       }
                                     },
-                                    "required": ["owner", "height", "source", "balance"]
+                                    "required": [
+                                      "owner",
+                                      "height",
+                                      "source",
+                                      "balance"
+                                    ]
                                   }
                                 }
                               },
-                              "required": ["owner", "state", "transferred", "settled_at", "funds", "deposits"]
+                              "required": [
+                                "owner",
+                                "state",
+                                "transferred",
+                                "settled_at",
+                                "funds",
+                                "deposits"
+                              ]
                             }
                           },
-                          "required": ["id", "state"]
+                          "required": [
+                            "id",
+                            "state"
+                          ]
                         }
                       },
-                      "required": ["deployment", "leases", "escrow_account"]
+                      "required": [
+                        "deployment",
+                        "leases",
+                        "escrow_account"
+                      ]
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -6626,7 +7894,9 @@
     "/akash/market/{version}/leases/list": {
       "get": {
         "summary": "List leases (database fallback)",
-        "tags": ["Leases"],
+        "tags": [
+          "Leases"
+        ],
         "security": [],
         "parameters": [
           {
@@ -6762,7 +8032,14 @@
                                     "type": "number"
                                   }
                                 },
-                                "required": ["owner", "dseq", "gseq", "oseq", "provider", "bseq"]
+                                "required": [
+                                  "owner",
+                                  "dseq",
+                                  "gseq",
+                                  "oseq",
+                                  "provider",
+                                  "bseq"
+                                ]
                               },
                               "state": {
                                 "type": "string"
@@ -6777,7 +8054,10 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": ["denom", "amount"]
+                                "required": [
+                                  "denom",
+                                  "amount"
+                                ]
                               },
                               "created_at": {
                                 "type": "string"
@@ -6789,7 +8069,13 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["id", "state", "price", "created_at", "closed_on"]
+                            "required": [
+                              "id",
+                              "state",
+                              "price",
+                              "created_at",
+                              "closed_on"
+                            ]
                           },
                           "escrow_payment": {
                             "type": "object",
@@ -6807,13 +8093,19 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": ["scope", "xid"]
+                                    "required": [
+                                      "scope",
+                                      "xid"
+                                    ]
                                   },
                                   "xid": {
                                     "type": "string"
                                   }
                                 },
-                                "required": ["aid", "xid"]
+                                "required": [
+                                  "aid",
+                                  "xid"
+                                ]
                               },
                               "state": {
                                 "type": "object",
@@ -6834,7 +8126,10 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": ["denom", "amount"]
+                                    "required": [
+                                      "denom",
+                                      "amount"
+                                    ]
                                   },
                                   "balance": {
                                     "type": "object",
@@ -6846,7 +8141,10 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": ["denom", "amount"]
+                                    "required": [
+                                      "denom",
+                                      "amount"
+                                    ]
                                   },
                                   "unsettled": {
                                     "type": "object",
@@ -6858,7 +8156,10 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": ["denom", "amount"]
+                                    "required": [
+                                      "denom",
+                                      "amount"
+                                    ]
                                   },
                                   "withdrawn": {
                                     "type": "object",
@@ -6870,16 +8171,32 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": ["denom", "amount"]
+                                    "required": [
+                                      "denom",
+                                      "amount"
+                                    ]
                                   }
                                 },
-                                "required": ["owner", "state", "rate", "balance", "unsettled", "withdrawn"]
+                                "required": [
+                                  "owner",
+                                  "state",
+                                  "rate",
+                                  "balance",
+                                  "unsettled",
+                                  "withdrawn"
+                                ]
                               }
                             },
-                            "required": ["id", "state"]
+                            "required": [
+                              "id",
+                              "state"
+                            ]
                           }
                         },
-                        "required": ["lease", "escrow_payment"]
+                        "required": [
+                          "lease",
+                          "escrow_payment"
+                        ]
                       }
                     },
                     "pagination": {
@@ -6893,10 +8210,16 @@
                           "type": "string"
                         }
                       },
-                      "required": ["next_key", "total"]
+                      "required": [
+                        "next_key",
+                        "total"
+                      ]
                     }
                   },
-                  "required": ["leases", "pagination"]
+                  "required": [
+                    "leases",
+                    "pagination"
+                  ]
                 }
               }
             }
@@ -6908,7 +8231,9 @@
       "get": {
         "summary": "List all API keys",
         "operationId": "listApiKeys",
-        "tags": ["API Keys"],
+        "tags": [
+          "API Keys"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -6959,11 +8284,21 @@
                             "type": "string"
                           }
                         },
-                        "required": ["id", "name", "expiresAt", "createdAt", "updatedAt", "lastUsedAt", "keyFormat"]
+                        "required": [
+                          "id",
+                          "name",
+                          "expiresAt",
+                          "createdAt",
+                          "updatedAt",
+                          "lastUsedAt",
+                          "keyFormat"
+                        ]
                       }
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -6972,7 +8307,9 @@
       },
       "post": {
         "summary": "Create new API key",
-        "tags": ["API Keys"],
+        "tags": [
+          "API Keys"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -6998,10 +8335,14 @@
                         "format": "date-time"
                       }
                     },
-                    "required": ["name"]
+                    "required": [
+                      "name"
+                    ]
                   }
                 },
-                "required": ["data"]
+                "required": [
+                  "data"
+                ]
               }
             }
           }
@@ -7049,10 +8390,21 @@
                           "type": "string"
                         }
                       },
-                      "required": ["id", "name", "expiresAt", "createdAt", "updatedAt", "lastUsedAt", "keyFormat", "apiKey"]
+                      "required": [
+                        "id",
+                        "name",
+                        "expiresAt",
+                        "createdAt",
+                        "updatedAt",
+                        "lastUsedAt",
+                        "keyFormat",
+                        "apiKey"
+                      ]
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -7063,7 +8415,9 @@
     "/v1/api-keys/{id}": {
       "get": {
         "summary": "Get API key by ID",
-        "tags": ["API Keys"],
+        "tags": [
+          "API Keys"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -7123,10 +8477,20 @@
                           "type": "string"
                         }
                       },
-                      "required": ["id", "name", "expiresAt", "createdAt", "updatedAt", "lastUsedAt", "keyFormat"]
+                      "required": [
+                        "id",
+                        "name",
+                        "expiresAt",
+                        "createdAt",
+                        "updatedAt",
+                        "lastUsedAt",
+                        "keyFormat"
+                      ]
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -7142,7 +8506,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["message"]
+                  "required": [
+                    "message"
+                  ]
                 }
               }
             }
@@ -7151,7 +8517,9 @@
       },
       "patch": {
         "summary": "Update API key",
-        "tags": ["API Keys"],
+        "tags": [
+          "API Keys"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -7186,7 +8554,9 @@
                     }
                   }
                 },
-                "required": ["data"]
+                "required": [
+                  "data"
+                ]
               }
             }
           }
@@ -7231,10 +8601,20 @@
                           "type": "string"
                         }
                       },
-                      "required": ["id", "name", "expiresAt", "createdAt", "updatedAt", "lastUsedAt", "keyFormat"]
+                      "required": [
+                        "id",
+                        "name",
+                        "expiresAt",
+                        "createdAt",
+                        "updatedAt",
+                        "lastUsedAt",
+                        "keyFormat"
+                      ]
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -7250,7 +8630,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["message"]
+                  "required": [
+                    "message"
+                  ]
                 }
               }
             }
@@ -7259,7 +8641,9 @@
       },
       "delete": {
         "summary": "Delete API key",
-        "tags": ["API Keys"],
+        "tags": [
+          "API Keys"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -7294,7 +8678,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["message"]
+                  "required": [
+                    "message"
+                  ]
                 }
               }
             }
@@ -7306,7 +8692,9 @@
       "get": {
         "summary": "List bids",
         "operationId": "listBids",
-        "tags": ["Bids"],
+        "tags": [
+          "Bids"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -7365,7 +8753,14 @@
                                     "type": "number"
                                   }
                                 },
-                                "required": ["owner", "dseq", "gseq", "oseq", "provider", "bseq"]
+                                "required": [
+                                  "owner",
+                                  "dseq",
+                                  "gseq",
+                                  "oseq",
+                                  "provider",
+                                  "bseq"
+                                ]
                               },
                               "state": {
                                 "type": "string"
@@ -7380,7 +8775,10 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": ["denom", "amount"]
+                                "required": [
+                                  "denom",
+                                  "amount"
+                                ]
                               },
                               "created_at": {
                                 "type": "string"
@@ -7403,7 +8801,9 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "required": ["val"]
+                                              "required": [
+                                                "val"
+                                              ]
                                             },
                                             "attributes": {
                                               "type": "array",
@@ -7417,11 +8817,17 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["key", "value"]
+                                                "required": [
+                                                  "key",
+                                                  "value"
+                                                ]
                                               }
                                             }
                                           },
-                                          "required": ["units", "attributes"]
+                                          "required": [
+                                            "units",
+                                            "attributes"
+                                          ]
                                         },
                                         "gpu": {
                                           "type": "object",
@@ -7433,7 +8839,9 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "required": ["val"]
+                                              "required": [
+                                                "val"
+                                              ]
                                             },
                                             "attributes": {
                                               "type": "array",
@@ -7447,11 +8855,17 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["key", "value"]
+                                                "required": [
+                                                  "key",
+                                                  "value"
+                                                ]
                                               }
                                             }
                                           },
-                                          "required": ["units", "attributes"]
+                                          "required": [
+                                            "units",
+                                            "attributes"
+                                          ]
                                         },
                                         "memory": {
                                           "type": "object",
@@ -7463,7 +8877,9 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "required": ["val"]
+                                              "required": [
+                                                "val"
+                                              ]
                                             },
                                             "attributes": {
                                               "type": "array",
@@ -7477,11 +8893,17 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["key", "value"]
+                                                "required": [
+                                                  "key",
+                                                  "value"
+                                                ]
                                               }
                                             }
                                           },
-                                          "required": ["quantity", "attributes"]
+                                          "required": [
+                                            "quantity",
+                                            "attributes"
+                                          ]
                                         },
                                         "storage": {
                                           "type": "array",
@@ -7498,7 +8920,9 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["val"]
+                                                "required": [
+                                                  "val"
+                                                ]
                                               },
                                               "attributes": {
                                                 "type": "array",
@@ -7512,11 +8936,18 @@
                                                       "type": "string"
                                                     }
                                                   },
-                                                  "required": ["key", "value"]
+                                                  "required": [
+                                                    "key",
+                                                    "value"
+                                                  ]
                                                 }
                                               }
                                             },
-                                            "required": ["name", "quantity", "attributes"]
+                                            "required": [
+                                              "name",
+                                              "quantity",
+                                              "attributes"
+                                            ]
                                           }
                                         },
                                         "endpoints": {
@@ -7531,24 +8962,42 @@
                                                 "type": "number"
                                               }
                                             },
-                                            "required": ["kind", "sequence_number"]
+                                            "required": [
+                                              "kind",
+                                              "sequence_number"
+                                            ]
                                           }
                                         }
                                       },
-                                      "required": ["cpu", "gpu", "memory", "storage", "endpoints"]
+                                      "required": [
+                                        "cpu",
+                                        "gpu",
+                                        "memory",
+                                        "storage",
+                                        "endpoints"
+                                      ]
                                     },
                                     "count": {
                                       "type": "number"
                                     }
                                   },
-                                  "required": ["resources", "count"]
+                                  "required": [
+                                    "resources",
+                                    "count"
+                                  ]
                                 }
                               },
                               "reclamation_window": {
                                 "type": "string"
                               }
                             },
-                            "required": ["id", "state", "price", "created_at", "resources_offer"]
+                            "required": [
+                              "id",
+                              "state",
+                              "price",
+                              "created_at",
+                              "resources_offer"
+                            ]
                           },
                           "escrow_account": {
                             "type": "object",
@@ -7563,7 +9012,10 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": ["scope", "xid"]
+                                "required": [
+                                  "scope",
+                                  "xid"
+                                ]
                               },
                               "state": {
                                 "type": "object",
@@ -7586,7 +9038,10 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": ["denom", "amount"]
+                                      "required": [
+                                        "denom",
+                                        "amount"
+                                      ]
                                     }
                                   },
                                   "settled_at": {
@@ -7604,7 +9059,10 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": ["denom", "amount"]
+                                      "required": [
+                                        "denom",
+                                        "amount"
+                                      ]
                                     }
                                   },
                                   "deposits": {
@@ -7631,24 +9089,47 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": ["denom", "amount"]
+                                          "required": [
+                                            "denom",
+                                            "amount"
+                                          ]
                                         }
                                       },
-                                      "required": ["owner", "height", "source", "balance"]
+                                      "required": [
+                                        "owner",
+                                        "height",
+                                        "source",
+                                        "balance"
+                                      ]
                                     }
                                   }
                                 },
-                                "required": ["owner", "state", "transferred", "settled_at", "funds", "deposits"]
+                                "required": [
+                                  "owner",
+                                  "state",
+                                  "transferred",
+                                  "settled_at",
+                                  "funds",
+                                  "deposits"
+                                ]
                               }
                             },
-                            "required": ["id", "state"]
+                            "required": [
+                              "id",
+                              "state"
+                            ]
                           }
                         },
-                        "required": ["bid", "escrow_account"]
+                        "required": [
+                          "bid",
+                          "escrow_account"
+                        ]
                       }
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -7659,7 +9140,9 @@
     "/v1/bids/{dseq}": {
       "get": {
         "summary": "List bids by dseq",
-        "tags": ["Bids"],
+        "tags": [
+          "Bids"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -7718,7 +9201,14 @@
                                     "type": "number"
                                   }
                                 },
-                                "required": ["owner", "dseq", "gseq", "oseq", "provider", "bseq"]
+                                "required": [
+                                  "owner",
+                                  "dseq",
+                                  "gseq",
+                                  "oseq",
+                                  "provider",
+                                  "bseq"
+                                ]
                               },
                               "state": {
                                 "type": "string"
@@ -7733,7 +9223,10 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": ["denom", "amount"]
+                                "required": [
+                                  "denom",
+                                  "amount"
+                                ]
                               },
                               "created_at": {
                                 "type": "string"
@@ -7756,7 +9249,9 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "required": ["val"]
+                                              "required": [
+                                                "val"
+                                              ]
                                             },
                                             "attributes": {
                                               "type": "array",
@@ -7770,11 +9265,17 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["key", "value"]
+                                                "required": [
+                                                  "key",
+                                                  "value"
+                                                ]
                                               }
                                             }
                                           },
-                                          "required": ["units", "attributes"]
+                                          "required": [
+                                            "units",
+                                            "attributes"
+                                          ]
                                         },
                                         "gpu": {
                                           "type": "object",
@@ -7786,7 +9287,9 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "required": ["val"]
+                                              "required": [
+                                                "val"
+                                              ]
                                             },
                                             "attributes": {
                                               "type": "array",
@@ -7800,11 +9303,17 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["key", "value"]
+                                                "required": [
+                                                  "key",
+                                                  "value"
+                                                ]
                                               }
                                             }
                                           },
-                                          "required": ["units", "attributes"]
+                                          "required": [
+                                            "units",
+                                            "attributes"
+                                          ]
                                         },
                                         "memory": {
                                           "type": "object",
@@ -7816,7 +9325,9 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "required": ["val"]
+                                              "required": [
+                                                "val"
+                                              ]
                                             },
                                             "attributes": {
                                               "type": "array",
@@ -7830,11 +9341,17 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["key", "value"]
+                                                "required": [
+                                                  "key",
+                                                  "value"
+                                                ]
                                               }
                                             }
                                           },
-                                          "required": ["quantity", "attributes"]
+                                          "required": [
+                                            "quantity",
+                                            "attributes"
+                                          ]
                                         },
                                         "storage": {
                                           "type": "array",
@@ -7851,7 +9368,9 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": ["val"]
+                                                "required": [
+                                                  "val"
+                                                ]
                                               },
                                               "attributes": {
                                                 "type": "array",
@@ -7865,11 +9384,18 @@
                                                       "type": "string"
                                                     }
                                                   },
-                                                  "required": ["key", "value"]
+                                                  "required": [
+                                                    "key",
+                                                    "value"
+                                                  ]
                                                 }
                                               }
                                             },
-                                            "required": ["name", "quantity", "attributes"]
+                                            "required": [
+                                              "name",
+                                              "quantity",
+                                              "attributes"
+                                            ]
                                           }
                                         },
                                         "endpoints": {
@@ -7884,24 +9410,42 @@
                                                 "type": "number"
                                               }
                                             },
-                                            "required": ["kind", "sequence_number"]
+                                            "required": [
+                                              "kind",
+                                              "sequence_number"
+                                            ]
                                           }
                                         }
                                       },
-                                      "required": ["cpu", "gpu", "memory", "storage", "endpoints"]
+                                      "required": [
+                                        "cpu",
+                                        "gpu",
+                                        "memory",
+                                        "storage",
+                                        "endpoints"
+                                      ]
                                     },
                                     "count": {
                                       "type": "number"
                                     }
                                   },
-                                  "required": ["resources", "count"]
+                                  "required": [
+                                    "resources",
+                                    "count"
+                                  ]
                                 }
                               },
                               "reclamation_window": {
                                 "type": "string"
                               }
                             },
-                            "required": ["id", "state", "price", "created_at", "resources_offer"]
+                            "required": [
+                              "id",
+                              "state",
+                              "price",
+                              "created_at",
+                              "resources_offer"
+                            ]
                           },
                           "escrow_account": {
                             "type": "object",
@@ -7916,7 +9460,10 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": ["scope", "xid"]
+                                "required": [
+                                  "scope",
+                                  "xid"
+                                ]
                               },
                               "state": {
                                 "type": "object",
@@ -7939,7 +9486,10 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": ["denom", "amount"]
+                                      "required": [
+                                        "denom",
+                                        "amount"
+                                      ]
                                     }
                                   },
                                   "settled_at": {
@@ -7957,7 +9507,10 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": ["denom", "amount"]
+                                      "required": [
+                                        "denom",
+                                        "amount"
+                                      ]
                                     }
                                   },
                                   "deposits": {
@@ -7984,24 +9537,47 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": ["denom", "amount"]
+                                          "required": [
+                                            "denom",
+                                            "amount"
+                                          ]
                                         }
                                       },
-                                      "required": ["owner", "height", "source", "balance"]
+                                      "required": [
+                                        "owner",
+                                        "height",
+                                        "source",
+                                        "balance"
+                                      ]
                                     }
                                   }
                                 },
-                                "required": ["owner", "state", "transferred", "settled_at", "funds", "deposits"]
+                                "required": [
+                                  "owner",
+                                  "state",
+                                  "transferred",
+                                  "settled_at",
+                                  "funds",
+                                  "deposits"
+                                ]
                               }
                             },
-                            "required": ["id", "state"]
+                            "required": [
+                              "id",
+                              "state"
+                            ]
                           }
                         },
-                        "required": ["bid", "escrow_account"]
+                        "required": [
+                          "bid",
+                          "escrow_account"
+                        ]
                       }
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -8012,7 +9588,9 @@
     "/v1/certificates": {
       "post": {
         "summary": "Create certificate",
-        "tags": ["Certificate"],
+        "tags": [
+          "Certificate"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -8033,7 +9611,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["error"]
+                  "required": [
+                    "error"
+                  ]
                 }
               }
             }
@@ -8044,7 +9624,9 @@
     "/v1/balances": {
       "get": {
         "summary": "Get user balances",
-        "tags": ["Wallet"],
+        "tags": [
+          "Wallet"
+        ],
         "security": [],
         "parameters": [
           {
@@ -8079,10 +9661,16 @@
                           "type": "number"
                         }
                       },
-                      "required": ["balance", "deployments", "total"]
+                      "required": [
+                        "balance",
+                        "deployments",
+                        "total"
+                      ]
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -8093,13 +9681,18 @@
     "/v1/providers": {
       "get": {
         "summary": "Get a list of providers.",
-        "tags": ["Providers"],
+        "tags": [
+          "Providers"
+        ],
         "security": [],
         "parameters": [
           {
             "schema": {
               "type": "string",
-              "enum": ["all", "trial"],
+              "enum": [
+                "all",
+                "trial"
+              ],
               "default": "all"
             },
             "required": false,
@@ -8231,7 +9824,12 @@
                               "type": "string"
                             }
                           },
-                          "required": ["vendor", "model", "ram", "interface"]
+                          "required": [
+                            "vendor",
+                            "model",
+                            "ram",
+                            "interface"
+                          ]
                         }
                       },
                       "attributes": {
@@ -8252,7 +9850,11 @@
                               }
                             }
                           },
-                          "required": ["key", "value", "auditedBy"]
+                          "required": [
+                            "key",
+                            "value",
+                            "auditedBy"
+                          ]
                         }
                       },
                       "host": {
@@ -8421,7 +10023,9 @@
     "/v1/providers/{address}": {
       "get": {
         "summary": "Get a provider details.",
-        "tags": ["Providers"],
+        "tags": [
+          "Providers"
+        ],
         "security": [],
         "parameters": [
           {
@@ -8542,7 +10146,11 @@
                               "type": "number"
                             }
                           },
-                          "required": ["active", "available", "pending"]
+                          "required": [
+                            "active",
+                            "available",
+                            "pending"
+                          ]
                         },
                         "gpu": {
                           "type": "object",
@@ -8557,7 +10165,11 @@
                               "type": "number"
                             }
                           },
-                          "required": ["active", "available", "pending"]
+                          "required": [
+                            "active",
+                            "available",
+                            "pending"
+                          ]
                         },
                         "memory": {
                           "type": "object",
@@ -8572,7 +10184,11 @@
                               "type": "number"
                             }
                           },
-                          "required": ["active", "available", "pending"]
+                          "required": [
+                            "active",
+                            "available",
+                            "pending"
+                          ]
                         },
                         "storage": {
                           "type": "object",
@@ -8590,7 +10206,11 @@
                                   "type": "number"
                                 }
                               },
-                              "required": ["active", "available", "pending"]
+                              "required": [
+                                "active",
+                                "available",
+                                "pending"
+                              ]
                             },
                             "persistent": {
                               "type": "object",
@@ -8605,13 +10225,25 @@
                                   "type": "number"
                                 }
                               },
-                              "required": ["active", "available", "pending"]
+                              "required": [
+                                "active",
+                                "available",
+                                "pending"
+                              ]
                             }
                           },
-                          "required": ["ephemeral", "persistent"]
+                          "required": [
+                            "ephemeral",
+                            "persistent"
+                          ]
                         }
                       },
-                      "required": ["cpu", "gpu", "memory", "storage"]
+                      "required": [
+                        "cpu",
+                        "gpu",
+                        "memory",
+                        "storage"
+                      ]
                     },
                     "gpuModels": {
                       "type": "array",
@@ -8631,7 +10263,12 @@
                             "type": "string"
                           }
                         },
-                        "required": ["vendor", "model", "ram", "interface"]
+                        "required": [
+                          "vendor",
+                          "model",
+                          "ram",
+                          "interface"
+                        ]
                       }
                     },
                     "attributes": {
@@ -8652,7 +10289,11 @@
                             }
                           }
                         },
-                        "required": ["key", "value", "auditedBy"]
+                        "required": [
+                          "key",
+                          "value",
+                          "auditedBy"
+                        ]
                       }
                     },
                     "host": {
@@ -8772,7 +10413,11 @@
                             "type": "string"
                           }
                         },
-                        "required": ["id", "isOnline", "checkDate"]
+                        "required": [
+                          "id",
+                          "isOnline",
+                          "checkDate"
+                        ]
                       }
                     }
                   },
@@ -8846,7 +10491,10 @@
     },
     "/v1/providers/{providerAddress}/active-leases-graph-data": {
       "get": {
-        "tags": ["Analytics", "Providers"],
+        "tags": [
+          "Analytics",
+          "Providers"
+        ],
         "security": [],
         "parameters": [
           {
@@ -8887,7 +10535,10 @@
                             "example": 100
                           }
                         },
-                        "required": ["date", "value"]
+                        "required": [
+                          "date",
+                          "value"
+                        ]
                       }
                     },
                     "now": {
@@ -8898,7 +10549,9 @@
                           "example": 100
                         }
                       },
-                      "required": ["count"]
+                      "required": [
+                        "count"
+                      ]
                     },
                     "compare": {
                       "type": "object",
@@ -8908,10 +10561,18 @@
                           "example": 100
                         }
                       },
-                      "required": ["count"]
+                      "required": [
+                        "count"
+                      ]
                     }
                   },
-                  "required": ["currentValue", "compareValue", "snapshots", "now", "compare"]
+                  "required": [
+                    "currentValue",
+                    "compareValue",
+                    "snapshots",
+                    "now",
+                    "compare"
+                  ]
                 }
               }
             }
@@ -8924,7 +10585,9 @@
     },
     "/v1/auditors": {
       "get": {
-        "tags": ["Providers"],
+        "tags": [
+          "Providers"
+        ],
         "security": [],
         "summary": "Get a list of auditors.",
         "responses": {
@@ -8950,7 +10613,12 @@
                         "type": "string"
                       }
                     },
-                    "required": ["id", "name", "address", "website"]
+                    "required": [
+                      "id",
+                      "name",
+                      "address",
+                      "website"
+                    ]
                   }
                 }
               }
@@ -8962,7 +10630,9 @@
     "/v1/provider-attributes-schema": {
       "get": {
         "summary": "Get the provider attributes schema",
-        "tags": ["Providers"],
+        "tags": [
+          "Providers"
+        ],
         "security": [],
         "responses": {
           "200": {
@@ -8980,7 +10650,13 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option"
+                          ]
                         },
                         "required": {
                           "type": "boolean"
@@ -9004,11 +10680,19 @@
                                 "nullable": true
                               }
                             },
-                            "required": ["key", "description"]
+                            "required": [
+                              "key",
+                              "description"
+                            ]
                           }
                         }
                       },
-                      "required": ["key", "type", "required", "description"]
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description"
+                      ]
                     },
                     "email": {
                       "type": "object",
@@ -9018,7 +10702,13 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option"
+                          ]
                         },
                         "required": {
                           "type": "boolean"
@@ -9042,11 +10732,19 @@
                                 "nullable": true
                               }
                             },
-                            "required": ["key", "description"]
+                            "required": [
+                              "key",
+                              "description"
+                            ]
                           }
                         }
                       },
-                      "required": ["key", "type", "required", "description"]
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description"
+                      ]
                     },
                     "organization": {
                       "type": "object",
@@ -9056,7 +10754,13 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option"
+                          ]
                         },
                         "required": {
                           "type": "boolean"
@@ -9080,11 +10784,19 @@
                                 "nullable": true
                               }
                             },
-                            "required": ["key", "description"]
+                            "required": [
+                              "key",
+                              "description"
+                            ]
                           }
                         }
                       },
-                      "required": ["key", "type", "required", "description"]
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description"
+                      ]
                     },
                     "website": {
                       "type": "object",
@@ -9094,7 +10806,13 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option"
+                          ]
                         },
                         "required": {
                           "type": "boolean"
@@ -9118,11 +10836,19 @@
                                 "nullable": true
                               }
                             },
-                            "required": ["key", "description"]
+                            "required": [
+                              "key",
+                              "description"
+                            ]
                           }
                         }
                       },
-                      "required": ["key", "type", "required", "description"]
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description"
+                      ]
                     },
                     "tier": {
                       "type": "object",
@@ -9132,7 +10858,13 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option"
+                          ]
                         },
                         "required": {
                           "type": "boolean"
@@ -9156,11 +10888,19 @@
                                 "nullable": true
                               }
                             },
-                            "required": ["key", "description"]
+                            "required": [
+                              "key",
+                              "description"
+                            ]
                           }
                         }
                       },
-                      "required": ["key", "type", "required", "description"]
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description"
+                      ]
                     },
                     "status-page": {
                       "type": "object",
@@ -9170,7 +10910,13 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option"
+                          ]
                         },
                         "required": {
                           "type": "boolean"
@@ -9194,11 +10940,19 @@
                                 "nullable": true
                               }
                             },
-                            "required": ["key", "description"]
+                            "required": [
+                              "key",
+                              "description"
+                            ]
                           }
                         }
                       },
-                      "required": ["key", "type", "required", "description"]
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description"
+                      ]
                     },
                     "location-region": {
                       "type": "object",
@@ -9208,7 +10962,13 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option"
+                          ]
                         },
                         "required": {
                           "type": "boolean"
@@ -9232,11 +10992,19 @@
                                 "nullable": true
                               }
                             },
-                            "required": ["key", "description"]
+                            "required": [
+                              "key",
+                              "description"
+                            ]
                           }
                         }
                       },
-                      "required": ["key", "type", "required", "description"]
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description"
+                      ]
                     },
                     "country": {
                       "type": "object",
@@ -9246,7 +11014,13 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option"
+                          ]
                         },
                         "required": {
                           "type": "boolean"
@@ -9270,11 +11044,19 @@
                                 "nullable": true
                               }
                             },
-                            "required": ["key", "description"]
+                            "required": [
+                              "key",
+                              "description"
+                            ]
                           }
                         }
                       },
-                      "required": ["key", "type", "required", "description"]
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description"
+                      ]
                     },
                     "city": {
                       "type": "object",
@@ -9284,7 +11066,13 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option"
+                          ]
                         },
                         "required": {
                           "type": "boolean"
@@ -9308,11 +11096,19 @@
                                 "nullable": true
                               }
                             },
-                            "required": ["key", "description"]
+                            "required": [
+                              "key",
+                              "description"
+                            ]
                           }
                         }
                       },
-                      "required": ["key", "type", "required", "description"]
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description"
+                      ]
                     },
                     "timezone": {
                       "type": "object",
@@ -9322,7 +11118,13 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option"
+                          ]
                         },
                         "required": {
                           "type": "boolean"
@@ -9346,11 +11148,19 @@
                                 "nullable": true
                               }
                             },
-                            "required": ["key", "description"]
+                            "required": [
+                              "key",
+                              "description"
+                            ]
                           }
                         }
                       },
-                      "required": ["key", "type", "required", "description"]
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description"
+                      ]
                     },
                     "location-type": {
                       "type": "object",
@@ -9360,7 +11170,13 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option"
+                          ]
                         },
                         "required": {
                           "type": "boolean"
@@ -9384,11 +11200,19 @@
                                 "nullable": true
                               }
                             },
-                            "required": ["key", "description"]
+                            "required": [
+                              "key",
+                              "description"
+                            ]
                           }
                         }
                       },
-                      "required": ["key", "type", "required", "description"]
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description"
+                      ]
                     },
                     "hosting-provider": {
                       "type": "object",
@@ -9398,7 +11222,13 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option"
+                          ]
                         },
                         "required": {
                           "type": "boolean"
@@ -9422,11 +11252,19 @@
                                 "nullable": true
                               }
                             },
-                            "required": ["key", "description"]
+                            "required": [
+                              "key",
+                              "description"
+                            ]
                           }
                         }
                       },
-                      "required": ["key", "type", "required", "description"]
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description"
+                      ]
                     },
                     "hardware-cpu": {
                       "type": "object",
@@ -9436,7 +11274,13 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option"
+                          ]
                         },
                         "required": {
                           "type": "boolean"
@@ -9460,11 +11304,19 @@
                                 "nullable": true
                               }
                             },
-                            "required": ["key", "description"]
+                            "required": [
+                              "key",
+                              "description"
+                            ]
                           }
                         }
                       },
-                      "required": ["key", "type", "required", "description"]
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description"
+                      ]
                     },
                     "hardware-cpu-arch": {
                       "type": "object",
@@ -9474,7 +11326,13 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option"
+                          ]
                         },
                         "required": {
                           "type": "boolean"
@@ -9498,11 +11356,19 @@
                                 "nullable": true
                               }
                             },
-                            "required": ["key", "description"]
+                            "required": [
+                              "key",
+                              "description"
+                            ]
                           }
                         }
                       },
-                      "required": ["key", "type", "required", "description"]
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description"
+                      ]
                     },
                     "hardware-gpu": {
                       "type": "object",
@@ -9512,7 +11378,13 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option"
+                          ]
                         },
                         "required": {
                           "type": "boolean"
@@ -9536,11 +11408,19 @@
                                 "nullable": true
                               }
                             },
-                            "required": ["key", "description"]
+                            "required": [
+                              "key",
+                              "description"
+                            ]
                           }
                         }
                       },
-                      "required": ["key", "type", "required", "description"]
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description"
+                      ]
                     },
                     "hardware-gpu-model": {
                       "type": "object",
@@ -9550,7 +11430,13 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option"
+                          ]
                         },
                         "required": {
                           "type": "boolean"
@@ -9574,11 +11460,19 @@
                                 "nullable": true
                               }
                             },
-                            "required": ["key", "description"]
+                            "required": [
+                              "key",
+                              "description"
+                            ]
                           }
                         }
                       },
-                      "required": ["key", "type", "required", "description"]
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description"
+                      ]
                     },
                     "hardware-disk": {
                       "type": "object",
@@ -9588,7 +11482,13 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option"
+                          ]
                         },
                         "required": {
                           "type": "boolean"
@@ -9612,11 +11512,19 @@
                                 "nullable": true
                               }
                             },
-                            "required": ["key", "description"]
+                            "required": [
+                              "key",
+                              "description"
+                            ]
                           }
                         }
                       },
-                      "required": ["key", "type", "required", "description"]
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description"
+                      ]
                     },
                     "hardware-memory": {
                       "type": "object",
@@ -9626,7 +11534,13 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option"
+                          ]
                         },
                         "required": {
                           "type": "boolean"
@@ -9650,11 +11564,19 @@
                                 "nullable": true
                               }
                             },
-                            "required": ["key", "description"]
+                            "required": [
+                              "key",
+                              "description"
+                            ]
                           }
                         }
                       },
-                      "required": ["key", "type", "required", "description"]
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description"
+                      ]
                     },
                     "network-provider": {
                       "type": "object",
@@ -9664,7 +11586,13 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option"
+                          ]
                         },
                         "required": {
                           "type": "boolean"
@@ -9688,11 +11616,19 @@
                                 "nullable": true
                               }
                             },
-                            "required": ["key", "description"]
+                            "required": [
+                              "key",
+                              "description"
+                            ]
                           }
                         }
                       },
-                      "required": ["key", "type", "required", "description"]
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description"
+                      ]
                     },
                     "network-speed-up": {
                       "type": "object",
@@ -9702,7 +11638,13 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option"
+                          ]
                         },
                         "required": {
                           "type": "boolean"
@@ -9726,11 +11668,19 @@
                                 "nullable": true
                               }
                             },
-                            "required": ["key", "description"]
+                            "required": [
+                              "key",
+                              "description"
+                            ]
                           }
                         }
                       },
-                      "required": ["key", "type", "required", "description"]
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description"
+                      ]
                     },
                     "network-speed-down": {
                       "type": "object",
@@ -9740,7 +11690,13 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option"
+                          ]
                         },
                         "required": {
                           "type": "boolean"
@@ -9764,11 +11720,19 @@
                                 "nullable": true
                               }
                             },
-                            "required": ["key", "description"]
+                            "required": [
+                              "key",
+                              "description"
+                            ]
                           }
                         }
                       },
-                      "required": ["key", "type", "required", "description"]
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description"
+                      ]
                     },
                     "feat-persistent-storage": {
                       "type": "object",
@@ -9778,7 +11742,13 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option"
+                          ]
                         },
                         "required": {
                           "type": "boolean"
@@ -9802,11 +11772,19 @@
                                 "nullable": true
                               }
                             },
-                            "required": ["key", "description"]
+                            "required": [
+                              "key",
+                              "description"
+                            ]
                           }
                         }
                       },
-                      "required": ["key", "type", "required", "description"]
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description"
+                      ]
                     },
                     "feat-persistent-storage-type": {
                       "type": "object",
@@ -9816,7 +11794,13 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option"
+                          ]
                         },
                         "required": {
                           "type": "boolean"
@@ -9840,11 +11824,19 @@
                                 "nullable": true
                               }
                             },
-                            "required": ["key", "description"]
+                            "required": [
+                              "key",
+                              "description"
+                            ]
                           }
                         }
                       },
-                      "required": ["key", "type", "required", "description"]
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description"
+                      ]
                     },
                     "workload-support-chia": {
                       "type": "object",
@@ -9854,7 +11846,13 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option"
+                          ]
                         },
                         "required": {
                           "type": "boolean"
@@ -9878,11 +11876,19 @@
                                 "nullable": true
                               }
                             },
-                            "required": ["key", "description"]
+                            "required": [
+                              "key",
+                              "description"
+                            ]
                           }
                         }
                       },
-                      "required": ["key", "type", "required", "description"]
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description"
+                      ]
                     },
                     "workload-support-chia-capabilities": {
                       "type": "object",
@@ -9892,7 +11898,13 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option"
+                          ]
                         },
                         "required": {
                           "type": "boolean"
@@ -9916,11 +11928,19 @@
                                 "nullable": true
                               }
                             },
-                            "required": ["key", "description"]
+                            "required": [
+                              "key",
+                              "description"
+                            ]
                           }
                         }
                       },
-                      "required": ["key", "type", "required", "description"]
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description"
+                      ]
                     },
                     "feat-endpoint-ip": {
                       "type": "object",
@@ -9930,7 +11950,13 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option"
+                          ]
                         },
                         "required": {
                           "type": "boolean"
@@ -9954,11 +11980,19 @@
                                 "nullable": true
                               }
                             },
-                            "required": ["key", "description"]
+                            "required": [
+                              "key",
+                              "description"
+                            ]
                           }
                         }
                       },
-                      "required": ["key", "type", "required", "description"]
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description"
+                      ]
                     },
                     "feat-endpoint-custom-domain": {
                       "type": "object",
@@ -9968,7 +12002,13 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option"
+                          ]
                         },
                         "required": {
                           "type": "boolean"
@@ -9992,11 +12032,19 @@
                                 "nullable": true
                               }
                             },
-                            "required": ["key", "description"]
+                            "required": [
+                              "key",
+                              "description"
+                            ]
                           }
                         }
                       },
-                      "required": ["key", "type", "required", "description"]
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description"
+                      ]
                     }
                   },
                   "required": [
@@ -10038,7 +12086,9 @@
     "/v1/provider-regions": {
       "get": {
         "summary": "Get a list of provider regions",
-        "tags": ["Providers"],
+        "tags": [
+          "Providers"
+        ],
         "security": [],
         "responses": {
           "200": {
@@ -10066,7 +12116,11 @@
                         "type": "string"
                       }
                     },
-                    "required": ["providers", "key", "description"]
+                    "required": [
+                      "providers",
+                      "key",
+                      "description"
+                    ]
                   }
                 }
               }
@@ -10078,7 +12132,9 @@
     "/v1/provider-dashboard/{owner}": {
       "get": {
         "summary": "Get dashboard data for provider console.",
-        "tags": ["Providers"],
+        "tags": [
+          "Providers"
+        ],
         "security": [],
         "parameters": [
           {
@@ -10266,7 +12322,10 @@
                       ]
                     }
                   },
-                  "required": ["current", "previous"]
+                  "required": [
+                    "current",
+                    "previous"
+                  ]
                 }
               }
             }
@@ -10280,7 +12339,9 @@
     "/v1/provider-earnings/{owner}": {
       "get": {
         "summary": "Get earnings data for provider console.",
-        "tags": ["Providers"],
+        "tags": [
+          "Providers"
+        ],
         "security": [],
         "parameters": [
           {
@@ -10340,10 +12401,17 @@
                           "type": "number"
                         }
                       },
-                      "required": ["totalUAktEarned", "totalUUsdcEarned", "totalUActEarned", "totalUUsdEarned"]
+                      "required": [
+                        "totalUAktEarned",
+                        "totalUUsdcEarned",
+                        "totalUActEarned",
+                        "totalUUsdEarned"
+                      ]
                     }
                   },
-                  "required": ["earnings"]
+                  "required": [
+                    "earnings"
+                  ]
                 }
               }
             }
@@ -10357,7 +12425,9 @@
     "/v1/provider-versions": {
       "get": {
         "summary": "Get providers grouped by version.",
-        "tags": ["Providers"],
+        "tags": [
+          "Providers"
+        ],
         "security": [],
         "responses": {
           "200": {
@@ -10385,7 +12455,12 @@
                         }
                       }
                     },
-                    "required": ["version", "count", "ratio", "providers"]
+                    "required": [
+                      "version",
+                      "count",
+                      "ratio",
+                      "providers"
+                    ]
                   }
                 }
               }
@@ -10396,14 +12471,22 @@
     },
     "/v1/provider-graph-data/{dataName}": {
       "get": {
-        "tags": ["Analytics"],
+        "tags": [
+          "Analytics"
+        ],
         "security": [],
         "parameters": [
           {
             "schema": {
               "type": "string",
               "example": "cpu",
-              "enum": ["count", "cpu", "gpu", "memory", "storage"]
+              "enum": [
+                "count",
+                "cpu",
+                "gpu",
+                "memory",
+                "storage"
+              ]
             },
             "required": true,
             "name": "dataName",
@@ -10438,7 +12521,10 @@
                             "example": 100
                           }
                         },
-                        "required": ["date", "value"]
+                        "required": [
+                          "date",
+                          "value"
+                        ]
                       }
                     },
                     "now": {
@@ -10465,7 +12551,13 @@
                           "example": 100
                         }
                       },
-                      "required": ["count", "cpu", "gpu", "memory", "storage"]
+                      "required": [
+                        "count",
+                        "cpu",
+                        "gpu",
+                        "memory",
+                        "storage"
+                      ]
                     },
                     "compare": {
                       "type": "object",
@@ -10491,10 +12583,20 @@
                           "example": 100
                         }
                       },
-                      "required": ["count", "cpu", "gpu", "memory", "storage"]
+                      "required": [
+                        "count",
+                        "cpu",
+                        "gpu",
+                        "memory",
+                        "storage"
+                      ]
                     }
                   },
-                  "required": ["currentValue", "compareValue", "snapshots"]
+                  "required": [
+                    "currentValue",
+                    "compareValue",
+                    "snapshots"
+                  ]
                 }
               }
             }
@@ -10508,7 +12610,10 @@
     "/v1/providers/{provider}/deployments/{skip}/{limit}": {
       "get": {
         "summary": "Get a list of deployments for a provider.",
-        "tags": ["Providers", "Deployments"],
+        "tags": [
+          "Providers",
+          "Deployments"
+        ],
         "security": [],
         "parameters": [
           {
@@ -10548,7 +12653,10 @@
           {
             "schema": {
               "type": "string",
-              "enum": ["active", "closed"],
+              "enum": [
+                "active",
+                "closed"
+              ],
               "description": "Filter by status",
               "example": "closed"
             },
@@ -10622,7 +12730,13 @@
                                 "type": "number"
                               }
                             },
-                            "required": ["cpu", "memory", "gpu", "ephemeralStorage", "persistentStorage"]
+                            "required": [
+                              "cpu",
+                              "memory",
+                              "gpu",
+                              "ephemeralStorage",
+                              "persistentStorage"
+                            ]
                           },
                           "leases": {
                             "type": "array",
@@ -10678,7 +12792,13 @@
                                       "type": "number"
                                     }
                                   },
-                                  "required": ["cpu", "memory", "gpu", "ephemeralStorage", "persistentStorage"]
+                                  "required": [
+                                    "cpu",
+                                    "memory",
+                                    "gpu",
+                                    "ephemeralStorage",
+                                    "persistentStorage"
+                                  ]
                                 }
                               },
                               "required": [
@@ -10712,7 +12832,10 @@
                       }
                     }
                   },
-                  "required": ["total", "deployments"]
+                  "required": [
+                    "total",
+                    "deployments"
+                  ]
                 }
               }
             }
@@ -10726,7 +12849,9 @@
     "/v1/create-jwt-token": {
       "post": {
         "summary": "Create new JWT token for managed wallet",
-        "tags": ["JWT Token"],
+        "tags": [
+          "JWT Token"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -10756,10 +12881,15 @@
                         }
                       }
                     },
-                    "required": ["ttl", "leases"]
+                    "required": [
+                      "ttl",
+                      "leases"
+                    ]
                   }
                 },
-                "required": ["data"]
+                "required": [
+                  "data"
+                ]
               }
             }
           }
@@ -10779,10 +12909,14 @@
                           "type": "string"
                         }
                       },
-                      "required": ["token"]
+                      "required": [
+                        "token"
+                      ]
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -10792,7 +12926,9 @@
     },
     "/v1/graph-data/{dataName}": {
       "get": {
-        "tags": ["Analytics"],
+        "tags": [
+          "Analytics"
+        ],
         "security": [],
         "parameters": [
           {
@@ -10864,11 +13000,18 @@
                             "example": 100
                           }
                         },
-                        "required": ["date", "value"]
+                        "required": [
+                          "date",
+                          "value"
+                        ]
                       }
                     }
                   },
-                  "required": ["currentValue", "compareValue", "snapshots"]
+                  "required": [
+                    "currentValue",
+                    "compareValue",
+                    "snapshots"
+                  ]
                 }
               }
             }
@@ -10881,7 +13024,9 @@
     },
     "/v1/bme/dashboard-data": {
       "get": {
-        "tags": ["Analytics"],
+        "tags": [
+          "Analytics"
+        ],
         "security": [],
         "responses": {
           "200": {
@@ -11018,7 +13163,10 @@
                       ]
                     }
                   },
-                  "required": ["now", "compare"]
+                  "required": [
+                    "now",
+                    "compare"
+                  ]
                 }
               }
             }
@@ -11028,7 +13176,9 @@
     },
     "/v1/bme/status-history": {
       "get": {
-        "tags": ["Analytics"],
+        "tags": [
+          "Analytics"
+        ],
         "security": [],
         "responses": {
           "200": {
@@ -11061,7 +13211,13 @@
                         "example": 1.5
                       }
                     },
-                    "required": ["height", "date", "previousStatus", "newStatus", "collateralRatio"]
+                    "required": [
+                      "height",
+                      "date",
+                      "previousStatus",
+                      "newStatus",
+                      "collateralRatio"
+                    ]
                   }
                 }
               }
@@ -11072,7 +13228,9 @@
     },
     "/v1/dashboard-data": {
       "get": {
-        "tags": ["Analytics"],
+        "tags": [
+          "Analytics"
+        ],
         "security": [],
         "responses": {
           "200": {
@@ -11107,7 +13265,14 @@
                           "type": "number"
                         }
                       },
-                      "required": ["height", "transactionCount", "bondedTokens", "totalSupply", "communityPool", "inflation"]
+                      "required": [
+                        "height",
+                        "transactionCount",
+                        "bondedTokens",
+                        "totalSupply",
+                        "communityPool",
+                        "inflation"
+                      ]
                     },
                     "now": {
                       "type": "object",
@@ -11387,7 +13552,10 @@
                                 "type": "number"
                               }
                             },
-                            "required": ["date", "value"]
+                            "required": [
+                              "date",
+                              "value"
+                            ]
                           }
                         },
                         "now": {
@@ -11409,7 +13577,13 @@
                               "type": "number"
                             }
                           },
-                          "required": ["count", "cpu", "gpu", "memory", "storage"]
+                          "required": [
+                            "count",
+                            "cpu",
+                            "gpu",
+                            "memory",
+                            "storage"
+                          ]
                         },
                         "compare": {
                           "type": "object",
@@ -11430,10 +13604,22 @@
                               "type": "number"
                             }
                           },
-                          "required": ["count", "cpu", "gpu", "memory", "storage"]
+                          "required": [
+                            "count",
+                            "cpu",
+                            "gpu",
+                            "memory",
+                            "storage"
+                          ]
                         }
                       },
-                      "required": ["currentValue", "compareValue", "snapshots", "now", "compare"]
+                      "required": [
+                        "currentValue",
+                        "compareValue",
+                        "snapshots",
+                        "now",
+                        "compare"
+                      ]
                     },
                     "latestBlocks": {
                       "type": "array",
@@ -11461,7 +13647,12 @@
                                 "nullable": true
                               }
                             },
-                            "required": ["address", "operatorAddress", "moniker", "avatarUrl"]
+                            "required": [
+                              "address",
+                              "operatorAddress",
+                              "moniker",
+                              "avatarUrl"
+                            ]
                           },
                           "transactionCount": {
                             "type": "number"
@@ -11473,7 +13664,13 @@
                             "type": "string"
                           }
                         },
-                        "required": ["height", "proposer", "transactionCount", "totalTransactionCount", "datetime"]
+                        "required": [
+                          "height",
+                          "proposer",
+                          "transactionCount",
+                          "totalTransactionCount",
+                          "datetime"
+                        ]
                       }
                     },
                     "latestTransactions": {
@@ -11524,15 +13721,38 @@
                                   "type": "number"
                                 }
                               },
-                              "required": ["id", "type", "amount"]
+                              "required": [
+                                "id",
+                                "type",
+                                "amount"
+                              ]
                             }
                           }
                         },
-                        "required": ["height", "datetime", "hash", "isSuccess", "error", "gasUsed", "gasWanted", "fee", "memo", "messages"]
+                        "required": [
+                          "height",
+                          "datetime",
+                          "hash",
+                          "isSuccess",
+                          "error",
+                          "gasUsed",
+                          "gasWanted",
+                          "fee",
+                          "memo",
+                          "messages"
+                        ]
                       }
                     }
                   },
-                  "required": ["chainStats", "now", "compare", "networkCapacity", "networkCapacityStats", "latestBlocks", "latestTransactions"]
+                  "required": [
+                    "chainStats",
+                    "now",
+                    "compare",
+                    "networkCapacity",
+                    "networkCapacityStats",
+                    "latestBlocks",
+                    "latestTransactions"
+                  ]
                 }
               }
             }
@@ -11542,7 +13762,9 @@
     },
     "/v1/network-capacity": {
       "get": {
-        "tags": ["Analytics"],
+        "tags": [
+          "Analytics"
+        ],
         "security": [],
         "responses": {
           "200": {
@@ -11574,7 +13796,12 @@
                               "type": "number"
                             }
                           },
-                          "required": ["active", "pending", "available", "total"]
+                          "required": [
+                            "active",
+                            "pending",
+                            "available",
+                            "total"
+                          ]
                         },
                         "gpu": {
                           "type": "object",
@@ -11592,7 +13819,12 @@
                               "type": "number"
                             }
                           },
-                          "required": ["active", "pending", "available", "total"]
+                          "required": [
+                            "active",
+                            "pending",
+                            "available",
+                            "total"
+                          ]
                         },
                         "memory": {
                           "type": "object",
@@ -11610,7 +13842,12 @@
                               "type": "number"
                             }
                           },
-                          "required": ["active", "pending", "available", "total"]
+                          "required": [
+                            "active",
+                            "pending",
+                            "available",
+                            "total"
+                          ]
                         },
                         "storage": {
                           "type": "object",
@@ -11631,7 +13868,12 @@
                                   "type": "number"
                                 }
                               },
-                              "required": ["active", "pending", "available", "total"]
+                              "required": [
+                                "active",
+                                "pending",
+                                "available",
+                                "total"
+                              ]
                             },
                             "persistent": {
                               "type": "object",
@@ -11649,7 +13891,12 @@
                                   "type": "number"
                                 }
                               },
-                              "required": ["active", "pending", "available", "total"]
+                              "required": [
+                                "active",
+                                "pending",
+                                "available",
+                                "total"
+                              ]
                             },
                             "total": {
                               "type": "object",
@@ -11667,16 +13914,33 @@
                                   "type": "number"
                                 }
                               },
-                              "required": ["active", "pending", "available", "total"]
+                              "required": [
+                                "active",
+                                "pending",
+                                "available",
+                                "total"
+                              ]
                             }
                           },
-                          "required": ["ephemeral", "persistent", "total"]
+                          "required": [
+                            "ephemeral",
+                            "persistent",
+                            "total"
+                          ]
                         }
                       },
-                      "required": ["cpu", "gpu", "memory", "storage"]
+                      "required": [
+                        "cpu",
+                        "gpu",
+                        "memory",
+                        "storage"
+                      ]
                     }
                   },
-                  "required": ["activeProviderCount", "resources"]
+                  "required": [
+                    "activeProviderCount",
+                    "resources"
+                  ]
                 }
               }
             }
@@ -11687,7 +13951,9 @@
     "/v1/blocks": {
       "get": {
         "summary": "Get a list of recent blocks.",
-        "tags": ["Blocks"],
+        "tags": [
+          "Blocks"
+        ],
         "security": [],
         "parameters": [
           {
@@ -11734,7 +14000,12 @@
                             "nullable": true
                           }
                         },
-                        "required": ["address", "operatorAddress", "moniker", "avatarUrl"]
+                        "required": [
+                          "address",
+                          "operatorAddress",
+                          "moniker",
+                          "avatarUrl"
+                        ]
                       },
                       "transactionCount": {
                         "type": "number"
@@ -11746,7 +14017,13 @@
                         "type": "string"
                       }
                     },
-                    "required": ["height", "proposer", "transactionCount", "totalTransactionCount", "datetime"]
+                    "required": [
+                      "height",
+                      "proposer",
+                      "transactionCount",
+                      "totalTransactionCount",
+                      "datetime"
+                    ]
                   }
                 }
               }
@@ -11758,7 +14035,9 @@
     "/v1/blocks/{height}": {
       "get": {
         "summary": "Get a block by height.",
-        "tags": ["Blocks"],
+        "tags": [
+          "Blocks"
+        ],
         "security": [],
         "parameters": [
           {
@@ -11803,7 +14082,11 @@
                           "type": "string"
                         }
                       },
-                      "required": ["operatorAddress", "moniker", "address"]
+                      "required": [
+                        "operatorAddress",
+                        "moniker",
+                        "address"
+                      ]
                     },
                     "hash": {
                       "type": "string"
@@ -11850,15 +14133,33 @@
                                   "type": "number"
                                 }
                               },
-                              "required": ["id", "type", "amount"]
+                              "required": [
+                                "id",
+                                "type",
+                                "amount"
+                              ]
                             }
                           }
                         },
-                        "required": ["hash", "isSuccess", "fee", "datetime", "messages"]
+                        "required": [
+                          "hash",
+                          "isSuccess",
+                          "fee",
+                          "datetime",
+                          "messages"
+                        ]
                       }
                     }
                   },
-                  "required": ["height", "datetime", "proposer", "hash", "gasUsed", "gasWanted", "transactions"]
+                  "required": [
+                    "height",
+                    "datetime",
+                    "proposer",
+                    "hash",
+                    "gasUsed",
+                    "gasWanted",
+                    "transactions"
+                  ]
                 }
               }
             }
@@ -11875,7 +14176,9 @@
     "/v1/predicted-block-date/{height}": {
       "get": {
         "summary": "Get the estimated date of a future block.",
-        "tags": ["Blocks"],
+        "tags": [
+          "Blocks"
+        ],
         "security": [],
         "parameters": [
           {
@@ -11920,7 +14223,11 @@
                       "example": 10000
                     }
                   },
-                  "required": ["predictedDate", "height", "blockWindow"]
+                  "required": [
+                    "predictedDate",
+                    "height",
+                    "blockWindow"
+                  ]
                 }
               }
             }
@@ -11934,7 +14241,9 @@
     "/v1/predicted-date-height/{timestamp}": {
       "get": {
         "summary": "Get the estimated height of a future date and time.",
-        "tags": ["Blocks"],
+        "tags": [
+          "Blocks"
+        ],
         "security": [],
         "parameters": [
           {
@@ -11980,7 +14289,11 @@
                       "example": 10000
                     }
                   },
-                  "required": ["predictedHeight", "date", "blockWindow"]
+                  "required": [
+                    "predictedHeight",
+                    "date",
+                    "blockWindow"
+                  ]
                 }
               }
             }
@@ -11994,7 +14307,9 @@
     "/v1/transactions": {
       "get": {
         "summary": "Get a list of transactions.",
-        "tags": ["Transactions"],
+        "tags": [
+          "Transactions"
+        ],
         "security": [],
         "parameters": [
           {
@@ -12064,11 +14379,26 @@
                               "type": "number"
                             }
                           },
-                          "required": ["id", "type", "amount"]
+                          "required": [
+                            "id",
+                            "type",
+                            "amount"
+                          ]
                         }
                       }
                     },
-                    "required": ["height", "datetime", "hash", "isSuccess", "error", "gasUsed", "gasWanted", "fee", "memo", "messages"]
+                    "required": [
+                      "height",
+                      "datetime",
+                      "hash",
+                      "isSuccess",
+                      "error",
+                      "gasUsed",
+                      "gasWanted",
+                      "fee",
+                      "memo",
+                      "messages"
+                    ]
                   }
                 }
               }
@@ -12080,7 +14410,9 @@
     "/v1/transactions/{hash}": {
       "get": {
         "summary": "Get a transaction by hash.",
-        "tags": ["Transactions"],
+        "tags": [
+          "Transactions"
+        ],
         "security": [],
         "parameters": [
           {
@@ -12162,11 +14494,27 @@
                             "nullable": true
                           }
                         },
-                        "required": ["id", "type", "data"]
+                        "required": [
+                          "id",
+                          "type",
+                          "data"
+                        ]
                       }
                     }
                   },
-                  "required": ["height", "datetime", "hash", "isSuccess", "signers", "error", "gasUsed", "gasWanted", "fee", "memo", "messages"]
+                  "required": [
+                    "height",
+                    "datetime",
+                    "hash",
+                    "isSuccess",
+                    "signers",
+                    "error",
+                    "gasUsed",
+                    "gasWanted",
+                    "fee",
+                    "memo",
+                    "messages"
+                  ]
                 }
               }
             }
@@ -12179,13 +14527,18 @@
     },
     "/v1/market-data/{coin?}": {
       "get": {
-        "tags": ["Analytics"],
+        "tags": [
+          "Analytics"
+        ],
         "security": [],
         "parameters": [
           {
             "schema": {
               "type": "string",
-              "enum": ["akash-network", "akt"],
+              "enum": [
+                "akash-network",
+                "akt"
+              ],
               "default": "akt",
               "example": "akt"
             },
@@ -12221,7 +14574,14 @@
                       "type": "number"
                     }
                   },
-                  "required": ["price", "volume", "marketCap", "marketCapRank", "priceChange24h", "priceChangePercentage24"]
+                  "required": [
+                    "price",
+                    "volume",
+                    "marketCap",
+                    "marketCapRank",
+                    "priceChange24h",
+                    "priceChangePercentage24"
+                  ]
                 }
               }
             }
@@ -12231,7 +14591,9 @@
     },
     "/v1/validators": {
       "get": {
-        "tags": ["Validators"],
+        "tags": [
+          "Validators"
+        ],
         "security": [],
         "responses": {
           "200": {
@@ -12269,7 +14631,16 @@
                         "nullable": true
                       }
                     },
-                    "required": ["operatorAddress", "moniker", "votingPower", "commission", "identity", "votingPowerRatio", "rank", "keybaseAvatarUrl"]
+                    "required": [
+                      "operatorAddress",
+                      "moniker",
+                      "votingPower",
+                      "commission",
+                      "identity",
+                      "votingPowerRatio",
+                      "rank",
+                      "keybaseAvatarUrl"
+                    ]
                   }
                 }
               }
@@ -12280,7 +14651,9 @@
     },
     "/v1/validators/{address}": {
       "get": {
-        "tags": ["Validators"],
+        "tags": [
+          "Validators"
+        ],
         "security": [],
         "parameters": [
           {
@@ -12375,7 +14748,9 @@
     },
     "/v1/pricing": {
       "post": {
-        "tags": ["Other"],
+        "tags": [
+          "Other"
+        ],
         "security": [],
         "summary": "Estimate the price of a deployment on akash and other cloud providers.",
         "requestBody": {
@@ -12404,7 +14779,11 @@
                         "example": 1000000000
                       }
                     },
-                    "required": ["cpu", "memory", "storage"]
+                    "required": [
+                      "cpu",
+                      "memory",
+                      "storage"
+                    ]
                   },
                   {
                     "type": "array",
@@ -12428,7 +14807,11 @@
                           "example": 1000000000
                         }
                       },
-                      "required": ["cpu", "memory", "storage"]
+                      "required": [
+                        "cpu",
+                        "memory",
+                        "storage"
+                      ]
                     },
                     "minItems": 1,
                     "maxItems": 10
@@ -12468,7 +14851,11 @@
                               "example": 1000000000
                             }
                           },
-                          "required": ["cpu", "memory", "storage"]
+                          "required": [
+                            "cpu",
+                            "memory",
+                            "storage"
+                          ]
                         },
                         "akash": {
                           "type": "number",
@@ -12487,7 +14874,13 @@
                           "description": "Azure price estimation (USD/month)"
                         }
                       },
-                      "required": ["spec", "akash", "aws", "gcp", "azure"]
+                      "required": [
+                        "spec",
+                        "akash",
+                        "aws",
+                        "gcp",
+                        "azure"
+                      ]
                     },
                     {
                       "type": "array",
@@ -12514,7 +14907,11 @@
                                 "example": 1000000000
                               }
                             },
-                            "required": ["cpu", "memory", "storage"]
+                            "required": [
+                              "cpu",
+                              "memory",
+                              "storage"
+                            ]
                           },
                           "akash": {
                             "type": "number",
@@ -12533,7 +14930,13 @@
                             "description": "Azure price estimation (USD/month)"
                           }
                         },
-                        "required": ["spec", "akash", "aws", "gcp", "azure"]
+                        "required": [
+                          "spec",
+                          "akash",
+                          "aws",
+                          "gcp",
+                          "azure"
+                        ]
                       }
                     }
                   ]
@@ -12550,7 +14953,9 @@
     "/v1/gpu": {
       "get": {
         "summary": "Get a list of gpu models and their availability.",
-        "tags": ["Gpu"],
+        "tags": [
+          "Gpu"
+        ],
         "security": [],
         "parameters": [
           {
@@ -12607,7 +15012,10 @@
                               "type": "number"
                             }
                           },
-                          "required": ["allocatable", "allocated"]
+                          "required": [
+                            "allocatable",
+                            "allocated"
+                          ]
                         },
                         "details": {
                           "type": "object",
@@ -12632,15 +15040,26 @@
                                   "type": "number"
                                 }
                               },
-                              "required": ["model", "ram", "interface", "allocatable", "allocated"]
+                              "required": [
+                                "model",
+                                "ram",
+                                "interface",
+                                "allocatable",
+                                "allocated"
+                              ]
                             }
                           }
                         }
                       },
-                      "required": ["total", "details"]
+                      "required": [
+                        "total",
+                        "details"
+                      ]
                     }
                   },
-                  "required": ["gpus"]
+                  "required": [
+                    "gpus"
+                  ]
                 }
               }
             }
@@ -12654,7 +15073,9 @@
     "/v1/gpu-models": {
       "get": {
         "summary": "Get a list of gpu models per vendor. Based on the content from https://raw.githubusercontent.com/akash-network/provider-configs/main/devices/pcie/gpus.json.",
-        "tags": ["Gpu"],
+        "tags": [
+          "Gpu"
+        ],
         "security": [],
         "responses": {
           "200": {
@@ -12698,11 +15119,20 @@
                               }
                             }
                           },
-                          "required": ["name", "displayName", "memory", "interface"]
+                          "required": [
+                            "name",
+                            "displayName",
+                            "memory",
+                            "interface"
+                          ]
                         }
                       }
                     },
-                    "required": ["name", "displayName", "models"]
+                    "required": [
+                      "name",
+                      "displayName",
+                      "models"
+                    ]
                   }
                 }
               }
@@ -12713,7 +15143,9 @@
     },
     "/v1/gpu-breakdown": {
       "get": {
-        "tags": ["Gpu"],
+        "tags": [
+          "Gpu"
+        ],
         "security": [],
         "summary": "Gets gpu analytics breakdown by vendor and model. If no vendor or model is provided, all GPUs are returned.",
         "parameters": [
@@ -12769,7 +15201,16 @@
                         "type": "number"
                       }
                     },
-                    "required": ["date", "vendor", "model", "providerCount", "nodeCount", "totalGpus", "leasedGpus", "gpuUtilization"]
+                    "required": [
+                      "date",
+                      "vendor",
+                      "model",
+                      "providerCount",
+                      "nodeCount",
+                      "totalGpus",
+                      "leasedGpus",
+                      "gpuUtilization"
+                    ]
                   }
                 }
               }
@@ -12782,7 +15223,9 @@
       "get": {
         "summary": "Get a list of gpu models with their availability and pricing.",
         "operationId": "listGpuPrices",
-        "tags": ["Gpu"],
+        "tags": [
+          "Gpu"
+        ],
         "security": [],
         "responses": {
           "200": {
@@ -12802,7 +15245,10 @@
                           "type": "number"
                         }
                       },
-                      "required": ["total", "available"]
+                      "required": [
+                        "total",
+                        "available"
+                      ]
                     },
                     "models": {
                       "type": "array",
@@ -12831,7 +15277,10 @@
                                 "type": "number"
                               }
                             },
-                            "required": ["total", "available"]
+                            "required": [
+                              "total",
+                              "available"
+                            ]
                           },
                           "providerAvailability": {
                             "type": "object",
@@ -12843,7 +15292,10 @@
                                 "type": "number"
                               }
                             },
-                            "required": ["total", "available"]
+                            "required": [
+                              "total",
+                              "available"
+                            ]
                           },
                           "price": {
                             "type": "object",
@@ -12869,14 +15321,32 @@
                                 "type": "number"
                               }
                             },
-                            "required": ["currency", "min", "max", "avg", "weightedAverage", "med"]
+                            "required": [
+                              "currency",
+                              "min",
+                              "max",
+                              "avg",
+                              "weightedAverage",
+                              "med"
+                            ]
                           }
                         },
-                        "required": ["vendor", "model", "ram", "interface", "availability", "providerAvailability", "price"]
+                        "required": [
+                          "vendor",
+                          "model",
+                          "ram",
+                          "interface",
+                          "availability",
+                          "providerAvailability",
+                          "price"
+                        ]
                       }
                     }
                   },
-                  "required": ["availability", "models"]
+                  "required": [
+                    "availability",
+                    "models"
+                  ]
                 }
               }
             }
@@ -12886,7 +15356,9 @@
     },
     "/v1/proposals": {
       "get": {
-        "tags": ["Proposals"],
+        "tags": [
+          "Proposals"
+        ],
         "security": [],
         "responses": {
           "200": {
@@ -12920,7 +15392,15 @@
                         "type": "number"
                       }
                     },
-                    "required": ["id", "title", "status", "submitTime", "votingStartTime", "votingEndTime", "totalDeposit"]
+                    "required": [
+                      "id",
+                      "title",
+                      "status",
+                      "submitTime",
+                      "votingStartTime",
+                      "votingEndTime",
+                      "totalDeposit"
+                    ]
                   }
                 }
               }
@@ -12931,7 +15411,9 @@
     },
     "/v1/proposals/{id}": {
       "get": {
-        "tags": ["Proposals"],
+        "tags": [
+          "Proposals"
+        ],
         "security": [],
         "parameters": [
           {
@@ -12997,7 +15479,13 @@
                           "type": "number"
                         }
                       },
-                      "required": ["yes", "abstain", "no", "noWithVeto", "total"]
+                      "required": [
+                        "yes",
+                        "abstain",
+                        "no",
+                        "noWithVeto",
+                        "total"
+                      ]
                     },
                     "paramChanges": {
                       "type": "array",
@@ -13014,7 +15502,10 @@
                             "nullable": true
                           }
                         },
-                        "required": ["subspace", "key"]
+                        "required": [
+                          "subspace",
+                          "key"
+                        ]
                       }
                     }
                   },
@@ -13045,7 +15536,9 @@
     },
     "/v1/templates-list": {
       "get": {
-        "tags": ["Other"],
+        "tags": [
+          "Other"
+        ],
         "security": [],
         "responses": {
           "200": {
@@ -13088,15 +15581,25 @@
                                   }
                                 }
                               },
-                              "required": ["id", "name", "logoUrl", "summary"]
+                              "required": [
+                                "id",
+                                "name",
+                                "logoUrl",
+                                "summary"
+                              ]
                             }
                           }
                         },
-                        "required": ["title", "templates"]
+                        "required": [
+                          "title",
+                          "templates"
+                        ]
                       }
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -13106,7 +15609,9 @@
     },
     "/v1/templates/{id}": {
       "get": {
-        "tags": ["Other"],
+        "tags": [
+          "Other"
+        ],
         "security": [],
         "parameters": [
           {
@@ -13172,10 +15677,23 @@
                           }
                         }
                       },
-                      "required": ["id", "name", "path", "logoUrl", "summary", "readme", "deploy", "persistentStorageEnabled", "githubUrl", "config"]
+                      "required": [
+                        "id",
+                        "name",
+                        "path",
+                        "logoUrl",
+                        "summary",
+                        "readme",
+                        "deploy",
+                        "persistentStorageEnabled",
+                        "githubUrl",
+                        "config"
+                      ]
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -13192,7 +15710,9 @@
     "/v1/leases-duration/{owner}": {
       "get": {
         "summary": "Get leases durations.",
-        "tags": ["Analytics"],
+        "tags": [
+          "Analytics"
+        ],
         "security": [],
         "parameters": [
           {
@@ -13307,7 +15827,12 @@
                       }
                     }
                   },
-                  "required": ["leaseCount", "totalDurationInSeconds", "totalDurationInHours", "leases"]
+                  "required": [
+                    "leaseCount",
+                    "totalDurationInSeconds",
+                    "totalDurationInHours",
+                    "leases"
+                  ]
                 }
               }
             }
@@ -13321,7 +15846,9 @@
     "/v1/addresses/{address}": {
       "get": {
         "summary": "Get address details",
-        "tags": ["Addresses"],
+        "tags": [
+          "Addresses"
+        ],
         "security": [],
         "parameters": [
           {
@@ -13376,7 +15903,11 @@
                             "nullable": true
                           }
                         },
-                        "required": ["validator", "amount", "reward"]
+                        "required": [
+                          "validator",
+                          "amount",
+                          "reward"
+                        ]
                       }
                     },
                     "available": {
@@ -13409,7 +15940,9 @@
                             "type": "number"
                           }
                         },
-                        "required": ["amount"]
+                        "required": [
+                          "amount"
+                        ]
                       }
                     },
                     "redelegations": {
@@ -13461,7 +15994,13 @@
                             "type": "number"
                           }
                         },
-                        "required": ["srcAddress", "dstAddress", "creationHeight", "completionTime", "amount"]
+                        "required": [
+                          "srcAddress",
+                          "dstAddress",
+                          "creationHeight",
+                          "completionTime",
+                          "amount"
+                        ]
                       }
                     },
                     "commission": {
@@ -13522,15 +16061,42 @@
                                   "type": "boolean"
                                 }
                               },
-                              "required": ["id", "type", "amount", "isReceiver"]
+                              "required": [
+                                "id",
+                                "type",
+                                "amount",
+                                "isReceiver"
+                              ]
                             }
                           }
                         },
-                        "required": ["height", "datetime", "hash", "isSuccess", "error", "gasUsed", "gasWanted", "fee", "memo", "isSigner", "messages"]
+                        "required": [
+                          "height",
+                          "datetime",
+                          "hash",
+                          "isSuccess",
+                          "error",
+                          "gasUsed",
+                          "gasWanted",
+                          "fee",
+                          "memo",
+                          "isSigner",
+                          "messages"
+                        ]
                       }
                     }
                   },
-                  "required": ["total", "delegations", "available", "delegated", "rewards", "assets", "redelegations", "commission", "latestTransactions"]
+                  "required": [
+                    "total",
+                    "delegations",
+                    "available",
+                    "delegated",
+                    "rewards",
+                    "assets",
+                    "redelegations",
+                    "commission",
+                    "latestTransactions"
+                  ]
                 }
               }
             }
@@ -13544,7 +16110,10 @@
     "/v1/addresses/{address}/transactions/{skip}/{limit}": {
       "get": {
         "summary": "Get a list of transactions for a given address.",
-        "tags": ["Addresses", "Transactions"],
+        "tags": [
+          "Addresses",
+          "Transactions"
+        ],
         "security": [],
         "parameters": [
           {
@@ -13648,15 +16217,35 @@
                                   "type": "boolean"
                                 }
                               },
-                              "required": ["id", "type", "amount", "isReceiver"]
+                              "required": [
+                                "id",
+                                "type",
+                                "amount",
+                                "isReceiver"
+                              ]
                             }
                           }
                         },
-                        "required": ["height", "datetime", "hash", "isSuccess", "error", "gasUsed", "gasWanted", "fee", "memo", "isSigner", "messages"]
+                        "required": [
+                          "height",
+                          "datetime",
+                          "hash",
+                          "isSuccess",
+                          "error",
+                          "gasUsed",
+                          "gasWanted",
+                          "fee",
+                          "memo",
+                          "isSigner",
+                          "messages"
+                        ]
                       }
                     }
                   },
-                  "required": ["count", "results"]
+                  "required": [
+                    "count",
+                    "results"
+                  ]
                 }
               }
             }
@@ -13670,7 +16259,9 @@
     "/v1/blockchain-status": {
       "get": {
         "summary": "Get blockchain reachability status",
-        "tags": ["Chain"],
+        "tags": [
+          "Chain"
+        ],
         "security": [],
         "responses": {
           "200": {
@@ -13684,7 +16275,9 @@
                       "type": "boolean"
                     }
                   },
-                  "required": ["isBlockchainReachable"]
+                  "required": [
+                    "isBlockchainReachable"
+                  ]
                 }
               }
             }
@@ -13696,7 +16289,9 @@
       "post": {
         "operationId": "screenProviders",
         "summary": "Screen providers by deployment resource requirements",
-        "tags": ["Bid Screening"],
+        "tags": [
+          "Bid Screening"
+        ],
         "security": [],
         "requestBody": {
           "content": {
@@ -13746,7 +16341,10 @@
                               "example": "false"
                             }
                           },
-                          "required": ["key", "value"]
+                          "required": [
+                            "key",
+                            "value"
+                          ]
                         },
                         "default": []
                       }
@@ -13777,7 +16375,9 @@
                                       "maxLength": 80
                                     }
                                   },
-                                  "required": ["val"]
+                                  "required": [
+                                    "val"
+                                  ]
                                 },
                                 "attributes": {
                                   "type": "array",
@@ -13798,11 +16398,16 @@
                                         "example": "false"
                                       }
                                     },
-                                    "required": ["key", "value"]
+                                    "required": [
+                                      "key",
+                                      "value"
+                                    ]
                                   }
                                 }
                               },
-                              "required": ["units"]
+                              "required": [
+                                "units"
+                              ]
                             },
                             "memory": {
                               "type": "object",
@@ -13815,7 +16420,9 @@
                                       "maxLength": 80
                                     }
                                   },
-                                  "required": ["val"]
+                                  "required": [
+                                    "val"
+                                  ]
                                 },
                                 "attributes": {
                                   "type": "array",
@@ -13836,11 +16443,16 @@
                                         "example": "false"
                                       }
                                     },
-                                    "required": ["key", "value"]
+                                    "required": [
+                                      "key",
+                                      "value"
+                                    ]
                                   }
                                 }
                               },
-                              "required": ["quantity"]
+                              "required": [
+                                "quantity"
+                              ]
                             },
                             "gpu": {
                               "type": "object",
@@ -13853,7 +16465,9 @@
                                       "maxLength": 80
                                     }
                                   },
-                                  "required": ["val"]
+                                  "required": [
+                                    "val"
+                                  ]
                                 },
                                 "attributes": {
                                   "type": "array",
@@ -13874,11 +16488,16 @@
                                         "example": "false"
                                       }
                                     },
-                                    "required": ["key", "value"]
+                                    "required": [
+                                      "key",
+                                      "value"
+                                    ]
                                   }
                                 }
                               },
-                              "required": ["units"]
+                              "required": [
+                                "units"
+                              ]
                             },
                             "storage": {
                               "type": "array",
@@ -13898,7 +16517,9 @@
                                         "maxLength": 80
                                       }
                                     },
-                                    "required": ["val"]
+                                    "required": [
+                                      "val"
+                                    ]
                                   },
                                   "attributes": {
                                     "type": "array",
@@ -13919,11 +16540,17 @@
                                           "example": "false"
                                         }
                                       },
-                                      "required": ["key", "value"]
+                                      "required": [
+                                        "key",
+                                        "value"
+                                      ]
                                     }
                                   }
                                 },
-                                "required": ["name", "quantity"]
+                                "required": [
+                                  "name",
+                                  "quantity"
+                                ]
                               }
                             },
                             "endpoints": {
@@ -13933,7 +16560,13 @@
                               }
                             }
                           },
-                          "required": ["id", "cpu", "memory", "gpu", "storage"]
+                          "required": [
+                            "id",
+                            "cpu",
+                            "memory",
+                            "gpu",
+                            "storage"
+                          ]
                         },
                         "count": {
                           "type": "integer",
@@ -13952,10 +16585,17 @@
                               "pattern": "^\\d+$"
                             }
                           },
-                          "required": ["denom", "amount"]
+                          "required": [
+                            "denom",
+                            "amount"
+                          ]
                         }
                       },
-                      "required": ["resource", "count", "price"]
+                      "required": [
+                        "resource",
+                        "count",
+                        "price"
+                      ]
                     },
                     "description": "Resource units with replica counts"
                   },
@@ -13972,7 +16612,10 @@
                     "example": 3600
                   }
                 },
-                "required": ["resources", "timezone"]
+                "required": [
+                  "resources",
+                  "timezone"
+                ]
               }
             }
           }
@@ -14045,16 +16688,31 @@
                                   "description": "Downtime clipped to that day, in seconds (max 86400)"
                                 }
                               },
-                              "required": ["date", "hasOpenIncident", "incidentCount", "downtimeSeconds"]
+                              "required": [
+                                "date",
+                                "hasOpenIncident",
+                                "incidentCount",
+                                "downtimeSeconds"
+                              ]
                             },
                             "description": "Per-day downtime over a rolling 7-day window"
                           }
                         },
-                        "required": ["owner", "hostUri", "isAudited", "createdAt", "location", "organization", "incidents"]
+                        "required": [
+                          "owner",
+                          "hostUri",
+                          "isAudited",
+                          "createdAt",
+                          "location",
+                          "organization",
+                          "incidents"
+                        ]
                       }
                     }
                   },
-                  "required": ["providers"]
+                  "required": [
+                    "providers"
+                  ]
                 }
               }
             }
@@ -14069,7 +16727,9 @@
       "post": {
         "operationId": "validateConfidentialComputeAttestation",
         "summary": "Validate confidential compute attestation evidence against the hardware vendors (AMD SEV-SNP, Intel TDX, NVIDIA)",
-        "tags": ["Confidential Compute"],
+        "tags": [
+          "Confidential Compute"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -14096,7 +16756,12 @@
                   },
                   "tee_platform": {
                     "type": "string",
-                    "enum": ["snp", "tdx", "snp-gpu", "tdx-gpu"],
+                    "enum": [
+                      "snp",
+                      "tdx",
+                      "snp-gpu",
+                      "tdx-gpu"
+                    ],
                     "description": "TEE platform that produced the evidence"
                   },
                   "cert_chain": {
@@ -14128,13 +16793,20 @@
                           "example": "BQAAAAAA..."
                         }
                       },
-                      "required": ["device_index", "report"]
+                      "required": [
+                        "device_index",
+                        "report"
+                      ]
                     },
                     "default": [],
                     "description": "Per-GPU attestation reports; empty for CPU-only platforms"
                   }
                 },
-                "required": ["nonce", "report", "tee_platform"]
+                "required": [
+                  "nonce",
+                  "report",
+                  "tee_platform"
+                ]
               }
             }
           }
@@ -14149,7 +16821,11 @@
                   "properties": {
                     "overall": {
                       "type": "string",
-                      "enum": ["valid", "invalid", "unverifiable"],
+                      "enum": [
+                        "valid",
+                        "invalid",
+                        "unverifiable"
+                      ],
                       "description": "Rollup: valid only if every report is valid; invalid if any report is invalid; otherwise unverifiable"
                     },
                     "nonce": {
@@ -14165,15 +16841,24 @@
                             "properties": {
                               "kind": {
                                 "type": "string",
-                                "enum": ["cpu"]
+                                "enum": [
+                                  "cpu"
+                                ]
                               },
                               "vendor": {
                                 "type": "string",
-                                "enum": ["amd-sev-snp", "intel-tdx"]
+                                "enum": [
+                                  "amd-sev-snp",
+                                  "intel-tdx"
+                                ]
                               },
                               "status": {
                                 "type": "string",
-                                "enum": ["valid", "invalid", "unverifiable"],
+                                "enum": [
+                                  "valid",
+                                  "invalid",
+                                  "unverifiable"
+                                ],
                                 "description": "valid = chained to the vendor root, signature/EAT verified, and bound to the request nonce; invalid = a check ran and failed (bad signature, untrusted chain, nonce mismatch); unverifiable = the check could not be completed (vendor service unreachable, not configured, missing material)"
                               },
                               "detail": {
@@ -14203,14 +16888,21 @@
                                 "description": "Granular sub-results behind the verdict; fields are omitted when not evaluated"
                               }
                             },
-                            "required": ["kind", "vendor", "status", "detail"]
+                            "required": [
+                              "kind",
+                              "vendor",
+                              "status",
+                              "detail"
+                            ]
                           },
                           {
                             "type": "object",
                             "properties": {
                               "kind": {
                                 "type": "string",
-                                "enum": ["gpu"]
+                                "enum": [
+                                  "gpu"
+                                ]
                               },
                               "device_index": {
                                 "type": "integer",
@@ -14218,11 +16910,17 @@
                               },
                               "vendor": {
                                 "type": "string",
-                                "enum": ["nvidia"]
+                                "enum": [
+                                  "nvidia"
+                                ]
                               },
                               "status": {
                                 "type": "string",
-                                "enum": ["valid", "invalid", "unverifiable"],
+                                "enum": [
+                                  "valid",
+                                  "invalid",
+                                  "unverifiable"
+                                ],
                                 "description": "valid = chained to the vendor root, signature/EAT verified, and bound to the request nonce; invalid = a check ran and failed (bad signature, untrusted chain, nonce mismatch); unverifiable = the check could not be completed (vendor service unreachable, not configured, missing material)"
                               },
                               "detail": {
@@ -14252,13 +16950,23 @@
                                 "description": "Granular sub-results behind the verdict; fields are omitted when not evaluated"
                               }
                             },
-                            "required": ["kind", "device_index", "vendor", "status", "detail"]
+                            "required": [
+                              "kind",
+                              "device_index",
+                              "vendor",
+                              "status",
+                              "detail"
+                            ]
                           }
                         ]
                       }
                     }
                   },
-                  "required": ["overall", "nonce", "reports"]
+                  "required": [
+                    "overall",
+                    "nonce",
+                    "reports"
+                  ]
                 }
               }
             }
@@ -14344,7 +17052,9 @@
             }
           }
         },
-        "tags": ["Alert"]
+        "tags": [
+          "Alert"
+        ]
       },
       "get": {
         "operationId": "listAlerts",
@@ -14446,7 +17156,9 @@
             }
           }
         },
-        "tags": ["Alert"]
+        "tags": [
+          "Alert"
+        ]
       }
     },
     "/v1/alerts/{id}": {
@@ -14522,7 +17234,9 @@
             }
           }
         },
-        "tags": ["Alert"]
+        "tags": [
+          "Alert"
+        ]
       },
       "patch": {
         "operationId": "updateAlert",
@@ -14606,7 +17320,9 @@
             }
           }
         },
-        "tags": ["Alert"]
+        "tags": [
+          "Alert"
+        ]
       },
       "delete": {
         "operationId": "deleteAlert",
@@ -14680,7 +17396,9 @@
             }
           }
         },
-        "tags": ["Alert"]
+        "tags": [
+          "Alert"
+        ]
       }
     },
     "/v1/notification-channels": {
@@ -14758,7 +17476,9 @@
             }
           }
         },
-        "tags": ["NotificationChannel"]
+        "tags": [
+          "NotificationChannel"
+        ]
       },
       "get": {
         "operationId": "listNotificationChannels",
@@ -14842,7 +17562,9 @@
             }
           }
         },
-        "tags": ["NotificationChannel"]
+        "tags": [
+          "NotificationChannel"
+        ]
       }
     },
     "/v1/notification-channels/default": {
@@ -14864,7 +17586,9 @@
             "description": "Creates the default notification channel only if it doesn't exist."
           }
         },
-        "tags": ["NotificationChannel"]
+        "tags": [
+          "NotificationChannel"
+        ]
       }
     },
     "/v1/notification-channels/{id}": {
@@ -14950,7 +17674,9 @@
             }
           }
         },
-        "tags": ["NotificationChannel"]
+        "tags": [
+          "NotificationChannel"
+        ]
       },
       "patch": {
         "operationId": "updateNotificationChannel",
@@ -15044,7 +17770,9 @@
             }
           }
         },
-        "tags": ["NotificationChannel"]
+        "tags": [
+          "NotificationChannel"
+        ]
       },
       "delete": {
         "operationId": "deleteNotificationChannel",
@@ -15128,7 +17856,9 @@
             }
           }
         },
-        "tags": ["NotificationChannel"]
+        "tags": [
+          "NotificationChannel"
+        ]
       }
     },
     "/v1/deployment-alerts/{dseq}": {
@@ -15223,7 +17953,9 @@
             }
           }
         },
-        "tags": ["DeploymentAlert"]
+        "tags": [
+          "DeploymentAlert"
+        ]
       },
       "get": {
         "operationId": "listDeploymentAlerts",
@@ -15297,7 +18029,9 @@
             }
           }
         },
-        "tags": ["DeploymentAlert"]
+        "tags": [
+          "DeploymentAlert"
+        ]
       }
     }
   },
@@ -15345,7 +18079,10 @@
                         "type": "boolean"
                       }
                     },
-                    "required": ["dseq", "type"]
+                    "required": [
+                      "dseq",
+                      "type"
+                    ]
                   },
                   "conditions": {
                     "oneOf": [
@@ -15354,7 +18091,9 @@
                         "properties": {
                           "operator": {
                             "type": "string",
-                            "enum": ["and"]
+                            "enum": [
+                              "and"
+                            ]
                           },
                           "value": {
                             "type": "array",
@@ -15366,23 +18105,33 @@
                                   "oneOf": [
                                     {
                                       "type": "string",
-                                      "enum": ["eq"]
+                                      "enum": [
+                                        "eq"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["lt"]
+                                      "enum": [
+                                        "lt"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["gt"]
+                                      "enum": [
+                                        "gt"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["lte"]
+                                      "enum": [
+                                        "lte"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["gte"]
+                                      "enum": [
+                                        "gte"
+                                      ]
                                     }
                                   ]
                                 },
@@ -15403,18 +18152,27 @@
                                   ]
                                 }
                               },
-                              "required": ["operator", "field", "value"]
+                              "required": [
+                                "operator",
+                                "field",
+                                "value"
+                              ]
                             }
                           }
                         },
-                        "required": ["operator", "value"]
+                        "required": [
+                          "operator",
+                          "value"
+                        ]
                       },
                       {
                         "type": "object",
                         "properties": {
                           "operator": {
                             "type": "string",
-                            "enum": ["or"]
+                            "enum": [
+                              "or"
+                            ]
                           },
                           "value": {
                             "type": "array",
@@ -15426,23 +18184,33 @@
                                   "oneOf": [
                                     {
                                       "type": "string",
-                                      "enum": ["eq"]
+                                      "enum": [
+                                        "eq"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["lt"]
+                                      "enum": [
+                                        "lt"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["gt"]
+                                      "enum": [
+                                        "gt"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["lte"]
+                                      "enum": [
+                                        "lte"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["gte"]
+                                      "enum": [
+                                        "gte"
+                                      ]
                                     }
                                   ]
                                 },
@@ -15463,11 +18231,18 @@
                                   ]
                                 }
                               },
-                              "required": ["operator", "field", "value"]
+                              "required": [
+                                "operator",
+                                "field",
+                                "value"
+                              ]
                             }
                           }
                         },
-                        "required": ["operator", "value"]
+                        "required": [
+                          "operator",
+                          "value"
+                        ]
                       },
                       {
                         "type": "object",
@@ -15476,23 +18251,33 @@
                             "oneOf": [
                               {
                                 "type": "string",
-                                "enum": ["eq"]
+                                "enum": [
+                                  "eq"
+                                ]
                               },
                               {
                                 "type": "string",
-                                "enum": ["lt"]
+                                "enum": [
+                                  "lt"
+                                ]
                               },
                               {
                                 "type": "string",
-                                "enum": ["gt"]
+                                "enum": [
+                                  "gt"
+                                ]
                               },
                               {
                                 "type": "string",
-                                "enum": ["lte"]
+                                "enum": [
+                                  "lte"
+                                ]
                               },
                               {
                                 "type": "string",
-                                "enum": ["gte"]
+                                "enum": [
+                                  "gte"
+                                ]
                               }
                             ]
                           },
@@ -15513,16 +18298,29 @@
                             ]
                           }
                         },
-                        "required": ["operator", "field", "value"]
+                        "required": [
+                          "operator",
+                          "field",
+                          "value"
+                        ]
                       }
                     ]
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["CHAIN_MESSAGE"]
+                    "enum": [
+                      "CHAIN_MESSAGE"
+                    ]
                   }
                 },
-                "required": ["notificationChannelId", "name", "summary", "description", "conditions", "type"]
+                "required": [
+                  "notificationChannelId",
+                  "name",
+                  "summary",
+                  "description",
+                  "conditions",
+                  "type"
+                ]
               },
               {
                 "type": "object",
@@ -15561,7 +18359,10 @@
                         "type": "boolean"
                       }
                     },
-                    "required": ["dseq", "type"]
+                    "required": [
+                      "dseq",
+                      "type"
+                    ]
                   },
                   "conditions": {
                     "oneOf": [
@@ -15570,7 +18371,9 @@
                         "properties": {
                           "operator": {
                             "type": "string",
-                            "enum": ["and"]
+                            "enum": [
+                              "and"
+                            ]
                           },
                           "value": {
                             "type": "array",
@@ -15582,23 +18385,33 @@
                                   "oneOf": [
                                     {
                                       "type": "string",
-                                      "enum": ["eq"]
+                                      "enum": [
+                                        "eq"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["lt"]
+                                      "enum": [
+                                        "lt"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["gt"]
+                                      "enum": [
+                                        "gt"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["lte"]
+                                      "enum": [
+                                        "lte"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["gte"]
+                                      "enum": [
+                                        "gte"
+                                      ]
                                     }
                                   ]
                                 },
@@ -15619,18 +18432,27 @@
                                   ]
                                 }
                               },
-                              "required": ["operator", "field", "value"]
+                              "required": [
+                                "operator",
+                                "field",
+                                "value"
+                              ]
                             }
                           }
                         },
-                        "required": ["operator", "value"]
+                        "required": [
+                          "operator",
+                          "value"
+                        ]
                       },
                       {
                         "type": "object",
                         "properties": {
                           "operator": {
                             "type": "string",
-                            "enum": ["or"]
+                            "enum": [
+                              "or"
+                            ]
                           },
                           "value": {
                             "type": "array",
@@ -15642,23 +18464,33 @@
                                   "oneOf": [
                                     {
                                       "type": "string",
-                                      "enum": ["eq"]
+                                      "enum": [
+                                        "eq"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["lt"]
+                                      "enum": [
+                                        "lt"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["gt"]
+                                      "enum": [
+                                        "gt"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["lte"]
+                                      "enum": [
+                                        "lte"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["gte"]
+                                      "enum": [
+                                        "gte"
+                                      ]
                                     }
                                   ]
                                 },
@@ -15679,11 +18511,18 @@
                                   ]
                                 }
                               },
-                              "required": ["operator", "field", "value"]
+                              "required": [
+                                "operator",
+                                "field",
+                                "value"
+                              ]
                             }
                           }
                         },
-                        "required": ["operator", "value"]
+                        "required": [
+                          "operator",
+                          "value"
+                        ]
                       },
                       {
                         "type": "object",
@@ -15692,23 +18531,33 @@
                             "oneOf": [
                               {
                                 "type": "string",
-                                "enum": ["eq"]
+                                "enum": [
+                                  "eq"
+                                ]
                               },
                               {
                                 "type": "string",
-                                "enum": ["lt"]
+                                "enum": [
+                                  "lt"
+                                ]
                               },
                               {
                                 "type": "string",
-                                "enum": ["gt"]
+                                "enum": [
+                                  "gt"
+                                ]
                               },
                               {
                                 "type": "string",
-                                "enum": ["lte"]
+                                "enum": [
+                                  "lte"
+                                ]
                               },
                               {
                                 "type": "string",
-                                "enum": ["gte"]
+                                "enum": [
+                                  "gte"
+                                ]
                               }
                             ]
                           },
@@ -15729,16 +18578,29 @@
                             ]
                           }
                         },
-                        "required": ["operator", "field", "value"]
+                        "required": [
+                          "operator",
+                          "field",
+                          "value"
+                        ]
                       }
                     ]
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["CHAIN_EVENT"]
+                    "enum": [
+                      "CHAIN_EVENT"
+                    ]
                   }
                 },
-                "required": ["notificationChannelId", "name", "summary", "description", "conditions", "type"]
+                "required": [
+                  "notificationChannelId",
+                  "name",
+                  "summary",
+                  "description",
+                  "conditions",
+                  "type"
+                ]
               },
               {
                 "type": "object",
@@ -15765,7 +18627,9 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["DEPLOYMENT_BALANCE"]
+                    "enum": [
+                      "DEPLOYMENT_BALANCE"
+                    ]
                   },
                   "conditions": {
                     "oneOf": [
@@ -15774,7 +18638,9 @@
                         "properties": {
                           "operator": {
                             "type": "string",
-                            "enum": ["and"]
+                            "enum": [
+                              "and"
+                            ]
                           },
                           "value": {
                             "type": "array",
@@ -15786,46 +18652,67 @@
                                   "oneOf": [
                                     {
                                       "type": "string",
-                                      "enum": ["eq"]
+                                      "enum": [
+                                        "eq"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["lt"]
+                                      "enum": [
+                                        "lt"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["gt"]
+                                      "enum": [
+                                        "gt"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["lte"]
+                                      "enum": [
+                                        "lte"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["gte"]
+                                      "enum": [
+                                        "gte"
+                                      ]
                                     }
                                   ]
                                 },
                                 "field": {
                                   "type": "string",
-                                  "enum": ["balance"]
+                                  "enum": [
+                                    "balance"
+                                  ]
                                 },
                                 "value": {
                                   "type": "number"
                                 }
                               },
-                              "required": ["operator", "field", "value"]
+                              "required": [
+                                "operator",
+                                "field",
+                                "value"
+                              ]
                             }
                           }
                         },
-                        "required": ["operator", "value"]
+                        "required": [
+                          "operator",
+                          "value"
+                        ]
                       },
                       {
                         "type": "object",
                         "properties": {
                           "operator": {
                             "type": "string",
-                            "enum": ["or"]
+                            "enum": [
+                              "or"
+                            ]
                           },
                           "value": {
                             "type": "array",
@@ -15837,39 +18724,58 @@
                                   "oneOf": [
                                     {
                                       "type": "string",
-                                      "enum": ["eq"]
+                                      "enum": [
+                                        "eq"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["lt"]
+                                      "enum": [
+                                        "lt"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["gt"]
+                                      "enum": [
+                                        "gt"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["lte"]
+                                      "enum": [
+                                        "lte"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["gte"]
+                                      "enum": [
+                                        "gte"
+                                      ]
                                     }
                                   ]
                                 },
                                 "field": {
                                   "type": "string",
-                                  "enum": ["balance"]
+                                  "enum": [
+                                    "balance"
+                                  ]
                                 },
                                 "value": {
                                   "type": "number"
                                 }
                               },
-                              "required": ["operator", "field", "value"]
+                              "required": [
+                                "operator",
+                                "field",
+                                "value"
+                              ]
                             }
                           }
                         },
-                        "required": ["operator", "value"]
+                        "required": [
+                          "operator",
+                          "value"
+                        ]
                       },
                       {
                         "type": "object",
@@ -15878,35 +18784,51 @@
                             "oneOf": [
                               {
                                 "type": "string",
-                                "enum": ["eq"]
+                                "enum": [
+                                  "eq"
+                                ]
                               },
                               {
                                 "type": "string",
-                                "enum": ["lt"]
+                                "enum": [
+                                  "lt"
+                                ]
                               },
                               {
                                 "type": "string",
-                                "enum": ["gt"]
+                                "enum": [
+                                  "gt"
+                                ]
                               },
                               {
                                 "type": "string",
-                                "enum": ["lte"]
+                                "enum": [
+                                  "lte"
+                                ]
                               },
                               {
                                 "type": "string",
-                                "enum": ["gte"]
+                                "enum": [
+                                  "gte"
+                                ]
                               }
                             ]
                           },
                           "field": {
                             "type": "string",
-                            "enum": ["balance"]
+                            "enum": [
+                              "balance"
+                            ]
                           },
                           "value": {
                             "type": "number"
                           }
                         },
-                        "required": ["operator", "field", "value"]
+                        "required": [
+                          "operator",
+                          "field",
+                          "value"
+                        ]
                       }
                     ]
                   },
@@ -15924,10 +18846,21 @@
                         "type": "boolean"
                       }
                     },
-                    "required": ["dseq", "owner"]
+                    "required": [
+                      "dseq",
+                      "owner"
+                    ]
                   }
                 },
-                "required": ["notificationChannelId", "name", "summary", "description", "type", "conditions", "params"]
+                "required": [
+                  "notificationChannelId",
+                  "name",
+                  "summary",
+                  "description",
+                  "type",
+                  "conditions",
+                  "params"
+                ]
               },
               {
                 "type": "object",
@@ -15954,7 +18887,9 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["WALLET_BALANCE"]
+                    "enum": [
+                      "WALLET_BALANCE"
+                    ]
                   },
                   "conditions": {
                     "oneOf": [
@@ -15963,7 +18898,9 @@
                         "properties": {
                           "operator": {
                             "type": "string",
-                            "enum": ["and"]
+                            "enum": [
+                              "and"
+                            ]
                           },
                           "value": {
                             "type": "array",
@@ -15975,46 +18912,67 @@
                                   "oneOf": [
                                     {
                                       "type": "string",
-                                      "enum": ["eq"]
+                                      "enum": [
+                                        "eq"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["lt"]
+                                      "enum": [
+                                        "lt"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["gt"]
+                                      "enum": [
+                                        "gt"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["lte"]
+                                      "enum": [
+                                        "lte"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["gte"]
+                                      "enum": [
+                                        "gte"
+                                      ]
                                     }
                                   ]
                                 },
                                 "field": {
                                   "type": "string",
-                                  "enum": ["balance"]
+                                  "enum": [
+                                    "balance"
+                                  ]
                                 },
                                 "value": {
                                   "type": "number"
                                 }
                               },
-                              "required": ["operator", "field", "value"]
+                              "required": [
+                                "operator",
+                                "field",
+                                "value"
+                              ]
                             }
                           }
                         },
-                        "required": ["operator", "value"]
+                        "required": [
+                          "operator",
+                          "value"
+                        ]
                       },
                       {
                         "type": "object",
                         "properties": {
                           "operator": {
                             "type": "string",
-                            "enum": ["or"]
+                            "enum": [
+                              "or"
+                            ]
                           },
                           "value": {
                             "type": "array",
@@ -16026,39 +18984,58 @@
                                   "oneOf": [
                                     {
                                       "type": "string",
-                                      "enum": ["eq"]
+                                      "enum": [
+                                        "eq"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["lt"]
+                                      "enum": [
+                                        "lt"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["gt"]
+                                      "enum": [
+                                        "gt"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["lte"]
+                                      "enum": [
+                                        "lte"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["gte"]
+                                      "enum": [
+                                        "gte"
+                                      ]
                                     }
                                   ]
                                 },
                                 "field": {
                                   "type": "string",
-                                  "enum": ["balance"]
+                                  "enum": [
+                                    "balance"
+                                  ]
                                 },
                                 "value": {
                                   "type": "number"
                                 }
                               },
-                              "required": ["operator", "field", "value"]
+                              "required": [
+                                "operator",
+                                "field",
+                                "value"
+                              ]
                             }
                           }
                         },
-                        "required": ["operator", "value"]
+                        "required": [
+                          "operator",
+                          "value"
+                        ]
                       },
                       {
                         "type": "object",
@@ -16067,35 +19044,51 @@
                             "oneOf": [
                               {
                                 "type": "string",
-                                "enum": ["eq"]
+                                "enum": [
+                                  "eq"
+                                ]
                               },
                               {
                                 "type": "string",
-                                "enum": ["lt"]
+                                "enum": [
+                                  "lt"
+                                ]
                               },
                               {
                                 "type": "string",
-                                "enum": ["gt"]
+                                "enum": [
+                                  "gt"
+                                ]
                               },
                               {
                                 "type": "string",
-                                "enum": ["lte"]
+                                "enum": [
+                                  "lte"
+                                ]
                               },
                               {
                                 "type": "string",
-                                "enum": ["gte"]
+                                "enum": [
+                                  "gte"
+                                ]
                               }
                             ]
                           },
                           "field": {
                             "type": "string",
-                            "enum": ["balance"]
+                            "enum": [
+                              "balance"
+                            ]
                           },
                           "value": {
                             "type": "number"
                           }
                         },
-                        "required": ["operator", "field", "value"]
+                        "required": [
+                          "operator",
+                          "field",
+                          "value"
+                        ]
                       }
                     ]
                   },
@@ -16112,15 +19105,28 @@
                         "type": "boolean"
                       }
                     },
-                    "required": ["owner", "denom"]
+                    "required": [
+                      "owner",
+                      "denom"
+                    ]
                   }
                 },
-                "required": ["notificationChannelId", "name", "summary", "description", "type", "conditions", "params"]
+                "required": [
+                  "notificationChannelId",
+                  "name",
+                  "summary",
+                  "description",
+                  "type",
+                  "conditions",
+                  "params"
+                ]
               }
             ]
           }
         },
-        "required": ["data"]
+        "required": [
+          "data"
+        ]
       },
       "AlertOutputResponse": {
         "type": "object",
@@ -16179,7 +19185,10 @@
                         "type": "boolean"
                       }
                     },
-                    "required": ["dseq", "type"]
+                    "required": [
+                      "dseq",
+                      "type"
+                    ]
                   },
                   "conditions": {
                     "oneOf": [
@@ -16188,7 +19197,9 @@
                         "properties": {
                           "operator": {
                             "type": "string",
-                            "enum": ["and"]
+                            "enum": [
+                              "and"
+                            ]
                           },
                           "value": {
                             "type": "array",
@@ -16200,23 +19211,33 @@
                                   "oneOf": [
                                     {
                                       "type": "string",
-                                      "enum": ["eq"]
+                                      "enum": [
+                                        "eq"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["lt"]
+                                      "enum": [
+                                        "lt"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["gt"]
+                                      "enum": [
+                                        "gt"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["lte"]
+                                      "enum": [
+                                        "lte"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["gte"]
+                                      "enum": [
+                                        "gte"
+                                      ]
                                     }
                                   ]
                                 },
@@ -16237,18 +19258,27 @@
                                   ]
                                 }
                               },
-                              "required": ["operator", "field", "value"]
+                              "required": [
+                                "operator",
+                                "field",
+                                "value"
+                              ]
                             }
                           }
                         },
-                        "required": ["operator", "value"]
+                        "required": [
+                          "operator",
+                          "value"
+                        ]
                       },
                       {
                         "type": "object",
                         "properties": {
                           "operator": {
                             "type": "string",
-                            "enum": ["or"]
+                            "enum": [
+                              "or"
+                            ]
                           },
                           "value": {
                             "type": "array",
@@ -16260,23 +19290,33 @@
                                   "oneOf": [
                                     {
                                       "type": "string",
-                                      "enum": ["eq"]
+                                      "enum": [
+                                        "eq"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["lt"]
+                                      "enum": [
+                                        "lt"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["gt"]
+                                      "enum": [
+                                        "gt"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["lte"]
+                                      "enum": [
+                                        "lte"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["gte"]
+                                      "enum": [
+                                        "gte"
+                                      ]
                                     }
                                   ]
                                 },
@@ -16297,11 +19337,18 @@
                                   ]
                                 }
                               },
-                              "required": ["operator", "field", "value"]
+                              "required": [
+                                "operator",
+                                "field",
+                                "value"
+                              ]
                             }
                           }
                         },
-                        "required": ["operator", "value"]
+                        "required": [
+                          "operator",
+                          "value"
+                        ]
                       },
                       {
                         "type": "object",
@@ -16310,23 +19357,33 @@
                             "oneOf": [
                               {
                                 "type": "string",
-                                "enum": ["eq"]
+                                "enum": [
+                                  "eq"
+                                ]
                               },
                               {
                                 "type": "string",
-                                "enum": ["lt"]
+                                "enum": [
+                                  "lt"
+                                ]
                               },
                               {
                                 "type": "string",
-                                "enum": ["gt"]
+                                "enum": [
+                                  "gt"
+                                ]
                               },
                               {
                                 "type": "string",
-                                "enum": ["lte"]
+                                "enum": [
+                                  "lte"
+                                ]
                               },
                               {
                                 "type": "string",
-                                "enum": ["gte"]
+                                "enum": [
+                                  "gte"
+                                ]
                               }
                             ]
                           },
@@ -16347,13 +19404,19 @@
                             ]
                           }
                         },
-                        "required": ["operator", "field", "value"]
+                        "required": [
+                          "operator",
+                          "field",
+                          "value"
+                        ]
                       }
                     ]
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["CHAIN_MESSAGE"]
+                    "enum": [
+                      "CHAIN_MESSAGE"
+                    ]
                   }
                 },
                 "required": [
@@ -16423,7 +19486,10 @@
                         "type": "boolean"
                       }
                     },
-                    "required": ["dseq", "type"]
+                    "required": [
+                      "dseq",
+                      "type"
+                    ]
                   },
                   "conditions": {
                     "oneOf": [
@@ -16432,7 +19498,9 @@
                         "properties": {
                           "operator": {
                             "type": "string",
-                            "enum": ["and"]
+                            "enum": [
+                              "and"
+                            ]
                           },
                           "value": {
                             "type": "array",
@@ -16444,23 +19512,33 @@
                                   "oneOf": [
                                     {
                                       "type": "string",
-                                      "enum": ["eq"]
+                                      "enum": [
+                                        "eq"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["lt"]
+                                      "enum": [
+                                        "lt"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["gt"]
+                                      "enum": [
+                                        "gt"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["lte"]
+                                      "enum": [
+                                        "lte"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["gte"]
+                                      "enum": [
+                                        "gte"
+                                      ]
                                     }
                                   ]
                                 },
@@ -16481,18 +19559,27 @@
                                   ]
                                 }
                               },
-                              "required": ["operator", "field", "value"]
+                              "required": [
+                                "operator",
+                                "field",
+                                "value"
+                              ]
                             }
                           }
                         },
-                        "required": ["operator", "value"]
+                        "required": [
+                          "operator",
+                          "value"
+                        ]
                       },
                       {
                         "type": "object",
                         "properties": {
                           "operator": {
                             "type": "string",
-                            "enum": ["or"]
+                            "enum": [
+                              "or"
+                            ]
                           },
                           "value": {
                             "type": "array",
@@ -16504,23 +19591,33 @@
                                   "oneOf": [
                                     {
                                       "type": "string",
-                                      "enum": ["eq"]
+                                      "enum": [
+                                        "eq"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["lt"]
+                                      "enum": [
+                                        "lt"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["gt"]
+                                      "enum": [
+                                        "gt"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["lte"]
+                                      "enum": [
+                                        "lte"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["gte"]
+                                      "enum": [
+                                        "gte"
+                                      ]
                                     }
                                   ]
                                 },
@@ -16541,11 +19638,18 @@
                                   ]
                                 }
                               },
-                              "required": ["operator", "field", "value"]
+                              "required": [
+                                "operator",
+                                "field",
+                                "value"
+                              ]
                             }
                           }
                         },
-                        "required": ["operator", "value"]
+                        "required": [
+                          "operator",
+                          "value"
+                        ]
                       },
                       {
                         "type": "object",
@@ -16554,23 +19658,33 @@
                             "oneOf": [
                               {
                                 "type": "string",
-                                "enum": ["eq"]
+                                "enum": [
+                                  "eq"
+                                ]
                               },
                               {
                                 "type": "string",
-                                "enum": ["lt"]
+                                "enum": [
+                                  "lt"
+                                ]
                               },
                               {
                                 "type": "string",
-                                "enum": ["gt"]
+                                "enum": [
+                                  "gt"
+                                ]
                               },
                               {
                                 "type": "string",
-                                "enum": ["lte"]
+                                "enum": [
+                                  "lte"
+                                ]
                               },
                               {
                                 "type": "string",
-                                "enum": ["gte"]
+                                "enum": [
+                                  "gte"
+                                ]
                               }
                             ]
                           },
@@ -16591,13 +19705,19 @@
                             ]
                           }
                         },
-                        "required": ["operator", "field", "value"]
+                        "required": [
+                          "operator",
+                          "field",
+                          "value"
+                        ]
                       }
                     ]
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["CHAIN_EVENT"]
+                    "enum": [
+                      "CHAIN_EVENT"
+                    ]
                   }
                 },
                 "required": [
@@ -16655,7 +19775,9 @@
                   "updatedAt": {},
                   "type": {
                     "type": "string",
-                    "enum": ["DEPLOYMENT_BALANCE"]
+                    "enum": [
+                      "DEPLOYMENT_BALANCE"
+                    ]
                   },
                   "conditions": {
                     "oneOf": [
@@ -16664,7 +19786,9 @@
                         "properties": {
                           "operator": {
                             "type": "string",
-                            "enum": ["and"]
+                            "enum": [
+                              "and"
+                            ]
                           },
                           "value": {
                             "type": "array",
@@ -16676,46 +19800,67 @@
                                   "oneOf": [
                                     {
                                       "type": "string",
-                                      "enum": ["eq"]
+                                      "enum": [
+                                        "eq"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["lt"]
+                                      "enum": [
+                                        "lt"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["gt"]
+                                      "enum": [
+                                        "gt"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["lte"]
+                                      "enum": [
+                                        "lte"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["gte"]
+                                      "enum": [
+                                        "gte"
+                                      ]
                                     }
                                   ]
                                 },
                                 "field": {
                                   "type": "string",
-                                  "enum": ["balance"]
+                                  "enum": [
+                                    "balance"
+                                  ]
                                 },
                                 "value": {
                                   "type": "number"
                                 }
                               },
-                              "required": ["operator", "field", "value"]
+                              "required": [
+                                "operator",
+                                "field",
+                                "value"
+                              ]
                             }
                           }
                         },
-                        "required": ["operator", "value"]
+                        "required": [
+                          "operator",
+                          "value"
+                        ]
                       },
                       {
                         "type": "object",
                         "properties": {
                           "operator": {
                             "type": "string",
-                            "enum": ["or"]
+                            "enum": [
+                              "or"
+                            ]
                           },
                           "value": {
                             "type": "array",
@@ -16727,39 +19872,58 @@
                                   "oneOf": [
                                     {
                                       "type": "string",
-                                      "enum": ["eq"]
+                                      "enum": [
+                                        "eq"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["lt"]
+                                      "enum": [
+                                        "lt"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["gt"]
+                                      "enum": [
+                                        "gt"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["lte"]
+                                      "enum": [
+                                        "lte"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["gte"]
+                                      "enum": [
+                                        "gte"
+                                      ]
                                     }
                                   ]
                                 },
                                 "field": {
                                   "type": "string",
-                                  "enum": ["balance"]
+                                  "enum": [
+                                    "balance"
+                                  ]
                                 },
                                 "value": {
                                   "type": "number"
                                 }
                               },
-                              "required": ["operator", "field", "value"]
+                              "required": [
+                                "operator",
+                                "field",
+                                "value"
+                              ]
                             }
                           }
                         },
-                        "required": ["operator", "value"]
+                        "required": [
+                          "operator",
+                          "value"
+                        ]
                       },
                       {
                         "type": "object",
@@ -16768,35 +19932,51 @@
                             "oneOf": [
                               {
                                 "type": "string",
-                                "enum": ["eq"]
+                                "enum": [
+                                  "eq"
+                                ]
                               },
                               {
                                 "type": "string",
-                                "enum": ["lt"]
+                                "enum": [
+                                  "lt"
+                                ]
                               },
                               {
                                 "type": "string",
-                                "enum": ["gt"]
+                                "enum": [
+                                  "gt"
+                                ]
                               },
                               {
                                 "type": "string",
-                                "enum": ["lte"]
+                                "enum": [
+                                  "lte"
+                                ]
                               },
                               {
                                 "type": "string",
-                                "enum": ["gte"]
+                                "enum": [
+                                  "gte"
+                                ]
                               }
                             ]
                           },
                           "field": {
                             "type": "string",
-                            "enum": ["balance"]
+                            "enum": [
+                              "balance"
+                            ]
                           },
                           "value": {
                             "type": "number"
                           }
                         },
-                        "required": ["operator", "field", "value"]
+                        "required": [
+                          "operator",
+                          "field",
+                          "value"
+                        ]
                       }
                     ]
                   },
@@ -16814,7 +19994,10 @@
                         "type": "boolean"
                       }
                     },
-                    "required": ["dseq", "owner"]
+                    "required": [
+                      "dseq",
+                      "owner"
+                    ]
                   }
                 },
                 "required": [
@@ -16873,7 +20056,9 @@
                   "updatedAt": {},
                   "type": {
                     "type": "string",
-                    "enum": ["WALLET_BALANCE"]
+                    "enum": [
+                      "WALLET_BALANCE"
+                    ]
                   },
                   "conditions": {
                     "oneOf": [
@@ -16882,7 +20067,9 @@
                         "properties": {
                           "operator": {
                             "type": "string",
-                            "enum": ["and"]
+                            "enum": [
+                              "and"
+                            ]
                           },
                           "value": {
                             "type": "array",
@@ -16894,46 +20081,67 @@
                                   "oneOf": [
                                     {
                                       "type": "string",
-                                      "enum": ["eq"]
+                                      "enum": [
+                                        "eq"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["lt"]
+                                      "enum": [
+                                        "lt"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["gt"]
+                                      "enum": [
+                                        "gt"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["lte"]
+                                      "enum": [
+                                        "lte"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["gte"]
+                                      "enum": [
+                                        "gte"
+                                      ]
                                     }
                                   ]
                                 },
                                 "field": {
                                   "type": "string",
-                                  "enum": ["balance"]
+                                  "enum": [
+                                    "balance"
+                                  ]
                                 },
                                 "value": {
                                   "type": "number"
                                 }
                               },
-                              "required": ["operator", "field", "value"]
+                              "required": [
+                                "operator",
+                                "field",
+                                "value"
+                              ]
                             }
                           }
                         },
-                        "required": ["operator", "value"]
+                        "required": [
+                          "operator",
+                          "value"
+                        ]
                       },
                       {
                         "type": "object",
                         "properties": {
                           "operator": {
                             "type": "string",
-                            "enum": ["or"]
+                            "enum": [
+                              "or"
+                            ]
                           },
                           "value": {
                             "type": "array",
@@ -16945,39 +20153,58 @@
                                   "oneOf": [
                                     {
                                       "type": "string",
-                                      "enum": ["eq"]
+                                      "enum": [
+                                        "eq"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["lt"]
+                                      "enum": [
+                                        "lt"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["gt"]
+                                      "enum": [
+                                        "gt"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["lte"]
+                                      "enum": [
+                                        "lte"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["gte"]
+                                      "enum": [
+                                        "gte"
+                                      ]
                                     }
                                   ]
                                 },
                                 "field": {
                                   "type": "string",
-                                  "enum": ["balance"]
+                                  "enum": [
+                                    "balance"
+                                  ]
                                 },
                                 "value": {
                                   "type": "number"
                                 }
                               },
-                              "required": ["operator", "field", "value"]
+                              "required": [
+                                "operator",
+                                "field",
+                                "value"
+                              ]
                             }
                           }
                         },
-                        "required": ["operator", "value"]
+                        "required": [
+                          "operator",
+                          "value"
+                        ]
                       },
                       {
                         "type": "object",
@@ -16986,35 +20213,51 @@
                             "oneOf": [
                               {
                                 "type": "string",
-                                "enum": ["eq"]
+                                "enum": [
+                                  "eq"
+                                ]
                               },
                               {
                                 "type": "string",
-                                "enum": ["lt"]
+                                "enum": [
+                                  "lt"
+                                ]
                               },
                               {
                                 "type": "string",
-                                "enum": ["gt"]
+                                "enum": [
+                                  "gt"
+                                ]
                               },
                               {
                                 "type": "string",
-                                "enum": ["lte"]
+                                "enum": [
+                                  "lte"
+                                ]
                               },
                               {
                                 "type": "string",
-                                "enum": ["gte"]
+                                "enum": [
+                                  "gte"
+                                ]
                               }
                             ]
                           },
                           "field": {
                             "type": "string",
-                            "enum": ["balance"]
+                            "enum": [
+                              "balance"
+                            ]
                           },
                           "value": {
                             "type": "number"
                           }
                         },
-                        "required": ["operator", "field", "value"]
+                        "required": [
+                          "operator",
+                          "field",
+                          "value"
+                        ]
                       }
                     ]
                   },
@@ -17031,7 +20274,10 @@
                         "type": "boolean"
                       }
                     },
-                    "required": ["owner", "denom"]
+                    "required": [
+                      "owner",
+                      "denom"
+                    ]
                   }
                 },
                 "required": [
@@ -17053,7 +20299,9 @@
             ]
           }
         },
-        "required": ["data"]
+        "required": [
+          "data"
+        ]
       },
       "ValidationErrorResponse": {
         "type": "object",
@@ -17077,10 +20325,16 @@
                 }
               }
             },
-            "required": ["issues"]
+            "required": [
+              "issues"
+            ]
           }
         },
-        "required": ["statusCode", "message", "errors"]
+        "required": [
+          "statusCode",
+          "message",
+          "errors"
+        ]
       },
       "UnauthorizedErrorResponse": {
         "type": "object",
@@ -17094,7 +20348,10 @@
             "type": "string"
           }
         },
-        "required": ["statusCode", "message"]
+        "required": [
+          "statusCode",
+          "message"
+        ]
       },
       "ForbiddenErrorResponse": {
         "type": "object",
@@ -17108,7 +20365,10 @@
             "type": "string"
           }
         },
-        "required": ["statusCode", "message"]
+        "required": [
+          "statusCode",
+          "message"
+        ]
       },
       "InternalServerErrorResponse": {
         "type": "object",
@@ -17122,7 +20382,10 @@
             "type": "string"
           }
         },
-        "required": ["statusCode", "message"]
+        "required": [
+          "statusCode",
+          "message"
+        ]
       },
       "AlertListOutputResponse": {
         "type": "object",
@@ -17183,7 +20446,10 @@
                           "type": "boolean"
                         }
                       },
-                      "required": ["dseq", "type"]
+                      "required": [
+                        "dseq",
+                        "type"
+                      ]
                     },
                     "conditions": {
                       "oneOf": [
@@ -17192,7 +20458,9 @@
                           "properties": {
                             "operator": {
                               "type": "string",
-                              "enum": ["and"]
+                              "enum": [
+                                "and"
+                              ]
                             },
                             "value": {
                               "type": "array",
@@ -17204,23 +20472,33 @@
                                     "oneOf": [
                                       {
                                         "type": "string",
-                                        "enum": ["eq"]
+                                        "enum": [
+                                          "eq"
+                                        ]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": ["lt"]
+                                        "enum": [
+                                          "lt"
+                                        ]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": ["gt"]
+                                        "enum": [
+                                          "gt"
+                                        ]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": ["lte"]
+                                        "enum": [
+                                          "lte"
+                                        ]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": ["gte"]
+                                        "enum": [
+                                          "gte"
+                                        ]
                                       }
                                     ]
                                   },
@@ -17241,18 +20519,27 @@
                                     ]
                                   }
                                 },
-                                "required": ["operator", "field", "value"]
+                                "required": [
+                                  "operator",
+                                  "field",
+                                  "value"
+                                ]
                               }
                             }
                           },
-                          "required": ["operator", "value"]
+                          "required": [
+                            "operator",
+                            "value"
+                          ]
                         },
                         {
                           "type": "object",
                           "properties": {
                             "operator": {
                               "type": "string",
-                              "enum": ["or"]
+                              "enum": [
+                                "or"
+                              ]
                             },
                             "value": {
                               "type": "array",
@@ -17264,23 +20551,33 @@
                                     "oneOf": [
                                       {
                                         "type": "string",
-                                        "enum": ["eq"]
+                                        "enum": [
+                                          "eq"
+                                        ]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": ["lt"]
+                                        "enum": [
+                                          "lt"
+                                        ]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": ["gt"]
+                                        "enum": [
+                                          "gt"
+                                        ]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": ["lte"]
+                                        "enum": [
+                                          "lte"
+                                        ]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": ["gte"]
+                                        "enum": [
+                                          "gte"
+                                        ]
                                       }
                                     ]
                                   },
@@ -17301,11 +20598,18 @@
                                     ]
                                   }
                                 },
-                                "required": ["operator", "field", "value"]
+                                "required": [
+                                  "operator",
+                                  "field",
+                                  "value"
+                                ]
                               }
                             }
                           },
-                          "required": ["operator", "value"]
+                          "required": [
+                            "operator",
+                            "value"
+                          ]
                         },
                         {
                           "type": "object",
@@ -17314,23 +20618,33 @@
                               "oneOf": [
                                 {
                                   "type": "string",
-                                  "enum": ["eq"]
+                                  "enum": [
+                                    "eq"
+                                  ]
                                 },
                                 {
                                   "type": "string",
-                                  "enum": ["lt"]
+                                  "enum": [
+                                    "lt"
+                                  ]
                                 },
                                 {
                                   "type": "string",
-                                  "enum": ["gt"]
+                                  "enum": [
+                                    "gt"
+                                  ]
                                 },
                                 {
                                   "type": "string",
-                                  "enum": ["lte"]
+                                  "enum": [
+                                    "lte"
+                                  ]
                                 },
                                 {
                                   "type": "string",
-                                  "enum": ["gte"]
+                                  "enum": [
+                                    "gte"
+                                  ]
                                 }
                               ]
                             },
@@ -17351,13 +20665,19 @@
                               ]
                             }
                           },
-                          "required": ["operator", "field", "value"]
+                          "required": [
+                            "operator",
+                            "field",
+                            "value"
+                          ]
                         }
                       ]
                     },
                     "type": {
                       "type": "string",
-                      "enum": ["CHAIN_MESSAGE"]
+                      "enum": [
+                        "CHAIN_MESSAGE"
+                      ]
                     }
                   },
                   "required": [
@@ -17427,7 +20747,10 @@
                           "type": "boolean"
                         }
                       },
-                      "required": ["dseq", "type"]
+                      "required": [
+                        "dseq",
+                        "type"
+                      ]
                     },
                     "conditions": {
                       "oneOf": [
@@ -17436,7 +20759,9 @@
                           "properties": {
                             "operator": {
                               "type": "string",
-                              "enum": ["and"]
+                              "enum": [
+                                "and"
+                              ]
                             },
                             "value": {
                               "type": "array",
@@ -17448,23 +20773,33 @@
                                     "oneOf": [
                                       {
                                         "type": "string",
-                                        "enum": ["eq"]
+                                        "enum": [
+                                          "eq"
+                                        ]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": ["lt"]
+                                        "enum": [
+                                          "lt"
+                                        ]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": ["gt"]
+                                        "enum": [
+                                          "gt"
+                                        ]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": ["lte"]
+                                        "enum": [
+                                          "lte"
+                                        ]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": ["gte"]
+                                        "enum": [
+                                          "gte"
+                                        ]
                                       }
                                     ]
                                   },
@@ -17485,18 +20820,27 @@
                                     ]
                                   }
                                 },
-                                "required": ["operator", "field", "value"]
+                                "required": [
+                                  "operator",
+                                  "field",
+                                  "value"
+                                ]
                               }
                             }
                           },
-                          "required": ["operator", "value"]
+                          "required": [
+                            "operator",
+                            "value"
+                          ]
                         },
                         {
                           "type": "object",
                           "properties": {
                             "operator": {
                               "type": "string",
-                              "enum": ["or"]
+                              "enum": [
+                                "or"
+                              ]
                             },
                             "value": {
                               "type": "array",
@@ -17508,23 +20852,33 @@
                                     "oneOf": [
                                       {
                                         "type": "string",
-                                        "enum": ["eq"]
+                                        "enum": [
+                                          "eq"
+                                        ]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": ["lt"]
+                                        "enum": [
+                                          "lt"
+                                        ]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": ["gt"]
+                                        "enum": [
+                                          "gt"
+                                        ]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": ["lte"]
+                                        "enum": [
+                                          "lte"
+                                        ]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": ["gte"]
+                                        "enum": [
+                                          "gte"
+                                        ]
                                       }
                                     ]
                                   },
@@ -17545,11 +20899,18 @@
                                     ]
                                   }
                                 },
-                                "required": ["operator", "field", "value"]
+                                "required": [
+                                  "operator",
+                                  "field",
+                                  "value"
+                                ]
                               }
                             }
                           },
-                          "required": ["operator", "value"]
+                          "required": [
+                            "operator",
+                            "value"
+                          ]
                         },
                         {
                           "type": "object",
@@ -17558,23 +20919,33 @@
                               "oneOf": [
                                 {
                                   "type": "string",
-                                  "enum": ["eq"]
+                                  "enum": [
+                                    "eq"
+                                  ]
                                 },
                                 {
                                   "type": "string",
-                                  "enum": ["lt"]
+                                  "enum": [
+                                    "lt"
+                                  ]
                                 },
                                 {
                                   "type": "string",
-                                  "enum": ["gt"]
+                                  "enum": [
+                                    "gt"
+                                  ]
                                 },
                                 {
                                   "type": "string",
-                                  "enum": ["lte"]
+                                  "enum": [
+                                    "lte"
+                                  ]
                                 },
                                 {
                                   "type": "string",
-                                  "enum": ["gte"]
+                                  "enum": [
+                                    "gte"
+                                  ]
                                 }
                               ]
                             },
@@ -17595,13 +20966,19 @@
                               ]
                             }
                           },
-                          "required": ["operator", "field", "value"]
+                          "required": [
+                            "operator",
+                            "field",
+                            "value"
+                          ]
                         }
                       ]
                     },
                     "type": {
                       "type": "string",
-                      "enum": ["CHAIN_EVENT"]
+                      "enum": [
+                        "CHAIN_EVENT"
+                      ]
                     }
                   },
                   "required": [
@@ -17659,7 +21036,9 @@
                     "updatedAt": {},
                     "type": {
                       "type": "string",
-                      "enum": ["DEPLOYMENT_BALANCE"]
+                      "enum": [
+                        "DEPLOYMENT_BALANCE"
+                      ]
                     },
                     "conditions": {
                       "oneOf": [
@@ -17668,7 +21047,9 @@
                           "properties": {
                             "operator": {
                               "type": "string",
-                              "enum": ["and"]
+                              "enum": [
+                                "and"
+                              ]
                             },
                             "value": {
                               "type": "array",
@@ -17680,46 +21061,67 @@
                                     "oneOf": [
                                       {
                                         "type": "string",
-                                        "enum": ["eq"]
+                                        "enum": [
+                                          "eq"
+                                        ]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": ["lt"]
+                                        "enum": [
+                                          "lt"
+                                        ]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": ["gt"]
+                                        "enum": [
+                                          "gt"
+                                        ]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": ["lte"]
+                                        "enum": [
+                                          "lte"
+                                        ]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": ["gte"]
+                                        "enum": [
+                                          "gte"
+                                        ]
                                       }
                                     ]
                                   },
                                   "field": {
                                     "type": "string",
-                                    "enum": ["balance"]
+                                    "enum": [
+                                      "balance"
+                                    ]
                                   },
                                   "value": {
                                     "type": "number"
                                   }
                                 },
-                                "required": ["operator", "field", "value"]
+                                "required": [
+                                  "operator",
+                                  "field",
+                                  "value"
+                                ]
                               }
                             }
                           },
-                          "required": ["operator", "value"]
+                          "required": [
+                            "operator",
+                            "value"
+                          ]
                         },
                         {
                           "type": "object",
                           "properties": {
                             "operator": {
                               "type": "string",
-                              "enum": ["or"]
+                              "enum": [
+                                "or"
+                              ]
                             },
                             "value": {
                               "type": "array",
@@ -17731,39 +21133,58 @@
                                     "oneOf": [
                                       {
                                         "type": "string",
-                                        "enum": ["eq"]
+                                        "enum": [
+                                          "eq"
+                                        ]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": ["lt"]
+                                        "enum": [
+                                          "lt"
+                                        ]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": ["gt"]
+                                        "enum": [
+                                          "gt"
+                                        ]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": ["lte"]
+                                        "enum": [
+                                          "lte"
+                                        ]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": ["gte"]
+                                        "enum": [
+                                          "gte"
+                                        ]
                                       }
                                     ]
                                   },
                                   "field": {
                                     "type": "string",
-                                    "enum": ["balance"]
+                                    "enum": [
+                                      "balance"
+                                    ]
                                   },
                                   "value": {
                                     "type": "number"
                                   }
                                 },
-                                "required": ["operator", "field", "value"]
+                                "required": [
+                                  "operator",
+                                  "field",
+                                  "value"
+                                ]
                               }
                             }
                           },
-                          "required": ["operator", "value"]
+                          "required": [
+                            "operator",
+                            "value"
+                          ]
                         },
                         {
                           "type": "object",
@@ -17772,35 +21193,51 @@
                               "oneOf": [
                                 {
                                   "type": "string",
-                                  "enum": ["eq"]
+                                  "enum": [
+                                    "eq"
+                                  ]
                                 },
                                 {
                                   "type": "string",
-                                  "enum": ["lt"]
+                                  "enum": [
+                                    "lt"
+                                  ]
                                 },
                                 {
                                   "type": "string",
-                                  "enum": ["gt"]
+                                  "enum": [
+                                    "gt"
+                                  ]
                                 },
                                 {
                                   "type": "string",
-                                  "enum": ["lte"]
+                                  "enum": [
+                                    "lte"
+                                  ]
                                 },
                                 {
                                   "type": "string",
-                                  "enum": ["gte"]
+                                  "enum": [
+                                    "gte"
+                                  ]
                                 }
                               ]
                             },
                             "field": {
                               "type": "string",
-                              "enum": ["balance"]
+                              "enum": [
+                                "balance"
+                              ]
                             },
                             "value": {
                               "type": "number"
                             }
                           },
-                          "required": ["operator", "field", "value"]
+                          "required": [
+                            "operator",
+                            "field",
+                            "value"
+                          ]
                         }
                       ]
                     },
@@ -17818,7 +21255,10 @@
                           "type": "boolean"
                         }
                       },
-                      "required": ["dseq", "owner"]
+                      "required": [
+                        "dseq",
+                        "owner"
+                      ]
                     }
                   },
                   "required": [
@@ -17877,7 +21317,9 @@
                     "updatedAt": {},
                     "type": {
                       "type": "string",
-                      "enum": ["WALLET_BALANCE"]
+                      "enum": [
+                        "WALLET_BALANCE"
+                      ]
                     },
                     "conditions": {
                       "oneOf": [
@@ -17886,7 +21328,9 @@
                           "properties": {
                             "operator": {
                               "type": "string",
-                              "enum": ["and"]
+                              "enum": [
+                                "and"
+                              ]
                             },
                             "value": {
                               "type": "array",
@@ -17898,46 +21342,67 @@
                                     "oneOf": [
                                       {
                                         "type": "string",
-                                        "enum": ["eq"]
+                                        "enum": [
+                                          "eq"
+                                        ]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": ["lt"]
+                                        "enum": [
+                                          "lt"
+                                        ]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": ["gt"]
+                                        "enum": [
+                                          "gt"
+                                        ]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": ["lte"]
+                                        "enum": [
+                                          "lte"
+                                        ]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": ["gte"]
+                                        "enum": [
+                                          "gte"
+                                        ]
                                       }
                                     ]
                                   },
                                   "field": {
                                     "type": "string",
-                                    "enum": ["balance"]
+                                    "enum": [
+                                      "balance"
+                                    ]
                                   },
                                   "value": {
                                     "type": "number"
                                   }
                                 },
-                                "required": ["operator", "field", "value"]
+                                "required": [
+                                  "operator",
+                                  "field",
+                                  "value"
+                                ]
                               }
                             }
                           },
-                          "required": ["operator", "value"]
+                          "required": [
+                            "operator",
+                            "value"
+                          ]
                         },
                         {
                           "type": "object",
                           "properties": {
                             "operator": {
                               "type": "string",
-                              "enum": ["or"]
+                              "enum": [
+                                "or"
+                              ]
                             },
                             "value": {
                               "type": "array",
@@ -17949,39 +21414,58 @@
                                     "oneOf": [
                                       {
                                         "type": "string",
-                                        "enum": ["eq"]
+                                        "enum": [
+                                          "eq"
+                                        ]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": ["lt"]
+                                        "enum": [
+                                          "lt"
+                                        ]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": ["gt"]
+                                        "enum": [
+                                          "gt"
+                                        ]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": ["lte"]
+                                        "enum": [
+                                          "lte"
+                                        ]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": ["gte"]
+                                        "enum": [
+                                          "gte"
+                                        ]
                                       }
                                     ]
                                   },
                                   "field": {
                                     "type": "string",
-                                    "enum": ["balance"]
+                                    "enum": [
+                                      "balance"
+                                    ]
                                   },
                                   "value": {
                                     "type": "number"
                                   }
                                 },
-                                "required": ["operator", "field", "value"]
+                                "required": [
+                                  "operator",
+                                  "field",
+                                  "value"
+                                ]
                               }
                             }
                           },
-                          "required": ["operator", "value"]
+                          "required": [
+                            "operator",
+                            "value"
+                          ]
                         },
                         {
                           "type": "object",
@@ -17990,35 +21474,51 @@
                               "oneOf": [
                                 {
                                   "type": "string",
-                                  "enum": ["eq"]
+                                  "enum": [
+                                    "eq"
+                                  ]
                                 },
                                 {
                                   "type": "string",
-                                  "enum": ["lt"]
+                                  "enum": [
+                                    "lt"
+                                  ]
                                 },
                                 {
                                   "type": "string",
-                                  "enum": ["gt"]
+                                  "enum": [
+                                    "gt"
+                                  ]
                                 },
                                 {
                                   "type": "string",
-                                  "enum": ["lte"]
+                                  "enum": [
+                                    "lte"
+                                  ]
                                 },
                                 {
                                   "type": "string",
-                                  "enum": ["gte"]
+                                  "enum": [
+                                    "gte"
+                                  ]
                                 }
                               ]
                             },
                             "field": {
                               "type": "string",
-                              "enum": ["balance"]
+                              "enum": [
+                                "balance"
+                              ]
                             },
                             "value": {
                               "type": "number"
                             }
                           },
-                          "required": ["operator", "field", "value"]
+                          "required": [
+                            "operator",
+                            "field",
+                            "value"
+                          ]
                         }
                       ]
                     },
@@ -18035,7 +21535,10 @@
                           "type": "boolean"
                         }
                       },
-                      "required": ["owner", "denom"]
+                      "required": [
+                        "owner",
+                        "denom"
+                      ]
                     }
                   },
                   "required": [
@@ -18089,10 +21592,20 @@
                 "type": "boolean"
               }
             },
-            "required": ["page", "limit", "total", "totalPages", "hasNextPage", "hasPreviousPage"]
+            "required": [
+              "page",
+              "limit",
+              "total",
+              "totalPages",
+              "hasNextPage",
+              "hasPreviousPage"
+            ]
           }
         },
-        "required": ["data", "pagination"]
+        "required": [
+          "data",
+          "pagination"
+        ]
       },
       "AlertPatchInput": {
         "type": "object",
@@ -18129,7 +21642,9 @@
                         "properties": {
                           "operator": {
                             "type": "string",
-                            "enum": ["and"]
+                            "enum": [
+                              "and"
+                            ]
                           },
                           "value": {
                             "type": "array",
@@ -18141,23 +21656,33 @@
                                   "oneOf": [
                                     {
                                       "type": "string",
-                                      "enum": ["eq"]
+                                      "enum": [
+                                        "eq"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["lt"]
+                                      "enum": [
+                                        "lt"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["gt"]
+                                      "enum": [
+                                        "gt"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["lte"]
+                                      "enum": [
+                                        "lte"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["gte"]
+                                      "enum": [
+                                        "gte"
+                                      ]
                                     }
                                   ]
                                 },
@@ -18178,18 +21703,27 @@
                                   ]
                                 }
                               },
-                              "required": ["operator", "field", "value"]
+                              "required": [
+                                "operator",
+                                "field",
+                                "value"
+                              ]
                             }
                           }
                         },
-                        "required": ["operator", "value"]
+                        "required": [
+                          "operator",
+                          "value"
+                        ]
                       },
                       {
                         "type": "object",
                         "properties": {
                           "operator": {
                             "type": "string",
-                            "enum": ["or"]
+                            "enum": [
+                              "or"
+                            ]
                           },
                           "value": {
                             "type": "array",
@@ -18201,23 +21735,33 @@
                                   "oneOf": [
                                     {
                                       "type": "string",
-                                      "enum": ["eq"]
+                                      "enum": [
+                                        "eq"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["lt"]
+                                      "enum": [
+                                        "lt"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["gt"]
+                                      "enum": [
+                                        "gt"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["lte"]
+                                      "enum": [
+                                        "lte"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["gte"]
+                                      "enum": [
+                                        "gte"
+                                      ]
                                     }
                                   ]
                                 },
@@ -18238,11 +21782,18 @@
                                   ]
                                 }
                               },
-                              "required": ["operator", "field", "value"]
+                              "required": [
+                                "operator",
+                                "field",
+                                "value"
+                              ]
                             }
                           }
                         },
-                        "required": ["operator", "value"]
+                        "required": [
+                          "operator",
+                          "value"
+                        ]
                       },
                       {
                         "type": "object",
@@ -18251,23 +21802,33 @@
                             "oneOf": [
                               {
                                 "type": "string",
-                                "enum": ["eq"]
+                                "enum": [
+                                  "eq"
+                                ]
                               },
                               {
                                 "type": "string",
-                                "enum": ["lt"]
+                                "enum": [
+                                  "lt"
+                                ]
                               },
                               {
                                 "type": "string",
-                                "enum": ["gt"]
+                                "enum": [
+                                  "gt"
+                                ]
                               },
                               {
                                 "type": "string",
-                                "enum": ["lte"]
+                                "enum": [
+                                  "lte"
+                                ]
                               },
                               {
                                 "type": "string",
-                                "enum": ["gte"]
+                                "enum": [
+                                  "gte"
+                                ]
                               }
                             ]
                           },
@@ -18288,7 +21849,11 @@
                             ]
                           }
                         },
-                        "required": ["operator", "field", "value"]
+                        "required": [
+                          "operator",
+                          "field",
+                          "value"
+                        ]
                       }
                     ]
                   },
@@ -18299,7 +21864,9 @@
                         "properties": {
                           "operator": {
                             "type": "string",
-                            "enum": ["and"]
+                            "enum": [
+                              "and"
+                            ]
                           },
                           "value": {
                             "type": "array",
@@ -18311,46 +21878,67 @@
                                   "oneOf": [
                                     {
                                       "type": "string",
-                                      "enum": ["eq"]
+                                      "enum": [
+                                        "eq"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["lt"]
+                                      "enum": [
+                                        "lt"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["gt"]
+                                      "enum": [
+                                        "gt"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["lte"]
+                                      "enum": [
+                                        "lte"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["gte"]
+                                      "enum": [
+                                        "gte"
+                                      ]
                                     }
                                   ]
                                 },
                                 "field": {
                                   "type": "string",
-                                  "enum": ["balance"]
+                                  "enum": [
+                                    "balance"
+                                  ]
                                 },
                                 "value": {
                                   "type": "number"
                                 }
                               },
-                              "required": ["operator", "field", "value"]
+                              "required": [
+                                "operator",
+                                "field",
+                                "value"
+                              ]
                             }
                           }
                         },
-                        "required": ["operator", "value"]
+                        "required": [
+                          "operator",
+                          "value"
+                        ]
                       },
                       {
                         "type": "object",
                         "properties": {
                           "operator": {
                             "type": "string",
-                            "enum": ["or"]
+                            "enum": [
+                              "or"
+                            ]
                           },
                           "value": {
                             "type": "array",
@@ -18362,39 +21950,58 @@
                                   "oneOf": [
                                     {
                                       "type": "string",
-                                      "enum": ["eq"]
+                                      "enum": [
+                                        "eq"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["lt"]
+                                      "enum": [
+                                        "lt"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["gt"]
+                                      "enum": [
+                                        "gt"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["lte"]
+                                      "enum": [
+                                        "lte"
+                                      ]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": ["gte"]
+                                      "enum": [
+                                        "gte"
+                                      ]
                                     }
                                   ]
                                 },
                                 "field": {
                                   "type": "string",
-                                  "enum": ["balance"]
+                                  "enum": [
+                                    "balance"
+                                  ]
                                 },
                                 "value": {
                                   "type": "number"
                                 }
                               },
-                              "required": ["operator", "field", "value"]
+                              "required": [
+                                "operator",
+                                "field",
+                                "value"
+                              ]
                             }
                           }
                         },
-                        "required": ["operator", "value"]
+                        "required": [
+                          "operator",
+                          "value"
+                        ]
                       },
                       {
                         "type": "object",
@@ -18403,35 +22010,51 @@
                             "oneOf": [
                               {
                                 "type": "string",
-                                "enum": ["eq"]
+                                "enum": [
+                                  "eq"
+                                ]
                               },
                               {
                                 "type": "string",
-                                "enum": ["lt"]
+                                "enum": [
+                                  "lt"
+                                ]
                               },
                               {
                                 "type": "string",
-                                "enum": ["gt"]
+                                "enum": [
+                                  "gt"
+                                ]
                               },
                               {
                                 "type": "string",
-                                "enum": ["lte"]
+                                "enum": [
+                                  "lte"
+                                ]
                               },
                               {
                                 "type": "string",
-                                "enum": ["gte"]
+                                "enum": [
+                                  "gte"
+                                ]
                               }
                             ]
                           },
                           "field": {
                             "type": "string",
-                            "enum": ["balance"]
+                            "enum": [
+                              "balance"
+                            ]
                           },
                           "value": {
                             "type": "number"
                           }
                         },
-                        "required": ["operator", "field", "value"]
+                        "required": [
+                          "operator",
+                          "field",
+                          "value"
+                        ]
                       }
                     ]
                   }
@@ -18440,7 +22063,9 @@
             }
           }
         },
-        "required": ["data"]
+        "required": [
+          "data"
+        ]
       },
       "NotificationChannelCreateInput": {
         "type": "object",
@@ -18453,7 +22078,9 @@
               },
               "type": {
                 "type": "string",
-                "enum": ["email"]
+                "enum": [
+                  "email"
+                ]
               },
               "config": {
                 "type": "object",
@@ -18466,16 +22093,24 @@
                     }
                   }
                 },
-                "required": ["addresses"]
+                "required": [
+                  "addresses"
+                ]
               },
               "isDefault": {
                 "type": "boolean"
               }
             },
-            "required": ["name", "type", "config"]
+            "required": [
+              "name",
+              "type",
+              "config"
+            ]
           }
         },
-        "required": ["data"]
+        "required": [
+          "data"
+        ]
       },
       "NotificationChannelOutput": {
         "type": "object",
@@ -18488,7 +22123,9 @@
               },
               "type": {
                 "type": "string",
-                "enum": ["email"]
+                "enum": [
+                  "email"
+                ]
               },
               "config": {
                 "type": "object",
@@ -18501,7 +22138,9 @@
                     }
                   }
                 },
-                "required": ["addresses"]
+                "required": [
+                  "addresses"
+                ]
               },
               "isDefault": {
                 "type": "boolean"
@@ -18517,10 +22156,21 @@
               "createdAt": {},
               "updatedAt": {}
             },
-            "required": ["name", "type", "config", "isDefault", "id", "userId", "createdAt", "updatedAt"]
+            "required": [
+              "name",
+              "type",
+              "config",
+              "isDefault",
+              "id",
+              "userId",
+              "createdAt",
+              "updatedAt"
+            ]
           }
         },
-        "required": ["data"]
+        "required": [
+          "data"
+        ]
       },
       "NotificationChannelCreateDefaultInput": {
         "type": "object",
@@ -18533,7 +22183,9 @@
               },
               "type": {
                 "type": "string",
-                "enum": ["email"]
+                "enum": [
+                  "email"
+                ]
               },
               "config": {
                 "type": "object",
@@ -18546,13 +22198,21 @@
                     }
                   }
                 },
-                "required": ["addresses"]
+                "required": [
+                  "addresses"
+                ]
               }
             },
-            "required": ["name", "type", "config"]
+            "required": [
+              "name",
+              "type",
+              "config"
+            ]
           }
         },
-        "required": ["data"]
+        "required": [
+          "data"
+        ]
       },
       "NotFoundErrorResponse": {
         "type": "object",
@@ -18566,7 +22226,10 @@
             "type": "string"
           }
         },
-        "required": ["statusCode", "message"]
+        "required": [
+          "statusCode",
+          "message"
+        ]
       },
       "NotificationChannelListOutput": {
         "type": "object",
@@ -18581,7 +22244,9 @@
                 },
                 "type": {
                   "type": "string",
-                  "enum": ["email"]
+                  "enum": [
+                    "email"
+                  ]
                 },
                 "config": {
                   "type": "object",
@@ -18594,7 +22259,9 @@
                       }
                     }
                   },
-                  "required": ["addresses"]
+                  "required": [
+                    "addresses"
+                  ]
                 },
                 "isDefault": {
                   "type": "boolean"
@@ -18610,7 +22277,16 @@
                 "createdAt": {},
                 "updatedAt": {}
               },
-              "required": ["name", "type", "config", "isDefault", "id", "userId", "createdAt", "updatedAt"]
+              "required": [
+                "name",
+                "type",
+                "config",
+                "isDefault",
+                "id",
+                "userId",
+                "createdAt",
+                "updatedAt"
+              ]
             }
           },
           "pagination": {
@@ -18645,10 +22321,20 @@
                 "type": "boolean"
               }
             },
-            "required": ["page", "limit", "total", "totalPages", "hasNextPage", "hasPreviousPage"]
+            "required": [
+              "page",
+              "limit",
+              "total",
+              "totalPages",
+              "hasNextPage",
+              "hasPreviousPage"
+            ]
           }
         },
-        "required": ["data", "pagination"]
+        "required": [
+          "data",
+          "pagination"
+        ]
       },
       "NotificationChannelPatchInput": {
         "type": "object",
@@ -18661,7 +22347,9 @@
               },
               "type": {
                 "type": "string",
-                "enum": ["email"]
+                "enum": [
+                  "email"
+                ]
               },
               "config": {
                 "type": "object",
@@ -18674,12 +22362,16 @@
                     }
                   }
                 },
-                "required": ["addresses"]
+                "required": [
+                  "addresses"
+                ]
               }
             }
           }
         },
-        "required": ["data"]
+        "required": [
+          "data"
+        ]
       },
       "DeploymentAlertCreateInput": {
         "type": "object",
@@ -18707,7 +22399,10 @@
                         "exclusiveMinimum": false
                       }
                     },
-                    "required": ["notificationChannelId", "threshold"]
+                    "required": [
+                      "notificationChannelId",
+                      "threshold"
+                    ]
                   },
                   "deploymentClosed": {
                     "type": "object",
@@ -18721,15 +22416,21 @@
                         "default": true
                       }
                     },
-                    "required": ["notificationChannelId"]
+                    "required": [
+                      "notificationChannelId"
+                    ]
                   }
                 }
               }
             },
-            "required": ["alerts"]
+            "required": [
+              "alerts"
+            ]
           }
         },
-        "required": ["data"]
+        "required": [
+          "data"
+        ]
       },
       "DeploymentAlertsResponse": {
         "type": "object",
@@ -18773,7 +22474,12 @@
                         "type": "boolean"
                       }
                     },
-                    "required": ["notificationChannelId", "threshold", "id", "status"]
+                    "required": [
+                      "notificationChannelId",
+                      "threshold",
+                      "id",
+                      "status"
+                    ]
                   },
                   "deploymentClosed": {
                     "type": "object",
@@ -18797,15 +22503,24 @@
                         "type": "boolean"
                       }
                     },
-                    "required": ["notificationChannelId", "id", "status"]
+                    "required": [
+                      "notificationChannelId",
+                      "id",
+                      "status"
+                    ]
                   }
                 }
               }
             },
-            "required": ["dseq", "alerts"]
+            "required": [
+              "dseq",
+              "alerts"
+            ]
           }
         },
-        "required": ["data"]
+        "required": [
+          "data"
+        ]
       }
     },
     "securitySchemes": {

--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -199,7 +199,7 @@
                           "threshold",
                           "prediction"
                         ],
-                        "description": "Rule used to decide when and how much to top up: `threshold` charges the fixed amount as soon as the balance reaches the threshold, `prediction` covers the next 7 days of projected spend. Left unchanged when omitted."
+                        "description": "Rule used to decide when and how much to top up: `threshold` charges the fixed amount as soon as the balance reaches the threshold, `prediction` covers the next 7 days of projected spend. Defaults to `prediction` on create when omitted; left unchanged on update."
                       },
                       "autoReloadThreshold": {
                         "type": "number",
@@ -310,7 +310,7 @@
                           "threshold",
                           "prediction"
                         ],
-                        "description": "Rule used to decide when and how much to top up: `threshold` charges the fixed amount as soon as the balance reaches the threshold, `prediction` covers the next 7 days of projected spend. Left unchanged when omitted."
+                        "description": "Rule used to decide when and how much to top up: `threshold` charges the fixed amount as soon as the balance reaches the threshold, `prediction` covers the next 7 days of projected spend. Defaults to `prediction` on create when omitted; left unchanged on update."
                       },
                       "autoReloadThreshold": {
                         "type": "number",

--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "servers": [
     {
-      "url": "https://console-api-sandbox.akash.network"
+      "url": "http://localhost:3080"
     }
   ],
   "info": {
@@ -14,9 +14,7 @@
     "/v1/wallets": {
       "get": {
         "summary": "Get a list of wallets",
-        "tags": [
-          "Wallet"
-        ],
+        "tags": ["Wallet"],
         "security": [
           {
             "BearerAuth": []
@@ -76,22 +74,11 @@
                             "type": "string"
                           }
                         },
-                        "required": [
-                          "id",
-                          "userId",
-                          "creditAmount",
-                          "address",
-                          "denom",
-                          "isTrialing",
-                          "topUpMinAmountUsd",
-                          "createdAt"
-                        ]
+                        "required": ["id", "userId", "creditAmount", "address", "denom", "isTrialing", "topUpMinAmountUsd", "createdAt"]
                       }
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -104,9 +91,7 @@
         "summary": "Get wallet settings",
         "operationId": "getWalletSettings",
         "description": "Retrieves the wallet settings for the current user's wallet",
-        "tags": [
-          "WalletSetting"
-        ],
+        "tags": ["WalletSetting"],
         "security": [
           {
             "BearerAuth": []
@@ -129,6 +114,11 @@
                         "autoReloadEnabled": {
                           "type": "boolean"
                         },
+                        "autoReloadMode": {
+                          "type": "string",
+                          "enum": ["threshold", "prediction"],
+                          "description": "Rule used to decide when and how much to top up."
+                        },
                         "autoReloadThreshold": {
                           "type": "number",
                           "description": "USD credit balance at or below which an automatic top-up is triggered."
@@ -138,16 +128,10 @@
                           "description": "USD amount charged to the default payment method on each automatic top-up."
                         }
                       },
-                      "required": [
-                        "autoReloadEnabled",
-                        "autoReloadThreshold",
-                        "autoReloadAmount"
-                      ]
+                      "required": ["autoReloadEnabled", "autoReloadMode", "autoReloadThreshold", "autoReloadAmount"]
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -161,9 +145,7 @@
         "summary": "Create wallet settings",
         "operationId": "createWalletSettings",
         "description": "Creates wallet settings for a user wallet",
-        "tags": [
-          "WalletSetting"
-        ],
+        "tags": ["WalletSetting"],
         "security": [
           {
             "BearerAuth": []
@@ -184,6 +166,11 @@
                       "autoReloadEnabled": {
                         "type": "boolean"
                       },
+                      "autoReloadMode": {
+                        "type": "string",
+                        "enum": ["threshold", "prediction"],
+                        "description": "Rule used to decide when and how much to top up: `threshold` charges the fixed amount as soon as the balance reaches the threshold, `prediction` covers the next 7 days of projected spend. Left unchanged when omitted."
+                      },
                       "autoReloadThreshold": {
                         "type": "number",
                         "minimum": 5,
@@ -197,14 +184,10 @@
                         "description": "USD amount charged on each automatic top-up (minimum 20, maximum 10000). Defaults are applied on create when omitted."
                       }
                     },
-                    "required": [
-                      "autoReloadEnabled"
-                    ]
+                    "required": ["autoReloadEnabled"]
                   }
                 },
-                "required": [
-                  "data"
-                ]
+                "required": ["data"]
               }
             }
           }
@@ -223,6 +206,11 @@
                         "autoReloadEnabled": {
                           "type": "boolean"
                         },
+                        "autoReloadMode": {
+                          "type": "string",
+                          "enum": ["threshold", "prediction"],
+                          "description": "Rule used to decide when and how much to top up."
+                        },
                         "autoReloadThreshold": {
                           "type": "number",
                           "description": "USD credit balance at or below which an automatic top-up is triggered."
@@ -232,16 +220,10 @@
                           "description": "USD amount charged to the default payment method on each automatic top-up."
                         }
                       },
-                      "required": [
-                        "autoReloadEnabled",
-                        "autoReloadThreshold",
-                        "autoReloadAmount"
-                      ]
+                      "required": ["autoReloadEnabled", "autoReloadMode", "autoReloadThreshold", "autoReloadAmount"]
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -255,9 +237,7 @@
         "summary": "Update wallet settings",
         "operationId": "updateWalletSettings",
         "description": "Updates wallet settings for a user wallet",
-        "tags": [
-          "WalletSetting"
-        ],
+        "tags": ["WalletSetting"],
         "security": [
           {
             "BearerAuth": []
@@ -278,6 +258,11 @@
                       "autoReloadEnabled": {
                         "type": "boolean"
                       },
+                      "autoReloadMode": {
+                        "type": "string",
+                        "enum": ["threshold", "prediction"],
+                        "description": "Rule used to decide when and how much to top up: `threshold` charges the fixed amount as soon as the balance reaches the threshold, `prediction` covers the next 7 days of projected spend. Left unchanged when omitted."
+                      },
                       "autoReloadThreshold": {
                         "type": "number",
                         "minimum": 5,
@@ -291,14 +276,10 @@
                         "description": "USD amount charged on each automatic top-up (minimum 20, maximum 10000). Defaults are applied on create when omitted."
                       }
                     },
-                    "required": [
-                      "autoReloadEnabled"
-                    ]
+                    "required": ["autoReloadEnabled"]
                   }
                 },
-                "required": [
-                  "data"
-                ]
+                "required": ["data"]
               }
             }
           }
@@ -317,6 +298,11 @@
                         "autoReloadEnabled": {
                           "type": "boolean"
                         },
+                        "autoReloadMode": {
+                          "type": "string",
+                          "enum": ["threshold", "prediction"],
+                          "description": "Rule used to decide when and how much to top up."
+                        },
                         "autoReloadThreshold": {
                           "type": "number",
                           "description": "USD credit balance at or below which an automatic top-up is triggered."
@@ -326,16 +312,10 @@
                           "description": "USD amount charged to the default payment method on each automatic top-up."
                         }
                       },
-                      "required": [
-                        "autoReloadEnabled",
-                        "autoReloadThreshold",
-                        "autoReloadAmount"
-                      ]
+                      "required": ["autoReloadEnabled", "autoReloadMode", "autoReloadThreshold", "autoReloadAmount"]
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -349,9 +329,7 @@
         "summary": "Delete wallet settings",
         "operationId": "deleteWalletSettings",
         "description": "Deletes wallet settings for a user wallet",
-        "tags": [
-          "WalletSetting"
-        ],
+        "tags": ["WalletSetting"],
         "security": [
           {
             "BearerAuth": []
@@ -373,9 +351,7 @@
     "/v1/tx": {
       "post": {
         "summary": "Signs a transaction via a user managed wallet",
-        "tags": [
-          "Wallet"
-        ],
+        "tags": ["Wallet"],
         "security": [
           {
             "BearerAuth": []
@@ -416,23 +392,15 @@
                               "type": "string"
                             }
                           },
-                          "required": [
-                            "typeUrl",
-                            "value"
-                          ]
+                          "required": ["typeUrl", "value"]
                         },
                         "minItems": 1
                       }
                     },
-                    "required": [
-                      "userId",
-                      "messages"
-                    ]
+                    "required": ["userId", "messages"]
                   }
                 },
-                "required": [
-                  "data"
-                ]
+                "required": ["data"]
               }
             }
           }
@@ -458,16 +426,10 @@
                           "type": "string"
                         }
                       },
-                      "required": [
-                        "code",
-                        "transactionHash",
-                        "rawLog"
-                      ]
+                      "required": ["code", "transactionHash", "rawLog"]
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -478,9 +440,7 @@
     "/v1/stripe-webhook": {
       "post": {
         "summary": "Stripe Webhook Handler",
-        "tags": [
-          "Payment"
-        ],
+        "tags": ["Payment"],
         "security": [],
         "requestBody": {
           "content": {
@@ -507,9 +467,7 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "error"
-                  ]
+                  "required": ["error"]
                 }
               }
             }
@@ -522,9 +480,7 @@
         "operationId": "listStripePrices",
         "summary": "Get available Stripe pricing options",
         "description": "Retrieves the list of available pricing options for wallet top-ups, including custom amounts and standard pricing tiers",
-        "tags": [
-          "Payment"
-        ],
+        "tags": ["Payment"],
         "security": [
           {
             "BearerAuth": []
@@ -556,17 +512,11 @@
                             "type": "boolean"
                           }
                         },
-                        "required": [
-                          "currency",
-                          "unitAmount",
-                          "isCustom"
-                        ]
+                        "required": ["currency", "unitAmount", "isCustom"]
                       }
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -578,9 +528,7 @@
       "post": {
         "operationId": "applyStripeCoupon",
         "summary": "Apply a coupon to the current user",
-        "tags": [
-          "Payment"
-        ],
+        "tags": ["Payment"],
         "security": [
           {
             "BearerAuth": []
@@ -608,15 +556,10 @@
                         "type": "boolean"
                       }
                     },
-                    "required": [
-                      "couponId",
-                      "userId"
-                    ]
+                    "required": ["couponId", "userId"]
                   }
                 },
-                "required": [
-                  "data"
-                ]
+                "required": ["data"]
               }
             }
           }
@@ -660,9 +603,7 @@
                               "nullable": true
                             }
                           },
-                          "required": [
-                            "id"
-                          ]
+                          "required": ["id"]
                         },
                         "amountAdded": {
                           "type": "number"
@@ -672,15 +613,7 @@
                         },
                         "transactionStatus": {
                           "type": "string",
-                          "enum": [
-                            "created",
-                            "pending",
-                            "requires_action",
-                            "succeeded",
-                            "failed",
-                            "refunded",
-                            "canceled"
-                          ]
+                          "enum": ["created", "pending", "requires_action", "succeeded", "failed", "refunded", "canceled"]
                         },
                         "error": {
                           "type": "object",
@@ -695,16 +628,12 @@
                               "type": "string"
                             }
                           },
-                          "required": [
-                            "message"
-                          ]
+                          "required": ["message"]
                         }
                       }
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -717,9 +646,7 @@
         "operationId": "updateStripeCustomerOrganization",
         "summary": "Update customer organization",
         "description": "Updates the organization/business name for the current user's Stripe customer account",
-        "tags": [
-          "Payment"
-        ],
+        "tags": ["Payment"],
         "security": [
           {
             "BearerAuth": []
@@ -738,9 +665,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "organization"
-                ]
+                "required": ["organization"]
               }
             }
           }
@@ -757,9 +682,7 @@
         "operationId": "createSetupIntent",
         "summary": "Create a Stripe SetupIntent for adding a payment method",
         "description": "Creates a Stripe SetupIntent that allows users to securely add payment methods to their account. The SetupIntent provides a client secret that can be used with Stripe's frontend SDKs to collect payment method details.",
-        "tags": [
-          "Payment"
-        ],
+        "tags": ["Payment"],
         "security": [
           {
             "BearerAuth": []
@@ -784,14 +707,10 @@
                           "nullable": true
                         }
                       },
-                      "required": [
-                        "clientSecret"
-                      ]
+                      "required": ["clientSecret"]
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -803,9 +722,7 @@
       "post": {
         "operationId": "setDefaultPaymentMethod",
         "summary": "Marks a payment method as the default.",
-        "tags": [
-          "Payment"
-        ],
+        "tags": ["Payment"],
         "security": [
           {
             "BearerAuth": []
@@ -827,14 +744,10 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "id"
-                    ]
+                    "required": ["id"]
                   }
                 },
-                "required": [
-                  "data"
-                ]
+                "required": ["data"]
               }
             }
           }
@@ -849,9 +762,7 @@
         "operationId": "getDefaultPaymentMethod",
         "summary": "Get the default payment method for the current user",
         "description": "Retrieves the default payment method associated with the current user's account, including card details, validation status, and billing information.",
-        "tags": [
-          "Payment"
-        ],
+        "tags": ["Payment"],
         "security": [
           {
             "BearerAuth": []
@@ -921,12 +832,7 @@
                               }
                             }
                           },
-                          "required": [
-                            "brand",
-                            "last4",
-                            "exp_month",
-                            "exp_year"
-                          ]
+                          "required": ["brand", "last4", "exp_month", "exp_year"]
                         },
                         "link": {
                           "type": "object",
@@ -970,14 +876,7 @@
                                   "nullable": true
                                 }
                               },
-                              "required": [
-                                "city",
-                                "country",
-                                "line1",
-                                "line2",
-                                "postal_code",
-                                "state"
-                              ]
+                              "required": ["city", "country", "line1", "line2", "postal_code", "state"]
                             },
                             "email": {
                               "type": "string",
@@ -997,15 +896,10 @@
                           "type": "string"
                         }
                       },
-                      "required": [
-                        "type",
-                        "id"
-                      ]
+                      "required": ["type", "id"]
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -1021,9 +915,7 @@
         "operationId": "listPaymentMethods",
         "summary": "Get all payment methods for the current user",
         "description": "Retrieves all saved payment methods associated with the current user's account, including card details, validation status, and billing information.",
-        "tags": [
-          "Payment"
-        ],
+        "tags": ["Payment"],
         "security": [
           {
             "BearerAuth": []
@@ -1095,12 +987,7 @@
                                 }
                               }
                             },
-                            "required": [
-                              "brand",
-                              "last4",
-                              "exp_month",
-                              "exp_year"
-                            ]
+                            "required": ["brand", "last4", "exp_month", "exp_year"]
                           },
                           "link": {
                             "type": "object",
@@ -1144,14 +1031,7 @@
                                     "nullable": true
                                   }
                                 },
-                                "required": [
-                                  "city",
-                                  "country",
-                                  "line1",
-                                  "line2",
-                                  "postal_code",
-                                  "state"
-                                ]
+                                "required": ["city", "country", "line1", "line2", "postal_code", "state"]
                               },
                               "email": {
                                 "type": "string",
@@ -1171,16 +1051,11 @@
                             "type": "string"
                           }
                         },
-                        "required": [
-                          "type",
-                          "id"
-                        ]
+                        "required": ["type", "id"]
                       }
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -1193,9 +1068,7 @@
         "operationId": "deletePaymentMethod",
         "summary": "Remove a payment method",
         "description": "Permanently removes a saved payment method from the user's account. This action cannot be undone.",
-        "tags": [
-          "Payment"
-        ],
+        "tags": ["Payment"],
         "security": [
           {
             "BearerAuth": []
@@ -1228,9 +1101,7 @@
         "operationId": "validatePaymentMethod",
         "summary": "Validates a payment method after 3D Secure authentication",
         "description": "Completes the validation process for a payment method that required 3D Secure authentication. This endpoint should be called after the user completes the 3D Secure challenge.",
-        "tags": [
-          "Payment"
-        ],
+        "tags": ["Payment"],
         "security": [
           {
             "BearerAuth": []
@@ -1255,15 +1126,10 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "paymentMethodId",
-                      "paymentIntentId"
-                    ]
+                    "required": ["paymentMethodId", "paymentIntentId"]
                   }
                 },
-                "required": [
-                  "data"
-                ]
+                "required": ["data"]
               }
             }
           }
@@ -1280,9 +1146,7 @@
                       "type": "boolean"
                     }
                   },
-                  "required": [
-                    "success"
-                  ]
+                  "required": ["success"]
                 }
               }
             }
@@ -1295,9 +1159,7 @@
         "operationId": "confirmStripeTransaction",
         "summary": "Confirm a payment using a saved payment method",
         "description": "Processes a payment using a previously saved payment method. This endpoint handles wallet top-ups and may require 3D Secure authentication for certain payment methods or amounts.",
-        "tags": [
-          "Payment"
-        ],
+        "tags": ["Payment"],
         "security": [
           {
             "BearerAuth": []
@@ -1333,16 +1195,10 @@
                         "format": "uuid"
                       }
                     },
-                    "required": [
-                      "userId",
-                      "paymentMethodId",
-                      "amount"
-                    ]
+                    "required": ["userId", "paymentMethodId", "amount"]
                   }
                 },
-                "required": [
-                  "data"
-                ]
+                "required": ["data"]
               }
             }
           }
@@ -1375,26 +1231,13 @@
                         },
                         "transactionStatus": {
                           "type": "string",
-                          "enum": [
-                            "created",
-                            "pending",
-                            "requires_action",
-                            "succeeded",
-                            "failed",
-                            "refunded",
-                            "canceled"
-                          ]
+                          "enum": ["created", "pending", "requires_action", "succeeded", "failed", "refunded", "canceled"]
                         }
                       },
-                      "required": [
-                        "success",
-                        "transactionId"
-                      ]
+                      "required": ["success", "transactionId"]
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -1426,26 +1269,13 @@
                         },
                         "transactionStatus": {
                           "type": "string",
-                          "enum": [
-                            "created",
-                            "pending",
-                            "requires_action",
-                            "succeeded",
-                            "failed",
-                            "refunded",
-                            "canceled"
-                          ]
+                          "enum": ["created", "pending", "requires_action", "succeeded", "failed", "refunded", "canceled"]
                         }
                       },
-                      "required": [
-                        "success",
-                        "transactionId"
-                      ]
+                      "required": ["success", "transactionId"]
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -1457,9 +1287,7 @@
       "get": {
         "operationId": "listStripeTransactions",
         "summary": "Get transaction history for the current customer",
-        "tags": [
-          "Payment"
-        ],
+        "tags": ["Payment"],
         "security": [
           {
             "BearerAuth": []
@@ -1538,11 +1366,7 @@
                               },
                               "type": {
                                 "type": "string",
-                                "enum": [
-                                  "payment_intent",
-                                  "coupon_claim",
-                                  "manual_credit"
-                                ]
+                                "enum": ["payment_intent", "coupon_claim", "manual_credit"]
                               },
                               "amount": {
                                 "type": "number"
@@ -1583,15 +1407,7 @@
                                 "nullable": true
                               }
                             },
-                            "required": [
-                              "id",
-                              "type",
-                              "amount",
-                              "amountRefunded",
-                              "currency",
-                              "status",
-                              "created"
-                            ]
+                            "required": ["id", "type", "amount", "amountRefunded", "currency", "status", "created"]
                           }
                         },
                         "totalCount": {
@@ -1601,16 +1417,10 @@
                           "type": "boolean"
                         }
                       },
-                      "required": [
-                        "transactions",
-                        "totalCount",
-                        "hasMore"
-                      ]
+                      "required": ["transactions", "totalCount", "hasMore"]
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -1622,9 +1432,7 @@
       "get": {
         "operationId": "exportStripeTransactions",
         "summary": "Export transaction history as CSV for the current customer",
-        "tags": [
-          "Payment"
-        ],
+        "tags": ["Payment"],
         "security": [
           {
             "BearerAuth": []
@@ -1685,9 +1493,7 @@
     "/v1/usage/history": {
       "get": {
         "summary": "Get historical data of billing and usage for a wallet address.",
-        "tags": [
-          "Billing"
-        ],
+        "tags": ["Billing"],
         "security": [],
         "parameters": [
           {
@@ -1810,9 +1616,7 @@
     "/v1/usage/history/stats": {
       "get": {
         "summary": "Get historical usage stats for a wallet address.",
-        "tags": [
-          "Billing"
-        ],
+        "tags": ["Billing"],
         "security": [],
         "parameters": [
           {
@@ -1877,12 +1681,7 @@
                       "example": 1.5
                     }
                   },
-                  "required": [
-                    "totalSpent",
-                    "averageSpentPerDay",
-                    "totalDeployments",
-                    "averageDeploymentsPerDay"
-                  ]
+                  "required": ["totalSpent", "averageSpentPerDay", "totalDeployments", "averageDeploymentsPerDay"]
                 }
               }
             }
@@ -1896,9 +1695,7 @@
     "/v1/register-user": {
       "post": {
         "summary": "Registers a new user",
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "security": [],
         "requestBody": {
           "content": {
@@ -1919,11 +1716,7 @@
                     "type": "boolean"
                   }
                 },
-                "required": [
-                  "wantedUsername",
-                  "email",
-                  "emailVerified"
-                ]
+                "required": ["wantedUsername", "email", "emailVerified"]
               }
             }
           }
@@ -1983,23 +1776,13 @@
                           "format": "date-time"
                         }
                       },
-                      "required": [
-                        "id",
-                        "userId",
-                        "username",
-                        "email",
-                        "emailVerified",
-                        "subscribedToNewsletter"
-                      ]
+                      "required": ["id", "userId", "username", "email", "emailVerified", "subscribedToNewsletter"]
                     },
                     "isNewUser": {
                       "type": "boolean"
                     }
                   },
-                  "required": [
-                    "data",
-                    "isNewUser"
-                  ]
+                  "required": ["data", "isNewUser"]
                 }
               }
             }
@@ -2010,9 +1793,7 @@
     "/v1/user/me": {
       "get": {
         "summary": "Retrieves the logged in user",
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "security": [
           {
             "BearerAuth": []
@@ -2076,19 +1857,10 @@
                           "format": "date-time"
                         }
                       },
-                      "required": [
-                        "id",
-                        "userId",
-                        "username",
-                        "email",
-                        "emailVerified",
-                        "subscribedToNewsletter"
-                      ]
+                      "required": ["id", "userId", "username", "email", "emailVerified", "subscribedToNewsletter"]
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -2099,9 +1871,7 @@
     "/v1/user/byUsername/{username}": {
       "get": {
         "summary": "Get user by username",
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "security": [],
         "parameters": [
           {
@@ -2129,10 +1899,7 @@
                       "nullable": true
                     }
                   },
-                  "required": [
-                    "username",
-                    "bio"
-                  ]
+                  "required": ["username", "bio"]
                 }
               }
             }
@@ -2146,9 +1913,7 @@
     "/v1/user/updateSettings": {
       "put": {
         "summary": "Update user settings",
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "security": [
           {
             "BearerAuth": []
@@ -2191,9 +1956,7 @@
                     "maxLength": 200
                   }
                 },
-                "required": [
-                  "username"
-                ]
+                "required": ["username"]
               }
             }
           }
@@ -2214,9 +1977,7 @@
     "/v1/user/checkUsernameAvailability/{username}": {
       "get": {
         "summary": "Check if username is available",
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "security": [],
         "parameters": [
           {
@@ -2240,9 +2001,7 @@
                       "type": "boolean"
                     }
                   },
-                  "required": [
-                    "isAvailable"
-                  ]
+                  "required": ["isAvailable"]
                 }
               }
             }
@@ -2253,9 +2012,7 @@
     "/v1/user/subscribeToNewsletter": {
       "post": {
         "summary": "Subscribe to newsletter",
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "security": [
           {
             "BearerAuth": []
@@ -2277,9 +2034,7 @@
     "/v1/user/skipOnboarding": {
       "post": {
         "summary": "Skip onboarding",
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "security": [
           {
             "BearerAuth": []
@@ -2301,9 +2056,7 @@
     "/v1/user/template/{id}": {
       "get": {
         "summary": "Get template by ID",
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "security": [],
         "parameters": [
           {
@@ -2332,9 +2085,7 @@
     "/v1/user/saveTemplate": {
       "post": {
         "summary": "Save template",
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "security": [
           {
             "BearerAuth": []
@@ -2376,14 +2127,7 @@
                     "maxLength": 2000
                   }
                 },
-                "required": [
-                  "sdl",
-                  "title",
-                  "cpu",
-                  "ram",
-                  "storage",
-                  "isPublic"
-                ]
+                "required": ["sdl", "title", "cpu", "ram", "storage", "isPublic"]
               }
             }
           }
@@ -2404,9 +2148,7 @@
     "/v1/user/saveTemplateDesc": {
       "post": {
         "summary": "Save template description",
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "security": [
           {
             "BearerAuth": []
@@ -2429,10 +2171,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "id",
-                  "description"
-                ]
+                "required": ["id", "description"]
               }
             }
           }
@@ -2450,9 +2189,7 @@
     "/v1/user/templates/{username}": {
       "get": {
         "summary": "Get templates by username",
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "security": [],
         "parameters": [
           {
@@ -2477,9 +2214,7 @@
     "/v1/user/deleteTemplate/{id}": {
       "delete": {
         "summary": "Delete template",
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "security": [
           {
             "BearerAuth": []
@@ -2515,9 +2250,7 @@
     "/v1/user/favoriteTemplates": {
       "get": {
         "summary": "Get favorite templates",
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "security": [
           {
             "BearerAuth": []
@@ -2539,9 +2272,7 @@
     "/v1/user/addFavoriteTemplate/{templateId}": {
       "post": {
         "summary": "Add favorite template",
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "security": [
           {
             "BearerAuth": []
@@ -2577,9 +2308,7 @@
     "/v1/user/removeFavoriteTemplate/{templateId}": {
       "delete": {
         "summary": "Remove favorite template",
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "security": [
           {
             "BearerAuth": []
@@ -2615,9 +2344,7 @@
     "/v1/send-verification-email": {
       "post": {
         "summary": "Resends a verification email",
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "security": [],
         "requestBody": {
           "required": true,
@@ -2633,14 +2360,10 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "userId"
-                    ]
+                    "required": ["userId"]
                   }
                 },
-                "required": [
-                  "data"
-                ]
+                "required": ["data"]
               }
             }
           }
@@ -2656,9 +2379,7 @@
     "/v1/send-verification-code": {
       "post": {
         "summary": "Sends a verification code to the authenticated user's email",
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "security": [
           {
             "BearerAuth": []
@@ -2679,14 +2400,10 @@
                           "type": "string"
                         }
                       },
-                      "required": [
-                        "codeSentAt"
-                      ]
+                      "required": ["codeSentAt"]
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -2700,9 +2417,7 @@
     "/v1/auth/signup": {
       "post": {
         "summary": "Creates a new user without sending a verification email",
-        "tags": [
-          "Auth"
-        ],
+        "tags": ["Auth"],
         "security": [],
         "requestBody": {
           "required": true,
@@ -2720,10 +2435,7 @@
                     "minLength": 8
                   }
                 },
-                "required": [
-                  "email",
-                  "password"
-                ]
+                "required": ["email", "password"]
               }
             }
           }
@@ -2738,9 +2450,7 @@
     "/v1/verify-email-code": {
       "post": {
         "summary": "Verifies the email using a 6-digit code",
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "security": [
           {
             "BearerAuth": []
@@ -2761,14 +2471,10 @@
                         "pattern": "^\\d{6}$"
                       }
                     },
-                    "required": [
-                      "code"
-                    ]
+                    "required": ["code"]
                   }
                 },
-                "required": [
-                  "data"
-                ]
+                "required": ["data"]
               }
             }
           }
@@ -2789,9 +2495,7 @@
     "/v1/verify-email": {
       "post": {
         "summary": "Checks if the email is verified",
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "security": [],
         "requestBody": {
           "required": true,
@@ -2808,14 +2512,10 @@
                         "format": "email"
                       }
                     },
-                    "required": [
-                      "email"
-                    ]
+                    "required": ["email"]
                   }
                 },
-                "required": [
-                  "data"
-                ]
+                "required": ["data"]
               }
             }
           }
@@ -2835,14 +2535,10 @@
                           "type": "boolean"
                         }
                       },
-                      "required": [
-                        "emailVerified"
-                      ]
+                      "required": ["emailVerified"]
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -2859,9 +2555,7 @@
     "/v1/deployment-settings/{userId}/{dseq}": {
       "get": {
         "summary": "Get deployment settings by user ID and dseq",
-        "tags": [
-          "Deployment Settings"
-        ],
+        "tags": ["Deployment Settings"],
         "security": [
           {
             "BearerAuth": []
@@ -2931,21 +2625,10 @@
                           "format": "date-time"
                         }
                       },
-                      "required": [
-                        "id",
-                        "userId",
-                        "dseq",
-                        "autoTopUpEnabled",
-                        "estimatedTopUpAmount",
-                        "topUpFrequencyMs",
-                        "createdAt",
-                        "updatedAt"
-                      ]
+                      "required": ["id", "userId", "dseq", "autoTopUpEnabled", "estimatedTopUpAmount", "topUpFrequencyMs", "createdAt", "updatedAt"]
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -2961,9 +2644,7 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "message"
-                  ]
+                  "required": ["message"]
                 }
               }
             }
@@ -2972,9 +2653,7 @@
       },
       "patch": {
         "summary": "Update deployment settings",
-        "tags": [
-          "Deployment Settings"
-        ],
+        "tags": ["Deployment Settings"],
         "security": [
           {
             "BearerAuth": []
@@ -3018,14 +2697,10 @@
                         "description": "Whether auto top-up is enabled for this deployment"
                       }
                     },
-                    "required": [
-                      "autoTopUpEnabled"
-                    ]
+                    "required": ["autoTopUpEnabled"]
                   }
                 },
-                "required": [
-                  "data"
-                ]
+                "required": ["data"]
               }
             }
           }
@@ -3070,21 +2745,10 @@
                           "format": "date-time"
                         }
                       },
-                      "required": [
-                        "id",
-                        "userId",
-                        "dseq",
-                        "autoTopUpEnabled",
-                        "estimatedTopUpAmount",
-                        "topUpFrequencyMs",
-                        "createdAt",
-                        "updatedAt"
-                      ]
+                      "required": ["id", "userId", "dseq", "autoTopUpEnabled", "estimatedTopUpAmount", "topUpFrequencyMs", "createdAt", "updatedAt"]
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -3100,9 +2764,7 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "message"
-                  ]
+                  "required": ["message"]
                 }
               }
             }
@@ -3113,9 +2775,7 @@
     "/v1/deployment-settings": {
       "post": {
         "summary": "Create deployment settings",
-        "tags": [
-          "Deployment Settings"
-        ],
+        "tags": ["Deployment Settings"],
         "security": [
           {
             "BearerAuth": []
@@ -3148,15 +2808,10 @@
                         "description": "Whether auto top-up is enabled for this deployment"
                       }
                     },
-                    "required": [
-                      "userId",
-                      "dseq"
-                    ]
+                    "required": ["userId", "dseq"]
                   }
                 },
-                "required": [
-                  "data"
-                ]
+                "required": ["data"]
               }
             }
           }
@@ -3201,21 +2856,10 @@
                           "format": "date-time"
                         }
                       },
-                      "required": [
-                        "id",
-                        "userId",
-                        "dseq",
-                        "autoTopUpEnabled",
-                        "estimatedTopUpAmount",
-                        "topUpFrequencyMs",
-                        "createdAt",
-                        "updatedAt"
-                      ]
+                      "required": ["id", "userId", "dseq", "autoTopUpEnabled", "estimatedTopUpAmount", "topUpFrequencyMs", "createdAt", "updatedAt"]
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -3226,9 +2870,7 @@
     "/v2/deployment-settings/{dseq}": {
       "get": {
         "summary": "Get deployment settings by dseq",
-        "tags": [
-          "Deployment Settings"
-        ],
+        "tags": ["Deployment Settings"],
         "security": [
           {
             "BearerAuth": []
@@ -3299,21 +2941,10 @@
                           "format": "date-time"
                         }
                       },
-                      "required": [
-                        "id",
-                        "userId",
-                        "dseq",
-                        "autoTopUpEnabled",
-                        "estimatedTopUpAmount",
-                        "topUpFrequencyMs",
-                        "createdAt",
-                        "updatedAt"
-                      ]
+                      "required": ["id", "userId", "dseq", "autoTopUpEnabled", "estimatedTopUpAmount", "topUpFrequencyMs", "createdAt", "updatedAt"]
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -3329,9 +2960,7 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "message"
-                  ]
+                  "required": ["message"]
                 }
               }
             }
@@ -3340,9 +2969,7 @@
       },
       "patch": {
         "summary": "Update deployment settings",
-        "tags": [
-          "Deployment Settings"
-        ],
+        "tags": ["Deployment Settings"],
         "security": [
           {
             "BearerAuth": []
@@ -3387,14 +3014,10 @@
                         "description": "Whether auto top-up is enabled for this deployment"
                       }
                     },
-                    "required": [
-                      "autoTopUpEnabled"
-                    ]
+                    "required": ["autoTopUpEnabled"]
                   }
                 },
-                "required": [
-                  "data"
-                ]
+                "required": ["data"]
               }
             }
           }
@@ -3439,21 +3062,10 @@
                           "format": "date-time"
                         }
                       },
-                      "required": [
-                        "id",
-                        "userId",
-                        "dseq",
-                        "autoTopUpEnabled",
-                        "estimatedTopUpAmount",
-                        "topUpFrequencyMs",
-                        "createdAt",
-                        "updatedAt"
-                      ]
+                      "required": ["id", "userId", "dseq", "autoTopUpEnabled", "estimatedTopUpAmount", "topUpFrequencyMs", "createdAt", "updatedAt"]
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -3469,9 +3081,7 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "message"
-                  ]
+                  "required": ["message"]
                 }
               }
             }
@@ -3482,9 +3092,7 @@
     "/v2/deployment-settings": {
       "post": {
         "summary": "Create deployment settings",
-        "tags": [
-          "Deployment Settings"
-        ],
+        "tags": ["Deployment Settings"],
         "security": [
           {
             "BearerAuth": []
@@ -3518,14 +3126,10 @@
                         "description": "User ID. Defaults to the current authenticated user if not provided"
                       }
                     },
-                    "required": [
-                      "dseq"
-                    ]
+                    "required": ["dseq"]
                   }
                 },
-                "required": [
-                  "data"
-                ]
+                "required": ["data"]
               }
             }
           }
@@ -3570,21 +3174,10 @@
                           "format": "date-time"
                         }
                       },
-                      "required": [
-                        "id",
-                        "userId",
-                        "dseq",
-                        "autoTopUpEnabled",
-                        "estimatedTopUpAmount",
-                        "topUpFrequencyMs",
-                        "createdAt",
-                        "updatedAt"
-                      ]
+                      "required": ["id", "userId", "dseq", "autoTopUpEnabled", "estimatedTopUpAmount", "topUpFrequencyMs", "createdAt", "updatedAt"]
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -3596,9 +3189,7 @@
       "get": {
         "summary": "Get a deployment",
         "operationId": "getDeployment",
-        "tags": [
-          "Deployments"
-        ],
+        "tags": ["Deployments"],
         "security": [
           {
             "BearerAuth": []
@@ -3645,10 +3236,7 @@
                                   "pattern": "^d+$"
                                 }
                               },
-                              "required": [
-                                "owner",
-                                "dseq"
-                              ]
+                              "required": ["owner", "dseq"]
                             },
                             "state": {
                               "type": "string"
@@ -3660,12 +3248,7 @@
                               "type": "string"
                             }
                           },
-                          "required": [
-                            "id",
-                            "state",
-                            "hash",
-                            "created_at"
-                          ]
+                          "required": ["id", "state", "hash", "created_at"]
                         },
                         "leases": {
                           "type": "array",
@@ -3695,14 +3278,7 @@
                                     "type": "number"
                                   }
                                 },
-                                "required": [
-                                  "owner",
-                                  "dseq",
-                                  "gseq",
-                                  "oseq",
-                                  "provider",
-                                  "bseq"
-                                ]
+                                "required": ["owner", "dseq", "gseq", "oseq", "provider", "bseq"]
                               },
                               "state": {
                                 "type": "string"
@@ -3717,10 +3293,7 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": [
-                                  "denom",
-                                  "amount"
-                                ]
+                                "required": ["denom", "amount"]
                               },
                               "created_at": {
                                 "type": "string"
@@ -3755,10 +3328,7 @@
                                             "type": "number"
                                           }
                                         },
-                                        "required": [
-                                          "port",
-                                          "externalPort"
-                                        ]
+                                        "required": ["port", "externalPort"]
                                       }
                                     }
                                   },
@@ -3782,12 +3352,7 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": [
-                                          "IP",
-                                          "Port",
-                                          "ExternalPort",
-                                          "Protocol"
-                                        ]
+                                        "required": ["IP", "Port", "ExternalPort", "Protocol"]
                                       }
                                     }
                                   },
@@ -3841,21 +3406,10 @@
                                     }
                                   }
                                 },
-                                "required": [
-                                  "forwarded_ports",
-                                  "ips",
-                                  "services"
-                                ]
+                                "required": ["forwarded_ports", "ips", "services"]
                               }
                             },
-                            "required": [
-                              "id",
-                              "state",
-                              "price",
-                              "created_at",
-                              "closed_on",
-                              "status"
-                            ]
+                            "required": ["id", "state", "price", "created_at", "closed_on", "status"]
                           }
                         },
                         "escrow_account": {
@@ -3871,10 +3425,7 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "scope",
-                                "xid"
-                              ]
+                              "required": ["scope", "xid"]
                             },
                             "state": {
                               "type": "object",
@@ -3897,10 +3448,7 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": [
-                                      "denom",
-                                      "amount"
-                                    ]
+                                    "required": ["denom", "amount"]
                                   }
                                 },
                                 "settled_at": {
@@ -3918,10 +3466,7 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": [
-                                      "denom",
-                                      "amount"
-                                    ]
+                                    "required": ["denom", "amount"]
                                   }
                                 },
                                 "deposits": {
@@ -3948,47 +3493,23 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": [
-                                          "denom",
-                                          "amount"
-                                        ]
+                                        "required": ["denom", "amount"]
                                       }
                                     },
-                                    "required": [
-                                      "owner",
-                                      "height",
-                                      "source",
-                                      "balance"
-                                    ]
+                                    "required": ["owner", "height", "source", "balance"]
                                   }
                                 }
                               },
-                              "required": [
-                                "owner",
-                                "state",
-                                "transferred",
-                                "settled_at",
-                                "funds",
-                                "deposits"
-                              ]
+                              "required": ["owner", "state", "transferred", "settled_at", "funds", "deposits"]
                             }
                           },
-                          "required": [
-                            "id",
-                            "state"
-                          ]
+                          "required": ["id", "state"]
                         }
                       },
-                      "required": [
-                        "deployment",
-                        "leases",
-                        "escrow_account"
-                      ]
+                      "required": ["deployment", "leases", "escrow_account"]
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -3998,9 +3519,7 @@
       "delete": {
         "summary": "Close a deployment",
         "operationId": "closeDeployment",
-        "tags": [
-          "Deployments"
-        ],
+        "tags": ["Deployments"],
         "security": [
           {
             "BearerAuth": []
@@ -4037,14 +3556,10 @@
                           "type": "boolean"
                         }
                       },
-                      "required": [
-                        "success"
-                      ]
+                      "required": ["success"]
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -4054,9 +3569,7 @@
       "put": {
         "summary": "Update a deployment",
         "operationId": "updateDeployment",
-        "tags": [
-          "Deployments"
-        ],
+        "tags": ["Deployments"],
         "security": [
           {
             "BearerAuth": []
@@ -4091,14 +3604,10 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "sdl"
-                    ]
+                    "required": ["sdl"]
                   }
                 },
-                "required": [
-                  "data"
-                ]
+                "required": ["data"]
               }
             }
           }
@@ -4128,10 +3637,7 @@
                                   "pattern": "^d+$"
                                 }
                               },
-                              "required": [
-                                "owner",
-                                "dseq"
-                              ]
+                              "required": ["owner", "dseq"]
                             },
                             "state": {
                               "type": "string"
@@ -4143,12 +3649,7 @@
                               "type": "string"
                             }
                           },
-                          "required": [
-                            "id",
-                            "state",
-                            "hash",
-                            "created_at"
-                          ]
+                          "required": ["id", "state", "hash", "created_at"]
                         },
                         "leases": {
                           "type": "array",
@@ -4178,14 +3679,7 @@
                                     "type": "number"
                                   }
                                 },
-                                "required": [
-                                  "owner",
-                                  "dseq",
-                                  "gseq",
-                                  "oseq",
-                                  "provider",
-                                  "bseq"
-                                ]
+                                "required": ["owner", "dseq", "gseq", "oseq", "provider", "bseq"]
                               },
                               "state": {
                                 "type": "string"
@@ -4200,10 +3694,7 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": [
-                                  "denom",
-                                  "amount"
-                                ]
+                                "required": ["denom", "amount"]
                               },
                               "created_at": {
                                 "type": "string"
@@ -4238,10 +3729,7 @@
                                             "type": "number"
                                           }
                                         },
-                                        "required": [
-                                          "port",
-                                          "externalPort"
-                                        ]
+                                        "required": ["port", "externalPort"]
                                       }
                                     }
                                   },
@@ -4265,12 +3753,7 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": [
-                                          "IP",
-                                          "Port",
-                                          "ExternalPort",
-                                          "Protocol"
-                                        ]
+                                        "required": ["IP", "Port", "ExternalPort", "Protocol"]
                                       }
                                     }
                                   },
@@ -4324,21 +3807,10 @@
                                     }
                                   }
                                 },
-                                "required": [
-                                  "forwarded_ports",
-                                  "ips",
-                                  "services"
-                                ]
+                                "required": ["forwarded_ports", "ips", "services"]
                               }
                             },
-                            "required": [
-                              "id",
-                              "state",
-                              "price",
-                              "created_at",
-                              "closed_on",
-                              "status"
-                            ]
+                            "required": ["id", "state", "price", "created_at", "closed_on", "status"]
                           }
                         },
                         "escrow_account": {
@@ -4354,10 +3826,7 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "scope",
-                                "xid"
-                              ]
+                              "required": ["scope", "xid"]
                             },
                             "state": {
                               "type": "object",
@@ -4380,10 +3849,7 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": [
-                                      "denom",
-                                      "amount"
-                                    ]
+                                    "required": ["denom", "amount"]
                                   }
                                 },
                                 "settled_at": {
@@ -4401,10 +3867,7 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": [
-                                      "denom",
-                                      "amount"
-                                    ]
+                                    "required": ["denom", "amount"]
                                   }
                                 },
                                 "deposits": {
@@ -4431,47 +3894,23 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": [
-                                          "denom",
-                                          "amount"
-                                        ]
+                                        "required": ["denom", "amount"]
                                       }
                                     },
-                                    "required": [
-                                      "owner",
-                                      "height",
-                                      "source",
-                                      "balance"
-                                    ]
+                                    "required": ["owner", "height", "source", "balance"]
                                   }
                                 }
                               },
-                              "required": [
-                                "owner",
-                                "state",
-                                "transferred",
-                                "settled_at",
-                                "funds",
-                                "deposits"
-                              ]
+                              "required": ["owner", "state", "transferred", "settled_at", "funds", "deposits"]
                             }
                           },
-                          "required": [
-                            "id",
-                            "state"
-                          ]
+                          "required": ["id", "state"]
                         }
                       },
-                      "required": [
-                        "deployment",
-                        "leases",
-                        "escrow_account"
-                      ]
+                      "required": ["deployment", "leases", "escrow_account"]
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -4483,9 +3922,7 @@
       "post": {
         "summary": "Create new deployment",
         "operationId": "createDeployment",
-        "tags": [
-          "Deployments"
-        ],
+        "tags": ["Deployments"],
         "security": [
           {
             "BearerAuth": []
@@ -4511,15 +3948,10 @@
                         "description": "Amount to deposit in dollars (e.g. 5.5)"
                       }
                     },
-                    "required": [
-                      "sdl",
-                      "deposit"
-                    ]
+                    "required": ["sdl", "deposit"]
                   }
                 },
-                "required": [
-                  "data"
-                ]
+                "required": ["data"]
               }
             }
           }
@@ -4555,23 +3987,13 @@
                               "type": "string"
                             }
                           },
-                          "required": [
-                            "code",
-                            "transactionHash",
-                            "rawLog"
-                          ]
+                          "required": ["code", "transactionHash", "rawLog"]
                         }
                       },
-                      "required": [
-                        "dseq",
-                        "manifest",
-                        "signTx"
-                      ]
+                      "required": ["dseq", "manifest", "signTx"]
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -4581,9 +4003,7 @@
       "get": {
         "summary": "List deployments with pagination and filtering",
         "operationId": "listDeployments",
-        "tags": [
-          "Deployments"
-        ],
+        "tags": ["Deployments"],
         "security": [
           {
             "BearerAuth": []
@@ -4644,10 +4064,7 @@
                                         "pattern": "^d+$"
                                       }
                                     },
-                                    "required": [
-                                      "owner",
-                                      "dseq"
-                                    ]
+                                    "required": ["owner", "dseq"]
                                   },
                                   "state": {
                                     "type": "string"
@@ -4659,12 +4076,7 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": [
-                                  "id",
-                                  "state",
-                                  "hash",
-                                  "created_at"
-                                ]
+                                "required": ["id", "state", "hash", "created_at"]
                               },
                               "leases": {
                                 "type": "array",
@@ -4694,14 +4106,7 @@
                                           "type": "number"
                                         }
                                       },
-                                      "required": [
-                                        "owner",
-                                        "dseq",
-                                        "gseq",
-                                        "oseq",
-                                        "provider",
-                                        "bseq"
-                                      ]
+                                      "required": ["owner", "dseq", "gseq", "oseq", "provider", "bseq"]
                                     },
                                     "state": {
                                       "type": "string"
@@ -4716,10 +4121,7 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": [
-                                        "denom",
-                                        "amount"
-                                      ]
+                                      "required": ["denom", "amount"]
                                     },
                                     "created_at": {
                                       "type": "string"
@@ -4731,13 +4133,7 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": [
-                                    "id",
-                                    "state",
-                                    "price",
-                                    "created_at",
-                                    "closed_on"
-                                  ]
+                                  "required": ["id", "state", "price", "created_at", "closed_on"]
                                 }
                               },
                               "escrow_account": {
@@ -4753,10 +4149,7 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": [
-                                      "scope",
-                                      "xid"
-                                    ]
+                                    "required": ["scope", "xid"]
                                   },
                                   "state": {
                                     "type": "object",
@@ -4779,10 +4172,7 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": [
-                                            "denom",
-                                            "amount"
-                                          ]
+                                          "required": ["denom", "amount"]
                                         }
                                       },
                                       "settled_at": {
@@ -4800,10 +4190,7 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": [
-                                            "denom",
-                                            "amount"
-                                          ]
+                                          "required": ["denom", "amount"]
                                         }
                                       },
                                       "deposits": {
@@ -4830,42 +4217,20 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "required": [
-                                                "denom",
-                                                "amount"
-                                              ]
+                                              "required": ["denom", "amount"]
                                             }
                                           },
-                                          "required": [
-                                            "owner",
-                                            "height",
-                                            "source",
-                                            "balance"
-                                          ]
+                                          "required": ["owner", "height", "source", "balance"]
                                         }
                                       }
                                     },
-                                    "required": [
-                                      "owner",
-                                      "state",
-                                      "transferred",
-                                      "settled_at",
-                                      "funds",
-                                      "deposits"
-                                    ]
+                                    "required": ["owner", "state", "transferred", "settled_at", "funds", "deposits"]
                                   }
                                 },
-                                "required": [
-                                  "id",
-                                  "state"
-                                ]
+                                "required": ["id", "state"]
                               }
                             },
-                            "required": [
-                              "deployment",
-                              "leases",
-                              "escrow_account"
-                            ]
+                            "required": ["deployment", "leases", "escrow_account"]
                           }
                         },
                         "pagination": {
@@ -4884,23 +4249,13 @@
                               "type": "boolean"
                             }
                           },
-                          "required": [
-                            "total",
-                            "skip",
-                            "limit",
-                            "hasMore"
-                          ]
+                          "required": ["total", "skip", "limit", "hasMore"]
                         }
                       },
-                      "required": [
-                        "deployments",
-                        "pagination"
-                      ]
+                      "required": ["deployments", "pagination"]
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -4912,9 +4267,7 @@
       "post": {
         "summary": "Deposit into a deployment",
         "operationId": "depositDeployment",
-        "tags": [
-          "Deployments"
-        ],
+        "tags": ["Deployments"],
         "security": [
           {
             "BearerAuth": []
@@ -4942,15 +4295,10 @@
                         "description": "Amount to deposit in dollars (e.g. 5.5)"
                       }
                     },
-                    "required": [
-                      "dseq",
-                      "deposit"
-                    ]
+                    "required": ["dseq", "deposit"]
                   }
                 },
-                "required": [
-                  "data"
-                ]
+                "required": ["data"]
               }
             }
           }
@@ -4980,10 +4328,7 @@
                                   "pattern": "^d+$"
                                 }
                               },
-                              "required": [
-                                "owner",
-                                "dseq"
-                              ]
+                              "required": ["owner", "dseq"]
                             },
                             "state": {
                               "type": "string"
@@ -4995,12 +4340,7 @@
                               "type": "string"
                             }
                           },
-                          "required": [
-                            "id",
-                            "state",
-                            "hash",
-                            "created_at"
-                          ]
+                          "required": ["id", "state", "hash", "created_at"]
                         },
                         "leases": {
                           "type": "array",
@@ -5030,14 +4370,7 @@
                                     "type": "number"
                                   }
                                 },
-                                "required": [
-                                  "owner",
-                                  "dseq",
-                                  "gseq",
-                                  "oseq",
-                                  "provider",
-                                  "bseq"
-                                ]
+                                "required": ["owner", "dseq", "gseq", "oseq", "provider", "bseq"]
                               },
                               "state": {
                                 "type": "string"
@@ -5052,10 +4385,7 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": [
-                                  "denom",
-                                  "amount"
-                                ]
+                                "required": ["denom", "amount"]
                               },
                               "created_at": {
                                 "type": "string"
@@ -5090,10 +4420,7 @@
                                             "type": "number"
                                           }
                                         },
-                                        "required": [
-                                          "port",
-                                          "externalPort"
-                                        ]
+                                        "required": ["port", "externalPort"]
                                       }
                                     }
                                   },
@@ -5117,12 +4444,7 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": [
-                                          "IP",
-                                          "Port",
-                                          "ExternalPort",
-                                          "Protocol"
-                                        ]
+                                        "required": ["IP", "Port", "ExternalPort", "Protocol"]
                                       }
                                     }
                                   },
@@ -5176,21 +4498,10 @@
                                     }
                                   }
                                 },
-                                "required": [
-                                  "forwarded_ports",
-                                  "ips",
-                                  "services"
-                                ]
+                                "required": ["forwarded_ports", "ips", "services"]
                               }
                             },
-                            "required": [
-                              "id",
-                              "state",
-                              "price",
-                              "created_at",
-                              "closed_on",
-                              "status"
-                            ]
+                            "required": ["id", "state", "price", "created_at", "closed_on", "status"]
                           }
                         },
                         "escrow_account": {
@@ -5206,10 +4517,7 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "scope",
-                                "xid"
-                              ]
+                              "required": ["scope", "xid"]
                             },
                             "state": {
                               "type": "object",
@@ -5232,10 +4540,7 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": [
-                                      "denom",
-                                      "amount"
-                                    ]
+                                    "required": ["denom", "amount"]
                                   }
                                 },
                                 "settled_at": {
@@ -5253,10 +4558,7 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": [
-                                      "denom",
-                                      "amount"
-                                    ]
+                                    "required": ["denom", "amount"]
                                   }
                                 },
                                 "deposits": {
@@ -5283,47 +4585,23 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": [
-                                          "denom",
-                                          "amount"
-                                        ]
+                                        "required": ["denom", "amount"]
                                       }
                                     },
-                                    "required": [
-                                      "owner",
-                                      "height",
-                                      "source",
-                                      "balance"
-                                    ]
+                                    "required": ["owner", "height", "source", "balance"]
                                   }
                                 }
                               },
-                              "required": [
-                                "owner",
-                                "state",
-                                "transferred",
-                                "settled_at",
-                                "funds",
-                                "deposits"
-                              ]
+                              "required": ["owner", "state", "transferred", "settled_at", "funds", "deposits"]
                             }
                           },
-                          "required": [
-                            "id",
-                            "state"
-                          ]
+                          "required": ["id", "state"]
                         }
                       },
-                      "required": [
-                        "deployment",
-                        "leases",
-                        "escrow_account"
-                      ]
+                      "required": ["deployment", "leases", "escrow_account"]
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -5334,10 +4612,7 @@
     "/v1/addresses/{address}/deployments/{skip}/{limit}": {
       "get": {
         "summary": "Get a list of deployments by owner address.",
-        "tags": [
-          "Addresses",
-          "Deployments"
-        ],
+        "tags": ["Addresses", "Deployments"],
         "security": [],
         "parameters": [
           {
@@ -5377,10 +4652,7 @@
           {
             "schema": {
               "type": "string",
-              "enum": [
-                "active",
-                "closed"
-              ],
+              "enum": ["active", "closed"],
               "description": "Filter by status",
               "example": "closed"
             },
@@ -5461,10 +4733,7 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": [
-                                    "address",
-                                    "hostUri"
-                                  ]
+                                  "required": ["address", "hostUri"]
                                 },
                                 "dseq": {
                                   "type": "string",
@@ -5489,42 +4758,18 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": [
-                                    "denom",
-                                    "amount"
-                                  ]
+                                  "required": ["denom", "amount"]
                                 }
                               },
-                              "required": [
-                                "id",
-                                "owner",
-                                "dseq",
-                                "gseq",
-                                "oseq",
-                                "state",
-                                "price"
-                              ]
+                              "required": ["id", "owner", "dseq", "gseq", "oseq", "state", "price"]
                             }
                           }
                         },
-                        "required": [
-                          "owner",
-                          "dseq",
-                          "status",
-                          "createdHeight",
-                          "cpuUnits",
-                          "gpuUnits",
-                          "memoryQuantity",
-                          "storageQuantity",
-                          "leases"
-                        ]
+                        "required": ["owner", "dseq", "status", "createdHeight", "cpuUnits", "gpuUnits", "memoryQuantity", "storageQuantity", "leases"]
                       }
                     }
                   },
-                  "required": [
-                    "count",
-                    "results"
-                  ]
+                  "required": ["count", "results"]
                 }
               }
             }
@@ -5538,9 +4783,7 @@
     "/v1/deployment/{owner}/{dseq}": {
       "get": {
         "summary": "Get deployment details",
-        "tags": [
-          "Deployments"
-        ],
+        "tags": ["Deployments"],
         "security": [],
         "parameters": [
           {
@@ -5627,19 +4870,11 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": [
-                                    "key",
-                                    "value"
-                                  ]
+                                  "required": ["key", "value"]
                                 }
                               }
                             },
-                            "required": [
-                              "address",
-                              "hostUri",
-                              "isDeleted",
-                              "attributes"
-                            ]
+                            "required": ["address", "hostUri", "isDeleted", "attributes"]
                           },
                           "status": {
                             "type": "string"
@@ -5660,17 +4895,7 @@
                             "type": "number"
                           }
                         },
-                        "required": [
-                          "gseq",
-                          "oseq",
-                          "provider",
-                          "status",
-                          "monthlyCostUDenom",
-                          "cpuUnits",
-                          "gpuUnits",
-                          "memoryQuantity",
-                          "storageQuantity"
-                        ]
+                        "required": ["gseq", "oseq", "provider", "status", "monthlyCostUDenom", "cpuUnits", "gpuUnits", "memoryQuantity", "storageQuantity"]
                       }
                     },
                     "events": {
@@ -5688,11 +4913,7 @@
                             "type": "string"
                           }
                         },
-                        "required": [
-                          "txHash",
-                          "date",
-                          "type"
-                        ]
+                        "required": ["txHash", "date", "type"]
                       }
                     },
                     "other": {
@@ -5711,10 +4932,7 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "owner",
-                                "dseq"
-                              ]
+                              "required": ["owner", "dseq"]
                             },
                             "state": {
                               "type": "string"
@@ -5726,12 +4944,7 @@
                               "type": "string"
                             }
                           },
-                          "required": [
-                            "id",
-                            "state",
-                            "hash",
-                            "created_at"
-                          ]
+                          "required": ["id", "state", "hash", "created_at"]
                         },
                         "groups": {
                           "type": "array",
@@ -5751,11 +4964,7 @@
                                     "type": "number"
                                   }
                                 },
-                                "required": [
-                                  "owner",
-                                  "dseq",
-                                  "gseq"
-                                ]
+                                "required": ["owner", "dseq", "gseq"]
                               },
                               "state": {
                                 "type": "string"
@@ -5785,10 +4994,7 @@
                                             }
                                           }
                                         },
-                                        "required": [
-                                          "all_of",
-                                          "any_of"
-                                        ]
+                                        "required": ["all_of", "any_of"]
                                       },
                                       "attributes": {
                                         "type": "array",
@@ -5802,17 +5008,11 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": [
-                                            "key",
-                                            "value"
-                                          ]
+                                          "required": ["key", "value"]
                                         }
                                       }
                                     },
-                                    "required": [
-                                      "signed_by",
-                                      "attributes"
-                                    ]
+                                    "required": ["signed_by", "attributes"]
                                   },
                                   "resources": {
                                     "type": "array",
@@ -5835,9 +5035,7 @@
                                                       "type": "string"
                                                     }
                                                   },
-                                                  "required": [
-                                                    "val"
-                                                  ]
+                                                  "required": ["val"]
                                                 },
                                                 "attributes": {
                                                   "type": "array",
@@ -5851,17 +5049,11 @@
                                                         "type": "string"
                                                       }
                                                     },
-                                                    "required": [
-                                                      "key",
-                                                      "value"
-                                                    ]
+                                                    "required": ["key", "value"]
                                                   }
                                                 }
                                               },
-                                              "required": [
-                                                "units",
-                                                "attributes"
-                                              ]
+                                              "required": ["units", "attributes"]
                                             },
                                             "memory": {
                                               "type": "object",
@@ -5873,9 +5065,7 @@
                                                       "type": "string"
                                                     }
                                                   },
-                                                  "required": [
-                                                    "val"
-                                                  ]
+                                                  "required": ["val"]
                                                 },
                                                 "attributes": {
                                                   "type": "array",
@@ -5889,17 +5079,11 @@
                                                         "type": "string"
                                                       }
                                                     },
-                                                    "required": [
-                                                      "key",
-                                                      "value"
-                                                    ]
+                                                    "required": ["key", "value"]
                                                   }
                                                 }
                                               },
-                                              "required": [
-                                                "quantity",
-                                                "attributes"
-                                              ]
+                                              "required": ["quantity", "attributes"]
                                             },
                                             "storage": {
                                               "type": "array",
@@ -5916,9 +5100,7 @@
                                                         "type": "string"
                                                       }
                                                     },
-                                                    "required": [
-                                                      "val"
-                                                    ]
+                                                    "required": ["val"]
                                                   },
                                                   "attributes": {
                                                     "type": "array",
@@ -5932,18 +5114,11 @@
                                                           "type": "string"
                                                         }
                                                       },
-                                                      "required": [
-                                                        "key",
-                                                        "value"
-                                                      ]
+                                                      "required": ["key", "value"]
                                                     }
                                                   }
                                                 },
-                                                "required": [
-                                                  "name",
-                                                  "quantity",
-                                                  "attributes"
-                                                ]
+                                                "required": ["name", "quantity", "attributes"]
                                               }
                                             },
                                             "gpu": {
@@ -5956,9 +5131,7 @@
                                                       "type": "string"
                                                     }
                                                   },
-                                                  "required": [
-                                                    "val"
-                                                  ]
+                                                  "required": ["val"]
                                                 },
                                                 "attributes": {
                                                   "type": "array",
@@ -5972,17 +5145,11 @@
                                                         "type": "string"
                                                       }
                                                     },
-                                                    "required": [
-                                                      "key",
-                                                      "value"
-                                                    ]
+                                                    "required": ["key", "value"]
                                                   }
                                                 }
                                               },
-                                              "required": [
-                                                "units",
-                                                "attributes"
-                                              ]
+                                              "required": ["units", "attributes"]
                                             },
                                             "endpoints": {
                                               "type": "array",
@@ -5996,21 +5163,11 @@
                                                     "type": "number"
                                                   }
                                                 },
-                                                "required": [
-                                                  "kind",
-                                                  "sequence_number"
-                                                ]
+                                                "required": ["kind", "sequence_number"]
                                               }
                                             }
                                           },
-                                          "required": [
-                                            "id",
-                                            "cpu",
-                                            "memory",
-                                            "storage",
-                                            "gpu",
-                                            "endpoints"
-                                          ]
+                                          "required": ["id", "cpu", "memory", "storage", "gpu", "endpoints"]
                                         },
                                         "count": {
                                           "type": "number"
@@ -6025,36 +5182,20 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": [
-                                            "denom",
-                                            "amount"
-                                          ]
+                                          "required": ["denom", "amount"]
                                         }
                                       },
-                                      "required": [
-                                        "resource",
-                                        "count",
-                                        "price"
-                                      ]
+                                      "required": ["resource", "count", "price"]
                                     }
                                   }
                                 },
-                                "required": [
-                                  "name",
-                                  "requirements",
-                                  "resources"
-                                ]
+                                "required": ["name", "requirements", "resources"]
                               },
                               "created_at": {
                                 "type": "string"
                               }
                             },
-                            "required": [
-                              "id",
-                              "state",
-                              "group_spec",
-                              "created_at"
-                            ]
+                            "required": ["id", "state", "group_spec", "created_at"]
                           }
                         },
                         "escrow_account": {
@@ -6070,10 +5211,7 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "scope",
-                                "xid"
-                              ]
+                              "required": ["scope", "xid"]
                             },
                             "state": {
                               "type": "object",
@@ -6096,10 +5234,7 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": [
-                                      "denom",
-                                      "amount"
-                                    ]
+                                    "required": ["denom", "amount"]
                                   }
                                 },
                                 "settled_at": {
@@ -6117,10 +5252,7 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": [
-                                      "denom",
-                                      "amount"
-                                    ]
+                                    "required": ["denom", "amount"]
                                   }
                                 },
                                 "deposits": {
@@ -6147,55 +5279,23 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": [
-                                          "denom",
-                                          "amount"
-                                        ]
+                                        "required": ["denom", "amount"]
                                       }
                                     },
-                                    "required": [
-                                      "owner",
-                                      "height",
-                                      "source",
-                                      "balance"
-                                    ]
+                                    "required": ["owner", "height", "source", "balance"]
                                   }
                                 }
                               },
-                              "required": [
-                                "owner",
-                                "state",
-                                "transferred",
-                                "settled_at",
-                                "funds",
-                                "deposits"
-                              ]
+                              "required": ["owner", "state", "transferred", "settled_at", "funds", "deposits"]
                             }
                           },
-                          "required": [
-                            "id",
-                            "state"
-                          ]
+                          "required": ["id", "state"]
                         }
                       },
-                      "required": [
-                        "deployment",
-                        "groups",
-                        "escrow_account"
-                      ]
+                      "required": ["deployment", "groups", "escrow_account"]
                     }
                   },
-                  "required": [
-                    "owner",
-                    "dseq",
-                    "balance",
-                    "denom",
-                    "status",
-                    "totalMonthlyCostUDenom",
-                    "leases",
-                    "events",
-                    "other"
-                  ]
+                  "required": ["owner", "dseq", "balance", "denom", "status", "totalMonthlyCostUDenom", "leases", "events", "other"]
                 }
               }
             }
@@ -6212,9 +5312,7 @@
     "/akash/deployment/{version}/deployments/list": {
       "get": {
         "summary": "List deployments (database fallback)",
-        "tags": [
-          "Deployments"
-        ],
+        "tags": ["Deployments"],
         "security": [],
         "parameters": [
           {
@@ -6228,10 +5326,7 @@
           {
             "schema": {
               "type": "string",
-              "enum": [
-                "active",
-                "closed"
-              ]
+              "enum": ["active", "closed"]
             },
             "required": false,
             "name": "filters.state",
@@ -6308,10 +5403,7 @@
                                     "pattern": "^d+$"
                                   }
                                 },
-                                "required": [
-                                  "owner",
-                                  "dseq"
-                                ]
+                                "required": ["owner", "dseq"]
                               },
                               "state": {
                                 "type": "string"
@@ -6323,12 +5415,7 @@
                                 "type": "string"
                               }
                             },
-                            "required": [
-                              "id",
-                              "state",
-                              "hash",
-                              "created_at"
-                            ]
+                            "required": ["id", "state", "hash", "created_at"]
                           },
                           "groups": {
                             "type": "array",
@@ -6349,11 +5436,7 @@
                                       "type": "number"
                                     }
                                   },
-                                  "required": [
-                                    "owner",
-                                    "dseq",
-                                    "gseq"
-                                  ]
+                                  "required": ["owner", "dseq", "gseq"]
                                 },
                                 "state": {
                                   "type": "string"
@@ -6383,10 +5466,7 @@
                                               }
                                             }
                                           },
-                                          "required": [
-                                            "all_of",
-                                            "any_of"
-                                          ]
+                                          "required": ["all_of", "any_of"]
                                         },
                                         "attributes": {
                                           "type": "array",
@@ -6400,17 +5480,11 @@
                                                 "type": "string"
                                               }
                                             },
-                                            "required": [
-                                              "key",
-                                              "value"
-                                            ]
+                                            "required": ["key", "value"]
                                           }
                                         }
                                       },
-                                      "required": [
-                                        "signed_by",
-                                        "attributes"
-                                      ]
+                                      "required": ["signed_by", "attributes"]
                                     },
                                     "resources": {
                                       "type": "array",
@@ -6433,9 +5507,7 @@
                                                         "type": "string"
                                                       }
                                                     },
-                                                    "required": [
-                                                      "val"
-                                                    ]
+                                                    "required": ["val"]
                                                   },
                                                   "attributes": {
                                                     "type": "array",
@@ -6449,17 +5521,11 @@
                                                           "type": "string"
                                                         }
                                                       },
-                                                      "required": [
-                                                        "key",
-                                                        "value"
-                                                      ]
+                                                      "required": ["key", "value"]
                                                     }
                                                   }
                                                 },
-                                                "required": [
-                                                  "units",
-                                                  "attributes"
-                                                ]
+                                                "required": ["units", "attributes"]
                                               },
                                               "memory": {
                                                 "type": "object",
@@ -6471,9 +5537,7 @@
                                                         "type": "string"
                                                       }
                                                     },
-                                                    "required": [
-                                                      "val"
-                                                    ]
+                                                    "required": ["val"]
                                                   },
                                                   "attributes": {
                                                     "type": "array",
@@ -6487,17 +5551,11 @@
                                                           "type": "string"
                                                         }
                                                       },
-                                                      "required": [
-                                                        "key",
-                                                        "value"
-                                                      ]
+                                                      "required": ["key", "value"]
                                                     }
                                                   }
                                                 },
-                                                "required": [
-                                                  "quantity",
-                                                  "attributes"
-                                                ]
+                                                "required": ["quantity", "attributes"]
                                               },
                                               "storage": {
                                                 "type": "array",
@@ -6514,9 +5572,7 @@
                                                           "type": "string"
                                                         }
                                                       },
-                                                      "required": [
-                                                        "val"
-                                                      ]
+                                                      "required": ["val"]
                                                     },
                                                     "attributes": {
                                                       "type": "array",
@@ -6530,18 +5586,11 @@
                                                             "type": "string"
                                                           }
                                                         },
-                                                        "required": [
-                                                          "key",
-                                                          "value"
-                                                        ]
+                                                        "required": ["key", "value"]
                                                       }
                                                     }
                                                   },
-                                                  "required": [
-                                                    "name",
-                                                    "quantity",
-                                                    "attributes"
-                                                  ]
+                                                  "required": ["name", "quantity", "attributes"]
                                                 }
                                               },
                                               "gpu": {
@@ -6554,9 +5603,7 @@
                                                         "type": "string"
                                                       }
                                                     },
-                                                    "required": [
-                                                      "val"
-                                                    ]
+                                                    "required": ["val"]
                                                   },
                                                   "attributes": {
                                                     "type": "array",
@@ -6570,17 +5617,11 @@
                                                           "type": "string"
                                                         }
                                                       },
-                                                      "required": [
-                                                        "key",
-                                                        "value"
-                                                      ]
+                                                      "required": ["key", "value"]
                                                     }
                                                   }
                                                 },
-                                                "required": [
-                                                  "units",
-                                                  "attributes"
-                                                ]
+                                                "required": ["units", "attributes"]
                                               },
                                               "endpoints": {
                                                 "type": "array",
@@ -6594,21 +5635,11 @@
                                                       "type": "number"
                                                     }
                                                   },
-                                                  "required": [
-                                                    "kind",
-                                                    "sequence_number"
-                                                  ]
+                                                  "required": ["kind", "sequence_number"]
                                                 }
                                               }
                                             },
-                                            "required": [
-                                              "id",
-                                              "cpu",
-                                              "memory",
-                                              "storage",
-                                              "gpu",
-                                              "endpoints"
-                                            ]
+                                            "required": ["id", "cpu", "memory", "storage", "gpu", "endpoints"]
                                           },
                                           "count": {
                                             "type": "number"
@@ -6623,36 +5654,20 @@
                                                 "type": "string"
                                               }
                                             },
-                                            "required": [
-                                              "denom",
-                                              "amount"
-                                            ]
+                                            "required": ["denom", "amount"]
                                           }
                                         },
-                                        "required": [
-                                          "resource",
-                                          "count",
-                                          "price"
-                                        ]
+                                        "required": ["resource", "count", "price"]
                                       }
                                     }
                                   },
-                                  "required": [
-                                    "name",
-                                    "requirements",
-                                    "resources"
-                                  ]
+                                  "required": ["name", "requirements", "resources"]
                                 },
                                 "created_at": {
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "id",
-                                "state",
-                                "group_spec",
-                                "created_at"
-                              ]
+                              "required": ["id", "state", "group_spec", "created_at"]
                             }
                           },
                           "escrow_account": {
@@ -6668,10 +5683,7 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": [
-                                  "scope",
-                                  "xid"
-                                ]
+                                "required": ["scope", "xid"]
                               },
                               "state": {
                                 "type": "object",
@@ -6694,10 +5706,7 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": [
-                                        "denom",
-                                        "amount"
-                                      ]
+                                      "required": ["denom", "amount"]
                                     }
                                   },
                                   "settled_at": {
@@ -6715,10 +5724,7 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": [
-                                        "denom",
-                                        "amount"
-                                      ]
+                                      "required": ["denom", "amount"]
                                     }
                                   },
                                   "deposits": {
@@ -6745,42 +5751,20 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": [
-                                            "denom",
-                                            "amount"
-                                          ]
+                                          "required": ["denom", "amount"]
                                         }
                                       },
-                                      "required": [
-                                        "owner",
-                                        "height",
-                                        "source",
-                                        "balance"
-                                      ]
+                                      "required": ["owner", "height", "source", "balance"]
                                     }
                                   }
                                 },
-                                "required": [
-                                  "owner",
-                                  "state",
-                                  "transferred",
-                                  "settled_at",
-                                  "funds",
-                                  "deposits"
-                                ]
+                                "required": ["owner", "state", "transferred", "settled_at", "funds", "deposits"]
                               }
                             },
-                            "required": [
-                              "id",
-                              "state"
-                            ]
+                            "required": ["id", "state"]
                           }
                         },
-                        "required": [
-                          "deployment",
-                          "groups",
-                          "escrow_account"
-                        ]
+                        "required": ["deployment", "groups", "escrow_account"]
                       }
                     },
                     "pagination": {
@@ -6794,16 +5778,10 @@
                           "type": "string"
                         }
                       },
-                      "required": [
-                        "next_key",
-                        "total"
-                      ]
+                      "required": ["next_key", "total"]
                     }
                   },
-                  "required": [
-                    "deployments",
-                    "pagination"
-                  ]
+                  "required": ["deployments", "pagination"]
                 }
               }
             }
@@ -6814,9 +5792,7 @@
     "/akash/deployment/{version}/deployments/info": {
       "get": {
         "summary": "Get deployment info (database fallback)",
-        "tags": [
-          "Deployments"
-        ],
+        "tags": ["Deployments"],
         "security": [],
         "parameters": [
           {
@@ -6859,11 +5835,7 @@
                           }
                         }
                       },
-                      "required": [
-                        "code",
-                        "message",
-                        "details"
-                      ]
+                      "required": ["code", "message", "details"]
                     },
                     {
                       "type": "object",
@@ -6882,10 +5854,7 @@
                                   "pattern": "^d+$"
                                 }
                               },
-                              "required": [
-                                "owner",
-                                "dseq"
-                              ]
+                              "required": ["owner", "dseq"]
                             },
                             "state": {
                               "type": "string"
@@ -6897,12 +5866,7 @@
                               "type": "string"
                             }
                           },
-                          "required": [
-                            "id",
-                            "state",
-                            "hash",
-                            "created_at"
-                          ]
+                          "required": ["id", "state", "hash", "created_at"]
                         },
                         "groups": {
                           "type": "array",
@@ -6923,11 +5887,7 @@
                                     "type": "number"
                                   }
                                 },
-                                "required": [
-                                  "owner",
-                                  "dseq",
-                                  "gseq"
-                                ]
+                                "required": ["owner", "dseq", "gseq"]
                               },
                               "state": {
                                 "type": "string"
@@ -6957,10 +5917,7 @@
                                             }
                                           }
                                         },
-                                        "required": [
-                                          "all_of",
-                                          "any_of"
-                                        ]
+                                        "required": ["all_of", "any_of"]
                                       },
                                       "attributes": {
                                         "type": "array",
@@ -6974,17 +5931,11 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": [
-                                            "key",
-                                            "value"
-                                          ]
+                                          "required": ["key", "value"]
                                         }
                                       }
                                     },
-                                    "required": [
-                                      "signed_by",
-                                      "attributes"
-                                    ]
+                                    "required": ["signed_by", "attributes"]
                                   },
                                   "resources": {
                                     "type": "array",
@@ -7007,9 +5958,7 @@
                                                       "type": "string"
                                                     }
                                                   },
-                                                  "required": [
-                                                    "val"
-                                                  ]
+                                                  "required": ["val"]
                                                 },
                                                 "attributes": {
                                                   "type": "array",
@@ -7023,17 +5972,11 @@
                                                         "type": "string"
                                                       }
                                                     },
-                                                    "required": [
-                                                      "key",
-                                                      "value"
-                                                    ]
+                                                    "required": ["key", "value"]
                                                   }
                                                 }
                                               },
-                                              "required": [
-                                                "units",
-                                                "attributes"
-                                              ]
+                                              "required": ["units", "attributes"]
                                             },
                                             "memory": {
                                               "type": "object",
@@ -7045,9 +5988,7 @@
                                                       "type": "string"
                                                     }
                                                   },
-                                                  "required": [
-                                                    "val"
-                                                  ]
+                                                  "required": ["val"]
                                                 },
                                                 "attributes": {
                                                   "type": "array",
@@ -7061,17 +6002,11 @@
                                                         "type": "string"
                                                       }
                                                     },
-                                                    "required": [
-                                                      "key",
-                                                      "value"
-                                                    ]
+                                                    "required": ["key", "value"]
                                                   }
                                                 }
                                               },
-                                              "required": [
-                                                "quantity",
-                                                "attributes"
-                                              ]
+                                              "required": ["quantity", "attributes"]
                                             },
                                             "storage": {
                                               "type": "array",
@@ -7088,9 +6023,7 @@
                                                         "type": "string"
                                                       }
                                                     },
-                                                    "required": [
-                                                      "val"
-                                                    ]
+                                                    "required": ["val"]
                                                   },
                                                   "attributes": {
                                                     "type": "array",
@@ -7104,18 +6037,11 @@
                                                           "type": "string"
                                                         }
                                                       },
-                                                      "required": [
-                                                        "key",
-                                                        "value"
-                                                      ]
+                                                      "required": ["key", "value"]
                                                     }
                                                   }
                                                 },
-                                                "required": [
-                                                  "name",
-                                                  "quantity",
-                                                  "attributes"
-                                                ]
+                                                "required": ["name", "quantity", "attributes"]
                                               }
                                             },
                                             "gpu": {
@@ -7128,9 +6054,7 @@
                                                       "type": "string"
                                                     }
                                                   },
-                                                  "required": [
-                                                    "val"
-                                                  ]
+                                                  "required": ["val"]
                                                 },
                                                 "attributes": {
                                                   "type": "array",
@@ -7144,17 +6068,11 @@
                                                         "type": "string"
                                                       }
                                                     },
-                                                    "required": [
-                                                      "key",
-                                                      "value"
-                                                    ]
+                                                    "required": ["key", "value"]
                                                   }
                                                 }
                                               },
-                                              "required": [
-                                                "units",
-                                                "attributes"
-                                              ]
+                                              "required": ["units", "attributes"]
                                             },
                                             "endpoints": {
                                               "type": "array",
@@ -7168,21 +6086,11 @@
                                                     "type": "number"
                                                   }
                                                 },
-                                                "required": [
-                                                  "kind",
-                                                  "sequence_number"
-                                                ]
+                                                "required": ["kind", "sequence_number"]
                                               }
                                             }
                                           },
-                                          "required": [
-                                            "id",
-                                            "cpu",
-                                            "memory",
-                                            "storage",
-                                            "gpu",
-                                            "endpoints"
-                                          ]
+                                          "required": ["id", "cpu", "memory", "storage", "gpu", "endpoints"]
                                         },
                                         "count": {
                                           "type": "number"
@@ -7197,36 +6105,20 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": [
-                                            "denom",
-                                            "amount"
-                                          ]
+                                          "required": ["denom", "amount"]
                                         }
                                       },
-                                      "required": [
-                                        "resource",
-                                        "count",
-                                        "price"
-                                      ]
+                                      "required": ["resource", "count", "price"]
                                     }
                                   }
                                 },
-                                "required": [
-                                  "name",
-                                  "requirements",
-                                  "resources"
-                                ]
+                                "required": ["name", "requirements", "resources"]
                               },
                               "created_at": {
                                 "type": "string"
                               }
                             },
-                            "required": [
-                              "id",
-                              "state",
-                              "group_spec",
-                              "created_at"
-                            ]
+                            "required": ["id", "state", "group_spec", "created_at"]
                           }
                         },
                         "escrow_account": {
@@ -7242,10 +6134,7 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "scope",
-                                "xid"
-                              ]
+                              "required": ["scope", "xid"]
                             },
                             "state": {
                               "type": "object",
@@ -7268,10 +6157,7 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": [
-                                      "denom",
-                                      "amount"
-                                    ]
+                                    "required": ["denom", "amount"]
                                   }
                                 },
                                 "settled_at": {
@@ -7289,10 +6175,7 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": [
-                                      "denom",
-                                      "amount"
-                                    ]
+                                    "required": ["denom", "amount"]
                                   }
                                 },
                                 "deposits": {
@@ -7319,42 +6202,20 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": [
-                                          "denom",
-                                          "amount"
-                                        ]
+                                        "required": ["denom", "amount"]
                                       }
                                     },
-                                    "required": [
-                                      "owner",
-                                      "height",
-                                      "source",
-                                      "balance"
-                                    ]
+                                    "required": ["owner", "height", "source", "balance"]
                                   }
                                 }
                               },
-                              "required": [
-                                "owner",
-                                "state",
-                                "transferred",
-                                "settled_at",
-                                "funds",
-                                "deposits"
-                              ]
+                              "required": ["owner", "state", "transferred", "settled_at", "funds", "deposits"]
                             }
                           },
-                          "required": [
-                            "id",
-                            "state"
-                          ]
+                          "required": ["id", "state"]
                         }
                       },
-                      "required": [
-                        "deployment",
-                        "groups",
-                        "escrow_account"
-                      ]
+                      "required": ["deployment", "groups", "escrow_account"]
                     }
                   ]
                 }
@@ -7370,9 +6231,7 @@
     "/v1/weekly-cost": {
       "get": {
         "summary": "Get weekly deployment cost",
-        "tags": [
-          "Deployments"
-        ],
+        "tags": ["Deployments"],
         "security": [
           {
             "BearerAuth": []
@@ -7397,14 +6256,10 @@
                           "description": "Total weekly cost in USD for all deployments with auto top-up enabled"
                         }
                       },
-                      "required": [
-                        "weeklyCost"
-                      ]
+                      "required": ["weeklyCost"]
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -7416,9 +6271,7 @@
       "post": {
         "summary": "Create leases and send manifest",
         "operationId": "createLease",
-        "tags": [
-          "Leases"
-        ],
+        "tags": ["Leases"],
         "security": [
           {
             "BearerAuth": []
@@ -7455,19 +6308,11 @@
                           "type": "string"
                         }
                       },
-                      "required": [
-                        "dseq",
-                        "gseq",
-                        "oseq",
-                        "provider"
-                      ]
+                      "required": ["dseq", "gseq", "oseq", "provider"]
                     }
                   }
                 },
-                "required": [
-                  "manifest",
-                  "leases"
-                ]
+                "required": ["manifest", "leases"]
               }
             }
           }
@@ -7497,10 +6342,7 @@
                                   "pattern": "^d+$"
                                 }
                               },
-                              "required": [
-                                "owner",
-                                "dseq"
-                              ]
+                              "required": ["owner", "dseq"]
                             },
                             "state": {
                               "type": "string"
@@ -7512,12 +6354,7 @@
                               "type": "string"
                             }
                           },
-                          "required": [
-                            "id",
-                            "state",
-                            "hash",
-                            "created_at"
-                          ]
+                          "required": ["id", "state", "hash", "created_at"]
                         },
                         "leases": {
                           "type": "array",
@@ -7547,14 +6384,7 @@
                                     "type": "number"
                                   }
                                 },
-                                "required": [
-                                  "owner",
-                                  "dseq",
-                                  "gseq",
-                                  "oseq",
-                                  "provider",
-                                  "bseq"
-                                ]
+                                "required": ["owner", "dseq", "gseq", "oseq", "provider", "bseq"]
                               },
                               "state": {
                                 "type": "string"
@@ -7569,10 +6399,7 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": [
-                                  "denom",
-                                  "amount"
-                                ]
+                                "required": ["denom", "amount"]
                               },
                               "created_at": {
                                 "type": "string"
@@ -7607,10 +6434,7 @@
                                             "type": "number"
                                           }
                                         },
-                                        "required": [
-                                          "port",
-                                          "externalPort"
-                                        ]
+                                        "required": ["port", "externalPort"]
                                       }
                                     }
                                   },
@@ -7634,12 +6458,7 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": [
-                                          "IP",
-                                          "Port",
-                                          "ExternalPort",
-                                          "Protocol"
-                                        ]
+                                        "required": ["IP", "Port", "ExternalPort", "Protocol"]
                                       }
                                     }
                                   },
@@ -7693,21 +6512,10 @@
                                     }
                                   }
                                 },
-                                "required": [
-                                  "forwarded_ports",
-                                  "ips",
-                                  "services"
-                                ]
+                                "required": ["forwarded_ports", "ips", "services"]
                               }
                             },
-                            "required": [
-                              "id",
-                              "state",
-                              "price",
-                              "created_at",
-                              "closed_on",
-                              "status"
-                            ]
+                            "required": ["id", "state", "price", "created_at", "closed_on", "status"]
                           }
                         },
                         "escrow_account": {
@@ -7723,10 +6531,7 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "scope",
-                                "xid"
-                              ]
+                              "required": ["scope", "xid"]
                             },
                             "state": {
                               "type": "object",
@@ -7749,10 +6554,7 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": [
-                                      "denom",
-                                      "amount"
-                                    ]
+                                    "required": ["denom", "amount"]
                                   }
                                 },
                                 "settled_at": {
@@ -7770,10 +6572,7 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": [
-                                      "denom",
-                                      "amount"
-                                    ]
+                                    "required": ["denom", "amount"]
                                   }
                                 },
                                 "deposits": {
@@ -7800,47 +6599,23 @@
                                             "type": "string"
                                           }
                                         },
-                                        "required": [
-                                          "denom",
-                                          "amount"
-                                        ]
+                                        "required": ["denom", "amount"]
                                       }
                                     },
-                                    "required": [
-                                      "owner",
-                                      "height",
-                                      "source",
-                                      "balance"
-                                    ]
+                                    "required": ["owner", "height", "source", "balance"]
                                   }
                                 }
                               },
-                              "required": [
-                                "owner",
-                                "state",
-                                "transferred",
-                                "settled_at",
-                                "funds",
-                                "deposits"
-                              ]
+                              "required": ["owner", "state", "transferred", "settled_at", "funds", "deposits"]
                             }
                           },
-                          "required": [
-                            "id",
-                            "state"
-                          ]
+                          "required": ["id", "state"]
                         }
                       },
-                      "required": [
-                        "deployment",
-                        "leases",
-                        "escrow_account"
-                      ]
+                      "required": ["deployment", "leases", "escrow_account"]
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -7851,9 +6626,7 @@
     "/akash/market/{version}/leases/list": {
       "get": {
         "summary": "List leases (database fallback)",
-        "tags": [
-          "Leases"
-        ],
+        "tags": ["Leases"],
         "security": [],
         "parameters": [
           {
@@ -7989,14 +6762,7 @@
                                     "type": "number"
                                   }
                                 },
-                                "required": [
-                                  "owner",
-                                  "dseq",
-                                  "gseq",
-                                  "oseq",
-                                  "provider",
-                                  "bseq"
-                                ]
+                                "required": ["owner", "dseq", "gseq", "oseq", "provider", "bseq"]
                               },
                               "state": {
                                 "type": "string"
@@ -8011,10 +6777,7 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": [
-                                  "denom",
-                                  "amount"
-                                ]
+                                "required": ["denom", "amount"]
                               },
                               "created_at": {
                                 "type": "string"
@@ -8026,13 +6789,7 @@
                                 "type": "string"
                               }
                             },
-                            "required": [
-                              "id",
-                              "state",
-                              "price",
-                              "created_at",
-                              "closed_on"
-                            ]
+                            "required": ["id", "state", "price", "created_at", "closed_on"]
                           },
                           "escrow_payment": {
                             "type": "object",
@@ -8050,19 +6807,13 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": [
-                                      "scope",
-                                      "xid"
-                                    ]
+                                    "required": ["scope", "xid"]
                                   },
                                   "xid": {
                                     "type": "string"
                                   }
                                 },
-                                "required": [
-                                  "aid",
-                                  "xid"
-                                ]
+                                "required": ["aid", "xid"]
                               },
                               "state": {
                                 "type": "object",
@@ -8083,10 +6834,7 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": [
-                                      "denom",
-                                      "amount"
-                                    ]
+                                    "required": ["denom", "amount"]
                                   },
                                   "balance": {
                                     "type": "object",
@@ -8098,10 +6846,7 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": [
-                                      "denom",
-                                      "amount"
-                                    ]
+                                    "required": ["denom", "amount"]
                                   },
                                   "unsettled": {
                                     "type": "object",
@@ -8113,10 +6858,7 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": [
-                                      "denom",
-                                      "amount"
-                                    ]
+                                    "required": ["denom", "amount"]
                                   },
                                   "withdrawn": {
                                     "type": "object",
@@ -8128,32 +6870,16 @@
                                         "type": "string"
                                       }
                                     },
-                                    "required": [
-                                      "denom",
-                                      "amount"
-                                    ]
+                                    "required": ["denom", "amount"]
                                   }
                                 },
-                                "required": [
-                                  "owner",
-                                  "state",
-                                  "rate",
-                                  "balance",
-                                  "unsettled",
-                                  "withdrawn"
-                                ]
+                                "required": ["owner", "state", "rate", "balance", "unsettled", "withdrawn"]
                               }
                             },
-                            "required": [
-                              "id",
-                              "state"
-                            ]
+                            "required": ["id", "state"]
                           }
                         },
-                        "required": [
-                          "lease",
-                          "escrow_payment"
-                        ]
+                        "required": ["lease", "escrow_payment"]
                       }
                     },
                     "pagination": {
@@ -8167,16 +6893,10 @@
                           "type": "string"
                         }
                       },
-                      "required": [
-                        "next_key",
-                        "total"
-                      ]
+                      "required": ["next_key", "total"]
                     }
                   },
-                  "required": [
-                    "leases",
-                    "pagination"
-                  ]
+                  "required": ["leases", "pagination"]
                 }
               }
             }
@@ -8188,9 +6908,7 @@
       "get": {
         "summary": "List all API keys",
         "operationId": "listApiKeys",
-        "tags": [
-          "API Keys"
-        ],
+        "tags": ["API Keys"],
         "security": [
           {
             "BearerAuth": []
@@ -8241,21 +6959,11 @@
                             "type": "string"
                           }
                         },
-                        "required": [
-                          "id",
-                          "name",
-                          "expiresAt",
-                          "createdAt",
-                          "updatedAt",
-                          "lastUsedAt",
-                          "keyFormat"
-                        ]
+                        "required": ["id", "name", "expiresAt", "createdAt", "updatedAt", "lastUsedAt", "keyFormat"]
                       }
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -8264,9 +6972,7 @@
       },
       "post": {
         "summary": "Create new API key",
-        "tags": [
-          "API Keys"
-        ],
+        "tags": ["API Keys"],
         "security": [
           {
             "BearerAuth": []
@@ -8292,14 +6998,10 @@
                         "format": "date-time"
                       }
                     },
-                    "required": [
-                      "name"
-                    ]
+                    "required": ["name"]
                   }
                 },
-                "required": [
-                  "data"
-                ]
+                "required": ["data"]
               }
             }
           }
@@ -8347,21 +7049,10 @@
                           "type": "string"
                         }
                       },
-                      "required": [
-                        "id",
-                        "name",
-                        "expiresAt",
-                        "createdAt",
-                        "updatedAt",
-                        "lastUsedAt",
-                        "keyFormat",
-                        "apiKey"
-                      ]
+                      "required": ["id", "name", "expiresAt", "createdAt", "updatedAt", "lastUsedAt", "keyFormat", "apiKey"]
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -8372,9 +7063,7 @@
     "/v1/api-keys/{id}": {
       "get": {
         "summary": "Get API key by ID",
-        "tags": [
-          "API Keys"
-        ],
+        "tags": ["API Keys"],
         "security": [
           {
             "BearerAuth": []
@@ -8434,20 +7123,10 @@
                           "type": "string"
                         }
                       },
-                      "required": [
-                        "id",
-                        "name",
-                        "expiresAt",
-                        "createdAt",
-                        "updatedAt",
-                        "lastUsedAt",
-                        "keyFormat"
-                      ]
+                      "required": ["id", "name", "expiresAt", "createdAt", "updatedAt", "lastUsedAt", "keyFormat"]
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -8463,9 +7142,7 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "message"
-                  ]
+                  "required": ["message"]
                 }
               }
             }
@@ -8474,9 +7151,7 @@
       },
       "patch": {
         "summary": "Update API key",
-        "tags": [
-          "API Keys"
-        ],
+        "tags": ["API Keys"],
         "security": [
           {
             "BearerAuth": []
@@ -8511,9 +7186,7 @@
                     }
                   }
                 },
-                "required": [
-                  "data"
-                ]
+                "required": ["data"]
               }
             }
           }
@@ -8558,20 +7231,10 @@
                           "type": "string"
                         }
                       },
-                      "required": [
-                        "id",
-                        "name",
-                        "expiresAt",
-                        "createdAt",
-                        "updatedAt",
-                        "lastUsedAt",
-                        "keyFormat"
-                      ]
+                      "required": ["id", "name", "expiresAt", "createdAt", "updatedAt", "lastUsedAt", "keyFormat"]
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -8587,9 +7250,7 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "message"
-                  ]
+                  "required": ["message"]
                 }
               }
             }
@@ -8598,9 +7259,7 @@
       },
       "delete": {
         "summary": "Delete API key",
-        "tags": [
-          "API Keys"
-        ],
+        "tags": ["API Keys"],
         "security": [
           {
             "BearerAuth": []
@@ -8635,9 +7294,7 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "message"
-                  ]
+                  "required": ["message"]
                 }
               }
             }
@@ -8649,9 +7306,7 @@
       "get": {
         "summary": "List bids",
         "operationId": "listBids",
-        "tags": [
-          "Bids"
-        ],
+        "tags": ["Bids"],
         "security": [
           {
             "BearerAuth": []
@@ -8710,14 +7365,7 @@
                                     "type": "number"
                                   }
                                 },
-                                "required": [
-                                  "owner",
-                                  "dseq",
-                                  "gseq",
-                                  "oseq",
-                                  "provider",
-                                  "bseq"
-                                ]
+                                "required": ["owner", "dseq", "gseq", "oseq", "provider", "bseq"]
                               },
                               "state": {
                                 "type": "string"
@@ -8732,10 +7380,7 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": [
-                                  "denom",
-                                  "amount"
-                                ]
+                                "required": ["denom", "amount"]
                               },
                               "created_at": {
                                 "type": "string"
@@ -8758,9 +7403,7 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "required": [
-                                                "val"
-                                              ]
+                                              "required": ["val"]
                                             },
                                             "attributes": {
                                               "type": "array",
@@ -8774,17 +7417,11 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": [
-                                                  "key",
-                                                  "value"
-                                                ]
+                                                "required": ["key", "value"]
                                               }
                                             }
                                           },
-                                          "required": [
-                                            "units",
-                                            "attributes"
-                                          ]
+                                          "required": ["units", "attributes"]
                                         },
                                         "gpu": {
                                           "type": "object",
@@ -8796,9 +7433,7 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "required": [
-                                                "val"
-                                              ]
+                                              "required": ["val"]
                                             },
                                             "attributes": {
                                               "type": "array",
@@ -8812,17 +7447,11 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": [
-                                                  "key",
-                                                  "value"
-                                                ]
+                                                "required": ["key", "value"]
                                               }
                                             }
                                           },
-                                          "required": [
-                                            "units",
-                                            "attributes"
-                                          ]
+                                          "required": ["units", "attributes"]
                                         },
                                         "memory": {
                                           "type": "object",
@@ -8834,9 +7463,7 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "required": [
-                                                "val"
-                                              ]
+                                              "required": ["val"]
                                             },
                                             "attributes": {
                                               "type": "array",
@@ -8850,17 +7477,11 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": [
-                                                  "key",
-                                                  "value"
-                                                ]
+                                                "required": ["key", "value"]
                                               }
                                             }
                                           },
-                                          "required": [
-                                            "quantity",
-                                            "attributes"
-                                          ]
+                                          "required": ["quantity", "attributes"]
                                         },
                                         "storage": {
                                           "type": "array",
@@ -8877,9 +7498,7 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": [
-                                                  "val"
-                                                ]
+                                                "required": ["val"]
                                               },
                                               "attributes": {
                                                 "type": "array",
@@ -8893,18 +7512,11 @@
                                                       "type": "string"
                                                     }
                                                   },
-                                                  "required": [
-                                                    "key",
-                                                    "value"
-                                                  ]
+                                                  "required": ["key", "value"]
                                                 }
                                               }
                                             },
-                                            "required": [
-                                              "name",
-                                              "quantity",
-                                              "attributes"
-                                            ]
+                                            "required": ["name", "quantity", "attributes"]
                                           }
                                         },
                                         "endpoints": {
@@ -8919,42 +7531,24 @@
                                                 "type": "number"
                                               }
                                             },
-                                            "required": [
-                                              "kind",
-                                              "sequence_number"
-                                            ]
+                                            "required": ["kind", "sequence_number"]
                                           }
                                         }
                                       },
-                                      "required": [
-                                        "cpu",
-                                        "gpu",
-                                        "memory",
-                                        "storage",
-                                        "endpoints"
-                                      ]
+                                      "required": ["cpu", "gpu", "memory", "storage", "endpoints"]
                                     },
                                     "count": {
                                       "type": "number"
                                     }
                                   },
-                                  "required": [
-                                    "resources",
-                                    "count"
-                                  ]
+                                  "required": ["resources", "count"]
                                 }
                               },
                               "reclamation_window": {
                                 "type": "string"
                               }
                             },
-                            "required": [
-                              "id",
-                              "state",
-                              "price",
-                              "created_at",
-                              "resources_offer"
-                            ]
+                            "required": ["id", "state", "price", "created_at", "resources_offer"]
                           },
                           "escrow_account": {
                             "type": "object",
@@ -8969,10 +7563,7 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": [
-                                  "scope",
-                                  "xid"
-                                ]
+                                "required": ["scope", "xid"]
                               },
                               "state": {
                                 "type": "object",
@@ -8995,10 +7586,7 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": [
-                                        "denom",
-                                        "amount"
-                                      ]
+                                      "required": ["denom", "amount"]
                                     }
                                   },
                                   "settled_at": {
@@ -9016,10 +7604,7 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": [
-                                        "denom",
-                                        "amount"
-                                      ]
+                                      "required": ["denom", "amount"]
                                     }
                                   },
                                   "deposits": {
@@ -9046,47 +7631,24 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": [
-                                            "denom",
-                                            "amount"
-                                          ]
+                                          "required": ["denom", "amount"]
                                         }
                                       },
-                                      "required": [
-                                        "owner",
-                                        "height",
-                                        "source",
-                                        "balance"
-                                      ]
+                                      "required": ["owner", "height", "source", "balance"]
                                     }
                                   }
                                 },
-                                "required": [
-                                  "owner",
-                                  "state",
-                                  "transferred",
-                                  "settled_at",
-                                  "funds",
-                                  "deposits"
-                                ]
+                                "required": ["owner", "state", "transferred", "settled_at", "funds", "deposits"]
                               }
                             },
-                            "required": [
-                              "id",
-                              "state"
-                            ]
+                            "required": ["id", "state"]
                           }
                         },
-                        "required": [
-                          "bid",
-                          "escrow_account"
-                        ]
+                        "required": ["bid", "escrow_account"]
                       }
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -9097,9 +7659,7 @@
     "/v1/bids/{dseq}": {
       "get": {
         "summary": "List bids by dseq",
-        "tags": [
-          "Bids"
-        ],
+        "tags": ["Bids"],
         "security": [
           {
             "BearerAuth": []
@@ -9158,14 +7718,7 @@
                                     "type": "number"
                                   }
                                 },
-                                "required": [
-                                  "owner",
-                                  "dseq",
-                                  "gseq",
-                                  "oseq",
-                                  "provider",
-                                  "bseq"
-                                ]
+                                "required": ["owner", "dseq", "gseq", "oseq", "provider", "bseq"]
                               },
                               "state": {
                                 "type": "string"
@@ -9180,10 +7733,7 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": [
-                                  "denom",
-                                  "amount"
-                                ]
+                                "required": ["denom", "amount"]
                               },
                               "created_at": {
                                 "type": "string"
@@ -9206,9 +7756,7 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "required": [
-                                                "val"
-                                              ]
+                                              "required": ["val"]
                                             },
                                             "attributes": {
                                               "type": "array",
@@ -9222,17 +7770,11 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": [
-                                                  "key",
-                                                  "value"
-                                                ]
+                                                "required": ["key", "value"]
                                               }
                                             }
                                           },
-                                          "required": [
-                                            "units",
-                                            "attributes"
-                                          ]
+                                          "required": ["units", "attributes"]
                                         },
                                         "gpu": {
                                           "type": "object",
@@ -9244,9 +7786,7 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "required": [
-                                                "val"
-                                              ]
+                                              "required": ["val"]
                                             },
                                             "attributes": {
                                               "type": "array",
@@ -9260,17 +7800,11 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": [
-                                                  "key",
-                                                  "value"
-                                                ]
+                                                "required": ["key", "value"]
                                               }
                                             }
                                           },
-                                          "required": [
-                                            "units",
-                                            "attributes"
-                                          ]
+                                          "required": ["units", "attributes"]
                                         },
                                         "memory": {
                                           "type": "object",
@@ -9282,9 +7816,7 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "required": [
-                                                "val"
-                                              ]
+                                              "required": ["val"]
                                             },
                                             "attributes": {
                                               "type": "array",
@@ -9298,17 +7830,11 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": [
-                                                  "key",
-                                                  "value"
-                                                ]
+                                                "required": ["key", "value"]
                                               }
                                             }
                                           },
-                                          "required": [
-                                            "quantity",
-                                            "attributes"
-                                          ]
+                                          "required": ["quantity", "attributes"]
                                         },
                                         "storage": {
                                           "type": "array",
@@ -9325,9 +7851,7 @@
                                                     "type": "string"
                                                   }
                                                 },
-                                                "required": [
-                                                  "val"
-                                                ]
+                                                "required": ["val"]
                                               },
                                               "attributes": {
                                                 "type": "array",
@@ -9341,18 +7865,11 @@
                                                       "type": "string"
                                                     }
                                                   },
-                                                  "required": [
-                                                    "key",
-                                                    "value"
-                                                  ]
+                                                  "required": ["key", "value"]
                                                 }
                                               }
                                             },
-                                            "required": [
-                                              "name",
-                                              "quantity",
-                                              "attributes"
-                                            ]
+                                            "required": ["name", "quantity", "attributes"]
                                           }
                                         },
                                         "endpoints": {
@@ -9367,42 +7884,24 @@
                                                 "type": "number"
                                               }
                                             },
-                                            "required": [
-                                              "kind",
-                                              "sequence_number"
-                                            ]
+                                            "required": ["kind", "sequence_number"]
                                           }
                                         }
                                       },
-                                      "required": [
-                                        "cpu",
-                                        "gpu",
-                                        "memory",
-                                        "storage",
-                                        "endpoints"
-                                      ]
+                                      "required": ["cpu", "gpu", "memory", "storage", "endpoints"]
                                     },
                                     "count": {
                                       "type": "number"
                                     }
                                   },
-                                  "required": [
-                                    "resources",
-                                    "count"
-                                  ]
+                                  "required": ["resources", "count"]
                                 }
                               },
                               "reclamation_window": {
                                 "type": "string"
                               }
                             },
-                            "required": [
-                              "id",
-                              "state",
-                              "price",
-                              "created_at",
-                              "resources_offer"
-                            ]
+                            "required": ["id", "state", "price", "created_at", "resources_offer"]
                           },
                           "escrow_account": {
                             "type": "object",
@@ -9417,10 +7916,7 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": [
-                                  "scope",
-                                  "xid"
-                                ]
+                                "required": ["scope", "xid"]
                               },
                               "state": {
                                 "type": "object",
@@ -9443,10 +7939,7 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": [
-                                        "denom",
-                                        "amount"
-                                      ]
+                                      "required": ["denom", "amount"]
                                     }
                                   },
                                   "settled_at": {
@@ -9464,10 +7957,7 @@
                                           "type": "string"
                                         }
                                       },
-                                      "required": [
-                                        "denom",
-                                        "amount"
-                                      ]
+                                      "required": ["denom", "amount"]
                                     }
                                   },
                                   "deposits": {
@@ -9494,47 +7984,24 @@
                                               "type": "string"
                                             }
                                           },
-                                          "required": [
-                                            "denom",
-                                            "amount"
-                                          ]
+                                          "required": ["denom", "amount"]
                                         }
                                       },
-                                      "required": [
-                                        "owner",
-                                        "height",
-                                        "source",
-                                        "balance"
-                                      ]
+                                      "required": ["owner", "height", "source", "balance"]
                                     }
                                   }
                                 },
-                                "required": [
-                                  "owner",
-                                  "state",
-                                  "transferred",
-                                  "settled_at",
-                                  "funds",
-                                  "deposits"
-                                ]
+                                "required": ["owner", "state", "transferred", "settled_at", "funds", "deposits"]
                               }
                             },
-                            "required": [
-                              "id",
-                              "state"
-                            ]
+                            "required": ["id", "state"]
                           }
                         },
-                        "required": [
-                          "bid",
-                          "escrow_account"
-                        ]
+                        "required": ["bid", "escrow_account"]
                       }
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -9545,9 +8012,7 @@
     "/v1/certificates": {
       "post": {
         "summary": "Create certificate",
-        "tags": [
-          "Certificate"
-        ],
+        "tags": ["Certificate"],
         "security": [
           {
             "BearerAuth": []
@@ -9568,9 +8033,7 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "error"
-                  ]
+                  "required": ["error"]
                 }
               }
             }
@@ -9581,9 +8044,7 @@
     "/v1/balances": {
       "get": {
         "summary": "Get user balances",
-        "tags": [
-          "Wallet"
-        ],
+        "tags": ["Wallet"],
         "security": [],
         "parameters": [
           {
@@ -9618,16 +8079,10 @@
                           "type": "number"
                         }
                       },
-                      "required": [
-                        "balance",
-                        "deployments",
-                        "total"
-                      ]
+                      "required": ["balance", "deployments", "total"]
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -9638,18 +8093,13 @@
     "/v1/providers": {
       "get": {
         "summary": "Get a list of providers.",
-        "tags": [
-          "Providers"
-        ],
+        "tags": ["Providers"],
         "security": [],
         "parameters": [
           {
             "schema": {
               "type": "string",
-              "enum": [
-                "all",
-                "trial"
-              ],
+              "enum": ["all", "trial"],
               "default": "all"
             },
             "required": false,
@@ -9781,12 +8231,7 @@
                               "type": "string"
                             }
                           },
-                          "required": [
-                            "vendor",
-                            "model",
-                            "ram",
-                            "interface"
-                          ]
+                          "required": ["vendor", "model", "ram", "interface"]
                         }
                       },
                       "attributes": {
@@ -9807,11 +8252,7 @@
                               }
                             }
                           },
-                          "required": [
-                            "key",
-                            "value",
-                            "auditedBy"
-                          ]
+                          "required": ["key", "value", "auditedBy"]
                         }
                       },
                       "host": {
@@ -9980,9 +8421,7 @@
     "/v1/providers/{address}": {
       "get": {
         "summary": "Get a provider details.",
-        "tags": [
-          "Providers"
-        ],
+        "tags": ["Providers"],
         "security": [],
         "parameters": [
           {
@@ -10103,11 +8542,7 @@
                               "type": "number"
                             }
                           },
-                          "required": [
-                            "active",
-                            "available",
-                            "pending"
-                          ]
+                          "required": ["active", "available", "pending"]
                         },
                         "gpu": {
                           "type": "object",
@@ -10122,11 +8557,7 @@
                               "type": "number"
                             }
                           },
-                          "required": [
-                            "active",
-                            "available",
-                            "pending"
-                          ]
+                          "required": ["active", "available", "pending"]
                         },
                         "memory": {
                           "type": "object",
@@ -10141,11 +8572,7 @@
                               "type": "number"
                             }
                           },
-                          "required": [
-                            "active",
-                            "available",
-                            "pending"
-                          ]
+                          "required": ["active", "available", "pending"]
                         },
                         "storage": {
                           "type": "object",
@@ -10163,11 +8590,7 @@
                                   "type": "number"
                                 }
                               },
-                              "required": [
-                                "active",
-                                "available",
-                                "pending"
-                              ]
+                              "required": ["active", "available", "pending"]
                             },
                             "persistent": {
                               "type": "object",
@@ -10182,25 +8605,13 @@
                                   "type": "number"
                                 }
                               },
-                              "required": [
-                                "active",
-                                "available",
-                                "pending"
-                              ]
+                              "required": ["active", "available", "pending"]
                             }
                           },
-                          "required": [
-                            "ephemeral",
-                            "persistent"
-                          ]
+                          "required": ["ephemeral", "persistent"]
                         }
                       },
-                      "required": [
-                        "cpu",
-                        "gpu",
-                        "memory",
-                        "storage"
-                      ]
+                      "required": ["cpu", "gpu", "memory", "storage"]
                     },
                     "gpuModels": {
                       "type": "array",
@@ -10220,12 +8631,7 @@
                             "type": "string"
                           }
                         },
-                        "required": [
-                          "vendor",
-                          "model",
-                          "ram",
-                          "interface"
-                        ]
+                        "required": ["vendor", "model", "ram", "interface"]
                       }
                     },
                     "attributes": {
@@ -10246,11 +8652,7 @@
                             }
                           }
                         },
-                        "required": [
-                          "key",
-                          "value",
-                          "auditedBy"
-                        ]
+                        "required": ["key", "value", "auditedBy"]
                       }
                     },
                     "host": {
@@ -10370,11 +8772,7 @@
                             "type": "string"
                           }
                         },
-                        "required": [
-                          "id",
-                          "isOnline",
-                          "checkDate"
-                        ]
+                        "required": ["id", "isOnline", "checkDate"]
                       }
                     }
                   },
@@ -10448,10 +8846,7 @@
     },
     "/v1/providers/{providerAddress}/active-leases-graph-data": {
       "get": {
-        "tags": [
-          "Analytics",
-          "Providers"
-        ],
+        "tags": ["Analytics", "Providers"],
         "security": [],
         "parameters": [
           {
@@ -10492,10 +8887,7 @@
                             "example": 100
                           }
                         },
-                        "required": [
-                          "date",
-                          "value"
-                        ]
+                        "required": ["date", "value"]
                       }
                     },
                     "now": {
@@ -10506,9 +8898,7 @@
                           "example": 100
                         }
                       },
-                      "required": [
-                        "count"
-                      ]
+                      "required": ["count"]
                     },
                     "compare": {
                       "type": "object",
@@ -10518,18 +8908,10 @@
                           "example": 100
                         }
                       },
-                      "required": [
-                        "count"
-                      ]
+                      "required": ["count"]
                     }
                   },
-                  "required": [
-                    "currentValue",
-                    "compareValue",
-                    "snapshots",
-                    "now",
-                    "compare"
-                  ]
+                  "required": ["currentValue", "compareValue", "snapshots", "now", "compare"]
                 }
               }
             }
@@ -10542,9 +8924,7 @@
     },
     "/v1/auditors": {
       "get": {
-        "tags": [
-          "Providers"
-        ],
+        "tags": ["Providers"],
         "security": [],
         "summary": "Get a list of auditors.",
         "responses": {
@@ -10570,12 +8950,7 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "id",
-                      "name",
-                      "address",
-                      "website"
-                    ]
+                    "required": ["id", "name", "address", "website"]
                   }
                 }
               }
@@ -10587,9 +8962,7 @@
     "/v1/provider-attributes-schema": {
       "get": {
         "summary": "Get the provider attributes schema",
-        "tags": [
-          "Providers"
-        ],
+        "tags": ["Providers"],
         "security": [],
         "responses": {
           "200": {
@@ -10607,13 +8980,7 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "string",
-                            "number",
-                            "boolean",
-                            "option",
-                            "multiple-option"
-                          ]
+                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
                         },
                         "required": {
                           "type": "boolean"
@@ -10637,19 +9004,11 @@
                                 "nullable": true
                               }
                             },
-                            "required": [
-                              "key",
-                              "description"
-                            ]
+                            "required": ["key", "description"]
                           }
                         }
                       },
-                      "required": [
-                        "key",
-                        "type",
-                        "required",
-                        "description"
-                      ]
+                      "required": ["key", "type", "required", "description"]
                     },
                     "email": {
                       "type": "object",
@@ -10659,13 +9018,7 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "string",
-                            "number",
-                            "boolean",
-                            "option",
-                            "multiple-option"
-                          ]
+                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
                         },
                         "required": {
                           "type": "boolean"
@@ -10689,19 +9042,11 @@
                                 "nullable": true
                               }
                             },
-                            "required": [
-                              "key",
-                              "description"
-                            ]
+                            "required": ["key", "description"]
                           }
                         }
                       },
-                      "required": [
-                        "key",
-                        "type",
-                        "required",
-                        "description"
-                      ]
+                      "required": ["key", "type", "required", "description"]
                     },
                     "organization": {
                       "type": "object",
@@ -10711,13 +9056,7 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "string",
-                            "number",
-                            "boolean",
-                            "option",
-                            "multiple-option"
-                          ]
+                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
                         },
                         "required": {
                           "type": "boolean"
@@ -10741,19 +9080,11 @@
                                 "nullable": true
                               }
                             },
-                            "required": [
-                              "key",
-                              "description"
-                            ]
+                            "required": ["key", "description"]
                           }
                         }
                       },
-                      "required": [
-                        "key",
-                        "type",
-                        "required",
-                        "description"
-                      ]
+                      "required": ["key", "type", "required", "description"]
                     },
                     "website": {
                       "type": "object",
@@ -10763,13 +9094,7 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "string",
-                            "number",
-                            "boolean",
-                            "option",
-                            "multiple-option"
-                          ]
+                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
                         },
                         "required": {
                           "type": "boolean"
@@ -10793,19 +9118,11 @@
                                 "nullable": true
                               }
                             },
-                            "required": [
-                              "key",
-                              "description"
-                            ]
+                            "required": ["key", "description"]
                           }
                         }
                       },
-                      "required": [
-                        "key",
-                        "type",
-                        "required",
-                        "description"
-                      ]
+                      "required": ["key", "type", "required", "description"]
                     },
                     "tier": {
                       "type": "object",
@@ -10815,13 +9132,7 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "string",
-                            "number",
-                            "boolean",
-                            "option",
-                            "multiple-option"
-                          ]
+                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
                         },
                         "required": {
                           "type": "boolean"
@@ -10845,19 +9156,11 @@
                                 "nullable": true
                               }
                             },
-                            "required": [
-                              "key",
-                              "description"
-                            ]
+                            "required": ["key", "description"]
                           }
                         }
                       },
-                      "required": [
-                        "key",
-                        "type",
-                        "required",
-                        "description"
-                      ]
+                      "required": ["key", "type", "required", "description"]
                     },
                     "status-page": {
                       "type": "object",
@@ -10867,13 +9170,7 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "string",
-                            "number",
-                            "boolean",
-                            "option",
-                            "multiple-option"
-                          ]
+                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
                         },
                         "required": {
                           "type": "boolean"
@@ -10897,19 +9194,11 @@
                                 "nullable": true
                               }
                             },
-                            "required": [
-                              "key",
-                              "description"
-                            ]
+                            "required": ["key", "description"]
                           }
                         }
                       },
-                      "required": [
-                        "key",
-                        "type",
-                        "required",
-                        "description"
-                      ]
+                      "required": ["key", "type", "required", "description"]
                     },
                     "location-region": {
                       "type": "object",
@@ -10919,13 +9208,7 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "string",
-                            "number",
-                            "boolean",
-                            "option",
-                            "multiple-option"
-                          ]
+                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
                         },
                         "required": {
                           "type": "boolean"
@@ -10949,19 +9232,11 @@
                                 "nullable": true
                               }
                             },
-                            "required": [
-                              "key",
-                              "description"
-                            ]
+                            "required": ["key", "description"]
                           }
                         }
                       },
-                      "required": [
-                        "key",
-                        "type",
-                        "required",
-                        "description"
-                      ]
+                      "required": ["key", "type", "required", "description"]
                     },
                     "country": {
                       "type": "object",
@@ -10971,13 +9246,7 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "string",
-                            "number",
-                            "boolean",
-                            "option",
-                            "multiple-option"
-                          ]
+                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
                         },
                         "required": {
                           "type": "boolean"
@@ -11001,19 +9270,11 @@
                                 "nullable": true
                               }
                             },
-                            "required": [
-                              "key",
-                              "description"
-                            ]
+                            "required": ["key", "description"]
                           }
                         }
                       },
-                      "required": [
-                        "key",
-                        "type",
-                        "required",
-                        "description"
-                      ]
+                      "required": ["key", "type", "required", "description"]
                     },
                     "city": {
                       "type": "object",
@@ -11023,13 +9284,7 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "string",
-                            "number",
-                            "boolean",
-                            "option",
-                            "multiple-option"
-                          ]
+                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
                         },
                         "required": {
                           "type": "boolean"
@@ -11053,19 +9308,11 @@
                                 "nullable": true
                               }
                             },
-                            "required": [
-                              "key",
-                              "description"
-                            ]
+                            "required": ["key", "description"]
                           }
                         }
                       },
-                      "required": [
-                        "key",
-                        "type",
-                        "required",
-                        "description"
-                      ]
+                      "required": ["key", "type", "required", "description"]
                     },
                     "timezone": {
                       "type": "object",
@@ -11075,13 +9322,7 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "string",
-                            "number",
-                            "boolean",
-                            "option",
-                            "multiple-option"
-                          ]
+                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
                         },
                         "required": {
                           "type": "boolean"
@@ -11105,19 +9346,11 @@
                                 "nullable": true
                               }
                             },
-                            "required": [
-                              "key",
-                              "description"
-                            ]
+                            "required": ["key", "description"]
                           }
                         }
                       },
-                      "required": [
-                        "key",
-                        "type",
-                        "required",
-                        "description"
-                      ]
+                      "required": ["key", "type", "required", "description"]
                     },
                     "location-type": {
                       "type": "object",
@@ -11127,13 +9360,7 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "string",
-                            "number",
-                            "boolean",
-                            "option",
-                            "multiple-option"
-                          ]
+                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
                         },
                         "required": {
                           "type": "boolean"
@@ -11157,19 +9384,11 @@
                                 "nullable": true
                               }
                             },
-                            "required": [
-                              "key",
-                              "description"
-                            ]
+                            "required": ["key", "description"]
                           }
                         }
                       },
-                      "required": [
-                        "key",
-                        "type",
-                        "required",
-                        "description"
-                      ]
+                      "required": ["key", "type", "required", "description"]
                     },
                     "hosting-provider": {
                       "type": "object",
@@ -11179,13 +9398,7 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "string",
-                            "number",
-                            "boolean",
-                            "option",
-                            "multiple-option"
-                          ]
+                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
                         },
                         "required": {
                           "type": "boolean"
@@ -11209,19 +9422,11 @@
                                 "nullable": true
                               }
                             },
-                            "required": [
-                              "key",
-                              "description"
-                            ]
+                            "required": ["key", "description"]
                           }
                         }
                       },
-                      "required": [
-                        "key",
-                        "type",
-                        "required",
-                        "description"
-                      ]
+                      "required": ["key", "type", "required", "description"]
                     },
                     "hardware-cpu": {
                       "type": "object",
@@ -11231,13 +9436,7 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "string",
-                            "number",
-                            "boolean",
-                            "option",
-                            "multiple-option"
-                          ]
+                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
                         },
                         "required": {
                           "type": "boolean"
@@ -11261,19 +9460,11 @@
                                 "nullable": true
                               }
                             },
-                            "required": [
-                              "key",
-                              "description"
-                            ]
+                            "required": ["key", "description"]
                           }
                         }
                       },
-                      "required": [
-                        "key",
-                        "type",
-                        "required",
-                        "description"
-                      ]
+                      "required": ["key", "type", "required", "description"]
                     },
                     "hardware-cpu-arch": {
                       "type": "object",
@@ -11283,13 +9474,7 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "string",
-                            "number",
-                            "boolean",
-                            "option",
-                            "multiple-option"
-                          ]
+                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
                         },
                         "required": {
                           "type": "boolean"
@@ -11313,19 +9498,11 @@
                                 "nullable": true
                               }
                             },
-                            "required": [
-                              "key",
-                              "description"
-                            ]
+                            "required": ["key", "description"]
                           }
                         }
                       },
-                      "required": [
-                        "key",
-                        "type",
-                        "required",
-                        "description"
-                      ]
+                      "required": ["key", "type", "required", "description"]
                     },
                     "hardware-gpu": {
                       "type": "object",
@@ -11335,13 +9512,7 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "string",
-                            "number",
-                            "boolean",
-                            "option",
-                            "multiple-option"
-                          ]
+                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
                         },
                         "required": {
                           "type": "boolean"
@@ -11365,19 +9536,11 @@
                                 "nullable": true
                               }
                             },
-                            "required": [
-                              "key",
-                              "description"
-                            ]
+                            "required": ["key", "description"]
                           }
                         }
                       },
-                      "required": [
-                        "key",
-                        "type",
-                        "required",
-                        "description"
-                      ]
+                      "required": ["key", "type", "required", "description"]
                     },
                     "hardware-gpu-model": {
                       "type": "object",
@@ -11387,13 +9550,7 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "string",
-                            "number",
-                            "boolean",
-                            "option",
-                            "multiple-option"
-                          ]
+                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
                         },
                         "required": {
                           "type": "boolean"
@@ -11417,19 +9574,11 @@
                                 "nullable": true
                               }
                             },
-                            "required": [
-                              "key",
-                              "description"
-                            ]
+                            "required": ["key", "description"]
                           }
                         }
                       },
-                      "required": [
-                        "key",
-                        "type",
-                        "required",
-                        "description"
-                      ]
+                      "required": ["key", "type", "required", "description"]
                     },
                     "hardware-disk": {
                       "type": "object",
@@ -11439,13 +9588,7 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "string",
-                            "number",
-                            "boolean",
-                            "option",
-                            "multiple-option"
-                          ]
+                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
                         },
                         "required": {
                           "type": "boolean"
@@ -11469,19 +9612,11 @@
                                 "nullable": true
                               }
                             },
-                            "required": [
-                              "key",
-                              "description"
-                            ]
+                            "required": ["key", "description"]
                           }
                         }
                       },
-                      "required": [
-                        "key",
-                        "type",
-                        "required",
-                        "description"
-                      ]
+                      "required": ["key", "type", "required", "description"]
                     },
                     "hardware-memory": {
                       "type": "object",
@@ -11491,13 +9626,7 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "string",
-                            "number",
-                            "boolean",
-                            "option",
-                            "multiple-option"
-                          ]
+                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
                         },
                         "required": {
                           "type": "boolean"
@@ -11521,19 +9650,11 @@
                                 "nullable": true
                               }
                             },
-                            "required": [
-                              "key",
-                              "description"
-                            ]
+                            "required": ["key", "description"]
                           }
                         }
                       },
-                      "required": [
-                        "key",
-                        "type",
-                        "required",
-                        "description"
-                      ]
+                      "required": ["key", "type", "required", "description"]
                     },
                     "network-provider": {
                       "type": "object",
@@ -11543,13 +9664,7 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "string",
-                            "number",
-                            "boolean",
-                            "option",
-                            "multiple-option"
-                          ]
+                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
                         },
                         "required": {
                           "type": "boolean"
@@ -11573,19 +9688,11 @@
                                 "nullable": true
                               }
                             },
-                            "required": [
-                              "key",
-                              "description"
-                            ]
+                            "required": ["key", "description"]
                           }
                         }
                       },
-                      "required": [
-                        "key",
-                        "type",
-                        "required",
-                        "description"
-                      ]
+                      "required": ["key", "type", "required", "description"]
                     },
                     "network-speed-up": {
                       "type": "object",
@@ -11595,13 +9702,7 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "string",
-                            "number",
-                            "boolean",
-                            "option",
-                            "multiple-option"
-                          ]
+                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
                         },
                         "required": {
                           "type": "boolean"
@@ -11625,19 +9726,11 @@
                                 "nullable": true
                               }
                             },
-                            "required": [
-                              "key",
-                              "description"
-                            ]
+                            "required": ["key", "description"]
                           }
                         }
                       },
-                      "required": [
-                        "key",
-                        "type",
-                        "required",
-                        "description"
-                      ]
+                      "required": ["key", "type", "required", "description"]
                     },
                     "network-speed-down": {
                       "type": "object",
@@ -11647,13 +9740,7 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "string",
-                            "number",
-                            "boolean",
-                            "option",
-                            "multiple-option"
-                          ]
+                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
                         },
                         "required": {
                           "type": "boolean"
@@ -11677,19 +9764,11 @@
                                 "nullable": true
                               }
                             },
-                            "required": [
-                              "key",
-                              "description"
-                            ]
+                            "required": ["key", "description"]
                           }
                         }
                       },
-                      "required": [
-                        "key",
-                        "type",
-                        "required",
-                        "description"
-                      ]
+                      "required": ["key", "type", "required", "description"]
                     },
                     "feat-persistent-storage": {
                       "type": "object",
@@ -11699,13 +9778,7 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "string",
-                            "number",
-                            "boolean",
-                            "option",
-                            "multiple-option"
-                          ]
+                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
                         },
                         "required": {
                           "type": "boolean"
@@ -11729,19 +9802,11 @@
                                 "nullable": true
                               }
                             },
-                            "required": [
-                              "key",
-                              "description"
-                            ]
+                            "required": ["key", "description"]
                           }
                         }
                       },
-                      "required": [
-                        "key",
-                        "type",
-                        "required",
-                        "description"
-                      ]
+                      "required": ["key", "type", "required", "description"]
                     },
                     "feat-persistent-storage-type": {
                       "type": "object",
@@ -11751,13 +9816,7 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "string",
-                            "number",
-                            "boolean",
-                            "option",
-                            "multiple-option"
-                          ]
+                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
                         },
                         "required": {
                           "type": "boolean"
@@ -11781,19 +9840,11 @@
                                 "nullable": true
                               }
                             },
-                            "required": [
-                              "key",
-                              "description"
-                            ]
+                            "required": ["key", "description"]
                           }
                         }
                       },
-                      "required": [
-                        "key",
-                        "type",
-                        "required",
-                        "description"
-                      ]
+                      "required": ["key", "type", "required", "description"]
                     },
                     "workload-support-chia": {
                       "type": "object",
@@ -11803,13 +9854,7 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "string",
-                            "number",
-                            "boolean",
-                            "option",
-                            "multiple-option"
-                          ]
+                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
                         },
                         "required": {
                           "type": "boolean"
@@ -11833,19 +9878,11 @@
                                 "nullable": true
                               }
                             },
-                            "required": [
-                              "key",
-                              "description"
-                            ]
+                            "required": ["key", "description"]
                           }
                         }
                       },
-                      "required": [
-                        "key",
-                        "type",
-                        "required",
-                        "description"
-                      ]
+                      "required": ["key", "type", "required", "description"]
                     },
                     "workload-support-chia-capabilities": {
                       "type": "object",
@@ -11855,13 +9892,7 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "string",
-                            "number",
-                            "boolean",
-                            "option",
-                            "multiple-option"
-                          ]
+                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
                         },
                         "required": {
                           "type": "boolean"
@@ -11885,19 +9916,11 @@
                                 "nullable": true
                               }
                             },
-                            "required": [
-                              "key",
-                              "description"
-                            ]
+                            "required": ["key", "description"]
                           }
                         }
                       },
-                      "required": [
-                        "key",
-                        "type",
-                        "required",
-                        "description"
-                      ]
+                      "required": ["key", "type", "required", "description"]
                     },
                     "feat-endpoint-ip": {
                       "type": "object",
@@ -11907,13 +9930,7 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "string",
-                            "number",
-                            "boolean",
-                            "option",
-                            "multiple-option"
-                          ]
+                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
                         },
                         "required": {
                           "type": "boolean"
@@ -11937,19 +9954,11 @@
                                 "nullable": true
                               }
                             },
-                            "required": [
-                              "key",
-                              "description"
-                            ]
+                            "required": ["key", "description"]
                           }
                         }
                       },
-                      "required": [
-                        "key",
-                        "type",
-                        "required",
-                        "description"
-                      ]
+                      "required": ["key", "type", "required", "description"]
                     },
                     "feat-endpoint-custom-domain": {
                       "type": "object",
@@ -11959,13 +9968,7 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "string",
-                            "number",
-                            "boolean",
-                            "option",
-                            "multiple-option"
-                          ]
+                          "enum": ["string", "number", "boolean", "option", "multiple-option"]
                         },
                         "required": {
                           "type": "boolean"
@@ -11989,19 +9992,11 @@
                                 "nullable": true
                               }
                             },
-                            "required": [
-                              "key",
-                              "description"
-                            ]
+                            "required": ["key", "description"]
                           }
                         }
                       },
-                      "required": [
-                        "key",
-                        "type",
-                        "required",
-                        "description"
-                      ]
+                      "required": ["key", "type", "required", "description"]
                     }
                   },
                   "required": [
@@ -12043,9 +10038,7 @@
     "/v1/provider-regions": {
       "get": {
         "summary": "Get a list of provider regions",
-        "tags": [
-          "Providers"
-        ],
+        "tags": ["Providers"],
         "security": [],
         "responses": {
           "200": {
@@ -12073,11 +10066,7 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "providers",
-                      "key",
-                      "description"
-                    ]
+                    "required": ["providers", "key", "description"]
                   }
                 }
               }
@@ -12089,9 +10078,7 @@
     "/v1/provider-dashboard/{owner}": {
       "get": {
         "summary": "Get dashboard data for provider console.",
-        "tags": [
-          "Providers"
-        ],
+        "tags": ["Providers"],
         "security": [],
         "parameters": [
           {
@@ -12279,10 +10266,7 @@
                       ]
                     }
                   },
-                  "required": [
-                    "current",
-                    "previous"
-                  ]
+                  "required": ["current", "previous"]
                 }
               }
             }
@@ -12296,9 +10280,7 @@
     "/v1/provider-earnings/{owner}": {
       "get": {
         "summary": "Get earnings data for provider console.",
-        "tags": [
-          "Providers"
-        ],
+        "tags": ["Providers"],
         "security": [],
         "parameters": [
           {
@@ -12358,17 +10340,10 @@
                           "type": "number"
                         }
                       },
-                      "required": [
-                        "totalUAktEarned",
-                        "totalUUsdcEarned",
-                        "totalUActEarned",
-                        "totalUUsdEarned"
-                      ]
+                      "required": ["totalUAktEarned", "totalUUsdcEarned", "totalUActEarned", "totalUUsdEarned"]
                     }
                   },
-                  "required": [
-                    "earnings"
-                  ]
+                  "required": ["earnings"]
                 }
               }
             }
@@ -12382,9 +10357,7 @@
     "/v1/provider-versions": {
       "get": {
         "summary": "Get providers grouped by version.",
-        "tags": [
-          "Providers"
-        ],
+        "tags": ["Providers"],
         "security": [],
         "responses": {
           "200": {
@@ -12412,12 +10385,7 @@
                         }
                       }
                     },
-                    "required": [
-                      "version",
-                      "count",
-                      "ratio",
-                      "providers"
-                    ]
+                    "required": ["version", "count", "ratio", "providers"]
                   }
                 }
               }
@@ -12428,22 +10396,14 @@
     },
     "/v1/provider-graph-data/{dataName}": {
       "get": {
-        "tags": [
-          "Analytics"
-        ],
+        "tags": ["Analytics"],
         "security": [],
         "parameters": [
           {
             "schema": {
               "type": "string",
               "example": "cpu",
-              "enum": [
-                "count",
-                "cpu",
-                "gpu",
-                "memory",
-                "storage"
-              ]
+              "enum": ["count", "cpu", "gpu", "memory", "storage"]
             },
             "required": true,
             "name": "dataName",
@@ -12478,10 +10438,7 @@
                             "example": 100
                           }
                         },
-                        "required": [
-                          "date",
-                          "value"
-                        ]
+                        "required": ["date", "value"]
                       }
                     },
                     "now": {
@@ -12508,13 +10465,7 @@
                           "example": 100
                         }
                       },
-                      "required": [
-                        "count",
-                        "cpu",
-                        "gpu",
-                        "memory",
-                        "storage"
-                      ]
+                      "required": ["count", "cpu", "gpu", "memory", "storage"]
                     },
                     "compare": {
                       "type": "object",
@@ -12540,20 +10491,10 @@
                           "example": 100
                         }
                       },
-                      "required": [
-                        "count",
-                        "cpu",
-                        "gpu",
-                        "memory",
-                        "storage"
-                      ]
+                      "required": ["count", "cpu", "gpu", "memory", "storage"]
                     }
                   },
-                  "required": [
-                    "currentValue",
-                    "compareValue",
-                    "snapshots"
-                  ]
+                  "required": ["currentValue", "compareValue", "snapshots"]
                 }
               }
             }
@@ -12567,10 +10508,7 @@
     "/v1/providers/{provider}/deployments/{skip}/{limit}": {
       "get": {
         "summary": "Get a list of deployments for a provider.",
-        "tags": [
-          "Providers",
-          "Deployments"
-        ],
+        "tags": ["Providers", "Deployments"],
         "security": [],
         "parameters": [
           {
@@ -12610,10 +10548,7 @@
           {
             "schema": {
               "type": "string",
-              "enum": [
-                "active",
-                "closed"
-              ],
+              "enum": ["active", "closed"],
               "description": "Filter by status",
               "example": "closed"
             },
@@ -12687,13 +10622,7 @@
                                 "type": "number"
                               }
                             },
-                            "required": [
-                              "cpu",
-                              "memory",
-                              "gpu",
-                              "ephemeralStorage",
-                              "persistentStorage"
-                            ]
+                            "required": ["cpu", "memory", "gpu", "ephemeralStorage", "persistentStorage"]
                           },
                           "leases": {
                             "type": "array",
@@ -12749,13 +10678,7 @@
                                       "type": "number"
                                     }
                                   },
-                                  "required": [
-                                    "cpu",
-                                    "memory",
-                                    "gpu",
-                                    "ephemeralStorage",
-                                    "persistentStorage"
-                                  ]
+                                  "required": ["cpu", "memory", "gpu", "ephemeralStorage", "persistentStorage"]
                                 }
                               },
                               "required": [
@@ -12789,10 +10712,7 @@
                       }
                     }
                   },
-                  "required": [
-                    "total",
-                    "deployments"
-                  ]
+                  "required": ["total", "deployments"]
                 }
               }
             }
@@ -12806,9 +10726,7 @@
     "/v1/create-jwt-token": {
       "post": {
         "summary": "Create new JWT token for managed wallet",
-        "tags": [
-          "JWT Token"
-        ],
+        "tags": ["JWT Token"],
         "security": [
           {
             "BearerAuth": []
@@ -12838,15 +10756,10 @@
                         }
                       }
                     },
-                    "required": [
-                      "ttl",
-                      "leases"
-                    ]
+                    "required": ["ttl", "leases"]
                   }
                 },
-                "required": [
-                  "data"
-                ]
+                "required": ["data"]
               }
             }
           }
@@ -12866,14 +10779,10 @@
                           "type": "string"
                         }
                       },
-                      "required": [
-                        "token"
-                      ]
+                      "required": ["token"]
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -12883,9 +10792,7 @@
     },
     "/v1/graph-data/{dataName}": {
       "get": {
-        "tags": [
-          "Analytics"
-        ],
+        "tags": ["Analytics"],
         "security": [],
         "parameters": [
           {
@@ -12957,18 +10864,11 @@
                             "example": 100
                           }
                         },
-                        "required": [
-                          "date",
-                          "value"
-                        ]
+                        "required": ["date", "value"]
                       }
                     }
                   },
-                  "required": [
-                    "currentValue",
-                    "compareValue",
-                    "snapshots"
-                  ]
+                  "required": ["currentValue", "compareValue", "snapshots"]
                 }
               }
             }
@@ -12981,9 +10881,7 @@
     },
     "/v1/bme/dashboard-data": {
       "get": {
-        "tags": [
-          "Analytics"
-        ],
+        "tags": ["Analytics"],
         "security": [],
         "responses": {
           "200": {
@@ -13120,10 +11018,7 @@
                       ]
                     }
                   },
-                  "required": [
-                    "now",
-                    "compare"
-                  ]
+                  "required": ["now", "compare"]
                 }
               }
             }
@@ -13133,9 +11028,7 @@
     },
     "/v1/bme/status-history": {
       "get": {
-        "tags": [
-          "Analytics"
-        ],
+        "tags": ["Analytics"],
         "security": [],
         "responses": {
           "200": {
@@ -13168,13 +11061,7 @@
                         "example": 1.5
                       }
                     },
-                    "required": [
-                      "height",
-                      "date",
-                      "previousStatus",
-                      "newStatus",
-                      "collateralRatio"
-                    ]
+                    "required": ["height", "date", "previousStatus", "newStatus", "collateralRatio"]
                   }
                 }
               }
@@ -13185,9 +11072,7 @@
     },
     "/v1/dashboard-data": {
       "get": {
-        "tags": [
-          "Analytics"
-        ],
+        "tags": ["Analytics"],
         "security": [],
         "responses": {
           "200": {
@@ -13222,14 +11107,7 @@
                           "type": "number"
                         }
                       },
-                      "required": [
-                        "height",
-                        "transactionCount",
-                        "bondedTokens",
-                        "totalSupply",
-                        "communityPool",
-                        "inflation"
-                      ]
+                      "required": ["height", "transactionCount", "bondedTokens", "totalSupply", "communityPool", "inflation"]
                     },
                     "now": {
                       "type": "object",
@@ -13509,10 +11387,7 @@
                                 "type": "number"
                               }
                             },
-                            "required": [
-                              "date",
-                              "value"
-                            ]
+                            "required": ["date", "value"]
                           }
                         },
                         "now": {
@@ -13534,13 +11409,7 @@
                               "type": "number"
                             }
                           },
-                          "required": [
-                            "count",
-                            "cpu",
-                            "gpu",
-                            "memory",
-                            "storage"
-                          ]
+                          "required": ["count", "cpu", "gpu", "memory", "storage"]
                         },
                         "compare": {
                           "type": "object",
@@ -13561,22 +11430,10 @@
                               "type": "number"
                             }
                           },
-                          "required": [
-                            "count",
-                            "cpu",
-                            "gpu",
-                            "memory",
-                            "storage"
-                          ]
+                          "required": ["count", "cpu", "gpu", "memory", "storage"]
                         }
                       },
-                      "required": [
-                        "currentValue",
-                        "compareValue",
-                        "snapshots",
-                        "now",
-                        "compare"
-                      ]
+                      "required": ["currentValue", "compareValue", "snapshots", "now", "compare"]
                     },
                     "latestBlocks": {
                       "type": "array",
@@ -13604,12 +11461,7 @@
                                 "nullable": true
                               }
                             },
-                            "required": [
-                              "address",
-                              "operatorAddress",
-                              "moniker",
-                              "avatarUrl"
-                            ]
+                            "required": ["address", "operatorAddress", "moniker", "avatarUrl"]
                           },
                           "transactionCount": {
                             "type": "number"
@@ -13621,13 +11473,7 @@
                             "type": "string"
                           }
                         },
-                        "required": [
-                          "height",
-                          "proposer",
-                          "transactionCount",
-                          "totalTransactionCount",
-                          "datetime"
-                        ]
+                        "required": ["height", "proposer", "transactionCount", "totalTransactionCount", "datetime"]
                       }
                     },
                     "latestTransactions": {
@@ -13678,38 +11524,15 @@
                                   "type": "number"
                                 }
                               },
-                              "required": [
-                                "id",
-                                "type",
-                                "amount"
-                              ]
+                              "required": ["id", "type", "amount"]
                             }
                           }
                         },
-                        "required": [
-                          "height",
-                          "datetime",
-                          "hash",
-                          "isSuccess",
-                          "error",
-                          "gasUsed",
-                          "gasWanted",
-                          "fee",
-                          "memo",
-                          "messages"
-                        ]
+                        "required": ["height", "datetime", "hash", "isSuccess", "error", "gasUsed", "gasWanted", "fee", "memo", "messages"]
                       }
                     }
                   },
-                  "required": [
-                    "chainStats",
-                    "now",
-                    "compare",
-                    "networkCapacity",
-                    "networkCapacityStats",
-                    "latestBlocks",
-                    "latestTransactions"
-                  ]
+                  "required": ["chainStats", "now", "compare", "networkCapacity", "networkCapacityStats", "latestBlocks", "latestTransactions"]
                 }
               }
             }
@@ -13719,9 +11542,7 @@
     },
     "/v1/network-capacity": {
       "get": {
-        "tags": [
-          "Analytics"
-        ],
+        "tags": ["Analytics"],
         "security": [],
         "responses": {
           "200": {
@@ -13753,12 +11574,7 @@
                               "type": "number"
                             }
                           },
-                          "required": [
-                            "active",
-                            "pending",
-                            "available",
-                            "total"
-                          ]
+                          "required": ["active", "pending", "available", "total"]
                         },
                         "gpu": {
                           "type": "object",
@@ -13776,12 +11592,7 @@
                               "type": "number"
                             }
                           },
-                          "required": [
-                            "active",
-                            "pending",
-                            "available",
-                            "total"
-                          ]
+                          "required": ["active", "pending", "available", "total"]
                         },
                         "memory": {
                           "type": "object",
@@ -13799,12 +11610,7 @@
                               "type": "number"
                             }
                           },
-                          "required": [
-                            "active",
-                            "pending",
-                            "available",
-                            "total"
-                          ]
+                          "required": ["active", "pending", "available", "total"]
                         },
                         "storage": {
                           "type": "object",
@@ -13825,12 +11631,7 @@
                                   "type": "number"
                                 }
                               },
-                              "required": [
-                                "active",
-                                "pending",
-                                "available",
-                                "total"
-                              ]
+                              "required": ["active", "pending", "available", "total"]
                             },
                             "persistent": {
                               "type": "object",
@@ -13848,12 +11649,7 @@
                                   "type": "number"
                                 }
                               },
-                              "required": [
-                                "active",
-                                "pending",
-                                "available",
-                                "total"
-                              ]
+                              "required": ["active", "pending", "available", "total"]
                             },
                             "total": {
                               "type": "object",
@@ -13871,33 +11667,16 @@
                                   "type": "number"
                                 }
                               },
-                              "required": [
-                                "active",
-                                "pending",
-                                "available",
-                                "total"
-                              ]
+                              "required": ["active", "pending", "available", "total"]
                             }
                           },
-                          "required": [
-                            "ephemeral",
-                            "persistent",
-                            "total"
-                          ]
+                          "required": ["ephemeral", "persistent", "total"]
                         }
                       },
-                      "required": [
-                        "cpu",
-                        "gpu",
-                        "memory",
-                        "storage"
-                      ]
+                      "required": ["cpu", "gpu", "memory", "storage"]
                     }
                   },
-                  "required": [
-                    "activeProviderCount",
-                    "resources"
-                  ]
+                  "required": ["activeProviderCount", "resources"]
                 }
               }
             }
@@ -13908,9 +11687,7 @@
     "/v1/blocks": {
       "get": {
         "summary": "Get a list of recent blocks.",
-        "tags": [
-          "Blocks"
-        ],
+        "tags": ["Blocks"],
         "security": [],
         "parameters": [
           {
@@ -13957,12 +11734,7 @@
                             "nullable": true
                           }
                         },
-                        "required": [
-                          "address",
-                          "operatorAddress",
-                          "moniker",
-                          "avatarUrl"
-                        ]
+                        "required": ["address", "operatorAddress", "moniker", "avatarUrl"]
                       },
                       "transactionCount": {
                         "type": "number"
@@ -13974,13 +11746,7 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "height",
-                      "proposer",
-                      "transactionCount",
-                      "totalTransactionCount",
-                      "datetime"
-                    ]
+                    "required": ["height", "proposer", "transactionCount", "totalTransactionCount", "datetime"]
                   }
                 }
               }
@@ -13992,9 +11758,7 @@
     "/v1/blocks/{height}": {
       "get": {
         "summary": "Get a block by height.",
-        "tags": [
-          "Blocks"
-        ],
+        "tags": ["Blocks"],
         "security": [],
         "parameters": [
           {
@@ -14039,11 +11803,7 @@
                           "type": "string"
                         }
                       },
-                      "required": [
-                        "operatorAddress",
-                        "moniker",
-                        "address"
-                      ]
+                      "required": ["operatorAddress", "moniker", "address"]
                     },
                     "hash": {
                       "type": "string"
@@ -14090,33 +11850,15 @@
                                   "type": "number"
                                 }
                               },
-                              "required": [
-                                "id",
-                                "type",
-                                "amount"
-                              ]
+                              "required": ["id", "type", "amount"]
                             }
                           }
                         },
-                        "required": [
-                          "hash",
-                          "isSuccess",
-                          "fee",
-                          "datetime",
-                          "messages"
-                        ]
+                        "required": ["hash", "isSuccess", "fee", "datetime", "messages"]
                       }
                     }
                   },
-                  "required": [
-                    "height",
-                    "datetime",
-                    "proposer",
-                    "hash",
-                    "gasUsed",
-                    "gasWanted",
-                    "transactions"
-                  ]
+                  "required": ["height", "datetime", "proposer", "hash", "gasUsed", "gasWanted", "transactions"]
                 }
               }
             }
@@ -14133,9 +11875,7 @@
     "/v1/predicted-block-date/{height}": {
       "get": {
         "summary": "Get the estimated date of a future block.",
-        "tags": [
-          "Blocks"
-        ],
+        "tags": ["Blocks"],
         "security": [],
         "parameters": [
           {
@@ -14180,11 +11920,7 @@
                       "example": 10000
                     }
                   },
-                  "required": [
-                    "predictedDate",
-                    "height",
-                    "blockWindow"
-                  ]
+                  "required": ["predictedDate", "height", "blockWindow"]
                 }
               }
             }
@@ -14198,9 +11934,7 @@
     "/v1/predicted-date-height/{timestamp}": {
       "get": {
         "summary": "Get the estimated height of a future date and time.",
-        "tags": [
-          "Blocks"
-        ],
+        "tags": ["Blocks"],
         "security": [],
         "parameters": [
           {
@@ -14246,11 +11980,7 @@
                       "example": 10000
                     }
                   },
-                  "required": [
-                    "predictedHeight",
-                    "date",
-                    "blockWindow"
-                  ]
+                  "required": ["predictedHeight", "date", "blockWindow"]
                 }
               }
             }
@@ -14264,9 +11994,7 @@
     "/v1/transactions": {
       "get": {
         "summary": "Get a list of transactions.",
-        "tags": [
-          "Transactions"
-        ],
+        "tags": ["Transactions"],
         "security": [],
         "parameters": [
           {
@@ -14336,26 +12064,11 @@
                               "type": "number"
                             }
                           },
-                          "required": [
-                            "id",
-                            "type",
-                            "amount"
-                          ]
+                          "required": ["id", "type", "amount"]
                         }
                       }
                     },
-                    "required": [
-                      "height",
-                      "datetime",
-                      "hash",
-                      "isSuccess",
-                      "error",
-                      "gasUsed",
-                      "gasWanted",
-                      "fee",
-                      "memo",
-                      "messages"
-                    ]
+                    "required": ["height", "datetime", "hash", "isSuccess", "error", "gasUsed", "gasWanted", "fee", "memo", "messages"]
                   }
                 }
               }
@@ -14367,9 +12080,7 @@
     "/v1/transactions/{hash}": {
       "get": {
         "summary": "Get a transaction by hash.",
-        "tags": [
-          "Transactions"
-        ],
+        "tags": ["Transactions"],
         "security": [],
         "parameters": [
           {
@@ -14451,27 +12162,11 @@
                             "nullable": true
                           }
                         },
-                        "required": [
-                          "id",
-                          "type",
-                          "data"
-                        ]
+                        "required": ["id", "type", "data"]
                       }
                     }
                   },
-                  "required": [
-                    "height",
-                    "datetime",
-                    "hash",
-                    "isSuccess",
-                    "signers",
-                    "error",
-                    "gasUsed",
-                    "gasWanted",
-                    "fee",
-                    "memo",
-                    "messages"
-                  ]
+                  "required": ["height", "datetime", "hash", "isSuccess", "signers", "error", "gasUsed", "gasWanted", "fee", "memo", "messages"]
                 }
               }
             }
@@ -14484,18 +12179,13 @@
     },
     "/v1/market-data/{coin?}": {
       "get": {
-        "tags": [
-          "Analytics"
-        ],
+        "tags": ["Analytics"],
         "security": [],
         "parameters": [
           {
             "schema": {
               "type": "string",
-              "enum": [
-                "akash-network",
-                "akt"
-              ],
+              "enum": ["akash-network", "akt"],
               "default": "akt",
               "example": "akt"
             },
@@ -14531,14 +12221,7 @@
                       "type": "number"
                     }
                   },
-                  "required": [
-                    "price",
-                    "volume",
-                    "marketCap",
-                    "marketCapRank",
-                    "priceChange24h",
-                    "priceChangePercentage24"
-                  ]
+                  "required": ["price", "volume", "marketCap", "marketCapRank", "priceChange24h", "priceChangePercentage24"]
                 }
               }
             }
@@ -14548,9 +12231,7 @@
     },
     "/v1/validators": {
       "get": {
-        "tags": [
-          "Validators"
-        ],
+        "tags": ["Validators"],
         "security": [],
         "responses": {
           "200": {
@@ -14588,16 +12269,7 @@
                         "nullable": true
                       }
                     },
-                    "required": [
-                      "operatorAddress",
-                      "moniker",
-                      "votingPower",
-                      "commission",
-                      "identity",
-                      "votingPowerRatio",
-                      "rank",
-                      "keybaseAvatarUrl"
-                    ]
+                    "required": ["operatorAddress", "moniker", "votingPower", "commission", "identity", "votingPowerRatio", "rank", "keybaseAvatarUrl"]
                   }
                 }
               }
@@ -14608,9 +12280,7 @@
     },
     "/v1/validators/{address}": {
       "get": {
-        "tags": [
-          "Validators"
-        ],
+        "tags": ["Validators"],
         "security": [],
         "parameters": [
           {
@@ -14705,9 +12375,7 @@
     },
     "/v1/pricing": {
       "post": {
-        "tags": [
-          "Other"
-        ],
+        "tags": ["Other"],
         "security": [],
         "summary": "Estimate the price of a deployment on akash and other cloud providers.",
         "requestBody": {
@@ -14736,11 +12404,7 @@
                         "example": 1000000000
                       }
                     },
-                    "required": [
-                      "cpu",
-                      "memory",
-                      "storage"
-                    ]
+                    "required": ["cpu", "memory", "storage"]
                   },
                   {
                     "type": "array",
@@ -14764,11 +12428,7 @@
                           "example": 1000000000
                         }
                       },
-                      "required": [
-                        "cpu",
-                        "memory",
-                        "storage"
-                      ]
+                      "required": ["cpu", "memory", "storage"]
                     },
                     "minItems": 1,
                     "maxItems": 10
@@ -14808,11 +12468,7 @@
                               "example": 1000000000
                             }
                           },
-                          "required": [
-                            "cpu",
-                            "memory",
-                            "storage"
-                          ]
+                          "required": ["cpu", "memory", "storage"]
                         },
                         "akash": {
                           "type": "number",
@@ -14831,13 +12487,7 @@
                           "description": "Azure price estimation (USD/month)"
                         }
                       },
-                      "required": [
-                        "spec",
-                        "akash",
-                        "aws",
-                        "gcp",
-                        "azure"
-                      ]
+                      "required": ["spec", "akash", "aws", "gcp", "azure"]
                     },
                     {
                       "type": "array",
@@ -14864,11 +12514,7 @@
                                 "example": 1000000000
                               }
                             },
-                            "required": [
-                              "cpu",
-                              "memory",
-                              "storage"
-                            ]
+                            "required": ["cpu", "memory", "storage"]
                           },
                           "akash": {
                             "type": "number",
@@ -14887,13 +12533,7 @@
                             "description": "Azure price estimation (USD/month)"
                           }
                         },
-                        "required": [
-                          "spec",
-                          "akash",
-                          "aws",
-                          "gcp",
-                          "azure"
-                        ]
+                        "required": ["spec", "akash", "aws", "gcp", "azure"]
                       }
                     }
                   ]
@@ -14910,9 +12550,7 @@
     "/v1/gpu": {
       "get": {
         "summary": "Get a list of gpu models and their availability.",
-        "tags": [
-          "Gpu"
-        ],
+        "tags": ["Gpu"],
         "security": [],
         "parameters": [
           {
@@ -14969,10 +12607,7 @@
                               "type": "number"
                             }
                           },
-                          "required": [
-                            "allocatable",
-                            "allocated"
-                          ]
+                          "required": ["allocatable", "allocated"]
                         },
                         "details": {
                           "type": "object",
@@ -14997,26 +12632,15 @@
                                   "type": "number"
                                 }
                               },
-                              "required": [
-                                "model",
-                                "ram",
-                                "interface",
-                                "allocatable",
-                                "allocated"
-                              ]
+                              "required": ["model", "ram", "interface", "allocatable", "allocated"]
                             }
                           }
                         }
                       },
-                      "required": [
-                        "total",
-                        "details"
-                      ]
+                      "required": ["total", "details"]
                     }
                   },
-                  "required": [
-                    "gpus"
-                  ]
+                  "required": ["gpus"]
                 }
               }
             }
@@ -15030,9 +12654,7 @@
     "/v1/gpu-models": {
       "get": {
         "summary": "Get a list of gpu models per vendor. Based on the content from https://raw.githubusercontent.com/akash-network/provider-configs/main/devices/pcie/gpus.json.",
-        "tags": [
-          "Gpu"
-        ],
+        "tags": ["Gpu"],
         "security": [],
         "responses": {
           "200": {
@@ -15076,20 +12698,11 @@
                               }
                             }
                           },
-                          "required": [
-                            "name",
-                            "displayName",
-                            "memory",
-                            "interface"
-                          ]
+                          "required": ["name", "displayName", "memory", "interface"]
                         }
                       }
                     },
-                    "required": [
-                      "name",
-                      "displayName",
-                      "models"
-                    ]
+                    "required": ["name", "displayName", "models"]
                   }
                 }
               }
@@ -15100,9 +12713,7 @@
     },
     "/v1/gpu-breakdown": {
       "get": {
-        "tags": [
-          "Gpu"
-        ],
+        "tags": ["Gpu"],
         "security": [],
         "summary": "Gets gpu analytics breakdown by vendor and model. If no vendor or model is provided, all GPUs are returned.",
         "parameters": [
@@ -15158,16 +12769,7 @@
                         "type": "number"
                       }
                     },
-                    "required": [
-                      "date",
-                      "vendor",
-                      "model",
-                      "providerCount",
-                      "nodeCount",
-                      "totalGpus",
-                      "leasedGpus",
-                      "gpuUtilization"
-                    ]
+                    "required": ["date", "vendor", "model", "providerCount", "nodeCount", "totalGpus", "leasedGpus", "gpuUtilization"]
                   }
                 }
               }
@@ -15180,9 +12782,7 @@
       "get": {
         "summary": "Get a list of gpu models with their availability and pricing.",
         "operationId": "listGpuPrices",
-        "tags": [
-          "Gpu"
-        ],
+        "tags": ["Gpu"],
         "security": [],
         "responses": {
           "200": {
@@ -15202,10 +12802,7 @@
                           "type": "number"
                         }
                       },
-                      "required": [
-                        "total",
-                        "available"
-                      ]
+                      "required": ["total", "available"]
                     },
                     "models": {
                       "type": "array",
@@ -15234,10 +12831,7 @@
                                 "type": "number"
                               }
                             },
-                            "required": [
-                              "total",
-                              "available"
-                            ]
+                            "required": ["total", "available"]
                           },
                           "providerAvailability": {
                             "type": "object",
@@ -15249,10 +12843,7 @@
                                 "type": "number"
                               }
                             },
-                            "required": [
-                              "total",
-                              "available"
-                            ]
+                            "required": ["total", "available"]
                           },
                           "price": {
                             "type": "object",
@@ -15278,32 +12869,14 @@
                                 "type": "number"
                               }
                             },
-                            "required": [
-                              "currency",
-                              "min",
-                              "max",
-                              "avg",
-                              "weightedAverage",
-                              "med"
-                            ]
+                            "required": ["currency", "min", "max", "avg", "weightedAverage", "med"]
                           }
                         },
-                        "required": [
-                          "vendor",
-                          "model",
-                          "ram",
-                          "interface",
-                          "availability",
-                          "providerAvailability",
-                          "price"
-                        ]
+                        "required": ["vendor", "model", "ram", "interface", "availability", "providerAvailability", "price"]
                       }
                     }
                   },
-                  "required": [
-                    "availability",
-                    "models"
-                  ]
+                  "required": ["availability", "models"]
                 }
               }
             }
@@ -15313,9 +12886,7 @@
     },
     "/v1/proposals": {
       "get": {
-        "tags": [
-          "Proposals"
-        ],
+        "tags": ["Proposals"],
         "security": [],
         "responses": {
           "200": {
@@ -15349,15 +12920,7 @@
                         "type": "number"
                       }
                     },
-                    "required": [
-                      "id",
-                      "title",
-                      "status",
-                      "submitTime",
-                      "votingStartTime",
-                      "votingEndTime",
-                      "totalDeposit"
-                    ]
+                    "required": ["id", "title", "status", "submitTime", "votingStartTime", "votingEndTime", "totalDeposit"]
                   }
                 }
               }
@@ -15368,9 +12931,7 @@
     },
     "/v1/proposals/{id}": {
       "get": {
-        "tags": [
-          "Proposals"
-        ],
+        "tags": ["Proposals"],
         "security": [],
         "parameters": [
           {
@@ -15436,13 +12997,7 @@
                           "type": "number"
                         }
                       },
-                      "required": [
-                        "yes",
-                        "abstain",
-                        "no",
-                        "noWithVeto",
-                        "total"
-                      ]
+                      "required": ["yes", "abstain", "no", "noWithVeto", "total"]
                     },
                     "paramChanges": {
                       "type": "array",
@@ -15459,10 +13014,7 @@
                             "nullable": true
                           }
                         },
-                        "required": [
-                          "subspace",
-                          "key"
-                        ]
+                        "required": ["subspace", "key"]
                       }
                     }
                   },
@@ -15493,9 +13045,7 @@
     },
     "/v1/templates-list": {
       "get": {
-        "tags": [
-          "Other"
-        ],
+        "tags": ["Other"],
         "security": [],
         "responses": {
           "200": {
@@ -15538,25 +13088,15 @@
                                   }
                                 }
                               },
-                              "required": [
-                                "id",
-                                "name",
-                                "logoUrl",
-                                "summary"
-                              ]
+                              "required": ["id", "name", "logoUrl", "summary"]
                             }
                           }
                         },
-                        "required": [
-                          "title",
-                          "templates"
-                        ]
+                        "required": ["title", "templates"]
                       }
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -15566,9 +13106,7 @@
     },
     "/v1/templates/{id}": {
       "get": {
-        "tags": [
-          "Other"
-        ],
+        "tags": ["Other"],
         "security": [],
         "parameters": [
           {
@@ -15634,23 +13172,10 @@
                           }
                         }
                       },
-                      "required": [
-                        "id",
-                        "name",
-                        "path",
-                        "logoUrl",
-                        "summary",
-                        "readme",
-                        "deploy",
-                        "persistentStorageEnabled",
-                        "githubUrl",
-                        "config"
-                      ]
+                      "required": ["id", "name", "path", "logoUrl", "summary", "readme", "deploy", "persistentStorageEnabled", "githubUrl", "config"]
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -15667,9 +13192,7 @@
     "/v1/leases-duration/{owner}": {
       "get": {
         "summary": "Get leases durations.",
-        "tags": [
-          "Analytics"
-        ],
+        "tags": ["Analytics"],
         "security": [],
         "parameters": [
           {
@@ -15784,12 +13307,7 @@
                       }
                     }
                   },
-                  "required": [
-                    "leaseCount",
-                    "totalDurationInSeconds",
-                    "totalDurationInHours",
-                    "leases"
-                  ]
+                  "required": ["leaseCount", "totalDurationInSeconds", "totalDurationInHours", "leases"]
                 }
               }
             }
@@ -15803,9 +13321,7 @@
     "/v1/addresses/{address}": {
       "get": {
         "summary": "Get address details",
-        "tags": [
-          "Addresses"
-        ],
+        "tags": ["Addresses"],
         "security": [],
         "parameters": [
           {
@@ -15860,11 +13376,7 @@
                             "nullable": true
                           }
                         },
-                        "required": [
-                          "validator",
-                          "amount",
-                          "reward"
-                        ]
+                        "required": ["validator", "amount", "reward"]
                       }
                     },
                     "available": {
@@ -15897,9 +13409,7 @@
                             "type": "number"
                           }
                         },
-                        "required": [
-                          "amount"
-                        ]
+                        "required": ["amount"]
                       }
                     },
                     "redelegations": {
@@ -15951,13 +13461,7 @@
                             "type": "number"
                           }
                         },
-                        "required": [
-                          "srcAddress",
-                          "dstAddress",
-                          "creationHeight",
-                          "completionTime",
-                          "amount"
-                        ]
+                        "required": ["srcAddress", "dstAddress", "creationHeight", "completionTime", "amount"]
                       }
                     },
                     "commission": {
@@ -16018,42 +13522,15 @@
                                   "type": "boolean"
                                 }
                               },
-                              "required": [
-                                "id",
-                                "type",
-                                "amount",
-                                "isReceiver"
-                              ]
+                              "required": ["id", "type", "amount", "isReceiver"]
                             }
                           }
                         },
-                        "required": [
-                          "height",
-                          "datetime",
-                          "hash",
-                          "isSuccess",
-                          "error",
-                          "gasUsed",
-                          "gasWanted",
-                          "fee",
-                          "memo",
-                          "isSigner",
-                          "messages"
-                        ]
+                        "required": ["height", "datetime", "hash", "isSuccess", "error", "gasUsed", "gasWanted", "fee", "memo", "isSigner", "messages"]
                       }
                     }
                   },
-                  "required": [
-                    "total",
-                    "delegations",
-                    "available",
-                    "delegated",
-                    "rewards",
-                    "assets",
-                    "redelegations",
-                    "commission",
-                    "latestTransactions"
-                  ]
+                  "required": ["total", "delegations", "available", "delegated", "rewards", "assets", "redelegations", "commission", "latestTransactions"]
                 }
               }
             }
@@ -16067,10 +13544,7 @@
     "/v1/addresses/{address}/transactions/{skip}/{limit}": {
       "get": {
         "summary": "Get a list of transactions for a given address.",
-        "tags": [
-          "Addresses",
-          "Transactions"
-        ],
+        "tags": ["Addresses", "Transactions"],
         "security": [],
         "parameters": [
           {
@@ -16174,35 +13648,15 @@
                                   "type": "boolean"
                                 }
                               },
-                              "required": [
-                                "id",
-                                "type",
-                                "amount",
-                                "isReceiver"
-                              ]
+                              "required": ["id", "type", "amount", "isReceiver"]
                             }
                           }
                         },
-                        "required": [
-                          "height",
-                          "datetime",
-                          "hash",
-                          "isSuccess",
-                          "error",
-                          "gasUsed",
-                          "gasWanted",
-                          "fee",
-                          "memo",
-                          "isSigner",
-                          "messages"
-                        ]
+                        "required": ["height", "datetime", "hash", "isSuccess", "error", "gasUsed", "gasWanted", "fee", "memo", "isSigner", "messages"]
                       }
                     }
                   },
-                  "required": [
-                    "count",
-                    "results"
-                  ]
+                  "required": ["count", "results"]
                 }
               }
             }
@@ -16216,9 +13670,7 @@
     "/v1/blockchain-status": {
       "get": {
         "summary": "Get blockchain reachability status",
-        "tags": [
-          "Chain"
-        ],
+        "tags": ["Chain"],
         "security": [],
         "responses": {
           "200": {
@@ -16232,9 +13684,7 @@
                       "type": "boolean"
                     }
                   },
-                  "required": [
-                    "isBlockchainReachable"
-                  ]
+                  "required": ["isBlockchainReachable"]
                 }
               }
             }
@@ -16246,9 +13696,7 @@
       "post": {
         "operationId": "screenProviders",
         "summary": "Screen providers by deployment resource requirements",
-        "tags": [
-          "Bid Screening"
-        ],
+        "tags": ["Bid Screening"],
         "security": [],
         "requestBody": {
           "content": {
@@ -16298,10 +13746,7 @@
                               "example": "false"
                             }
                           },
-                          "required": [
-                            "key",
-                            "value"
-                          ]
+                          "required": ["key", "value"]
                         },
                         "default": []
                       }
@@ -16332,9 +13777,7 @@
                                       "maxLength": 80
                                     }
                                   },
-                                  "required": [
-                                    "val"
-                                  ]
+                                  "required": ["val"]
                                 },
                                 "attributes": {
                                   "type": "array",
@@ -16355,16 +13798,11 @@
                                         "example": "false"
                                       }
                                     },
-                                    "required": [
-                                      "key",
-                                      "value"
-                                    ]
+                                    "required": ["key", "value"]
                                   }
                                 }
                               },
-                              "required": [
-                                "units"
-                              ]
+                              "required": ["units"]
                             },
                             "memory": {
                               "type": "object",
@@ -16377,9 +13815,7 @@
                                       "maxLength": 80
                                     }
                                   },
-                                  "required": [
-                                    "val"
-                                  ]
+                                  "required": ["val"]
                                 },
                                 "attributes": {
                                   "type": "array",
@@ -16400,16 +13836,11 @@
                                         "example": "false"
                                       }
                                     },
-                                    "required": [
-                                      "key",
-                                      "value"
-                                    ]
+                                    "required": ["key", "value"]
                                   }
                                 }
                               },
-                              "required": [
-                                "quantity"
-                              ]
+                              "required": ["quantity"]
                             },
                             "gpu": {
                               "type": "object",
@@ -16422,9 +13853,7 @@
                                       "maxLength": 80
                                     }
                                   },
-                                  "required": [
-                                    "val"
-                                  ]
+                                  "required": ["val"]
                                 },
                                 "attributes": {
                                   "type": "array",
@@ -16445,16 +13874,11 @@
                                         "example": "false"
                                       }
                                     },
-                                    "required": [
-                                      "key",
-                                      "value"
-                                    ]
+                                    "required": ["key", "value"]
                                   }
                                 }
                               },
-                              "required": [
-                                "units"
-                              ]
+                              "required": ["units"]
                             },
                             "storage": {
                               "type": "array",
@@ -16474,9 +13898,7 @@
                                         "maxLength": 80
                                       }
                                     },
-                                    "required": [
-                                      "val"
-                                    ]
+                                    "required": ["val"]
                                   },
                                   "attributes": {
                                     "type": "array",
@@ -16497,17 +13919,11 @@
                                           "example": "false"
                                         }
                                       },
-                                      "required": [
-                                        "key",
-                                        "value"
-                                      ]
+                                      "required": ["key", "value"]
                                     }
                                   }
                                 },
-                                "required": [
-                                  "name",
-                                  "quantity"
-                                ]
+                                "required": ["name", "quantity"]
                               }
                             },
                             "endpoints": {
@@ -16517,13 +13933,7 @@
                               }
                             }
                           },
-                          "required": [
-                            "id",
-                            "cpu",
-                            "memory",
-                            "gpu",
-                            "storage"
-                          ]
+                          "required": ["id", "cpu", "memory", "gpu", "storage"]
                         },
                         "count": {
                           "type": "integer",
@@ -16542,17 +13952,10 @@
                               "pattern": "^\\d+$"
                             }
                           },
-                          "required": [
-                            "denom",
-                            "amount"
-                          ]
+                          "required": ["denom", "amount"]
                         }
                       },
-                      "required": [
-                        "resource",
-                        "count",
-                        "price"
-                      ]
+                      "required": ["resource", "count", "price"]
                     },
                     "description": "Resource units with replica counts"
                   },
@@ -16569,10 +13972,7 @@
                     "example": 3600
                   }
                 },
-                "required": [
-                  "resources",
-                  "timezone"
-                ]
+                "required": ["resources", "timezone"]
               }
             }
           }
@@ -16645,31 +14045,16 @@
                                   "description": "Downtime clipped to that day, in seconds (max 86400)"
                                 }
                               },
-                              "required": [
-                                "date",
-                                "hasOpenIncident",
-                                "incidentCount",
-                                "downtimeSeconds"
-                              ]
+                              "required": ["date", "hasOpenIncident", "incidentCount", "downtimeSeconds"]
                             },
                             "description": "Per-day downtime over a rolling 7-day window"
                           }
                         },
-                        "required": [
-                          "owner",
-                          "hostUri",
-                          "isAudited",
-                          "createdAt",
-                          "location",
-                          "organization",
-                          "incidents"
-                        ]
+                        "required": ["owner", "hostUri", "isAudited", "createdAt", "location", "organization", "incidents"]
                       }
                     }
                   },
-                  "required": [
-                    "providers"
-                  ]
+                  "required": ["providers"]
                 }
               }
             }
@@ -16684,9 +14069,7 @@
       "post": {
         "operationId": "validateConfidentialComputeAttestation",
         "summary": "Validate confidential compute attestation evidence against the hardware vendors (AMD SEV-SNP, Intel TDX, NVIDIA)",
-        "tags": [
-          "Confidential Compute"
-        ],
+        "tags": ["Confidential Compute"],
         "security": [
           {
             "BearerAuth": []
@@ -16713,12 +14096,7 @@
                   },
                   "tee_platform": {
                     "type": "string",
-                    "enum": [
-                      "snp",
-                      "tdx",
-                      "snp-gpu",
-                      "tdx-gpu"
-                    ],
+                    "enum": ["snp", "tdx", "snp-gpu", "tdx-gpu"],
                     "description": "TEE platform that produced the evidence"
                   },
                   "cert_chain": {
@@ -16750,20 +14128,13 @@
                           "example": "BQAAAAAA..."
                         }
                       },
-                      "required": [
-                        "device_index",
-                        "report"
-                      ]
+                      "required": ["device_index", "report"]
                     },
                     "default": [],
                     "description": "Per-GPU attestation reports; empty for CPU-only platforms"
                   }
                 },
-                "required": [
-                  "nonce",
-                  "report",
-                  "tee_platform"
-                ]
+                "required": ["nonce", "report", "tee_platform"]
               }
             }
           }
@@ -16778,11 +14149,7 @@
                   "properties": {
                     "overall": {
                       "type": "string",
-                      "enum": [
-                        "valid",
-                        "invalid",
-                        "unverifiable"
-                      ],
+                      "enum": ["valid", "invalid", "unverifiable"],
                       "description": "Rollup: valid only if every report is valid; invalid if any report is invalid; otherwise unverifiable"
                     },
                     "nonce": {
@@ -16798,24 +14165,15 @@
                             "properties": {
                               "kind": {
                                 "type": "string",
-                                "enum": [
-                                  "cpu"
-                                ]
+                                "enum": ["cpu"]
                               },
                               "vendor": {
                                 "type": "string",
-                                "enum": [
-                                  "amd-sev-snp",
-                                  "intel-tdx"
-                                ]
+                                "enum": ["amd-sev-snp", "intel-tdx"]
                               },
                               "status": {
                                 "type": "string",
-                                "enum": [
-                                  "valid",
-                                  "invalid",
-                                  "unverifiable"
-                                ],
+                                "enum": ["valid", "invalid", "unverifiable"],
                                 "description": "valid = chained to the vendor root, signature/EAT verified, and bound to the request nonce; invalid = a check ran and failed (bad signature, untrusted chain, nonce mismatch); unverifiable = the check could not be completed (vendor service unreachable, not configured, missing material)"
                               },
                               "detail": {
@@ -16845,21 +14203,14 @@
                                 "description": "Granular sub-results behind the verdict; fields are omitted when not evaluated"
                               }
                             },
-                            "required": [
-                              "kind",
-                              "vendor",
-                              "status",
-                              "detail"
-                            ]
+                            "required": ["kind", "vendor", "status", "detail"]
                           },
                           {
                             "type": "object",
                             "properties": {
                               "kind": {
                                 "type": "string",
-                                "enum": [
-                                  "gpu"
-                                ]
+                                "enum": ["gpu"]
                               },
                               "device_index": {
                                 "type": "integer",
@@ -16867,17 +14218,11 @@
                               },
                               "vendor": {
                                 "type": "string",
-                                "enum": [
-                                  "nvidia"
-                                ]
+                                "enum": ["nvidia"]
                               },
                               "status": {
                                 "type": "string",
-                                "enum": [
-                                  "valid",
-                                  "invalid",
-                                  "unverifiable"
-                                ],
+                                "enum": ["valid", "invalid", "unverifiable"],
                                 "description": "valid = chained to the vendor root, signature/EAT verified, and bound to the request nonce; invalid = a check ran and failed (bad signature, untrusted chain, nonce mismatch); unverifiable = the check could not be completed (vendor service unreachable, not configured, missing material)"
                               },
                               "detail": {
@@ -16907,23 +14252,13 @@
                                 "description": "Granular sub-results behind the verdict; fields are omitted when not evaluated"
                               }
                             },
-                            "required": [
-                              "kind",
-                              "device_index",
-                              "vendor",
-                              "status",
-                              "detail"
-                            ]
+                            "required": ["kind", "device_index", "vendor", "status", "detail"]
                           }
                         ]
                       }
                     }
                   },
-                  "required": [
-                    "overall",
-                    "nonce",
-                    "reports"
-                  ]
+                  "required": ["overall", "nonce", "reports"]
                 }
               }
             }
@@ -17009,9 +14344,7 @@
             }
           }
         },
-        "tags": [
-          "Alert"
-        ]
+        "tags": ["Alert"]
       },
       "get": {
         "operationId": "listAlerts",
@@ -17113,9 +14446,7 @@
             }
           }
         },
-        "tags": [
-          "Alert"
-        ]
+        "tags": ["Alert"]
       }
     },
     "/v1/alerts/{id}": {
@@ -17191,9 +14522,7 @@
             }
           }
         },
-        "tags": [
-          "Alert"
-        ]
+        "tags": ["Alert"]
       },
       "patch": {
         "operationId": "updateAlert",
@@ -17277,9 +14606,7 @@
             }
           }
         },
-        "tags": [
-          "Alert"
-        ]
+        "tags": ["Alert"]
       },
       "delete": {
         "operationId": "deleteAlert",
@@ -17353,9 +14680,7 @@
             }
           }
         },
-        "tags": [
-          "Alert"
-        ]
+        "tags": ["Alert"]
       }
     },
     "/v1/notification-channels": {
@@ -17433,9 +14758,7 @@
             }
           }
         },
-        "tags": [
-          "NotificationChannel"
-        ]
+        "tags": ["NotificationChannel"]
       },
       "get": {
         "operationId": "listNotificationChannels",
@@ -17519,9 +14842,7 @@
             }
           }
         },
-        "tags": [
-          "NotificationChannel"
-        ]
+        "tags": ["NotificationChannel"]
       }
     },
     "/v1/notification-channels/default": {
@@ -17543,9 +14864,7 @@
             "description": "Creates the default notification channel only if it doesn't exist."
           }
         },
-        "tags": [
-          "NotificationChannel"
-        ]
+        "tags": ["NotificationChannel"]
       }
     },
     "/v1/notification-channels/{id}": {
@@ -17631,9 +14950,7 @@
             }
           }
         },
-        "tags": [
-          "NotificationChannel"
-        ]
+        "tags": ["NotificationChannel"]
       },
       "patch": {
         "operationId": "updateNotificationChannel",
@@ -17727,9 +15044,7 @@
             }
           }
         },
-        "tags": [
-          "NotificationChannel"
-        ]
+        "tags": ["NotificationChannel"]
       },
       "delete": {
         "operationId": "deleteNotificationChannel",
@@ -17813,9 +15128,7 @@
             }
           }
         },
-        "tags": [
-          "NotificationChannel"
-        ]
+        "tags": ["NotificationChannel"]
       }
     },
     "/v1/deployment-alerts/{dseq}": {
@@ -17910,9 +15223,7 @@
             }
           }
         },
-        "tags": [
-          "DeploymentAlert"
-        ]
+        "tags": ["DeploymentAlert"]
       },
       "get": {
         "operationId": "listDeploymentAlerts",
@@ -17986,9 +15297,7 @@
             }
           }
         },
-        "tags": [
-          "DeploymentAlert"
-        ]
+        "tags": ["DeploymentAlert"]
       }
     }
   },
@@ -18036,10 +15345,7 @@
                         "type": "boolean"
                       }
                     },
-                    "required": [
-                      "dseq",
-                      "type"
-                    ]
+                    "required": ["dseq", "type"]
                   },
                   "conditions": {
                     "oneOf": [
@@ -18048,9 +15354,7 @@
                         "properties": {
                           "operator": {
                             "type": "string",
-                            "enum": [
-                              "and"
-                            ]
+                            "enum": ["and"]
                           },
                           "value": {
                             "type": "array",
@@ -18062,33 +15366,23 @@
                                   "oneOf": [
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "eq"
-                                      ]
+                                      "enum": ["eq"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "lt"
-                                      ]
+                                      "enum": ["lt"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "gt"
-                                      ]
+                                      "enum": ["gt"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "lte"
-                                      ]
+                                      "enum": ["lte"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "gte"
-                                      ]
+                                      "enum": ["gte"]
                                     }
                                   ]
                                 },
@@ -18109,27 +15403,18 @@
                                   ]
                                 }
                               },
-                              "required": [
-                                "operator",
-                                "field",
-                                "value"
-                              ]
+                              "required": ["operator", "field", "value"]
                             }
                           }
                         },
-                        "required": [
-                          "operator",
-                          "value"
-                        ]
+                        "required": ["operator", "value"]
                       },
                       {
                         "type": "object",
                         "properties": {
                           "operator": {
                             "type": "string",
-                            "enum": [
-                              "or"
-                            ]
+                            "enum": ["or"]
                           },
                           "value": {
                             "type": "array",
@@ -18141,33 +15426,23 @@
                                   "oneOf": [
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "eq"
-                                      ]
+                                      "enum": ["eq"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "lt"
-                                      ]
+                                      "enum": ["lt"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "gt"
-                                      ]
+                                      "enum": ["gt"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "lte"
-                                      ]
+                                      "enum": ["lte"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "gte"
-                                      ]
+                                      "enum": ["gte"]
                                     }
                                   ]
                                 },
@@ -18188,18 +15463,11 @@
                                   ]
                                 }
                               },
-                              "required": [
-                                "operator",
-                                "field",
-                                "value"
-                              ]
+                              "required": ["operator", "field", "value"]
                             }
                           }
                         },
-                        "required": [
-                          "operator",
-                          "value"
-                        ]
+                        "required": ["operator", "value"]
                       },
                       {
                         "type": "object",
@@ -18208,33 +15476,23 @@
                             "oneOf": [
                               {
                                 "type": "string",
-                                "enum": [
-                                  "eq"
-                                ]
+                                "enum": ["eq"]
                               },
                               {
                                 "type": "string",
-                                "enum": [
-                                  "lt"
-                                ]
+                                "enum": ["lt"]
                               },
                               {
                                 "type": "string",
-                                "enum": [
-                                  "gt"
-                                ]
+                                "enum": ["gt"]
                               },
                               {
                                 "type": "string",
-                                "enum": [
-                                  "lte"
-                                ]
+                                "enum": ["lte"]
                               },
                               {
                                 "type": "string",
-                                "enum": [
-                                  "gte"
-                                ]
+                                "enum": ["gte"]
                               }
                             ]
                           },
@@ -18255,29 +15513,16 @@
                             ]
                           }
                         },
-                        "required": [
-                          "operator",
-                          "field",
-                          "value"
-                        ]
+                        "required": ["operator", "field", "value"]
                       }
                     ]
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "CHAIN_MESSAGE"
-                    ]
+                    "enum": ["CHAIN_MESSAGE"]
                   }
                 },
-                "required": [
-                  "notificationChannelId",
-                  "name",
-                  "summary",
-                  "description",
-                  "conditions",
-                  "type"
-                ]
+                "required": ["notificationChannelId", "name", "summary", "description", "conditions", "type"]
               },
               {
                 "type": "object",
@@ -18316,10 +15561,7 @@
                         "type": "boolean"
                       }
                     },
-                    "required": [
-                      "dseq",
-                      "type"
-                    ]
+                    "required": ["dseq", "type"]
                   },
                   "conditions": {
                     "oneOf": [
@@ -18328,9 +15570,7 @@
                         "properties": {
                           "operator": {
                             "type": "string",
-                            "enum": [
-                              "and"
-                            ]
+                            "enum": ["and"]
                           },
                           "value": {
                             "type": "array",
@@ -18342,33 +15582,23 @@
                                   "oneOf": [
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "eq"
-                                      ]
+                                      "enum": ["eq"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "lt"
-                                      ]
+                                      "enum": ["lt"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "gt"
-                                      ]
+                                      "enum": ["gt"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "lte"
-                                      ]
+                                      "enum": ["lte"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "gte"
-                                      ]
+                                      "enum": ["gte"]
                                     }
                                   ]
                                 },
@@ -18389,27 +15619,18 @@
                                   ]
                                 }
                               },
-                              "required": [
-                                "operator",
-                                "field",
-                                "value"
-                              ]
+                              "required": ["operator", "field", "value"]
                             }
                           }
                         },
-                        "required": [
-                          "operator",
-                          "value"
-                        ]
+                        "required": ["operator", "value"]
                       },
                       {
                         "type": "object",
                         "properties": {
                           "operator": {
                             "type": "string",
-                            "enum": [
-                              "or"
-                            ]
+                            "enum": ["or"]
                           },
                           "value": {
                             "type": "array",
@@ -18421,33 +15642,23 @@
                                   "oneOf": [
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "eq"
-                                      ]
+                                      "enum": ["eq"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "lt"
-                                      ]
+                                      "enum": ["lt"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "gt"
-                                      ]
+                                      "enum": ["gt"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "lte"
-                                      ]
+                                      "enum": ["lte"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "gte"
-                                      ]
+                                      "enum": ["gte"]
                                     }
                                   ]
                                 },
@@ -18468,18 +15679,11 @@
                                   ]
                                 }
                               },
-                              "required": [
-                                "operator",
-                                "field",
-                                "value"
-                              ]
+                              "required": ["operator", "field", "value"]
                             }
                           }
                         },
-                        "required": [
-                          "operator",
-                          "value"
-                        ]
+                        "required": ["operator", "value"]
                       },
                       {
                         "type": "object",
@@ -18488,33 +15692,23 @@
                             "oneOf": [
                               {
                                 "type": "string",
-                                "enum": [
-                                  "eq"
-                                ]
+                                "enum": ["eq"]
                               },
                               {
                                 "type": "string",
-                                "enum": [
-                                  "lt"
-                                ]
+                                "enum": ["lt"]
                               },
                               {
                                 "type": "string",
-                                "enum": [
-                                  "gt"
-                                ]
+                                "enum": ["gt"]
                               },
                               {
                                 "type": "string",
-                                "enum": [
-                                  "lte"
-                                ]
+                                "enum": ["lte"]
                               },
                               {
                                 "type": "string",
-                                "enum": [
-                                  "gte"
-                                ]
+                                "enum": ["gte"]
                               }
                             ]
                           },
@@ -18535,29 +15729,16 @@
                             ]
                           }
                         },
-                        "required": [
-                          "operator",
-                          "field",
-                          "value"
-                        ]
+                        "required": ["operator", "field", "value"]
                       }
                     ]
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "CHAIN_EVENT"
-                    ]
+                    "enum": ["CHAIN_EVENT"]
                   }
                 },
-                "required": [
-                  "notificationChannelId",
-                  "name",
-                  "summary",
-                  "description",
-                  "conditions",
-                  "type"
-                ]
+                "required": ["notificationChannelId", "name", "summary", "description", "conditions", "type"]
               },
               {
                 "type": "object",
@@ -18584,9 +15765,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "DEPLOYMENT_BALANCE"
-                    ]
+                    "enum": ["DEPLOYMENT_BALANCE"]
                   },
                   "conditions": {
                     "oneOf": [
@@ -18595,9 +15774,7 @@
                         "properties": {
                           "operator": {
                             "type": "string",
-                            "enum": [
-                              "and"
-                            ]
+                            "enum": ["and"]
                           },
                           "value": {
                             "type": "array",
@@ -18609,67 +15786,46 @@
                                   "oneOf": [
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "eq"
-                                      ]
+                                      "enum": ["eq"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "lt"
-                                      ]
+                                      "enum": ["lt"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "gt"
-                                      ]
+                                      "enum": ["gt"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "lte"
-                                      ]
+                                      "enum": ["lte"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "gte"
-                                      ]
+                                      "enum": ["gte"]
                                     }
                                   ]
                                 },
                                 "field": {
                                   "type": "string",
-                                  "enum": [
-                                    "balance"
-                                  ]
+                                  "enum": ["balance"]
                                 },
                                 "value": {
                                   "type": "number"
                                 }
                               },
-                              "required": [
-                                "operator",
-                                "field",
-                                "value"
-                              ]
+                              "required": ["operator", "field", "value"]
                             }
                           }
                         },
-                        "required": [
-                          "operator",
-                          "value"
-                        ]
+                        "required": ["operator", "value"]
                       },
                       {
                         "type": "object",
                         "properties": {
                           "operator": {
                             "type": "string",
-                            "enum": [
-                              "or"
-                            ]
+                            "enum": ["or"]
                           },
                           "value": {
                             "type": "array",
@@ -18681,58 +15837,39 @@
                                   "oneOf": [
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "eq"
-                                      ]
+                                      "enum": ["eq"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "lt"
-                                      ]
+                                      "enum": ["lt"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "gt"
-                                      ]
+                                      "enum": ["gt"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "lte"
-                                      ]
+                                      "enum": ["lte"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "gte"
-                                      ]
+                                      "enum": ["gte"]
                                     }
                                   ]
                                 },
                                 "field": {
                                   "type": "string",
-                                  "enum": [
-                                    "balance"
-                                  ]
+                                  "enum": ["balance"]
                                 },
                                 "value": {
                                   "type": "number"
                                 }
                               },
-                              "required": [
-                                "operator",
-                                "field",
-                                "value"
-                              ]
+                              "required": ["operator", "field", "value"]
                             }
                           }
                         },
-                        "required": [
-                          "operator",
-                          "value"
-                        ]
+                        "required": ["operator", "value"]
                       },
                       {
                         "type": "object",
@@ -18741,51 +15878,35 @@
                             "oneOf": [
                               {
                                 "type": "string",
-                                "enum": [
-                                  "eq"
-                                ]
+                                "enum": ["eq"]
                               },
                               {
                                 "type": "string",
-                                "enum": [
-                                  "lt"
-                                ]
+                                "enum": ["lt"]
                               },
                               {
                                 "type": "string",
-                                "enum": [
-                                  "gt"
-                                ]
+                                "enum": ["gt"]
                               },
                               {
                                 "type": "string",
-                                "enum": [
-                                  "lte"
-                                ]
+                                "enum": ["lte"]
                               },
                               {
                                 "type": "string",
-                                "enum": [
-                                  "gte"
-                                ]
+                                "enum": ["gte"]
                               }
                             ]
                           },
                           "field": {
                             "type": "string",
-                            "enum": [
-                              "balance"
-                            ]
+                            "enum": ["balance"]
                           },
                           "value": {
                             "type": "number"
                           }
                         },
-                        "required": [
-                          "operator",
-                          "field",
-                          "value"
-                        ]
+                        "required": ["operator", "field", "value"]
                       }
                     ]
                   },
@@ -18803,21 +15924,10 @@
                         "type": "boolean"
                       }
                     },
-                    "required": [
-                      "dseq",
-                      "owner"
-                    ]
+                    "required": ["dseq", "owner"]
                   }
                 },
-                "required": [
-                  "notificationChannelId",
-                  "name",
-                  "summary",
-                  "description",
-                  "type",
-                  "conditions",
-                  "params"
-                ]
+                "required": ["notificationChannelId", "name", "summary", "description", "type", "conditions", "params"]
               },
               {
                 "type": "object",
@@ -18844,9 +15954,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "WALLET_BALANCE"
-                    ]
+                    "enum": ["WALLET_BALANCE"]
                   },
                   "conditions": {
                     "oneOf": [
@@ -18855,9 +15963,7 @@
                         "properties": {
                           "operator": {
                             "type": "string",
-                            "enum": [
-                              "and"
-                            ]
+                            "enum": ["and"]
                           },
                           "value": {
                             "type": "array",
@@ -18869,67 +15975,46 @@
                                   "oneOf": [
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "eq"
-                                      ]
+                                      "enum": ["eq"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "lt"
-                                      ]
+                                      "enum": ["lt"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "gt"
-                                      ]
+                                      "enum": ["gt"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "lte"
-                                      ]
+                                      "enum": ["lte"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "gte"
-                                      ]
+                                      "enum": ["gte"]
                                     }
                                   ]
                                 },
                                 "field": {
                                   "type": "string",
-                                  "enum": [
-                                    "balance"
-                                  ]
+                                  "enum": ["balance"]
                                 },
                                 "value": {
                                   "type": "number"
                                 }
                               },
-                              "required": [
-                                "operator",
-                                "field",
-                                "value"
-                              ]
+                              "required": ["operator", "field", "value"]
                             }
                           }
                         },
-                        "required": [
-                          "operator",
-                          "value"
-                        ]
+                        "required": ["operator", "value"]
                       },
                       {
                         "type": "object",
                         "properties": {
                           "operator": {
                             "type": "string",
-                            "enum": [
-                              "or"
-                            ]
+                            "enum": ["or"]
                           },
                           "value": {
                             "type": "array",
@@ -18941,58 +16026,39 @@
                                   "oneOf": [
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "eq"
-                                      ]
+                                      "enum": ["eq"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "lt"
-                                      ]
+                                      "enum": ["lt"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "gt"
-                                      ]
+                                      "enum": ["gt"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "lte"
-                                      ]
+                                      "enum": ["lte"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "gte"
-                                      ]
+                                      "enum": ["gte"]
                                     }
                                   ]
                                 },
                                 "field": {
                                   "type": "string",
-                                  "enum": [
-                                    "balance"
-                                  ]
+                                  "enum": ["balance"]
                                 },
                                 "value": {
                                   "type": "number"
                                 }
                               },
-                              "required": [
-                                "operator",
-                                "field",
-                                "value"
-                              ]
+                              "required": ["operator", "field", "value"]
                             }
                           }
                         },
-                        "required": [
-                          "operator",
-                          "value"
-                        ]
+                        "required": ["operator", "value"]
                       },
                       {
                         "type": "object",
@@ -19001,51 +16067,35 @@
                             "oneOf": [
                               {
                                 "type": "string",
-                                "enum": [
-                                  "eq"
-                                ]
+                                "enum": ["eq"]
                               },
                               {
                                 "type": "string",
-                                "enum": [
-                                  "lt"
-                                ]
+                                "enum": ["lt"]
                               },
                               {
                                 "type": "string",
-                                "enum": [
-                                  "gt"
-                                ]
+                                "enum": ["gt"]
                               },
                               {
                                 "type": "string",
-                                "enum": [
-                                  "lte"
-                                ]
+                                "enum": ["lte"]
                               },
                               {
                                 "type": "string",
-                                "enum": [
-                                  "gte"
-                                ]
+                                "enum": ["gte"]
                               }
                             ]
                           },
                           "field": {
                             "type": "string",
-                            "enum": [
-                              "balance"
-                            ]
+                            "enum": ["balance"]
                           },
                           "value": {
                             "type": "number"
                           }
                         },
-                        "required": [
-                          "operator",
-                          "field",
-                          "value"
-                        ]
+                        "required": ["operator", "field", "value"]
                       }
                     ]
                   },
@@ -19062,28 +16112,15 @@
                         "type": "boolean"
                       }
                     },
-                    "required": [
-                      "owner",
-                      "denom"
-                    ]
+                    "required": ["owner", "denom"]
                   }
                 },
-                "required": [
-                  "notificationChannelId",
-                  "name",
-                  "summary",
-                  "description",
-                  "type",
-                  "conditions",
-                  "params"
-                ]
+                "required": ["notificationChannelId", "name", "summary", "description", "type", "conditions", "params"]
               }
             ]
           }
         },
-        "required": [
-          "data"
-        ]
+        "required": ["data"]
       },
       "AlertOutputResponse": {
         "type": "object",
@@ -19142,10 +16179,7 @@
                         "type": "boolean"
                       }
                     },
-                    "required": [
-                      "dseq",
-                      "type"
-                    ]
+                    "required": ["dseq", "type"]
                   },
                   "conditions": {
                     "oneOf": [
@@ -19154,9 +16188,7 @@
                         "properties": {
                           "operator": {
                             "type": "string",
-                            "enum": [
-                              "and"
-                            ]
+                            "enum": ["and"]
                           },
                           "value": {
                             "type": "array",
@@ -19168,33 +16200,23 @@
                                   "oneOf": [
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "eq"
-                                      ]
+                                      "enum": ["eq"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "lt"
-                                      ]
+                                      "enum": ["lt"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "gt"
-                                      ]
+                                      "enum": ["gt"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "lte"
-                                      ]
+                                      "enum": ["lte"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "gte"
-                                      ]
+                                      "enum": ["gte"]
                                     }
                                   ]
                                 },
@@ -19215,27 +16237,18 @@
                                   ]
                                 }
                               },
-                              "required": [
-                                "operator",
-                                "field",
-                                "value"
-                              ]
+                              "required": ["operator", "field", "value"]
                             }
                           }
                         },
-                        "required": [
-                          "operator",
-                          "value"
-                        ]
+                        "required": ["operator", "value"]
                       },
                       {
                         "type": "object",
                         "properties": {
                           "operator": {
                             "type": "string",
-                            "enum": [
-                              "or"
-                            ]
+                            "enum": ["or"]
                           },
                           "value": {
                             "type": "array",
@@ -19247,33 +16260,23 @@
                                   "oneOf": [
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "eq"
-                                      ]
+                                      "enum": ["eq"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "lt"
-                                      ]
+                                      "enum": ["lt"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "gt"
-                                      ]
+                                      "enum": ["gt"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "lte"
-                                      ]
+                                      "enum": ["lte"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "gte"
-                                      ]
+                                      "enum": ["gte"]
                                     }
                                   ]
                                 },
@@ -19294,18 +16297,11 @@
                                   ]
                                 }
                               },
-                              "required": [
-                                "operator",
-                                "field",
-                                "value"
-                              ]
+                              "required": ["operator", "field", "value"]
                             }
                           }
                         },
-                        "required": [
-                          "operator",
-                          "value"
-                        ]
+                        "required": ["operator", "value"]
                       },
                       {
                         "type": "object",
@@ -19314,33 +16310,23 @@
                             "oneOf": [
                               {
                                 "type": "string",
-                                "enum": [
-                                  "eq"
-                                ]
+                                "enum": ["eq"]
                               },
                               {
                                 "type": "string",
-                                "enum": [
-                                  "lt"
-                                ]
+                                "enum": ["lt"]
                               },
                               {
                                 "type": "string",
-                                "enum": [
-                                  "gt"
-                                ]
+                                "enum": ["gt"]
                               },
                               {
                                 "type": "string",
-                                "enum": [
-                                  "lte"
-                                ]
+                                "enum": ["lte"]
                               },
                               {
                                 "type": "string",
-                                "enum": [
-                                  "gte"
-                                ]
+                                "enum": ["gte"]
                               }
                             ]
                           },
@@ -19361,19 +16347,13 @@
                             ]
                           }
                         },
-                        "required": [
-                          "operator",
-                          "field",
-                          "value"
-                        ]
+                        "required": ["operator", "field", "value"]
                       }
                     ]
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "CHAIN_MESSAGE"
-                    ]
+                    "enum": ["CHAIN_MESSAGE"]
                   }
                 },
                 "required": [
@@ -19443,10 +16423,7 @@
                         "type": "boolean"
                       }
                     },
-                    "required": [
-                      "dseq",
-                      "type"
-                    ]
+                    "required": ["dseq", "type"]
                   },
                   "conditions": {
                     "oneOf": [
@@ -19455,9 +16432,7 @@
                         "properties": {
                           "operator": {
                             "type": "string",
-                            "enum": [
-                              "and"
-                            ]
+                            "enum": ["and"]
                           },
                           "value": {
                             "type": "array",
@@ -19469,33 +16444,23 @@
                                   "oneOf": [
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "eq"
-                                      ]
+                                      "enum": ["eq"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "lt"
-                                      ]
+                                      "enum": ["lt"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "gt"
-                                      ]
+                                      "enum": ["gt"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "lte"
-                                      ]
+                                      "enum": ["lte"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "gte"
-                                      ]
+                                      "enum": ["gte"]
                                     }
                                   ]
                                 },
@@ -19516,27 +16481,18 @@
                                   ]
                                 }
                               },
-                              "required": [
-                                "operator",
-                                "field",
-                                "value"
-                              ]
+                              "required": ["operator", "field", "value"]
                             }
                           }
                         },
-                        "required": [
-                          "operator",
-                          "value"
-                        ]
+                        "required": ["operator", "value"]
                       },
                       {
                         "type": "object",
                         "properties": {
                           "operator": {
                             "type": "string",
-                            "enum": [
-                              "or"
-                            ]
+                            "enum": ["or"]
                           },
                           "value": {
                             "type": "array",
@@ -19548,33 +16504,23 @@
                                   "oneOf": [
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "eq"
-                                      ]
+                                      "enum": ["eq"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "lt"
-                                      ]
+                                      "enum": ["lt"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "gt"
-                                      ]
+                                      "enum": ["gt"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "lte"
-                                      ]
+                                      "enum": ["lte"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "gte"
-                                      ]
+                                      "enum": ["gte"]
                                     }
                                   ]
                                 },
@@ -19595,18 +16541,11 @@
                                   ]
                                 }
                               },
-                              "required": [
-                                "operator",
-                                "field",
-                                "value"
-                              ]
+                              "required": ["operator", "field", "value"]
                             }
                           }
                         },
-                        "required": [
-                          "operator",
-                          "value"
-                        ]
+                        "required": ["operator", "value"]
                       },
                       {
                         "type": "object",
@@ -19615,33 +16554,23 @@
                             "oneOf": [
                               {
                                 "type": "string",
-                                "enum": [
-                                  "eq"
-                                ]
+                                "enum": ["eq"]
                               },
                               {
                                 "type": "string",
-                                "enum": [
-                                  "lt"
-                                ]
+                                "enum": ["lt"]
                               },
                               {
                                 "type": "string",
-                                "enum": [
-                                  "gt"
-                                ]
+                                "enum": ["gt"]
                               },
                               {
                                 "type": "string",
-                                "enum": [
-                                  "lte"
-                                ]
+                                "enum": ["lte"]
                               },
                               {
                                 "type": "string",
-                                "enum": [
-                                  "gte"
-                                ]
+                                "enum": ["gte"]
                               }
                             ]
                           },
@@ -19662,19 +16591,13 @@
                             ]
                           }
                         },
-                        "required": [
-                          "operator",
-                          "field",
-                          "value"
-                        ]
+                        "required": ["operator", "field", "value"]
                       }
                     ]
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "CHAIN_EVENT"
-                    ]
+                    "enum": ["CHAIN_EVENT"]
                   }
                 },
                 "required": [
@@ -19732,9 +16655,7 @@
                   "updatedAt": {},
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "DEPLOYMENT_BALANCE"
-                    ]
+                    "enum": ["DEPLOYMENT_BALANCE"]
                   },
                   "conditions": {
                     "oneOf": [
@@ -19743,9 +16664,7 @@
                         "properties": {
                           "operator": {
                             "type": "string",
-                            "enum": [
-                              "and"
-                            ]
+                            "enum": ["and"]
                           },
                           "value": {
                             "type": "array",
@@ -19757,67 +16676,46 @@
                                   "oneOf": [
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "eq"
-                                      ]
+                                      "enum": ["eq"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "lt"
-                                      ]
+                                      "enum": ["lt"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "gt"
-                                      ]
+                                      "enum": ["gt"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "lte"
-                                      ]
+                                      "enum": ["lte"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "gte"
-                                      ]
+                                      "enum": ["gte"]
                                     }
                                   ]
                                 },
                                 "field": {
                                   "type": "string",
-                                  "enum": [
-                                    "balance"
-                                  ]
+                                  "enum": ["balance"]
                                 },
                                 "value": {
                                   "type": "number"
                                 }
                               },
-                              "required": [
-                                "operator",
-                                "field",
-                                "value"
-                              ]
+                              "required": ["operator", "field", "value"]
                             }
                           }
                         },
-                        "required": [
-                          "operator",
-                          "value"
-                        ]
+                        "required": ["operator", "value"]
                       },
                       {
                         "type": "object",
                         "properties": {
                           "operator": {
                             "type": "string",
-                            "enum": [
-                              "or"
-                            ]
+                            "enum": ["or"]
                           },
                           "value": {
                             "type": "array",
@@ -19829,58 +16727,39 @@
                                   "oneOf": [
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "eq"
-                                      ]
+                                      "enum": ["eq"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "lt"
-                                      ]
+                                      "enum": ["lt"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "gt"
-                                      ]
+                                      "enum": ["gt"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "lte"
-                                      ]
+                                      "enum": ["lte"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "gte"
-                                      ]
+                                      "enum": ["gte"]
                                     }
                                   ]
                                 },
                                 "field": {
                                   "type": "string",
-                                  "enum": [
-                                    "balance"
-                                  ]
+                                  "enum": ["balance"]
                                 },
                                 "value": {
                                   "type": "number"
                                 }
                               },
-                              "required": [
-                                "operator",
-                                "field",
-                                "value"
-                              ]
+                              "required": ["operator", "field", "value"]
                             }
                           }
                         },
-                        "required": [
-                          "operator",
-                          "value"
-                        ]
+                        "required": ["operator", "value"]
                       },
                       {
                         "type": "object",
@@ -19889,51 +16768,35 @@
                             "oneOf": [
                               {
                                 "type": "string",
-                                "enum": [
-                                  "eq"
-                                ]
+                                "enum": ["eq"]
                               },
                               {
                                 "type": "string",
-                                "enum": [
-                                  "lt"
-                                ]
+                                "enum": ["lt"]
                               },
                               {
                                 "type": "string",
-                                "enum": [
-                                  "gt"
-                                ]
+                                "enum": ["gt"]
                               },
                               {
                                 "type": "string",
-                                "enum": [
-                                  "lte"
-                                ]
+                                "enum": ["lte"]
                               },
                               {
                                 "type": "string",
-                                "enum": [
-                                  "gte"
-                                ]
+                                "enum": ["gte"]
                               }
                             ]
                           },
                           "field": {
                             "type": "string",
-                            "enum": [
-                              "balance"
-                            ]
+                            "enum": ["balance"]
                           },
                           "value": {
                             "type": "number"
                           }
                         },
-                        "required": [
-                          "operator",
-                          "field",
-                          "value"
-                        ]
+                        "required": ["operator", "field", "value"]
                       }
                     ]
                   },
@@ -19951,10 +16814,7 @@
                         "type": "boolean"
                       }
                     },
-                    "required": [
-                      "dseq",
-                      "owner"
-                    ]
+                    "required": ["dseq", "owner"]
                   }
                 },
                 "required": [
@@ -20013,9 +16873,7 @@
                   "updatedAt": {},
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "WALLET_BALANCE"
-                    ]
+                    "enum": ["WALLET_BALANCE"]
                   },
                   "conditions": {
                     "oneOf": [
@@ -20024,9 +16882,7 @@
                         "properties": {
                           "operator": {
                             "type": "string",
-                            "enum": [
-                              "and"
-                            ]
+                            "enum": ["and"]
                           },
                           "value": {
                             "type": "array",
@@ -20038,67 +16894,46 @@
                                   "oneOf": [
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "eq"
-                                      ]
+                                      "enum": ["eq"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "lt"
-                                      ]
+                                      "enum": ["lt"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "gt"
-                                      ]
+                                      "enum": ["gt"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "lte"
-                                      ]
+                                      "enum": ["lte"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "gte"
-                                      ]
+                                      "enum": ["gte"]
                                     }
                                   ]
                                 },
                                 "field": {
                                   "type": "string",
-                                  "enum": [
-                                    "balance"
-                                  ]
+                                  "enum": ["balance"]
                                 },
                                 "value": {
                                   "type": "number"
                                 }
                               },
-                              "required": [
-                                "operator",
-                                "field",
-                                "value"
-                              ]
+                              "required": ["operator", "field", "value"]
                             }
                           }
                         },
-                        "required": [
-                          "operator",
-                          "value"
-                        ]
+                        "required": ["operator", "value"]
                       },
                       {
                         "type": "object",
                         "properties": {
                           "operator": {
                             "type": "string",
-                            "enum": [
-                              "or"
-                            ]
+                            "enum": ["or"]
                           },
                           "value": {
                             "type": "array",
@@ -20110,58 +16945,39 @@
                                   "oneOf": [
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "eq"
-                                      ]
+                                      "enum": ["eq"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "lt"
-                                      ]
+                                      "enum": ["lt"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "gt"
-                                      ]
+                                      "enum": ["gt"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "lte"
-                                      ]
+                                      "enum": ["lte"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "gte"
-                                      ]
+                                      "enum": ["gte"]
                                     }
                                   ]
                                 },
                                 "field": {
                                   "type": "string",
-                                  "enum": [
-                                    "balance"
-                                  ]
+                                  "enum": ["balance"]
                                 },
                                 "value": {
                                   "type": "number"
                                 }
                               },
-                              "required": [
-                                "operator",
-                                "field",
-                                "value"
-                              ]
+                              "required": ["operator", "field", "value"]
                             }
                           }
                         },
-                        "required": [
-                          "operator",
-                          "value"
-                        ]
+                        "required": ["operator", "value"]
                       },
                       {
                         "type": "object",
@@ -20170,51 +16986,35 @@
                             "oneOf": [
                               {
                                 "type": "string",
-                                "enum": [
-                                  "eq"
-                                ]
+                                "enum": ["eq"]
                               },
                               {
                                 "type": "string",
-                                "enum": [
-                                  "lt"
-                                ]
+                                "enum": ["lt"]
                               },
                               {
                                 "type": "string",
-                                "enum": [
-                                  "gt"
-                                ]
+                                "enum": ["gt"]
                               },
                               {
                                 "type": "string",
-                                "enum": [
-                                  "lte"
-                                ]
+                                "enum": ["lte"]
                               },
                               {
                                 "type": "string",
-                                "enum": [
-                                  "gte"
-                                ]
+                                "enum": ["gte"]
                               }
                             ]
                           },
                           "field": {
                             "type": "string",
-                            "enum": [
-                              "balance"
-                            ]
+                            "enum": ["balance"]
                           },
                           "value": {
                             "type": "number"
                           }
                         },
-                        "required": [
-                          "operator",
-                          "field",
-                          "value"
-                        ]
+                        "required": ["operator", "field", "value"]
                       }
                     ]
                   },
@@ -20231,10 +17031,7 @@
                         "type": "boolean"
                       }
                     },
-                    "required": [
-                      "owner",
-                      "denom"
-                    ]
+                    "required": ["owner", "denom"]
                   }
                 },
                 "required": [
@@ -20256,9 +17053,7 @@
             ]
           }
         },
-        "required": [
-          "data"
-        ]
+        "required": ["data"]
       },
       "ValidationErrorResponse": {
         "type": "object",
@@ -20282,16 +17077,10 @@
                 }
               }
             },
-            "required": [
-              "issues"
-            ]
+            "required": ["issues"]
           }
         },
-        "required": [
-          "statusCode",
-          "message",
-          "errors"
-        ]
+        "required": ["statusCode", "message", "errors"]
       },
       "UnauthorizedErrorResponse": {
         "type": "object",
@@ -20305,10 +17094,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "statusCode",
-          "message"
-        ]
+        "required": ["statusCode", "message"]
       },
       "ForbiddenErrorResponse": {
         "type": "object",
@@ -20322,10 +17108,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "statusCode",
-          "message"
-        ]
+        "required": ["statusCode", "message"]
       },
       "InternalServerErrorResponse": {
         "type": "object",
@@ -20339,10 +17122,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "statusCode",
-          "message"
-        ]
+        "required": ["statusCode", "message"]
       },
       "AlertListOutputResponse": {
         "type": "object",
@@ -20403,10 +17183,7 @@
                           "type": "boolean"
                         }
                       },
-                      "required": [
-                        "dseq",
-                        "type"
-                      ]
+                      "required": ["dseq", "type"]
                     },
                     "conditions": {
                       "oneOf": [
@@ -20415,9 +17192,7 @@
                           "properties": {
                             "operator": {
                               "type": "string",
-                              "enum": [
-                                "and"
-                              ]
+                              "enum": ["and"]
                             },
                             "value": {
                               "type": "array",
@@ -20429,33 +17204,23 @@
                                     "oneOf": [
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "eq"
-                                        ]
+                                        "enum": ["eq"]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "lt"
-                                        ]
+                                        "enum": ["lt"]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "gt"
-                                        ]
+                                        "enum": ["gt"]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "lte"
-                                        ]
+                                        "enum": ["lte"]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "gte"
-                                        ]
+                                        "enum": ["gte"]
                                       }
                                     ]
                                   },
@@ -20476,27 +17241,18 @@
                                     ]
                                   }
                                 },
-                                "required": [
-                                  "operator",
-                                  "field",
-                                  "value"
-                                ]
+                                "required": ["operator", "field", "value"]
                               }
                             }
                           },
-                          "required": [
-                            "operator",
-                            "value"
-                          ]
+                          "required": ["operator", "value"]
                         },
                         {
                           "type": "object",
                           "properties": {
                             "operator": {
                               "type": "string",
-                              "enum": [
-                                "or"
-                              ]
+                              "enum": ["or"]
                             },
                             "value": {
                               "type": "array",
@@ -20508,33 +17264,23 @@
                                     "oneOf": [
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "eq"
-                                        ]
+                                        "enum": ["eq"]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "lt"
-                                        ]
+                                        "enum": ["lt"]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "gt"
-                                        ]
+                                        "enum": ["gt"]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "lte"
-                                        ]
+                                        "enum": ["lte"]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "gte"
-                                        ]
+                                        "enum": ["gte"]
                                       }
                                     ]
                                   },
@@ -20555,18 +17301,11 @@
                                     ]
                                   }
                                 },
-                                "required": [
-                                  "operator",
-                                  "field",
-                                  "value"
-                                ]
+                                "required": ["operator", "field", "value"]
                               }
                             }
                           },
-                          "required": [
-                            "operator",
-                            "value"
-                          ]
+                          "required": ["operator", "value"]
                         },
                         {
                           "type": "object",
@@ -20575,33 +17314,23 @@
                               "oneOf": [
                                 {
                                   "type": "string",
-                                  "enum": [
-                                    "eq"
-                                  ]
+                                  "enum": ["eq"]
                                 },
                                 {
                                   "type": "string",
-                                  "enum": [
-                                    "lt"
-                                  ]
+                                  "enum": ["lt"]
                                 },
                                 {
                                   "type": "string",
-                                  "enum": [
-                                    "gt"
-                                  ]
+                                  "enum": ["gt"]
                                 },
                                 {
                                   "type": "string",
-                                  "enum": [
-                                    "lte"
-                                  ]
+                                  "enum": ["lte"]
                                 },
                                 {
                                   "type": "string",
-                                  "enum": [
-                                    "gte"
-                                  ]
+                                  "enum": ["gte"]
                                 }
                               ]
                             },
@@ -20622,19 +17351,13 @@
                               ]
                             }
                           },
-                          "required": [
-                            "operator",
-                            "field",
-                            "value"
-                          ]
+                          "required": ["operator", "field", "value"]
                         }
                       ]
                     },
                     "type": {
                       "type": "string",
-                      "enum": [
-                        "CHAIN_MESSAGE"
-                      ]
+                      "enum": ["CHAIN_MESSAGE"]
                     }
                   },
                   "required": [
@@ -20704,10 +17427,7 @@
                           "type": "boolean"
                         }
                       },
-                      "required": [
-                        "dseq",
-                        "type"
-                      ]
+                      "required": ["dseq", "type"]
                     },
                     "conditions": {
                       "oneOf": [
@@ -20716,9 +17436,7 @@
                           "properties": {
                             "operator": {
                               "type": "string",
-                              "enum": [
-                                "and"
-                              ]
+                              "enum": ["and"]
                             },
                             "value": {
                               "type": "array",
@@ -20730,33 +17448,23 @@
                                     "oneOf": [
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "eq"
-                                        ]
+                                        "enum": ["eq"]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "lt"
-                                        ]
+                                        "enum": ["lt"]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "gt"
-                                        ]
+                                        "enum": ["gt"]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "lte"
-                                        ]
+                                        "enum": ["lte"]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "gte"
-                                        ]
+                                        "enum": ["gte"]
                                       }
                                     ]
                                   },
@@ -20777,27 +17485,18 @@
                                     ]
                                   }
                                 },
-                                "required": [
-                                  "operator",
-                                  "field",
-                                  "value"
-                                ]
+                                "required": ["operator", "field", "value"]
                               }
                             }
                           },
-                          "required": [
-                            "operator",
-                            "value"
-                          ]
+                          "required": ["operator", "value"]
                         },
                         {
                           "type": "object",
                           "properties": {
                             "operator": {
                               "type": "string",
-                              "enum": [
-                                "or"
-                              ]
+                              "enum": ["or"]
                             },
                             "value": {
                               "type": "array",
@@ -20809,33 +17508,23 @@
                                     "oneOf": [
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "eq"
-                                        ]
+                                        "enum": ["eq"]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "lt"
-                                        ]
+                                        "enum": ["lt"]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "gt"
-                                        ]
+                                        "enum": ["gt"]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "lte"
-                                        ]
+                                        "enum": ["lte"]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "gte"
-                                        ]
+                                        "enum": ["gte"]
                                       }
                                     ]
                                   },
@@ -20856,18 +17545,11 @@
                                     ]
                                   }
                                 },
-                                "required": [
-                                  "operator",
-                                  "field",
-                                  "value"
-                                ]
+                                "required": ["operator", "field", "value"]
                               }
                             }
                           },
-                          "required": [
-                            "operator",
-                            "value"
-                          ]
+                          "required": ["operator", "value"]
                         },
                         {
                           "type": "object",
@@ -20876,33 +17558,23 @@
                               "oneOf": [
                                 {
                                   "type": "string",
-                                  "enum": [
-                                    "eq"
-                                  ]
+                                  "enum": ["eq"]
                                 },
                                 {
                                   "type": "string",
-                                  "enum": [
-                                    "lt"
-                                  ]
+                                  "enum": ["lt"]
                                 },
                                 {
                                   "type": "string",
-                                  "enum": [
-                                    "gt"
-                                  ]
+                                  "enum": ["gt"]
                                 },
                                 {
                                   "type": "string",
-                                  "enum": [
-                                    "lte"
-                                  ]
+                                  "enum": ["lte"]
                                 },
                                 {
                                   "type": "string",
-                                  "enum": [
-                                    "gte"
-                                  ]
+                                  "enum": ["gte"]
                                 }
                               ]
                             },
@@ -20923,19 +17595,13 @@
                               ]
                             }
                           },
-                          "required": [
-                            "operator",
-                            "field",
-                            "value"
-                          ]
+                          "required": ["operator", "field", "value"]
                         }
                       ]
                     },
                     "type": {
                       "type": "string",
-                      "enum": [
-                        "CHAIN_EVENT"
-                      ]
+                      "enum": ["CHAIN_EVENT"]
                     }
                   },
                   "required": [
@@ -20993,9 +17659,7 @@
                     "updatedAt": {},
                     "type": {
                       "type": "string",
-                      "enum": [
-                        "DEPLOYMENT_BALANCE"
-                      ]
+                      "enum": ["DEPLOYMENT_BALANCE"]
                     },
                     "conditions": {
                       "oneOf": [
@@ -21004,9 +17668,7 @@
                           "properties": {
                             "operator": {
                               "type": "string",
-                              "enum": [
-                                "and"
-                              ]
+                              "enum": ["and"]
                             },
                             "value": {
                               "type": "array",
@@ -21018,67 +17680,46 @@
                                     "oneOf": [
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "eq"
-                                        ]
+                                        "enum": ["eq"]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "lt"
-                                        ]
+                                        "enum": ["lt"]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "gt"
-                                        ]
+                                        "enum": ["gt"]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "lte"
-                                        ]
+                                        "enum": ["lte"]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "gte"
-                                        ]
+                                        "enum": ["gte"]
                                       }
                                     ]
                                   },
                                   "field": {
                                     "type": "string",
-                                    "enum": [
-                                      "balance"
-                                    ]
+                                    "enum": ["balance"]
                                   },
                                   "value": {
                                     "type": "number"
                                   }
                                 },
-                                "required": [
-                                  "operator",
-                                  "field",
-                                  "value"
-                                ]
+                                "required": ["operator", "field", "value"]
                               }
                             }
                           },
-                          "required": [
-                            "operator",
-                            "value"
-                          ]
+                          "required": ["operator", "value"]
                         },
                         {
                           "type": "object",
                           "properties": {
                             "operator": {
                               "type": "string",
-                              "enum": [
-                                "or"
-                              ]
+                              "enum": ["or"]
                             },
                             "value": {
                               "type": "array",
@@ -21090,58 +17731,39 @@
                                     "oneOf": [
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "eq"
-                                        ]
+                                        "enum": ["eq"]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "lt"
-                                        ]
+                                        "enum": ["lt"]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "gt"
-                                        ]
+                                        "enum": ["gt"]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "lte"
-                                        ]
+                                        "enum": ["lte"]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "gte"
-                                        ]
+                                        "enum": ["gte"]
                                       }
                                     ]
                                   },
                                   "field": {
                                     "type": "string",
-                                    "enum": [
-                                      "balance"
-                                    ]
+                                    "enum": ["balance"]
                                   },
                                   "value": {
                                     "type": "number"
                                   }
                                 },
-                                "required": [
-                                  "operator",
-                                  "field",
-                                  "value"
-                                ]
+                                "required": ["operator", "field", "value"]
                               }
                             }
                           },
-                          "required": [
-                            "operator",
-                            "value"
-                          ]
+                          "required": ["operator", "value"]
                         },
                         {
                           "type": "object",
@@ -21150,51 +17772,35 @@
                               "oneOf": [
                                 {
                                   "type": "string",
-                                  "enum": [
-                                    "eq"
-                                  ]
+                                  "enum": ["eq"]
                                 },
                                 {
                                   "type": "string",
-                                  "enum": [
-                                    "lt"
-                                  ]
+                                  "enum": ["lt"]
                                 },
                                 {
                                   "type": "string",
-                                  "enum": [
-                                    "gt"
-                                  ]
+                                  "enum": ["gt"]
                                 },
                                 {
                                   "type": "string",
-                                  "enum": [
-                                    "lte"
-                                  ]
+                                  "enum": ["lte"]
                                 },
                                 {
                                   "type": "string",
-                                  "enum": [
-                                    "gte"
-                                  ]
+                                  "enum": ["gte"]
                                 }
                               ]
                             },
                             "field": {
                               "type": "string",
-                              "enum": [
-                                "balance"
-                              ]
+                              "enum": ["balance"]
                             },
                             "value": {
                               "type": "number"
                             }
                           },
-                          "required": [
-                            "operator",
-                            "field",
-                            "value"
-                          ]
+                          "required": ["operator", "field", "value"]
                         }
                       ]
                     },
@@ -21212,10 +17818,7 @@
                           "type": "boolean"
                         }
                       },
-                      "required": [
-                        "dseq",
-                        "owner"
-                      ]
+                      "required": ["dseq", "owner"]
                     }
                   },
                   "required": [
@@ -21274,9 +17877,7 @@
                     "updatedAt": {},
                     "type": {
                       "type": "string",
-                      "enum": [
-                        "WALLET_BALANCE"
-                      ]
+                      "enum": ["WALLET_BALANCE"]
                     },
                     "conditions": {
                       "oneOf": [
@@ -21285,9 +17886,7 @@
                           "properties": {
                             "operator": {
                               "type": "string",
-                              "enum": [
-                                "and"
-                              ]
+                              "enum": ["and"]
                             },
                             "value": {
                               "type": "array",
@@ -21299,67 +17898,46 @@
                                     "oneOf": [
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "eq"
-                                        ]
+                                        "enum": ["eq"]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "lt"
-                                        ]
+                                        "enum": ["lt"]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "gt"
-                                        ]
+                                        "enum": ["gt"]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "lte"
-                                        ]
+                                        "enum": ["lte"]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "gte"
-                                        ]
+                                        "enum": ["gte"]
                                       }
                                     ]
                                   },
                                   "field": {
                                     "type": "string",
-                                    "enum": [
-                                      "balance"
-                                    ]
+                                    "enum": ["balance"]
                                   },
                                   "value": {
                                     "type": "number"
                                   }
                                 },
-                                "required": [
-                                  "operator",
-                                  "field",
-                                  "value"
-                                ]
+                                "required": ["operator", "field", "value"]
                               }
                             }
                           },
-                          "required": [
-                            "operator",
-                            "value"
-                          ]
+                          "required": ["operator", "value"]
                         },
                         {
                           "type": "object",
                           "properties": {
                             "operator": {
                               "type": "string",
-                              "enum": [
-                                "or"
-                              ]
+                              "enum": ["or"]
                             },
                             "value": {
                               "type": "array",
@@ -21371,58 +17949,39 @@
                                     "oneOf": [
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "eq"
-                                        ]
+                                        "enum": ["eq"]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "lt"
-                                        ]
+                                        "enum": ["lt"]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "gt"
-                                        ]
+                                        "enum": ["gt"]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "lte"
-                                        ]
+                                        "enum": ["lte"]
                                       },
                                       {
                                         "type": "string",
-                                        "enum": [
-                                          "gte"
-                                        ]
+                                        "enum": ["gte"]
                                       }
                                     ]
                                   },
                                   "field": {
                                     "type": "string",
-                                    "enum": [
-                                      "balance"
-                                    ]
+                                    "enum": ["balance"]
                                   },
                                   "value": {
                                     "type": "number"
                                   }
                                 },
-                                "required": [
-                                  "operator",
-                                  "field",
-                                  "value"
-                                ]
+                                "required": ["operator", "field", "value"]
                               }
                             }
                           },
-                          "required": [
-                            "operator",
-                            "value"
-                          ]
+                          "required": ["operator", "value"]
                         },
                         {
                           "type": "object",
@@ -21431,51 +17990,35 @@
                               "oneOf": [
                                 {
                                   "type": "string",
-                                  "enum": [
-                                    "eq"
-                                  ]
+                                  "enum": ["eq"]
                                 },
                                 {
                                   "type": "string",
-                                  "enum": [
-                                    "lt"
-                                  ]
+                                  "enum": ["lt"]
                                 },
                                 {
                                   "type": "string",
-                                  "enum": [
-                                    "gt"
-                                  ]
+                                  "enum": ["gt"]
                                 },
                                 {
                                   "type": "string",
-                                  "enum": [
-                                    "lte"
-                                  ]
+                                  "enum": ["lte"]
                                 },
                                 {
                                   "type": "string",
-                                  "enum": [
-                                    "gte"
-                                  ]
+                                  "enum": ["gte"]
                                 }
                               ]
                             },
                             "field": {
                               "type": "string",
-                              "enum": [
-                                "balance"
-                              ]
+                              "enum": ["balance"]
                             },
                             "value": {
                               "type": "number"
                             }
                           },
-                          "required": [
-                            "operator",
-                            "field",
-                            "value"
-                          ]
+                          "required": ["operator", "field", "value"]
                         }
                       ]
                     },
@@ -21492,10 +18035,7 @@
                           "type": "boolean"
                         }
                       },
-                      "required": [
-                        "owner",
-                        "denom"
-                      ]
+                      "required": ["owner", "denom"]
                     }
                   },
                   "required": [
@@ -21549,20 +18089,10 @@
                 "type": "boolean"
               }
             },
-            "required": [
-              "page",
-              "limit",
-              "total",
-              "totalPages",
-              "hasNextPage",
-              "hasPreviousPage"
-            ]
+            "required": ["page", "limit", "total", "totalPages", "hasNextPage", "hasPreviousPage"]
           }
         },
-        "required": [
-          "data",
-          "pagination"
-        ]
+        "required": ["data", "pagination"]
       },
       "AlertPatchInput": {
         "type": "object",
@@ -21599,9 +18129,7 @@
                         "properties": {
                           "operator": {
                             "type": "string",
-                            "enum": [
-                              "and"
-                            ]
+                            "enum": ["and"]
                           },
                           "value": {
                             "type": "array",
@@ -21613,33 +18141,23 @@
                                   "oneOf": [
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "eq"
-                                      ]
+                                      "enum": ["eq"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "lt"
-                                      ]
+                                      "enum": ["lt"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "gt"
-                                      ]
+                                      "enum": ["gt"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "lte"
-                                      ]
+                                      "enum": ["lte"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "gte"
-                                      ]
+                                      "enum": ["gte"]
                                     }
                                   ]
                                 },
@@ -21660,27 +18178,18 @@
                                   ]
                                 }
                               },
-                              "required": [
-                                "operator",
-                                "field",
-                                "value"
-                              ]
+                              "required": ["operator", "field", "value"]
                             }
                           }
                         },
-                        "required": [
-                          "operator",
-                          "value"
-                        ]
+                        "required": ["operator", "value"]
                       },
                       {
                         "type": "object",
                         "properties": {
                           "operator": {
                             "type": "string",
-                            "enum": [
-                              "or"
-                            ]
+                            "enum": ["or"]
                           },
                           "value": {
                             "type": "array",
@@ -21692,33 +18201,23 @@
                                   "oneOf": [
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "eq"
-                                      ]
+                                      "enum": ["eq"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "lt"
-                                      ]
+                                      "enum": ["lt"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "gt"
-                                      ]
+                                      "enum": ["gt"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "lte"
-                                      ]
+                                      "enum": ["lte"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "gte"
-                                      ]
+                                      "enum": ["gte"]
                                     }
                                   ]
                                 },
@@ -21739,18 +18238,11 @@
                                   ]
                                 }
                               },
-                              "required": [
-                                "operator",
-                                "field",
-                                "value"
-                              ]
+                              "required": ["operator", "field", "value"]
                             }
                           }
                         },
-                        "required": [
-                          "operator",
-                          "value"
-                        ]
+                        "required": ["operator", "value"]
                       },
                       {
                         "type": "object",
@@ -21759,33 +18251,23 @@
                             "oneOf": [
                               {
                                 "type": "string",
-                                "enum": [
-                                  "eq"
-                                ]
+                                "enum": ["eq"]
                               },
                               {
                                 "type": "string",
-                                "enum": [
-                                  "lt"
-                                ]
+                                "enum": ["lt"]
                               },
                               {
                                 "type": "string",
-                                "enum": [
-                                  "gt"
-                                ]
+                                "enum": ["gt"]
                               },
                               {
                                 "type": "string",
-                                "enum": [
-                                  "lte"
-                                ]
+                                "enum": ["lte"]
                               },
                               {
                                 "type": "string",
-                                "enum": [
-                                  "gte"
-                                ]
+                                "enum": ["gte"]
                               }
                             ]
                           },
@@ -21806,11 +18288,7 @@
                             ]
                           }
                         },
-                        "required": [
-                          "operator",
-                          "field",
-                          "value"
-                        ]
+                        "required": ["operator", "field", "value"]
                       }
                     ]
                   },
@@ -21821,9 +18299,7 @@
                         "properties": {
                           "operator": {
                             "type": "string",
-                            "enum": [
-                              "and"
-                            ]
+                            "enum": ["and"]
                           },
                           "value": {
                             "type": "array",
@@ -21835,67 +18311,46 @@
                                   "oneOf": [
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "eq"
-                                      ]
+                                      "enum": ["eq"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "lt"
-                                      ]
+                                      "enum": ["lt"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "gt"
-                                      ]
+                                      "enum": ["gt"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "lte"
-                                      ]
+                                      "enum": ["lte"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "gte"
-                                      ]
+                                      "enum": ["gte"]
                                     }
                                   ]
                                 },
                                 "field": {
                                   "type": "string",
-                                  "enum": [
-                                    "balance"
-                                  ]
+                                  "enum": ["balance"]
                                 },
                                 "value": {
                                   "type": "number"
                                 }
                               },
-                              "required": [
-                                "operator",
-                                "field",
-                                "value"
-                              ]
+                              "required": ["operator", "field", "value"]
                             }
                           }
                         },
-                        "required": [
-                          "operator",
-                          "value"
-                        ]
+                        "required": ["operator", "value"]
                       },
                       {
                         "type": "object",
                         "properties": {
                           "operator": {
                             "type": "string",
-                            "enum": [
-                              "or"
-                            ]
+                            "enum": ["or"]
                           },
                           "value": {
                             "type": "array",
@@ -21907,58 +18362,39 @@
                                   "oneOf": [
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "eq"
-                                      ]
+                                      "enum": ["eq"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "lt"
-                                      ]
+                                      "enum": ["lt"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "gt"
-                                      ]
+                                      "enum": ["gt"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "lte"
-                                      ]
+                                      "enum": ["lte"]
                                     },
                                     {
                                       "type": "string",
-                                      "enum": [
-                                        "gte"
-                                      ]
+                                      "enum": ["gte"]
                                     }
                                   ]
                                 },
                                 "field": {
                                   "type": "string",
-                                  "enum": [
-                                    "balance"
-                                  ]
+                                  "enum": ["balance"]
                                 },
                                 "value": {
                                   "type": "number"
                                 }
                               },
-                              "required": [
-                                "operator",
-                                "field",
-                                "value"
-                              ]
+                              "required": ["operator", "field", "value"]
                             }
                           }
                         },
-                        "required": [
-                          "operator",
-                          "value"
-                        ]
+                        "required": ["operator", "value"]
                       },
                       {
                         "type": "object",
@@ -21967,51 +18403,35 @@
                             "oneOf": [
                               {
                                 "type": "string",
-                                "enum": [
-                                  "eq"
-                                ]
+                                "enum": ["eq"]
                               },
                               {
                                 "type": "string",
-                                "enum": [
-                                  "lt"
-                                ]
+                                "enum": ["lt"]
                               },
                               {
                                 "type": "string",
-                                "enum": [
-                                  "gt"
-                                ]
+                                "enum": ["gt"]
                               },
                               {
                                 "type": "string",
-                                "enum": [
-                                  "lte"
-                                ]
+                                "enum": ["lte"]
                               },
                               {
                                 "type": "string",
-                                "enum": [
-                                  "gte"
-                                ]
+                                "enum": ["gte"]
                               }
                             ]
                           },
                           "field": {
                             "type": "string",
-                            "enum": [
-                              "balance"
-                            ]
+                            "enum": ["balance"]
                           },
                           "value": {
                             "type": "number"
                           }
                         },
-                        "required": [
-                          "operator",
-                          "field",
-                          "value"
-                        ]
+                        "required": ["operator", "field", "value"]
                       }
                     ]
                   }
@@ -22020,9 +18440,7 @@
             }
           }
         },
-        "required": [
-          "data"
-        ]
+        "required": ["data"]
       },
       "NotificationChannelCreateInput": {
         "type": "object",
@@ -22035,9 +18453,7 @@
               },
               "type": {
                 "type": "string",
-                "enum": [
-                  "email"
-                ]
+                "enum": ["email"]
               },
               "config": {
                 "type": "object",
@@ -22050,24 +18466,16 @@
                     }
                   }
                 },
-                "required": [
-                  "addresses"
-                ]
+                "required": ["addresses"]
               },
               "isDefault": {
                 "type": "boolean"
               }
             },
-            "required": [
-              "name",
-              "type",
-              "config"
-            ]
+            "required": ["name", "type", "config"]
           }
         },
-        "required": [
-          "data"
-        ]
+        "required": ["data"]
       },
       "NotificationChannelOutput": {
         "type": "object",
@@ -22080,9 +18488,7 @@
               },
               "type": {
                 "type": "string",
-                "enum": [
-                  "email"
-                ]
+                "enum": ["email"]
               },
               "config": {
                 "type": "object",
@@ -22095,9 +18501,7 @@
                     }
                   }
                 },
-                "required": [
-                  "addresses"
-                ]
+                "required": ["addresses"]
               },
               "isDefault": {
                 "type": "boolean"
@@ -22113,21 +18517,10 @@
               "createdAt": {},
               "updatedAt": {}
             },
-            "required": [
-              "name",
-              "type",
-              "config",
-              "isDefault",
-              "id",
-              "userId",
-              "createdAt",
-              "updatedAt"
-            ]
+            "required": ["name", "type", "config", "isDefault", "id", "userId", "createdAt", "updatedAt"]
           }
         },
-        "required": [
-          "data"
-        ]
+        "required": ["data"]
       },
       "NotificationChannelCreateDefaultInput": {
         "type": "object",
@@ -22140,9 +18533,7 @@
               },
               "type": {
                 "type": "string",
-                "enum": [
-                  "email"
-                ]
+                "enum": ["email"]
               },
               "config": {
                 "type": "object",
@@ -22155,21 +18546,13 @@
                     }
                   }
                 },
-                "required": [
-                  "addresses"
-                ]
+                "required": ["addresses"]
               }
             },
-            "required": [
-              "name",
-              "type",
-              "config"
-            ]
+            "required": ["name", "type", "config"]
           }
         },
-        "required": [
-          "data"
-        ]
+        "required": ["data"]
       },
       "NotFoundErrorResponse": {
         "type": "object",
@@ -22183,10 +18566,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "statusCode",
-          "message"
-        ]
+        "required": ["statusCode", "message"]
       },
       "NotificationChannelListOutput": {
         "type": "object",
@@ -22201,9 +18581,7 @@
                 },
                 "type": {
                   "type": "string",
-                  "enum": [
-                    "email"
-                  ]
+                  "enum": ["email"]
                 },
                 "config": {
                   "type": "object",
@@ -22216,9 +18594,7 @@
                       }
                     }
                   },
-                  "required": [
-                    "addresses"
-                  ]
+                  "required": ["addresses"]
                 },
                 "isDefault": {
                   "type": "boolean"
@@ -22234,16 +18610,7 @@
                 "createdAt": {},
                 "updatedAt": {}
               },
-              "required": [
-                "name",
-                "type",
-                "config",
-                "isDefault",
-                "id",
-                "userId",
-                "createdAt",
-                "updatedAt"
-              ]
+              "required": ["name", "type", "config", "isDefault", "id", "userId", "createdAt", "updatedAt"]
             }
           },
           "pagination": {
@@ -22278,20 +18645,10 @@
                 "type": "boolean"
               }
             },
-            "required": [
-              "page",
-              "limit",
-              "total",
-              "totalPages",
-              "hasNextPage",
-              "hasPreviousPage"
-            ]
+            "required": ["page", "limit", "total", "totalPages", "hasNextPage", "hasPreviousPage"]
           }
         },
-        "required": [
-          "data",
-          "pagination"
-        ]
+        "required": ["data", "pagination"]
       },
       "NotificationChannelPatchInput": {
         "type": "object",
@@ -22304,9 +18661,7 @@
               },
               "type": {
                 "type": "string",
-                "enum": [
-                  "email"
-                ]
+                "enum": ["email"]
               },
               "config": {
                 "type": "object",
@@ -22319,16 +18674,12 @@
                     }
                   }
                 },
-                "required": [
-                  "addresses"
-                ]
+                "required": ["addresses"]
               }
             }
           }
         },
-        "required": [
-          "data"
-        ]
+        "required": ["data"]
       },
       "DeploymentAlertCreateInput": {
         "type": "object",
@@ -22356,10 +18707,7 @@
                         "exclusiveMinimum": false
                       }
                     },
-                    "required": [
-                      "notificationChannelId",
-                      "threshold"
-                    ]
+                    "required": ["notificationChannelId", "threshold"]
                   },
                   "deploymentClosed": {
                     "type": "object",
@@ -22373,21 +18721,15 @@
                         "default": true
                       }
                     },
-                    "required": [
-                      "notificationChannelId"
-                    ]
+                    "required": ["notificationChannelId"]
                   }
                 }
               }
             },
-            "required": [
-              "alerts"
-            ]
+            "required": ["alerts"]
           }
         },
-        "required": [
-          "data"
-        ]
+        "required": ["data"]
       },
       "DeploymentAlertsResponse": {
         "type": "object",
@@ -22431,12 +18773,7 @@
                         "type": "boolean"
                       }
                     },
-                    "required": [
-                      "notificationChannelId",
-                      "threshold",
-                      "id",
-                      "status"
-                    ]
+                    "required": ["notificationChannelId", "threshold", "id", "status"]
                   },
                   "deploymentClosed": {
                     "type": "object",
@@ -22460,24 +18797,15 @@
                         "type": "boolean"
                       }
                     },
-                    "required": [
-                      "notificationChannelId",
-                      "id",
-                      "status"
-                    ]
+                    "required": ["notificationChannelId", "id", "status"]
                   }
                 }
               }
             },
-            "required": [
-              "dseq",
-              "alerts"
-            ]
+            "required": ["dseq", "alerts"]
           }
         },
-        "required": [
-          "data"
-        ]
+        "required": ["data"]
       }
     },
     "securitySchemes": {

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -15012,6 +15012,14 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                         "autoReloadEnabled": {
                           "type": "boolean",
                         },
+                        "autoReloadMode": {
+                          "description": "Rule used to decide when and how much to top up.",
+                          "enum": [
+                            "threshold",
+                            "prediction",
+                          ],
+                          "type": "string",
+                        },
                         "autoReloadThreshold": {
                           "description": "USD credit balance at or below which an automatic top-up is triggered.",
                           "type": "number",
@@ -15019,6 +15027,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                       },
                       "required": [
                         "autoReloadEnabled",
+                        "autoReloadMode",
                         "autoReloadThreshold",
                         "autoReloadAmount",
                       ],
@@ -15070,6 +15079,14 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                       "autoReloadEnabled": {
                         "type": "boolean",
                       },
+                      "autoReloadMode": {
+                        "description": "Rule used to decide when and how much to top up: \`threshold\` charges the fixed amount as soon as the balance reaches the threshold, \`prediction\` covers the next 7 days of projected spend. Left unchanged when omitted.",
+                        "enum": [
+                          "threshold",
+                          "prediction",
+                        ],
+                        "type": "string",
+                      },
                       "autoReloadThreshold": {
                         "description": "USD credit balance at or below which an automatic top-up is triggered (minimum 5, maximum 10000). Defaults are applied on create when omitted.",
                         "maximum": 10000,
@@ -15106,6 +15123,14 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                         "autoReloadEnabled": {
                           "type": "boolean",
                         },
+                        "autoReloadMode": {
+                          "description": "Rule used to decide when and how much to top up.",
+                          "enum": [
+                            "threshold",
+                            "prediction",
+                          ],
+                          "type": "string",
+                        },
                         "autoReloadThreshold": {
                           "description": "USD credit balance at or below which an automatic top-up is triggered.",
                           "type": "number",
@@ -15113,6 +15138,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                       },
                       "required": [
                         "autoReloadEnabled",
+                        "autoReloadMode",
                         "autoReloadThreshold",
                         "autoReloadAmount",
                       ],
@@ -15164,6 +15190,14 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                       "autoReloadEnabled": {
                         "type": "boolean",
                       },
+                      "autoReloadMode": {
+                        "description": "Rule used to decide when and how much to top up: \`threshold\` charges the fixed amount as soon as the balance reaches the threshold, \`prediction\` covers the next 7 days of projected spend. Left unchanged when omitted.",
+                        "enum": [
+                          "threshold",
+                          "prediction",
+                        ],
+                        "type": "string",
+                      },
                       "autoReloadThreshold": {
                         "description": "USD credit balance at or below which an automatic top-up is triggered (minimum 5, maximum 10000). Defaults are applied on create when omitted.",
                         "maximum": 10000,
@@ -15200,6 +15234,14 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                         "autoReloadEnabled": {
                           "type": "boolean",
                         },
+                        "autoReloadMode": {
+                          "description": "Rule used to decide when and how much to top up.",
+                          "enum": [
+                            "threshold",
+                            "prediction",
+                          ],
+                          "type": "string",
+                        },
                         "autoReloadThreshold": {
                           "description": "USD credit balance at or below which an automatic top-up is triggered.",
                           "type": "number",
@@ -15207,6 +15249,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                       },
                       "required": [
                         "autoReloadEnabled",
+                        "autoReloadMode",
                         "autoReloadThreshold",
                         "autoReloadAmount",
                       ],

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -15080,7 +15080,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                         "type": "boolean",
                       },
                       "autoReloadMode": {
-                        "description": "Rule used to decide when and how much to top up: \`threshold\` charges the fixed amount as soon as the balance reaches the threshold, \`prediction\` covers the next 7 days of projected spend. Left unchanged when omitted.",
+                        "description": "Rule used to decide when and how much to top up: \`threshold\` charges the fixed amount as soon as the balance reaches the threshold, \`prediction\` covers the next 7 days of projected spend. Defaults to \`prediction\` on create when omitted; left unchanged on update.",
                         "enum": [
                           "threshold",
                           "prediction",
@@ -15191,7 +15191,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                         "type": "boolean",
                       },
                       "autoReloadMode": {
-                        "description": "Rule used to decide when and how much to top up: \`threshold\` charges the fixed amount as soon as the balance reaches the threshold, \`prediction\` covers the next 7 days of projected spend. Left unchanged when omitted.",
+                        "description": "Rule used to decide when and how much to top up: \`threshold\` charges the fixed amount as soon as the balance reaches the threshold, \`prediction\` covers the next 7 days of projected spend. Defaults to \`prediction\` on create when omitted; left unchanged on update.",
                         "enum": [
                           "threshold",
                           "prediction",

--- a/apps/api/test/functional/wallet-settings.spec.ts
+++ b/apps/api/test/functional/wallet-settings.spec.ts
@@ -66,6 +66,18 @@ describe("Wallet Settings", () => {
       expect(response.status).toBe(400);
     });
 
+    it("returns 400 when autoReloadMode is not a known mode", async () => {
+      const { token } = await setup();
+
+      const response = await app.request("/v1/wallet-settings", {
+        method: "PUT",
+        headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+        body: JSON.stringify({ data: { autoReloadEnabled: true, autoReloadMode: "fixed" } })
+      });
+
+      expect(response.status).toBe(400);
+    });
+
     it("returns 400 when autoReloadThreshold exceeds the maximum", async () => {
       const { token } = await setup();
 

--- a/apps/api/test/seeders/wallet-setting.seeder.ts
+++ b/apps/api/test/seeders/wallet-setting.seeder.ts
@@ -8,6 +8,7 @@ export const generateWalletSetting = (overrides: Partial<WalletSettingOutput>) =
     userId: faker.string.uuid(),
     walletId: faker.number.int({ min: 1, max: 1000 }),
     autoReloadEnabled: faker.datatype.boolean(),
+    autoReloadMode: "prediction" as const,
     autoReloadThreshold: faker.number.int({ min: 500, max: 100000 }),
     autoReloadAmount: faker.number.int({ min: 2000, max: 100000 }),
     createdAt: faker.date.recent(),

--- a/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/AccountBalanceOverview.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/AccountBalanceOverview.spec.tsx
@@ -115,22 +115,22 @@ describe(AccountBalanceOverview.name, () => {
     expect(screen.getByRole("link", { name: /llama-chat/ })).toHaveAttribute("href", UrlService.deploymentDetails("42"));
   });
 
-  it("reassures when auto recharge is on", () => {
+  it("reassures when automatic top-ups are on", () => {
     setup({ autoReloadEnabled: true });
 
-    expect(screen.getByText(/Auto Recharge is on/)).toBeInTheDocument();
+    expect(screen.getByText(/Automatic top-ups are on/)).toBeInTheDocument();
   });
 
-  it("stays quiet about auto recharge when it is off", () => {
+  it("stays quiet about automatic top-ups when they are off", () => {
     setup({ autoReloadEnabled: false });
 
-    expect(screen.queryByText(/Auto Recharge is on/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Automatic top-ups are on/)).not.toBeInTheDocument();
   });
 
-  it("hides the auto recharge line when the bar already surfaces the top-up threshold", () => {
+  it("hides the reassurance line when the bar already surfaces the top-up threshold", () => {
     setup({ autoReloadEnabled: true, autoReloadThreshold: 275 });
 
-    expect(screen.queryByText(/Auto Recharge is on/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Automatic top-ups are on/)).not.toBeInTheDocument();
   });
 
   it("renders a skeleton instead of balance while loading", () => {

--- a/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/AccountBalanceOverview.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/AccountBalanceOverview.tsx
@@ -172,7 +172,7 @@ export const AccountBalanceOverview: React.FunctionComponent<{ dependencies?: ty
         )}
 
         {overview.autoReloadThreshold == null && overview.autoReloadEnabled && (
-          <p className="text-sm text-success">Auto Recharge is on. Your deployments stay funded.</p>
+          <p className="text-sm text-success">Automatic top-ups are on. Your deployments stay funded.</p>
         )}
       </d.CardContent>
     </d.Card>

--- a/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/useAccountBalanceOverview.spec.ts
+++ b/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/useAccountBalanceOverview.spec.ts
@@ -1,10 +1,16 @@
 import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
 
 import { UACT_DENOM, UAKT_DENOM } from "@src/config/denom.config";
+import type { Balances } from "@src/types";
+import type { LeaseDto } from "@src/types/deployment";
 import { LIVE_LEASE_STATES } from "@src/utils/leaseUtils";
-import { DEPENDENCIES, useAccountBalanceOverview } from "./useAccountBalanceOverview";
+import type { DEPENDENCIES } from "./useAccountBalanceOverview";
+import { useAccountBalanceOverview } from "./useAccountBalanceOverview";
 
 import { renderHook } from "@testing-library/react";
+
+type WalletSettings = NonNullable<ReturnType<typeof DEPENDENCIES.useWalletSettingsQuery>["data"]>;
 
 describe(useAccountBalanceOverview.name, () => {
   it("splits total into available and reserved", () => {
@@ -176,7 +182,7 @@ describe(useAccountBalanceOverview.name, () => {
     }));
     const reservedTotal = reservedDeployments.reduce((sum, deployment) => sum + deployment.fundsUsd, 0);
 
-    const balances = {
+    const balances = Object.assign(mock<Balances>(), {
       balanceUAKT: 0,
       balanceUUSDC: 0,
       balanceUACT: (input.totalUsd ?? 0) - reservedTotal,
@@ -188,48 +194,66 @@ describe(useAccountBalanceOverview.name, () => {
       deploymentGrantsUACT: 0,
       activeDeployments,
       deploymentGrants: []
-    };
+    });
 
-    const leases = input.leases
-      ? input.leases.map(lease => ({
-          dseq: lease.dseq,
-          state: lease.state ?? "active",
-          price: { denom: UACT_DENOM, amount: lease.amount ?? "1000000" }
-        }))
-      : input.hasLiveLease
-        ? [{ state: "active", price: { denom: UACT_DENOM, amount: "1000000" } }]
-        : [];
+    const leaseFixtures = input.leases ?? (input.hasLiveLease ? [{ dseq: "live", amount: "1000000" }] : []);
+    const leases = leaseFixtures.map(lease =>
+      Object.assign(mock<LeaseDto>(), {
+        dseq: lease.dseq,
+        state: lease.state ?? "active",
+        price: { denom: UACT_DENOM, amount: lease.amount ?? "1000000" }
+      })
+    );
 
-    const dependencies = {
-      ...DEPENDENCIES,
-      useWallet: () => ({ address: "akash1abc" }),
-      usePricing: () => ({
+    const useWallet: typeof DEPENDENCIES.useWallet = () => Object.assign(mock<ReturnType<typeof DEPENDENCIES.useWallet>>(), { address: "akash1abc" });
+
+    const udenomToUsd = (amount: string | number) => Number(amount);
+    const usePricing: typeof DEPENDENCIES.usePricing = () =>
+      Object.assign(mock<ReturnType<typeof DEPENDENCIES.usePricing>>(), {
         price: input.priceUnavailable ? undefined : 1,
         isLoaded: !input.priceUnavailable,
-        udenomToUsd: (amount: string | number) => Number(amount)
-      }),
-      useAutoReloadMode: () => ({
-        mode: input.autoReloadMode ?? "prediction",
-        isThresholdModeOffered: input.autoReloadMode === "threshold",
-        showsThresholdRule: input.autoReloadMode === "threshold",
-        isLoading: false
-      }),
-      useBalances: () => ({
-        data: input.balancesMissing ? undefined : balances,
-        isError: input.balancesError ?? false,
-        fetchStatus: input.balancesIdle ? "idle" : "fetching"
-      }),
-      useAllLeases: vi.fn(() => ({ data: leases })),
-      useWalletSettingsQuery: () => ({
-        data: {
-          autoReloadEnabled: input.autoReloadEnabled ?? false,
-          autoReloadMode: input.autoReloadMode ?? "prediction",
-          autoReloadThreshold: input.autoReloadThreshold
-        }
-      }),
-      useLocalNotes: () => ({ getDeploymentName: (dseq: string | number | null) => input.names?.[String(dseq)] ?? null })
-    } as unknown as typeof DEPENDENCIES;
+        udenomToUsd
+      });
 
-    return { ...renderHook(() => useAccountBalanceOverview({ dependencies })), useAllLeases: dependencies.useAllLeases };
+    const useAutoReloadMode: typeof DEPENDENCIES.useAutoReloadMode = () => ({
+      mode: input.autoReloadMode ?? "prediction",
+      isThresholdModeOffered: input.autoReloadMode === "threshold",
+      showsThresholdRule: input.autoReloadMode === "threshold",
+      isLoading: false
+    });
+
+    const balancesQuery = Object.assign(mock<ReturnType<typeof DEPENDENCIES.useBalances>>(), {
+      data: input.balancesMissing ? undefined : balances,
+      isError: input.balancesError ?? false,
+      fetchStatus: input.balancesIdle ? ("idle" as const) : ("fetching" as const)
+    });
+    const useBalances: typeof DEPENDENCIES.useBalances = () => balancesQuery;
+
+    const leasesQuery = Object.assign(mock<ReturnType<typeof DEPENDENCIES.useAllLeases>>(), { data: leases });
+    const useAllLeases = vi.fn<typeof DEPENDENCIES.useAllLeases>(() => leasesQuery);
+
+    const walletSettingsQuery = Object.assign(mock<ReturnType<typeof DEPENDENCIES.useWalletSettingsQuery>>(), {
+      data: Object.assign(mock<WalletSettings>(), {
+        autoReloadEnabled: input.autoReloadEnabled ?? false,
+        autoReloadMode: input.autoReloadMode ?? ("prediction" as const),
+        autoReloadThreshold: input.autoReloadThreshold
+      })
+    });
+    const useWalletSettingsQuery: typeof DEPENDENCIES.useWalletSettingsQuery = () => walletSettingsQuery;
+
+    const getDeploymentName = (dseq: string | number | null) => input.names?.[String(dseq)] ?? null;
+    const useLocalNotes: typeof DEPENDENCIES.useLocalNotes = () => Object.assign(mock<ReturnType<typeof DEPENDENCIES.useLocalNotes>>(), { getDeploymentName });
+
+    const dependencies: typeof DEPENDENCIES = {
+      useWallet,
+      usePricing,
+      useAutoReloadMode,
+      useBalances,
+      useAllLeases,
+      useWalletSettingsQuery,
+      useLocalNotes
+    };
+
+    return { ...renderHook(() => useAccountBalanceOverview({ dependencies })), useAllLeases };
   }
 });

--- a/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/useAccountBalanceOverview.spec.ts
+++ b/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/useAccountBalanceOverview.spec.ts
@@ -100,20 +100,20 @@ describe(useAccountBalanceOverview.name, () => {
     expect(result.current.autoReloadEnabled).toBe(true);
   });
 
-  it("exposes the auto reload threshold when the fixed-threshold flag and auto reload are both on", () => {
-    const { result } = setup({ fixedThresholdEnabled: true, autoReloadEnabled: true, autoReloadThreshold: 275 });
+  it("exposes the auto reload threshold in threshold mode when auto reload is on", () => {
+    const { result } = setup({ autoReloadMode: "threshold", autoReloadEnabled: true, autoReloadThreshold: 275 });
 
     expect(result.current.autoReloadThreshold).toBe(275);
   });
 
-  it("hides the auto reload threshold when the fixed-threshold flag is off", () => {
-    const { result } = setup({ fixedThresholdEnabled: false, autoReloadEnabled: true, autoReloadThreshold: 275 });
+  it("hides the auto reload threshold in prediction mode", () => {
+    const { result } = setup({ autoReloadMode: "prediction", autoReloadEnabled: true, autoReloadThreshold: 275 });
 
     expect(result.current.autoReloadThreshold).toBeNull();
   });
 
   it("hides the auto reload threshold when auto reload is off", () => {
-    const { result } = setup({ fixedThresholdEnabled: true, autoReloadEnabled: false, autoReloadThreshold: 275 });
+    const { result } = setup({ autoReloadMode: "threshold", autoReloadEnabled: false, autoReloadThreshold: 275 });
 
     expect(result.current.autoReloadThreshold).toBeNull();
   });
@@ -163,7 +163,7 @@ describe(useAccountBalanceOverview.name, () => {
     hasLiveLease?: boolean;
     autoReloadEnabled?: boolean;
     autoReloadThreshold?: number;
-    fixedThresholdEnabled?: boolean;
+    autoReloadMode?: "prediction" | "threshold";
     balancesMissing?: boolean;
     balancesError?: boolean;
     balancesIdle?: boolean;
@@ -208,14 +208,25 @@ describe(useAccountBalanceOverview.name, () => {
         isLoaded: !input.priceUnavailable,
         udenomToUsd: (amount: string | number) => Number(amount)
       }),
-      useFlag: () => input.fixedThresholdEnabled ?? false,
+      useAutoReloadMode: () => ({
+        mode: input.autoReloadMode ?? "prediction",
+        isThresholdModeOffered: input.autoReloadMode === "threshold",
+        showsThresholdRule: input.autoReloadMode === "threshold",
+        isLoading: false
+      }),
       useBalances: () => ({
         data: input.balancesMissing ? undefined : balances,
         isError: input.balancesError ?? false,
         fetchStatus: input.balancesIdle ? "idle" : "fetching"
       }),
       useAllLeases: vi.fn(() => ({ data: leases })),
-      useWalletSettingsQuery: () => ({ data: { autoReloadEnabled: input.autoReloadEnabled ?? false, autoReloadThreshold: input.autoReloadThreshold } }),
+      useWalletSettingsQuery: () => ({
+        data: {
+          autoReloadEnabled: input.autoReloadEnabled ?? false,
+          autoReloadMode: input.autoReloadMode ?? "prediction",
+          autoReloadThreshold: input.autoReloadThreshold
+        }
+      }),
       useLocalNotes: () => ({ getDeploymentName: (dseq: string | number | null) => input.names?.[String(dseq)] ?? null })
     } as unknown as typeof DEPENDENCIES;
 

--- a/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/useAccountBalanceOverview.ts
+++ b/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/useAccountBalanceOverview.ts
@@ -2,9 +2,9 @@
 import { useMemo } from "react";
 import differenceInCalendarDays from "date-fns/differenceInCalendarDays";
 
+import { useAutoReloadMode } from "@src/components/billing-usage/useAutoReloadMode";
 import { useLocalNotes } from "@src/components/LocalNoteManager/useLocalNotes";
 import { useWallet } from "@src/context/WalletProvider";
-import { useFlag } from "@src/hooks/useFlag";
 import { usePricing } from "@src/hooks/usePricing/usePricing";
 import { computeWalletBalance } from "@src/hooks/useWalletBalance";
 import { useWalletSettingsQuery } from "@src/queries";
@@ -16,7 +16,7 @@ import { getLeasesCostPerBlockUsd, getTimeLeft, perBlockToHourly } from "@src/ut
 export const DEPENDENCIES = {
   useWallet,
   usePricing,
-  useFlag,
+  useAutoReloadMode,
   useBalances,
   useAllLeases,
   useWalletSettingsQuery,
@@ -40,7 +40,7 @@ export type AccountBalanceOverview = {
   lastsUntil: Date | null;
   runwayDays: number | null;
   autoReloadEnabled: boolean;
-  /** The auto-top-up trigger balance to mark on the bar, or null when no marker should render (flag off, auto-reload off, or unset). */
+  /** The auto-top-up trigger balance to mark on the bar, or null when no marker should render (prediction mode, auto-reload off, or unset). */
   autoReloadThreshold: number | null;
   isLoading: boolean;
   /** True when balances can't be loaded: the query errored out or the chain API fallback disabled it. */
@@ -54,7 +54,7 @@ export function useAccountBalanceOverview({ dependencies: d = DEPENDENCIES }: { 
   const { data: leases } = d.useAllLeases(address, { state: LIVE_LEASE_STATES, enabled: !!address });
   const { data: walletSettings } = d.useWalletSettingsQuery();
   const { getDeploymentName } = d.useLocalNotes();
-  const isFixedThresholdEnabled = d.useFlag("auto_reload_fixed_threshold");
+  const { showsThresholdRule } = d.useAutoReloadMode();
 
   /** Not gated on the AKT market price: managed wallets hold ACT/USDC (1:1 USD), and blocking on market data would strand the card on its skeleton during an outage. */
   const walletBalance = useMemo(() => (balances ? computeWalletBalance(balances, price ?? 0, udenomToUsd) : null), [balances, price, udenomToUsd]);
@@ -92,7 +92,7 @@ export function useAccountBalanceOverview({ dependencies: d = DEPENDENCIES }: { 
   const lastsUntil = hasSpend ? getTimeLeft(spend.perBlockUsd, totalUsd) : null;
   const autoReloadEnabled = walletSettings?.autoReloadEnabled ?? false;
   const isBalanceUnavailable = !balances && (isBalancesError || (!!address && balancesFetchStatus === "idle"));
-  const autoReloadThreshold = isFixedThresholdEnabled && autoReloadEnabled ? walletSettings?.autoReloadThreshold ?? null : null;
+  const autoReloadThreshold = showsThresholdRule && autoReloadEnabled ? walletSettings?.autoReloadThreshold ?? null : null;
 
   return {
     totalUsd,

--- a/apps/deploy-web/src/components/billing-usage/AutoTopUpSection/AutoTopUpSection.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AutoTopUpSection/AutoTopUpSection.spec.tsx
@@ -6,23 +6,29 @@ import { act, fireEvent, render, screen } from "@testing-library/react";
 import { MockComponents } from "@tests/unit/mocks";
 
 describe(AutoTopUpSection.name, () => {
-  it("shows the weekly recharge estimate when the fixed-threshold flag is off", () => {
-    setup({ isFixedThresholdEnabled: false, defaultPaymentMethod: { id: "pm_123" }, weeklyCost: 42 });
+  it("shows the weekly recharge estimate when threshold mode is not offered", () => {
+    setup({ isThresholdModeOffered: false, defaultPaymentMethod: { id: "pm_123" }, weeklyCost: 42 });
 
     expect(screen.getByText("Auto Recharge")).toBeInTheDocument();
     expect(screen.getByText(/per week/)).toHaveTextContent("42");
   });
 
-  describe("when the fixed-threshold flag is enabled", () => {
+  it("runs the weekly cost query without waiting for wallet settings when threshold mode is not offered", () => {
+    const { dependencies } = setup({ isThresholdModeOffered: false, defaultPaymentMethod: { id: "pm_123" }, isWalletSettingsLoading: true });
+
+    expect(dependencies.useWeeklyDeploymentCostQuery).toHaveBeenCalledWith({ enabled: true });
+  });
+
+  describe("when threshold mode is offered", () => {
     it("renders the Auto Top-Up title", () => {
-      setup({ isFixedThresholdEnabled: true, defaultPaymentMethod: { id: "pm_123" } });
+      setup({ isThresholdModeOffered: true, defaultPaymentMethod: { id: "pm_123" } });
 
       expect(screen.getByText("Auto Top-Up")).toBeInTheDocument();
     });
 
     it("shows the threshold and top-up amounts when enabled", () => {
       setup({
-        isFixedThresholdEnabled: true,
+        isThresholdModeOffered: true,
         defaultPaymentMethod: { id: "pm_123" },
         walletSettings: { autoReloadEnabled: true, autoReloadThreshold: 20, autoReloadAmount: 100 }
       });
@@ -33,15 +39,101 @@ describe(AutoTopUpSection.name, () => {
       expect(screen.getByText("100")).toBeInTheDocument();
     });
 
+    it("shows the predicted weekly spend when the stored mode is prediction", () => {
+      setup({
+        isThresholdModeOffered: true,
+        autoReloadMode: "prediction",
+        defaultPaymentMethod: { id: "pm_123" },
+        walletSettings: { autoReloadEnabled: true, autoReloadMode: "prediction" },
+        weeklyCost: 42
+      });
+
+      expect(screen.getByText("Auto Top-Up")).toBeInTheDocument();
+      expect(screen.getByText("Predicted spend")).toBeInTheDocument();
+      expect(screen.getByText("42")).toBeInTheDocument();
+      expect(screen.queryByText("Threshold")).not.toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /edit auto top-up settings/i })).toBeInTheDocument();
+    });
+
+    it("passes the stored mode to the settings dialog", () => {
+      const { dependencies } = setup({
+        isThresholdModeOffered: true,
+        autoReloadMode: "prediction",
+        defaultPaymentMethod: { id: "pm_123" },
+        walletSettings: { autoReloadEnabled: true, autoReloadMode: "prediction" }
+      });
+
+      expect(dependencies.AutoTopUpSettingsPopup).toHaveBeenCalledWith(expect.objectContaining({ mode: "prediction" }), expect.anything());
+    });
+
+    it("skips the weekly cost query in threshold mode and runs it in prediction mode", () => {
+      const { dependencies: thresholdDependencies } = setup({
+        isThresholdModeOffered: true,
+        defaultPaymentMethod: { id: "pm_123" },
+        walletSettings: { autoReloadEnabled: true, autoReloadMode: "threshold" }
+      });
+
+      expect(thresholdDependencies.useWeeklyDeploymentCostQuery).toHaveBeenCalledWith({ enabled: false });
+
+      const { dependencies: predictionDependencies } = setup({
+        isThresholdModeOffered: true,
+        autoReloadMode: "prediction",
+        defaultPaymentMethod: { id: "pm_123" },
+        walletSettings: { autoReloadEnabled: true, autoReloadMode: "prediction" }
+      });
+
+      expect(predictionDependencies.useWeeklyDeploymentCostQuery).toHaveBeenCalledWith({ enabled: true });
+    });
+
     it("prompts to turn on auto top-up when disabled with a payment method", () => {
-      setup({ isFixedThresholdEnabled: true, defaultPaymentMethod: { id: "pm_123" }, walletSettings: { autoReloadEnabled: false } });
+      setup({ isThresholdModeOffered: true, defaultPaymentMethod: { id: "pm_123" }, walletSettings: { autoReloadEnabled: false } });
 
       expect(screen.getByText(/Turn on Auto Top-Up to add funds automatically/)).toBeInTheDocument();
     });
 
+    it("prompts with predicted-spend wording when disabled in prediction mode", () => {
+      setup({
+        isThresholdModeOffered: true,
+        autoReloadMode: "prediction",
+        defaultPaymentMethod: { id: "pm_123" },
+        walletSettings: { autoReloadEnabled: false, autoReloadMode: "prediction" }
+      });
+
+      expect(screen.getByText(/Turn on Auto Top-Up to automatically cover the week ahead/)).toBeInTheDocument();
+      expect(screen.queryByText(/when your balance runs low/)).not.toBeInTheDocument();
+    });
+
+    it("shows a skeleton instead of a zero predicted spend while the weekly cost is still loading", () => {
+      setup({
+        isThresholdModeOffered: true,
+        autoReloadMode: "prediction",
+        defaultPaymentMethod: { id: "pm_123" },
+        walletSettings: { autoReloadEnabled: true, autoReloadMode: "prediction" },
+        isWeeklyCostLoading: true
+      });
+
+      expect(screen.getByText("Predicted spend")).toBeInTheDocument();
+      expect(screen.queryByText("0")).not.toBeInTheDocument();
+    });
+
+    describe("while wallet settings are still loading", () => {
+      it("disables the switch so the settings dialog cannot be seeded from unresolved settings", () => {
+        setup({ isThresholdModeOffered: true, defaultPaymentMethod: { id: "pm_123" }, isWalletSettingsLoading: true });
+
+        expect(screen.getByRole("switch")).toBeDisabled();
+      });
+
+      it("holds back the mode description instead of committing to the fallback mode", () => {
+        setup({ isThresholdModeOffered: true, defaultPaymentMethod: { id: "pm_123" }, isWalletSettingsLoading: true });
+
+        expect(screen.queryByText(/Tops up when your/)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Tops up to cover the week ahead/)).not.toBeInTheDocument();
+      });
+    });
+
     it("opens the settings dialog in enable mode without mutating when the switch is turned on", () => {
       const { dependencies, upsertMutate } = setup({
-        isFixedThresholdEnabled: true,
+        isThresholdModeOffered: true,
         defaultPaymentMethod: { id: "pm_123" },
         walletSettings: { autoReloadEnabled: false }
       });
@@ -55,7 +147,7 @@ describe(AutoTopUpSection.name, () => {
     it("confirms then disables auto top-up when the switch is turned off", async () => {
       const upsertMutate = vi.fn();
       setup({
-        isFixedThresholdEnabled: true,
+        isThresholdModeOffered: true,
         defaultPaymentMethod: { id: "pm_123" },
         walletSettings: { autoReloadEnabled: true, autoReloadThreshold: 20, autoReloadAmount: 100 },
         confirmResult: true,
@@ -71,7 +163,7 @@ describe(AutoTopUpSection.name, () => {
 
     it("opens the settings dialog in edit mode from the edit button", () => {
       const { dependencies } = setup({
-        isFixedThresholdEnabled: true,
+        isThresholdModeOffered: true,
         defaultPaymentMethod: { id: "pm_123" },
         walletSettings: { autoReloadEnabled: true, autoReloadThreshold: 20, autoReloadAmount: 100 }
       });
@@ -83,7 +175,7 @@ describe(AutoTopUpSection.name, () => {
 
     it("shows the next top-up estimate even when the default payment method is not a card", () => {
       setup({
-        isFixedThresholdEnabled: true,
+        isThresholdModeOffered: true,
         defaultPaymentMethod: { id: "pm_123" },
         walletSettings: { autoReloadEnabled: true, autoReloadThreshold: 20, autoReloadAmount: 50 },
         perHour: 1,
@@ -96,7 +188,7 @@ describe(AutoTopUpSection.name, () => {
 
     it("names the default card in the charge summary", () => {
       setup({
-        isFixedThresholdEnabled: true,
+        isThresholdModeOffered: true,
         defaultPaymentMethod: { id: "pm_123", card: { brand: "visa", last4: "4242" } },
         walletSettings: { autoReloadEnabled: true, autoReloadThreshold: 20, autoReloadAmount: 50 }
       });
@@ -105,7 +197,7 @@ describe(AutoTopUpSection.name, () => {
     });
 
     it("disables the switch and hides the edit button without a payment method", () => {
-      setup({ isFixedThresholdEnabled: true, defaultPaymentMethod: undefined });
+      setup({ isThresholdModeOffered: true, defaultPaymentMethod: undefined });
 
       expect(screen.getByRole("switch")).toBeDisabled();
       expect(screen.queryByRole("button", { name: /edit auto top-up settings/i })).not.toBeInTheDocument();
@@ -113,14 +205,14 @@ describe(AutoTopUpSection.name, () => {
     });
 
     it("shows a skeleton instead of the add-payment-method prompt while the payment method query is loading", () => {
-      setup({ isFixedThresholdEnabled: true, defaultPaymentMethod: undefined, isDefaultPaymentMethodLoading: true });
+      setup({ isThresholdModeOffered: true, defaultPaymentMethod: undefined, isDefaultPaymentMethodLoading: true });
 
       expect(screen.queryByText(/Add a payment method/)).not.toBeInTheDocument();
     });
 
     it("opens the add-payment-method flow from the prompt when there is no payment method", () => {
       const openAddPaymentMethod = vi.fn();
-      setup({ isFixedThresholdEnabled: true, defaultPaymentMethod: undefined, openAddPaymentMethod });
+      setup({ isThresholdModeOffered: true, defaultPaymentMethod: undefined, openAddPaymentMethod });
 
       fireEvent.click(screen.getByText("Add a payment method"));
 
@@ -129,7 +221,7 @@ describe(AutoTopUpSection.name, () => {
 
     it("disables the edit button while a settings update is in flight", () => {
       setup({
-        isFixedThresholdEnabled: true,
+        isThresholdModeOffered: true,
         defaultPaymentMethod: { id: "pm_123" },
         walletSettings: { autoReloadEnabled: true, autoReloadThreshold: 20, autoReloadAmount: 100 },
         isPending: true
@@ -141,7 +233,7 @@ describe(AutoTopUpSection.name, () => {
     it("does not disable auto top-up when the confirmation is cancelled", async () => {
       const upsertMutate = vi.fn();
       setup({
-        isFixedThresholdEnabled: true,
+        isThresholdModeOffered: true,
         defaultPaymentMethod: { id: "pm_123" },
         walletSettings: { autoReloadEnabled: true, autoReloadThreshold: 20, autoReloadAmount: 100 },
         confirmResult: false,
@@ -159,7 +251,7 @@ describe(AutoTopUpSection.name, () => {
       const enqueueSnackbar = vi.fn();
       const upsertMutate = vi.fn((_payload, options) => options?.onSuccess?.({ data: { autoReloadEnabled: false } }));
       setup({
-        isFixedThresholdEnabled: true,
+        isThresholdModeOffered: true,
         defaultPaymentMethod: { id: "pm_123" },
         walletSettings: { autoReloadEnabled: true, autoReloadThreshold: 20, autoReloadAmount: 100 },
         confirmResult: true,
@@ -176,7 +268,7 @@ describe(AutoTopUpSection.name, () => {
 
     it("closes the settings dialog when the popup requests it", () => {
       const { dependencies } = setup({
-        isFixedThresholdEnabled: true,
+        isThresholdModeOffered: true,
         defaultPaymentMethod: { id: "pm_123" },
         walletSettings: { autoReloadEnabled: true, autoReloadThreshold: 20, autoReloadAmount: 100 }
       });
@@ -191,11 +283,14 @@ describe(AutoTopUpSection.name, () => {
   });
 
   function setup(input: {
-    isFixedThresholdEnabled?: boolean;
+    isThresholdModeOffered?: boolean;
+    autoReloadMode?: "prediction" | "threshold";
     defaultPaymentMethod?: { id: string; card?: { brand?: string; last4?: string } };
     isDefaultPaymentMethodLoading?: boolean;
-    walletSettings?: { autoReloadEnabled: boolean; autoReloadThreshold?: number; autoReloadAmount?: number };
+    walletSettings?: { autoReloadEnabled: boolean; autoReloadMode?: "prediction" | "threshold"; autoReloadThreshold?: number; autoReloadAmount?: number };
+    isWalletSettingsLoading?: boolean;
     weeklyCost?: number;
+    isWeeklyCostLoading?: boolean;
     confirmResult?: boolean;
     upsertMutate?: ReturnType<typeof vi.fn>;
     enqueueSnackbar?: ReturnType<typeof vi.fn>;
@@ -216,11 +311,22 @@ describe(AutoTopUpSection.name, () => {
 
     const dependencies = {
       ...MockComponents(DEPENDENCIES),
-      useFlag: vi.fn(() => input.isFixedThresholdEnabled ?? false),
+      useAutoReloadMode: vi.fn(() => {
+        const mode = input.autoReloadMode ?? (input.isThresholdModeOffered ? "threshold" : "prediction");
+        return {
+          mode,
+          isThresholdModeOffered: input.isThresholdModeOffered ?? false,
+          showsThresholdRule: !!input.isThresholdModeOffered && mode === "threshold",
+          isLoading: false
+        };
+      }),
       useSnackbar: vi.fn(() => ({ enqueueSnackbar })),
       useDefaultPaymentMethodQuery: vi.fn(() => ({ data: input.defaultPaymentMethod, isLoading: input.isDefaultPaymentMethodLoading ?? false })),
-      useWalletSettingsQuery: vi.fn(() => ({ data: input.walletSettings ?? { autoReloadEnabled: false }, isLoading: false })),
-      useWeeklyDeploymentCostQuery: vi.fn(() => ({ data: input.weeklyCost ?? 5 })),
+      useWalletSettingsQuery: vi.fn(() => ({
+        data: input.isWalletSettingsLoading ? undefined : input.walletSettings ?? { autoReloadEnabled: false },
+        isLoading: input.isWalletSettingsLoading ?? false
+      })),
+      useWeeklyDeploymentCostQuery: vi.fn(() => ({ data: input.isWeeklyCostLoading ? undefined : input.weeklyCost ?? 5 })),
       useWalletSettingsMutations: vi.fn(() => ({ upsertWalletSettings: { mutate: upsertMutate, isPending: input.isPending ?? false } })),
       useAccountBalanceOverview: vi.fn(() => ({ perHour: input.perHour ?? 0, available: input.available ?? 0 })),
       useBillingActions: vi.fn(() => ({ openAddPaymentMethod })),

--- a/apps/deploy-web/src/components/billing-usage/AutoTopUpSection/AutoTopUpSection.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AutoTopUpSection/AutoTopUpSection.spec.tsx
@@ -13,6 +13,13 @@ describe(AutoTopUpSection.name, () => {
     expect(screen.getByText(/per week/)).toHaveTextContent("42");
   });
 
+  it("shows a skeleton instead of a zero recharge estimate while the weekly cost is still loading", () => {
+    setup({ isThresholdModeOffered: false, defaultPaymentMethod: { id: "pm_123" }, isWeeklyCostLoading: true });
+
+    expect(screen.getByText(/per week/)).toBeInTheDocument();
+    expect(screen.queryByText("0")).not.toBeInTheDocument();
+  });
+
   it("runs the weekly cost query without waiting for wallet settings when threshold mode is not offered", () => {
     const { dependencies } = setup({ isThresholdModeOffered: false, defaultPaymentMethod: { id: "pm_123" }, isWalletSettingsLoading: true });
 

--- a/apps/deploy-web/src/components/billing-usage/AutoTopUpSection/AutoTopUpSection.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AutoTopUpSection/AutoTopUpSection.tsx
@@ -183,7 +183,13 @@ export const AutoTopUpSection: React.FunctionComponent<{ dependencies?: typeof D
             </p>
           ) : !isThresholdModeOffered ? (
             <p className="text-sm text-muted-foreground">
-              Recharge amount is approximately <span className="font-medium text-foreground">{usd(weeklyCost ?? 0)}</span> per week
+              Recharge amount is approximately{" "}
+              {weeklyCost === undefined ? (
+                <d.Skeleton className="inline-block h-4 w-12 align-middle" />
+              ) : (
+                <span className="font-medium text-foreground">{usd(weeklyCost)}</span>
+              )}{" "}
+              per week
             </p>
           ) : autoReloadEnabled ? (
             <div className="space-y-4">

--- a/apps/deploy-web/src/components/billing-usage/AutoTopUpSection/AutoTopUpSection.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AutoTopUpSection/AutoTopUpSection.tsx
@@ -15,7 +15,7 @@ import {
 } from "@src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup";
 import { useBillingActions } from "@src/components/billing-usage/BillingActionsProvider/BillingActionsProvider";
 import { UsdValue } from "@src/components/billing-usage/UsdValue/UsdValue";
-import { useFlag } from "@src/hooks/useFlag";
+import { useAutoReloadMode } from "@src/components/billing-usage/useAutoReloadMode";
 import { useDefaultPaymentMethodQuery, useWalletSettingsMutations, useWalletSettingsQuery, useWeeklyDeploymentCostQuery } from "@src/queries";
 import { capitalizeFirstLetter } from "@src/utils/stringUtils";
 
@@ -30,7 +30,7 @@ export const DEPENDENCIES = {
   useAccountBalanceOverview,
   usePopup,
   useBillingActions,
-  useFlag,
+  useAutoReloadMode,
   AutoTopUpSettingsPopup,
   UsdValue,
   Button,
@@ -46,11 +46,11 @@ export const DEPENDENCIES = {
 
 export const AutoTopUpSection: React.FunctionComponent<{ dependencies?: typeof DEPENDENCIES }> = ({ dependencies: d = DEPENDENCIES }) => {
   const [autoTopUpPopup, setAutoTopUpPopup] = useState<{ open: boolean; enableOnSave: boolean }>({ open: false, enableOnSave: false });
-  const isFixedThresholdEnabled = d.useFlag("auto_reload_fixed_threshold");
+  const { mode, isThresholdModeOffered, showsThresholdRule } = d.useAutoReloadMode();
   const { enqueueSnackbar } = d.useSnackbar();
   const { data: defaultPaymentMethod, isLoading: isDefaultPaymentMethodLoading } = d.useDefaultPaymentMethodQuery();
   const { data: walletSettings, isLoading: isWalletSettingsLoading } = d.useWalletSettingsQuery();
-  const { data: weeklyCost } = d.useWeeklyDeploymentCostQuery({ enabled: !isFixedThresholdEnabled });
+  const { data: weeklyCost } = d.useWeeklyDeploymentCostQuery({ enabled: !showsThresholdRule });
   const { upsertWalletSettings } = d.useWalletSettingsMutations();
   const { openAddPaymentMethod } = d.useBillingActions();
   const overview = d.useAccountBalanceOverview();
@@ -122,8 +122,8 @@ export const AutoTopUpSection: React.FunctionComponent<{ dependencies?: typeof D
   const isFirstLoad = (isWalletSettingsLoading && !walletSettings) || (isDefaultPaymentMethodLoading && !defaultPaymentMethod);
 
   const isReloadChangeDisabled = useMemo(() => {
-    return !hasPaymentMethod || upsertWalletSettings.isPending;
-  }, [hasPaymentMethod, upsertWalletSettings.isPending]);
+    return isFirstLoad || !hasPaymentMethod || upsertWalletSettings.isPending;
+  }, [isFirstLoad, hasPaymentMethod, upsertWalletSettings.isPending]);
 
   const defaultCardLabel = useMemo(() => {
     const card = (defaultPaymentMethod as PaymentMethod | null | undefined)?.card;
@@ -149,18 +149,22 @@ export const AutoTopUpSection: React.FunctionComponent<{ dependencies?: typeof D
         )}
         <d.CardHeader className="flex flex-row items-start justify-between space-y-0 pb-4">
           <div className="space-y-1">
-            <h3 className="text-lg font-bold leading-none">{isFixedThresholdEnabled ? "Auto Top-Up" : "Auto Recharge"}</h3>
-            {isFixedThresholdEnabled ? (
+            <h3 className="text-lg font-bold leading-none">{isThresholdModeOffered ? "Auto Top-Up" : "Auto Recharge"}</h3>
+            {isFirstLoad ? (
+              <d.Skeleton className="h-4 w-72" />
+            ) : !isThresholdModeOffered ? (
+              <p className="text-sm text-muted-foreground">Automatically adds credits to keep your deployments running.</p>
+            ) : showsThresholdRule ? (
               <p className="text-sm text-muted-foreground">
                 Tops up when your <span className="font-medium text-success">available</span> balance runs low.
               </p>
             ) : (
-              <p className="text-sm text-muted-foreground">Automatically adds credits to keep your deployments running.</p>
+              <p className="text-sm text-muted-foreground">Tops up to cover the week ahead for your running deployments.</p>
             )}
           </div>
           <d.Switch
             checked={autoReloadEnabled}
-            onCheckedChange={isFixedThresholdEnabled ? handleAutoTopUpSwitch : toggleAutoReload}
+            onCheckedChange={isThresholdModeOffered ? handleAutoTopUpSwitch : toggleAutoReload}
             disabled={isReloadChangeDisabled}
           />
         </d.CardHeader>
@@ -175,12 +179,16 @@ export const AutoTopUpSection: React.FunctionComponent<{ dependencies?: typeof D
               <button type="button" onClick={openAddPaymentMethod} className="text-primary underline">
                 Add a payment method
               </button>{" "}
-              to enable auto {isFixedThresholdEnabled ? "top-up" : "recharge"}
+              to enable auto {isThresholdModeOffered ? "top-up" : "recharge"}
             </p>
-          ) : isFixedThresholdEnabled ? (
-            autoReloadEnabled ? (
-              <div className="space-y-4">
-                <div className="flex flex-wrap items-start justify-between gap-4">
+          ) : !isThresholdModeOffered ? (
+            <p className="text-sm text-muted-foreground">
+              Recharge amount is approximately <span className="font-medium text-foreground">{usd(weeklyCost ?? 0)}</span> per week
+            </p>
+          ) : autoReloadEnabled ? (
+            <div className="space-y-4">
+              <div className="flex flex-wrap items-start justify-between gap-4">
+                {showsThresholdRule ? (
                   <div className="flex flex-wrap gap-x-12 gap-y-4">
                     <div className="space-y-1">
                       <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Threshold</p>
@@ -193,18 +201,26 @@ export const AutoTopUpSection: React.FunctionComponent<{ dependencies?: typeof D
                       <p className="text-xs text-muted-foreground">added each time</p>
                     </div>
                   </div>
-                  <d.Button
-                    variant="outline"
-                    size="sm"
-                    className="gap-2"
-                    aria-label="Edit auto top-up settings"
-                    disabled={isReloadChangeDisabled}
-                    onClick={() => setAutoTopUpPopup({ open: true, enableOnSave: false })}
-                  >
-                    <d.Edit className="h-4 w-4" />
-                    Edit
-                  </d.Button>
-                </div>
+                ) : (
+                  <div className="space-y-1">
+                    <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Predicted spend</p>
+                    {weeklyCost === undefined ? <d.Skeleton className="h-8 w-24" /> : <p className="text-2xl font-bold leading-none">{usd(weeklyCost)}</p>}
+                    <p className="text-xs text-muted-foreground">per week, from your running deployments</p>
+                  </div>
+                )}
+                <d.Button
+                  variant="outline"
+                  size="sm"
+                  className="gap-2"
+                  aria-label="Edit auto top-up settings"
+                  disabled={isReloadChangeDisabled}
+                  onClick={() => setAutoTopUpPopup({ open: true, enableOnSave: false })}
+                >
+                  <d.Edit className="h-4 w-4" />
+                  Edit
+                </d.Button>
+              </div>
+              {showsThresholdRule ? (
                 <p className="border-t pt-4 text-sm text-muted-foreground">
                   Charges {defaultCardLabel ?? "your default payment method"} when your available balance falls below the threshold.
                   {nextTopUpDays !== null && (
@@ -215,23 +231,28 @@ export const AutoTopUpSection: React.FunctionComponent<{ dependencies?: typeof D
                     </>
                   )}
                 </p>
-              </div>
-            ) : (
-              <p className="text-sm text-muted-foreground">Turn on Auto Top-Up to add funds automatically when your balance runs low.</p>
-            )
+              ) : (
+                <p className="border-t pt-4 text-sm text-muted-foreground">
+                  Charges {defaultCardLabel ?? "your default payment method"} for whatever your deployments need to keep running for another week.
+                </p>
+              )}
+            </div>
           ) : (
             <p className="text-sm text-muted-foreground">
-              Recharge amount is approximately <span className="font-medium text-foreground">{usd(weeklyCost ?? 0)}</span> per week
+              {showsThresholdRule
+                ? "Turn on Auto Top-Up to add funds automatically when your balance runs low."
+                : "Turn on Auto Top-Up to automatically cover the week ahead for your running deployments."}
             </p>
           )}
         </d.CardContent>
       </d.Card>
 
-      {isFixedThresholdEnabled && (
+      {isThresholdModeOffered && (
         <d.AutoTopUpSettingsPopup
           open={autoTopUpPopup.open}
           onClose={() => setAutoTopUpPopup(prev => ({ ...prev, open: false }))}
           enableOnSave={autoTopUpPopup.enableOnSave}
+          mode={mode}
           threshold={walletSettings?.autoReloadThreshold}
           amount={walletSettings?.autoReloadAmount}
         />

--- a/apps/deploy-web/src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup.spec.tsx
@@ -81,7 +81,10 @@ describe(AutoTopUpSettingsPopup.name, () => {
 
     await submit();
 
-    expect(upsertMutate).toHaveBeenCalledWith({ data: { autoReloadEnabled: true, autoReloadThreshold: 20, autoReloadAmount: 100 } }, expect.anything());
+    expect(upsertMutate).toHaveBeenCalledWith(
+      { data: { autoReloadEnabled: true, autoReloadMode: "threshold", autoReloadThreshold: 20, autoReloadAmount: 100 } },
+      expect.anything()
+    );
   });
 
   it("saves the enabled flag with values in edit mode", async () => {
@@ -90,7 +93,65 @@ describe(AutoTopUpSettingsPopup.name, () => {
 
     await submit();
 
-    expect(upsertMutate).toHaveBeenCalledWith({ data: { autoReloadEnabled: true, autoReloadThreshold: 30, autoReloadAmount: 150 } }, expect.anything());
+    expect(upsertMutate).toHaveBeenCalledWith(
+      { data: { autoReloadEnabled: true, autoReloadMode: "threshold", autoReloadThreshold: 30, autoReloadAmount: 150 } },
+      expect.anything()
+    );
+  });
+
+  it("preselects threshold mode when the account has no stored mode", () => {
+    setup({});
+
+    expect(modeRadio(/fixed threshold/i)).toBeChecked();
+    expect(thresholdInput()).toBeInTheDocument();
+  });
+
+  it("preselects the stored mode and hides the threshold fields in prediction mode", () => {
+    setup({ mode: "prediction" });
+
+    expect(modeRadio(/predicted spend/i)).toBeChecked();
+    expect(screen.queryByLabelText(/when credit balance drops to or below/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/purchase this amount/i)).not.toBeInTheDocument();
+  });
+
+  it("saves prediction mode without threshold values", async () => {
+    const upsertMutate = vi.fn();
+    setup({ mode: "threshold", threshold: 30, amount: 150, upsertMutate });
+
+    fireEvent.click(modeRadio(/predicted spend/i));
+    await submit();
+
+    expect(upsertMutate).toHaveBeenCalledWith({ data: { autoReloadEnabled: true, autoReloadMode: "prediction" } }, expect.anything());
+  });
+
+  it("saves threshold mode with values when switching back from prediction", async () => {
+    const upsertMutate = vi.fn();
+    setup({ mode: "prediction", threshold: 30, amount: 150, upsertMutate });
+
+    fireEvent.click(modeRadio(/fixed threshold/i));
+    await submit();
+
+    expect(upsertMutate).toHaveBeenCalledWith(
+      { data: { autoReloadEnabled: true, autoReloadMode: "threshold", autoReloadThreshold: 30, autoReloadAmount: 150 } },
+      expect.anything()
+    );
+  });
+
+  it("saves prediction mode even when a stored threshold is below the threshold-mode minimum", async () => {
+    const upsertMutate = vi.fn();
+    setup({ mode: "prediction", threshold: 1, amount: 1, upsertMutate });
+
+    await submit();
+
+    expect(upsertMutate).toHaveBeenCalledWith({ data: { autoReloadEnabled: true, autoReloadMode: "prediction" } }, expect.anything());
+  });
+
+  it("resets the mode when the dialog transitions from closed to open", () => {
+    const { props, rerender } = setup({ open: false, mode: "threshold" });
+
+    rerender(<AutoTopUpSettingsPopup {...props} open mode="prediction" />);
+
+    expect(modeRadio(/predicted spend/i)).toBeChecked();
   });
 
   it("closes and shows a success snackbar when the save succeeds", async () => {
@@ -135,6 +196,10 @@ describe(AutoTopUpSettingsPopup.name, () => {
     expect(amountInput().value).toBe("150");
   });
 
+  function modeRadio(name: RegExp) {
+    return screen.getByRole("radio", { name });
+  }
+
   function thresholdInput() {
     return screen.getByLabelText(/when credit balance drops to or below/i) as HTMLInputElement;
   }
@@ -152,6 +217,7 @@ describe(AutoTopUpSettingsPopup.name, () => {
   function setup(input: {
     open?: boolean;
     enableOnSave?: boolean;
+    mode?: "prediction" | "threshold";
     threshold?: number;
     amount?: number;
     onClose?: () => void;
@@ -184,6 +250,7 @@ describe(AutoTopUpSettingsPopup.name, () => {
       open: input.open ?? true,
       onClose: input.onClose ?? vi.fn(),
       enableOnSave: input.enableOnSave ?? false,
+      mode: input.mode,
       threshold: input.threshold,
       amount: input.amount,
       dependencies

--- a/apps/deploy-web/src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup.tsx
@@ -3,15 +3,29 @@
 import React, { useEffect, useMemo, useRef } from "react";
 import { useForm } from "react-hook-form";
 import type { PaymentMethod } from "@akashnetwork/http-sdk";
-import { Form, FormField, FormInput, LoadingButton, Popup, Snackbar } from "@akashnetwork/ui/components";
+import {
+  Field,
+  FieldContent,
+  FieldLabel,
+  FieldTitle,
+  Form,
+  FormField,
+  FormInput,
+  LoadingButton,
+  Popup,
+  RadioGroup,
+  RadioGroupItem,
+  Snackbar
+} from "@akashnetwork/ui/components";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { CreditCard } from "iconoir-react";
 import { useSnackbar } from "notistack";
 import { z } from "zod";
 
 import { getPaymentMethodDisplay } from "@src/components/shared/PaymentMethodCard/PaymentMethodCard";
-import { useDefaultPaymentMethodQuery, useWalletSettingsMutations } from "@src/queries";
+import { type AutoReloadMode, useDefaultPaymentMethodQuery, useWalletSettingsMutations } from "@src/queries";
 
+export const DEFAULT_AUTO_RELOAD_MODE: AutoReloadMode = "threshold";
 export const DEFAULT_AUTO_RELOAD_THRESHOLD = 20;
 export const DEFAULT_AUTO_RELOAD_AMOUNT = 100;
 
@@ -24,16 +38,48 @@ const AUTO_RELOAD_MAX_USD = 10_000;
 /** Mirrors STANDARD_TOP_UP_MIN_AMOUNT_USD — the fixed floor the backend applies to every recurring auto-top-up charge, independent of the trial-aware one-time top-up minimum. */
 const AUTO_RELOAD_AMOUNT_MIN_USD = 20;
 
-const autoTopUpSchema = z.object({
-  autoReloadThreshold: z.coerce
-    .number()
-    .min(AUTO_RELOAD_THRESHOLD_MIN_USD, `Minimum threshold is $${AUTO_RELOAD_THRESHOLD_MIN_USD}`)
-    .max(AUTO_RELOAD_MAX_USD, `Maximum threshold is $${AUTO_RELOAD_MAX_USD}`),
-  autoReloadAmount: z.coerce
-    .number()
-    .min(AUTO_RELOAD_AMOUNT_MIN_USD, `Minimum amount is $${AUTO_RELOAD_AMOUNT_MIN_USD}`)
-    .max(AUTO_RELOAD_MAX_USD, `Maximum amount is $${AUTO_RELOAD_MAX_USD}`)
-});
+const MODE_OPTIONS: Array<{ value: AutoReloadMode; id: string; title: string; description: string }> = [
+  {
+    value: "threshold",
+    id: "auto-reload-mode-threshold",
+    title: "Fixed threshold",
+    description: "Charge a set amount as soon as your available balance runs low."
+  },
+  {
+    value: "prediction",
+    id: "auto-reload-mode-prediction",
+    title: "Predicted spend",
+    description: "Charge whatever it takes to cover the next week of your current deployments."
+  }
+];
+
+/**
+ * The threshold and amount bounds only apply in threshold mode: prediction mode derives its amounts from projected
+ * spend, and its inputs aren't rendered, so a stored value outside the bounds must not block the save.
+ */
+const autoTopUpSchema = z
+  .object({
+    autoReloadMode: z.enum(["threshold", "prediction"]),
+    autoReloadThreshold: z.coerce.number(),
+    autoReloadAmount: z.coerce.number()
+  })
+  .superRefine((values, ctx) => {
+    if (values.autoReloadMode !== "threshold") return;
+
+    const boundedFields = [
+      { name: "autoReloadThreshold" as const, value: values.autoReloadThreshold, min: AUTO_RELOAD_THRESHOLD_MIN_USD, label: "threshold" },
+      { name: "autoReloadAmount" as const, value: values.autoReloadAmount, min: AUTO_RELOAD_AMOUNT_MIN_USD, label: "amount" }
+    ];
+
+    for (const { name, value, min, label } of boundedFields) {
+      if (value < min) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, path: [name], message: `Minimum ${label} is $${min}` });
+      }
+      if (value > AUTO_RELOAD_MAX_USD) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, path: [name], message: `Maximum ${label} is $${AUTO_RELOAD_MAX_USD}` });
+      }
+    }
+  });
 
 type AutoTopUpFormValues = z.infer<typeof autoTopUpSchema>;
 
@@ -49,6 +95,7 @@ interface AutoTopUpSettingsPopupProps {
   onClose: () => void;
   /** True for the first-enable flow (Save turns auto top-up on); false when editing an already-enabled account. */
   enableOnSave: boolean;
+  mode?: AutoReloadMode;
   threshold?: number;
   amount?: number;
   dependencies?: typeof DEPENDENCIES;
@@ -58,6 +105,7 @@ export const AutoTopUpSettingsPopup: React.FC<AutoTopUpSettingsPopupProps> = ({
   open,
   onClose,
   enableOnSave,
+  mode,
   threshold,
   amount,
   dependencies: d = DEPENDENCIES
@@ -68,10 +116,11 @@ export const AutoTopUpSettingsPopup: React.FC<AutoTopUpSettingsPopupProps> = ({
 
   const defaultValues = useMemo<AutoTopUpFormValues>(
     () => ({
+      autoReloadMode: mode ?? DEFAULT_AUTO_RELOAD_MODE,
       autoReloadThreshold: threshold ?? DEFAULT_AUTO_RELOAD_THRESHOLD,
       autoReloadAmount: amount ?? DEFAULT_AUTO_RELOAD_AMOUNT
     }),
-    [threshold, amount]
+    [mode, threshold, amount]
   );
 
   const form = d.useForm<AutoTopUpFormValues>({
@@ -90,6 +139,7 @@ export const AutoTopUpSettingsPopup: React.FC<AutoTopUpSettingsPopupProps> = ({
     [open, defaultValues, form]
   );
 
+  const selectedMode = form.watch("autoReloadMode");
   const cardDisplay = defaultPaymentMethod ? getPaymentMethodDisplay(defaultPaymentMethod as PaymentMethod) : null;
 
   const saveSettings = form.handleSubmit(values => {
@@ -97,8 +147,11 @@ export const AutoTopUpSettingsPopup: React.FC<AutoTopUpSettingsPopupProps> = ({
       {
         data: {
           autoReloadEnabled: true,
-          autoReloadThreshold: values.autoReloadThreshold,
-          autoReloadAmount: values.autoReloadAmount
+          autoReloadMode: values.autoReloadMode,
+          ...(values.autoReloadMode === "threshold" && {
+            autoReloadThreshold: values.autoReloadThreshold,
+            autoReloadAmount: values.autoReloadAmount
+          })
         }
       },
       {
@@ -132,32 +185,60 @@ export const AutoTopUpSettingsPopup: React.FC<AutoTopUpSettingsPopupProps> = ({
 
           <FormField
             control={form.control}
-            name="autoReloadThreshold"
+            name="autoReloadMode"
             render={({ field }) => (
-              <FormInput
-                {...field}
-                type="number"
-                step="0.01"
-                label={`When credit balance drops to or below (minimum $${AUTO_RELOAD_THRESHOLD_MIN_USD})`}
-                description="If your current balance is at or below the threshold you set, your top-up will kick in shortly after you save."
-                startIcon={<div className="pl-3 text-sm text-muted-foreground">$</div>}
-              />
+              <RadioGroup value={field.value} onValueChange={field.onChange} aria-label="Auto top-up mode">
+                {MODE_OPTIONS.map(option => (
+                  <FieldLabel key={option.value} htmlFor={option.id}>
+                    <Field orientation="horizontal" className="cursor-pointer p-3">
+                      <RadioGroupItem value={option.value} id={option.id} className="self-center" />
+                      <FieldContent>
+                        <FieldTitle className="font-medium">{option.title}</FieldTitle>
+                        <p className="text-sm text-muted-foreground">{option.description}</p>
+                      </FieldContent>
+                    </Field>
+                  </FieldLabel>
+                ))}
+              </RadioGroup>
             )}
           />
 
-          <FormField
-            control={form.control}
-            name="autoReloadAmount"
-            render={({ field }) => (
-              <FormInput
-                {...field}
-                type="number"
-                step="0.01"
-                label={`Purchase this amount (minimum $${AUTO_RELOAD_AMOUNT_MIN_USD})`}
-                startIcon={<div className="pl-3 text-sm text-muted-foreground">$</div>}
+          {selectedMode === "threshold" ? (
+            <>
+              <FormField
+                control={form.control}
+                name="autoReloadThreshold"
+                render={({ field }) => (
+                  <FormInput
+                    {...field}
+                    type="number"
+                    step="0.01"
+                    label={`When credit balance drops to or below (minimum $${AUTO_RELOAD_THRESHOLD_MIN_USD})`}
+                    description="If your current balance is at or below the threshold you set, your top-up will kick in shortly after you save."
+                    startIcon={<div className="pl-3 text-sm text-muted-foreground">$</div>}
+                  />
+                )}
               />
-            )}
-          />
+
+              <FormField
+                control={form.control}
+                name="autoReloadAmount"
+                render={({ field }) => (
+                  <FormInput
+                    {...field}
+                    type="number"
+                    step="0.01"
+                    label={`Purchase this amount (minimum $${AUTO_RELOAD_AMOUNT_MIN_USD})`}
+                    startIcon={<div className="pl-3 text-sm text-muted-foreground">$</div>}
+                  />
+                )}
+              />
+            </>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              We check your deployments once a day and charge enough to keep them running for another week. There is nothing else to configure.
+            </p>
+          )}
 
           <LoadingButton type="submit" className="w-full" loading={upsertWalletSettings.isPending}>
             Save changes

--- a/apps/deploy-web/src/components/billing-usage/useAutoReloadMode.spec.ts
+++ b/apps/deploy-web/src/components/billing-usage/useAutoReloadMode.spec.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
 
-import { DEPENDENCIES, useAutoReloadMode } from "./useAutoReloadMode";
+import type { DEPENDENCIES } from "./useAutoReloadMode";
+import { useAutoReloadMode } from "./useAutoReloadMode";
 
 import { renderHook } from "@testing-library/react";
+
+type WalletSettingsQueryResult = ReturnType<typeof DEPENDENCIES.useWalletSettingsQuery>;
+type WalletSettings = NonNullable<WalletSettingsQueryResult["data"]>;
 
 describe(useAutoReloadMode.name, () => {
   it("uses the stored mode even when threshold mode is not offered", () => {
@@ -42,15 +47,15 @@ describe(useAutoReloadMode.name, () => {
   });
 
   function setup(input: { isThresholdModeOffered?: boolean; storedMode?: "prediction" | "threshold"; isLoading?: boolean }) {
-    const dependencies = {
-      ...DEPENDENCIES,
-      useFlag: () => input.isThresholdModeOffered ?? false,
-      useWalletSettingsQuery: () => ({
-        data: input.storedMode ? { autoReloadMode: input.storedMode } : null,
-        isLoading: input.isLoading ?? false
-      })
-    } as unknown as typeof DEPENDENCIES;
+    const useFlag: typeof DEPENDENCIES.useFlag = () => input.isThresholdModeOffered ?? false;
 
-    return renderHook(() => useAutoReloadMode({ dependencies }));
+    const walletSettings = input.storedMode ? Object.assign(mock<WalletSettings>(), { autoReloadMode: input.storedMode }) : null;
+    const walletSettingsQuery = Object.assign(mock<WalletSettingsQueryResult>(), {
+      data: walletSettings,
+      isLoading: input.isLoading ?? false
+    });
+    const useWalletSettingsQuery: typeof DEPENDENCIES.useWalletSettingsQuery = () => walletSettingsQuery;
+
+    return renderHook(() => useAutoReloadMode({ dependencies: { useFlag, useWalletSettingsQuery } }));
   }
 });

--- a/apps/deploy-web/src/components/billing-usage/useAutoReloadMode.spec.ts
+++ b/apps/deploy-web/src/components/billing-usage/useAutoReloadMode.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { DEPENDENCIES, useAutoReloadMode } from "./useAutoReloadMode";
+
+import { renderHook } from "@testing-library/react";
+
+describe(useAutoReloadMode.name, () => {
+  it("uses the stored mode even when threshold mode is not offered", () => {
+    const { result } = setup({ isThresholdModeOffered: false, storedMode: "threshold" });
+
+    expect(result.current.mode).toBe("threshold");
+  });
+
+  it("uses the stored mode when threshold mode is offered", () => {
+    const { result } = setup({ isThresholdModeOffered: true, storedMode: "prediction" });
+
+    expect(result.current.mode).toBe("prediction");
+  });
+
+  it("defaults to threshold when nothing is stored and threshold mode is offered", () => {
+    const { result } = setup({ isThresholdModeOffered: true });
+
+    expect(result.current.mode).toBe("threshold");
+  });
+
+  it("defaults to prediction when nothing is stored and threshold mode is not offered", () => {
+    const { result } = setup({ isThresholdModeOffered: false });
+
+    expect(result.current.mode).toBe("prediction");
+  });
+
+  it("reports whether threshold mode is offered", () => {
+    const { result } = setup({ isThresholdModeOffered: true });
+
+    expect(result.current.isThresholdModeOffered).toBe(true);
+  });
+
+  it("shows the threshold rule only when it is offered and selected", () => {
+    expect(setup({ isThresholdModeOffered: true, storedMode: "threshold" }).result.current.showsThresholdRule).toBe(true);
+    expect(setup({ isThresholdModeOffered: true, storedMode: "prediction" }).result.current.showsThresholdRule).toBe(false);
+    expect(setup({ isThresholdModeOffered: false, storedMode: "threshold" }).result.current.showsThresholdRule).toBe(false);
+  });
+
+  function setup(input: { isThresholdModeOffered?: boolean; storedMode?: "prediction" | "threshold"; isLoading?: boolean }) {
+    const dependencies = {
+      ...DEPENDENCIES,
+      useFlag: () => input.isThresholdModeOffered ?? false,
+      useWalletSettingsQuery: () => ({
+        data: input.storedMode ? { autoReloadMode: input.storedMode } : null,
+        isLoading: input.isLoading ?? false
+      })
+    } as unknown as typeof DEPENDENCIES;
+
+    return renderHook(() => useAutoReloadMode({ dependencies }));
+  }
+});

--- a/apps/deploy-web/src/components/billing-usage/useAutoReloadMode.ts
+++ b/apps/deploy-web/src/components/billing-usage/useAutoReloadMode.ts
@@ -1,0 +1,32 @@
+"use client";
+import { useFlag } from "@src/hooks/useFlag";
+import { type AutoReloadMode, useWalletSettingsQuery } from "@src/queries";
+
+export const DEPENDENCIES = { useFlag, useWalletSettingsQuery };
+
+export type AutoReloadModeState = {
+  mode: AutoReloadMode;
+  /** Whether threshold mode is offered at all: the picker, the Edit affordance, and the default for a new enablement. */
+  isThresholdModeOffered: boolean;
+  /** Whether to present the fixed-threshold rule. False while the flag is off, so a rollback shows the legacy card everywhere at once. */
+  showsThresholdRule: boolean;
+  isLoading: boolean;
+};
+
+/**
+ * The stored mode always wins, so the billing page never advertises a rule the reload job isn't running. The flag
+ * only decides what an account that has never configured auto reload defaults to.
+ */
+export function useAutoReloadMode({ dependencies: d = DEPENDENCIES }: { dependencies?: typeof DEPENDENCIES } = {}): AutoReloadModeState {
+  const isThresholdModeOffered = d.useFlag("auto_reload_fixed_threshold");
+  const { data: walletSettings, isLoading } = d.useWalletSettingsQuery();
+
+  const mode = walletSettings?.autoReloadMode ?? (isThresholdModeOffered ? "threshold" : "prediction");
+
+  return {
+    mode,
+    isThresholdModeOffered,
+    showsThresholdRule: isThresholdModeOffered && mode === "threshold",
+    isLoading
+  };
+}

--- a/apps/deploy-web/src/queries/useWalletSettingsQueries.tsx
+++ b/apps/deploy-web/src/queries/useWalletSettingsQueries.tsx
@@ -47,3 +47,5 @@ export const useWalletSettingsMutations = () => {
 };
 
 type WalletSettings = paths["/v1/wallet-settings"]["get"]["responses"][200]["content"]["application/json"];
+
+export type AutoReloadMode = WalletSettings["data"]["autoReloadMode"];

--- a/packages/console-api-types/src/schema.d.ts
+++ b/packages/console-api-types/src/schema.d.ts
@@ -7133,7 +7133,7 @@ export interface operations {
           data: {
             autoReloadEnabled: boolean;
             /**
-             * @description Rule used to decide when and how much to top up: `threshold` charges the fixed amount as soon as the balance reaches the threshold, `prediction` covers the next 7 days of projected spend. Left unchanged when omitted.
+             * @description Rule used to decide when and how much to top up: `threshold` charges the fixed amount as soon as the balance reaches the threshold, `prediction` covers the next 7 days of projected spend. Defaults to `prediction` on create when omitted; left unchanged on update.
              * @enum {string}
              */
             autoReloadMode?: "threshold" | "prediction";
@@ -7190,7 +7190,7 @@ export interface operations {
           data: {
             autoReloadEnabled: boolean;
             /**
-             * @description Rule used to decide when and how much to top up: `threshold` charges the fixed amount as soon as the balance reaches the threshold, `prediction` covers the next 7 days of projected spend. Left unchanged when omitted.
+             * @description Rule used to decide when and how much to top up: `threshold` charges the fixed amount as soon as the balance reaches the threshold, `prediction` covers the next 7 days of projected spend. Defaults to `prediction` on create when omitted; left unchanged on update.
              * @enum {string}
              */
             autoReloadMode?: "threshold" | "prediction";

--- a/packages/console-api-types/src/schema.d.ts
+++ b/packages/console-api-types/src/schema.d.ts
@@ -7098,6 +7098,11 @@ export interface operations {
           "application/json": {
             data: {
               autoReloadEnabled: boolean;
+              /**
+               * @description Rule used to decide when and how much to top up.
+               * @enum {string}
+               */
+              autoReloadMode: "threshold" | "prediction";
               /** @description USD credit balance at or below which an automatic top-up is triggered. */
               autoReloadThreshold: number;
               /** @description USD amount charged to the default payment method on each automatic top-up. */
@@ -7127,6 +7132,11 @@ export interface operations {
         "application/json": {
           data: {
             autoReloadEnabled: boolean;
+            /**
+             * @description Rule used to decide when and how much to top up: `threshold` charges the fixed amount as soon as the balance reaches the threshold, `prediction` covers the next 7 days of projected spend. Left unchanged when omitted.
+             * @enum {string}
+             */
+            autoReloadMode?: "threshold" | "prediction";
             /** @description USD credit balance at or below which an automatic top-up is triggered (minimum 5, maximum 10000). Defaults are applied on create when omitted. */
             autoReloadThreshold?: number;
             /** @description USD amount charged on each automatic top-up (minimum 20, maximum 10000). Defaults are applied on create when omitted. */
@@ -7145,6 +7155,11 @@ export interface operations {
           "application/json": {
             data: {
               autoReloadEnabled: boolean;
+              /**
+               * @description Rule used to decide when and how much to top up.
+               * @enum {string}
+               */
+              autoReloadMode: "threshold" | "prediction";
               /** @description USD credit balance at or below which an automatic top-up is triggered. */
               autoReloadThreshold: number;
               /** @description USD amount charged to the default payment method on each automatic top-up. */
@@ -7174,6 +7189,11 @@ export interface operations {
         "application/json": {
           data: {
             autoReloadEnabled: boolean;
+            /**
+             * @description Rule used to decide when and how much to top up: `threshold` charges the fixed amount as soon as the balance reaches the threshold, `prediction` covers the next 7 days of projected spend. Left unchanged when omitted.
+             * @enum {string}
+             */
+            autoReloadMode?: "threshold" | "prediction";
             /** @description USD credit balance at or below which an automatic top-up is triggered (minimum 5, maximum 10000). Defaults are applied on create when omitted. */
             autoReloadThreshold?: number;
             /** @description USD amount charged on each automatic top-up (minimum 20, maximum 10000). Defaults are applied on create when omitted. */
@@ -7192,6 +7212,11 @@ export interface operations {
           "application/json": {
             data: {
               autoReloadEnabled: boolean;
+              /**
+               * @description Rule used to decide when and how much to top up.
+               * @enum {string}
+               */
+              autoReloadMode: "threshold" | "prediction";
               /** @description USD credit balance at or below which an automatic top-up is triggered. */
               autoReloadThreshold: number;
               /** @description USD amount charged to the default payment method on each automatic top-up. */


### PR DESCRIPTION
## Why

Auto reload has two possible rules today, and which one runs is decided by the global `auto_reload_fixed_threshold` flag. Turning that flag on would move every existing user from predicted-spend to the fixed threshold rule in one step. Background jobs also run without a real unleash user, so a flag can't express a per-user choice in the handler at all.

Part of CON-884

## What

Adds an `auto_reload_mode` enum column (`prediction` | `threshold`) to `wallet_settings` and makes the reload job branch on it instead of the flag.

- **Migration** is additive with `DEFAULT 'prediction'`, so every existing row keeps the behavior its owner signed up for. No backfill, no forced reconfiguration.
- **Threshold mode is opt-in.** The client asks for it explicitly on the wallet-settings write; an update that omits `autoReloadMode` leaves the stored mode untouched, so a disable/enable cycle can't silently switch anyone.
- `WalletBalanceReloadCheckHandler` no longer reads the flag, so a flag flip mid-rollout can't override a mode a user chose. `AUTO_RELOAD_FIXED_THRESHOLD` is dropped from the api's `FeatureFlags` — the flag lives on in `apps/deploy-web` only, where it gates whether the mode picker is offered.
- A mode change now counts as a reload-rule change, so switching modes cancels and re-enqueues the balance check the same way editing the threshold does.
- Reload metrics (`reloads_triggered_total`, `reloads_skipped_total`, both histograms) carry a `mode` attribute so adoption and per-mode skip rates are visible while both modes are live.
- The handler README was rewritten around the two modes: prediction is a supported mode now, not a legacy path awaiting removal.

No breaking contract change — `autoReloadMode` is optional on input and always present on output.

The frontend that surfaces the picker is a follow-up PR stacked on this branch (it derives its types from the regenerated `console-api-types`, so this one has to land first).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added selectable wallet auto-reload modes: threshold-based or projected-spend-based.
  * Wallet settings now display and accept the selected mode.
  * Changing the mode triggers an immediate reload check when auto-reload is enabled.
  * API documentation now describes supported modes and behavior.
  * Updated automatic top-up messaging and mode-specific settings guidance.

* **Bug Fixes**
  * Invalid auto-reload modes are rejected with a validation error.

* **Monitoring**
  * Reload activity metrics and logs now identify the selected mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->