### PR TITLE
fix(deployment): fund deployments to a target runway instead of adding a flat window

### DIFF
--- a/apps/api/src/deployment/config/env.config.spec.ts
+++ b/apps/api/src/deployment/config/env.config.spec.ts
@@ -56,6 +56,26 @@ describe("deployment envSchema", () => {
       expect(!result.success && result.error.issues[0].path).toEqual(["AUTO_TOP_UP_TARGET_RUNWAY_IN_H"]);
     });
 
+    it("rejects a negative target runway even when it stays above the look-ahead window", () => {
+      const result = envSchema.safeParse(setup({ AUTO_TOP_UP_TARGET_RUNWAY_IN_H: -1, AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H: -2 }));
+
+      expect(result.success).toBe(false);
+      expect(!result.success && result.error.issues.some(issue => issue.path[0] === "AUTO_TOP_UP_TARGET_RUNWAY_IN_H")).toBe(true);
+    });
+
+    it("rejects a negative look-ahead window", () => {
+      const result = envSchema.safeParse(setup({ AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H: -24 }));
+
+      expect(result.success).toBe(false);
+      expect(!result.success && result.error.issues.some(issue => issue.path[0] === "AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H")).toBe(true);
+    });
+
+    it("accepts a zero look-ahead window", () => {
+      const result = envSchema.safeParse(setup({ AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H: 0 }));
+
+      expect(result.success).toBe(true);
+    });
+
     it("accepts a target runway above the look-ahead window", () => {
       const result = envSchema.safeParse(setup({ AUTO_TOP_UP_TARGET_RUNWAY_IN_H: 36, AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H: 12 }));
 

--- a/apps/api/src/deployment/config/env.config.spec.ts
+++ b/apps/api/src/deployment/config/env.config.spec.ts
@@ -76,6 +76,20 @@ describe("deployment envSchema", () => {
       expect(result.success).toBe(true);
     });
 
+    it("rejects an infinite target runway", () => {
+      const result = envSchema.safeParse(setup({ AUTO_TOP_UP_TARGET_RUNWAY_IN_H: "Infinity" }));
+
+      expect(result.success).toBe(false);
+      expect(!result.success && result.error.issues.some(issue => issue.path[0] === "AUTO_TOP_UP_TARGET_RUNWAY_IN_H")).toBe(true);
+    });
+
+    it("rejects an infinite look-ahead window", () => {
+      const result = envSchema.safeParse(setup({ AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H: Infinity }));
+
+      expect(result.success).toBe(false);
+      expect(!result.success && result.error.issues.some(issue => issue.path[0] === "AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H")).toBe(true);
+    });
+
     it("accepts a target runway above the look-ahead window", () => {
       const result = envSchema.safeParse(setup({ AUTO_TOP_UP_TARGET_RUNWAY_IN_H: 36, AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H: 12 }));
 

--- a/apps/api/src/deployment/config/env.config.spec.ts
+++ b/apps/api/src/deployment/config/env.config.spec.ts
@@ -5,40 +5,65 @@ import { envSchema } from "./env.config";
 describe("deployment envSchema", () => {
   describe("DEPLOYMENT_DEFAULT_DEPOSIT", () => {
     it("defaults to 0.5 when omitted", () => {
-      const config = setup();
-      expect(config.DEPLOYMENT_DEFAULT_DEPOSIT).toBe(0.5);
+      expect(envSchema.parse(setup()).DEPLOYMENT_DEFAULT_DEPOSIT).toBe(0.5);
     });
 
     it("accepts a positive value", () => {
-      const config = setup({ DEPLOYMENT_DEFAULT_DEPOSIT: "1.25" });
-      expect(config.DEPLOYMENT_DEFAULT_DEPOSIT).toBe(1.25);
+      expect(envSchema.parse(setup({ DEPLOYMENT_DEFAULT_DEPOSIT: "1.25" })).DEPLOYMENT_DEFAULT_DEPOSIT).toBe(1.25);
     });
 
     it("rejects a zero value", () => {
-      expect(() => setup({ DEPLOYMENT_DEFAULT_DEPOSIT: "0" })).toThrow();
+      expect(() => envSchema.parse(setup({ DEPLOYMENT_DEFAULT_DEPOSIT: "0" }))).toThrow();
     });
 
     it("rejects a negative value", () => {
-      expect(() => setup({ DEPLOYMENT_DEFAULT_DEPOSIT: "-1" })).toThrow();
+      expect(() => envSchema.parse(setup({ DEPLOYMENT_DEFAULT_DEPOSIT: "-1" }))).toThrow();
     });
 
     it("rejects a value that rounds to zero on-chain", () => {
-      expect(() => setup({ DEPLOYMENT_DEFAULT_DEPOSIT: "0.0000001" })).toThrow();
+      expect(() => envSchema.parse(setup({ DEPLOYMENT_DEFAULT_DEPOSIT: "0.0000001" }))).toThrow();
     });
 
     it("rejects a non-finite value", () => {
-      expect(() => setup({ DEPLOYMENT_DEFAULT_DEPOSIT: "Infinity" })).toThrow();
+      expect(() => envSchema.parse(setup({ DEPLOYMENT_DEFAULT_DEPOSIT: "Infinity" }))).toThrow();
     });
 
     it("rejects a non-numeric value", () => {
-      expect(() => setup({ DEPLOYMENT_DEFAULT_DEPOSIT: "abc" })).toThrow();
+      expect(() => envSchema.parse(setup({ DEPLOYMENT_DEFAULT_DEPOSIT: "abc" }))).toThrow();
     });
   });
 
-  function setup(input?: { DEPLOYMENT_DEFAULT_DEPOSIT?: string }) {
-    return envSchema.parse({
-      PROVIDER_PROXY_URL: "https://provider-proxy.test",
-      ...input
+  describe("AUTO_TOP_UP_TARGET_RUNWAY_IN_H", () => {
+    it("accepts the default target runway and look-ahead window", () => {
+      const result = envSchema.safeParse(setup());
+
+      expect(result.success).toBe(true);
+      expect(result.success && result.data.AUTO_TOP_UP_TARGET_RUNWAY_IN_H).toBe(48);
+      expect(result.success && result.data.AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H).toBe(24);
     });
+
+    it("rejects a target runway equal to the look-ahead window", () => {
+      const result = envSchema.safeParse(setup({ AUTO_TOP_UP_TARGET_RUNWAY_IN_H: 24, AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H: 24 }));
+
+      expect(result.success).toBe(false);
+      expect(!result.success && result.error.issues[0].path).toEqual(["AUTO_TOP_UP_TARGET_RUNWAY_IN_H"]);
+    });
+
+    it("rejects a target runway below the look-ahead window", () => {
+      const result = envSchema.safeParse(setup({ AUTO_TOP_UP_TARGET_RUNWAY_IN_H: 12, AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H: 24 }));
+
+      expect(result.success).toBe(false);
+      expect(!result.success && result.error.issues[0].path).toEqual(["AUTO_TOP_UP_TARGET_RUNWAY_IN_H"]);
+    });
+
+    it("accepts a target runway above the look-ahead window", () => {
+      const result = envSchema.safeParse(setup({ AUTO_TOP_UP_TARGET_RUNWAY_IN_H: 36, AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H: 12 }));
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  function setup(overrides: Record<string, unknown> = {}) {
+    return { PROVIDER_PROXY_URL: "https://provider-proxy.example.com", ...overrides };
   }
 });

--- a/apps/api/src/deployment/config/env.config.spec.ts
+++ b/apps/api/src/deployment/config/env.config.spec.ts
@@ -97,6 +97,42 @@ describe("deployment envSchema", () => {
     });
   });
 
+  describe("AUTO_TOP_UP_BALANCE_HEADROOM_IN_USD", () => {
+    it("defaults to 5 when omitted", () => {
+      const result = envSchema.safeParse(setup());
+
+      expect(result.success).toBe(true);
+      expect(result.success && result.data.AUTO_TOP_UP_BALANCE_HEADROOM_IN_USD).toBe(5);
+    });
+
+    it("accepts a zero headroom", () => {
+      const result = envSchema.safeParse(setup({ AUTO_TOP_UP_BALANCE_HEADROOM_IN_USD: 0 }));
+
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects a negative headroom", () => {
+      const result = envSchema.safeParse(setup({ AUTO_TOP_UP_BALANCE_HEADROOM_IN_USD: -5 }));
+
+      expect(result.success).toBe(false);
+      expect(!result.success && result.error.issues.some(issue => issue.path[0] === "AUTO_TOP_UP_BALANCE_HEADROOM_IN_USD")).toBe(true);
+    });
+
+    it("rejects an infinite headroom, which would waive the floor and spend the whole balance", () => {
+      const result = envSchema.safeParse(setup({ AUTO_TOP_UP_BALANCE_HEADROOM_IN_USD: Infinity }));
+
+      expect(result.success).toBe(false);
+      expect(!result.success && result.error.issues.some(issue => issue.path[0] === "AUTO_TOP_UP_BALANCE_HEADROOM_IN_USD")).toBe(true);
+    });
+
+    it("rejects a headroom coerced from an infinite string", () => {
+      const result = envSchema.safeParse(setup({ AUTO_TOP_UP_BALANCE_HEADROOM_IN_USD: "Infinity" }));
+
+      expect(result.success).toBe(false);
+      expect(!result.success && result.error.issues.some(issue => issue.path[0] === "AUTO_TOP_UP_BALANCE_HEADROOM_IN_USD")).toBe(true);
+    });
+  });
+
   function setup(overrides: Record<string, unknown> = {}) {
     return { PROVIDER_PROXY_URL: "https://provider-proxy.example.com", ...overrides };
   }

--- a/apps/api/src/deployment/config/env.config.ts
+++ b/apps/api/src/deployment/config/env.config.ts
@@ -8,8 +8,9 @@ export const envSchema = z
     /**
      * Hours of runway automatic funding brings a deployment up to, counting the runway it already holds.
      * Must stay above `AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H`: funding only triggers once a deployment drops
-     * inside that window, so the gap between the two is what a single deposit covers. At or below it every
-     * deposit sizes to zero and automatic funding stops entirely, hence the schema check below.
+     * inside that window, so the gap between the two is the smallest deposit a triggering deployment can
+     * receive. At or below the window that floor is zero, so a deployment triggering at the edge of the
+     * window is funded nothing and simply re-triggers, hence the schema check below.
      */
     AUTO_TOP_UP_TARGET_RUNWAY_IN_H: z.number({ coerce: true }).positive().finite().optional().default(48),
     AUTO_TOP_UP_DEDUP_COOLDOWN_IN_MIN: z.number({ coerce: true }).positive().optional().default(60),
@@ -37,7 +38,7 @@ export const envSchema = z
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ["AUTO_TOP_UP_TARGET_RUNWAY_IN_H"],
-        message: `AUTO_TOP_UP_TARGET_RUNWAY_IN_H (${env.AUTO_TOP_UP_TARGET_RUNWAY_IN_H}) must be greater than AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H (${env.AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H}), otherwise automatic funding sizes every deposit to zero`
+        message: `AUTO_TOP_UP_TARGET_RUNWAY_IN_H (${env.AUTO_TOP_UP_TARGET_RUNWAY_IN_H}) must be greater than AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H (${env.AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H}), otherwise a deployment triggering at the edge of the window is sized a zero deposit`
       });
     }
   });

--- a/apps/api/src/deployment/config/env.config.ts
+++ b/apps/api/src/deployment/config/env.config.ts
@@ -2,28 +2,44 @@ import { z } from "zod";
 
 import { denomToUdenom } from "@src/utils/math";
 
-export const envSchema = z.object({
-  AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H: z.number({ coerce: true }).optional().default(24),
-  AUTO_TOP_UP_AMOUNT_IN_H: z.number({ coerce: true }).optional().default(48),
-  AUTO_TOP_UP_DEDUP_COOLDOWN_IN_MIN: z.number({ coerce: true }).positive().optional().default(60),
-  /**
-   * Dollar floor auto-funding leaves in the available deployment allowance so a user with credits left can still
-   * create a deployment. Whole dollars: `DEPLOYMENT_GRANT_DENOM` is `uact` on real networks, 1:1 with USD.
-   * 0 restores the previous drain-to-zero behavior.
-   */
-  AUTO_TOP_UP_BALANCE_HEADROOM_IN_USD: z.number({ coerce: true }).nonnegative().optional().default(5),
-  /**
-   * Deposit (in dollars) the platform bootstraps a managed deployment with when the caller no longer supplies one.
-   * Must stay at or above the chain's `min_deposits` for the active `DEPLOYMENT_GRANT_DENOM`, or the create tx is rejected
-   * on-chain. Kept minimal on purpose: auto-funding tops the deployment up to its runway right after the lease starts.
-   */
-  DEPLOYMENT_DEFAULT_DEPOSIT: z
-    .number({ coerce: true })
-    .refine(value => Number.isFinite(value) && denomToUdenom(value) > 0, "must be a finite amount that converts to a positive on-chain deposit")
-    .optional()
-    .default(0.5),
-  PROVIDER_PROXY_URL: z.string().url(),
-  GPU_BOT_WALLET_MNEMONIC: z.string().optional()
-});
+export const envSchema = z
+  .object({
+    AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H: z.number({ coerce: true }).optional().default(24),
+    /**
+     * Hours of runway automatic funding brings a deployment up to, counting the runway it already holds.
+     * Must stay above `AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H`: funding only triggers once a deployment drops
+     * inside that window, so the gap between the two is what a single deposit covers. At or below it every
+     * deposit sizes to zero and automatic funding stops entirely, hence the schema check below.
+     */
+    AUTO_TOP_UP_TARGET_RUNWAY_IN_H: z.number({ coerce: true }).optional().default(48),
+    AUTO_TOP_UP_DEDUP_COOLDOWN_IN_MIN: z.number({ coerce: true }).positive().optional().default(60),
+    /**
+     * Dollar floor auto-funding leaves in the available deployment allowance so a user with credits left can still
+     * create a deployment. Whole dollars: `DEPLOYMENT_GRANT_DENOM` is `uact` on real networks, 1:1 with USD.
+     * 0 restores the previous drain-to-zero behavior.
+     */
+    AUTO_TOP_UP_BALANCE_HEADROOM_IN_USD: z.number({ coerce: true }).nonnegative().optional().default(5),
+    /**
+     * Deposit (in dollars) the platform bootstraps a managed deployment with when the caller no longer supplies one.
+     * Must stay at or above the chain's `min_deposits` for the active `DEPLOYMENT_GRANT_DENOM`, or the create tx is rejected
+     * on-chain. Kept minimal on purpose: auto-funding tops the deployment up to its runway right after the lease starts.
+     */
+    DEPLOYMENT_DEFAULT_DEPOSIT: z
+      .number({ coerce: true })
+      .refine(value => Number.isFinite(value) && denomToUdenom(value) > 0, "must be a finite amount that converts to a positive on-chain deposit")
+      .optional()
+      .default(0.5),
+    PROVIDER_PROXY_URL: z.string().url(),
+    GPU_BOT_WALLET_MNEMONIC: z.string().optional()
+  })
+  .superRefine((env, ctx) => {
+    if (env.AUTO_TOP_UP_TARGET_RUNWAY_IN_H <= env.AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["AUTO_TOP_UP_TARGET_RUNWAY_IN_H"],
+        message: `AUTO_TOP_UP_TARGET_RUNWAY_IN_H (${env.AUTO_TOP_UP_TARGET_RUNWAY_IN_H}) must be greater than AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H (${env.AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H}), otherwise automatic funding sizes every deposit to zero`
+      });
+    }
+  });
 
 export type DeploymentConfig = z.infer<typeof envSchema>;

--- a/apps/api/src/deployment/config/env.config.ts
+++ b/apps/api/src/deployment/config/env.config.ts
@@ -4,14 +4,14 @@ import { denomToUdenom } from "@src/utils/math";
 
 export const envSchema = z
   .object({
-    AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H: z.number({ coerce: true }).nonnegative().optional().default(24),
+    AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H: z.number({ coerce: true }).nonnegative().finite().optional().default(24),
     /**
      * Hours of runway automatic funding brings a deployment up to, counting the runway it already holds.
      * Must stay above `AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H`: funding only triggers once a deployment drops
      * inside that window, so the gap between the two is what a single deposit covers. At or below it every
      * deposit sizes to zero and automatic funding stops entirely, hence the schema check below.
      */
-    AUTO_TOP_UP_TARGET_RUNWAY_IN_H: z.number({ coerce: true }).positive().optional().default(48),
+    AUTO_TOP_UP_TARGET_RUNWAY_IN_H: z.number({ coerce: true }).positive().finite().optional().default(48),
     AUTO_TOP_UP_DEDUP_COOLDOWN_IN_MIN: z.number({ coerce: true }).positive().optional().default(60),
     /**
      * Dollar floor auto-funding leaves in the available deployment allowance so a user with credits left can still

--- a/apps/api/src/deployment/config/env.config.ts
+++ b/apps/api/src/deployment/config/env.config.ts
@@ -18,7 +18,7 @@ export const envSchema = z
      * create a deployment. Whole dollars: `DEPLOYMENT_GRANT_DENOM` is `uact` on real networks, 1:1 with USD.
      * 0 restores the previous drain-to-zero behavior.
      */
-    AUTO_TOP_UP_BALANCE_HEADROOM_IN_USD: z.number({ coerce: true }).nonnegative().optional().default(5),
+    AUTO_TOP_UP_BALANCE_HEADROOM_IN_USD: z.number({ coerce: true }).nonnegative().finite().optional().default(5),
     /**
      * Deposit (in dollars) the platform bootstraps a managed deployment with when the caller no longer supplies one.
      * Must stay at or above the chain's `min_deposits` for the active `DEPLOYMENT_GRANT_DENOM`, or the create tx is rejected

--- a/apps/api/src/deployment/config/env.config.ts
+++ b/apps/api/src/deployment/config/env.config.ts
@@ -4,14 +4,14 @@ import { denomToUdenom } from "@src/utils/math";
 
 export const envSchema = z
   .object({
-    AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H: z.number({ coerce: true }).optional().default(24),
+    AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H: z.number({ coerce: true }).nonnegative().optional().default(24),
     /**
      * Hours of runway automatic funding brings a deployment up to, counting the runway it already holds.
      * Must stay above `AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H`: funding only triggers once a deployment drops
      * inside that window, so the gap between the two is what a single deposit covers. At or below it every
      * deposit sizes to zero and automatic funding stops entirely, hence the schema check below.
      */
-    AUTO_TOP_UP_TARGET_RUNWAY_IN_H: z.number({ coerce: true }).optional().default(48),
+    AUTO_TOP_UP_TARGET_RUNWAY_IN_H: z.number({ coerce: true }).positive().optional().default(48),
     AUTO_TOP_UP_DEDUP_COOLDOWN_IN_MIN: z.number({ coerce: true }).positive().optional().default(60),
     /**
      * Dollar floor auto-funding leaves in the available deployment allowance so a user with credits left can still

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
@@ -82,7 +82,7 @@ describe(DrainingDeploymentService.name, () => {
       );
 
       const callback = vi.fn();
-      for await (const result of service.findDrainingDeploymentsByOwner()) {
+      for await (const result of service.findDrainingDeploymentsByOwner(currentHeight)) {
         callback(result);
       }
 
@@ -111,7 +111,7 @@ describe(DrainingDeploymentService.name, () => {
 
   describe("findDrainingDeploymentsForOwner", () => {
     it("returns the owner's active draining deployments enriched with block rate and predicted close height", async () => {
-      const { service, deploymentSettingRepository } = setup();
+      const { service, deploymentSettingRepository, currentHeight } = setup();
       const address = createAkashAddress();
       const settings = [createAutoTopUpDeployment({ address, dseq: "1001" }), createAutoTopUpDeployment({ address, dseq: "1002" })];
       const leases = settings.map(setting =>
@@ -121,7 +121,7 @@ describe(DrainingDeploymentService.name, () => {
       deploymentSettingRepository.findAutoTopUpDeploymentsByOwner.mockResolvedValue(settings);
       vi.spyOn(service, "findLeases").mockResolvedValue(leases);
 
-      const result = await service.findDrainingDeploymentsForOwner(address, mock<DeploymentTopUpInstrumentation>());
+      const result = await service.findDrainingDeploymentsForOwner(address, mock<DeploymentTopUpInstrumentation>(), currentHeight);
 
       expect(deploymentSettingRepository.findAutoTopUpDeploymentsByOwner).toHaveBeenCalledWith(address);
       expect(result).toHaveLength(2);
@@ -148,7 +148,7 @@ describe(DrainingDeploymentService.name, () => {
         })
       ]);
 
-      const result = await service.findDrainingDeploymentsForOwner(address, sink);
+      const result = await service.findDrainingDeploymentsForOwner(address, sink, currentHeight);
 
       expect(result).toHaveLength(1);
       expect(result[0].dseq).toBe(activeSetting.dseq);
@@ -158,11 +158,11 @@ describe(DrainingDeploymentService.name, () => {
     });
 
     it("returns an empty array without querying leases when the owner has no auto-top-up deployments", async () => {
-      const { service, deploymentSettingRepository } = setup();
+      const { service, deploymentSettingRepository, currentHeight } = setup();
       const findLeasesSpy = vi.spyOn(service, "findLeases");
       deploymentSettingRepository.findAutoTopUpDeploymentsByOwner.mockResolvedValue([]);
 
-      const result = await service.findDrainingDeploymentsForOwner(createAkashAddress(), mock<DeploymentTopUpInstrumentation>());
+      const result = await service.findDrainingDeploymentsForOwner(createAkashAddress(), mock<DeploymentTopUpInstrumentation>(), currentHeight);
 
       expect(result).toEqual([]);
       expect(findLeasesSpy).not.toHaveBeenCalled();
@@ -229,17 +229,119 @@ describe(DrainingDeploymentService.name, () => {
     });
   });
 
-  describe("calculateTopUpAmount", () => {
-    it("calculates amount for integer block rate", async () => {
-      const { service } = setup();
-      const result = await service.calculateTopUpAmount({ blockRate: 50 });
+  describe("calculateAmountToTargetRunway", () => {
+    it("funds only the gap when the deployment already holds part of the target runway", () => {
+      const { service, currentHeight } = setup();
+
+      const result = service.calculateAmountToTargetRunway(
+        { blockRate: 50, predictedClosedHeight: currentHeight + averageBlockCountInAnHour * 24 },
+        currentHeight
+      );
+
+      expect(result).toBe(50 * averageBlockCountInAnHour * 24);
+      expect(result).toBeLessThan(50 * averageBlockCountInAnHour * 48);
+    });
+
+    it("funds the full target when the escrow runs out right now", () => {
+      const { service, currentHeight } = setup();
+
+      const result = service.calculateAmountToTargetRunway({ blockRate: 50, predictedClosedHeight: currentHeight }, currentHeight);
+
       expect(result).toBe(1440000);
     });
 
-    it("floors decimal block rate", async () => {
-      const { service } = setup();
-      const result = await service.calculateTopUpAmount({ blockRate: 10.7 });
+    it("caps an overdue deployment at the target instead of funding its arrears", () => {
+      const { service, currentHeight } = setup();
+
+      const result = service.calculateAmountToTargetRunway({ blockRate: 50, predictedClosedHeight: currentHeight - 5000 }, currentHeight);
+
+      expect(result).toBe(1440000);
+    });
+
+    it("returns 0 when the deployment already holds more than the target runway", () => {
+      const { service, currentHeight } = setup();
+
+      const result = service.calculateAmountToTargetRunway(
+        { blockRate: 50, predictedClosedHeight: currentHeight + averageBlockCountInAnHour * 72 },
+        currentHeight
+      );
+
+      expect(result).toBe(0);
+    });
+
+    it("returns 0 for a non-positive block rate", () => {
+      const { service, currentHeight } = setup();
+
+      expect(service.calculateAmountToTargetRunway({ blockRate: 0, predictedClosedHeight: currentHeight }, currentHeight)).toBe(0);
+      expect(service.calculateAmountToTargetRunway({ blockRate: -5, predictedClosedHeight: currentHeight }, currentHeight)).toBe(0);
+    });
+
+    it("returns 0 rather than NaN when the predicted close height is missing", () => {
+      const { service, currentHeight } = setup();
+      const withoutPredictedCloseHeight = { blockRate: 50, predictedClosedHeight: undefined } as unknown as Pick<
+        DrainingDeploymentOutput,
+        "blockRate" | "predictedClosedHeight"
+      >;
+
+      const result = service.calculateAmountToTargetRunway(withoutPredictedCloseHeight, currentHeight);
+
+      expect(result).toBe(0);
+      expect(Number.isNaN(result)).toBe(false);
+    });
+
+    it("handles the numeric strings the database fallback returns", () => {
+      const { service, currentHeight } = setup();
+      const fromDatabaseFallback = {
+        blockRate: "50",
+        predictedClosedHeight: String(currentHeight + averageBlockCountInAnHour * 24)
+      } as unknown as Pick<DrainingDeploymentOutput, "blockRate" | "predictedClosedHeight">;
+
+      const result = service.calculateAmountToTargetRunway(fromDatabaseFallback, currentHeight);
+
+      expect(result).toBe(50 * averageBlockCountInAnHour * 24);
+    });
+
+    it("floors a decimal block rate", () => {
+      const { service, currentHeight } = setup();
+
+      const result = service.calculateAmountToTargetRunway({ blockRate: 10.7, predictedClosedHeight: currentHeight }, currentHeight);
+
       expect(result).toBe(308160);
+    });
+
+    it("derives the amount from the given height without querying the chain", () => {
+      const { service, blockHttpService, currentHeight } = setup();
+
+      service.calculateAmountToTargetRunway({ blockRate: 50, predictedClosedHeight: currentHeight }, currentHeight);
+
+      expect(blockHttpService.getCurrentHeight).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("calculateSteadyStateTopUpAmount", () => {
+    it("reports the cost of the hours between the look-ahead window and the target", () => {
+      const { service } = setup();
+
+      const result = service.calculateSteadyStateTopUpAmount({ blockRate: 50 });
+
+      expect(result).toBe(50 * averageBlockCountInAnHour * 24);
+    });
+
+    it("floors a decimal block rate", () => {
+      const { service } = setup();
+
+      expect(service.calculateSteadyStateTopUpAmount({ blockRate: 10.7 })).toBe(154080);
+    });
+
+    it("stays a function of configuration alone, ignoring how much runway is held", () => {
+      const { service, currentHeight } = setup();
+
+      const wellFunded = service.calculateSteadyStateTopUpAmount(
+        createDrainingDeployment({ blockRate: 50, predictedClosedHeight: currentHeight + averageBlockCountInAnHour * 168 })
+      );
+      const draining = service.calculateSteadyStateTopUpAmount(createDrainingDeployment({ blockRate: 50, predictedClosedHeight: currentHeight }));
+
+      expect(wellFunded).toBe(draining);
     });
   });
 
@@ -255,13 +357,13 @@ describe(DrainingDeploymentService.name, () => {
       const { service, userWalletRepository, leaseRepository } = setup();
       userWalletRepository.findOneByUserId.mockResolvedValue(userWallet);
       leaseRepository.findOneByDseqAndOwner.mockResolvedValue(deployment);
-      vi.spyOn(service, "calculateTopUpAmount").mockResolvedValue(expectedTopUpAmount);
+      vi.spyOn(service, "calculateSteadyStateTopUpAmount").mockReturnValue(expectedTopUpAmount);
 
       const amount = await service.calculateTopUpAmountForDseqAndUserId(dseq, userId);
 
       expect(userWalletRepository.findOneByUserId).toHaveBeenCalledWith(userId);
       expect(leaseRepository.findOneByDseqAndOwner).toHaveBeenCalledWith(dseq, address);
-      expect(service.calculateTopUpAmount).toHaveBeenCalledWith(deployment);
+      expect(service.calculateSteadyStateTopUpAmount).toHaveBeenCalledWith(deployment);
       expect(amount).toBe(expectedTopUpAmount);
     });
 
@@ -601,7 +703,7 @@ describe(DrainingDeploymentService.name, () => {
 
     const config = mockConfigService<DeploymentConfigService>({
       AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H: 24,
-      AUTO_TOP_UP_AMOUNT_IN_H: 48
+      AUTO_TOP_UP_TARGET_RUNWAY_IN_H: 48
     });
 
     const instrumentation = mock<TopUpManagedDeploymentsInstrumentationService>();

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
@@ -39,10 +39,13 @@ export class DrainingDeploymentService {
    * fetches draining deployment data, and marks closed deployments.
    * Yields batches of active draining deployments per owner.
    *
+   * The caller passes the block height the whole run is scoped to so the look-ahead window that admits
+   * a deployment and the amount that funds it are derived from the same height.
+   *
    * @yields Object with owner address and array of draining deployments
    */
-  async *findDrainingDeploymentsByOwner(): AsyncGenerator<{ address: string; walletId: number; deployments: DrainingDeployment[] }> {
-    const expectedClosureHeight = await this.#getExpectedClosureHeight();
+  async *findDrainingDeploymentsByOwner(currentHeight: number): AsyncGenerator<{ address: string; walletId: number; deployments: DrainingDeployment[] }> {
+    const expectedClosureHeight = this.#getExpectedClosureHeight(currentHeight);
 
     for await (const { address, walletId, deploymentSettings } of this.deploymentSettingRepository.findAutoTopUpDeploymentsByOwnerIteratively()) {
       const deployments = await this.#resolveActiveDrainingDeployments(deploymentSettings, address, expectedClosureHeight, this.instrumentation);
@@ -58,15 +61,18 @@ export class DrainingDeploymentService {
    * look-ahead window, auto-top-up gate, and closed-marking as the cron sweep.
    * Backs the event-driven immediate funding triggered when credits land.
    */
-  async findDrainingDeploymentsForOwner(address: string, instrumentation: DeploymentTopUpInstrumentation): Promise<DrainingDeployment[]> {
+  async findDrainingDeploymentsForOwner(
+    address: string,
+    instrumentation: DeploymentTopUpInstrumentation,
+    currentHeight: number
+  ): Promise<DrainingDeployment[]> {
     const deploymentSettings = await this.deploymentSettingRepository.findAutoTopUpDeploymentsByOwner(address);
-    const expectedClosureHeight = await this.#getExpectedClosureHeight();
+    const expectedClosureHeight = this.#getExpectedClosureHeight(currentHeight);
 
     return this.#resolveActiveDrainingDeployments(deploymentSettings, address, expectedClosureHeight, instrumentation);
   }
 
-  async #getExpectedClosureHeight(): Promise<number> {
-    const currentHeight = await this.blockHttpService.getCurrentHeight();
+  #getExpectedClosureHeight(currentHeight: number): number {
     return Math.floor(currentHeight + averageBlockCountInAnHour * this.config.get("AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H"));
   }
 
@@ -119,13 +125,12 @@ export class DrainingDeploymentService {
   }
 
   /**
-   * Calculates the top-up amount needed for a specific deployment and user.
-   * Looks up the user's wallet and deployment setting, then calculates
-   * the required top-up amount based on the deployment's block rate.
+   * Estimates what a single automatic funding event costs for a specific deployment and user.
+   * Looks up the user's wallet and lease, then reports the steady-state per-event amount.
    *
    * @param dseq - Deployment sequence number
    * @param userId - User ID to look up wallet for
-   * @returns Top-up amount in credits, or 0 if user wallet or deployment not found
+   * @returns Estimated top-up amount in credits, or 0 if user wallet or deployment not found
    */
   async calculateTopUpAmountForDseqAndUserId(dseq: string, userId: string): Promise<number> {
     const userWallet = await this.userWalletRepository.findOneByUserId(userId);
@@ -140,19 +145,51 @@ export class DrainingDeploymentService {
       return 0;
     }
 
-    return this.calculateTopUpAmount(deploymentSetting);
+    return this.calculateSteadyStateTopUpAmount(deploymentSetting);
   }
 
   /**
-   * Calculates the top-up amount needed for a deployment based on its block rate.
-   * The calculation uses the configured auto-top-up interval to determine
-   * how many blocks worth of funds are needed.
+   * Funds a deployment up to the target runway, counting the runway its escrow already covers, so a
+   * deployment never holds more than the target. Funding only triggers once a deployment drops inside
+   * the look-ahead window, so the amount is at least the gap between the window and the target.
+   *
+   * A deployment whose escrow already ran out is in arrears on chain, but the funded-until floor is
+   * `currentHeight` rather than the overdue height: a stale `predictedClosedHeight` far in the past
+   * would otherwise size a huge deposit. Such a deployment reaches slightly less than the target and
+   * the next sweep tops up the remainder.
+   *
+   * @param deployment - Deployment with its block rate and predicted closure height
+   * @param currentHeight - Block height the funding run is scoped to
+   * @returns Top-up amount in credits, or 0 when the deployment already holds the target
+   */
+  calculateAmountToTargetRunway(deployment: Pick<DrainingDeploymentOutput, "blockRate" | "predictedClosedHeight">, currentHeight: number): number {
+    const blockRate = Number(deployment.blockRate);
+    const predictedClosedHeight = Number(deployment.predictedClosedHeight);
+    const isUsable = Number.isFinite(blockRate) && blockRate > 0 && Number.isFinite(predictedClosedHeight);
+
+    if (!isUsable) {
+      return 0;
+    }
+
+    const targetHeight = currentHeight + averageBlockCountInAnHour * this.config.get("AUTO_TOP_UP_TARGET_RUNWAY_IN_H");
+    const fundedUntil = Math.max(currentHeight, predictedClosedHeight);
+
+    return Math.max(0, Math.floor(blockRate * (targetHeight - fundedUntil)));
+  }
+
+  /**
+   * The amount a funding event deposits once a deployment is in the funded steady state: it drains from
+   * the target runway down to the look-ahead window before the next event tops it back up to the target.
+   * Reported to users as the estimated per-event cost, so it stays a stable function of configuration
+   * rather than of a deployment's current escrow, which would read as zero right after a top-up.
    *
    * @param deployment - Deployment with block rate information
-   * @returns Top-up amount in credits
+   * @returns Estimated top-up amount in credits
    */
-  async calculateTopUpAmount(deployment: Pick<DrainingDeploymentOutput, "blockRate">): Promise<number> {
-    return Math.floor(deployment.blockRate * (averageBlockCountInAnHour * this.config.get("AUTO_TOP_UP_AMOUNT_IN_H")));
+  calculateSteadyStateTopUpAmount(deployment: Pick<DrainingDeploymentOutput, "blockRate">): number {
+    const hoursPerEvent = this.config.get("AUTO_TOP_UP_TARGET_RUNWAY_IN_H") - this.config.get("AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H");
+
+    return Math.floor(Number(deployment.blockRate) * averageBlockCountInAnHour * hoursPerEvent);
   }
 
   /**

--- a/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.spec.ts
+++ b/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.spec.ts
@@ -57,7 +57,7 @@ describe(InitialDeploymentFundingService.name, () => {
     const { service, drainingDeploymentService, rpcMessageService, managedSignerService, walletReloadJobService, instrumentation } = setup();
     const depositMessage = { typeUrl: "/akash.escrow.v1.MsgAccountDeposit", value: {} };
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
-    drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(500000);
+    drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(500000);
     rpcMessageService.getDepositDeploymentMsg.mockReturnValue(depositMessage as ReturnType<RpcMessageService["getDepositDeploymentMsg"]>);
 
     await service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" });
@@ -74,10 +74,32 @@ describe(InitialDeploymentFundingService.name, () => {
     expect(instrumentation.recordDeposit).toHaveBeenCalledWith(500000, "uakt", expect.objectContaining({ dseq: "123", address: "akash1owner" }));
   });
 
+  it("sizes the deposit to the target runway from the same height as the look-ahead check", async () => {
+    const { service, drainingDeploymentService, blockHttpService } = setup();
+    const deployment = createDrainingDeployment();
+    drainingDeploymentService.findLeases.mockResolvedValue([deployment]);
+    drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(500000);
+
+    await service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" });
+
+    expect(drainingDeploymentService.calculateAmountToTargetRunway).toHaveBeenCalledWith(deployment, CURRENT_HEIGHT);
+    expect(blockHttpService.getCurrentHeight).toHaveBeenCalledTimes(1);
+  });
+
+  it("deposits only the gap up to the target for a partially funded deployment", async () => {
+    const { service, drainingDeploymentService, rpcMessageService } = setup();
+    drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
+    drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(720000);
+
+    await service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" });
+
+    expect(rpcMessageService.getDepositDeploymentMsg).toHaveBeenCalledWith(expect.objectContaining({ amount: 720000 }));
+  });
+
   it("records the deposit and tolerates a wallet reload scheduling failure without failing the job", async () => {
     const { service, drainingDeploymentService, managedSignerService, walletReloadJobService, instrumentation, logger } = setup();
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
-    drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(500000);
+    drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(500000);
     managedSignerService.executeDerivedTx.mockResolvedValue({ code: 0, hash: "TESTHASH", rawLog: "[]" });
     walletReloadJobService.scheduleImmediate.mockRejectedValue(new Error("Failed to schedule wallet balance reload check"));
 
@@ -90,7 +112,7 @@ describe(InitialDeploymentFundingService.name, () => {
   it("completes the job when logging the wallet reload scheduling failure itself throws", async () => {
     const { service, drainingDeploymentService, walletReloadJobService, instrumentation, logger } = setup();
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
-    drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(500000);
+    drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(500000);
     walletReloadJobService.scheduleImmediate.mockRejectedValue(new Error("Failed to schedule wallet balance reload check"));
     logger.error.mockImplementation(() => {
       throw new Error("logger transport failure");
@@ -104,7 +126,7 @@ describe(InitialDeploymentFundingService.name, () => {
   it("skips funding when auto top-up is disabled for the deployment", async () => {
     const { service, drainingDeploymentService, userWalletRepository, deploymentSettingRepository, managedSignerService, logger } = setup();
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
-    drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(500000);
+    drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(500000);
     userWalletRepository.findById.mockResolvedValue(createUserWallet({ id: 1, address: "akash1owner", userId: "user-1" }));
     deploymentSettingRepository.findOneBy.mockResolvedValue(mock<DeploymentSettingsOutput>({ autoTopUpEnabled: false }));
 
@@ -118,7 +140,7 @@ describe(InitialDeploymentFundingService.name, () => {
   it("funds the deployment when auto top-up is explicitly enabled", async () => {
     const { service, drainingDeploymentService, deploymentSettingRepository, managedSignerService } = setup();
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
-    drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(500000);
+    drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(500000);
     deploymentSettingRepository.findOneBy.mockResolvedValue(mock<DeploymentSettingsOutput>({ autoTopUpEnabled: true }));
 
     await service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" });
@@ -129,7 +151,7 @@ describe(InitialDeploymentFundingService.name, () => {
   it("throws and skips the wallet reload when the deposit tx fails on-chain", async () => {
     const { service, drainingDeploymentService, managedSignerService, walletReloadJobService, logger } = setup();
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
-    drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(500000);
+    drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(500000);
     managedSignerService.executeDerivedTx.mockResolvedValue({ code: 5, hash: "TESTHASH", rawLog: "insufficient funds" });
 
     await expect(service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" })).rejects.toThrow("insufficient funds");
@@ -141,7 +163,7 @@ describe(InitialDeploymentFundingService.name, () => {
   it("skips terminally when the deposit is rejected because the deployment escrow is closed", async () => {
     const { service, drainingDeploymentService, managedSignerService, chainErrorService, walletReloadJobService, instrumentation } = setup();
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
-    drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(500000);
+    drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(500000);
     managedSignerService.executeDerivedTx.mockRejectedValue(new Error("Deployment closed"));
     chainErrorService.isDeploymentClosedError.mockReturnValue(true);
 
@@ -154,7 +176,7 @@ describe(InitialDeploymentFundingService.name, () => {
   it("rethrows deposit errors unrelated to a closed deployment", async () => {
     const { service, drainingDeploymentService, managedSignerService, walletReloadJobService, instrumentation } = setup();
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
-    drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(500000);
+    drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(500000);
     managedSignerService.executeDerivedTx.mockRejectedValue(new Error("Bad status on response: 503"));
 
     await expect(service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" })).rejects.toThrow("Bad status on response: 503");
@@ -166,7 +188,7 @@ describe(InitialDeploymentFundingService.name, () => {
   it("skips terminally when the deposit tx lands with a closed account in the raw log", async () => {
     const { service, drainingDeploymentService, managedSignerService, chainErrorService, walletReloadJobService, instrumentation, logger } = setup();
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
-    drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(500000);
+    drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(500000);
     managedSignerService.executeDerivedTx.mockResolvedValue({ code: 5, hash: "TESTHASH", rawLog: "account closed" });
     chainErrorService.isDeploymentClosedError.mockReturnValue(true);
 
@@ -180,7 +202,7 @@ describe(InitialDeploymentFundingService.name, () => {
   it("falls back to a descriptive error when the failed deposit tx has no raw log", async () => {
     const { service, drainingDeploymentService, managedSignerService } = setup();
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
-    drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(500000);
+    drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(500000);
     managedSignerService.executeDerivedTx.mockResolvedValue({ code: 5, hash: "TESTHASH", rawLog: "" });
 
     await expect(service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" })).rejects.toThrow(
@@ -191,7 +213,7 @@ describe(InitialDeploymentFundingService.name, () => {
   it("clamps the deposit to the fresh deployment limit", async () => {
     const { service, drainingDeploymentService, rpcMessageService, cachedBalanceService } = setup();
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
-    drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(500000);
+    drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(500000);
     cachedBalanceService.getFresh.mockResolvedValue(new CachedBalance(200000, 0));
 
     await service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" });
@@ -202,7 +224,7 @@ describe(InitialDeploymentFundingService.name, () => {
   it("skips funding when the deployment limit is exhausted", async () => {
     const { service, drainingDeploymentService, managedSignerService, instrumentation, cachedBalanceService } = setup();
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
-    drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(500000);
+    drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(500000);
     cachedBalanceService.getFresh.mockResolvedValue(new CachedBalance(0, 0));
 
     await service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" });
@@ -217,7 +239,7 @@ describe(InitialDeploymentFundingService.name, () => {
   it("leaves the balance headroom untouched when sizing the deposit", async () => {
     const { service, drainingDeploymentService, rpcMessageService, cachedBalanceService } = setup();
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
-    drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(10_000_000);
+    drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(10_000_000);
     cachedBalanceService.getFresh.mockResolvedValue(new CachedBalance(10_000_000, 5_000_000));
 
     await service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" });
@@ -228,7 +250,7 @@ describe(InitialDeploymentFundingService.name, () => {
   it("funds the full balance when it is at or below the headroom", async () => {
     const { service, drainingDeploymentService, rpcMessageService, cachedBalanceService } = setup();
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
-    drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(10_000_000);
+    drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(10_000_000);
     cachedBalanceService.getFresh.mockResolvedValue(new CachedBalance(4_000_000, 5_000_000));
 
     await service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" });
@@ -239,7 +261,7 @@ describe(InitialDeploymentFundingService.name, () => {
   it("funds the full balance when it sits exactly at the headroom", async () => {
     const { service, drainingDeploymentService, rpcMessageService, cachedBalanceService } = setup();
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
-    drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(10_000_000);
+    drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(10_000_000);
     cachedBalanceService.getFresh.mockResolvedValue(new CachedBalance(5_000_000, 5_000_000));
 
     await service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" });
@@ -250,7 +272,7 @@ describe(InitialDeploymentFundingService.name, () => {
   it("skips funding when the wallet is not found", async () => {
     const { service, drainingDeploymentService, userWalletRepository, managedSignerService, instrumentation } = setup();
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
-    drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(500000);
+    drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(500000);
     userWalletRepository.findById.mockResolvedValue(undefined);
 
     await service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" });
@@ -262,7 +284,7 @@ describe(InitialDeploymentFundingService.name, () => {
   it("skips funding when the fee allowance is exhausted", async () => {
     const { service, drainingDeploymentService, managedSignerService, instrumentation } = setup();
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
-    drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(500000);
+    drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(500000);
     managedSignerService.ensureFeeGrants.mockResolvedValue(0);
 
     await service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" });

--- a/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.ts
+++ b/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.ts
@@ -80,7 +80,7 @@ export class InitialDeploymentFundingService {
       return;
     }
 
-    const desiredAmount = await this.drainingDeploymentService.calculateTopUpAmount(deployment);
+    const desiredAmount = this.drainingDeploymentService.calculateAmountToTargetRunway(deployment, currentHeight);
     const balance = await this.cachedBalanceService.getFresh(address);
     const amount = Math.min(desiredAmount, balance.spendable);
 

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.integration.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.integration.ts
@@ -141,8 +141,6 @@ describe(TopUpManagedDeploymentsService.name, () => {
       );
     });
 
-    // A draining deployment that still holds 12h of runway is topped up to the 48h target,
-    // so the deposit covers the missing 36h rather than a flat 48h on top of what it holds.
     it("deposits only the runway missing from the target rather than a flat window", async () => {
       const { topUpService, executeDerivedTx, createUserWithWallet, createDeploymentSetting, mockLeasesForOwner, mockDeploymentsForOwner, stubGetFreshLimits } =
         await setup();

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.integration.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.integration.ts
@@ -24,16 +24,10 @@ const ESCROW_AMOUNT = "50000";
 /** Mirrors the `AUTO_TOP_UP_BALANCE_HEADROOM_IN_USD` default of $5, in the grant denom's micro units. */
 const HEADROOM_UDENOM = 5000000;
 
-function depositedAmounts(executeDerivedTx: { mock: { calls: unknown[][] } }): number[] {
-  return executeDerivedTx.mock.calls
-    .flatMap(call => call[1] as { value: { deposit?: { amount?: { amount: string } } } }[])
-    .map(message => Number(message.value.deposit?.amount?.amount));
-}
-
 type DepositMessage = { value: { deposit?: { amount?: { amount: string } } } };
 
 /** Flattens every deposit message broadcast across all txs into the numeric amounts they carry. */
-function depositAmountsOf(executeDerivedTx: { mock: { calls: unknown[][] } }): number[] {
+function depositedAmounts(executeDerivedTx: { mock: { calls: unknown[][] } }): number[] {
   return executeDerivedTx.mock.calls.flatMap(call => call[1] as DepositMessage[]).map(message => Number(message.value.deposit?.amount?.amount));
 }
 
@@ -167,7 +161,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
       await topUpService.topUpDeployments({ dryRun: false });
 
       expect(executeDerivedTx).toHaveBeenCalledOnce();
-      expect(depositAmountsOf(executeDerivedTx)).toEqual([BLOCK_RATE * averageBlockCountInAnHour * (48 - hoursOfRunwayHeld)]);
+      expect(depositedAmounts(executeDerivedTx)).toEqual([BLOCK_RATE * averageBlockCountInAnHour * (48 - hoursOfRunwayHeld)]);
     });
 
     // Owner has two deployment settings with auto top-up enabled, but both deployments

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.integration.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.integration.ts
@@ -9,6 +9,7 @@ import { ManagedSignerService } from "@src/billing/services/managed-signer/manag
 import type { ApiPgDatabase } from "@src/core";
 import { CORE_CONFIG, POSTGRES_DB, resolveTable } from "@src/core";
 import { UserRepository } from "@src/user/repositories";
+import { averageBlockCountInAnHour } from "@src/utils/constants";
 import { TopUpManagedDeploymentsService } from "./top-up-managed-deployments.service";
 
 import { createAkashAddress } from "@test/seeders/akash-address.seeder";
@@ -27,6 +28,13 @@ function depositedAmounts(executeDerivedTx: { mock: { calls: unknown[][] } }): n
   return executeDerivedTx.mock.calls
     .flatMap(call => call[1] as { value: { deposit?: { amount?: { amount: string } } } }[])
     .map(message => Number(message.value.deposit?.amount?.amount));
+}
+
+type DepositMessage = { value: { deposit?: { amount?: { amount: string } } } };
+
+/** Flattens every deposit message broadcast across all txs into the numeric amounts they carry. */
+function depositAmountsOf(executeDerivedTx: { mock: { calls: unknown[][] } }): number[] {
+  return executeDerivedTx.mock.calls.flatMap(call => call[1] as DepositMessage[]).map(message => Number(message.value.deposit?.amount?.amount));
 }
 
 /**
@@ -131,6 +139,37 @@ describe(TopUpManagedDeploymentsService.name, () => {
           })
         ])
       );
+    });
+
+    // A draining deployment that still holds 12h of runway is topped up to the 48h target,
+    // so the deposit covers the missing 36h rather than a flat 48h on top of what it holds.
+    it("deposits only the runway missing from the target rather than a flat window", async () => {
+      const { topUpService, executeDerivedTx, createUserWithWallet, createDeploymentSetting, mockLeasesForOwner, mockDeploymentsForOwner, stubGetFreshLimits } =
+        await setup();
+      const { user, address } = await createUserWithWallet();
+      const dseq = "700001";
+      const hoursOfRunwayHeld = 12;
+      const blocksOfRunwayHeld = averageBlockCountInAnHour * hoursOfRunwayHeld;
+
+      await createDeploymentSetting(user.id, dseq);
+
+      mockLeasesForOwner(address, [createActiveLease(address, dseq)]);
+      mockDeploymentsForOwner(address, [
+        createDeploymentInfoSeed({
+          owner: address,
+          dseq,
+          state: "active",
+          amount: String(blocksOfRunwayHeld * BLOCK_RATE),
+          denom: DENOM,
+          createdAt: String(CURRENT_HEIGHT)
+        })
+      ]);
+      stubGetFreshLimits({ [address]: 100000000 });
+
+      await topUpService.topUpDeployments({ dryRun: false });
+
+      expect(executeDerivedTx).toHaveBeenCalledOnce();
+      expect(depositAmountsOf(executeDerivedTx)).toEqual([BLOCK_RATE * averageBlockCountInAnHour * (48 - hoursOfRunwayHeld)]);
     });
 
     // Owner has two deployment settings with auto top-up enabled, but both deployments

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
@@ -86,7 +86,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
         })()
       );
 
-      drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(desiredAmount);
+      drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(desiredAmount);
       cachedBalanceService.get.mockResolvedValue(createMockCachedBalance(() => sufficientAmount));
 
       await service.topUpDeployments({ dryRun: false });
@@ -149,6 +149,40 @@ describe(TopUpManagedDeploymentsService.name, () => {
       expect(fundDrainingInstrumentation.recordDeposit).not.toHaveBeenCalled();
     });
 
+    it("sizes every owner in the sweep from a single block height", async () => {
+      const { service, drainingDeploymentService, cachedBalanceService, blockHttpService } = setup();
+      const deployments = createManyAutoTopUpDeployments(3);
+
+      drainingDeploymentService.findDrainingDeploymentsByOwner.mockImplementation(() =>
+        (async function* () {
+          for (const deployment of deployments) {
+            const draining = {
+              ...deployment,
+              ...createDrainingDeployment({
+                dseq: Number(deployment.dseq),
+                owner: deployment.address,
+                predictedClosedHeight: CURRENT_BLOCK_HEIGHT + 1500,
+                denom: DEPLOYMENT_GRANT_DENOM
+              }),
+              dseq: deployment.dseq
+            } as DrainingDeployment;
+            yield { address: deployment.address, walletId: deployment.walletId, deployments: [draining] };
+          }
+        })()
+      );
+      drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(1000000);
+      cachedBalanceService.get.mockResolvedValue(createMockCachedBalance(() => 1000000));
+
+      await service.topUpDeployments({ dryRun: false });
+
+      expect(drainingDeploymentService.findDrainingDeploymentsByOwner).toHaveBeenCalledWith(CURRENT_BLOCK_HEIGHT);
+      expect(drainingDeploymentService.calculateAmountToTargetRunway).toHaveBeenCalledTimes(deployments.length);
+      drainingDeploymentService.calculateAmountToTargetRunway.mock.calls.forEach(([, height]) => {
+        expect(height).toBe(CURRENT_BLOCK_HEIGHT);
+      });
+      expect(blockHttpService.getCurrentHeight).toHaveBeenCalledTimes(2);
+    });
+
     it("should handle errors and continue processing", async () => {
       const { service, drainingDeploymentService, cachedBalanceService, managedSignerService } = setup();
       const deployments = createManyAutoTopUpDeployments(2);
@@ -181,7 +215,9 @@ describe(TopUpManagedDeploymentsService.name, () => {
         })()
       );
 
-      drainingDeploymentService.calculateTopUpAmount.mockResolvedValueOnce(1000000).mockRejectedValueOnce(new Error("Failed to calculate amount"));
+      drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValueOnce(1000000).mockImplementationOnce(() => {
+        throw new Error("Failed to calculate amount");
+      });
 
       cachedBalanceService.get.mockResolvedValue(createMockCachedBalance(() => 500000));
 
@@ -221,7 +257,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
           }
         })()
       );
-      drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(1000000);
+      drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(1000000);
       cachedBalanceService.get.mockResolvedValue(createMockCachedBalance(() => 500000));
 
       await service.topUpDeployments({ dryRun: true });
@@ -276,7 +312,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
         })()
       );
 
-      drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(desiredAmount);
+      drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(desiredAmount);
       cachedBalanceService.get.mockResolvedValue(createMockCachedBalance(() => sufficientAmount));
 
       await service.topUpDeployments({ dryRun: false });
@@ -342,7 +378,9 @@ describe(TopUpManagedDeploymentsService.name, () => {
         })()
       );
 
-      drainingDeploymentService.calculateTopUpAmount.mockRejectedValue(error);
+      drainingDeploymentService.calculateAmountToTargetRunway.mockImplementation(() => {
+        throw error;
+      });
 
       await service.topUpDeployments({ dryRun: false });
 
@@ -367,7 +405,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
 
       chainErrorService.isMasterWalletInsufficientFundsError.mockResolvedValueOnce(true).mockResolvedValue(false);
       managedSignerService.executeDerivedTx.mockRejectedValueOnce(error).mockResolvedValue(mockTx);
-      drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(1000000);
+      drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(1000000);
       drainingDeploymentService.findDrainingDeploymentsByOwner.mockImplementation(() =>
         (async function* () {
           const byAddress = deployments.reduce(
@@ -423,7 +461,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
         rawLog: "success"
       });
       managedSignerService.executeDerivedTx.mockRejectedValueOnce(error).mockResolvedValueOnce(mockTx).mockResolvedValueOnce(mockTx);
-      drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(1000000);
+      drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(1000000);
       drainingDeploymentService.findDrainingDeploymentsByOwner.mockImplementation(() =>
         (async function* () {
           const byAddress = deployments.reduce(
@@ -480,7 +518,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
           };
         })()
       );
-      drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(1000000);
+      drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(1000000);
       cachedBalanceService.get.mockResolvedValue(createMockCachedBalance(() => 500000));
 
       await service.topUpDeployments({ dryRun: false });
@@ -514,7 +552,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
           };
         })()
       );
-      drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(1000000);
+      drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(1000000);
       cachedBalanceService.get.mockResolvedValue(createMockCachedBalance(() => 500000));
 
       await service.topUpDeployments({ dryRun: false });
@@ -548,7 +586,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
           };
         })()
       );
-      drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(1000000);
+      drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(1000000);
       cachedBalanceService.get.mockResolvedValue(createMockCachedBalance(() => 500000));
 
       await service.topUpDeployments({ dryRun: true });
@@ -574,12 +612,12 @@ describe(TopUpManagedDeploymentsService.name, () => {
       const sufficientAmount = faker.number.int({ min: 1000000, max: 2000000 });
 
       drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([createDrainingFor(owner, walletId), createDrainingFor(owner, walletId)]);
-      drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(faker.number.int({ min: 3500000, max: 4000000 }));
+      drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(faker.number.int({ min: 3500000, max: 4000000 }));
       cachedBalanceService.getFresh.mockResolvedValue(createMockCachedBalance(() => sufficientAmount));
 
       await service.topUpDrainingDeploymentsForOwner({ walletId, address: owner });
 
-      expect(drainingDeploymentService.findDrainingDeploymentsForOwner).toHaveBeenCalledWith(owner, fundDrainingInstrumentation);
+      expect(drainingDeploymentService.findDrainingDeploymentsForOwner).toHaveBeenCalledWith(owner, fundDrainingInstrumentation, CURRENT_BLOCK_HEIGHT);
       expect(managedSignerService.executeDerivedTx).toHaveBeenCalledTimes(1);
       expect(managedSignerService.executeDerivedTx).toHaveBeenCalledWith(walletId, [
         expect.objectContaining({ typeUrl: "/akash.escrow.v1.MsgAccountDeposit" }),
@@ -598,7 +636,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
       const walletId = faker.number.int({ min: 1000000, max: 9999999 });
 
       drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([createDrainingFor(owner, walletId)]);
-      drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(1000000);
+      drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(1000000);
       cachedBalanceService.getFresh.mockResolvedValue(createMockCachedBalance(() => 500000));
 
       await service.topUpDrainingDeploymentsForOwner({ walletId, address: owner });
@@ -634,7 +672,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
       });
 
       drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([deployment]);
-      drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(0);
+      drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(0);
       cachedBalanceService.getFresh.mockResolvedValue(balance);
 
       await service.topUpDrainingDeploymentsForOwner({ walletId, address: owner });
@@ -663,7 +701,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
       const error = new Error("insufficient funds");
 
       drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([createDrainingFor(owner, walletId)]);
-      drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(1000000);
+      drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(1000000);
       cachedBalanceService.getFresh.mockResolvedValue(createMockCachedBalance(() => 1000000));
       managedSignerService.executeDerivedTx.mockRejectedValue(error);
       chainErrorService.isMasterWalletInsufficientFundsError.mockResolvedValue(true);
@@ -684,7 +722,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
       const balance = createMockCachedBalance(() => 1000000);
 
       drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([won, claimedByAnotherPass]);
-      drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(1000000);
+      drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(1000000);
       cachedBalanceService.getFresh.mockResolvedValue(balance);
       deploymentSettingRepository.claimForFunding.mockResolvedValue([createFundingClaim(won.id)]);
 
@@ -701,16 +739,16 @@ describe(TopUpManagedDeploymentsService.name, () => {
       const { service, drainingDeploymentService, cachedBalanceService, managedSignerService, deploymentSettingRepository } = setup();
       const owner = createAkashAddress();
       const walletId = faker.number.int({ min: 1000000, max: 9999999 });
-      const withoutRunwayToBuy = createDrainingFor(owner, walletId);
+      const withAnomalousZeroAmount = createDrainingFor(owner, walletId);
       const fundable = createDrainingFor(owner, walletId);
 
-      drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([withoutRunwayToBuy, fundable]);
-      drainingDeploymentService.calculateTopUpAmount.mockResolvedValueOnce(0).mockResolvedValue(1000000);
+      drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([withAnomalousZeroAmount, fundable]);
+      drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValueOnce(0).mockResolvedValue(1000000);
       cachedBalanceService.getFresh.mockResolvedValue(createMockCachedBalance(() => 1000000));
 
       await service.topUpDrainingDeploymentsForOwner({ walletId, address: owner });
 
-      expect(deploymentSettingRepository.releaseFundingClaim).toHaveBeenCalledWith([createFundingClaim(withoutRunwayToBuy.id)]);
+      expect(deploymentSettingRepository.releaseFundingClaim).toHaveBeenCalledWith([createFundingClaim(withAnomalousZeroAmount.id)]);
       expect(managedSignerService.executeDerivedTx).toHaveBeenCalledWith(walletId, [
         expect.objectContaining({ value: expect.objectContaining({ id: expect.objectContaining({ xid: expect.stringContaining(`/${fundable.dseq}`) }) }) })
       ]);
@@ -723,7 +761,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
       const deployment = createDrainingFor(owner, walletId);
 
       drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([deployment]);
-      drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(1000000);
+      drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(1000000);
       cachedBalanceService.getFresh.mockResolvedValue(createMockCachedBalance(() => 1000000));
       deploymentSettingRepository.claimForFunding.mockResolvedValue([createFundingClaim(deployment.id)]);
       fundDrainingInstrumentation.recordDeposit.mockImplementation(() => {
@@ -751,7 +789,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
       const releaseError = new Error("connection terminated");
 
       drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([deployment]);
-      drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(1000000);
+      drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(1000000);
       cachedBalanceService.getFresh.mockResolvedValue(createMockCachedBalance(() => 1000000));
       deploymentSettingRepository.claimForFunding.mockResolvedValue([createFundingClaim(deployment.id)]);
       deploymentSettingRepository.releaseFundingClaim.mockRejectedValue(releaseError);
@@ -779,7 +817,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
       const walletId = faker.number.int({ min: 1000000, max: 9999999 });
 
       drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([createDrainingFor(owner, walletId)]);
-      drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(1000000);
+      drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(1000000);
       cachedBalanceService.getFresh.mockResolvedValue(createMockCachedBalance(() => 1000000));
       deploymentSettingRepository.claimForFunding.mockResolvedValue([]);
 
@@ -797,7 +835,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
       const deployment = createDrainingFor(owner, walletId);
 
       drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([deployment]);
-      drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(1000000);
+      drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(1000000);
       cachedBalanceService.getFresh.mockResolvedValue(createMockCachedBalance(() => 1000000));
       deploymentSettingRepository.claimForFunding.mockResolvedValue([createFundingClaim(deployment.id)]);
 
@@ -815,7 +853,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
       const deployment = createDrainingFor(owner, walletId);
 
       drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([deployment]);
-      drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(1000000);
+      drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(1000000);
       cachedBalanceService.getFresh.mockResolvedValue(createMockCachedBalance(() => 1000000));
       deploymentSettingRepository.claimForFunding.mockResolvedValue([createFundingClaim(deployment.id)]);
       managedSignerService.executeDerivedTx.mockResolvedValue(mock<IndexedTx>({ code: 11, hash: "tx-hash", rawLog: "out of gas" }));
@@ -834,7 +872,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
       const deployment = createDrainingFor(owner, walletId);
 
       drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([deployment]);
-      drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(1000000);
+      drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(1000000);
       cachedBalanceService.getFresh.mockResolvedValue(createMockCachedBalance(() => 1000000));
       deploymentSettingRepository.claimForFunding.mockResolvedValue([createFundingClaim(deployment.id)]);
       managedSignerService.executeDerivedTx.mockRejectedValue(new Error("broadcast timed out"));
@@ -852,7 +890,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
       const deployment = createDrainingFor(owner, walletId);
 
       drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([deployment]);
-      drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(1000000);
+      drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(1000000);
       cachedBalanceService.getFresh.mockResolvedValue(createMockCachedBalance(() => 1000000));
       deploymentSettingRepository.claimForFunding.mockResolvedValue([createFundingClaim(deployment.id)]);
       managedSignerService.executeDerivedTx.mockRejectedValue(new Error("insufficient funds"));

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
@@ -743,7 +743,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
       const fundable = createDrainingFor(owner, walletId);
 
       drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([withAnomalousZeroAmount, fundable]);
-      drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValueOnce(0).mockResolvedValue(1000000);
+      drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValueOnce(0).mockReturnValue(1000000);
       cachedBalanceService.getFresh.mockResolvedValue(createMockCachedBalance(() => 1000000));
 
       await service.topUpDrainingDeploymentsForOwner({ walletId, address: owner });

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
@@ -42,15 +42,21 @@ export class TopUpManagedDeploymentsService {
     private readonly deploymentConfig: DeploymentConfigService
   ) {}
 
+  /**
+   * The whole sweep is sized from a single block height: refetching per owner would make a deployment's
+   * amount depend on where in the run its owner happens to fall, and would let the amount be derived from
+   * a different height than the look-ahead window that admitted the deployment.
+   */
   async topUpDeployments(options: DryRunOptions): Promise<Result<void, unknown[]>> {
-    this.instrumentation.start(await this.blockHttpService.getCurrentHeight(), options);
+    const currentHeight = await this.blockHttpService.getCurrentHeight();
+    this.instrumentation.start(currentHeight, options);
     const errors: unknown[] = [];
 
     try {
-      for await (const owner of this.drainingDeploymentService.findDrainingDeploymentsByOwner()) {
+      for await (const owner of this.drainingDeploymentService.findDrainingDeploymentsByOwner(currentHeight)) {
         try {
           const balance = await this.cachedBalanceService.get(owner.address);
-          await this.#fundOwnerDeployments(owner, options, balance, this.instrumentation);
+          await this.#fundOwnerDeployments(owner, options, balance, this.instrumentation, currentHeight);
         } catch (error: unknown) {
           errors.push(error);
         }
@@ -71,7 +77,8 @@ export class TopUpManagedDeploymentsService {
    * about to drain does not wait up to an hour for the next scheduled pass.
    */
   async topUpDrainingDeploymentsForOwner({ walletId, address }: { walletId: number; address: string }): Promise<void> {
-    const deployments = await this.drainingDeploymentService.findDrainingDeploymentsForOwner(address, this.fundDrainingInstrumentation);
+    const currentHeight = await this.blockHttpService.getCurrentHeight();
+    const deployments = await this.drainingDeploymentService.findDrainingDeploymentsForOwner(address, this.fundDrainingInstrumentation, currentHeight);
 
     if (!deployments.length) {
       this.fundDrainingInstrumentation.recordSkipped({ owner: address, deploymentCount: 0 });
@@ -79,17 +86,18 @@ export class TopUpManagedDeploymentsService {
     }
 
     const balance = await this.cachedBalanceService.getFresh(address);
-    await this.#fundOwnerDeployments({ address, walletId, deployments }, { dryRun: false }, balance, this.fundDrainingInstrumentation);
+    await this.#fundOwnerDeployments({ address, walletId, deployments }, { dryRun: false }, balance, this.fundDrainingInstrumentation, currentHeight);
   }
 
   async #fundOwnerDeployments(
     { address, walletId, deployments }: { address: string; walletId: number; deployments: DrainingDeployment[] },
     options: DryRunOptions,
     balance: CachedBalance,
-    instrumentation: DeploymentTopUpInstrumentation
+    instrumentation: DeploymentTopUpInstrumentation,
+    currentHeight: number
   ): Promise<void> {
     if (options.dryRun) {
-      const messageInputs = await this.collectMessages(deployments, balance, instrumentation);
+      const messageInputs = await this.collectMessages(deployments, balance, instrumentation, currentHeight);
 
       if (!messageInputs.length) {
         instrumentation.recordSkipped({ owner: address, deploymentCount: deployments.length });
@@ -111,7 +119,8 @@ export class TopUpManagedDeploymentsService {
     const messageInputs = await this.collectMessages(
       deployments.filter(deployment => claimedIds.has(deployment.id)),
       balance,
-      instrumentation
+      instrumentation,
+      currentHeight
     );
     const preparedIds = new Set(messageInputs.map(input => input.deployment.id));
 
@@ -172,7 +181,8 @@ export class TopUpManagedDeploymentsService {
   private async collectMessages(
     deployments: DrainingDeployment[],
     balance: CachedBalance,
-    instrumentation: DeploymentTopUpInstrumentation
+    instrumentation: DeploymentTopUpInstrumentation,
+    currentHeight: number
   ): Promise<CollectedMessage[]> {
     const denom = this.billingConfig.get("DEPLOYMENT_GRANT_DENOM");
 
@@ -181,7 +191,7 @@ export class TopUpManagedDeploymentsService {
         instrumentation.recordDeploymentPreparation(deployment.address, deployment.predictedClosedHeight);
 
         try {
-          const desiredAmount = await this.drainingDeploymentService.calculateTopUpAmount(deployment);
+          const desiredAmount = this.drainingDeploymentService.calculateAmountToTargetRunway(deployment, currentHeight);
           if (desiredAmount <= 0) {
             instrumentation.recordInvalidDepositAmount({
               desiredAmount,

--- a/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/AccountBalanceOverview.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/AccountBalanceOverview.tsx
@@ -27,9 +27,9 @@ export const DEPENDENCIES = {
 };
 
 /**
- * Approx. hours of running cost each deployment's escrow is kept funded to (the auto-funding target).
- * ~48h in steady state, governed by the backend auto-top-up config (`AUTO_TOP_UP_AMOUNT_IN_H` sizing +
- * `AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H` trigger, each ~24h). Update if that target changes.
+ * Hours of running cost each deployment's escrow is kept funded to, and the ceiling it never exceeds:
+ * automatic funding tops a deployment up to this target rather than adding to what it already holds.
+ * Mirrors the backend `AUTO_TOP_UP_TARGET_RUNWAY_IN_H`. Update if that target changes.
  */
 const RESERVE_WINDOW_HOURS = 48;
 


### PR DESCRIPTION
## Why

Fixes CON-791

Automatic funding added a flat 48h of a deployment's cost on top of whatever escrow it already held. Since funding triggers while a deployment can still hold 24h of runway, a deployment could end up holding ~72h of cost: a $5/h GPU deployment locked ~$360 and moved ~$240 in a single event.

That lump drains the available deployment allowance all at once, which triggers card charges even when the user's total funds sit far above their threshold, and it widens the window where creating a new deployment fails with a 402 (ref CON-512).

## What

Both funding flows (the hourly cron / credit-landed sweep, and the lease-start initial funding) now size a deposit as `target − runway already held`:

```
targetHeight = currentHeight + blocksPerHour * TARGET_RUNWAY_IN_H
fundedUntil  = max(currentHeight, predictedClosedHeight)
amount       = max(0, floor(blockRate * (targetHeight - fundedUntil)))
```

A deployment now holds at most the 48h target, and a single event moves ~24h of cost (target minus the trigger window). `predictedClosedHeight` and `blockRate` were already on every draining-deployment record, so there is no new data source, and the shape matches what `calculateAllDeploymentCostUntilDate` already does.

`calculateTopUpAmount` splits into two methods with distinct jobs:

- `calculateAmountToTargetRunway(deployment, currentHeight)` — pure and synchronous, used by both funding flows.
- `calculateSteadyStateTopUpAmount(deployment)` — `target − window` hours of cost, backing the user-visible `estimatedTopUpAmount`.

### Three properties this relies on

**One run-scoped block height.** The sweep threads a single height from `topUpDeployments` through discovery and sizing. Refetching per owner (even a memoized height) would make a deployment's amount depend on where in a long run its owner falls, and would let the amount be derived from a different height than the look-ahead window that admitted the deployment. `InitialDeploymentFundingService` already worked this way; this makes the cron match. It also removes a duplicate `getCurrentHeight` call.

**The target must stay above the look-ahead window.** Funding only triggers once a deployment drops inside the window, so the gap between the two is the floor on what a triggering deployment receives, and with the defaults that floor is 24h of cost. At or below the window the floor is zero: a deployment triggering right at the window edge is sized nothing and just re-triggers. It is not a total stop, since a deployment that has drained past the edge still gets a positive deposit, but it is a silent hole at exactly the point funding is supposed to engage. The schema now rejects that configuration rather than letting it deploy.

**`predictedClosedHeight` cannot be trusted to be a finite number.** The column is `DECIMAL(30,0)`, typed as `number` but delivered as a string (or `NULL`) by the raw-SQL fallback path. Multiplication tolerated that; subtracting it yields `NaN`, and `NaN <= 0` is `false` — so a `NaN` would pass the amount guard, pass `reserveSufficientAmount`'s check, poison the owner's remaining reservable balance via `-= NaN`, and reach the chain as `amount: "NaN"`. The calculator now guards for it.

### On the zero-amount path

`desiredAmount <= 0` keeps reporting through `recordInvalidDepositAmount`. Given the trigger window and the new schema check, zero is unreachable by construction, so it stays an anomaly signal rather than becoming an expected outcome — no new telemetry, no new summarizer field.

### Configuration

`AUTO_TOP_UP_AMOUNT_IN_H` is renamed to `AUTO_TOP_UP_TARGET_RUNWAY_IN_H` (default unchanged at 48) to match the new meaning. **Operator step before merge:** confirm whether Doppler overrides the old name anywhere. The rename makes a stale override inert, which is the safe direction since the default 48 is the correct target, but an intentional override needs re-creating under the new name.

### Why the estimate is not the live to-target amount

`estimatedTopUpAmount` reports the steady-state per-event cost instead. A live to-target number would read "Estimated amount: $0.00" for any recently topped-up deployment in the deployment settings and detail-page tooltips, it would read the indexer DB (where `predictedClosedHeight` has no closure-height filter and can be `NULL`), and it would add a chain call to a read path that currently makes none.

### Side effects worth flagging

- Expect the `auto_top_up_deposit_amount` and `fund_draining_deployments_deposit_amount` histograms to shift down and widen after deploy, from a constant `blockRate * 28800` to a 24h–48h band. The p50 drop is the fix working, not a regression.
- `wallet-balance-reload-check` already provisions to-target via `calculateAllDeploymentCostUntilDate`, so this removes a long-standing inconsistency between what the reload check plans for and what the top-up actually deposits.
- Lease-start funding takes no `claimForFunding` claim, so it can already double-fund alongside the cron path (48h + 48h today, the known CON-837 residual). To-target caps the second deposit at the target once the first tx is visible over RPC — a net improvement.

## Verification

Rebased onto `main` at 96f91ad4 (#3620, which added the auto-funding balance headroom). Three files conflicted, all on the auto-funding path:

- `env.config.ts`: #3620's `AUTO_TOP_UP_BALANCE_HEADROOM_IN_USD` now sits inside the object that the target-vs-window `superRefine` wraps, next to `DEPLOYMENT_DEFAULT_DEPOSIT` from the earlier #3597 merge. Both later commits' `positive().finite()` guards land on the merged shape.
- `initial-deployment-funding.service.ts`: keeps #3620's `CachedBalanceService` read and takes this PR's to-target sizing. The two stack: `calculateAmountToTargetRunway` decides what the deployment asks for, and `CachedBalance.spendable` caps it at what sits above the headroom floor. The cron sweep already worked this way, since `reserveSufficientAmount` clamps against that same floor, so lease-start funding now matches it.
- `initial-deployment-funding.service.spec.ts`: #3620's three headroom cases stub the now-synchronous `calculateAmountToTargetRunway`, and this PR's two to-target cases drop their explicit balance stub for the `setup` default, matching how #3620 left the cases that don't exercise clamping.

Review follow-ups on top of the rebase: `AUTO_TOP_UP_BALANCE_HEADROOM_IN_USD` gained `.finite()`, since `Infinity` cleared `nonnegative()` and then hit `CachedBalance`'s waiver branch, making the whole balance spendable instead of none of it. The two identical deposit-amount helpers the rebase left in the top-up integration test are now one.

- 1446 unit tests pass (147 files), including new cases for partial runway, escrow exhausted exactly now, an overdue deployment, already-above-target, zero block rate, missing height (0 rather than NaN), the DB fallback's numeric strings, and the sweep sizing every owner from one height.
- 31/31 deployment integration tests pass against a real DB, covering both the new case where a deployment holding 12h of runway receives exactly 36h of cost and #3620's headroom cases.
- `tsc --noEmit` reports 40 errors, identical to the `origin/main` baseline (pre-existing `lru-cache`/cosmjs noise) and none in the touched paths. Lint and prettier clean.
- Four integration and nine functional failures show up locally, in the `user`/`api-key` repository throttle cases and the providers/addresses endpoints. All thirteen reproduce unchanged on untouched `origin/main`, so they are local environment gaps rather than anything this branch introduces. CI covers these suites.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto top-ups now fund deployments up to the configured target runway, accounting for escrow balances and predicted closures.
  * Initial deployment funding uses the same runway-based calculation and respects available balance headroom.
  * Top-up calculations use a consistent block height during each processing sweep.

* **Bug Fixes**
  * Improved handling of overdue deployments, invalid rates, and insufficient balances.
  * Prevents unnecessary deposits when sufficient runway is available.
  * Configuration validates finite values and requires the target runway to exceed the look-ahead window.

* **Documentation**
  * Updated escrow reserve guidance and renamed “Auto Recharge” to “Automatic top-ups.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



