### PR TITLE
refactor(provider): stop re-dialing a provider host that is known to be down

### DIFF
--- a/apps/provider-proxy/src/config/env.config.ts
+++ b/apps/provider-proxy/src/config/env.config.ts
@@ -6,7 +6,13 @@ export const appConfigSchema = z.object({
     .enum(["true", "false"])
     .default("false")
     .transform(val => val === "true"),
-  PORT: z.number({ coerce: true }).min(0).default(3040)
+  PORT: z.number({ coerce: true }).min(0).default(3040),
+  PROVIDER_UNREACHABLE_TRACKING_ENABLED: z
+    .enum(["true", "false"])
+    .default("true")
+    .transform(val => val === "true"),
+  PROVIDER_UNREACHABLE_FAILURE_THRESHOLD: z.number({ coerce: true }).min(1).default(3),
+  PROVIDER_UNREACHABLE_COOLDOWN_MS: z.number({ coerce: true }).min(0).default(60_000)
 });
 
 export type AppConfig = z.infer<typeof appConfigSchema>;

--- a/apps/provider-proxy/src/container.ts
+++ b/apps/provider-proxy/src/container.ts
@@ -6,6 +6,7 @@ import { createOtelLogger } from "@akashnetwork/logging/otel";
 import type { AppConfig } from "./config/env.config";
 import { appConfigSchema } from "./config/env.config";
 import { CertificateValidator, createCertificateValidatorInstrumentation } from "./services/CertificateValidator/CertificateValidator";
+import { createProviderConnectionTrackerInstrumentation, ProviderConnectionTracker } from "./services/ProviderConnectionTracker/ProviderConnectionTracker";
 import { ProviderProxy } from "./services/ProviderProxy";
 import { ProviderService } from "./services/ProviderService/ProviderService";
 import { WebsocketStats } from "./services/WebsocketStats";
@@ -15,6 +16,7 @@ export interface Container {
   wsStats: WebsocketStats;
   providerProxy: ProviderProxy;
   certificateValidator: CertificateValidator;
+  providerConnectionTracker: ProviderConnectionTracker | undefined;
   httpLogger: LoggerService | undefined;
   httpLoggerInterceptor: HttpLoggerInterceptor;
   wsLogger: LoggerService | undefined;
@@ -45,7 +47,21 @@ export function createContainer(untrustedConfig: Record<string, unknown>): Conta
     providerService,
     isLoggingDisabled ? undefined : createCertificateValidatorInstrumentation(createOtelLogger({ name: "cert-validator" }))
   );
-  const providerProxy = new ProviderProxy(certificateValidator, appConfig.ALLOW_PROXY_TO_LOCAL_NETWORK ? undefined : createForbidPrivateNetworkLookup());
+  const providerConnectionTracker = appConfig.PROVIDER_UNREACHABLE_TRACKING_ENABLED
+    ? new ProviderConnectionTracker(
+        Date.now,
+        {
+          failureThreshold: appConfig.PROVIDER_UNREACHABLE_FAILURE_THRESHOLD,
+          cooldownMs: appConfig.PROVIDER_UNREACHABLE_COOLDOWN_MS
+        },
+        isLoggingDisabled ? undefined : createProviderConnectionTrackerInstrumentation(createOtelLogger({ name: "connection-tracker" }))
+      )
+    : undefined;
+  const providerProxy = new ProviderProxy(
+    certificateValidator,
+    appConfig.ALLOW_PROXY_TO_LOCAL_NETWORK ? undefined : createForbidPrivateNetworkLookup(),
+    providerConnectionTracker
+  );
   const wsLogger = isLoggingDisabled ? undefined : createOtelLogger({ name: "ws" });
   const httpLogger = isLoggingDisabled ? undefined : createOtelLogger({ name: "http" });
   const httpLoggerInterceptor = new HttpLoggerInterceptor(httpLogger);
@@ -54,6 +70,7 @@ export function createContainer(untrustedConfig: Record<string, unknown>): Conta
     wsStats,
     providerProxy,
     certificateValidator,
+    providerConnectionTracker,
     httpLogger,
     httpLoggerInterceptor,
     wsLogger,

--- a/apps/provider-proxy/src/routes/proxyProviderRequest.ts
+++ b/apps/provider-proxy/src/routes/proxyProviderRequest.ts
@@ -98,7 +98,7 @@ export async function proxyProviderRequest(ctx: AppContext): Promise<Response | 
     {
       retryIf(result) {
         const isServerError = result.ok && (!result.response.statusCode || result.response.statusCode >= 500);
-        const isConnectionError = result.ok === false && result.code === "connectionError" && canRetryOnError(result.error);
+        const isConnectionError = result.ok === false && result.code === "connectionError" && !result.shortCircuited && canRetryOnError(result.error);
         return !clientAbortSignal.aborted && (isServerError || isConnectionError);
       },
       logger: ctx.get("container").appLogger
@@ -125,6 +125,7 @@ export async function proxyProviderRequest(ctx: AppContext): Promise<Response | 
       event: "PROXY_REQUEST_ERROR",
       errorCategory,
       errno,
+      shortCircuited: proxyResult.shortCircuited ?? false,
       url,
       method,
       providerAddress,

--- a/apps/provider-proxy/src/services/ProviderConnectionTracker/ProviderConnectionTracker.spec.ts
+++ b/apps/provider-proxy/src/services/ProviderConnectionTracker/ProviderConnectionTracker.spec.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { ProviderConnectionTrackerInstrumentation } from "./ProviderConnectionTracker";
+import { ProviderConnectionTracker } from "./ProviderConnectionTracker";
+
+describe(ProviderConnectionTracker.name, () => {
+  it("keeps dialing until the failure threshold is reached", () => {
+    const { tracker, fail } = setup({ failureThreshold: 3 });
+
+    fail("provider-a");
+    fail("provider-a");
+
+    expect(tracker.shouldSkipDial("provider-a")).toBe(false);
+
+    fail("provider-a");
+
+    expect(tracker.shouldSkipDial("provider-a")).toBe(true);
+  });
+
+  it.each(["ECONNRESET", "ETIMEDOUT", "EPIPE"])("never starts a cooldown for %s", errno => {
+    const { tracker, fail } = setup({ failureThreshold: 1 });
+
+    fail("provider-a", errno);
+    fail("provider-a", errno);
+
+    expect(tracker.shouldSkipDial("provider-a")).toBe(false);
+  });
+
+  it("allows exactly one probe per cooldown window, even when asked concurrently", () => {
+    const { tracker, fail, advance } = setup({ failureThreshold: 1, cooldownMs: 60_000 });
+
+    fail("provider-a");
+    advance(60_000);
+
+    expect(tracker.shouldSkipDial("provider-a")).toBe(false);
+    expect(tracker.shouldSkipDial("provider-a")).toBe(true);
+    expect(tracker.shouldSkipDial("provider-a")).toBe(true);
+  });
+
+  it("re-arms the cooldown when the probe fails again", () => {
+    const { tracker, fail, advance } = setup({ failureThreshold: 1, cooldownMs: 60_000 });
+
+    fail("provider-a");
+    advance(60_000);
+    tracker.shouldSkipDial("provider-a");
+    advance(30_000);
+
+    expect(tracker.shouldSkipDial("provider-a")).toBe(true);
+  });
+
+  it("resumes dialing once the provider answers", () => {
+    const { tracker, fail } = setup({ failureThreshold: 1 });
+
+    fail("provider-a");
+    tracker.recordReachable("provider-a");
+
+    expect(tracker.shouldSkipDial("provider-a")).toBe(false);
+  });
+
+  it("counts failures per key", () => {
+    const { tracker, fail } = setup({ failureThreshold: 2 });
+
+    fail("provider-a");
+    fail("provider-b");
+    fail("provider-a");
+
+    expect(tracker.shouldSkipDial("provider-a")).toBe(true);
+    expect(tracker.shouldSkipDial("provider-b")).toBe(false);
+  });
+
+  it("hands back the error that caused the cooldown", () => {
+    const { tracker } = setup({ failureThreshold: 1 });
+    const error = Object.assign(new Error("connect EHOSTUNREACH"), { code: "EHOSTUNREACH" });
+
+    tracker.recordUnreachable("provider-a", error, "EHOSTUNREACH");
+
+    expect(tracker.getLastError("provider-a")).toBe(error);
+  });
+
+  it("reports a cooldown starting and clearing", () => {
+    const instrumentation = { onCooldownStarted: vi.fn(), onProbeAllowed: vi.fn(), onCleared: vi.fn() };
+    const { tracker, fail } = setup({ failureThreshold: 1, instrumentation });
+
+    fail("provider-a");
+    tracker.recordReachable("provider-a");
+
+    expect(instrumentation.onCooldownStarted).toHaveBeenCalledWith("provider-a", "EHOSTUNREACH", expect.any(Number));
+    expect(instrumentation.onCleared).toHaveBeenCalledWith("provider-a");
+  });
+
+  it("stays quiet about a provider it never saw fail", () => {
+    const instrumentation = { onCleared: vi.fn() };
+    const { tracker } = setup({ instrumentation });
+
+    tracker.recordReachable("provider-a");
+
+    expect(instrumentation.onCleared).not.toHaveBeenCalled();
+  });
+
+  function setup(input: { failureThreshold?: number; cooldownMs?: number; instrumentation?: ProviderConnectionTrackerInstrumentation } = {}) {
+    let clock = 1_000;
+    const tracker = new ProviderConnectionTracker(
+      () => clock,
+      { failureThreshold: input.failureThreshold ?? 3, cooldownMs: input.cooldownMs ?? 60_000 },
+      input.instrumentation
+    );
+
+    return {
+      tracker,
+      advance: (ms: number) => {
+        clock += ms;
+      },
+      fail: (key: string, errno = "EHOSTUNREACH") => tracker.recordUnreachable(key, Object.assign(new Error(errno), { code: errno }), errno)
+    };
+  }
+});

--- a/apps/provider-proxy/src/services/ProviderConnectionTracker/ProviderConnectionTracker.spec.ts
+++ b/apps/provider-proxy/src/services/ProviderConnectionTracker/ProviderConnectionTracker.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import type { ProviderConnectionTrackerInstrumentation } from "./ProviderConnectionTracker";
-import { ProviderConnectionTracker } from "./ProviderConnectionTracker";
+import { ProviderConnectionTracker, toStateRetentionMs } from "./ProviderConnectionTracker";
 
 describe(ProviderConnectionTracker.name, () => {
   it("keeps dialing until the failure threshold is reached", () => {
@@ -95,6 +95,14 @@ describe(ProviderConnectionTracker.name, () => {
     tracker.recordReachable("provider-a");
 
     expect(instrumentation.onCleared).not.toHaveBeenCalled();
+  });
+
+  it("keeps a short-cooldown provider in memory for the default retention", () => {
+    expect(toStateRetentionMs(60_000)).toBe(10 * 60 * 1000);
+  });
+
+  it("retains a provider past a cooldown longer than the default retention", () => {
+    expect(toStateRetentionMs(15 * 60 * 1000)).toBeGreaterThan(15 * 60 * 1000);
   });
 
   function setup(input: { failureThreshold?: number; cooldownMs?: number; instrumentation?: ProviderConnectionTrackerInstrumentation } = {}) {

--- a/apps/provider-proxy/src/services/ProviderConnectionTracker/ProviderConnectionTracker.ts
+++ b/apps/provider-proxy/src/services/ProviderConnectionTracker/ProviderConnectionTracker.ts
@@ -1,0 +1,92 @@
+import type { LoggerService } from "@akashnetwork/logging";
+import { LRUCache } from "lru-cache";
+
+/**
+ * Errnos that mean the host itself is not there: no route, no DNS, nothing listening. They stay true for as
+ * long as the provider is down, so re-dialing on every request only buys another connect timeout.
+ *
+ * ECONNRESET, ETIMEDOUT and EPIPE are deliberately absent. The proxy destroys its own request when the
+ * per-attempt timeout fires and a client abort does the same, both surfacing as ECONNRESET, so treating them
+ * as unreachable would let one slow poll blind every other caller on a healthy provider.
+ */
+const UNREACHABLE_ERRNOS = ["EHOSTUNREACH", "ENETUNREACH", "ENOTFOUND", "EAI_AGAIN", "ECONNREFUSED"];
+
+export interface ProviderConnectionTrackerOptions {
+  failureThreshold: number;
+  cooldownMs: number;
+}
+
+export interface ProviderConnectionTrackerInstrumentation {
+  onCooldownStarted?(key: string, errno: string, until: number): void;
+  onProbeAllowed?(key: string, consecutiveFailures: number): void;
+  onCleared?(key: string): void;
+}
+
+interface ProviderConnectionState {
+  consecutiveFailures: number;
+  cooldownUntil: number;
+  lastError: unknown;
+}
+
+export class ProviderConnectionTracker {
+  private readonly states = new LRUCache<string, ProviderConnectionState>({
+    max: 10_000,
+    ttl: 10 * 60 * 1000
+  });
+
+  constructor(
+    private readonly now: () => number,
+    private readonly options: ProviderConnectionTrackerOptions,
+    private readonly instrumentation?: ProviderConnectionTrackerInstrumentation
+  ) {}
+
+  /**
+   * Consumes the single probe allowed per cooldown window, so calling this is a decision rather than a
+   * question. Letting the probe through also re-arms the window, which means a stampede of concurrent
+   * requests produces exactly one dial and a still-dead provider stays skipped without any timer.
+   */
+  shouldSkipDial(key: string): boolean {
+    const state = this.states.get(key);
+    if (!state || state.cooldownUntil === 0) return false;
+
+    if (this.now() < state.cooldownUntil) return true;
+
+    state.cooldownUntil = this.now() + this.options.cooldownMs;
+    this.instrumentation?.onProbeAllowed?.(key, state.consecutiveFailures);
+    return false;
+  }
+
+  recordUnreachable(key: string, error: unknown, errno: string | undefined): void {
+    if (!errno || !UNREACHABLE_ERRNOS.includes(errno)) return;
+
+    const state = this.states.get(key) ?? { consecutiveFailures: 0, cooldownUntil: 0, lastError: error };
+    state.consecutiveFailures += 1;
+    state.lastError = error;
+
+    if (state.consecutiveFailures >= this.options.failureThreshold) {
+      state.cooldownUntil = this.now() + this.options.cooldownMs;
+      this.instrumentation?.onCooldownStarted?.(key, errno, state.cooldownUntil);
+    }
+
+    this.states.set(key, state);
+  }
+
+  recordReachable(key: string): void {
+    if (!this.states.has(key)) return;
+
+    this.states.delete(key);
+    this.instrumentation?.onCleared?.(key);
+  }
+
+  getLastError(key: string): unknown {
+    return this.states.get(key)?.lastError;
+  }
+}
+
+export function createProviderConnectionTrackerInstrumentation(logger: LoggerService): ProviderConnectionTrackerInstrumentation {
+  return {
+    onCooldownStarted: (key, errno, until) => logger.warn({ event: "PROVIDER_UNREACHABLE_COOLDOWN_STARTED", key, errno, until }),
+    onProbeAllowed: (key, consecutiveFailures) => logger.info({ event: "PROVIDER_UNREACHABLE_PROBE_ALLOWED", key, consecutiveFailures }),
+    onCleared: key => logger.info({ event: "PROVIDER_UNREACHABLE_CLEARED", key })
+  };
+}

--- a/apps/provider-proxy/src/services/ProviderConnectionTracker/ProviderConnectionTracker.ts
+++ b/apps/provider-proxy/src/services/ProviderConnectionTracker/ProviderConnectionTracker.ts
@@ -11,6 +11,18 @@ import { LRUCache } from "lru-cache";
  */
 const UNREACHABLE_ERRNOS = ["EHOSTUNREACH", "ENETUNREACH", "ENOTFOUND", "EAI_AGAIN", "ECONNREFUSED"];
 
+/** Floor for how long a tracked provider is kept in memory. Eviction is a memory backstop, never a decision. */
+const MIN_STATE_RETENTION_MS = 10 * 60 * 1000;
+
+/**
+ * An entry must outlive the cooldown it encodes: evicting mid-cooldown would resume dialing a host we already
+ * know is down. Only a dial result rewrites the entry and refreshes its age, so retention spans two windows to
+ * cover the one path that skips the write, a probe failing with an errno outside UNREACHABLE_ERRNOS.
+ */
+export function toStateRetentionMs(cooldownMs: number): number {
+  return Math.max(MIN_STATE_RETENTION_MS, cooldownMs * 2);
+}
+
 export interface ProviderConnectionTrackerOptions {
   failureThreshold: number;
   cooldownMs: number;
@@ -29,16 +41,18 @@ interface ProviderConnectionState {
 }
 
 export class ProviderConnectionTracker {
-  private readonly states = new LRUCache<string, ProviderConnectionState>({
-    max: 10_000,
-    ttl: 10 * 60 * 1000
-  });
+  private readonly states: LRUCache<string, ProviderConnectionState>;
 
   constructor(
     private readonly now: () => number,
     private readonly options: ProviderConnectionTrackerOptions,
     private readonly instrumentation?: ProviderConnectionTrackerInstrumentation
-  ) {}
+  ) {
+    this.states = new LRUCache<string, ProviderConnectionState>({
+      max: 10_000,
+      ttl: toStateRetentionMs(options.cooldownMs)
+    });
+  }
 
   /**
    * Consumes the single probe allowed per cooldown window, so calling this is a decision rather than a

--- a/apps/provider-proxy/src/services/ProviderProxy.spec.ts
+++ b/apps/provider-proxy/src/services/ProviderProxy.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { CertificateValidator } from "./CertificateValidator/CertificateValidator";
+import type { ProviderConnectionTracker } from "./ProviderConnectionTracker/ProviderConnectionTracker";
+import { ProviderProxy } from "./ProviderProxy";
+
+describe(ProviderProxy.name, () => {
+  it("returns the cached failure without dialing while the provider is in cooldown", async () => {
+    const error = Object.assign(new Error("connect EHOSTUNREACH"), { code: "EHOSTUNREACH" });
+    const { proxy, connectionTracker } = setup({ shouldSkipDial: true, lastError: error });
+
+    const result = await proxy.connect("https://provider.example.com:8443/lease/1/1/1/status", {
+      method: "GET",
+      providerAddress: "akash1provider"
+    });
+
+    expect(result).toEqual({ ok: false, code: "connectionError", error, shortCircuited: true });
+    expect(connectionTracker.getLastError).toHaveBeenCalledWith("akash1provider|https://provider.example.com:8443");
+  });
+
+  it("keys the cooldown by provider and dial target together", async () => {
+    const { proxy, connectionTracker } = setup({ shouldSkipDial: true });
+
+    await proxy.connect("https://provider.example.com:8443/status", { method: "GET", providerAddress: "akash1provider" });
+
+    expect(connectionTracker.shouldSkipDial).toHaveBeenCalledWith("akash1provider|https://provider.example.com:8443");
+  });
+
+  it("does not consult the tracker when there is no provider to key on", async () => {
+    const { proxy, connectionTracker } = setup({ shouldSkipDial: true });
+
+    await proxy.connect("https://provider.example.com:8443/status", { method: "GET", providerAddress: "", signal: AbortSignal.abort() });
+
+    expect(connectionTracker.shouldSkipDial).not.toHaveBeenCalled();
+  });
+
+  function setup(input: { shouldSkipDial?: boolean; lastError?: unknown } = {}) {
+    const connectionTracker = mock<ProviderConnectionTracker>({
+      shouldSkipDial: vi.fn().mockReturnValue(input.shouldSkipDial ?? false),
+      getLastError: vi.fn().mockReturnValue(input.lastError)
+    });
+    const proxy = new ProviderProxy(mock<CertificateValidator>(), undefined, connectionTracker);
+
+    return { proxy, connectionTracker };
+  }
+});

--- a/apps/provider-proxy/src/services/ProviderProxy.spec.ts
+++ b/apps/provider-proxy/src/services/ProviderProxy.spec.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "node:events";
+import type { ClientRequest } from "node:http";
+import https from "node:https";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { CertificateValidator } from "./CertificateValidator/CertificateValidator";
@@ -29,11 +32,27 @@ describe(ProviderProxy.name, () => {
 
   it("does not consult the tracker when there is no provider to key on", async () => {
     const { proxy, connectionTracker } = setup({ shouldSkipDial: true });
+    const error = Object.assign(new Error("connect ECONNREFUSED"), { code: "ECONNREFUSED" });
+    stubDialFailure(error);
 
-    await proxy.connect("https://provider.example.com:8443/status", { method: "GET", providerAddress: "", signal: AbortSignal.abort() });
+    const result = await proxy.connect("https://provider.example.com:8443/status", { method: "GET", providerAddress: "" });
 
+    expect(result).toEqual({ ok: false, code: "connectionError", error });
     expect(connectionTracker.shouldSkipDial).not.toHaveBeenCalled();
+    expect(connectionTracker.recordUnreachable).not.toHaveBeenCalled();
   });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function stubDialFailure(error: Error) {
+    const request = Object.assign(new EventEmitter(), { write: vi.fn(), end: vi.fn(), destroy: vi.fn(), reusedSocket: false });
+    vi.spyOn(https, "request").mockImplementation(() => {
+      setImmediate(() => request.emit("error", error));
+      return request as unknown as ClientRequest;
+    });
+  }
 
   function setup(input: { shouldSkipDial?: boolean; lastError?: unknown } = {}) {
     const connectionTracker = mock<ProviderConnectionTracker>({

--- a/apps/provider-proxy/src/services/ProviderProxy.ts
+++ b/apps/provider-proxy/src/services/ProviderProxy.ts
@@ -7,9 +7,11 @@ import { TLSSocket } from "node:tls";
 import type { z } from "zod";
 
 import type { NetworkLookup } from "../utils/createForbidPrivateNetworkLookup/createForbidPrivateNetworkLookup";
+import { toErrno } from "../utils/errno";
 import type { providerRequestSchema } from "../utils/schema";
 import { propagateTracingContext } from "../utils/telemetry";
 import type { CertificateValidator, CertValidationResultError } from "./CertificateValidator/CertificateValidator";
+import type { ProviderConnectionTracker } from "./ProviderConnectionTracker/ProviderConnectionTracker";
 
 export class ProviderProxy {
   /**
@@ -20,13 +22,26 @@ export class ProviderProxy {
   });
   readonly #certificateValidator: CertificateValidator;
   readonly #networkLookup?: NetworkLookup;
+  readonly #connectionTracker?: ProviderConnectionTracker;
 
-  constructor(certificateValidator: CertificateValidator, networkLookup?: NetworkLookup) {
+  constructor(certificateValidator: CertificateValidator, networkLookup?: NetworkLookup, connectionTracker?: ProviderConnectionTracker) {
     this.#certificateValidator = certificateValidator;
     this.#networkLookup = networkLookup;
+    this.#connectionTracker = connectionTracker;
   }
 
   connect(url: string, options: ProxyConnectOptions): Promise<ProxyConnectionResult> {
+    const trackerKey = this.getTrackerKey(url, options);
+
+    if (trackerKey && this.#connectionTracker?.shouldSkipDial(trackerKey)) {
+      return Promise.resolve({
+        ok: false,
+        code: "connectionError",
+        error: this.#connectionTracker.getLastError(trackerKey),
+        shortCircuited: true
+      });
+    }
+
     return new Promise<ProxyConnectionResult>((resolve, reject) => {
       const { agentCacheKey, ...requestOptions } = this.getRequestOptions(options);
       const req = https.request(
@@ -37,15 +52,19 @@ export class ProviderProxy {
             res.on(
               "error",
               propagateTracingContext(error => {
+                this.recordUnreachable(trackerKey, error);
                 resolve({ ok: false, code: "connectionError", error });
               })
             );
 
             const socket = res.socket;
             if (!socket || !(socket instanceof TLSSocket)) {
+              this.recordReachable(trackerKey);
               res.destroy();
               return resolve({ ok: false, code: "insecureConnection" });
             }
+
+            this.recordReachable(trackerKey);
 
             if (socket.authorized) {
               // CA validation is successful, so certificate is not self-signed
@@ -102,6 +121,7 @@ export class ProviderProxy {
         req.on(
           "error",
           propagateTracingContext(error => {
+            this.recordUnreachable(trackerKey, error);
             resolve({ ok: false, code: "connectionError", error });
           })
         );
@@ -119,6 +139,25 @@ export class ProviderProxy {
       if (options.body && options.method !== "GET") req.write(options.body);
       req.end();
     });
+  }
+
+  /**
+   * Keyed by provider and dial target together so a provider that re-registers a new hostUri does not
+   * inherit the dead host's cooldown. The mTLS cert hash is deliberately left out, unlike the agent cache
+   * key, because whether a host answers has nothing to do with which credentials are presented.
+   */
+  private getTrackerKey(url: string, options: ProxyConnectOptions): string | undefined {
+    if (!this.#connectionTracker || !options.providerAddress) return undefined;
+
+    return `${options.providerAddress}|${new URL(url).origin}`;
+  }
+
+  private recordReachable(trackerKey: string | undefined): void {
+    if (trackerKey) this.#connectionTracker?.recordReachable(trackerKey);
+  }
+
+  private recordUnreachable(trackerKey: string | undefined, error: unknown): void {
+    if (trackerKey) this.#connectionTracker?.recordUnreachable(trackerKey, error, toErrno(error));
   }
 
   private getRequestOptions(options: ProxyConnectOptions) {
@@ -187,4 +226,4 @@ interface ProxyConnectionResultSuccess {
 type ProxyConnectionResultError =
   | { ok: false; code: "invalidCertificate"; reason: CertValidationResultError["code"] }
   | { ok: false; code: "insecureConnection" }
-  | { ok: false; code: "connectionError"; error: unknown };
+  | { ok: false; code: "connectionError"; error: unknown; shortCircuited?: true };

--- a/apps/provider-proxy/test/functional/provider-proxy-http.spec.ts
+++ b/apps/provider-proxy/test/functional/provider-proxy-http.spec.ts
@@ -449,6 +449,32 @@ describe("Provider HTTP proxy", () => {
     expect(body).toBe(`Provider ${new URL(providerUrl).origin} is temporarily unavailable`);
   });
 
+  it("does not short-circuit a provider that answers with an error", async () => {
+    const providerAddress = generateBech32();
+    const validCertPair = await createX509CertPair({ commonName: providerAddress });
+
+    const { providerUrl } = await startProviderServer({
+      certPair: validCertPair,
+      handlers: {
+        "/500"(_, res) {
+          res.writeHead(500);
+          res.end("Internal Server Error");
+        }
+      }
+    });
+    const chainServer = await startChainApiServer([validCertPair.cert]);
+    await startServer({ REST_API_NODE_URL: chainServer.url, PROVIDER_UNREACHABLE_FAILURE_THRESHOLD: 1 });
+    const dial = () =>
+      request("/", {
+        method: "POST",
+        body: JSON.stringify({ method: "GET", url: `${providerUrl}/500`, providerAddress })
+      });
+
+    await dial();
+
+    expect((await dial()).status).toBe(503);
+  });
+
   it("responds with 502 if provider host hangs up connection", async () => {
     const providerAddress = generateBech32();
     const validCertPair = await createX509CertPair({


### PR DESCRIPTION
> Stacked on #3647. Base is `fix/deployment-skip-non-live-lease-status` and will be retargeted to `main` once that merges.

## Why

**This PR does not change how many 5xx responses callers see. It changes what each one costs.** Worth saying up front, because a circuit breaker looks like it should quiet the 503 alert and it does not: every request still gets one response. #3647 is what moves that number.

What this fixes is waste. A provider that has been switched off gets re-dialed on every single request, and each attempt pays a full connect timeout before failing. Two mainnet providers accounted for 667 such failures in 24 hours, all `EHOSTUNREACH`, against hosts that have been unroutable for weeks. Nothing in the proxy remembers that the previous request just failed the same way. `#agentsCache` looks like it might, but it is a TLS session cache with no health semantics.

## What

After a few consecutive hard connection failures the proxy skips the dial for a cooldown window and answers from the cached error, letting exactly one probe through per window so recovery is noticed.

Reading the tracker consumes that probe, which is why the method is `shouldSkipDial` rather than a question. A stampede of concurrent requests produces one dial rather than one each, and a still-dead provider re-arms the window automatically. No timers involved, which also keeps the spec free of fake clocks.

### Deliberate choices worth reviewing

- **Which errnos trip it.** Only `EHOSTUNREACH`, `ENETUNREACH`, `ENOTFOUND`, `EAI_AGAIN`, `ECONNREFUSED`. `ECONNRESET`, `ETIMEDOUT` and `EPIPE` are excluded on purpose: the proxy destroys its own request when the per-attempt timeout fires and a client abort does the same, both surfacing as `ECONNRESET`. Since `apps/api` sends `timeout: 15000` while the browser default is 9s, counting those would let one slow poll blind every other caller on a healthy provider. The included set still covers 695 of the 751 connection errors observed in 24h.
- **The key is `providerAddress|origin`.** Per provider as the problem requires, plus the dial target, so a provider that re-registers a new `hostUri` does not inherit the dead host's cooldown. The mTLS cert hash is deliberately left out, unlike the agent cache key, because whether a host answers has nothing to do with which credentials are presented.
- **Where the check sits.** Before `getRequestOptions`, so a skipped request never builds an agent, never touches `#agentsCache` and never reaches `CertificateValidator`. The short circuit can only produce an error, never a response body, so there is no path where a request that previously validated a certificate now returns data without validating it.
- **Short-circuited results are excluded from the in-request retry.** Without that, a cached `ECONNREFUSED` passes `canRetryOnError` and burns the 200/400/800ms backoff on three instant failures.
- **Websockets neither read nor write the tracker.** They are interactive rather than polled, so there is no cross-request amplification to suppress, and a cooldown earned by REST polling should not block a shell someone just opened. The tracker is on the container rather than private to `ProviderProxy` so this can change if the data ever says otherwise.
- **Hand-rolled rather than cockatiel.** cockatiel is not a dependency here (`lru-cache` already is) and its breaker is single-keyed, so a per-provider map would be needed anyway. More importantly `ProviderProxy.connect` *resolves* `{ ok: false, code: "connectionError" }` instead of rejecting, which cockatiel counts as success.

> Also worth writing down for whoever finds it later: do **not** enable the opt-in breaker in `createFetchAdapter` for the api to proxy client. It is keyed per axios client, not per provider, so one dead provider would open the circuit for all provider traffic from `apps/api`, manifests included.

Off with `PROVIDER_UNREACHABLE_TRACKING_ENABLED=false`. Threshold and window are `PROVIDER_UNREACHABLE_FAILURE_THRESHOLD` (3) and `PROVIDER_UNREACHABLE_COOLDOWN_MS` (60000).

## Verification

`npm test`, `npm run lint -- --quiet`, `npx tsc --noEmit` in `apps/provider-proxy`. 13 test files and 135 tests pass, zero tsc errors under `src/`.

New coverage: 11 tracker cases (threshold, the excluded errnos, one-probe-per-window under repeated calls, re-arming, clearing on recovery, per-key isolation) and 3 `ProviderProxy` cases for the short-circuit and its key.

I checked these actually catch a regression rather than passing vacuously: disabling the short circuit fails both `ProviderProxy` cases. I also dropped two functional tests I had written first, which asserted the second dial returned faster than 100ms. They passed with the short circuit disabled, because the unreachable host used in those tests fails DNS in well under 100ms either way, so the timing assertion discriminated nothing. The behaviour is asserted at the unit level instead. The remaining functional test is the one that does discriminate: a provider answering HTTP 500 repeatedly must keep returning 503 and must never trip the cooldown.
