### PR TITLE
fix(deployment): stop probing providers for leases that are not live

### DIFF
--- a/apps/api/src/deployment/services/deployment-reader/deployment-reader.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-reader/deployment-reader.service.spec.ts
@@ -63,6 +63,92 @@ describe(DeploymentReaderService.name, () => {
       await expect(service.findByWalletAndDseq(wallet, dseq)).rejects.toThrow();
       expect(fallbackDeploymentReaderService.findByOwnerAndDseq).not.toHaveBeenCalled();
     });
+
+    it.each(["closed", "insufficient_funds"])("does not ask the provider for the status of a %s lease", async state => {
+      const wallet = createUserWallet() as WalletInitialized;
+      const dseq = "12345";
+      const lease = createLeaseApiResponse({ owner: wallet.address, dseq, state });
+      const { service, providerService } = setup({ leases: [lease] });
+
+      await service.findByWalletAndDseq(wallet, dseq);
+
+      expect(providerService.getLeaseStatus).not.toHaveBeenCalled();
+      expect(providerService.toProviderAuth).not.toHaveBeenCalled();
+    });
+
+    it("still returns a closed lease, with a null status", async () => {
+      const wallet = createUserWallet() as WalletInitialized;
+      const dseq = "12345";
+      const lease = createLeaseApiResponse({ owner: wallet.address, dseq, state: "closed" });
+      const { service } = setup({ leases: [lease] });
+
+      const result = await service.findByWalletAndDseq(wallet, dseq);
+
+      expect(result.leases).toHaveLength(1);
+      expect(result.leases[0]).toMatchObject({ state: "closed", status: null });
+    });
+
+    it.each(["active", "reclaiming"])("asks the provider for the status of a %s lease", async state => {
+      const wallet = createUserWallet() as WalletInitialized;
+      const dseq = "12345";
+      const lease = createLeaseApiResponse({ owner: wallet.address, dseq, state });
+      const { service, providerService } = setup({ leases: [lease] });
+
+      await service.findByWalletAndDseq(wallet, dseq);
+
+      expect(providerService.getLeaseStatus).toHaveBeenCalledWith(
+        lease.lease.id.provider,
+        lease.lease.id.dseq,
+        lease.lease.id.gseq,
+        lease.lease.id.oseq,
+        expect.anything()
+      );
+    });
+
+    it("returns every lease but only probes the live one", async () => {
+      const wallet = createUserWallet() as WalletInitialized;
+      const dseq = "12345";
+      const activeLease = createLeaseApiResponse({ owner: wallet.address, dseq, state: "active" });
+      const leases = [
+        activeLease,
+        createLeaseApiResponse({ owner: wallet.address, dseq, state: "closed" }),
+        createLeaseApiResponse({ owner: wallet.address, dseq, state: "insufficient_funds" })
+      ];
+      const { service, providerService } = setup({ leases });
+
+      const result = await service.findByWalletAndDseq(wallet, dseq);
+
+      expect(result.leases).toHaveLength(3);
+      expect(providerService.getLeaseStatus).toHaveBeenCalledTimes(1);
+      expect(providerService.getLeaseStatus).toHaveBeenCalledWith(
+        activeLease.lease.id.provider,
+        activeLease.lease.id.dseq,
+        activeLease.lease.id.gseq,
+        activeLease.lease.id.oseq,
+        expect.anything()
+      );
+    });
+
+    it("reports a null status and logs a warning when a live lease's provider fails", async () => {
+      const wallet = createUserWallet() as WalletInitialized;
+      const dseq = "12345";
+      const lease = createLeaseApiResponse({ owner: wallet.address, dseq, state: "active" });
+      const { service, providerService, logger } = setup({ leases: [lease] });
+
+      providerService.getLeaseStatus.mockRejectedValue(createHttpError(503));
+
+      const result = await service.findByWalletAndDseq(wallet, dseq);
+
+      expect(result.leases[0]).toMatchObject({ status: null });
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: "LEASE_STATUS_FETCH_FAILED",
+          provider: lease.lease.id.provider,
+          dseq: lease.lease.id.dseq,
+          leaseState: "active"
+        })
+      );
+    });
   });
 
   describe("list", () => {
@@ -171,6 +257,7 @@ describe(DeploymentReaderService.name, () => {
       fallbackDeploymentInfo?: ReturnType<typeof createDeploymentInfoSeed>;
       fallbackDeploymentList?: ReturnType<typeof createDeploymentListResponseSeed>;
       fallbackLeases?: ReturnType<typeof createLeaseApiResponse>[];
+      leases?: ReturnType<typeof createLeaseApiResponse>[];
     } = {}
   ) {
     const defaultWallet = createUserWallet() as WalletInitialized;
@@ -192,7 +279,7 @@ describe(DeploymentReaderService.name, () => {
         findAll: vi.fn().mockResolvedValue(input.fallbackDeploymentList ?? defaultDeploymentList)
       }),
       leaseHttpService: mock<LeaseHttpService>({
-        list: vi.fn().mockResolvedValue({ leases: [], pagination: { next_key: null, total: "0" } })
+        list: vi.fn().mockResolvedValue({ leases: input.leases ?? [], pagination: { next_key: null, total: String(input.leases?.length ?? 0) } })
       }),
       fallbackLeaseReaderService: mock<FallbackLeaseReaderService>({
         list: vi.fn().mockResolvedValue({

--- a/apps/api/src/deployment/services/deployment-reader/deployment-reader.service.ts
+++ b/apps/api/src/deployment/services/deployment-reader/deployment-reader.service.ts
@@ -5,9 +5,11 @@ import {
   DeploymentInfo,
   DeploymentListResponse,
   FindAllParams,
+  isLeaseLive,
   LeaseHttpService,
   LeaseListParams,
-  RestAkashLeaseListResponse
+  RestAkashLeaseListResponse,
+  RpcLease
 } from "@akashnetwork/http-sdk";
 import { PromisePool } from "@supercharge/promise-pool";
 import { AxiosError } from "axios";
@@ -60,36 +62,7 @@ export class DeploymentReaderService {
 
     const { leases } = await this.getLeaseList({ owner, dseq });
 
-    const leasesWithStatus = await Promise.all(
-      leases.map(async ({ lease }) => {
-        try {
-          const leaseStatus = await this.providerService.getLeaseStatus(
-            lease.id.provider,
-            lease.id.dseq,
-            lease.id.gseq,
-            lease.id.oseq,
-            await this.providerService.toProviderAuth({ walletId: wallet.id, provider: lease.id.provider }, ["status"])
-          );
-          return {
-            lease,
-            status: leaseStatus
-          };
-        } catch (error) {
-          this.logger.warn({
-            event: "LEASE_STATUS_FETCH_FAILED",
-            provider: lease.id.provider,
-            dseq: lease.id.dseq,
-            gseq: lease.id.gseq,
-            oseq: lease.id.oseq,
-            error
-          });
-          return {
-            lease,
-            status: null
-          };
-        }
-      })
-    );
+    const leasesWithStatus = await Promise.all(leases.map(({ lease }) => this.withLeaseStatus(wallet, lease)));
 
     return {
       deployment: deploymentResponse.deployment,
@@ -99,6 +72,39 @@ export class DeploymentReaderService {
       })),
       escrow_account: deploymentResponse.escrow_account
     };
+  }
+
+  /**
+   * A provider serves /lease/../status only while the lease is live: a closed lease answers 404, and a lease
+   * whose provider went offline costs a full connect timeout. Neither yields a status, so a non-live lease is
+   * reported as null without a provider round-trip. The lease itself stays in the response whatever its state.
+   */
+  private async withLeaseStatus(wallet: WalletInitialized, lease: RpcLease["lease"]) {
+    if (!isLeaseLive(lease)) {
+      return { lease, status: null };
+    }
+
+    try {
+      const status = await this.providerService.getLeaseStatus(
+        lease.id.provider,
+        lease.id.dseq,
+        lease.id.gseq,
+        lease.id.oseq,
+        await this.providerService.toProviderAuth({ walletId: wallet.id, provider: lease.id.provider }, ["status"])
+      );
+      return { lease, status };
+    } catch (error) {
+      this.logger.warn({
+        event: "LEASE_STATUS_FETCH_FAILED",
+        provider: lease.id.provider,
+        dseq: lease.id.dseq,
+        gseq: lease.id.gseq,
+        oseq: lease.id.oseq,
+        leaseState: lease.state,
+        error
+      });
+      return { lease, status: null };
+    }
   }
 
   public async list({

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.spec.tsx
@@ -1,4 +1,5 @@
 import { TooltipProvider } from "@akashnetwork/ui/components";
+import { AxiosError } from "axios";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
@@ -174,16 +175,39 @@ describe(PlacementCard.name, () => {
     });
   }
 
+  it.each([502, 503])("warns that the provider is not responding when lease status fails with %s", status => {
+    setup({ leaseStatusError: new AxiosError("Unavailable", String(status), undefined, undefined, { status } as never) });
+
+    expect(screen.queryByText("Provider not responding")).toBeInTheDocument();
+  });
+
+  it("drops the warning once the lease is no longer live", () => {
+    setup({
+      lease: buildLease({ state: "closed" }),
+      leaseStatusError: new AxiosError("Unavailable", "502", undefined, undefined, { status: 502 } as never)
+    });
+
+    expect(screen.queryByText("Provider not responding")).not.toBeInTheDocument();
+  });
+
+  it("does not warn when lease status simply reports nothing", () => {
+    setup({ leaseStatus: null });
+
+    expect(screen.queryByText("Provider not responding")).not.toBeInTheDocument();
+  });
+
   function setup(input?: {
     lease?: LeaseDto;
     provider?: ApiProviderList;
     leaseStatus?: LeaseStatusDto | null;
+    leaseStatusError?: unknown;
     manifestServices?: Record<string, ManifestServiceDetail>;
     placementServices?: Record<string, ManifestServiceDetail>;
     dependencies?: Partial<typeof DEPENDENCIES>;
   }) {
     const leaseStatus = input && "leaseStatus" in input ? input.leaseStatus : buildStatus(["web"]);
-    const useLeaseStatus: typeof DEPENDENCIES.useLeaseStatus = () => mock<ReturnType<typeof DEPENDENCIES.useLeaseStatus>>({ data: leaseStatus });
+    const useLeaseStatus: typeof DEPENDENCIES.useLeaseStatus = () =>
+      mock<ReturnType<typeof DEPENDENCIES.useLeaseStatus>>({ data: leaseStatus, error: input?.leaseStatusError ?? null });
     const useTeeResourceCarveouts: typeof DEPENDENCIES.useTeeResourceCarveouts = () => [];
 
     return render(

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 
 import { useTeeResourceCarveouts } from "@src/hooks/useTeeResourceCarveouts";
 import { useLeaseStatus } from "@src/queries/useLeaseQuery";
+import { isProviderUnavailableError } from "@src/services/query-error-policy/query-error-policy";
 import type { LeaseDto } from "@src/types/deployment";
 import type { ApiProviderList } from "@src/types/provider";
 import { getGroupTeeType } from "@src/utils/confidentialCompute";
@@ -56,7 +57,8 @@ export const PlacementCard: FC<PlacementCardProps> = ({
   dependencies: d = DEPENDENCIES
 }) => {
   const isLeaseActive = isLeaseLive(lease);
-  const { data: leaseStatus } = d.useLeaseStatus({ provider, lease, enabled: isLeaseActive && !!provider, refetchInterval: 30_000 });
+  const { data: leaseStatus, error: leaseStatusError } = d.useLeaseStatus({ provider, lease, enabled: isLeaseActive && !!provider, refetchInterval: 30_000 });
+  const isProviderUnreachable = isLeaseActive && isProviderUnavailableError(leaseStatusError);
   const carveouts = d.useTeeResourceCarveouts(lease);
   const [expanded, setExpanded] = useState<ReadonlySet<string>>(() => new Set());
 
@@ -96,6 +98,7 @@ export const PlacementCard: FC<PlacementCardProps> = ({
             </div>
             <h3 className="text-2xl font-medium tracking-tight">{name}</h3>
             {isReclaiming(lease) && <StatusBadge label="Reclaiming" tone="warning" />}
+            {isProviderUnreachable && <StatusBadge label="Provider not responding" tone="warning" />}
           </div>
           {(region || providerName) && (
             <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">

--- a/apps/deploy-web/src/components/deployments/LeaseRow.tsx
+++ b/apps/deploy-web/src/components/deployments/LeaseRow.tsx
@@ -24,6 +24,7 @@ import { useBidInfo } from "@src/queries/useBidQuery";
 import type { LeaseStatusDto } from "@src/queries/useLeaseQuery";
 import { useLeaseStatus } from "@src/queries/useLeaseQuery";
 import { useProviderStatus } from "@src/queries/useProvidersQuery";
+import { isProviderUnavailableError } from "@src/services/query-error-policy/query-error-policy";
 import type { LeaseDto } from "@src/types/deployment";
 import type { ApiProviderList } from "@src/types/provider";
 import { copyTextToClipboard } from "@src/utils/copyClipboard";
@@ -89,6 +90,7 @@ export const LeaseRow = React.forwardRef<AcceptRefType, Props>(
     });
     const errorMessage = typeof error === "string" ? error : error?.message;
     const isLeaseNotFound = errorMessage?.includes("lease not found") && isLeaseActive;
+    const isProviderUnreachable = isProviderUnavailableError(error) && isLeaseActive;
     const servicesNames = useMemo(() => (leaseStatus ? Object.keys(leaseStatus.services) : []), [leaseStatus]);
     const [isSendingManifest, setIsSendingManifest] = useState(false);
     const { data: bid } = useBidInfo(lease.owner, lease.dseq, lease.gseq, lease.oseq, lease.provider);
@@ -258,6 +260,13 @@ export const LeaseRow = React.forwardRef<AcceptRefType, Props>(
               }
             />
           </div>
+
+          {isProviderUnreachable && (
+            <Alert variant="warning">
+              This provider is not responding, so the status of your services cannot be shown. The lease stays open and continues to be billed until you close
+              the deployment.
+            </Alert>
+          )}
 
           {isLeaseNotFound && (
             <Alert variant="warning">

--- a/apps/deploy-web/src/queries/useLeaseQuery.spec.tsx
+++ b/apps/deploy-web/src/queries/useLeaseQuery.spec.tsx
@@ -8,6 +8,7 @@ import type { Props as ServicesProviderProps } from "@src/context/ServicesProvid
 import type { UseProviderCredentialsResult } from "@src/hooks/useProviderCredentials/useProviderCredentials";
 import type { FallbackableHttpClient } from "@src/services/createFallbackableHttpClient/createFallbackableHttpClient";
 import type { ProviderProxyService } from "@src/services/provider-proxy/provider-proxy.service";
+import { isProviderUnavailableError } from "@src/services/query-error-policy/query-error-policy";
 import type { DeploymentGroup, LeaseDto } from "@src/types/deployment";
 import type { ApiProviderList } from "@src/types/provider";
 import { leaseToDto } from "@src/utils/deploymentDetailUtils";
@@ -603,6 +604,25 @@ describe("useLeaseQuery", () => {
       await vi.waitFor(() => {
         expect(result.current.data).toBeNull();
       });
+    });
+
+    it.each([502, 503])("surfaces a %s from the provider proxy as a provider-unavailable error", async status => {
+      const providerProxy = mock<ProviderProxyService>({
+        request: vi.fn().mockRejectedValue(new AxiosError("Unavailable", String(status), undefined, undefined, { status } as any))
+      });
+      const { result } = setupLeaseStatus({
+        lease: mockLease,
+        services: {
+          providerProxy: () => providerProxy
+        }
+      });
+
+      await vi.waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      expect(isProviderUnavailableError(result.current.error)).toBe(true);
+      expect(providerProxy.request).toHaveBeenCalledTimes(1);
     });
 
     it("fetches lease status when a JWT is available", async () => {

--- a/apps/deploy-web/src/queries/useLeaseQuery.spec.tsx
+++ b/apps/deploy-web/src/queries/useLeaseQuery.spec.tsx
@@ -804,6 +804,31 @@ describe("useLeaseQuery", () => {
       expect(result.current[1].data?.services.api?.uris).toEqual(["api.example"]);
     });
 
+    it.each([502, 503])("useLeaseStatuses fails a %s from the provider proxy on the first attempt", async status => {
+      const provider = buildProvider();
+      const providerProxy = mock<ProviderProxyService>({
+        request: vi.fn().mockRejectedValue(new AxiosError("Unavailable", String(status), undefined, undefined, { status } as any))
+      });
+      const dependencies: typeof USE_LEASE_STATUS_DEPENDENCIES = {
+        ...USE_LEASE_STATUS_DEPENDENCIES,
+        useProviderCredentials: () => ({
+          details: { type: "jwt", value: "jwt-token", isExpired: false, usable: true, error: null },
+          ensureToken: vi.fn().mockResolvedValue("jwt-token")
+        })
+      };
+
+      const { result } = setupQuery(() => useLeaseStatuses([{ lease: mockLease, provider }], { dependencies }), {
+        services: { providerProxy: () => providerProxy }
+      });
+
+      await vi.waitFor(() => {
+        expect(result.current[0].isError).toBe(true);
+      });
+
+      expect(isProviderUnavailableError(result.current[0].error)).toBe(true);
+      expect(providerProxy.request).toHaveBeenCalledTimes(1);
+    });
+
     it("coerces the provider's null endpoint collections to empty arrays", async () => {
       const statusWithNulls = {
         forwarded_ports: { web: null },

--- a/apps/deploy-web/src/queries/useLeaseQuery.ts
+++ b/apps/deploy-web/src/queries/useLeaseQuery.ts
@@ -7,6 +7,7 @@ import mapValues from "lodash/mapValues";
 import { useServices } from "@src/context/ServicesProvider";
 import { useProviderCredentials } from "@src/hooks/useProviderCredentials/useProviderCredentials";
 import { useScopedFetchProviderUrl } from "@src/hooks/useScopedFetchProviderUrl";
+import { isProviderUnavailableError, retryOnServerError, SKIP_REPORTING_PROVIDER_UNAVAILABLE } from "@src/services/query-error-policy/query-error-policy";
 import type { DeploymentDto, LeaseDto, RpcLease } from "@src/types/deployment";
 import type { ApiProviderList } from "@src/types/provider";
 import { ApiUrlService, loadWithPagination } from "@src/utils/apiUtils";
@@ -129,6 +130,8 @@ export function useLeaseStatus(
         request: (url, requestOptions) => fetchProviderUrl(url, requestOptions)
       }),
     ...options,
+    retry: retryUnlessProviderIsUnavailable,
+    meta: SKIP_REPORTING_PROVIDER_UNAVAILABLE,
     enabled: options.enabled !== false && !!provider?.hostUri && providerCredentials.details.usable,
     // Defensive: the attestation sidecar is a pod container under the current provider design and
     // never appears as a lease-status service, so this is a passthrough today. It keeps the sidecar
@@ -165,6 +168,8 @@ export function useLeaseStatuses(
         });
       },
       ...options,
+      retry: retryUnlessProviderIsUnavailable,
+      meta: SKIP_REPORTING_PROVIDER_UNAVAILABLE,
       enabled: options.enabled !== false && !!provider?.hostUri && providerCredentials.details.usable,
       select: (data: LeaseStatusDto | null) => {
         const filtered = data ? omitAttestationSidecar(data) : data;
@@ -176,6 +181,14 @@ export function useLeaseStatuses(
 
 function leaseStatusQueryKey(lease?: LeaseDto | null) {
   return QueryKeys.getLeaseStatusKey(lease?.dseq || "", lease?.gseq ?? 0, lease?.oseq ?? 0);
+}
+
+/**
+ * An unreachable provider is not a Console fault and retrying cannot fix it, so these polls fail on the first
+ * attempt instead of burning three and reporting each one.
+ */
+function retryUnlessProviderIsUnavailable(failureCount: number, error: unknown): boolean {
+  return !isProviderUnavailableError(error) && retryOnServerError(failureCount, error);
 }
 
 function isLeaseStatusUnavailable(error: unknown): boolean {

--- a/apps/deploy-web/src/queries/useLeaseQuery.ts
+++ b/apps/deploy-web/src/queries/useLeaseQuery.ts
@@ -109,12 +109,18 @@ export function useLeaseExistenceQuery(address: string, options: Omit<UseQueryOp
   });
 }
 
+/**
+ * Lease-status polls own their retry and error-reporting policy, so `retry` and `meta` are not caller-settable:
+ * both hooks below set them unconditionally, and accepting them here would silently drop whatever a caller passed.
+ */
+type LeaseStatusQueryOptions = Omit<UseQueryOptions<LeaseStatusDto | null>, "queryKey" | "queryFn" | "retry" | "meta">;
+
 export function useLeaseStatus(
   params: {
     provider?: ApiProviderList | null;
     lease?: LeaseDto | null;
     dependencies?: typeof USE_LEASE_STATUS_DEPENDENCIES;
-  } & Omit<UseQueryOptions<LeaseStatusDto | null>, "queryKey" | "queryFn"> = {}
+  } & LeaseStatusQueryOptions = {}
 ) {
   const { provider, lease, dependencies: d = USE_LEASE_STATUS_DEPENDENCIES, select: callerSelect, ...options } = params;
   const providerCredentials = d.useProviderCredentials();
@@ -149,7 +155,7 @@ export const USE_LEASE_STATUS_DEPENDENCIES = {
 
 export function useLeaseStatuses(
   items: { lease: LeaseDto; provider?: ApiProviderList | null }[],
-  params: { dependencies?: typeof USE_LEASE_STATUS_DEPENDENCIES } & Omit<UseQueryOptions<LeaseStatusDto | null>, "queryKey" | "queryFn"> = {}
+  params: { dependencies?: typeof USE_LEASE_STATUS_DEPENDENCIES } & LeaseStatusQueryOptions = {}
 ) {
   const { dependencies: d = USE_LEASE_STATUS_DEPENDENCIES, select: callerSelect, ...options } = params;
   const providerCredentials = d.useProviderCredentials();

--- a/apps/deploy-web/src/services/app-di-container/app-di-container.ts
+++ b/apps/deploy-web/src/services/app-di-container/app-di-container.ts
@@ -5,7 +5,6 @@ import {
   AuthHttpService,
   createHttpClient,
   DeploymentSettingHttpService,
-  isHttpError,
   ManagedDeploymentHttpService,
   ManagedWalletHttpService,
   StripeService as HttpStripeService,
@@ -20,6 +19,7 @@ import type { Axios, AxiosInstance, AxiosResponse, InternalAxiosRequestConfig } 
 import { browserEnvConfig } from "@src/config/browser-env.config";
 import { UrlReturnToStack } from "@src/hooks/useReturnTo/UrlReturnToStack";
 import { AnalyticsService } from "@src/services/analytics/analytics.service";
+import { retryOnServerError, shouldReportQueryError } from "@src/services/query-error-policy/query-error-policy";
 import networkStore from "@src/store/networkStore";
 import { registry } from "@src/utils/customRegistry";
 import { UrlService } from "@src/utils/urlUtils";
@@ -157,13 +157,14 @@ export const createAppRootContainer = (config: ServicesConfig) => {
       new QueryClient({
         defaultOptions: {
           queries: {
-            retry(failureCount, error) {
-              return isHttpError(error) && !!error.response && error.response.status >= 500 && failureCount < 3;
-            }
+            retry: retryOnServerError
           }
         },
         queryCache: new QueryCache({
-          onError: error => container.errorHandler.reportError({ error })
+          onError: (error, query) => {
+            if (!shouldReportQueryError(error, query.meta)) return;
+            container.errorHandler.reportError({ error });
+          }
         }),
         mutationCache: new MutationCache({
           onError: error => container.errorHandler.reportError({ error })

--- a/apps/deploy-web/src/services/query-error-policy/query-error-policy.spec.ts
+++ b/apps/deploy-web/src/services/query-error-policy/query-error-policy.spec.ts
@@ -1,0 +1,71 @@
+import { AxiosError } from "axios";
+import { describe, expect, it, vi } from "vitest";
+
+import { isProviderUnavailableError, retryOnServerError, shouldReportQueryError, SKIP_REPORTING_PROVIDER_UNAVAILABLE } from "./query-error-policy";
+
+describe("query-error-policy", () => {
+  describe("isProviderUnavailableError", () => {
+    it.each([502, 503])("is true for a %s from the provider proxy", status => {
+      expect(isProviderUnavailableError(httpError(status))).toBe(true);
+    });
+
+    it.each([404, 500, 400])("is false for a %s", status => {
+      expect(isProviderUnavailableError(httpError(status))).toBe(false);
+    });
+
+    it("is false when there is no response at all", () => {
+      expect(isProviderUnavailableError(new AxiosError("Network Error", "ERR_NETWORK"))).toBe(false);
+    });
+
+    it("is false for a non-http error", () => {
+      expect(isProviderUnavailableError(new Error("boom"))).toBe(false);
+    });
+  });
+
+  describe("retryOnServerError", () => {
+    it("retries a server error up to three times", () => {
+      expect(retryOnServerError(0, httpError(500))).toBe(true);
+      expect(retryOnServerError(2, httpError(500))).toBe(true);
+      expect(retryOnServerError(3, httpError(500))).toBe(false);
+    });
+
+    it("does not retry a client error", () => {
+      expect(retryOnServerError(0, httpError(404))).toBe(false);
+    });
+
+    it("does not retry a non-http error", () => {
+      expect(retryOnServerError(0, new Error("boom"))).toBe(false);
+    });
+  });
+
+  describe("shouldReportQueryError", () => {
+    it("reports when the query carries no meta", () => {
+      expect(shouldReportQueryError(httpError(500), undefined)).toBe(true);
+    });
+
+    it("reports when the query opts out of a different error", () => {
+      expect(shouldReportQueryError(httpError(500), SKIP_REPORTING_PROVIDER_UNAVAILABLE)).toBe(true);
+    });
+
+    it("stays quiet for the error the query opted out of", () => {
+      expect(shouldReportQueryError(httpError(502), SKIP_REPORTING_PROVIDER_UNAVAILABLE)).toBe(false);
+    });
+
+    it("passes the error to the predicate", () => {
+      const skipErrorReporting = vi.fn().mockReturnValue(false);
+      const error = httpError(500);
+
+      shouldReportQueryError(error, { skipErrorReporting });
+
+      expect(skipErrorReporting).toHaveBeenCalledWith(error);
+    });
+
+    it("reports when meta holds no predicate", () => {
+      expect(shouldReportQueryError(httpError(502), { somethingElse: true })).toBe(true);
+    });
+  });
+
+  function httpError(status: number) {
+    return new AxiosError("Request failed", String(status), undefined, undefined, { status } as never);
+  }
+});

--- a/apps/deploy-web/src/services/query-error-policy/query-error-policy.ts
+++ b/apps/deploy-web/src/services/query-error-policy/query-error-policy.ts
@@ -1,0 +1,30 @@
+import { isHttpError } from "@akashnetwork/http-sdk";
+
+const MAX_SERVER_ERROR_RETRIES = 3;
+
+/** The provider proxy answers 502 when it cannot reach the provider host and 503 when the provider itself failed. */
+const PROVIDER_UNAVAILABLE_STATUSES = [502, 503];
+
+/** Server errors are usually transient, so they get a few attempts. Everything else fails on the first try. */
+export function retryOnServerError(failureCount: number, error: unknown): boolean {
+  return isHttpError(error) && !!error.response && error.response.status >= 500 && failureCount < MAX_SERVER_ERROR_RETRIES;
+}
+
+/**
+ * Whether a request failed because the provider behind the proxy is down rather than because Console is.
+ * Only meaningful for calls that go through the provider proxy, since it owns these two statuses.
+ */
+export function isProviderUnavailableError(error: unknown): boolean {
+  return isHttpError(error) && !!error.response && PROVIDER_UNAVAILABLE_STATUSES.includes(error.response.status);
+}
+
+/**
+ * Queries opt out of error reporting by putting a predicate on React Query's `meta`, which is the documented
+ * way to hand per-query policy to the global cache handler.
+ */
+export function shouldReportQueryError(error: unknown, meta: Record<string, unknown> | undefined): boolean {
+  const skipErrorReporting = meta?.skipErrorReporting;
+  return typeof skipErrorReporting === "function" ? !skipErrorReporting(error) : true;
+}
+
+export const SKIP_REPORTING_PROVIDER_UNAVAILABLE = { skipErrorReporting: isProviderUnavailableError };

--- a/apps/deploy-web/src/utils/leaseUtils.spec.ts
+++ b/apps/deploy-web/src/utils/leaseUtils.spec.ts
@@ -1,21 +1,9 @@
 import { describe, expect, it } from "vitest";
 
 import type { DeploymentGroup, LeaseDto } from "@src/types/deployment";
-import { hasLiveGpuLease, isLeaseLive } from "./leaseUtils";
+import { hasLiveGpuLease } from "./leaseUtils";
 
 describe("leaseUtils", () => {
-  describe("isLeaseLive", () => {
-    it("treats active and reclaiming leases as live", () => {
-      expect(isLeaseLive(createLease({ state: "active" }))).toBe(true);
-      expect(isLeaseLive(createLease({ state: "reclaiming" }))).toBe(true);
-    });
-
-    it("treats closed / insufficient_funds leases as not live", () => {
-      expect(isLeaseLive(createLease({ state: "closed" }))).toBe(false);
-      expect(isLeaseLive(createLease({ state: "insufficient_funds" }))).toBe(false);
-    });
-  });
-
   describe("hasLiveGpuLease", () => {
     it("is true when a live lease has a GPU", () => {
       expect(hasLiveGpuLease([createLease({ state: "active", gpuAmount: 1 })])).toBe(true);

--- a/apps/deploy-web/src/utils/leaseUtils.ts
+++ b/apps/deploy-web/src/utils/leaseUtils.ts
@@ -1,11 +1,8 @@
+import { isLeaseLive } from "@akashnetwork/http-sdk";
+
 import type { LeaseDto } from "@src/types/deployment";
 
-export const LIVE_LEASE_STATES = ["active", "reclaiming"] as const;
-
-/** A lease whose workload is still running — actively leased or in the reclamation grace period. */
-export function isLeaseLive(lease: Pick<LeaseDto, "state">): boolean {
-  return LIVE_LEASE_STATES.some(state => lease.state === state);
-}
+export { isLeaseLive, LIVE_LEASE_STATES } from "@akashnetwork/http-sdk";
 
 /** Whether any live lease is running on GPU — drives hourly-vs-monthly cost display in the headers. */
 export function hasLiveGpuLease(leases: Pick<LeaseDto, "state" | "gpuAmount">[] | null | undefined): boolean {

--- a/apps/provider-proxy/src/routes/proxyProviderRequest.ts
+++ b/apps/provider-proxy/src/routes/proxyProviderRequest.ts
@@ -5,6 +5,7 @@ import { Readable } from "stream";
 import type { ReadableStreamDefaultReader } from "stream/web";
 
 import type { AppContext } from "../types/AppContext";
+import { toErrno, toProviderErrorCategory } from "../utils/errno";
 import { canRetryOnError, httpRetry } from "../utils/retry";
 import { addProviderAuthValidation, providerRequestSchema } from "../utils/schema";
 
@@ -47,6 +48,22 @@ export const proxyRoute = createRoute({
         }
       },
       description: "Returned if host SSL certificate is invalid"
+    },
+    502: {
+      content: {
+        "text/plain": {
+          schema: z.string()
+        }
+      },
+      description: "Returned if the proxied host could not be reached at all"
+    },
+    503: {
+      content: {
+        "text/plain": {
+          schema: z.string()
+        }
+      },
+      description: "Returned if the proxied host answered with a server error"
     },
     200: {
       description: "Returns proxied response"
@@ -101,21 +118,20 @@ export async function proxyProviderRequest(ctx: AppContext): Promise<Response | 
   }
 
   if (proxyResult.ok === false && proxyResult.code === "connectionError") {
+    const errno = toErrno(proxyResult.error);
+    const errorCategory = toProviderErrorCategory(errno);
+
     ctx.get("container").appLogger?.warn({
       event: "PROXY_REQUEST_ERROR",
+      errorCategory,
+      errno,
       url,
       method,
       providerAddress,
       error: proxyResult.error
     });
 
-    if (
-      proxyResult.error &&
-      typeof proxyResult.error === "object" &&
-      proxyResult.error &&
-      "code" in proxyResult.error &&
-      String(proxyResult.error.code).startsWith("ERR_SSL_")
-    ) {
+    if (errorCategory === "clientCertificateError") {
       return ctx.json(
         {
           error: {
@@ -134,10 +150,11 @@ export async function proxyProviderRequest(ctx: AppContext): Promise<Response | 
       );
     }
 
-    if ((Error as any).isError(proxyResult.error) && (proxyResult.error as NodeJS.ErrnoException).code === "EFORBIDDEN") {
+    if (errorCategory === "blockedAddress") {
       ctx.get("container").appLogger?.warn({
         event: "PROXY_REQUEST_ERROR",
-        code: (proxyResult.error as NodeJS.ErrnoException).code,
+        errorCategory,
+        errno,
         url,
         method,
         providerAddress,
@@ -161,7 +178,7 @@ export async function proxyProviderRequest(ctx: AppContext): Promise<Response | 
       );
     }
 
-    return ctx.text(`Provider ${new URL(url).origin} is temporarily unavailable`, 503);
+    return ctx.text(`Provider ${new URL(url).origin} is temporarily unavailable`, 502);
   }
 
   const headers = new Headers();
@@ -182,6 +199,7 @@ export async function proxyProviderRequest(ctx: AppContext): Promise<Response | 
 
     ctx.get("container").appLogger?.error({
       event: "PROXY_REQUEST_ERROR",
+      errorCategory: "providerServerError",
       url,
       method,
       providerAddress,

--- a/apps/provider-proxy/src/routes/proxyProviderRequest.ts
+++ b/apps/provider-proxy/src/routes/proxyProviderRequest.ts
@@ -131,7 +131,7 @@ export async function proxyProviderRequest(ctx: AppContext): Promise<Response | 
       error: proxyResult.error
     });
 
-    if (errorCategory === "clientCertificateError") {
+    if (errorCategory === "tlsHandshakeError") {
       return ctx.json(
         {
           error: {
@@ -151,15 +151,6 @@ export async function proxyProviderRequest(ctx: AppContext): Promise<Response | 
     }
 
     if (errorCategory === "blockedAddress") {
-      ctx.get("container").appLogger?.warn({
-        event: "PROXY_REQUEST_ERROR",
-        errorCategory,
-        errno,
-        url,
-        method,
-        providerAddress,
-        error: proxyResult.error
-      });
       return ctx.json(
         {
           error: {

--- a/apps/provider-proxy/src/utils/errno.spec.ts
+++ b/apps/provider-proxy/src/utils/errno.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { toErrno, toProviderErrorCategory } from "./errno";
+
+describe("toErrno", () => {
+  it("reads the code off an ErrnoException", () => {
+    expect(toErrno(Object.assign(new Error("connect EHOSTUNREACH"), { code: "EHOSTUNREACH" }))).toBe("EHOSTUNREACH");
+  });
+
+  it("returns undefined for an error without a code", () => {
+    expect(toErrno(new Error("boom"))).toBeUndefined();
+  });
+
+  it("returns undefined for a non-string code", () => {
+    expect(toErrno(Object.assign(new Error("boom"), { code: 42 }))).toBeUndefined();
+  });
+
+  it.each([null, undefined, "EHOSTUNREACH"])("returns undefined for %s", value => {
+    expect(toErrno(value)).toBeUndefined();
+  });
+});
+
+describe("toProviderErrorCategory", () => {
+  it.each(["ERR_SSL_WRONG_VERSION_NUMBER", "ERR_SSL_PACKET_LENGTH_TOO_LONG"])("classifies %s as a client certificate error", errno => {
+    expect(toProviderErrorCategory(errno)).toBe("clientCertificateError");
+  });
+
+  it("classifies the private-network guard rejection as a blocked address", () => {
+    expect(toProviderErrorCategory("EFORBIDDEN")).toBe("blockedAddress");
+  });
+
+  it.each(["EHOSTUNREACH", "ECONNREFUSED", "ECONNRESET", "ENOTFOUND", undefined])("classifies %s as the provider being unreachable", errno => {
+    expect(toProviderErrorCategory(errno)).toBe("providerUnreachable");
+  });
+});

--- a/apps/provider-proxy/src/utils/errno.spec.ts
+++ b/apps/provider-proxy/src/utils/errno.spec.ts
@@ -21,9 +21,12 @@ describe("toErrno", () => {
 });
 
 describe("toProviderErrorCategory", () => {
-  it.each(["ERR_SSL_WRONG_VERSION_NUMBER", "ERR_SSL_PACKET_LENGTH_TOO_LONG"])("classifies %s as a client certificate error", errno => {
-    expect(toProviderErrorCategory(errno)).toBe("clientCertificateError");
-  });
+  it.each(["ERR_SSL_SSLV3_ALERT_BAD_CERTIFICATE", "ERR_SSL_WRONG_VERSION_NUMBER", "ERR_SSL_PACKET_LENGTH_TOO_LONG"])(
+    "classifies %s as a TLS handshake error",
+    errno => {
+      expect(toProviderErrorCategory(errno)).toBe("tlsHandshakeError");
+    }
+  );
 
   it("classifies the private-network guard rejection as a blocked address", () => {
     expect(toProviderErrorCategory("EFORBIDDEN")).toBe("blockedAddress");

--- a/apps/provider-proxy/src/utils/errno.ts
+++ b/apps/provider-proxy/src/utils/errno.ts
@@ -10,15 +10,19 @@ export function toErrno(error: unknown): string | undefined {
   return typeof code === "string" ? code : undefined;
 }
 
-export type ProviderErrorCategory = "clientCertificateError" | "blockedAddress" | "providerUnreachable";
+export type ProviderErrorCategory = "tlsHandshakeError" | "blockedAddress" | "providerUnreachable";
 
 /**
- * Splits connection failures into the classes that matter downstream: a bad client certificate and a blocked
- * address are caller mistakes answered with 400, while everything else is the provider being unreachable and
- * is answered with 502. Only the last class tracks third-party downtime, so alerting keys off it.
+ * Splits connection failures into the classes that matter downstream: a failed TLS handshake and a blocked
+ * address are answered with 400, while everything else is the provider being unreachable and is answered
+ * with 502. Only the last class tracks third-party downtime, so alerting keys off it.
+ *
+ * The ERR_SSL_ prefix covers more than a rejected client certificate, since OpenSSL also reports protocol
+ * and record failures under it. Narrowing it would change which errors answer 400, so the existing routing
+ * is kept and the category is named after what the prefix actually means.
  */
 export function toProviderErrorCategory(errno: string | undefined): ProviderErrorCategory {
-  if (errno?.startsWith("ERR_SSL_")) return "clientCertificateError";
+  if (errno?.startsWith("ERR_SSL_")) return "tlsHandshakeError";
   if (errno === "EFORBIDDEN") return "blockedAddress";
   return "providerUnreachable";
 }

--- a/apps/provider-proxy/src/utils/errno.ts
+++ b/apps/provider-proxy/src/utils/errno.ts
@@ -1,0 +1,24 @@
+/**
+ * Reads the libuv/OpenSSL error code off an unknown thrown value. Node surfaces connection failures as an
+ * ErrnoException whose `code` is the only machine-readable signal of what went wrong, and the logger's
+ * serializer folds it into a stack string, so it has to be pulled out before logging to stay queryable.
+ */
+export function toErrno(error: unknown): string | undefined {
+  if (!error || typeof error !== "object" || !("code" in error)) return undefined;
+
+  const code = (error as NodeJS.ErrnoException).code;
+  return typeof code === "string" ? code : undefined;
+}
+
+export type ProviderErrorCategory = "clientCertificateError" | "blockedAddress" | "providerUnreachable";
+
+/**
+ * Splits connection failures into the classes that matter downstream: a bad client certificate and a blocked
+ * address are caller mistakes answered with 400, while everything else is the provider being unreachable and
+ * is answered with 502. Only the last class tracks third-party downtime, so alerting keys off it.
+ */
+export function toProviderErrorCategory(errno: string | undefined): ProviderErrorCategory {
+  if (errno?.startsWith("ERR_SSL_")) return "clientCertificateError";
+  if (errno === "EFORBIDDEN") return "blockedAddress";
+  return "providerUnreachable";
+}

--- a/apps/provider-proxy/test/functional/provider-proxy-http.spec.ts
+++ b/apps/provider-proxy/test/functional/provider-proxy-http.spec.ts
@@ -424,7 +424,7 @@ describe("Provider HTTP proxy", () => {
     expect(body).toEqual(`Provider ${providerUrl} is temporarily unavailable`);
   });
 
-  it("responds with 503 if provider host is not reachable", async () => {
+  it("responds with 502 if provider host is not reachable", async () => {
     const providerAddress = generateBech32();
     const validCertPair = await createX509CertPair({
       commonName: providerAddress
@@ -444,12 +444,12 @@ describe("Provider HTTP proxy", () => {
       })
     });
 
-    expect(response.status).toBe(503);
+    expect(response.status).toBe(502);
     const body = await response.text();
     expect(body).toBe(`Provider ${new URL(providerUrl).origin} is temporarily unavailable`);
   });
 
-  it("responds with 503 if provider host hangs up connection", async () => {
+  it("responds with 502 if provider host hangs up connection", async () => {
     const providerAddress = generateBech32();
     const validCertPair = await createX509CertPair({
       commonName: providerAddress
@@ -475,7 +475,7 @@ describe("Provider HTTP proxy", () => {
       })
     });
 
-    expect(response.status).toBe(503);
+    expect(response.status).toBe(502);
     const body = await response.text();
     expect(body).toBe(`Provider ${providerUrl} is temporarily unavailable`);
   });

--- a/packages/http-sdk/src/index.ts
+++ b/packages/http-sdk/src/index.ts
@@ -15,6 +15,7 @@ export * from "./bid/bid-http.service";
 export * from "./deployment/deployment-http.service";
 export * from "./deployment/managed-deployment-http.service";
 export * from "./lease/lease-http.service";
+export * from "./lease/lease-state";
 export * from "./provider/provider-http.service";
 export * from "./utils/isHttpError";
 export * from "./git-hub/git-hub-http.service";

--- a/packages/http-sdk/src/lease/lease-http.service.ts
+++ b/packages/http-sdk/src/lease/lease-http.service.ts
@@ -1,5 +1,6 @@
 import { extractData } from "../http/http.service";
 import type { HttpClient } from "../utils/httpClient";
+import type { LeaseState } from "./lease-state";
 
 export interface RpcLease {
   lease: {
@@ -70,7 +71,7 @@ export type RestAkashLeaseListResponse = {
 export type LeaseListParams = {
   owner: string;
   dseq?: string;
-  state?: "active" | "insufficient_funds" | "closed" | "reclaiming";
+  state?: LeaseState;
   pagination?: {
     limit?: number;
     key?: string;

--- a/packages/http-sdk/src/lease/lease-state.spec.ts
+++ b/packages/http-sdk/src/lease/lease-state.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { isLeaseLive, LIVE_LEASE_STATES } from "./lease-state";
+
+describe("lease-state", () => {
+  describe("isLeaseLive", () => {
+    it.each(["active", "reclaiming"])("treats a %s lease as live", state => {
+      expect(isLeaseLive({ state })).toBe(true);
+    });
+
+    it.each(["closed", "insufficient_funds"])("treats a %s lease as not live", state => {
+      expect(isLeaseLive({ state })).toBe(false);
+    });
+
+    it("treats an unrecognized state as not live", () => {
+      expect(isLeaseLive({ state: "some_future_state" })).toBe(false);
+    });
+  });
+
+  describe("LIVE_LEASE_STATES", () => {
+    it("lists exactly the states whose workload is still running", () => {
+      expect(LIVE_LEASE_STATES).toEqual(["active", "reclaiming"]);
+    });
+  });
+});

--- a/packages/http-sdk/src/lease/lease-state.ts
+++ b/packages/http-sdk/src/lease/lease-state.ts
@@ -1,0 +1,8 @@
+export type LeaseState = "active" | "insufficient_funds" | "closed" | "reclaiming";
+
+export const LIVE_LEASE_STATES = ["active", "reclaiming"] as const satisfies readonly LeaseState[];
+
+/** A lease whose workload is still running — actively leased or in the reclamation grace period. */
+export function isLeaseLive(lease: { state: string }): boolean {
+  return LIVE_LEASE_STATES.some(state => lease.state === state);
+}


### PR DESCRIPTION
## Why

The Slack alert `too many 503 by service console (prod provider-proxy-mainnet)` keeps firing, and it reads as a Console outage. It isn't one. We are dialing third-party providers about leases that no longer exist, plus a handful of providers that are switched off, and turning both into 503s logged at error level.

24 hours of production data:

| | |
| --- | --- |
| `/lease/:dseq/:gseq/:oseq/status` share of provider-proxy traffic | 57,858 / ~70,640 (82%) |
| `LEASE_STATUS_FETCH_FAILED` in `apps/api` | 10,133 |
| ...provider answered 404 (up, but no such lease) | 9,325 (92%) |
| ...provider-proxy answered 503 (host unreachable) | 728 (7%) |

Every one of those 503s was a connection failure: `EHOSTUNREACH` 668, `ECONNRESET` 56, `ECONNREFUSED` 25, `ENOTFOUND` 2. Not one was a provider 500.

Checked the worst offenders against the chain:

- dseq `1787235371529`, lease closed and escrow closed. Probed 2,249 times in 24h.
- dseq `1782746866154`, lease closed. Probed 1,518 times.
- dseq `1787235344385`, no lease at all for that provider. Probed 2,215 times.

89% of the 503s come from two home-hosted community providers, both unroutable from an independent network and both still registered on chain. One is attached to a lease that closed on Aug 7, sixteen days before these logs.

The traffic comes from external API consumers (userAgent `node`) polling `GET /v1/deployments/{dseq}` every 30-40s per deployment, indefinitely, closed deployments included.

## What

### Skip the probe for non-live leases (`apps/api`)

`findByWalletAndDseq` fanned `getLeaseStatus` out over every lease of a deployment with no state filter, so closed leases were re-probed on every poll. The browser has always guarded this with `isLeaseLive`; only the server path was missing it. The predicate moves into `packages/http-sdk` next to the lease-state union it partitions, so both clients share one definition instead of the duplicate that caused this.

The lease still appears in the response whatever its state, now with `status: null`, which is what these calls already resolved to in practice 92% of the time via a 404.

### Answer 502 when the host cannot be reached (`apps/provider-proxy`)

The proxy returned 503 both when it could not open a connection and when the provider itself answered 5xx. Those are different faults with different owners, and collapsing them is why an alert counting 5xx by service has been reporting third-party downtime. Connection failures now answer 502, and a provider server error keeps 503.

`errorCategory` and `errno` become real log fields. Until now the only record of why a connection failed was the errno spliced into a stack string by the log serializer, so `sum by (errno)` was not possible from Loki.

### Behavior changes to know about

- An `insufficient_funds` lease whose provider still answers used to return a real status and now returns `null`. That matches what the browser has always done, so this makes the two clients agree rather than inventing a new rule.
- A provider-proxy connection failure is now 502 rather than 503. `apps/api` already maps both to the `service_unavailable` error code, so its public contract is unchanged and only the numeric status shifts. Neither status was retried at the axios layer before or after, since these calls are POSTs.
- 502 and 503 are now declared on the proxy route, which documented neither despite returning 503 all along.

## Verification

`npm test`, `npm run lint -- --quiet`, and `npx tsc --noEmit` in `packages/http-sdk`, `apps/api`, `apps/provider-proxy`, and `apps/deploy-web`. 1520 api unit tests, 3435 deploy-web unit tests, 119 provider-proxy tests, and 34 api functional deployment tests pass. tsc error counts are unchanged against the pre-existing baseline in both `apps/api` (40) and `apps/deploy-web` (136).

The four new `deployment-reader` cases were confirmed to fail against the unfixed service. The functional case asserting 503 for a provider 500 is kept as the regression guard for the split.

Expected 24h after deploy: `LEASE_STATUS_FETCH_FAILED` drops from 10,133 to under ~800, provider-proxy 404s drop from 9,447 to a few hundred, 503s drop to roughly zero with the volume reappearing as 502, and `sum by (errno)` starts working.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Lease listings now show accurate statuses for active and reclaiming leases while avoiding unnecessary checks for closed or insufficient-funds leases.
  * Provider status failures no longer prevent lease results from loading.
  * Unreachable providers and connection hangups now return HTTP 502; provider server errors return HTTP 503.
  * Deployment and lease views now warn when an active provider is unavailable.
  * Provider-unavailable errors are no longer retried unnecessarily, while eligible server errors continue to retry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->