### PR TITLE
feat(deployment): reject disabling automatic funding behind the threshold flag

### DIFF
--- a/apps/api/src/deployment/http-schemas/deployment-setting.schema.ts
+++ b/apps/api/src/deployment/http-schemas/deployment-setting.schema.ts
@@ -32,8 +32,9 @@ export const CreateDeploymentSettingRequestSchema = z.object({
     dseq: DseqSchema.openapi({
       description: "Deployment sequence number"
     }),
-    autoTopUpEnabled: z.boolean().default(false).openapi({
-      description: "Whether auto top-up is enabled for this deployment"
+    autoTopUpEnabled: z.boolean().optional().openapi({
+      description:
+        "Whether auto top-up is enabled for this deployment. Defaults to enabled when omitted; an explicit false is rejected once always-on funding is rolled out"
     })
   })
 });
@@ -41,7 +42,7 @@ export const CreateDeploymentSettingRequestSchema = z.object({
 export const UpdateDeploymentSettingRequestSchema = z.object({
   data: z.object({
     autoTopUpEnabled: z.boolean().optional().openapi({
-      description: "Whether auto top-up is enabled for this deployment"
+      description: "Whether auto top-up is enabled for this deployment. An explicit false is rejected once always-on funding is rolled out"
     }),
     runtimeLimitHours: z
       .number()
@@ -82,8 +83,9 @@ export const CreateDeploymentSettingV2RequestSchema = z.object({
     dseq: DseqSchema.openapi({
       description: "Deployment sequence number"
     }),
-    autoTopUpEnabled: z.boolean().default(false).openapi({
-      description: "Whether auto top-up is enabled for this deployment"
+    autoTopUpEnabled: z.boolean().optional().openapi({
+      description:
+        "Whether auto top-up is enabled for this deployment. Defaults to enabled when omitted; an explicit false is rejected once always-on funding is rolled out"
     }),
     userId: z.string().uuid().optional().openapi({
       description: "User ID. Defaults to the current authenticated user if not provided"

--- a/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.spec.ts
@@ -11,6 +11,7 @@ import { FundDeploymentCommand } from "@src/billing/commands/fund-deployment.com
 import type { UserWalletRepository } from "@src/billing/repositories";
 import type { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
 import type { DomainEventsService } from "@src/core/services/domain-events/domain-events.service";
+import type { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
 import type { DeploymentSettingRepository, DeploymentSettingsOutput } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import type { DeploymentConfigService } from "../deployment-config/deployment-config.service";
 import type { DrainingDeploymentService } from "../draining-deployment/draining-deployment.service";
@@ -504,6 +505,60 @@ describe(DeploymentSettingService.name, () => {
     });
   });
 
+  describe("when always-on funding is rolled out", () => {
+    it("rejects an upsert turning auto top-up off before touching the row", async () => {
+      const { service, deploymentSettingRepository } = setup({ isAlwaysOnFundingEnabled: true });
+      const params = { userId: faker.string.uuid(), dseq: faker.string.numeric(6) };
+
+      await expect(service.upsert(params, { autoTopUpEnabled: false })).rejects.toMatchObject({ status: 400 });
+      expect(deploymentSettingRepository.findOneBy).not.toHaveBeenCalled();
+      expect(deploymentSettingRepository.updateBy).not.toHaveBeenCalled();
+    });
+
+    it("rejects an opt-out sent alongside a runtime limit instead of silently overriding it", async () => {
+      const { service, deploymentSettingRepository } = setup({ isAlwaysOnFundingEnabled: true });
+      const params = { userId: faker.string.uuid(), dseq: faker.string.numeric(6) };
+
+      await expect(service.upsert(params, { runtimeLimitHours: 12, autoTopUpEnabled: false })).rejects.toMatchObject({ status: 400 });
+      expect(deploymentSettingRepository.create).not.toHaveBeenCalled();
+    });
+
+    it("rejects a create with funding off", async () => {
+      const { service, deploymentSettingRepository } = setup({ isAlwaysOnFundingEnabled: true });
+
+      await expect(service.create({ userId: faker.string.uuid(), dseq: faker.string.numeric(6), autoTopUpEnabled: false })).rejects.toMatchObject({
+        status: 400
+      });
+      expect(deploymentSettingRepository.create).not.toHaveBeenCalled();
+    });
+
+    it("accepts an upsert turning auto top-up on", async () => {
+      const { service, deploymentSettingRepository } = setup({ isAlwaysOnFundingEnabled: true });
+      const params = { userId: faker.string.uuid(), dseq: faker.string.numeric(6) };
+
+      deploymentSettingRepository.accessibleBy.mockReturnValue(deploymentSettingRepository);
+      deploymentSettingRepository.findOneBy.mockResolvedValue(createDeploymentSettingsOutput({ ...params, autoTopUpEnabled: false }));
+      deploymentSettingRepository.updateBy.mockResolvedValue(createDeploymentSettingsOutput({ ...params, autoTopUpEnabled: true }) as never);
+
+      const result = await service.upsert(params, { autoTopUpEnabled: true });
+
+      expect(result).toEqual(expect.objectContaining({ autoTopUpEnabled: true }));
+    });
+
+    it("accepts a create that omits the funding preference", async () => {
+      const { service, deploymentSettingRepository } = setup({ isAlwaysOnFundingEnabled: true });
+      const input = { userId: faker.string.uuid(), dseq: faker.string.numeric(6) };
+
+      deploymentSettingRepository.accessibleBy.mockReturnValue(deploymentSettingRepository);
+      deploymentSettingRepository.create.mockResolvedValue(createDeploymentSettingsOutput({ ...input, autoTopUpEnabled: true }));
+
+      const result = await service.create(input);
+
+      expect(deploymentSettingRepository.create).toHaveBeenCalledWith(input);
+      expect(result).toEqual(expect.objectContaining({ autoTopUpEnabled: true }));
+    });
+  });
+
   /** Mirrors how drizzle surfaces a unique violation: a wrapper error carrying the driver error as its cause. */
   function createUniqueViolation() {
     const driverError = Object.assign(Object.create(PostgresError.prototype), {
@@ -532,7 +587,7 @@ describe(DeploymentSettingService.name, () => {
     };
   }
 
-  function setup() {
+  function setup(input: { isAlwaysOnFundingEnabled?: boolean } = {}) {
     const deploymentSettingRepository = mock<DeploymentSettingRepository>();
     const authService = mock<AuthService>();
     const drainingDeploymentService = mock<DrainingDeploymentService>();
@@ -540,6 +595,8 @@ describe(DeploymentSettingService.name, () => {
     const userWalletRepository = mock<UserWalletRepository>();
     const instrumentation = mock<TopUpManagedDeploymentsInstrumentationService>();
     const domainEvents = mock<DomainEventsService>();
+    const featureFlagsService = mock<FeatureFlagsService>();
+    featureFlagsService.isEnabled.mockReturnValue(input.isAlwaysOnFundingEnabled ?? false);
 
     const config = mockConfigService<DeploymentConfigService>({
       AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H: 24
@@ -553,7 +610,8 @@ describe(DeploymentSettingService.name, () => {
       config,
       userWalletRepository,
       instrumentation,
-      domainEvents
+      domainEvents,
+      featureFlagsService
     );
 
     return {
@@ -565,7 +623,8 @@ describe(DeploymentSettingService.name, () => {
       config,
       userWalletRepository,
       instrumentation,
-      domainEvents
+      domainEvents,
+      featureFlagsService
     };
   }
 });

--- a/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.ts
+++ b/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.ts
@@ -10,6 +10,8 @@ import { UserWalletRepository } from "@src/billing/repositories";
 import { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
 import { isUniqueViolation } from "@src/core/repositories/base.repository";
 import { DomainEventsService } from "@src/core/services/domain-events/domain-events.service";
+import { FeatureFlags } from "@src/core/services/feature-flags/feature-flags";
+import { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
 import { FindDeploymentSettingParams } from "@src/deployment/http-schemas/deployment-setting.schema";
 import { MAX_RUNTIME_LIMIT_INCREMENT_HOURS } from "@src/deployment/http-schemas/runtime-limit";
 import {
@@ -44,7 +46,8 @@ export class DeploymentSettingService {
     private readonly config: DeploymentConfigService,
     private readonly userWalletRepository: UserWalletRepository,
     private readonly instrumentation: TopUpManagedDeploymentsInstrumentationService,
-    private readonly domainEvents: DomainEventsService
+    private readonly domainEvents: DomainEventsService,
+    private readonly featureFlags: FeatureFlagsService
   ) {}
 
   async findOrCreateByUserIdAndDseq(params: FindDeploymentSettingParams): Promise<DeploymentSettingWithEstimatedTopUpAmount | undefined> {
@@ -74,6 +77,8 @@ export class DeploymentSettingService {
   }
 
   async create(input: DeploymentSettingsInput): Promise<DeploymentSettingWithEstimatedTopUpAmount> {
+    this.#assertFundingStaysOn(input.autoTopUpEnabled);
+
     const result = await this.withEstimatedTopUpAmount(await this.deploymentSettingRepository.accessibleBy(this.authService.ability, "create").create(input));
 
     if (result.autoTopUpEnabled) {
@@ -84,6 +89,8 @@ export class DeploymentSettingService {
   }
 
   async upsert(params: FindDeploymentSettingParams, input: DeploymentSettingChange): Promise<DeploymentSettingWithEstimatedTopUpAmount> {
+    this.#assertFundingStaysOn(input.autoTopUpEnabled);
+
     try {
       const { setting, existing } = await this.#writeReconcilingConcurrentCreate(params, input);
 
@@ -96,6 +103,21 @@ export class DeploymentSettingService {
       assert(!(error instanceof ForbiddenError), 404, "Deployment setting not found");
       throw error;
     }
+  }
+
+  /**
+   * Under the fixed-threshold rollout, deployment funding is always on (CON-734): an explicit
+   * opt-out is rejected rather than stored, so the state removed by the one-time backfill cannot be
+   * recreated. Gated on the same flag that hides the toggle in the UI, so the API and the interface
+   * flip together per user; off-flag the legacy opt-out contract holds. Runtime limits stay the
+   * supported way to bound a deployment's spend.
+   */
+  #assertFundingStaysOn(autoTopUpEnabled: boolean | undefined): void {
+    assert(
+      autoTopUpEnabled !== false || !this.featureFlags.isEnabled(FeatureFlags.AUTO_RELOAD_FIXED_THRESHOLD),
+      400,
+      "Automatic deployment funding cannot be turned off. Set a runtime limit to bound how long the deployment runs."
+    );
   }
 
   /**

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -5454,8 +5454,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                   "data": {
                     "properties": {
                       "autoTopUpEnabled": {
-                        "default": false,
-                        "description": "Whether auto top-up is enabled for this deployment",
+                        "description": "Whether auto top-up is enabled for this deployment. Defaults to enabled when omitted; an explicit false is rejected once always-on funding is rolled out",
                         "type": "boolean",
                       },
                       "dseq": {
@@ -5727,7 +5726,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                   "data": {
                     "properties": {
                       "autoTopUpEnabled": {
-                        "description": "Whether auto top-up is enabled for this deployment",
+                        "description": "Whether auto top-up is enabled for this deployment. An explicit false is rejected once always-on funding is rolled out",
                         "type": "boolean",
                       },
                       "runtimeLimitHours": {
@@ -15627,8 +15626,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                   "data": {
                     "properties": {
                       "autoTopUpEnabled": {
-                        "default": false,
-                        "description": "Whether auto top-up is enabled for this deployment",
+                        "description": "Whether auto top-up is enabled for this deployment. Defaults to enabled when omitted; an explicit false is rejected once always-on funding is rolled out",
                         "type": "boolean",
                       },
                       "dseq": {
@@ -15902,7 +15900,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                   "data": {
                     "properties": {
                       "autoTopUpEnabled": {
-                        "description": "Whether auto top-up is enabled for this deployment",
+                        "description": "Whether auto top-up is enabled for this deployment. An explicit false is rejected once always-on funding is rolled out",
                         "type": "boolean",
                       },
                       "runtimeLimitHours": {

--- a/apps/api/test/functional/deployment-setting.spec.ts
+++ b/apps/api/test/functional/deployment-setting.spec.ts
@@ -463,6 +463,77 @@ describe("Deployment Settings", () => {
     });
   });
 
+  describe("disabling automatic funding", () => {
+    it("returns 400 for a PATCH turning auto top-up off", async () => {
+      const { token, user } = await setup();
+      const dseq = faker.number.int({ min: 1, max: 1000000 }).toString();
+      await deploymentSettingRepository.create({ userId: user.id, dseq, autoTopUpEnabled: true });
+
+      const response = await app.request(`/v1/deployment-settings/${user.id}/${dseq}`, {
+        method: "PATCH",
+        headers: {
+          authorization: `Bearer ${token}`,
+          "content-type": "application/json"
+        },
+        body: JSON.stringify({ data: { autoTopUpEnabled: false } })
+      });
+
+      expect(response.status).toBe(400);
+      expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq })).toMatchObject({ autoTopUpEnabled: true });
+    });
+
+    it("returns 400 when an opt-out arrives alongside a runtime limit", async () => {
+      const { token, user } = await setup();
+      const dseq = faker.number.int({ min: 1, max: 1000000 }).toString();
+      await deploymentSettingRepository.create({ userId: user.id, dseq, autoTopUpEnabled: true });
+
+      const response = await app.request(`/v2/deployment-settings/${dseq}`, {
+        method: "PATCH",
+        headers: {
+          authorization: `Bearer ${token}`,
+          "content-type": "application/json"
+        },
+        body: JSON.stringify({ data: { autoTopUpEnabled: false, runtimeLimitHours: 12 } })
+      });
+
+      expect(response.status).toBe(400);
+      expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq })).toMatchObject({ runtimeLimitHours: null });
+    });
+
+    it("returns 400 for a POST creating a setting with funding off", async () => {
+      const { token } = await setup();
+      const dseq = faker.number.int({ min: 1, max: 1000000 }).toString();
+
+      const response = await app.request("/v2/deployment-settings", {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${token}`,
+          "content-type": "application/json"
+        },
+        body: JSON.stringify({ data: { dseq, autoTopUpEnabled: false } })
+      });
+
+      expect(response.status).toBe(400);
+    });
+
+    it("creates a funded setting when the field is omitted", async () => {
+      const { token } = await setup();
+      const dseq = faker.number.int({ min: 1, max: 1000000 }).toString();
+
+      const response = await app.request("/v2/deployment-settings", {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${token}`,
+          "content-type": "application/json"
+        },
+        body: JSON.stringify({ data: { dseq } })
+      });
+
+      expect(response.status).toBe(201);
+      expect(await response.json()).toEqual({ data: expect.objectContaining({ autoTopUpEnabled: true }) });
+    });
+  });
+
   function patchRuntimeLimit({ dseq, token, runtimeLimitHours }: { dseq: string; token: string; runtimeLimitHours: number | null }) {
     return app.request(`/v2/deployment-settings/${dseq}`, {
       method: "PATCH",


### PR DESCRIPTION
## Why

Part of CON-734

Removing the auto top-up toggle from the UI (#3651) is not enough to make deployment funding always on: `PATCH /v2/deployment-settings/{dseq}` still accepts `autoTopUpEnabled: false`, so the opt-out state the one-time backfill (#3654) removes could simply be recreated through the API.

## What

With `auto_reload_fixed_threshold` on for the user, the deployment-setting service rejects an explicit `autoTopUpEnabled: false` with a 400 on both the create and update paths, pointing at runtime limits as the supported way to bound a deployment. The guard lives in the service rather than the zod schema because the flag is evaluated per user at request time. It is the same flag that hides the toggle (#3651) and gates managed deposits, so the API and the UI flip together during rollout. With the flag off, the legacy opt-out contract is unchanged.

Two related contract details:

- The create request schemas stop defaulting an omitted `autoTopUpEnabled` to `false`. An omitted field now reaches the repository default (enabled, per #3636), matching the lazy-create path; before, a POST that never mentioned the field silently created an opt-out row.
- Sending `false` alongside a runtime limit used to be silently overridden to `true`; under the flag it is now rejected like any other opt-out.

Removing the field from the schemas entirely is the post-rollout cleanup and stays out of scope here.

Covered by service unit tests for both flag states and functional tests (which run with all flags on) for POST and PATCH on v1 and v2. The OpenAPI docs snapshot picks up the description changes.

#3636 and #3651 have merged; this PR now targets `main` directly.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Automatic funding now defaults to enabled when no preference is provided during deployment setup.
  - When always-on funding is active, deployment settings consistently enforce automatic funding across supported creation and update flows.

- **Bug Fixes**
  - Requests attempting to disable automatic funding now receive a clear validation error when always-on funding is enabled.
  - Existing opt-out behavior remains available while always-on funding is not active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->