### PR TITLE
feat(deployment): hide per-deployment escrow controls behind the escrow-abstraction flags

### DIFF
--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.spec.tsx
@@ -125,6 +125,24 @@ describe("DeploymentDetailHeader", () => {
     expect(screen.getByTestId("escrow-balance")).toHaveTextContent("3.72");
   });
 
+  describe("when escrow is abstracted behind the threshold flag", () => {
+    it("hides the balance and auto top-up tiles on an always-on deployment", () => {
+      setup({ escrowBalanceUdenom: 3_720_000, autoTopUpEnabled: true, isEscrowAbstracted: true });
+
+      expect(screen.queryByText("BALANCE")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("escrow-balance")).not.toBeInTheDocument();
+      expect(screen.queryByText("AUTO TOP-UP")).not.toBeInTheDocument();
+      expect(screen.getByText("COST")).toBeInTheDocument();
+    });
+
+    it("keeps the runtime limit tile on a limited deployment", () => {
+      setup({ runtimeLimitHours: 12, isEscrowAbstracted: true });
+
+      expect(screen.getByText("RUNTIME LIMIT")).toBeInTheDocument();
+      expect(screen.queryByText("BALANCE")).not.toBeInTheDocument();
+    });
+  });
+
   it("passes every lease and provider to the visit control", () => {
     const DeploymentVisitControl = vi.fn(() => <div>visit</div>);
     const leases = [buildLeaseInPlacement("1", "dcloud-us"), buildLeaseInPlacement("2", "dcloud-eu")];
@@ -232,6 +250,7 @@ describe("DeploymentDetailHeader", () => {
     providers?: ApiProviderList[];
     gpuAmount?: number;
     groups?: DeploymentGroup[];
+    isEscrowAbstracted?: boolean;
     dependencies?: Partial<typeof DEPENDENCIES>;
   }) {
     const changeDeploymentName = vi.fn();
@@ -242,6 +261,7 @@ describe("DeploymentDetailHeader", () => {
         getDeploymentData: () => (input.storedManifest ? { manifest: input.storedManifest, name: input.name ?? undefined } : null)
       });
     const useWallet: typeof DEPENDENCIES.useWallet = () => mock<ReturnType<typeof DEPENDENCIES.useWallet>>({ isTrialing: input.isTrialing ?? false });
+    const useFlag: typeof DEPENDENCIES.useFlag = () => input.isEscrowAbstracted ?? false;
     const useDeclaredTeeTypes: typeof DEPENDENCIES.useDeclaredTeeTypes = () => [];
     const useDeclaredGpuInterconnect: typeof DEPENDENCIES.useDeclaredGpuInterconnect = () => ({ enabled: false, fabrics: [] });
     const TrialDeploymentBadge = vi.fn(() => <div>trial-badge</div>);
@@ -282,6 +302,7 @@ describe("DeploymentDetailHeader", () => {
         dependencies={MockComponents(DEPENDENCIES, {
           useLocalNotes,
           useWallet,
+          useFlag,
           useDeploymentEscrowBalance,
           PriceValue,
           useDeploymentSettingQuery,

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.spec.tsx
@@ -261,7 +261,7 @@ describe("DeploymentDetailHeader", () => {
         getDeploymentData: () => (input.storedManifest ? { manifest: input.storedManifest, name: input.name ?? undefined } : null)
       });
     const useWallet: typeof DEPENDENCIES.useWallet = () => mock<ReturnType<typeof DEPENDENCIES.useWallet>>({ isTrialing: input.isTrialing ?? false });
-    const useFlag: typeof DEPENDENCIES.useFlag = () => input.isEscrowAbstracted ?? false;
+    const useIsEscrowAbstracted: typeof DEPENDENCIES.useIsEscrowAbstracted = () => input.isEscrowAbstracted ?? false;
     const useDeclaredTeeTypes: typeof DEPENDENCIES.useDeclaredTeeTypes = () => [];
     const useDeclaredGpuInterconnect: typeof DEPENDENCIES.useDeclaredGpuInterconnect = () => ({ enabled: false, fabrics: [] });
     const TrialDeploymentBadge = vi.fn(() => <div>trial-badge</div>);
@@ -302,7 +302,7 @@ describe("DeploymentDetailHeader", () => {
         dependencies={MockComponents(DEPENDENCIES, {
           useLocalNotes,
           useWallet,
-          useFlag,
+          useIsEscrowAbstracted,
           useDeploymentEscrowBalance,
           PriceValue,
           useDeploymentSettingQuery,

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.tsx
@@ -15,7 +15,7 @@ import { useWallet } from "@src/context/WalletProvider";
 import { useDeclaredGpuInterconnect } from "@src/hooks/useDeclaredGpuInterconnect";
 import { useDeclaredTeeTypes } from "@src/hooks/useDeclaredTeeTypes";
 import { useDeploymentEscrowBalance } from "@src/hooks/useDeploymentEscrowBalance/useDeploymentEscrowBalance";
-import { useFlag } from "@src/hooks/useFlag";
+import { useIsEscrowAbstracted } from "@src/hooks/useIsEscrowAbstracted";
 import { useTickingNow } from "@src/hooks/useTickingNow";
 import { useDeploymentSettingQuery } from "@src/queries/deploymentSettingsQuery";
 import type { DeploymentDto, LeaseDto } from "@src/types/deployment";
@@ -37,7 +37,7 @@ import { DeploymentStatusBadge } from "./DeploymentStatusBadge";
 export const DEPENDENCIES = {
   useLocalNotes,
   useWallet,
-  useFlag,
+  useIsEscrowAbstracted,
   useDeploymentEscrowBalance,
   useDeploymentSettingQuery,
   useDeclaredTeeTypes,
@@ -68,7 +68,7 @@ export interface DeploymentDetailHeaderProps {
 export const DeploymentDetailHeader: FC<DeploymentDetailHeaderProps> = ({ deployment, leases, providers, dependencies: d = DEPENDENCIES }) => {
   const { getDeploymentName, changeDeploymentName, getDeploymentData } = d.useLocalNotes();
   const { isTrialing } = d.useWallet();
-  const isEscrowAbstracted = d.useFlag("auto_reload_fixed_threshold");
+  const isEscrowAbstracted = d.useIsEscrowAbstracted();
   const { balanceUdenom, denom } = d.useDeploymentEscrowBalance({ deployment, leases });
   const { data: settings } = d.useDeploymentSettingQuery({ dseq: deployment.dseq });
   const teeTypes = d.useDeclaredTeeTypes(deployment);

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.tsx
@@ -15,6 +15,7 @@ import { useWallet } from "@src/context/WalletProvider";
 import { useDeclaredGpuInterconnect } from "@src/hooks/useDeclaredGpuInterconnect";
 import { useDeclaredTeeTypes } from "@src/hooks/useDeclaredTeeTypes";
 import { useDeploymentEscrowBalance } from "@src/hooks/useDeploymentEscrowBalance/useDeploymentEscrowBalance";
+import { useFlag } from "@src/hooks/useFlag";
 import { useTickingNow } from "@src/hooks/useTickingNow";
 import { useDeploymentSettingQuery } from "@src/queries/deploymentSettingsQuery";
 import type { DeploymentDto, LeaseDto } from "@src/types/deployment";
@@ -36,6 +37,7 @@ import { DeploymentStatusBadge } from "./DeploymentStatusBadge";
 export const DEPENDENCIES = {
   useLocalNotes,
   useWallet,
+  useFlag,
   useDeploymentEscrowBalance,
   useDeploymentSettingQuery,
   useDeclaredTeeTypes,
@@ -66,6 +68,7 @@ export interface DeploymentDetailHeaderProps {
 export const DeploymentDetailHeader: FC<DeploymentDetailHeaderProps> = ({ deployment, leases, providers, dependencies: d = DEPENDENCIES }) => {
   const { getDeploymentName, changeDeploymentName, getDeploymentData } = d.useLocalNotes();
   const { isTrialing } = d.useWallet();
+  const isEscrowAbstracted = d.useFlag("auto_reload_fixed_threshold");
   const { balanceUdenom, denom } = d.useDeploymentEscrowBalance({ deployment, leases });
   const { data: settings } = d.useDeploymentSettingQuery({ dseq: deployment.dseq });
   const teeTypes = d.useDeclaredTeeTypes(deployment);
@@ -118,9 +121,11 @@ export const DeploymentDetailHeader: FC<DeploymentDetailHeaderProps> = ({ deploy
           <SummaryItem label="COST">
             {costPerBlockUDenom ? <d.CostRate perBlockUDenom={costPerBlockUDenom} denom={denom} gpuCount={liveGpuCount} /> : "—"}
           </SummaryItem>
-          <SummaryItem label="BALANCE">
-            <d.PriceValue denom={denom} value={udenomToDenom(balanceUdenom, 6)} />
-          </SummaryItem>
+          {!isEscrowAbstracted && (
+            <SummaryItem label="BALANCE">
+              <d.PriceValue denom={denom} value={udenomToDenom(balanceUdenom, 6)} />
+            </SummaryItem>
+          )}
           {settings?.runtimeLimitHours ? (
             <SummaryItem
               label={
@@ -135,25 +140,27 @@ export const DeploymentDetailHeader: FC<DeploymentDetailHeaderProps> = ({ deploy
               {formatRuntimeLimit(settings.runtimeLimitHours, runtimeEndsAt, now)}
             </SummaryItem>
           ) : (
-            <SummaryItem
-              label={
-                <span className="inline-flex items-center gap-1">
-                  AUTO TOP-UP
-                  <d.CustomTooltip title="Automatically add credits when your balance gets low to keep your deployments running.">
-                    <InfoCircle width={12} height={12} className="text-muted-foreground" />
-                  </d.CustomTooltip>
-                </span>
-              }
-            >
-              {settings?.autoTopUpEnabled ? (
-                <Badge className="gap-1 rounded-md border-transparent bg-blue-500 px-2 py-0.5 text-white hover:bg-blue-500 dark:bg-blue-600 dark:hover:bg-blue-600">
-                  <CheckCircle width={12} height={12} />
-                  Active
-                </Badge>
-              ) : (
-                <span className="text-muted-foreground">Off</span>
-              )}
-            </SummaryItem>
+            !isEscrowAbstracted && (
+              <SummaryItem
+                label={
+                  <span className="inline-flex items-center gap-1">
+                    AUTO TOP-UP
+                    <d.CustomTooltip title="Automatically add credits when your balance gets low to keep your deployments running.">
+                      <InfoCircle width={12} height={12} className="text-muted-foreground" />
+                    </d.CustomTooltip>
+                  </span>
+                }
+              >
+                {settings?.autoTopUpEnabled ? (
+                  <Badge className="gap-1 rounded-md border-transparent bg-blue-500 px-2 py-0.5 text-white hover:bg-blue-500 dark:bg-blue-600 dark:hover:bg-blue-600">
+                    <CheckCircle width={12} height={12} />
+                    Active
+                  </Badge>
+                ) : (
+                  <span className="text-muted-foreground">Off</span>
+                )}
+              </SummaryItem>
+            )
           )}
           <SummaryItem label="GPU">{formatGpuLabel(deployment.gpuAmount ?? 0, getDeploymentGpuModels(deployment.groups))}</SummaryItem>
           <SummaryItem label="vCPU">{roundDecimal(deployment.cpuAmount, 2)}</SummaryItem>

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.tsx
@@ -116,56 +116,60 @@ export const DeploymentDetailHeader: FC<DeploymentDetailHeaderProps> = ({ deploy
       </div>
 
       <Card className="w-full shrink-0 lg:w-auto">
-        <CardContent className="grid grid-cols-4 gap-x-10 gap-y-5 p-6">
-          <SummaryItem label="TOTAL SERVICES">{servicesCount}</SummaryItem>
-          <SummaryItem label="COST">
-            {costPerBlockUDenom ? <d.CostRate perBlockUDenom={costPerBlockUDenom} denom={denom} gpuCount={liveGpuCount} /> : "—"}
-          </SummaryItem>
-          {!isEscrowAbstracted && (
-            <SummaryItem label="BALANCE">
-              <d.PriceValue denom={denom} value={udenomToDenom(balanceUdenom, 6)} />
+        <CardContent className="flex flex-col gap-5 p-6">
+          <div className="grid grid-cols-4 gap-x-10">
+            <SummaryItem label="TOTAL SERVICES">{servicesCount}</SummaryItem>
+            <SummaryItem label="COST">
+              {costPerBlockUDenom ? <d.CostRate perBlockUDenom={costPerBlockUDenom} denom={denom} gpuCount={liveGpuCount} /> : "—"}
             </SummaryItem>
-          )}
-          {settings?.runtimeLimitHours ? (
-            <SummaryItem
-              label={
-                <span className="inline-flex items-center gap-1">
-                  RUNTIME LIMIT
-                  <d.CustomTooltip title="This deployment closes automatically once its runtime limit is reached. Unused funds are returned to your balance.">
-                    <InfoCircle width={12} height={12} className="text-muted-foreground" />
-                  </d.CustomTooltip>
-                </span>
-              }
-            >
-              {formatRuntimeLimit(settings.runtimeLimitHours, runtimeEndsAt, now)}
-            </SummaryItem>
-          ) : (
-            !isEscrowAbstracted && (
+            {!isEscrowAbstracted && (
+              <SummaryItem label="BALANCE">
+                <d.PriceValue denom={denom} value={udenomToDenom(balanceUdenom, 6)} />
+              </SummaryItem>
+            )}
+            {settings?.runtimeLimitHours ? (
               <SummaryItem
                 label={
                   <span className="inline-flex items-center gap-1">
-                    AUTO TOP-UP
-                    <d.CustomTooltip title="Automatically add credits when your balance gets low to keep your deployments running.">
+                    RUNTIME LIMIT
+                    <d.CustomTooltip title="This deployment closes automatically once its runtime limit is reached. Unused funds are returned to your balance.">
                       <InfoCircle width={12} height={12} className="text-muted-foreground" />
                     </d.CustomTooltip>
                   </span>
                 }
               >
-                {settings?.autoTopUpEnabled ? (
-                  <Badge className="gap-1 rounded-md border-transparent bg-blue-500 px-2 py-0.5 text-white hover:bg-blue-500 dark:bg-blue-600 dark:hover:bg-blue-600">
-                    <CheckCircle width={12} height={12} />
-                    Active
-                  </Badge>
-                ) : (
-                  <span className="text-muted-foreground">Off</span>
-                )}
+                {formatRuntimeLimit(settings.runtimeLimitHours, runtimeEndsAt, now)}
               </SummaryItem>
-            )
-          )}
-          <SummaryItem label="GPU">{formatGpuLabel(deployment.gpuAmount ?? 0, getDeploymentGpuModels(deployment.groups))}</SummaryItem>
-          <SummaryItem label="vCPU">{roundDecimal(deployment.cpuAmount, 2)}</SummaryItem>
-          <SummaryItem label="MEMORY">{`${roundDecimal(memory.value, 2)} ${memory.unit}`}</SummaryItem>
-          <SummaryItem label="STORAGE">{`${roundDecimal(storage.value, 2)} ${storage.unit}`}</SummaryItem>
+            ) : (
+              !isEscrowAbstracted && (
+                <SummaryItem
+                  label={
+                    <span className="inline-flex items-center gap-1">
+                      AUTO TOP-UP
+                      <d.CustomTooltip title="Automatically add credits when your balance gets low to keep your deployments running.">
+                        <InfoCircle width={12} height={12} className="text-muted-foreground" />
+                      </d.CustomTooltip>
+                    </span>
+                  }
+                >
+                  {settings?.autoTopUpEnabled ? (
+                    <Badge className="gap-1 rounded-md border-transparent bg-blue-500 px-2 py-0.5 text-white hover:bg-blue-500 dark:bg-blue-600 dark:hover:bg-blue-600">
+                      <CheckCircle width={12} height={12} />
+                      Active
+                    </Badge>
+                  ) : (
+                    <span className="text-muted-foreground">Off</span>
+                  )}
+                </SummaryItem>
+              )
+            )}
+          </div>
+          <div className="grid grid-cols-4 gap-x-10">
+            <SummaryItem label="GPU">{formatGpuLabel(deployment.gpuAmount ?? 0, getDeploymentGpuModels(deployment.groups))}</SummaryItem>
+            <SummaryItem label="vCPU">{roundDecimal(deployment.cpuAmount, 2)}</SummaryItem>
+            <SummaryItem label="MEMORY">{`${roundDecimal(memory.value, 2)} ${memory.unit}`}</SummaryItem>
+            <SummaryItem label="STORAGE">{`${roundDecimal(storage.value, 2)} ${storage.unit}`}</SummaryItem>
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentBillingSection.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentBillingSection.spec.tsx
@@ -169,7 +169,7 @@ describe("DeploymentBillingSection", () => {
     const analyticsService = mock<ReturnType<typeof DEPENDENCIES.useServices>["analyticsService"]>();
     const useServices: typeof DEPENDENCIES.useServices = () => mock<ReturnType<typeof DEPENDENCIES.useServices>>({ analyticsService });
     const useWallet: typeof DEPENDENCIES.useWallet = () => mock<ReturnType<typeof DEPENDENCIES.useWallet>>({ denom: "uakt" });
-    const useFlag: typeof DEPENDENCIES.useFlag = () => input.isEscrowAbstracted ?? false;
+    const useIsEscrowAbstracted: typeof DEPENDENCIES.useIsEscrowAbstracted = () => input.isEscrowAbstracted ?? false;
     const usePricing: typeof DEPENDENCIES.usePricing = () => mock<ReturnType<typeof DEPENDENCIES.usePricing>>({ udenomToUsd: () => 0 });
     const useAutoTopUp: typeof DEPENDENCIES.useAutoTopUp = () =>
       mock<ReturnType<typeof DEPENDENCIES.useAutoTopUp>>({
@@ -223,7 +223,7 @@ describe("DeploymentBillingSection", () => {
         dependencies={MockComponents(DEPENDENCIES, {
           useServices,
           useWallet,
-          useFlag,
+          useIsEscrowAbstracted,
           usePricing,
           usePopup,
           useAutoTopUp,

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentBillingSection.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentBillingSection.spec.tsx
@@ -130,6 +130,27 @@ describe("DeploymentBillingSection", () => {
     expect(screen.queryByRole("button", { name: "Switch to always on" })).not.toBeInTheDocument();
   });
 
+  describe("when escrow is abstracted behind the threshold flag", () => {
+    it("hides the balance, Add funds, and the auto top-up toggle on an always-on deployment", () => {
+      setup({ state: "active", isEscrowAbstracted: true });
+
+      expect(screen.queryByText("Current balance")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("current-balance")).not.toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "Add funds" })).not.toBeInTheDocument();
+      expect(screen.queryByRole("switch", { name: "Auto Top-Up" })).not.toBeInTheDocument();
+    });
+
+    it("keeps the runtime-limit controls on a limited deployment while hiding the balance", () => {
+      setup({ state: "active", runtimeLimitHours: 12, isEscrowAbstracted: true });
+
+      expect(screen.getByText("Runtime limit: 12h")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Add hours" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Switch to always on" })).toBeInTheDocument();
+      expect(screen.queryByText("Current balance")).not.toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "Add funds" })).not.toBeInTheDocument();
+    });
+  });
+
   function setup(input: {
     state?: string;
     isEnabled?: boolean;
@@ -139,6 +160,7 @@ describe("DeploymentBillingSection", () => {
     runtimeEndsAt?: string | null;
     patchError?: Error;
     isConfirmed?: boolean;
+    isEscrowAbstracted?: boolean;
   }) {
     const setEnabled = vi.fn();
     const deposit = vi.fn();
@@ -147,6 +169,7 @@ describe("DeploymentBillingSection", () => {
     const analyticsService = mock<ReturnType<typeof DEPENDENCIES.useServices>["analyticsService"]>();
     const useServices: typeof DEPENDENCIES.useServices = () => mock<ReturnType<typeof DEPENDENCIES.useServices>>({ analyticsService });
     const useWallet: typeof DEPENDENCIES.useWallet = () => mock<ReturnType<typeof DEPENDENCIES.useWallet>>({ denom: "uakt" });
+    const useFlag: typeof DEPENDENCIES.useFlag = () => input.isEscrowAbstracted ?? false;
     const usePricing: typeof DEPENDENCIES.usePricing = () => mock<ReturnType<typeof DEPENDENCIES.usePricing>>({ udenomToUsd: () => 0 });
     const useAutoTopUp: typeof DEPENDENCIES.useAutoTopUp = () =>
       mock<ReturnType<typeof DEPENDENCIES.useAutoTopUp>>({
@@ -200,6 +223,7 @@ describe("DeploymentBillingSection", () => {
         dependencies={MockComponents(DEPENDENCIES, {
           useServices,
           useWallet,
+          useFlag,
           usePricing,
           usePopup,
           useAutoTopUp,

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentBillingSection.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentBillingSection.tsx
@@ -13,7 +13,7 @@ import { useServices } from "@src/context/ServicesProvider";
 import { useWallet } from "@src/context/WalletProvider";
 import { useAutoTopUp } from "@src/hooks/useAutoTopUp/useAutoTopUp";
 import { useDeploymentEscrowBalance } from "@src/hooks/useDeploymentEscrowBalance/useDeploymentEscrowBalance";
-import { useFlag } from "@src/hooks/useFlag";
+import { useIsEscrowAbstracted } from "@src/hooks/useIsEscrowAbstracted";
 import { usePricing } from "@src/hooks/usePricing/usePricing";
 import { useTickingNow } from "@src/hooks/useTickingNow";
 import { useUpdateDeploymentSettingMutation } from "@src/queries/deploymentSettingsQuery";
@@ -28,7 +28,7 @@ import { AddRuntimeHoursModal } from "./AddRuntimeHoursModal";
 export const DEPENDENCIES = {
   useServices,
   useWallet,
-  useFlag,
+  useIsEscrowAbstracted,
   usePopup,
   usePricing,
   useAutoTopUp,
@@ -56,7 +56,7 @@ export const DeploymentBillingSection: FC<DeploymentBillingSectionProps> = ({ de
   const { udenomToUsd } = d.usePricing();
   const { confirm } = d.usePopup();
   const { enqueueSnackbar } = d.useSnackbar();
-  const isEscrowAbstracted = d.useFlag("auto_reload_fixed_threshold");
+  const isEscrowAbstracted = d.useIsEscrowAbstracted();
   const [isDepositing, setIsDepositing] = useState(false);
   const [isAddingHours, setIsAddingHours] = useState(false);
   const isActive = deployment.state === "active";

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentBillingSection.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentBillingSection.tsx
@@ -13,6 +13,7 @@ import { useServices } from "@src/context/ServicesProvider";
 import { useWallet } from "@src/context/WalletProvider";
 import { useAutoTopUp } from "@src/hooks/useAutoTopUp/useAutoTopUp";
 import { useDeploymentEscrowBalance } from "@src/hooks/useDeploymentEscrowBalance/useDeploymentEscrowBalance";
+import { useFlag } from "@src/hooks/useFlag";
 import { usePricing } from "@src/hooks/usePricing/usePricing";
 import { useTickingNow } from "@src/hooks/useTickingNow";
 import { useUpdateDeploymentSettingMutation } from "@src/queries/deploymentSettingsQuery";
@@ -27,6 +28,7 @@ import { AddRuntimeHoursModal } from "./AddRuntimeHoursModal";
 export const DEPENDENCIES = {
   useServices,
   useWallet,
+  useFlag,
   usePopup,
   usePricing,
   useAutoTopUp,
@@ -54,6 +56,7 @@ export const DeploymentBillingSection: FC<DeploymentBillingSectionProps> = ({ de
   const { udenomToUsd } = d.usePricing();
   const { confirm } = d.usePopup();
   const { enqueueSnackbar } = d.useSnackbar();
+  const isEscrowAbstracted = d.useFlag("auto_reload_fixed_threshold");
   const [isDepositing, setIsDepositing] = useState(false);
   const [isAddingHours, setIsAddingHours] = useState(false);
   const isActive = deployment.state === "active";
@@ -140,13 +143,17 @@ export const DeploymentBillingSection: FC<DeploymentBillingSectionProps> = ({ de
     <div className="rounded-xl border bg-card p-6">
       <div className="flex flex-wrap items-center justify-between gap-4">
         <div className="space-y-1">
-          <div className="text-xs uppercase tracking-wide text-muted-foreground">Current balance</div>
-          <div className="text-2xl font-bold">
-            <d.PriceValue denom={escrowDenom} value={udenomToDenom(balanceUdenom, 6)} />
-          </div>
+          {!isEscrowAbstracted && (
+            <>
+              <div className="text-xs uppercase tracking-wide text-muted-foreground">Current balance</div>
+              <div className="text-2xl font-bold">
+                <d.PriceValue denom={escrowDenom} value={udenomToDenom(balanceUdenom, 6)} />
+              </div>
+            </>
+          )}
           {isRuntimeLimited && <div className="text-sm text-muted-foreground">Runtime limit: {formatRuntimeLimit(runtimeLimitHours, runtimeEndsAt, now)}</div>}
         </div>
-        {isActive && (
+        {isActive && (isRuntimeLimited || !isEscrowAbstracted) && (
           <Button variant="outline" size="md" onClick={isRuntimeLimited ? openAddHoursModal : openDepositModal}>
             {isRuntimeLimited ? "Add hours" : "Add funds"}
           </Button>
@@ -171,7 +178,7 @@ export const DeploymentBillingSection: FC<DeploymentBillingSectionProps> = ({ de
         </div>
       )}
 
-      {isActive && !isRuntimeLimited && (
+      {!isEscrowAbstracted && isActive && !isRuntimeLimited && (
         <div className="mt-6 flex items-center justify-between gap-4 border-t pt-6">
           <div className="space-y-1">
             <div className="flex items-center gap-2 font-medium">
@@ -201,7 +208,9 @@ export const DeploymentBillingSection: FC<DeploymentBillingSectionProps> = ({ de
         </div>
       )}
 
-      {isDepositing && <d.DeploymentDepositModal denom={escrowDenom} disableMin onCancel={() => setIsDepositing(false)} onSubmit={submitDeposit} />}
+      {!isEscrowAbstracted && isDepositing && (
+        <d.DeploymentDepositModal denom={escrowDenom} disableMin onCancel={() => setIsDepositing(false)} onSubmit={submitDeposit} />
+      )}
 
       {isAddingHours && isRuntimeLimited && (
         <d.AddRuntimeHoursModal

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentSettings.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentSettings.spec.tsx
@@ -30,11 +30,34 @@ describe("DeploymentSettings", () => {
     expect(screen.getByText("notifications:false")).toBeInTheDocument();
   });
 
-  function setup(input: { state?: string; isSignedIn?: boolean }) {
+  describe("when escrow is abstracted behind the threshold flag", () => {
+    it("hides the billing section for an always-on deployment", () => {
+      setup({ state: "active", isSignedIn: true, isEscrowAbstracted: true });
+
+      expect(screen.queryByText("billing-section")).not.toBeInTheDocument();
+      expect(screen.queryByText("Billing")).not.toBeInTheDocument();
+      expect(screen.getByText("notifications:true")).toBeInTheDocument();
+    });
+
+    it("keeps the billing section for a runtime-limited deployment", () => {
+      setup({ state: "active", isSignedIn: true, isEscrowAbstracted: true, runtimeLimitHours: 12 });
+
+      expect(screen.getByText("billing-section")).toBeInTheDocument();
+      expect(screen.getByText("Billing")).toBeInTheDocument();
+    });
+  });
+
+  function setup(input: { state?: string; isSignedIn?: boolean; isEscrowAbstracted?: boolean; runtimeLimitHours?: number | null }) {
     const useUser: typeof DEPENDENCIES.useUser = () =>
       mock<ReturnType<typeof DEPENDENCIES.useUser>>({
         user: input.isSignedIn ? mock<NonNullable<ReturnType<typeof DEPENDENCIES.useUser>["user"]>>({ userId: "u1" }) : undefined
       });
+    const useFlag: typeof DEPENDENCIES.useFlag = () => input.isEscrowAbstracted ?? false;
+    const settings = Object.assign(mock<NonNullable<ReturnType<typeof DEPENDENCIES.useDeploymentSettingQuery>["data"]>>(), {
+      runtimeLimitHours: input.runtimeLimitHours ?? null
+    });
+    const useDeploymentSettingQuery: typeof DEPENDENCIES.useDeploymentSettingQuery = () =>
+      Object.assign(mock<ReturnType<typeof DEPENDENCIES.useDeploymentSettingQuery>>(), { data: settings });
     const DeploymentBillingSection: typeof DEPENDENCIES.DeploymentBillingSection = vi.fn(() => <div>billing-section</div>);
     const DeploymentNotificationsSection: typeof DEPENDENCIES.DeploymentNotificationsSection = vi.fn(props => (
       <div>notifications:{String(props.isEnabled)}</div>
@@ -46,7 +69,14 @@ describe("DeploymentSettings", () => {
         deployment={mock<DeploymentDto>({ dseq: "1786440078202", state: input.state ?? "active" })}
         leases={[mock<LeaseDto>({ id: "1", state: "active" })]}
         onDeploymentChange={vi.fn()}
-        dependencies={MockComponents(DEPENDENCIES, { useUser, DeploymentBillingSection, DeploymentNotificationsSection, DeploymentDangerZone })}
+        dependencies={MockComponents(DEPENDENCIES, {
+          useUser,
+          useFlag,
+          useDeploymentSettingQuery,
+          DeploymentBillingSection,
+          DeploymentNotificationsSection,
+          DeploymentDangerZone
+        })}
       />
     );
   }

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentSettings.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentSettings.spec.tsx
@@ -45,9 +45,22 @@ describe("DeploymentSettings", () => {
       expect(screen.getByText("billing-section")).toBeInTheDocument();
       expect(screen.getByText("Billing")).toBeInTheDocument();
     });
+
+    it("keeps the billing section hidden until the deployment settings resolve", () => {
+      setup({ state: "active", isSignedIn: true, isEscrowAbstracted: true, isLoadingSettings: true });
+
+      expect(screen.queryByText("billing-section")).not.toBeInTheDocument();
+      expect(screen.queryByText("Billing")).not.toBeInTheDocument();
+    });
   });
 
-  function setup(input: { state?: string; isSignedIn?: boolean; isEscrowAbstracted?: boolean; runtimeLimitHours?: number | null }) {
+  function setup(input: {
+    state?: string;
+    isSignedIn?: boolean;
+    isEscrowAbstracted?: boolean;
+    runtimeLimitHours?: number | null;
+    isLoadingSettings?: boolean;
+  }) {
     const useUser: typeof DEPENDENCIES.useUser = () =>
       mock<ReturnType<typeof DEPENDENCIES.useUser>>({
         user: input.isSignedIn ? mock<NonNullable<ReturnType<typeof DEPENDENCIES.useUser>["user"]>>({ userId: "u1" }) : undefined
@@ -57,7 +70,7 @@ describe("DeploymentSettings", () => {
       runtimeLimitHours: input.runtimeLimitHours ?? null
     });
     const useDeploymentSettingQuery: typeof DEPENDENCIES.useDeploymentSettingQuery = () =>
-      Object.assign(mock<ReturnType<typeof DEPENDENCIES.useDeploymentSettingQuery>>(), { data: settings });
+      Object.assign(mock<ReturnType<typeof DEPENDENCIES.useDeploymentSettingQuery>>(), { data: input.isLoadingSettings ? undefined : settings });
     const DeploymentBillingSection: typeof DEPENDENCIES.DeploymentBillingSection = vi.fn(() => <div>billing-section</div>);
     const DeploymentNotificationsSection: typeof DEPENDENCIES.DeploymentNotificationsSection = vi.fn(props => (
       <div>notifications:{String(props.isEnabled)}</div>

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentSettings.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentSettings.spec.tsx
@@ -65,7 +65,7 @@ describe("DeploymentSettings", () => {
       mock<ReturnType<typeof DEPENDENCIES.useUser>>({
         user: input.isSignedIn ? mock<NonNullable<ReturnType<typeof DEPENDENCIES.useUser>["user"]>>({ userId: "u1" }) : undefined
       });
-    const useFlag: typeof DEPENDENCIES.useFlag = () => input.isEscrowAbstracted ?? false;
+    const useIsEscrowAbstracted: typeof DEPENDENCIES.useIsEscrowAbstracted = () => input.isEscrowAbstracted ?? false;
     const settings = Object.assign(mock<NonNullable<ReturnType<typeof DEPENDENCIES.useDeploymentSettingQuery>["data"]>>(), {
       runtimeLimitHours: input.runtimeLimitHours ?? null
     });
@@ -84,7 +84,7 @@ describe("DeploymentSettings", () => {
         onDeploymentChange={vi.fn()}
         dependencies={MockComponents(DEPENDENCIES, {
           useUser,
-          useFlag,
+          useIsEscrowAbstracted,
           useDeploymentSettingQuery,
           DeploymentBillingSection,
           DeploymentNotificationsSection,

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentSettings.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentSettings.tsx
@@ -1,7 +1,9 @@
 "use client";
 import type { FC, ReactNode } from "react";
 
+import { useFlag } from "@src/hooks/useFlag";
 import { useUser } from "@src/hooks/useUser";
+import { useDeploymentSettingQuery } from "@src/queries/deploymentSettingsQuery";
 import type { DeploymentDto, LeaseDto } from "@src/types/deployment";
 import { DeploymentTabHeader } from "../DeploymentTabHeader";
 import { DeploymentBillingSection } from "./DeploymentBillingSection";
@@ -10,6 +12,8 @@ import { DeploymentNotificationsSection } from "./DeploymentNotificationsSection
 
 export const DEPENDENCIES = {
   useUser,
+  useFlag,
+  useDeploymentSettingQuery,
   DeploymentBillingSection,
   DeploymentNotificationsSection,
   DeploymentDangerZone
@@ -26,12 +30,17 @@ export const DeploymentSettings: FC<DeploymentSettingsProps> = ({ deployment, le
   const { user } = d.useUser();
   const isAlertsEnabled = !!user?.userId;
   const isActive = deployment.state === "active";
+  const isEscrowAbstracted = d.useFlag("auto_reload_fixed_threshold");
+  const { data: settings } = d.useDeploymentSettingQuery({ dseq: deployment.dseq });
+  const showsBillingSection = !isEscrowAbstracted || !!settings?.runtimeLimitHours;
 
   return (
     <div className="space-y-8">
-      <SettingsSection title="Billing">
-        <d.DeploymentBillingSection deployment={deployment} leases={leases} onFundsChanged={onDeploymentChange} />
-      </SettingsSection>
+      {showsBillingSection && (
+        <SettingsSection title="Billing">
+          <d.DeploymentBillingSection deployment={deployment} leases={leases} onFundsChanged={onDeploymentChange} />
+        </SettingsSection>
+      )}
 
       <SettingsSection title="Notifications">
         <d.DeploymentNotificationsSection deployment={deployment} isEnabled={isAlertsEnabled} />

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentSettings.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentSettings.tsx
@@ -1,7 +1,7 @@
 "use client";
 import type { FC, ReactNode } from "react";
 
-import { useFlag } from "@src/hooks/useFlag";
+import { useIsEscrowAbstracted } from "@src/hooks/useIsEscrowAbstracted";
 import { useUser } from "@src/hooks/useUser";
 import { useDeploymentSettingQuery } from "@src/queries/deploymentSettingsQuery";
 import type { DeploymentDto, LeaseDto } from "@src/types/deployment";
@@ -12,7 +12,7 @@ import { DeploymentNotificationsSection } from "./DeploymentNotificationsSection
 
 export const DEPENDENCIES = {
   useUser,
-  useFlag,
+  useIsEscrowAbstracted,
   useDeploymentSettingQuery,
   DeploymentBillingSection,
   DeploymentNotificationsSection,
@@ -30,7 +30,7 @@ export const DeploymentSettings: FC<DeploymentSettingsProps> = ({ deployment, le
   const { user } = d.useUser();
   const isAlertsEnabled = !!user?.userId;
   const isActive = deployment.state === "active";
-  const isEscrowAbstracted = d.useFlag("auto_reload_fixed_threshold");
+  const isEscrowAbstracted = d.useIsEscrowAbstracted();
   const { data: settings } = d.useDeploymentSettingQuery({ dseq: deployment.dseq });
   const showsBillingSection = !isEscrowAbstracted || !!settings?.runtimeLimitHours;
 

--- a/apps/deploy-web/src/components/deployments/DeploymentDetailTopBar/DeploymentDetailTopBar.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetailTopBar/DeploymentDetailTopBar.spec.tsx
@@ -174,6 +174,29 @@ describe(DeploymentDetailTopBar.name, () => {
     });
   });
 
+  describe("when escrow is abstracted behind the threshold flag", () => {
+    it("hides Add funds and the auto top-up section on an active deployment", () => {
+      const deps = setup({
+        deployment: createDeployment({ state: "active" }),
+        isEscrowAbstracted: true
+      });
+
+      expect(deps.Button).not.toHaveBeenCalledWith(expect.objectContaining({ children: "Add funds" }), {});
+      expect(screen.queryByText("Auto top-up")).not.toBeInTheDocument();
+      expect(deps.Switch).not.toHaveBeenCalled();
+    });
+
+    it("keeps the Edit Name and Close actions", () => {
+      const deps = setup({
+        deployment: createDeployment({ state: "active" }),
+        isEscrowAbstracted: true
+      });
+
+      expect(deps.CustomDropdownLinkItem).toHaveBeenCalledWith(expect.objectContaining({ children: "Edit Name" }), {});
+      expect(deps.CustomDropdownLinkItem).toHaveBeenCalledWith(expect.objectContaining({ children: "Close" }), {});
+    });
+  });
+
   describe("closed deployment", () => {
     it("renders Edit Name button", () => {
       setup({
@@ -228,6 +251,7 @@ describe(DeploymentDetailTopBar.name, () => {
     removeLeases?: () => void;
     onDeploymentClose?: () => void;
     hasInAppHistory?: boolean;
+    isEscrowAbstracted?: boolean;
     router?: { back?: () => void; push?: () => void };
     wallet?: { denom?: string; signAndBroadcastTx?: () => Promise<boolean> };
     analyticsTrack?: ReturnType<typeof vi.fn>;
@@ -271,6 +295,7 @@ describe(DeploymentDetailTopBar.name, () => {
         udenomToUsd: vi.fn(() => 0)
       })) as typeof DEPENDENCIES.usePricing,
       useHasInAppHistory: vi.fn(() => input?.hasInAppHistory ?? false) as typeof DEPENDENCIES.useHasInAppHistory,
+      useFlag: vi.fn(() => input?.isEscrowAbstracted ?? false) as typeof DEPENDENCIES.useFlag,
       useManagedDeploymentConfirm: vi.fn(() => ({
         closeDeploymentConfirm: vi.fn(() => Promise.resolve(true))
       })) as typeof DEPENDENCIES.useManagedDeploymentConfirm,

--- a/apps/deploy-web/src/components/deployments/DeploymentDetailTopBar/DeploymentDetailTopBar.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetailTopBar/DeploymentDetailTopBar.spec.tsx
@@ -295,7 +295,7 @@ describe(DeploymentDetailTopBar.name, () => {
         udenomToUsd: vi.fn(() => 0)
       })) as typeof DEPENDENCIES.usePricing,
       useHasInAppHistory: vi.fn(() => input?.hasInAppHistory ?? false) as typeof DEPENDENCIES.useHasInAppHistory,
-      useFlag: vi.fn(() => input?.isEscrowAbstracted ?? false) as typeof DEPENDENCIES.useFlag,
+      useIsEscrowAbstracted: vi.fn(() => input?.isEscrowAbstracted ?? false) as typeof DEPENDENCIES.useIsEscrowAbstracted,
       useManagedDeploymentConfirm: vi.fn(() => ({
         closeDeploymentConfirm: vi.fn(() => Promise.resolve(true))
       })) as typeof DEPENDENCIES.useManagedDeploymentConfirm,

--- a/apps/deploy-web/src/components/deployments/DeploymentDetailTopBar/DeploymentDetailTopBar.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetailTopBar/DeploymentDetailTopBar.tsx
@@ -19,6 +19,7 @@ import { useWallet } from "@src/context/WalletProvider";
 import { useCurrencyFormatter } from "@src/hooks/useCurrencyFormatter/useCurrencyFormatter";
 import { useDeploymentMetrics } from "@src/hooks/useDeploymentMetrics";
 import { useDepositDeployment } from "@src/hooks/useDepositDeployment/useDepositDeployment";
+import { useFlag } from "@src/hooks/useFlag";
 import { useHasInAppHistory } from "@src/hooks/useHasInAppHistory";
 import { useManagedDeploymentConfirm } from "@src/hooks/useManagedDeploymentConfirm";
 import { usePricing } from "@src/hooks/usePricing/usePricing";
@@ -46,6 +47,7 @@ export const DEPENDENCIES = {
   useWallet,
   useCurrencyFormatter,
   useDepositDeployment,
+  useFlag,
   useDeploymentMetrics,
   useManagedDeploymentConfirm,
   useHasInAppHistory,
@@ -89,6 +91,7 @@ export const DeploymentDetailTopBar: React.FunctionComponent<Props> = ({
   const deploymentSetting = d.useDeploymentSettingQuery({ dseq: deployment.dseq });
   const { realTimeLeft, deploymentCost } = d.useDeploymentMetrics({ deployment, leases });
   const { confirm } = d.usePopup();
+  const isEscrowAbstracted = d.useFlag("auto_reload_fixed_threshold");
 
   function handleBackClick() {
     if (hasInAppHistory) {
@@ -232,38 +235,42 @@ export const DeploymentDetailTopBar: React.FunctionComponent<Props> = ({
                 </d.CustomDropdownLinkItem>
               </d.DropdownMenuContent>
             </d.DropdownMenu>
-            <d.Button
-              variant="default"
-              className="ml-2 whitespace-nowrap"
-              onClick={() => {
-                setIsDepositingDeployment(true);
-                analyticsService.track("deposit_deployment_btn_clk", "Amplitude");
-              }}
-              size="sm"
-            >
-              Add funds
-            </d.Button>
+            {!isEscrowAbstracted && (
+              <>
+                <d.Button
+                  variant="default"
+                  className="ml-2 whitespace-nowrap"
+                  onClick={() => {
+                    setIsDepositingDeployment(true);
+                    analyticsService.track("deposit_deployment_btn_clk", "Amplitude");
+                  }}
+                  size="sm"
+                >
+                  Add funds
+                </d.Button>
 
-            <div className="ml-4 flex items-center gap-2">
-              <d.Switch checked={deploymentSetting.data?.autoTopUpEnabled} onCheckedChange={setAutoTopUpEnabled} disabled={deploymentSetting.isLoading} />
-              <span>Auto top-up</span>
-              <d.CustomTooltip
-                title={
-                  <div className="space-y-2">
-                    <div>
-                      <div>Estimated amount: ${udenomToUsd(deploymentSetting.data?.estimatedTopUpAmount || 0, wallet.denom)}</div>
-                      <div>Check period: {formatDuration(intervalToDuration({ start: 0, end: deploymentSetting.data?.topUpFrequencyMs || 0 }))}</div>
-                    </div>
-                    <div className="text-xs text-muted-foreground">
-                      Auto top-up will only occur if there are insufficient funds to maintain the deployment until the next scheduled check.
-                    </div>
-                  </div>
-                }
-              >
-                <span className="cursor-help text-muted-foreground">ⓘ</span>
-              </d.CustomTooltip>
-              {deploymentSetting.isLoading && <d.Spinner size="small" />}
-            </div>
+                <div className="ml-4 flex items-center gap-2">
+                  <d.Switch checked={deploymentSetting.data?.autoTopUpEnabled} onCheckedChange={setAutoTopUpEnabled} disabled={deploymentSetting.isLoading} />
+                  <span>Auto top-up</span>
+                  <d.CustomTooltip
+                    title={
+                      <div className="space-y-2">
+                        <div>
+                          <div>Estimated amount: ${udenomToUsd(deploymentSetting.data?.estimatedTopUpAmount || 0, wallet.denom)}</div>
+                          <div>Check period: {formatDuration(intervalToDuration({ start: 0, end: deploymentSetting.data?.topUpFrequencyMs || 0 }))}</div>
+                        </div>
+                        <div className="text-xs text-muted-foreground">
+                          Auto top-up will only occur if there are insufficient funds to maintain the deployment until the next scheduled check.
+                        </div>
+                      </div>
+                    }
+                  >
+                    <span className="cursor-help text-muted-foreground">ⓘ</span>
+                  </d.CustomTooltip>
+                  {deploymentSetting.isLoading && <d.Spinner size="small" />}
+                </div>
+              </>
+            )}
           </div>
         )}
 
@@ -302,7 +309,7 @@ export const DeploymentDetailTopBar: React.FunctionComponent<Props> = ({
         )}
       </div>
 
-      {isDepositingDeployment && (
+      {!isEscrowAbstracted && isDepositingDeployment && (
         <d.DeploymentDepositModal
           denom={getEscrowDenom(deployment)}
           disableMin

--- a/apps/deploy-web/src/components/deployments/DeploymentDetailTopBar/DeploymentDetailTopBar.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetailTopBar/DeploymentDetailTopBar.tsx
@@ -19,8 +19,8 @@ import { useWallet } from "@src/context/WalletProvider";
 import { useCurrencyFormatter } from "@src/hooks/useCurrencyFormatter/useCurrencyFormatter";
 import { useDeploymentMetrics } from "@src/hooks/useDeploymentMetrics";
 import { useDepositDeployment } from "@src/hooks/useDepositDeployment/useDepositDeployment";
-import { useFlag } from "@src/hooks/useFlag";
 import { useHasInAppHistory } from "@src/hooks/useHasInAppHistory";
+import { useIsEscrowAbstracted } from "@src/hooks/useIsEscrowAbstracted";
 import { useManagedDeploymentConfirm } from "@src/hooks/useManagedDeploymentConfirm";
 import { usePricing } from "@src/hooks/usePricing/usePricing";
 import { useRedeploy } from "@src/hooks/useRedeploy/useRedeploy";
@@ -47,7 +47,7 @@ export const DEPENDENCIES = {
   useWallet,
   useCurrencyFormatter,
   useDepositDeployment,
-  useFlag,
+  useIsEscrowAbstracted,
   useDeploymentMetrics,
   useManagedDeploymentConfirm,
   useHasInAppHistory,
@@ -91,7 +91,7 @@ export const DeploymentDetailTopBar: React.FunctionComponent<Props> = ({
   const deploymentSetting = d.useDeploymentSettingQuery({ dseq: deployment.dseq });
   const { realTimeLeft, deploymentCost } = d.useDeploymentMetrics({ deployment, leases });
   const { confirm } = d.usePopup();
-  const isEscrowAbstracted = d.useFlag("auto_reload_fixed_threshold");
+  const isEscrowAbstracted = d.useIsEscrowAbstracted();
 
   function handleBackClick() {
     if (hasInAppHistory) {

--- a/apps/deploy-web/src/components/deployments/DeploymentList.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentList.spec.tsx
@@ -221,7 +221,7 @@ describe(DeploymentList.name, () => {
     });
 
     const useWallet: typeof DEPENDENCIES.useWallet = () => mock<ReturnType<typeof DEPENDENCIES.useWallet>>({ address: "akash1owner", hasWallet: true });
-    const useFlag: typeof DEPENDENCIES.useFlag = () => input.isEscrowAbstracted ?? false;
+    const useIsEscrowAbstracted: typeof DEPENDENCIES.useIsEscrowAbstracted = () => input.isEscrowAbstracted ?? false;
     const useProviderList: typeof DEPENDENCIES.useProviderList = () => mock<ReturnType<typeof DEPENDENCIES.useProviderList>>({ data: [], isFetching: false });
     const useBlockchainStatus: typeof DEPENDENCIES.useBlockchainStatus = () =>
       mock<ReturnType<typeof DEPENDENCIES.useBlockchainStatus>>({ isBlockchainDown: false });
@@ -247,7 +247,7 @@ describe(DeploymentList.name, () => {
           useDeploymentsPage,
           useDeploymentList,
           useWallet,
-          useFlag,
+          useIsEscrowAbstracted,
           useProviderList,
           useBlockchainStatus,
           useLocalNotes,

--- a/apps/deploy-web/src/components/deployments/DeploymentList.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentList.spec.tsx
@@ -178,6 +178,22 @@ describe(DeploymentList.name, () => {
     expect(screen.queryByText("No deployment found.")).not.toBeInTheDocument();
   });
 
+  it("labels the cost column with the escrow balance when escrow is visible", () => {
+    setup({ data: { deployments: [mock<DeploymentDto>({ dseq: "100", state: "active" })], hasNextPage: false } });
+
+    expect(screen.getByText("Cost and balance")).toBeInTheDocument();
+  });
+
+  it("labels the cost column without the escrow balance when escrow is abstracted behind the threshold flag", () => {
+    setup({
+      data: { deployments: [mock<DeploymentDto>({ dseq: "100", state: "active" })], hasNextPage: false },
+      isEscrowAbstracted: true
+    });
+
+    expect(screen.getByText("Cost")).toBeInTheDocument();
+    expect(screen.queryByText("Cost and balance")).not.toBeInTheDocument();
+  });
+
   function setup(
     input: {
       data?: DeploymentsPage;
@@ -186,6 +202,7 @@ describe(DeploymentList.name, () => {
       isFetching?: boolean;
       isError?: boolean;
       isListError?: boolean;
+      isEscrowAbstracted?: boolean;
       getDeploymentName?: (dseq: string | number | null) => string | null;
     } = {}
   ) {
@@ -204,6 +221,7 @@ describe(DeploymentList.name, () => {
     });
 
     const useWallet: typeof DEPENDENCIES.useWallet = () => mock<ReturnType<typeof DEPENDENCIES.useWallet>>({ address: "akash1owner", hasWallet: true });
+    const useFlag: typeof DEPENDENCIES.useFlag = () => input.isEscrowAbstracted ?? false;
     const useProviderList: typeof DEPENDENCIES.useProviderList = () => mock<ReturnType<typeof DEPENDENCIES.useProviderList>>({ data: [], isFetching: false });
     const useBlockchainStatus: typeof DEPENDENCIES.useBlockchainStatus = () =>
       mock<ReturnType<typeof DEPENDENCIES.useBlockchainStatus>>({ isBlockchainDown: false });
@@ -229,6 +247,7 @@ describe(DeploymentList.name, () => {
           useDeploymentsPage,
           useDeploymentList,
           useWallet,
+          useFlag,
           useProviderList,
           useBlockchainStatus,
           useLocalNotes,

--- a/apps/deploy-web/src/components/deployments/DeploymentList.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentList.tsx
@@ -30,7 +30,7 @@ import { useLocalNotes } from "@src/components/LocalNoteManager";
 import { LinkTo } from "@src/components/shared/LinkTo";
 import { useBlockchainStatus } from "@src/context/BlockchainStatusProvider";
 import { useWallet } from "@src/context/WalletProvider";
-import { useFlag } from "@src/hooks/useFlag";
+import { useIsEscrowAbstracted } from "@src/hooks/useIsEscrowAbstracted";
 import { useListSelection } from "@src/hooks/useListSelection/useListSelection";
 import { useManagedDeploymentConfirm } from "@src/hooks/useManagedDeploymentConfirm";
 import { useNewDeploymentUrl } from "@src/hooks/useNewDeploymentUrl/useNewDeploymentUrl";
@@ -46,7 +46,7 @@ import { DeploymentListRow } from "./DeploymentListRow";
 
 export const DEPENDENCIES = {
   useWallet,
-  useFlag,
+  useIsEscrowAbstracted,
   useProviderList,
   useBlockchainStatus,
   useLocalNotes,
@@ -66,7 +66,7 @@ type Props = {
 export const DeploymentList: React.FunctionComponent<Props> = ({ dependencies = DEPENDENCIES }) => {
   const {
     useWallet,
-    useFlag,
+    useIsEscrowAbstracted,
     useProviderList,
     useBlockchainStatus,
     useLocalNotes,
@@ -79,7 +79,7 @@ export const DeploymentList: React.FunctionComponent<Props> = ({ dependencies = 
     DeploymentListRow
   } = dependencies;
   const { address, signAndBroadcastTx, hasWallet } = useWallet();
-  const isEscrowAbstracted = useFlag("auto_reload_fixed_threshold");
+  const isEscrowAbstracted = useIsEscrowAbstracted();
   const { data: providers, isFetching: isLoadingProviders } = useProviderList();
   const { isBlockchainDown } = useBlockchainStatus();
   const { getDeploymentName } = useLocalNotes();

--- a/apps/deploy-web/src/components/deployments/DeploymentList.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentList.tsx
@@ -30,6 +30,7 @@ import { useLocalNotes } from "@src/components/LocalNoteManager";
 import { LinkTo } from "@src/components/shared/LinkTo";
 import { useBlockchainStatus } from "@src/context/BlockchainStatusProvider";
 import { useWallet } from "@src/context/WalletProvider";
+import { useFlag } from "@src/hooks/useFlag";
 import { useListSelection } from "@src/hooks/useListSelection/useListSelection";
 import { useManagedDeploymentConfirm } from "@src/hooks/useManagedDeploymentConfirm";
 import { useNewDeploymentUrl } from "@src/hooks/useNewDeploymentUrl/useNewDeploymentUrl";
@@ -45,6 +46,7 @@ import { DeploymentListRow } from "./DeploymentListRow";
 
 export const DEPENDENCIES = {
   useWallet,
+  useFlag,
   useProviderList,
   useBlockchainStatus,
   useLocalNotes,
@@ -64,6 +66,7 @@ type Props = {
 export const DeploymentList: React.FunctionComponent<Props> = ({ dependencies = DEPENDENCIES }) => {
   const {
     useWallet,
+    useFlag,
     useProviderList,
     useBlockchainStatus,
     useLocalNotes,
@@ -76,6 +79,7 @@ export const DeploymentList: React.FunctionComponent<Props> = ({ dependencies = 
     DeploymentListRow
   } = dependencies;
   const { address, signAndBroadcastTx, hasWallet } = useWallet();
+  const isEscrowAbstracted = useFlag("auto_reload_fixed_threshold");
   const { data: providers, isFetching: isLoadingProviders } = useProviderList();
   const { isBlockchainDown } = useBlockchainStatus();
   const { getDeploymentName } = useLocalNotes();
@@ -301,7 +305,7 @@ export const DeploymentList: React.FunctionComponent<Props> = ({ dependencies = 
                 <TableHead className="text-center">Specs</TableHead>
                 <TableHead className="text-center">Name</TableHead>
                 <TableHead className="text-center">DSEQ</TableHead>
-                <TableHead className="text-center">Cost and balance</TableHead>
+                <TableHead className="text-center">{isEscrowAbstracted ? "Cost" : "Cost and balance"}</TableHead>
                 <TableHead className="text-center">Leases</TableHead>
                 <TableHead></TableHead>
               </TableRow>

--- a/apps/deploy-web/src/components/deployments/DeploymentListRow.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentListRow.tsx
@@ -27,6 +27,7 @@ import { useServices } from "@src/context/ServicesProvider";
 import { useWallet } from "@src/context/WalletProvider";
 import { useDeclaredGpuInterconnect } from "@src/hooks/useDeclaredGpuInterconnect";
 import { useDepositDeployment } from "@src/hooks/useDepositDeployment/useDepositDeployment";
+import { useFlag } from "@src/hooks/useFlag";
 import { useManagedDeploymentConfirm } from "@src/hooks/useManagedDeploymentConfirm";
 import { useProviderCredentials } from "@src/hooks/useProviderCredentials/useProviderCredentials";
 import { useRealTimeLeft } from "@src/hooks/useRealTimeLeft";
@@ -54,6 +55,10 @@ import { DeploymentDepositModal } from "./DeploymentDepositModal/DeploymentDepos
 import { DeploymentName } from "./DeploymentName/DeploymentName";
 import { LeaseChip } from "./LeaseChip";
 
+export const DEPENDENCIES = {
+  useFlag
+};
+
 type Props = {
   deployment: NamedDeploymentDto;
   isSelectable?: boolean;
@@ -62,10 +67,20 @@ type Props = {
   providers: Array<ApiProviderList> | undefined;
   refreshDeployments: () => void;
   children?: ReactNode;
+  dependencies?: typeof DEPENDENCIES;
 };
 
-export const DeploymentListRow: React.FunctionComponent<Props> = ({ deployment, isSelectable, onSelectDeployment, checked, providers, refreshDeployments }) => {
+export const DeploymentListRow: React.FunctionComponent<Props> = ({
+  deployment,
+  isSelectable,
+  onSelectDeployment,
+  checked,
+  providers,
+  refreshDeployments,
+  dependencies: d = DEPENDENCIES
+}) => {
   const router = useRouter();
+  const isEscrowAbstracted = d.useFlag("auto_reload_fixed_threshold");
   const { analyticsService } = useServices();
   const [open, setOpen] = useState(false);
   const [isDepositingDeployment, setIsDepositingDeployment] = useState(false);
@@ -226,7 +241,7 @@ export const DeploymentListRow: React.FunctionComponent<Props> = ({ deployment, 
                 <PriceEstimateTooltip denom={getEscrowDenom(deployment)} value={deploymentCost} showAsHourly={hasGpu} />
               </div>
             )}
-            {isActive && !!escrowBalanceInDenom && !!escrowBalance && (
+            {!isEscrowAbstracted && isActive && !!escrowBalanceInDenom && !!escrowBalance && (
               <CustomTooltip
                 title={
                   <div className="text-left">
@@ -256,7 +271,7 @@ export const DeploymentListRow: React.FunctionComponent<Props> = ({ deployment, 
               </CustomTooltip>
             )}
           </div>
-          {isActive && ((isValidTimeLeft && realTimeLeft) || isRunningOutOfFunds) && (
+          {!isEscrowAbstracted && isActive && ((isValidTimeLeft && realTimeLeft) || isRunningOutOfFunds) && (
             <CustomTooltip
               disabled={!(showTimeLeftWarning || isRunningOutOfFunds)}
               title={
@@ -329,7 +344,7 @@ export const DeploymentListRow: React.FunctionComponent<Props> = ({ deployment, 
                 >
                   <ClickAwayListener onClickAway={() => setOpen(false)}>
                     <div>
-                      {isActive && (
+                      {!isEscrowAbstracted && isActive && (
                         <CustomDropdownLinkItem onClick={showDepositModal} icon={<Plus fontSize="small" />}>
                           Add funds
                         </CustomDropdownLinkItem>
@@ -365,7 +380,7 @@ export const DeploymentListRow: React.FunctionComponent<Props> = ({ deployment, 
         </TableCell>
       </TableRow>
 
-      {isActive && isDepositingDeployment && (
+      {!isEscrowAbstracted && isActive && isDepositingDeployment && (
         <DeploymentDepositModal
           denom={getEscrowDenom(deployment)}
           disableMin

--- a/apps/deploy-web/src/components/deployments/DeploymentListRow.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentListRow.tsx
@@ -27,7 +27,7 @@ import { useServices } from "@src/context/ServicesProvider";
 import { useWallet } from "@src/context/WalletProvider";
 import { useDeclaredGpuInterconnect } from "@src/hooks/useDeclaredGpuInterconnect";
 import { useDepositDeployment } from "@src/hooks/useDepositDeployment/useDepositDeployment";
-import { useFlag } from "@src/hooks/useFlag";
+import { useIsEscrowAbstracted } from "@src/hooks/useIsEscrowAbstracted";
 import { useManagedDeploymentConfirm } from "@src/hooks/useManagedDeploymentConfirm";
 import { useProviderCredentials } from "@src/hooks/useProviderCredentials/useProviderCredentials";
 import { useRealTimeLeft } from "@src/hooks/useRealTimeLeft";
@@ -56,7 +56,7 @@ import { DeploymentName } from "./DeploymentName/DeploymentName";
 import { LeaseChip } from "./LeaseChip";
 
 export const DEPENDENCIES = {
-  useFlag
+  useIsEscrowAbstracted
 };
 
 type Props = {
@@ -80,7 +80,7 @@ export const DeploymentListRow: React.FunctionComponent<Props> = ({
   dependencies: d = DEPENDENCIES
 }) => {
   const router = useRouter();
-  const isEscrowAbstracted = d.useFlag("auto_reload_fixed_threshold");
+  const isEscrowAbstracted = d.useIsEscrowAbstracted();
   const { analyticsService } = useServices();
   const [open, setOpen] = useState(false);
   const [isDepositingDeployment, setIsDepositingDeployment] = useState(false);

--- a/apps/deploy-web/src/components/deployments/DeploymentSubHeader.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentSubHeader.tsx
@@ -16,7 +16,7 @@ import { TrialDeploymentBadge } from "@src/components/shared/TrialDeploymentBadg
 import { useServices } from "@src/context/ServicesProvider";
 import { useWallet } from "@src/context/WalletProvider";
 import { useDeploymentMetrics } from "@src/hooks/useDeploymentMetrics";
-import { useFlag } from "@src/hooks/useFlag";
+import { useIsEscrowAbstracted } from "@src/hooks/useIsEscrowAbstracted";
 import { useTrialDeploymentTimeRemaining } from "@src/hooks/useTrialDeploymentTimeRemaining";
 import type { DeploymentDto, LeaseDto } from "@src/types/deployment";
 import type { TeeType } from "@src/utils/confidentialCompute";
@@ -26,7 +26,7 @@ import { hasLiveGpuLease, isLeaseLive } from "@src/utils/leaseUtils";
 import { udenomToDenom } from "@src/utils/mathHelpers";
 
 export const DEPENDENCIES = {
-  useFlag
+  useIsEscrowAbstracted
 };
 
 type Props = {
@@ -45,7 +45,7 @@ export const DeploymentSubHeader: React.FunctionComponent<Props> = ({
   interconnect = { enabled: false, fabrics: [] },
   dependencies: d = DEPENDENCIES
 }) => {
-  const isEscrowAbstracted = d.useFlag("auto_reload_fixed_threshold");
+  const isEscrowAbstracted = d.useIsEscrowAbstracted();
   const { deploymentCost, realTimeLeft } = useDeploymentMetrics({ deployment, leases });
   const isActive = deployment.state === "active";
   const hasLeases = !!leases && leases.length > 0;

--- a/apps/deploy-web/src/components/deployments/DeploymentSubHeader.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentSubHeader.tsx
@@ -16,6 +16,7 @@ import { TrialDeploymentBadge } from "@src/components/shared/TrialDeploymentBadg
 import { useServices } from "@src/context/ServicesProvider";
 import { useWallet } from "@src/context/WalletProvider";
 import { useDeploymentMetrics } from "@src/hooks/useDeploymentMetrics";
+import { useFlag } from "@src/hooks/useFlag";
 import { useTrialDeploymentTimeRemaining } from "@src/hooks/useTrialDeploymentTimeRemaining";
 import type { DeploymentDto, LeaseDto } from "@src/types/deployment";
 import type { TeeType } from "@src/utils/confidentialCompute";
@@ -24,15 +25,27 @@ import type { DeclaredGpuInterconnect } from "@src/utils/gpuInterconnect";
 import { hasLiveGpuLease, isLeaseLive } from "@src/utils/leaseUtils";
 import { udenomToDenom } from "@src/utils/mathHelpers";
 
+export const DEPENDENCIES = {
+  useFlag
+};
+
 type Props = {
   deployment: DeploymentDto;
   leases: LeaseDto[] | undefined | null;
   teeTypes?: TeeType[];
   interconnect?: DeclaredGpuInterconnect;
   children?: ReactNode;
+  dependencies?: typeof DEPENDENCIES;
 };
 
-export const DeploymentSubHeader: React.FunctionComponent<Props> = ({ deployment, leases, teeTypes = [], interconnect = { enabled: false, fabrics: [] } }) => {
+export const DeploymentSubHeader: React.FunctionComponent<Props> = ({
+  deployment,
+  leases,
+  teeTypes = [],
+  interconnect = { enabled: false, fabrics: [] },
+  dependencies: d = DEPENDENCIES
+}) => {
+  const isEscrowAbstracted = d.useFlag("auto_reload_fixed_threshold");
   const { deploymentCost, realTimeLeft } = useDeploymentMetrics({ deployment, leases });
   const isActive = deployment.state === "active";
   const hasLeases = !!leases && leases.length > 0;
@@ -51,35 +64,33 @@ export const DeploymentSubHeader: React.FunctionComponent<Props> = ({ deployment
   return (
     <div className="grid grid-cols-2 gap-6 p-6">
       <div>
-        <LabelValue
-          label="Balance"
-          labelWidth="6rem"
-          value={
-            <div className="flex items-center space-x-2">
-              <PriceValue
-                denom={getEscrowDenom(deployment)}
-                value={udenomToDenom(isActive && hasActiveLeases && realTimeLeft ? realTimeLeft?.escrow : deployment.escrowBalance, 6)}
-              />
+        {!isEscrowAbstracted && (
+          <LabelValue
+            label="Balance"
+            labelWidth="6rem"
+            value={
+              <div className="flex items-center space-x-2">
+                <PriceValue
+                  denom={getEscrowDenom(deployment)}
+                  value={udenomToDenom(isActive && hasActiveLeases && realTimeLeft ? realTimeLeft?.escrow : deployment.escrowBalance, 6)}
+                />
 
-              {isActive && hasActiveLeases && !!realTimeLeft && realTimeLeft.escrow <= 0 && (
-                <CustomTooltip title="Your deployment is out of funds and can be closed by your provider at any time now. You can add funds to keep active.">
-                  <WarningCircle className="text-xs text-destructive" />
-                </CustomTooltip>
-              )}
-            </div>
-          }
-        />
+                {isActive && hasActiveLeases && !!realTimeLeft && realTimeLeft.escrow <= 0 && (
+                  <CustomTooltip title="Your deployment is out of funds and can be closed by your provider at any time now. You can add funds to keep active.">
+                    <WarningCircle className="text-xs text-destructive" />
+                  </CustomTooltip>
+                )}
+              </div>
+            }
+          />
+        )}
         <LabelValue
           label="Cost"
           labelWidth="6rem"
           value={
             !!deploymentCost && (
               <div className="flex items-center space-x-2">
-                <PricePerTimeUnit
-                  denom={getEscrowDenom(deployment)}
-                  perBlockValue={udenomToDenom(deploymentCost, 10)}
-                  showAsHourly={hasGpu}
-                />
+                <PricePerTimeUnit denom={getEscrowDenom(deployment)} perBlockValue={udenomToDenom(deploymentCost, 10)} showAsHourly={hasGpu} />
               </div>
             )
           }
@@ -115,16 +126,18 @@ export const DeploymentSubHeader: React.FunctionComponent<Props> = ({ deployment
             </div>
           }
         />
-        <LabelValue
-          label="Time left"
-          labelWidth="6rem"
-          value={
-            <div className="flex items-center space-x-2">
-              {realTimeLeft && isValid(realTimeLeft?.timeLeft) && <span>~{formatDistanceToNow(realTimeLeft?.timeLeft)}</span>}
-              {isTrialing && trialTimeRemaining && <span className="text-xs text-primary">(Trial: {trialTimeRemaining})</span>}
-            </div>
-          }
-        />
+        {(!isEscrowAbstracted || (isTrialing && trialTimeRemaining)) && (
+          <LabelValue
+            label="Time left"
+            labelWidth="6rem"
+            value={
+              <div className="flex items-center space-x-2">
+                {!isEscrowAbstracted && realTimeLeft && isValid(realTimeLeft?.timeLeft) && <span>~{formatDistanceToNow(realTimeLeft?.timeLeft)}</span>}
+                {isTrialing && trialTimeRemaining && <span className="text-xs text-primary">(Trial: {trialTimeRemaining})</span>}
+              </div>
+            }
+          />
+        )}
         <LabelValue
           label="DSEQ"
           labelWidth="6rem"

--- a/apps/deploy-web/src/hooks/useIsEscrowAbstracted.spec.ts
+++ b/apps/deploy-web/src/hooks/useIsEscrowAbstracted.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { type DEPENDENCIES, useIsEscrowAbstracted } from "./useIsEscrowAbstracted";
+
+import { renderHook } from "@testing-library/react";
+
+describe(useIsEscrowAbstracted.name, () => {
+  it("abstracts escrow once the platform owns the deposit and the funding-mode control is live", () => {
+    const { result } = setup({ isDepositManagedByPlatform: true, hasFundingModeControl: true });
+
+    expect(result.current).toBe(true);
+  });
+
+  it("keeps the escrow controls while the funding-mode control that replaces them is off", () => {
+    const { result } = setup({ isDepositManagedByPlatform: true, hasFundingModeControl: false });
+
+    expect(result.current).toBe(false);
+  });
+
+  it("keeps the escrow controls while the deposit is still the user's to manage", () => {
+    const { result } = setup({ isDepositManagedByPlatform: false, hasFundingModeControl: true });
+
+    expect(result.current).toBe(false);
+  });
+
+  it("keeps the escrow controls when neither side has rolled out", () => {
+    const { result } = setup({ isDepositManagedByPlatform: false, hasFundingModeControl: false });
+
+    expect(result.current).toBe(false);
+  });
+
+  function setup(input: { isDepositManagedByPlatform: boolean; hasFundingModeControl: boolean }) {
+    const useFlag: typeof DEPENDENCIES.useFlag = flag =>
+      flag === "auto_reload_fixed_threshold" ? input.isDepositManagedByPlatform : input.hasFundingModeControl;
+
+    return renderHook(() => useIsEscrowAbstracted({ useFlag }));
+  }
+});

--- a/apps/deploy-web/src/hooks/useIsEscrowAbstracted.ts
+++ b/apps/deploy-web/src/hooks/useIsEscrowAbstracted.ts
@@ -1,0 +1,19 @@
+import { useFlag } from "./useFlag";
+
+export const DEPENDENCIES = { useFlag };
+
+/**
+ * Whether escrow is abstracted away from the user, i.e. whether the per-deployment escrow figures and controls
+ * (balance, time left, "Add funds", the auto top-up toggle) should be hidden.
+ *
+ * Both flags have to be on. `auto_reload_fixed_threshold` is what makes the platform own the deposit: the API
+ * then bootstraps every deployment with a fixed amount and ignores a caller-supplied one. `deployment_runtime_limit`
+ * is what puts the funding-mode control (runtime limit vs. always on) in place of the old toggle. Hiding the old
+ * controls while only one of them is on would leave a deployment with no funding control at all.
+ */
+export function useIsEscrowAbstracted(dependencies: typeof DEPENDENCIES = DEPENDENCIES) {
+  const isDepositManagedByPlatform = dependencies.useFlag("auto_reload_fixed_threshold");
+  const hasFundingModeControl = dependencies.useFlag("deployment_runtime_limit");
+
+  return isDepositManagedByPlatform && hasFundingModeControl;
+}


### PR DESCRIPTION
## Why

Part of CON-738

With escrow abstracted away (CON-733) and deployment funding always on (CON-734), the per-deployment escrow UI stops making sense: users never manage escrow themselves. This PR hides the "Add funds" action, the auto top-up toggle, and the escrow balance / time-left figures behind a `useIsEscrowAbstracted` hook that requires two flags. `auto_reload_fixed_threshold` is what makes the platform own the deposit (the API bootstraps a fixed amount and ignores a caller-supplied one), and `deployment_runtime_limit` is what puts the CON-886 funding-mode control in place of the old toggle. Requiring both means the old controls never disappear before their replacement exists, which is the coordination CON-738 asks for, and either flag going off is a full rollback.

## What

With both flags on:

- Deployments list: the escrow balance chip, the time-left line with its low-funds warning, and the "Add funds" row action are hidden. The column header reads "Cost" instead of "Cost and balance". Cost stays visible.
- Redesigned detail page: the header loses the BALANCE and AUTO TOP-UP tiles (RUNTIME LIMIT stays for limited deployments). The summary card also splits into two rows: services and cost (plus balance and runtime limit when they apply) on top, then the four resource tiles together underneath, so dropping tiles no longer strands memory and storage on a half-empty row. The settings Billing card drops the balance figure, "Add funds", and the auto top-up switch, keeping only the runtime-limit controls from CON-886 ("Add hours", "Switch to always on"). For always-on deployments the Billing section would be empty, so it's hidden entirely.
- Legacy detail page: the top bar loses "Add funds" and the auto top-up switch; the sub header loses the Balance and Time left rows (the trial countdown stays for trial users).

With either flag off, everything renders as before. Conditional rendering only, no deletions: dead-code cleanup happens after the flag reaches 100%.

Related notes:

- The per-deployment balance-alert configuration removal ships separately in #3634.
- `DeploymentListRow` and `DeploymentSubHeader` had no specs (they read context hooks directly, so a spec needs heavy scaffolding); their flag guards are thin conditionals. The other five touched components' specs cover both flag states.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated deployment views for escrow-abstracted deployments.
  * Hid balance, add-funds, auto top-up, deposit, and time-left controls when applicable.
  * Preserved runtime-limit and trial-time information where relevant.
  * Updated cost labels to distinguish cost-only views from cost and balance.
* **Bug Fixes**
  * Improved billing and deployment settings visibility based on deployment configuration.
* **Tests**
  * Added coverage for escrow-abstracted, limited, always-on, active, and loading states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->