### PR TITLE
fix(billing): report the reserved balance net of unsettled deployment spend

### DIFF
--- a/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/useAccountBalanceOverview.spec.ts
+++ b/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/useAccountBalanceOverview.spec.ts
@@ -160,10 +160,69 @@ describe(useAccountBalanceOverview.name, () => {
     expect(result.current.available).toBe(350);
   });
 
+  it("nets what the provider earned since the escrow settled off the reserved amount", () => {
+    const { result } = setup({
+      deployments: [{ dseq: "1", fundsUsd: 100, settledAt: 1000 }],
+      leases: [{ dseq: "1", amount: "1000000" }],
+      latestBlockHeight: 1050
+    });
+
+    expect(result.current.deployments[0].reservedUsd).toBeCloseTo(50, 6);
+    expect(result.current.reserved).toBeCloseTo(50, 6);
+  });
+
+  it("reports the settled amount for a deployment that settled at the current height", () => {
+    const { result } = setup({
+      deployments: [{ dseq: "1", fundsUsd: 100, settledAt: 1050 }],
+      leases: [{ dseq: "1", amount: "1000000" }],
+      latestBlockHeight: 1050
+    });
+
+    expect(result.current.deployments[0].reservedUsd).toBe(100);
+  });
+
+  it("reports the settled amount for a deployment with no live lease", () => {
+    const { result } = setup({
+      deployments: [{ dseq: "1", fundsUsd: 100, settledAt: 1000 }],
+      leases: [],
+      latestBlockHeight: 1050
+    });
+
+    expect(result.current.deployments[0].reservedUsd).toBe(100);
+  });
+
+  it("reports the settled amount while the latest block height is unknown", () => {
+    const { result } = setup({
+      deployments: [{ dseq: "1", fundsUsd: 100, settledAt: 1000 }],
+      leases: [{ dseq: "1", amount: "1000000" }]
+    });
+
+    expect(result.current.deployments[0].reservedUsd).toBe(100);
+  });
+
+  it("leaves available untouched by the accrual, since total and reserved both drop by it", () => {
+    const settled = setup({
+      totalUsd: 500,
+      deployments: [{ dseq: "1", fundsUsd: 100, settledAt: 1050 }],
+      leases: [{ dseq: "1", amount: "1000000" }],
+      latestBlockHeight: 1050
+    });
+    const accrued = setup({
+      totalUsd: 500,
+      deployments: [{ dseq: "1", fundsUsd: 100, settledAt: 1000 }],
+      leases: [{ dseq: "1", amount: "1000000" }],
+      latestBlockHeight: 1050
+    });
+
+    expect(accrued.result.current.totalUsd).toBeCloseTo(450, 6);
+    expect(accrued.result.current.available).toBeCloseTo(settled.result.current.available, 6);
+  });
+
   function setup(input: {
     totalUsd?: number;
     reservedUsd?: number;
-    deployments?: Array<{ dseq: string; fundsUsd: number }>;
+    deployments?: Array<{ dseq: string; fundsUsd: number; settledAt?: number }>;
+    latestBlockHeight?: number;
     names?: Record<string, string>;
     leases?: Array<{ dseq: string; amount?: string; state?: string }>;
     hasLiveLease?: boolean;
@@ -178,7 +237,7 @@ describe(useAccountBalanceOverview.name, () => {
     const reservedDeployments = input.deployments ?? (input.reservedUsd ? [{ dseq: "reserved", fundsUsd: input.reservedUsd }] : []);
     const activeDeployments = reservedDeployments.map(deployment => ({
       dseq: deployment.dseq,
-      escrowAccount: { state: { funds: [{ denom: UAKT_DENOM, amount: String(deployment.fundsUsd) }] } }
+      escrowAccount: { state: { settled_at: String(deployment.settledAt ?? ""), funds: [{ denom: UAKT_DENOM, amount: String(deployment.fundsUsd) }] } }
     }));
     const reservedTotal = reservedDeployments.reduce((sum, deployment) => sum + deployment.fundsUsd, 0);
 
@@ -232,6 +291,11 @@ describe(useAccountBalanceOverview.name, () => {
     const leasesQuery = Object.assign(mock<ReturnType<typeof DEPENDENCIES.useAllLeases>>(), { data: leases });
     const useAllLeases = vi.fn<typeof DEPENDENCIES.useAllLeases>(() => leasesQuery);
 
+    const blockQuery = Object.assign(mock<ReturnType<typeof DEPENDENCIES.useBlock>>(), {
+      data: input.latestBlockHeight === undefined ? undefined : { block: { header: { height: String(input.latestBlockHeight) } } }
+    });
+    const useBlock: typeof DEPENDENCIES.useBlock = () => blockQuery;
+
     const walletSettingsQuery = Object.assign(mock<ReturnType<typeof DEPENDENCIES.useWalletSettingsQuery>>(), {
       data: Object.assign(mock<WalletSettings>(), {
         autoReloadEnabled: input.autoReloadEnabled ?? false,
@@ -250,6 +314,7 @@ describe(useAccountBalanceOverview.name, () => {
       useAutoReloadMode,
       useBalances,
       useAllLeases,
+      useBlock,
       useWalletSettingsQuery,
       useLocalNotes
     };

--- a/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/useAccountBalanceOverview.spec.ts
+++ b/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/useAccountBalanceOverview.spec.ts
@@ -218,6 +218,18 @@ describe(useAccountBalanceOverview.name, () => {
     expect(accrued.result.current.available).toBeCloseTo(settled.result.current.available, 6);
   });
 
+  it("skips the latest-block poll while the wallet has nothing deployed", () => {
+    const { useBlock } = setup({ totalUsd: 500, deployments: [] });
+
+    expect(useBlock).toHaveBeenCalledWith("latest", expect.objectContaining({ enabled: false }));
+  });
+
+  it("polls the latest block once the wallet holds an escrow", () => {
+    const { useBlock } = setup({ deployments: [{ dseq: "1", fundsUsd: 100, settledAt: 1000 }] });
+
+    expect(useBlock).toHaveBeenCalledWith("latest", expect.objectContaining({ enabled: true }));
+  });
+
   function setup(input: {
     totalUsd?: number;
     reservedUsd?: number;
@@ -294,7 +306,7 @@ describe(useAccountBalanceOverview.name, () => {
     const blockQuery = Object.assign(mock<ReturnType<typeof DEPENDENCIES.useBlock>>(), {
       data: input.latestBlockHeight === undefined ? undefined : { block: { header: { height: String(input.latestBlockHeight) } } }
     });
-    const useBlock: typeof DEPENDENCIES.useBlock = () => blockQuery;
+    const useBlock = vi.fn<typeof DEPENDENCIES.useBlock>(() => blockQuery);
 
     const walletSettingsQuery = Object.assign(mock<ReturnType<typeof DEPENDENCIES.useWalletSettingsQuery>>(), {
       data: Object.assign(mock<WalletSettings>(), {
@@ -319,6 +331,6 @@ describe(useAccountBalanceOverview.name, () => {
       useLocalNotes
     };
 
-    return { ...renderHook(() => useAccountBalanceOverview({ dependencies })), useAllLeases };
+    return { ...renderHook(() => useAccountBalanceOverview({ dependencies })), useAllLeases, useBlock };
   }
 });

--- a/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/useAccountBalanceOverview.ts
+++ b/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/useAccountBalanceOverview.ts
@@ -55,7 +55,9 @@ export function useAccountBalanceOverview({ dependencies: d = DEPENDENCIES }: { 
   const { price, udenomToUsd } = d.usePricing();
   const { data: balances, isError: isBalancesError, fetchStatus: balancesFetchStatus } = d.useBalances(address);
   const { data: leases } = d.useAllLeases(address, { state: LIVE_LEASE_STATES, enabled: !!address });
-  const { data: latestBlock } = d.useBlock("latest", { refetchInterval: 30000 });
+  const hasActiveDeployments = !!balances?.activeDeployments.length;
+  /** Gated on the wallet holding an escrow: an account with nothing running shouldn't poll the chain every 30 seconds. */
+  const { data: latestBlock } = d.useBlock("latest", { refetchInterval: 30000, enabled: hasActiveDeployments });
   const { data: walletSettings } = d.useWalletSettingsQuery();
   const { getDeploymentName } = d.useLocalNotes();
   const { showsThresholdRule } = d.useAutoReloadMode();

--- a/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/useAccountBalanceOverview.ts
+++ b/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/useAccountBalanceOverview.ts
@@ -6,12 +6,14 @@ import { useAutoReloadMode } from "@src/components/billing-usage/useAutoReloadMo
 import { useLocalNotes } from "@src/components/LocalNoteManager/useLocalNotes";
 import { useWallet } from "@src/context/WalletProvider";
 import { usePricing } from "@src/hooks/usePricing/usePricing";
+import type { LiveEscrowInput } from "@src/hooks/useWalletBalance";
 import { computeWalletBalance } from "@src/hooks/useWalletBalance";
 import { useWalletSettingsQuery } from "@src/queries";
 import { useBalances } from "@src/queries/useBalancesQuery";
+import { useBlock } from "@src/queries/useBlocksQuery";
 import { useAllLeases } from "@src/queries/useLeaseQuery";
 import { isLeaseLive, LIVE_LEASE_STATES } from "@src/utils/leaseUtils";
-import { getLeasesCostPerBlockUsd, getTimeLeft, perBlockToHourly } from "@src/utils/priceUtils";
+import { getLeaseCostPerBlockUsdByDseq, getLiveEscrowBalance, getTimeLeft, perBlockToHourly } from "@src/utils/priceUtils";
 
 export const DEPENDENCIES = {
   useWallet,
@@ -19,6 +21,7 @@ export const DEPENDENCIES = {
   useAutoReloadMode,
   useBalances,
   useAllLeases,
+  useBlock,
   useWalletSettingsQuery,
   useLocalNotes
 };
@@ -52,38 +55,51 @@ export function useAccountBalanceOverview({ dependencies: d = DEPENDENCIES }: { 
   const { price, udenomToUsd } = d.usePricing();
   const { data: balances, isError: isBalancesError, fetchStatus: balancesFetchStatus } = d.useBalances(address);
   const { data: leases } = d.useAllLeases(address, { state: LIVE_LEASE_STATES, enabled: !!address });
+  const { data: latestBlock } = d.useBlock("latest", { refetchInterval: 30000 });
   const { data: walletSettings } = d.useWalletSettingsQuery();
   const { getDeploymentName } = d.useLocalNotes();
   const { showsThresholdRule } = d.useAutoReloadMode();
 
+  const liveEscrow = useMemo<LiveEscrowInput>(
+    () => ({
+      latestBlockHeight: latestBlock ? Number(latestBlock.block.header.height) : undefined,
+      perBlockUsdByDseq: getLeaseCostPerBlockUsdByDseq(leases?.filter(isLeaseLive) ?? [])
+    }),
+    [leases, latestBlock]
+  );
+
   /** Not gated on the AKT market price: managed wallets hold ACT/USDC (1:1 USD), and blocking on market data would strand the card on its skeleton during an outage. */
-  const walletBalance = useMemo(() => (balances ? computeWalletBalance(balances, price ?? 0, udenomToUsd) : null), [balances, price, udenomToUsd]);
+  const walletBalance = useMemo(
+    () => (balances ? computeWalletBalance(balances, price ?? 0, udenomToUsd, liveEscrow) : null),
+    [balances, price, udenomToUsd, liveEscrow]
+  );
 
-  const { perHourByDseq, spend } = useMemo(() => {
-    const perHourByDseq = new Map<string, number>();
-    if (!leases) return { perHourByDseq, spend: { perBlockUsd: 0, perHour: 0 } };
+  const spend = useMemo(() => {
+    const perBlockUsd = [...liveEscrow.perBlockUsdByDseq.values()].reduce((total, deploymentPerBlockUsd) => total + deploymentPerBlockUsd, 0);
 
-    let totalPerBlockUsd = 0;
-    for (const lease of leases.filter(isLeaseLive)) {
-      const perBlockUsd = getLeasesCostPerBlockUsd([lease]);
-      totalPerBlockUsd += perBlockUsd;
-      perHourByDseq.set(lease.dseq, (perHourByDseq.get(lease.dseq) ?? 0) + perBlockToHourly(perBlockUsd));
-    }
-
-    return { perHourByDseq, spend: { perBlockUsd: totalPerBlockUsd, perHour: perBlockToHourly(totalPerBlockUsd) } };
-  }, [leases]);
+    return { perBlockUsd, perHour: perBlockToHourly(perBlockUsd) };
+  }, [liveEscrow]);
 
   const deployments = useMemo<ReservedDeployment[]>(() => {
     if (!balances) return [];
     return balances.activeDeployments
-      .map(deployment => ({
-        dseq: deployment.dseq,
-        name: getDeploymentName(deployment.dseq) ?? `Deployment ${deployment.dseq}`,
-        reservedUsd: deployment.escrowAccount.state.funds.reduce((sum, fund) => sum + udenomToUsd(fund.amount, fund.denom), 0),
-        perHourUsd: perHourByDseq.get(deployment.dseq) ?? 0
-      }))
+      .map(deployment => {
+        const pricePerBlock = liveEscrow.perBlockUsdByDseq.get(deployment.dseq) ?? 0;
+
+        return {
+          dseq: deployment.dseq,
+          name: getDeploymentName(deployment.dseq) ?? `Deployment ${deployment.dseq}`,
+          reservedUsd: getLiveEscrowBalance({
+            settledBalance: deployment.escrowAccount.state.funds.reduce((sum, fund) => sum + udenomToUsd(fund.amount, fund.denom), 0),
+            pricePerBlock,
+            settledAt: Number(deployment.escrowAccount.state.settled_at),
+            latestBlockHeight: liveEscrow.latestBlockHeight
+          }),
+          perHourUsd: perBlockToHourly(pricePerBlock)
+        };
+      })
       .sort((a, b) => b.reservedUsd - a.reservedUsd);
-  }, [balances, getDeploymentName, udenomToUsd, perHourByDseq]);
+  }, [balances, getDeploymentName, udenomToUsd, liveEscrow]);
 
   const totalUsd = walletBalance?.totalUsd ?? 0;
   const reserved = deployments.reduce((sum, deployment) => sum + deployment.reservedUsd, 0);

--- a/apps/deploy-web/src/hooks/useRealTimeLeft.spec.ts
+++ b/apps/deploy-web/src/hooks/useRealTimeLeft.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { FallbackableHttpClient } from "@src/services/createFallbackableHttpClient/createFallbackableHttpClient";
+import { setupQuery } from "../../tests/unit/query-client";
+import { useRealTimeLeft } from "./useRealTimeLeft";
+
+describe(useRealTimeLeft.name, () => {
+  it("drains the escrow by what the provider earned since the last settlement", async () => {
+    const { result } = setup({ pricePerBlock: 100, balance: 50_000, settledAt: 1000, latestBlockHeight: 1100 });
+
+    await vi.waitFor(() => {
+      expect(result.current?.escrow).toBe(40_000);
+    });
+  });
+
+  it("reports the settled escrow when no lease is spending", async () => {
+    const { result } = setup({ pricePerBlock: 0, balance: 50_000, settledAt: 1000, latestBlockHeight: 1100 });
+
+    await vi.waitFor(() => {
+      expect(result.current?.escrow).toBe(50_000);
+    });
+  });
+
+  it("clamps the escrow at zero once the accrued spend exceeds the balance", async () => {
+    const { result } = setup({ pricePerBlock: 100, balance: 5_000, settledAt: 1000, latestBlockHeight: 1100 });
+
+    await vi.waitFor(() => {
+      expect(result.current?.escrow).toBe(0);
+    });
+  });
+
+  function setup(input: { pricePerBlock: number; balance: number; settledAt: number; latestBlockHeight: number }) {
+    const chainApiHttpClient = mock<FallbackableHttpClient>({
+      defaults: { baseURL: "https://chain.test" },
+      isFallbackEnabled: false,
+      get: vi.fn().mockResolvedValue({ data: { block: { header: { height: String(input.latestBlockHeight) } } } })
+    } as unknown as FallbackableHttpClient);
+
+    return setupQuery(() => useRealTimeLeft(input.pricePerBlock, input.balance, input.settledAt, 900), {
+      services: { chainApiHttpClient: () => chainApiHttpClient }
+    });
+  }
+});

--- a/apps/deploy-web/src/hooks/useRealTimeLeft.spec.ts
+++ b/apps/deploy-web/src/hooks/useRealTimeLeft.spec.ts
@@ -31,11 +31,10 @@ describe(useRealTimeLeft.name, () => {
   });
 
   function setup(input: { pricePerBlock: number; balance: number; settledAt: number; latestBlockHeight: number }) {
-    const chainApiHttpClient = mock<FallbackableHttpClient>({
-      defaults: { baseURL: "https://chain.test" },
-      isFallbackEnabled: false,
-      get: vi.fn().mockResolvedValue({ data: { block: { header: { height: String(input.latestBlockHeight) } } } })
-    } as unknown as FallbackableHttpClient);
+    const chainApiHttpClient = mock<FallbackableHttpClient>();
+    chainApiHttpClient.isFallbackEnabled = false;
+    chainApiHttpClient.defaults = mock<FallbackableHttpClient["defaults"]>({ baseURL: "https://chain.test" });
+    chainApiHttpClient.get.mockResolvedValue({ data: { block: { header: { height: String(input.latestBlockHeight) } } } });
 
     return setupQuery(() => useRealTimeLeft(input.pricePerBlock, input.balance, input.settledAt, 900), {
       services: { chainApiHttpClient: () => chainApiHttpClient }

--- a/apps/deploy-web/src/hooks/useRealTimeLeft.ts
+++ b/apps/deploy-web/src/hooks/useRealTimeLeft.ts
@@ -1,7 +1,7 @@
 import add from "date-fns/add";
 
 import { useBlock } from "@src/queries/useBlocksQuery";
-import { averageBlockTime } from "@src/utils/priceUtils";
+import { averageBlockTime, getLiveEscrowBalance } from "@src/utils/priceUtils";
 
 export function useRealTimeLeft(pricePerBlock: number, balance: number, settledAt: number, createdAt: number) {
   const { data: latestBlock } = useBlock("latest", {
@@ -9,7 +9,7 @@ export function useRealTimeLeft(pricePerBlock: number, balance: number, settledA
   });
   if (!latestBlock) return;
 
-  const latestBlockHeight = latestBlock.block.header.height;
+  const latestBlockHeight = Number(latestBlock.block.header.height);
   const blocksPassed = Math.abs(settledAt - latestBlockHeight);
   const blocksSinceCreation = Math.abs(createdAt - latestBlockHeight);
 
@@ -18,7 +18,7 @@ export function useRealTimeLeft(pricePerBlock: number, balance: number, settledA
 
   return {
     timeLeft: add(new Date(timestamp), { seconds: blocksLeft * averageBlockTime }),
-    escrow: Math.max(blocksLeft * pricePerBlock, 0),
+    escrow: getLiveEscrowBalance({ settledBalance: balance, pricePerBlock, settledAt, latestBlockHeight }),
     amountSpent: Math.min(blocksSinceCreation * pricePerBlock, balance)
   };
 }

--- a/apps/deploy-web/src/hooks/useWalletBalance.spec.ts
+++ b/apps/deploy-web/src/hooks/useWalletBalance.spec.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import { UACT_DENOM } from "@src/config/denom.config";
+import type { Balances } from "@src/types";
+import type { DeploymentDto } from "@src/types/deployment";
+import { udenomToDenom } from "@src/utils/mathHelpers";
+import type { LiveEscrowInput } from "./useWalletBalance";
+import { computeWalletBalance } from "./useWalletBalance";
+
+describe(computeWalletBalance.name, () => {
+  it("reports the settled escrow when no live escrow input is given", () => {
+    const { balances, udenomToUsd } = setup({ fundsUact: 10_000_000, settledAt: 1000 });
+
+    const balance = computeWalletBalance(balances, 0, udenomToUsd);
+
+    expect(balance.totalDeploymentEscrowUSD).toBeCloseTo(10, 6);
+    expect(balance.totalUsd).toBeCloseTo(10, 6);
+  });
+
+  it("nets off what the provider earned since the escrow last settled", () => {
+    const { balances, udenomToUsd, liveEscrow } = setup({
+      fundsUact: 10_000_000,
+      settledAt: 1000,
+      latestBlockHeight: 1100,
+      perBlockUsd: 0.02
+    });
+
+    const balance = computeWalletBalance(balances, 0, udenomToUsd, liveEscrow);
+
+    expect(balance.totalDeploymentEscrowUSD).toBeCloseTo(8, 6);
+    expect(balance.totalUsd).toBeCloseTo(8, 6);
+  });
+
+  it("keeps the liquid balance out of the accrual", () => {
+    const { balances, udenomToUsd, liveEscrow } = setup({
+      fundsUact: 10_000_000,
+      balanceUact: 5_000_000,
+      settledAt: 1000,
+      latestBlockHeight: 1100,
+      perBlockUsd: 0.02
+    });
+
+    const balance = computeWalletBalance(balances, 0, udenomToUsd, liveEscrow);
+
+    expect(balance.totalUsd).toBeCloseTo(13, 6);
+  });
+
+  it("reports the settled escrow for a deployment with no live lease", () => {
+    const { balances, udenomToUsd, liveEscrow } = setup({
+      fundsUact: 10_000_000,
+      settledAt: 1000,
+      latestBlockHeight: 1100
+    });
+
+    const balance = computeWalletBalance(balances, 0, udenomToUsd, liveEscrow);
+
+    expect(balance.totalDeploymentEscrowUSD).toBeCloseTo(10, 6);
+  });
+
+  function setup(input: { fundsUact: number; balanceUact?: number; settledAt: number; latestBlockHeight?: number; perBlockUsd?: number }) {
+    const dseq = "1";
+    const balances = Object.assign(mock<Balances>(), {
+      balanceUAKT: 0,
+      balanceUUSDC: 0,
+      balanceUACT: input.balanceUact ?? 0,
+      activeDeployments: [
+        mock<DeploymentDto>({
+          dseq,
+          escrowAccount: mock<DeploymentDto["escrowAccount"]>({
+            state: mock<DeploymentDto["escrowAccount"]["state"]>({
+              settled_at: String(input.settledAt),
+              funds: [{ denom: UACT_DENOM, amount: String(input.fundsUact) }]
+            })
+          })
+        })
+      ],
+      deploymentGrants: []
+    });
+
+    const liveEscrow: LiveEscrowInput = {
+      latestBlockHeight: input.latestBlockHeight,
+      perBlockUsdByDseq: new Map(input.perBlockUsd ? [[dseq, input.perBlockUsd]] : [])
+    };
+
+    return { balances, liveEscrow, udenomToUsd: (amount: string | number, denom: string) => (denom === UACT_DENOM ? udenomToDenom(amount, 6) : 0) };
+  }
+});

--- a/apps/deploy-web/src/hooks/useWalletBalance.ts
+++ b/apps/deploy-web/src/hooks/useWalletBalance.ts
@@ -5,10 +5,13 @@ import { UACT_DENOM, UAKT_DENOM } from "@src/config/denom.config";
 import { useWallet } from "@src/context/WalletProvider";
 import { useChainParam } from "@src/hooks/useChainParam/useChainParam";
 import { useBalances } from "@src/queries/useBalancesQuery";
+import { useBlock } from "@src/queries/useBlocksQuery";
+import { useAllLeases } from "@src/queries/useLeaseQuery";
 import walletStore from "@src/store/walletStore";
 import type { Balances } from "@src/types";
+import { isLeaseLive, LIVE_LEASE_STATES } from "@src/utils/leaseUtils";
 import { udenomToDenom } from "@src/utils/mathHelpers";
-import { uaktToAKT } from "@src/utils/priceUtils";
+import { getLeaseCostPerBlockUsdByDseq, getLiveEscrowBalance, uaktToAKT } from "@src/utils/priceUtils";
 import type { PricingContext } from "./usePricing/usePricing";
 import { usePricing } from "./usePricing/usePricing";
 import { useUsdcDenom } from "./useDenom";
@@ -37,12 +40,33 @@ export type WalletBalanceReturnType = {
   balance: WalletBalance | null;
 };
 
+/**
+ * The live per-block USD burn of every deployment, alongside the height to measure it from. Without it the
+ * escrow totals read back the chain's settled figures, which sit high until the escrow next settles.
+ */
+export type LiveEscrowInput = {
+  latestBlockHeight?: number;
+  perBlockUsdByDseq: Map<string, number>;
+};
+
 /** Converts on-chain balances into USD totals; shared by the wallet-balance atom and callers needing the same figures synchronously. */
-export function computeWalletBalance(balances: Balances, price: number, udenomToUsd: PricingContext["udenomToUsd"]): WalletBalance {
+export function computeWalletBalance(
+  balances: Balances,
+  price: number,
+  udenomToUsd: PricingContext["udenomToUsd"],
+  liveEscrow?: LiveEscrowInput
+): WalletBalance {
   const aktUsdValue = uaktToAKT(balances.balanceUAKT, 6) * price;
   const totalUsdcValue = udenomToDenom(balances.balanceUUSDC, 6);
   const totalDeploymentEscrowUSD = balances.activeDeployments.reduce(
-    (acc, d) => acc + d.escrowAccount.state.funds.reduce((fundAcc, fund) => fundAcc + udenomToUsd(fund.amount, fund.denom), 0),
+    (acc, d) =>
+      acc +
+      getLiveEscrowBalance({
+        settledBalance: d.escrowAccount.state.funds.reduce((fundAcc, fund) => fundAcc + udenomToUsd(fund.amount, fund.denom), 0),
+        pricePerBlock: liveEscrow?.perBlockUsdByDseq.get(d.dseq) ?? 0,
+        settledAt: Number(d.escrowAccount.state.settled_at),
+        latestBlockHeight: liveEscrow?.latestBlockHeight
+      }),
     0
   );
   const { deploymentGrants } = balances;
@@ -75,14 +99,15 @@ export const useWalletBalance = (): WalletBalanceReturnType => {
   const { address } = useWallet();
   const { data: balances, isFetching: isLoadingBalances, refetch } = useBalances(address);
   const [walletBalance, setWalletBalance] = useAtom(walletStore.balance);
+  const liveEscrow = useLiveEscrow(address, balances);
 
   useEffect(
     function publishBalanceWhenLoaded() {
       if (balances) {
-        setWalletBalance(computeWalletBalance(balances, price ?? 0, udenomToUsd));
+        setWalletBalance(computeWalletBalance(balances, price ?? 0, udenomToUsd, liveEscrow));
       }
     },
-    [price, balances, udenomToUsd]
+    [price, balances, udenomToUsd, liveEscrow]
   );
 
   return {
@@ -91,6 +116,24 @@ export const useWalletBalance = (): WalletBalanceReturnType => {
     refetch
   };
 };
+
+/**
+ * Both queries are gated on the wallet actually holding an escrow, so an account with nothing running pays
+ * for neither: `useWalletBalance` is mounted app-wide through `PaymentPollingProvider`.
+ */
+function useLiveEscrow(address: string, balances: Balances | null | undefined): LiveEscrowInput {
+  const hasActiveDeployments = !!balances?.activeDeployments.length;
+  const { data: leases } = useAllLeases(address, { state: LIVE_LEASE_STATES, enabled: !!address && hasActiveDeployments });
+  const { data: latestBlock } = useBlock("latest", { refetchInterval: 30000, enabled: hasActiveDeployments });
+
+  return useMemo(
+    () => ({
+      latestBlockHeight: latestBlock ? Number(latestBlock.block.header.height) : undefined,
+      perBlockUsdByDseq: getLeaseCostPerBlockUsdByDseq(leases?.filter(isLeaseLive) ?? [])
+    }),
+    [leases, latestBlock]
+  );
+}
 
 type DenomData = {
   min: number;

--- a/apps/deploy-web/src/utils/priceUtils.spec.ts
+++ b/apps/deploy-web/src/utils/priceUtils.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { UACT_DENOM, UAKT_DENOM } from "@src/config/denom.config";
-import { averageBlockTime, getLeasesCostPerBlockUsd, perBlockToHourly } from "./priceUtils";
+import { averageBlockTime, getLeaseCostPerBlockUsdByDseq, getLeasesCostPerBlockUsd, getLiveEscrowBalance, perBlockToHourly } from "./priceUtils";
 
 describe("perBlockToHourly", () => {
   it("converts a per-block price into its hourly equivalent (3600 / blockTime blocks per hour)", () => {
@@ -21,5 +21,54 @@ describe(getLeasesCostPerBlockUsd.name, () => {
     const leases = [{ price: { denom: UAKT_DENOM, amount: "5000000000" } }, { price: { denom: "ibc/usdc", amount: "5000000000" } }];
 
     expect(getLeasesCostPerBlockUsd(leases)).toBe(0);
+  });
+});
+
+describe(getLeaseCostPerBlockUsdByDseq.name, () => {
+  it("sums every lease of a deployment under its dseq", () => {
+    const leases = [
+      { dseq: "1", price: { denom: UACT_DENOM, amount: "500000" } },
+      { dseq: "1", price: { denom: UACT_DENOM, amount: "500000" } },
+      { dseq: "2", price: { denom: UACT_DENOM, amount: "250000" } }
+    ];
+
+    const perBlockUsdByDseq = getLeaseCostPerBlockUsdByDseq(leases);
+
+    expect(perBlockUsdByDseq.get("1")).toBeCloseTo(1, 6);
+    expect(perBlockUsdByDseq.get("2")).toBeCloseTo(0.25, 6);
+  });
+
+  it("has no entry for a deployment without leases", () => {
+    expect(getLeaseCostPerBlockUsdByDseq([]).get("1")).toBeUndefined();
+  });
+});
+
+describe(getLiveEscrowBalance.name, () => {
+  it("subtracts what the provider earned since the escrow last settled", () => {
+    expect(getLiveEscrowBalance({ settledBalance: 100, pricePerBlock: 0.5, settledAt: 1000, latestBlockHeight: 1100 })).toBeCloseTo(50, 6);
+  });
+
+  it("returns the settled balance when the escrow settled at the current height", () => {
+    expect(getLiveEscrowBalance({ settledBalance: 100, pricePerBlock: 0.5, settledAt: 1100, latestBlockHeight: 1100 })).toBe(100);
+  });
+
+  it("returns the settled balance when no live lease is spending", () => {
+    expect(getLiveEscrowBalance({ settledBalance: 100, pricePerBlock: 0, settledAt: 1000, latestBlockHeight: 1100 })).toBe(100);
+  });
+
+  it("returns the settled balance when the latest block height is unknown", () => {
+    expect(getLiveEscrowBalance({ settledBalance: 100, pricePerBlock: 0.5, settledAt: 1000 })).toBe(100);
+  });
+
+  it("returns the settled balance when the settled height cannot be parsed", () => {
+    expect(getLiveEscrowBalance({ settledBalance: 100, pricePerBlock: 0.5, settledAt: NaN, latestBlockHeight: 1100 })).toBe(100);
+  });
+
+  it("clamps to zero once the accrued spend exceeds the settled balance", () => {
+    expect(getLiveEscrowBalance({ settledBalance: 10, pricePerBlock: 0.5, settledAt: 1000, latestBlockHeight: 1100 })).toBe(0);
+  });
+
+  it("never adds funds when the escrow settled ahead of a stale cached height", () => {
+    expect(getLiveEscrowBalance({ settledBalance: 100, pricePerBlock: 0.5, settledAt: 1100, latestBlockHeight: 1000 })).toBe(100);
   });
 });

--- a/apps/deploy-web/src/utils/priceUtils.ts
+++ b/apps/deploy-web/src/utils/priceUtils.ts
@@ -75,6 +75,43 @@ export function getLeasesCostPerBlockUsd(leases: PricedLease[]): number {
   }, 0);
 }
 
+/**
+ * Groups the per-block USD price of the given leases by the deployment they belong to. Pass already-live leases.
+ */
+export function getLeaseCostPerBlockUsdByDseq(leases: (PricedLease & { dseq: string })[]): Map<string, number> {
+  const perBlockUsdByDseq = new Map<string, number>();
+
+  for (const lease of leases) {
+    perBlockUsdByDseq.set(lease.dseq, (perBlockUsdByDseq.get(lease.dseq) ?? 0) + getLeasesCostPerBlockUsd([lease]));
+  }
+
+  return perBlockUsdByDseq;
+}
+
+/**
+ * Nets off what a provider has earned since the escrow last settled. The chain only decrements an escrow's
+ * funds on settlement (deposit, withdrawal, lease close), so between settlements the raw figure reads high.
+ * Units follow the inputs: pass the balance and the price both in udenom, or both in USD.
+ * Falls back to the settled balance when the height is unknown or nothing is being spent.
+ */
+export function getLiveEscrowBalance({
+  settledBalance,
+  pricePerBlock,
+  settledAt,
+  latestBlockHeight
+}: {
+  settledBalance: number;
+  pricePerBlock: number;
+  settledAt: number;
+  latestBlockHeight?: number;
+}): number {
+  if (latestBlockHeight === undefined || !Number.isFinite(latestBlockHeight) || !Number.isFinite(settledAt) || !pricePerBlock) return settledBalance;
+
+  const blocksSinceSettlement = Math.max(latestBlockHeight - settledAt, 0);
+
+  return Math.max(settledBalance - blocksSinceSettlement * pricePerBlock, 0);
+}
+
 export function getTimeLeft(pricePerBlock: number, balance: number) {
   const blocksLeft = balance / pricePerBlock;
   const timestamp = new Date().getTime();


### PR DESCRIPTION
## Why

The Billing page and the deployment pages report different numbers for the same escrow. A user saw RESERVED $8.22 on Billing while the deployment's Settings tab showed BALANCE $7.44, a gap of about 5.2 hours of unsettled spend at $0.15/hr.

The chain only decrements an escrow's `funds` when it settles: a deposit, a withdrawal, a lease close. Between settlements that figure reads high. `useRealTimeLeft` already nets off what the provider has earned since `settled_at`, which is why the deployment pages read lower. Billing summed `funds` straight from the chain.

This predates the runtime-limit work. `DeploymentSubHeader` and `DeploymentListRow` have used the live figure on main all along, so the deployments list has always disagreed with Billing too.

Fixes CON-892

## What

Pulled the subtraction out into `getLiveEscrowBalance` in `priceUtils` and called it from the three places that need it.

Both sides of `available = totalUsd - reserved` net the same accrual. Deducting only from `reserved` would have inflated AVAILABLE by the accrued amount and invited the user to spend money already owed to a provider. Since both terms drop by the same number AVAILABLE is arithmetically unchanged, and there's a test asserting exactly that.

The netting lives in `computeWalletBalance`, so it reaches every `useWalletBalance` consumer rather than just Billing. That matters because the redesigned deployment detail header renders BALANCE from the wallet atom, right next to the Settings tab's live per-deployment balance. The same mismatch was visible on a single screen.

`useWalletBalance` now pulls live leases and the latest block height, both gated on the wallet actually having an active deployment. The hook is mounted app-wide through `PaymentPollingProvider`, so an account with nothing running issues neither request, and accounts that do have deployments share the query cache with the Billing page and the deployments list. The tradeoff is that the wallet atom re-publishes on the 30s block refetch for those accounts.

Two behaviour changes fall out of the shared helper. A `settled_at` ahead of a stale cached block height no longer counts as spend, and a zero per-block price returns the settled balance instead of `NaN`. `timeLeft` and `amountSpent` in `useRealTimeLeft` are untouched, so the out-of-funds warning and the `isValid(timeLeft)` checks behave as before.

One pre-existing limitation I did not widen: `getLeasesCostPerBlockUsd` only prices ACT leases, so an AKT-funded legacy deployment gets no netting on Billing and falls back to the settled figure. The `perHour` figure already behaved that way.

### Testing

`npm run test:unit` in `apps/deploy-web`: 367 files, 3533 tests pass. `lint --quiet` clean, `tsc --noEmit` adds nothing to the app's existing baseline. New coverage is 7 cases on `getLiveEscrowBalance`, 4 on `computeWalletBalance`, 3 on `useRealTimeLeft`, and 5 on the Billing hook.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Wallet and account balance estimates now reflect real-time deployment escrow usage.
  * Provider earnings accrue correctly after escrow settlement.
  * Live lease costs are calculated per deployment using the latest blockchain height.
  * Balances remain accurate when deployments have no active leases or when chain data is unavailable.

* **Bug Fixes**
  * Prevented escrow balances and remaining time from becoming negative.
  * Preserved available funds while accounting for current deployment spending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->