### PR TITLE
feat(billing): recommend fixed threshold and key the top-up hatch in the balance legend

### DIFF
--- a/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/AccountBalanceOverview.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/AccountBalanceOverview.spec.tsx
@@ -133,6 +133,20 @@ describe(AccountBalanceOverview.name, () => {
     expect(screen.queryByText(/Automatic top-ups are on/)).not.toBeInTheDocument();
   });
 
+  it("explains the threshold line and hatch in the legend when a threshold is set", () => {
+    setup({ autoReloadEnabled: true, autoReloadThreshold: 275 });
+
+    expect(screen.getByText(/Tops up at/)).toHaveTextContent("275");
+    expect(screen.getByText("Top-up buffer")).toBeInTheDocument();
+  });
+
+  it("keeps the marker legend out when no threshold applies", () => {
+    setup({ autoReloadEnabled: true, autoReloadThreshold: null });
+
+    expect(screen.queryByText(/Tops up at/)).not.toBeInTheDocument();
+    expect(screen.queryByText("Top-up buffer")).not.toBeInTheDocument();
+  });
+
   it("renders a skeleton instead of balance while loading", () => {
     setup({ isLoading: true });
 

--- a/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/AccountBalanceOverview.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/AccountBalanceOverview.spec.tsx
@@ -133,18 +133,18 @@ describe(AccountBalanceOverview.name, () => {
     expect(screen.queryByText(/Automatic top-ups are on/)).not.toBeInTheDocument();
   });
 
-  it("explains the threshold line and hatch in the legend when a threshold is set", () => {
+  it("names the top-up threshold under the available balance when one is set", () => {
     setup({ autoReloadEnabled: true, autoReloadThreshold: 275 });
 
     expect(screen.getByText(/Tops up at/)).toHaveTextContent("275");
-    expect(screen.getByText("Top-up buffer")).toBeInTheDocument();
+    expect(screen.queryByText("Free to spend on something new")).not.toBeInTheDocument();
   });
 
-  it("keeps the marker legend out when no threshold applies", () => {
+  it("describes the available balance generically when no threshold applies", () => {
     setup({ autoReloadEnabled: true, autoReloadThreshold: null });
 
     expect(screen.queryByText(/Tops up at/)).not.toBeInTheDocument();
-    expect(screen.queryByText("Top-up buffer")).not.toBeInTheDocument();
+    expect(screen.getByText("Free to spend on something new")).toBeInTheDocument();
   });
 
   it("renders a skeleton instead of balance while loading", () => {

--- a/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/AccountBalanceOverview.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/AccountBalanceOverview.tsx
@@ -7,7 +7,7 @@ import Link from "next/link";
 
 import { UsdValue } from "@src/components/billing-usage/UsdValue/UsdValue";
 import { UrlService } from "@src/utils/urlUtils";
-import { BalanceBreakdownBar, buildBalanceSegments, ThresholdHatchSwatch } from "./BalanceBreakdownBar";
+import { BalanceBreakdownBar, buildBalanceSegments } from "./BalanceBreakdownBar";
 import { useAccountBalanceOverview } from "./useAccountBalanceOverview";
 
 export const DEPENDENCIES = {
@@ -123,26 +123,18 @@ export const AccountBalanceOverview: React.FunctionComponent<{ dependencies?: ty
               <span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: "hsl(var(--success))" }} aria-hidden />
               <span>Available</span>
             </div>
-            <div className="flex flex-wrap items-center gap-x-5 gap-y-2">
-              <span className="text-2xl font-bold leading-none text-success" aria-label="Available balance">
-                {usd(overview.available)}
-              </span>
-              {overview.autoReloadThreshold != null && (
-                <span className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-muted-foreground">
-                  <span className="flex items-center gap-2">
-                    <span className="h-4 w-0 shrink-0 border-l-2 border-dashed border-foreground" aria-hidden />
-                    <span>
-                      Tops up at <span className="font-medium text-foreground">{usd(overview.autoReloadThreshold)}</span>
-                    </span>
-                  </span>
-                  <span className="flex items-center gap-2">
-                    <ThresholdHatchSwatch />
-                    <span>Top-up buffer</span>
-                  </span>
-                </span>
-              )}
+            <div className="text-2xl font-bold leading-none text-success" aria-label="Available balance">
+              {usd(overview.available)}
             </div>
-            <p className="text-sm text-muted-foreground">Free to spend on something new</p>
+            <p className="text-sm text-muted-foreground">
+              {overview.autoReloadThreshold != null ? (
+                <>
+                  Tops up at <span className="font-medium text-foreground">{usd(overview.autoReloadThreshold)}</span>
+                </>
+              ) : (
+                "Free to spend on something new"
+              )}
+            </p>
           </div>
         </div>
 

--- a/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/AccountBalanceOverview.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/AccountBalanceOverview.tsx
@@ -123,27 +123,28 @@ export const AccountBalanceOverview: React.FunctionComponent<{ dependencies?: ty
               <span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: "hsl(var(--success))" }} aria-hidden />
               <span>Available</span>
             </div>
-            <div className="text-2xl font-bold leading-none text-success" aria-label="Available balance">
-              {usd(overview.available)}
+            <div className="flex flex-wrap items-center gap-x-5 gap-y-2">
+              <span className="text-2xl font-bold leading-none text-success" aria-label="Available balance">
+                {usd(overview.available)}
+              </span>
+              {overview.autoReloadThreshold != null && (
+                <span className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-muted-foreground">
+                  <span className="flex items-center gap-2">
+                    <span className="h-4 w-0 shrink-0 border-l-2 border-dashed border-foreground" aria-hidden />
+                    <span>
+                      Tops up at <span className="font-medium text-foreground">{usd(overview.autoReloadThreshold)}</span>
+                    </span>
+                  </span>
+                  <span className="flex items-center gap-2">
+                    <ThresholdHatchSwatch />
+                    <span>Top-up buffer</span>
+                  </span>
+                </span>
+              )}
             </div>
             <p className="text-sm text-muted-foreground">Free to spend on something new</p>
           </div>
         </div>
-
-        {overview.autoReloadThreshold != null && (
-          <div className="flex flex-wrap items-center gap-x-6 gap-y-2 text-xs text-muted-foreground">
-            <span className="flex items-center gap-1.5">
-              <span className="h-3 w-0 shrink-0 border-l-2 border-dashed border-foreground" aria-hidden />
-              <span>
-                Tops up at <span className="font-medium text-foreground">{usd(overview.autoReloadThreshold)}</span>
-              </span>
-            </span>
-            <span className="flex items-center gap-1.5">
-              <ThresholdHatchSwatch />
-              <span>Top-up buffer</span>
-            </span>
-          </div>
-        )}
 
         {reservedSegments.length > 0 && (
           <div className="border-t pt-4">

--- a/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/AccountBalanceOverview.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/AccountBalanceOverview.tsx
@@ -7,7 +7,7 @@ import Link from "next/link";
 
 import { UsdValue } from "@src/components/billing-usage/UsdValue/UsdValue";
 import { UrlService } from "@src/utils/urlUtils";
-import { BalanceBreakdownBar, buildBalanceSegments } from "./BalanceBreakdownBar";
+import { BalanceBreakdownBar, buildBalanceSegments, ThresholdHatchSwatch } from "./BalanceBreakdownBar";
 import { useAccountBalanceOverview } from "./useAccountBalanceOverview";
 
 export const DEPENDENCIES = {
@@ -129,6 +129,21 @@ export const AccountBalanceOverview: React.FunctionComponent<{ dependencies?: ty
             <p className="text-sm text-muted-foreground">Free to spend on something new</p>
           </div>
         </div>
+
+        {overview.autoReloadThreshold != null && (
+          <div className="flex flex-wrap items-center gap-x-6 gap-y-2 text-xs text-muted-foreground">
+            <span className="flex items-center gap-1.5">
+              <span className="h-3 w-0 shrink-0 border-l-2 border-dashed border-foreground" aria-hidden />
+              <span>
+                Tops up at <span className="font-medium text-foreground">{usd(overview.autoReloadThreshold)}</span>
+              </span>
+            </span>
+            <span className="flex items-center gap-1.5">
+              <ThresholdHatchSwatch />
+              <span>Top-up buffer</span>
+            </span>
+          </div>
+        )}
 
         {reservedSegments.length > 0 && (
           <div className="border-t pt-4">

--- a/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/BalanceBreakdownBar.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/BalanceBreakdownBar.spec.tsx
@@ -1,7 +1,7 @@
 import { IntlProvider } from "react-intl";
 import { describe, expect, it } from "vitest";
 
-import { BalanceBreakdownBar, buildBalanceSegments } from "./BalanceBreakdownBar";
+import { BalanceBreakdownBar, buildBalanceSegments, THRESHOLD_HATCH_BACKGROUND } from "./BalanceBreakdownBar";
 import type { ReservedDeployment } from "./useAccountBalanceOverview";
 
 import { render, screen } from "@testing-library/react";
@@ -81,16 +81,18 @@ describe(BalanceBreakdownBar.name, () => {
       threshold: 250
     });
 
-    expect(screen.getByText(/Tops up at/)).toHaveTextContent("$250");
+    expect(screen.getByTestId("balance-threshold-hatch")).toBeInTheDocument();
+    expect(screen.getByTestId("balance-threshold-line")).toBeInTheDocument();
   });
 
   it("omits the threshold marker when no threshold is provided", () => {
     setup({ segments: [{ key: "available", label: "Available", amountUsd: 1000, color: "hsl(var(--success))" }] });
 
-    expect(screen.queryByText(/Tops up at/)).not.toBeInTheDocument();
+    expect(screen.queryByTestId("balance-threshold-hatch")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("balance-threshold-line")).not.toBeInTheDocument();
   });
 
-  it("positions the marker as the far-right slice of the bar", () => {
+  it("anchors the hatch to the start of the available segment", () => {
     setup({
       segments: [
         { key: "d1", label: "llama", amountUsd: 1000, color: "hsl(var(--primary))" },
@@ -99,8 +101,28 @@ describe(BalanceBreakdownBar.name, () => {
       threshold: 250
     });
 
-    expect(screen.getByTestId("balance-threshold-hatch").style.width).toBe("12.5%");
-    expect(screen.getByTestId("balance-threshold-line").style.left).toBe("87.5%");
+    const hatch = screen.getByTestId("balance-threshold-hatch");
+    expect(hatch.style.width).toBe("25%");
+    expect(hatch.parentElement).toHaveAttribute("title", "Available: $1,000.00");
+    expect(screen.getByTestId("balance-threshold-line").style.left).toBe("25%");
+    expect(screen.getByRole("img").children).toHaveLength(2);
+  });
+
+  it("covers the whole available segment and hides the line when available is at or below the threshold", () => {
+    setup({
+      segments: [
+        { key: "d1", label: "llama", amountUsd: 1000, color: "hsl(var(--primary))" },
+        { key: "available", label: "Available", amountUsd: 200, color: "hsl(var(--success))" }
+      ],
+      threshold: 250
+    });
+
+    expect(screen.getByTestId("balance-threshold-hatch").style.width).toBe("100%");
+    expect(screen.queryByTestId("balance-threshold-line")).not.toBeInTheDocument();
+  });
+
+  it("paints the hatch with the warning token", () => {
+    expect(THRESHOLD_HATCH_BACKGROUND).toContain("var(--warning)");
   });
 
   function setup(input: { segments: Parameters<typeof BalanceBreakdownBar>[0]["segments"]; threshold?: number | null }) {

--- a/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/BalanceBreakdownBar.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/BalanceBreakdownBar.spec.tsx
@@ -121,8 +121,8 @@ describe(BalanceBreakdownBar.name, () => {
     expect(screen.queryByTestId("balance-threshold-line")).not.toBeInTheDocument();
   });
 
-  it("paints the hatch with the warning token", () => {
-    expect(THRESHOLD_HATCH_BACKGROUND).toContain("var(--warning)");
+  it("paints the hatch with the theme background token so it stays green and white/dark", () => {
+    expect(THRESHOLD_HATCH_BACKGROUND).toContain("var(--background)");
   });
 
   function setup(input: { segments: Parameters<typeof BalanceBreakdownBar>[0]["segments"]; threshold?: number | null }) {

--- a/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/BalanceBreakdownBar.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/BalanceBreakdownBar.spec.tsx
@@ -1,7 +1,7 @@
 import { IntlProvider } from "react-intl";
 import { describe, expect, it } from "vitest";
 
-import { BalanceBreakdownBar, buildBalanceSegments, THRESHOLD_HATCH_BACKGROUND } from "./BalanceBreakdownBar";
+import { BalanceBreakdownBar, buildBalanceSegments } from "./BalanceBreakdownBar";
 import type { ReservedDeployment } from "./useAccountBalanceOverview";
 
 import { render, screen } from "@testing-library/react";
@@ -81,18 +81,18 @@ describe(BalanceBreakdownBar.name, () => {
       threshold: 250
     });
 
-    expect(screen.getByTestId("balance-threshold-hatch")).toBeInTheDocument();
     expect(screen.getByTestId("balance-threshold-line")).toBeInTheDocument();
+    expect(screen.getByTestId("balance-threshold-caption")).toHaveTextContent("Tops up at $250.00");
   });
 
   it("omits the threshold marker when no threshold is provided", () => {
     setup({ segments: [{ key: "available", label: "Available", amountUsd: 1000, color: "hsl(var(--success))" }] });
 
-    expect(screen.queryByTestId("balance-threshold-hatch")).not.toBeInTheDocument();
     expect(screen.queryByTestId("balance-threshold-line")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("balance-threshold-caption")).not.toBeInTheDocument();
   });
 
-  it("anchors the hatch to the start of the available segment", () => {
+  it("places the marker a threshold's worth into the available segment", () => {
     setup({
       segments: [
         { key: "d1", label: "llama", amountUsd: 1000, color: "hsl(var(--primary))" },
@@ -101,14 +101,14 @@ describe(BalanceBreakdownBar.name, () => {
       threshold: 250
     });
 
-    const hatch = screen.getByTestId("balance-threshold-hatch");
-    expect(hatch.style.width).toBe("25%");
-    expect(hatch.parentElement).toHaveAttribute("title", "Available: $1,000.00");
-    expect(screen.getByTestId("balance-threshold-line").style.left).toBe("25%");
+    const line = screen.getByTestId("balance-threshold-line");
+    expect(line.style.left).toBe("25%");
+    expect(line.parentElement).toHaveAttribute("title", "Available: $1,000.00");
+    expect(screen.getByTestId("balance-threshold-caption").style.left).toBe("25%");
     expect(screen.getByRole("img").children).toHaveLength(2);
   });
 
-  it("covers the whole available segment and hides the line when available is at or below the threshold", () => {
+  it("drops the marker when available is at or below the threshold", () => {
     setup({
       segments: [
         { key: "d1", label: "llama", amountUsd: 1000, color: "hsl(var(--primary))" },
@@ -117,12 +117,8 @@ describe(BalanceBreakdownBar.name, () => {
       threshold: 250
     });
 
-    expect(screen.getByTestId("balance-threshold-hatch").style.width).toBe("100%");
     expect(screen.queryByTestId("balance-threshold-line")).not.toBeInTheDocument();
-  });
-
-  it("paints the hatch with the theme background token so it stays green and white/dark", () => {
-    expect(THRESHOLD_HATCH_BACKGROUND).toContain("var(--background)");
+    expect(screen.queryByTestId("balance-threshold-caption")).not.toBeInTheDocument();
   });
 
   function setup(input: { segments: Parameters<typeof BalanceBreakdownBar>[0]["segments"]; threshold?: number | null }) {

--- a/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/BalanceBreakdownBar.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/BalanceBreakdownBar.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React from "react";
 import { useIntl } from "react-intl";
+import { Flash } from "iconoir-react";
 
 import type { ReservedDeployment } from "./useAccountBalanceOverview";
 
@@ -29,35 +30,22 @@ function badgeBackground(hue: string, alpha: number): string {
 }
 
 /**
- * Diagonal hatch overlaid on the Available segment to flag the auto-top-up trigger zone.
- * Stripes are the page background token at partial alpha, so the zone stays recognisably the Available
- * green, just lightened in light mode and darkened in dark mode. Full alpha reads as a separate white or
- * black band rather than a texture over the green.
+ * Vertical dashes for the threshold line: a 4px mark every 7px, so each mark stays taller than the line
+ * is wide and reads as a dash rather than a dot. Drawn as a gradient because `border-dashed` hands the
+ * dash length and spacing to the browser with no way to tune them.
  */
-export const THRESHOLD_HATCH_BACKGROUND =
-  "repeating-linear-gradient(45deg, transparent 0, transparent 3px, hsl(var(--background) / 0.62) 3px, hsl(var(--background) / 0.62) 6px)";
-
-/** Miniature of the bar's top-up zone (background-colored hatch over the Available green) for legend use. */
-export const ThresholdHatchSwatch: React.FunctionComponent = () => (
-  <span
-    className="h-3.5 w-3.5 shrink-0 rounded-[3px]"
-    style={{ backgroundColor: "hsl(var(--success))", backgroundImage: THRESHOLD_HATCH_BACKGROUND }}
-    aria-hidden
-  />
-);
+const THRESHOLD_LINE_DASHES = "repeating-linear-gradient(to bottom, hsl(var(--foreground)) 0 4px, transparent 4px 7px)";
 
 /**
- * Positions the auto-top-up marker inside the Available segment: the hatch spans the first
- * min(threshold, available) dollars past the reserved/available boundary and the dashed line marks its
- * right edge. Percentages are relative to the segment so the marker stays glued to that boundary
- * regardless of the 2px gaps between segments.
+ * Where the auto-top-up marker sits inside the Available segment: the dashed line lands `threshold`
+ * dollars past the reserved/available boundary, which is where the bar's right edge will be once the
+ * balance has drained far enough to trigger a top-up. Expressed as a percentage of the segment so it
+ * stays glued to that boundary regardless of the 2px gaps between segments. Null once available is at or
+ * below the threshold, where the line would fall on the segment's own right edge and read as noise.
  */
 function buildThresholdMarker(threshold: number, available: number) {
-  const markerAmount = Math.min(threshold, available);
-  return {
-    hatchWidthPct: (markerAmount / available) * 100,
-    isClamped: available <= threshold
-  };
+  if (available <= threshold) return null;
+  return { positionPct: (threshold / available) * 100, amountUsd: threshold };
 }
 
 /**
@@ -91,6 +79,12 @@ export function buildBalanceSegments(deployments: ReservedDeployment[], availabl
   return [...reservedSegments, availableSegment].filter(segment => segment.amountUsd > 0);
 }
 
+/**
+ * The dashed threshold marker deliberately overflows the bar vertically and captions itself underneath,
+ * so the bar cannot clip its own children: the rounded pill shape comes from rounding the end segments
+ * rather than an `overflow-hidden` container, and the wrapper reserves the caption's height with padding
+ * because the caption is positioned out of flow.
+ */
 export const BalanceBreakdownBar: React.FunctionComponent<{
   segments: BalanceSegment[];
   hoveredKey?: string | null;
@@ -104,41 +98,45 @@ export const BalanceBreakdownBar: React.FunctionComponent<{
   const marker = threshold !== null && threshold > 0 && available > 0 ? buildThresholdMarker(threshold, available) : null;
 
   return (
-    <div className="flex h-3 w-full gap-[2px] overflow-hidden rounded-full" role="img" aria-label={`Balance breakdown: ${label}`}>
-      {segments.map(segment => (
-        <div
-          key={segment.key}
-          className="relative h-full min-w-[3px] transition-opacity duration-150"
-          style={{
-            flexGrow: segment.amountUsd,
-            flexBasis: 0,
-            backgroundColor: segment.color,
-            opacity: hoveredKey && hoveredKey !== segment.key ? 0.35 : 1
-          }}
-          title={`${segment.label}: ${formatUsd(segment.amountUsd)}`}
-          onMouseEnter={() => onHover?.(segment.key)}
-          onMouseLeave={() => onHover?.(null)}
-        >
-          {segment.key === "available" && marker && (
-            <>
-              <div
-                className="pointer-events-none absolute inset-y-0 left-0"
-                style={{ width: `${marker.hatchWidthPct}%`, backgroundImage: THRESHOLD_HATCH_BACKGROUND }}
-                data-testid="balance-threshold-hatch"
-                aria-hidden
-              />
-              {!marker.isClamped && (
+    <div className={marker === null ? undefined : "pb-6"}>
+      <div className="flex h-3 w-full gap-[2px]" role="img" aria-label={`Balance breakdown: ${label}`}>
+        {segments.map(segment => (
+          <div
+            key={segment.key}
+            className="relative h-full min-w-[3px] transition-opacity duration-150 first:rounded-l-full last:rounded-r-full"
+            style={{
+              flexGrow: segment.amountUsd,
+              flexBasis: 0,
+              backgroundColor: segment.color,
+              opacity: hoveredKey && hoveredKey !== segment.key ? 0.35 : 1
+            }}
+            title={`${segment.label}: ${formatUsd(segment.amountUsd)}`}
+            onMouseEnter={() => onHover?.(segment.key)}
+            onMouseLeave={() => onHover?.(null)}
+          >
+            {segment.key === "available" && marker && (
+              <>
                 <div
-                  className="pointer-events-none absolute inset-y-0 border-l-2 border-dashed border-foreground"
-                  style={{ left: `${marker.hatchWidthPct}%` }}
+                  className="pointer-events-none absolute -inset-y-1.5 w-[3px] -translate-x-1/2"
+                  style={{ left: `${marker.positionPct}%`, backgroundImage: THRESHOLD_LINE_DASHES }}
                   data-testid="balance-threshold-line"
                   aria-hidden
                 />
-              )}
-            </>
-          )}
-        </div>
-      ))}
+                <div
+                  className="pointer-events-none absolute top-full mt-2 flex -translate-x-1/2 items-center gap-1 whitespace-nowrap text-xs text-muted-foreground"
+                  style={{ left: `${marker.positionPct}%` }}
+                  data-testid="balance-threshold-caption"
+                >
+                  <Flash className="h-3 w-3 shrink-0" />
+                  <span>
+                    Tops up at <span className="font-medium text-foreground">{formatUsd(marker.amountUsd)}</span>
+                  </span>
+                </div>
+              </>
+            )}
+          </div>
+        ))}
+      </div>
     </div>
   );
 };

--- a/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/BalanceBreakdownBar.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/BalanceBreakdownBar.tsx
@@ -1,7 +1,6 @@
 "use client";
 import React from "react";
 import { useIntl } from "react-intl";
-import { Flash } from "iconoir-react";
 
 import type { ReservedDeployment } from "./useAccountBalanceOverview";
 
@@ -29,17 +28,34 @@ function badgeBackground(hue: string, alpha: number): string {
   return `hsl(${hue} / ${Number(Math.max(0.08, alpha * 0.2).toFixed(3))})`;
 }
 
-/** Diagonal hatch overlaid on the available bar to flag the auto-top-up trigger zone; theme-aware via the foreground token. */
-const HATCH_BACKGROUND =
-  "repeating-linear-gradient(45deg, transparent 0, transparent 3px, hsl(var(--foreground) / 0.28) 3px, hsl(var(--foreground) / 0.28) 6px)";
+/**
+ * Diagonal hatch overlaid on the Available segment to flag the auto-top-up trigger zone.
+ * Warning-orange because the token is identical in light and dark themes, pops against the success
+ * green underneath, and cannot be confused with the monochrome primary ramp of the reserved segments.
+ */
+export const THRESHOLD_HATCH_BACKGROUND =
+  "repeating-linear-gradient(45deg, transparent 0, transparent 4px, hsl(var(--warning) / 0.9) 4px, hsl(var(--warning) / 0.9) 8px)";
 
-/** Positions the auto-top-up marker as the far-right slice of the bar: the dotted line is its left edge, the hatch is the slice itself. */
-function buildThresholdMarker(threshold: number, available: number, total: number) {
+/** Miniature of the bar's top-up zone (warning hatch over the Available green) for legend use. */
+export const ThresholdHatchSwatch: React.FunctionComponent = () => (
+  <span
+    className="h-3 w-3 shrink-0 rounded-[3px]"
+    style={{ backgroundColor: "hsl(var(--success))", backgroundImage: THRESHOLD_HATCH_BACKGROUND }}
+    aria-hidden
+  />
+);
+
+/**
+ * Positions the auto-top-up marker inside the Available segment: the hatch spans the first
+ * min(threshold, available) dollars past the reserved/available boundary and the dashed line marks its
+ * right edge. Percentages are relative to the segment so the marker stays glued to that boundary
+ * regardless of the 2px gaps between segments.
+ */
+function buildThresholdMarker(threshold: number, available: number) {
   const markerAmount = Math.min(threshold, available);
   return {
-    threshold,
-    hatchWidthPct: (markerAmount / total) * 100,
-    linePositionPct: ((total - markerAmount) / total) * 100
+    hatchWidthPct: (markerAmount / available) * 100,
+    isClamped: available <= threshold
   };
 }
 
@@ -83,55 +99,45 @@ export const BalanceBreakdownBar: React.FunctionComponent<{
   const intl = useIntl();
   const formatUsd = (value: number) => intl.formatNumber(value, { style: "currency", currency: "USD" });
   const label = segments.map(segment => `${segment.label} ${formatUsd(segment.amountUsd)}`).join(", ");
-  const total = segments.reduce((sum, segment) => sum + segment.amountUsd, 0);
   const available = segments.find(segment => segment.key === "available")?.amountUsd ?? 0;
-  const marker = threshold !== null && threshold > 0 && available > 0 && total > 0 ? buildThresholdMarker(threshold, available, total) : null;
+  const marker = threshold !== null && threshold > 0 && available > 0 ? buildThresholdMarker(threshold, available) : null;
 
   return (
-    <div className="space-y-1">
-      <div className="relative">
-        <div className="relative flex h-3 w-full gap-[2px] overflow-hidden rounded-full" role="img" aria-label={`Balance breakdown: ${label}`}>
-          {segments.map(segment => (
-            <div
-              key={segment.key}
-              className="h-full min-w-[3px] transition-opacity duration-150"
-              style={{
-                flexGrow: segment.amountUsd,
-                flexBasis: 0,
-                backgroundColor: segment.color,
-                opacity: hoveredKey && hoveredKey !== segment.key ? 0.35 : 1
-              }}
-              title={`${segment.label}: ${formatUsd(segment.amountUsd)}`}
-              onMouseEnter={() => onHover?.(segment.key)}
-              onMouseLeave={() => onHover?.(null)}
-            />
-          ))}
-          {marker && (
-            <div
-              className="pointer-events-none absolute inset-y-0 right-0"
-              style={{ width: `${marker.hatchWidthPct}%`, backgroundImage: HATCH_BACKGROUND }}
-              data-testid="balance-threshold-hatch"
-              aria-hidden
-            />
+    <div className="flex h-3 w-full gap-[2px] overflow-hidden rounded-full" role="img" aria-label={`Balance breakdown: ${label}`}>
+      {segments.map(segment => (
+        <div
+          key={segment.key}
+          className="relative h-full min-w-[3px] transition-opacity duration-150"
+          style={{
+            flexGrow: segment.amountUsd,
+            flexBasis: 0,
+            backgroundColor: segment.color,
+            opacity: hoveredKey && hoveredKey !== segment.key ? 0.35 : 1
+          }}
+          title={`${segment.label}: ${formatUsd(segment.amountUsd)}`}
+          onMouseEnter={() => onHover?.(segment.key)}
+          onMouseLeave={() => onHover?.(null)}
+        >
+          {segment.key === "available" && marker && (
+            <>
+              <div
+                className="pointer-events-none absolute inset-y-0 left-0"
+                style={{ width: `${marker.hatchWidthPct}%`, backgroundImage: THRESHOLD_HATCH_BACKGROUND }}
+                data-testid="balance-threshold-hatch"
+                aria-hidden
+              />
+              {!marker.isClamped && (
+                <div
+                  className="pointer-events-none absolute inset-y-0 border-l-2 border-dashed border-foreground"
+                  style={{ left: `${marker.hatchWidthPct}%` }}
+                  data-testid="balance-threshold-line"
+                  aria-hidden
+                />
+              )}
+            </>
           )}
         </div>
-        {marker && (
-          <div
-            className="pointer-events-none absolute inset-y-[-2px] border-l-2 border-dashed border-foreground"
-            style={{ left: `${marker.linePositionPct}%` }}
-            data-testid="balance-threshold-line"
-            aria-hidden
-          />
-        )}
-      </div>
-      {marker && (
-        <p className="flex items-center justify-end gap-1 text-xs text-muted-foreground">
-          <Flash className="h-3 w-3" aria-hidden />
-          <span>
-            Tops up at <span className="font-medium text-foreground">{formatUsd(marker.threshold)}</span>
-          </span>
-        </p>
-      )}
+      ))}
     </div>
   );
 };

--- a/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/BalanceBreakdownBar.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/BalanceBreakdownBar.tsx
@@ -30,16 +30,17 @@ function badgeBackground(hue: string, alpha: number): string {
 
 /**
  * Diagonal hatch overlaid on the Available segment to flag the auto-top-up trigger zone.
- * Warning-orange because the token is identical in light and dark themes, pops against the success
- * green underneath, and cannot be confused with the monochrome primary ramp of the reserved segments.
+ * Stripes are the page background token at partial alpha, so the zone stays recognisably the Available
+ * green, just lightened in light mode and darkened in dark mode. Full alpha reads as a separate white or
+ * black band rather than a texture over the green.
  */
 export const THRESHOLD_HATCH_BACKGROUND =
-  "repeating-linear-gradient(45deg, transparent 0, transparent 4px, hsl(var(--warning) / 0.9) 4px, hsl(var(--warning) / 0.9) 8px)";
+  "repeating-linear-gradient(45deg, transparent 0, transparent 3px, hsl(var(--background) / 0.62) 3px, hsl(var(--background) / 0.62) 6px)";
 
-/** Miniature of the bar's top-up zone (warning hatch over the Available green) for legend use. */
+/** Miniature of the bar's top-up zone (background-colored hatch over the Available green) for legend use. */
 export const ThresholdHatchSwatch: React.FunctionComponent = () => (
   <span
-    className="h-3 w-3 shrink-0 rounded-[3px]"
+    className="h-3.5 w-3.5 shrink-0 rounded-[3px]"
     style={{ backgroundColor: "hsl(var(--success))", backgroundImage: THRESHOLD_HATCH_BACKGROUND }}
     aria-hidden
   />

--- a/apps/deploy-web/src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup.spec.tsx
@@ -196,6 +196,20 @@ describe(AutoTopUpSettingsPopup.name, () => {
     expect(amountInput().value).toBe("150");
   });
 
+  it("recommends the fixed threshold mode in the enable flow", () => {
+    setup({ enableOnSave: true });
+
+    expect(screen.getByText("Recommended")).toBeInTheDocument();
+    expect(modeRadio(/fixed threshold/i)).toHaveAccessibleName(/recommended/i);
+    expect(modeRadio(/predicted spend/i)).not.toHaveAccessibleName(/recommended/i);
+  });
+
+  it("does not recommend a mode when editing existing settings", () => {
+    setup({ enableOnSave: false });
+
+    expect(screen.queryByText("Recommended")).not.toBeInTheDocument();
+  });
+
   function modeRadio(name: RegExp) {
     return screen.getByRole("radio", { name });
   }

--- a/apps/deploy-web/src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useMemo, useRef } from "react";
 import { useForm } from "react-hook-form";
 import type { PaymentMethod } from "@akashnetwork/http-sdk";
 import {
+  Badge,
   Field,
   FieldContent,
   FieldLabel,
@@ -38,12 +39,13 @@ const AUTO_RELOAD_MAX_USD = 10_000;
 /** Mirrors STANDARD_TOP_UP_MIN_AMOUNT_USD — the fixed floor the backend applies to every recurring auto-top-up charge, independent of the trial-aware one-time top-up minimum. */
 const AUTO_RELOAD_AMOUNT_MIN_USD = 20;
 
-const MODE_OPTIONS: Array<{ value: AutoReloadMode; id: string; title: string; description: string }> = [
+const MODE_OPTIONS: Array<{ value: AutoReloadMode; id: string; title: string; description: string; recommended?: boolean }> = [
   {
     value: "threshold",
     id: "auto-reload-mode-threshold",
     title: "Fixed threshold",
-    description: "Charge a set amount as soon as your available balance runs low."
+    description: "Charge a set amount as soon as your available balance runs low.",
+    recommended: true
   },
   {
     value: "prediction",
@@ -193,7 +195,14 @@ export const AutoTopUpSettingsPopup: React.FC<AutoTopUpSettingsPopupProps> = ({
                     <Field orientation="horizontal" className="cursor-pointer p-3">
                       <RadioGroupItem value={option.value} id={option.id} className="self-center" />
                       <FieldContent>
-                        <FieldTitle className="font-medium">{option.title}</FieldTitle>
+                        <FieldTitle className="font-medium">
+                          {option.title}
+                          {enableOnSave && option.recommended && (
+                            <Badge variant="info" className="h-4 px-1.5 py-0">
+                              Recommended
+                            </Badge>
+                          )}
+                        </FieldTitle>
                         <p className="text-sm text-muted-foreground">{option.description}</p>
                       </FieldContent>
                     </Field>


### PR DESCRIPTION
## Why

Part of CON-733. Three small gaps in the escrow-abstraction billing UI. The auto-top-up zone on the balance bar was drawn as faint gray stripes anchored to the far right, so it was easy to miss, and whenever the available balance sat at or below the threshold the stripes swallowed the whole green segment and looked mispositioned. Nothing on the page explained what the stripes or the dashed line meant. And the Auto Top-Up modal gave no hint which mode we recommend when someone turns it on for the first time.

## What

- The hatch now starts at the reserved/available boundary and covers the first `min(threshold, available)` dollars of the Available segment, with the dashed threshold line at its right edge. It is drawn inside the segment, so the 2px gaps between segments can't skew its position, and it dims with the segment on hover. When available <= threshold the whole green segment is hatched and the line is hidden: its true position would lie past the bar's right edge, where the rounded corners would clip it.
- The stripes use the warning token instead of foreground at 28% alpha. Warning orange is the same in both themes, stands out against the success green, and can't be mistaken for the reserved segments' primary ramp. Foreground is nearly identical to primary in both themes, which is why the old stripes disappeared into the bar.
- A new legend row under Reserved/Available: a dashed swatch with "Tops up at $X" (this replaces the caption that used to sit under the bar) and a hatch swatch labeled "Top-up buffer".
- "Fixed threshold" gets a "Recommended" badge in the Auto Top-Up modal, but only in the first-enable flow (Switch on). Editing existing settings shows no badge.

One trade-off: the dashed line used to overhang the bar by 2px vertically. It now lives inside the clipped bar; the stronger hatch and the legend carry the visibility instead.

Verified with unit tests and a light/dark render built from the real theme tokens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic top-up threshold guidance alongside the available balance.
  * Marked fixed-threshold automatic top-up as “Recommended” during initial setup.

* **Bug Fixes**
  * Improved threshold marker placement and visibility when available balance is low.
  * Removed the previous buffer visualization in favor of a clearer threshold marker and caption.
  * Hidden setup recommendations when editing existing automatic top-up settings.
  * Preserved the “Free to spend” message when no threshold is configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->