### PR TITLE
fix(deployment): leave account-balance headroom for new deployments when auto-funding runs

### DIFF
--- a/apps/api/src/billing/services/chain-error/chain-error.service.spec.ts
+++ b/apps/api/src/billing/services/chain-error/chain-error.service.spec.ts
@@ -184,7 +184,7 @@ describe(ChainErrorService.name, () => {
 
       const appErr = await service.toAppError(err, encodeMessages);
       expect(appErr).toBeInstanceOf(PaymentRequired);
-      expect(appErr.message).toBe("Insufficient balance");
+      expect(appErr.message).toBe("Not enough balance to cover the deployment deposit. Add credits or turn on auto recharge to continue.");
     });
 
     it("returns 402 for insufficient balance error with message prefix", async () => {
@@ -196,7 +196,9 @@ describe(ChainErrorService.name, () => {
 
       const appErr = await service.toAppError(err, messages);
       expect(appErr).toBeInstanceOf(PaymentRequired);
-      expect(appErr.message).toBe("Failed to create deployment: Insufficient balance");
+      expect(appErr.message).toBe(
+        "Failed to create deployment: Not enough balance to cover the deployment deposit. Add credits or turn on auto recharge to continue."
+      );
     });
 
     it("returns 402 for simple insufficient balance message", async () => {
@@ -205,7 +207,7 @@ describe(ChainErrorService.name, () => {
 
       const appErr = await service.toAppError(err, encodeMessages);
       expect(appErr).toBeInstanceOf(PaymentRequired);
-      expect(appErr.message).toBe("Insufficient balance");
+      expect(appErr.message).toBe("Not enough balance to cover the deployment deposit. Add credits or turn on auto recharge to continue.");
     });
 
     it("returns 400 for escrow settlement underflow panic", async () => {

--- a/apps/api/src/billing/services/chain-error/chain-error.service.ts
+++ b/apps/api/src/billing/services/chain-error/chain-error.service.ts
@@ -70,7 +70,7 @@ export class ChainErrorService {
     },
     "insufficient balance": {
       code: 402,
-      message: "Insufficient balance"
+      message: "Not enough balance to cover the deployment deposit. Add credits or turn on auto recharge to continue."
     },
     [ESCROW_SETTLEMENT_UNDERFLOW_MESSAGE]: {
       code: 400,

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
@@ -88,7 +88,91 @@ describe(ManagedSignerService.name, () => {
         retrieveDeploymentLimit: vi.fn().mockResolvedValue(0)
       });
 
-      await expect(service.executeDerivedDecodedTxByUserId("user-123", [deploymentMessage])).rejects.toThrow("Not enough funds to cover the deployment costs");
+      await expect(service.executeDerivedDecodedTxByUserId("user-123", [deploymentMessage])).rejects.toThrow(
+        "Not enough balance to cover the deployment deposit. Add credits or turn on auto recharge to continue."
+      );
+    });
+
+    it("refuses a create whose deposit exceeds the deployment allowance instead of leaving it to chain simulation", async () => {
+      const { service, walletReloadJobService, logger, txManagerService } = setupForCreate({ deploymentLimit: 400000 });
+
+      await expect(service.executeDerivedDecodedTxByUserId("user-123", [createDeploymentMessage(500000)])).rejects.toThrow(
+        "Add credits or turn on auto recharge to continue."
+      );
+
+      expect(txManagerService.signAndBroadcastWithDerivedWallet).not.toHaveBeenCalled();
+      expect(walletReloadJobService.scheduleImmediate).toHaveBeenCalledWith({ userId: "user-123" });
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: "DEPLOYMENT_CREATE_REFUSED_INSUFFICIENT_ALLOWANCE",
+          deploymentAllowance: 400000,
+          requiredDeposit: 500000,
+          reloadScheduled: false
+        })
+      );
+    });
+
+    it("tells the user a top up is on the way when auto recharge covers the shortfall", async () => {
+      const { service } = setupForCreate({ deploymentLimit: 400000, scheduleImmediate: vi.fn().mockResolvedValue(true) });
+
+      await expect(service.executeDerivedDecodedTxByUserId("user-123", [createDeploymentMessage(500000)])).rejects.toThrow(
+        "A top up from your saved payment method is on the way, so try again in a moment."
+      );
+    });
+
+    it("allows a create whose deposit the deployment allowance exactly covers", async () => {
+      const { service, txManagerService } = setupForCreate({ deploymentLimit: 500000 });
+
+      await service.executeDerivedDecodedTxByUserId("user-123", [createDeploymentMessage(500000)]);
+
+      expect(txManagerService.signAndBroadcastWithDerivedWallet).toHaveBeenCalled();
+    });
+
+    it("ignores deposits denominated in another denom, which the chain rejects on its own", async () => {
+      const { service, txManagerService } = setupForCreate({ deploymentLimit: 1 });
+
+      await service.executeDerivedDecodedTxByUserId("user-123", [createDeploymentMessage(500000, "uusdc")]);
+
+      expect(txManagerService.signAndBroadcastWithDerivedWallet).toHaveBeenCalled();
+    });
+
+    it("surfaces the 402 even when scheduling the reload fails", async () => {
+      const { service, logger } = setupForCreate({
+        deploymentLimit: 400000,
+        scheduleImmediate: vi.fn().mockRejectedValue(new Error("Failed to schedule wallet balance reload check"))
+      });
+
+      await expect(service.executeDerivedDecodedTxByUserId("user-123", [createDeploymentMessage(500000)])).rejects.toThrow(
+        "Add credits or turn on auto recharge to continue."
+      );
+
+      expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "INSUFFICIENT_BALANCE_RELOAD_SCHEDULE_FAILED", userId: "user-123" }));
+    });
+
+    it("schedules a reload when the chain refuses the broadcast for insufficient balance", async () => {
+      const { service, walletReloadJobService } = setupForCreate({
+        deploymentLimit: 500000,
+        signAndBroadcastWithDerivedWallet: vi.fn().mockRejectedValue(new Error("deposit invalid: insufficient balance")),
+        transformChainError: vi.fn().mockResolvedValue(createError(402, "Not enough balance to cover the deployment deposit."))
+      });
+
+      await expect(service.executeDerivedDecodedTxByUserId("user-123", [createDeploymentMessage(500000)])).rejects.toThrow(
+        "Not enough balance to cover the deployment deposit."
+      );
+
+      expect(walletReloadJobService.scheduleImmediate).toHaveBeenCalledWith({ userId: "user-123" });
+    });
+
+    it("does not schedule a reload when the broadcast fails for a reason other than balance", async () => {
+      const { service, walletReloadJobService } = setupForCreate({
+        deploymentLimit: 500000,
+        signAndBroadcastWithDerivedWallet: vi.fn().mockRejectedValue(new Error("bid not open")),
+        transformChainError: vi.fn().mockResolvedValue(createError(400, "Cannot create lease"))
+      });
+
+      await expect(service.executeDerivedDecodedTxByUserId("user-123", [createDeploymentMessage(500000)])).rejects.toThrow("Cannot create lease");
+
+      expect(walletReloadJobService.scheduleImmediate).not.toHaveBeenCalled();
     });
 
     it("skips trial validation when anonymous free trial is disabled", async () => {
@@ -740,6 +824,26 @@ describe(ManagedSignerService.name, () => {
     });
   });
 
+  function createDeploymentMessage(depositAmount: number, denom = "uakt"): EncodeObject {
+    return {
+      typeUrl: MsgCreateDeployment.$type,
+      value: MsgCreateDeployment.fromPartial({ deposit: { amount: { denom, amount: depositAmount.toString() } } })
+    };
+  }
+
+  function setupForCreate(input: { deploymentLimit: number } & Omit<NonNullable<Parameters<typeof setup>[0]>, "retrieveDeploymentLimit">) {
+    const { deploymentLimit, ...rest } = input;
+
+    return setup({
+      findOneByUserId: vi.fn().mockResolvedValue(createUserWallet({ userId: "user-123", feeAllowance: 100, deploymentAllowance: deploymentLimit })),
+      findById: vi.fn().mockResolvedValue(createUser({ userId: "user-123" })),
+      retrieveDeploymentLimit: vi.fn().mockResolvedValue(deploymentLimit),
+      signAndBroadcastWithDerivedWallet: vi.fn().mockResolvedValue({ code: 0, hash: "TESTHASH", rawLog: "[]" }),
+      refreshUserWalletLimits: vi.fn(),
+      ...rest
+    });
+  }
+
   function setup(input?: {
     findOneByUserId?: UserWalletRepository["findOneByUserId"];
     findById?: UserRepository["findById"];
@@ -755,6 +859,7 @@ describe(ManagedSignerService.name, () => {
     publish?: DomainEventsService["publish"];
     transformChainError?: ChainErrorService["toAppError"];
     hasLeases?: LeaseHttpService["hasLeases"];
+    scheduleImmediate?: WalletReloadJobService["scheduleImmediate"];
     decode?: Registry["decode"];
   }) {
     const mocks = {
@@ -792,9 +897,10 @@ describe(ManagedSignerService.name, () => {
         hasLeases: input?.hasLeases ?? vi.fn(async () => false)
       }),
       walletReloadJobService: mock<WalletReloadJobService>({
-        scheduleImmediate: vi.fn()
+        scheduleImmediate: input?.scheduleImmediate ?? vi.fn().mockResolvedValue(false)
       }),
       billingConfigService: mockConfigService<BillingConfigService>({
+        DEPLOYMENT_GRANT_DENOM: "uakt",
         FEE_ALLOWANCE_REFILL_AMOUNT: 1000000,
         FEE_ALLOWANCE_REFILL_THRESHOLD: 100000,
         TRIAL_ALLOWANCE_EXPIRATION_DAYS: 30
@@ -805,7 +911,8 @@ describe(ManagedSignerService.name, () => {
       trialActivationJobService: mock<TrialActivationJobService>(),
       logger: mock<LoggerService>({
         setContext: vi.fn(),
-        error: vi.fn()
+        error: vi.fn(),
+        warn: vi.fn()
       })
     };
 

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
@@ -136,6 +136,16 @@ describe(ManagedSignerService.name, () => {
       expect(txManagerService.signAndBroadcastWithDerivedWallet).toHaveBeenCalled();
     });
 
+    it("refuses a batch where a negative deposit would otherwise offset a positive one", async () => {
+      const { service, txManagerService } = setupForCreate({ deploymentLimit: 400000 });
+
+      await expect(service.executeDerivedDecodedTxByUserId("user-123", [createDeploymentMessage(500000), createDeploymentMessage(-500000)])).rejects.toThrow(
+        "Add credits or turn on auto recharge to continue."
+      );
+
+      expect(txManagerService.signAndBroadcastWithDerivedWallet).not.toHaveBeenCalled();
+    });
+
     it("surfaces the 402 even when scheduling the reload fails", async () => {
       const { service, logger } = setupForCreate({
         deploymentLimit: 400000,

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
@@ -101,7 +101,7 @@ describe(ManagedSignerService.name, () => {
       );
 
       expect(txManagerService.signAndBroadcastWithDerivedWallet).not.toHaveBeenCalled();
-      expect(walletReloadJobService.scheduleImmediate).toHaveBeenCalledWith({ userId: "user-123" });
+      expect(walletReloadJobService.scheduleImmediate).toHaveBeenCalledWith({ userId: "user-123" }, { triggeredByDeployment: true });
       expect(logger.warn).toHaveBeenCalledWith(
         expect.objectContaining({
           event: "DEPLOYMENT_CREATE_REFUSED_INSUFFICIENT_ALLOWANCE",
@@ -170,7 +170,17 @@ describe(ManagedSignerService.name, () => {
         "Not enough balance to cover the deployment deposit."
       );
 
-      expect(walletReloadJobService.scheduleImmediate).toHaveBeenCalledWith({ userId: "user-123" });
+      expect(walletReloadJobService.scheduleImmediate).toHaveBeenCalledWith({ userId: "user-123" }, { triggeredByDeployment: true });
+    });
+
+    it("flags the reload as deployment triggered so a first create is not skipped for having no active deployment", async () => {
+      const { service, walletReloadJobService } = setupForCreate({ deploymentLimit: 0 });
+
+      await expect(service.executeDerivedDecodedTxByUserId("user-123", [createDeploymentMessage(500000)])).rejects.toThrow(
+        "Add credits or turn on auto recharge to continue."
+      );
+
+      expect(walletReloadJobService.scheduleImmediate).toHaveBeenCalledWith(expect.anything(), { triggeredByDeployment: true });
     });
 
     it("does not schedule a reload when the broadcast fails for a reason other than balance", async () => {

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
@@ -7,7 +7,7 @@ import { EncodeObject, Registry } from "@cosmjs/proto-signing";
 import { IndexedTx } from "@cosmjs/stargate";
 import { context, trace } from "@opentelemetry/api";
 import assert from "http-assert";
-import { BadRequest } from "http-errors";
+import { BadRequest, isHttpError } from "http-errors";
 import pick from "lodash/pick";
 import { singleton } from "tsyringe";
 
@@ -33,6 +33,10 @@ import { TrialValidationService } from "../trial-validation/trial-validation.ser
 type StringifiedEncodeObject = Omit<EncodeObject, "value"> & { value: string };
 
 const SPENDING_TXS = [MsgCreateDeployment, MsgAccountDeposit];
+
+const INSUFFICIENT_DEPOSIT_BALANCE_MESSAGE = "Not enough balance to cover the deployment deposit. Add credits or turn on auto recharge to continue.";
+const INSUFFICIENT_DEPOSIT_BALANCE_RELOADING_MESSAGE =
+  "Not enough balance to cover the deployment deposit. A top up from your saved payment method is on the way, so try again in a moment.";
 
 @singleton()
 export class ManagedSignerService {
@@ -123,11 +127,18 @@ export class ManagedSignerService {
     const hasCreateTrialLeaseMessage = userWallet.isTrialing && !!createLeaseMessage;
     const hasLeases = hasCreateTrialLeaseMessage ? await this.leaseHttpService.hasLeases(userWallet.address!) : null;
 
-    const tx = await this.executeDerivedTx(userWallet.id, messages);
+    let tx: Awaited<ReturnType<ManagedSignerService["executeDerivedTx"]>>;
 
-    if (tx.code !== COSMOS_TX_CODE_OK) {
-      this.logger.error({ event: "TX_LANDED_WITH_NON_ZERO_CODE", txHash: tx.hash, code: tx.code, rawLog: tx.rawLog });
-      throw await this.chainErrorService.toAppError(new Error(tx.rawLog || `tx ${tx.hash} failed on-chain with code ${tx.code}`), messages);
+    try {
+      tx = await this.executeDerivedTx(userWallet.id, messages);
+
+      if (tx.code !== COSMOS_TX_CODE_OK) {
+        this.logger.error({ event: "TX_LANDED_WITH_NON_ZERO_CODE", txHash: tx.hash, code: tx.code, rawLog: tx.rawLog });
+        throw await this.chainErrorService.toAppError(new Error(tx.rawLog || `tx ${tx.hash} failed on-chain with code ${tx.code}`), messages);
+      }
+    } catch (error) {
+      await this.#scheduleReloadOnPaymentRequired(error, userWallet);
+      throw error;
     }
 
     if (hasCreateTrialLeaseMessage) {
@@ -206,24 +217,85 @@ export class ManagedSignerService {
    * Always fetches fee allowance from the chain to ensure accuracy, as database values may be out of sync.
    * Fetches deployment allowance from the chain only when a deployment message is present, otherwise uses cached value.
    * Automatically refills fee authorization for eligible trial wallets if fee allowance is below FEE_ALLOWANCE_REFILL_THRESHOLD.
-   * Throws an assertion error if insufficient funds are available.
    *
    * @param userWallet - The user wallet to validate balances for
    * @param messages - Array of transaction messages to check for deployment messages
    * @throws {HttpError} 402 if there are not enough funds to cover the transaction fee
-   * @throws {HttpError} 402 if there are not enough funds to cover deployment costs (when deployment message is present)
+   * @throws {HttpError} 402 if the deployment allowance cannot cover the deposits the create messages ask for
    */
   async #validateBalances(userWallet: UserWalletOutput, messages: EncodeObject[]) {
     return withSpan("ManagedSignerService.validateBalances", async () => {
-      const hasDeploymentMessage = messages.some(message => message.typeUrl.endsWith(".MsgCreateDeployment"));
+      const createDeploymentMessages = this.#getCreateDeploymentMessages(messages);
+      const hasDeploymentMessage = createDeploymentMessages.length > 0;
       const [feeAllowance, deploymentAllowance] = await Promise.all([
         this.ensureFeeGrants(userWallet),
         !hasDeploymentMessage ? Promise.resolve(userWallet.deploymentAllowance) : this.balancesService.retrieveDeploymentLimit(userWallet)
       ]);
 
       assert(feeAllowance > 0, 402, "Not enough funds to cover the transaction fee");
-      assert(!hasDeploymentMessage || deploymentAllowance > 0, 402, "Not enough funds to cover the deployment costs");
+
+      const requiredDeposit = this.#sumDepositsDrawnFromGrant(createDeploymentMessages);
+
+      if (hasDeploymentMessage && (deploymentAllowance <= 0 || deploymentAllowance < requiredDeposit)) {
+        const reloadScheduled = await this.#scheduleReloadForInsufficientBalance(userWallet);
+
+        this.logger.warn({
+          event: "DEPLOYMENT_CREATE_REFUSED_INSUFFICIENT_ALLOWANCE",
+          userId: userWallet.userId,
+          address: userWallet.address,
+          deploymentAllowance,
+          requiredDeposit,
+          reloadScheduled
+        });
+
+        assert(false, 402, reloadScheduled ? INSUFFICIENT_DEPOSIT_BALANCE_RELOADING_MESSAGE : INSUFFICIENT_DEPOSIT_BALANCE_MESSAGE);
+      }
     });
+  }
+
+  #getCreateDeploymentMessages(messages: EncodeObject[]): { typeUrl: string; value: MsgCreateDeployment }[] {
+    return messages.filter((message): message is { typeUrl: string; value: MsgCreateDeployment } => message.typeUrl.endsWith(".MsgCreateDeployment"));
+  }
+
+  /**
+   * A create deposit is drawn purely from the deployment grant, so the deposits in the batch are directly
+   * comparable to the grant's remaining spend limit. Comparing against the real amount rather than a bare `> 0`
+   * refuses the request here instead of several seconds later in chain simulation, where the shortfall surfaces
+   * as an opaque 402.
+   */
+  #sumDepositsDrawnFromGrant(createDeploymentMessages: { value: MsgCreateDeployment }[]): number {
+    const denom = this.billingConfigService.get("DEPLOYMENT_GRANT_DENOM");
+
+    return createDeploymentMessages.reduce((total, message) => {
+      const deposit = message.value.deposit?.amount;
+      return deposit?.denom === denom ? total + Number(deposit.amount) : total;
+    }, 0);
+  }
+
+  /**
+   * Refills the balance for a spend the chain refused even though the pre-flight check passed: auto-funding can
+   * drain the grant in the window between the two. The reload check itself decides whether a charge is due.
+   */
+  async #scheduleReloadOnPaymentRequired(error: unknown, userWallet: UserWalletOutput): Promise<void> {
+    if (!isHttpError(error) || error.status !== 402) {
+      return;
+    }
+
+    await this.#scheduleReloadForInsufficientBalance(userWallet);
+  }
+
+  /**
+   * Refills the balance the refused request could not cover, so a user with auto recharge on can retry instead of
+   * topping up by hand. Scheduling failures are swallowed: the caller is about to receive a clean 402 and turning
+   * that into a 500 would lose the actionable message. The returned flag reports whether auto recharge is on.
+   */
+  async #scheduleReloadForInsufficientBalance(userWallet: UserWalletOutput): Promise<boolean> {
+    try {
+      return await this.walletReloadJobService.scheduleImmediate({ userId: userWallet.userId });
+    } catch (error) {
+      this.logger.error({ event: "INSUFFICIENT_BALANCE_RELOAD_SCHEDULE_FAILED", userId: userWallet.userId, error });
+      return false;
+    }
   }
 
   async ensureFeeGrants(wallet: Pick<UserWalletOutput, "address" | "isTrialing" | "createdAt" | "activatedAt">): Promise<number> {

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
@@ -262,13 +262,23 @@ export class ManagedSignerService {
    * comparable to the grant's remaining spend limit. Comparing against the real amount rather than a bare `> 0`
    * refuses the request here instead of several seconds later in chain simulation, where the shortfall surfaces
    * as an opaque 402.
+   *
+   * Only positive deposits count. `/v1/tx` takes a caller-supplied batch and the request schema does not
+   * constrain the deposit's sign, so summing raw values would let a negative deposit offset a positive one and
+   * understate what the chain is about to charge against the grant. The chain rejects the negative message and
+   * fails the whole tx anyway; this keeps the sum a true lower bound instead of a bypass of the check.
    */
   #sumDepositsDrawnFromGrant(createDeploymentMessages: { value: MsgCreateDeployment }[]): number {
     const denom = this.billingConfigService.get("DEPLOYMENT_GRANT_DENOM");
 
     return createDeploymentMessages.reduce((total, message) => {
       const deposit = message.value.deposit?.amount;
-      return deposit?.denom === denom ? total + Number(deposit.amount) : total;
+
+      if (deposit?.denom !== denom) {
+        return total;
+      }
+
+      return total + Math.max(0, Number(deposit.amount));
     }, 0);
   }
 

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
@@ -298,10 +298,14 @@ export class ManagedSignerService {
    * Refills the balance the refused request could not cover, so a user with auto recharge on can retry instead of
    * topping up by hand. Scheduling failures are swallowed: the caller is about to receive a clean 402 and turning
    * that into a 500 would lose the actionable message. The returned flag reports whether auto recharge is on.
+   *
+   * `triggeredByDeployment` is required here: the refused request is a create, so the owner may hold no active
+   * deployment yet. Without it the reload check skips on its indexer-fed active-deployment guard and never charges,
+   * leaving the caller with a 402 promising a top-up that never arrives.
    */
   async #scheduleReloadForInsufficientBalance(userWallet: UserWalletOutput): Promise<boolean> {
     try {
-      return await this.walletReloadJobService.scheduleImmediate({ userId: userWallet.userId });
+      return await this.walletReloadJobService.scheduleImmediate({ userId: userWallet.userId }, { triggeredByDeployment: true });
     } catch (error) {
       this.logger.error({ event: "INSUFFICIENT_BALANCE_RELOAD_SCHEDULE_FAILED", userId: userWallet.userId, error });
       return false;

--- a/apps/api/src/deployment/config/env.config.ts
+++ b/apps/api/src/deployment/config/env.config.ts
@@ -7,6 +7,12 @@ export const envSchema = z.object({
   AUTO_TOP_UP_AMOUNT_IN_H: z.number({ coerce: true }).optional().default(48),
   AUTO_TOP_UP_DEDUP_COOLDOWN_IN_MIN: z.number({ coerce: true }).positive().optional().default(60),
   /**
+   * Dollar floor auto-funding leaves in the available deployment allowance so a user with credits left can still
+   * create a deployment. Whole dollars: `DEPLOYMENT_GRANT_DENOM` is `uact` on real networks, 1:1 with USD.
+   * 0 restores the previous drain-to-zero behavior.
+   */
+  AUTO_TOP_UP_BALANCE_HEADROOM_IN_USD: z.number({ coerce: true }).nonnegative().optional().default(5),
+  /**
    * Deposit (in dollars) the platform bootstraps a managed deployment with when the caller no longer supplies one.
    * Must stay at or above the chain's `min_deposits` for the active `DEPLOYMENT_GRANT_DENOM`, or the create tx is rejected
    * on-chain. Kept minimal on purpose: auto-funding tops the deployment up to its runway right after the lease starts.

--- a/apps/api/src/deployment/services/cached-balance/cached-balance.service.spec.ts
+++ b/apps/api/src/deployment/services/cached-balance/cached-balance.service.spec.ts
@@ -1,9 +1,12 @@
-import type { Mocked } from "vitest";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
 
 import type { BalancesService } from "@src/billing/services/balances/balances.service";
+import type { LoggerService } from "@src/core";
+import type { DeploymentConfigService } from "@src/deployment/services/deployment-config/deployment-config.service";
 import { CachedBalanceService } from "./cached-balance.service";
 
+import { mockConfigService } from "@test/mocks/config-service.mock";
 import { createAkashAddress } from "@test/seeders";
 
 describe(CachedBalanceService.name, () => {
@@ -11,7 +14,7 @@ describe(CachedBalanceService.name, () => {
     const address = createAkashAddress();
     const DEPLOYMENT_LIMIT = 1000;
 
-    it("should fetch and cache balance for new address", async () => {
+    it("fetches and caches the balance for a new address", async () => {
       const { service, balancesService } = setup();
       balancesService.getFreshLimits.mockResolvedValue({
         deployment: DEPLOYMENT_LIMIT,
@@ -33,7 +36,7 @@ describe(CachedBalanceService.name, () => {
       expect(remainingAmount).toBe(500);
     });
 
-    it("should use cached balance for existing address", async () => {
+    it("uses the cached balance for an existing address", async () => {
       const { service, balancesService } = setup();
       balancesService.getFreshLimits.mockResolvedValue({
         deployment: DEPLOYMENT_LIMIT,
@@ -46,7 +49,7 @@ describe(CachedBalanceService.name, () => {
       expect(balancesService.getFreshLimits).toHaveBeenCalledTimes(1);
     });
 
-    it("should throw error when trying to reserve more than available", async () => {
+    it("throws when trying to reserve more than available", async () => {
       const { service, balancesService } = setup();
       balancesService.getFreshLimits.mockResolvedValue({
         deployment: DEPLOYMENT_LIMIT,
@@ -60,7 +63,7 @@ describe(CachedBalanceService.name, () => {
       expect(() => balance.reserveSufficientAmount(200)).toThrow("Insufficient balance");
     });
 
-    it("should return maximum available amount when requesting more than available", async () => {
+    it("returns the maximum available amount when requesting more than available", async () => {
       const { service, balancesService } = setup();
       balancesService.getFreshLimits.mockResolvedValue({
         deployment: DEPLOYMENT_LIMIT,
@@ -73,7 +76,7 @@ describe(CachedBalanceService.name, () => {
       expect(amount).toBe(1000);
     });
 
-    it("should throw error when trying to reserve zero or negative amount", async () => {
+    it("throws when trying to reserve a zero or negative amount", async () => {
       const { service, balancesService } = setup();
       balancesService.getFreshLimits.mockResolvedValue({
         deployment: DEPLOYMENT_LIMIT,
@@ -104,13 +107,79 @@ describe(CachedBalanceService.name, () => {
     });
   });
 
-  function setup() {
-    const balancesService = {
-      getFreshLimits: vi.fn()
-    } as unknown as Mocked<BalancesService>;
+  describe("balance headroom", () => {
+    const address = createAkashAddress();
 
-    const service = new CachedBalanceService(balancesService);
+    it("keeps the headroom out of the spendable amount", async () => {
+      const { service, balancesService } = setup({ headroomInUsd: 5 });
+      balancesService.getFreshLimits.mockResolvedValue({ deployment: 200_000_000, fee: 100 });
 
-    return { service, balancesService };
+      const balance = await service.getFresh(address);
+
+      expect(balance.available).toBe(200_000_000);
+      expect(balance.spendable).toBe(195_000_000);
+      expect(balance.headroomWaived).toBe(false);
+    });
+
+    it("keeps the headroom across a whole batch of reservations", async () => {
+      const { service, balancesService } = setup({ headroomInUsd: 5 });
+      balancesService.getFreshLimits.mockResolvedValue({ deployment: 10_000_000, fee: 100 });
+
+      const balance = await service.getFresh(address);
+      const first = balance.reserveSufficientAmount(4_000_000);
+      const second = balance.reserveSufficientAmount(4_000_000);
+
+      expect(first + second).toBe(5_000_000);
+      expect(() => balance.reserveSufficientAmount(1)).toThrow("Insufficient balance");
+    });
+
+    it("waives the headroom when the balance is at or below it so running deployments still get funded", async () => {
+      const { service, balancesService } = setup({ headroomInUsd: 5 });
+      balancesService.getFreshLimits.mockResolvedValue({ deployment: 4_000_000, fee: 100 });
+
+      const balance = await service.getFresh(address);
+
+      expect(balance.spendable).toBe(4_000_000);
+      expect(balance.headroomWaived).toBe(true);
+      expect(balance.reserveSufficientAmount(10_000_000)).toBe(4_000_000);
+    });
+
+    it("spends the full balance when the headroom is disabled", async () => {
+      const { service, balancesService } = setup({ headroomInUsd: 0 });
+      balancesService.getFreshLimits.mockResolvedValue({ deployment: 200_000_000, fee: 100 });
+
+      const balance = await service.getFresh(address);
+
+      expect(balance.spendable).toBe(200_000_000);
+      expect(balance.headroomWaived).toBe(false);
+    });
+
+    it("logs the headroom decision so the floor can be tuned from data", async () => {
+      const { service, balancesService, logger } = setup({ headroomInUsd: 5 });
+      balancesService.getFreshLimits.mockResolvedValue({ deployment: 6_000_000, fee: 100 });
+
+      await service.getFresh(address);
+
+      expect(logger.info).toHaveBeenCalledWith({
+        event: "AUTO_TOP_UP_BALANCE_HEADROOM",
+        address,
+        available: 6_000_000,
+        headroom: 5_000_000,
+        spendable: 1_000_000,
+        waived: false
+      });
+    });
+  });
+
+  function setup(input?: { headroomInUsd?: number }) {
+    const balancesService = mock<BalancesService>();
+    const deploymentConfig = mockConfigService<DeploymentConfigService>({
+      AUTO_TOP_UP_BALANCE_HEADROOM_IN_USD: input?.headroomInUsd ?? 0
+    });
+    const logger = mock<LoggerService>();
+
+    const service = new CachedBalanceService(balancesService, deploymentConfig, logger);
+
+    return { service, balancesService, deploymentConfig, logger };
   }
 });

--- a/apps/api/src/deployment/services/cached-balance/cached-balance.service.ts
+++ b/apps/api/src/deployment/services/cached-balance/cached-balance.service.ts
@@ -2,18 +2,46 @@ import { singleton } from "tsyringe";
 
 import { BalancesService } from "@src/billing/services/balances/balances.service";
 import { memoizeAsync } from "@src/caching/helpers";
+import { LoggerService } from "@src/core";
+import { DeploymentConfigService } from "@src/deployment/services/deployment-config/deployment-config.service";
+import { denomToUdenom } from "@src/utils/math";
 
 export class CachedBalance {
-  constructor(private value: number) {}
+  readonly #available: number;
+  readonly #headroomWaived: boolean;
+  #spendable: number;
+
+  /**
+   * The headroom yields the moment the balance cannot cover it: keeping running deployments alive outranks
+   * reserving room for a new one. It is resolved once, from the balance the funding pass started with, so a
+   * batch cannot chip the floor away one deployment at a time.
+   */
+  constructor(available: number, headroom: number) {
+    this.#available = available;
+    this.#headroomWaived = headroom > 0 && available <= headroom;
+    this.#spendable = available > headroom ? available - headroom : available;
+  }
+
+  public get available() {
+    return this.#available;
+  }
+
+  public get spendable() {
+    return this.#spendable;
+  }
+
+  public get headroomWaived() {
+    return this.#headroomWaived;
+  }
 
   public reserveSufficientAmount(desiredAmount: number) {
-    const value = Math.min(desiredAmount, this.value);
+    const value = Math.min(desiredAmount, this.#spendable);
 
     if (value <= 0) {
-      throw new Error(`Insufficient balance: ${this.value} < ${desiredAmount}`);
+      throw new Error(`Insufficient balance: ${this.#spendable} < ${desiredAmount}`);
     }
 
-    this.value -= value;
+    this.#spendable -= value;
 
     return value;
   }
@@ -23,7 +51,13 @@ export class CachedBalance {
 export class CachedBalanceService {
   public get = memoizeAsync((address: string) => this.buildForAddress(address), { cacheItemLimit: 10_000 });
 
-  constructor(private readonly balancesService: BalancesService) {}
+  constructor(
+    private readonly balancesService: BalancesService,
+    private readonly deploymentConfig: DeploymentConfigService,
+    private readonly logger: LoggerService
+  ) {
+    this.logger.setContext(CachedBalanceService.name);
+  }
 
   /**
    * Reads a fresh balance bypassing the per-address memo. The memo is keyed for
@@ -36,6 +70,18 @@ export class CachedBalanceService {
 
   private async buildForAddress(address: string): Promise<CachedBalance> {
     const limits = await this.balancesService.getFreshLimits({ address });
-    return new CachedBalance(limits.deployment);
+    const headroom = denomToUdenom(this.deploymentConfig.get("AUTO_TOP_UP_BALANCE_HEADROOM_IN_USD"));
+    const balance = new CachedBalance(limits.deployment, headroom);
+
+    this.logger.info({
+      event: "AUTO_TOP_UP_BALANCE_HEADROOM",
+      address,
+      available: balance.available,
+      headroom,
+      spendable: balance.spendable,
+      waived: balance.headroomWaived
+    });
+
+    return balance;
   }
 }

--- a/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.spec.ts
+++ b/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.spec.ts
@@ -3,7 +3,6 @@ import { mock } from "vitest-mock-extended";
 
 import type { UserWalletRepository } from "@src/billing/repositories";
 import type { RpcMessageService } from "@src/billing/services";
-import type { BalancesService } from "@src/billing/services/balances/balances.service";
 import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import type { ChainErrorService } from "@src/billing/services/chain-error/chain-error.service";
 import type { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
@@ -12,6 +11,7 @@ import type { BlockHttpService } from "@src/chain/services/block-http/block-http
 import type { CreateLogger } from "@src/core";
 import type { DeploymentSettingRepository, DeploymentSettingsOutput } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import type { DrainingDeploymentOutput } from "@src/deployment/repositories/lease/lease.repository";
+import { CachedBalance, type CachedBalanceService } from "@src/deployment/services/cached-balance/cached-balance.service";
 import type { DeploymentConfigService } from "@src/deployment/services/deployment-config/deployment-config.service";
 import type { DrainingDeploymentService } from "@src/deployment/services/draining-deployment/draining-deployment.service";
 import { InitialDeploymentFundingService } from "./initial-deployment-funding.service";
@@ -54,11 +54,10 @@ describe(InitialDeploymentFundingService.name, () => {
   });
 
   it("deposits the calculated top-up amount and schedules a wallet reload", async () => {
-    const { service, drainingDeploymentService, balancesService, rpcMessageService, managedSignerService, walletReloadJobService, instrumentation } = setup();
+    const { service, drainingDeploymentService, rpcMessageService, managedSignerService, walletReloadJobService, instrumentation } = setup();
     const depositMessage = { typeUrl: "/akash.escrow.v1.MsgAccountDeposit", value: {} };
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
     drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(500000);
-    balancesService.getFreshLimits.mockResolvedValue({ fee: 100000, deployment: 1000000 });
     rpcMessageService.getDepositDeploymentMsg.mockReturnValue(depositMessage as ReturnType<RpcMessageService["getDepositDeploymentMsg"]>);
 
     await service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" });
@@ -76,10 +75,9 @@ describe(InitialDeploymentFundingService.name, () => {
   });
 
   it("records the deposit and tolerates a wallet reload scheduling failure without failing the job", async () => {
-    const { service, drainingDeploymentService, balancesService, managedSignerService, walletReloadJobService, instrumentation, logger } = setup();
+    const { service, drainingDeploymentService, managedSignerService, walletReloadJobService, instrumentation, logger } = setup();
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
     drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(500000);
-    balancesService.getFreshLimits.mockResolvedValue({ fee: 100000, deployment: 1000000 });
     managedSignerService.executeDerivedTx.mockResolvedValue({ code: 0, hash: "TESTHASH", rawLog: "[]" });
     walletReloadJobService.scheduleImmediate.mockRejectedValue(new Error("Failed to schedule wallet balance reload check"));
 
@@ -90,10 +88,9 @@ describe(InitialDeploymentFundingService.name, () => {
   });
 
   it("completes the job when logging the wallet reload scheduling failure itself throws", async () => {
-    const { service, drainingDeploymentService, balancesService, walletReloadJobService, instrumentation, logger } = setup();
+    const { service, drainingDeploymentService, walletReloadJobService, instrumentation, logger } = setup();
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
     drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(500000);
-    balancesService.getFreshLimits.mockResolvedValue({ fee: 100000, deployment: 1000000 });
     walletReloadJobService.scheduleImmediate.mockRejectedValue(new Error("Failed to schedule wallet balance reload check"));
     logger.error.mockImplementation(() => {
       throw new Error("logger transport failure");
@@ -105,10 +102,9 @@ describe(InitialDeploymentFundingService.name, () => {
   });
 
   it("skips funding when auto top-up is disabled for the deployment", async () => {
-    const { service, drainingDeploymentService, balancesService, userWalletRepository, deploymentSettingRepository, managedSignerService, logger } = setup();
+    const { service, drainingDeploymentService, userWalletRepository, deploymentSettingRepository, managedSignerService, logger } = setup();
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
     drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(500000);
-    balancesService.getFreshLimits.mockResolvedValue({ fee: 100000, deployment: 1000000 });
     userWalletRepository.findById.mockResolvedValue(createUserWallet({ id: 1, address: "akash1owner", userId: "user-1" }));
     deploymentSettingRepository.findOneBy.mockResolvedValue(mock<DeploymentSettingsOutput>({ autoTopUpEnabled: false }));
 
@@ -120,10 +116,9 @@ describe(InitialDeploymentFundingService.name, () => {
   });
 
   it("funds the deployment when auto top-up is explicitly enabled", async () => {
-    const { service, drainingDeploymentService, balancesService, deploymentSettingRepository, managedSignerService } = setup();
+    const { service, drainingDeploymentService, deploymentSettingRepository, managedSignerService } = setup();
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
     drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(500000);
-    balancesService.getFreshLimits.mockResolvedValue({ fee: 100000, deployment: 1000000 });
     deploymentSettingRepository.findOneBy.mockResolvedValue(mock<DeploymentSettingsOutput>({ autoTopUpEnabled: true }));
 
     await service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" });
@@ -132,10 +127,9 @@ describe(InitialDeploymentFundingService.name, () => {
   });
 
   it("throws and skips the wallet reload when the deposit tx fails on-chain", async () => {
-    const { service, drainingDeploymentService, balancesService, managedSignerService, walletReloadJobService, logger } = setup();
+    const { service, drainingDeploymentService, managedSignerService, walletReloadJobService, logger } = setup();
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
     drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(500000);
-    balancesService.getFreshLimits.mockResolvedValue({ fee: 100000, deployment: 1000000 });
     managedSignerService.executeDerivedTx.mockResolvedValue({ code: 5, hash: "TESTHASH", rawLog: "insufficient funds" });
 
     await expect(service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" })).rejects.toThrow("insufficient funds");
@@ -145,10 +139,9 @@ describe(InitialDeploymentFundingService.name, () => {
   });
 
   it("skips terminally when the deposit is rejected because the deployment escrow is closed", async () => {
-    const { service, drainingDeploymentService, balancesService, managedSignerService, chainErrorService, walletReloadJobService, instrumentation } = setup();
+    const { service, drainingDeploymentService, managedSignerService, chainErrorService, walletReloadJobService, instrumentation } = setup();
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
     drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(500000);
-    balancesService.getFreshLimits.mockResolvedValue({ fee: 100000, deployment: 1000000 });
     managedSignerService.executeDerivedTx.mockRejectedValue(new Error("Deployment closed"));
     chainErrorService.isDeploymentClosedError.mockReturnValue(true);
 
@@ -159,10 +152,9 @@ describe(InitialDeploymentFundingService.name, () => {
   });
 
   it("rethrows deposit errors unrelated to a closed deployment", async () => {
-    const { service, drainingDeploymentService, balancesService, managedSignerService, walletReloadJobService, instrumentation } = setup();
+    const { service, drainingDeploymentService, managedSignerService, walletReloadJobService, instrumentation } = setup();
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
     drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(500000);
-    balancesService.getFreshLimits.mockResolvedValue({ fee: 100000, deployment: 1000000 });
     managedSignerService.executeDerivedTx.mockRejectedValue(new Error("Bad status on response: 503"));
 
     await expect(service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" })).rejects.toThrow("Bad status on response: 503");
@@ -172,11 +164,9 @@ describe(InitialDeploymentFundingService.name, () => {
   });
 
   it("skips terminally when the deposit tx lands with a closed account in the raw log", async () => {
-    const { service, drainingDeploymentService, balancesService, managedSignerService, chainErrorService, walletReloadJobService, instrumentation, logger } =
-      setup();
+    const { service, drainingDeploymentService, managedSignerService, chainErrorService, walletReloadJobService, instrumentation, logger } = setup();
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
     drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(500000);
-    balancesService.getFreshLimits.mockResolvedValue({ fee: 100000, deployment: 1000000 });
     managedSignerService.executeDerivedTx.mockResolvedValue({ code: 5, hash: "TESTHASH", rawLog: "account closed" });
     chainErrorService.isDeploymentClosedError.mockReturnValue(true);
 
@@ -188,10 +178,9 @@ describe(InitialDeploymentFundingService.name, () => {
   });
 
   it("falls back to a descriptive error when the failed deposit tx has no raw log", async () => {
-    const { service, drainingDeploymentService, balancesService, managedSignerService } = setup();
+    const { service, drainingDeploymentService, managedSignerService } = setup();
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
     drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(500000);
-    balancesService.getFreshLimits.mockResolvedValue({ fee: 100000, deployment: 1000000 });
     managedSignerService.executeDerivedTx.mockResolvedValue({ code: 5, hash: "TESTHASH", rawLog: "" });
 
     await expect(service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" })).rejects.toThrow(
@@ -200,10 +189,10 @@ describe(InitialDeploymentFundingService.name, () => {
   });
 
   it("clamps the deposit to the fresh deployment limit", async () => {
-    const { service, drainingDeploymentService, balancesService, rpcMessageService } = setup();
+    const { service, drainingDeploymentService, rpcMessageService, cachedBalanceService } = setup();
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
     drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(500000);
-    balancesService.getFreshLimits.mockResolvedValue({ fee: 100000, deployment: 200000 });
+    cachedBalanceService.getFresh.mockResolvedValue(new CachedBalance(200000, 0));
 
     await service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" });
 
@@ -211,22 +200,57 @@ describe(InitialDeploymentFundingService.name, () => {
   });
 
   it("skips funding when the deployment limit is exhausted", async () => {
-    const { service, drainingDeploymentService, balancesService, managedSignerService, instrumentation } = setup();
+    const { service, drainingDeploymentService, managedSignerService, instrumentation, cachedBalanceService } = setup();
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
     drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(500000);
-    balancesService.getFreshLimits.mockResolvedValue({ fee: 100000, deployment: 0 });
+    cachedBalanceService.getFresh.mockResolvedValue(new CachedBalance(0, 0));
 
     await service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" });
 
     expect(managedSignerService.executeDerivedTx).not.toHaveBeenCalled();
-    expect(instrumentation.recordSkipped).toHaveBeenCalledWith("insufficient_balance", expect.objectContaining({ dseq: "123", address: "akash1owner" }));
+    expect(instrumentation.recordSkipped).toHaveBeenCalledWith(
+      "insufficient_balance",
+      expect.objectContaining({ dseq: "123", address: "akash1owner", available: 0, spendable: 0 })
+    );
+  });
+
+  it("leaves the balance headroom untouched when sizing the deposit", async () => {
+    const { service, drainingDeploymentService, rpcMessageService, cachedBalanceService } = setup();
+    drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
+    drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(10_000_000);
+    cachedBalanceService.getFresh.mockResolvedValue(new CachedBalance(10_000_000, 5_000_000));
+
+    await service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" });
+
+    expect(rpcMessageService.getDepositDeploymentMsg).toHaveBeenCalledWith(expect.objectContaining({ amount: 5_000_000 }));
+  });
+
+  it("funds the full balance when it is at or below the headroom", async () => {
+    const { service, drainingDeploymentService, rpcMessageService, cachedBalanceService } = setup();
+    drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
+    drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(10_000_000);
+    cachedBalanceService.getFresh.mockResolvedValue(new CachedBalance(4_000_000, 5_000_000));
+
+    await service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" });
+
+    expect(rpcMessageService.getDepositDeploymentMsg).toHaveBeenCalledWith(expect.objectContaining({ amount: 4_000_000 }));
+  });
+
+  it("funds the full balance when it sits exactly at the headroom", async () => {
+    const { service, drainingDeploymentService, rpcMessageService, cachedBalanceService } = setup();
+    drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
+    drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(10_000_000);
+    cachedBalanceService.getFresh.mockResolvedValue(new CachedBalance(5_000_000, 5_000_000));
+
+    await service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" });
+
+    expect(rpcMessageService.getDepositDeploymentMsg).toHaveBeenCalledWith(expect.objectContaining({ amount: 5_000_000 }));
   });
 
   it("skips funding when the wallet is not found", async () => {
-    const { service, drainingDeploymentService, balancesService, userWalletRepository, managedSignerService, instrumentation } = setup();
+    const { service, drainingDeploymentService, userWalletRepository, managedSignerService, instrumentation } = setup();
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
     drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(500000);
-    balancesService.getFreshLimits.mockResolvedValue({ fee: 100000, deployment: 1000000 });
     userWalletRepository.findById.mockResolvedValue(undefined);
 
     await service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" });
@@ -236,10 +260,9 @@ describe(InitialDeploymentFundingService.name, () => {
   });
 
   it("skips funding when the fee allowance is exhausted", async () => {
-    const { service, drainingDeploymentService, balancesService, managedSignerService, instrumentation } = setup();
+    const { service, drainingDeploymentService, managedSignerService, instrumentation } = setup();
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
     drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(500000);
-    balancesService.getFreshLimits.mockResolvedValue({ fee: 100000, deployment: 1000000 });
     managedSignerService.ensureFeeGrants.mockResolvedValue(0);
 
     await service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" });
@@ -262,7 +285,7 @@ describe(InitialDeploymentFundingService.name, () => {
   function setup() {
     const blockHttpService = mock<BlockHttpService>();
     const drainingDeploymentService = mock<DrainingDeploymentService>();
-    const balancesService = mock<BalancesService>();
+    const cachedBalanceService = mock<CachedBalanceService>();
     const rpcMessageService = mock<RpcMessageService>();
     const managedSignerService = mock<ManagedSignerService>();
     const userWalletRepository = mock<UserWalletRepository>();
@@ -276,6 +299,7 @@ describe(InitialDeploymentFundingService.name, () => {
     const createLogger: CreateLogger = () => logger;
 
     blockHttpService.getCurrentHeight.mockResolvedValue(CURRENT_HEIGHT);
+    cachedBalanceService.getFresh.mockResolvedValue(new CachedBalance(1000000, 0));
     userWalletRepository.findById.mockResolvedValue(createUserWallet({ id: 1, address: "akash1owner" }));
     managedSignerService.ensureFeeGrants.mockResolvedValue(100000);
     managedSignerService.executeDerivedTx.mockResolvedValue({ code: 0, hash: "TESTHASH", rawLog: "[]" });
@@ -284,7 +308,7 @@ describe(InitialDeploymentFundingService.name, () => {
     const service = new InitialDeploymentFundingService(
       blockHttpService,
       drainingDeploymentService,
-      balancesService,
+      cachedBalanceService,
       rpcMessageService,
       managedSignerService,
       userWalletRepository,
@@ -301,7 +325,7 @@ describe(InitialDeploymentFundingService.name, () => {
       service,
       blockHttpService,
       drainingDeploymentService,
-      balancesService,
+      cachedBalanceService,
       rpcMessageService,
       managedSignerService,
       userWalletRepository,

--- a/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.ts
+++ b/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.ts
@@ -2,7 +2,6 @@ import { inject, singleton } from "tsyringe";
 
 import { UserWalletRepository } from "@src/billing/repositories";
 import { RpcMessageService } from "@src/billing/services";
-import { BalancesService } from "@src/billing/services/balances/balances.service";
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import { ChainErrorService } from "@src/billing/services/chain-error/chain-error.service";
 import { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
@@ -10,6 +9,7 @@ import { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/
 import { BlockHttpService } from "@src/chain/services/block-http/block-http.service";
 import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
 import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import { CachedBalanceService } from "@src/deployment/services/cached-balance/cached-balance.service";
 import { DeploymentConfigService } from "@src/deployment/services/deployment-config/deployment-config.service";
 import { DrainingDeploymentService } from "@src/deployment/services/draining-deployment/draining-deployment.service";
 import { InitialDeploymentFundingInstrumentationService } from "@src/deployment/services/initial-deployment-funding/initial-deployment-funding-instrumentation.service";
@@ -33,7 +33,7 @@ export class InitialDeploymentFundingService {
   constructor(
     private readonly blockHttpService: BlockHttpService,
     private readonly drainingDeploymentService: DrainingDeploymentService,
-    private readonly balancesService: BalancesService,
+    private readonly cachedBalanceService: CachedBalanceService,
     private readonly rpcMessageService: RpcMessageService,
     private readonly managedSignerService: ManagedSignerService,
     private readonly userWalletRepository: UserWalletRepository,
@@ -81,11 +81,17 @@ export class InitialDeploymentFundingService {
     }
 
     const desiredAmount = await this.drainingDeploymentService.calculateTopUpAmount(deployment);
-    const { deployment: deploymentLimit } = await this.balancesService.getFreshLimits({ address });
-    const amount = Math.min(desiredAmount, deploymentLimit);
+    const balance = await this.cachedBalanceService.getFresh(address);
+    const amount = Math.min(desiredAmount, balance.spendable);
 
     if (amount <= 0) {
-      this.instrumentation.recordSkipped("insufficient_balance", { dseq, address, desiredAmount, deploymentLimit });
+      this.instrumentation.recordSkipped("insufficient_balance", {
+        dseq,
+        address,
+        desiredAmount,
+        available: balance.available,
+        spendable: balance.spendable
+      });
       return;
     }
 

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.integration.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.integration.ts
@@ -20,6 +20,14 @@ const CLOSED_HEIGHT = String(CURRENT_HEIGHT - 500);
 const DENOM = "uakt";
 const BLOCK_RATE = 50;
 const ESCROW_AMOUNT = "50000";
+/** Mirrors the `AUTO_TOP_UP_BALANCE_HEADROOM_IN_USD` default of $5, in the grant denom's micro units. */
+const HEADROOM_UDENOM = 5000000;
+
+function depositedAmounts(executeDerivedTx: { mock: { calls: unknown[][] } }): number[] {
+  return executeDerivedTx.mock.calls
+    .flatMap(call => call[1] as { value: { deposit?: { amount?: { amount: string } } } }[])
+    .map(message => Number(message.value.deposit?.amount?.amount));
+}
 
 /**
  * This test defines the business rules for the auto top-up job.
@@ -197,6 +205,48 @@ describe(TopUpManagedDeploymentsService.name, () => {
 
       expect(result.ok).toBe(true);
       expect(executeDerivedTx).not.toHaveBeenCalled();
+    });
+
+    // Owner has a draining deployment and a balance just above the headroom floor.
+    // The deposit is capped at what sits above the floor, leaving the floor available
+    // for the user to create a new deployment.
+    it("leaves the balance headroom untouched when funding a draining deployment", async () => {
+      const { topUpService, executeDerivedTx, createUserWithWallet, createDeploymentSetting, mockLeasesForOwner, mockDeploymentsForOwner, stubGetFreshLimits } =
+        await setup();
+      const { user, address } = await createUserWithWallet();
+      const drainingDseq = "900001";
+
+      await createDeploymentSetting(user.id, drainingDseq);
+
+      mockLeasesForOwner(address, [createActiveLease(address, drainingDseq)]);
+      mockDeploymentsForOwner(address, [createActiveDeployment(address, drainingDseq)]);
+      stubGetFreshLimits({ [address]: HEADROOM_UDENOM + 500000 });
+
+      await topUpService.topUpDeployments({ dryRun: false });
+
+      expect(executeDerivedTx).toHaveBeenCalledOnce();
+      expect(depositedAmounts(executeDerivedTx)).toEqual([500000]);
+    });
+
+    // Owner's whole balance sits below the headroom floor. Keeping existing deployments
+    // running outranks reserving room for a new one, so the floor is waived and the
+    // deployment is funded from everything that is left.
+    it("waives the headroom when the balance is below it", async () => {
+      const { topUpService, executeDerivedTx, createUserWithWallet, createDeploymentSetting, mockLeasesForOwner, mockDeploymentsForOwner, stubGetFreshLimits } =
+        await setup();
+      const { user, address } = await createUserWithWallet();
+      const drainingDseq = "900002";
+
+      await createDeploymentSetting(user.id, drainingDseq);
+
+      mockLeasesForOwner(address, [createActiveLease(address, drainingDseq)]);
+      mockDeploymentsForOwner(address, [createActiveDeployment(address, drainingDseq)]);
+      stubGetFreshLimits({ [address]: 1000000 });
+
+      await topUpService.topUpDeployments({ dryRun: false });
+
+      expect(executeDerivedTx).toHaveBeenCalledOnce();
+      expect(depositedAmounts(executeDerivedTx)).toEqual([1000000]);
     });
   });
 

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.integration.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.integration.ts
@@ -207,10 +207,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
       expect(executeDerivedTx).not.toHaveBeenCalled();
     });
 
-    // Owner has a draining deployment and a balance just above the headroom floor.
-    // The deposit is capped at what sits above the floor, leaving the floor available
-    // for the user to create a new deployment.
-    it("leaves the balance headroom untouched when funding a draining deployment", async () => {
+    it("caps the deposit at what sits above the headroom floor so a new deployment can still be created", async () => {
       const { topUpService, executeDerivedTx, createUserWithWallet, createDeploymentSetting, mockLeasesForOwner, mockDeploymentsForOwner, stubGetFreshLimits } =
         await setup();
       const { user, address } = await createUserWithWallet();
@@ -228,10 +225,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
       expect(depositedAmounts(executeDerivedTx)).toEqual([500000]);
     });
 
-    // Owner's whole balance sits below the headroom floor. Keeping existing deployments
-    // running outranks reserving room for a new one, so the floor is waived and the
-    // deployment is funded from everything that is left.
-    it("waives the headroom when the balance is below it", async () => {
+    it("funds a draining deployment from the whole balance when it sits below the headroom floor", async () => {
       const { topUpService, executeDerivedTx, createUserWithWallet, createDeploymentSetting, mockLeasesForOwner, mockDeploymentsForOwner, stubGetFreshLimits } =
         await setup();
       const { user, address } = await createUserWithWallet();

--- a/apps/api/test/functional/sign-and-broadcast-tx.spec.ts
+++ b/apps/api/test/functional/sign-and-broadcast-tx.spec.ts
@@ -19,6 +19,9 @@ import { createDeploymentListResponseSeed } from "@test/seeders/deployment-list-
 import { createFeeAllowanceResponse } from "@test/seeders/fee-allowance-response.seeder";
 import { WalletTestingService } from "@test/services/wallet-testing.service";
 
+/** Deposit the create-deployment message asks for. The seeded deployment grant must cover it or the create is refused. */
+const DEPLOYMENT_DEPOSIT_UDENOM = 5_000_000;
+
 describe("Tx Sign", () => {
   const registry = container.resolve<Registry>(TYPE_REGISTRY);
   const walletService = new WalletTestingService(app);
@@ -31,7 +34,7 @@ describe("Tx Sign", () => {
   describe("POST /v1/tx", () => {
     it("creates a deployment for a user", async () => {
       const { user, token, wallet } = await setup({
-        deploymentAllowance: 1_000_000
+        deploymentAllowance: DEPLOYMENT_DEPOSIT_UDENOM
       });
 
       const res = await app.request("/v1/tx", {
@@ -43,6 +46,24 @@ describe("Tx Sign", () => {
 
       expect(res.status).toBe(200);
       expect(result).toMatchObject({ data: { code: 0, transactionHash: expect.any(String), hash: expect.any(String) } });
+    });
+
+    it("responds with 402 Payment Required when the deployment allowance cannot cover the deposit", async () => {
+      const { user, token, wallet } = await setup({
+        deploymentAllowance: DEPLOYMENT_DEPOSIT_UDENOM - 1
+      });
+
+      const res = await app.request("/v1/tx", {
+        method: "POST",
+        body: await createMessageForDeployment(user.id, wallet.address),
+        headers: { "Content-Type": "application/json", authorization: `Bearer ${token}` }
+      });
+
+      expect(res.status).toBe(402);
+      expect(await res.json()).toMatchObject({
+        error: "PaymentRequiredError",
+        message: "Not enough balance to cover the deployment deposit. Add credits or turn on auto recharge to continue."
+      });
     });
 
     it("creates blockchain transaction", async () => {
@@ -99,7 +120,7 @@ describe("Tx Sign", () => {
       const responseBody = await res.json();
       expect(responseBody).toMatchObject({
         error: "PaymentRequiredError",
-        message: "Insufficient balance"
+        message: "Not enough balance to cover the deployment deposit. Add credits or turn on auto recharge to continue."
       });
     });
   });
@@ -154,7 +175,10 @@ describe("Tx Sign", () => {
           },
           groups: manifest.value.groupSpecs,
           hash: await generateManifestVersion(manifest.value.groups),
-          deposit: { amount: { denom: container.resolve(BILLING_CONFIG).DEPLOYMENT_GRANT_DENOM, amount: "5000000" }, sources: [Source.grant] }
+          deposit: {
+            amount: { denom: container.resolve(BILLING_CONFIG).DEPLOYMENT_GRANT_DENOM, amount: DEPLOYMENT_DEPOSIT_UDENOM.toString() },
+            sources: [Source.grant]
+          }
         }
       }
     ];


### PR DESCRIPTION
## Why

Closes CON-882
Closes CON-512

Auto-funding sized every deposit as `min(desired, remaining allowance)`, so one top-up of an expensive deployment could take the whole deployment grant. The user then could not create anything until credits landed, and the create failed with a bare 402. That is the failure CON-512 has been tracking across several customers.

The two remaining CON-512 mitigations from the 2026-08-05 sequencing note are also here: an actionable error and a reactive reload on failure. The one Serhii called must-have (a reload check after every top-up) already shipped, and CON-741/CON-761/CON-791 covered the other contributors.

## What

**The headroom rule** (documented on CON-882 before implementation, as its AC 1 asks):

> Auto-funding may spend the available deployment allowance down to a floor of `AUTO_TOP_UP_BALANCE_HEADROOM_IN_USD` (default $5). The floor is waived in full when the available balance is already at or below it.

Two properties are load-bearing. The floor is resolved once per funding pass, from the balance the pass started with, so a batch cannot chip it away one deployment at a time and let the last deployment eat it. And it is waived rather than scaled down when the balance sits under it, because keeping running deployments alive outranks reserving room for a new one.

$5 is ten times the platform default deposit of $0.50 and costs a $5/h GPU deployment one hour of runway. It sits below the $20 auto-recharge threshold default, so it neither adds nor removes charge cycles. `CachedBalanceService` logs `AUTO_TOP_UP_BALANCE_HEADROOM` with `available`, `headroom`, `spendable` and `waived` on every pass, so the default can be raised from data rather than guesswork.

The lease-start path now reads its balance through `CachedBalanceService` as well, which collapses the second `Math.min` clamp that had drifted out of sync with the cron's.

**The create pre-flight** only asserted that the deployment allowance was above zero, so a create whose deposit exceeded the allowance passed the check and died seconds later in chain simulation. Since a create deposit is drawn purely from the deployment grant, the pre-flight now sums the deposits in the batch and compares against the real amount. On a refusal it schedules an immediate wallet reload check and picks its message from whether that reload was scheduled:

- auto recharge on: "Not enough balance to cover the deployment deposit. A top up from your saved payment method is on the way, so try again in a moment."
- otherwise: "Not enough balance to cover the deployment deposit. Add credits or turn on auto recharge to continue."

Scheduling failures are swallowed so they cannot turn a clean 402 into a 500. The same reload runs when the chain refuses the broadcast with a 402, which covers auto-funding draining the grant between the pre-flight read and the broadcast.

The functional fixture had seeded a 1 ACT allowance against a 5 ACT deposit and passed only because the old check never looked. It now seeds an allowance that covers the deposit, and a new case asserts the 402 at the HTTP boundary.

Alerting on `DEPLOYMENT_CREATE_REFUSED_INSUFFICIENT_ALLOWANCE` is a Grafana change rather than code, so it is not in this PR.

### Verification

`apps/api`: 1404 unit, 276 functional, and the deployment integration tests pass; lint clean; no new `tsc` errors. Four pre-existing integration failures in `user.repository` and `api-key.repository` reproduce on a clean tree and are unrelated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deployment funding now preserves configurable balance headroom for ongoing usage.
  * Automatic reloads can be triggered when deployment deposits or transaction failures leave insufficient allowance.
  * Added configurable headroom for automatic recharge calculations.
  * Auto-recharge guidance now recommends adding credits or enabling automatic recharging.

* **Bug Fixes**
  * Deployment deposits are validated against the exact required amount and denomination.
  * Improved insufficient-balance and payment-required handling with clearer HTTP 402 responses.
  * Funding now correctly uses spendable balance while preserving configured headroom.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->