### PR TITLE
refactor(deployment): extract the secrets sealing key into its own service

### DIFF
--- a/apps/api/src/deployment/config/sdl-secrets.config.ts
+++ b/apps/api/src/deployment/config/sdl-secrets.config.ts
@@ -40,3 +40,11 @@ export const SDL_SECRETS_REQUIRED_CLAIMS = ["kid", "sub", "exp"] as const;
  * with enough slack above the client's own lifetime to absorb clock skew.
  */
 export const SDL_SECRETS_MAX_SEAL_LIFETIME_MS = 15 * 60 * 1000;
+
+/**
+ * The only message a client gets when anything about the sealing key goes wrong. Deliberately says
+ * nothing: the error handler echoes `message` for every `http-errors` instance regardless of
+ * `expose`, so a specific message would tell a caller whether this instance can reach Cloud KMS,
+ * holds a verified key, or has warmed its cache yet.
+ */
+export const SDL_SECRETS_UNAVAILABLE_ERROR_MESSAGE = "Service temporarily unavailable";

--- a/apps/api/src/deployment/index.ts
+++ b/apps/api/src/deployment/index.ts
@@ -1,1 +1,3 @@
+import "./providers/sdl-secrets-sealing-key.provider";
+
 export * from "./services";

--- a/apps/api/src/deployment/providers/sdl-secrets-sealing-key.provider.ts
+++ b/apps/api/src/deployment/providers/sdl-secrets-sealing-key.provider.ts
@@ -1,0 +1,34 @@
+import { container, instancePerContainerCachingFactory } from "tsyringe";
+
+import type { AppInitializer } from "@src/core/providers/app-initializer";
+import { APP_INITIALIZER, ON_APP_START } from "@src/core/providers/app-initializer";
+import { LOGGER_FACTORY } from "@src/core/providers/logging.provider";
+import { SdlSecretsSealingKeyService } from "@src/deployment/services/sdl-secrets-sealing-key/sdl-secrets-sealing-key.service";
+
+/**
+ * Puts the sealing key in memory at boot so request paths that wrap a key — signup above all — never
+ * reach for it themselves. The fetch is neither awaited nor allowed to reject: `startServer` waits on
+ * every initializer and disposes the container when one throws, so an unreachable key service would
+ * otherwise stall or abort boot over a key nothing has needed yet.
+ *
+ * The logger is resolved while the container is still known to be alive, because the rejection it
+ * reports can arrive after a different initializer has already had the container disposed — resolving
+ * anything from that handler would throw inside it and turn a logged warm-up failure into an
+ * unhandled rejection that kills the process and hides the real start-up error.
+ */
+container.register(APP_INITIALIZER, {
+  useFactory: instancePerContainerCachingFactory(c => {
+    const logger = c.resolve(LOGGER_FACTORY)({ context: "SDL_SECRETS_SEALING_KEY" });
+    const logWarmupFailure = (error: unknown) => logger.error({ event: "SDL_SECRETS_KEY_WARMUP_FAILED", error });
+
+    return {
+      async [ON_APP_START]() {
+        try {
+          void c.resolve(SdlSecretsSealingKeyService).getSealingKey().catch(logWarmupFailure);
+        } catch (error) {
+          logWarmupFailure(error);
+        }
+      }
+    } satisfies AppInitializer;
+  })
+});

--- a/apps/api/src/deployment/services/sdl-secrets-context/sdl-secrets-context.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl-secrets-context/sdl-secrets-context.service.spec.ts
@@ -1,30 +1,19 @@
-import { protos } from "@google-cloud/kms";
-import crc32c from "fast-crc32c";
-import { createPublicKey, generateKeyPairSync } from "node:crypto";
+import { generateKeyPairSync } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { AuthService } from "@src/auth/services/auth.service";
-import type { CreateLogger } from "@src/core";
-import type { SdlSecretsKmsClient } from "@src/deployment/providers/kms.provider";
+import type { SdlSecretsSealingKey, SdlSecretsSealingKeyService } from "@src/deployment/services/sdl-secrets-sealing-key/sdl-secrets-sealing-key.service";
 import type { UserOutput } from "@src/user/repositories";
-import type { SdlSecretsPublicJwk } from "./sdl-secrets-context.service";
 import { SdlSecretsContextService } from "./sdl-secrets-context.service";
 
 describe(SdlSecretsContextService.name, () => {
-  it("returns the KMS public key as an RSA-OAEP-256 encryption JWK", async () => {
-    const { service, pem } = setup();
+  it("publishes the sealing key as the JWK a client encrypts to", async () => {
+    const { service, sealingKey } = setup();
 
     const context = await service.getContext();
 
-    expect(context.jwk).toEqual({
-      kty: "RSA",
-      n: expect.any(String),
-      e: "AQAB",
-      use: "enc",
-      alg: "RSA-OAEP-256"
-    });
-    expect(asSpkiPem(context.jwk)).toBe(pem);
+    expect(context.jwk).toBe(sealingKey.jwk);
   });
 
   it("returns the kid of the crypto key version the seal must name", async () => {
@@ -51,121 +40,28 @@ describe(SdlSecretsContextService.name, () => {
     expect(context.requiredClaims).toEqual(["kid", "sub", "exp"]);
   });
 
-  it("fetches the public key once and serves later calls from memory", async () => {
-    const { service, kmsClient } = setup();
-
-    await service.getContext();
-    await service.getContext();
-
-    expect(kmsClient.getPublicKey).toHaveBeenCalledTimes(1);
-  });
-
-  it("asks KMS for the configured crypto key version", async () => {
-    const { service, kmsClient } = setup({ versionName: "projects/p/locations/global/keyRings/r/cryptoKeys/k/cryptoKeyVersions/1" });
-
-    await service.getContext();
-
-    expect(kmsClient.getPublicKey).toHaveBeenCalledWith({ name: "projects/p/locations/global/keyRings/r/cryptoKeys/k/cryptoKeyVersions/1" });
-  });
-
-  it("fails with 503 when KMS is unreachable", async () => {
-    const { service, kmsClient } = setup();
-    kmsClient.getPublicKey.mockRejectedValue(new Error("14 UNAVAILABLE"));
+  it("propagates the failure when the sealing key cannot be verified", async () => {
+    const { service, sealingKeyService } = setup();
+    sealingKeyService.getSealingKey.mockRejectedValue(Object.assign(new Error("unverifiable"), { status: 503 }));
 
     await expect(service.getContext()).rejects.toMatchObject({ status: 503 });
   });
 
-  it("retries the fetch after a failure instead of caching it", async () => {
-    const { service, kmsClient, publicKeyResponse } = setup();
-    kmsClient.getPublicKey.mockRejectedValueOnce(new Error("14 UNAVAILABLE"));
-
-    await expect(service.getContext()).rejects.toThrow();
-    kmsClient.getPublicKey.mockResolvedValue([publicKeyResponse]);
-
-    await expect(service.getContext()).resolves.toMatchObject({ kid: "sdl-secrets.v1" });
-  });
-
-  it("rejects a public key whose checksum does not match its PEM", async () => {
-    const { service, kmsClient, publicKeyResponse } = setup();
-    kmsClient.getPublicKey.mockResolvedValue([{ ...publicKeyResponse, pemCrc32c: { value: "1" } }]);
-
-    await expect(service.getContext()).rejects.toMatchObject({ status: 503 });
-  });
-
-  it("rejects a public key that belongs to another crypto key version", async () => {
-    const { service, kmsClient, publicKeyResponse } = setup();
-    kmsClient.getPublicKey.mockResolvedValue([{ ...publicKeyResponse, name: "projects/p/other" }]);
-
-    await expect(service.getContext()).rejects.toMatchObject({ status: 503 });
-  });
-
-  it("rejects a response carrying no PEM", async () => {
-    const { service, kmsClient, publicKeyResponse } = setup();
-    kmsClient.getPublicKey.mockResolvedValue([{ ...publicKeyResponse, pem: "" }]);
-
-    await expect(service.getContext()).rejects.toMatchObject({ status: 503 });
-  });
-
-  it("rejects a key that cannot perform RSA-OAEP-256", async () => {
-    const ellipticCurvePem = generateKeyPairSync("ec", { namedCurve: "P-256" }).publicKey.export({ type: "spki", format: "pem" }).toString();
-    const { service } = setup({ pem: ellipticCurvePem });
-
-    await expect(service.getContext()).rejects.toMatchObject({ status: 503 });
-  });
-
-  it("rejects a PEM that cannot be parsed as a public key", async () => {
-    const { service } = setup({ pem: "-----BEGIN PUBLIC KEY-----\nnot-a-key\n-----END PUBLIC KEY-----\n" });
-
-    await expect(service.getContext()).rejects.toMatchObject({ status: 503 });
-  });
-
-  it.each(["RSA_DECRYPT_OAEP_3072_SHA1", "RSA_DECRYPT_OAEP_4096_SHA512", "RSA_SIGN_PKCS1_3072_SHA256", null] as const)(
-    "rejects a key version provisioned as %s rather than for RSA-OAEP-256",
-    async algorithm => {
-      const { service, kmsClient, publicKeyResponse } = setup();
-      kmsClient.getPublicKey.mockResolvedValue([{ ...publicKeyResponse, algorithm }]);
-
-      await expect(service.getContext()).rejects.toMatchObject({ status: 503 });
-    }
-  );
-
-  it("accepts an algorithm reported as an enum ordinal rather than a name", async () => {
-    const { service, kmsClient, publicKeyResponse } = setup();
-    kmsClient.getPublicKey.mockResolvedValue([
-      { ...publicKeyResponse, algorithm: protos.google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionAlgorithm.RSA_DECRYPT_OAEP_3072_SHA256 }
-    ]);
-
-    await expect(service.getContext()).resolves.toMatchObject({ jwk: expect.objectContaining({ alg: "RSA-OAEP-256" }) });
-  });
-
-  function asSpkiPem(jwk: SdlSecretsPublicJwk) {
-    return createPublicKey({ key: { ...jwk }, format: "jwk" })
-      .export({ type: "spki", format: "pem" })
-      .toString();
-  }
-
-  function setup(input?: { pem?: string; kid?: string; versionName?: string; currentUser?: UserOutput }) {
-    const pem = input?.pem ?? generateKeyPairSync("rsa", { modulusLength: 3072 }).publicKey.export({ type: "spki", format: "pem" }).toString();
-    const versionName = input?.versionName ?? "projects/console-test/locations/global/keyRings/console-api/cryptoKeys/sdl-secrets/cryptoKeyVersions/1";
-    const publicKeyResponse: protos.google.cloud.kms.v1.IPublicKey = {
-      pem,
-      name: versionName,
-      algorithm: "RSA_DECRYPT_OAEP_3072_SHA256",
-      pemCrc32c: { value: String(crc32c.calculate(pem)) }
+  function setup(input?: { kid?: string; currentUser?: UserOutput }) {
+    const sealingKey: SdlSecretsSealingKey = {
+      kid: input?.kid ?? "sdl-secrets.v1",
+      publicKey: generateKeyPairSync("rsa", { modulusLength: 3072 }).publicKey,
+      jwk: { kty: "RSA", n: "modulus", e: "AQAB", use: "enc", alg: "RSA-OAEP-256" }
     };
-
-    const kmsClient = mock<SdlSecretsKmsClient>();
-    kmsClient.getPublicKey.mockResolvedValue([publicKeyResponse]);
+    const sealingKeyService = mock<SdlSecretsSealingKeyService>();
+    sealingKeyService.getSealingKey.mockResolvedValue(sealingKey);
 
     const authService = mock<AuthService>({
       currentUser: input?.currentUser ?? mock<UserOutput>({ id: "3f2b6f7a-1c1d-4b0e-8b8a-9a0f5f5c2b11" })
     });
 
-    const logger = mock<ReturnType<CreateLogger>>();
-    const createLogger: CreateLogger = () => logger;
-    const kmsTarget = { client: kmsClient, versionName, kid: input?.kid ?? "sdl-secrets.v1" };
-    const service = new SdlSecretsContextService(kmsTarget, authService, createLogger);
+    const service = new SdlSecretsContextService(sealingKeyService, authService);
 
-    return { service, kmsClient, authService, logger, pem, versionName, publicKeyResponse };
+    return { service, sealingKeyService, authService, sealingKey };
   }
 });

--- a/apps/api/src/deployment/services/sdl-secrets-context/sdl-secrets-context.service.ts
+++ b/apps/api/src/deployment/services/sdl-secrets-context/sdl-secrets-context.service.ts
@@ -1,21 +1,11 @@
-import crc32c from "fast-crc32c";
-import createError from "http-errors";
-import { createPublicKey } from "node:crypto";
-import { inject, singleton } from "tsyringe";
+import { singleton } from "tsyringe";
 
 import { AuthService } from "@src/auth/services/auth.service";
-import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
-import { SDL_SECRETS_REQUIRED_CLAIMS, SDL_SECRETS_SEAL_ALGORITHM, SDL_SECRETS_SEALING_KEY_ALGORITHMS } from "@src/deployment/config/sdl-secrets.config";
-import type { SdlSecretsKmsTarget } from "@src/deployment/providers/kms.provider";
-import { SDL_SECRETS_KMS_TARGET } from "@src/deployment/providers/kms.provider";
+import { SDL_SECRETS_REQUIRED_CLAIMS } from "@src/deployment/config/sdl-secrets.config";
+import type { SdlSecretsPublicJwk } from "@src/deployment/services/sdl-secrets-sealing-key/sdl-secrets-sealing-key.service";
+import { SdlSecretsSealingKeyService } from "@src/deployment/services/sdl-secrets-sealing-key/sdl-secrets-sealing-key.service";
 
-export interface SdlSecretsPublicJwk {
-  kty: string;
-  n: string;
-  e: string;
-  use: string;
-  alg: string;
-}
+export type { SdlSecretsPublicJwk };
 
 export interface SdlSecretsContext {
   kid: string;
@@ -24,26 +14,15 @@ export interface SdlSecretsContext {
   requiredClaims: Array<(typeof SDL_SECRETS_REQUIRED_CLAIMS)[number]>;
 }
 
-interface SealingKey {
-  kid: string;
-  jwk: SdlSecretsPublicJwk;
-}
-
 @singleton()
 export class SdlSecretsContextService {
-  #sealingKeyPromise?: Promise<SealingKey>;
-  readonly #loggerService: ReturnType<CreateLogger>;
-
   constructor(
-    @inject(SDL_SECRETS_KMS_TARGET) private readonly kmsTarget: SdlSecretsKmsTarget,
-    private readonly authService: AuthService,
-    @inject(LOGGER_FACTORY) createLogger: CreateLogger
-  ) {
-    this.#loggerService = createLogger({ context: SdlSecretsContextService.name });
-  }
+    private readonly sealingKeyService: SdlSecretsSealingKeyService,
+    private readonly authService: AuthService
+  ) {}
 
   async getContext(): Promise<SdlSecretsContext> {
-    const { kid, jwk } = await this.#getSealingKey();
+    const { kid, jwk } = await this.sealingKeyService.getSealingKey();
 
     return {
       kid,
@@ -51,81 +30,5 @@ export class SdlSecretsContextService {
       jwk,
       requiredClaims: [...SDL_SECRETS_REQUIRED_CLAIMS]
     };
-  }
-
-  /**
-   * Serving a cached key means a KMS outage cannot take this endpoint down and traffic does not
-   * consume the read quota. A failed fetch is not cached, so the next caller retries.
-   */
-  #getSealingKey(): Promise<SealingKey> {
-    if (!this.#sealingKeyPromise) {
-      this.#sealingKeyPromise = this.#fetchSealingKey().catch(error => {
-        this.#sealingKeyPromise = undefined;
-        throw error;
-      });
-    }
-
-    return this.#sealingKeyPromise;
-  }
-
-  async #fetchSealingKey(): Promise<SealingKey> {
-    const { versionName, kid } = this.kmsTarget;
-    const publicKey = await this.#readPublicKey(this.kmsTarget);
-
-    if (publicKey.name !== versionName) {
-      throw this.#rejectUntrustworthyKey("SDL_SECRETS_KEY_NAME_MISMATCH", { expected: versionName, received: publicKey.name });
-    }
-
-    if (!publicKey.pem) {
-      throw this.#rejectUntrustworthyKey("SDL_SECRETS_KEY_PEM_MISSING", { versionName });
-    }
-
-    if (crc32c.calculate(publicKey.pem) !== Number(publicKey.pemCrc32c?.value)) {
-      throw this.#rejectUntrustworthyKey("SDL_SECRETS_KEY_CHECKSUM_MISMATCH", { versionName });
-    }
-
-    if (!SDL_SECRETS_SEALING_KEY_ALGORITHMS.has(publicKey.algorithm ?? "")) {
-      throw this.#rejectUntrustworthyKey("SDL_SECRETS_KEY_ALGORITHM_UNSUPPORTED", { versionName, algorithm: publicKey.algorithm });
-    }
-
-    this.#loggerService.info({ event: "SDL_SECRETS_KEY_PUBLISHED", kid, algorithm: publicKey.algorithm });
-
-    return { kid, jwk: this.#toSealingJwk(publicKey.pem) };
-  }
-
-  async #readPublicKey({ client, versionName }: SdlSecretsKmsTarget) {
-    try {
-      const [publicKey] = await client.getPublicKey({ name: versionName });
-
-      return publicKey;
-    } catch (error) {
-      this.#loggerService.error({ event: "SDL_SECRETS_KEY_FETCH_FAILED", versionName, error });
-
-      throw createError(503, "Unable to reach the SDL secrets key management service");
-    }
-  }
-
-  #rejectUntrustworthyKey(event: string, details: Record<string, unknown>) {
-    this.#loggerService.error({ event, ...details });
-
-    return createError(503, "SDL secrets encryption key could not be verified");
-  }
-
-  #toSealingJwk(pem: string): SdlSecretsPublicJwk {
-    const { kty, n, e } = this.#exportJwk(pem);
-
-    if (kty !== "RSA" || !n || !e) {
-      throw this.#rejectUntrustworthyKey("SDL_SECRETS_KEY_NOT_RSA", { kty });
-    }
-
-    return { kty, n, e, use: "enc", alg: SDL_SECRETS_SEAL_ALGORITHM };
-  }
-
-  #exportJwk(pem: string) {
-    try {
-      return createPublicKey(pem).export({ format: "jwk" });
-    } catch (error) {
-      throw this.#rejectUntrustworthyKey("SDL_SECRETS_KEY_PEM_UNPARSABLE", { error });
-    }
   }
 }

--- a/apps/api/src/deployment/services/sdl-secrets-sealing-key/sdl-secrets-sealing-key.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl-secrets-sealing-key/sdl-secrets-sealing-key.service.spec.ts
@@ -1,0 +1,193 @@
+import { protos } from "@google-cloud/kms";
+import crc32c from "fast-crc32c";
+import { createPublicKey, generateKeyPairSync } from "node:crypto";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { CreateLogger } from "@src/core";
+import { SDL_SECRETS_UNAVAILABLE_ERROR_MESSAGE } from "@src/deployment/config/sdl-secrets.config";
+import type { SdlSecretsKmsClient } from "@src/deployment/providers/kms.provider";
+import type { SdlSecretsPublicJwk } from "./sdl-secrets-sealing-key.service";
+import { SdlSecretsSealingKeyService } from "./sdl-secrets-sealing-key.service";
+
+describe(SdlSecretsSealingKeyService.name, () => {
+  it("returns the KMS public key as an RSA-OAEP-256 encryption JWK", async () => {
+    const { service, pem } = setup();
+
+    const { jwk } = await service.getSealingKey();
+
+    expect(jwk).toEqual({
+      kty: "RSA",
+      n: expect.any(String),
+      e: "AQAB",
+      use: "enc",
+      alg: "RSA-OAEP-256"
+    });
+    expect(asSpkiPem(jwk)).toBe(pem);
+  });
+
+  it("returns the public key as a key object wrapping can encrypt with", async () => {
+    const { service, pem } = setup();
+
+    const { publicKey } = await service.getSealingKey();
+
+    expect(publicKey.export({ type: "spki", format: "pem" }).toString()).toBe(pem);
+  });
+
+  it("returns the kid of the crypto key version the seal must name", async () => {
+    const { service } = setup({ kid: "sdl-secrets.v7" });
+
+    const { kid } = await service.getSealingKey();
+
+    expect(kid).toBe("sdl-secrets.v7");
+  });
+
+  it("fetches the public key once and serves later calls from memory", async () => {
+    const { service, kmsClient } = setup();
+
+    await service.getSealingKey();
+    await service.getSealingKey();
+
+    expect(kmsClient.getPublicKey).toHaveBeenCalledTimes(1);
+  });
+
+  describe("peekSealingKey", () => {
+    it("returns nothing while the key has not been fetched yet", () => {
+      const { service } = setup();
+
+      expect(service.peekSealingKey()).toBeUndefined();
+    });
+
+    it("returns the key once it is held", async () => {
+      const { service } = setup({ kid: "sdl-secrets.v2" });
+      await service.getSealingKey();
+
+      expect(service.peekSealingKey()).toMatchObject({ kid: "sdl-secrets.v2" });
+    });
+
+    it("starts a fetch so a later peek finds the key", async () => {
+      const { service, kmsClient } = setup();
+
+      expect(service.peekSealingKey()).toBeUndefined();
+
+      await vi.waitFor(() => expect(service.peekSealingKey()).toMatchObject({ kid: "sdl-secrets.v1" }));
+
+      expect(kmsClient.getPublicKey).toHaveBeenCalledTimes(1);
+    });
+
+    it("swallows a failed fetch it started instead of rejecting the caller", async () => {
+      const { service, kmsClient } = setup();
+      kmsClient.getPublicKey.mockRejectedValue(new Error("14 UNAVAILABLE"));
+
+      expect(service.peekSealingKey()).toBeUndefined();
+      await vi.waitFor(() => expect(kmsClient.getPublicKey).toHaveBeenCalled());
+
+      expect(service.peekSealingKey()).toBeUndefined();
+    });
+  });
+
+  it("asks KMS for the configured crypto key version", async () => {
+    const { service, kmsClient } = setup({ versionName: "projects/p/locations/global/keyRings/r/cryptoKeys/k/cryptoKeyVersions/1" });
+
+    await service.getSealingKey();
+
+    expect(kmsClient.getPublicKey).toHaveBeenCalledWith({ name: "projects/p/locations/global/keyRings/r/cryptoKeys/k/cryptoKeyVersions/1" });
+  });
+
+  it("fails with 503 when KMS is unreachable", async () => {
+    const { service, kmsClient } = setup();
+    kmsClient.getPublicKey.mockRejectedValue(new Error("14 UNAVAILABLE"));
+
+    await expect(service.getSealingKey()).rejects.toMatchObject({ status: 503, message: SDL_SECRETS_UNAVAILABLE_ERROR_MESSAGE });
+  });
+
+  it("retries the fetch after a failure instead of caching it", async () => {
+    const { service, kmsClient, publicKeyResponse } = setup();
+    kmsClient.getPublicKey.mockRejectedValueOnce(new Error("14 UNAVAILABLE"));
+
+    await expect(service.getSealingKey()).rejects.toThrow();
+    kmsClient.getPublicKey.mockResolvedValue([publicKeyResponse]);
+
+    await expect(service.getSealingKey()).resolves.toMatchObject({ kid: "sdl-secrets.v1" });
+  });
+
+  it("rejects a public key whose checksum does not match its PEM", async () => {
+    const { service, kmsClient, publicKeyResponse } = setup();
+    kmsClient.getPublicKey.mockResolvedValue([{ ...publicKeyResponse, pemCrc32c: { value: "1" } }]);
+
+    await expect(service.getSealingKey()).rejects.toMatchObject({ status: 503, message: SDL_SECRETS_UNAVAILABLE_ERROR_MESSAGE });
+  });
+
+  it("rejects a public key that belongs to another crypto key version", async () => {
+    const { service, kmsClient, publicKeyResponse } = setup();
+    kmsClient.getPublicKey.mockResolvedValue([{ ...publicKeyResponse, name: "projects/p/other" }]);
+
+    await expect(service.getSealingKey()).rejects.toMatchObject({ status: 503, message: SDL_SECRETS_UNAVAILABLE_ERROR_MESSAGE });
+  });
+
+  it("rejects a response carrying no PEM", async () => {
+    const { service, kmsClient, publicKeyResponse } = setup();
+    kmsClient.getPublicKey.mockResolvedValue([{ ...publicKeyResponse, pem: "" }]);
+
+    await expect(service.getSealingKey()).rejects.toMatchObject({ status: 503, message: SDL_SECRETS_UNAVAILABLE_ERROR_MESSAGE });
+  });
+
+  it("rejects a key that cannot perform RSA-OAEP-256", async () => {
+    const ellipticCurvePem = generateKeyPairSync("ec", { namedCurve: "P-256" }).publicKey.export({ type: "spki", format: "pem" }).toString();
+    const { service } = setup({ pem: ellipticCurvePem });
+
+    await expect(service.getSealingKey()).rejects.toMatchObject({ status: 503, message: SDL_SECRETS_UNAVAILABLE_ERROR_MESSAGE });
+  });
+
+  it("rejects a PEM that cannot be parsed as a public key", async () => {
+    const { service } = setup({ pem: "-----BEGIN PUBLIC KEY-----\nnot-a-key\n-----END PUBLIC KEY-----\n" });
+
+    await expect(service.getSealingKey()).rejects.toMatchObject({ status: 503, message: SDL_SECRETS_UNAVAILABLE_ERROR_MESSAGE });
+  });
+
+  it.each(["RSA_DECRYPT_OAEP_3072_SHA1", "RSA_DECRYPT_OAEP_4096_SHA512", "RSA_SIGN_PKCS1_3072_SHA256", null] as const)(
+    "rejects a key version provisioned as %s rather than for RSA-OAEP-256",
+    async algorithm => {
+      const { service, kmsClient, publicKeyResponse } = setup();
+      kmsClient.getPublicKey.mockResolvedValue([{ ...publicKeyResponse, algorithm }]);
+
+      await expect(service.getSealingKey()).rejects.toMatchObject({ status: 503, message: SDL_SECRETS_UNAVAILABLE_ERROR_MESSAGE });
+    }
+  );
+
+  it("accepts an algorithm reported as an enum ordinal rather than a name", async () => {
+    const { service, kmsClient, publicKeyResponse } = setup();
+    kmsClient.getPublicKey.mockResolvedValue([
+      { ...publicKeyResponse, algorithm: protos.google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionAlgorithm.RSA_DECRYPT_OAEP_3072_SHA256 }
+    ]);
+
+    await expect(service.getSealingKey()).resolves.toMatchObject({ jwk: expect.objectContaining({ alg: "RSA-OAEP-256" }) });
+  });
+
+  function asSpkiPem(jwk: SdlSecretsPublicJwk) {
+    return createPublicKey({ key: { ...jwk }, format: "jwk" })
+      .export({ type: "spki", format: "pem" })
+      .toString();
+  }
+
+  function setup(input?: { pem?: string; kid?: string; versionName?: string }) {
+    const pem = input?.pem ?? generateKeyPairSync("rsa", { modulusLength: 3072 }).publicKey.export({ type: "spki", format: "pem" }).toString();
+    const versionName = input?.versionName ?? "projects/console-test/locations/global/keyRings/console-api/cryptoKeys/sdl-secrets/cryptoKeyVersions/1";
+    const publicKeyResponse: protos.google.cloud.kms.v1.IPublicKey = {
+      pem,
+      name: versionName,
+      algorithm: "RSA_DECRYPT_OAEP_3072_SHA256",
+      pemCrc32c: { value: String(crc32c.calculate(pem)) }
+    };
+
+    const kmsClient = mock<SdlSecretsKmsClient>();
+    kmsClient.getPublicKey.mockResolvedValue([publicKeyResponse]);
+
+    const logger = mock<ReturnType<CreateLogger>>();
+    const createLogger: CreateLogger = () => logger;
+    const kmsTarget = { client: kmsClient, versionName, kid: input?.kid ?? "sdl-secrets.v1" };
+    const service = new SdlSecretsSealingKeyService(kmsTarget, createLogger);
+
+    return { service, kmsClient, logger, pem, versionName, publicKeyResponse };
+  }
+});

--- a/apps/api/src/deployment/services/sdl-secrets-sealing-key/sdl-secrets-sealing-key.service.ts
+++ b/apps/api/src/deployment/services/sdl-secrets-sealing-key/sdl-secrets-sealing-key.service.ts
@@ -1,0 +1,144 @@
+import crc32c from "fast-crc32c";
+import createError from "http-errors";
+import type { KeyObject } from "node:crypto";
+import { createPublicKey } from "node:crypto";
+import { inject, singleton } from "tsyringe";
+
+import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
+import {
+  SDL_SECRETS_SEAL_ALGORITHM,
+  SDL_SECRETS_SEALING_KEY_ALGORITHMS,
+  SDL_SECRETS_UNAVAILABLE_ERROR_MESSAGE
+} from "@src/deployment/config/sdl-secrets.config";
+import type { SdlSecretsKmsTarget } from "@src/deployment/providers/kms.provider";
+import { SDL_SECRETS_KMS_TARGET } from "@src/deployment/providers/kms.provider";
+
+export interface SdlSecretsPublicJwk {
+  kty: string;
+  n: string;
+  e: string;
+  use: string;
+  alg: string;
+}
+
+export interface SdlSecretsSealingKey {
+  kid: string;
+  publicKey: KeyObject;
+  jwk: SdlSecretsPublicJwk;
+}
+
+/**
+ * Holds the public half of the SDL secrets KMS key. Wrapping and publishing both need only this
+ * half, so every consumer works off one verified in-memory copy instead of spending a KMS read.
+ */
+@singleton()
+export class SdlSecretsSealingKeyService {
+  #sealingKeyPromise?: Promise<SdlSecretsSealingKey>;
+  #heldSealingKey?: SdlSecretsSealingKey;
+  readonly #loggerService: ReturnType<CreateLogger>;
+
+  constructor(
+    @inject(SDL_SECRETS_KMS_TARGET) private readonly kmsTarget: SdlSecretsKmsTarget,
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
+  ) {
+    this.#loggerService = createLogger({ context: SdlSecretsSealingKeyService.name });
+  }
+
+  /**
+   * Serving a cached key means a KMS outage cannot take this endpoint down and traffic does not
+   * consume the read quota. A failed fetch is not cached, so the next caller retries.
+   */
+  getSealingKey(): Promise<SdlSecretsSealingKey> {
+    if (!this.#sealingKeyPromise) {
+      this.#sealingKeyPromise = this.#fetchSealingKey()
+        .then(sealingKey => {
+          this.#heldSealingKey = sealingKey;
+
+          return sealingKey;
+        })
+        .catch(error => {
+          this.#sealingKeyPromise = undefined;
+          throw error;
+        });
+    }
+
+    return this.#sealingKeyPromise;
+  }
+
+  /**
+   * The sealing key only if it is already in memory, plus a fetch started for the next caller when
+   * it is not. Request paths that must not depend on KMS availability — signup above all — read the
+   * key this way: an unreachable key service stalls a fetch for as long as its own timeouts allow,
+   * and a request that merely wants to wrap a key cannot afford to wait on that. The started fetch
+   * logs its own failure, so a cold key heals without anything blocking on it.
+   */
+  peekSealingKey(): SdlSecretsSealingKey | undefined {
+    if (!this.#heldSealingKey) {
+      this.getSealingKey().catch(() => undefined);
+    }
+
+    return this.#heldSealingKey;
+  }
+
+  async #fetchSealingKey(): Promise<SdlSecretsSealingKey> {
+    const { versionName, kid } = this.kmsTarget;
+    const publicKey = await this.#readPublicKey(this.kmsTarget);
+
+    if (publicKey.name !== versionName) {
+      throw this.#rejectUntrustworthyKey("SDL_SECRETS_KEY_NAME_MISMATCH", { expected: versionName, received: publicKey.name });
+    }
+
+    if (!publicKey.pem) {
+      throw this.#rejectUntrustworthyKey("SDL_SECRETS_KEY_PEM_MISSING", { versionName });
+    }
+
+    if (crc32c.calculate(publicKey.pem) !== Number(publicKey.pemCrc32c?.value)) {
+      throw this.#rejectUntrustworthyKey("SDL_SECRETS_KEY_CHECKSUM_MISMATCH", { versionName });
+    }
+
+    if (!SDL_SECRETS_SEALING_KEY_ALGORITHMS.has(publicKey.algorithm ?? "")) {
+      throw this.#rejectUntrustworthyKey("SDL_SECRETS_KEY_ALGORITHM_UNSUPPORTED", { versionName, algorithm: publicKey.algorithm });
+    }
+
+    this.#loggerService.info({ event: "SDL_SECRETS_KEY_PUBLISHED", kid, algorithm: publicKey.algorithm });
+
+    return { kid, ...this.#toSealingKeyMaterial(publicKey.pem) };
+  }
+
+  async #readPublicKey({ client, versionName }: SdlSecretsKmsTarget) {
+    try {
+      const [publicKey] = await client.getPublicKey({ name: versionName });
+
+      return publicKey;
+    } catch (error) {
+      this.#loggerService.error({ event: "SDL_SECRETS_KEY_FETCH_FAILED", versionName, error });
+
+      throw createError(503, SDL_SECRETS_UNAVAILABLE_ERROR_MESSAGE);
+    }
+  }
+
+  #rejectUntrustworthyKey(event: string, details: Record<string, unknown>) {
+    this.#loggerService.error({ event, ...details });
+
+    return createError(503, SDL_SECRETS_UNAVAILABLE_ERROR_MESSAGE);
+  }
+
+  #toSealingKeyMaterial(pem: string): Omit<SdlSecretsSealingKey, "kid"> {
+    const publicKey = this.#createPublicKey(pem);
+    const { kty, n, e } = publicKey.export({ format: "jwk" });
+
+    if (kty !== "RSA" || !n || !e) {
+      throw this.#rejectUntrustworthyKey("SDL_SECRETS_KEY_NOT_RSA", { kty });
+    }
+
+    return { publicKey, jwk: { kty, n, e, use: "enc", alg: SDL_SECRETS_SEAL_ALGORITHM } };
+  }
+
+  #createPublicKey(pem: string) {
+    try {
+      return createPublicKey(pem);
+    } catch (error) {
+      throw this.#rejectUntrustworthyKey("SDL_SECRETS_KEY_PEM_UNPARSABLE", { error });
+    }
+  }
+}


### PR DESCRIPTION
## Why

The SDL secrets feature currently protects every user's secrets with a single shared key. One flaw is then everybody's exposure, and rotation means re-encrypting every value ever stored, which nobody can afford to do. A key per user makes rotation a re-wrap of one small record, contains a compromise to the one user it belongs to, and turns account deletion into a crypto-shred.

Wrapping a per-user key needs the public half of the KMS sealing key. Today that half is fetched, verified and cached inside `SdlSecretsContextService`, where the only way to reach it is through the shape the public-JWK endpoint returns — a JWK, not something you can encrypt with. This PR moves the key out first so the rest of the stack has something to wrap against.

ref CON-851

## What

Behaviour-preserving extraction of the sealing key into `SdlSecretsSealingKeyService`, plus two additions:

- The service exposes the verified `KeyObject` alongside the JWK, so a caller that wants to encrypt does not have to reconstruct a key from the published JWK. `SdlSecretsContextService` keeps its contract and now just reads `kid`/`jwk` from the new service; all the KMS fetch, checksum, key-name and algorithm verification tests moved with the code.
- `peekSealingKey()` returns the key only if it is already in memory and otherwise starts a fetch for the next caller. This exists for request paths that must not wait on KMS.
- A new `APP_INITIALIZER` warms the key at boot. **The warm-up deliberately does not await and cannot reject**: `startServer` waits on every initializer and disposes the container when one throws, so awaiting an unreachable key service would stall or abort boot over a key nothing has needed yet. The logger is resolved while the container is still known to be alive, because the rejection it reports can arrive after another initializer has already had the container disposed.
- `SDL_SECRETS_UNAVAILABLE_ERROR_MESSAGE` replaces the three distinct 503 messages. The generic message exists because **the error handler echoes `message` for every `http-errors` instance regardless of `expose`** — a specific message would tell a caller whether this instance can reach Cloud KMS, holds a verified key, or has warmed its cache yet.

No migration, no route or response change.

## Stack

1. **→ this PR** — `refactor/deployment-extract-secrets-sealing-key`: the sealing key becomes its own service
2. `feat/deployment-add-user-data-key-table`: the `data_keys` table and its repository
3. `feat/deployment-wrap-a-data-key-per-user`: the service that mints and wraps a DEK
4. `feat/user-create-a-data-key-at-signup`: the signup hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added secure retrieval and caching of the SDL secrets sealing key.
  - Added startup warm-up to improve key availability when the application begins.
  - Added validation of key identity, format, algorithm, and integrity.
  - Added public key metadata for encryption workflows.
  - Service failures now return a temporary-unavailability response.

- **Bug Fixes**
  - Improved handling and logging of sealing-key retrieval failures.

- **Tests**
  - Added comprehensive coverage for key retrieval, caching, validation, retries, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->