### PR TITLE
fix(auth): map auth0 management api errors on signup

### DIFF
--- a/apps/api/src/auth/controllers/auth/auth.controller.spec.ts
+++ b/apps/api/src/auth/controllers/auth/auth.controller.spec.ts
@@ -1,4 +1,4 @@
-import { ResponseError } from "auth0";
+import { ManagementApiError, ResponseError } from "auth0";
 import { container as rootContainer } from "tsyringe";
 import { describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
@@ -11,6 +11,15 @@ import type { UserService } from "@src/user/services/user/user.service";
 import { AuthController } from "./auth.controller";
 
 import { createUser } from "@test/seeders/user.seeder";
+
+/**
+ * Mirrors what the management client's own `parseError` builds for a JSON error body. Production throws
+ * this class, not `ResponseError`, so the mapping has to be exercised against it.
+ */
+function createManagementApiError(statusCode: number, message: string, error = "Bad Request") {
+  const body = JSON.stringify({ statusCode, error, message, errorCode: "auth0_idp_error" });
+  return new ManagementApiError("auth0_idp_error", error, statusCode, body, new Headers(), message);
+}
 
 describe(AuthController.name, () => {
   describe("signup", () => {
@@ -28,27 +37,62 @@ describe(AuthController.name, () => {
       });
     });
 
-    it("throws http error when auth0 returns a non-409 error", async () => {
+    it("converts 409 (user exists) to a 422 that does not confirm the email is registered", async () => {
       const { controller, auth0Service } = setup();
 
-      auth0Service.createUser.mockRejectedValue(
-        new ResponseError(400, JSON.stringify({ message: "PasswordStrengthError: Password is too weak" }), new Headers())
-      );
+      auth0Service.createUser.mockRejectedValue(createManagementApiError(409, "The user already exists.", "Conflict"));
 
-      await expect(controller.signup({ email: "user@example.com", password: "weak" })).rejects.toThrow("PasswordStrengthError: Password is too weak");
+      await expect(controller.signup({ email: "user@example.com", password: "StrongPassword123!" })).rejects.toMatchObject({
+        status: 422,
+        message: "Unable to create account. Please try again or use a different email."
+      });
     });
 
-    it("converts 409 (user exists) to generic 422 error", async () => {
+    it("passes a rejected password through with auth0's own message", async () => {
       const { controller, auth0Service } = setup();
 
-      auth0Service.createUser.mockRejectedValue(new ResponseError(409, JSON.stringify({ message: "The user already exists." }), new Headers()));
+      auth0Service.createUser.mockRejectedValue(createManagementApiError(400, "PasswordStrengthError: Password is too weak"));
 
-      await expect(controller.signup({ email: "user@example.com", password: "StrongPassword123!" })).rejects.toThrow(
-        "Unable to create account. Please try again or use a different email."
-      );
+      await expect(controller.signup({ email: "user@example.com", password: "weak" })).rejects.toMatchObject({
+        status: 400,
+        message: "PasswordStrengthError: Password is too weak"
+      });
     });
 
-    it("re-throws non-ResponseError errors", async () => {
+    it("passes a rate limit through as 429", async () => {
+      const { controller, auth0Service } = setup();
+
+      auth0Service.createUser.mockRejectedValue(createManagementApiError(429, "Too many requests", "Too Many Requests"));
+
+      await expect(controller.signup({ email: "user@example.com", password: "StrongPassword123!" })).rejects.toMatchObject({
+        status: 429,
+        message: "Too many requests"
+      });
+    });
+
+    it("converts an auth0 outage to a 502 without echoing its message", async () => {
+      const { controller, auth0Service } = setup();
+
+      auth0Service.createUser.mockRejectedValue(createManagementApiError(503, "Service temporarily unavailable", "Service Unavailable"));
+
+      await expect(controller.signup({ email: "user@example.com", password: "StrongPassword123!" })).rejects.toMatchObject({
+        status: 502,
+        message: "Unable to create the account right now. Please try again."
+      });
+    });
+
+    it("converts 409 to 422 when auth0 returns an unparseable body", async () => {
+      const { controller, auth0Service } = setup();
+
+      auth0Service.createUser.mockRejectedValue(new ResponseError(409, "<html>Conflict</html>", new Headers(), "Response returned an error code"));
+
+      await expect(controller.signup({ email: "user@example.com", password: "StrongPassword123!" })).rejects.toMatchObject({
+        status: 422,
+        message: "Unable to create account. Please try again or use a different email."
+      });
+    });
+
+    it("re-throws errors that did not come from the auth0 api", async () => {
       const { controller, auth0Service } = setup();
 
       auth0Service.createUser.mockRejectedValue(new Error("Network failure"));

--- a/apps/api/src/auth/controllers/auth/auth.controller.ts
+++ b/apps/api/src/auth/controllers/auth/auth.controller.ts
@@ -1,4 +1,3 @@
-import { ResponseError } from "auth0";
 import createError from "http-errors";
 import { singleton } from "tsyringe";
 
@@ -8,8 +7,15 @@ import type { SignupInput } from "@src/auth/routes/signup/signup.router";
 import type { VerifyEmailCodeRequest } from "@src/auth/routes/verify-email-code/verify-email-code.router";
 import { AuthService, Protected } from "@src/auth/services/auth.service";
 import { AUTH0_DB_CONNECTION, Auth0Service } from "@src/auth/services/auth0/auth0.service";
+import { extractAuth0ErrorMessage, isAuth0ApiError } from "@src/auth/services/auth0/auth0-error";
 import { EmailVerificationCodeService } from "@src/auth/services/email-verification-code/email-verification-code.service";
 import { UserService } from "@src/user/services/user/user.service";
+
+/** Deliberately vague so a failed signup cannot be used to confirm whether an email is already registered. */
+const ACCOUNT_UNAVAILABLE_MESSAGE = "Unable to create account. Please try again or use a different email.";
+
+/** Auth0 being down is not the caller's fault, and its internal message is not useful to them. */
+const AUTH_PROVIDER_UNAVAILABLE_MESSAGE = "Unable to create the account right now. Please try again.";
 
 @singleton()
 export class AuthController {
@@ -28,24 +34,19 @@ export class AuthController {
         connection: AUTH0_DB_CONNECTION
       });
     } catch (error) {
-      if (error instanceof ResponseError) {
-        if (error.statusCode === 409) {
-          throw createError(422, "Unable to create account. Please try again or use a different email.");
-        }
-
-        throw createError(error.statusCode, this.extractAuth0Message(error));
+      if (!isAuth0ApiError(error)) {
+        throw error;
       }
 
-      throw error;
-    }
-  }
+      if (error.statusCode === 409) {
+        throw createError(422, ACCOUNT_UNAVAILABLE_MESSAGE);
+      }
 
-  private extractAuth0Message(error: ResponseError): string {
-    try {
-      const body = JSON.parse(error.body);
-      return body.message || error.message;
-    } catch {
-      return error.message;
+      if (error.statusCode >= 500) {
+        throw createError(502, AUTH_PROVIDER_UNAVAILABLE_MESSAGE);
+      }
+
+      throw createError(error.statusCode, extractAuth0ErrorMessage(error));
     }
   }
 

--- a/apps/api/src/auth/routes/signup/signup.router.ts
+++ b/apps/api/src/auth/routes/signup/signup.router.ts
@@ -33,10 +33,10 @@ const route = createRoute({
     204: {
       description: "User created successfully"
     },
-    400: { description: "Auth0 rejected the email or password" },
+    400: { description: "The email or password was rejected" },
     422: { description: "Account could not be created" },
     429: { description: "Too many attempts" },
-    502: { description: "Auth0 is unavailable" }
+    502: { description: "Account creation is temporarily unavailable" }
   }
 });
 

--- a/apps/api/src/auth/routes/signup/signup.router.ts
+++ b/apps/api/src/auth/routes/signup/signup.router.ts
@@ -32,7 +32,11 @@ const route = createRoute({
   responses: {
     204: {
       description: "User created successfully"
-    }
+    },
+    400: { description: "Auth0 rejected the email or password" },
+    422: { description: "Account could not be created" },
+    429: { description: "Too many attempts" },
+    502: { description: "Auth0 is unavailable" }
   }
 });
 

--- a/apps/api/src/auth/services/auth0/auth0-error.spec.ts
+++ b/apps/api/src/auth/services/auth0/auth0-error.spec.ts
@@ -1,0 +1,105 @@
+import { ManagementApiError, ManagementClient, ResponseError } from "auth0";
+import nock from "nock";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { Auth0ApiError } from "./auth0-error";
+import { extractAuth0ErrorMessage, isAuth0ApiError } from "./auth0-error";
+
+describe("isAuth0ApiError", () => {
+  it("accepts the ManagementApiError the management client throws for a JSON error body", () => {
+    const { managementApiError } = setup();
+
+    expect(isAuth0ApiError(managementApiError)).toBe(true);
+  });
+
+  it("accepts the ResponseError the management client falls back to for a non-JSON error body", () => {
+    const { responseError } = setup();
+
+    expect(isAuth0ApiError(responseError)).toBe(true);
+  });
+
+  it("rejects an error without a status code", () => {
+    expect(isAuth0ApiError(new Error("Network failure"))).toBe(false);
+  });
+
+  it("rejects a non-error object carrying a status code", () => {
+    expect(isAuth0ApiError({ statusCode: 409, body: "{}" })).toBe(false);
+  });
+
+  it("rejects nullish values", () => {
+    expect(isAuth0ApiError(null)).toBe(false);
+    expect(isAuth0ApiError(undefined)).toBe(false);
+  });
+
+  function setup() {
+    const body = JSON.stringify({ statusCode: 409, error: "Conflict", message: "The user already exists.", errorCode: "auth0_idp_error" });
+
+    return {
+      managementApiError: new ManagementApiError("auth0_idp_error", "Conflict", 409, body, new Headers(), "The user already exists."),
+      responseError: new ResponseError(409, body, new Headers(), "Response returned an error code")
+    };
+  }
+});
+
+describe("extractAuth0ErrorMessage", () => {
+  it("returns the message from a JSON body", () => {
+    const error = new ResponseError(400, JSON.stringify({ message: "PasswordStrengthError: Password is too weak" }), new Headers(), "Generic");
+
+    expect(extractAuth0ErrorMessage(error)).toBe("PasswordStrengthError: Password is too weak");
+  });
+
+  it("falls back to the error message when the body is not JSON", () => {
+    const error = new ResponseError(502, "<html>Bad Gateway</html>", new Headers(), "Response returned an error code");
+
+    expect(extractAuth0ErrorMessage(error)).toBe("Response returned an error code");
+  });
+
+  it("falls back to the error message when the JSON body carries no message", () => {
+    const error = new ResponseError(400, JSON.stringify({ errorCode: "invalid_body" }), new Headers(), "Response returned an error code");
+
+    expect(extractAuth0ErrorMessage(error)).toBe("Response returned an error code");
+  });
+});
+
+describe("management client error contract", () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  it("recognises the error the management client actually throws for a conflict", async () => {
+    const { client } = setup({
+      status: 409,
+      body: { statusCode: 409, error: "Conflict", message: "The user already exists.", errorCode: "auth0_idp_error" }
+    });
+
+    const error = await client.users
+      .create({ email: "user@example.com", password: "StrongPassword123!", connection: "Username-Password-Authentication" })
+      .catch((thrown: unknown) => thrown);
+
+    expect(error).toBeInstanceOf(ManagementApiError);
+    expect(error).not.toBeInstanceOf(ResponseError);
+    expect(isAuth0ApiError(error)).toBe(true);
+    expect((error as Auth0ApiError).statusCode).toBe(409);
+  });
+
+  it("recognises the error the management client falls back to for an unparseable body", async () => {
+    const { client } = setup({ status: 409, body: "<html>Conflict</html>" });
+
+    const error = await client.users
+      .create({ email: "user@example.com", password: "StrongPassword123!", connection: "Username-Password-Authentication" })
+      .catch((thrown: unknown) => thrown);
+
+    expect(error).toBeInstanceOf(ResponseError);
+    expect(isAuth0ApiError(error)).toBe(true);
+    expect((error as Auth0ApiError).statusCode).toBe(409);
+  });
+
+  function setup(createUserResponse: { status: number; body: Record<string, unknown> | string }) {
+    const domain = "unit-test.auth0.local";
+
+    nock(`https://${domain}`).post("/oauth/token").reply(200, { access_token: "test-token", expires_in: 86400, token_type: "Bearer" });
+    nock(`https://${domain}`).post("/api/v2/users").reply(createUserResponse.status, createUserResponse.body);
+
+    return { client: new ManagementClient({ domain, clientId: "test-client-id", clientSecret: "test-client-secret" }) };
+  }
+});

--- a/apps/api/src/auth/services/auth0/auth0-error.ts
+++ b/apps/api/src/auth/services/auth0/auth0-error.ts
@@ -1,0 +1,24 @@
+/**
+ * Auth0's `ManagementClient` installs its own `parseError`, which throws `ManagementApiError` when the
+ * error body is valid JSON and `ResponseError` when it is not. Neither class extends the other, so
+ * matching on shape rather than on class keeps this working if the SDK introduces a third error type.
+ */
+export type Auth0ApiError = Error & { statusCode: number; body: string };
+
+export function isAuth0ApiError(error: unknown): error is Auth0ApiError {
+  return (
+    error instanceof Error && typeof (error as Partial<Auth0ApiError>).statusCode === "number" && typeof (error as Partial<Auth0ApiError>).body === "string"
+  );
+}
+
+/**
+ * `ManagementApiError` already carries Auth0's message, but `ResponseError` sets a generic one and
+ * keeps the detail in the raw body, so prefer the body's message whenever it parses.
+ */
+export function extractAuth0ErrorMessage(error: Auth0ApiError): string {
+  try {
+    return JSON.parse(error.body).message || error.message;
+  } catch {
+    return error.message;
+  }
+}

--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -2774,6 +2774,18 @@
         "responses": {
           "204": {
             "description": "User created successfully"
+          },
+          "400": {
+            "description": "Auth0 rejected the email or password"
+          },
+          "422": {
+            "description": "Account could not be created"
+          },
+          "429": {
+            "description": "Too many attempts"
+          },
+          "502": {
+            "description": "Auth0 is unavailable"
           }
         }
       }

--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -2776,7 +2776,7 @@
             "description": "User created successfully"
           },
           "400": {
-            "description": "Auth0 rejected the email or password"
+            "description": "The email or password was rejected"
           },
           "422": {
             "description": "Account could not be created"
@@ -2785,7 +2785,7 @@
             "description": "Too many attempts"
           },
           "502": {
-            "description": "Auth0 is unavailable"
+            "description": "Account creation is temporarily unavailable"
           }
         }
       }

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -2672,6 +2672,18 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
           "204": {
             "description": "User created successfully",
           },
+          "400": {
+            "description": "Auth0 rejected the email or password",
+          },
+          "422": {
+            "description": "Account could not be created",
+          },
+          "429": {
+            "description": "Too many attempts",
+          },
+          "502": {
+            "description": "Auth0 is unavailable",
+          },
         },
         "security": [],
         "summary": "Creates a new user without sending a verification email",

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -2673,7 +2673,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
             "description": "User created successfully",
           },
           "400": {
-            "description": "Auth0 rejected the email or password",
+            "description": "The email or password was rejected",
           },
           "422": {
             "description": "Account could not be created",
@@ -2682,7 +2682,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
             "description": "Too many attempts",
           },
           "502": {
-            "description": "Auth0 is unavailable",
+            "description": "Account creation is temporarily unavailable",
           },
         },
         "security": [],

--- a/apps/api/test/functional/auth-signup.spec.ts
+++ b/apps/api/test/functional/auth-signup.spec.ts
@@ -1,0 +1,81 @@
+import nock from "nock";
+import { container } from "tsyringe";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { AuthConfigService } from "@src/auth/services/auth-config/auth-config.service";
+import { app } from "@src/rest-app";
+
+describe("Signup", () => {
+  const auth0Domain = container.resolve(AuthConfigService).get("AUTH0_M2M_DOMAIN");
+
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  describe("POST /v1/auth/signup", () => {
+    it("returns 204 when auth0 creates the user", async () => {
+      const { email, password } = setup({ status: 201, body: { user_id: "auth0|created" } });
+
+      const response = await signup({ email, password });
+
+      expect(response.status).toBe(204);
+    });
+
+    it("returns 422 without confirming the email when auth0 reports the user already exists", async () => {
+      const { email, password } = setup({
+        status: 409,
+        body: { statusCode: 409, error: "Conflict", message: "The user already exists.", errorCode: "auth0_idp_error" }
+      });
+
+      const response = await signup({ email, password });
+
+      expect(response.status).toBe(422);
+      await expect(response.json()).resolves.toMatchObject({
+        message: "Unable to create account. Please try again or use a different email."
+      });
+    });
+
+    it("returns 400 with auth0's message when auth0 rejects the password", async () => {
+      const { email, password } = setup({
+        status: 400,
+        body: { statusCode: 400, error: "Bad Request", message: "PasswordStrengthError: Password is too weak", errorCode: "invalid_body" }
+      });
+
+      const response = await signup({ email, password });
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toMatchObject({ message: "PasswordStrengthError: Password is too weak" });
+    });
+
+    it("returns 502 without echoing auth0's message when auth0 is unavailable", async () => {
+      const { email, password } = setup({
+        status: 503,
+        body: { statusCode: 503, error: "Service Unavailable", message: "Service temporarily unavailable" }
+      });
+
+      const response = await signup({ email, password });
+
+      expect(response.status).toBe(502);
+      await expect(response.json()).resolves.toMatchObject({ message: "Unable to create the account right now. Please try again." });
+    });
+  });
+
+  function signup(body: { email: string; password: string }) {
+    return app.request("/v1/auth/signup", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body)
+    });
+  }
+
+  function setup(auth0CreateUserResponse: { status: number; body: Record<string, unknown> }) {
+    nock(`https://${auth0Domain}`)
+      .persist()
+      .post("/oauth/token")
+      .reply(200, { access_token: "test-management-token", expires_in: 86400, token_type: "Bearer" });
+
+    nock(`https://${auth0Domain}`).post("/api/v2/users").reply(auth0CreateUserResponse.status, auth0CreateUserResponse.body);
+
+    return { email: "signup-test@example.com", password: "StrongPassword123!" };
+  }
+});

--- a/apps/deploy-web/src/components/auth/PasswordAuth/PasswordAuth.spec.tsx
+++ b/apps/deploy-web/src/components/auth/PasswordAuth/PasswordAuth.spec.tsx
@@ -148,6 +148,69 @@ describe(PasswordAuth.name, () => {
       expect(authService.signup).toHaveBeenCalledTimes(1);
     });
 
+    it("submits again without surfacing an error after the captcha was dismissed mid-flight", async () => {
+      const SignUpFormMock = vi.fn(ComponentMock as typeof SignUpForm);
+      const RemoteApiErrorMock = vi.fn(({ error }) => error && <div>Unexpected error</div>);
+      const { authService, renderAndWaitResponse, dismissCaptcha } = setup({
+        searchParams: { tab: "signup" },
+        dependencies: { SignUpForm: SignUpFormMock, RemoteApiError: RemoteApiErrorMock }
+      });
+      let rejectDismissedCaptcha: (reason: unknown) => void = () => {};
+      renderAndWaitResponse.mockReturnValue(
+        new Promise((_, reject) => {
+          rejectDismissedCaptcha = reject;
+        })
+      );
+      const credentials: SignUpFormValues = {
+        email: "test@example.com",
+        password: "password123",
+        termsAndConditions: true
+      };
+
+      await act(async () => SignUpFormMock.mock.lastCall![0].onSubmit(credentials));
+      await vi.waitFor(() => {
+        expect(renderAndWaitResponse).toHaveBeenCalled();
+      });
+      await act(async () => {
+        dismissCaptcha();
+        rejectDismissedCaptcha({ reason: "dismissed" });
+      });
+
+      expect(screen.queryByText(/unexpected error/i)).not.toBeInTheDocument();
+
+      renderAndWaitResponse.mockResolvedValue({ token: "test-captcha-token" });
+      await act(async () => SignUpFormMock.mock.lastCall![0].onSubmit(credentials));
+
+      await vi.waitFor(() => {
+        expect(authService.signup).toHaveBeenCalledWith({ ...credentials, captchaToken: "test-captcha-token" });
+      });
+    });
+
+    it("submits again after a failed attempt", async () => {
+      const SignUpFormMock = vi.fn(ComponentMock as typeof SignUpForm);
+      const { authService } = setup({
+        searchParams: { tab: "signup" },
+        dependencies: { SignUpForm: SignUpFormMock }
+      });
+      authService.signup.mockRejectedValueOnce(new Error("Email already in use"));
+      const credentials: SignUpFormValues = {
+        email: "test@example.com",
+        password: "password123",
+        termsAndConditions: true
+      };
+
+      await act(async () => SignUpFormMock.mock.lastCall![0].onSubmit(credentials));
+      await vi.waitFor(() => {
+        expect(authService.signup).toHaveBeenCalledTimes(1);
+      });
+
+      await act(async () => SignUpFormMock.mock.lastCall![0].onSubmit(credentials));
+
+      await vi.waitFor(() => {
+        expect(authService.signup).toHaveBeenCalledTimes(2);
+      });
+    });
+
     it("renders RemoteApiError when sign-up fails", async () => {
       const SignUpFormMock = vi.fn(ComponentMock as typeof SignUpForm);
       const RemoteApiErrorMock = vi.fn(({ error }) => error && <div>Unexpected error</div>);
@@ -261,12 +324,13 @@ describe(PasswordAuth.name, () => {
       return pageParams as ReadonlyURLSearchParams;
     };
 
-    const Turnstile = vi.fn(({ turnstileRef }: { turnstileRef?: RefObject<TurnstileRef> }) => {
+    const renderAndWaitResponse = vi.fn<TurnstileRef["renderAndWaitResponse"]>().mockResolvedValue({ token: "test-captcha-token" });
+    let notifyCaptchaDismissed: (() => void) | undefined;
+    const Turnstile = vi.fn(({ turnstileRef, onDismissed }: { turnstileRef?: RefObject<TurnstileRef>; onDismissed?: () => void }) => {
       if (turnstileRef) {
-        (turnstileRef as { current: TurnstileRef }).current = mock<TurnstileRef>({
-          renderAndWaitResponse: vi.fn().mockResolvedValue({ token: "test-captcha-token" })
-        });
+        (turnstileRef as { current: TurnstileRef }).current = mock<TurnstileRef>({ renderAndWaitResponse });
       }
+      notifyCaptchaDismissed = onDismissed;
       return null;
     });
     const analyticsService = mock<AnalyticsService>();
@@ -287,6 +351,14 @@ describe(PasswordAuth.name, () => {
       </TestContainerProvider>
     );
 
-    return { authService, analyticsService, router, checkSession, navigateBack };
+    return {
+      authService,
+      analyticsService,
+      router,
+      checkSession,
+      navigateBack,
+      renderAndWaitResponse,
+      dismissCaptcha: () => notifyCaptchaDismissed?.()
+    };
   }
 });

--- a/apps/deploy-web/src/components/auth/PasswordAuth/PasswordAuth.spec.tsx
+++ b/apps/deploy-web/src/components/auth/PasswordAuth/PasswordAuth.spec.tsx
@@ -124,6 +124,30 @@ describe(PasswordAuth.name, () => {
       });
     });
 
+    it("ignores a second submit while the first is still in flight", async () => {
+      const SignUpFormMock = vi.fn(ComponentMock as typeof SignUpForm);
+      const { authService } = setup({
+        searchParams: { tab: "signup" },
+        dependencies: { SignUpForm: SignUpFormMock }
+      });
+      authService.signup.mockReturnValue(new Promise(() => {}));
+      const credentials: SignUpFormValues = {
+        email: "test@example.com",
+        password: "password123",
+        termsAndConditions: true
+      };
+
+      act(() => {
+        SignUpFormMock.mock.lastCall![0].onSubmit(credentials);
+        SignUpFormMock.mock.lastCall![0].onSubmit(credentials);
+      });
+
+      await vi.waitFor(() => {
+        expect(authService.signup).toHaveBeenCalled();
+      });
+      expect(authService.signup).toHaveBeenCalledTimes(1);
+    });
+
     it("renders RemoteApiError when sign-up fails", async () => {
       const SignUpFormMock = vi.fn(ComponentMock as typeof SignUpForm);
       const RemoteApiErrorMock = vi.fn(({ error }) => error && <div>Unexpected error</div>);

--- a/apps/deploy-web/src/components/auth/PasswordAuth/PasswordAuth.spec.tsx
+++ b/apps/deploy-web/src/components/auth/PasswordAuth/PasswordAuth.spec.tsx
@@ -59,6 +59,33 @@ describe(PasswordAuth.name, () => {
     });
   });
 
+  it("does not authenticate with a captcha challenge that resolves after the user switched tabs", async () => {
+    const TabsMock = vi.fn(ComponentMock as typeof Tabs);
+    const SignInFormMock = vi.fn(ComponentMock as typeof SignInForm);
+    const { authService, renderAndWaitResponse, abandonPendingChallenge } = setup({
+      dependencies: { Tabs: TabsMock as unknown as typeof Tabs, SignInForm: SignInFormMock }
+    });
+    let solvePendingCaptcha: (response: { token: string }) => void = () => {};
+    let rejectPendingCaptcha: (reason: unknown) => void = () => {};
+    renderAndWaitResponse.mockReturnValue(
+      new Promise((resolve, reject) => {
+        solvePendingCaptcha = resolve;
+        rejectPendingCaptcha = reject;
+      })
+    );
+    abandonPendingChallenge.mockImplementation(() => rejectPendingCaptcha({ reason: "dismissed" }));
+
+    await act(async () => SignInFormMock.mock.lastCall![0].onSubmit({ email: "test@example.com", password: "password123" }));
+    await vi.waitFor(() => {
+      expect(renderAndWaitResponse).toHaveBeenCalled();
+    });
+
+    await act(async () => TabsMock.mock.lastCall![0].onValueChange?.("signup"));
+    await act(async () => solvePendingCaptcha({ token: "test-captcha-token" }));
+
+    expect(authService.login).not.toHaveBeenCalled();
+  });
+
   describe("when SignIn tab is open", () => {
     it("runs sign-in flow with captcha token, refreshes the session, and navigates back", async () => {
       const SignInFormMock = vi.fn(ComponentMock as typeof SignInForm);
@@ -325,10 +352,11 @@ describe(PasswordAuth.name, () => {
     };
 
     const renderAndWaitResponse = vi.fn<TurnstileRef["renderAndWaitResponse"]>().mockResolvedValue({ token: "test-captcha-token" });
+    const abandonPendingChallenge = vi.fn<TurnstileRef["abandonPendingChallenge"]>();
     let notifyCaptchaDismissed: (() => void) | undefined;
     const Turnstile = vi.fn(({ turnstileRef, onDismissed }: { turnstileRef?: RefObject<TurnstileRef>; onDismissed?: () => void }) => {
       if (turnstileRef) {
-        (turnstileRef as { current: TurnstileRef }).current = mock<TurnstileRef>({ renderAndWaitResponse });
+        (turnstileRef as { current: TurnstileRef }).current = mock<TurnstileRef>({ renderAndWaitResponse, abandonPendingChallenge });
       }
       notifyCaptchaDismissed = onDismissed;
       return null;
@@ -358,6 +386,7 @@ describe(PasswordAuth.name, () => {
       checkSession,
       navigateBack,
       renderAndWaitResponse,
+      abandonPendingChallenge,
       dismissCaptcha: () => notifyCaptchaDismissed?.()
     };
   }

--- a/apps/deploy-web/src/components/auth/PasswordAuth/PasswordAuth.tsx
+++ b/apps/deploy-web/src/components/auth/PasswordAuth/PasswordAuth.tsx
@@ -94,8 +94,10 @@ export function PasswordAuth({ dependencies: d = DEPENDENCIES }: Props = {}) {
     }
   });
 
+  /** Turnstile keeps a silent challenge running until it needs interaction, so an abandoned one would otherwise solve later and fire the request the user walked away from. */
   const abandonAuthAttempt = useCallback(() => {
     isAuthInFlight.current = false;
+    turnstileRef.current?.abandonPendingChallenge();
     signInOrSignUp.reset();
     forgotPassword.reset();
   }, [signInOrSignUp, forgotPassword]);

--- a/apps/deploy-web/src/components/auth/PasswordAuth/PasswordAuth.tsx
+++ b/apps/deploy-web/src/components/auth/PasswordAuth/PasswordAuth.tsx
@@ -50,6 +50,7 @@ export function PasswordAuth({ dependencies: d = DEPENDENCIES }: Props = {}) {
   const { navigateBack } = d.useReturnTo({ defaultReturnTo: "/" });
   const [email, setEmail] = useState("");
   const turnstileRef = useRef<TurnstileRef | null>(null);
+  const isAuthInFlight = useRef(false);
 
   const signInOrSignUp = useMutation({
     async mutationFn(input: Tagged<"signin", SignInFormValues> | Tagged<"signup", SignUpFormValues>) {
@@ -69,6 +70,19 @@ export function PasswordAuth({ dependencies: d = DEPENDENCIES }: Props = {}) {
       navigateBack();
     }
   });
+
+  const submitCredentials = useCallback(
+    (input: Tagged<"signin", SignInFormValues> | Tagged<"signup", SignUpFormValues>) => {
+      if (isAuthInFlight.current) return;
+      isAuthInFlight.current = true;
+      signInOrSignUp.mutate(input, {
+        onSettled: () => {
+          isAuthInFlight.current = false;
+        }
+      });
+    },
+    [signInOrSignUp]
+  );
 
   const forgotPassword = useMutation({
     async mutationFn(input: { email: string }) {
@@ -175,13 +189,13 @@ export function PasswordAuth({ dependencies: d = DEPENDENCIES }: Props = {}) {
                 isLoading={signInOrSignUp.isPending}
                 defaultEmail={email}
                 onEmailChange={setEmail}
-                onSubmit={value => signInOrSignUp.mutate({ type: "signin", value })}
+                onSubmit={value => submitCredentials({ type: "signin", value })}
                 onForgotPasswordClick={() => setActiveView("forgot-password")}
               />
             </d.TabsContent>
 
             <d.TabsContent value="signup" className="mt-0">
-              <d.SignUpForm isLoading={signInOrSignUp.isPending} onSubmit={value => signInOrSignUp.mutate({ type: "signup", value })} />
+              <d.SignUpForm isLoading={signInOrSignUp.isPending} onSubmit={value => submitCredentials({ type: "signup", value })} />
             </d.TabsContent>
           </d.Tabs>
         )}

--- a/apps/deploy-web/src/components/auth/PasswordAuth/PasswordAuth.tsx
+++ b/apps/deploy-web/src/components/auth/PasswordAuth/PasswordAuth.tsx
@@ -94,13 +94,11 @@ export function PasswordAuth({ dependencies: d = DEPENDENCIES }: Props = {}) {
     }
   });
 
-  const resetMutations = useCallback(
-    function resetMutations() {
-      signInOrSignUp.reset();
-      forgotPassword.reset();
-    },
-    [signInOrSignUp, forgotPassword]
-  );
+  const abandonAuthAttempt = useCallback(() => {
+    isAuthInFlight.current = false;
+    signInOrSignUp.reset();
+    forgotPassword.reset();
+  }, [signInOrSignUp, forgotPassword]);
 
   const requestedTab = searchParams.get("tab");
   const activeView = requestedTab !== "login" && requestedTab !== "signup" && requestedTab !== "forgot-password" ? "login" : requestedTab;
@@ -109,10 +107,10 @@ export function PasswordAuth({ dependencies: d = DEPENDENCIES }: Props = {}) {
       const tabId = value !== "login" && value !== "signup" && value !== "forgot-password" ? "login" : value;
       const newSearchParams = new URLSearchParams(searchParams);
       newSearchParams.set("tab", tabId);
-      resetMutations();
+      abandonAuthAttempt();
       router.replace(`?${newSearchParams.toString()}`, undefined, { shallow: true });
     },
-    [searchParams, router, resetMutations]
+    [searchParams, router, abandonAuthAttempt]
   );
 
   return (
@@ -203,7 +201,7 @@ export function PasswordAuth({ dependencies: d = DEPENDENCIES }: Props = {}) {
           turnstileRef={turnstileRef}
           enabled={publicConfig.NEXT_PUBLIC_TURNSTILE_ENABLED}
           siteKey={publicConfig.NEXT_PUBLIC_TURNSTILE_SITE_KEY}
-          onDismissed={resetMutations}
+          onDismissed={abandonAuthAttempt}
         />
       </div>
     </>

--- a/apps/deploy-web/src/components/auth/PasswordlessAuth/PasswordlessAuth.spec.tsx
+++ b/apps/deploy-web/src/components/auth/PasswordlessAuth/PasswordlessAuth.spec.tsx
@@ -165,6 +165,40 @@ describe(PasswordlessAuth.name, () => {
     expect(token).toBe("test-captcha-token");
   });
 
+  it("does not hand a captcha token to a screen the user has left", async () => {
+    const EmailCodeVerifyMock = vi.fn(ComponentMock);
+    const { renderAndWaitResponse, abandonPendingChallenge } = setup({
+      step: "verify",
+      initialEmail: "alice@example.com",
+      dependencies: { EmailCodeVerify: EmailCodeVerifyMock as never }
+    });
+    let solvePendingCaptcha: (response: { token: string }) => void = () => {};
+    let rejectPendingCaptcha: (reason: unknown) => void = () => {};
+    renderAndWaitResponse.mockReturnValue(
+      new Promise((resolve, reject) => {
+        solvePendingCaptcha = resolve;
+        rejectPendingCaptcha = reject;
+      })
+    );
+    abandonPendingChallenge.mockImplementation(() => rejectPendingCaptcha({ reason: "dismissed" }));
+    const receiveCaptchaToken = vi.fn();
+
+    const { getCaptchaToken, onEditEmail } = EmailCodeVerifyMock.mock.lastCall![0];
+    getCaptchaToken().then(receiveCaptchaToken, () => undefined);
+    await act(async () => onEditEmail());
+    await act(async () => solvePendingCaptcha({ token: "test-captcha-token" }));
+
+    expect(receiveCaptchaToken).not.toHaveBeenCalled();
+  });
+
+  it("abandons the pending captcha challenge when the widget is dismissed", async () => {
+    const { abandonPendingChallenge, dismissCaptcha } = setup();
+
+    await act(async () => dismissCaptcha());
+
+    expect(abandonPendingChallenge).toHaveBeenCalled();
+  });
+
   it("shows the $1 credit subtext", () => {
     setup();
     expect(screen.getByText(/\$1 credit to deploy your first container/i)).toBeInTheDocument();
@@ -239,12 +273,14 @@ describe(PasswordlessAuth.name, () => {
     const useRouter: typeof DEPENDENCIES.useRouter = (() => ({ push, replace, pathname: "/login" })) as never;
     const useSearchParams: typeof DEPENDENCIES.useSearchParams = (() => params) as never;
 
-    const Turnstile = vi.fn(({ turnstileRef }: { turnstileRef?: RefObject<TurnstileRef> }) => {
+    const renderAndWaitResponse = vi.fn<TurnstileRef["renderAndWaitResponse"]>().mockResolvedValue({ token: "test-captcha-token" });
+    const abandonPendingChallenge = vi.fn<TurnstileRef["abandonPendingChallenge"]>();
+    let notifyCaptchaDismissed: (() => void) | undefined;
+    const Turnstile = vi.fn(({ turnstileRef, onDismissed }: { turnstileRef?: RefObject<TurnstileRef>; onDismissed?: () => void }) => {
       if (turnstileRef) {
-        (turnstileRef as { current: TurnstileRef }).current = mock<TurnstileRef>({
-          renderAndWaitResponse: vi.fn().mockResolvedValue({ token: "test-captcha-token" })
-        });
+        (turnstileRef as { current: TurnstileRef }).current = mock<TurnstileRef>({ renderAndWaitResponse, abandonPendingChallenge });
       }
+      notifyCaptchaDismissed = onDismissed;
       return null;
     });
 
@@ -267,7 +303,18 @@ describe(PasswordlessAuth.name, () => {
       </TestContainerProvider>
     );
 
-    return { analyticsService, onEmailChange, onFlowReset, checkSession, navigateBack, push, replace };
+    return {
+      analyticsService,
+      onEmailChange,
+      onFlowReset,
+      checkSession,
+      navigateBack,
+      push,
+      replace,
+      renderAndWaitResponse,
+      abandonPendingChallenge,
+      dismissCaptcha: () => notifyCaptchaDismissed?.()
+    };
   }
 });
 

--- a/apps/deploy-web/src/components/auth/PasswordlessAuth/PasswordlessAuth.tsx
+++ b/apps/deploy-web/src/components/auth/PasswordlessAuth/PasswordlessAuth.tsx
@@ -70,12 +70,27 @@ export function PasswordlessAuth({ dependencies: d = DEPENDENCIES, ...props }: P
     [router, searchParams, onEmailChange]
   );
 
+  /**
+   * Drops whatever the active screen has in flight. Turnstile keeps a silent challenge running until it
+   * needs interaction, so an abandoned one would otherwise solve later and fire the request for a screen
+   * the user has left; remounting discards the rejected mutation's error along with it.
+   */
+  const abandonActiveAttempt = useCallback(() => {
+    turnstileRef.current?.abandonPendingChallenge();
+    setScreenKey(value => value + 1);
+  }, []);
+
   const goBackToEntry = useCallback(() => {
     const params = new URLSearchParams(searchParams);
     params.delete("step");
     const query = params.toString();
     router.replace(query ? `?${query}` : router.pathname, undefined, { shallow: true });
   }, [router, searchParams]);
+
+  const restartEmailEntry = useCallback(() => {
+    abandonActiveAttempt();
+    goBackToEntry();
+  }, [abandonActiveAttempt, goBackToEntry]);
 
   /**
    * Sends a visitor who reached `?step=verify` without an in-flight email (a deep link, or a reload
@@ -131,10 +146,6 @@ export function PasswordlessAuth({ dependencies: d = DEPENDENCIES, ...props }: P
     await checkSession();
   }, [checkSession, onFlowReset]);
 
-  const remountActiveScreen = useCallback(() => {
-    setScreenKey(value => value + 1);
-  }, []);
-
   if (user && !error) return <d.BootLoading />;
 
   return (
@@ -189,7 +200,7 @@ export function PasswordlessAuth({ dependencies: d = DEPENDENCIES, ...props }: P
           key={`verify-${screenKey}`}
           email={email}
           getCaptchaToken={getCaptchaToken}
-          onEditEmail={goBackToEntry}
+          onEditEmail={restartEmailEntry}
           onVerified={handleVerified}
         />
       )}
@@ -197,7 +208,7 @@ export function PasswordlessAuth({ dependencies: d = DEPENDENCIES, ...props }: P
         turnstileRef={turnstileRef}
         enabled={publicConfig.NEXT_PUBLIC_TURNSTILE_ENABLED}
         siteKey={publicConfig.NEXT_PUBLIC_TURNSTILE_SITE_KEY}
-        onDismissed={remountActiveScreen}
+        onDismissed={abandonActiveAttempt}
       />
     </>
   );

--- a/apps/deploy-web/src/components/turnstile/Turnstile.spec.tsx
+++ b/apps/deploy-web/src/components/turnstile/Turnstile.spec.tsx
@@ -151,6 +151,48 @@ describe(Turnstile.name, () => {
       });
     });
 
+    it("rejects the pending challenge when the widget is dismissed", async () => {
+      let rejection: unknown;
+      const { turnstileRef } = await setup({ enabled: true, components: { Button: ButtonMock } });
+
+      const promise = turnstileRef.current!.renderAndWaitResponse().catch(error => {
+        rejection = error;
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: /dismiss captcha/i }));
+        await wait(0);
+      });
+      await promise;
+
+      expect(rejection).toMatchObject({ reason: "dismissed" });
+    });
+
+    it("does not resolve an abandoned challenge when a later one succeeds", async () => {
+      let triggerSuccess: ((token: string) => void) | undefined;
+      const ReactTurnstile = forwardRef<TurnstileInstance | undefined, TurnstileProps>((props, ref) => {
+        useForwardedRef(ref);
+        triggerSuccess = (token: string) => props.onSuccess?.(token);
+        return <div>Turnstile</div>;
+      });
+      const { turnstileRef } = await setup({ enabled: true, components: { ReactTurnstile, Button: ButtonMock } });
+
+      const abandoned = vi.fn();
+      turnstileRef.current!.renderAndWaitResponse().then(abandoned, () => undefined);
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: /dismiss captcha/i }));
+        await wait(0);
+      });
+
+      const retried = turnstileRef.current!.renderAndWaitResponse();
+      await act(async () => {
+        triggerSuccess?.("test-token");
+        await wait(0);
+      });
+
+      await expect(retried).resolves.toEqual({ token: "test-token" });
+      expect(abandoned).not.toHaveBeenCalled();
+    });
+
     it("resolves with disabled token when turnstile is disabled", async () => {
       const { turnstileRef } = await setup({ enabled: false });
 
@@ -181,6 +223,12 @@ describe(Turnstile.name, () => {
 
     return { ...result, turnstileRef };
   }
+
+  const ButtonMock = forwardRef<HTMLButtonElement, React.ComponentProps<typeof COMPONENTS.Button>>((props, ref) => (
+    <button type="button" {...props} ref={ref} onClick={props.onClick}>
+      {props.children}
+    </button>
+  ));
 
   function useForwardedRef<T>(ref: React.ForwardedRef<T>, instance: T = mock<T>()) {
     useEffect(() => {

--- a/apps/deploy-web/src/components/turnstile/Turnstile.spec.tsx
+++ b/apps/deploy-web/src/components/turnstile/Turnstile.spec.tsx
@@ -167,6 +167,46 @@ describe(Turnstile.name, () => {
       expect(rejection).toMatchObject({ reason: "dismissed" });
     });
 
+    it("rejects the pending challenge when the caller abandons it", async () => {
+      let rejection: unknown;
+      const { turnstileRef } = await setup({ enabled: true });
+
+      const promise = turnstileRef.current!.renderAndWaitResponse().catch(error => {
+        rejection = error;
+      });
+      await act(async () => {
+        turnstileRef.current!.abandonPendingChallenge();
+        await wait(0);
+      });
+      await promise;
+
+      expect(rejection).toMatchObject({ reason: "dismissed" });
+    });
+
+    it("does not resolve a challenge abandoned by the caller when it later succeeds", async () => {
+      let triggerSuccess: ((token: string) => void) | undefined;
+      const ReactTurnstile = forwardRef<TurnstileInstance | undefined, TurnstileProps>((props, ref) => {
+        useForwardedRef(ref);
+        triggerSuccess = (token: string) => props.onSuccess?.(token);
+        return <div>Turnstile</div>;
+      });
+      const { turnstileRef } = await setup({ enabled: true, components: { ReactTurnstile } });
+
+      const abandoned = vi.fn();
+      turnstileRef.current!.renderAndWaitResponse().then(abandoned, () => undefined);
+      await act(async () => {
+        turnstileRef.current!.abandonPendingChallenge();
+        await wait(0);
+      });
+
+      await act(async () => {
+        triggerSuccess?.("test-token");
+        await wait(0);
+      });
+
+      expect(abandoned).not.toHaveBeenCalled();
+    });
+
     it("does not resolve an abandoned challenge when a later one succeeds", async () => {
       let triggerSuccess: ((token: string) => void) | undefined;
       const ReactTurnstile = forwardRef<TurnstileInstance | undefined, TurnstileProps>((props, ref) => {

--- a/apps/deploy-web/src/components/turnstile/Turnstile.tsx
+++ b/apps/deploy-web/src/components/turnstile/Turnstile.tsx
@@ -25,6 +25,7 @@ export const COMPONENTS = {
 
 export type TurnstileRef = {
   renderAndWaitResponse: () => Promise<{ token: string }>;
+  abandonPendingChallenge: () => void;
 };
 
 type TurnstileProps = {
@@ -68,6 +69,9 @@ export const Turnstile = forwardRef<TurnstileRef, TurnstileProps>(function Turns
   useImperativeHandle(
     ref || externalTurnstileRef,
     () => ({
+      abandonPendingChallenge() {
+        abandonPendingChallenge.current?.();
+      },
       renderAndWaitResponse() {
         if (!enabled) {
           return Promise.resolve({ token: "disabled-turnstile-token" });

--- a/apps/deploy-web/src/components/turnstile/Turnstile.tsx
+++ b/apps/deploy-web/src/components/turnstile/Turnstile.tsx
@@ -50,9 +50,12 @@ export const Turnstile = forwardRef<TurnstileRef, TurnstileProps>(function Turns
     turnstileRef.current?.render();
     turnstileRef.current?.execute();
   }, []);
+  const abandonPendingChallenge = useRef<(() => void) | undefined>(undefined);
+  /** Notifies the parent before rejecting so it can drop the abandoned attempt instead of rendering it as a failure. */
   const hideWidget = useCallback(() => {
     setStatus("dismissed");
     onDismissed?.();
+    abandonPendingChallenge.current?.();
   }, [onDismissed]);
 
   useWhen(status === "error" || status === "expired", () => {
@@ -70,20 +73,28 @@ export const Turnstile = forwardRef<TurnstileRef, TurnstileProps>(function Turns
           return Promise.resolve({ token: "disabled-turnstile-token" });
         }
 
+        abandonPendingChallenge.current?.();
         resetWidget();
         return new Promise((resolve, reject) => {
-          const successListener = (event: Event) => {
+          const stopWaiting = () => {
             eventBus.current.removeEventListener("success", successListener);
             eventBus.current.removeEventListener("error", errorListener);
+            abandonPendingChallenge.current = undefined;
+          };
+          const successListener = (event: Event) => {
+            stopWaiting();
             resolve((event as CustomEvent<{ token: string }>).detail);
           };
           const errorListener = (event: Event) => {
-            eventBus.current.removeEventListener("success", successListener);
-            eventBus.current.removeEventListener("error", errorListener);
+            stopWaiting();
             const details = (event as CustomEvent<{ reason: string; error?: string }>).detail;
             reject({ status, ...details });
           };
 
+          abandonPendingChallenge.current = () => {
+            stopWaiting();
+            reject({ reason: "dismissed" });
+          };
           eventBus.current.addEventListener("success", successListener);
           eventBus.current.addEventListener("error", errorListener);
         });

--- a/apps/deploy-web/src/services/session/session.service.spec.ts
+++ b/apps/deploy-web/src/services/session/session.service.spec.ts
@@ -1,4 +1,5 @@
 import type { HttpClient } from "@akashnetwork/http-sdk";
+import type { AxiosRequestConfig } from "axios";
 import type { Result } from "ts-results";
 import { describe, expect, it, vi } from "vitest";
 import { mock, type MockProxy } from "vitest-mock-extended";
@@ -136,6 +137,24 @@ describe(SessionService.name, () => {
       );
       expect(externalHttpClient.post).not.toHaveBeenCalled();
       expect(externalHttpClient.get).not.toHaveBeenCalled();
+    });
+
+    it("returns signup_failed instead of throwing when the console api is failing", async () => {
+      const { service, consoleApiHttpClient, externalHttpClient } = setup();
+
+      consoleApiHttpClient.post.mockImplementationOnce(respectValidateStatus({ status: 500, data: { message: "Internal server error" }, headers: {} }));
+
+      const result = await service.signUp({ email: "user@example.com", password: "StrongPassword123!" });
+
+      expect(result.ok).toBe(false);
+      const error = expectErr(result);
+      expect(error).toEqual(
+        expect.objectContaining({
+          message: "Signup is temporarily unavailable. Please try again in a moment.",
+          code: "signup_failed"
+        })
+      );
+      expect(externalHttpClient.post).not.toHaveBeenCalled();
     });
 
     it("returns user_exists when user already exists and sign-in fails", async () => {
@@ -631,6 +650,19 @@ function createHttpClientMock(): MockProxy<HttpClient> {
     post: vi.fn(),
     get: vi.fn()
   } as unknown as HttpClient);
+}
+
+/**
+ * Axios rejects rather than resolves when `validateStatus` refuses a status, so a mock that always resolves
+ * cannot tell a tolerated status from a rejected one. This reproduces that branch.
+ */
+function respectValidateStatus(response: { status: number; data: unknown; headers: Record<string, string> }) {
+  return async (_url: string, _data?: unknown, config?: AxiosRequestConfig) => {
+    if (config?.validateStatus && !config.validateStatus(response.status)) {
+      throw Object.assign(new Error(`Request failed with status code ${response.status}`), { response });
+    }
+    return response;
+  };
 }
 
 function createIdToken(payload: Record<string, unknown>) {

--- a/apps/deploy-web/src/services/session/session.service.ts
+++ b/apps/deploy-web/src/services/session/session.service.ts
@@ -89,9 +89,17 @@ export class SessionService {
         password: input.password
       },
       {
-        validateStatus: notServerError
+        validateStatus: acceptAnyStatus
       }
     );
+
+    if (signupResponse.status >= 500) {
+      return Err({
+        message: "Signup is temporarily unavailable. Please try again in a moment.",
+        code: "signup_failed",
+        cause: extractResponseDetails(signupResponse)
+      });
+    }
 
     const isUserExists = signupResponse.status === 422;
     if (signupResponse.status >= 400 && !isUserExists) {
@@ -401,6 +409,11 @@ export interface OauthConfig {
 
 function notServerError(status: number) {
   return status >= 200 && status < 500;
+}
+
+/** Signup reports a failing API as a readable error, so a 5xx has to resolve like any other status instead of throwing. */
+function acceptAnyStatus() {
+  return true;
 }
 
 /** Auth0's `x-ratelimit-reset` is a Unix epoch timestamp; consumers want "seconds until retry". */


### PR DESCRIPTION
## Why

Production returned a **500** for `POST /v1/auth/signup` whenever Auth0 rejected the signup:

```
ManagementApiError: The user already exists.
    at Auth0Service.createUser (apps/api/src/auth/services/auth0/auth0.service.ts:11:5)
    at AuthController.signup (apps/api/src/auth/controllers/auth/auth.controller.ts:25:35)
```

The 409 handling already existed — it just never ran. It guarded on `error instanceof ResponseError`,
but `ManagementClient` installs its own `parseError` that throws **`ManagementApiError`** whenever the
error body is valid JSON, which the Management API always sends. The two classes are siblings, not
parent and child, so the entire catch block was dead code and every Auth0 rejection fell through to
the 500 fallback in `HonoErrorHandlerService`.

Duplicate emails were the reported case, but weak passwords and rate limits were 500s too:

| Auth0 response | Intended | Before |
|---|---|---|
| 409 `The user already exists.` | 422 | **500** |
| 400 `PasswordStrengthError` | 400 + message | **500** |
| 429 too many requests | 429 | **500** |

The 422 is load-bearing rather than cosmetic. `SessionService.signUp` treats it as "user exists" and
*continues* to `signIn()`, so signing up with an existing email and the right password quietly logs you
in; a wrong password falls through to a deliberate 204 that avoids confirming the email is registered.
Neither ran, because `validateStatus` capped at 499 and made axios throw — `signUp()` rejected, and
`defineApiHandler` has no try/catch, so the rejection escaped to Sentry and Next served a bare 500.
Users on the password signup path saw "An unexpected error occurred".

The existing specs passed because all four hand-built `new ResponseError(...)` — a class the real client
never throws here — and asserted only on `message`, never `status`. Green tests, broken production.

## What

**`apps/api`**

- Match Auth0 errors on **shape** (`statusCode` + `body`) in a new `auth0-error.ts` instead of on class.
  Matching on class is what caused this, so a future SDK error type cannot silently reintroduce it. The
  spec pins the structural check against the real `ManagementApiError` and `ResponseError`, so a renamed
  field fails loudly.
- Map an Auth0 5xx to a 502 with our own message rather than echoing Auth0's internal one.
- Declare the error responses the route can actually return (previously only 204).

**`apps/deploy-web`**

- `signUp` now resolves a 5xx into a readable `signup_failed` instead of rejecting into an unhandled 500.
- Guard `PasswordAuth` against concurrent submits. `SignUpForm`'s only defence was `disabled={isLoading}`,
  which needs a re-render, while `form.handleSubmit` resolves validation asynchronously; React Query does
  not dedupe mutations. This is how a duplicate signup request gets sent in the first place.

**Tests** — each new test was confirmed to fail without its fix:

- `auth-signup.spec.ts` (functional) nocks the Management API and asserts the HTTP status. On `main` it
  reports `expected 500 to be 422` — the reported bug, end to end.
- A contract test builds a real `ManagementClient` and asserts it throws `ManagementApiError` and
  explicitly **not** `ResponseError`, documenting exactly why the old guard failed.
- Controller specs now use the class production throws and assert `status`, not just `message`.
- The session spec's http mock now honours `validateStatus`, since a mock that always resolves cannot
  tell a tolerated status from a rejected one.

### Notes for review

- `packages/console-api-types` was **not** regenerated. Doing so produces a ~19k-line diff from
  pre-existing staleness, unrelated to this change. `swagger/openapi.json` was regenerated but trimmed
  to the signup path, because a full regen also pulls in an unrelated `/v1/sdl-secrets-context` route
  that someone added without regenerating.
- Two adjacent problems are deliberately **not** fixed here and want their own issues:
  - `POST /v1/auth/signup` is `SECURITY_NONE` with no rate limiting, so a script can bypass the Turnstile
    captcha that guards the only legitimate caller. The reported request looks like exactly that: a
    browser `User-Agent` on a route only ever called server-side, where no client sets one. Enforcing the
    captcha at the API would move `TURNSTILE_SECRET_KEY` into it and change the request contract — a
    feature, not a bug fix. Worth noting the raw endpoint is also an enumeration oracle, and this PR
    improves that on its own by making a rejected signup indistinguishable from other failures.
  - `isNetworkOrIdempotentRequestError` skips the method check on its raw-network-error branch, so an
    unwrapped `ECONNRESET` can retry a POST. The predicate only receives the error, so threading the
    method in means building the retry policy per request while keeping the circuit breaker shared — a
    restructure of a package every app depends on, for a branch axios's fetch adapter almost certainly
    never reaches.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved signup error handling for duplicate accounts, weak passwords, rate limits, and temporary service outages.
  - Added clear API documentation for account-creation error responses.
  - Added reliable retry behavior after failed or dismissed CAPTCHA challenges.

- **Bug Fixes**
  - Prevented duplicate sign-in and signup submissions.
  - Signup now reports service outages gracefully instead of failing unexpectedly.
  - Corrected CAPTCHA dismissal and pending-request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->