### PR TITLE
feat(deployment): show loading skeletons on the redesigned deployment detail page

### DIFF
--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.spec.tsx
@@ -79,6 +79,27 @@ describe("DeploymentDetail", () => {
     setup({ deployment: null, error });
 
     expect(screen.getByText(/this deployment does not exist/i)).toBeInTheDocument();
+    expect(screen.queryByTestId("deployment-detail-skeleton")).not.toBeInTheDocument();
+  });
+
+  it("renders the page skeleton while the deployment loads", () => {
+    setup({ deployment: null });
+
+    expect(screen.getByTestId("deployment-detail-skeleton")).toBeInTheDocument();
+    expect(screen.queryByRole("tablist")).not.toBeInTheDocument();
+  });
+
+  it("renders the page skeleton until leases resolve", () => {
+    setup({ isLeasesLoaded: false });
+
+    expect(screen.getByTestId("deployment-detail-skeleton")).toBeInTheDocument();
+    expect(screen.queryByRole("tablist")).not.toBeInTheDocument();
+  });
+
+  it("keeps the skeleton away when leases fail to load", () => {
+    setup({ isLeasesLoaded: false, isLeasesError: true });
+
+    expect(screen.queryByTestId("deployment-detail-skeleton")).not.toBeInTheDocument();
   });
 
   it("redirects an in-progress deployment with no lease to the configure flow", () => {
@@ -113,6 +134,7 @@ describe("DeploymentDetail", () => {
     deployment?: DeploymentDto | null;
     leases?: LeaseDto[] | null;
     isLeasesLoaded?: boolean;
+    isLeasesError?: boolean;
     error?: Error | null;
     tab?: string;
     leaseState?: string;
@@ -140,7 +162,12 @@ describe("DeploymentDetail", () => {
     const useDeploymentDetail: typeof DEPENDENCIES.useDeploymentDetail = () =>
       mock<ReturnType<typeof DEPENDENCIES.useDeploymentDetail>>({ data: deployment, isFetching: false, error: input?.error ?? null });
     const useDeploymentLeaseList: typeof DEPENDENCIES.useDeploymentLeaseList = () =>
-      mock<ReturnType<typeof DEPENDENCIES.useDeploymentLeaseList>>({ data: leases, isLoading: false, isSuccess: input?.isLeasesLoaded ?? true });
+      mock<ReturnType<typeof DEPENDENCIES.useDeploymentLeaseList>>({
+        data: leases,
+        isLoading: false,
+        isSuccess: input?.isLeasesLoaded ?? true,
+        isError: input?.isLeasesError ?? false
+      });
     const useProviderList: typeof DEPENDENCIES.useProviderList = () =>
       mock<ReturnType<typeof DEPENDENCIES.useProviderList>>({ data: providers, isFetching: false });
     const redeploy = vi.fn();

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.tsx
@@ -1,7 +1,7 @@
 "use client";
 import type { FC } from "react";
 import { useEffect, useState } from "react";
-import { buttonVariants, Tabs, TabsList, TabsTrigger } from "@akashnetwork/ui/components";
+import { buttonVariants, Skeleton, Tabs, TabsList, TabsTrigger } from "@akashnetwork/ui/components";
 import { cn } from "@akashnetwork/ui/utils";
 import { ArrowLeft } from "iconoir-react";
 import Link from "next/link";
@@ -84,7 +84,8 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = ({ dseq, dependencies
     data: leases,
     isLoading: isLoadingLeases,
     refetch: getLeases,
-    isSuccess: isLeasesLoaded
+    isSuccess: isLeasesLoaded,
+    isError: isLeasesError
   } = d.useDeploymentLeaseList(address, deployment, {
     enabled: deployment?.state === "active",
     refetchOnWindowFocus: false
@@ -95,6 +96,7 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = ({ dseq, dependencies
   const deploymentManifest = storedDeployment?.manifest || "";
   const isActive = deployment?.state === "active" && !!leases?.some(isLeaseLive);
   const isDeploymentNotFound = !!deploymentError && (deploymentError as any).response?.data?.message?.includes("Deployment not found") && !isLoadingDeployment;
+  const showsPageSkeleton = !isDeploymentNotFound && !deploymentError && !isLeasesError && (!deployment || !isLeasesLoaded);
 
   useEffect(() => {
     if (deployment) {
@@ -162,6 +164,8 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = ({ dseq, dependencies
         </div>
       )}
 
+      {showsPageSkeleton && <DeploymentDetailSkeleton />}
+
       {deployment && isLeasesLoaded && (
         <>
           <div className={PAGE_BAND}>
@@ -228,4 +232,30 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = ({ dseq, dependencies
 
 const TabInactiveState: FC<{ label?: string }> = ({ label = "Available when the deployment is active." }) => (
   <div className="py-12 text-center text-sm text-muted-foreground">{label}</div>
+);
+
+/** Lightweight ghost of the detail page — header band, tab strip and one content card — shown while the deployment and its leases resolve. */
+const DeploymentDetailSkeleton: FC = () => (
+  <div className="flex flex-1 flex-col" data-testid="deployment-detail-skeleton">
+    <div className={cn(PAGE_BAND, "flex flex-col gap-6 pb-6 lg:flex-row lg:items-start lg:justify-between")}>
+      <div className="space-y-3">
+        <Skeleton className="h-5 w-24 rounded-full" />
+        <Skeleton className="h-9 w-72" />
+        <Skeleton className="h-9 w-80" />
+      </div>
+      <Skeleton className="h-32 w-full rounded-xl lg:w-96" />
+    </div>
+    <div className="border-b border-t">
+      <div className={cn(PAGE_BAND, "flex gap-8 py-3")}>
+        {TABS.map(tab => (
+          <Skeleton key={tab} className="h-5 w-14" />
+        ))}
+      </div>
+    </div>
+    <div className="flex-1 bg-muted py-6">
+      <div className={PAGE_BAND}>
+        <Skeleton className="h-64 w-full rounded-xl" />
+      </div>
+    </div>
+  </div>
 );

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.spec.tsx
@@ -139,6 +139,13 @@ describe(PlacementCard.name, () => {
     expect(PlacementServiceRow.mock.calls[0][0]).toEqual(expect.objectContaining({ isLeaseStatusPending: false }));
   });
 
+  it("does not mark rows pending when the status query stays disabled and never fetches", () => {
+    const PlacementServiceRow = vi.fn((_props: Parameters<typeof DEPENDENCIES.PlacementServiceRow>[0]) => <div>service-row</div>);
+    setup({ leaseStatus: null, manifestServices: { web: {} }, dependencies: { PlacementServiceRow } });
+
+    expect(PlacementServiceRow.mock.calls[0][0]).toEqual(expect.objectContaining({ isLeaseStatusPending: false }));
+  });
+
   it("shows the reclamation card and no reclaiming badge when the lease has been reclaimed", () => {
     const ReclamationCard = vi.fn(() => <div>reclamation</div>);
     setup({ lease: buildLease({ state: "closed", groupState: "paused" }), leaseStatus: null, dependencies: { ReclamationCard } });
@@ -238,7 +245,8 @@ describe(PlacementCard.name, () => {
       mock<ReturnType<typeof DEPENDENCIES.useLeaseStatus>>({
         data: leaseStatus,
         error: input?.leaseStatusError ?? null,
-        isPending: input?.isLeaseStatusPending ?? false
+        isPending: !leaseStatus && !input?.leaseStatusError,
+        isLoading: input?.isLeaseStatusPending ?? false
       });
     const useTeeResourceCarveouts: typeof DEPENDENCIES.useTeeResourceCarveouts = () => [];
 

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.spec.tsx
@@ -112,6 +112,33 @@ describe(PlacementCard.name, () => {
     expect(PlacementServiceRow).toHaveBeenCalledTimes(2);
   });
 
+  it("marks service rows pending while the lease status is loading", () => {
+    const PlacementServiceRow = vi.fn((_props: Parameters<typeof DEPENDENCIES.PlacementServiceRow>[0]) => <div>service-row</div>);
+    setup({ leaseStatus: null, isLeaseStatusPending: true, manifestServices: { web: {} }, dependencies: { PlacementServiceRow } });
+
+    expect(PlacementServiceRow.mock.calls[0][0]).toEqual(expect.objectContaining({ isLeaseStatusPending: true }));
+  });
+
+  it("does not mark rows pending once the lease is closed", () => {
+    const PlacementServiceRow = vi.fn((_props: Parameters<typeof DEPENDENCIES.PlacementServiceRow>[0]) => <div>service-row</div>);
+    setup({
+      lease: buildLease({ state: "closed" }),
+      leaseStatus: null,
+      isLeaseStatusPending: true,
+      manifestServices: { web: {} },
+      dependencies: { PlacementServiceRow }
+    });
+
+    expect(PlacementServiceRow.mock.calls[0][0]).toEqual(expect.objectContaining({ isLeaseStatusPending: false }));
+  });
+
+  it("does not mark rows pending while the provider is unknown", () => {
+    const PlacementServiceRow = vi.fn((_props: Parameters<typeof DEPENDENCIES.PlacementServiceRow>[0]) => <div>service-row</div>);
+    setup({ provider: undefined, leaseStatus: null, isLeaseStatusPending: true, manifestServices: { web: {} }, dependencies: { PlacementServiceRow } });
+
+    expect(PlacementServiceRow.mock.calls[0][0]).toEqual(expect.objectContaining({ isLeaseStatusPending: false }));
+  });
+
   it("shows the reclamation card and no reclaiming badge when the lease has been reclaimed", () => {
     const ReclamationCard = vi.fn(() => <div>reclamation</div>);
     setup({ lease: buildLease({ state: "closed", groupState: "paused" }), leaseStatus: null, dependencies: { ReclamationCard } });
@@ -201,13 +228,18 @@ describe(PlacementCard.name, () => {
     provider?: ApiProviderList;
     leaseStatus?: LeaseStatusDto | null;
     leaseStatusError?: unknown;
+    isLeaseStatusPending?: boolean;
     manifestServices?: Record<string, ManifestServiceDetail>;
     placementServices?: Record<string, ManifestServiceDetail>;
     dependencies?: Partial<typeof DEPENDENCIES>;
   }) {
     const leaseStatus = input && "leaseStatus" in input ? input.leaseStatus : buildStatus(["web"]);
     const useLeaseStatus: typeof DEPENDENCIES.useLeaseStatus = () =>
-      mock<ReturnType<typeof DEPENDENCIES.useLeaseStatus>>({ data: leaseStatus, error: input?.leaseStatusError ?? null });
+      mock<ReturnType<typeof DEPENDENCIES.useLeaseStatus>>({
+        data: leaseStatus,
+        error: input?.leaseStatusError ?? null,
+        isPending: input?.isLeaseStatusPending ?? false
+      });
     const useTeeResourceCarveouts: typeof DEPENDENCIES.useTeeResourceCarveouts = () => [];
 
     return render(
@@ -215,7 +247,7 @@ describe(PlacementCard.name, () => {
         <PlacementCard
           index={0}
           lease={input?.lease ?? buildLease()}
-          provider={input?.provider ?? buildProvider()}
+          provider={input && "provider" in input ? input.provider : buildProvider()}
           manifestServices={input?.manifestServices ?? {}}
           placementServices={input?.placementServices}
           dseq="123"

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.tsx
@@ -57,7 +57,13 @@ export const PlacementCard: FC<PlacementCardProps> = ({
   dependencies: d = DEPENDENCIES
 }) => {
   const isLeaseActive = isLeaseLive(lease);
-  const { data: leaseStatus, error: leaseStatusError } = d.useLeaseStatus({ provider, lease, enabled: isLeaseActive && !!provider, refetchInterval: 30_000 });
+  const {
+    data: leaseStatus,
+    error: leaseStatusError,
+    isPending
+  } = d.useLeaseStatus({ provider, lease, enabled: isLeaseActive && !!provider, refetchInterval: 30_000 });
+  /** Raw isPending stays true forever for a disabled query (closed lease, unknown provider), so mirror the enabled gate. */
+  const isLeaseStatusPending = isLeaseActive && !!provider && isPending;
   const isProviderUnreachable = isLeaseActive && isProviderUnavailableError(leaseStatusError);
   const carveouts = d.useTeeResourceCarveouts(lease);
   const [expanded, setExpanded] = useState<ReadonlySet<string>>(() => new Set());
@@ -158,6 +164,7 @@ export const PlacementCard: FC<PlacementCardProps> = ({
                 uris={leaseStatus?.services?.[serviceName]?.uris}
                 forwardedPorts={leaseStatus?.forwarded_ports?.[serviceName]}
                 ips={leaseStatus?.ips?.[serviceName]}
+                isLeaseStatusPending={isLeaseStatusPending}
                 open={expanded.has(serviceName)}
                 onOpenChange={next => handleOpenChange(serviceName, next)}
               />

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.tsx
@@ -60,10 +60,10 @@ export const PlacementCard: FC<PlacementCardProps> = ({
   const {
     data: leaseStatus,
     error: leaseStatusError,
-    isPending
+    isLoading
   } = d.useLeaseStatus({ provider, lease, enabled: isLeaseActive && !!provider, refetchInterval: 30_000 });
-  /** Raw isPending stays true forever for a disabled query (closed lease, unknown provider), so mirror the enabled gate. */
-  const isLeaseStatusPending = isLeaseActive && !!provider && isPending;
+  /** isLoading, not isPending: useLeaseStatus also gates `enabled` on provider.hostUri and usable provider credentials, so the query can stay disabled forever with isPending stuck true, while isLoading is false for a query that never fetches. */
+  const isLeaseStatusPending = isLeaseActive && !!provider && isLoading;
   const isProviderUnreachable = isLeaseActive && isProviderUnavailableError(leaseStatusError);
   const carveouts = d.useTeeResourceCarveouts(lease);
   const [expanded, setExpanded] = useState<ReadonlySet<string>>(() => new Set());

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementServiceRow.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementServiceRow.spec.tsx
@@ -119,6 +119,39 @@ describe(PlacementServiceRow.name, () => {
 
     expect(screen.getByText("Running")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /web/ })).not.toBeInTheDocument();
+    expect(screen.queryByTestId("service-details-skeleton")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("service-replicas-skeleton")).not.toBeInTheDocument();
+  });
+
+  it("makes a pending live row expandable before any detail arrives", () => {
+    setup({ isLeaseStatusPending: true });
+
+    expect(screen.getByRole("button", { name: /web/ })).toBeInTheDocument();
+    expect(screen.getByTestId("service-replicas-skeleton")).toBeInTheDocument();
+  });
+
+  it("reserves the endpoint area with skeleton lines while the lease status is pending", async () => {
+    setup({ isLeaseStatusPending: true, detail: { image: "nginx:1.25" } });
+
+    await expandService();
+
+    expect(screen.getByText("Image")).toBeInTheDocument();
+    expect(screen.getByTestId("service-details-skeleton")).toBeInTheDocument();
+  });
+
+  it("shows the real replica count instead of a skeleton once the service reports one", () => {
+    setup({ isLeaseStatusPending: true, service: mock<LeaseServiceStatus>({ available: 2, total: 3 }) });
+
+    expect(screen.getByText("2/3 replicas")).toBeInTheDocument();
+    expect(screen.queryByTestId("service-replicas-skeleton")).not.toBeInTheDocument();
+  });
+
+  it("keeps closed rows free of skeletons even if marked pending", () => {
+    setup({ leaseState: "closed", isLeaseStatusPending: true });
+
+    expect(screen.queryByRole("button", { name: /web/ })).not.toBeInTheDocument();
+    expect(screen.queryByTestId("service-replicas-skeleton")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("service-details-skeleton")).not.toBeInTheDocument();
   });
 
   it("shows image and resources when expanded", async () => {

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementServiceRow.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementServiceRow.tsx
@@ -1,7 +1,7 @@
 "use client";
 import type { FC, ReactNode } from "react";
 import { useState } from "react";
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@akashnetwork/ui/components";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger, Skeleton } from "@akashnetwork/ui/components";
 import { Box, Globe, Label, NavArrowDown, NavArrowRight } from "iconoir-react";
 
 import type { ForwardedPort, LeaseServiceStatus, ServiceIp } from "@src/queries/useLeaseQuery";
@@ -24,6 +24,8 @@ export interface PlacementServiceRowProps {
   ips?: ServiceIp[] | null;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
+  /** True while the lease-status poll for a live lease has not settled; endpoint details render as skeleton lines instead of popping in. */
+  isLeaseStatusPending?: boolean;
 }
 
 export const PlacementServiceRow: FC<PlacementServiceRowProps> = ({
@@ -36,7 +38,8 @@ export const PlacementServiceRow: FC<PlacementServiceRowProps> = ({
   forwardedPorts,
   ips,
   open: openProp,
-  onOpenChange
+  onOpenChange,
+  isLeaseStatusPending
 }) => {
   const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
   const isControlled = openProp !== undefined;
@@ -47,6 +50,7 @@ export const PlacementServiceRow: FC<PlacementServiceRowProps> = ({
   const portChips = toPortChips({ forwardedPorts, ips, closed });
   const replicaLabel = closed ? undefined : formatReplicaCount(service);
   const hasDetails = !!(detail?.resources || detail?.image || uriLinks.length > 0 || portChips.length > 0);
+  const showsPendingDetails = !!isLeaseStatusPending && !closed;
 
   function handleOpenChange(next: boolean) {
     if (!isControlled) setUncontrolledOpen(next);
@@ -64,9 +68,13 @@ export const PlacementServiceRow: FC<PlacementServiceRowProps> = ({
     <div className="flex min-w-0 flex-1 items-center justify-end">
       <span className="shrink-0 text-sm text-muted-foreground">{replicaLabel}</span>
     </div>
+  ) : showsPendingDetails ? (
+    <div className="flex min-w-0 flex-1 items-center justify-end">
+      <Skeleton className="h-4 w-24" data-testid="service-replicas-skeleton" />
+    </div>
   ) : null;
 
-  if (closed || !hasDetails) {
+  if (closed || (!hasDetails && !showsPendingDetails)) {
     return (
       <div className="overflow-hidden rounded-lg border">
         <div className="flex items-center gap-3 p-4">
@@ -108,6 +116,12 @@ export const PlacementServiceRow: FC<PlacementServiceRowProps> = ({
             <PortChips items={portChips} />
           </ServiceDetailRow>
         ) : null}
+        {showsPendingDetails && (
+          <div className="space-y-3 border-t px-5 py-4" data-testid="service-details-skeleton">
+            <Skeleton className="h-4 w-3/5" />
+            <Skeleton className="h-4 w-2/5" />
+          </div>
+        )}
       </CollapsibleContent>
     </Collapsible>
   );

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentVisitControl/DeploymentVisitControl.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentVisitControl/DeploymentVisitControl.spec.tsx
@@ -6,7 +6,7 @@ import type { LeaseDto } from "@src/types/deployment";
 import type { ApiProviderList } from "@src/types/provider";
 import { DEPENDENCIES, DeploymentVisitControl } from "./DeploymentVisitControl";
 
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MockComponents } from "@tests/unit/mocks";
 
@@ -16,6 +16,43 @@ describe(DeploymentVisitControl.name, () => {
 
     expect(screen.queryByRole("link", { name: "Visit" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Visit" })).not.toBeInTheDocument();
+    expect(screen.queryByTestId("visit-control-skeleton")).not.toBeInTheDocument();
+  });
+
+  it("shows a skeleton while lease statuses have not settled", () => {
+    setup({ endpointsByLease: {}, pendingLeases: ["1"] });
+
+    expect(screen.getByTestId("visit-control-skeleton")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Visit" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Visit" })).not.toBeInTheDocument();
+  });
+
+  it("shows the resolved endpoint instead of the skeleton while another lease is still pending", async () => {
+    setup({
+      leases: [buildLease("us", "akash1us"), buildLease("eu", "akash1eu")],
+      providers: [mock<ApiProviderList>({ owner: "akash1us" }), mock<ApiProviderList>({ owner: "akash1eu" })],
+      endpointsByLease: { us: { web: ["us.akash.app"] } },
+      pendingLeases: ["eu"]
+    });
+
+    expect(await screen.findByRole("link", { name: "Visit" })).toBeInTheDocument();
+    expect(screen.queryByTestId("visit-control-skeleton")).not.toBeInTheDocument();
+  });
+
+  it("gives up on the skeleton when statuses never settle", () => {
+    vi.useFakeTimers();
+    try {
+      setup({ endpointsByLease: {}, pendingLeases: ["1"] });
+
+      act(() => {
+        vi.advanceTimersByTime(15_000);
+      });
+
+      expect(screen.queryByTestId("visit-control-skeleton")).not.toBeInTheDocument();
+      expect(screen.queryByRole("link", { name: "Visit" })).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("shows the URI, a copy button, and a Visit link when there is one endpoint", async () => {
@@ -82,12 +119,20 @@ describe(DeploymentVisitControl.name, () => {
     return mock<LeaseDto>({ id, provider, state: "active" });
   }
 
-  function setup(input: { leases?: LeaseDto[]; providers?: ApiProviderList[]; endpointsByLease: Record<string, Record<string, string[]>> }) {
+  function setup(input: {
+    leases?: LeaseDto[];
+    providers?: ApiProviderList[];
+    endpointsByLease: Record<string, Record<string, string[]>>;
+    pendingLeases?: string[];
+  }) {
     const leases = input.leases ?? [buildLease("1", "akash1provider")];
     const providers = input.providers ?? [mock<ApiProviderList>({ owner: "akash1provider" })];
 
     const useLeaseStatuses: typeof DEPENDENCIES.useLeaseStatuses = items =>
       items.map(({ lease }) => {
+        if (input.pendingLeases?.includes(lease.id)) {
+          return mock<ReturnType<typeof DEPENDENCIES.useLeaseStatuses>[number]>({ data: undefined, isPending: true });
+        }
         const services: Record<string, string[]> = input.endpointsByLease[lease.id] ?? {};
         const leaseStatus = mock<LeaseStatusDto>();
         leaseStatus.forwarded_ports = {};
@@ -99,7 +144,7 @@ describe(DeploymentVisitControl.name, () => {
             return [name, service];
           })
         );
-        return mock<ReturnType<typeof DEPENDENCIES.useLeaseStatuses>[number]>({ data: leaseStatus });
+        return mock<ReturnType<typeof DEPENDENCIES.useLeaseStatuses>[number]>({ data: leaseStatus, isPending: false });
       });
 
     const CopyTextToClipboardButton = vi.fn(({ value, "aria-label": label }: { value: string; "aria-label"?: string }) => (

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentVisitControl/DeploymentVisitControl.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentVisitControl/DeploymentVisitControl.tsx
@@ -1,6 +1,6 @@
 "use client";
 import type { FC } from "react";
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   Button,
   buttonVariants,
@@ -8,7 +8,8 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
-  DropdownMenuTrigger
+  DropdownMenuTrigger,
+  Skeleton
 } from "@akashnetwork/ui/components";
 import { cn } from "@akashnetwork/ui/utils";
 import { Globe, NavArrowDown } from "iconoir-react";
@@ -23,7 +24,8 @@ import { collectVisitEndpoints, endpointLabel } from "./visitEndpoints";
 
 export const DEPENDENCIES = {
   useLeaseStatuses,
-  CopyTextToClipboardButton
+  CopyTextToClipboardButton,
+  Skeleton
 };
 
 export interface DeploymentVisitControlProps {
@@ -31,6 +33,13 @@ export interface DeploymentVisitControlProps {
   providers: ApiProviderList[];
   dependencies?: typeof DEPENDENCIES;
 }
+
+/**
+ * Upper bound on how long the endpoint skeleton may wait for lease statuses that never settle
+ * (their queries stay disabled when a provider is missing from the list or provider credentials fail),
+ * after which the control collapses to nothing exactly as it did before skeletons existed.
+ */
+const ENDPOINT_SKELETON_MAX_WAIT_MS = 15_000;
 
 export const DeploymentVisitControl: FC<DeploymentVisitControlProps> = ({ leases, providers, dependencies: d = DEPENDENCIES }) => {
   const items = useMemo(
@@ -43,6 +52,21 @@ export const DeploymentVisitControl: FC<DeploymentVisitControlProps> = ({ leases
   );
   const statuses = d.useLeaseStatuses(items, { refetchInterval: 30_000 });
   const endpoints = statuses.flatMap(status => collectVisitEndpoints(status.data));
+
+  const [hasWaitExpired, setHasWaitExpired] = useState(false);
+  useEffect(function stopWaitingEventually() {
+    const timer = setTimeout(() => setHasWaitExpired(true), ENDPOINT_SKELETON_MAX_WAIT_MS);
+    return () => clearTimeout(timer);
+  }, []);
+
+  if (!hasWaitExpired && endpoints.length === 0 && statuses.some(status => status.isPending)) {
+    return (
+      <div className="flex items-center gap-2" data-testid="visit-control-skeleton">
+        <d.Skeleton className="h-9 w-64 max-w-xs" />
+        <d.Skeleton className="h-9 w-16" />
+      </div>
+    );
+  }
 
   return <VisitControlView endpoints={endpoints} CopyTextToClipboardButton={d.CopyTextToClipboardButton} />;
 };


### PR DESCRIPTION
## Why

Part of CON-733. On the redesigned deployment detail page, async content pops in with no loading state. The page body is blank until the deployment and leases resolve, the Visit control appears out of nowhere once provider statuses land, and service rows grow an expand chevron and URL/Ports rows while you're reading them.

## What

- The page shows a full-page skeleton (header band, tab strip, one content card) while the deployment and lease list load. Error and not-found states behave as they do today.
- The header Visit control shows a skeleton chip and button while lease statuses are pending, bounded by a 15s give-up timer. A missing provider or a failed provider-JWT generation leaves those queries disabled forever, and after the timer the control collapses to nothing, exactly as before.
- Live service rows marked pending are expandable up front (no chevron pop-in), with a skeleton where the replica count will land and skeleton lines in the expanded details area where the URL and Ports rows appear. Closed leases and unknown providers never show skeletons; the pending flag mirrors the query's enabled gate.

Tests: 13 new cases across the four touched specs. The lease-status mocks now pin `isPending` and `isError` explicitly, since vitest-mock-extended's truthy auto-mocks would otherwise flip existing tests into the new loading branches.