### PR TITLE
fix(styling): make the selected tab readable in light mode

### DIFF
--- a/apps/deploy-web/src/components/billing-usage/AddCreditsTabs/AddCreditsTabs.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AddCreditsTabs/AddCreditsTabs.tsx
@@ -56,7 +56,7 @@ export function AddCreditsTabs({ initialTab = "purchase", onDone, onRedeemed, on
 
   return (
     <d.Tabs value={activeTab} onValueChange={handleTabChange} className="space-y-6">
-      <d.TabsList className="grid w-full grid-cols-2 border-0 bg-muted">
+      <d.TabsList className="grid w-full grid-cols-2">
         <d.TabsTrigger value="purchase" disabled={isProcessing && activeTab !== "purchase"}>
           Purchase credits
         </d.TabsTrigger>

--- a/packages/ui/components/tabs.tsx
+++ b/packages/ui/components/tabs.tsx
@@ -10,7 +10,7 @@ const TabsList = React.forwardRef<React.ElementRef<typeof TabsPrimitive.List>, R
   ({ className, ...props }, ref) => (
     <TabsPrimitive.List
       ref={ref}
-      className={cn("text-muted-foreground border-border inline-flex items-center justify-start gap-1 rounded-lg border p-1", className)}
+      className={cn("text-muted-foreground bg-muted inline-flex items-center justify-start gap-1 rounded-lg p-1", className)}
       {...props}
     />
   )


### PR DESCRIPTION
## Why

In light mode the `Active` / `Closed` toggle on the Deployments list barely shows which tab is selected.

The cause is in the shared Tabs primitive rather than the page. `TabsTrigger` paints the selected pill with `data-[state=active]:bg-card`, and in the light palette two tokens land on the same value:

| token | light | dark |
| --- | --- | --- |
| `--background` | `0 0% 100%` | `0 0% 4%` |
| `--card` | `120 33% 100%` | `0 0% 9%` |

`120 33% 100%` is white, so the selected pill rendered white on white. That left `shadow-sm` and the text color to carry the state by themselves. In dark mode `--card` (9%) does lift off `--background` (4%), which is why only light mode looked flat.

No Linear issue for this one. It came out of a screenshot review.

## What

`TabsList` now paints a muted track instead of drawing an outline, so the selected pill has something to read against.

```diff
- "text-muted-foreground border-border inline-flex ... rounded-lg border p-1"
+ "text-muted-foreground bg-muted inline-flex ... rounded-lg p-1"
```

This is the treatment `AddCreditsTabs` was already applying by hand (`border-0 bg-muted`). Promoting it to the default means that call site drops its override and inherits, so the diff there is a deletion rather than an addition.

Both themes improve. In light the white pill sits on a light gray track; in dark the pill is defined by the track around it instead of relying on a low-contrast border.

### Blast radius

The fix is in the primitive, so every tab bar picks it up. Of the 17 `TabsList` call sites, 13 gain the filled track and lose the outline: Deployments, Alerts, user profile, provider detail, template detail, rollback modal, remote deploy and legacy deployment detail, plus the stats-web address tabs and three provider-console pages.

The other four set their own background and are unaffected. `AddCreditsTabs` already looked like the new default. The three underline-style bars (`PasswordAuth`, `ShareDeployButton`, `DeploymentDetail`) pass `bg-transparent` and `border-0`, which still wins.

One leftover worth a follow-up rather than this PR: `PasswordAuth` and `ShareDeployButton` carry `border-0 border-l-0 border-r-0 border-t-0` purely to cancel the default border that no longer exists. Dead weight now, but cleaning it means touching auth code for no visual gain.

No spec asserts a class on `TabsList` or `TabsTrigger`, so nothing needed a test change.

### Checks

- `DeploymentList` and `AddCreditsTabs` unit tests: 22 passed, also green as a pre-edit baseline
- `packages/ui`: 86 passed
- deploy-web lint clean
- `tsc --noEmit`: 88 errors before and after, none of them in the changed files. Bare `tsc` picks up spec files that the build config excludes, and that noise predates this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined tab list styling for improved visual consistency.
  * Updated tab backgrounds to use a muted appearance while retaining layout, spacing, text colors, and custom styling.
  * Adjusted billing usage tabs to align with the updated visual treatment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->