### PR TITLE
feat(billing): let users pick the auto top-up mode in billing settings

### DIFF
--- a/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/AccountBalanceOverview.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/AccountBalanceOverview.spec.tsx
@@ -115,22 +115,22 @@ describe(AccountBalanceOverview.name, () => {
     expect(screen.getByRole("link", { name: /llama-chat/ })).toHaveAttribute("href", UrlService.deploymentDetails("42"));
   });
 
-  it("reassures when auto recharge is on", () => {
+  it("reassures when automatic top-ups are on", () => {
     setup({ autoReloadEnabled: true });
 
-    expect(screen.getByText(/Auto Recharge is on/)).toBeInTheDocument();
+    expect(screen.getByText(/Automatic top-ups are on/)).toBeInTheDocument();
   });
 
-  it("stays quiet about auto recharge when it is off", () => {
+  it("stays quiet about automatic top-ups when they are off", () => {
     setup({ autoReloadEnabled: false });
 
-    expect(screen.queryByText(/Auto Recharge is on/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Automatic top-ups are on/)).not.toBeInTheDocument();
   });
 
-  it("hides the auto recharge line when the bar already surfaces the top-up threshold", () => {
+  it("hides the reassurance line when the bar already surfaces the top-up threshold", () => {
     setup({ autoReloadEnabled: true, autoReloadThreshold: 275 });
 
-    expect(screen.queryByText(/Auto Recharge is on/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Automatic top-ups are on/)).not.toBeInTheDocument();
   });
 
   it("renders a skeleton instead of balance while loading", () => {

--- a/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/AccountBalanceOverview.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/AccountBalanceOverview.tsx
@@ -172,7 +172,7 @@ export const AccountBalanceOverview: React.FunctionComponent<{ dependencies?: ty
         )}
 
         {overview.autoReloadThreshold == null && overview.autoReloadEnabled && (
-          <p className="text-sm text-success">Auto Recharge is on. Your deployments stay funded.</p>
+          <p className="text-sm text-success">Automatic top-ups are on. Your deployments stay funded.</p>
         )}
       </d.CardContent>
     </d.Card>

--- a/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/useAccountBalanceOverview.spec.ts
+++ b/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/useAccountBalanceOverview.spec.ts
@@ -100,20 +100,20 @@ describe(useAccountBalanceOverview.name, () => {
     expect(result.current.autoReloadEnabled).toBe(true);
   });
 
-  it("exposes the auto reload threshold when the fixed-threshold flag and auto reload are both on", () => {
-    const { result } = setup({ fixedThresholdEnabled: true, autoReloadEnabled: true, autoReloadThreshold: 275 });
+  it("exposes the auto reload threshold in threshold mode when auto reload is on", () => {
+    const { result } = setup({ autoReloadMode: "threshold", autoReloadEnabled: true, autoReloadThreshold: 275 });
 
     expect(result.current.autoReloadThreshold).toBe(275);
   });
 
-  it("hides the auto reload threshold when the fixed-threshold flag is off", () => {
-    const { result } = setup({ fixedThresholdEnabled: false, autoReloadEnabled: true, autoReloadThreshold: 275 });
+  it("hides the auto reload threshold in prediction mode", () => {
+    const { result } = setup({ autoReloadMode: "prediction", autoReloadEnabled: true, autoReloadThreshold: 275 });
 
     expect(result.current.autoReloadThreshold).toBeNull();
   });
 
   it("hides the auto reload threshold when auto reload is off", () => {
-    const { result } = setup({ fixedThresholdEnabled: true, autoReloadEnabled: false, autoReloadThreshold: 275 });
+    const { result } = setup({ autoReloadMode: "threshold", autoReloadEnabled: false, autoReloadThreshold: 275 });
 
     expect(result.current.autoReloadThreshold).toBeNull();
   });
@@ -163,7 +163,7 @@ describe(useAccountBalanceOverview.name, () => {
     hasLiveLease?: boolean;
     autoReloadEnabled?: boolean;
     autoReloadThreshold?: number;
-    fixedThresholdEnabled?: boolean;
+    autoReloadMode?: "prediction" | "threshold";
     balancesMissing?: boolean;
     balancesError?: boolean;
     balancesIdle?: boolean;
@@ -208,14 +208,25 @@ describe(useAccountBalanceOverview.name, () => {
         isLoaded: !input.priceUnavailable,
         udenomToUsd: (amount: string | number) => Number(amount)
       }),
-      useFlag: () => input.fixedThresholdEnabled ?? false,
+      useAutoReloadMode: () => ({
+        mode: input.autoReloadMode ?? "prediction",
+        isThresholdModeOffered: input.autoReloadMode === "threshold",
+        showsThresholdRule: input.autoReloadMode === "threshold",
+        isLoading: false
+      }),
       useBalances: () => ({
         data: input.balancesMissing ? undefined : balances,
         isError: input.balancesError ?? false,
         fetchStatus: input.balancesIdle ? "idle" : "fetching"
       }),
       useAllLeases: vi.fn(() => ({ data: leases })),
-      useWalletSettingsQuery: () => ({ data: { autoReloadEnabled: input.autoReloadEnabled ?? false, autoReloadThreshold: input.autoReloadThreshold } }),
+      useWalletSettingsQuery: () => ({
+        data: {
+          autoReloadEnabled: input.autoReloadEnabled ?? false,
+          autoReloadMode: input.autoReloadMode ?? "prediction",
+          autoReloadThreshold: input.autoReloadThreshold
+        }
+      }),
       useLocalNotes: () => ({ getDeploymentName: (dseq: string | number | null) => input.names?.[String(dseq)] ?? null })
     } as unknown as typeof DEPENDENCIES;
 

--- a/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/useAccountBalanceOverview.ts
+++ b/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/useAccountBalanceOverview.ts
@@ -2,9 +2,9 @@
 import { useMemo } from "react";
 import differenceInCalendarDays from "date-fns/differenceInCalendarDays";
 
+import { useAutoReloadMode } from "@src/components/billing-usage/useAutoReloadMode";
 import { useLocalNotes } from "@src/components/LocalNoteManager/useLocalNotes";
 import { useWallet } from "@src/context/WalletProvider";
-import { useFlag } from "@src/hooks/useFlag";
 import { usePricing } from "@src/hooks/usePricing/usePricing";
 import { computeWalletBalance } from "@src/hooks/useWalletBalance";
 import { useWalletSettingsQuery } from "@src/queries";
@@ -16,7 +16,7 @@ import { getLeasesCostPerBlockUsd, getTimeLeft, perBlockToHourly } from "@src/ut
 export const DEPENDENCIES = {
   useWallet,
   usePricing,
-  useFlag,
+  useAutoReloadMode,
   useBalances,
   useAllLeases,
   useWalletSettingsQuery,
@@ -40,7 +40,7 @@ export type AccountBalanceOverview = {
   lastsUntil: Date | null;
   runwayDays: number | null;
   autoReloadEnabled: boolean;
-  /** The auto-top-up trigger balance to mark on the bar, or null when no marker should render (flag off, auto-reload off, or unset). */
+  /** The auto-top-up trigger balance to mark on the bar, or null when no marker should render (prediction mode, auto-reload off, or unset). */
   autoReloadThreshold: number | null;
   isLoading: boolean;
   /** True when balances can't be loaded: the query errored out or the chain API fallback disabled it. */
@@ -54,7 +54,7 @@ export function useAccountBalanceOverview({ dependencies: d = DEPENDENCIES }: { 
   const { data: leases } = d.useAllLeases(address, { state: LIVE_LEASE_STATES, enabled: !!address });
   const { data: walletSettings } = d.useWalletSettingsQuery();
   const { getDeploymentName } = d.useLocalNotes();
-  const isFixedThresholdEnabled = d.useFlag("auto_reload_fixed_threshold");
+  const { showsThresholdRule } = d.useAutoReloadMode();
 
   /** Not gated on the AKT market price: managed wallets hold ACT/USDC (1:1 USD), and blocking on market data would strand the card on its skeleton during an outage. */
   const walletBalance = useMemo(() => (balances ? computeWalletBalance(balances, price ?? 0, udenomToUsd) : null), [balances, price, udenomToUsd]);
@@ -92,7 +92,7 @@ export function useAccountBalanceOverview({ dependencies: d = DEPENDENCIES }: { 
   const lastsUntil = hasSpend ? getTimeLeft(spend.perBlockUsd, totalUsd) : null;
   const autoReloadEnabled = walletSettings?.autoReloadEnabled ?? false;
   const isBalanceUnavailable = !balances && (isBalancesError || (!!address && balancesFetchStatus === "idle"));
-  const autoReloadThreshold = isFixedThresholdEnabled && autoReloadEnabled ? walletSettings?.autoReloadThreshold ?? null : null;
+  const autoReloadThreshold = showsThresholdRule && autoReloadEnabled ? walletSettings?.autoReloadThreshold ?? null : null;
 
   return {
     totalUsd,

--- a/apps/deploy-web/src/components/billing-usage/AutoTopUpSection/AutoTopUpSection.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AutoTopUpSection/AutoTopUpSection.spec.tsx
@@ -13,6 +13,12 @@ describe(AutoTopUpSection.name, () => {
     expect(screen.getByText(/per week/)).toHaveTextContent("42");
   });
 
+  it("runs the weekly cost query without waiting for wallet settings when threshold mode is not offered", () => {
+    const { dependencies } = setup({ isThresholdModeOffered: false, defaultPaymentMethod: { id: "pm_123" }, isWalletSettingsLoading: true });
+
+    expect(dependencies.useWeeklyDeploymentCostQuery).toHaveBeenCalledWith({ enabled: true });
+  });
+
   describe("when threshold mode is offered", () => {
     it("renders the Auto Top-Up title", () => {
       setup({ isThresholdModeOffered: true, defaultPaymentMethod: { id: "pm_123" } });
@@ -83,6 +89,46 @@ describe(AutoTopUpSection.name, () => {
       setup({ isThresholdModeOffered: true, defaultPaymentMethod: { id: "pm_123" }, walletSettings: { autoReloadEnabled: false } });
 
       expect(screen.getByText(/Turn on Auto Top-Up to add funds automatically/)).toBeInTheDocument();
+    });
+
+    it("prompts with predicted-spend wording when disabled in prediction mode", () => {
+      setup({
+        isThresholdModeOffered: true,
+        autoReloadMode: "prediction",
+        defaultPaymentMethod: { id: "pm_123" },
+        walletSettings: { autoReloadEnabled: false, autoReloadMode: "prediction" }
+      });
+
+      expect(screen.getByText(/Turn on Auto Top-Up to automatically cover the week ahead/)).toBeInTheDocument();
+      expect(screen.queryByText(/when your balance runs low/)).not.toBeInTheDocument();
+    });
+
+    it("shows a skeleton instead of a zero predicted spend while the weekly cost is still loading", () => {
+      setup({
+        isThresholdModeOffered: true,
+        autoReloadMode: "prediction",
+        defaultPaymentMethod: { id: "pm_123" },
+        walletSettings: { autoReloadEnabled: true, autoReloadMode: "prediction" },
+        isWeeklyCostLoading: true
+      });
+
+      expect(screen.getByText("Predicted spend")).toBeInTheDocument();
+      expect(screen.queryByText("0")).not.toBeInTheDocument();
+    });
+
+    describe("while wallet settings are still loading", () => {
+      it("disables the switch so the settings dialog cannot be seeded from unresolved settings", () => {
+        setup({ isThresholdModeOffered: true, defaultPaymentMethod: { id: "pm_123" }, isWalletSettingsLoading: true });
+
+        expect(screen.getByRole("switch")).toBeDisabled();
+      });
+
+      it("holds back the mode description instead of committing to the fallback mode", () => {
+        setup({ isThresholdModeOffered: true, defaultPaymentMethod: { id: "pm_123" }, isWalletSettingsLoading: true });
+
+        expect(screen.queryByText(/Tops up when your/)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Tops up to cover the week ahead/)).not.toBeInTheDocument();
+      });
     });
 
     it("opens the settings dialog in enable mode without mutating when the switch is turned on", () => {
@@ -242,7 +288,9 @@ describe(AutoTopUpSection.name, () => {
     defaultPaymentMethod?: { id: string; card?: { brand?: string; last4?: string } };
     isDefaultPaymentMethodLoading?: boolean;
     walletSettings?: { autoReloadEnabled: boolean; autoReloadMode?: "prediction" | "threshold"; autoReloadThreshold?: number; autoReloadAmount?: number };
+    isWalletSettingsLoading?: boolean;
     weeklyCost?: number;
+    isWeeklyCostLoading?: boolean;
     confirmResult?: boolean;
     upsertMutate?: ReturnType<typeof vi.fn>;
     enqueueSnackbar?: ReturnType<typeof vi.fn>;
@@ -274,8 +322,11 @@ describe(AutoTopUpSection.name, () => {
       }),
       useSnackbar: vi.fn(() => ({ enqueueSnackbar })),
       useDefaultPaymentMethodQuery: vi.fn(() => ({ data: input.defaultPaymentMethod, isLoading: input.isDefaultPaymentMethodLoading ?? false })),
-      useWalletSettingsQuery: vi.fn(() => ({ data: input.walletSettings ?? { autoReloadEnabled: false }, isLoading: false })),
-      useWeeklyDeploymentCostQuery: vi.fn(() => ({ data: input.weeklyCost ?? 5 })),
+      useWalletSettingsQuery: vi.fn(() => ({
+        data: input.isWalletSettingsLoading ? undefined : input.walletSettings ?? { autoReloadEnabled: false },
+        isLoading: input.isWalletSettingsLoading ?? false
+      })),
+      useWeeklyDeploymentCostQuery: vi.fn(() => ({ data: input.isWeeklyCostLoading ? undefined : input.weeklyCost ?? 5 })),
       useWalletSettingsMutations: vi.fn(() => ({ upsertWalletSettings: { mutate: upsertMutate, isPending: input.isPending ?? false } })),
       useAccountBalanceOverview: vi.fn(() => ({ perHour: input.perHour ?? 0, available: input.available ?? 0 })),
       useBillingActions: vi.fn(() => ({ openAddPaymentMethod })),

--- a/apps/deploy-web/src/components/billing-usage/AutoTopUpSection/AutoTopUpSection.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AutoTopUpSection/AutoTopUpSection.spec.tsx
@@ -6,23 +6,23 @@ import { act, fireEvent, render, screen } from "@testing-library/react";
 import { MockComponents } from "@tests/unit/mocks";
 
 describe(AutoTopUpSection.name, () => {
-  it("shows the weekly recharge estimate when the fixed-threshold flag is off", () => {
-    setup({ isFixedThresholdEnabled: false, defaultPaymentMethod: { id: "pm_123" }, weeklyCost: 42 });
+  it("shows the weekly recharge estimate when threshold mode is not offered", () => {
+    setup({ isThresholdModeOffered: false, defaultPaymentMethod: { id: "pm_123" }, weeklyCost: 42 });
 
     expect(screen.getByText("Auto Recharge")).toBeInTheDocument();
     expect(screen.getByText(/per week/)).toHaveTextContent("42");
   });
 
-  describe("when the fixed-threshold flag is enabled", () => {
+  describe("when threshold mode is offered", () => {
     it("renders the Auto Top-Up title", () => {
-      setup({ isFixedThresholdEnabled: true, defaultPaymentMethod: { id: "pm_123" } });
+      setup({ isThresholdModeOffered: true, defaultPaymentMethod: { id: "pm_123" } });
 
       expect(screen.getByText("Auto Top-Up")).toBeInTheDocument();
     });
 
     it("shows the threshold and top-up amounts when enabled", () => {
       setup({
-        isFixedThresholdEnabled: true,
+        isThresholdModeOffered: true,
         defaultPaymentMethod: { id: "pm_123" },
         walletSettings: { autoReloadEnabled: true, autoReloadThreshold: 20, autoReloadAmount: 100 }
       });
@@ -33,15 +33,61 @@ describe(AutoTopUpSection.name, () => {
       expect(screen.getByText("100")).toBeInTheDocument();
     });
 
+    it("shows the predicted weekly spend when the stored mode is prediction", () => {
+      setup({
+        isThresholdModeOffered: true,
+        autoReloadMode: "prediction",
+        defaultPaymentMethod: { id: "pm_123" },
+        walletSettings: { autoReloadEnabled: true, autoReloadMode: "prediction" },
+        weeklyCost: 42
+      });
+
+      expect(screen.getByText("Auto Top-Up")).toBeInTheDocument();
+      expect(screen.getByText("Predicted spend")).toBeInTheDocument();
+      expect(screen.getByText("42")).toBeInTheDocument();
+      expect(screen.queryByText("Threshold")).not.toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /edit auto top-up settings/i })).toBeInTheDocument();
+    });
+
+    it("passes the stored mode to the settings dialog", () => {
+      const { dependencies } = setup({
+        isThresholdModeOffered: true,
+        autoReloadMode: "prediction",
+        defaultPaymentMethod: { id: "pm_123" },
+        walletSettings: { autoReloadEnabled: true, autoReloadMode: "prediction" }
+      });
+
+      expect(dependencies.AutoTopUpSettingsPopup).toHaveBeenCalledWith(expect.objectContaining({ mode: "prediction" }), expect.anything());
+    });
+
+    it("skips the weekly cost query in threshold mode and runs it in prediction mode", () => {
+      const { dependencies: thresholdDependencies } = setup({
+        isThresholdModeOffered: true,
+        defaultPaymentMethod: { id: "pm_123" },
+        walletSettings: { autoReloadEnabled: true, autoReloadMode: "threshold" }
+      });
+
+      expect(thresholdDependencies.useWeeklyDeploymentCostQuery).toHaveBeenCalledWith({ enabled: false });
+
+      const { dependencies: predictionDependencies } = setup({
+        isThresholdModeOffered: true,
+        autoReloadMode: "prediction",
+        defaultPaymentMethod: { id: "pm_123" },
+        walletSettings: { autoReloadEnabled: true, autoReloadMode: "prediction" }
+      });
+
+      expect(predictionDependencies.useWeeklyDeploymentCostQuery).toHaveBeenCalledWith({ enabled: true });
+    });
+
     it("prompts to turn on auto top-up when disabled with a payment method", () => {
-      setup({ isFixedThresholdEnabled: true, defaultPaymentMethod: { id: "pm_123" }, walletSettings: { autoReloadEnabled: false } });
+      setup({ isThresholdModeOffered: true, defaultPaymentMethod: { id: "pm_123" }, walletSettings: { autoReloadEnabled: false } });
 
       expect(screen.getByText(/Turn on Auto Top-Up to add funds automatically/)).toBeInTheDocument();
     });
 
     it("opens the settings dialog in enable mode without mutating when the switch is turned on", () => {
       const { dependencies, upsertMutate } = setup({
-        isFixedThresholdEnabled: true,
+        isThresholdModeOffered: true,
         defaultPaymentMethod: { id: "pm_123" },
         walletSettings: { autoReloadEnabled: false }
       });
@@ -55,7 +101,7 @@ describe(AutoTopUpSection.name, () => {
     it("confirms then disables auto top-up when the switch is turned off", async () => {
       const upsertMutate = vi.fn();
       setup({
-        isFixedThresholdEnabled: true,
+        isThresholdModeOffered: true,
         defaultPaymentMethod: { id: "pm_123" },
         walletSettings: { autoReloadEnabled: true, autoReloadThreshold: 20, autoReloadAmount: 100 },
         confirmResult: true,
@@ -71,7 +117,7 @@ describe(AutoTopUpSection.name, () => {
 
     it("opens the settings dialog in edit mode from the edit button", () => {
       const { dependencies } = setup({
-        isFixedThresholdEnabled: true,
+        isThresholdModeOffered: true,
         defaultPaymentMethod: { id: "pm_123" },
         walletSettings: { autoReloadEnabled: true, autoReloadThreshold: 20, autoReloadAmount: 100 }
       });
@@ -83,7 +129,7 @@ describe(AutoTopUpSection.name, () => {
 
     it("shows the next top-up estimate even when the default payment method is not a card", () => {
       setup({
-        isFixedThresholdEnabled: true,
+        isThresholdModeOffered: true,
         defaultPaymentMethod: { id: "pm_123" },
         walletSettings: { autoReloadEnabled: true, autoReloadThreshold: 20, autoReloadAmount: 50 },
         perHour: 1,
@@ -96,7 +142,7 @@ describe(AutoTopUpSection.name, () => {
 
     it("names the default card in the charge summary", () => {
       setup({
-        isFixedThresholdEnabled: true,
+        isThresholdModeOffered: true,
         defaultPaymentMethod: { id: "pm_123", card: { brand: "visa", last4: "4242" } },
         walletSettings: { autoReloadEnabled: true, autoReloadThreshold: 20, autoReloadAmount: 50 }
       });
@@ -105,7 +151,7 @@ describe(AutoTopUpSection.name, () => {
     });
 
     it("disables the switch and hides the edit button without a payment method", () => {
-      setup({ isFixedThresholdEnabled: true, defaultPaymentMethod: undefined });
+      setup({ isThresholdModeOffered: true, defaultPaymentMethod: undefined });
 
       expect(screen.getByRole("switch")).toBeDisabled();
       expect(screen.queryByRole("button", { name: /edit auto top-up settings/i })).not.toBeInTheDocument();
@@ -113,14 +159,14 @@ describe(AutoTopUpSection.name, () => {
     });
 
     it("shows a skeleton instead of the add-payment-method prompt while the payment method query is loading", () => {
-      setup({ isFixedThresholdEnabled: true, defaultPaymentMethod: undefined, isDefaultPaymentMethodLoading: true });
+      setup({ isThresholdModeOffered: true, defaultPaymentMethod: undefined, isDefaultPaymentMethodLoading: true });
 
       expect(screen.queryByText(/Add a payment method/)).not.toBeInTheDocument();
     });
 
     it("opens the add-payment-method flow from the prompt when there is no payment method", () => {
       const openAddPaymentMethod = vi.fn();
-      setup({ isFixedThresholdEnabled: true, defaultPaymentMethod: undefined, openAddPaymentMethod });
+      setup({ isThresholdModeOffered: true, defaultPaymentMethod: undefined, openAddPaymentMethod });
 
       fireEvent.click(screen.getByText("Add a payment method"));
 
@@ -129,7 +175,7 @@ describe(AutoTopUpSection.name, () => {
 
     it("disables the edit button while a settings update is in flight", () => {
       setup({
-        isFixedThresholdEnabled: true,
+        isThresholdModeOffered: true,
         defaultPaymentMethod: { id: "pm_123" },
         walletSettings: { autoReloadEnabled: true, autoReloadThreshold: 20, autoReloadAmount: 100 },
         isPending: true
@@ -141,7 +187,7 @@ describe(AutoTopUpSection.name, () => {
     it("does not disable auto top-up when the confirmation is cancelled", async () => {
       const upsertMutate = vi.fn();
       setup({
-        isFixedThresholdEnabled: true,
+        isThresholdModeOffered: true,
         defaultPaymentMethod: { id: "pm_123" },
         walletSettings: { autoReloadEnabled: true, autoReloadThreshold: 20, autoReloadAmount: 100 },
         confirmResult: false,
@@ -159,7 +205,7 @@ describe(AutoTopUpSection.name, () => {
       const enqueueSnackbar = vi.fn();
       const upsertMutate = vi.fn((_payload, options) => options?.onSuccess?.({ data: { autoReloadEnabled: false } }));
       setup({
-        isFixedThresholdEnabled: true,
+        isThresholdModeOffered: true,
         defaultPaymentMethod: { id: "pm_123" },
         walletSettings: { autoReloadEnabled: true, autoReloadThreshold: 20, autoReloadAmount: 100 },
         confirmResult: true,
@@ -176,7 +222,7 @@ describe(AutoTopUpSection.name, () => {
 
     it("closes the settings dialog when the popup requests it", () => {
       const { dependencies } = setup({
-        isFixedThresholdEnabled: true,
+        isThresholdModeOffered: true,
         defaultPaymentMethod: { id: "pm_123" },
         walletSettings: { autoReloadEnabled: true, autoReloadThreshold: 20, autoReloadAmount: 100 }
       });
@@ -191,10 +237,11 @@ describe(AutoTopUpSection.name, () => {
   });
 
   function setup(input: {
-    isFixedThresholdEnabled?: boolean;
+    isThresholdModeOffered?: boolean;
+    autoReloadMode?: "prediction" | "threshold";
     defaultPaymentMethod?: { id: string; card?: { brand?: string; last4?: string } };
     isDefaultPaymentMethodLoading?: boolean;
-    walletSettings?: { autoReloadEnabled: boolean; autoReloadThreshold?: number; autoReloadAmount?: number };
+    walletSettings?: { autoReloadEnabled: boolean; autoReloadMode?: "prediction" | "threshold"; autoReloadThreshold?: number; autoReloadAmount?: number };
     weeklyCost?: number;
     confirmResult?: boolean;
     upsertMutate?: ReturnType<typeof vi.fn>;
@@ -216,7 +263,15 @@ describe(AutoTopUpSection.name, () => {
 
     const dependencies = {
       ...MockComponents(DEPENDENCIES),
-      useFlag: vi.fn(() => input.isFixedThresholdEnabled ?? false),
+      useAutoReloadMode: vi.fn(() => {
+        const mode = input.autoReloadMode ?? (input.isThresholdModeOffered ? "threshold" : "prediction");
+        return {
+          mode,
+          isThresholdModeOffered: input.isThresholdModeOffered ?? false,
+          showsThresholdRule: !!input.isThresholdModeOffered && mode === "threshold",
+          isLoading: false
+        };
+      }),
       useSnackbar: vi.fn(() => ({ enqueueSnackbar })),
       useDefaultPaymentMethodQuery: vi.fn(() => ({ data: input.defaultPaymentMethod, isLoading: input.isDefaultPaymentMethodLoading ?? false })),
       useWalletSettingsQuery: vi.fn(() => ({ data: input.walletSettings ?? { autoReloadEnabled: false }, isLoading: false })),

--- a/apps/deploy-web/src/components/billing-usage/AutoTopUpSection/AutoTopUpSection.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AutoTopUpSection/AutoTopUpSection.tsx
@@ -50,7 +50,7 @@ export const AutoTopUpSection: React.FunctionComponent<{ dependencies?: typeof D
   const { enqueueSnackbar } = d.useSnackbar();
   const { data: defaultPaymentMethod, isLoading: isDefaultPaymentMethodLoading } = d.useDefaultPaymentMethodQuery();
   const { data: walletSettings, isLoading: isWalletSettingsLoading } = d.useWalletSettingsQuery();
-  const { data: weeklyCost } = d.useWeeklyDeploymentCostQuery({ enabled: !showsThresholdRule && !isWalletSettingsLoading });
+  const { data: weeklyCost } = d.useWeeklyDeploymentCostQuery({ enabled: !showsThresholdRule });
   const { upsertWalletSettings } = d.useWalletSettingsMutations();
   const { openAddPaymentMethod } = d.useBillingActions();
   const overview = d.useAccountBalanceOverview();
@@ -122,8 +122,8 @@ export const AutoTopUpSection: React.FunctionComponent<{ dependencies?: typeof D
   const isFirstLoad = (isWalletSettingsLoading && !walletSettings) || (isDefaultPaymentMethodLoading && !defaultPaymentMethod);
 
   const isReloadChangeDisabled = useMemo(() => {
-    return !hasPaymentMethod || upsertWalletSettings.isPending;
-  }, [hasPaymentMethod, upsertWalletSettings.isPending]);
+    return isFirstLoad || !hasPaymentMethod || upsertWalletSettings.isPending;
+  }, [isFirstLoad, hasPaymentMethod, upsertWalletSettings.isPending]);
 
   const defaultCardLabel = useMemo(() => {
     const card = (defaultPaymentMethod as PaymentMethod | null | undefined)?.card;
@@ -150,7 +150,9 @@ export const AutoTopUpSection: React.FunctionComponent<{ dependencies?: typeof D
         <d.CardHeader className="flex flex-row items-start justify-between space-y-0 pb-4">
           <div className="space-y-1">
             <h3 className="text-lg font-bold leading-none">{isThresholdModeOffered ? "Auto Top-Up" : "Auto Recharge"}</h3>
-            {!isThresholdModeOffered ? (
+            {isFirstLoad ? (
+              <d.Skeleton className="h-4 w-72" />
+            ) : !isThresholdModeOffered ? (
               <p className="text-sm text-muted-foreground">Automatically adds credits to keep your deployments running.</p>
             ) : showsThresholdRule ? (
               <p className="text-sm text-muted-foreground">
@@ -202,7 +204,7 @@ export const AutoTopUpSection: React.FunctionComponent<{ dependencies?: typeof D
                 ) : (
                   <div className="space-y-1">
                     <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Predicted spend</p>
-                    <p className="text-2xl font-bold leading-none">{usd(weeklyCost ?? 0)}</p>
+                    {weeklyCost === undefined ? <d.Skeleton className="h-8 w-24" /> : <p className="text-2xl font-bold leading-none">{usd(weeklyCost)}</p>}
                     <p className="text-xs text-muted-foreground">per week, from your running deployments</p>
                   </div>
                 )}
@@ -236,7 +238,11 @@ export const AutoTopUpSection: React.FunctionComponent<{ dependencies?: typeof D
               )}
             </div>
           ) : (
-            <p className="text-sm text-muted-foreground">Turn on Auto Top-Up to add funds automatically when your balance runs low.</p>
+            <p className="text-sm text-muted-foreground">
+              {showsThresholdRule
+                ? "Turn on Auto Top-Up to add funds automatically when your balance runs low."
+                : "Turn on Auto Top-Up to automatically cover the week ahead for your running deployments."}
+            </p>
           )}
         </d.CardContent>
       </d.Card>

--- a/apps/deploy-web/src/components/billing-usage/AutoTopUpSection/AutoTopUpSection.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AutoTopUpSection/AutoTopUpSection.tsx
@@ -15,7 +15,7 @@ import {
 } from "@src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup";
 import { useBillingActions } from "@src/components/billing-usage/BillingActionsProvider/BillingActionsProvider";
 import { UsdValue } from "@src/components/billing-usage/UsdValue/UsdValue";
-import { useFlag } from "@src/hooks/useFlag";
+import { useAutoReloadMode } from "@src/components/billing-usage/useAutoReloadMode";
 import { useDefaultPaymentMethodQuery, useWalletSettingsMutations, useWalletSettingsQuery, useWeeklyDeploymentCostQuery } from "@src/queries";
 import { capitalizeFirstLetter } from "@src/utils/stringUtils";
 
@@ -30,7 +30,7 @@ export const DEPENDENCIES = {
   useAccountBalanceOverview,
   usePopup,
   useBillingActions,
-  useFlag,
+  useAutoReloadMode,
   AutoTopUpSettingsPopup,
   UsdValue,
   Button,
@@ -46,11 +46,11 @@ export const DEPENDENCIES = {
 
 export const AutoTopUpSection: React.FunctionComponent<{ dependencies?: typeof DEPENDENCIES }> = ({ dependencies: d = DEPENDENCIES }) => {
   const [autoTopUpPopup, setAutoTopUpPopup] = useState<{ open: boolean; enableOnSave: boolean }>({ open: false, enableOnSave: false });
-  const isFixedThresholdEnabled = d.useFlag("auto_reload_fixed_threshold");
+  const { mode, isThresholdModeOffered, showsThresholdRule } = d.useAutoReloadMode();
   const { enqueueSnackbar } = d.useSnackbar();
   const { data: defaultPaymentMethod, isLoading: isDefaultPaymentMethodLoading } = d.useDefaultPaymentMethodQuery();
   const { data: walletSettings, isLoading: isWalletSettingsLoading } = d.useWalletSettingsQuery();
-  const { data: weeklyCost } = d.useWeeklyDeploymentCostQuery({ enabled: !isFixedThresholdEnabled });
+  const { data: weeklyCost } = d.useWeeklyDeploymentCostQuery({ enabled: !showsThresholdRule && !isWalletSettingsLoading });
   const { upsertWalletSettings } = d.useWalletSettingsMutations();
   const { openAddPaymentMethod } = d.useBillingActions();
   const overview = d.useAccountBalanceOverview();
@@ -149,18 +149,20 @@ export const AutoTopUpSection: React.FunctionComponent<{ dependencies?: typeof D
         )}
         <d.CardHeader className="flex flex-row items-start justify-between space-y-0 pb-4">
           <div className="space-y-1">
-            <h3 className="text-lg font-bold leading-none">{isFixedThresholdEnabled ? "Auto Top-Up" : "Auto Recharge"}</h3>
-            {isFixedThresholdEnabled ? (
+            <h3 className="text-lg font-bold leading-none">{isThresholdModeOffered ? "Auto Top-Up" : "Auto Recharge"}</h3>
+            {!isThresholdModeOffered ? (
+              <p className="text-sm text-muted-foreground">Automatically adds credits to keep your deployments running.</p>
+            ) : showsThresholdRule ? (
               <p className="text-sm text-muted-foreground">
                 Tops up when your <span className="font-medium text-success">available</span> balance runs low.
               </p>
             ) : (
-              <p className="text-sm text-muted-foreground">Automatically adds credits to keep your deployments running.</p>
+              <p className="text-sm text-muted-foreground">Tops up to cover the week ahead for your running deployments.</p>
             )}
           </div>
           <d.Switch
             checked={autoReloadEnabled}
-            onCheckedChange={isFixedThresholdEnabled ? handleAutoTopUpSwitch : toggleAutoReload}
+            onCheckedChange={isThresholdModeOffered ? handleAutoTopUpSwitch : toggleAutoReload}
             disabled={isReloadChangeDisabled}
           />
         </d.CardHeader>
@@ -175,12 +177,16 @@ export const AutoTopUpSection: React.FunctionComponent<{ dependencies?: typeof D
               <button type="button" onClick={openAddPaymentMethod} className="text-primary underline">
                 Add a payment method
               </button>{" "}
-              to enable auto {isFixedThresholdEnabled ? "top-up" : "recharge"}
+              to enable auto {isThresholdModeOffered ? "top-up" : "recharge"}
             </p>
-          ) : isFixedThresholdEnabled ? (
-            autoReloadEnabled ? (
-              <div className="space-y-4">
-                <div className="flex flex-wrap items-start justify-between gap-4">
+          ) : !isThresholdModeOffered ? (
+            <p className="text-sm text-muted-foreground">
+              Recharge amount is approximately <span className="font-medium text-foreground">{usd(weeklyCost ?? 0)}</span> per week
+            </p>
+          ) : autoReloadEnabled ? (
+            <div className="space-y-4">
+              <div className="flex flex-wrap items-start justify-between gap-4">
+                {showsThresholdRule ? (
                   <div className="flex flex-wrap gap-x-12 gap-y-4">
                     <div className="space-y-1">
                       <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Threshold</p>
@@ -193,18 +199,26 @@ export const AutoTopUpSection: React.FunctionComponent<{ dependencies?: typeof D
                       <p className="text-xs text-muted-foreground">added each time</p>
                     </div>
                   </div>
-                  <d.Button
-                    variant="outline"
-                    size="sm"
-                    className="gap-2"
-                    aria-label="Edit auto top-up settings"
-                    disabled={isReloadChangeDisabled}
-                    onClick={() => setAutoTopUpPopup({ open: true, enableOnSave: false })}
-                  >
-                    <d.Edit className="h-4 w-4" />
-                    Edit
-                  </d.Button>
-                </div>
+                ) : (
+                  <div className="space-y-1">
+                    <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Predicted spend</p>
+                    <p className="text-2xl font-bold leading-none">{usd(weeklyCost ?? 0)}</p>
+                    <p className="text-xs text-muted-foreground">per week, from your running deployments</p>
+                  </div>
+                )}
+                <d.Button
+                  variant="outline"
+                  size="sm"
+                  className="gap-2"
+                  aria-label="Edit auto top-up settings"
+                  disabled={isReloadChangeDisabled}
+                  onClick={() => setAutoTopUpPopup({ open: true, enableOnSave: false })}
+                >
+                  <d.Edit className="h-4 w-4" />
+                  Edit
+                </d.Button>
+              </div>
+              {showsThresholdRule ? (
                 <p className="border-t pt-4 text-sm text-muted-foreground">
                   Charges {defaultCardLabel ?? "your default payment method"} when your available balance falls below the threshold.
                   {nextTopUpDays !== null && (
@@ -215,23 +229,24 @@ export const AutoTopUpSection: React.FunctionComponent<{ dependencies?: typeof D
                     </>
                   )}
                 </p>
-              </div>
-            ) : (
-              <p className="text-sm text-muted-foreground">Turn on Auto Top-Up to add funds automatically when your balance runs low.</p>
-            )
+              ) : (
+                <p className="border-t pt-4 text-sm text-muted-foreground">
+                  Charges {defaultCardLabel ?? "your default payment method"} for whatever your deployments need to keep running for another week.
+                </p>
+              )}
+            </div>
           ) : (
-            <p className="text-sm text-muted-foreground">
-              Recharge amount is approximately <span className="font-medium text-foreground">{usd(weeklyCost ?? 0)}</span> per week
-            </p>
+            <p className="text-sm text-muted-foreground">Turn on Auto Top-Up to add funds automatically when your balance runs low.</p>
           )}
         </d.CardContent>
       </d.Card>
 
-      {isFixedThresholdEnabled && (
+      {isThresholdModeOffered && (
         <d.AutoTopUpSettingsPopup
           open={autoTopUpPopup.open}
           onClose={() => setAutoTopUpPopup(prev => ({ ...prev, open: false }))}
           enableOnSave={autoTopUpPopup.enableOnSave}
+          mode={mode}
           threshold={walletSettings?.autoReloadThreshold}
           amount={walletSettings?.autoReloadAmount}
         />

--- a/apps/deploy-web/src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup.spec.tsx
@@ -81,7 +81,10 @@ describe(AutoTopUpSettingsPopup.name, () => {
 
     await submit();
 
-    expect(upsertMutate).toHaveBeenCalledWith({ data: { autoReloadEnabled: true, autoReloadThreshold: 20, autoReloadAmount: 100 } }, expect.anything());
+    expect(upsertMutate).toHaveBeenCalledWith(
+      { data: { autoReloadEnabled: true, autoReloadMode: "threshold", autoReloadThreshold: 20, autoReloadAmount: 100 } },
+      expect.anything()
+    );
   });
 
   it("saves the enabled flag with values in edit mode", async () => {
@@ -90,7 +93,65 @@ describe(AutoTopUpSettingsPopup.name, () => {
 
     await submit();
 
-    expect(upsertMutate).toHaveBeenCalledWith({ data: { autoReloadEnabled: true, autoReloadThreshold: 30, autoReloadAmount: 150 } }, expect.anything());
+    expect(upsertMutate).toHaveBeenCalledWith(
+      { data: { autoReloadEnabled: true, autoReloadMode: "threshold", autoReloadThreshold: 30, autoReloadAmount: 150 } },
+      expect.anything()
+    );
+  });
+
+  it("preselects threshold mode when the account has no stored mode", () => {
+    setup({});
+
+    expect(modeRadio(/fixed threshold/i)).toBeChecked();
+    expect(thresholdInput()).toBeInTheDocument();
+  });
+
+  it("preselects the stored mode and hides the threshold fields in prediction mode", () => {
+    setup({ mode: "prediction" });
+
+    expect(modeRadio(/predicted spend/i)).toBeChecked();
+    expect(screen.queryByLabelText(/when credit balance drops to or below/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/purchase this amount/i)).not.toBeInTheDocument();
+  });
+
+  it("saves prediction mode without threshold values", async () => {
+    const upsertMutate = vi.fn();
+    setup({ mode: "threshold", threshold: 30, amount: 150, upsertMutate });
+
+    fireEvent.click(modeRadio(/predicted spend/i));
+    await submit();
+
+    expect(upsertMutate).toHaveBeenCalledWith({ data: { autoReloadEnabled: true, autoReloadMode: "prediction" } }, expect.anything());
+  });
+
+  it("saves threshold mode with values when switching back from prediction", async () => {
+    const upsertMutate = vi.fn();
+    setup({ mode: "prediction", threshold: 30, amount: 150, upsertMutate });
+
+    fireEvent.click(modeRadio(/fixed threshold/i));
+    await submit();
+
+    expect(upsertMutate).toHaveBeenCalledWith(
+      { data: { autoReloadEnabled: true, autoReloadMode: "threshold", autoReloadThreshold: 30, autoReloadAmount: 150 } },
+      expect.anything()
+    );
+  });
+
+  it("saves prediction mode even when a stored threshold is below the threshold-mode minimum", async () => {
+    const upsertMutate = vi.fn();
+    setup({ mode: "prediction", threshold: 1, amount: 1, upsertMutate });
+
+    await submit();
+
+    expect(upsertMutate).toHaveBeenCalledWith({ data: { autoReloadEnabled: true, autoReloadMode: "prediction" } }, expect.anything());
+  });
+
+  it("resets the mode when the dialog transitions from closed to open", () => {
+    const { props, rerender } = setup({ open: false, mode: "threshold" });
+
+    rerender(<AutoTopUpSettingsPopup {...props} open mode="prediction" />);
+
+    expect(modeRadio(/predicted spend/i)).toBeChecked();
   });
 
   it("closes and shows a success snackbar when the save succeeds", async () => {
@@ -135,6 +196,10 @@ describe(AutoTopUpSettingsPopup.name, () => {
     expect(amountInput().value).toBe("150");
   });
 
+  function modeRadio(name: RegExp) {
+    return screen.getByRole("radio", { name });
+  }
+
   function thresholdInput() {
     return screen.getByLabelText(/when credit balance drops to or below/i) as HTMLInputElement;
   }
@@ -152,6 +217,7 @@ describe(AutoTopUpSettingsPopup.name, () => {
   function setup(input: {
     open?: boolean;
     enableOnSave?: boolean;
+    mode?: "prediction" | "threshold";
     threshold?: number;
     amount?: number;
     onClose?: () => void;
@@ -184,6 +250,7 @@ describe(AutoTopUpSettingsPopup.name, () => {
       open: input.open ?? true,
       onClose: input.onClose ?? vi.fn(),
       enableOnSave: input.enableOnSave ?? false,
+      mode: input.mode,
       threshold: input.threshold,
       amount: input.amount,
       dependencies

--- a/apps/deploy-web/src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup.tsx
@@ -3,15 +3,29 @@
 import React, { useEffect, useMemo, useRef } from "react";
 import { useForm } from "react-hook-form";
 import type { PaymentMethod } from "@akashnetwork/http-sdk";
-import { Form, FormField, FormInput, LoadingButton, Popup, Snackbar } from "@akashnetwork/ui/components";
+import {
+  Field,
+  FieldContent,
+  FieldLabel,
+  FieldTitle,
+  Form,
+  FormField,
+  FormInput,
+  LoadingButton,
+  Popup,
+  RadioGroup,
+  RadioGroupItem,
+  Snackbar
+} from "@akashnetwork/ui/components";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { CreditCard } from "iconoir-react";
 import { useSnackbar } from "notistack";
 import { z } from "zod";
 
 import { getPaymentMethodDisplay } from "@src/components/shared/PaymentMethodCard/PaymentMethodCard";
-import { useDefaultPaymentMethodQuery, useWalletSettingsMutations } from "@src/queries";
+import { type AutoReloadMode, useDefaultPaymentMethodQuery, useWalletSettingsMutations } from "@src/queries";
 
+export const DEFAULT_AUTO_RELOAD_MODE: AutoReloadMode = "threshold";
 export const DEFAULT_AUTO_RELOAD_THRESHOLD = 20;
 export const DEFAULT_AUTO_RELOAD_AMOUNT = 100;
 
@@ -24,16 +38,48 @@ const AUTO_RELOAD_MAX_USD = 10_000;
 /** Mirrors STANDARD_TOP_UP_MIN_AMOUNT_USD — the fixed floor the backend applies to every recurring auto-top-up charge, independent of the trial-aware one-time top-up minimum. */
 const AUTO_RELOAD_AMOUNT_MIN_USD = 20;
 
-const autoTopUpSchema = z.object({
-  autoReloadThreshold: z.coerce
-    .number()
-    .min(AUTO_RELOAD_THRESHOLD_MIN_USD, `Minimum threshold is $${AUTO_RELOAD_THRESHOLD_MIN_USD}`)
-    .max(AUTO_RELOAD_MAX_USD, `Maximum threshold is $${AUTO_RELOAD_MAX_USD}`),
-  autoReloadAmount: z.coerce
-    .number()
-    .min(AUTO_RELOAD_AMOUNT_MIN_USD, `Minimum amount is $${AUTO_RELOAD_AMOUNT_MIN_USD}`)
-    .max(AUTO_RELOAD_MAX_USD, `Maximum amount is $${AUTO_RELOAD_MAX_USD}`)
-});
+const MODE_OPTIONS: Array<{ value: AutoReloadMode; id: string; title: string; description: string }> = [
+  {
+    value: "threshold",
+    id: "auto-reload-mode-threshold",
+    title: "Fixed threshold",
+    description: "Charge a set amount as soon as your available balance runs low."
+  },
+  {
+    value: "prediction",
+    id: "auto-reload-mode-prediction",
+    title: "Predicted spend",
+    description: "Charge whatever it takes to cover the next week of your current deployments."
+  }
+];
+
+/**
+ * The threshold and amount bounds only apply in threshold mode: prediction mode derives its amounts from projected
+ * spend, and its inputs aren't rendered, so a stored value outside the bounds must not block the save.
+ */
+const autoTopUpSchema = z
+  .object({
+    autoReloadMode: z.enum(["threshold", "prediction"]),
+    autoReloadThreshold: z.coerce.number(),
+    autoReloadAmount: z.coerce.number()
+  })
+  .superRefine((values, ctx) => {
+    if (values.autoReloadMode !== "threshold") return;
+
+    const boundedFields = [
+      { name: "autoReloadThreshold" as const, value: values.autoReloadThreshold, min: AUTO_RELOAD_THRESHOLD_MIN_USD, label: "threshold" },
+      { name: "autoReloadAmount" as const, value: values.autoReloadAmount, min: AUTO_RELOAD_AMOUNT_MIN_USD, label: "amount" }
+    ];
+
+    for (const { name, value, min, label } of boundedFields) {
+      if (value < min) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, path: [name], message: `Minimum ${label} is $${min}` });
+      }
+      if (value > AUTO_RELOAD_MAX_USD) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, path: [name], message: `Maximum ${label} is $${AUTO_RELOAD_MAX_USD}` });
+      }
+    }
+  });
 
 type AutoTopUpFormValues = z.infer<typeof autoTopUpSchema>;
 
@@ -49,6 +95,7 @@ interface AutoTopUpSettingsPopupProps {
   onClose: () => void;
   /** True for the first-enable flow (Save turns auto top-up on); false when editing an already-enabled account. */
   enableOnSave: boolean;
+  mode?: AutoReloadMode;
   threshold?: number;
   amount?: number;
   dependencies?: typeof DEPENDENCIES;
@@ -58,6 +105,7 @@ export const AutoTopUpSettingsPopup: React.FC<AutoTopUpSettingsPopupProps> = ({
   open,
   onClose,
   enableOnSave,
+  mode,
   threshold,
   amount,
   dependencies: d = DEPENDENCIES
@@ -68,10 +116,11 @@ export const AutoTopUpSettingsPopup: React.FC<AutoTopUpSettingsPopupProps> = ({
 
   const defaultValues = useMemo<AutoTopUpFormValues>(
     () => ({
+      autoReloadMode: mode ?? DEFAULT_AUTO_RELOAD_MODE,
       autoReloadThreshold: threshold ?? DEFAULT_AUTO_RELOAD_THRESHOLD,
       autoReloadAmount: amount ?? DEFAULT_AUTO_RELOAD_AMOUNT
     }),
-    [threshold, amount]
+    [mode, threshold, amount]
   );
 
   const form = d.useForm<AutoTopUpFormValues>({
@@ -90,6 +139,7 @@ export const AutoTopUpSettingsPopup: React.FC<AutoTopUpSettingsPopupProps> = ({
     [open, defaultValues, form]
   );
 
+  const selectedMode = form.watch("autoReloadMode");
   const cardDisplay = defaultPaymentMethod ? getPaymentMethodDisplay(defaultPaymentMethod as PaymentMethod) : null;
 
   const saveSettings = form.handleSubmit(values => {
@@ -97,8 +147,11 @@ export const AutoTopUpSettingsPopup: React.FC<AutoTopUpSettingsPopupProps> = ({
       {
         data: {
           autoReloadEnabled: true,
-          autoReloadThreshold: values.autoReloadThreshold,
-          autoReloadAmount: values.autoReloadAmount
+          autoReloadMode: values.autoReloadMode,
+          ...(values.autoReloadMode === "threshold" && {
+            autoReloadThreshold: values.autoReloadThreshold,
+            autoReloadAmount: values.autoReloadAmount
+          })
         }
       },
       {
@@ -132,32 +185,60 @@ export const AutoTopUpSettingsPopup: React.FC<AutoTopUpSettingsPopupProps> = ({
 
           <FormField
             control={form.control}
-            name="autoReloadThreshold"
+            name="autoReloadMode"
             render={({ field }) => (
-              <FormInput
-                {...field}
-                type="number"
-                step="0.01"
-                label={`When credit balance drops to or below (minimum $${AUTO_RELOAD_THRESHOLD_MIN_USD})`}
-                description="If your current balance is at or below the threshold you set, your top-up will kick in shortly after you save."
-                startIcon={<div className="pl-3 text-sm text-muted-foreground">$</div>}
-              />
+              <RadioGroup value={field.value} onValueChange={field.onChange} aria-label="Auto top-up mode">
+                {MODE_OPTIONS.map(option => (
+                  <FieldLabel key={option.value} htmlFor={option.id}>
+                    <Field orientation="horizontal" className="cursor-pointer p-3">
+                      <RadioGroupItem value={option.value} id={option.id} className="self-center" />
+                      <FieldContent>
+                        <FieldTitle className="font-medium">{option.title}</FieldTitle>
+                        <p className="text-sm text-muted-foreground">{option.description}</p>
+                      </FieldContent>
+                    </Field>
+                  </FieldLabel>
+                ))}
+              </RadioGroup>
             )}
           />
 
-          <FormField
-            control={form.control}
-            name="autoReloadAmount"
-            render={({ field }) => (
-              <FormInput
-                {...field}
-                type="number"
-                step="0.01"
-                label={`Purchase this amount (minimum $${AUTO_RELOAD_AMOUNT_MIN_USD})`}
-                startIcon={<div className="pl-3 text-sm text-muted-foreground">$</div>}
+          {selectedMode === "threshold" ? (
+            <>
+              <FormField
+                control={form.control}
+                name="autoReloadThreshold"
+                render={({ field }) => (
+                  <FormInput
+                    {...field}
+                    type="number"
+                    step="0.01"
+                    label={`When credit balance drops to or below (minimum $${AUTO_RELOAD_THRESHOLD_MIN_USD})`}
+                    description="If your current balance is at or below the threshold you set, your top-up will kick in shortly after you save."
+                    startIcon={<div className="pl-3 text-sm text-muted-foreground">$</div>}
+                  />
+                )}
               />
-            )}
-          />
+
+              <FormField
+                control={form.control}
+                name="autoReloadAmount"
+                render={({ field }) => (
+                  <FormInput
+                    {...field}
+                    type="number"
+                    step="0.01"
+                    label={`Purchase this amount (minimum $${AUTO_RELOAD_AMOUNT_MIN_USD})`}
+                    startIcon={<div className="pl-3 text-sm text-muted-foreground">$</div>}
+                  />
+                )}
+              />
+            </>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              We check your deployments once a day and charge enough to keep them running for another week. There is nothing else to configure.
+            </p>
+          )}
 
           <LoadingButton type="submit" className="w-full" loading={upsertWalletSettings.isPending}>
             Save changes

--- a/apps/deploy-web/src/components/billing-usage/useAutoReloadMode.spec.ts
+++ b/apps/deploy-web/src/components/billing-usage/useAutoReloadMode.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { DEPENDENCIES, useAutoReloadMode } from "./useAutoReloadMode";
+
+import { renderHook } from "@testing-library/react";
+
+describe(useAutoReloadMode.name, () => {
+  it("uses the stored mode even when threshold mode is not offered", () => {
+    const { result } = setup({ isThresholdModeOffered: false, storedMode: "threshold" });
+
+    expect(result.current.mode).toBe("threshold");
+  });
+
+  it("uses the stored mode when threshold mode is offered", () => {
+    const { result } = setup({ isThresholdModeOffered: true, storedMode: "prediction" });
+
+    expect(result.current.mode).toBe("prediction");
+  });
+
+  it("defaults to threshold when nothing is stored and threshold mode is offered", () => {
+    const { result } = setup({ isThresholdModeOffered: true });
+
+    expect(result.current.mode).toBe("threshold");
+  });
+
+  it("defaults to prediction when nothing is stored and threshold mode is not offered", () => {
+    const { result } = setup({ isThresholdModeOffered: false });
+
+    expect(result.current.mode).toBe("prediction");
+  });
+
+  it("reports whether threshold mode is offered", () => {
+    const { result } = setup({ isThresholdModeOffered: true });
+
+    expect(result.current.isThresholdModeOffered).toBe(true);
+  });
+
+  it("shows the threshold rule only when it is offered and selected", () => {
+    expect(setup({ isThresholdModeOffered: true, storedMode: "threshold" }).result.current.showsThresholdRule).toBe(true);
+    expect(setup({ isThresholdModeOffered: true, storedMode: "prediction" }).result.current.showsThresholdRule).toBe(false);
+    expect(setup({ isThresholdModeOffered: false, storedMode: "threshold" }).result.current.showsThresholdRule).toBe(false);
+  });
+
+  function setup(input: { isThresholdModeOffered?: boolean; storedMode?: "prediction" | "threshold"; isLoading?: boolean }) {
+    const dependencies = {
+      ...DEPENDENCIES,
+      useFlag: () => input.isThresholdModeOffered ?? false,
+      useWalletSettingsQuery: () => ({
+        data: input.storedMode ? { autoReloadMode: input.storedMode } : null,
+        isLoading: input.isLoading ?? false
+      })
+    } as unknown as typeof DEPENDENCIES;
+
+    return renderHook(() => useAutoReloadMode({ dependencies }));
+  }
+});

--- a/apps/deploy-web/src/components/billing-usage/useAutoReloadMode.ts
+++ b/apps/deploy-web/src/components/billing-usage/useAutoReloadMode.ts
@@ -1,0 +1,32 @@
+"use client";
+import { useFlag } from "@src/hooks/useFlag";
+import { type AutoReloadMode, useWalletSettingsQuery } from "@src/queries";
+
+export const DEPENDENCIES = { useFlag, useWalletSettingsQuery };
+
+export type AutoReloadModeState = {
+  mode: AutoReloadMode;
+  /** Whether threshold mode is offered at all: the picker, the Edit affordance, and the default for a new enablement. */
+  isThresholdModeOffered: boolean;
+  /** Whether to present the fixed-threshold rule. False while the flag is off, so a rollback shows the legacy card everywhere at once. */
+  showsThresholdRule: boolean;
+  isLoading: boolean;
+};
+
+/**
+ * The stored mode always wins, so the billing page never advertises a rule the reload job isn't running. The flag
+ * only decides what an account that has never configured auto reload defaults to.
+ */
+export function useAutoReloadMode({ dependencies: d = DEPENDENCIES }: { dependencies?: typeof DEPENDENCIES } = {}): AutoReloadModeState {
+  const isThresholdModeOffered = d.useFlag("auto_reload_fixed_threshold");
+  const { data: walletSettings, isLoading } = d.useWalletSettingsQuery();
+
+  const mode = walletSettings?.autoReloadMode ?? (isThresholdModeOffered ? "threshold" : "prediction");
+
+  return {
+    mode,
+    isThresholdModeOffered,
+    showsThresholdRule: isThresholdModeOffered && mode === "threshold",
+    isLoading
+  };
+}

--- a/apps/deploy-web/src/queries/useWalletSettingsQueries.tsx
+++ b/apps/deploy-web/src/queries/useWalletSettingsQueries.tsx
@@ -47,3 +47,5 @@ export const useWalletSettingsMutations = () => {
 };
 
 type WalletSettings = paths["/v1/wallet-settings"]["get"]["responses"][200]["content"]["application/json"];
+
+export type AutoReloadMode = WalletSettings["data"]["autoReloadMode"];


### PR DESCRIPTION
## Why

The billing page decided which auto top-up rule to describe from the `auto_reload_fixed_threshold` flag alone. A user on predicted spend would have started seeing threshold copy the moment the flag went on, and nobody could move between the two rules.

Closes CON-884

> [!NOTE]
> Stacked on #3619 — retarget to `main` once that merges. The types for `autoReloadMode` come from the `console-api-types` regenerated there.

## What

The settings dialog now owns a two-option mode picker, and the card summarises whichever mode the account is on.

- **Threshold mode** keeps the balance/amount inputs. **Prediction mode** drops them and explains that the amount comes from projected spend.
- Saving in prediction mode omits the threshold values entirely, and their bounds now only apply in threshold mode — a stored value outside the bounds can no longer block a save through inputs the user can't see.
- The card renders a per-mode summary (threshold shows X/Y, prediction shows the weekly estimate) with the same Edit button for both, so a prediction user finally has a way to reach these settings.
- New `useAutoReloadMode` hook resolves the mode in one place: the **stored** mode wins, so the page never advertises a rule the reload job isn't running, and the flag only picks the default for an account that has never configured auto top-up. The balance bar's threshold marker keys off the same predicate as the card, so the two can't disagree — including on a flag rollback.
- With the flag off, everything falls back to today's Auto Recharge card. The weekly-cost query is only issued in prediction mode.

### Verified locally

Ran the app against mocked wallet settings and walked both modes:

- **Threshold**: card shows `THRESHOLD $20.00` / `TOP UP $100.00` and "Charges Visa \*\*\*\* 4242 when your available balance falls below the threshold."
- **Prediction**: card shows `PREDICTED SPEND $42.50` "per week, from your running deployments" and "Charges Visa \*\*\*\* 4242 for whatever your deployments need to keep running for another week."
- Switching threshold → prediction in the dialog hides the two inputs and saves exactly `{"data":{"autoReloadEnabled":true,"autoReloadMode":"prediction"}}`; switching back sends the mode plus both values. No console errors on either path.