### PR TITLE
refactor(deployment): align detail page width with the deployment list

### DIFF
--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.tsx
@@ -47,9 +47,9 @@ export const DEPENDENCIES = {
   DeploymentSettings
 };
 
-/** Caps every band of the page at 1280px so the layout stops stretching on very wide screens. Sits inside each
- *  full-bleed wrapper's padding, so the header, tab labels and tab body all share one left edge. */
-const CAPPED_CONTENT = "mx-auto w-full max-w-screen-xl";
+/** Matches Layout's default `container p-6` content column so every band lines up with the deployment list and the
+ *  other pages. Sits inside each full-bleed wrapper, so the header, tab labels and tab body all share one left edge. */
+const PAGE_BAND = "container px-6";
 
 const TABS = ["DETAILS", "LOGS", "EVENTS", "SHELL", "UPDATE", "SETTINGS"] as const;
 type Tab = (typeof TABS)[number];
@@ -145,12 +145,12 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = ({ dseq, dependencies
     <d.Layout
       isLoading={isLoadingLeases || isLoadingDeployment || isLoadingProviders}
       disableContainer
-      containerClassName="flex min-h-[calc(100dvh_-_var(--app-header-height,57px)_-_4px)] flex-col px-6 pt-4"
+      containerClassName="flex min-h-[calc(100dvh_-_var(--app-header-height,57px)_-_4px)] flex-col pt-4"
     >
       <d.NextSeo title={`Deployment detail #${dseq}`} />
 
       {isDeploymentNotFound && (
-        <div className="mt-8 text-center">
+        <div className={cn(PAGE_BAND, "mt-8 text-center")}>
           <Title className="mb-2">404</Title>
           <p>This deployment does not exist or it was created using another wallet.</p>
           <div className="pt-4">
@@ -164,15 +164,15 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = ({ dseq, dependencies
 
       {deployment && isLeasesLoaded && (
         <>
-          <div className={CAPPED_CONTENT}>
+          <div className={PAGE_BAND}>
             <d.DeploymentDetailHeader deployment={deployment} leases={leases} providers={providers || []} />
 
             <d.ReclamationBanner leases={leases} dseq={dseq} className="mb-6" />
           </div>
 
           <Tabs value={activeTab} onValueChange={value => changeTab(value as Tab)} className="flex flex-1 flex-col">
-            <div className="-mx-6 border-b border-t px-6">
-              <TabsList className={cn(CAPPED_CONTENT, "flex h-auto justify-start gap-8 rounded-none border-0 bg-transparent p-0")}>
+            <div className="border-b border-t">
+              <TabsList className={cn("flex h-auto justify-start gap-8 rounded-none border-0 bg-transparent py-0", PAGE_BAND)}>
                 {TABS.map(tab => (
                   <TabsTrigger
                     key={tab}
@@ -185,8 +185,8 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = ({ dseq, dependencies
               </TabsList>
             </div>
 
-            <div className="-mx-6 flex-1 bg-muted px-6 py-6">
-              <div className={CAPPED_CONTENT}>
+            <div className="flex-1 bg-muted py-6">
+              <div className={PAGE_BAND}>
                 {activeTab === "DETAILS" && (
                   <d.DeploymentPlacements
                     leases={leases || []}


### PR DESCRIPTION
## Why

The redesigned deployment detail page and the deployment list don't line up. The list uses Layout's default `container p-6`, so its content is 1400px minus 24px of padding each side. The detail page opts out of the container and caps each of its bands at 1280px, inside its own padding. Above roughly a 1330px viewport the two diverge, and at 1400px the detail content is 72px narrower and starts at a different left edge, so the page visibly shifts sideways as you move between list and detail.

Both pages now use the same container.

Part of CON-821

### This reverses the 1280px cap from #3617

That cap came out of designer review and it fixed something real: the page had no max width at all and kept stretching on a wide monitor. But it introduced a width nothing else in the app uses, which is what causes the misalignment. The alternative was to keep the cap and narrow the list instead. I went with the container so every page agrees, and whoever asked for 1280px should take a second look.

Everything sits behind `deployment_detail_redesign`, so nothing changes for users until the flag rolls out.

## What

`CAPPED_CONTENT` (`mx-auto w-full max-w-screen-xl`) becomes `PAGE_BAND` (`container px-6`), the same content column Layout gives every other page.

The horizontal padding moves from the page wrapper into each band. #3617 noted that the padding had to stay outside the capped wrapper or the tab labels would land 24px off the header's left edge, which holds when only some bands move. Here the header, tab strip and tab body all carry the identical `container px-6`, so they share one left edge and the full-bleed wrappers no longer need their `-mx-6` breakout. The tab underline and the grey tab body still reach both edges of the viewport.

Two details worth a look:

The 404 branch picks up the band as well. It had been getting its gutters from the wrapper's `px-6`, so without a band it would run edge to edge on a phone.

`TabsList` keeps `py-0` rather than `p-0`, with `PAGE_BAND` last in the `cn()` call. `cn` is `twMerge`, and `p-0` after `px-6` strips the horizontal padding: `twMerge("container px-6", "flex bg-transparent p-0")` returns `container flex bg-transparent p-0`.

## Testing

Compiled the app's Tailwind config against a fixture holding both class structures and measured content boxes in headless Chromium. The list column and all three detail bands match exactly at every width, and both full-bleed bands still span the whole viewport.

```
vw=1920  list=1352@284  detail[header tabs body]=1352@284 1352@284 1352@284  aligned=YES  bands-full-bleed=YES
vw=1600  list=1352@124  detail[header tabs body]=1352@124 1352@124 1352@124  aligned=YES  bands-full-bleed=YES
vw=1400  list=1352@24   detail[header tabs body]=1352@24 1352@24 1352@24     aligned=YES  bands-full-bleed=YES
vw=1328  list=1280@24   detail[header tabs body]=1280@24 1280@24 1280@24     aligned=YES  bands-full-bleed=YES
vw=1200  list=1152@24   detail[header tabs body]=1152@24 1152@24 1152@24     aligned=YES  bands-full-bleed=YES
vw= 768  list=720@24    detail[header tabs body]=720@24 720@24 720@24        aligned=YES  bands-full-bleed=YES
vw= 390  list=342@24    detail[header tabs body]=342@24 342@24 342@24        aligned=YES  bands-full-bleed=YES
```

- `npm run test:unit -- DeploymentDetail`: 138 tests across 16 files pass.
- `eslint --quiet` clean.
- `tsc --noEmit` reports 88 errors, identical to the `origin/main` baseline measured by stashing this change. None of them touch `DeploymentDetail`.

No live browser pass. The page needs an authed session with a leased deployment, so sign-off on how the wider column actually reads is still open.
