### PR TITLE
fix(deployment): backfill missing settings rows so existing deployments keep being funded

### DIFF
--- a/apps/api/src/app/console.ts
+++ b/apps/api/src/app/console.ts
@@ -61,6 +61,16 @@ program
   });
 
 program
+  .command("backfill-deployment-settings")
+  .description("Create missing deployment settings rows for open deployments so the funding sweep can see them")
+  .option("-d, --dry-run", "Only count and log the missing rows without creating them", false)
+  .action(async (options, command) => {
+    await executeCliHandler(command.name(), async () => {
+      return container.resolve(TopUpDeploymentsController).backfillDeploymentSettings(options);
+    });
+  });
+
+program
   .command("close-expired-deployments")
   .description("Close deployments that reached their runtime limit")
   .option("-d, --dry-run", "Log which deployments would be closed without broadcasting", false)

--- a/apps/api/src/deployment/controllers/deployment/top-up-deployments.controller.spec.ts
+++ b/apps/api/src/deployment/controllers/deployment/top-up-deployments.controller.spec.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import type { MockProxy } from "vitest-mock-extended";
 import { mock } from "vitest-mock-extended";
 
+import type { DeploymentSettingsBackfillService } from "@src/deployment/services/deployment-settings-backfill/deployment-settings-backfill.service";
 import type { ExpiredDeploymentsCloserService } from "@src/deployment/services/expired-deployments-closer/expired-deployments-closer.service";
 import type { StaleManagedDeploymentsCleanerService } from "@src/deployment/services/stale-managed-deployments-cleaner/stale-managed-deployments-cleaner.service";
 import type { TopUpManagedDeploymentsService } from "@src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service";
@@ -43,22 +44,41 @@ describe(TopUpDeploymentsController.name, () => {
     });
   });
 
+  describe("backfillDeploymentSettings", () => {
+    it("calls the service to backfill deployment settings", async () => {
+      const { controller, deploymentSettingsBackfillService } = setup();
+      const options = { dryRun: true };
+
+      await controller.backfillDeploymentSettings(options);
+
+      expect(deploymentSettingsBackfillService.backfillDeploymentSettings).toHaveBeenCalledWith(options);
+    });
+  });
+
   function setup(): {
     controller: TopUpDeploymentsController;
     topUpManagedDeploymentsService: MockProxy<TopUpManagedDeploymentsService>;
     staleDeploymentsCleanerService: MockProxy<StaleManagedDeploymentsCleanerService>;
     expiredDeploymentsCloserService: MockProxy<ExpiredDeploymentsCloserService>;
+    deploymentSettingsBackfillService: MockProxy<DeploymentSettingsBackfillService>;
   } {
     const topUpManagedDeploymentsService = mock<TopUpManagedDeploymentsService>();
     const staleDeploymentsCleanerService = mock<StaleManagedDeploymentsCleanerService>();
     const expiredDeploymentsCloserService = mock<ExpiredDeploymentsCloserService>();
-    const controller = new TopUpDeploymentsController(topUpManagedDeploymentsService, staleDeploymentsCleanerService, expiredDeploymentsCloserService);
+    const deploymentSettingsBackfillService = mock<DeploymentSettingsBackfillService>();
+    const controller = new TopUpDeploymentsController(
+      topUpManagedDeploymentsService,
+      staleDeploymentsCleanerService,
+      expiredDeploymentsCloserService,
+      deploymentSettingsBackfillService
+    );
 
     return {
       controller,
       topUpManagedDeploymentsService,
       staleDeploymentsCleanerService,
-      expiredDeploymentsCloserService
+      expiredDeploymentsCloserService,
+      deploymentSettingsBackfillService
     };
   }
 });

--- a/apps/api/src/deployment/controllers/deployment/top-up-deployments.controller.ts
+++ b/apps/api/src/deployment/controllers/deployment/top-up-deployments.controller.ts
@@ -1,6 +1,7 @@
 import { singleton } from "tsyringe";
 
 import type { DryRunOptions } from "@src/core/types/console";
+import { DeploymentSettingsBackfillService } from "@src/deployment/services/deployment-settings-backfill/deployment-settings-backfill.service";
 import { ExpiredDeploymentsCloserService } from "@src/deployment/services/expired-deployments-closer/expired-deployments-closer.service";
 import { StaleManagedDeploymentsCleanerService } from "@src/deployment/services/stale-managed-deployments-cleaner/stale-managed-deployments-cleaner.service";
 import { TopUpManagedDeploymentsService } from "@src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service";
@@ -11,7 +12,8 @@ export class TopUpDeploymentsController {
   constructor(
     private readonly topUpManagedDeploymentsService: TopUpManagedDeploymentsService,
     private readonly staleDeploymentsCleanerService: StaleManagedDeploymentsCleanerService,
-    private readonly expiredDeploymentsCloserService: ExpiredDeploymentsCloserService
+    private readonly expiredDeploymentsCloserService: ExpiredDeploymentsCloserService,
+    private readonly deploymentSettingsBackfillService: DeploymentSettingsBackfillService
   ) {}
 
   async topUpDeployments(options: DryRunOptions) {
@@ -24,5 +26,9 @@ export class TopUpDeploymentsController {
 
   async closeExpiredDeployments(options: DryRunOptions) {
     return await this.expiredDeploymentsCloserService.closeExpiredDeployments(options);
+  }
+
+  async backfillDeploymentSettings(options: DryRunOptions) {
+    return await this.deploymentSettingsBackfillService.backfillDeploymentSettings(options);
   }
 }

--- a/apps/api/src/deployment/repositories/lease/lease.repository.ts
+++ b/apps/api/src/deployment/repositories/lease/lease.repository.ts
@@ -56,6 +56,16 @@ export class LeaseRepository implements DrainingDeploymentLeaseSource {
    * @param dseqs - Array of deployment sequence numbers to filter by
    * @returns Array of draining deployment outputs
    */
+  async findOpenDseqsByOwner(owner: string): Promise<string[]> {
+    const leases = await Lease.findAll({
+      where: { owner, closedHeight: null },
+      attributes: [[fn("DISTINCT", col("dseq")), "dseq"]],
+      raw: true
+    });
+
+    return leases.map(lease => String((lease as unknown as { dseq: string | number }).dseq));
+  }
+
   async findManyByDseqAndOwner(closureHeight: number, owner: string, dseqs: string[]): Promise<DrainingDeploymentOutput[]> {
     if (!dseqs.length) return [];
 

--- a/apps/api/src/deployment/services/deployment-settings-backfill/deployment-settings-backfill.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-settings-backfill/deployment-settings-backfill.service.spec.ts
@@ -1,0 +1,105 @@
+import { PostgresError } from "postgres";
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { UserWalletOutput, UserWalletRepository } from "@src/billing/repositories";
+import type { LoggerService } from "@src/core";
+import type { DeploymentSettingRepository, DeploymentSettingsOutput } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import type { LeaseRepository } from "@src/deployment/repositories/lease/lease.repository";
+import { DeploymentSettingsBackfillService } from "./deployment-settings-backfill.service";
+
+import { createUserWallet } from "@test/seeders/user-wallet.seeder";
+
+describe(DeploymentSettingsBackfillService.name, () => {
+  it("creates settings rows for open deployments that lack them", async () => {
+    const { service, leaseRepository, deploymentSettingRepository } = setup();
+    leaseRepository.findOpenDseqsByOwner.mockResolvedValue(["1", "2", "3"]);
+    deploymentSettingRepository.find.mockResolvedValue([mock<DeploymentSettingsOutput>({ dseq: "2" })]);
+
+    const summary = await service.backfillDeploymentSettings({ dryRun: false });
+
+    expect(leaseRepository.findOpenDseqsByOwner).toHaveBeenCalledWith("akash1owner");
+    expect(deploymentSettingRepository.create).toHaveBeenCalledWith({ userId: "user-1", dseq: "1" });
+    expect(deploymentSettingRepository.create).toHaveBeenCalledWith({ userId: "user-1", dseq: "3" });
+    expect(deploymentSettingRepository.create).not.toHaveBeenCalledWith({ userId: "user-1", dseq: "2" });
+    expect(summary).toEqual({ scannedWallets: 1, openDeployments: 3, missingSettings: 2, createdSettings: 2 });
+  });
+
+  it("only counts the missing rows on a dry run", async () => {
+    const { service, deploymentSettingRepository } = setup();
+    deploymentSettingRepository.find.mockResolvedValue([]);
+
+    const summary = await service.backfillDeploymentSettings({ dryRun: true });
+
+    expect(deploymentSettingRepository.create).not.toHaveBeenCalled();
+    expect(summary).toEqual({ scannedWallets: 1, openDeployments: 1, missingSettings: 1, createdSettings: 0 });
+  });
+
+  it("skips wallets without an address", async () => {
+    const { service, leaseRepository } = setup({ wallets: [createUserWallet({ address: null })] });
+
+    const summary = await service.backfillDeploymentSettings({ dryRun: true });
+
+    expect(leaseRepository.findOpenDseqsByOwner).not.toHaveBeenCalled();
+    expect(summary.scannedWallets).toBe(0);
+  });
+
+  it("does not read settings for a wallet without open leases", async () => {
+    const { service, leaseRepository, deploymentSettingRepository } = setup();
+    leaseRepository.findOpenDseqsByOwner.mockResolvedValue([]);
+
+    const summary = await service.backfillDeploymentSettings({ dryRun: false });
+
+    expect(deploymentSettingRepository.find).not.toHaveBeenCalled();
+    expect(summary).toEqual({ scannedWallets: 1, openDeployments: 0, missingSettings: 0, createdSettings: 0 });
+  });
+
+  it("treats a row created concurrently as already backfilled", async () => {
+    const { service, deploymentSettingRepository } = setup();
+    deploymentSettingRepository.find.mockResolvedValue([]);
+    deploymentSettingRepository.create.mockRejectedValue(createUniqueViolation());
+
+    const summary = await service.backfillDeploymentSettings({ dryRun: false });
+
+    expect(summary).toEqual({ scannedWallets: 1, openDeployments: 1, missingSettings: 1, createdSettings: 0 });
+  });
+
+  it("rethrows insert failures other than the unique race", async () => {
+    const { service, deploymentSettingRepository } = setup();
+    deploymentSettingRepository.find.mockResolvedValue([]);
+    deploymentSettingRepository.create.mockRejectedValue(new Error("db down"));
+
+    await expect(service.backfillDeploymentSettings({ dryRun: false })).rejects.toThrow("db down");
+  });
+
+  /** Mirrors how drizzle surfaces a unique violation: a wrapper error carrying the driver error as its cause. */
+  function createUniqueViolation() {
+    const driverError = Object.assign(Object.create(PostgresError.prototype), {
+      name: "PostgresError",
+      code: "23505",
+      constraint_name: "dseq_user_id_idx",
+      message: 'duplicate key value violates unique constraint "dseq_user_id_idx"'
+    });
+
+    return new Error("Failed query: insert into deployment_settings", { cause: driverError });
+  }
+
+  function setup(input?: { wallets?: UserWalletOutput[] }) {
+    const wallets = input?.wallets ?? [createUserWallet({ userId: "user-1", address: "akash1owner" })];
+
+    const userWalletRepository = mock<UserWalletRepository>();
+    userWalletRepository.paginate.mockImplementation(async (_params, cb) => {
+      await cb(wallets);
+    });
+
+    const leaseRepository = mock<LeaseRepository>();
+    leaseRepository.findOpenDseqsByOwner.mockResolvedValue(["1"]);
+
+    const deploymentSettingRepository = mock<DeploymentSettingRepository>();
+    const logger = mock<LoggerService>();
+
+    const service = new DeploymentSettingsBackfillService(userWalletRepository, leaseRepository, deploymentSettingRepository, logger);
+
+    return { service, userWalletRepository, leaseRepository, deploymentSettingRepository, logger };
+  }
+});

--- a/apps/api/src/deployment/services/deployment-settings-backfill/deployment-settings-backfill.service.ts
+++ b/apps/api/src/deployment/services/deployment-settings-backfill/deployment-settings-backfill.service.ts
@@ -1,0 +1,104 @@
+import { singleton } from "tsyringe";
+
+import { UserWalletRepository } from "@src/billing/repositories";
+import { LoggerService } from "@src/core";
+import { isUniqueViolation } from "@src/core/repositories/base.repository";
+import type { DryRunOptions } from "@src/core/types/console";
+import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import { LeaseRepository } from "@src/deployment/repositories/lease/lease.repository";
+
+export interface DeploymentSettingsBackfillSummary {
+  scannedWallets: number;
+  openDeployments: number;
+  missingSettings: number;
+  createdSettings: number;
+}
+
+/**
+ * One-off backfill for CON-895: deployments created outside the web app before settings rows were
+ * written eagerly have no deployment_settings row, so the funding sweep never sees them. Walks every
+ * managed wallet, diffs its open-lease dseqs from the chain database against its settings rows, and
+ * creates the missing rows on the repository defaults. A dry run only counts, which doubles as the
+ * measurement of the affected population before the sweep is widened.
+ */
+@singleton()
+export class DeploymentSettingsBackfillService {
+  constructor(
+    private readonly userWalletRepository: UserWalletRepository,
+    private readonly leaseRepository: LeaseRepository,
+    private readonly deploymentSettingRepository: DeploymentSettingRepository,
+    private readonly logger: LoggerService
+  ) {}
+
+  async backfillDeploymentSettings({ dryRun }: DryRunOptions): Promise<DeploymentSettingsBackfillSummary> {
+    const summary: DeploymentSettingsBackfillSummary = {
+      scannedWallets: 0,
+      openDeployments: 0,
+      missingSettings: 0,
+      createdSettings: 0
+    };
+
+    await this.userWalletRepository.paginate({ limit: 100 }, async wallets => {
+      for (const wallet of wallets) {
+        if (!wallet.address || !wallet.userId) {
+          continue;
+        }
+
+        summary.scannedWallets++;
+        await this.backfillWallet({ userId: wallet.userId, address: wallet.address }, { dryRun }, summary);
+      }
+    });
+
+    this.logger.info({ event: "DEPLOYMENT_SETTINGS_BACKFILL_COMPLETED", dryRun, ...summary });
+
+    return summary;
+  }
+
+  private async backfillWallet(
+    wallet: { userId: string; address: string },
+    { dryRun }: DryRunOptions,
+    summary: DeploymentSettingsBackfillSummary
+  ): Promise<void> {
+    const openDseqs = await this.leaseRepository.findOpenDseqsByOwner(wallet.address);
+
+    if (!openDseqs.length) {
+      return;
+    }
+
+    summary.openDeployments += openDseqs.length;
+
+    const settings = await this.deploymentSettingRepository.find({ userId: wallet.userId }, { select: ["dseq"] });
+    const knownDseqs = new Set(settings.map(setting => setting.dseq));
+    const missingDseqs = openDseqs.filter(dseq => !knownDseqs.has(dseq));
+
+    if (!missingDseqs.length) {
+      return;
+    }
+
+    summary.missingSettings += missingDseqs.length;
+    this.logger.info({ event: "DEPLOYMENT_SETTINGS_MISSING", dryRun, userId: wallet.userId, address: wallet.address, dseqs: missingDseqs });
+
+    if (dryRun) {
+      return;
+    }
+
+    for (const dseq of missingDseqs) {
+      await this.createSetting(wallet.userId, dseq, summary);
+    }
+  }
+
+  /**
+   * A unique violation means the row appeared between the diff and the insert (the detail page's lazy
+   * create or the lease-start funding path), which is the backfill's goal already reached, not an error.
+   */
+  private async createSetting(userId: string, dseq: string, summary: DeploymentSettingsBackfillSummary): Promise<void> {
+    try {
+      await this.deploymentSettingRepository.create({ userId, dseq });
+      summary.createdSettings++;
+    } catch (error) {
+      if (!isUniqueViolation(error)) {
+        throw error;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Why

Part of CON-895

The eager-create fix in #3656 only covers deployments from now on (plus any older deployment that starts a new lease). A deployment created outside the web app before that fix, with a lease already running, still has no `deployment_settings` row and stays invisible to the funding sweep until it drains and closes. CON-895 also asks for the affected population to be counted before release, since backfilling widens the sweep and increases both credit spend and the draw on the shared deposit authorization from CON-512.

## What

Adds a one-off `backfill-deployment-settings` CLI command (same shape as `top-up-deployments` and `close-expired-deployments`). It pages through managed wallets, reads each wallet's open-lease dseqs from the chain database, diffs them against the wallet's settings rows, and creates the missing rows on the repository defaults (auto top-up enabled). This has to be code rather than a SQL migration because leases and `deployment_settings` live in different databases.

With `--dry-run` it only counts and logs, which is the measurement step:

1. Run the dry run against prod and post the counts on CON-895.
2. Sanity-check the extra funding draw against the deposit authorization headroom.
3. Run it for real; the next hourly sweep picks the deployments up.

A concurrent row creation (detail page lazy create or lease-start funding) loses gracefully: the unique violation is treated as the backfill's goal already reached.

## Stacked on

#3656 (base branch `fix/deployment-fund-deployments-created-outside-web-app`)