### PR TITLE
fix(deployment): tell the user when a provider stops responding

### DIFF
--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.spec.tsx
@@ -1,4 +1,5 @@
 import { TooltipProvider } from "@akashnetwork/ui/components";
+import { AxiosError } from "axios";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
@@ -174,16 +175,30 @@ describe(PlacementCard.name, () => {
     });
   }
 
+  it.each([502, 503])("warns that the provider is not responding when lease status fails with %s", status => {
+    setup({ leaseStatusError: new AxiosError("Unavailable", String(status), undefined, undefined, { status } as never) });
+
+    expect(screen.queryByText("Provider not responding")).toBeInTheDocument();
+  });
+
+  it("does not warn when lease status simply reports nothing", () => {
+    setup({ leaseStatus: null });
+
+    expect(screen.queryByText("Provider not responding")).not.toBeInTheDocument();
+  });
+
   function setup(input?: {
     lease?: LeaseDto;
     provider?: ApiProviderList;
     leaseStatus?: LeaseStatusDto | null;
+    leaseStatusError?: unknown;
     manifestServices?: Record<string, ManifestServiceDetail>;
     placementServices?: Record<string, ManifestServiceDetail>;
     dependencies?: Partial<typeof DEPENDENCIES>;
   }) {
     const leaseStatus = input && "leaseStatus" in input ? input.leaseStatus : buildStatus(["web"]);
-    const useLeaseStatus: typeof DEPENDENCIES.useLeaseStatus = () => mock<ReturnType<typeof DEPENDENCIES.useLeaseStatus>>({ data: leaseStatus });
+    const useLeaseStatus: typeof DEPENDENCIES.useLeaseStatus = () =>
+      mock<ReturnType<typeof DEPENDENCIES.useLeaseStatus>>({ data: leaseStatus, error: input?.leaseStatusError ?? null });
     const useTeeResourceCarveouts: typeof DEPENDENCIES.useTeeResourceCarveouts = () => [];
 
     return render(

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.spec.tsx
@@ -181,6 +181,15 @@ describe(PlacementCard.name, () => {
     expect(screen.queryByText("Provider not responding")).toBeInTheDocument();
   });
 
+  it("drops the warning once the lease is no longer live", () => {
+    setup({
+      lease: buildLease({ state: "closed" }),
+      leaseStatusError: new AxiosError("Unavailable", "502", undefined, undefined, { status: 502 } as never)
+    });
+
+    expect(screen.queryByText("Provider not responding")).not.toBeInTheDocument();
+  });
+
   it("does not warn when lease status simply reports nothing", () => {
     setup({ leaseStatus: null });
 

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 
 import { useTeeResourceCarveouts } from "@src/hooks/useTeeResourceCarveouts";
 import { useLeaseStatus } from "@src/queries/useLeaseQuery";
+import { isProviderUnavailableError } from "@src/services/query-error-policy/query-error-policy";
 import type { LeaseDto } from "@src/types/deployment";
 import type { ApiProviderList } from "@src/types/provider";
 import { getGroupTeeType } from "@src/utils/confidentialCompute";
@@ -56,7 +57,8 @@ export const PlacementCard: FC<PlacementCardProps> = ({
   dependencies: d = DEPENDENCIES
 }) => {
   const isLeaseActive = isLeaseLive(lease);
-  const { data: leaseStatus } = d.useLeaseStatus({ provider, lease, enabled: isLeaseActive && !!provider, refetchInterval: 30_000 });
+  const { data: leaseStatus, error: leaseStatusError } = d.useLeaseStatus({ provider, lease, enabled: isLeaseActive && !!provider, refetchInterval: 30_000 });
+  const isProviderUnreachable = isProviderUnavailableError(leaseStatusError);
   const carveouts = d.useTeeResourceCarveouts(lease);
   const [expanded, setExpanded] = useState<ReadonlySet<string>>(() => new Set());
 
@@ -96,6 +98,7 @@ export const PlacementCard: FC<PlacementCardProps> = ({
             </div>
             <h3 className="text-2xl font-medium tracking-tight">{name}</h3>
             {isReclaiming(lease) && <StatusBadge label="Reclaiming" tone="warning" />}
+            {isProviderUnreachable && <StatusBadge label="Provider not responding" tone="warning" />}
           </div>
           {(region || providerName) && (
             <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.tsx
@@ -58,7 +58,7 @@ export const PlacementCard: FC<PlacementCardProps> = ({
 }) => {
   const isLeaseActive = isLeaseLive(lease);
   const { data: leaseStatus, error: leaseStatusError } = d.useLeaseStatus({ provider, lease, enabled: isLeaseActive && !!provider, refetchInterval: 30_000 });
-  const isProviderUnreachable = isProviderUnavailableError(leaseStatusError);
+  const isProviderUnreachable = isLeaseActive && isProviderUnavailableError(leaseStatusError);
   const carveouts = d.useTeeResourceCarveouts(lease);
   const [expanded, setExpanded] = useState<ReadonlySet<string>>(() => new Set());
 

--- a/apps/deploy-web/src/components/deployments/LeaseRow.tsx
+++ b/apps/deploy-web/src/components/deployments/LeaseRow.tsx
@@ -24,6 +24,7 @@ import { useBidInfo } from "@src/queries/useBidQuery";
 import type { LeaseStatusDto } from "@src/queries/useLeaseQuery";
 import { useLeaseStatus } from "@src/queries/useLeaseQuery";
 import { useProviderStatus } from "@src/queries/useProvidersQuery";
+import { isProviderUnavailableError } from "@src/services/query-error-policy/query-error-policy";
 import type { LeaseDto } from "@src/types/deployment";
 import type { ApiProviderList } from "@src/types/provider";
 import { copyTextToClipboard } from "@src/utils/copyClipboard";
@@ -89,6 +90,7 @@ export const LeaseRow = React.forwardRef<AcceptRefType, Props>(
     });
     const errorMessage = typeof error === "string" ? error : error?.message;
     const isLeaseNotFound = errorMessage?.includes("lease not found") && isLeaseActive;
+    const isProviderUnreachable = isProviderUnavailableError(error) && isLeaseActive;
     const servicesNames = useMemo(() => (leaseStatus ? Object.keys(leaseStatus.services) : []), [leaseStatus]);
     const [isSendingManifest, setIsSendingManifest] = useState(false);
     const { data: bid } = useBidInfo(lease.owner, lease.dseq, lease.gseq, lease.oseq, lease.provider);
@@ -258,6 +260,13 @@ export const LeaseRow = React.forwardRef<AcceptRefType, Props>(
               }
             />
           </div>
+
+          {isProviderUnreachable && (
+            <Alert variant="warning">
+              This provider is not responding, so the status of your services cannot be shown. The lease stays open and continues to be billed until you close
+              the deployment.
+            </Alert>
+          )}
 
           {isLeaseNotFound && (
             <Alert variant="warning">

--- a/apps/deploy-web/src/queries/useLeaseQuery.spec.tsx
+++ b/apps/deploy-web/src/queries/useLeaseQuery.spec.tsx
@@ -8,6 +8,7 @@ import type { Props as ServicesProviderProps } from "@src/context/ServicesProvid
 import type { UseProviderCredentialsResult } from "@src/hooks/useProviderCredentials/useProviderCredentials";
 import type { FallbackableHttpClient } from "@src/services/createFallbackableHttpClient/createFallbackableHttpClient";
 import type { ProviderProxyService } from "@src/services/provider-proxy/provider-proxy.service";
+import { isProviderUnavailableError } from "@src/services/query-error-policy/query-error-policy";
 import type { DeploymentGroup, LeaseDto } from "@src/types/deployment";
 import type { ApiProviderList } from "@src/types/provider";
 import { leaseToDto } from "@src/utils/deploymentDetailUtils";
@@ -603,6 +604,25 @@ describe("useLeaseQuery", () => {
       await vi.waitFor(() => {
         expect(result.current.data).toBeNull();
       });
+    });
+
+    it.each([502, 503])("surfaces a %s from the provider proxy as a provider-unavailable error", async status => {
+      const providerProxy = mock<ProviderProxyService>({
+        request: vi.fn().mockRejectedValue(new AxiosError("Unavailable", String(status), undefined, undefined, { status } as any))
+      });
+      const { result } = setupLeaseStatus({
+        lease: mockLease,
+        services: {
+          providerProxy: () => providerProxy
+        }
+      });
+
+      await vi.waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      expect(isProviderUnavailableError(result.current.error)).toBe(true);
+      expect(providerProxy.request).toHaveBeenCalledTimes(1);
     });
 
     it("fetches lease status when a JWT is available", async () => {

--- a/apps/deploy-web/src/queries/useLeaseQuery.ts
+++ b/apps/deploy-web/src/queries/useLeaseQuery.ts
@@ -7,6 +7,7 @@ import mapValues from "lodash/mapValues";
 import { useServices } from "@src/context/ServicesProvider";
 import { useProviderCredentials } from "@src/hooks/useProviderCredentials/useProviderCredentials";
 import { useScopedFetchProviderUrl } from "@src/hooks/useScopedFetchProviderUrl";
+import { isProviderUnavailableError, retryOnServerError, SKIP_REPORTING_PROVIDER_UNAVAILABLE } from "@src/services/query-error-policy/query-error-policy";
 import type { DeploymentDto, LeaseDto, RpcLease } from "@src/types/deployment";
 import type { ApiProviderList } from "@src/types/provider";
 import { ApiUrlService, loadWithPagination } from "@src/utils/apiUtils";
@@ -129,6 +130,8 @@ export function useLeaseStatus(
         request: (url, requestOptions) => fetchProviderUrl(url, requestOptions)
       }),
     ...options,
+    retry: retryUnlessProviderIsUnavailable,
+    meta: SKIP_REPORTING_PROVIDER_UNAVAILABLE,
     enabled: options.enabled !== false && !!provider?.hostUri && providerCredentials.details.usable,
     // Defensive: the attestation sidecar is a pod container under the current provider design and
     // never appears as a lease-status service, so this is a passthrough today. It keeps the sidecar
@@ -165,6 +168,8 @@ export function useLeaseStatuses(
         });
       },
       ...options,
+      retry: retryUnlessProviderIsUnavailable,
+      meta: SKIP_REPORTING_PROVIDER_UNAVAILABLE,
       enabled: options.enabled !== false && !!provider?.hostUri && providerCredentials.details.usable,
       select: (data: LeaseStatusDto | null) => {
         const filtered = data ? omitAttestationSidecar(data) : data;
@@ -176,6 +181,14 @@ export function useLeaseStatuses(
 
 function leaseStatusQueryKey(lease?: LeaseDto | null) {
   return QueryKeys.getLeaseStatusKey(lease?.dseq || "", lease?.gseq ?? 0, lease?.oseq ?? 0);
+}
+
+/**
+ * An unreachable provider is not a Console fault and retrying cannot fix it, so these polls fail on the first
+ * attempt instead of burning three and reporting each one.
+ */
+function retryUnlessProviderIsUnavailable(failureCount: number, error: unknown): boolean {
+  return !isProviderUnavailableError(error) && retryOnServerError(failureCount, error);
 }
 
 function isLeaseStatusUnavailable(error: unknown): boolean {

--- a/apps/deploy-web/src/services/app-di-container/app-di-container.ts
+++ b/apps/deploy-web/src/services/app-di-container/app-di-container.ts
@@ -5,7 +5,6 @@ import {
   AuthHttpService,
   createHttpClient,
   DeploymentSettingHttpService,
-  isHttpError,
   ManagedDeploymentHttpService,
   ManagedWalletHttpService,
   StripeService as HttpStripeService,
@@ -20,6 +19,7 @@ import type { Axios, AxiosInstance, AxiosResponse, InternalAxiosRequestConfig } 
 import { browserEnvConfig } from "@src/config/browser-env.config";
 import { UrlReturnToStack } from "@src/hooks/useReturnTo/UrlReturnToStack";
 import { AnalyticsService } from "@src/services/analytics/analytics.service";
+import { retryOnServerError, shouldReportQueryError } from "@src/services/query-error-policy/query-error-policy";
 import networkStore from "@src/store/networkStore";
 import { registry } from "@src/utils/customRegistry";
 import { UrlService } from "@src/utils/urlUtils";
@@ -157,13 +157,14 @@ export const createAppRootContainer = (config: ServicesConfig) => {
       new QueryClient({
         defaultOptions: {
           queries: {
-            retry(failureCount, error) {
-              return isHttpError(error) && !!error.response && error.response.status >= 500 && failureCount < 3;
-            }
+            retry: retryOnServerError
           }
         },
         queryCache: new QueryCache({
-          onError: error => container.errorHandler.reportError({ error })
+          onError: (error, query) => {
+            if (!shouldReportQueryError(error, query.meta)) return;
+            container.errorHandler.reportError({ error });
+          }
         }),
         mutationCache: new MutationCache({
           onError: error => container.errorHandler.reportError({ error })

--- a/apps/deploy-web/src/services/query-error-policy/query-error-policy.spec.ts
+++ b/apps/deploy-web/src/services/query-error-policy/query-error-policy.spec.ts
@@ -1,0 +1,71 @@
+import { AxiosError } from "axios";
+import { describe, expect, it, vi } from "vitest";
+
+import { isProviderUnavailableError, retryOnServerError, shouldReportQueryError, SKIP_REPORTING_PROVIDER_UNAVAILABLE } from "./query-error-policy";
+
+describe("query-error-policy", () => {
+  describe("isProviderUnavailableError", () => {
+    it.each([502, 503])("is true for a %s from the provider proxy", status => {
+      expect(isProviderUnavailableError(httpError(status))).toBe(true);
+    });
+
+    it.each([404, 500, 400])("is false for a %s", status => {
+      expect(isProviderUnavailableError(httpError(status))).toBe(false);
+    });
+
+    it("is false when there is no response at all", () => {
+      expect(isProviderUnavailableError(new AxiosError("Network Error", "ERR_NETWORK"))).toBe(false);
+    });
+
+    it("is false for a non-http error", () => {
+      expect(isProviderUnavailableError(new Error("boom"))).toBe(false);
+    });
+  });
+
+  describe("retryOnServerError", () => {
+    it("retries a server error up to three times", () => {
+      expect(retryOnServerError(0, httpError(500))).toBe(true);
+      expect(retryOnServerError(2, httpError(500))).toBe(true);
+      expect(retryOnServerError(3, httpError(500))).toBe(false);
+    });
+
+    it("does not retry a client error", () => {
+      expect(retryOnServerError(0, httpError(404))).toBe(false);
+    });
+
+    it("does not retry a non-http error", () => {
+      expect(retryOnServerError(0, new Error("boom"))).toBe(false);
+    });
+  });
+
+  describe("shouldReportQueryError", () => {
+    it("reports when the query carries no meta", () => {
+      expect(shouldReportQueryError(httpError(500), undefined)).toBe(true);
+    });
+
+    it("reports when the query opts out of a different error", () => {
+      expect(shouldReportQueryError(httpError(500), SKIP_REPORTING_PROVIDER_UNAVAILABLE)).toBe(true);
+    });
+
+    it("stays quiet for the error the query opted out of", () => {
+      expect(shouldReportQueryError(httpError(502), SKIP_REPORTING_PROVIDER_UNAVAILABLE)).toBe(false);
+    });
+
+    it("passes the error to the predicate", () => {
+      const skipErrorReporting = vi.fn().mockReturnValue(false);
+      const error = httpError(500);
+
+      shouldReportQueryError(error, { skipErrorReporting });
+
+      expect(skipErrorReporting).toHaveBeenCalledWith(error);
+    });
+
+    it("reports when meta holds no predicate", () => {
+      expect(shouldReportQueryError(httpError(502), { somethingElse: true })).toBe(true);
+    });
+  });
+
+  function httpError(status: number) {
+    return new AxiosError("Request failed", String(status), undefined, undefined, { status } as never);
+  }
+});

--- a/apps/deploy-web/src/services/query-error-policy/query-error-policy.ts
+++ b/apps/deploy-web/src/services/query-error-policy/query-error-policy.ts
@@ -1,0 +1,30 @@
+import { isHttpError } from "@akashnetwork/http-sdk";
+
+const MAX_SERVER_ERROR_RETRIES = 3;
+
+/** The provider proxy answers 502 when it cannot reach the provider host and 503 when the provider itself failed. */
+const PROVIDER_UNAVAILABLE_STATUSES = [502, 503];
+
+/** Server errors are usually transient, so they get a few attempts. Everything else fails on the first try. */
+export function retryOnServerError(failureCount: number, error: unknown): boolean {
+  return isHttpError(error) && !!error.response && error.response.status >= 500 && failureCount < MAX_SERVER_ERROR_RETRIES;
+}
+
+/**
+ * Whether a request failed because the provider behind the proxy is down rather than because Console is.
+ * Only meaningful for calls that go through the provider proxy, since it owns these two statuses.
+ */
+export function isProviderUnavailableError(error: unknown): boolean {
+  return isHttpError(error) && !!error.response && PROVIDER_UNAVAILABLE_STATUSES.includes(error.response.status);
+}
+
+/**
+ * Queries opt out of error reporting by putting a predicate on React Query's `meta`, which is the documented
+ * way to hand per-query policy to the global cache handler.
+ */
+export function shouldReportQueryError(error: unknown, meta: Record<string, unknown> | undefined): boolean {
+  const skipErrorReporting = meta?.skipErrorReporting;
+  return typeof skipErrorReporting === "function" ? !skipErrorReporting(error) : true;
+}
+
+export const SKIP_REPORTING_PROVIDER_UNAVAILABLE = { skipErrorReporting: isProviderUnavailableError };


### PR DESCRIPTION
> Stacked on #3647. Review that one first; this PR's base is `fix/deployment-skip-non-live-lease-status` and will be retargeted to `main` once it merges.

## Why

While tracking down the provider-proxy 503 alert (#3647) I found a mainnet account in a state the UI says nothing about: an active lease with open escrow on a provider whose host is unroutable. The deployment page renders no services, which looks identical to a deployment that has not started yet, and the lease keeps being billed. That account has been in this state long enough to show up as 507 failed status polls in 24 hours.

The same polls were also generating noise nobody asked for. A 502 or 503 from the proxy fell through `isLeaseStatusUnavailable`, which only handles 404 and network errors, so React Query retried each failed poll three times and the global query cache handler sent one Sentry event per poll per open tab. Retrying cannot reach a host that is unreachable.

## What

### Surface the failure instead of swallowing it

Lease status polls now let a provider-unavailable error through, and the placement card renders a `Provider not responding` badge next to the existing status badges. A 404 still collapses to no status, since a provider that answers and has no such lease is a different situation with different advice.

The legacy detail page (still live behind the redesign flag) gets an equivalent warning in `LeaseRow`, which says the lease stays open and continues to be billed until the deployment is closed.

### Stop the retries and the Sentry events

The retry rule and the two predicates move out of `app-di-container` into `services/query-error-policy`, since the lease-status hooks now need to compose them rather than just inherit them. The reporting opt-out rides on React Query's `meta`, which is the documented way to hand per-query policy to the global cache handler, so it stays scoped to lease status. A Console fault on the same query still retries and still reports.

## Notes for review

- `retry` and `meta` are applied after `...options` in both hooks, alongside `enabled`, so the hook owns this policy. No caller passes either today.
- 502 and 503 are both treated as provider-unavailable. 503 is what the proxy returns for a provider that answered 5xx, and 502 is what #3647 introduces for a host that could not be reached. Neither is a Console fault and neither has a status to show.
- A 500 from the proxy is untouched: it still retries and still reports.

## Verification

`npm test`, `npm run lint -- --quiet`, and `npx tsc --noEmit` in `apps/deploy-web`. 360 test files and 3455 tests pass, up from 359 and 3435. tsc error count is unchanged against the pre-existing baseline of 136.

New coverage: 15 cases for the policy module, 2 hook cases asserting a 502 and a 503 surface as provider-unavailable with exactly one request attempted, and 3 PlacementCard cases for the badge.
