### PR TITLE
feat(deployment): refuse sealed secrets before any KMS call when intake is off or oversized

### DIFF
--- a/apps/api/src/core/services/feature-flags/feature-flags.ts
+++ b/apps/api/src/core/services/feature-flags/feature-flags.ts
@@ -3,7 +3,8 @@ export const FeatureFlags = {
   NOTIFICATIONS_ALERT_UPDATE: "notifications_general_alerts_update",
   AUTO_CREDIT_RELOAD: "auto_credit_reload",
   AUTO_RELOAD_FIXED_THRESHOLD: "auto_reload_fixed_threshold",
-  TRIAL_FINGERPRINT_CHECK: "trial_fingerprint_check"
+  TRIAL_FINGERPRINT_CHECK: "trial_fingerprint_check",
+  SDL_SECRETS_SEALED_INTAKE: "sdl_secrets_sealed_intake"
 } as const;
 
 export type FeatureFlagValue = (typeof FeatureFlags)[keyof typeof FeatureFlags];

--- a/apps/api/src/deployment/config/sdl-secrets.config.ts
+++ b/apps/api/src/deployment/config/sdl-secrets.config.ts
@@ -40,3 +40,12 @@ export const SDL_SECRETS_REQUIRED_CLAIMS = ["kid", "sub", "exp"] as const;
  * with enough slack above the client's own lifetime to absorb clock skew.
  */
 export const SDL_SECRETS_MAX_SEAL_LIFETIME_MS = 15 * 60 * 1000;
+
+/**
+ * Largest compact JWE the console will even look at. A wrapped content encryption key is at most 512
+ * bytes and the header, initialization vector and tag together are a few hundred more, so everything
+ * above that is the sealed payload — 16Kb holds a realistic set of secrets several times over while
+ * staying ~32x tighter than the generic 512Kb body limit every route inherits. Measured before the
+ * seal is split, so an oversized payload can never spend an unwrap.
+ */
+export const SDL_SECRETS_MAX_SEAL_BYTES = 16 * 1024;

--- a/apps/api/src/deployment/routes/echo-sdl-secrets/echo-sdl-secrets.router.ts
+++ b/apps/api/src/deployment/routes/echo-sdl-secrets/echo-sdl-secrets.router.ts
@@ -1,0 +1,71 @@
+import { z } from "@hono/zod-openapi";
+import createError from "http-errors";
+import { container } from "tsyringe";
+
+import { createRoute } from "@src/core/lib/create-route/create-route";
+import { CoreConfigService } from "@src/core/services/core-config/core-config.service";
+import { OpenApiHonoHandler } from "@src/core/services/open-api-hono-handler/open-api-hono-handler";
+import { SECURITY_BEARER_OR_API_KEY } from "@src/core/services/openapi-docs/openapi-security";
+import { SdlSecretsUnsealerService } from "@src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service";
+
+/**
+ * TEMPORARY. Exists only to prove the seal round-trip end to end against a live KMS, and must be
+ * deleted before sealed intake ships: returning decrypted secrets is precisely the property the
+ * whole scheme exists to deny, so no endpoint may do it. The production guard below is a safety
+ * net, not a licence to keep this route.
+ */
+export const echoSdlSecretsRouter = new OpenApiHonoHandler();
+
+const EchoSdlSecretsRequestSchema = z.object({
+  seal: z.string().openapi({
+    description: "All of a deployment's secrets as a single compact JWE"
+  }),
+  sdl: z.string().openapi({
+    description: "The SDL the seal's optional `sdlHash` claim is checked against"
+  })
+});
+
+const EchoSdlSecretsResponseSchema = z.object({
+  secrets: z.record(z.string()).openapi({
+    description: "The decrypted secrets, echoed back verbatim"
+  })
+});
+
+const route = createRoute({
+  method: "post",
+  path: "/v1/sdl-secrets-echo",
+  summary: "Decrypt sealed SDL secrets and echo them back (development only)",
+  tags: ["SDL Secrets"],
+  security: SECURITY_BEARER_OR_API_KEY,
+  hiddenInOpenApiDocs: true,
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: EchoSdlSecretsRequestSchema
+        }
+      }
+    }
+  },
+  responses: {
+    200: {
+      description: "Returns the decrypted secrets",
+      content: {
+        "application/json": {
+          schema: EchoSdlSecretsResponseSchema
+        }
+      }
+    }
+  }
+});
+
+echoSdlSecretsRouter.openapi(route, async function routeEchoSdlSecrets(c) {
+  if (container.resolve(CoreConfigService).get("NODE_ENV") === "production") {
+    throw createError(404, "Not Found");
+  }
+
+  const { seal, sdl } = c.req.valid("json");
+  const secrets = await container.resolve(SdlSecretsUnsealerService).open({ seal, sdl });
+
+  return c.json({ secrets }, 200);
+});

--- a/apps/api/src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service.spec.ts
@@ -1,8 +1,8 @@
 import type { protos } from "@google-cloud/kms";
 import crc32c from "fast-crc32c";
 import { grpc } from "google-gax";
-import { CompactEncrypt, importJWK } from "jose";
-import { constants, createHash, generateKeyPairSync, privateDecrypt, randomBytes, randomUUID } from "node:crypto";
+import { compactDecrypt, CompactEncrypt, importJWK } from "jose";
+import { constants, createCipheriv, createHash, generateKeyPairSync, privateDecrypt, publicEncrypt, randomBytes, randomUUID } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
 
@@ -20,6 +20,10 @@ const SDL = 'version: "2.0"\nservices:\n  web:\n    image: nginx\n';
 
 function sdlHashOf(sdl: string) {
   return createHash("sha256").update(sdl, "utf8").digest("base64url");
+}
+
+function sealClaims(claims?: Record<string, unknown>) {
+  return { alg: "RSA-OAEP-256", enc: "A256GCM", kid: KID, sub: SUBJECT, exp: Math.floor(Date.now() / 1000) + 300, ...claims };
 }
 
 describe(SdlSecretsUnsealerService.name, () => {
@@ -114,6 +118,26 @@ describe(SdlSecretsUnsealerService.name, () => {
 
     await expect(open([stripped, ...rest].join("."))).rejects.toMatchObject({ status: 400 });
     expect(sdlHash).toEqual(sdlHashOf(SDL));
+  });
+
+  it("assembles a seal jose opens, so the decoder's wire format is not private to it", async () => {
+    const { assembleSeal, privateKey, clientSecrets } = setup();
+
+    const { plaintext } = await compactDecrypt(assembleSeal(clientSecrets), privateKey);
+
+    expect(JSON.parse(new TextDecoder().decode(plaintext))).toEqual(clientSecrets);
+  });
+
+  it("opens a seal assembled from the same primitives and AAD convention it decodes with", async () => {
+    const { open, assembleSeal, clientSecrets } = setup();
+
+    await expect(open(assembleSeal(clientSecrets))).resolves.toEqual(clientSecrets);
+  });
+
+  it("opens a hand-assembled seal bound to the SDL it was assembled against", async () => {
+    const { open, assembleSeal, clientSecrets } = setup();
+
+    await expect(open(assembleSeal(clientSecrets, { sdlHash: sdlHashOf(SDL) }))).resolves.toEqual(clientSecrets);
   });
 
   it("does not call KMS when the header is unacceptable", async () => {
@@ -331,12 +355,33 @@ describe(SdlSecretsUnsealerService.name, () => {
     const jwk = { ...publicKey.export({ format: "jwk" }), use: "enc", alg: "RSA-OAEP-256" };
     const clientSecrets = { DB_URL: `postgres://app:${randomUUID()}@db.internal/app`, API_TOKEN: randomBytes(20).toString("hex") };
 
-    const seal = async (secrets: unknown, claims?: Record<string, unknown>) => {
-      const header = { alg: "RSA-OAEP-256", enc: "A256GCM", kid: KID, sub: SUBJECT, exp: Math.floor(Date.now() / 1000) + 300, ...claims };
-
-      return new CompactEncrypt(new TextEncoder().encode(JSON.stringify(secrets)))
-        .setProtectedHeader(header as never)
+    const seal = async (secrets: unknown, claims?: Record<string, unknown>) =>
+      new CompactEncrypt(new TextEncoder().encode(JSON.stringify(secrets)))
+        .setProtectedHeader(sealClaims(claims) as never)
         .encrypt(await importJWK(jwk, "RSA-OAEP-256"));
+
+    /**
+     * Builds a compact JWE from the same stock primitives and AAD convention the service decodes
+     * with. The console only ever opens seals, so there is no production producer to test against;
+     * this is the closest honest reverse direction, and it fails whichever way a base64url,
+     * AAD-encoding or OAEP-digest divergence exists.
+     */
+    const assembleSeal = (secrets: unknown, claims?: Record<string, unknown>) => {
+      const protectedHeader = Buffer.from(JSON.stringify(sealClaims(claims))).toString("base64url");
+      const contentEncryptionKey = randomBytes(32);
+      const encryptedKey = publicEncrypt({ key: publicKey, padding: constants.RSA_PKCS1_OAEP_PADDING, oaepHash: "sha256" }, contentEncryptionKey);
+      const iv = randomBytes(12);
+      const cipher = createCipheriv("aes-256-gcm", contentEncryptionKey, iv);
+      cipher.setAAD(Buffer.from(protectedHeader, "ascii"));
+      const ciphertext = Buffer.concat([cipher.update(JSON.stringify(secrets), "utf8"), cipher.final()]);
+
+      return [
+        protectedHeader,
+        encryptedKey.toString("base64url"),
+        iv.toString("base64url"),
+        ciphertext.toString("base64url"),
+        cipher.getAuthTag().toString("base64url")
+      ].join(".");
     };
 
     const kmsClient = mock<SdlSecretsKmsClient>();
@@ -360,6 +405,6 @@ describe(SdlSecretsUnsealerService.name, () => {
     const service = new SdlSecretsUnsealerService(kmsTarget, authService, createLogger);
     const open = (seal: string, sdl = SDL) => service.open({ seal, sdl });
 
-    return { open, kmsClient, authService, logger, seal, clientSecrets };
+    return { open, kmsClient, authService, logger, seal, assembleSeal, privateKey, clientSecrets };
   }
 });

--- a/apps/api/src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service.spec.ts
@@ -8,7 +8,9 @@ import { mock } from "vitest-mock-extended";
 
 import type { AuthService } from "@src/auth/services/auth.service";
 import type { CreateLogger } from "@src/core";
-import { SDL_SECRETS_MAX_SEAL_LIFETIME_MS } from "@src/deployment/config/sdl-secrets.config";
+import { FeatureFlags } from "@src/core/services/feature-flags/feature-flags";
+import type { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
+import { SDL_SECRETS_MAX_SEAL_BYTES, SDL_SECRETS_MAX_SEAL_LIFETIME_MS } from "@src/deployment/config/sdl-secrets.config";
 import type { SdlSecretsKmsClient } from "@src/deployment/providers/kms.provider";
 import type { UserOutput } from "@src/user/repositories";
 import { SdlSecretsUnsealerService } from "./sdl-secrets-unsealer.service";
@@ -138,6 +140,28 @@ describe(SdlSecretsUnsealerService.name, () => {
     const { open, assembleSeal, clientSecrets } = setup();
 
     await expect(open(assembleSeal(clientSecrets, { sdlHash: sdlHashOf(SDL) }))).resolves.toEqual(clientSecrets);
+  });
+
+  it("refuses a sealed payload without spending an unwrap while sealed intake is off", async () => {
+    const { open, seal, kmsClient } = setup({ sealedIntakeEnabled: false });
+
+    await expect(open(await seal({ TOKEN: "t" }))).rejects.toMatchObject({ status: 403 });
+    expect(kmsClient.asymmetricDecrypt).not.toHaveBeenCalled();
+  });
+
+  it("refuses an oversized seal without spending an unwrap", async () => {
+    const { open, seal, kmsClient } = setup();
+    const oversized = (await seal({ TOKEN: "t" })).padEnd(SDL_SECRETS_MAX_SEAL_BYTES + 1, "A");
+
+    await expect(open(oversized)).rejects.toMatchObject({ status: 413 });
+    expect(kmsClient.asymmetricDecrypt).not.toHaveBeenCalled();
+  });
+
+  it("opens a seal carrying a realistic set of secrets, so the size limit does not bite legitimate payloads", async () => {
+    const { open, seal } = setup();
+    const manySecrets = Object.fromEntries(Array.from({ length: 20 }, (_, index) => [`SECRET_${index}`, randomBytes(100).toString("hex")]));
+
+    await expect(open(await seal(manySecrets))).resolves.toEqual(manySecrets);
   });
 
   it("does not call KMS when the header is unacceptable", async () => {
@@ -350,7 +374,7 @@ describe(SdlSecretsUnsealerService.name, () => {
     await expect(open(await seal({ TOKEN: "t" }))).rejects.toMatchObject({ status: 503 });
   });
 
-  function setup() {
+  function setup(input: { sealedIntakeEnabled?: boolean } = {}) {
     const { publicKey, privateKey } = generateKeyPairSync("rsa", { modulusLength: 3072 });
     const jwk = { ...publicKey.export({ format: "jwk" }), use: "enc", alg: "RSA-OAEP-256" };
     const clientSecrets = { DB_URL: `postgres://app:${randomUUID()}@db.internal/app`, API_TOKEN: randomBytes(20).toString("hex") };
@@ -398,11 +422,13 @@ describe(SdlSecretsUnsealerService.name, () => {
     });
 
     const authService = mock<AuthService>({ currentUser: mock<UserOutput>({ id: SUBJECT }) });
+    const featureFlagsService = mock<FeatureFlagsService>();
+    featureFlagsService.isEnabled.mockImplementation(flag => flag === FeatureFlags.SDL_SECRETS_SEALED_INTAKE && (input.sealedIntakeEnabled ?? true));
     const logger = mock<ReturnType<CreateLogger>>();
     const createLogger: CreateLogger = () => logger;
 
     const kmsTarget = { client: kmsClient, versionName: VERSION_NAME, kid: KID };
-    const service = new SdlSecretsUnsealerService(kmsTarget, authService, createLogger);
+    const service = new SdlSecretsUnsealerService(kmsTarget, authService, featureFlagsService, createLogger);
     const open = (seal: string, sdl = SDL) => service.open({ seal, sdl });
 
     return { open, kmsClient, authService, logger, seal, assembleSeal, privateKey, clientSecrets };

--- a/apps/api/src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service.ts
+++ b/apps/api/src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service.ts
@@ -6,8 +6,11 @@ import { inject, singleton } from "tsyringe";
 
 import { AuthService } from "@src/auth/services/auth.service";
 import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
+import { FeatureFlags } from "@src/core/services/feature-flags/feature-flags";
+import { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
 import {
   SDL_SECRETS_CONTENT_ENCRYPTION,
+  SDL_SECRETS_MAX_SEAL_BYTES,
   SDL_SECRETS_MAX_SEAL_LIFETIME_MS,
   SDL_SECRETS_SEAL_ALGORITHM,
   SDL_SECRETS_WRAPPED_KEY_BYTES
@@ -77,12 +80,16 @@ export class SdlSecretsUnsealerService {
   constructor(
     @inject(SDL_SECRETS_KMS_TARGET) private readonly kmsTarget: SdlSecretsKmsTarget,
     private readonly authService: AuthService,
+    private readonly featureFlagsService: FeatureFlagsService,
     @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
     this.#loggerService = createLogger({ context: SdlSecretsUnsealerService.name });
   }
 
   async open({ seal, sdl }: { seal: string; sdl: string }): Promise<SdlSecrets> {
+    this.#assertSealedIntakeIsEnabled();
+    this.#assertSealIsWithinSizeLimit(seal);
+
     const parts = this.#splitSeal(seal);
     this.#assertSegmentsAreWellFormed(parts);
     const header = this.#validateHeader(parts.protectedHeader);
@@ -99,6 +106,26 @@ export class SdlSecretsUnsealerService {
     });
 
     return secrets;
+  }
+
+  /**
+   * The gate lives here rather than on a route because `open` is the only place every present and
+   * future caller passes through. With the flag off — including when it does not exist yet, which
+   * resolves false — sealed intake is closed and plaintext intake is unaffected.
+   */
+  #assertSealedIntakeIsEnabled() {
+    if (!this.featureFlagsService.isEnabled(FeatureFlags.SDL_SECRETS_SEALED_INTAKE)) {
+      throw this.#reject(403, "SDL_SECRETS_SEALED_INTAKE_DISABLED", "Sealed secrets are not accepted", {});
+    }
+  }
+
+  /** Byte length, not character count: otherwise multi-byte padding slips a payload past the cap. */
+  #assertSealIsWithinSizeLimit(seal: string) {
+    const sealBytes = Buffer.byteLength(seal, "utf8");
+
+    if (sealBytes > SDL_SECRETS_MAX_SEAL_BYTES) {
+      throw this.#reject(413, "SDL_SECRETS_SEAL_TOO_LARGE", "Sealed secrets are too large", { sealBytes, maxSealBytes: SDL_SECRETS_MAX_SEAL_BYTES });
+    }
   }
 
   #splitSeal(seal: string): SealParts {


### PR DESCRIPTION
## Why

Without ordering the checks correctly, a malformed or hostile request costs a billable key operation. And a new intake path needs a kill switch before it has any callers, not after.

Closes CON-850

## What

Two refusals decided at the entrance of `SdlSecretsUnsealerService.open()`, before anything is spent:

- **Flag gate** — `sdl_secrets_sealed_intake` off → `403 SDL_SECRETS_SEALED_INTAKE_DISABLED`.
- **Size bound** — `SDL_SECRETS_MAX_SEAL_BYTES` (16Kb) exceeded → `413 SDL_SECRETS_SEAL_TOO_LARGE`. Measured with `Buffer.byteLength`, not `.length`, so multi-byte padding cannot slip a payload past the cap.

Both precede `#splitSeal`, so neither can reach KMS. Tests assert `asymmetricDecrypt` was never called, plus a realistic 20-secret payload still opens so the cap does not bite legitimate traffic.

### Decisions worth flagging

- **The gate is in the service, not on a route.** There is no sealed-intake route to gate yet, and `open()` is the only place every present and future caller passes through. Consequence: with the flag off nothing user-visible changes in this phase — the gate is dormant until PRD-0003 wires a caller.
- **Fail-closed by default.** `sdl_secrets_sealed_intake` does not exist in Unleash yet; an unknown flag resolves `false`, so merging before the ops step is safe. Creating the flag is a prerequisite for PRD-0003, not for this PR.
- **16Kb derivation** is in the constant's JSDoc: a wrapped CEK is at most 512 bytes and header/IV/tag are a few hundred more, so the cap is effectively a payload bound with several times the headroom a real secret set needs.
- **`GET /v1/sdl-secrets-context` is deliberately *not* gated.** A public key is not sensitive and clients need it discoverable; the refusal belongs at the point of acceptance.

### Known limitation on test level

The PRD asks for the flag-off case as a functional test. That is not achievable: `FEATURE_FLAGS_ENABLE_ALL=true` in `env/.env.functional.test`, and `isEnabled()` returns `true` on that config before consulting Unleash. Turning it off would break every other flagged path and would then demand Unleash credentials. So this is a unit test with `mock<FeatureFlagsService>()`; the mock is flag-specific, so checking the wrong flag name fails the happy path rather than passing silently.

Stacked on #3628.

🤖 Generated with [Claude Code](https://claude.com/claude-code)