### PR TITLE
feat(deployment): match placement service cards to the design

### DIFF
--- a/apps/deploy-web/src/components/deployments/DeploymentAlerts/DeploymentAlerts.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentAlerts/DeploymentAlerts.tsx
@@ -146,7 +146,7 @@ export const DeploymentAlertsView: FC<ChildrenProps & Props> = ({
   return (
     <FormProvider {...form}>
       <form onSubmit={form.handleSubmit(submit)}>
-        <div className="my-6 flex items-center text-xl font-semibold">
+        <div className="mb-6 flex items-center text-xl font-semibold">
           <h3 className="mr-6">Configure Alerts</h3>
           {!disabled && (
             <LoadingButton type="submit" loading={isSaving} disabled={!isDirty || isSaving} size="md">

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.spec.tsx
@@ -2,7 +2,6 @@ import yaml from "js-yaml";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
-import type { LeaseServiceStatus, LeaseStatusDto } from "@src/queries/useLeaseQuery";
 import type { DeploymentDto, DeploymentGroup, LeaseDto } from "@src/types/deployment";
 import type { ApiProviderList } from "@src/types/provider";
 import { DEPENDENCIES, DeploymentDetailHeader } from "./DeploymentDetailHeader";
@@ -18,8 +17,7 @@ describe("DeploymentDetailHeader", () => {
         services: { web: {}, api: {}, worker: {} },
         deployment: { web: { "dcloud-us": {} }, api: { "dcloud-us": {} }, worker: { "dcloud-eu": {} } }
       }),
-      leases: [buildLeaseInPlacement("1", "dcloud-us"), buildLeaseInPlacement("2", "dcloud-eu")],
-      serviceUris: { web: [] }
+      leases: [buildLeaseInPlacement("1", "dcloud-us"), buildLeaseInPlacement("2", "dcloud-eu")]
     });
 
     expect(screen.getByText("3")).toBeInTheDocument();
@@ -72,17 +70,13 @@ describe("DeploymentDetailHeader", () => {
     expect(screen.getByText("Off")).toBeInTheDocument();
   });
 
-  it("links to the service URI with a Visit action", () => {
-    setup({ serviceUris: { web: ["my-app.akash.app"] } });
+  it("passes every lease and provider to the visit control", () => {
+    const DeploymentVisitControl = vi.fn(() => <div>visit</div>);
+    const leases = [buildLeaseInPlacement("1", "dcloud-us"), buildLeaseInPlacement("2", "dcloud-eu")];
+    const providers = [mock<ApiProviderList>({ owner: "akash1provider" })];
+    setup({ leases, providers, dependencies: { DeploymentVisitControl } });
 
-    const visit = screen.getByRole("link", { name: "Visit" });
-    expect(visit).toHaveAttribute("href", "http://my-app.akash.app");
-  });
-
-  it("hides the Visit action when the lease has no status yet", () => {
-    setup({ hasLeaseStatus: false });
-
-    expect(screen.queryByRole("link", { name: "Visit" })).not.toBeInTheDocument();
+    expect(DeploymentVisitControl).toHaveBeenCalledWith(expect.objectContaining({ leases, providers }), {});
   });
 
   it("shows the trial badge when the wallet is trialing", () => {
@@ -172,30 +166,16 @@ describe("DeploymentDetailHeader", () => {
   }
 
   function setup(input: {
-    serviceUris?: Record<string, string[]>;
     autoTopUpEnabled?: boolean;
-    hasLeaseStatus?: boolean;
     name?: string | null;
     isTrialing?: boolean;
     storedManifest?: string | null;
     leases?: LeaseDto[];
+    providers?: ApiProviderList[];
     gpuAmount?: number;
     groups?: DeploymentGroup[];
+    dependencies?: Partial<typeof DEPENDENCIES>;
   }) {
-    const hasLeaseStatus = input.hasLeaseStatus ?? true;
-    let leaseStatus: LeaseStatusDto | null = null;
-    if (hasLeaseStatus) {
-      leaseStatus = mock<LeaseStatusDto>();
-      leaseStatus.forwarded_ports = {};
-      leaseStatus.services = Object.fromEntries(
-        Object.entries(input.serviceUris ?? { web: [] }).map(([name, uris]) => {
-          const service = mock<LeaseServiceStatus>();
-          service.uris = uris;
-          return [name, service];
-        })
-      );
-    }
-
     const changeDeploymentName = vi.fn();
     const useLocalNotes: typeof DEPENDENCIES.useLocalNotes = () =>
       mock<ReturnType<typeof DEPENDENCIES.useLocalNotes>>({
@@ -214,8 +194,8 @@ describe("DeploymentDetailHeader", () => {
       mock<ReturnType<typeof DEPENDENCIES.useDeploymentSettingQuery>>({
         data: mock<NonNullable<ReturnType<typeof DEPENDENCIES.useDeploymentSettingQuery>["data"]>>({ autoTopUpEnabled: input.autoTopUpEnabled ?? false })
       });
-    const useLeaseStatus: typeof DEPENDENCIES.useLeaseStatus = () => mock<ReturnType<typeof DEPENDENCIES.useLeaseStatus>>({ data: leaseStatus });
     const CostRate = vi.fn(() => <div>cost-rate</div>);
+    const DeploymentVisitControl = vi.fn(() => <div>visit</div>);
 
     const deployment = mock<DeploymentDto>({
       dseq: "1786440078202",
@@ -232,7 +212,7 @@ describe("DeploymentDetailHeader", () => {
       <DeploymentDetailHeader
         deployment={deployment}
         leases={input.leases ?? [mock<LeaseDto>({ id: "1", provider: "akash1provider", state: "active" })]}
-        providers={[mock<ApiProviderList>({ owner: "akash1provider" })]}
+        providers={input.providers ?? [mock<ApiProviderList>({ owner: "akash1provider" })]}
         dependencies={MockComponents(DEPENDENCIES, {
           useLocalNotes,
           useWallet,
@@ -240,11 +220,12 @@ describe("DeploymentDetailHeader", () => {
           useDeploymentSettingQuery,
           useDeclaredTeeTypes,
           useDeclaredGpuInterconnect,
-          useLeaseStatus,
           TrialDeploymentBadge,
           ConfidentialComputeBadge,
           GpuInterconnectBadge,
-          CostRate
+          CostRate,
+          DeploymentVisitControl,
+          ...input.dependencies
         })}
       />
     );

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.spec.tsx
@@ -132,6 +132,25 @@ describe("DeploymentDetailHeader", () => {
     expect(screen.queryByRole("button", { name: "Redeploy" })).not.toBeInTheDocument();
   });
 
+  it("shows the gpu count and model in the summary", () => {
+    setup({
+      gpuAmount: 1,
+      groups: [
+        mock<DeploymentGroup>({
+          group_spec: { resources: [{ resource: { gpu: { attributes: [{ key: "vendor/nvidia/model/h100", value: "true" }] } } }] }
+        } as Partial<DeploymentGroup>)
+      ]
+    });
+
+    expect(screen.getByText("1× H100")).toBeInTheDocument();
+  });
+
+  it("shows an em dash for gpu when the deployment has none", () => {
+    setup({ gpuAmount: 0 });
+
+    expect(screen.getByText("GPU").parentElement).toHaveTextContent("—");
+  });
+
   function buildPricedLease(input: { state: string; amount: string; gpuAmount: number }) {
     return mock<LeaseDto>({
       id: input.amount,
@@ -160,6 +179,8 @@ describe("DeploymentDetailHeader", () => {
     isTrialing?: boolean;
     storedManifest?: string | null;
     leases?: LeaseDto[];
+    gpuAmount?: number;
+    groups?: DeploymentGroup[];
   }) {
     const hasLeaseStatus = input.hasLeaseStatus ?? true;
     let leaseStatus: LeaseStatusDto | null = null;
@@ -200,9 +221,10 @@ describe("DeploymentDetailHeader", () => {
       dseq: "1786440078202",
       state: "active",
       cpuAmount: 2,
-      gpuAmount: 0,
+      gpuAmount: input.gpuAmount ?? 0,
       memoryAmount: 536870912,
       storageAmount: 536870912,
+      groups: input.groups ?? [],
       escrowAccount: mock<DeploymentDto["escrowAccount"]>({ state: mock<DeploymentDto["escrowAccount"]["state"]>({ funds: [] }) })
     });
 

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.spec.tsx
@@ -142,7 +142,7 @@ describe("DeploymentDetailHeader", () => {
       ]
     });
 
-    expect(screen.getByText("1× H100")).toBeInTheDocument();
+    expect(screen.getByText("H100")).toBeInTheDocument();
   });
 
   it("shows an em dash for gpu when the deployment has none", () => {

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.tsx
@@ -24,7 +24,13 @@ import { getEscrowDenom } from "@src/utils/deploymentUtils";
 import { isLeaseLive } from "@src/utils/leaseUtils";
 import { roundDecimal } from "@src/utils/mathHelpers";
 import { bytesToShrink } from "@src/utils/unitUtils";
-import { countPlacementServices, parseManifestServices, parseServicesByPlacement } from "./DeploymentPlacements/placementModel";
+import {
+  countPlacementServices,
+  formatGpuLabel,
+  getDeploymentGpuModels,
+  parseManifestServices,
+  parseServicesByPlacement
+} from "./DeploymentPlacements/placementModel";
 import { DeploymentStatusBadge } from "./DeploymentStatusBadge";
 
 export const DEPENDENCIES = {
@@ -125,6 +131,7 @@ export const DeploymentDetailHeader: FC<DeploymentDetailHeaderProps> = ({ deploy
             {costPerBlockUDenom ? <d.CostRate perBlockUDenom={costPerBlockUDenom} denom={denom} gpuCount={liveGpuCount} /> : "—"}
           </SummaryItem>
           <SummaryItem label="BALANCE">{walletBalance ? `$${walletBalance.totalUsd.toFixed(2)}` : "—"}</SummaryItem>
+          <SummaryItem label="GPU">{formatGpuLabel(deployment.gpuAmount ?? 0, getDeploymentGpuModels(deployment.groups))}</SummaryItem>
           <SummaryItem
             label={
               <span className="inline-flex items-center gap-1">
@@ -144,7 +151,6 @@ export const DeploymentDetailHeader: FC<DeploymentDetailHeaderProps> = ({ deploy
               <span className="text-muted-foreground">Off</span>
             )}
           </SummaryItem>
-          <SummaryItem label="GPU">{deployment.gpuAmount ? deployment.gpuAmount : "—"}</SummaryItem>
           <SummaryItem label="vCPU">{roundDecimal(deployment.cpuAmount, 2)}</SummaryItem>
           <SummaryItem label="MEMORY">{`${roundDecimal(memory.value, 2)} ${memory.unit}`}</SummaryItem>
           <SummaryItem label="STORAGE">{`${roundDecimal(storage.value, 2)} ${storage.unit}`}</SummaryItem>

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.tsx
@@ -1,10 +1,9 @@
 "use client";
 import type { FC, ReactNode } from "react";
 import { useMemo } from "react";
-import { Badge, Button, buttonVariants, Card, CardContent, CustomTooltip } from "@akashnetwork/ui/components";
+import { Badge, Button, Card, CardContent, CustomTooltip } from "@akashnetwork/ui/components";
 import { cn } from "@akashnetwork/ui/utils";
-import { CheckCircle, EditPencil, Globe, InfoCircle } from "iconoir-react";
-import Link from "next/link";
+import { CheckCircle, EditPencil, InfoCircle } from "iconoir-react";
 
 import { useLocalNotes } from "@src/components/LocalNoteManager";
 import { ConfidentialComputeBadge } from "@src/components/shared/ConfidentialComputeBadge";
@@ -16,8 +15,6 @@ import { useDeclaredGpuInterconnect } from "@src/hooks/useDeclaredGpuInterconnec
 import { useDeclaredTeeTypes } from "@src/hooks/useDeclaredTeeTypes";
 import { useWalletBalance } from "@src/hooks/useWalletBalance";
 import { useDeploymentSettingQuery } from "@src/queries/deploymentSettingsQuery";
-import type { LeaseStatusDto } from "@src/queries/useLeaseQuery";
-import { useLeaseStatus } from "@src/queries/useLeaseQuery";
 import type { DeploymentDto, LeaseDto } from "@src/types/deployment";
 import type { ApiProviderList } from "@src/types/provider";
 import { getEscrowDenom } from "@src/utils/deploymentUtils";
@@ -31,6 +28,7 @@ import {
   parseManifestServices,
   parseServicesByPlacement
 } from "./DeploymentPlacements/placementModel";
+import { DeploymentVisitControl } from "./DeploymentVisitControl/DeploymentVisitControl";
 import { DeploymentStatusBadge } from "./DeploymentStatusBadge";
 
 export const DEPENDENCIES = {
@@ -40,8 +38,8 @@ export const DEPENDENCIES = {
   useDeploymentSettingQuery,
   useDeclaredTeeTypes,
   useDeclaredGpuInterconnect,
-  useLeaseStatus,
   CostRate,
+  DeploymentVisitControl,
   CustomTooltip,
   ConfidentialComputeBadge,
   GpuInterconnectBadge,
@@ -74,10 +72,6 @@ export const DeploymentDetailHeader: FC<DeploymentDetailHeaderProps> = ({ deploy
   const costPerBlockUDenom = liveLeases.reduce((sum, lease) => sum + parseFloat(lease.price.amount), 0);
   const liveGpuCount = liveLeases.reduce((sum, lease) => sum + (lease.gpuAmount ?? 0), 0);
 
-  const liveLease = liveLeases[0] ?? null;
-  const provider = providers.find(p => p.owner === liveLease?.provider) ?? null;
-  const { data: leaseStatus } = d.useLeaseStatus({ provider, lease: liveLease, enabled: !!provider });
-
   const storedDeployment = getDeploymentData(deployment.dseq);
   const storedManifest = storedDeployment?.manifest;
   const manifestServices = useMemo(() => parseManifestServices(storedManifest), [storedManifest]);
@@ -86,7 +80,6 @@ export const DeploymentDetailHeader: FC<DeploymentDetailHeaderProps> = ({ deploy
   const name = getDeploymentName(deployment.dseq) || `Deployment #${deployment.dseq}`;
   const denom = getEscrowDenom(deployment);
   const servicesCount = countPlacementServices(leases ?? [], servicesByPlacement, manifestServices);
-  const primaryUri = getPrimaryUri(leaseStatus);
   const memory = bytesToShrink(deployment.memoryAmount);
   const storage = bytesToShrink(deployment.storageAmount);
 
@@ -111,17 +104,7 @@ export const DeploymentDetailHeader: FC<DeploymentDetailHeaderProps> = ({ deploy
             <EditPencil className="h-4 w-4" />
           </Button>
         </div>
-        {primaryUri && (
-          <div className="flex items-center gap-2">
-            <div className="inline-flex max-w-xs items-center gap-2 rounded-md border px-3 py-2 text-sm">
-              <Globe className="shrink-0 text-xs text-muted-foreground" />
-              <span className="truncate">{primaryUri}</span>
-            </div>
-            <Link href={`http://${primaryUri}`} target="_blank" rel="noreferrer" className={cn(buttonVariants({ variant: "default", size: "md" }))}>
-              Visit
-            </Link>
-          </div>
-        )}
+        <d.DeploymentVisitControl leases={leases ?? []} providers={providers} />
       </div>
 
       <Card className="w-full shrink-0 lg:w-auto">
@@ -166,15 +149,3 @@ const SummaryItem: FC<{ label: ReactNode; children: ReactNode }> = ({ label, chi
     <div className="whitespace-nowrap text-sm font-medium">{children}</div>
   </div>
 );
-
-function getPrimaryUri(leaseStatus: LeaseStatusDto | null | undefined): string | undefined {
-  if (!leaseStatus) return undefined;
-
-  const uri = Object.values(leaseStatus.services).flatMap(service => service.uris ?? [])[0];
-  if (uri) return uri;
-
-  const forwarded = Object.values(leaseStatus.forwarded_ports ?? {})
-    .flat()
-    .find(port => port.host);
-  return forwarded ? `${forwarded.host}:${forwarded.externalPort}` : undefined;
-}

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.tsx
@@ -131,7 +131,6 @@ export const DeploymentDetailHeader: FC<DeploymentDetailHeaderProps> = ({ deploy
             {costPerBlockUDenom ? <d.CostRate perBlockUDenom={costPerBlockUDenom} denom={denom} gpuCount={liveGpuCount} /> : "—"}
           </SummaryItem>
           <SummaryItem label="BALANCE">{walletBalance ? `$${walletBalance.totalUsd.toFixed(2)}` : "—"}</SummaryItem>
-          <SummaryItem label="GPU">{formatGpuLabel(deployment.gpuAmount ?? 0, getDeploymentGpuModels(deployment.groups))}</SummaryItem>
           <SummaryItem
             label={
               <span className="inline-flex items-center gap-1">
@@ -151,6 +150,7 @@ export const DeploymentDetailHeader: FC<DeploymentDetailHeaderProps> = ({ deploy
               <span className="text-muted-foreground">Off</span>
             )}
           </SummaryItem>
+          <SummaryItem label="GPU">{formatGpuLabel(deployment.gpuAmount ?? 0, getDeploymentGpuModels(deployment.groups))}</SummaryItem>
           <SummaryItem label="vCPU">{roundDecimal(deployment.cpuAmount, 2)}</SummaryItem>
           <SummaryItem label="MEMORY">{`${roundDecimal(memory.value, 2)} ${memory.unit}`}</SummaryItem>
           <SummaryItem label="STORAGE">{`${roundDecimal(storage.value, 2)} ${storage.unit}`}</SummaryItem>

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/DeploymentPlacements.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/DeploymentPlacements.spec.tsx
@@ -36,6 +36,7 @@ describe(DeploymentPlacements.name, () => {
     const manifest = yaml.dump({ services: { web: {}, api: {}, worker: {} } });
     setup({ leases: [buildLease("a"), buildLease("b")], deploymentManifest: manifest });
 
+    expect(screen.getByRole("heading", { name: "Placements" })).toBeInTheDocument();
     expect(screen.getByText("2 placements · 3 services")).toBeInTheDocument();
   });
 

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/DeploymentPlacements.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/DeploymentPlacements.tsx
@@ -37,7 +37,7 @@ export const DeploymentPlacements: FC<DeploymentPlacementsProps> = ({
   const serviceCount = countPlacementServices(leases, servicesByPlacement, manifestServices);
 
   return (
-    <div className="space-y-4">
+    <div>
       <DeploymentTabHeader
         title="Placements"
         actions={
@@ -47,18 +47,20 @@ export const DeploymentPlacements: FC<DeploymentPlacementsProps> = ({
         }
       />
 
-      {leases.map((lease, index) => (
-        <d.PlacementCard
-          key={lease.id}
-          index={index}
-          lease={lease}
-          provider={providers.find(provider => provider.owner === lease.provider)}
-          manifestServices={manifestServices}
-          placementServices={servicesByPlacement[getPlacementName(lease.group, index)]}
-          dseq={dseq}
-          onClosed={onClosed}
-        />
-      ))}
+      <div className="space-y-4">
+        {leases.map((lease, index) => (
+          <d.PlacementCard
+            key={lease.id}
+            index={index}
+            lease={lease}
+            provider={providers.find(provider => provider.owner === lease.provider)}
+            manifestServices={manifestServices}
+            placementServices={servicesByPlacement[getPlacementName(lease.group, index)]}
+            dseq={dseq}
+            onClosed={onClosed}
+          />
+        ))}
+      </div>
     </div>
   );
 };

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/DeploymentPlacements.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/DeploymentPlacements.tsx
@@ -37,7 +37,7 @@ export const DeploymentPlacements: FC<DeploymentPlacementsProps> = ({
   const serviceCount = countPlacementServices(leases, servicesByPlacement, manifestServices);
 
   return (
-    <div>
+    <div className="space-y-4">
       <DeploymentTabHeader
         title="Placements"
         actions={

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/DeploymentPlacements.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/DeploymentPlacements.tsx
@@ -36,8 +36,8 @@ export const DeploymentPlacements: FC<DeploymentPlacementsProps> = ({
   const serviceCount = countPlacementServices(leases, servicesByPlacement, manifestServices);
 
   return (
-    <div className="space-y-4">
-      <div className="flex items-center justify-between py-3 text-xs font-medium text-muted-foreground">
+    <div className="space-y-3">
+      <div className="flex items-center justify-between text-xs font-medium text-muted-foreground">
         <span className="uppercase tracking-wide">Placements</span>
         <span>
           {leases.length} {pluralize("placement", leases.length)} · {serviceCount} {pluralize("service", serviceCount)}

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/DeploymentPlacements.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/DeploymentPlacements.tsx
@@ -4,6 +4,7 @@ import { useMemo } from "react";
 
 import type { LeaseDto } from "@src/types/deployment";
 import type { ApiProviderList } from "@src/types/provider";
+import { DeploymentTabHeader } from "../DeploymentTabHeader";
 import { PlacementCard } from "./PlacementCard";
 import { countPlacementServices, getPlacementName, parseManifestServices, parseServicesByPlacement } from "./placementModel";
 
@@ -36,13 +37,15 @@ export const DeploymentPlacements: FC<DeploymentPlacementsProps> = ({
   const serviceCount = countPlacementServices(leases, servicesByPlacement, manifestServices);
 
   return (
-    <div className="space-y-3">
-      <div className="flex items-center justify-between text-xs font-medium text-muted-foreground">
-        <span className="uppercase tracking-wide">Placements</span>
-        <span>
-          {leases.length} {pluralize("placement", leases.length)} · {serviceCount} {pluralize("service", serviceCount)}
-        </span>
-      </div>
+    <div>
+      <DeploymentTabHeader
+        title="Placements"
+        actions={
+          <span className="text-sm text-muted-foreground">
+            {leases.length} {pluralize("placement", leases.length)} · {serviceCount} {pluralize("service", serviceCount)}
+          </span>
+        }
+      />
 
       {leases.map((lease, index) => (
         <d.PlacementCard

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.spec.tsx
@@ -79,6 +79,12 @@ describe(PlacementCard.name, () => {
     expect(screen.queryByRole("button", { name: /expand all/i })).not.toBeInTheDocument();
   });
 
+  it("hides expand all when the lease has been reclaimed while still active", () => {
+    setup({ lease: buildLease({ groupState: "paused" }) });
+
+    expect(screen.queryByRole("button", { name: /expand all/i })).not.toBeInTheDocument();
+  });
+
   it("renders one service row per live service reported by the lease status", () => {
     const PlacementServiceRow = vi.fn(() => <div>service-row</div>);
     setup({ leaseStatus: buildStatus(["web", "api"]), dependencies: { PlacementServiceRow } });

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.spec.tsx
@@ -46,7 +46,7 @@ describe(PlacementCard.name, () => {
       })
     });
 
-    expect(screen.getByText("1× H100")).toBeInTheDocument();
+    expect(screen.getByText("H100")).toBeInTheDocument();
   });
 
   it("expands every service when Expand all is clicked", async () => {

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.spec.tsx
@@ -38,6 +38,17 @@ describe(PlacementCard.name, () => {
     expect(screen.getByText("GPU")).toBeInTheDocument();
   });
 
+  it("shows the gpu count and model when the lease declares one", () => {
+    setup({
+      lease: buildLease({
+        gpuAmount: 1,
+        gpuAttributes: [{ key: "vendor/nvidia/model/h100", value: "true" }]
+      })
+    });
+
+    expect(screen.getByText("1× H100")).toBeInTheDocument();
+  });
+
   it("expands every service when Expand all is clicked", async () => {
     setup({
       leaseStatus: buildStatus(["web", "api"], {
@@ -108,7 +119,13 @@ describe(PlacementCard.name, () => {
     expect(screen.queryByText("Reclaiming")).not.toBeInTheDocument();
   });
 
-  function buildLease(input?: { groupName?: string; state?: string; groupState?: string; gpuAmount?: number }) {
+  function buildLease(input?: {
+    groupName?: string;
+    state?: string;
+    groupState?: string;
+    gpuAmount?: number;
+    gpuAttributes?: { key: string; value: string }[];
+  }) {
     return mock<LeaseDto>({
       id: "1",
       provider: "akash1p",
@@ -122,7 +139,7 @@ describe(PlacementCard.name, () => {
         group_spec: {
           name: input?.groupName ?? "dcloud",
           requirements: { attributes: [] as { key: string; value: string }[] },
-          resources: [] as DeploymentGroup["group_spec"]["resources"]
+          resources: input?.gpuAttributes ? [{ resource: { gpu: { attributes: input.gpuAttributes } } }] : ([] as DeploymentGroup["group_spec"]["resources"])
         }
       } as Partial<DeploymentGroup>)
     });

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.spec.tsx
@@ -22,7 +22,7 @@ describe(PlacementCard.name, () => {
     expect(screen.getByRole("heading", { name: "dcloud" })).toBeInTheDocument();
     expect(screen.getByLabelText("Placement 1")).toBeInTheDocument();
     expect(screen.getByText("us-east")).toBeInTheDocument();
-    expect(screen.getByText("Meridian Cloud")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Meridian Cloud/ })).toHaveAttribute("href", expect.stringContaining("/providers/akash1p"));
   });
 
   it("omits the GPU stat when the lease requests no GPU", () => {
@@ -69,8 +69,14 @@ describe(PlacementCard.name, () => {
   it("hides the region when the provider has not declared one", () => {
     setup({ provider: buildProvider() });
 
-    expect(screen.getByText("Meridian Cloud")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Meridian Cloud/ })).toBeInTheDocument();
     expect(screen.queryByText("us-east")).not.toBeInTheDocument();
+  });
+
+  it("hides expand all when the lease is closed", () => {
+    setup({ lease: buildLease({ state: "closed" }), leaseStatus: null });
+
+    expect(screen.queryByRole("button", { name: /expand all/i })).not.toBeInTheDocument();
   });
 
   it("renders one service row per live service reported by the lease status", () => {

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.spec.tsx
@@ -1,13 +1,15 @@
+import { TooltipProvider } from "@akashnetwork/ui/components";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
-import type { LeaseServiceStatus, LeaseStatusDto } from "@src/queries/useLeaseQuery";
+import type { ForwardedPort, LeaseServiceStatus, LeaseStatusDto } from "@src/queries/useLeaseQuery";
 import type { DeploymentGroup, LeaseDto } from "@src/types/deployment";
 import type { ApiProviderList } from "@src/types/provider";
 import { DEPENDENCIES, PlacementCard } from "./PlacementCard";
 import type { ManifestServiceDetail } from "./placementModel";
 
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MockComponents } from "@tests/unit/mocks";
 
 describe(PlacementCard.name, () => {
@@ -18,8 +20,39 @@ describe(PlacementCard.name, () => {
     });
 
     expect(screen.getByRole("heading", { name: "dcloud" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Placement 1")).toBeInTheDocument();
     expect(screen.getByText("us-east")).toBeInTheDocument();
     expect(screen.getByText("Meridian Cloud")).toBeInTheDocument();
+  });
+
+  it("omits the GPU stat when the lease requests no GPU", () => {
+    setup();
+
+    expect(screen.getByText("vCPU")).toBeInTheDocument();
+    expect(screen.queryByText("GPU")).not.toBeInTheDocument();
+  });
+
+  it("shows the GPU stat when the lease requests a GPU", () => {
+    setup({ lease: buildLease({ gpuAmount: 1 }) });
+
+    expect(screen.getByText("GPU")).toBeInTheDocument();
+  });
+
+  it("expands every service when Expand all is clicked", async () => {
+    setup({
+      leaseStatus: buildStatus(["web", "api"], {
+        web: [{ host: "provider.io", externalPort: 30000, port: 80, available: 1 }],
+        api: [{ host: "provider.io", externalPort: 30001, port: 8080, available: 1 }]
+      }),
+      dependencies: { PlacementServiceRow: DEPENDENCIES.PlacementServiceRow }
+    });
+
+    expect(screen.queryByText("Ports")).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /expand all/i }));
+
+    expect(screen.getAllByText("Ports")).toHaveLength(2);
+    expect(screen.getByRole("button", { name: /collapse all/i })).toBeInTheDocument();
   });
 
   it("hides the region when the provider has not declared one", () => {
@@ -75,13 +108,13 @@ describe(PlacementCard.name, () => {
     expect(screen.queryByText("Reclaiming")).not.toBeInTheDocument();
   });
 
-  function buildLease(input?: { groupName?: string; state?: string; groupState?: string }) {
+  function buildLease(input?: { groupName?: string; state?: string; groupState?: string; gpuAmount?: number }) {
     return mock<LeaseDto>({
       id: "1",
       provider: "akash1p",
       state: input?.state ?? "active",
       cpuAmount: 6,
-      gpuAmount: 0,
+      gpuAmount: input?.gpuAmount ?? 0,
       memoryAmount: 1_000_000,
       storageAmount: 2_000_000,
       group: mock<DeploymentGroup>({
@@ -95,10 +128,10 @@ describe(PlacementCard.name, () => {
     });
   }
 
-  function buildStatus(serviceNames: string[]) {
+  function buildStatus(serviceNames: string[], forwardedPorts: Record<string, ForwardedPort[]> = {}) {
     return mock<LeaseStatusDto>({
-      services: Object.fromEntries(serviceNames.map(name => [name, mock<LeaseServiceStatus>({ name, available: 1 })])),
-      forwarded_ports: {},
+      services: Object.fromEntries(serviceNames.map(name => [name, mock<LeaseServiceStatus>({ name, available: 1, uris: [] })])),
+      forwarded_ports: forwardedPorts,
       ips: {}
     });
   }
@@ -125,16 +158,18 @@ describe(PlacementCard.name, () => {
     const useTeeResourceCarveouts: typeof DEPENDENCIES.useTeeResourceCarveouts = () => [];
 
     return render(
-      <PlacementCard
-        index={0}
-        lease={input?.lease ?? buildLease()}
-        provider={input?.provider ?? buildProvider()}
-        manifestServices={input?.manifestServices ?? {}}
-        placementServices={input?.placementServices}
-        dseq="123"
-        onClosed={vi.fn()}
-        dependencies={MockComponents(DEPENDENCIES, { useLeaseStatus, useTeeResourceCarveouts, ...input?.dependencies })}
-      />
+      <TooltipProvider>
+        <PlacementCard
+          index={0}
+          lease={input?.lease ?? buildLease()}
+          provider={input?.provider ?? buildProvider()}
+          manifestServices={input?.manifestServices ?? {}}
+          placementServices={input?.placementServices}
+          dseq="123"
+          onClosed={vi.fn()}
+          dependencies={MockComponents(DEPENDENCIES, { useLeaseStatus, useTeeResourceCarveouts, ...input?.dependencies })}
+        />
+      </TooltipProvider>
     );
   }
 });

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.tsx
@@ -151,6 +151,7 @@ export const PlacementCard: FC<PlacementCardProps> = ({
                 service={leaseStatus?.services?.[serviceName]}
                 leaseState={lease.state}
                 isReclaimed={isReclaimed}
+                detail={services[serviceName]}
                 uris={leaseStatus?.services?.[serviceName]?.uris}
                 forwardedPorts={leaseStatus?.forwarded_ports?.[serviceName]}
                 ips={leaseStatus?.ips?.[serviceName]}

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 import type { FC } from "react";
+import { useState } from "react";
 import { MapPin, NavArrowRight, Server } from "iconoir-react";
 
 import { useTeeResourceCarveouts } from "@src/hooks/useTeeResourceCarveouts";
@@ -55,6 +56,7 @@ export const PlacementCard: FC<PlacementCardProps> = ({
   const isLeaseActive = isLeaseLive(lease);
   const { data: leaseStatus } = d.useLeaseStatus({ provider, lease, enabled: isLeaseActive && !!provider, refetchInterval: 30_000 });
   const carveouts = d.useTeeResourceCarveouts(lease);
+  const [expanded, setExpanded] = useState<ReadonlySet<string>>(() => new Set());
 
   const isReclaimed = isProviderReclaimed(lease);
   const teeType = getGroupTeeType(lease.group);
@@ -64,12 +66,32 @@ export const PlacementCard: FC<PlacementCardProps> = ({
   const services = placementServices ?? manifestServices;
   const serviceNames = leaseStatus ? Object.keys(leaseStatus.services) : Object.keys(services);
   const providerName = provider ? providerDisplayName(provider) : undefined;
+  const allExpanded = serviceNames.length > 0 && serviceNames.every(serviceName => expanded.has(serviceName));
+
+  function toggleAll() {
+    setExpanded(allExpanded ? new Set() : new Set(serviceNames));
+  }
+
+  function handleOpenChange(serviceName: string, next: boolean) {
+    setExpanded(current => {
+      const nextSet = new Set(current);
+      if (next) nextSet.add(serviceName);
+      else nextSet.delete(serviceName);
+      return nextSet;
+    });
+  }
 
   return (
     <div className="rounded-xl border bg-card">
       <div className="flex flex-col gap-6 border-b p-6 lg:flex-row lg:items-start lg:justify-between">
         <div className="space-y-4">
           <div className="flex flex-wrap items-center gap-3">
+            <div
+              aria-label={`Placement ${index + 1}`}
+              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-muted text-sm font-medium text-muted-foreground"
+            >
+              {index + 1}
+            </div>
             <h3 className="text-2xl font-medium tracking-tight">{name}</h3>
             {isReclaiming(lease) && <StatusBadge label="Reclaiming" tone="warning" />}
           </div>
@@ -91,7 +113,7 @@ export const PlacementCard: FC<PlacementCardProps> = ({
             </div>
           )}
         </div>
-        <div className="w-full lg:max-w-2xl">
+        <div className="lg:shrink-0">
           <PlacementStats stats={buildPlacementStats(lease, serviceNames.length, gpuModels)} />
         </div>
       </div>
@@ -104,23 +126,37 @@ export const PlacementCard: FC<PlacementCardProps> = ({
         </div>
       )}
 
-      <div className="space-y-2 p-6">
+      <div className="p-6">
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            <span>Services in this placement</span>
+            <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-muted px-1.5 text-[11px]">{serviceNames.length}</span>
+          </div>
+          {serviceNames.length > 0 && (
+            <button type="button" className="text-xs text-muted-foreground hover:text-foreground" onClick={toggleAll}>
+              {allExpanded ? "Collapse all" : "Expand all"}
+            </button>
+          )}
+        </div>
         {serviceNames.length === 0 ? (
           <p className="text-sm text-muted-foreground">No services found for this placement.</p>
         ) : (
-          serviceNames.map(serviceName => (
-            <d.PlacementServiceRow
-              key={serviceName}
-              serviceName={serviceName}
-              service={leaseStatus?.services?.[serviceName]}
-              leaseState={lease.state}
-              isReclaimed={isReclaimed}
-              detail={services[serviceName]}
-              uris={leaseStatus?.services?.[serviceName]?.uris}
-              forwardedPorts={leaseStatus?.forwarded_ports?.[serviceName]}
-              ips={leaseStatus?.ips?.[serviceName]}
-            />
-          ))
+          <div className="space-y-2">
+            {serviceNames.map(serviceName => (
+              <d.PlacementServiceRow
+                key={serviceName}
+                serviceName={serviceName}
+                service={leaseStatus?.services?.[serviceName]}
+                leaseState={lease.state}
+                isReclaimed={isReclaimed}
+                uris={leaseStatus?.services?.[serviceName]?.uris}
+                forwardedPorts={leaseStatus?.forwarded_ports?.[serviceName]}
+                ips={leaseStatus?.ips?.[serviceName]}
+                open={expanded.has(serviceName)}
+                onOpenChange={next => handleOpenChange(serviceName, next)}
+              />
+            ))}
+          </div>
         )}
       </div>
     </div>
@@ -130,17 +166,18 @@ export const PlacementCard: FC<PlacementCardProps> = ({
 function buildPlacementStats(lease: LeaseDto, serviceCount: number, gpuModels: string[]): PlacementStat[] {
   const memory = bytesToShrink(lease.memoryAmount);
   const storage = bytesToShrink(lease.storageAmount);
-
-  return [
-    { label: "Services", value: serviceCount },
-    { label: "GPU", value: formatGpu(lease.gpuAmount, gpuModels) },
+  const stats: PlacementStat[] = [
     { label: "vCPU", value: roundDecimal(lease.cpuAmount, 2) },
     { label: "Memory", value: `${roundDecimal(memory.value, 2)} ${memory.unit}` },
     { label: "Storage", value: `${roundDecimal(storage.value, 2)} ${storage.unit}` }
   ];
+  if (lease.gpuAmount && lease.gpuAmount > 0) {
+    stats.push({ label: "GPU", value: formatGpu(lease.gpuAmount, gpuModels) });
+  }
+  stats.push({ label: "Services", value: serviceCount });
+  return stats;
 }
 
-function formatGpu(gpuAmount: number | undefined, gpuModels: string[]): string | number {
-  if (!gpuAmount || gpuAmount <= 0) return "--";
+function formatGpu(gpuAmount: number, gpuModels: string[]): string | number {
   return gpuModels.length > 0 ? gpuModels.map(model => model.toUpperCase()).join(", ") : gpuAmount;
 }

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.tsx
@@ -134,7 +134,7 @@ export const PlacementCard: FC<PlacementCardProps> = ({
             <span>Services in this placement</span>
             <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-muted px-1.5 text-[11px]">{serviceNames.length}</span>
           </div>
-          {isLeaseActive && serviceNames.length > 0 && (
+          {isLeaseActive && !isReclaimed && serviceNames.length > 0 && (
             <button type="button" className="text-xs text-muted-foreground hover:text-foreground" onClick={toggleAll}>
               {allExpanded ? "Collapse all" : "Expand all"}
             </button>

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.tsx
@@ -2,6 +2,7 @@
 import type { FC } from "react";
 import { useState } from "react";
 import { MapPin, NavArrowRight, Server } from "iconoir-react";
+import Link from "next/link";
 
 import { useTeeResourceCarveouts } from "@src/hooks/useTeeResourceCarveouts";
 import { useLeaseStatus } from "@src/queries/useLeaseQuery";
@@ -13,6 +14,7 @@ import { roundDecimal } from "@src/utils/mathHelpers";
 import { providerDisplayName } from "@src/utils/providerUtils";
 import { isProviderReclaimed, isReclaiming } from "@src/utils/reclamationUtils";
 import { bytesToShrink } from "@src/utils/unitUtils";
+import { UrlService } from "@src/utils/urlUtils";
 import { ConfidentialComputeResources } from "../../ConfidentialComputeResources";
 import { DownloadAttestationEvidence } from "../../DownloadAttestationEvidence";
 import { ReclamationCard } from "../../ReclamationCard/ReclamationCard";
@@ -104,11 +106,11 @@ export const PlacementCard: FC<PlacementCardProps> = ({
                 </span>
               )}
               {region && providerName && <NavArrowRight className="h-3 w-3" />}
-              {providerName && (
-                <span className="inline-flex items-center gap-2">
+              {providerName && provider && (
+                <Link href={UrlService.providerDetail(provider.owner)} className="inline-flex items-center gap-2 hover:text-foreground">
                   <Server className="h-3 w-3" />
                   {providerName}
-                </span>
+                </Link>
               )}
             </div>
           )}
@@ -132,7 +134,7 @@ export const PlacementCard: FC<PlacementCardProps> = ({
             <span>Services in this placement</span>
             <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-muted px-1.5 text-[11px]">{serviceNames.length}</span>
           </div>
-          {serviceNames.length > 0 && (
+          {isLeaseActive && serviceNames.length > 0 && (
             <button type="button" className="text-xs text-muted-foreground hover:text-foreground" onClick={toggleAll}>
               {allExpanded ? "Collapse all" : "Expand all"}
             </button>

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.tsx
@@ -18,7 +18,7 @@ import { DownloadAttestationEvidence } from "../../DownloadAttestationEvidence";
 import { ReclamationCard } from "../../ReclamationCard/ReclamationCard";
 import { StatusBadge } from "../DeploymentStatusBadge";
 import type { ManifestServiceDetail } from "./placementModel";
-import { getPlacementGpuModels, getPlacementName, getProviderRegion } from "./placementModel";
+import { formatGpuLabel, getPlacementGpuModels, getPlacementName, getProviderRegion } from "./placementModel";
 import { PlacementServiceRow } from "./PlacementServiceRow";
 import type { PlacementStat } from "./PlacementStats";
 import { PlacementStats } from "./PlacementStats";
@@ -172,12 +172,8 @@ function buildPlacementStats(lease: LeaseDto, serviceCount: number, gpuModels: s
     { label: "Storage", value: `${roundDecimal(storage.value, 2)} ${storage.unit}` }
   ];
   if (lease.gpuAmount && lease.gpuAmount > 0) {
-    stats.push({ label: "GPU", value: formatGpu(lease.gpuAmount, gpuModels) });
+    stats.push({ label: "GPU", value: formatGpuLabel(lease.gpuAmount, gpuModels) });
   }
   stats.push({ label: "Services", value: serviceCount });
   return stats;
-}
-
-function formatGpu(gpuAmount: number, gpuModels: string[]): string | number {
-  return gpuModels.length > 0 ? gpuModels.map(model => model.toUpperCase()).join(", ") : gpuAmount;
 }

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementServiceRow.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementServiceRow.spec.tsx
@@ -69,11 +69,21 @@ describe(PlacementServiceRow.name, () => {
     expect(screen.queryByRole("link", { name: /app\.example\.com/ })).not.toBeInTheDocument();
   });
 
-  it("omits the ports row when there are no live endpoints", async () => {
+  it("is not expandable when there are no live endpoints", () => {
     setup({});
 
-    await expandService();
+    expect(screen.queryByRole("button", { name: /web/ })).not.toBeInTheDocument();
+    expect(screen.queryByText("Ports")).not.toBeInTheDocument();
+  });
 
+  it("is not expandable when the lease is closed", () => {
+    setup({
+      leaseState: "closed",
+      forwardedPorts: [{ host: "provider.io", externalPort: 30000, port: 80, available: 1 }]
+    });
+
+    expect(screen.getByText("Closed")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /web/ })).not.toBeInTheDocument();
     expect(screen.queryByText("Ports")).not.toBeInTheDocument();
   });
 

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementServiceRow.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementServiceRow.spec.tsx
@@ -29,77 +29,52 @@ describe(PlacementServiceRow.name, () => {
     expect(screen.queryByText("Running")).not.toBeInTheDocument();
   });
 
-  it("keeps the service contents collapsed until the row is expanded", async () => {
-    setup({ detail: { resources: { gpuUnits: 0, memory: { value: 36, unit: "Gi" } } } });
+  it("shows the service URI in the collapsed header", () => {
+    setup({ uris: ["shop.example.com"] });
 
-    expect(screen.queryByText("36 Gi")).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /shop\.example\.com/ })).toHaveAttribute("href", "http://shop.example.com");
+  });
+
+  it("shows the replica count in the collapsed header", () => {
+    setup({ service: mock<LeaseServiceStatus>({ available: 2, total: 3 }) });
+
+    expect(screen.getByText("2/3 replicas")).toBeInTheDocument();
+  });
+
+  it("keeps forwarded ports collapsed until the row is expanded", async () => {
+    setup({ forwardedPorts: [{ host: "provider.io", externalPort: 30000, port: 80, available: 1 }] });
+
+    expect(screen.queryByText("Ports")).not.toBeInTheDocument();
 
     await expandService();
 
-    expect(screen.getByText("Memory")).toBeInTheDocument();
-    expect(screen.getByText("36 Gi")).toBeInTheDocument();
+    expect(screen.getByText("Ports")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /80/ })).toHaveAttribute("href", "http://provider.io:30000");
   });
 
-  it("lists the service endpoints when expanded", async () => {
-    setup({ uris: ["app.example.com"] });
+  it("keeps the service collapsed when a URI link is clicked", async () => {
+    setup({
+      uris: ["app.example.com"],
+      forwardedPorts: [{ host: "provider.io", externalPort: 30000, port: 80, available: 1 }]
+    });
 
-    await expandService();
+    await userEvent.click(screen.getByRole("link", { name: /app\.example\.com/ }));
 
-    expect(screen.getByRole("link", { name: /app\.example\.com/ })).toHaveAttribute("href", "http://app.example.com");
+    expect(screen.queryByText("Ports")).not.toBeInTheDocument();
   });
 
-  it("hides the service endpoints once the lease is no longer live", async () => {
+  it("hides the service URI once the lease is no longer live", () => {
     setup({ uris: ["app.example.com"], leaseState: "closed" });
 
-    await expandService();
-
     expect(screen.queryByRole("link", { name: /app\.example\.com/ })).not.toBeInTheDocument();
-    expect(screen.getByText("None")).toBeInTheDocument();
   });
 
-  it("shows a None placeholder for Expose Ports when there are no endpoints", async () => {
+  it("omits the ports row when there are no live endpoints", async () => {
     setup({});
 
     await expandService();
 
-    expect(screen.getByText("Expose Ports")).toBeInTheDocument();
-    expect(screen.getByText("None")).toBeInTheDocument();
-  });
-
-  it("shows a None placeholder when the provider reports null endpoint collections", async () => {
-    setup({ uris: null, forwardedPorts: null, ips: null });
-
-    await expandService();
-
-    expect(screen.getByText("Expose Ports")).toBeInTheDocument();
-    expect(screen.getByText("None")).toBeInTheDocument();
-  });
-
-  it("shows the Docker image row when an image is known", async () => {
-    setup({ detail: { image: "nginx:1.25" } });
-
-    await expandService();
-
-    expect(screen.getByText("Docker image")).toBeInTheDocument();
-  });
-
-  it("shows environment variables and commands when present", async () => {
-    setup({ detail: { env: [{ key: "KEY", value: "value" }], command: "sh -c echo hi" } });
-
-    await expandService();
-
-    expect(screen.getByText("Environment Variables")).toBeInTheDocument();
-    expect(screen.getByText("KEY=value")).toBeInTheDocument();
-    expect(screen.getByText("Commands")).toBeInTheDocument();
-    expect(screen.getByText("sh -c echo hi")).toBeInTheDocument();
-  });
-
-  it("omits the Docker image row when no image is known", async () => {
-    setup({ detail: {} });
-
-    await expandService();
-
-    expect(screen.queryByText("Docker image")).not.toBeInTheDocument();
+    expect(screen.queryByText("Ports")).not.toBeInTheDocument();
   });
 
   function expandService() {

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementServiceRow.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementServiceRow.spec.tsx
@@ -26,7 +26,9 @@ describe(PlacementServiceRow.name, () => {
   it("reports loading when lease status has not arrived", () => {
     setup({ leaseState: "active" });
 
-    expect(screen.getByText("Loading")).toBeInTheDocument();
+    const badge = screen.getByText("Loading");
+    expect(badge).toBeInTheDocument();
+    expect(badge.querySelector(".animate-spin")).toBeInTheDocument();
   });
 
   it("reports a closed service when the lease has been reclaimed while still active", () => {

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementServiceRow.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementServiceRow.spec.tsx
@@ -69,11 +69,47 @@ describe(PlacementServiceRow.name, () => {
     expect(screen.queryByRole("link", { name: /app\.example\.com/ })).not.toBeInTheDocument();
   });
 
-  it("is not expandable when there are no live endpoints", () => {
-    setup({});
+  it("expands a running service even without live endpoints", async () => {
+    setup({ service: mock<LeaseServiceStatus>({ available: 1 }), leaseState: "active" });
 
-    expect(screen.queryByRole("button", { name: /web/ })).not.toBeInTheDocument();
-    expect(screen.queryByText("Ports")).not.toBeInTheDocument();
+    await expandService();
+
+    expect(screen.getByRole("button", { name: /web/ })).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("shows image and resources when expanded", async () => {
+    setup({
+      detail: {
+        image: "ghcr.io/acmecorp/llm-gateway:0.9.4",
+        resources: { gpuUnits: 0, cpu: 1, memory: { value: 2, unit: "Gi" }, storage: { value: 10, unit: "Gi" } }
+      }
+    });
+
+    await expandService();
+
+    expect(screen.getByText("Image")).toBeInTheDocument();
+    expect(screen.getByText("ghcr.io/acmecorp/llm-gateway:0.9.4")).toBeInTheDocument();
+    expect(screen.getByText("vCPU")).toBeInTheDocument();
+    expect(screen.getByText("Memory")).toBeInTheDocument();
+    expect(screen.getByText("2 Gi")).toBeInTheDocument();
+    expect(screen.getByText("Storage")).toBeInTheDocument();
+  });
+
+  it("does not show env vars or command", async () => {
+    setup({
+      detail: {
+        image: "nginx:1.25",
+        env: [{ key: "API_KEY", value: "secret" }],
+        command: "sh -c echo hi"
+      }
+    });
+
+    await expandService();
+
+    expect(screen.queryByText("Env vars")).not.toBeInTheDocument();
+    expect(screen.queryByText("Command")).not.toBeInTheDocument();
+    expect(screen.queryByText("API_KEY")).not.toBeInTheDocument();
+    expect(screen.queryByText("sh -c echo hi")).not.toBeInTheDocument();
   });
 
   it("is not expandable when the lease is closed", () => {

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementServiceRow.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementServiceRow.spec.tsx
@@ -22,6 +22,12 @@ describe(PlacementServiceRow.name, () => {
     expect(screen.getByText("Starting")).toBeInTheDocument();
   });
 
+  it("reports loading when lease status has not arrived", () => {
+    setup({ leaseState: "active" });
+
+    expect(screen.getByText("Loading")).toBeInTheDocument();
+  });
+
   it("reports a closed service when the lease has been reclaimed while still active", () => {
     setup({ service: mock<LeaseServiceStatus>({ available: 1 }), leaseState: "active", isReclaimed: true });
 

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementServiceRow.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementServiceRow.spec.tsx
@@ -29,9 +29,22 @@ describe(PlacementServiceRow.name, () => {
     expect(screen.queryByText("Running")).not.toBeInTheDocument();
   });
 
-  it("shows the service URI in the collapsed header", () => {
+  it("keeps the service URL out of the collapsed header", () => {
     setup({ uris: ["shop.example.com"] });
 
+    expect(screen.queryByRole("link", { name: /shop\.example\.com/ })).not.toBeInTheDocument();
+  });
+
+  it("shows the service URL below Image when expanded", async () => {
+    setup({
+      uris: ["shop.example.com"],
+      detail: { image: "nginx:1.25" }
+    });
+
+    await expandService();
+
+    expect(screen.getByText("Image")).toBeInTheDocument();
+    expect(screen.getByText("URL")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /shop\.example\.com/ })).toHaveAttribute("href", "http://shop.example.com");
   });
 
@@ -52,15 +65,17 @@ describe(PlacementServiceRow.name, () => {
     expect(screen.getByRole("link", { name: /80/ })).toHaveAttribute("href", "http://provider.io:30000");
   });
 
-  it("keeps the service collapsed when a URI link is clicked", async () => {
+  it("keeps the row expanded when a URL link is clicked", async () => {
     setup({
       uris: ["app.example.com"],
       forwardedPorts: [{ host: "provider.io", externalPort: 30000, port: 80, available: 1 }]
     });
 
+    await expandService();
     await userEvent.click(screen.getByRole("link", { name: /app\.example\.com/ }));
 
-    expect(screen.queryByText("Ports")).not.toBeInTheDocument();
+    expect(screen.getByText("Ports")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /web/ })).toHaveAttribute("aria-expanded", "true");
   });
 
   it("hides the service URI once the lease is no longer live", () => {

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementServiceRow.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementServiceRow.spec.tsx
@@ -104,11 +104,19 @@ describe(PlacementServiceRow.name, () => {
   });
 
   it("expands a running service even without live endpoints", async () => {
-    setup({ service: mock<LeaseServiceStatus>({ available: 1 }), leaseState: "active" });
+    setup({ service: mock<LeaseServiceStatus>({ available: 1 }), leaseState: "active", detail: { image: "nginx:1.25" } });
 
     await expandService();
 
     expect(screen.getByRole("button", { name: /web/ })).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("Image")).toBeInTheDocument();
+  });
+
+  it("is not expandable when there is nothing to show", () => {
+    setup({ service: mock<LeaseServiceStatus>({ available: 1 }), leaseState: "active" });
+
+    expect(screen.getByText("Running")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /web/ })).not.toBeInTheDocument();
   });
 
   it("shows image and resources when expanded", async () => {

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementServiceRow.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementServiceRow.spec.tsx
@@ -1,4 +1,5 @@
 import { TooltipProvider } from "@akashnetwork/ui/components";
+import { faker } from "@faker-js/faker";
 import { describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
 
@@ -60,6 +61,18 @@ describe(PlacementServiceRow.name, () => {
     expect(screen.getByText("2/3 replicas")).toBeInTheDocument();
   });
 
+  it("hides the replica count when the lease is closed", () => {
+    setup({ service: mock<LeaseServiceStatus>({ available: 2, total: 3 }), leaseState: "closed" });
+
+    expect(screen.queryByText("2/3 replicas")).not.toBeInTheDocument();
+  });
+
+  it("hides the replica count when the lease has been reclaimed", () => {
+    setup({ service: mock<LeaseServiceStatus>({ available: 2, total: 3 }), leaseState: "active", isReclaimed: true });
+
+    expect(screen.queryByText("2/3 replicas")).not.toBeInTheDocument();
+  });
+
   it("keeps forwarded ports collapsed until the row is expanded", async () => {
     setup({ forwardedPorts: [{ host: "provider.io", externalPort: 30000, port: 80, available: 1 }] });
 
@@ -117,10 +130,12 @@ describe(PlacementServiceRow.name, () => {
   });
 
   it("does not show env vars or command", async () => {
+    const envValue = faker.string.alphanumeric(24);
+
     setup({
       detail: {
         image: "nginx:1.25",
-        env: [{ key: "API_KEY", value: "secret" }],
+        env: [{ key: "API_KEY", value: envValue }],
         command: "sh -c echo hi"
       }
     });
@@ -130,6 +145,7 @@ describe(PlacementServiceRow.name, () => {
     expect(screen.queryByText("Env vars")).not.toBeInTheDocument();
     expect(screen.queryByText("Command")).not.toBeInTheDocument();
     expect(screen.queryByText("API_KEY")).not.toBeInTheDocument();
+    expect(screen.queryByText(envValue)).not.toBeInTheDocument();
     expect(screen.queryByText("sh -c echo hi")).not.toBeInTheDocument();
   });
 

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementServiceRow.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementServiceRow.tsx
@@ -2,7 +2,7 @@
 import type { FC, ReactNode } from "react";
 import { useState } from "react";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@akashnetwork/ui/components";
-import { Box, Label, NavArrowDown, NavArrowRight } from "iconoir-react";
+import { Box, Globe, Label, NavArrowDown, NavArrowRight } from "iconoir-react";
 
 import type { ForwardedPort, LeaseServiceStatus, ServiceIp } from "@src/queries/useLeaseQuery";
 import type { LeaseDto } from "@src/types/deployment";
@@ -59,12 +59,11 @@ export const PlacementServiceRow: FC<PlacementServiceRowProps> = ({
     </>
   );
 
-  const extras = (
-    <div className="flex min-w-0 flex-1 items-center gap-3">
-      <ServiceUriLinks items={uriLinks} />
-      {replicaLabel ? <span className="ml-auto shrink-0 text-sm text-muted-foreground">{replicaLabel}</span> : null}
+  const extras = replicaLabel ? (
+    <div className="flex min-w-0 flex-1 items-center justify-end">
+      <span className="shrink-0 text-sm text-muted-foreground">{replicaLabel}</span>
     </div>
-  );
+  ) : null;
 
   if (closed) {
     return (
@@ -96,6 +95,11 @@ export const PlacementServiceRow: FC<PlacementServiceRowProps> = ({
         {detail?.image ? (
           <ServiceDetailRow icon={<Box className="h-4 w-4" />} title="Image">
             <span className="break-all">{detail.image}</span>
+          </ServiceDetailRow>
+        ) : null}
+        {uriLinks.length > 0 ? (
+          <ServiceDetailRow icon={<Globe className="h-4 w-4" />} title="URL">
+            <ServiceUriLinks items={uriLinks} />
           </ServiceDetailRow>
         ) : null}
         {portChips.length > 0 ? (

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementServiceRow.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementServiceRow.tsx
@@ -115,8 +115,8 @@ export const PlacementServiceRow: FC<PlacementServiceRowProps> = ({
 const ServiceDetailRow: FC<{ icon: ReactNode; title: string; children: ReactNode }> = ({ icon, title, children }) => (
   <div className="flex items-center gap-2 border-t px-5 py-4">
     <span className="shrink-0 text-muted-foreground">{icon}</span>
-    <span className="w-32 shrink-0 text-base font-semibold">{title}</span>
-    <div className="min-w-0 flex-1 text-left text-base text-muted-foreground">{children}</div>
+    <span className="w-32 shrink-0 text-sm font-medium">{title}</span>
+    <div className="min-w-0 flex-1 text-left text-sm text-muted-foreground">{children}</div>
   </div>
 );
 

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementServiceRow.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementServiceRow.tsx
@@ -2,12 +2,15 @@
 import type { FC, ReactNode } from "react";
 import { useState } from "react";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@akashnetwork/ui/components";
-import { Label, NavArrowDown, NavArrowRight } from "iconoir-react";
+import { Box, Label, NavArrowDown, NavArrowRight } from "iconoir-react";
 
 import type { ForwardedPort, LeaseServiceStatus, ServiceIp } from "@src/queries/useLeaseQuery";
 import type { LeaseDto } from "@src/types/deployment";
 import { StatusBadge } from "../DeploymentStatusBadge";
+import type { ManifestServiceDetail, ManifestServiceResources } from "./placementModel";
 import { formatReplicaCount, getServiceStatus } from "./placementModel";
+import type { PlacementStat } from "./PlacementStats";
+import { PlacementStats } from "./PlacementStats";
 import { PortChips, ServiceUriLinks, toPortChips, toUriLinks } from "./ServiceEndpoints";
 
 export interface PlacementServiceRowProps {
@@ -15,6 +18,7 @@ export interface PlacementServiceRowProps {
   service?: LeaseServiceStatus;
   leaseState: LeaseDto["state"];
   isReclaimed?: boolean;
+  detail?: ManifestServiceDetail;
   uris?: string[] | null;
   forwardedPorts?: ForwardedPort[] | null;
   ips?: ServiceIp[] | null;
@@ -27,6 +31,7 @@ export const PlacementServiceRow: FC<PlacementServiceRowProps> = ({
   service,
   leaseState,
   isReclaimed,
+  detail,
   uris,
   forwardedPorts,
   ips,
@@ -41,7 +46,6 @@ export const PlacementServiceRow: FC<PlacementServiceRowProps> = ({
   const uriLinks = closed ? [] : toUriLinks(uris);
   const portChips = toPortChips({ forwardedPorts, ips, closed });
   const replicaLabel = formatReplicaCount(service);
-  const expandable = portChips.length > 0;
 
   function handleOpenChange(next: boolean) {
     if (!isControlled) setUncontrolledOpen(next);
@@ -62,7 +66,7 @@ export const PlacementServiceRow: FC<PlacementServiceRowProps> = ({
     </div>
   );
 
-  if (!expandable) {
+  if (closed) {
     return (
       <div className="overflow-hidden rounded-lg border">
         <div className="flex items-center gap-3 p-4">
@@ -84,20 +88,46 @@ export const PlacementServiceRow: FC<PlacementServiceRowProps> = ({
       </div>
 
       <CollapsibleContent>
-        <div className="border-t">
+        {detail?.resources ? (
+          <div className="border-t px-6 py-3">
+            <PlacementStats stats={buildServiceStats(detail.resources)} variant="spread" />
+          </div>
+        ) : null}
+        {detail?.image ? (
+          <ServiceDetailRow icon={<Box className="h-4 w-4" />} title="Image">
+            <span className="break-all">{detail.image}</span>
+          </ServiceDetailRow>
+        ) : null}
+        {portChips.length > 0 ? (
           <ServiceDetailRow icon={<Label className="h-4 w-4" />} title="Ports">
             <PortChips items={portChips} />
           </ServiceDetailRow>
-        </div>
+        ) : null}
       </CollapsibleContent>
     </Collapsible>
   );
 };
 
 const ServiceDetailRow: FC<{ icon: ReactNode; title: string; children: ReactNode }> = ({ icon, title, children }) => (
-  <div className="flex items-center gap-2 px-5 py-4">
+  <div className="flex items-center gap-2 border-t px-5 py-4">
     <span className="shrink-0 text-muted-foreground">{icon}</span>
     <span className="w-32 shrink-0 text-base font-semibold">{title}</span>
     <div className="min-w-0 flex-1 text-left text-base text-muted-foreground">{children}</div>
   </div>
 );
+
+function buildServiceStats(resources: ManifestServiceResources): PlacementStat[] {
+  const stats: PlacementStat[] = [
+    { label: "vCPU", value: resources.cpu ?? "—" },
+    { label: "Memory", value: formatSize(resources.memory) },
+    { label: "Storage", value: formatSize(resources.storage) }
+  ];
+  if (resources.gpuUnits > 0) {
+    stats.push({ label: "GPU", value: resources.gpuUnits });
+  }
+  return stats;
+}
+
+function formatSize(size: ManifestServiceResources["memory"]): string {
+  return size ? `${size.value} ${size.unit}`.trim() : "—";
+}

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementServiceRow.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementServiceRow.tsx
@@ -2,117 +2,82 @@
 import type { FC, ReactNode } from "react";
 import { useState } from "react";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@akashnetwork/ui/components";
-import { cn } from "@akashnetwork/ui/utils";
-import { Box, Globe, Key, NavArrowDown, NavArrowUp, Terminal } from "iconoir-react";
+import { Label, NavArrowDown, NavArrowRight } from "iconoir-react";
 
-import { CopyTextToClipboardButton } from "@src/components/shared/CopyTextToClipboardButton";
 import type { ForwardedPort, LeaseServiceStatus, ServiceIp } from "@src/queries/useLeaseQuery";
 import type { LeaseDto } from "@src/types/deployment";
-import type { ManifestEnvVar, ManifestServiceDetail, ManifestServiceResources, ServiceStatusView } from "./placementModel";
-import { getServiceStatus } from "./placementModel";
-import type { PlacementStat } from "./PlacementStats";
-import { PlacementStats } from "./PlacementStats";
-import { EndpointLinks, toForwardedPortLinks, toIpLinks, toUriLinks } from "./ServiceEndpoints";
+import { StatusBadge } from "../DeploymentStatusBadge";
+import { formatReplicaCount, getServiceStatus } from "./placementModel";
+import { PortChips, ServiceUriLinks, toPortChips, toUriLinks } from "./ServiceEndpoints";
 
 export interface PlacementServiceRowProps {
   serviceName: string;
   service?: LeaseServiceStatus;
   leaseState: LeaseDto["state"];
   isReclaimed?: boolean;
-  detail?: ManifestServiceDetail;
   uris?: string[] | null;
   forwardedPorts?: ForwardedPort[] | null;
   ips?: ServiceIp[] | null;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }
 
-export const PlacementServiceRow: FC<PlacementServiceRowProps> = ({ serviceName, service, leaseState, isReclaimed, detail, uris, forwardedPorts, ips }) => {
-  const [open, setOpen] = useState(false);
+export const PlacementServiceRow: FC<PlacementServiceRowProps> = ({
+  serviceName,
+  service,
+  leaseState,
+  isReclaimed,
+  uris,
+  forwardedPorts,
+  ips,
+  open: openProp,
+  onOpenChange
+}) => {
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
+  const isControlled = openProp !== undefined;
+  const open = isControlled ? openProp : uncontrolledOpen;
   const status = getServiceStatus(service, leaseState, isReclaimed);
-  const endpoints = status.tone === "closed" ? [] : [...toUriLinks(uris), ...toForwardedPortLinks(forwardedPorts), ...toIpLinks(ips)];
+  const closed = status.tone === "closed";
+  const uriLinks = closed ? [] : toUriLinks(uris);
+  const portChips = toPortChips({ forwardedPorts, ips, closed });
+  const replicaLabel = formatReplicaCount(service);
+
+  function handleOpenChange(next: boolean) {
+    if (!isControlled) setUncontrolledOpen(next);
+    onOpenChange?.(next);
+  }
 
   return (
-    <Collapsible open={open} onOpenChange={setOpen} className="overflow-hidden rounded-lg border">
-      <CollapsibleTrigger className="flex w-full items-center gap-4 p-4 text-left">
-        {open ? <NavArrowUp className="h-4 w-4 shrink-0" /> : <NavArrowDown className="h-4 w-4 shrink-0" />}
-        <span className="text-base font-medium">{serviceName}</span>
-        <ServiceStatusBadge status={status} />
-      </CollapsibleTrigger>
-
-      <CollapsibleContent>
-        {detail?.resources && (
-          <div className="border-t px-6 py-3">
-            <PlacementStats stats={buildServiceStats(detail.resources)} />
-          </div>
-        )}
-
-        <div className="border-t">
-          {detail?.image && (
-            <ServiceDetailRow icon={<Box className="h-4 w-4" />} title="Docker image">
-              <span className="inline-flex items-center gap-2">
-                <span className="break-all font-mono">{detail.image}</span>
-                <CopyTextToClipboardButton value={detail.image} />
-              </span>
-            </ServiceDetailRow>
-          )}
-          {detail?.env && detail.env.length > 0 && (
-            <ServiceDetailRow icon={<Key className="h-4 w-4" />} title="Environment Variables">
-              <span className="break-all font-mono">{detail.env.map(formatEnvVar).join(", ")}</span>
-            </ServiceDetailRow>
-          )}
-          {detail?.command && (
-            <ServiceDetailRow icon={<Terminal className="h-4 w-4" />} title="Commands">
-              <span className="break-all font-mono">{detail.command}</span>
-            </ServiceDetailRow>
-          )}
-          <ServiceDetailRow icon={<Globe className="h-4 w-4" />} title="Expose Ports">
-            {endpoints.length > 0 ? <EndpointLinks items={endpoints} /> : "None"}
-          </ServiceDetailRow>
+    <Collapsible open={open} onOpenChange={handleOpenChange} className="overflow-hidden rounded-lg border">
+      <div className="flex items-center gap-3 p-4">
+        <CollapsibleTrigger className="flex shrink-0 items-center gap-3 text-left">
+          {open ? <NavArrowDown className="h-4 w-4 shrink-0" /> : <NavArrowRight className="h-4 w-4 shrink-0" />}
+          <span className="text-base font-medium">{serviceName}</span>
+          <StatusBadge label={status.label} tone={status.tone} />
+        </CollapsibleTrigger>
+        <div className="flex min-w-0 flex-1 items-center gap-3">
+          <ServiceUriLinks items={uriLinks} />
+          {replicaLabel && <span className="ml-auto shrink-0 text-sm text-muted-foreground">{replicaLabel}</span>}
         </div>
-      </CollapsibleContent>
+      </div>
+
+      {portChips.length > 0 && (
+        <CollapsibleContent>
+          <div className="border-t">
+            <ServiceDetailRow icon={<Label className="h-4 w-4" />} title="Ports">
+              <PortChips items={portChips} />
+            </ServiceDetailRow>
+          </div>
+        </CollapsibleContent>
+      )}
     </Collapsible>
   );
 };
 
 const ServiceDetailRow: FC<{ icon: ReactNode; title: string; children: ReactNode }> = ({ icon, title, children }) => (
-  <div className="flex items-center gap-2 border-t px-5 py-4 first:border-t-0">
+  <div className="flex items-center gap-2 px-5 py-4">
     <span className="shrink-0 text-muted-foreground">{icon}</span>
-    <span className="w-60 shrink-0 text-base font-semibold">{title}</span>
+    <span className="w-32 shrink-0 text-base font-semibold">{title}</span>
     <div className="min-w-0 flex-1 text-left text-base text-muted-foreground">{children}</div>
   </div>
-);
-
-function buildServiceStats(resources: ManifestServiceResources): PlacementStat[] {
-  return [
-    { label: "GPU", value: resources.gpuUnits > 0 ? resources.gpuUnits : "--" },
-    { label: "vCPU", value: resources.cpu ?? "--" },
-    { label: "Memory", value: formatSize(resources.memory) },
-    { label: "Storage", value: formatSize(resources.storage) }
-  ];
-}
-
-function formatSize(size: ManifestServiceResources["memory"]): string {
-  return size ? `${size.value} ${size.unit}`.trim() : "--";
-}
-
-function formatEnvVar(env: ManifestEnvVar): string {
-  return env.value !== undefined ? `${env.key}=${env.value}` : env.key;
-}
-
-const STATUS_DOT_CLASS: Record<ServiceStatusView["tone"], string> = {
-  running: "bg-emerald-500",
-  pending: "bg-amber-500",
-  closed: "bg-destructive"
-};
-
-const STATUS_TEXT_CLASS: Record<ServiceStatusView["tone"], string> = {
-  running: "text-emerald-500",
-  pending: "text-amber-500",
-  closed: "text-destructive"
-};
-
-const ServiceStatusBadge: FC<{ status: ServiceStatusView }> = ({ status }) => (
-  <span className={cn("inline-flex items-center gap-1.5 text-sm font-medium", STATUS_TEXT_CLASS[status.tone])}>
-    <span className={cn("h-2 w-2 rounded-full", STATUS_DOT_CLASS[status.tone])} />
-    {status.label}
-  </span>
 );

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementServiceRow.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementServiceRow.tsx
@@ -46,6 +46,7 @@ export const PlacementServiceRow: FC<PlacementServiceRowProps> = ({
   const uriLinks = closed ? [] : toUriLinks(uris);
   const portChips = toPortChips({ forwardedPorts, ips, closed });
   const replicaLabel = closed ? undefined : formatReplicaCount(service);
+  const hasDetails = !!(detail?.resources || detail?.image || uriLinks.length > 0 || portChips.length > 0);
 
   function handleOpenChange(next: boolean) {
     if (!isControlled) setUncontrolledOpen(next);
@@ -65,7 +66,7 @@ export const PlacementServiceRow: FC<PlacementServiceRowProps> = ({
     </div>
   ) : null;
 
-  if (closed) {
+  if (closed || !hasDetails) {
     return (
       <div className="overflow-hidden rounded-lg border">
         <div className="flex items-center gap-3 p-4">

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementServiceRow.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementServiceRow.tsx
@@ -41,10 +41,36 @@ export const PlacementServiceRow: FC<PlacementServiceRowProps> = ({
   const uriLinks = closed ? [] : toUriLinks(uris);
   const portChips = toPortChips({ forwardedPorts, ips, closed });
   const replicaLabel = formatReplicaCount(service);
+  const expandable = portChips.length > 0;
 
   function handleOpenChange(next: boolean) {
     if (!isControlled) setUncontrolledOpen(next);
     onOpenChange?.(next);
+  }
+
+  const identity = (
+    <>
+      <span className="text-base font-medium">{serviceName}</span>
+      <StatusBadge label={status.label} tone={status.tone} />
+    </>
+  );
+
+  const extras = (
+    <div className="flex min-w-0 flex-1 items-center gap-3">
+      <ServiceUriLinks items={uriLinks} />
+      {replicaLabel ? <span className="ml-auto shrink-0 text-sm text-muted-foreground">{replicaLabel}</span> : null}
+    </div>
+  );
+
+  if (!expandable) {
+    return (
+      <div className="overflow-hidden rounded-lg border">
+        <div className="flex items-center gap-3 p-4">
+          <div className="flex items-center gap-3">{identity}</div>
+          {extras}
+        </div>
+      </div>
+    );
   }
 
   return (
@@ -52,24 +78,18 @@ export const PlacementServiceRow: FC<PlacementServiceRowProps> = ({
       <div className="flex items-center gap-3 p-4">
         <CollapsibleTrigger className="flex shrink-0 items-center gap-3 text-left">
           {open ? <NavArrowDown className="h-4 w-4 shrink-0" /> : <NavArrowRight className="h-4 w-4 shrink-0" />}
-          <span className="text-base font-medium">{serviceName}</span>
-          <StatusBadge label={status.label} tone={status.tone} />
+          {identity}
         </CollapsibleTrigger>
-        <div className="flex min-w-0 flex-1 items-center gap-3">
-          <ServiceUriLinks items={uriLinks} />
-          {replicaLabel && <span className="ml-auto shrink-0 text-sm text-muted-foreground">{replicaLabel}</span>}
-        </div>
+        {extras}
       </div>
 
-      {portChips.length > 0 && (
-        <CollapsibleContent>
-          <div className="border-t">
-            <ServiceDetailRow icon={<Label className="h-4 w-4" />} title="Ports">
-              <PortChips items={portChips} />
-            </ServiceDetailRow>
-          </div>
-        </CollapsibleContent>
-      )}
+      <CollapsibleContent>
+        <div className="border-t">
+          <ServiceDetailRow icon={<Label className="h-4 w-4" />} title="Ports">
+            <PortChips items={portChips} />
+          </ServiceDetailRow>
+        </div>
+      </CollapsibleContent>
     </Collapsible>
   );
 };

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementServiceRow.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementServiceRow.tsx
@@ -45,7 +45,7 @@ export const PlacementServiceRow: FC<PlacementServiceRowProps> = ({
   const closed = status.tone === "closed";
   const uriLinks = closed ? [] : toUriLinks(uris);
   const portChips = toPortChips({ forwardedPorts, ips, closed });
-  const replicaLabel = formatReplicaCount(service);
+  const replicaLabel = closed ? undefined : formatReplicaCount(service);
 
   function handleOpenChange(next: boolean) {
     if (!isControlled) setUncontrolledOpen(next);

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementStats.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementStats.tsx
@@ -1,16 +1,17 @@
 import type { FC, ReactNode } from "react";
+import { cn } from "@akashnetwork/ui/utils";
 
 export interface PlacementStat {
   label: string;
   value: ReactNode;
 }
 
-export const PlacementStats: FC<{ stats: PlacementStat[] }> = ({ stats }) => (
-  <div className="flex gap-6 sm:gap-10">
+export const PlacementStats: FC<{ stats: PlacementStat[]; variant?: "compact" | "spread" }> = ({ stats, variant = "compact" }) => (
+  <div className={cn("flex flex-wrap", variant === "spread" ? "w-full gap-10" : "justify-start gap-8 lg:justify-end")}>
     {stats.map(stat => (
-      <div key={stat.label} className="flex min-w-0 flex-1 flex-col gap-1">
+      <div key={stat.label} className={cn("flex min-w-0 flex-col gap-1", variant === "spread" && "flex-1")}>
         <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{stat.label}</span>
-        <span className="whitespace-nowrap font-mono text-base font-medium">{stat.value}</span>
+        <span className="whitespace-nowrap text-base font-semibold">{stat.value}</span>
       </div>
     ))}
   </div>

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/ServiceEndpoints.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/ServiceEndpoints.spec.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import type { EndpointLink, PortChip } from "./ServiceEndpoints";
 import { PortChips, ServiceUriLinks, toPortChips, toUriLinks } from "./ServiceEndpoints";
 
 import { render, screen } from "@testing-library/react";
@@ -29,6 +30,12 @@ describe("ServiceEndpoints", () => {
       ]);
     });
 
+    it("omits the href on an unavailable forwarded port even when a host is assigned", () => {
+      expect(toPortChips({ forwardedPorts: [{ host: "provider.io", externalPort: 30000, port: 80, available: 0 }] })).toEqual([
+        { port: 80, as: 30000, href: undefined, available: false }
+      ]);
+    });
+
     it("yields no chips when the lease is closed", () => {
       expect(toPortChips({ forwardedPorts: [{ host: "provider.io", externalPort: 30000, port: 80, available: 1 }], closed: true })).toEqual([]);
     });
@@ -42,26 +49,53 @@ describe("ServiceEndpoints", () => {
 
   describe("ServiceUriLinks", () => {
     it("renders a link per URI pointing at its open target", () => {
-      render(<ServiceUriLinks items={toUriLinks(["a.example.com", "b.example.com"])} />);
+      setup({ items: toUriLinks(["a.example.com", "b.example.com"]) });
 
       expect(screen.getByRole("link", { name: /a\.example\.com/ })).toHaveAttribute("href", "http://a.example.com");
       expect(screen.getByRole("link", { name: /b\.example\.com/ })).toHaveAttribute("href", "http://b.example.com");
     });
+
+    function setup(input: { items: EndpointLink[] }) {
+      return render(<ServiceUriLinks items={input.items} />);
+    }
   });
 
   describe("PortChips", () => {
     it("renders a clickable chip for a forwarded port", () => {
-      render(<PortChips items={toPortChips({ forwardedPorts: [{ host: "provider.io", externalPort: 30000, port: 3000, available: 1 }] })} />);
+      setup({ items: toPortChips({ forwardedPorts: [{ host: "provider.io", externalPort: 30000, port: 3000, available: 1 }] }) });
 
       expect(screen.getByRole("link", { name: /3000/ })).toHaveAttribute("href", "http://provider.io:30000");
       expect(screen.getByText(":30000")).toBeInTheDocument();
     });
 
     it("renders a host-less port as plain text rather than a link", () => {
-      render(<PortChips items={toPortChips({ forwardedPorts: [{ host: "", externalPort: 30000, port: 80, available: 0 }] })} />);
+      setup({ items: toPortChips({ forwardedPorts: [{ host: "", externalPort: 30000, port: 80, available: 0 }] }) });
 
       expect(screen.queryByRole("link")).not.toBeInTheDocument();
       expect(screen.getByText("80")).toBeInTheDocument();
     });
+
+    it("keeps an unavailable hosted port out of the tab order", () => {
+      setup({ items: toPortChips({ forwardedPorts: [{ host: "provider.io", externalPort: 30000, port: 80, available: 0 }] }) });
+
+      expect(screen.queryByRole("link")).not.toBeInTheDocument();
+      expect(screen.getByText("80")).toBeInTheDocument();
+    });
+
+    it("exposes availability to assistive technology", () => {
+      setup({ items: toPortChips({ forwardedPorts: [{ host: "provider.io", externalPort: 30000, port: 3000, available: 1 }] }) });
+
+      expect(screen.getByText("Available")).toBeInTheDocument();
+    });
+
+    it("marks an unavailable port as unavailable to assistive technology", () => {
+      setup({ items: toPortChips({ forwardedPorts: [{ host: "provider.io", externalPort: 30000, port: 80, available: 0 }] }) });
+
+      expect(screen.getByText("Unavailable")).toBeInTheDocument();
+    });
+
+    function setup(input: { items: PortChip[] }) {
+      return render(<PortChips items={input.items} />);
+    }
   });
 });

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/ServiceEndpoints.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/ServiceEndpoints.spec.tsx
@@ -45,6 +45,12 @@ describe("ServiceEndpoints", () => {
         { port: 80, as: 8080, proto: "tcp", href: "http://1.2.3.4:8080", available: true }
       ]);
     });
+
+    it("omits the href on a UDP leased IP", () => {
+      expect(toPortChips({ ips: [{ IP: "1.2.3.4", ExternalPort: 7777, Port: 7777, Protocol: "UDP" }] })).toEqual([
+        { port: 7777, as: 7777, proto: "udp", href: undefined, available: true }
+      ]);
+    });
   });
 
   describe("ServiceUriLinks", () => {

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/ServiceEndpoints.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/ServiceEndpoints.spec.tsx
@@ -1,14 +1,13 @@
-import { TooltipProvider } from "@akashnetwork/ui/components";
 import { describe, expect, it } from "vitest";
 
-import { EndpointLinks, toForwardedPortLinks, toIpLinks, toUriLinks } from "./ServiceEndpoints";
+import { PortChips, ServiceUriLinks, toPortChips, toUriLinks } from "./ServiceEndpoints";
 
 import { render, screen } from "@testing-library/react";
 
 describe("ServiceEndpoints", () => {
   describe("toUriLinks", () => {
-    it("builds an http link and copy value for each URI", () => {
-      expect(toUriLinks(["app.example.com"])).toEqual([{ text: "app.example.com", href: "http://app.example.com", copyValue: "app.example.com" }]);
+    it("builds an http link for each URI", () => {
+      expect(toUriLinks(["app.example.com"])).toEqual([{ text: "app.example.com", href: "http://app.example.com" }]);
     });
 
     it("yields no links when the provider reports no URIs", () => {
@@ -17,72 +16,52 @@ describe("ServiceEndpoints", () => {
     });
   });
 
-  describe("toForwardedPortLinks", () => {
-    it("links a forwarded port that has a host", () => {
-      expect(toForwardedPortLinks([{ host: "provider.io", externalPort: 30000, port: 80, available: 1 }])).toEqual([
-        { text: "80:30000", href: "http://provider.io:30000", disabled: false }
+  describe("toPortChips", () => {
+    it("builds a chip from a live forwarded port", () => {
+      expect(toPortChips({ forwardedPorts: [{ host: "provider.io", externalPort: 30151, port: 5432, available: 1 }] })).toEqual([
+        { port: 5432, as: 30151, href: "http://provider.io:30151", available: true }
       ]);
     });
 
-    it("omits the href and disables a host-less unavailable port", () => {
-      expect(toForwardedPortLinks([{ host: "", externalPort: 30000, port: 80, available: 0 }])).toEqual([
-        { text: "80:30000", href: undefined, disabled: true }
+    it("omits the href on a host-less forwarded port", () => {
+      expect(toPortChips({ forwardedPorts: [{ host: "", externalPort: 30000, port: 80, available: 0 }] })).toEqual([
+        { port: 80, as: 30000, href: undefined, available: false }
       ]);
     });
 
-    it("yields no links when the provider reports no forwarded ports", () => {
-      expect(toForwardedPortLinks(null)).toEqual([]);
-      expect(toForwardedPortLinks(undefined)).toEqual([]);
+    it("yields no chips when the lease is closed", () => {
+      expect(toPortChips({ forwardedPorts: [{ host: "provider.io", externalPort: 30000, port: 80, available: 1 }], closed: true })).toEqual([]);
+    });
+
+    it("builds a chip from a leased IP", () => {
+      expect(toPortChips({ ips: [{ IP: "1.2.3.4", ExternalPort: 8080, Port: 80, Protocol: "TCP" }] })).toEqual([
+        { port: 80, as: 8080, proto: "tcp", href: "http://1.2.3.4:8080", available: true }
+      ]);
     });
   });
 
-  describe("toIpLinks", () => {
-    it("builds an http link and copy value for each IP", () => {
-      const [link] = toIpLinks([{ IP: "1.2.3.4", ExternalPort: 8080, Port: 80, Protocol: "TCP" }]);
-
-      expect(link.href).toBe("http://1.2.3.4:8080");
-      expect(link.copyValue).toBe("1.2.3.4:8080");
-    });
-
-    it("yields no links when the provider reports no IPs", () => {
-      expect(toIpLinks(null)).toEqual([]);
-      expect(toIpLinks(undefined)).toEqual([]);
-    });
-  });
-
-  describe("EndpointLinks", () => {
-    it("renders a link per item pointing at its open target", () => {
-      render(
-        <TooltipProvider>
-          <EndpointLinks items={toUriLinks(["a.example.com", "b.example.com"])} />
-        </TooltipProvider>
-      );
+  describe("ServiceUriLinks", () => {
+    it("renders a link per URI pointing at its open target", () => {
+      render(<ServiceUriLinks items={toUriLinks(["a.example.com", "b.example.com"])} />);
 
       expect(screen.getByRole("link", { name: /a\.example\.com/ })).toHaveAttribute("href", "http://a.example.com");
       expect(screen.getByRole("link", { name: /b\.example\.com/ })).toHaveAttribute("href", "http://b.example.com");
     });
+  });
 
-    it("keeps a disabled forwarded-port link out of the tab order and marks it disabled", () => {
-      render(
-        <TooltipProvider>
-          <EndpointLinks items={toForwardedPortLinks([{ host: "provider.io", externalPort: 30000, port: 80, available: 0 }])} />
-        </TooltipProvider>
-      );
+  describe("PortChips", () => {
+    it("renders a clickable chip for a forwarded port", () => {
+      render(<PortChips items={toPortChips({ forwardedPorts: [{ host: "provider.io", externalPort: 30000, port: 3000, available: 1 }] })} />);
 
-      const link = screen.getByRole("link", { name: /80:30000/ });
-      expect(link).toHaveAttribute("tabindex", "-1");
-      expect(link).toHaveAttribute("aria-disabled", "true");
+      expect(screen.getByRole("link", { name: /3000/ })).toHaveAttribute("href", "http://provider.io:30000");
+      expect(screen.getByText(":30000")).toBeInTheDocument();
     });
 
     it("renders a host-less port as plain text rather than a link", () => {
-      render(
-        <TooltipProvider>
-          <EndpointLinks items={toForwardedPortLinks([{ host: "", externalPort: 30000, port: 80, available: 0 }])} />
-        </TooltipProvider>
-      );
+      render(<PortChips items={toPortChips({ forwardedPorts: [{ host: "", externalPort: 30000, port: 80, available: 0 }] })} />);
 
-      expect(screen.queryByRole("link", { name: /80:30000/ })).not.toBeInTheDocument();
-      expect(screen.getByText("80:30000")).toBeInTheDocument();
+      expect(screen.queryByRole("link")).not.toBeInTheDocument();
+      expect(screen.getByText("80")).toBeInTheDocument();
     });
   });
 });

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/ServiceEndpoints.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/ServiceEndpoints.tsx
@@ -26,18 +26,12 @@ export const ServiceUriLinks: FC<{ items: EndpointLink[] }> = ({ items }) => {
     <span className="inline-flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1">
       {items.map(item =>
         item.href ? (
-          <Link
-            key={item.text}
-            href={item.href}
-            target="_blank"
-            rel="noreferrer"
-            className="inline-flex min-w-0 items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
-          >
+          <Link key={item.text} href={item.href} target="_blank" rel="noreferrer" className="inline-flex min-w-0 items-center gap-1 hover:text-foreground">
             <span className="truncate">{item.text}</span>
             <OpenInWindow className="shrink-0 text-xs" />
           </Link>
         ) : (
-          <span key={item.text} className="truncate text-sm text-muted-foreground">
+          <span key={item.text} className="truncate">
             {item.text}
           </span>
         )

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/ServiceEndpoints.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/ServiceEndpoints.tsx
@@ -18,7 +18,7 @@ export interface PortChip {
   available: boolean;
 }
 
-/** URI chips for the collapsed service row: hostname + open-in-new-tab, no copy or comma separators. */
+/** URI links: hostname + open-in-new-tab, no copy or comma separators. */
 export const ServiceUriLinks: FC<{ items: EndpointLink[] }> = ({ items }) => {
   if (items.length === 0) return null;
 

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/ServiceEndpoints.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/ServiceEndpoints.tsx
@@ -55,7 +55,8 @@ export const PortChips: FC<{ items: PortChip[] }> = ({ items }) => (
           <span className="font-medium">{item.port}</span>
           {item.as !== undefined && <span className="text-muted-foreground"> :{item.as}</span>}
           {item.proto && <span className="text-muted-foreground"> /{item.proto}</span>}
-          <span className={cn("h-1.5 w-1.5 rounded-full", item.available ? "bg-emerald-500" : "bg-muted-foreground/40")} />
+          <span aria-hidden="true" className={cn("h-1.5 w-1.5 rounded-full", item.available ? "bg-emerald-500" : "bg-muted-foreground/40")} />
+          <span className="sr-only">{item.available ? "Available" : "Unavailable"}</span>
         </>
       );
 
@@ -84,12 +85,15 @@ export function toPortChips(input: { forwardedPorts?: ForwardedPort[] | null; ip
   const ips = Array.isArray(input.ips) ? input.ips : [];
 
   return [
-    ...forwarded.map(port => ({
-      port: port.port,
-      as: port.externalPort,
-      href: port.host ? `http://${port.host}:${port.externalPort}` : undefined,
-      available: port.available > 0
-    })),
+    ...forwarded.map(port => {
+      const available = port.available > 0;
+      return {
+        port: port.port,
+        as: port.externalPort,
+        href: available && port.host ? `http://${port.host}:${port.externalPort}` : undefined,
+        available
+      };
+    }),
     ...ips.map(ip => ({
       port: ip.Port,
       as: ip.ExternalPort,

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/ServiceEndpoints.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/ServiceEndpoints.tsx
@@ -1,76 +1,101 @@
-import type { FC, ReactNode } from "react";
-import { CustomTooltip } from "@akashnetwork/ui/components";
+import type { FC } from "react";
 import { cn } from "@akashnetwork/ui/utils";
-import { InfoCircle, OpenInWindow } from "iconoir-react";
+import { OpenInWindow } from "iconoir-react";
 import Link from "next/link";
 
-import { CopyTextToClipboardButton } from "@src/components/shared/CopyTextToClipboardButton";
 import type { ForwardedPort, ServiceIp } from "@src/queries/useLeaseQuery";
 
 export interface EndpointLink {
   text: string;
   href?: string;
-  copyValue?: string;
-  tooltip?: ReactNode;
-  disabled?: boolean;
 }
 
-/** A comma-delimited, right-aligned list of endpoints, each keeping its open-in-new-tab and copy actions. */
-export const EndpointLinks: FC<{ items: EndpointLink[] }> = ({ items }) => (
-  <span className="inline-flex flex-wrap items-center justify-start gap-x-1 gap-y-1">
-    {items.map((item, index) => (
-      <span key={`${item.text}-${index}`} className="inline-flex items-center gap-1">
-        {item.href ? (
+export interface PortChip {
+  port: number;
+  as?: number;
+  proto?: string;
+  href?: string;
+  available: boolean;
+}
+
+/** URI chips for the collapsed service row: hostname + open-in-new-tab, no copy or comma separators. */
+export const ServiceUriLinks: FC<{ items: EndpointLink[] }> = ({ items }) => {
+  if (items.length === 0) return null;
+
+  return (
+    <span className="inline-flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1">
+      {items.map(item =>
+        item.href ? (
           <Link
+            key={item.text}
             href={item.href}
             target="_blank"
             rel="noreferrer"
-            aria-disabled={item.disabled}
-            tabIndex={item.disabled ? -1 : undefined}
-            className={cn("inline-flex items-center gap-1 text-muted-foreground hover:text-foreground", { "pointer-events-none": item.disabled })}
+            className="inline-flex min-w-0 items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
           >
-            <span>{item.text}</span>
-            <OpenInWindow className="text-xs" />
+            <span className="truncate">{item.text}</span>
+            <OpenInWindow className="shrink-0 text-xs" />
           </Link>
         ) : (
-          <span className="text-muted-foreground">{item.text}</span>
-        )}
-        {item.tooltip && (
-          <CustomTooltip title={item.tooltip}>
-            <InfoCircle className="text-xs text-muted-foreground" />
-          </CustomTooltip>
-        )}
-        {item.copyValue && <CopyTextToClipboardButton value={item.copyValue} />}
-        {index < items.length - 1 && <span className="text-muted-foreground">,</span>}
-      </span>
-    ))}
+          <span key={item.text} className="truncate text-sm text-muted-foreground">
+            {item.text}
+          </span>
+        )
+      )}
+    </span>
+  );
+};
+
+export const PortChips: FC<{ items: PortChip[] }> = ({ items }) => (
+  <span className="inline-flex flex-wrap items-center gap-2">
+    {items.map((item, index) => {
+      const className = "inline-flex items-center gap-1.5 rounded-md border bg-muted/50 px-2.5 py-1 text-sm";
+      const content = (
+        <>
+          <span className="font-medium">{item.port}</span>
+          {item.as !== undefined && <span className="text-muted-foreground"> :{item.as}</span>}
+          {item.proto && <span className="text-muted-foreground"> /{item.proto}</span>}
+          <span className={cn("h-1.5 w-1.5 rounded-full", item.available ? "bg-emerald-500" : "bg-muted-foreground/40")} />
+        </>
+      );
+
+      return item.href ? (
+        <Link key={`${item.port}-${index}`} href={item.href} target="_blank" rel="noreferrer" className={className}>
+          {content}
+        </Link>
+      ) : (
+        <span key={`${item.port}-${index}`} className={className}>
+          {content}
+        </span>
+      );
+    })}
   </span>
 );
 
 export function toUriLinks(uris?: string[] | null): EndpointLink[] {
-  return (uris ?? []).map(uri => ({ text: uri, href: `http://${uri}`, copyValue: uri }));
+  return (Array.isArray(uris) ? uris : []).map(uri => ({ text: uri, href: `http://${uri}` }));
 }
 
-export function toForwardedPortLinks(ports?: ForwardedPort[] | null): EndpointLink[] {
-  return (ports ?? []).map(port => ({
-    text: `${port.port}:${port.externalPort}`,
-    href: port.host ? `http://${port.host}:${port.externalPort}` : undefined,
-    disabled: port.available < 1
-  }));
-}
+/** Live forwarded ports and leased IPs as chips. A closed lease yields no chips. */
+export function toPortChips(input: { forwardedPorts?: ForwardedPort[] | null; ips?: ServiceIp[] | null; closed?: boolean }): PortChip[] {
+  if (input.closed) return [];
 
-export function toIpLinks(ips?: ServiceIp[] | null): EndpointLink[] {
-  return (ips ?? []).map(ip => ({
-    text: `${ip.IP}:${ip.ExternalPort}`,
-    href: `http://${ip.IP}:${ip.ExternalPort}`,
-    copyValue: `${ip.IP}:${ip.ExternalPort}`,
-    tooltip: (
-      <>
-        <div>IP:&nbsp;{ip.IP}</div>
-        <div>External Port:&nbsp;{ip.ExternalPort}</div>
-        <div>Port:&nbsp;{ip.Port}</div>
-        <div>Protocol:&nbsp;{ip.Protocol}</div>
-      </>
-    )
-  }));
+  const forwarded = Array.isArray(input.forwardedPorts) ? input.forwardedPorts : [];
+  const ips = Array.isArray(input.ips) ? input.ips : [];
+
+  return [
+    ...forwarded.map(port => ({
+      port: port.port,
+      as: port.externalPort,
+      href: port.host ? `http://${port.host}:${port.externalPort}` : undefined,
+      available: port.available > 0
+    })),
+    ...ips.map(ip => ({
+      port: ip.Port,
+      as: ip.ExternalPort,
+      proto: ip.Protocol ? ip.Protocol.toLowerCase() : undefined,
+      href: `http://${ip.IP}:${ip.ExternalPort}`,
+      available: true
+    }))
+  ];
 }

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/ServiceEndpoints.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/ServiceEndpoints.tsx
@@ -92,7 +92,7 @@ export function toPortChips(input: { forwardedPorts?: ForwardedPort[] | null; ip
       port: ip.Port,
       as: ip.ExternalPort,
       proto: ip.Protocol ? ip.Protocol.toLowerCase() : undefined,
-      href: `http://${ip.IP}:${ip.ExternalPort}`,
+      href: !ip.Protocol || ip.Protocol.toUpperCase() === "TCP" ? `http://${ip.IP}:${ip.ExternalPort}` : undefined,
       available: true
     }))
   ];

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/placementModel.spec.ts
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/placementModel.spec.ts
@@ -5,7 +5,9 @@ import { mock } from "vitest-mock-extended";
 import type { LeaseServiceStatus } from "@src/queries/useLeaseQuery";
 import type { DeploymentGroup } from "@src/types/deployment";
 import {
+  formatGpuLabel,
   formatReplicaCount,
+  getDeploymentGpuModels,
   getPlacementGpuModels,
   getPlacementName,
   getProviderRegion,
@@ -187,6 +189,42 @@ describe("placementModel", () => {
 
     it("returns an empty list when no gpu is requested", () => {
       expect(getPlacementGpuModels(buildGroup({}))).toEqual([]);
+    });
+  });
+
+  describe("getDeploymentGpuModels", () => {
+    it("unions unique models from every group", () => {
+      expect(
+        getDeploymentGpuModels([
+          buildGroup({ gpuAttributes: [{ key: "vendor/nvidia/model/h100", value: "true" }] }),
+          buildGroup({ gpuAttributes: [{ key: "vendor/nvidia/model/h100", value: "true" }] }),
+          buildGroup({ gpuAttributes: [{ key: "vendor/nvidia/model/a100", value: "true" }] })
+        ])
+      ).toEqual(["h100", "a100"]);
+    });
+
+    it("returns an empty list when no groups declare a gpu", () => {
+      expect(getDeploymentGpuModels([buildGroup({})])).toEqual([]);
+      expect(getDeploymentGpuModels(undefined)).toEqual([]);
+    });
+  });
+
+  describe("formatGpuLabel", () => {
+    it("formats count and model as in the header design", () => {
+      expect(formatGpuLabel(1, ["h100"])).toBe("1× H100");
+      expect(formatGpuLabel(2, ["h100"])).toBe("2× H100");
+    });
+
+    it("joins multiple models after the count", () => {
+      expect(formatGpuLabel(2, ["h100", "a100"])).toBe("2× H100, A100");
+    });
+
+    it("falls back to the count when no model is declared", () => {
+      expect(formatGpuLabel(1, [])).toBe("1");
+    });
+
+    it("shows an em dash when the deployment has no gpu", () => {
+      expect(formatGpuLabel(0, ["h100"])).toBe("—");
     });
   });
 

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/placementModel.spec.ts
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/placementModel.spec.ts
@@ -5,6 +5,7 @@ import { mock } from "vitest-mock-extended";
 import type { LeaseServiceStatus } from "@src/queries/useLeaseQuery";
 import type { DeploymentGroup } from "@src/types/deployment";
 import {
+  formatReplicaCount,
   getPlacementGpuModels,
   getPlacementName,
   getProviderRegion,
@@ -213,6 +214,21 @@ describe("placementModel", () => {
 
     it("keeps a lease in the reclamation grace period non-terminal until it is reclaimed", () => {
       expect(getServiceStatus(buildService({ available: 1 }), "reclaiming")).toEqual({ label: "Running", tone: "running" });
+    });
+  });
+
+  describe("formatReplicaCount", () => {
+    it("formats available against total", () => {
+      expect(formatReplicaCount(buildService({ available: 1, total: 1 }))).toBe("1/1 replicas");
+      expect(formatReplicaCount(buildService({ available: 0, total: 3 }))).toBe("0/3 replicas");
+    });
+
+    it("is omitted when lease status has not arrived", () => {
+      expect(formatReplicaCount(undefined)).toBeUndefined();
+    });
+
+    it("is omitted when replica totals are not numeric", () => {
+      expect(formatReplicaCount(mock<LeaseServiceStatus>({ available: 1 }))).toBeUndefined();
     });
   });
 });

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/placementModel.spec.ts
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/placementModel.spec.ts
@@ -240,7 +240,10 @@ describe("placementModel", () => {
 
     it("reports starting when no replica is available yet", () => {
       expect(getServiceStatus(buildService({ available: 0 }), "active")).toEqual({ label: "Starting", tone: "pending" });
-      expect(getServiceStatus(undefined, "active")).toEqual({ label: "Starting", tone: "pending" });
+    });
+
+    it("reports loading until lease status arrives", () => {
+      expect(getServiceStatus(undefined, "active")).toEqual({ label: "Loading", tone: "pending" });
     });
 
     it("reports closed when the lease is closed", () => {

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/placementModel.spec.ts
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/placementModel.spec.ts
@@ -243,7 +243,7 @@ describe("placementModel", () => {
     });
 
     it("reports loading until lease status arrives", () => {
-      expect(getServiceStatus(undefined, "active")).toEqual({ label: "Loading", tone: "pending" });
+      expect(getServiceStatus(undefined, "active")).toEqual({ label: "Loading", tone: "loading" });
     });
 
     it("reports closed when the lease is closed", () => {

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/placementModel.spec.ts
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/placementModel.spec.ts
@@ -214,13 +214,13 @@ describe("placementModel", () => {
   });
 
   describe("formatGpuLabel", () => {
-    it("formats count and model as in the header design", () => {
-      expect(formatGpuLabel(1, ["h100"])).toBe("1× H100");
-      expect(formatGpuLabel(2, ["h100"])).toBe("2× H100");
+    it("formats the model name when one is declared", () => {
+      expect(formatGpuLabel(1, ["h100"])).toBe("H100");
+      expect(formatGpuLabel(2, ["a100"])).toBe("A100");
     });
 
-    it("joins multiple models after the count", () => {
-      expect(formatGpuLabel(2, ["h100", "a100"])).toBe("2× H100, A100");
+    it("joins multiple models", () => {
+      expect(formatGpuLabel(2, ["h100", "a100"])).toBe("H100, A100");
     });
 
     it("falls back to the count when no model is declared", () => {

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/placementModel.spec.ts
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/placementModel.spec.ts
@@ -190,6 +190,10 @@ describe("placementModel", () => {
     it("returns an empty list when no gpu is requested", () => {
       expect(getPlacementGpuModels(buildGroup({}))).toEqual([]);
     });
+
+    it("ignores a wildcard model when no gpu type is specified", () => {
+      expect(getPlacementGpuModels(buildGroup({ gpuAttributes: [{ key: "vendor/nvidia/model/*", value: "true" }] }))).toEqual([]);
+    });
   });
 
   describe("getDeploymentGpuModels", () => {
@@ -221,6 +225,7 @@ describe("placementModel", () => {
 
     it("falls back to the count when no model is declared", () => {
       expect(formatGpuLabel(1, [])).toBe("1");
+      expect(formatGpuLabel(1, ["*"])).toBe("1");
     });
 
     it("shows an em dash when the deployment has no gpu", () => {

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/placementModel.ts
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/placementModel.ts
@@ -160,7 +160,7 @@ function isNamedGpuModel(model: string | undefined): model is string {
   return !!model && model !== "*";
 }
 
-export type ServiceStatusTone = "running" | "pending" | "closed";
+export type ServiceStatusTone = "running" | "pending" | "loading" | "closed";
 
 export interface ServiceStatusView {
   label: string;
@@ -181,7 +181,7 @@ export function getServiceStatus(
   isReclaimed = false
 ): ServiceStatusView {
   if (!isLeaseLive({ state: leaseState }) || isReclaimed) return { label: "Closed", tone: "closed" };
-  if (!service) return { label: "Loading", tone: "pending" };
+  if (!service) return { label: "Loading", tone: "loading" };
   if (service.available > 0) return { label: "Running", tone: "running" };
   return { label: "Starting", tone: "pending" };
 }

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/placementModel.ts
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/placementModel.ts
@@ -172,6 +172,8 @@ export interface ServiceStatusView {
  * state. Any lease that is not live — closed, out of funds, or provider-reclaimed even while its `state`
  * still reads "active" — is terminal, so the row stays in sync with the ReclamationCard banner above it
  * and an escrow-drained lease shows "Closed" instead of spinning on "Starting" forever.
+ * Until lease status arrives, the row is "Loading" rather than "Starting", so a refresh of an already
+ * running service does not flash the wrong label.
  */
 export function getServiceStatus(
   service: Pick<LeaseServiceStatus, "available" | "total" | "ready_replicas"> | undefined,
@@ -179,7 +181,8 @@ export function getServiceStatus(
   isReclaimed = false
 ): ServiceStatusView {
   if (!isLeaseLive({ state: leaseState }) || isReclaimed) return { label: "Closed", tone: "closed" };
-  if (service && service.available > 0) return { label: "Running", tone: "running" };
+  if (!service) return { label: "Loading", tone: "pending" };
+  if (service.available > 0) return { label: "Running", tone: "running" };
   return { label: "Starting", tone: "pending" };
 }
 

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/placementModel.ts
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/placementModel.ts
@@ -142,18 +142,22 @@ export function getProviderRegion(
 
 export function getPlacementGpuModels(group: DeploymentGroup | undefined): string[] {
   const models = (group?.group_spec?.resources ?? []).flatMap(resource => getGpusFromAttributes(resource.resource.gpu?.attributes ?? []).map(gpu => gpu.model));
-  return Array.from(new Set(models.filter(Boolean)));
+  return Array.from(new Set(models.filter(isNamedGpuModel)));
 }
 
 export function getDeploymentGpuModels(groups: DeploymentGroup[] | undefined): string[] {
   return Array.from(new Set((groups ?? []).flatMap(group => getPlacementGpuModels(group))));
 }
 
-/** `{count}× {MODEL}` (e.g. `1× H100`); the count alone when no model is declared. */
+/** `{count}× {MODEL}` (e.g. `1× H100`); the count alone when no named model is declared. */
 export function formatGpuLabel(gpuAmount: number, models: string[]): string {
   if (!gpuAmount) return "—";
-  const names = models.filter(Boolean).map(model => model.toUpperCase());
+  const names = models.filter(isNamedGpuModel).map(model => model.toUpperCase());
   return names.length > 0 ? `${gpuAmount}× ${names.join(", ")}` : String(gpuAmount);
+}
+
+function isNamedGpuModel(model: string | undefined): model is string {
+  return !!model && model !== "*";
 }
 
 export type ServiceStatusTone = "running" | "pending" | "closed";

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/placementModel.ts
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/placementModel.ts
@@ -149,11 +149,11 @@ export function getDeploymentGpuModels(groups: DeploymentGroup[] | undefined): s
   return Array.from(new Set((groups ?? []).flatMap(group => getPlacementGpuModels(group))));
 }
 
-/** `{count}× {MODEL}` (e.g. `1× H100`); the count alone when no named model is declared. */
+/** Named model(s) (e.g. `A100`); the count alone when no named model is declared. */
 export function formatGpuLabel(gpuAmount: number, models: string[]): string {
   if (!gpuAmount) return "—";
   const names = models.filter(isNamedGpuModel).map(model => model.toUpperCase());
-  return names.length > 0 ? `${gpuAmount}× ${names.join(", ")}` : String(gpuAmount);
+  return names.length > 0 ? names.join(", ") : String(gpuAmount);
 }
 
 function isNamedGpuModel(model: string | undefined): model is string {

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/placementModel.ts
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/placementModel.ts
@@ -168,6 +168,12 @@ export function getServiceStatus(
   return { label: "Starting", tone: "pending" };
 }
 
+/** `{available}/{total} replicas` for the collapsed service row; omitted until lease status has arrived. */
+export function formatReplicaCount(service: Pick<LeaseServiceStatus, "available" | "total"> | undefined): string | undefined {
+  if (!service || typeof service.available !== "number" || typeof service.total !== "number") return undefined;
+  return `${service.available}/${service.total} replicas`;
+}
+
 function parseComputeResources(resources: unknown): ManifestServiceResources | undefined {
   if (!resources || typeof resources !== "object") return undefined;
 

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/placementModel.ts
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/placementModel.ts
@@ -145,6 +145,17 @@ export function getPlacementGpuModels(group: DeploymentGroup | undefined): strin
   return Array.from(new Set(models.filter(Boolean)));
 }
 
+export function getDeploymentGpuModels(groups: DeploymentGroup[] | undefined): string[] {
+  return Array.from(new Set((groups ?? []).flatMap(group => getPlacementGpuModels(group))));
+}
+
+/** `{count}× {MODEL}` (e.g. `1× H100`); the count alone when no model is declared. */
+export function formatGpuLabel(gpuAmount: number, models: string[]): string {
+  if (!gpuAmount) return "—";
+  const names = models.filter(Boolean).map(model => model.toUpperCase());
+  return names.length > 0 ? `${gpuAmount}× ${names.join(", ")}` : String(gpuAmount);
+}
+
 export type ServiceStatusTone = "running" | "pending" | "closed";
 
 export interface ServiceStatusView {

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentSettings.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentSettings.tsx
@@ -1,9 +1,9 @@
 "use client";
 import type { FC, ReactNode } from "react";
-import { cn } from "@akashnetwork/ui/utils";
 
 import { useUser } from "@src/hooks/useUser";
 import type { DeploymentDto, LeaseDto } from "@src/types/deployment";
+import { DeploymentTabHeader } from "../DeploymentTabHeader";
 import { DeploymentBillingSection } from "./DeploymentBillingSection";
 import { DeploymentDangerZone } from "./DeploymentDangerZone";
 import { DeploymentNotificationsSection } from "./DeploymentNotificationsSection";
@@ -47,8 +47,8 @@ export const DeploymentSettings: FC<DeploymentSettingsProps> = ({ deployment, le
 };
 
 const SettingsSection: FC<{ title: string; destructive?: boolean; children: ReactNode }> = ({ title, destructive, children }) => (
-  <section className="space-y-3">
-    <h2 className={cn("text-xs font-medium uppercase tracking-wide", destructive ? "text-destructive" : "text-muted-foreground")}>{title}</h2>
+  <section>
+    <DeploymentTabHeader title={title} destructive={destructive} />
     {children}
   </section>
 );

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentStatusBadge.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentStatusBadge.tsx
@@ -6,7 +6,7 @@ import type { LeaseDto } from "@src/types/deployment";
 import { isLeaseLive } from "@src/utils/leaseUtils";
 import { classifyLeaseCloseReason, getClosedLeaseLabel, isProviderReclaimed } from "@src/utils/reclamationUtils";
 
-export type StatusTone = "running" | "pending" | "warning" | "closed";
+export type StatusTone = "running" | "pending" | "loading" | "warning" | "closed";
 
 const STATUS_LABELS: Record<string, string> = {
   active: "Running",
@@ -21,6 +21,7 @@ const STATUS_TONES: Record<string, StatusTone> = {
 const BADGE_TONE_CLASS: Record<StatusTone, string> = {
   running: "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
   pending: "bg-amber-500/10 text-amber-600 dark:text-amber-400",
+  loading: "bg-muted text-muted-foreground",
   warning: "bg-warning/10 text-warning",
   closed: "bg-destructive/10 text-destructive"
 };
@@ -28,6 +29,7 @@ const BADGE_TONE_CLASS: Record<StatusTone, string> = {
 const DOT_TONE_CLASS: Record<StatusTone, string> = {
   running: "bg-emerald-500",
   pending: "bg-amber-500",
+  loading: "bg-muted-foreground",
   warning: "bg-warning",
   closed: "bg-destructive"
 };
@@ -74,10 +76,14 @@ export interface StatusBadgeProps {
 
 export const StatusBadge: FC<StatusBadgeProps> = ({ label, tone, className }) => (
   <span className={cn("inline-flex items-center gap-2 rounded-full px-2.5 py-1 text-xs font-medium", BADGE_TONE_CLASS[tone], className)}>
-    <span className="relative flex h-2 w-2">
-      {tone === "running" && <span className={cn("absolute inline-flex h-full w-full animate-ping rounded-full opacity-75", DOT_TONE_CLASS[tone])} />}
-      <span className={cn("relative inline-flex h-2 w-2 rounded-full", DOT_TONE_CLASS[tone])} />
-    </span>
+    {tone === "loading" ? (
+      <span className="h-3 w-3 shrink-0 animate-spin rounded-full border-2 border-current border-t-transparent" aria-hidden="true" />
+    ) : (
+      <span className="relative flex h-2 w-2">
+        {tone === "running" && <span className={cn("absolute inline-flex h-full w-full animate-ping rounded-full opacity-75", DOT_TONE_CLASS[tone])} />}
+        <span className={cn("relative inline-flex h-2 w-2 rounded-full", DOT_TONE_CLASS[tone])} />
+      </span>
+    )}
     {label}
   </span>
 );

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentTabHeader.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentTabHeader.spec.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from "react";
+import { describe, expect, it } from "vitest";
+
+import { DeploymentTabHeader } from "./DeploymentTabHeader";
+
+import { render, screen } from "@testing-library/react";
+
+describe(DeploymentTabHeader.name, () => {
+  it("renders the title as a heading", () => {
+    setup({ title: "Placements" });
+
+    expect(screen.getByRole("heading", { name: "Placements" })).toBeInTheDocument();
+  });
+
+  it("renders actions next to the title", () => {
+    setup({ title: "Placements", actions: <button type="button">Expand all</button> });
+
+    expect(screen.getByRole("button", { name: "Expand all" })).toBeInTheDocument();
+  });
+
+  function setup(input: { title: string; actions?: ReactNode }) {
+    return render(<DeploymentTabHeader title={input.title} actions={input.actions} />);
+  }
+});

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentTabHeader.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentTabHeader.tsx
@@ -9,7 +9,7 @@ export interface DeploymentTabHeaderProps {
 }
 
 export const DeploymentTabHeader: FC<DeploymentTabHeaderProps> = ({ title, actions, children, destructive }) => (
-  <div className="flex min-h-[50px] items-center justify-between gap-2">
+  <div className="flex items-center justify-between gap-2 pb-4">
     <div className="flex items-center gap-2">
       <h2 className={cn("text-sm font-normal text-muted-foreground", destructive && "text-destructive")}>{title}</h2>
       {children}

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentTabHeader.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentTabHeader.tsx
@@ -1,0 +1,19 @@
+import type { FC, ReactNode } from "react";
+import { cn } from "@akashnetwork/ui/utils";
+
+export interface DeploymentTabHeaderProps {
+  title: string;
+  actions?: ReactNode;
+  children?: ReactNode;
+  destructive?: boolean;
+}
+
+export const DeploymentTabHeader: FC<DeploymentTabHeaderProps> = ({ title, actions, children, destructive }) => (
+  <div className="flex min-h-[50px] items-center justify-between gap-2">
+    <div className="flex items-center gap-2">
+      <h2 className={cn("text-base font-medium", destructive && "text-destructive")}>{title}</h2>
+      {children}
+    </div>
+    {actions}
+  </div>
+);

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentTabHeader.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentTabHeader.tsx
@@ -11,7 +11,7 @@ export interface DeploymentTabHeaderProps {
 export const DeploymentTabHeader: FC<DeploymentTabHeaderProps> = ({ title, actions, children, destructive }) => (
   <div className="flex min-h-[50px] items-center justify-between gap-2">
     <div className="flex items-center gap-2">
-      <h2 className={cn("text-base font-medium", destructive && "text-destructive")}>{title}</h2>
+      <h2 className={cn("text-sm font-normal text-muted-foreground", destructive && "text-destructive")}>{title}</h2>
       {children}
     </div>
     {actions}

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentVisitControl/DeploymentVisitControl.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentVisitControl/DeploymentVisitControl.spec.tsx
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { LeaseServiceStatus, LeaseStatusDto } from "@src/queries/useLeaseQuery";
+import type { LeaseDto } from "@src/types/deployment";
+import type { ApiProviderList } from "@src/types/provider";
+import { DEPENDENCIES, DeploymentVisitControl } from "./DeploymentVisitControl";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MockComponents } from "@tests/unit/mocks";
+
+describe(DeploymentVisitControl.name, () => {
+  it("hides the visit control when no lease has an endpoint yet", async () => {
+    setup({ endpointsByLease: { "1": {} } });
+
+    expect(screen.queryByRole("link", { name: "Visit" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Visit" })).not.toBeInTheDocument();
+  });
+
+  it("shows the URI, a copy button, and a Visit link when there is one endpoint", async () => {
+    setup({ endpointsByLease: { "1": { web: ["app.akash.app"] } } });
+
+    const visit = await screen.findByRole("link", { name: "Visit" });
+    expect(visit).toHaveAttribute("href", "http://app.akash.app");
+    expect(screen.getByText("app.akash.app")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Copy URL" })).toBeInTheDocument();
+  });
+
+  it("opens a dropdown of every endpoint when a lease exposes more than one service", async () => {
+    setup({
+      endpointsByLease: {
+        "1": { storefront: ["shop.acmecorp.com"], api: ["api.shop.acmecorp.com"] }
+      }
+    });
+
+    await userEvent.click(await screen.findByRole("button", { name: "Visit" }));
+
+    expect(screen.getByText("2 endpoints")).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /storefront/i })).toHaveAttribute("href", "http://shop.acmecorp.com");
+    expect(screen.getByRole("menuitem", { name: /api/i })).toHaveAttribute("href", "http://api.shop.acmecorp.com");
+    expect(screen.getByText("shop.acmecorp.com")).toBeInTheDocument();
+    expect(screen.getByText("api.shop.acmecorp.com")).toBeInTheDocument();
+    expect(screen.getAllByText(":80")).toHaveLength(2);
+    expect(screen.getByRole("button", { name: "Copy storefront URL" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Copy api URL" })).toBeInTheDocument();
+  });
+
+  it("lists endpoints from every live placement in the Visit dropdown", async () => {
+    setup({
+      leases: [buildLease("us", "akash1us"), buildLease("eu", "akash1eu")],
+      providers: [mock<ApiProviderList>({ owner: "akash1us" }), mock<ApiProviderList>({ owner: "akash1eu" })],
+      endpointsByLease: {
+        us: { web: ["us.akash.app"] },
+        eu: { web: ["eu.akash.app"] }
+      }
+    });
+
+    await userEvent.click(await screen.findByRole("button", { name: "Visit" }));
+
+    expect(screen.getByText("2 endpoints")).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /us.akash.app/i })).toHaveAttribute("href", "http://us.akash.app");
+    expect(screen.getByRole("menuitem", { name: /eu.akash.app/i })).toHaveAttribute("href", "http://eu.akash.app");
+  });
+
+  it("leaves closed placements out of the Visit dropdown", async () => {
+    setup({
+      leases: [buildLease("live", "akash1us"), mock<LeaseDto>({ id: "closed", provider: "akash1eu", state: "closed" })],
+      providers: [mock<ApiProviderList>({ owner: "akash1us" }), mock<ApiProviderList>({ owner: "akash1eu" })],
+      endpointsByLease: {
+        live: { web: ["us.akash.app"] },
+        closed: { web: ["eu.akash.app"] }
+      }
+    });
+
+    const visit = await screen.findByRole("link", { name: "Visit" });
+    expect(visit).toHaveAttribute("href", "http://us.akash.app");
+    expect(screen.queryByRole("button", { name: "Visit" })).not.toBeInTheDocument();
+  });
+
+  function buildLease(id: string, provider: string) {
+    return mock<LeaseDto>({ id, provider, state: "active" });
+  }
+
+  function setup(input: { leases?: LeaseDto[]; providers?: ApiProviderList[]; endpointsByLease: Record<string, Record<string, string[]>> }) {
+    const leases = input.leases ?? [buildLease("1", "akash1provider")];
+    const providers = input.providers ?? [mock<ApiProviderList>({ owner: "akash1provider" })];
+
+    const useLeaseStatuses: typeof DEPENDENCIES.useLeaseStatuses = items =>
+      items.map(({ lease }) => {
+        const services: Record<string, string[]> = input.endpointsByLease[lease.id] ?? {};
+        const leaseStatus = mock<LeaseStatusDto>();
+        leaseStatus.forwarded_ports = {};
+        leaseStatus.ips = {};
+        leaseStatus.services = Object.fromEntries(
+          Object.entries(services).map(([name, uris]) => {
+            const service = mock<LeaseServiceStatus>();
+            service.uris = uris;
+            return [name, service];
+          })
+        );
+        return mock<ReturnType<typeof DEPENDENCIES.useLeaseStatuses>[number]>({ data: leaseStatus });
+      });
+
+    const CopyTextToClipboardButton = vi.fn(({ value, "aria-label": label }: { value: string; "aria-label"?: string }) => (
+      <button type="button" aria-label={label ?? "Copy URL"} data-value={value}>
+        copy
+      </button>
+    ));
+
+    return render(
+      <DeploymentVisitControl
+        leases={leases}
+        providers={providers}
+        dependencies={MockComponents(DEPENDENCIES, { useLeaseStatuses, CopyTextToClipboardButton })}
+      />
+    );
+  }
+});

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentVisitControl/DeploymentVisitControl.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentVisitControl/DeploymentVisitControl.tsx
@@ -1,0 +1,99 @@
+"use client";
+import type { FC } from "react";
+import { useMemo } from "react";
+import {
+  Button,
+  buttonVariants,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger
+} from "@akashnetwork/ui/components";
+import { cn } from "@akashnetwork/ui/utils";
+import { Globe, NavArrowDown } from "iconoir-react";
+
+import { CopyTextToClipboardButton } from "@src/components/shared/CopyTextToClipboardButton";
+import { useLeaseStatuses } from "@src/queries/useLeaseQuery";
+import type { LeaseDto } from "@src/types/deployment";
+import type { ApiProviderList } from "@src/types/provider";
+import { isLeaseLive } from "@src/utils/leaseUtils";
+import type { VisitEndpoint } from "./visitEndpoints";
+import { collectVisitEndpoints, endpointLabel } from "./visitEndpoints";
+
+export const DEPENDENCIES = {
+  useLeaseStatuses,
+  CopyTextToClipboardButton
+};
+
+export interface DeploymentVisitControlProps {
+  leases: LeaseDto[];
+  providers: ApiProviderList[];
+  dependencies?: typeof DEPENDENCIES;
+}
+
+export const DeploymentVisitControl: FC<DeploymentVisitControlProps> = ({ leases, providers, dependencies: d = DEPENDENCIES }) => {
+  const items = useMemo(
+    () =>
+      leases.filter(isLeaseLive).map(lease => ({
+        lease,
+        provider: providers.find(provider => provider.owner === lease.provider)
+      })),
+    [leases, providers]
+  );
+  const statuses = d.useLeaseStatuses(items, { refetchInterval: 30_000 });
+  const endpoints = statuses.flatMap(status => collectVisitEndpoints(status.data));
+
+  return <VisitControlView endpoints={endpoints} CopyTextToClipboardButton={d.CopyTextToClipboardButton} />;
+};
+
+const VisitControlView: FC<{
+  endpoints: VisitEndpoint[];
+  CopyTextToClipboardButton: typeof CopyTextToClipboardButton;
+}> = ({ endpoints, CopyTextToClipboardButton }) => {
+  if (endpoints.length === 0) return null;
+
+  if (endpoints.length === 1) {
+    const endpoint = endpoints[0];
+    return (
+      <div className="flex items-center gap-2">
+        <div className="inline-flex max-w-xs items-center gap-2 rounded-md border px-3 py-2 text-sm">
+          <Globe className="shrink-0 text-xs text-muted-foreground" />
+          <span className="truncate">{endpointLabel(endpoint)}</span>
+        </div>
+        <CopyTextToClipboardButton value={endpoint.href} aria-label="Copy URL" />
+        <a href={endpoint.href} target="_blank" rel="noreferrer" className={cn(buttonVariants({ variant: "default", size: "md" }))}>
+          Visit
+        </a>
+      </div>
+    );
+  }
+
+  return (
+    <DropdownMenu modal={false}>
+      <DropdownMenuTrigger asChild>
+        <Button variant="default" size="md" className="gap-1">
+          Visit
+          <NavArrowDown className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="min-w-80 rounded-xl p-2">
+        <DropdownMenuLabel className="px-2 py-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          {endpoints.length} {endpoints.length === 1 ? "endpoint" : "endpoints"}
+        </DropdownMenuLabel>
+        {endpoints.map(endpoint => (
+          <div key={endpoint.href} className="flex items-center gap-1">
+            <DropdownMenuItem asChild className="min-w-0 flex-1 cursor-pointer">
+              <a href={endpoint.href} target="_blank" rel="noreferrer" className="grid grid-cols-[7rem_1fr_auto] items-center gap-3">
+                <span className="truncate text-xs font-medium uppercase tracking-wide text-muted-foreground">{endpoint.serviceName}</span>
+                <span className="truncate">{endpoint.host}</span>
+                <span className="text-muted-foreground">:{endpoint.port}</span>
+              </a>
+            </DropdownMenuItem>
+            <CopyTextToClipboardButton value={endpoint.href} aria-label={`Copy ${endpoint.serviceName} URL`} />
+          </div>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentVisitControl/visitEndpoints.spec.ts
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentVisitControl/visitEndpoints.spec.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { ForwardedPort, LeaseServiceStatus, LeaseStatusDto, ServiceIp } from "@src/queries/useLeaseQuery";
+import { collectVisitEndpoints, endpointLabel } from "./visitEndpoints";
+
+describe("collectVisitEndpoints", () => {
+  it("returns nothing when lease status has not loaded", () => {
+    expect(collectVisitEndpoints(undefined)).toEqual([]);
+    expect(collectVisitEndpoints(null)).toEqual([]);
+  });
+
+  it("collects service URIs as http endpoints", () => {
+    const result = collectVisitEndpoints(buildStatus({ services: { web: ["app.akash.app"] } }));
+
+    expect(result).toEqual([{ serviceName: "web", host: "app.akash.app", port: 80, href: "http://app.akash.app" }]);
+  });
+
+  it("reads an explicit port off a URI", () => {
+    const result = collectVisitEndpoints(buildStatus({ services: { api: ["api.akash.app:3000"] } }));
+
+    expect(result).toEqual([{ serviceName: "api", host: "api.akash.app", port: 3000, href: "http://api.akash.app:3000" }]);
+  });
+
+  it("falls back to forwarded ports when a service has no URI", () => {
+    const result = collectVisitEndpoints(
+      buildStatus({
+        services: { web: [] },
+        forwardedPorts: { web: [mock<ForwardedPort>({ host: "provider.akash", externalPort: 31234 })] }
+      })
+    );
+
+    expect(result).toEqual([{ serviceName: "web", host: "provider.akash", port: 31234, href: "http://provider.akash:31234" }]);
+  });
+
+  it("skips forwarded ports that have no host", () => {
+    const result = collectVisitEndpoints(
+      buildStatus({
+        services: { web: [] },
+        forwardedPorts: { web: [mock<ForwardedPort>({ host: "", externalPort: 80 })] }
+      })
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  it("includes leased IPs", () => {
+    const result = collectVisitEndpoints(
+      buildStatus({
+        services: { web: [] },
+        ips: { web: [mock<ServiceIp>({ IP: "1.2.3.4", ExternalPort: 443 })] }
+      })
+    );
+
+    expect(result).toEqual([{ serviceName: "web", host: "1.2.3.4", port: 443, href: "http://1.2.3.4:443" }]);
+  });
+
+  it("keeps one row per href when a URI and forwarded port point at the same address", () => {
+    const result = collectVisitEndpoints(
+      buildStatus({
+        services: { web: ["provider.akash:31234"] },
+        forwardedPorts: { web: [mock<ForwardedPort>({ host: "provider.akash", externalPort: 31234 })] }
+      })
+    );
+
+    expect(result).toEqual([{ serviceName: "web", host: "provider.akash", port: 31234, href: "http://provider.akash:31234" }]);
+  });
+
+  it("collects every service on the lease", () => {
+    const result = collectVisitEndpoints(
+      buildStatus({
+        services: { storefront: ["shop.acmecorp.com"], api: ["api.shop.acmecorp.com"] }
+      })
+    );
+
+    expect(result.map(endpoint => endpoint.serviceName)).toEqual(["storefront", "api"]);
+  });
+});
+
+describe("endpointLabel", () => {
+  it("omits port 80 from the displayed host", () => {
+    expect(endpointLabel({ serviceName: "web", host: "app.akash.app", port: 80, href: "http://app.akash.app" })).toBe("app.akash.app");
+  });
+
+  it("keeps a non-default port on the displayed host", () => {
+    expect(endpointLabel({ serviceName: "web", host: "provider.akash", port: 31234, href: "http://provider.akash:31234" })).toBe("provider.akash:31234");
+  });
+});
+
+function buildStatus(input: {
+  services: Record<string, string[]>;
+  forwardedPorts?: Record<string, ForwardedPort[]>;
+  ips?: Record<string, ServiceIp[]>;
+}): LeaseStatusDto {
+  return mock<LeaseStatusDto>({
+    services: Object.fromEntries(
+      Object.entries(input.services).map(([name, uris]) => {
+        const service = mock<LeaseServiceStatus>();
+        service.uris = uris;
+        return [name, service];
+      })
+    ),
+    forwarded_ports: input.forwardedPorts ?? {},
+    ips: input.ips ?? {}
+  });
+}

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentVisitControl/visitEndpoints.spec.ts
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentVisitControl/visitEndpoints.spec.ts
@@ -48,11 +48,22 @@ describe("collectVisitEndpoints", () => {
     const result = collectVisitEndpoints(
       buildStatus({
         services: { web: [] },
-        ips: { web: [mock<ServiceIp>({ IP: "1.2.3.4", ExternalPort: 443 })] }
+        ips: { web: [mock<ServiceIp>({ IP: "1.2.3.4", ExternalPort: 443, Protocol: "TCP" })] }
       })
     );
 
     expect(result).toEqual([{ serviceName: "web", host: "1.2.3.4", port: 443, href: "http://1.2.3.4:443" }]);
+  });
+
+  it("skips leased IPs that are not TCP", () => {
+    const result = collectVisitEndpoints(
+      buildStatus({
+        services: { game: [] },
+        ips: { game: [mock<ServiceIp>({ IP: "1.2.3.4", ExternalPort: 7777, Protocol: "UDP" })] }
+      })
+    );
+
+    expect(result).toEqual([]);
   });
 
   it("keeps one row per href when a URI and forwarded port point at the same address", () => {

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentVisitControl/visitEndpoints.ts
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentVisitControl/visitEndpoints.ts
@@ -35,6 +35,7 @@ export function collectVisitEndpoints(status: LeaseStatusDto | null | undefined)
 
   for (const [serviceName, ips] of Object.entries(status.ips ?? {})) {
     for (const ip of ips) {
+      if (ip.Protocol && ip.Protocol.toUpperCase() !== "TCP") continue;
       add(serviceName, ip.IP, ip.ExternalPort, `http://${ip.IP}:${ip.ExternalPort}`);
     }
   }

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentVisitControl/visitEndpoints.ts
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentVisitControl/visitEndpoints.ts
@@ -1,0 +1,57 @@
+import type { LeaseStatusDto } from "@src/queries/useLeaseQuery";
+
+export interface VisitEndpoint {
+  serviceName: string;
+  host: string;
+  port: number;
+  href: string;
+}
+
+export function collectVisitEndpoints(status: LeaseStatusDto | null | undefined): VisitEndpoint[] {
+  if (!status) return [];
+
+  const endpoints: VisitEndpoint[] = [];
+  const seen = new Set<string>();
+
+  function add(serviceName: string, host: string, port: number, href: string) {
+    if (!host || seen.has(href)) return;
+    seen.add(href);
+    endpoints.push({ serviceName, host, port, href });
+  }
+
+  for (const [serviceName, service] of Object.entries(status.services)) {
+    for (const uri of service.uris ?? []) {
+      const { host, port } = parseHostPort(uri, 80);
+      add(serviceName, host, port, `http://${uri}`);
+    }
+  }
+
+  for (const [serviceName, ports] of Object.entries(status.forwarded_ports ?? {})) {
+    for (const port of ports) {
+      if (!port.host) continue;
+      add(serviceName, port.host, port.externalPort, `http://${port.host}:${port.externalPort}`);
+    }
+  }
+
+  for (const [serviceName, ips] of Object.entries(status.ips ?? {})) {
+    for (const ip of ips) {
+      add(serviceName, ip.IP, ip.ExternalPort, `http://${ip.IP}:${ip.ExternalPort}`);
+    }
+  }
+
+  return endpoints;
+}
+
+export function endpointLabel(endpoint: VisitEndpoint): string {
+  return endpoint.port === 80 ? endpoint.host : `${endpoint.host}:${endpoint.port}`;
+}
+
+function parseHostPort(value: string, fallbackPort: number): { host: string; port: number } {
+  const hostPart = value.replace(/^[a-z]+:\/\//i, "").split("/")[0] ?? value;
+  const match = hostPart.match(/^(.*):(\d+)$/);
+  if (match?.[1] && match[2]) {
+    return { host: match[1], port: Number(match[2]) };
+  }
+
+  return { host: hostPart, port: fallbackPort };
+}

--- a/apps/deploy-web/src/components/deployments/DeploymentDetailLegacy.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetailLegacy.tsx
@@ -273,7 +273,7 @@ export const DeploymentDetailLegacy: FC<DeploymentDetailLegacyProps> = ({ dseq }
             {activeTab === "EVENTS" && <DeploymentLogs leases={leases} selectedLogsMode="events" />}
             {activeTab === "SHELL" && <DeploymentLeaseShell leases={leases} />}
             {isAlertsEnabled && (
-              <div className={cn({ hidden: activeTab !== "ALERTS" })}>
+              <div className={cn("pt-6", { hidden: activeTab !== "ALERTS" })}>
                 <DeploymentAlerts deployment={deployment} onStateChange={recordAlertsChange} />
               </div>
             )}

--- a/apps/deploy-web/src/components/deployments/DeploymentLeaseShell.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentLeaseShell.tsx
@@ -246,7 +246,7 @@ export const DeploymentLeaseShell: React.FunctionComponent<Props> = ({ leases })
             <>
               {!isConnectionClosed && (
                 <>
-                  <div className="flex h-[56px] items-center space-x-4 p-2">
+                  <div className="flex min-h-[50px] items-center gap-4">
                     <div className="flex items-center">
                       {(leases?.length || 0) > 1 && <LeaseSelect leases={leases || []} defaultValue={selectedLease.id} onSelectedChange={handleLeaseChange} />}
 

--- a/apps/deploy-web/src/components/deployments/DeploymentLogs.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentLogs.tsx
@@ -248,7 +248,7 @@ export const DeploymentLogs: React.FunctionComponent<Props> = ({ leases, selecte
         <>
           {selectedLease && (
             <>
-              <div className="flex h-[56px] items-center space-x-4 p-2">
+              <div className="flex min-h-[50px] items-center gap-4">
                 <div className="flex items-center">
                   {(leases?.length || 0) > 1 && <LeaseSelect leases={leases || []} defaultValue={selectedLease.id} onSelectedChange={handleLeaseChange} />}
 

--- a/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.tsx
+++ b/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.tsx
@@ -21,7 +21,7 @@ import { TransactionMessageData as TransactionMessageDataOriginal } from "@src/u
 import RemoteDeployUpdate from "../../remote-deploy/update/RemoteDeployUpdate";
 import { SDLEditor } from "../../sdl/SDLEditor/SDLEditor";
 import { ManifestErrorSnackbar } from "../../shared/ManifestErrorSnackbar/ManifestErrorSnackbar";
-import { Title } from "../../shared/Title";
+import { DeploymentTabHeader } from "../DeploymentDetail/DeploymentTabHeader";
 
 export const DEPENDENCIES = {
   Alert,
@@ -34,7 +34,6 @@ export const DEPENDENCIES = {
   RemoteDeployUpdate,
   SDLEditor,
   ManifestErrorSnackbar,
-  Title,
   InfoCircle,
   WarningCircle,
   useWallet: useWalletOriginal,
@@ -197,62 +196,59 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
       ) : (
         <>
           <div>
-            <div className="flex h-[50px] items-center justify-between space-x-2 px-2 py-1">
-              <div className="flex items-center space-x-2">
-                <d.Title subTitle className="!text-base">
-                  Update Deployment
-                </d.Title>
+            <DeploymentTabHeader
+              title="Update Deployment"
+              actions={
+                <div className="flex items-center gap-2">
+                  {onRedeploy && (
+                    <d.Button variant="outline" size="md" className="gap-1" type="button" disabled={isSendingManifest} onClick={onRedeploy}>
+                      <Upload className="text-xs" />
+                      Redeploy
+                    </d.Button>
+                  )}
+                  <d.Button
+                    disabled={
+                      !providerCredentials.details.usable ||
+                      !!parsingError ||
+                      !editedManifest ||
+                      !providers ||
+                      isSendingManifest ||
+                      deployment.state !== "active" ||
+                      isBlockchainDown
+                    }
+                    onClick={() => handleUpdateClick()}
+                    size="md"
+                    type="button"
+                  >
+                    Update Deployment
+                  </d.Button>
+                </div>
+              }
+            >
+              <d.CustomTooltip
+                title={
+                  <div>
+                    Akash Groups are translated into Kubernetes Deployments, this means that only a few fields from the Akash SDL are mutable. For example
+                    image, command, args, env and exposed ports can be modified, but compute resources and placement criteria cannot. (
+                    <d.LinkTo onClick={handleUpdateDocClick}>View doc</d.LinkTo>)
+                  </div>
+                }
+              >
+                <d.InfoCircle className="text-xs text-muted-foreground" />
+              </d.CustomTooltip>
 
+              {!!deploymentVersion && deploymentVersion !== deployment.hash && (
                 <d.CustomTooltip
                   title={
-                    <div>
-                      Akash Groups are translated into Kubernetes Deployments, this means that only a few fields from the Akash SDL are mutable. For example
-                      image, command, args, env and exposed ports can be modified, but compute resources and placement criteria cannot. (
-                      <d.LinkTo onClick={handleUpdateDocClick}>View doc</d.LinkTo>)
-                    </div>
+                    <d.Alert variant="warning">
+                      Your local deployment file version doesn't match the one on-chain. If you click update, you will override the deployed version.
+                    </d.Alert>
                   }
                 >
-                  <d.InfoCircle className="text-xs text-muted-foreground" />
+                  <d.WarningCircle className="text-xs text-warning" />
                 </d.CustomTooltip>
-
-                {!!deploymentVersion && deploymentVersion !== deployment.hash && (
-                  <d.CustomTooltip
-                    title={
-                      <d.Alert variant="warning">
-                        Your local deployment file version doesn't match the one on-chain. If you click update, you will override the deployed version.
-                      </d.Alert>
-                    }
-                  >
-                    <d.WarningCircle className="text-xs text-warning" />
-                  </d.CustomTooltip>
-                )}
-              </div>
-
-              <div className="flex items-center gap-2">
-                {onRedeploy && (
-                  <d.Button variant="outline" size="md" className="gap-1" type="button" disabled={isSendingManifest} onClick={onRedeploy}>
-                    <Upload className="text-xs" />
-                    Redeploy
-                  </d.Button>
-                )}
-                <d.Button
-                  disabled={
-                    !providerCredentials.details.usable ||
-                    !!parsingError ||
-                    !editedManifest ||
-                    !providers ||
-                    isSendingManifest ||
-                    deployment.state !== "active" ||
-                    isBlockchainDown
-                  }
-                  onClick={() => handleUpdateClick()}
-                  size="md"
-                  type="button"
-                >
-                  Update Deployment
-                </d.Button>
-              </div>
-            </div>
+              )}
+            </DeploymentTabHeader>
 
             {parsingError && <d.Alert variant="warning">{parsingError}</d.Alert>}
 

--- a/apps/deploy-web/src/components/shared/CopyTextToClipboardButton.tsx
+++ b/apps/deploy-web/src/components/shared/CopyTextToClipboardButton.tsx
@@ -9,6 +9,7 @@ interface Props {
   value: string;
   message?: string;
   icon?: ForwardRefExoticComponent<Omit<SVGProps<SVGSVGElement>, "ref"> & RefAttributes<SVGSVGElement>>;
+  "aria-label"?: string;
 }
 
 const defaultProps = {
@@ -26,7 +27,14 @@ export const CopyTextToClipboardButton: React.FunctionComponent<Props> = props =
   }, [actualProps.value, enqueueSnackbar]);
 
   return (
-    <Button onClick={onClick} size="icon" className="h-8 w-8 rounded-full" variant="ghost">
+    <Button
+      type="button"
+      onClick={onClick}
+      size="icon"
+      className="h-8 w-8 rounded-full"
+      variant="ghost"
+      aria-label={props["aria-label"] ?? "Copy to clipboard"}
+    >
       <actualProps.icon className="text-xs text-muted-foreground" />
     </Button>
   );

--- a/apps/deploy-web/src/queries/useLeaseQuery.spec.tsx
+++ b/apps/deploy-web/src/queries/useLeaseQuery.spec.tsx
@@ -22,7 +22,8 @@ import {
   useAllLeases,
   useDeploymentLeaseList,
   useLeaseExistenceQuery,
-  useLeaseStatus
+  useLeaseStatus,
+  useLeaseStatuses
 } from "./useLeaseQuery";
 
 import { act } from "@testing-library/react";
@@ -571,6 +572,24 @@ describe("useLeaseQuery", () => {
       });
     });
 
+    it("returns null when the provider proxy cannot be reached", async () => {
+      const providerProxy = mock<ProviderProxyService>({
+        request: vi.fn().mockRejectedValue(new TypeError("Failed to fetch"))
+      });
+      const { result } = setupLeaseStatus({
+        lease: mockLease,
+        services: {
+          providerProxy: () => providerProxy
+        }
+      });
+
+      await vi.waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(result.current.data).toBeNull();
+    });
+
     it("returns null when fetching lease status fails with 404", async () => {
       const providerProxy = mock<ProviderProxyService>({
         request: vi.fn().mockRejectedValue(new AxiosError("Not Found", "404", undefined, undefined, { status: 404 } as any))
@@ -677,6 +696,92 @@ describe("useLeaseQuery", () => {
       const receivedServices = callerSelect.mock.calls[0][0]?.services ?? {};
       expect(receivedServices).toHaveProperty("web");
       expect(receivedServices).not.toHaveProperty("akash-attestation-sidecar");
+    });
+
+    it("fetches status for two live leases in parallel, keyed by gseq", async () => {
+      const provider = buildProvider();
+      const leaseA = { ...mockLease, id: "lease-a", gseq: 1 };
+      const leaseB = { ...mockLease, id: "lease-b", gseq: 2 };
+      const providerProxy = mock<ProviderProxyService>({
+        request: vi.fn().mockImplementation((url: string) => {
+          if (url.includes("/lease/123/1/1/status")) {
+            return Promise.resolve({ data: { services: { web: { name: "web", available: 1, uris: ["web.example"] } }, forwarded_ports: {}, ips: {} } });
+          }
+          if (url.includes("/lease/123/2/1/status")) {
+            return Promise.resolve({ data: { services: { api: { name: "api", available: 1, uris: ["api.example"] } }, forwarded_ports: {}, ips: {} } });
+          }
+          return Promise.resolve({ data: null });
+        })
+      });
+      const dependencies: typeof USE_LEASE_STATUS_DEPENDENCIES = {
+        ...USE_LEASE_STATUS_DEPENDENCIES,
+        useProviderCredentials: () => ({
+          details: { type: "jwt", value: "jwt-token", isExpired: false, usable: true, error: null },
+          ensureToken: vi.fn().mockResolvedValue("jwt-token")
+        })
+      };
+
+      const { result } = setupQuery(
+        () => ({
+          first: useLeaseStatus({ provider, lease: leaseA, dependencies }),
+          second: useLeaseStatus({ provider, lease: leaseB, dependencies })
+        }),
+        { services: { providerProxy: () => providerProxy } }
+      );
+
+      await vi.waitFor(() => {
+        expect(result.current.first.isSuccess).toBe(true);
+        expect(result.current.second.isSuccess).toBe(true);
+      });
+
+      expect(result.current.first.data?.services.web?.uris).toEqual(["web.example"]);
+      expect(result.current.second.data?.services.api?.uris).toEqual(["api.example"]);
+      expect(providerProxy.request).toHaveBeenCalledWith(expect.stringContaining("/lease/123/1/1/status"), expect.anything());
+      expect(providerProxy.request).toHaveBeenCalledWith(expect.stringContaining("/lease/123/2/1/status"), expect.anything());
+    });
+
+    it("useLeaseStatuses fetches every live lease", async () => {
+      const provider = buildProvider();
+      const leaseA = { ...mockLease, id: "lease-a", gseq: 1 };
+      const leaseB = { ...mockLease, id: "lease-b", gseq: 2 };
+      const providerProxy = mock<ProviderProxyService>({
+        request: vi.fn().mockImplementation((url: string) => {
+          if (url.includes("/lease/123/1/1/status")) {
+            return Promise.resolve({ data: { services: { web: { name: "web", available: 1, uris: ["web.example"] } }, forwarded_ports: {}, ips: {} } });
+          }
+          if (url.includes("/lease/123/2/1/status")) {
+            return Promise.resolve({ data: { services: { api: { name: "api", available: 1, uris: ["api.example"] } }, forwarded_ports: {}, ips: {} } });
+          }
+          return Promise.resolve({ data: null });
+        })
+      });
+      const dependencies: typeof USE_LEASE_STATUS_DEPENDENCIES = {
+        ...USE_LEASE_STATUS_DEPENDENCIES,
+        useProviderCredentials: () => ({
+          details: { type: "jwt", value: "jwt-token", isExpired: false, usable: true, error: null },
+          ensureToken: vi.fn().mockResolvedValue("jwt-token")
+        })
+      };
+
+      const { result } = setupQuery(
+        () =>
+          useLeaseStatuses(
+            [
+              { lease: leaseA, provider },
+              { lease: leaseB, provider }
+            ],
+            { dependencies }
+          ),
+        { services: { providerProxy: () => providerProxy } }
+      );
+
+      await vi.waitFor(() => {
+        expect(result.current[0].isSuccess).toBe(true);
+        expect(result.current[1].isSuccess).toBe(true);
+      });
+
+      expect(result.current[0].data?.services.web?.uris).toEqual(["web.example"]);
+      expect(result.current[1].data?.services.api?.uris).toEqual(["api.example"]);
     });
 
     it("coerces the provider's null endpoint collections to empty arrays", async () => {

--- a/apps/deploy-web/src/queries/useLeaseQuery.ts
+++ b/apps/deploy-web/src/queries/useLeaseQuery.ts
@@ -1,6 +1,6 @@
 import { isHttpError, type LeaseListParams } from "@akashnetwork/http-sdk";
 import type { UseQueryOptions } from "@tanstack/react-query";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { AxiosInstance } from "axios";
 import mapValues from "lodash/mapValues";
 
@@ -120,25 +120,16 @@ export function useLeaseStatus(
   const fetchProviderUrl = d.useScopedFetchProviderUrl(provider);
 
   return useQuery({
-    queryKey: QueryKeys.getLeaseStatusKey(lease?.dseq || "", lease?.gseq || NaN, lease?.oseq || NaN),
-    queryFn: async () => {
-      if (!lease || !isLeaseLive(lease) || !providerCredentials.details.usable) return null;
-
-      const token = await providerCredentials.ensureToken();
-      const response = await fetchProviderUrl<LeaseStatusResponse>(`/lease/${lease.dseq}/${lease.gseq}/${lease.oseq}/status`, {
-        method: "GET",
-        credentials: { type: "jwt", value: token }
-      }).catch(error => {
-        if (isHttpError(error) && error.response?.status === 404) {
-          return { data: null };
-        }
-        throw error;
-      });
-
-      return response.data ? normalizeLeaseStatus(response.data) : null;
-    },
+    queryKey: leaseStatusQueryKey(lease),
+    queryFn: () =>
+      fetchLeaseStatus({
+        lease,
+        provider,
+        ensureToken: providerCredentials.ensureToken,
+        request: (url, requestOptions) => fetchProviderUrl(url, requestOptions)
+      }),
     ...options,
-    enabled: options.enabled !== false && providerCredentials.details.usable,
+    enabled: options.enabled !== false && !!provider?.hostUri && providerCredentials.details.usable,
     // Defensive: the attestation sidecar is a pod container under the current provider design and
     // never appears as a lease-status service, so this is a passthrough today. It keeps the sidecar
     // out of every consumer (status list, logs/shell selectors) at one chokepoint if that changes.
@@ -152,6 +143,71 @@ export const USE_LEASE_STATUS_DEPENDENCIES = {
   useScopedFetchProviderUrl,
   useProviderCredentials
 };
+
+export function useLeaseStatuses(
+  items: { lease: LeaseDto; provider?: ApiProviderList | null }[],
+  params: { dependencies?: typeof USE_LEASE_STATUS_DEPENDENCIES } & Omit<UseQueryOptions<LeaseStatusDto | null>, "queryKey" | "queryFn"> = {}
+) {
+  const { dependencies: d = USE_LEASE_STATUS_DEPENDENCIES, select: callerSelect, ...options } = params;
+  const providerCredentials = d.useProviderCredentials();
+  const { providerProxy } = useServices();
+
+  return useQueries({
+    queries: items.map(({ lease, provider }) => ({
+      queryKey: leaseStatusQueryKey(lease),
+      queryFn: () => {
+        if (!provider) return null;
+        return fetchLeaseStatus({
+          lease,
+          provider,
+          ensureToken: providerCredentials.ensureToken,
+          request: (url, requestOptions) => providerProxy.request(url, { ...requestOptions, providerIdentity: provider })
+        });
+      },
+      ...options,
+      enabled: options.enabled !== false && !!provider?.hostUri && providerCredentials.details.usable,
+      select: (data: LeaseStatusDto | null) => {
+        const filtered = data ? omitAttestationSidecar(data) : data;
+        return callerSelect ? callerSelect(filtered) : filtered;
+      }
+    }))
+  });
+}
+
+function leaseStatusQueryKey(lease?: LeaseDto | null) {
+  return QueryKeys.getLeaseStatusKey(lease?.dseq || "", lease?.gseq ?? 0, lease?.oseq ?? 0);
+}
+
+function isLeaseStatusUnavailable(error: unknown): boolean {
+  if (isHttpError(error) && (!error.response || error.response.status === 404 || error.code === "ERR_NETWORK")) {
+    return true;
+  }
+
+  return error instanceof TypeError && /failed to fetch/i.test(error.message);
+}
+
+async function fetchLeaseStatus(input: {
+  lease?: LeaseDto | null;
+  provider?: ApiProviderList | null;
+  ensureToken: () => Promise<string>;
+  request: (url: string, options: { method: "GET"; credentials: { type: "jwt"; value: string } }) => Promise<{ data: LeaseStatusResponse | null }>;
+}): Promise<LeaseStatusDto | null> {
+  const { lease, provider, ensureToken, request } = input;
+  if (!lease || !provider || !isLeaseLive(lease)) return null;
+
+  const token = await ensureToken();
+  const response = await request(`/lease/${lease.dseq}/${lease.gseq}/${lease.oseq}/status`, {
+    method: "GET",
+    credentials: { type: "jwt", value: token }
+  }).catch(error => {
+    if (isLeaseStatusUnavailable(error)) {
+      return { data: null };
+    }
+    throw error;
+  });
+
+  return response.data ? normalizeLeaseStatus(response.data) : null;
+}
 
 export interface ForwardedPort {
   host: string;

--- a/apps/deploy-web/tests/ui/deployment-detail-preview.spec.ts
+++ b/apps/deploy-web/tests/ui/deployment-detail-preview.spec.ts
@@ -50,9 +50,7 @@ test.describe("Deployment detail redesign preview", () => {
       await expect(service).toBeVisible();
 
       await service.click();
-
-      await expect(page.getByText("Docker image")).toBeVisible();
-      await expect(page.getByText("nginx:latest")).toBeVisible();
+      await expect(service).toHaveAttribute("aria-expanded", "true");
     });
 
     await test.step("switches tabs via the tab query param without navigating", async () => {


### PR DESCRIPTION
## Why

The placements cards on the redesigned Details tab were a first pass. Against the design they were missing the URI and replica count on the collapsed row, the same status pill the page header uses, and port chips instead of comma-separated `80:30000` link text.

The expanded body also showed image, command, and env parsed from the SDL saved in this browser. That data isn't persisted for every deployment, so this PR stops rendering it.

Part of CON-821

## What

Collapsed service row: shared `StatusBadge`, live URI with an external-link icon, `{available}/{total} replicas`.

Expanded row: live forwarded ports and leased IPs as chips. No image, command, env, or per-service resources from the local manifest. Closed rows are not collapsible because there is nothing to show.

Placement card: numbered index, stats order vCPU / Memory / Storage / GPU (only if > 0) / Services, "Services in this placement" plus Expand all / Collapse all (hidden when the lease is closed). Stats sit compact on the right, semibold, with GPU omitted when the lease has none. The provider name links to the provider detail page.

Header summary: GPU sits on the first row as `{count}× {MODEL}` (e.g. `1× H100`) instead of a bare count on the second row.

Details tab heading spacing matches Settings (no extra padding above or below "Placements").

Unit specs cover replica formatting, port chips, collapsed URI, expand-all, the GPU model label, provider links, and closed-row expand. The preview e2e now asserts the service row expands (`aria-expanded`) instead of looking for "Docker image".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Provider names link directly to provider details.
  - Deployment and placement views display GPU models, counts, and replica statistics.
  - Service rows show replica counts, URIs, forwarded ports, and leased IPs with availability indicators.
  - Added consistent headers and actions across deployment sections.

- **Bug Fixes**
  - Improved handling of closed leases, unavailable endpoints, and loading statuses.
  - Refined placement and service layouts for clearer readability.
  - Expand/collapse controls are limited to active leases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->