### PR TITLE
feat(deployment): verify a secrets seal is bound to the SDL it was sealed against

### DIFF
--- a/apps/api/src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service.spec.ts
@@ -2,7 +2,7 @@ import type { protos } from "@google-cloud/kms";
 import crc32c from "fast-crc32c";
 import { grpc } from "google-gax";
 import { CompactEncrypt, importJWK } from "jose";
-import { constants, generateKeyPairSync, privateDecrypt, randomBytes, randomUUID } from "node:crypto";
+import { constants, createHash, generateKeyPairSync, privateDecrypt, randomBytes, randomUUID } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
 
@@ -16,270 +16,314 @@ import { SdlSecretsUnsealerService } from "./sdl-secrets-unsealer.service";
 const KID = "sdl-secrets.v1";
 const VERSION_NAME = "projects/console-test/locations/global/keyRings/console-api/cryptoKeys/sdl-secrets/cryptoKeyVersions/1";
 const SUBJECT = "3f2b6f7a-1c1d-4b0e-8b8a-9a0f5f5c2b11";
+const SDL = 'version: "2.0"\nservices:\n  web:\n    image: nginx\n';
+
+function sdlHashOf(sdl: string) {
+  return createHash("sha256").update(sdl, "utf8").digest("base64url");
+}
 
 describe(SdlSecretsUnsealerService.name, () => {
   it("returns the secrets a client sealed with a standard JOSE library", async () => {
-    const { service, seal, clientSecrets } = setup();
+    const { open, seal, clientSecrets } = setup();
 
-    const secrets = await service.open(await seal(clientSecrets));
+    const secrets = await open(await seal(clientSecrets));
 
     expect(secrets).toEqual(clientSecrets);
   });
 
   it("unwraps the content encryption key with the configured crypto key version", async () => {
-    const { service, seal, kmsClient } = setup();
+    const { open, seal, kmsClient } = setup();
 
-    await service.open(await seal({ TOKEN: "t" }));
+    await open(await seal({ TOKEN: "t" }));
 
     expect(kmsClient.asymmetricDecrypt).toHaveBeenCalledWith(expect.objectContaining({ name: VERSION_NAME }));
   });
 
   it("rejects a seal made for another user", async () => {
-    const { service, seal } = setup();
+    const { open, seal } = setup();
 
-    await expect(service.open(await seal({ TOKEN: "t" }, { sub: "6d0b1f4c-2222-4444-8888-1a2b3c4d5e6f" }))).rejects.toMatchObject({ status: 403 });
+    await expect(open(await seal({ TOKEN: "t" }, { sub: "6d0b1f4c-2222-4444-8888-1a2b3c4d5e6f" }))).rejects.toMatchObject({ status: 403 });
   });
 
   it("rejects an expired seal", async () => {
-    const { service, seal } = setup();
+    const { open, seal } = setup();
 
-    await expect(service.open(await seal({ TOKEN: "t" }, { exp: Math.floor(Date.now() / 1000) - 1 }))).rejects.toMatchObject({ status: 400 });
+    await expect(open(await seal({ TOKEN: "t" }, { exp: Math.floor(Date.now() / 1000) - 1 }))).rejects.toMatchObject({ status: 400 });
   });
 
   it("rejects a seal that expires further out than the maximum seal lifetime", async () => {
-    const { service, seal, kmsClient } = setup();
+    const { open, seal, kmsClient } = setup();
     const beyondMaxLifetime = Math.floor((Date.now() + SDL_SECRETS_MAX_SEAL_LIFETIME_MS) / 1000) + 60;
 
-    await expect(service.open(await seal({ TOKEN: "t" }, { exp: beyondMaxLifetime }))).rejects.toMatchObject({ status: 400 });
+    await expect(open(await seal({ TOKEN: "t" }, { exp: beyondMaxLifetime }))).rejects.toMatchObject({ status: 400 });
     expect(kmsClient.asymmetricDecrypt).not.toHaveBeenCalled();
   });
 
   it("rejects a seal carrying no expiry", async () => {
-    const { service, seal } = setup();
+    const { open, seal } = setup();
 
-    await expect(service.open(await seal({ TOKEN: "t" }, { exp: undefined }))).rejects.toMatchObject({ status: 400 });
+    await expect(open(await seal({ TOKEN: "t" }, { exp: undefined }))).rejects.toMatchObject({ status: 400 });
   });
 
   it("reports a seal made for a key the console no longer holds as a conflict so clients refetch", async () => {
-    const { service, seal } = setup();
+    const { open, seal } = setup();
 
-    await expect(service.open(await seal({ TOKEN: "t" }, { kid: "sdl-secrets.v9" }))).rejects.toMatchObject({ status: 409 });
+    await expect(open(await seal({ TOKEN: "t" }, { kid: "sdl-secrets.v9" }))).rejects.toMatchObject({ status: 409 });
   });
 
   it("rejects a content encryption the console does not accept", async () => {
-    const { service, seal } = setup();
+    const { open, seal } = setup();
 
-    await expect(service.open(await seal({ TOKEN: "t" }, { enc: "A128GCM" }))).rejects.toMatchObject({ status: 400 });
+    await expect(open(await seal({ TOKEN: "t" }, { enc: "A128GCM" }))).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("opens a seal carrying no SDL binding and records the open as unbound", async () => {
+    const { open, seal, clientSecrets, logger } = setup();
+
+    await expect(open(await seal(clientSecrets))).resolves.toEqual(clientSecrets);
+    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "SDL_SECRETS_SEAL_OPENED", sdlBound: false }));
+  });
+
+  it("opens a seal bound to the SDL it was sealed against and records the open as bound", async () => {
+    const { open, seal, clientSecrets, logger } = setup();
+
+    await expect(open(await seal(clientSecrets, { sdlHash: sdlHashOf(SDL) }))).resolves.toEqual(clientSecrets);
+    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "SDL_SECRETS_SEAL_OPENED", sdlBound: true }));
+  });
+
+  it("rejects a seal bound to a different SDL without spending an unwrap", async () => {
+    const { open, seal, kmsClient } = setup();
+    const sealedAgainstAnotherSdl = await seal({ TOKEN: "t" }, { sdlHash: sdlHashOf('version: "2.0"\nservices:\n  web:\n    image: attacker\n') });
+
+    await expect(open(sealedAgainstAnotherSdl, SDL)).rejects.toMatchObject({ status: 403 });
+    expect(kmsClient.asymmetricDecrypt).not.toHaveBeenCalled();
+  });
+
+  it("rejects a seal whose SDL binding is not a base64url digest", async () => {
+    const { open, seal, kmsClient } = setup();
+
+    await expect(open(await seal({ TOKEN: "t" }, { sdlHash: 42 }))).rejects.toMatchObject({ status: 403 });
+    expect(kmsClient.asymmetricDecrypt).not.toHaveBeenCalled();
+  });
+
+  it("rejects a seal whose SDL binding was stripped after sealing", async () => {
+    const { open, seal } = setup();
+    const [protectedHeader, ...rest] = (await seal({ TOKEN: "t" }, { sdlHash: sdlHashOf(SDL) })).split(".");
+    const { sdlHash, ...claimsWithoutBinding } = JSON.parse(Buffer.from(protectedHeader, "base64url").toString());
+    const stripped = Buffer.from(JSON.stringify(claimsWithoutBinding)).toString("base64url");
+
+    await expect(open([stripped, ...rest].join("."))).rejects.toMatchObject({ status: 400 });
+    expect(sdlHash).toEqual(sdlHashOf(SDL));
   });
 
   it("does not call KMS when the header is unacceptable", async () => {
-    const { service, seal, kmsClient } = setup();
+    const { open, seal, kmsClient } = setup();
 
-    await expect(service.open(await seal({ TOKEN: "t" }, { exp: 1 }))).rejects.toThrow();
+    await expect(open(await seal({ TOKEN: "t" }, { exp: 1 }))).rejects.toThrow();
 
     expect(kmsClient.asymmetricDecrypt).not.toHaveBeenCalled();
   });
 
   it("rejects a seal whose claims were altered after sealing", async () => {
-    const { service, seal, kmsClient } = setup();
+    const { open, seal, kmsClient } = setup();
     const [protectedHeader, ...rest] = (await seal({ TOKEN: "t" })).split(".");
     const claims = JSON.parse(Buffer.from(protectedHeader, "base64url").toString());
     const forged = Buffer.from(JSON.stringify({ ...claims, exp: claims.exp - 1 })).toString("base64url");
 
-    await expect(service.open([forged, ...rest].join("."))).rejects.toMatchObject({ status: 400 });
+    await expect(open([forged, ...rest].join("."))).rejects.toMatchObject({ status: 400 });
     expect(kmsClient.asymmetricDecrypt).toHaveBeenCalled();
   });
 
   it("rejects a seal whose ciphertext was altered after sealing", async () => {
-    const { service, seal } = setup();
+    const { open, seal } = setup();
     const parts = (await seal({ TOKEN: "t" })).split(".");
     parts[3] = Buffer.from("tampered").toString("base64url");
 
-    await expect(service.open(parts.join("."))).rejects.toMatchObject({ status: 400 });
+    await expect(open(parts.join("."))).rejects.toMatchObject({ status: 400 });
   });
 
   it("rejects a seal whose protected header is the JSON literal null", async () => {
-    const { service, seal, kmsClient } = setup();
+    const { open, seal, kmsClient } = setup();
     const [, ...rest] = (await seal({ TOKEN: "t" })).split(".");
 
-    await expect(service.open([Buffer.from("null").toString("base64url"), ...rest].join("."))).rejects.toMatchObject({ status: 400 });
+    await expect(open([Buffer.from("null").toString("base64url"), ...rest].join("."))).rejects.toMatchObject({ status: 400 });
     expect(kmsClient.asymmetricDecrypt).not.toHaveBeenCalled();
   });
 
   it("rejects a seal whose protected header is a JSON array", async () => {
-    const { service, seal } = setup();
+    const { open, seal } = setup();
     const [, ...rest] = (await seal({ TOKEN: "t" })).split(".");
 
-    await expect(service.open([Buffer.from("[]").toString("base64url"), ...rest].join("."))).rejects.toMatchObject({ status: 400 });
+    await expect(open([Buffer.from("[]").toString("base64url"), ...rest].join("."))).rejects.toMatchObject({ status: 400 });
   });
 
   it("rejects a seal whose content encryption key is not the length AES-256 requires", async () => {
-    const { service, seal, kmsClient } = setup();
+    const { open, seal, kmsClient } = setup();
     const shortKey = Buffer.alloc(16);
     kmsClient.asymmetricDecrypt.mockResolvedValue([
       { plaintext: shortKey, plaintextCrc32c: { value: String(crc32c.calculate(shortKey)) }, verifiedCiphertextCrc32c: true }
     ]);
 
-    await expect(service.open(await seal({ TOKEN: "t" }))).rejects.toMatchObject({ status: 400 });
+    await expect(open(await seal({ TOKEN: "t" }))).rejects.toMatchObject({ status: 400 });
   });
 
   it("rejects anything that is not a compact JWE", async () => {
-    const { service } = setup();
+    const { open } = setup();
 
-    await expect(service.open("not.a.jwe")).rejects.toMatchObject({ status: 400 });
+    await expect(open("not.a.jwe")).rejects.toMatchObject({ status: 400 });
   });
 
   it("rejects a payload that is not a flat object of strings", async () => {
-    const { service, seal } = setup();
+    const { open, seal } = setup();
 
-    await expect(service.open(await seal({ nested: { deep: "value" } }))).rejects.toMatchObject({ status: 400 });
+    await expect(open(await seal({ nested: { deep: "value" } }))).rejects.toMatchObject({ status: 400 });
   });
 
   it("fails with 503 when KMS is unreachable", async () => {
-    const { service, seal, kmsClient, logger } = setup();
+    const { open, seal, kmsClient, logger } = setup();
     kmsClient.asymmetricDecrypt.mockRejectedValue(Object.assign(new Error("14 UNAVAILABLE"), { code: grpc.status.UNAVAILABLE }));
 
-    await expect(service.open(await seal({ TOKEN: "t" }))).rejects.toMatchObject({ status: 503 });
+    await expect(open(await seal({ TOKEN: "t" }))).rejects.toMatchObject({ status: 503 });
     expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "SDL_SECRETS_CEK_UNWRAP_FAILED" }));
   });
 
   it("rejects a seal whose initialization vector is empty without spending an unwrap", async () => {
-    const { service, seal, kmsClient } = setup();
+    const { open, seal, kmsClient } = setup();
     const parts = (await seal({ TOKEN: "t" })).split(".");
     parts[2] = "";
 
-    await expect(service.open(parts.join("."))).rejects.toMatchObject({ status: 400 });
+    await expect(open(parts.join("."))).rejects.toMatchObject({ status: 400 });
     expect(kmsClient.asymmetricDecrypt).not.toHaveBeenCalled();
   });
 
   it("rejects a seal whose initialization vector is not the 96 bits A256GCM fixes", async () => {
-    const { service, seal, kmsClient } = setup();
+    const { open, seal, kmsClient } = setup();
     const parts = (await seal({ TOKEN: "t" })).split(".");
     parts[2] = randomBytes(13).toString("base64url");
 
-    await expect(service.open(parts.join("."))).rejects.toMatchObject({ status: 400 });
+    await expect(open(parts.join("."))).rejects.toMatchObject({ status: 400 });
     expect(kmsClient.asymmetricDecrypt).not.toHaveBeenCalled();
   });
 
   it("rejects a seal whose initialization vector is not base64url", async () => {
-    const { service, seal, kmsClient } = setup();
+    const { open, seal, kmsClient } = setup();
     const parts = (await seal({ TOKEN: "t" })).split(".");
     parts[2] = `${randomBytes(12).toString("base64url")}!!!!`;
 
-    await expect(service.open(parts.join("."))).rejects.toMatchObject({ status: 400 });
+    await expect(open(parts.join("."))).rejects.toMatchObject({ status: 400 });
     expect(kmsClient.asymmetricDecrypt).not.toHaveBeenCalled();
   });
 
   it("rejects a seal whose protected header is not base64url without spending an unwrap", async () => {
-    const { service, seal, kmsClient } = setup();
+    const { open, seal, kmsClient } = setup();
     const parts = (await seal({ TOKEN: "t" })).split(".");
     parts[0] = `${parts[0]}!`;
 
-    await expect(service.open(parts.join("."))).rejects.toMatchObject({ status: 400 });
+    await expect(open(parts.join("."))).rejects.toMatchObject({ status: 400 });
     expect(kmsClient.asymmetricDecrypt).not.toHaveBeenCalled();
   });
 
   it("rejects a seal whose ciphertext is not base64url without spending an unwrap", async () => {
-    const { service, seal, kmsClient } = setup();
+    const { open, seal, kmsClient } = setup();
     const parts = (await seal({ TOKEN: "t" })).split(".");
     parts[3] = `${parts[3]}!!!!`;
 
-    await expect(service.open(parts.join("."))).rejects.toMatchObject({ status: 400 });
+    await expect(open(parts.join("."))).rejects.toMatchObject({ status: 400 });
     expect(kmsClient.asymmetricDecrypt).not.toHaveBeenCalled();
   });
 
   it("rejects a seal whose encrypted key carries one base64url character too many without spending an unwrap", async () => {
-    const { service, seal, kmsClient } = setup();
+    const { open, seal, kmsClient } = setup();
     const parts = (await seal({ TOKEN: "t" })).split(".");
     parts[1] = `${parts[1]}A`;
 
-    await expect(service.open(parts.join("."))).rejects.toMatchObject({ status: 400 });
+    await expect(open(parts.join("."))).rejects.toMatchObject({ status: 400 });
     expect(kmsClient.asymmetricDecrypt).not.toHaveBeenCalled();
   });
 
   it("rejects a seal whose initialization vector carries one base64url character too many without spending an unwrap", async () => {
-    const { service, seal, kmsClient } = setup();
+    const { open, seal, kmsClient } = setup();
     const parts = (await seal({ TOKEN: "t" })).split(".");
     parts[2] = `${parts[2]}A`;
 
-    await expect(service.open(parts.join("."))).rejects.toMatchObject({ status: 400 });
+    await expect(open(parts.join("."))).rejects.toMatchObject({ status: 400 });
     expect(kmsClient.asymmetricDecrypt).not.toHaveBeenCalled();
   });
 
   it("rejects a seal carrying no encrypted key without spending an unwrap", async () => {
-    const { service, seal, kmsClient } = setup();
+    const { open, seal, kmsClient } = setup();
     const parts = (await seal({ TOKEN: "t" })).split(".");
     parts[1] = "";
 
-    await expect(service.open(parts.join("."))).rejects.toMatchObject({ status: 400 });
+    await expect(open(parts.join("."))).rejects.toMatchObject({ status: 400 });
     expect(kmsClient.asymmetricDecrypt).not.toHaveBeenCalled();
   });
 
   it("rejects a seal whose encrypted key is not base64url without spending an unwrap", async () => {
-    const { service, seal, kmsClient } = setup();
+    const { open, seal, kmsClient } = setup();
     const parts = (await seal({ TOKEN: "t" })).split(".");
     parts[1] = `${parts[1]}!!!!`;
 
-    await expect(service.open(parts.join("."))).rejects.toMatchObject({ status: 400 });
+    await expect(open(parts.join("."))).rejects.toMatchObject({ status: 400 });
     expect(kmsClient.asymmetricDecrypt).not.toHaveBeenCalled();
   });
 
   it("rejects a seal whose encrypted key is not the length the sealing key's modulus fixes without spending an unwrap", async () => {
-    const { service, seal, kmsClient } = setup();
+    const { open, seal, kmsClient } = setup();
     const parts = (await seal({ TOKEN: "t" })).split(".");
     parts[1] = randomBytes(200).toString("base64url");
 
-    await expect(service.open(parts.join("."))).rejects.toMatchObject({ status: 400 });
+    await expect(open(parts.join("."))).rejects.toMatchObject({ status: 400 });
     expect(kmsClient.asymmetricDecrypt).not.toHaveBeenCalled();
   });
 
   it("blames the client when KMS rejects the encrypted key as an invalid argument", async () => {
-    const { service, seal, kmsClient } = setup();
+    const { open, seal, kmsClient } = setup();
     kmsClient.asymmetricDecrypt.mockRejectedValue(Object.assign(new Error("3 INVALID_ARGUMENT: Decryption failed"), { code: grpc.status.INVALID_ARGUMENT }));
 
-    await expect(service.open(await seal({ TOKEN: "t" }))).rejects.toMatchObject({ status: 400 });
+    await expect(open(await seal({ TOKEN: "t" }))).rejects.toMatchObject({ status: 400 });
   });
 
   it("does not log a KMS invalid argument as a service fault", async () => {
-    const { service, seal, kmsClient, logger } = setup();
+    const { open, seal, kmsClient, logger } = setup();
     kmsClient.asymmetricDecrypt.mockRejectedValue(Object.assign(new Error("3 INVALID_ARGUMENT: Decryption failed"), { code: grpc.status.INVALID_ARGUMENT }));
 
-    await expect(service.open(await seal({ TOKEN: "t" }))).rejects.toThrow();
+    await expect(open(await seal({ TOKEN: "t" }))).rejects.toThrow();
 
     expect(logger.error).not.toHaveBeenCalled();
     expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "SDL_SECRETS_SEAL_ENCRYPTED_KEY_REJECTED" }));
   });
 
   it("rejects a seal whose authentication tag is not a length AES-GCM accepts", async () => {
-    const { service, seal, kmsClient } = setup();
+    const { open, seal, kmsClient } = setup();
     const parts = (await seal({ TOKEN: "t" })).split(".");
     parts[4] = Buffer.alloc(5).toString("base64url");
 
-    await expect(service.open(parts.join("."))).rejects.toMatchObject({ status: 400 });
+    await expect(open(parts.join("."))).rejects.toMatchObject({ status: 400 });
     expect(kmsClient.asymmetricDecrypt).not.toHaveBeenCalled();
   });
 
   it("rejects a seal whose authentication tag was truncated to a length AES-GCM accepts", async () => {
-    const { service, seal, kmsClient } = setup();
+    const { open, seal, kmsClient } = setup();
     const parts = (await seal({ TOKEN: "t" })).split(".");
     parts[4] = Buffer.from(parts[4], "base64url").subarray(0, 4).toString("base64url");
 
-    await expect(service.open(parts.join("."))).rejects.toMatchObject({ status: 400 });
+    await expect(open(parts.join("."))).rejects.toMatchObject({ status: 400 });
     expect(kmsClient.asymmetricDecrypt).not.toHaveBeenCalled();
   });
 
   it("fails with 503 when KMS returns no plaintext", async () => {
-    const { service, seal, kmsClient } = setup();
+    const { open, seal, kmsClient } = setup();
     kmsClient.asymmetricDecrypt.mockResolvedValue([{ verifiedCiphertextCrc32c: true }]);
 
-    await expect(service.open(await seal({ TOKEN: "t" }))).rejects.toMatchObject({ status: 503 });
+    await expect(open(await seal({ TOKEN: "t" }))).rejects.toMatchObject({ status: 503 });
   });
 
   it("fails with 503 when KMS reports a corrupted request", async () => {
-    const { service, seal, kmsClient } = setup();
+    const { open, seal, kmsClient } = setup();
     kmsClient.asymmetricDecrypt.mockResolvedValue([{ plaintext: Buffer.alloc(32), verifiedCiphertextCrc32c: false }]);
 
-    await expect(service.open(await seal({ TOKEN: "t" }))).rejects.toMatchObject({ status: 503 });
+    await expect(open(await seal({ TOKEN: "t" }))).rejects.toMatchObject({ status: 503 });
   });
 
   function setup() {
@@ -314,7 +358,8 @@ describe(SdlSecretsUnsealerService.name, () => {
 
     const kmsTarget = { client: kmsClient, versionName: VERSION_NAME, kid: KID };
     const service = new SdlSecretsUnsealerService(kmsTarget, authService, createLogger);
+    const open = (seal: string, sdl = SDL) => service.open({ seal, sdl });
 
-    return { service, kmsClient, authService, logger, seal, clientSecrets };
+    return { open, kmsClient, authService, logger, seal, clientSecrets };
   }
 });

--- a/apps/api/src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service.ts
+++ b/apps/api/src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service.ts
@@ -1,7 +1,7 @@
 import crc32c from "fast-crc32c";
 import { grpc } from "google-gax";
 import createError from "http-errors";
-import { createDecipheriv } from "node:crypto";
+import { createDecipheriv, createHash } from "node:crypto";
 import { inject, singleton } from "tsyringe";
 
 import { AuthService } from "@src/auth/services/auth.service";
@@ -23,6 +23,7 @@ interface SealHeader {
   kid?: unknown;
   sub?: unknown;
   exp?: unknown;
+  sdlHash?: unknown;
 }
 
 interface SealParts {
@@ -51,6 +52,10 @@ const CONTENT_ENCRYPTION_IV_BYTES = 12;
 /** A256GCM fixes the tag at 128 bits, and Node silently accepts shorter ones — 4 bytes of authentication is not authentication. */
 const CONTENT_ENCRYPTION_TAG_BYTES = 16;
 
+function isSdlBound(header: SealHeader) {
+  return header.sdlHash !== undefined;
+}
+
 /** gRPC reports the status of a failed call as a numeric `code` on the rejection. */
 function getGrpcStatus(error: unknown) {
   return error instanceof Error && "code" in error ? error.code : undefined;
@@ -63,7 +68,7 @@ function getGrpcStatus(error: unknown) {
  * apart by hand and each piece handed to a stock primitive. The only hand-written logic is the
  * split: the encrypted key goes to Cloud KMS, and the content is opened with AES-256-GCM using the
  * protected header's own ASCII as the additional authenticated data. That last detail is what makes
- * the header claims tamper-evident — altering `sub` or `exp` breaks the GCM tag.
+ * the header claims tamper-evident — altering `sub`, `exp` or `sdlHash` breaks the GCM tag.
  */
 @singleton()
 export class SdlSecretsUnsealerService {
@@ -77,15 +82,21 @@ export class SdlSecretsUnsealerService {
     this.#loggerService = createLogger({ context: SdlSecretsUnsealerService.name });
   }
 
-  async open(seal: string): Promise<SdlSecrets> {
+  async open({ seal, sdl }: { seal: string; sdl: string }): Promise<SdlSecrets> {
     const parts = this.#splitSeal(seal);
     this.#assertSegmentsAreWellFormed(parts);
-    this.#assertHeaderIsAcceptable(parts.protectedHeader);
+    const header = this.#validateHeader(parts.protectedHeader);
+    this.#assertSdlBinding(header, sdl);
 
     const contentEncryptionKey = await this.#unwrapContentEncryptionKey(parts.encryptedKey);
     const secrets = this.#decryptSecrets(parts, contentEncryptionKey);
 
-    this.#loggerService.info({ event: "SDL_SECRETS_SEAL_OPENED", kid: this.kmsTarget.kid, secretCount: Object.keys(secrets).length });
+    this.#loggerService.info({
+      event: "SDL_SECRETS_SEAL_OPENED",
+      kid: this.kmsTarget.kid,
+      secretCount: Object.keys(secrets).length,
+      sdlBound: isSdlBound(header)
+    });
 
     return secrets;
   }
@@ -103,7 +114,7 @@ export class SdlSecretsUnsealerService {
   }
 
   /** Everything here is free; nothing below it is. A malformed or stale seal must never reach Cloud KMS. */
-  #assertHeaderIsAcceptable(protectedHeader: string) {
+  #validateHeader(protectedHeader: string) {
     const header = this.#parseHeader(protectedHeader);
 
     if (header.alg !== SDL_SECRETS_SEAL_ALGORITHM || header.enc !== SDL_SECRETS_CONTENT_ENCRYPTION) {
@@ -135,6 +146,26 @@ export class SdlSecretsUnsealerService {
         exp: header.exp,
         maxLifetimeMs: SDL_SECRETS_MAX_SEAL_LIFETIME_MS
       });
+    }
+
+    return header;
+  }
+
+  /**
+   * `sub` binds a seal to a user; `sdlHash` binds it to a deployment, closing the gap where an
+   * intermediary forwards the seal and the credentials untouched while swapping the SDL for one it
+   * controls. The claim is optional on the wire but authenticated by the GCM tag, so it cannot be
+   * stripped from a seal that carries one — optionality weakens only clients that chose not to send it.
+   *
+   * The digest is over the `sdl` string exactly as it arrived, never over a parsed-then-re-serialized
+   * SDL: re-serializing reorders keys and rewrites whitespace, producing mismatches that are painful
+   * to debug. JSON string values round-trip byte-exact, so no raw-body access is needed.
+   */
+  #assertSdlBinding(header: SealHeader, sdl: string) {
+    if (!isSdlBound(header)) return;
+
+    if (header.sdlHash !== createHash("sha256").update(sdl, "utf8").digest("base64url")) {
+      throw this.#reject(403, "SDL_SECRETS_SEAL_SDL_MISMATCH", "Sealed secrets are bound to a different SDL", { received: header.sdlHash });
     }
   }
 


### PR DESCRIPTION
## Why

Sealed values are only worth sealing if the payload cannot be reused. `sub` binds a seal to a *user*; without a binding to the *deployment*, an intermediary that can modify a request forwards the sealed blob and the credentials untouched while swapping the SDL for one it controls — and the console substitutes the real secrets into it. The same gap turns a stolen credential plus a captured blob back into disclosure.

Ref CON-850

## What

`SdlSecretsUnsealerService.open()` now takes `{ seal, sdl }` and verifies the optional `sdlHash` claim against the SDL its caller supplies.

- `sdlHash` is the base64url SHA-256 of the `sdl` string **exactly as it arrived** — never of a parsed-then-re-serialized SDL, which reorders keys and rewrites whitespace. JSON string values round-trip byte-exact, so no raw-body access is needed.
- Absent claim → accepted. Present and mismatched → `403 SDL_SECRETS_SEAL_SDL_MISMATCH`, refused before any KMS call, so a hostile request costs no billable key operation.
- The claim is authenticated by the GCM tag (the protected header's ASCII is the AAD), so it cannot be stripped from a seal that carries one. Optionality weakens only clients that chose not to send it — which is what makes an optional-but-enforced security claim sound here.
- `SDL_SECRETS_SEAL_OPENED` gains `sdlBound`, so the proportion of unbound opens is answerable from emitted events. That measurement is what makes requiring the claim later a decision rather than a guess.
- `sdlHash` is deliberately **not** added to `SDL_SECRETS_REQUIRED_CLAIMS`; promoting it is out of scope.

The `sdl` parameter is required rather than optional: a caller with no SDL has no business opening a seal, and an optional parameter reintroduces exactly the footgun the claim exists to close.

Nothing secret enters the header — the digest is of the SDL, and no credential value appears there hashed or otherwise.

Stacked: base is `feat/secrets-jwk` (#3624).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - SDL secret seals can now be bound to the exact SDL content they were created for.
  - Added validation to reject seals with missing, invalid, stripped, or mismatched SDL bindings.
  - Unbound seals remain supported.
  - Successful unsealing now records whether the seal was SDL-bound.

- **Security Improvements**
  - Mismatched SDL bindings are rejected before key-management processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->