### PR TITLE
chore(billing): run mint-act every 10 minutes with non-overlapping runs

### DIFF
--- a/.helm/console-api-prod-mainnet-values.yaml
+++ b/.helm/console-api-prod-mainnet-values.yaml
@@ -36,7 +36,9 @@ jobs:
       - ./dist/console.js
       - gpu-pricing-bot
   - name: mint-act
-    schedule: "0 6 * * *" # 6:00 AM every day
+    schedule: "*/10 * * * *" # every 10 minutes
+    concurrencyPolicy: Forbid
+    activeDeadlineSeconds: 540
     command:
       - node
       - --require

--- a/apps/api/src/billing/config/env.config.spec.ts
+++ b/apps/api/src/billing/config/env.config.spec.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import { envSchema } from "./env.config";
+
+describe("envSchema", () => {
+  describe("MASTER_WALLET_AKT_RESERVE", () => {
+    it("rejects a negative value", () => {
+      const result = setup({ MASTER_WALLET_AKT_RESERVE: "-1" });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects a fractional value", () => {
+      const result = setup({ MASTER_WALLET_AKT_RESERVE: "1.5" });
+      expect(result.success).toBe(false);
+    });
+
+    it("accepts a non-negative integer", () => {
+      const result = setup({ MASTER_WALLET_AKT_RESERVE: "2000000000" });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts zero", () => {
+      const result = setup({ MASTER_WALLET_AKT_RESERVE: "0" });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("MASTER_WALLET_MAX_MINT_UAKT", () => {
+    it("rejects a negative value", () => {
+      const result = setup({ MASTER_WALLET_MAX_MINT_UAKT: "-1" });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects a fractional value", () => {
+      const result = setup({ MASTER_WALLET_MAX_MINT_UAKT: "1.5" });
+      expect(result.success).toBe(false);
+    });
+
+    it("accepts a non-negative integer", () => {
+      const result = setup({ MASTER_WALLET_MAX_MINT_UAKT: "5000000000" });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts zero", () => {
+      const result = setup({ MASTER_WALLET_MAX_MINT_UAKT: "0" });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  const validEnv = {
+    NETWORK: "sandbox",
+    RPC_NODE_ENDPOINT: "https://rpc.example.com",
+    TRIAL_DEPLOYMENT_ALLOWANCE_AMOUNT: "1000",
+    TRIAL_FEES_ALLOWANCE_AMOUNT: "1000",
+    DEPLOYMENT_GRANT_DENOM: "uakt",
+    FEE_ALLOWANCE_REFILL_THRESHOLD: "100",
+    FEE_ALLOWANCE_REFILL_AMOUNT: "100",
+    DEPLOYMENT_ALLOWANCE_REFILL_AMOUNT: "100",
+    STRIPE_SECRET_KEY: "sk_test",
+    STRIPE_PRODUCT_ID: "prod_test",
+    STRIPE_WEBHOOK_SECRET: "whsec_test",
+    CONSOLE_WEB_PAYMENT_LINK: "https://pay.example.com",
+    TX_SIGNER_BASE_URL: "https://tx-signer.example.com",
+    TX_SIGNER_API_KEY: "test-tx-signer-api-key-placeholder-value"
+  };
+
+  function setup(overrides: Record<string, string>) {
+    return envSchema.safeParse({ ...validEnv, ...overrides });
+  }
+});


### PR DESCRIPTION
## Why

#3561 rewrote `mint-act` into a capped sweep so it could run on a frequent cron, and closed with a three-step ops rollout. Steps 1 and 2 are done: the backlog has drained to the 2,000 AKT reserve. This is step 3, repointing the cron so AKT deposited during the day gets converted within minutes instead of waiting for the 6:00 AM slot.

Step 3 also called for the cron to be non-overlapping, and that needed more than a schedule edit.

## What

The schedule moves from `0 6 * * *` to `*/10 * * * *`, plus two new keys on the job.

The overlap guard is doing real work here. tx-signer signs unordered txs at sequence 0, so the account-sequence-mismatch that would normally serialize two concurrent mints never happens, and both burns land. The only guard today is `hasPendingSettlement()`, a lock-free read of chain state, so two pods starting together both read zero pending records and both proceed. They burn 2x the excess and pull the wallet below the fee reserve that pays for `refill-wallets` and the `top-up-deployments` fee grants. Both then log `MASTER_WALLET_MINT_CONFIRMED`, because `verifyMintedBalance` compares against a stale pre-mint snapshot, so nothing surfaces the problem.

`concurrencyPolicy: Forbid` closes that. `activeDeadlineSeconds: 540` has to ship alongside it, because Forbid on its own turns a pod hung on an unbounded RPC call into a permanent stop that ends the sweep with no error anywhere. 540s clears the command's ~7 minute self-bounded worst case (60s broadcast timeout, 120s settlement poll, 180s balance verify, plus boot and shutdown) and kills a hung pod a minute before the next tick, so Forbid never has a terminating pod to trip over.

I went with `*/10` rather than the fast end of #3561's 5-15 min range because it sits above that same ~7 minute ceiling, which keeps the schedule safe even on a cluster still running the old chart.

This needs console-api chart 0.11.0 or newer (akash-network/helm-charts#589). The current template doesn't emit either key, so on 0.10.5 and older they are silently ignored. That PR should merge first. Our deploy doesn't pin a chart version, so the next api deploy picks it up.

The second commit restores `env.config.spec.ts`, which #3589 deleted as collateral while hardening tx-signer. It pinned `MASTER_WALLET_AKT_RESERVE` and `MASTER_WALLET_MAX_MINT_UAKT` as non-negative integers, and those constraints are still on the schema but have been unguarded since. They matter more now the command runs 144x/day instead of once. Restored as it was, plus `TX_SIGNER_API_KEY` in the fixture, which #3589 made required. That is presumably why the file was dropped rather than updated.

### Verification

Rendered the 0.11.0 chart against this values file. The diff against the current prod render is exactly three lines, all on `mint-act`, and the other four cronjobs are byte-identical. I also checked against the strict k8s schema that `concurrencyPolicy` is a `CronJobSpec` field and `activeDeadlineSeconds` a `JobSpec` field. Both would be rejected at the swapped levels, which is the mistake helm-charts#554 existed to fix.

Restored spec: 8/8 pass, and removing `.int().nonnegative()` fails exactly the two "rejects" tests. `apps/api` lint clean, zero tsc delta.
