### PR TITLE
feat(billing): warn users by email before credits run out

### DIFF
--- a/apps/api/drizzle/0040_tan_puma.sql
+++ b/apps/api/drizzle/0040_tan_puma.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "user_wallets" ADD COLUMN "credits_low_notified_at" timestamp with time zone;

--- a/apps/api/drizzle/meta/0040_snapshot.json
+++ b/apps/api/drizzle/meta/0040_snapshot.json
@@ -1,0 +1,1511 @@
+{
+  "id": "9884c2f8-5222-474e-a35c-e3eee53b99ad",
+  "prevId": "cbb8f067-2da6-48d2-8d89-3b35a74fc994",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.user_wallets": {
+      "name": "user_wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_allowance": {
+          "name": "deployment_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "fee_allowance": {
+          "name": "fee_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "trial": {
+          "name": "trial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits_low_notified_at": {
+          "name": "credits_low_notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_wallets_user_id_userSetting_id_fk": {
+          "name": "user_wallets_user_id_userSetting_id_fk",
+          "tableFrom": "user_wallets",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_wallets_user_id_unique": {
+          "name": "user_wallets_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "user_wallets_address_unique": {
+          "name": "user_wallets_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_methods": {
+      "name": "payment_methods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_method_id": {
+          "name": "payment_method_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_validated": {
+          "name": "is_validated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payment_methods_fingerprint_payment_method_id_unique": {
+          "name": "payment_methods_fingerprint_payment_method_id_unique",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_default_unique": {
+          "name": "payment_methods_user_id_is_default_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"payment_methods\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_fingerprint_idx": {
+          "name": "payment_methods_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_idx": {
+          "name": "payment_methods_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_validated_idx": {
+          "name": "payment_methods_user_id_is_validated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_validated",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_fingerprint_payment_method_id_idx": {
+          "name": "payment_methods_user_id_fingerprint_payment_method_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_methods_user_id_userSetting_id_fk": {
+          "name": "payment_methods_user_id_userSetting_id_fk",
+          "tableFrom": "payment_methods",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_transactions": {
+      "name": "stripe_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "stripe_transaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "stripe_transaction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created'"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_refunded": {
+          "name": "amount_refunded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bonus_amount": {
+          "name": "bonus_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_charge_id": {
+          "name": "stripe_charge_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_coupon_id": {
+          "name": "stripe_coupon_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_promotion_code_id": {
+          "name": "stripe_promotion_code_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_idempotency_key": {
+          "name": "stripe_idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method_type": {
+          "name": "payment_method_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_brand": {
+          "name": "card_brand",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_last4": {
+          "name": "card_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_url": {
+          "name": "receipt_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_transactions_stripe_invoice_id_unique": {
+          "name": "stripe_transactions_stripe_invoice_id_unique",
+          "columns": [
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stripe_transactions\".\"stripe_invoice_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_idempotency_key_unique": {
+          "name": "stripe_transactions_stripe_idempotency_key_unique",
+          "columns": [
+            {
+              "expression": "stripe_idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stripe_transactions\".\"stripe_idempotency_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_user_id_idx": {
+          "name": "stripe_transactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_payment_intent_id_idx": {
+          "name": "stripe_transactions_stripe_payment_intent_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_payment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_charge_id_idx": {
+          "name": "stripe_transactions_stripe_charge_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_coupon_id_idx": {
+          "name": "stripe_transactions_stripe_coupon_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_coupon_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_promotion_code_id_idx": {
+          "name": "stripe_transactions_stripe_promotion_code_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_promotion_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_status_idx": {
+          "name": "stripe_transactions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_created_at_idx": {
+          "name": "stripe_transactions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_user_id_created_at_idx": {
+          "name": "stripe_transactions_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_transactions_user_id_userSetting_id_fk": {
+          "name": "stripe_transactions_user_id_userSetting_id_fk",
+          "tableFrom": "stripe_transactions",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_settings": {
+      "name": "wallet_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_reload_enabled": {
+          "name": "auto_reload_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_reload_mode": {
+          "name": "auto_reload_mode",
+          "type": "auto_reload_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'prediction'"
+        },
+        "auto_reload_threshold": {
+          "name": "auto_reload_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2000
+        },
+        "auto_reload_amount": {
+          "name": "auto_reload_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10000
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_settings_user_id_idx": {
+          "name": "wallet_settings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_settings_wallet_id_user_wallets_id_fk": {
+          "name": "wallet_settings_wallet_id_user_wallets_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "user_wallets",
+          "columnsFrom": [
+            "wallet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wallet_settings_user_id_userSetting_id_fk": {
+          "name": "wallet_settings_user_id_userSetting_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallet_settings_wallet_id_unique": {
+          "name": "wallet_settings_wallet_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wallet_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.userSetting": {
+      "name": "userSetting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscribedToNewsletter": {
+          "name": "subscribedToNewsletter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "youtubeUsername": {
+          "name": "youtubeUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitterUsername": {
+          "name": "twitterUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "githubUsername": {
+          "name": "githubUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_ip": {
+          "name": "last_ip",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_user_agent": {
+          "name": "last_user_agent",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fingerprint": {
+          "name": "last_fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboardingSkippedAt": {
+          "name": "onboardingSkippedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "userSetting_userId_unique": {
+          "name": "userSetting_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        },
+        "userSetting_username_unique": {
+          "name": "userSetting_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.template": {
+      "name": "template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "copiedFromId": {
+          "name": "copiedFromId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cpu": {
+          "name": "cpu",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ram": {
+          "name": "ram",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage": {
+          "name": "storage",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sdl": {
+          "name": "sdl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "template_userId_idx": {
+          "name": "template_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.templateFavorite": {
+      "name": "templateFavorite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "templateId": {
+          "name": "templateId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addedDate": {
+          "name": "addedDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "templateFavorite_userId_templateId_unique": {
+          "name": "templateFavorite_userId_templateId_unique",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "templateId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "templateFavorite_templateId_template_id_fk": {
+          "name": "templateFavorite_templateId_template_id_fk",
+          "tableFrom": "templateFavorite",
+          "tableTo": "template",
+          "columnsFrom": [
+            "templateId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_settings": {
+      "name": "deployment_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dseq": {
+          "name": "dseq",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_top_up_enabled": {
+          "name": "auto_top_up_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "closed": {
+          "name": "closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_funded_at": {
+          "name": "last_funded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_limit_hours": {
+          "name": "runtime_limit_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_ends_at": {
+          "name": "runtime_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "id_auto_top_up_enabled_closed_idx": {
+          "name": "id_auto_top_up_enabled_closed_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auto_top_up_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "closed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_settings_user_id_userSetting_id_fk": {
+          "name": "deployment_settings_user_id_userSetting_id_fk",
+          "tableFrom": "deployment_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dseq_user_id_idx": {
+          "name": "dseq_user_id_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "dseq",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_key": {
+          "name": "hashed_key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_format": {
+          "name": "key_format",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_user_id_userSetting_id_fk": {
+          "name": "api_keys_user_id_userSetting_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_hashed_key_unique": {
+          "name": "api_keys_hashed_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hashed_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_verification_codes": {
+      "name": "email_verification_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_verification_codes_user_id_idx": {
+          "name": "email_verification_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_verification_codes_user_id_userSetting_id_fk": {
+          "name": "email_verification_codes_user_id_userSetting_id_fk",
+          "tableFrom": "email_verification_codes",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.data_keys": {
+      "name": "data_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wrapped_key": {
+          "name": "wrapped_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wrapped_by_kid": {
+          "name": "wrapped_by_kid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "data_keys_wrapped_by_kid_idx": {
+          "name": "data_keys_wrapped_by_kid_idx",
+          "columns": [
+            {
+              "expression": "wrapped_by_kid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "data_keys_user_id_userSetting_id_fk": {
+          "name": "data_keys_user_id_userSetting_id_fk",
+          "tableFrom": "data_keys",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "data_keys_user_id_unique": {
+          "name": "data_keys_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.stripe_transaction_status": {
+      "name": "stripe_transaction_status",
+      "schema": "public",
+      "values": [
+        "created",
+        "pending",
+        "requires_action",
+        "succeeded",
+        "failed",
+        "refunded",
+        "canceled"
+      ]
+    },
+    "public.stripe_transaction_type": {
+      "name": "stripe_transaction_type",
+      "schema": "public",
+      "values": [
+        "payment_intent",
+        "coupon_claim",
+        "manual_credit"
+      ]
+    },
+    "public.auto_reload_mode": {
+      "name": "auto_reload_mode",
+      "schema": "public",
+      "values": [
+        "prediction",
+        "threshold"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -281,6 +281,13 @@
       "when": 1787319202427,
       "tag": "0039_smooth_justice",
       "breakpoints": true
+    },
+    {
+      "idx": 40,
+      "version": "7",
+      "when": 1787578784118,
+      "tag": "0040_tan_puma",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/app/providers/jobs.provider.ts
+++ b/apps/api/src/app/providers/jobs.provider.ts
@@ -2,6 +2,7 @@ import { container } from "tsyringe";
 
 import { ActivateTrialHandler } from "@src/billing/services/activate-trial/activate-trial.handler";
 import { WalletBalanceReloadCheckHandler } from "@src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler";
+import { WalletCreditsLowCheckHandler } from "@src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler";
 import type { AppInitializer } from "@src/core/providers/app-initializer";
 import { APP_INITIALIZER, ON_APP_START } from "@src/core/providers/app-initializer";
 import { JobQueueService } from "@src/core/services/job-queue/job-queue.service";
@@ -29,6 +30,7 @@ container.register(APP_INITIALIZER, {
         container.resolve(FundDeploymentHandler),
         container.resolve(FundDrainingDeploymentsHandler),
         container.resolve(WalletBalanceReloadCheckHandler),
+        container.resolve(WalletCreditsLowCheckHandler),
         container.resolve(FirstPurchaseBonusGrantedHandler),
         container.resolve(AutoRechargeSucceededHandler),
         container.resolve(ActivateTrialHandler)

--- a/apps/api/src/billing/events/wallet-credits-low-check.ts
+++ b/apps/api/src/billing/events/wallet-credits-low-check.ts
@@ -1,0 +1,15 @@
+import type { Job } from "@src/core";
+import { JOB_NAME } from "@src/core";
+import type { UserOutput } from "@src/user/repositories";
+
+export class WalletCreditsLowCheck implements Job {
+  static readonly [JOB_NAME] = "WalletCreditsLowCheck";
+  public readonly name = WalletCreditsLowCheck[JOB_NAME];
+  public readonly version = 1;
+
+  constructor(
+    public readonly data: {
+      userId: UserOutput["id"];
+    }
+  ) {}
+}

--- a/apps/api/src/billing/model-schemas/user-wallet/user-wallet.schema.ts
+++ b/apps/api/src/billing/model-schemas/user-wallet/user-wallet.schema.ts
@@ -1,5 +1,6 @@
 import { boolean, numeric, pgTable, serial, timestamp, uuid, varchar } from "drizzle-orm/pg-core";
 
+// eslint-disable-next-line import-x/no-cycle
 import { Users } from "@src/user/model-schemas/user/user.schema";
 
 export const UserWallets = pgTable("user_wallets", {

--- a/apps/api/src/billing/model-schemas/user-wallet/user-wallet.schema.ts
+++ b/apps/api/src/billing/model-schemas/user-wallet/user-wallet.schema.ts
@@ -1,6 +1,5 @@
 import { boolean, numeric, pgTable, serial, timestamp, uuid, varchar } from "drizzle-orm/pg-core";
 
-// eslint-disable-next-line import-x/no-cycle
 import { Users } from "@src/user/model-schemas/user/user.schema";
 
 export const UserWallets = pgTable("user_wallets", {
@@ -14,6 +13,7 @@ export const UserWallets = pgTable("user_wallets", {
   feeAllowance: allowance("fee_allowance"),
   isTrialing: boolean("trial").default(true),
   activatedAt: timestamp("activated_at", { withTimezone: true }),
+  creditsLowNotifiedAt: timestamp("credits_low_notified_at", { withTimezone: true }),
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at").defaultNow().notNull()
 });

--- a/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.spec.ts
+++ b/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.spec.ts
@@ -32,12 +32,34 @@ describe(WalletCreditsLowCheckHandler.name, () => {
     await handler.handle(job);
 
     expect(balancesService.getDeploymentBalanceInFiat).toHaveBeenCalledWith(wallet.address);
-    expect(drainingDeploymentService.calculateWeeklyDeploymentCostForAddress).toHaveBeenCalledWith(wallet.address);
+    expect(drainingDeploymentService.calculateWeeklyCoverageForAddress).toHaveBeenCalledWith(wallet.address);
     expect(notificationService.createNotification).toHaveBeenCalledWith(
       creditsRunningLowNotification(user, {
         balanceUsd,
         weeklyCostUsd,
         daysRemaining: 2,
+        paymentLink,
+        billingUrl: "https://console.akash.network/billing"
+      })
+    );
+  });
+
+  it("reports less than a day when a runtime-limited deployment front-loads the weekly cost", async () => {
+    const paymentLink = "https://console.akash.network/billing?openPayment=true";
+    const { handler, user, notificationService, job } = setup({
+      balanceUsd: 5,
+      weeklyCostUsd: 10,
+      cumulativeDailyCostsUsd: [10, 10, 10, 10, 10, 10, 10],
+      paymentLink
+    });
+
+    await handler.handle(job);
+
+    expect(notificationService.createNotification).toHaveBeenCalledWith(
+      creditsRunningLowNotification(user, {
+        balanceUsd: 5,
+        weeklyCostUsd: 10,
+        daysRemaining: 0,
         paymentLink,
         billingUrl: "https://console.akash.network/billing"
       })
@@ -53,7 +75,7 @@ describe(WalletCreditsLowCheckHandler.name, () => {
 
     expect(notificationService.createNotification).not.toHaveBeenCalled();
     expect(userWalletRepository.updateById).not.toHaveBeenCalled();
-    expect(drainingDeploymentService.calculateWeeklyDeploymentCostForAddress).not.toHaveBeenCalled();
+    expect(drainingDeploymentService.calculateWeeklyCoverageForAddress).not.toHaveBeenCalled();
     expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "CREDITS_LOW_CHECK_SKIPPED", reason: "auto_reload_enabled" }));
     expect(logger.warn).not.toHaveBeenCalled();
   });
@@ -177,6 +199,7 @@ describe(WalletCreditsLowCheckHandler.name, () => {
     user?: ReturnType<typeof createUser>;
     balanceUsd?: number;
     weeklyCostUsd?: number;
+    cumulativeDailyCostsUsd?: number[];
     paymentLink?: string;
   }) {
     const user = input?.user ?? createUser({ email: "user@example.com" });
@@ -197,6 +220,8 @@ describe(WalletCreditsLowCheckHandler.name, () => {
     const paymentLink = input?.paymentLink ?? "https://console.akash.network/billing?openPayment=true";
     const balanceUsd = input?.balanceUsd ?? 12.5;
     const weeklyCostUsd = input?.weeklyCostUsd ?? 35;
+    const cumulativeDailyCostsUsd =
+      input?.cumulativeDailyCostsUsd ?? (weeklyCostUsd === 0 ? [] : Array.from({ length: 7 }, (_, day) => ((day + 1) * weeklyCostUsd) / 7));
 
     const walletSettingRepository = mock<WalletSettingRepository>();
     const userWalletRepository = mock<UserWalletRepository>();
@@ -216,7 +241,7 @@ describe(WalletCreditsLowCheckHandler.name, () => {
     userWalletRepository.findOneByUserId.mockResolvedValue(wallet);
     userRepository.findById.mockResolvedValue(user);
     balancesService.getDeploymentBalanceInFiat.mockResolvedValue(balanceUsd);
-    drainingDeploymentService.calculateWeeklyDeploymentCostForAddress.mockResolvedValue(weeklyCostUsd);
+    drainingDeploymentService.calculateWeeklyCoverageForAddress.mockResolvedValue({ weeklyCostUsd, cumulativeDailyCostsUsd });
     userWalletRepository.updateById.mockResolvedValue(undefined);
 
     const handler = new WalletCreditsLowCheckHandler(

--- a/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.spec.ts
+++ b/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.spec.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { WalletCreditsLowCheck } from "@src/billing/events/wallet-credits-low-check";
+import type { UserWalletRepository, WalletSettingRepository } from "@src/billing/repositories";
+import type { BalancesService } from "@src/billing/services/balances/balances.service";
+import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
+import type { JobPayload } from "@src/core";
+import type { LoggerService } from "@src/core/providers/logging.provider";
+import type { DrainingDeploymentService } from "@src/deployment/services/draining-deployment/draining-deployment.service";
+import type { NotificationService } from "@src/notifications/services/notification/notification.service";
+import { creditsRunningLowNotification } from "@src/notifications/services/notification-templates/credits-running-low-notification";
+import type { UserRepository } from "@src/user/repositories";
+import { WalletCreditsLowCheckHandler } from "./wallet-credits-low-check.handler";
+
+import { mockConfigService } from "@test/mocks/config-service.mock";
+import { createUser } from "@test/seeders/user.seeder";
+import { createUserWallet } from "@test/seeders/user-wallet.seeder";
+import { generateWalletSetting } from "@test/seeders/wallet-setting.seeder";
+
+describe(WalletCreditsLowCheckHandler.name, () => {
+  it("sends the credits-running-low notification when paid, Auto Recharge is off, and coverage is below a week", async () => {
+    const balanceUsd = 12.5;
+    const weeklyCostUsd = 35;
+    const paymentLink = "https://console.akash.network/billing?openPayment=true";
+    const { handler, user, wallet, notificationService, balancesService, drainingDeploymentService, job } = setup({
+      balanceUsd,
+      weeklyCostUsd,
+      paymentLink
+    });
+
+    await handler.handle(job);
+
+    expect(balancesService.getDeploymentBalanceInFiat).toHaveBeenCalledWith(wallet.address);
+    expect(drainingDeploymentService.calculateWeeklyDeploymentCostForAddress).toHaveBeenCalledWith(wallet.address);
+    expect(notificationService.createNotification).toHaveBeenCalledWith(
+      creditsRunningLowNotification(user, {
+        balanceUsd,
+        weeklyCostUsd,
+        daysRemaining: 2,
+        paymentLink,
+        billingUrl: "https://console.akash.network/billing"
+      })
+    );
+  });
+
+  it("does not send when Auto Recharge is enabled", async () => {
+    const { handler, notificationService, userWalletRepository, drainingDeploymentService, logger, job } = setup({
+      autoReloadEnabled: true
+    });
+
+    await handler.handle(job);
+
+    expect(notificationService.createNotification).not.toHaveBeenCalled();
+    expect(userWalletRepository.updateById).not.toHaveBeenCalled();
+    expect(drainingDeploymentService.calculateWeeklyDeploymentCostForAddress).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "CREDITS_LOW_CHECK_SKIPPED", reason: "auto_reload_enabled" }));
+  });
+
+  it("does not send when the wallet is trialing", async () => {
+    const { handler, notificationService, userWalletRepository, logger, job } = setup({
+      isTrialing: true
+    });
+
+    await handler.handle(job);
+
+    expect(notificationService.createNotification).not.toHaveBeenCalled();
+    expect(userWalletRepository.updateById).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "CREDITS_LOW_CHECK_SKIPPED", reason: "trialing" }));
+  });
+
+  it("does not send when weekly cost is 0", async () => {
+    const { handler, notificationService, userWalletRepository, logger, job } = setup({
+      weeklyCostUsd: 0
+    });
+
+    await handler.handle(job);
+
+    expect(notificationService.createNotification).not.toHaveBeenCalled();
+    expect(userWalletRepository.updateById).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "CREDITS_LOW_CHECK_SKIPPED", reason: "zero_cost" }));
+  });
+
+  it("does not send when balance is at or above weekly cost", async () => {
+    const { handler, notificationService, userWalletRepository, logger, job } = setup({
+      balanceUsd: 35,
+      weeklyCostUsd: 35
+    });
+
+    await handler.handle(job);
+
+    expect(notificationService.createNotification).not.toHaveBeenCalled();
+    expect(userWalletRepository.updateById).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "CREDITS_LOW_CHECK_SKIPPED", reason: "sufficient_balance" }));
+  });
+
+  it("does not send when already notified and still low", async () => {
+    const { handler, notificationService, userWalletRepository, logger, job } = setup({
+      creditsLowNotifiedAt: new Date("2026-01-01T00:00:00.000Z")
+    });
+
+    await handler.handle(job);
+
+    expect(notificationService.createNotification).not.toHaveBeenCalled();
+    expect(userWalletRepository.updateById).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "CREDITS_LOW_CHECK_SKIPPED", reason: "already_notified" }));
+  });
+
+  it("clears creditsLowNotifiedAt when balance recovers", async () => {
+    const { handler, notificationService, userWalletRepository, wallet, job } = setup({
+      creditsLowNotifiedAt: new Date("2026-01-01T00:00:00.000Z"),
+      balanceUsd: 40,
+      weeklyCostUsd: 35
+    });
+
+    await handler.handle(job);
+
+    expect(notificationService.createNotification).not.toHaveBeenCalled();
+    expect(userWalletRepository.updateById).toHaveBeenCalledWith(wallet.id, { creditsLowNotifiedAt: null });
+  });
+
+  it("clears creditsLowNotifiedAt when weekly cost is 0", async () => {
+    const { handler, notificationService, userWalletRepository, wallet, job } = setup({
+      creditsLowNotifiedAt: new Date("2026-01-01T00:00:00.000Z"),
+      weeklyCostUsd: 0
+    });
+
+    await handler.handle(job);
+
+    expect(notificationService.createNotification).not.toHaveBeenCalled();
+    expect(userWalletRepository.updateById).toHaveBeenCalledWith(wallet.id, { creditsLowNotifiedAt: null });
+  });
+
+  it("does not send when the user has no email", async () => {
+    const { handler, notificationService, userWalletRepository, logger, job } = setup({
+      user: createUser({ email: null })
+    });
+
+    await handler.handle(job);
+
+    expect(notificationService.createNotification).not.toHaveBeenCalled();
+    expect(userWalletRepository.updateById).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "CREDITS_LOW_CHECK_SKIPPED", reason: "no_email" }));
+  });
+
+  it("stamps creditsLowNotifiedAt after a successful send", async () => {
+    const { handler, notificationService, userWalletRepository, wallet, logger, job } = setup();
+
+    await handler.handle(job);
+
+    expect(notificationService.createNotification).toHaveBeenCalled();
+    expect(userWalletRepository.updateById).toHaveBeenCalledWith(wallet.id, { creditsLowNotifiedAt: expect.any(Date) });
+    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "CREDITS_LOW_EMAIL_SENT" }));
+  });
+
+  it("sends when wallet settings are missing", async () => {
+    const { handler, notificationService, userWalletRepository, job } = setup({
+      walletSettingNotFound: true
+    });
+
+    await handler.handle(job);
+
+    expect(notificationService.createNotification).toHaveBeenCalled();
+    expect(userWalletRepository.updateById).toHaveBeenCalledWith(expect.any(Number), { creditsLowNotifiedAt: expect.any(Date) });
+  });
+
+  function setup(input?: {
+    autoReloadEnabled?: boolean;
+    walletSettingNotFound?: boolean;
+    isTrialing?: boolean;
+    creditsLowNotifiedAt?: Date | null;
+    user?: ReturnType<typeof createUser>;
+    balanceUsd?: number;
+    weeklyCostUsd?: number;
+    paymentLink?: string;
+  }) {
+    const user = input?.user ?? createUser({ email: "user@example.com" });
+    const wallet = createUserWallet({
+      userId: user.id,
+      isTrialing: input?.isTrialing ?? false,
+      creditsLowNotifiedAt: input?.creditsLowNotifiedAt ?? null
+    });
+    const walletSetting = generateWalletSetting({
+      userId: user.id,
+      walletId: wallet.id,
+      autoReloadEnabled: input?.autoReloadEnabled ?? false
+    });
+    const job: JobPayload<WalletCreditsLowCheck> = {
+      userId: user.id,
+      version: 1
+    };
+    const paymentLink = input?.paymentLink ?? "https://console.akash.network/billing?openPayment=true";
+    const balanceUsd = input?.balanceUsd ?? 12.5;
+    const weeklyCostUsd = input?.weeklyCostUsd ?? 35;
+
+    const walletSettingRepository = mock<WalletSettingRepository>();
+    const userWalletRepository = mock<UserWalletRepository>();
+    const userRepository = mock<UserRepository>();
+    const balancesService = mock<BalancesService>();
+    const drainingDeploymentService = mock<DrainingDeploymentService>();
+    const notificationService = mock<NotificationService>({
+      createNotification: vi.fn().mockResolvedValue(undefined)
+    });
+    const billingConfig = mockConfigService<BillingConfigService>({
+      CONSOLE_WEB_PAYMENT_LINK: paymentLink
+    });
+    const logger = mock<LoggerService>();
+
+    walletSettingRepository.findByUserId.mockResolvedValue(input?.walletSettingNotFound ? undefined : walletSetting);
+
+    userWalletRepository.findOneByUserId.mockResolvedValue(wallet);
+    userRepository.findById.mockResolvedValue(user);
+    balancesService.getDeploymentBalanceInFiat.mockResolvedValue(balanceUsd);
+    drainingDeploymentService.calculateWeeklyDeploymentCostForAddress.mockResolvedValue(weeklyCostUsd);
+    userWalletRepository.updateById.mockResolvedValue(undefined);
+
+    const handler = new WalletCreditsLowCheckHandler(
+      walletSettingRepository,
+      userWalletRepository,
+      userRepository,
+      balancesService,
+      drainingDeploymentService,
+      notificationService,
+      billingConfig,
+      logger
+    );
+
+    return {
+      handler,
+      walletSettingRepository,
+      userWalletRepository,
+      userRepository,
+      balancesService,
+      drainingDeploymentService,
+      notificationService,
+      billingConfig,
+      logger,
+      user,
+      wallet,
+      walletSetting,
+      job
+    };
+  }
+});

--- a/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.spec.ts
+++ b/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.spec.ts
@@ -170,6 +170,18 @@ describe(WalletCreditsLowCheckHandler.name, () => {
     expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "CREDITS_LOW_CHECK_SKIPPED", reason: "no_email" }));
   });
 
+  it("does not fail the job when stamping creditsLowNotifiedAt fails after a successful send", async () => {
+    const { handler, notificationService, userWalletRepository, user, logger, job } = setup();
+    const error = new Error("connection reset");
+    userWalletRepository.updateById.mockRejectedValue(error);
+
+    await expect(handler.handle(job)).resolves.toBeUndefined();
+
+    expect(notificationService.createNotification).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalledWith({ event: "CREDITS_LOW_NOTIFIED_STAMP_FAILED", userId: user.id, error });
+    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "CREDITS_LOW_EMAIL_SENT" }));
+  });
+
   it("stamps creditsLowNotifiedAt after a successful send", async () => {
     const { handler, notificationService, userWalletRepository, wallet, logger, job } = setup();
 

--- a/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.spec.ts
+++ b/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.spec.ts
@@ -54,7 +54,8 @@ describe(WalletCreditsLowCheckHandler.name, () => {
     expect(notificationService.createNotification).not.toHaveBeenCalled();
     expect(userWalletRepository.updateById).not.toHaveBeenCalled();
     expect(drainingDeploymentService.calculateWeeklyDeploymentCostForAddress).not.toHaveBeenCalled();
-    expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "CREDITS_LOW_CHECK_SKIPPED", reason: "auto_reload_enabled" }));
+    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "CREDITS_LOW_CHECK_SKIPPED", reason: "auto_reload_enabled" }));
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 
   it("does not send when the wallet is trialing", async () => {
@@ -66,7 +67,8 @@ describe(WalletCreditsLowCheckHandler.name, () => {
 
     expect(notificationService.createNotification).not.toHaveBeenCalled();
     expect(userWalletRepository.updateById).not.toHaveBeenCalled();
-    expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "CREDITS_LOW_CHECK_SKIPPED", reason: "trialing" }));
+    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "CREDITS_LOW_CHECK_SKIPPED", reason: "trialing" }));
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 
   it("does not send when weekly cost is 0", async () => {
@@ -78,7 +80,8 @@ describe(WalletCreditsLowCheckHandler.name, () => {
 
     expect(notificationService.createNotification).not.toHaveBeenCalled();
     expect(userWalletRepository.updateById).not.toHaveBeenCalled();
-    expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "CREDITS_LOW_CHECK_SKIPPED", reason: "zero_cost" }));
+    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "CREDITS_LOW_CHECK_SKIPPED", reason: "zero_cost" }));
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 
   it("does not send when balance is at or above weekly cost", async () => {
@@ -91,7 +94,8 @@ describe(WalletCreditsLowCheckHandler.name, () => {
 
     expect(notificationService.createNotification).not.toHaveBeenCalled();
     expect(userWalletRepository.updateById).not.toHaveBeenCalled();
-    expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "CREDITS_LOW_CHECK_SKIPPED", reason: "sufficient_balance" }));
+    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "CREDITS_LOW_CHECK_SKIPPED", reason: "sufficient_balance" }));
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 
   it("does not send when already notified and still low", async () => {
@@ -103,7 +107,8 @@ describe(WalletCreditsLowCheckHandler.name, () => {
 
     expect(notificationService.createNotification).not.toHaveBeenCalled();
     expect(userWalletRepository.updateById).not.toHaveBeenCalled();
-    expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "CREDITS_LOW_CHECK_SKIPPED", reason: "already_notified" }));
+    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "CREDITS_LOW_CHECK_SKIPPED", reason: "already_notified" }));
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 
   it("clears creditsLowNotifiedAt when balance recovers", async () => {

--- a/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.ts
+++ b/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.ts
@@ -73,7 +73,7 @@ export class WalletCreditsLowCheckHandler implements JobHandler<WalletCreditsLow
       })
     );
 
-    await this.userWalletRepository.updateById(wallet.id, { creditsLowNotifiedAt: new Date() });
+    await this.#stampNotified(wallet, payload.userId);
 
     this.logger.info({
       event: "CREDITS_LOW_EMAIL_SENT",
@@ -82,6 +82,19 @@ export class WalletCreditsLowCheckHandler implements JobHandler<WalletCreditsLow
       weeklyCostUsd,
       daysRemaining
     });
+  }
+
+  /**
+   * A failed stamp is logged instead of thrown: failing the job after a successful send would
+   * make the queue retry the handler and resend the email it just delivered. At worst the
+   * unstamped wallet sends one more email on the next scheduled check.
+   */
+  async #stampNotified(wallet: UserWalletOutput, userId: UserOutput["id"]): Promise<void> {
+    try {
+      await this.userWalletRepository.updateById(wallet.id, { creditsLowNotifiedAt: new Date() });
+    } catch (error) {
+      this.logger.error({ event: "CREDITS_LOW_NOTIFIED_STAMP_FAILED", userId, error });
+    }
   }
 
   async #getValidWalletResources(userId: UserOutput["id"]) {

--- a/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.ts
+++ b/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.ts
@@ -1,0 +1,127 @@
+import { singleton } from "tsyringe";
+
+import { WalletCreditsLowCheck } from "@src/billing/events/wallet-credits-low-check";
+import { isWalletInitialized, type UserWalletOutput, UserWalletRepository, WalletSettingRepository } from "@src/billing/repositories";
+import { BalancesService } from "@src/billing/services/balances/balances.service";
+import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
+import { type JobHandler, type JobPayload, LoggerService } from "@src/core";
+import { DrainingDeploymentService } from "@src/deployment/services/draining-deployment/draining-deployment.service";
+import { NotificationService } from "@src/notifications/services/notification/notification.service";
+import { creditsRunningLowNotification } from "@src/notifications/services/notification-templates/credits-running-low-notification";
+import { type UserOutput, UserRepository } from "@src/user/repositories";
+
+type SkipReason = "auto_reload_enabled" | "no_wallet" | "trialing" | "no_email" | "zero_cost" | "sufficient_balance" | "already_notified";
+
+@singleton()
+export class WalletCreditsLowCheckHandler implements JobHandler<WalletCreditsLowCheck> {
+  public readonly accepts = WalletCreditsLowCheck;
+
+  public readonly concurrency = 2;
+
+  public readonly policy = "singleton";
+
+  constructor(
+    private readonly walletSettingRepository: WalletSettingRepository,
+    private readonly userWalletRepository: UserWalletRepository,
+    private readonly userRepository: UserRepository,
+    private readonly balancesService: BalancesService,
+    private readonly drainingDeploymentService: DrainingDeploymentService,
+    private readonly notificationService: NotificationService,
+    private readonly billingConfig: BillingConfigService,
+    private readonly logger: LoggerService
+  ) {}
+
+  async handle(payload: JobPayload<WalletCreditsLowCheck>): Promise<void> {
+    const resources = await this.#getValidWalletResources(payload.userId);
+    if (!resources) {
+      return;
+    }
+
+    const { wallet, user } = resources;
+    const balanceUsd = await this.balancesService.getDeploymentBalanceInFiat(wallet.address);
+    const weeklyCostUsd = await this.drainingDeploymentService.calculateWeeklyDeploymentCostForAddress(wallet.address);
+
+    if (weeklyCostUsd === 0) {
+      await this.#clearNotifiedIfSet(wallet);
+      this.#skip("zero_cost", payload.userId);
+      return;
+    }
+
+    if (balanceUsd >= weeklyCostUsd) {
+      await this.#clearNotifiedIfSet(wallet);
+      this.#skip("sufficient_balance", payload.userId);
+      return;
+    }
+
+    if (wallet.creditsLowNotifiedAt) {
+      this.#skip("already_notified", payload.userId);
+      return;
+    }
+
+    const paymentLink = this.billingConfig.get("CONSOLE_WEB_PAYMENT_LINK");
+    const daysRemaining = Math.max(0, Math.floor(balanceUsd / (weeklyCostUsd / 7)));
+
+    await this.notificationService.createNotification(
+      creditsRunningLowNotification(user, {
+        balanceUsd,
+        weeklyCostUsd,
+        daysRemaining,
+        paymentLink,
+        billingUrl: paymentLink.split("?")[0]
+      })
+    );
+
+    await this.userWalletRepository.updateById(wallet.id, { creditsLowNotifiedAt: new Date() });
+
+    this.logger.info({
+      event: "CREDITS_LOW_EMAIL_SENT",
+      userId: payload.userId,
+      balanceUsd,
+      weeklyCostUsd,
+      daysRemaining
+    });
+  }
+
+  async #getValidWalletResources(userId: UserOutput["id"]) {
+    const walletSetting = await this.walletSettingRepository.findByUserId(userId);
+    if (walletSetting?.autoReloadEnabled) {
+      this.#skip("auto_reload_enabled", userId);
+      return;
+    }
+
+    const wallet = await this.userWalletRepository.findOneByUserId(userId);
+    if (!wallet || !isWalletInitialized(wallet)) {
+      this.#skip("no_wallet", userId);
+      return;
+    }
+
+    if (wallet.isTrialing) {
+      this.#skip("trialing", userId);
+      return;
+    }
+
+    const user = await this.userRepository.findById(userId);
+    if (!user?.email) {
+      this.#skip("no_email", userId);
+      return;
+    }
+
+    return { wallet, user };
+  }
+
+  async #clearNotifiedIfSet(wallet: UserWalletOutput): Promise<void> {
+    if (!wallet.creditsLowNotifiedAt) {
+      return;
+    }
+
+    await this.userWalletRepository.updateById(wallet.id, { creditsLowNotifiedAt: null });
+  }
+
+  #skip(reason: SkipReason, userId: UserOutput["id"]): void {
+    this.logger.warn({
+      event: "CREDITS_LOW_CHECK_SKIPPED",
+      userId,
+      reason
+    });
+  }
+}

--- a/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.ts
+++ b/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.ts
@@ -12,6 +12,8 @@ import { type UserOutput, UserRepository } from "@src/user/repositories";
 
 type SkipReason = "auto_reload_enabled" | "no_wallet" | "trialing" | "no_email" | "zero_cost" | "sufficient_balance" | "already_notified";
 
+const UNEXPECTED_SKIP_REASONS: ReadonlySet<SkipReason> = new Set(["no_wallet", "no_email"]);
+
 @singleton()
 export class WalletCreditsLowCheckHandler implements JobHandler<WalletCreditsLowCheck> {
   public readonly accepts = WalletCreditsLowCheck;
@@ -118,10 +120,17 @@ export class WalletCreditsLowCheckHandler implements JobHandler<WalletCreditsLow
   }
 
   #skip(reason: SkipReason, userId: UserOutput["id"]): void {
-    this.logger.warn({
+    const payload = {
       event: "CREDITS_LOW_CHECK_SKIPPED",
       userId,
       reason
-    });
+    };
+
+    if (UNEXPECTED_SKIP_REASONS.has(reason)) {
+      this.logger.warn(payload);
+      return;
+    }
+
+    this.logger.info(payload);
   }
 }

--- a/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.ts
+++ b/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.ts
@@ -41,7 +41,7 @@ export class WalletCreditsLowCheckHandler implements JobHandler<WalletCreditsLow
 
     const { wallet, user } = resources;
     const balanceUsd = await this.balancesService.getDeploymentBalanceInFiat(wallet.address);
-    const weeklyCostUsd = await this.drainingDeploymentService.calculateWeeklyDeploymentCostForAddress(wallet.address);
+    const { weeklyCostUsd, cumulativeDailyCostsUsd } = await this.drainingDeploymentService.calculateWeeklyCoverageForAddress(wallet.address);
 
     if (weeklyCostUsd === 0) {
       await this.#clearNotifiedIfSet(wallet);
@@ -61,7 +61,7 @@ export class WalletCreditsLowCheckHandler implements JobHandler<WalletCreditsLow
     }
 
     const paymentLink = this.billingConfig.get("CONSOLE_WEB_PAYMENT_LINK");
-    const daysRemaining = Math.max(0, Math.floor(balanceUsd / (weeklyCostUsd / 7)));
+    const daysRemaining = cumulativeDailyCostsUsd.filter(costUsd => costUsd <= balanceUsd).length;
 
     await this.notificationService.createNotification(
       creditsRunningLowNotification(user, {

--- a/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.spec.ts
+++ b/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.spec.ts
@@ -120,6 +120,17 @@ describe(WalletReloadJobService.name, () => {
       expectCreditsLowCheckScheduled(jobQueueService, userWallet.userId);
     });
 
+    it("does not throw when the job queue is unavailable and a credits-low check is due", async () => {
+      const { service, walletSettingRepository, jobQueueService, logger } = setup();
+      const userId = faker.string.uuid();
+      walletSettingRepository.findByUserId.mockResolvedValue(generateWalletSetting({ autoReloadEnabled: false, userId }));
+      jobQueueService.cancelCreatedBy.mockRejectedValue(new Error("Database not opened. Call open() before executing SQL."));
+
+      await expect(service.scheduleImmediate({ userId })).resolves.toBe(false);
+
+      expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "CREDITS_LOW_CHECK_SCHEDULE_FAILED", userId }));
+    });
+
     it("does not throw when a credits-low enqueue collides with an existing singleton", async () => {
       const { service, walletSettingRepository, jobQueueService, logger } = setup();
       const userId = faker.string.uuid();
@@ -292,6 +303,37 @@ describe(WalletReloadJobService.name, () => {
       expect(logger.info).toHaveBeenCalledWith({
         event: "CREDITS_LOW_CHECK_ALREADY_QUEUED",
         userId
+      });
+    });
+
+    it("logs and returns null when the enqueue throws", async () => {
+      const { service, jobQueueService, logger } = setup();
+      const userId = faker.string.uuid();
+      const error = new Error("Queue cache is not initialized");
+      jobQueueService.enqueue.mockRejectedValue(error);
+
+      await expect(service.scheduleCreditsLowCheck(userId)).resolves.toBeNull();
+
+      expect(logger.error).toHaveBeenCalledWith({
+        event: "CREDITS_LOW_CHECK_SCHEDULE_FAILED",
+        userId,
+        error
+      });
+    });
+
+    it("logs and returns null when the cleanup throws", async () => {
+      const { service, jobQueueService, logger } = setup();
+      const userId = faker.string.uuid();
+      const error = new Error("Database not opened. Call open() before executing SQL.");
+      jobQueueService.cancelCreatedBy.mockRejectedValue(error);
+
+      await expect(service.scheduleCreditsLowCheck(userId, { withCleanup: true })).resolves.toBeNull();
+
+      expect(jobQueueService.enqueue).not.toHaveBeenCalled();
+      expect(logger.error).toHaveBeenCalledWith({
+        event: "CREDITS_LOW_CHECK_SCHEDULE_FAILED",
+        userId,
+        error
       });
     });
   });

--- a/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.spec.ts
+++ b/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.spec.ts
@@ -3,38 +3,42 @@ import { describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import { WalletBalanceReloadCheck } from "@src/billing/events/wallet-balance-reload-check";
-import type { WalletSettingRepository } from "@src/billing/repositories";
+import { WalletCreditsLowCheck } from "@src/billing/events/wallet-credits-low-check";
+import type { UserWalletRepository, WalletSettingRepository } from "@src/billing/repositories";
 import type { JobQueueService } from "@src/core";
 import type { LoggerService } from "@src/core/providers/logging.provider";
 import { WalletReloadJobService } from "./wallet-reload-job.service";
 
+import { createUserWallet } from "@test/seeders/user-wallet.seeder";
 import { generateWalletSetting } from "@test/seeders/wallet-setting.seeder";
 
 describe(WalletReloadJobService.name, () => {
   describe("scheduleImmediate", () => {
-    it("returns early when walletSetting does not exist", async () => {
+    it("enqueues a credits-low check when walletSetting does not exist", async () => {
       const { service, walletSettingRepository, jobQueueService } = setup();
       const userId = faker.string.uuid();
       walletSettingRepository.findByUserId.mockResolvedValue(undefined);
+      jobQueueService.enqueue.mockResolvedValue(faker.string.uuid());
 
       const result = await service.scheduleImmediate({ userId });
 
       expect(result).toBe(false);
       expect(walletSettingRepository.findByUserId).toHaveBeenCalledWith(userId);
-      expect(jobQueueService.enqueue).not.toHaveBeenCalled();
+      expectCreditsLowCheckScheduled(jobQueueService, userId);
     });
 
-    it("returns early when autoReloadEnabled is false", async () => {
+    it("enqueues a credits-low check when autoReloadEnabled is false", async () => {
       const { service, walletSettingRepository, jobQueueService } = setup();
       const userId = faker.string.uuid();
-      const walletSetting = generateWalletSetting({ autoReloadEnabled: false });
+      const walletSetting = generateWalletSetting({ autoReloadEnabled: false, userId });
       walletSettingRepository.findByUserId.mockResolvedValue(walletSetting);
+      jobQueueService.enqueue.mockResolvedValue(faker.string.uuid());
 
       const result = await service.scheduleImmediate({ userId });
 
       expect(result).toBe(false);
       expect(walletSettingRepository.findByUserId).toHaveBeenCalledWith(userId);
-      expect(jobQueueService.enqueue).not.toHaveBeenCalled();
+      expectCreditsLowCheckScheduled(jobQueueService, walletSetting.userId);
     });
 
     it("calls scheduleForWalletSetting when conditions are met", async () => {
@@ -100,16 +104,20 @@ describe(WalletReloadJobService.name, () => {
       );
     });
 
-    it("returns false when no wallet setting is found by walletId", async () => {
-      const { service, walletSettingRepository, jobQueueService } = setup();
+    it("enqueues a credits-low check by walletId when no wallet setting exists", async () => {
+      const { service, walletSettingRepository, userWalletRepository, jobQueueService } = setup();
       const walletId = faker.number.int({ min: 1, max: 1000000 });
+      const userWallet = createUserWallet({ id: walletId });
       walletSettingRepository.findOneBy.mockResolvedValue(undefined);
+      userWalletRepository.findOneBy.mockResolvedValue(userWallet);
+      jobQueueService.enqueue.mockResolvedValue(faker.string.uuid());
 
       const result = await service.scheduleImmediate({ walletId });
 
       expect(result).toBe(false);
       expect(walletSettingRepository.findOneBy).toHaveBeenCalledWith({ walletId });
-      expect(jobQueueService.enqueue).not.toHaveBeenCalled();
+      expect(userWalletRepository.findOneBy).toHaveBeenCalledWith({ id: walletId });
+      expectCreditsLowCheckScheduled(jobQueueService, userWallet.userId);
     });
   });
 
@@ -232,16 +240,33 @@ describe(WalletReloadJobService.name, () => {
     });
   });
 
+  function expectCreditsLowCheckScheduled(jobQueueService: ReturnType<typeof mock<JobQueueService>>, userId: string) {
+    expect(jobQueueService.cancelCreatedBy).toHaveBeenCalledWith({
+      name: WalletCreditsLowCheck.name,
+      singletonKey: `${WalletCreditsLowCheck.name}.${userId}`
+    });
+    expect(jobQueueService.enqueue).toHaveBeenCalledWith(
+      expect.any(WalletCreditsLowCheck),
+      expect.objectContaining({
+        singletonKey: `${WalletCreditsLowCheck.name}.${userId}`
+      })
+    );
+    const [job] = jobQueueService.enqueue.mock.calls[0];
+    expect((job as WalletCreditsLowCheck).data).toEqual({ userId });
+  }
+
   function setup() {
     const walletSettingRepository = mock<WalletSettingRepository>();
+    const userWalletRepository = mock<UserWalletRepository>();
     const jobQueueService = mock<JobQueueService>();
     const logger = mock<LoggerService>();
 
-    const service = new WalletReloadJobService(walletSettingRepository, jobQueueService, logger);
+    const service = new WalletReloadJobService(walletSettingRepository, userWalletRepository, jobQueueService, logger);
 
     return {
       service,
       walletSettingRepository,
+      userWalletRepository,
       jobQueueService,
       logger
     };

--- a/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.spec.ts
+++ b/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.spec.ts
@@ -119,6 +119,17 @@ describe(WalletReloadJobService.name, () => {
       expect(userWalletRepository.findOneBy).toHaveBeenCalledWith({ id: walletId });
       expectCreditsLowCheckScheduled(jobQueueService, userWallet.userId);
     });
+
+    it("does not throw when a credits-low enqueue collides with an existing singleton", async () => {
+      const { service, walletSettingRepository, jobQueueService, logger } = setup();
+      const userId = faker.string.uuid();
+      walletSettingRepository.findByUserId.mockResolvedValue(generateWalletSetting({ autoReloadEnabled: false, userId }));
+      jobQueueService.enqueue.mockResolvedValue(null);
+
+      await expect(service.scheduleImmediate({ userId })).resolves.toBe(false);
+
+      expect(logger.error).not.toHaveBeenCalled();
+    });
   });
 
   describe("scheduleForWalletSetting", () => {
@@ -222,6 +233,65 @@ describe(WalletReloadJobService.name, () => {
       expect(logger.error).toHaveBeenCalledWith({
         event: "JOB_CREATION_FAILED",
         userId: walletSetting.userId
+      });
+    });
+  });
+
+  describe("scheduleCreditsLowCheckIfAutoReloadOff", () => {
+    it("does not enqueue a reload job when autoReloadEnabled is true", async () => {
+      const { service, walletSettingRepository, jobQueueService } = setup();
+      const walletId = faker.number.int({ min: 1, max: 1000000 });
+      const walletSetting = generateWalletSetting({ walletId, autoReloadEnabled: true });
+      walletSettingRepository.findOneBy.mockResolvedValue(walletSetting);
+      jobQueueService.enqueue.mockResolvedValue(faker.string.uuid());
+
+      await service.scheduleCreditsLowCheckIfAutoReloadOff({ walletId });
+
+      expect(jobQueueService.enqueue).not.toHaveBeenCalled();
+      expect(jobQueueService.cancelCreatedBy).not.toHaveBeenCalled();
+    });
+
+    it("enqueues a credits-low check when autoReloadEnabled is false", async () => {
+      const { service, walletSettingRepository, jobQueueService } = setup();
+      const walletId = faker.number.int({ min: 1, max: 1000000 });
+      const walletSetting = generateWalletSetting({ walletId, autoReloadEnabled: false });
+      walletSettingRepository.findOneBy.mockResolvedValue(walletSetting);
+      jobQueueService.enqueue.mockResolvedValue(faker.string.uuid());
+
+      await service.scheduleCreditsLowCheckIfAutoReloadOff({ walletId });
+
+      expectCreditsLowCheckScheduled(jobQueueService, walletSetting.userId);
+      expect(jobQueueService.enqueue).not.toHaveBeenCalledWith(expect.any(WalletBalanceReloadCheck), expect.anything());
+    });
+
+    it("enqueues a credits-low check when wallet setting does not exist", async () => {
+      const { service, walletSettingRepository, userWalletRepository, jobQueueService } = setup();
+      const walletId = faker.number.int({ min: 1, max: 1000000 });
+      const userWallet = createUserWallet({ id: walletId });
+      walletSettingRepository.findOneBy.mockResolvedValue(undefined);
+      userWalletRepository.findOneBy.mockResolvedValue(userWallet);
+      jobQueueService.enqueue.mockResolvedValue(faker.string.uuid());
+
+      await service.scheduleCreditsLowCheckIfAutoReloadOff({ walletId });
+
+      expect(userWalletRepository.findOneBy).toHaveBeenCalledWith({ id: walletId });
+      expectCreditsLowCheckScheduled(jobQueueService, userWallet.userId);
+      expect(jobQueueService.enqueue).not.toHaveBeenCalledWith(expect.any(WalletBalanceReloadCheck), expect.anything());
+    });
+  });
+
+  describe("scheduleCreditsLowCheck", () => {
+    it("returns successfully when enqueue returns null", async () => {
+      const { service, jobQueueService, logger } = setup();
+      const userId = faker.string.uuid();
+      jobQueueService.enqueue.mockResolvedValue(null);
+
+      await expect(service.scheduleCreditsLowCheck(userId)).resolves.toBeNull();
+
+      expect(logger.error).not.toHaveBeenCalled();
+      expect(logger.info).toHaveBeenCalledWith({
+        event: "CREDITS_LOW_CHECK_ALREADY_QUEUED",
+        userId
       });
     });
   });

--- a/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.ts
+++ b/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.ts
@@ -37,6 +37,21 @@ export class WalletReloadJobService {
     return false;
   }
 
+  async scheduleCreditsLowCheckIfAutoReloadOff(input: { walletId: number }): Promise<void> {
+    const walletSetting = await this.walletSettingRepository.findOneBy({ walletId: input.walletId });
+
+    if (walletSetting?.autoReloadEnabled) {
+      return;
+    }
+
+    const userId = await this.#resolveUserId(input, walletSetting);
+    if (!userId) {
+      return;
+    }
+
+    await this.scheduleCreditsLowCheck(userId, { withCleanup: true });
+  }
+
   async scheduleForWalletSetting(
     walletSetting: Pick<WalletSettingOutput, "id" | "userId">,
     options?: Pick<EnqueueOptions, "startAfter"> & { withCleanup?: boolean; triggeredByDeployment?: boolean }
@@ -71,7 +86,7 @@ export class WalletReloadJobService {
     await this.jobQueueService.cancelCreatedBy({ name: WalletBalanceReloadCheck.name, singletonKey: `${WalletBalanceReloadCheck.name}.${userId}` });
   }
 
-  async scheduleCreditsLowCheck(userId: string, options?: { withCleanup?: boolean }): Promise<string> {
+  async scheduleCreditsLowCheck(userId: string, options?: { withCleanup?: boolean }): Promise<string | null> {
     if (options?.withCleanup) {
       await this.cancelCreditsLowCheckByUserId(userId);
     }
@@ -81,11 +96,10 @@ export class WalletReloadJobService {
     });
 
     if (!createdJobId) {
-      this.logger.error({
-        event: "JOB_CREATION_FAILED",
+      this.logger.info({
+        event: "CREDITS_LOW_CHECK_ALREADY_QUEUED",
         userId
       });
-      throw new Error("Failed to schedule wallet credits low check");
     }
 
     return createdJobId;

--- a/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.ts
+++ b/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.ts
@@ -86,23 +86,36 @@ export class WalletReloadJobService {
     await this.jobQueueService.cancelCreatedBy({ name: WalletBalanceReloadCheck.name, singletonKey: `${WalletBalanceReloadCheck.name}.${userId}` });
   }
 
+  /**
+   * Best-effort: a failed schedule is logged instead of thrown so it never fails the
+   * spend or funding operation that triggered it, and the next spend re-schedules the check.
+   */
   async scheduleCreditsLowCheck(userId: string, options?: { withCleanup?: boolean }): Promise<string | null> {
-    if (options?.withCleanup) {
-      await this.cancelCreditsLowCheckByUserId(userId);
-    }
+    try {
+      if (options?.withCleanup) {
+        await this.cancelCreditsLowCheckByUserId(userId);
+      }
 
-    const createdJobId = await this.jobQueueService.enqueue(new WalletCreditsLowCheck({ userId }), {
-      singletonKey: `${WalletCreditsLowCheck.name}.${userId}`
-    });
-
-    if (!createdJobId) {
-      this.logger.info({
-        event: "CREDITS_LOW_CHECK_ALREADY_QUEUED",
-        userId
+      const createdJobId = await this.jobQueueService.enqueue(new WalletCreditsLowCheck({ userId }), {
+        singletonKey: `${WalletCreditsLowCheck.name}.${userId}`
       });
-    }
 
-    return createdJobId;
+      if (!createdJobId) {
+        this.logger.info({
+          event: "CREDITS_LOW_CHECK_ALREADY_QUEUED",
+          userId
+        });
+      }
+
+      return createdJobId;
+    } catch (error) {
+      this.logger.error({
+        event: "CREDITS_LOW_CHECK_SCHEDULE_FAILED",
+        userId,
+        error
+      });
+      return null;
+    }
   }
 
   async cancelCreditsLowCheckByUserId(userId: string): Promise<void> {

--- a/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.ts
+++ b/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.ts
@@ -1,7 +1,8 @@
 import { singleton } from "tsyringe";
 
 import { WalletBalanceReloadCheck } from "@src/billing/events/wallet-balance-reload-check";
-import { WalletSettingOutput, WalletSettingRepository } from "@src/billing/repositories";
+import { WalletCreditsLowCheck } from "@src/billing/events/wallet-credits-low-check";
+import { UserWalletRepository, WalletSettingOutput, WalletSettingRepository } from "@src/billing/repositories";
 import { EnqueueOptions, JobQueueService } from "@src/core";
 import { LoggerService } from "@src/core/providers/logging.provider";
 
@@ -9,6 +10,7 @@ import { LoggerService } from "@src/core/providers/logging.provider";
 export class WalletReloadJobService {
   constructor(
     private readonly walletSettingRepository: WalletSettingRepository,
+    private readonly userWalletRepository: UserWalletRepository,
     private readonly jobQueueService: JobQueueService,
     private readonly logger: LoggerService
   ) {
@@ -26,6 +28,12 @@ export class WalletReloadJobService {
       return true;
     }
 
+    const userId = await this.#resolveUserId(input, walletSetting);
+    if (!userId) {
+      return false;
+    }
+
+    await this.scheduleCreditsLowCheck(userId, { withCleanup: true });
     return false;
   }
 
@@ -61,6 +69,43 @@ export class WalletReloadJobService {
 
   async cancelCreatedByUserId(userId: string): Promise<void> {
     await this.jobQueueService.cancelCreatedBy({ name: WalletBalanceReloadCheck.name, singletonKey: `${WalletBalanceReloadCheck.name}.${userId}` });
+  }
+
+  async scheduleCreditsLowCheck(userId: string, options?: { withCleanup?: boolean }): Promise<string> {
+    if (options?.withCleanup) {
+      await this.cancelCreditsLowCheckByUserId(userId);
+    }
+
+    const createdJobId = await this.jobQueueService.enqueue(new WalletCreditsLowCheck({ userId }), {
+      singletonKey: `${WalletCreditsLowCheck.name}.${userId}`
+    });
+
+    if (!createdJobId) {
+      this.logger.error({
+        event: "JOB_CREATION_FAILED",
+        userId
+      });
+      throw new Error("Failed to schedule wallet credits low check");
+    }
+
+    return createdJobId;
+  }
+
+  async cancelCreditsLowCheckByUserId(userId: string): Promise<void> {
+    await this.jobQueueService.cancelCreatedBy({ name: WalletCreditsLowCheck.name, singletonKey: `${WalletCreditsLowCheck.name}.${userId}` });
+  }
+
+  async #resolveUserId(input: WalletReloadImmediateInput, walletSetting?: WalletSettingOutput): Promise<string | undefined> {
+    if (walletSetting?.userId) {
+      return walletSetting.userId;
+    }
+
+    if ("userId" in input) {
+      return input.userId;
+    }
+
+    const wallet = await this.userWalletRepository.findOneBy({ id: input.walletId });
+    return wallet?.userId;
   }
 }
 

--- a/apps/api/src/billing/services/wallet-settings/wallet-settings.service.integration.ts
+++ b/apps/api/src/billing/services/wallet-settings/wallet-settings.service.integration.ts
@@ -274,7 +274,7 @@ describe(WalletSettingService.name, () => {
   });
 
   describe("disableAutoReload", () => {
-    it("disables auto reload and cancels the pending reload job", async () => {
+    it("disables auto reload, cancels the pending reload job, and schedules a credits-low check", async () => {
       const { user, walletSettingRepository, walletReloadJobService, service } = setup();
       const enabledSetting = generateWalletSetting({ userId: user.id, autoReloadEnabled: true });
       walletSettingRepository.findByUserId.mockResolvedValue(enabledSetting);
@@ -283,6 +283,7 @@ describe(WalletSettingService.name, () => {
 
       expect(walletSettingRepository.updateById).toHaveBeenCalledWith(enabledSetting.id, { autoReloadEnabled: false });
       expect(walletReloadJobService.cancelCreatedByUserId).toHaveBeenCalledWith(user.id);
+      expect(walletReloadJobService.scheduleCreditsLowCheck).toHaveBeenCalledWith(user.id, { withCleanup: true });
     });
 
     it("does nothing when auto reload is already disabled", async () => {

--- a/apps/api/src/billing/services/wallet-settings/wallet-settings.service.spec.ts
+++ b/apps/api/src/billing/services/wallet-settings/wallet-settings.service.spec.ts
@@ -1,0 +1,107 @@
+import { createMongoAbility } from "@casl/ability";
+import { faker } from "@faker-js/faker";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { AuthService } from "@src/auth/services/auth.service";
+import type { UserWalletRepository, WalletSettingRepository } from "@src/billing/repositories";
+import type { PaymentMethod, PaymentMethodService } from "@src/billing/services/payment-method/payment-method.service";
+import type { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
+import type { LoggerService } from "@src/core/providers/logging.provider";
+import type { UserRepository } from "@src/user/repositories";
+import { WalletSettingService } from "./wallet-settings.service";
+
+import { generatePaymentMethod } from "@test/seeders/payment-method.seeder";
+import { createUser } from "@test/seeders/user.seeder";
+import { createUserWallet } from "@test/seeders/user-wallet.seeder";
+import { generateWalletSetting } from "@test/seeders/wallet-setting.seeder";
+
+describe(WalletSettingService.name, () => {
+  describe("upsertWalletSetting", () => {
+    it("cancels the credits-low job and clears creditsLowNotifiedAt when Auto Recharge is enabled", async () => {
+      const { user, walletSetting, walletSettingRepository, walletReloadJobService, userWalletRepository, jobId, service } = setup();
+      const disabledSetting = { ...walletSetting, autoReloadEnabled: false };
+      const enabledSetting = generateWalletSetting({
+        userId: user.id,
+        walletId: walletSetting.walletId,
+        autoReloadEnabled: true
+      });
+      walletSettingRepository.findByUserId.mockResolvedValue(disabledSetting);
+      walletSettingRepository.updateById.mockResolvedValue(enabledSetting as never);
+      walletReloadJobService.scheduleForWalletSetting.mockResolvedValue(jobId);
+
+      await service.upsertWalletSetting(user.id, { autoReloadEnabled: true });
+
+      expect(walletReloadJobService.scheduleForWalletSetting).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: enabledSetting.id,
+          userId: user.id
+        }),
+        { withCleanup: true }
+      );
+      expect(walletReloadJobService.cancelCreditsLowCheckByUserId).toHaveBeenCalledWith(user.id);
+      expect(userWalletRepository.updateById).toHaveBeenCalledWith(enabledSetting.walletId, { creditsLowNotifiedAt: null });
+    });
+
+    it("enqueues a credits-low check when Auto Recharge is disabled", async () => {
+      const { user, walletSetting, walletSettingRepository, walletReloadJobService, service } = setup();
+      const enabledSetting = { ...walletSetting, autoReloadEnabled: true };
+      const disabledSetting = { ...walletSetting, autoReloadEnabled: false };
+      walletSettingRepository.findByUserId.mockResolvedValue(enabledSetting);
+      walletSettingRepository.updateById.mockResolvedValue(disabledSetting as never);
+
+      await service.upsertWalletSetting(user.id, { autoReloadEnabled: false });
+
+      expect(walletReloadJobService.scheduleCreditsLowCheck).toHaveBeenCalledWith(user.id, { withCleanup: true });
+      expect(walletReloadJobService.scheduleForWalletSetting).not.toHaveBeenCalled();
+    });
+  });
+
+  function setup() {
+    const user = createUser();
+    const userWithStripe = { ...user, stripeCustomerId: faker.string.uuid() };
+    const userWallet = createUserWallet({ userId: user.id });
+    const walletSettingRepository = mock<WalletSettingRepository>();
+    walletSettingRepository.accessibleBy.mockReturnValue(walletSettingRepository);
+    const userWalletRepository = mock<UserWalletRepository>();
+    userWalletRepository.findOneByUserId.mockResolvedValue(userWallet);
+    const userRepository = mock<UserRepository>();
+    userRepository.findById.mockResolvedValue(userWithStripe);
+    const paymentMethod = { ...generatePaymentMethod(), validated: true };
+    const paymentMethodService = mock<PaymentMethodService>({
+      getDefaultPaymentMethod: vi.fn().mockResolvedValue(paymentMethod as PaymentMethod)
+    });
+    const walletSetting = generateWalletSetting({ userId: user.id });
+    walletSettingRepository.findByUserId.mockResolvedValue(walletSetting);
+    const ability = createMongoAbility();
+    const authService = mock<AuthService>({
+      currentUser: user,
+      ability
+    });
+    const jobId = faker.string.uuid();
+    const walletReloadJobService = mock<WalletReloadJobService>({
+      scheduleForWalletSetting: vi.fn().mockResolvedValue(jobId)
+    });
+    const logger = mock<LoggerService>();
+    const service = new WalletSettingService(
+      walletSettingRepository,
+      userWalletRepository,
+      userRepository,
+      paymentMethodService,
+      authService,
+      walletReloadJobService,
+      logger
+    );
+
+    return {
+      user: userWithStripe,
+      userWallet,
+      walletSetting,
+      walletSettingRepository,
+      userWalletRepository,
+      walletReloadJobService,
+      jobId,
+      service
+    };
+  }
+});

--- a/apps/api/src/billing/services/wallet-settings/wallet-settings.service.ts
+++ b/apps/api/src/billing/services/wallet-settings/wallet-settings.service.ts
@@ -133,17 +133,26 @@ export class WalletSettingService {
   }
 
   async #arrangeSchedule(prev?: WalletSettingOutput, next?: WalletSettingOutput) {
-    if (!next?.autoReloadEnabled) {
+    if (!next) {
       return;
     }
 
-    if (!prev?.autoReloadEnabled) {
-      await this.walletReloadJobService.scheduleForWalletSetting(next, { withCleanup: true });
+    if (next.autoReloadEnabled) {
+      if (!prev?.autoReloadEnabled) {
+        await this.walletReloadJobService.scheduleForWalletSetting(next, { withCleanup: true });
+        await this.walletReloadJobService.cancelCreditsLowCheckByUserId(next.userId);
+        await this.userWalletRepository.updateById(next.walletId, { creditsLowNotifiedAt: null });
+        return;
+      }
+
+      if (this.#hasReloadRuleChanged(prev, next)) {
+        await this.walletReloadJobService.scheduleForWalletSetting(next, { withCleanup: true });
+      }
       return;
     }
 
-    if (this.#hasReloadRuleChanged(prev, next)) {
-      await this.walletReloadJobService.scheduleForWalletSetting(next, { withCleanup: true });
+    if (prev?.autoReloadEnabled) {
+      await this.walletReloadJobService.scheduleCreditsLowCheck(next.userId, { withCleanup: true });
     }
   }
 

--- a/apps/api/src/billing/services/wallet-settings/wallet-settings.service.ts
+++ b/apps/api/src/billing/services/wallet-settings/wallet-settings.service.ts
@@ -63,6 +63,7 @@ export class WalletSettingService {
 
     await this.walletSettingRepository.accessibleBy(ability, "update").updateById(setting.id, { autoReloadEnabled: false });
     await this.walletReloadJobService.cancelCreatedByUserId(userId);
+    await this.walletReloadJobService.scheduleCreditsLowCheck(userId, { withCleanup: true });
     this.logger.info({ event: "AUTO_RELOAD_DISABLED", reason: "DEFAULT_PAYMENT_METHOD_REMOVED", userId });
   }
 

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
@@ -753,6 +753,188 @@ describe(DrainingDeploymentService.name, () => {
     }
   });
 
+  describe("calculateWeeklyDeploymentCostForAddress", () => {
+    it("calculates seven days of burn in fiat for always-on deployments still open", async () => {
+      const blockRate1 = 50;
+      const blockRate2 = 75;
+      const { service, address, balancesService, userWalletRepository, deploymentSettingRepository } = await setupWeeklyBurnForAddress({
+        deployments: [{ blockRate: blockRate1 }, { blockRate: blockRate2 }]
+      });
+
+      const result = await service.calculateWeeklyDeploymentCostForAddress(address);
+
+      const expectedCredits = Math.floor(blockRate1 * averageBlockCountInAnHour * 24 * 7) + Math.floor(blockRate2 * averageBlockCountInAnHour * 24 * 7);
+      expect(userWalletRepository.accessibleBy).not.toHaveBeenCalled();
+      expect(deploymentSettingRepository.accessibleBy).not.toHaveBeenCalled();
+      expect(balancesService.toFiatAmount).toHaveBeenCalledWith(expectedCredits);
+      expect(result).toBe(usdFromCredits(expectedCredits));
+    });
+
+    it("bills twelve hours of burn when the runtime deadline is twelve hours away", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2025-01-01T12:00:00.000Z"));
+
+      try {
+        const blockRate = 50;
+        const runtimeEndsAt = new Date(Date.now() + 12 * millisecondsInHour);
+        const { service, address, balancesService } = await setupWeeklyBurnForAddress({
+          deployments: [
+            {
+              blockRate,
+              runtimeLimitHours: 24,
+              runtimeEndsAt
+            }
+          ]
+        });
+
+        const result = await service.calculateWeeklyDeploymentCostForAddress(address);
+
+        const expectedCredits = Math.floor(blockRate * averageBlockCountInAnHour * 12);
+        const weekCredits = Math.floor(blockRate * averageBlockCountInAnHour * 24 * 7);
+        expect(balancesService.toFiatAmount).toHaveBeenCalledWith(expectedCredits);
+        expect(balancesService.toFiatAmount).not.toHaveBeenCalledWith(weekCredits);
+        expect(result).toBe(usdFromCredits(expectedCredits));
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("returns 0 when the runtime deadline is in the past", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2025-01-01T12:00:00.000Z"));
+
+      try {
+        const { service, address, balancesService } = await setupWeeklyBurnForAddress({
+          deployments: [
+            {
+              blockRate: 50,
+              runtimeLimitHours: 12,
+              runtimeEndsAt: new Date(Date.now() - millisecondsInHour)
+            }
+          ]
+        });
+
+        const result = await service.calculateWeeklyDeploymentCostForAddress(address);
+
+        expect(result).toBe(0);
+        expect(balancesService.toFiatAmount).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("bills three hours of burn for an unanchored runtime limit", async () => {
+      const blockRate = 50;
+      const { service, address, balancesService, deploymentSettingRepository } = await setupWeeklyBurnForAddress({
+        deployments: [
+          {
+            blockRate,
+            runtimeLimitHours: 3,
+            runtimeEndsAt: null
+          }
+        ]
+      });
+
+      const result = await service.calculateWeeklyDeploymentCostForAddress(address);
+
+      const expectedCredits = Math.floor(blockRate * averageBlockCountInAnHour * 3);
+      expect(deploymentSettingRepository.startRuntimeCountdown).not.toHaveBeenCalled();
+      expect(balancesService.toFiatAmount).toHaveBeenCalledWith(expectedCredits);
+      expect(result).toBe(usdFromCredits(expectedCredits));
+    });
+
+    it("returns 0 when user wallet is not found", async () => {
+      const { service, address } = await setupWeeklyBurnForAddress({
+        userWallet: undefined,
+        deployments: [{ predictedClosedHeight: 1000100, blockRate: 50 }]
+      });
+
+      const result = await service.calculateWeeklyDeploymentCostForAddress(address);
+
+      expect(result).toBe(0);
+    });
+
+    it("returns 0 when user wallet has no address", async () => {
+      const { service, address } = await setupWeeklyBurnForAddress({
+        userWallet: createUserWallet({ address: null }),
+        deployments: [{ predictedClosedHeight: 1000100, blockRate: 50 }]
+      });
+
+      const result = await service.calculateWeeklyDeploymentCostForAddress(address);
+
+      expect(result).toBe(0);
+    });
+
+    it("returns 0 when no deployments are found", async () => {
+      const { service, address } = await setupWeeklyBurnForAddress({
+        deployments: []
+      });
+
+      const result = await service.calculateWeeklyDeploymentCostForAddress(address);
+
+      expect(result).toBe(0);
+    });
+
+    it("returns 0 when block rate is zero", async () => {
+      const { service, address, balancesService } = await setupWeeklyBurnForAddress({
+        deployments: [{ blockRate: 0 }]
+      });
+
+      const result = await service.calculateWeeklyDeploymentCostForAddress(address);
+
+      expect(result).toBe(0);
+      expect(balancesService.toFiatAmount).not.toHaveBeenCalled();
+    });
+
+    function usdFromCredits(credits: number) {
+      return Number((credits / 1_000_000).toFixed(2));
+    }
+
+    async function setupWeeklyBurnForAddress(input: {
+      userWallet?: ReturnType<typeof createUserWallet> | undefined;
+      deployments: Array<{
+        predictedClosedHeight?: number | null;
+        blockRate: number;
+        runtimeLimitHours?: number | null;
+        runtimeEndsAt?: Date | null;
+      }>;
+    }) {
+      const address = createAkashAddress();
+      const userWallet = "userWallet" in input ? input.userWallet : createUserWallet({ address });
+
+      const baseSetup = setup();
+      baseSetup.userWalletRepository.findOneBy.mockResolvedValue(userWallet);
+
+      const deploymentSettings = input.deployments.map((deployment, idx) =>
+        createAutoTopUpDeployment({
+          address,
+          dseq: String(1000 + idx),
+          runtimeLimitHours: deployment.runtimeLimitHours ?? null,
+          runtimeEndsAt: deployment.runtimeEndsAt ?? null
+        })
+      );
+
+      const drainingDeployments = deploymentSettings.map((setting, idx) => {
+        const deployment = input.deployments[idx];
+        return createDrainingDeployment({
+          dseq: Number(setting.dseq),
+          owner: address,
+          blockRate: deployment?.blockRate ?? 0,
+          predictedClosedHeight: deployment?.predictedClosedHeight ?? baseSetup.currentHeight + 100
+        });
+      });
+
+      baseSetup.deploymentSettingRepository.findAutoTopUpDeploymentsByOwner.mockResolvedValue(deploymentSettings);
+      baseSetup.rpcService.findManyByDseqAndOwner.mockResolvedValue(drainingDeployments);
+      baseSetup.balancesService.toFiatAmount.mockImplementation(async (uaktAmount: number) => usdFromCredits(uaktAmount));
+
+      return {
+        ...baseSetup,
+        address
+      };
+    }
+  });
+
   describe("calculateAllDeploymentCostUntilDate", () => {
     it("calculates total cost for deployments closing within target date", async () => {
       vi.useFakeTimers();

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
@@ -753,7 +753,7 @@ describe(DrainingDeploymentService.name, () => {
     }
   });
 
-  describe("calculateWeeklyDeploymentCostForAddress", () => {
+  describe("calculateWeeklyCoverageForAddress", () => {
     it("calculates seven days of burn in fiat for always-on deployments still open", async () => {
       const blockRate1 = 50;
       const blockRate2 = 75;
@@ -761,13 +761,16 @@ describe(DrainingDeploymentService.name, () => {
         deployments: [{ blockRate: blockRate1 }, { blockRate: blockRate2 }]
       });
 
-      const result = await service.calculateWeeklyDeploymentCostForAddress(address);
+      const result = await service.calculateWeeklyCoverageForAddress(address);
 
-      const expectedCredits = Math.floor(blockRate1 * averageBlockCountInAnHour * 24 * 7) + Math.floor(blockRate2 * averageBlockCountInAnHour * 24 * 7);
+      const creditsForDays = (days: number) =>
+        Math.floor(blockRate1 * averageBlockCountInAnHour * 24 * days) + Math.floor(blockRate2 * averageBlockCountInAnHour * 24 * days);
+      const expectedCredits = creditsForDays(7);
       expect(userWalletRepository.accessibleBy).not.toHaveBeenCalled();
       expect(deploymentSettingRepository.accessibleBy).not.toHaveBeenCalled();
       expect(balancesService.toFiatAmount).toHaveBeenCalledWith(expectedCredits);
-      expect(result).toBe(usdFromCredits(expectedCredits));
+      expect(result.weeklyCostUsd).toBe(usdFromCredits(expectedCredits));
+      expect(result.cumulativeDailyCostsUsd).toEqual(Array.from({ length: 7 }, (_, day) => (creditsForDays(day + 1) / expectedCredits) * result.weeklyCostUsd));
     });
 
     it("bills twelve hours of burn when the runtime deadline is twelve hours away", async () => {
@@ -787,13 +790,14 @@ describe(DrainingDeploymentService.name, () => {
           ]
         });
 
-        const result = await service.calculateWeeklyDeploymentCostForAddress(address);
+        const result = await service.calculateWeeklyCoverageForAddress(address);
 
         const expectedCredits = Math.floor(blockRate * averageBlockCountInAnHour * 12);
         const weekCredits = Math.floor(blockRate * averageBlockCountInAnHour * 24 * 7);
         expect(balancesService.toFiatAmount).toHaveBeenCalledWith(expectedCredits);
         expect(balancesService.toFiatAmount).not.toHaveBeenCalledWith(weekCredits);
-        expect(result).toBe(usdFromCredits(expectedCredits));
+        expect(result.weeklyCostUsd).toBe(usdFromCredits(expectedCredits));
+        expect(result.cumulativeDailyCostsUsd).toEqual(Array.from({ length: 7 }, () => result.weeklyCostUsd));
       } finally {
         vi.useRealTimers();
       }
@@ -814,9 +818,9 @@ describe(DrainingDeploymentService.name, () => {
           ]
         });
 
-        const result = await service.calculateWeeklyDeploymentCostForAddress(address);
+        const result = await service.calculateWeeklyCoverageForAddress(address);
 
-        expect(result).toBe(0);
+        expect(result).toEqual({ weeklyCostUsd: 0, cumulativeDailyCostsUsd: [] });
         expect(balancesService.toFiatAmount).not.toHaveBeenCalled();
       } finally {
         vi.useRealTimers();
@@ -835,12 +839,31 @@ describe(DrainingDeploymentService.name, () => {
         ]
       });
 
-      const result = await service.calculateWeeklyDeploymentCostForAddress(address);
+      const result = await service.calculateWeeklyCoverageForAddress(address);
 
       const expectedCredits = Math.floor(blockRate * averageBlockCountInAnHour * 3);
       expect(deploymentSettingRepository.startRuntimeCountdown).not.toHaveBeenCalled();
       expect(balancesService.toFiatAmount).toHaveBeenCalledWith(expectedCredits);
-      expect(result).toBe(usdFromCredits(expectedCredits));
+      expect(result.weeklyCostUsd).toBe(usdFromCredits(expectedCredits));
+      expect(result.cumulativeDailyCostsUsd).toEqual(Array.from({ length: 7 }, () => result.weeklyCostUsd));
+    });
+
+    it("front-loads a short runtime limit into the first day while an always-on deployment accrues daily", async () => {
+      const limitedBlockRate = 500;
+      const alwaysOnBlockRate = 10;
+      const { service, address } = await setupWeeklyBurnForAddress({
+        deployments: [{ blockRate: limitedBlockRate, runtimeLimitHours: 2, runtimeEndsAt: null }, { blockRate: alwaysOnBlockRate }]
+      });
+
+      const result = await service.calculateWeeklyCoverageForAddress(address);
+
+      const limitedCredits = Math.floor(limitedBlockRate * averageBlockCountInAnHour * 2);
+      const alwaysOnCreditsForDays = (days: number) => Math.floor(alwaysOnBlockRate * averageBlockCountInAnHour * 24 * days);
+      const weeklyCredits = limitedCredits + alwaysOnCreditsForDays(7);
+      expect(result.weeklyCostUsd).toBe(usdFromCredits(weeklyCredits));
+      expect(result.cumulativeDailyCostsUsd).toEqual(
+        Array.from({ length: 7 }, (_, day) => ((limitedCredits + alwaysOnCreditsForDays(day + 1)) / weeklyCredits) * result.weeklyCostUsd)
+      );
     });
 
     it("returns 0 when user wallet is not found", async () => {
@@ -849,9 +872,9 @@ describe(DrainingDeploymentService.name, () => {
         deployments: [{ predictedClosedHeight: 1000100, blockRate: 50 }]
       });
 
-      const result = await service.calculateWeeklyDeploymentCostForAddress(address);
+      const result = await service.calculateWeeklyCoverageForAddress(address);
 
-      expect(result).toBe(0);
+      expect(result).toEqual({ weeklyCostUsd: 0, cumulativeDailyCostsUsd: [] });
     });
 
     it("returns 0 when user wallet has no address", async () => {
@@ -860,9 +883,9 @@ describe(DrainingDeploymentService.name, () => {
         deployments: [{ predictedClosedHeight: 1000100, blockRate: 50 }]
       });
 
-      const result = await service.calculateWeeklyDeploymentCostForAddress(address);
+      const result = await service.calculateWeeklyCoverageForAddress(address);
 
-      expect(result).toBe(0);
+      expect(result).toEqual({ weeklyCostUsd: 0, cumulativeDailyCostsUsd: [] });
     });
 
     it("returns 0 when no deployments are found", async () => {
@@ -870,9 +893,9 @@ describe(DrainingDeploymentService.name, () => {
         deployments: []
       });
 
-      const result = await service.calculateWeeklyDeploymentCostForAddress(address);
+      const result = await service.calculateWeeklyCoverageForAddress(address);
 
-      expect(result).toBe(0);
+      expect(result).toEqual({ weeklyCostUsd: 0, cumulativeDailyCostsUsd: [] });
     });
 
     it("returns 0 when block rate is zero", async () => {
@@ -880,9 +903,9 @@ describe(DrainingDeploymentService.name, () => {
         deployments: [{ blockRate: 0 }]
       });
 
-      const result = await service.calculateWeeklyDeploymentCostForAddress(address);
+      const result = await service.calculateWeeklyCoverageForAddress(address);
 
-      expect(result).toBe(0);
+      expect(result).toEqual({ weeklyCostUsd: 0, cumulativeDailyCostsUsd: [] });
       expect(balancesService.toFiatAmount).not.toHaveBeenCalled();
     });
 

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
@@ -19,6 +19,11 @@ import { TopUpManagedDeploymentsInstrumentationService } from "../top-up-managed
 
 export type { DrainingDeployment } from "@src/deployment/types/draining-deployment";
 
+export type WeeklyCoverage = {
+  weeklyCostUsd: number;
+  cumulativeDailyCostsUsd: number[];
+};
+
 @singleton()
 export class DrainingDeploymentService {
   constructor(
@@ -347,40 +352,48 @@ export class DrainingDeploymentService {
   }
 
   /**
-   * Weekly auto-top-up burn for an address, in USD.
+   * Weekly auto-top-up coverage for an address, in USD.
    * Caps each runtime-limited deployment at remaining hours (or the unanchored
    * limit) so a deadline inside the week is not billed as a full seven days.
+   * `cumulativeDailyCostsUsd[d - 1]` is what the first `d` days of that coverage cost, so a
+   * balance can be translated into covered days without assuming the capped weekly total
+   * is a uniform seven-day burn rate.
    * Not CASL-scoped — the credits-low job calls this with the wallet address.
    */
-  async calculateWeeklyDeploymentCostForAddress(address: string): Promise<number> {
+  async calculateWeeklyCoverageForAddress(address: string): Promise<WeeklyCoverage> {
+    const noCoverage: WeeklyCoverage = { weeklyCostUsd: 0, cumulativeDailyCostsUsd: [] };
+
     const deploymentSettings = await this.#findAutoTopUpDeploymentSettings(address);
     if (deploymentSettings.length === 0) {
-      return 0;
+      return noCoverage;
     }
 
     const currentHeight = await this.blockHttpService.getCurrentHeight();
     const leases = await this.#findDrainingDeployments(deploymentSettings, address, Number.MAX_SAFE_INTEGER);
     const settingsByDseq = keyBy(deploymentSettings, s => String(s.dseq));
 
-    const weeklyCost = await this.#accumulateDeploymentCost(leases, ({ dseq, predictedClosedHeight, blockRate }) => {
+    const burns = leases.flatMap(({ dseq, predictedClosedHeight, blockRate }) => {
       if (!predictedClosedHeight || predictedClosedHeight <= currentHeight || blockRate <= 0) {
-        return 0;
+        return [];
       }
 
-      const setting = settingsByDseq[String(dseq)];
-      const hours = this.#coverageHoursForDeployment(setting, currentHeight);
-      if (hours <= 0) {
-        return 0;
-      }
-
-      return Math.floor(blockRate * averageBlockCountInAnHour * hours);
+      const coverageHours = this.#coverageHoursForDeployment(settingsByDseq[String(dseq)], currentHeight);
+      return coverageHours > 0 ? [{ hourlyCredits: blockRate * averageBlockCountInAnHour, coverageHours }] : [];
     });
 
-    if (weeklyCost === 0) {
-      return 0;
+    const weeklyCredits = this.#creditsForHours(burns, 24 * 7);
+    if (weeklyCredits === 0) {
+      return noCoverage;
     }
 
-    return await this.balancesService.toFiatAmount(weeklyCost);
+    const weeklyCostUsd = await this.balancesService.toFiatAmount(weeklyCredits);
+    const cumulativeDailyCostsUsd = Array.from({ length: 7 }, (_, day) => (this.#creditsForHours(burns, (day + 1) * 24) / weeklyCredits) * weeklyCostUsd);
+
+    return { weeklyCostUsd, cumulativeDailyCostsUsd };
+  }
+
+  #creditsForHours(burns: Array<{ hourlyCredits: number; coverageHours: number }>, hours: number): number {
+    return burns.reduce((total, burn) => total + Math.floor(burn.hourlyCredits * Math.min(hours, burn.coverageHours)), 0);
   }
 
   /**

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
@@ -347,6 +347,62 @@ export class DrainingDeploymentService {
   }
 
   /**
+   * Weekly auto-top-up burn for an address, in USD.
+   * Caps each runtime-limited deployment at remaining hours (or the unanchored
+   * limit) so a deadline inside the week is not billed as a full seven days.
+   * Not CASL-scoped — the credits-low job calls this with the wallet address.
+   */
+  async calculateWeeklyDeploymentCostForAddress(address: string): Promise<number> {
+    const deploymentSettings = await this.#findAutoTopUpDeploymentSettings(address);
+    if (deploymentSettings.length === 0) {
+      return 0;
+    }
+
+    const currentHeight = await this.blockHttpService.getCurrentHeight();
+    const leases = await this.#findDrainingDeployments(deploymentSettings, address, Number.MAX_SAFE_INTEGER);
+    const settingsByDseq = keyBy(deploymentSettings, s => String(s.dseq));
+
+    const weeklyCost = await this.#accumulateDeploymentCost(leases, ({ dseq, predictedClosedHeight, blockRate }) => {
+      if (!predictedClosedHeight || predictedClosedHeight <= currentHeight || blockRate <= 0) {
+        return 0;
+      }
+
+      const setting = settingsByDseq[String(dseq)];
+      const hours = this.#coverageHoursForDeployment(setting, currentHeight);
+      if (hours <= 0) {
+        return 0;
+      }
+
+      return Math.floor(blockRate * averageBlockCountInAnHour * hours);
+    });
+
+    if (weeklyCost === 0) {
+      return 0;
+    }
+
+    return await this.balancesService.toFiatAmount(weeklyCost);
+  }
+
+  /**
+   * A week of coverage unless the setting has a runtime limit, then remaining
+   * hours (0 if the deadline has passed). An unanchored limit is the remaining hours.
+   */
+  #coverageHoursForDeployment(setting: AutoTopUpDeployment | undefined, currentHeight: number): number {
+    const weekHours = 24 * 7;
+
+    if (setting?.runtimeEndsAt) {
+      const remainingHours = (this.#getRuntimeLimitHeight(setting.runtimeEndsAt, currentHeight) - currentHeight) / averageBlockCountInAnHour;
+      return remainingHours <= 0 ? 0 : Math.min(weekHours, remainingHours);
+    }
+
+    if (setting?.runtimeLimitHours != null) {
+      return Math.min(weekHours, setting.runtimeLimitHours);
+    }
+
+    return weekHours;
+  }
+
+  /**
    * Finds auto top-up deployment settings for a given address.
    * Validates that the user wallet exists and has an address before querying.
    *

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.ts
@@ -275,6 +275,15 @@ export class TopUpManagedDeploymentsInstrumentationService implements Deployment
     });
   }
 
+  recordCreditsLowScheduleError({ error, ...details }: { walletId?: number; error: unknown }): void {
+    this.logger.error({
+      event: "CREDITS_LOW_SCHEDULE_SWEEP_ERROR",
+      ...details,
+      ...this.serializeError(error),
+      dryRun: this.options?.dryRun
+    });
+  }
+
   private serializeError(error: unknown): { message: string; stack?: string; data?: unknown } {
     if (error instanceof Error) {
       return {

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
@@ -6,12 +6,17 @@ import { faker } from "@faker-js/faker";
 import { describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
 
+import { WalletBalanceReloadCheck } from "@src/billing/events/wallet-balance-reload-check";
+import { WalletCreditsLowCheck } from "@src/billing/events/wallet-credits-low-check";
+import type { UserWalletRepository, WalletSettingRepository } from "@src/billing/repositories";
 import { RpcMessageService } from "@src/billing/services";
 import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import type { ChainErrorService } from "@src/billing/services/chain-error/chain-error.service";
 import type { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
-import type { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
+import { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
 import type { BlockHttpService } from "@src/chain/services/block-http/block-http.service";
+import type { JobQueueService } from "@src/core";
+import type { LoggerService } from "@src/core/providers/logging.provider";
 import type { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import type { DeploymentConfigService } from "@src/deployment/services/deployment-config/deployment-config.service";
 import type { DrainingDeployment, DrainingDeploymentService } from "@src/deployment/services/draining-deployment/draining-deployment.service";
@@ -24,6 +29,7 @@ import type { TopUpManagedDeploymentsInstrumentationService } from "./top-up-man
 import { createAkashAddress } from "@test/seeders";
 import { createAutoTopUpDeployment, createManyAutoTopUpDeployments } from "@test/seeders/auto-top-up-deployment.seeder";
 import { createDrainingDeployment } from "@test/seeders/draining-deployment.seeder";
+import { generateWalletSetting } from "@test/seeders/wallet-setting.seeder";
 
 describe(TopUpManagedDeploymentsService.name, () => {
   const DEPLOYMENT_GRANT_DENOM = "ibc/170C677610AC31DF0904FFE09CD3B5C657492170E7E52372E48756B71E56F2F1";
@@ -276,39 +282,54 @@ describe(TopUpManagedDeploymentsService.name, () => {
       expect(managedSignerService.executeDerivedTx).not.toHaveBeenCalled();
     });
 
-    it("schedules a check for a non-draining auto-top-up owner", async () => {
-      const { service, drainingDeploymentService, deploymentSettingRepository, walletReloadService, managedSignerService } = setup();
+    it("does not enqueue a reload job for a non-draining owner with Auto Recharge on", async () => {
+      const { service, drainingDeploymentService, deploymentSettingRepository, jobQueueService, walletSettingRepository, managedSignerService } =
+        setupWithWalletReloadJobs();
       const owner = createAkashAddress();
       const walletId = faker.number.int({ min: 1000000, max: 9999999 });
+      const walletSetting = generateWalletSetting({ walletId, autoReloadEnabled: true });
 
-      drainingDeploymentService.findDrainingDeploymentsByOwner.mockImplementation(() => (async function* () {})());
-      deploymentSettingRepository.findAutoTopUpDeploymentsByOwnerIteratively.mockImplementation(() =>
-        (async function* () {
-          yield { address: owner, walletId, deploymentSettings: [createAutoTopUpDeployment({ address: owner, walletId })] };
-        })()
-      );
+      mockNonDrainingAutoTopUpOwner(drainingDeploymentService, deploymentSettingRepository, owner, walletId);
+      walletSettingRepository.findOneBy.mockResolvedValue(walletSetting);
 
       await service.topUpDeployments({ dryRun: false });
 
-      expect(walletReloadService.scheduleImmediate).toHaveBeenCalledWith({ walletId });
+      expect(jobQueueService.enqueue).not.toHaveBeenCalled();
       expect(managedSignerService.executeDerivedTx).not.toHaveBeenCalled();
     });
 
-    it("does not schedule extra checks for auto-top-up owners on dry run", async () => {
-      const { service, drainingDeploymentService, deploymentSettingRepository, walletReloadService } = setup();
+    it("enqueues a credits-low check for a non-draining owner with Auto Recharge off", async () => {
+      const { service, drainingDeploymentService, deploymentSettingRepository, jobQueueService, walletSettingRepository } = setupWithWalletReloadJobs();
       const owner = createAkashAddress();
       const walletId = faker.number.int({ min: 1000000, max: 9999999 });
+      const walletSetting = generateWalletSetting({ walletId, autoReloadEnabled: false });
 
-      drainingDeploymentService.findDrainingDeploymentsByOwner.mockImplementation(() => (async function* () {})());
-      deploymentSettingRepository.findAutoTopUpDeploymentsByOwnerIteratively.mockImplementation(() =>
-        (async function* () {
-          yield { address: owner, walletId, deploymentSettings: [createAutoTopUpDeployment({ address: owner, walletId })] };
-        })()
+      mockNonDrainingAutoTopUpOwner(drainingDeploymentService, deploymentSettingRepository, owner, walletId);
+      walletSettingRepository.findOneBy.mockResolvedValue(walletSetting);
+
+      await service.topUpDeployments({ dryRun: false });
+
+      expect(jobQueueService.enqueue).toHaveBeenCalledWith(
+        expect.any(WalletCreditsLowCheck),
+        expect.objectContaining({
+          singletonKey: `${WalletCreditsLowCheck.name}.${walletSetting.userId}`
+        })
       );
+      expect(jobQueueService.enqueue).not.toHaveBeenCalledWith(expect.any(WalletBalanceReloadCheck), expect.anything());
+    });
+
+    it("does not schedule extra checks for auto-top-up owners on dry run", async () => {
+      const { service, drainingDeploymentService, deploymentSettingRepository, jobQueueService, walletSettingRepository } = setupWithWalletReloadJobs();
+      const owner = createAkashAddress();
+      const walletId = faker.number.int({ min: 1000000, max: 9999999 });
+      const walletSetting = generateWalletSetting({ walletId, autoReloadEnabled: false });
+
+      mockNonDrainingAutoTopUpOwner(drainingDeploymentService, deploymentSettingRepository, owner, walletId);
+      walletSettingRepository.findOneBy.mockResolvedValue(walletSetting);
 
       await service.topUpDeployments({ dryRun: true });
 
-      expect(walletReloadService.scheduleImmediate).not.toHaveBeenCalled();
+      expect(jobQueueService.enqueue).not.toHaveBeenCalled();
     });
 
     it("should top up draining deployments for the same owner in the same tx", async () => {
@@ -946,7 +967,38 @@ describe(TopUpManagedDeploymentsService.name, () => {
     }
   });
 
-  function setup(input?: { currentBlockHeight?: number; feeAllowance?: number }) {
+  function mockNonDrainingAutoTopUpOwner(
+    drainingDeploymentService: ReturnType<typeof mock<DrainingDeploymentService>>,
+    deploymentSettingRepository: ReturnType<typeof mock<DeploymentSettingRepository>>,
+    owner: string,
+    walletId: number
+  ) {
+    drainingDeploymentService.findDrainingDeploymentsByOwner.mockImplementation(() => (async function* () {})());
+    deploymentSettingRepository.findAutoTopUpDeploymentsByOwnerIteratively.mockImplementation(() =>
+      (async function* () {
+        yield { address: owner, walletId, deploymentSettings: [createAutoTopUpDeployment({ address: owner, walletId })] };
+      })()
+    );
+  }
+
+  function setupWithWalletReloadJobs(input?: { currentBlockHeight?: number; feeAllowance?: number }) {
+    const walletSettingRepository = mock<WalletSettingRepository>();
+    const userWalletRepository = mock<UserWalletRepository>();
+    const jobQueueService = mock<JobQueueService>();
+    const logger = mock<LoggerService>();
+    jobQueueService.enqueue.mockResolvedValue(faker.string.uuid());
+    const walletReloadService = new WalletReloadJobService(walletSettingRepository, userWalletRepository, jobQueueService, logger);
+
+    return {
+      ...setup({ ...input, walletReloadService }),
+      walletSettingRepository,
+      userWalletRepository,
+      jobQueueService,
+      logger
+    };
+  }
+
+  function setup(input?: { currentBlockHeight?: number; feeAllowance?: number; walletReloadService?: WalletReloadJobService }) {
     const currentBlockHeight = input?.currentBlockHeight ?? CURRENT_BLOCK_HEIGHT;
     const feeAllowance = input?.feeAllowance ?? SUFFICIENT_FEE_ALLOWANCE;
 
@@ -969,7 +1021,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
     chainErrorService.isMasterWalletInsufficientFundsError.mockResolvedValue(false);
     const instrumentation = mock<TopUpManagedDeploymentsInstrumentationService>();
     const fundDrainingInstrumentation = mock<FundDrainingDeploymentsInstrumentationService>();
-    const walletReloadService = mock<WalletReloadJobService>();
+    const walletReloadService = input?.walletReloadService ?? mock<WalletReloadJobService>();
     const deploymentSettingRepository = mock<DeploymentSettingRepository>();
     deploymentSettingRepository.claimForFunding.mockImplementation(async (ids: string[]) => ids.map(createFundingClaim));
     deploymentSettingRepository.releaseFundingClaim.mockResolvedValue(undefined);

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
@@ -318,6 +318,22 @@ describe(TopUpManagedDeploymentsService.name, () => {
       expect(jobQueueService.enqueue).not.toHaveBeenCalledWith(expect.any(WalletBalanceReloadCheck), expect.anything());
     });
 
+    it("keeps a failed credits-low sweep out of the funding run's status and result", async () => {
+      const { service, drainingDeploymentService, deploymentSettingRepository, walletSettingRepository, instrumentation } = setupWithWalletReloadJobs();
+      const owner = createAkashAddress();
+      const walletId = faker.number.int({ min: 1000000, max: 9999999 });
+      const error = new Error("connection reset");
+
+      mockNonDrainingAutoTopUpOwner(drainingDeploymentService, deploymentSettingRepository, owner, walletId);
+      walletSettingRepository.findOneBy.mockRejectedValue(error);
+
+      const result = await service.topUpDeployments({ dryRun: false });
+
+      expect(result.ok).toBe(true);
+      expect(instrumentation.recordCreditsLowScheduleError).toHaveBeenCalledWith({ walletId, error });
+      expect(instrumentation.finish).toHaveBeenCalledWith("success", CURRENT_BLOCK_HEIGHT);
+    });
+
     it("does not schedule extra checks for auto-top-up owners on dry run", async () => {
       const { service, drainingDeploymentService, deploymentSettingRepository, jobQueueService, walletSettingRepository } = setupWithWalletReloadJobs();
       const owner = createAkashAddress();

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
@@ -276,6 +276,41 @@ describe(TopUpManagedDeploymentsService.name, () => {
       expect(managedSignerService.executeDerivedTx).not.toHaveBeenCalled();
     });
 
+    it("schedules a check for a non-draining auto-top-up owner", async () => {
+      const { service, drainingDeploymentService, deploymentSettingRepository, walletReloadService, managedSignerService } = setup();
+      const owner = createAkashAddress();
+      const walletId = faker.number.int({ min: 1000000, max: 9999999 });
+
+      drainingDeploymentService.findDrainingDeploymentsByOwner.mockImplementation(() => (async function* () {})());
+      deploymentSettingRepository.findAutoTopUpDeploymentsByOwnerIteratively.mockImplementation(() =>
+        (async function* () {
+          yield { address: owner, walletId, deploymentSettings: [createAutoTopUpDeployment({ address: owner, walletId })] };
+        })()
+      );
+
+      await service.topUpDeployments({ dryRun: false });
+
+      expect(walletReloadService.scheduleImmediate).toHaveBeenCalledWith({ walletId });
+      expect(managedSignerService.executeDerivedTx).not.toHaveBeenCalled();
+    });
+
+    it("does not schedule extra checks for auto-top-up owners on dry run", async () => {
+      const { service, drainingDeploymentService, deploymentSettingRepository, walletReloadService } = setup();
+      const owner = createAkashAddress();
+      const walletId = faker.number.int({ min: 1000000, max: 9999999 });
+
+      drainingDeploymentService.findDrainingDeploymentsByOwner.mockImplementation(() => (async function* () {})());
+      deploymentSettingRepository.findAutoTopUpDeploymentsByOwnerIteratively.mockImplementation(() =>
+        (async function* () {
+          yield { address: owner, walletId, deploymentSettings: [createAutoTopUpDeployment({ address: owner, walletId })] };
+        })()
+      );
+
+      await service.topUpDeployments({ dryRun: true });
+
+      expect(walletReloadService.scheduleImmediate).not.toHaveBeenCalled();
+    });
+
     it("should top up draining deployments for the same owner in the same tx", async () => {
       const { service, drainingDeploymentService, cachedBalanceService, managedSignerService } = setup();
       const owner = createAkashAddress();
@@ -938,6 +973,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
     const deploymentSettingRepository = mock<DeploymentSettingRepository>();
     deploymentSettingRepository.claimForFunding.mockImplementation(async (ids: string[]) => ids.map(createFundingClaim));
     deploymentSettingRepository.releaseFundingClaim.mockResolvedValue(undefined);
+    deploymentSettingRepository.findAutoTopUpDeploymentsByOwnerIteratively.mockImplementation(() => (async function* () {})());
     const deploymentConfig = mockConfigService<DeploymentConfigService>({ AUTO_TOP_UP_DEDUP_COOLDOWN_IN_MIN: 60 });
 
     const service = new TopUpManagedDeploymentsService(

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
@@ -63,7 +63,7 @@ export class TopUpManagedDeploymentsService {
       }
 
       if (!options.dryRun) {
-        await this.#scheduleCreditsLowChecksForAutoTopUpOwners(errors);
+        await this.#scheduleCreditsLowChecksForAutoTopUpOwners();
       }
     } catch (error: unknown) {
       errors.push(error);
@@ -156,13 +156,21 @@ export class TopUpManagedDeploymentsService {
     await this.walletReloadService.scheduleImmediate({ walletId });
   }
 
-  async #scheduleCreditsLowChecksForAutoTopUpOwners(errors: unknown[]): Promise<void> {
-    for await (const owner of this.deploymentSettingRepository.findAutoTopUpDeploymentsByOwnerIteratively()) {
-      try {
-        await this.walletReloadService.scheduleCreditsLowCheckIfAutoReloadOff({ walletId: owner.walletId });
-      } catch (error: unknown) {
-        errors.push(error);
+  /**
+   * Best-effort: the sweep only schedules credits-low email checks, so its failures are logged
+   * and kept out of the funding run's status and result, which report on funding alone.
+   */
+  async #scheduleCreditsLowChecksForAutoTopUpOwners(): Promise<void> {
+    try {
+      for await (const owner of this.deploymentSettingRepository.findAutoTopUpDeploymentsByOwnerIteratively()) {
+        try {
+          await this.walletReloadService.scheduleCreditsLowCheckIfAutoReloadOff({ walletId: owner.walletId });
+        } catch (error: unknown) {
+          this.instrumentation.recordCreditsLowScheduleError({ walletId: owner.walletId, error });
+        }
       }
+    } catch (error: unknown) {
+      this.instrumentation.recordCreditsLowScheduleError({ error });
     }
   }
 

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
@@ -61,6 +61,10 @@ export class TopUpManagedDeploymentsService {
           errors.push(error);
         }
       }
+
+      if (!options.dryRun) {
+        await this.#scheduleImmediateForAutoTopUpOwners(errors);
+      }
     } catch (error: unknown) {
       errors.push(error);
     } finally {
@@ -150,6 +154,16 @@ export class TopUpManagedDeploymentsService {
     }
 
     await this.walletReloadService.scheduleImmediate({ walletId });
+  }
+
+  async #scheduleImmediateForAutoTopUpOwners(errors: unknown[]): Promise<void> {
+    for await (const owner of this.deploymentSettingRepository.findAutoTopUpDeploymentsByOwnerIteratively()) {
+      try {
+        await this.walletReloadService.scheduleImmediate({ walletId: owner.walletId });
+      } catch (error: unknown) {
+        errors.push(error);
+      }
+    }
   }
 
   /**

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
@@ -63,7 +63,7 @@ export class TopUpManagedDeploymentsService {
       }
 
       if (!options.dryRun) {
-        await this.#scheduleImmediateForAutoTopUpOwners(errors);
+        await this.#scheduleCreditsLowChecksForAutoTopUpOwners(errors);
       }
     } catch (error: unknown) {
       errors.push(error);
@@ -156,10 +156,10 @@ export class TopUpManagedDeploymentsService {
     await this.walletReloadService.scheduleImmediate({ walletId });
   }
 
-  async #scheduleImmediateForAutoTopUpOwners(errors: unknown[]): Promise<void> {
+  async #scheduleCreditsLowChecksForAutoTopUpOwners(errors: unknown[]): Promise<void> {
     for await (const owner of this.deploymentSettingRepository.findAutoTopUpDeploymentsByOwnerIteratively()) {
       try {
-        await this.walletReloadService.scheduleImmediate({ walletId: owner.walletId });
+        await this.walletReloadService.scheduleCreditsLowCheckIfAutoReloadOff({ walletId: owner.walletId });
       } catch (error: unknown) {
         errors.push(error);
       }

--- a/apps/api/src/notifications/services/notification-templates/credits-running-low-notification.spec.ts
+++ b/apps/api/src/notifications/services/notification-templates/credits-running-low-notification.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { creditsRunningLowNotification } from "./credits-running-low-notification";
+
+import { createUser } from "@test/seeders/user.seeder";
+
+describe(creditsRunningLowNotification.name, () => {
+  it("returns a notification with balance, coverage, payment and billing links", () => {
+    const user = createUser({ id: "user-123", email: "user@example.com" });
+
+    const result = creditsRunningLowNotification(user, {
+      balanceUsd: 12.5,
+      weeklyCostUsd: 35,
+      daysRemaining: 2,
+      paymentLink: "https://console.akash.network/billing?openPayment=true",
+      billingUrl: "https://console.akash.network/billing"
+    });
+
+    expect(result.notificationId).toBe("creditsRunningLow.user-123");
+    expect(result.payload.summary).toBe("Your Akash credits are running low");
+    expect(result.payload.description).toContain("<strong>$12.50</strong>");
+    expect(result.payload.description).toContain("about 2 days of current usage");
+    expect(result.payload.description).toContain('<a href="https://console.akash.network/billing?openPayment=true">Add credits</a>');
+    expect(result.payload.description).toContain('<a href="https://console.akash.network/billing">enable Auto Recharge</a>');
+    expect(result.user).toEqual({ id: "user-123", email: "user@example.com" });
+  });
+
+  it("says less than a day when days remaining is below 1", () => {
+    const user = createUser({ id: "user-123", email: "user@example.com" });
+
+    const result = creditsRunningLowNotification(user, {
+      balanceUsd: 1,
+      weeklyCostUsd: 70,
+      daysRemaining: 0,
+      paymentLink: "https://console.akash.network/billing?openPayment=true",
+      billingUrl: "https://console.akash.network/billing"
+    });
+
+    expect(result.payload.description).toContain("about less than a day of current usage");
+  });
+
+  it("uses singular day when days remaining is 1", () => {
+    const user = createUser({ id: "user-123", email: "user@example.com" });
+
+    const result = creditsRunningLowNotification(user, {
+      balanceUsd: 10,
+      weeklyCostUsd: 70,
+      daysRemaining: 1,
+      paymentLink: "https://console.akash.network/billing?openPayment=true",
+      billingUrl: "https://console.akash.network/billing"
+    });
+
+    expect(result.payload.description).toContain("about 1 day of current usage");
+    expect(result.payload.description).not.toContain("1 days");
+  });
+});

--- a/apps/api/src/notifications/services/notification-templates/credits-running-low-notification.ts
+++ b/apps/api/src/notifications/services/notification-templates/credits-running-low-notification.ts
@@ -1,0 +1,24 @@
+import type { UserOutput } from "@src/user/repositories";
+import type { CreateNotificationInput } from "../notification/notification.service";
+
+export function creditsRunningLowNotification(
+  user: UserOutput,
+  vars: { balanceUsd: number; weeklyCostUsd: number; daysRemaining: number; paymentLink: string; billingUrl: string }
+): CreateNotificationInput {
+  const formatter = new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" });
+  const balance = formatter.format(vars.balanceUsd);
+  const coverage = vars.daysRemaining < 1 ? "less than a day" : `${vars.daysRemaining} day${vars.daysRemaining === 1 ? "" : "s"}`;
+
+  return {
+    notificationId: `creditsRunningLow.${user.id}`,
+    payload: {
+      summary: "Your Akash credits are running low",
+      description:
+        `Your remaining credits are <strong>${balance}</strong>, about ${coverage} of current usage. ` +
+        `Add credits or turn on Auto Recharge to keep your deployments running. ` +
+        `<a href="${vars.paymentLink}">Add credits</a> or ` +
+        `<a href="${vars.billingUrl}">enable Auto Recharge</a>.`
+    },
+    user: { id: user.id, email: user.email }
+  };
+}

--- a/apps/api/test/seeders/user-wallet.seeder.ts
+++ b/apps/api/test/seeders/user-wallet.seeder.ts
@@ -12,7 +12,8 @@ export function createUserWallet({
   isTrialing = faker.helpers.arrayElement([true, false]),
   createdAt = faker.date.past(),
   updatedAt = faker.date.past(),
-  activatedAt = createdAt
+  activatedAt = createdAt,
+  creditsLowNotifiedAt = null
 }: Partial<UserWalletOutput> = {}): UserWalletOutput {
   return {
     id,
@@ -24,7 +25,8 @@ export function createUserWallet({
     creditAmount: deploymentAllowance,
     createdAt,
     updatedAt,
-    activatedAt
+    activatedAt,
+    creditsLowNotifiedAt
   };
 }
 


### PR DESCRIPTION
## Why

Part of CON-736

Once escrow is hidden and deployments stay funded from account credits, paid users only find out they're out of money after a deployment has already closed. Auto Recharge covers that if it's on. If it isn't, they need a heads-up with time to add credits or turn Auto Recharge on.

This is stacked on #3630. That PR already has Drizzle 0038 and rewrote draining-deployment / top-up math. Branching from main would collide on the migration number.

## What

Sends one account-level email when remaining grant credits drop below about a week of auto-top-up spend. Runtime-limited deployments (from #3630) only count remaining hours, not a full week.

Skip when Auto Recharge is on (those users already get the recharge-succeeded email). Skip trial users. One email per low period; send again only after they recover above a week of coverage and drop below again.

Drizzle 0039 adds nullable `credits_low_notified_at` on `user_wallets`. Additive, no backfill, no rewrite.

The hourly top-up extra pass only schedules this coverage check when Auto Recharge is off, so it does not cancel and re-run the daily reload job.

No breaking API change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added low-credit notifications showing remaining balance, estimated usage coverage, and payment and billing links.
  - Notifications avoid duplicate alerts and account for automatic recharge settings.
  - Added weekly cost and coverage estimates for managed deployments.

- **Bug Fixes**
  - Low-credit alerts are cleared when balances recover or automatic recharge is enabled.
  - Improved handling of missing wallet settings, notification details, and scheduling errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->