### PR TITLE
feat(billing): cap automatic card charges to one per hour by default

### DIFF
--- a/apps/api/drizzle/0044_wallet_settings_last_auto_charge_at.sql
+++ b/apps/api/drizzle/0044_wallet_settings_last_auto_charge_at.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "wallet_settings" ADD COLUMN "last_auto_charge_at" timestamp;

--- a/apps/api/drizzle/meta/0044_snapshot.json
+++ b/apps/api/drizzle/meta/0044_snapshot.json
@@ -1,0 +1,1534 @@
+{
+  "id": "0c5ec86e-303d-464c-b336-1e65cf1e5a45",
+  "prevId": "7d238aae-847e-4efe-b5aa-2959bb86e3b6",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.user_wallets": {
+      "name": "user_wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_allowance": {
+          "name": "deployment_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "fee_allowance": {
+          "name": "fee_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "trial": {
+          "name": "trial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits_low_notified_at": {
+          "name": "credits_low_notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_wallets_user_id_userSetting_id_fk": {
+          "name": "user_wallets_user_id_userSetting_id_fk",
+          "tableFrom": "user_wallets",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_wallets_user_id_unique": {
+          "name": "user_wallets_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "user_wallets_address_unique": {
+          "name": "user_wallets_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_methods": {
+      "name": "payment_methods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_method_id": {
+          "name": "payment_method_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_validated": {
+          "name": "is_validated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payment_methods_fingerprint_payment_method_id_unique": {
+          "name": "payment_methods_fingerprint_payment_method_id_unique",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_default_unique": {
+          "name": "payment_methods_user_id_is_default_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"payment_methods\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_fingerprint_idx": {
+          "name": "payment_methods_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_idx": {
+          "name": "payment_methods_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_validated_idx": {
+          "name": "payment_methods_user_id_is_validated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_validated",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_fingerprint_payment_method_id_idx": {
+          "name": "payment_methods_user_id_fingerprint_payment_method_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_methods_user_id_userSetting_id_fk": {
+          "name": "payment_methods_user_id_userSetting_id_fk",
+          "tableFrom": "payment_methods",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_transactions": {
+      "name": "stripe_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "stripe_transaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "stripe_transaction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created'"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_refunded": {
+          "name": "amount_refunded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bonus_amount": {
+          "name": "bonus_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_charge_id": {
+          "name": "stripe_charge_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_coupon_id": {
+          "name": "stripe_coupon_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_promotion_code_id": {
+          "name": "stripe_promotion_code_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_idempotency_key": {
+          "name": "stripe_idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method_type": {
+          "name": "payment_method_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_brand": {
+          "name": "card_brand",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_last4": {
+          "name": "card_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_url": {
+          "name": "receipt_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_transactions_stripe_invoice_id_unique": {
+          "name": "stripe_transactions_stripe_invoice_id_unique",
+          "columns": [
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stripe_transactions\".\"stripe_invoice_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_idempotency_key_unique": {
+          "name": "stripe_transactions_stripe_idempotency_key_unique",
+          "columns": [
+            {
+              "expression": "stripe_idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stripe_transactions\".\"stripe_idempotency_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_user_id_idx": {
+          "name": "stripe_transactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_payment_intent_id_idx": {
+          "name": "stripe_transactions_stripe_payment_intent_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_payment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_charge_id_idx": {
+          "name": "stripe_transactions_stripe_charge_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_coupon_id_idx": {
+          "name": "stripe_transactions_stripe_coupon_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_coupon_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_promotion_code_id_idx": {
+          "name": "stripe_transactions_stripe_promotion_code_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_promotion_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_status_idx": {
+          "name": "stripe_transactions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_created_at_idx": {
+          "name": "stripe_transactions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_user_id_created_at_idx": {
+          "name": "stripe_transactions_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_transactions_user_id_userSetting_id_fk": {
+          "name": "stripe_transactions_user_id_userSetting_id_fk",
+          "tableFrom": "stripe_transactions",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_settings": {
+      "name": "wallet_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_reload_enabled": {
+          "name": "auto_reload_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_reload_mode": {
+          "name": "auto_reload_mode",
+          "type": "auto_reload_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'prediction'"
+        },
+        "auto_reload_threshold": {
+          "name": "auto_reload_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2000
+        },
+        "auto_reload_amount": {
+          "name": "auto_reload_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10000
+        },
+        "last_auto_charge_at": {
+          "name": "last_auto_charge_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_settings_user_id_idx": {
+          "name": "wallet_settings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_settings_wallet_id_user_wallets_id_fk": {
+          "name": "wallet_settings_wallet_id_user_wallets_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "user_wallets",
+          "columnsFrom": [
+            "wallet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wallet_settings_user_id_userSetting_id_fk": {
+          "name": "wallet_settings_user_id_userSetting_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallet_settings_wallet_id_unique": {
+          "name": "wallet_settings_wallet_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wallet_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.userSetting": {
+      "name": "userSetting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscribedToNewsletter": {
+          "name": "subscribedToNewsletter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "youtubeUsername": {
+          "name": "youtubeUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitterUsername": {
+          "name": "twitterUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "githubUsername": {
+          "name": "githubUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_ip": {
+          "name": "last_ip",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_user_agent": {
+          "name": "last_user_agent",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fingerprint": {
+          "name": "last_fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboardingSkippedAt": {
+          "name": "onboardingSkippedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "userSetting_userId_unique": {
+          "name": "userSetting_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        },
+        "userSetting_username_unique": {
+          "name": "userSetting_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.template": {
+      "name": "template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "copiedFromId": {
+          "name": "copiedFromId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cpu": {
+          "name": "cpu",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ram": {
+          "name": "ram",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage": {
+          "name": "storage",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sdl": {
+          "name": "sdl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "template_userId_idx": {
+          "name": "template_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.templateFavorite": {
+      "name": "templateFavorite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "templateId": {
+          "name": "templateId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addedDate": {
+          "name": "addedDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "templateFavorite_userId_templateId_unique": {
+          "name": "templateFavorite_userId_templateId_unique",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "templateId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "templateFavorite_templateId_template_id_fk": {
+          "name": "templateFavorite_templateId_template_id_fk",
+          "tableFrom": "templateFavorite",
+          "tableTo": "template",
+          "columnsFrom": [
+            "templateId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_settings": {
+      "name": "deployment_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dseq": {
+          "name": "dseq",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_top_up_enabled": {
+          "name": "auto_top_up_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closed": {
+          "name": "closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_funded_at": {
+          "name": "last_funded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_limit_hours": {
+          "name": "runtime_limit_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sdl": {
+          "name": "sdl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manifest_version": {
+          "name": "manifest_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_ends_at": {
+          "name": "runtime_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_ending_notified_for": {
+          "name": "runtime_ending_notified_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "id_auto_top_up_enabled_closed_idx": {
+          "name": "id_auto_top_up_enabled_closed_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auto_top_up_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "closed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_settings_user_id_userSetting_id_fk": {
+          "name": "deployment_settings_user_id_userSetting_id_fk",
+          "tableFrom": "deployment_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dseq_user_id_idx": {
+          "name": "dseq_user_id_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "dseq",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_key": {
+          "name": "hashed_key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_format": {
+          "name": "key_format",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_user_id_userSetting_id_fk": {
+          "name": "api_keys_user_id_userSetting_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_hashed_key_unique": {
+          "name": "api_keys_hashed_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hashed_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_verification_codes": {
+      "name": "email_verification_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_verification_codes_user_id_idx": {
+          "name": "email_verification_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_verification_codes_user_id_userSetting_id_fk": {
+          "name": "email_verification_codes_user_id_userSetting_id_fk",
+          "tableFrom": "email_verification_codes",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.data_keys": {
+      "name": "data_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wrapped_key": {
+          "name": "wrapped_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wrapped_by_kid": {
+          "name": "wrapped_by_kid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "data_keys_wrapped_by_kid_idx": {
+          "name": "data_keys_wrapped_by_kid_idx",
+          "columns": [
+            {
+              "expression": "wrapped_by_kid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "data_keys_user_id_userSetting_id_fk": {
+          "name": "data_keys_user_id_userSetting_id_fk",
+          "tableFrom": "data_keys",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "data_keys_user_id_unique": {
+          "name": "data_keys_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.stripe_transaction_status": {
+      "name": "stripe_transaction_status",
+      "schema": "public",
+      "values": [
+        "created",
+        "pending",
+        "requires_action",
+        "succeeded",
+        "failed",
+        "refunded",
+        "canceled"
+      ]
+    },
+    "public.stripe_transaction_type": {
+      "name": "stripe_transaction_type",
+      "schema": "public",
+      "values": [
+        "payment_intent",
+        "coupon_claim",
+        "manual_credit"
+      ]
+    },
+    "public.auto_reload_mode": {
+      "name": "auto_reload_mode",
+      "schema": "public",
+      "values": [
+        "prediction",
+        "threshold"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -309,6 +309,13 @@
       "when": 1787670520752,
       "tag": "0043_store_deployment_sdl",
       "breakpoints": true
+    },
+    {
+      "idx": 44,
+      "version": "7",
+      "when": 1787674771013,
+      "tag": "0044_wallet_settings_last_auto_charge_at",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/billing/config/env.config.spec.ts
+++ b/apps/api/src/billing/config/env.config.spec.ts
@@ -25,6 +25,30 @@ describe("envSchema", () => {
     });
   });
 
+  describe("AUTO_RELOAD_CHARGE_COOLDOWN_IN_MIN", () => {
+    it("defaults to 60 when absent", () => {
+      const result = setup({});
+      expect(result.success).toBe(true);
+      expect(result.data?.AUTO_RELOAD_CHARGE_COOLDOWN_IN_MIN).toBe(60);
+    });
+
+    it("coerces a string value", () => {
+      const result = setup({ AUTO_RELOAD_CHARGE_COOLDOWN_IN_MIN: "30" });
+      expect(result.success).toBe(true);
+      expect(result.data?.AUTO_RELOAD_CHARGE_COOLDOWN_IN_MIN).toBe(30);
+    });
+
+    it("accepts zero to disable the cap", () => {
+      const result = setup({ AUTO_RELOAD_CHARGE_COOLDOWN_IN_MIN: "0" });
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects a negative value", () => {
+      const result = setup({ AUTO_RELOAD_CHARGE_COOLDOWN_IN_MIN: "-1" });
+      expect(result.success).toBe(false);
+    });
+  });
+
   describe("MASTER_WALLET_MAX_MINT_UAKT", () => {
     it("rejects a negative value", () => {
       const result = setup({ MASTER_WALLET_MAX_MINT_UAKT: "-1" });

--- a/apps/api/src/billing/config/env.config.ts
+++ b/apps/api/src/billing/config/env.config.ts
@@ -37,6 +37,12 @@ export const envSchema = z.object({
     .default(AUDITOR)
     .transform(val => (val ? val.split(",").map(addr => addr.trim()) : [])),
   MANAGED_WALLET_TRIAL_MIN_TOP_UP_AMOUNT: z.number({ coerce: true }).min(20).default(20),
+  /**
+   * Minimum minutes between automatic threshold-mode card charges per wallet — the default of 60
+   * caps them at one per hour. 0 disables the cap (unlike AUTO_TOP_UP_DEDUP_COOLDOWN_IN_MIN, which
+   * has no disable semantics).
+   */
+  AUTO_RELOAD_CHARGE_COOLDOWN_IN_MIN: z.number({ coerce: true }).min(0).default(60),
   MANAGED_WALLET_TRIAL_BLOCKED_GPU_MODELS: z
     .string()
     .default("nvidia/b300,nvidia/b200,nvidia/h200,nvidia/h100,nvidia/pro6000se,nvidia/pro6000we,nvidia/a100,nvidia/rtx5090,nvidia/rtx4090,nvidia/rtx3090")

--- a/apps/api/src/billing/model-schemas/wallet-setting/wallet-setting.schema.ts
+++ b/apps/api/src/billing/model-schemas/wallet-setting/wallet-setting.schema.ts
@@ -28,6 +28,12 @@ export const WalletSetting = pgTable(
     autoReloadMode: autoReloadModeEnum("auto_reload_mode").notNull().default("prediction"),
     autoReloadThreshold: integer("auto_reload_threshold").notNull().default(2000),
     autoReloadAmount: integer("auto_reload_amount").notNull().default(10000),
+    /**
+     * Claim marker rate-limiting automatic threshold-mode charges: set by the winning claim right
+     * before the card is charged, cleared when the charge attempt fails. Null means the wallet has
+     * never been auto-charged (or the last attempt was released).
+     */
+    lastAutoChargeAt: timestamp("last_auto_charge_at"),
     createdAt: timestamp("created_at").defaultNow(),
     updatedAt: timestamp("updated_at").defaultNow()
   },

--- a/apps/api/src/billing/repositories/wallet-settings/wallet-settings.repository.integration.ts
+++ b/apps/api/src/billing/repositories/wallet-settings/wallet-settings.repository.integration.ts
@@ -6,12 +6,23 @@ import { describe, expect, it } from "vitest";
 import type { ApiPgDatabase } from "@src/core";
 import { POSTGRES_DB, resolveTable } from "@src/core";
 import { UserRepository } from "@src/user/repositories";
+import type { ChargeClaimAttempt } from "./wallet-settings.repository";
 import { WalletSettingRepository } from "./wallet-settings.repository";
 
 import { createAkashAddress } from "@test/seeders/akash-address.seeder";
 
 const COOLDOWN_MINUTES = 60;
 const NO_COOLDOWN = 0;
+
+/** Narrows an attempt the assertions have already established was won. */
+function claimOf(attempt: ChargeClaimAttempt) {
+  return (attempt as Extract<ChargeClaimAttempt, { won: true }>).claim;
+}
+
+/** Narrows an attempt the assertions have already established was rate limited. */
+function reopenSecondsOf(attempt: ChargeClaimAttempt) {
+  return (attempt as Extract<ChargeClaimAttempt, { won: false }>).secondsUntilWindowReopen;
+}
 
 describe(WalletSettingRepository.name, () => {
   describe("claimForCharge", () => {
@@ -20,7 +31,7 @@ describe(WalletSettingRepository.name, () => {
 
       const results = await Promise.all(Array.from({ length: 5 }, () => walletSettingRepository.claimForCharge(settingId, COOLDOWN_MINUTES)));
 
-      expect(results.filter(Boolean)).toHaveLength(1);
+      expect(results.filter(result => result.won)).toHaveLength(1);
     });
 
     it("does not re-claim a wallet charged within the cooldown", async () => {
@@ -29,8 +40,31 @@ describe(WalletSettingRepository.name, () => {
       const first = await walletSettingRepository.claimForCharge(settingId, COOLDOWN_MINUTES);
       const second = await walletSettingRepository.claimForCharge(settingId, COOLDOWN_MINUTES);
 
-      expect(first).toEqual({ id: settingId, claimedAt: expect.any(String) });
-      expect(second).toBeUndefined();
+      expect(first).toEqual({ won: true, claim: { id: settingId, claimedAt: expect.any(String) } });
+      expect(second).toEqual({ won: false, secondsUntilWindowReopen: expect.any(Number) });
+    });
+
+    it("reports only the cooldown still owed, not a whole fresh one", async () => {
+      const { walletSettingRepository, settingId, backdateLastAutoChargeAt } = await setup();
+      const minutesElapsed = 59;
+
+      await walletSettingRepository.claimForCharge(settingId, COOLDOWN_MINUTES);
+      await backdateLastAutoChargeAt(settingId, minutesElapsed);
+      const blocked = await walletSettingRepository.claimForCharge(settingId, COOLDOWN_MINUTES);
+
+      expect(blocked.won).toBe(false);
+      expect(reopenSecondsOf(blocked)).toBeCloseTo((COOLDOWN_MINUTES - minutesElapsed) * 60, -1);
+    });
+
+    it("measures the cooldown still owed against the cooldown it was asked for", async () => {
+      const { walletSettingRepository, settingId, backdateLastAutoChargeAt } = await setup();
+
+      await walletSettingRepository.claimForCharge(settingId, COOLDOWN_MINUTES);
+      await backdateLastAutoChargeAt(settingId, COOLDOWN_MINUTES + 5);
+      const blocked = await walletSettingRepository.claimForCharge(settingId, 2 * COOLDOWN_MINUTES);
+
+      expect(blocked.won).toBe(false);
+      expect(reopenSecondsOf(blocked)).toBeCloseTo(55 * 60, -1);
     });
 
     it("claims again once the cooldown has elapsed", async () => {
@@ -40,7 +74,7 @@ describe(WalletSettingRepository.name, () => {
       await backdateLastAutoChargeAt(settingId, COOLDOWN_MINUTES + 1);
       const afterCooldown = await walletSettingRepository.claimForCharge(settingId, COOLDOWN_MINUTES);
 
-      expect(afterCooldown).toEqual({ id: settingId, claimedAt: expect.any(String) });
+      expect(afterCooldown).toEqual({ won: true, claim: { id: settingId, claimedAt: expect.any(String) } });
     });
 
     it("claims consecutively when the cooldown is zero", async () => {
@@ -49,8 +83,8 @@ describe(WalletSettingRepository.name, () => {
       const first = await walletSettingRepository.claimForCharge(settingId, NO_COOLDOWN);
       const second = await walletSettingRepository.claimForCharge(settingId, NO_COOLDOWN);
 
-      expect(first).toEqual({ id: settingId, claimedAt: expect.any(String) });
-      expect(second).toEqual({ id: settingId, claimedAt: expect.any(String) });
+      expect(first).toEqual({ won: true, claim: { id: settingId, claimedAt: expect.any(String) } });
+      expect(second).toEqual({ won: true, claim: { id: settingId, claimedAt: expect.any(String) } });
     });
   });
 
@@ -58,26 +92,39 @@ describe(WalletSettingRepository.name, () => {
     it("makes a claimed wallet immediately claimable again", async () => {
       const { walletSettingRepository, settingId } = await setup();
 
-      const claim = await walletSettingRepository.claimForCharge(settingId, COOLDOWN_MINUTES);
-      await walletSettingRepository.releaseChargeClaim(claim!);
+      const attempt = await walletSettingRepository.claimForCharge(settingId, COOLDOWN_MINUTES);
+      await walletSettingRepository.releaseChargeClaim(claimOf(attempt));
       const afterRelease = await walletSettingRepository.claimForCharge(settingId, COOLDOWN_MINUTES);
 
-      expect(afterRelease).toEqual({ id: settingId, claimedAt: expect.any(String) });
+      expect(afterRelease).toEqual({ won: true, claim: { id: settingId, claimedAt: expect.any(String) } });
     });
 
     it("leaves a newer claim in place when the caller whose claim aged out releases late", async () => {
       const { walletSettingRepository, settingId } = await setup();
 
-      const agedOutClaim = await walletSettingRepository.claimForCharge(settingId, COOLDOWN_MINUTES);
-      const newerClaim = await walletSettingRepository.claimForCharge(settingId, NO_COOLDOWN);
-      await walletSettingRepository.releaseChargeClaim(agedOutClaim!);
+      const agedOutAttempt = await walletSettingRepository.claimForCharge(settingId, COOLDOWN_MINUTES);
+      const newerAttempt = await walletSettingRepository.claimForCharge(settingId, NO_COOLDOWN);
+      await walletSettingRepository.releaseChargeClaim(claimOf(agedOutAttempt));
 
-      expect(newerClaim).toBeDefined();
-      expect(await walletSettingRepository.claimForCharge(settingId, COOLDOWN_MINUTES)).toBeUndefined();
+      expect(newerAttempt.won).toBe(true);
+      expect((await walletSettingRepository.claimForCharge(settingId, COOLDOWN_MINUTES)).won).toBe(false);
 
-      await walletSettingRepository.releaseChargeClaim(newerClaim!);
+      await walletSettingRepository.releaseChargeClaim(claimOf(newerAttempt));
 
-      expect(await walletSettingRepository.claimForCharge(settingId, COOLDOWN_MINUTES)).toEqual({ id: settingId, claimedAt: expect.any(String) });
+      expect(await walletSettingRepository.claimForCharge(settingId, COOLDOWN_MINUTES)).toEqual({
+        won: true,
+        claim: { id: settingId, claimedAt: expect.any(String) }
+      });
+    });
+
+    it("owes no cooldown when the released row has no charge to wait on", async () => {
+      const { walletSettingRepository, settingId } = await setup();
+
+      const attempt = await walletSettingRepository.claimForCharge(settingId, COOLDOWN_MINUTES);
+      await walletSettingRepository.releaseChargeClaim(claimOf(attempt));
+      const reclaimed = await walletSettingRepository.claimForCharge(settingId, COOLDOWN_MINUTES);
+
+      expect(reclaimed.won).toBe(true);
     });
   });
 

--- a/apps/api/src/billing/repositories/wallet-settings/wallet-settings.repository.integration.ts
+++ b/apps/api/src/billing/repositories/wallet-settings/wallet-settings.repository.integration.ts
@@ -1,0 +1,111 @@
+import { faker } from "@faker-js/faker";
+import { eq, sql } from "drizzle-orm";
+import { container } from "tsyringe";
+import { describe, expect, it } from "vitest";
+
+import type { ApiPgDatabase } from "@src/core";
+import { POSTGRES_DB, resolveTable } from "@src/core";
+import { UserRepository } from "@src/user/repositories";
+import { WalletSettingRepository } from "./wallet-settings.repository";
+
+import { createAkashAddress } from "@test/seeders/akash-address.seeder";
+
+const COOLDOWN_MINUTES = 60;
+const NO_COOLDOWN = 0;
+
+describe(WalletSettingRepository.name, () => {
+  describe("claimForCharge", () => {
+    it("awards a claim to exactly one caller across concurrent attempts", async () => {
+      const { walletSettingRepository, settingId } = await setup();
+
+      const results = await Promise.all(Array.from({ length: 5 }, () => walletSettingRepository.claimForCharge(settingId, COOLDOWN_MINUTES)));
+
+      expect(results.filter(Boolean)).toHaveLength(1);
+    });
+
+    it("does not re-claim a wallet charged within the cooldown", async () => {
+      const { walletSettingRepository, settingId } = await setup();
+
+      const first = await walletSettingRepository.claimForCharge(settingId, COOLDOWN_MINUTES);
+      const second = await walletSettingRepository.claimForCharge(settingId, COOLDOWN_MINUTES);
+
+      expect(first).toEqual({ id: settingId, claimedAt: expect.any(String) });
+      expect(second).toBeUndefined();
+    });
+
+    it("claims again once the cooldown has elapsed", async () => {
+      const { walletSettingRepository, settingId, backdateLastAutoChargeAt } = await setup();
+
+      await walletSettingRepository.claimForCharge(settingId, COOLDOWN_MINUTES);
+      await backdateLastAutoChargeAt(settingId, COOLDOWN_MINUTES + 1);
+      const afterCooldown = await walletSettingRepository.claimForCharge(settingId, COOLDOWN_MINUTES);
+
+      expect(afterCooldown).toEqual({ id: settingId, claimedAt: expect.any(String) });
+    });
+
+    it("claims consecutively when the cooldown is zero", async () => {
+      const { walletSettingRepository, settingId } = await setup();
+
+      const first = await walletSettingRepository.claimForCharge(settingId, NO_COOLDOWN);
+      const second = await walletSettingRepository.claimForCharge(settingId, NO_COOLDOWN);
+
+      expect(first).toEqual({ id: settingId, claimedAt: expect.any(String) });
+      expect(second).toEqual({ id: settingId, claimedAt: expect.any(String) });
+    });
+  });
+
+  describe("releaseChargeClaim", () => {
+    it("makes a claimed wallet immediately claimable again", async () => {
+      const { walletSettingRepository, settingId } = await setup();
+
+      const claim = await walletSettingRepository.claimForCharge(settingId, COOLDOWN_MINUTES);
+      await walletSettingRepository.releaseChargeClaim(claim!);
+      const afterRelease = await walletSettingRepository.claimForCharge(settingId, COOLDOWN_MINUTES);
+
+      expect(afterRelease).toEqual({ id: settingId, claimedAt: expect.any(String) });
+    });
+
+    it("leaves a newer claim in place when the caller whose claim aged out releases late", async () => {
+      const { walletSettingRepository, settingId } = await setup();
+
+      const agedOutClaim = await walletSettingRepository.claimForCharge(settingId, COOLDOWN_MINUTES);
+      const newerClaim = await walletSettingRepository.claimForCharge(settingId, NO_COOLDOWN);
+      await walletSettingRepository.releaseChargeClaim(agedOutClaim!);
+
+      expect(newerClaim).toBeDefined();
+      expect(await walletSettingRepository.claimForCharge(settingId, COOLDOWN_MINUTES)).toBeUndefined();
+
+      await walletSettingRepository.releaseChargeClaim(newerClaim!);
+
+      expect(await walletSettingRepository.claimForCharge(settingId, COOLDOWN_MINUTES)).toEqual({ id: settingId, claimedAt: expect.any(String) });
+    });
+  });
+
+  async function setup() {
+    const userRepository = container.resolve(UserRepository);
+    const walletSettingRepository = container.resolve(WalletSettingRepository);
+    const db = container.resolve<ApiPgDatabase>(POSTGRES_DB);
+    const walletSettingsTable = resolveTable("WalletSetting");
+    const userWalletsTable = resolveTable("UserWallets");
+
+    const user = await userRepository.create({ userId: faker.string.uuid() });
+    const [wallet] = await db
+      .insert(userWalletsTable)
+      .values({ userId: user.id, address: createAkashAddress(), deploymentAllowance: "10000000", feeAllowance: "5000000" })
+      .returning({ id: userWalletsTable.id });
+    const setting = await walletSettingRepository.create({ userId: user.id, walletId: wallet.id });
+
+    async function backdateLastAutoChargeAt(id: string, minutesAgo: number) {
+      await db
+        .update(walletSettingsTable)
+        .set({ lastAutoChargeAt: sql`now() - (${minutesAgo} * interval '1 minute')` })
+        .where(eq(walletSettingsTable.id, id));
+    }
+
+    return {
+      walletSettingRepository,
+      settingId: setting.id,
+      backdateLastAutoChargeAt
+    };
+  }
+});

--- a/apps/api/src/billing/repositories/wallet-settings/wallet-settings.repository.ts
+++ b/apps/api/src/billing/repositories/wallet-settings/wallet-settings.repository.ts
@@ -19,6 +19,14 @@ export type ChargeClaim = {
   claimedAt: string;
 };
 
+/**
+ * A lost claim carries how long is left on the cooldown that blocked it, so the caller defers only
+ * for the remainder instead of a whole fresh cooldown. Postgres computes it: `last_auto_charge_at`
+ * is a timestamp without time zone, so reading it back as a JS Date would shift it by the driver's
+ * local offset. Zero means the window is already open again.
+ */
+export type ChargeClaimAttempt = { won: true; claim: ChargeClaim } | { won: false; secondsUntilWindowReopen: number };
+
 @singleton()
 export class WalletSettingRepository extends BaseRepository<Table, WalletSettingInput, WalletSettingOutput> {
   constructor(
@@ -60,9 +68,10 @@ export class WalletSettingRepository extends BaseRepository<Table, WalletSetting
    * wallet is claimable when it has never been auto-charged or its last charge is older than the
    * cooldown; concurrent callers resolve to a single winner via the row-lock re-check. A cooldown
    * of 0 always claims, disabling the cap. The claim marker comes back as text to keep full
-   * microsecond precision, which `releaseChargeClaim` matches on.
+   * microsecond precision, which `releaseChargeClaim` matches on. A lost claim reads back the
+   * cooldown still owed, so the caller can wait out only what is left rather than a whole fresh one.
    */
-  async claimForCharge(id: WalletSettingOutput["id"], cooldownMinutes: number): Promise<ChargeClaim | undefined> {
+  async claimForCharge(id: WalletSettingOutput["id"], cooldownMinutes: number): Promise<ChargeClaimAttempt> {
     const [claim] = await this.cursor
       .update(this.table)
       .set({ lastAutoChargeAt: sql`now()`, updatedAt: sql`now()` })
@@ -74,7 +83,18 @@ export class WalletSettingRepository extends BaseRepository<Table, WalletSetting
       )
       .returning({ id: this.table.id, claimedAt: sql<string>`${this.table.lastAutoChargeAt}::text` });
 
-    return claim;
+    if (claim) {
+      return { won: true, claim };
+    }
+
+    const [blocking] = await this.cursor
+      .select({
+        secondsUntilWindowReopen: sql<string>`greatest(extract(epoch from (${this.table.lastAutoChargeAt} + (${cooldownMinutes} * interval '1 minute') - now())), 0)`
+      })
+      .from(this.table)
+      .where(eq(this.table.id, id));
+
+    return { won: false, secondsUntilWindowReopen: Number(blocking?.secondsUntilWindowReopen ?? 0) };
   }
 
   /**

--- a/apps/api/src/billing/repositories/wallet-settings/wallet-settings.repository.ts
+++ b/apps/api/src/billing/repositories/wallet-settings/wallet-settings.repository.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { and, eq, isNull, lt, or, sql } from "drizzle-orm";
 import { singleton } from "tsyringe";
 
 import { type ApiPgDatabase, type ApiPgTables, InjectPg, InjectPgTable } from "@src/core/providers";
@@ -12,6 +12,12 @@ type DbWalletSettingOutput = ApiPgTables["WalletSetting"]["$inferSelect"];
 export type WalletSettingInput = Partial<DbWalletSettingInput>;
 
 export type WalletSettingOutput = DbWalletSettingOutput;
+
+/** A won auto-charge claim: the wallet setting id and the exact marker the claim wrote. */
+export type ChargeClaim = {
+  id: string;
+  claimedAt: string;
+};
 
 @singleton()
 export class WalletSettingRepository extends BaseRepository<Table, WalletSettingInput, WalletSettingOutput> {
@@ -47,5 +53,39 @@ export class WalletSettingRepository extends BaseRepository<Table, WalletSetting
     if (!walletSetting) return undefined;
 
     return walletSetting;
+  }
+
+  /**
+   * Atomically claims the right to auto-charge a wallet, rate-limiting threshold-mode reloads. A
+   * wallet is claimable when it has never been auto-charged or its last charge is older than the
+   * cooldown; concurrent callers resolve to a single winner via the row-lock re-check. A cooldown
+   * of 0 always claims, disabling the cap. The claim marker comes back as text to keep full
+   * microsecond precision, which `releaseChargeClaim` matches on.
+   */
+  async claimForCharge(id: WalletSettingOutput["id"], cooldownMinutes: number): Promise<ChargeClaim | undefined> {
+    const [claim] = await this.cursor
+      .update(this.table)
+      .set({ lastAutoChargeAt: sql`now()`, updatedAt: sql`now()` })
+      .where(
+        and(
+          eq(this.table.id, id),
+          or(isNull(this.table.lastAutoChargeAt), lt(this.table.lastAutoChargeAt, sql`now() - (${cooldownMinutes} * interval '1 minute')`))
+        )
+      )
+      .returning({ id: this.table.id, claimedAt: sql<string>`${this.table.lastAutoChargeAt}::text` });
+
+    return claim;
+  }
+
+  /**
+   * Releases a charge claim so the next check can retry, used when the charge attempt failed. The
+   * release is scoped to the exact marker its claim wrote, so a caller whose claim already aged out
+   * of the cooldown and was re-taken by another check cannot clear that newer claim.
+   */
+  async releaseChargeClaim(claim: ChargeClaim): Promise<void> {
+    await this.cursor
+      .update(this.table)
+      .set({ lastAutoChargeAt: null, updatedAt: sql`now()` })
+      .where(and(eq(this.table.id, claim.id), eq(this.table.lastAutoChargeAt, sql`${claim.claimedAt}::timestamp`)));
   }
 }

--- a/apps/api/src/billing/services/wallet-balance-reload-check/README.md
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/README.md
@@ -30,6 +30,14 @@ The check is a pure balance comparison: it does not project future spend. The ba
 
 One guard sits after the comparison: when the wallet owns no active deployment the charge is skipped (`no_active_deployments`), so leftover credit below the threshold never gets topped up on an idle wallet. Checks enqueued by initial deployment funding (`triggeredByDeployment`) bypass that count, because it reads the indexer-fed `Deployment` table, which lags chain state right after a lease starts.
 
+### Charge rate limit
+
+A second guard sits right before the charge: at most one automatic charge per `AUTO_RELOAD_CHARGE_COOLDOWN_IN_MIN` (default 60 minutes; `0` disables the cap) per wallet. Deployment funding drains a balance in lumps, so without a cap an expensive deployment can produce a burst of identical card charges within minutes: each one costs a flat Stripe fee, risks issuer velocity declines mid-burst, and reads as statement shock (CON-843 measures these bursts).
+
+The cap is an atomic claim on `wallet_settings.last_auto_charge_at`, the same guarded-UPDATE pattern escrow top-ups use for `last_funded_at`: concurrent checks racing for the same wallet resolve to a single winner, so two overlapping jobs cannot both charge. A failed charge attempt releases the claim, so retry behavior is unchanged. A lost claim records a `charge_rate_limited` skip and reschedules the check for when the window reopens (cooldown plus a 1-minute buffer) instead of the usual 24h safety net, so a rate-limited reload is deferred, never dropped.
+
+Manual top-ups never touch this path, and prediction mode is exempt.
+
 ### Worked examples (defaults: threshold $20, amount $100)
 
 | Balance | Threshold | Amount | Outcome |
@@ -49,7 +57,7 @@ Checks are **spend-event-driven**, not fixed to a daily cadence. A check is enqu
 1. When a user enables auto top-up (immediate, prefilled from the settings dialog).
 2. When a user changes their mode, threshold, or amount while enabled (immediate — backs the dialog's "top-up runs shortly after saving").
 3. After every spending broadcast, after initial deployment funding, and after each escrow top-up cycle.
-4. On a self-rescheduled 24h job that acts only as a safety net.
+4. On a self-rescheduled job that acts only as a safety net: 24h out normally, or at the charge-window reopen when the previous check was rate-limited.
 
 Because pg-boss's `singleton` policy uniqueness applies only to *active* jobs, an immediate enqueue is never swallowed by the pending daily safety-net job. Top-ups therefore happen within seconds of the balance crossing the threshold.
 
@@ -71,7 +79,7 @@ The charge uses a job-scoped idempotency key (`WalletBalanceReloadCheck.<jobId>`
 
 ## What happens on failure?
 
-- **Payment fails**: Error is logged and re-thrown (job fails, will retry).
+- **Payment fails**: The charge claim is released (best-effort), then the error is logged and re-thrown (job fails, will retry under the same idempotency key).
 - **Validation fails**: Error is logged, job completes successfully (no retry needed).
 - **Scheduling next check fails**: Error is logged and re-thrown.
 

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check-instrumentation.service.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check-instrumentation.service.ts
@@ -98,7 +98,7 @@ export class WalletBalanceReloadCheckInstrumentationService {
     });
   }
 
-  recordReloadSkipped(input: ReloadMetricInput & { reason: "zero_cost" | "sufficient_balance" | "no_active_deployments" }): void {
+  recordReloadSkipped(input: ReloadMetricInput & { reason: "zero_cost" | "sufficient_balance" | "no_active_deployments" | "charge_rate_limited" }): void {
     this.reloadsSkipped.add(1, {
       mode: input.mode,
       reason: input.reason
@@ -130,6 +130,14 @@ export class WalletBalanceReloadCheckInstrumentationService {
       mode: input.mode,
       event: "WALLET_BALANCE_RELOAD_FAILED",
       error: input.error
+    });
+  }
+
+  recordChargeClaimReleaseError(walletSettingId: string, error: unknown): void {
+    this.logger.error({
+      event: "ERROR_RELEASING_CHARGE_CLAIM",
+      walletSettingId,
+      error
     });
   }
 

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.spec.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.spec.ts
@@ -562,6 +562,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
         autoReloadThresholdUsd: 20,
         autoReloadAmountUsd: 100,
         chargeClaimWon: false,
+        secondsUntilWindowReopen: cooldownMinutes * 60,
         chargeCooldownMinutes: cooldownMinutes
       });
 
@@ -574,6 +575,44 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       expect(scheduledDate.getTime()).toBeCloseTo(expectedReopenDate.getTime(), -3);
     });
 
+    it("waits out only the cooldown still owed when the claim is lost late in the window", async () => {
+      const { handler, walletReloadJobService, job, jobMeta } = setup({
+        autoReloadMode: "threshold",
+        balance: 10,
+        autoReloadThresholdUsd: 20,
+        autoReloadAmountUsd: 100,
+        chargeClaimWon: false,
+        secondsUntilWindowReopen: 60,
+        chargeCooldownMinutes: 60
+      });
+
+      await handler.handle(job, jobMeta);
+
+      const expectedReopenDate = addMilliseconds(new Date(), 2 * millisecondsInMinute);
+      const scheduleCall = walletReloadJobService.scheduleForWalletSetting.mock.calls[0];
+      const scheduledDate = new Date(scheduleCall[1]?.startAfter as string);
+      expect(scheduledDate.getTime()).toBeCloseTo(expectedReopenDate.getTime(), -3);
+    });
+
+    it("defers by the buffer alone when no cooldown is still owed", async () => {
+      const { handler, walletReloadJobService, job, jobMeta } = setup({
+        autoReloadMode: "threshold",
+        balance: 10,
+        autoReloadThresholdUsd: 20,
+        autoReloadAmountUsd: 100,
+        chargeClaimWon: false,
+        secondsUntilWindowReopen: 0,
+        chargeCooldownMinutes: 60
+      });
+
+      await handler.handle(job, jobMeta);
+
+      const expectedReopenDate = addMilliseconds(new Date(), millisecondsInMinute);
+      const scheduleCall = walletReloadJobService.scheduleForWalletSetting.mock.calls[0];
+      const scheduledDate = new Date(scheduleCall[1]?.startAfter as string);
+      expect(scheduledDate.getTime()).toBeCloseTo(expectedReopenDate.getTime(), -3);
+    });
+
     it("keeps the daily next check when the cooldown reopens later than it", async () => {
       const { handler, walletReloadJobService, job, jobMeta } = setup({
         autoReloadMode: "threshold",
@@ -581,6 +620,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
         autoReloadThresholdUsd: 20,
         autoReloadAmountUsd: 100,
         chargeClaimWon: false,
+        secondsUntilWindowReopen: 48 * 60 * 60,
         chargeCooldownMinutes: 48 * 60
       });
 
@@ -640,6 +680,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
     activeDeploymentCount?: number;
     triggeredByDeployment?: boolean;
     chargeClaimWon?: boolean;
+    secondsUntilWindowReopen?: number;
     chargeCooldownMinutes?: number;
     user?: ReturnType<typeof createUser>;
     wallet?: ReturnType<typeof createUserWallet>;
@@ -680,7 +721,11 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
 
     const chargeClaim: ChargeClaim = { id: walletSetting.id, claimedAt: new Date().toISOString() };
     const walletSettingRepository = mock<WalletSettingRepository>();
-    walletSettingRepository.claimForCharge.mockResolvedValue(input?.chargeClaimWon === false ? undefined : chargeClaim);
+    walletSettingRepository.claimForCharge.mockResolvedValue(
+      input?.chargeClaimWon === false
+        ? { won: false, secondsUntilWindowReopen: input?.secondsUntilWindowReopen ?? 0 }
+        : { won: true, claim: chargeClaim }
+    );
     const billingConfig = mockConfigService<BillingConfigService>({
       AUTO_RELOAD_CHARGE_COOLDOWN_IN_MIN: input?.chargeCooldownMinutes ?? 60
     });

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.spec.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.spec.ts
@@ -1,12 +1,13 @@
 import { faker } from "@faker-js/faker";
-import { addMilliseconds, millisecondsInHour } from "date-fns";
+import { addMilliseconds, millisecondsInHour, millisecondsInMinute } from "date-fns";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import { WalletBalanceReloadCheck } from "@src/billing/events/wallet-balance-reload-check";
 import { usdToCents } from "@src/billing/lib/currency/currency";
-import type { WalletSettingRepository } from "@src/billing/repositories";
+import type { ChargeClaim, WalletSettingRepository } from "@src/billing/repositories";
 import type { BalancesService } from "@src/billing/services/balances/balances.service";
+import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import type { PaymentMethodService } from "@src/billing/services/payment-method/payment-method.service";
 import type { StripeTransactionService } from "@src/billing/services/stripe-transaction/stripe-transaction.service";
 import type { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
@@ -17,6 +18,7 @@ import type { JobPayload } from "../../../core";
 import { WalletBalanceReloadCheckHandler } from "./wallet-balance-reload-check.handler";
 import type { WalletBalanceReloadCheckInstrumentationService } from "./wallet-balance-reload-check-instrumentation.service";
 
+import { mockConfigService } from "@test/mocks/config-service.mock";
 import { generateMergedPaymentMethod as generatePaymentMethod } from "@test/seeders/payment-method.seeder";
 import { createUser } from "@test/seeders/user.seeder";
 import { createUserWallet } from "@test/seeders/user-wallet.seeder";
@@ -213,6 +215,20 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
           withCleanup: true
         })
       );
+    });
+
+    it("charges in prediction mode without consulting the charge rate limit", async () => {
+      const { handler, walletSettingRepository, stripeTransactionService, job, jobMeta } = setup({
+        balance: 10.0,
+        weeklyCostInDenom: 50_000_000,
+        weeklyCostInFiat: 50.0,
+        chargeClaimWon: false
+      });
+
+      await handler.handle(job, jobMeta);
+
+      expect(walletSettingRepository.claimForCharge).not.toHaveBeenCalled();
+      expect(stripeTransactionService.createPaymentIntent).toHaveBeenCalledWith(expect.objectContaining({ amount: 40 }));
     });
 
     it("records reload failure and throws when payment intent fails", async () => {
@@ -500,6 +516,115 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
         logContext: expect.objectContaining({ walletAddress: expect.any(String), balance: 10, threshold: 20, reloadAmount: 100 })
       });
     });
+
+    it("claims the charge window with the configured cooldown and keeps the claim after a successful charge", async () => {
+      const { handler, walletSettingRepository, stripeTransactionService, walletSetting, job, jobMeta } = setup({
+        autoReloadMode: "threshold",
+        balance: 10,
+        autoReloadThresholdUsd: 20,
+        autoReloadAmountUsd: 100,
+        chargeCooldownMinutes: 30
+      });
+
+      await handler.handle(job, jobMeta);
+
+      expect(walletSettingRepository.claimForCharge).toHaveBeenCalledWith(walletSetting.id, 30);
+      expect(stripeTransactionService.createPaymentIntent).toHaveBeenCalledWith(expect.objectContaining({ amount: 100 }));
+      expect(walletSettingRepository.releaseChargeClaim).not.toHaveBeenCalled();
+    });
+
+    it("skips without charging when another charge happened within the cooldown", async () => {
+      const { handler, stripeTransactionService, instrumentationService, job, jobMeta } = setup({
+        autoReloadMode: "threshold",
+        balance: 10,
+        autoReloadThresholdUsd: 20,
+        autoReloadAmountUsd: 100,
+        chargeClaimWon: false
+      });
+
+      await handler.handle(job, jobMeta);
+
+      expect(stripeTransactionService.createPaymentIntent).not.toHaveBeenCalled();
+      expect(instrumentationService.recordReloadSkipped).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mode: "threshold",
+          reason: "charge_rate_limited",
+          logContext: expect.objectContaining({ balance: 10, threshold: 20, nextCheckAt: expect.any(Date) })
+        })
+      );
+    });
+
+    it("defers the next check to the window reopen when rate limited", async () => {
+      const cooldownMinutes = 60;
+      const { handler, walletReloadJobService, job, jobMeta } = setup({
+        autoReloadMode: "threshold",
+        balance: 10,
+        autoReloadThresholdUsd: 20,
+        autoReloadAmountUsd: 100,
+        chargeClaimWon: false,
+        chargeCooldownMinutes: cooldownMinutes
+      });
+
+      await handler.handle(job, jobMeta);
+
+      const expectedReopenDate = addMilliseconds(new Date(), (cooldownMinutes + 1) * millisecondsInMinute);
+      const scheduleCall = walletReloadJobService.scheduleForWalletSetting.mock.calls[0];
+      expect(scheduleCall[1]).toEqual(expect.objectContaining({ withCleanup: true }));
+      const scheduledDate = new Date(scheduleCall[1]?.startAfter as string);
+      expect(scheduledDate.getTime()).toBeCloseTo(expectedReopenDate.getTime(), -3);
+    });
+
+    it("keeps the daily next check when the cooldown reopens later than it", async () => {
+      const { handler, walletReloadJobService, job, jobMeta } = setup({
+        autoReloadMode: "threshold",
+        balance: 10,
+        autoReloadThresholdUsd: 20,
+        autoReloadAmountUsd: 100,
+        chargeClaimWon: false,
+        chargeCooldownMinutes: 48 * 60
+      });
+
+      await handler.handle(job, jobMeta);
+
+      const expectedNextCheckDate = addMilliseconds(new Date(), 24 * millisecondsInHour);
+      const scheduleCall = walletReloadJobService.scheduleForWalletSetting.mock.calls[0];
+      const scheduledDate = new Date(scheduleCall[1]?.startAfter as string);
+      expect(scheduledDate.getTime()).toBeCloseTo(expectedNextCheckDate.getTime(), -3);
+    });
+
+    it("releases the claim and rethrows when the payment intent fails", async () => {
+      const error = new Error("Payment failed");
+      const { handler, walletSettingRepository, stripeTransactionService, chargeClaim, job, jobMeta } = setup({
+        autoReloadMode: "threshold",
+        balance: 10,
+        autoReloadThresholdUsd: 20,
+        autoReloadAmountUsd: 100
+      });
+      stripeTransactionService.createPaymentIntent.mockRejectedValue(error);
+      walletSettingRepository.releaseChargeClaim.mockResolvedValue();
+
+      await expect(handler.handle(job, jobMeta)).rejects.toThrow(error);
+
+      expect(walletSettingRepository.releaseChargeClaim).toHaveBeenCalledWith(chargeClaim);
+    });
+
+    it("rethrows the payment error when releasing the claim also fails", async () => {
+      const paymentError = new Error("Payment failed");
+      const releaseError = new Error("Release failed");
+      const { handler, walletSettingRepository, stripeTransactionService, instrumentationService, chargeClaim, job, jobMeta } = setup({
+        autoReloadMode: "threshold",
+        balance: 10,
+        autoReloadThresholdUsd: 20,
+        autoReloadAmountUsd: 100
+      });
+      stripeTransactionService.createPaymentIntent.mockRejectedValue(paymentError);
+      walletSettingRepository.releaseChargeClaim.mockRejectedValue(releaseError);
+
+      await expect(handler.handle(job, jobMeta)).rejects.toThrow(paymentError);
+
+      expect(instrumentationService.recordChargeClaimReleaseError).toHaveBeenCalledWith(chargeClaim.id, releaseError);
+      expect(instrumentationService.recordReloadFailed).toHaveBeenCalledWith(expect.objectContaining({ error: paymentError }));
+    });
   });
 
   function setup(input?: {
@@ -514,6 +639,8 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
     autoReloadMode?: "prediction" | "threshold";
     activeDeploymentCount?: number;
     triggeredByDeployment?: boolean;
+    chargeClaimWon?: boolean;
+    chargeCooldownMinutes?: number;
     user?: ReturnType<typeof createUser>;
     wallet?: ReturnType<typeof createUserWallet>;
   }) {
@@ -551,7 +678,12 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       id: faker.string.uuid()
     };
 
+    const chargeClaim: ChargeClaim = { id: walletSetting.id, claimedAt: new Date().toISOString() };
     const walletSettingRepository = mock<WalletSettingRepository>();
+    walletSettingRepository.claimForCharge.mockResolvedValue(input?.chargeClaimWon === false ? undefined : chargeClaim);
+    const billingConfig = mockConfigService<BillingConfigService>({
+      AUTO_RELOAD_CHARGE_COOLDOWN_IN_MIN: input?.chargeCooldownMinutes ?? 60
+    });
     const balancesService = mock<BalancesService>({
       ensure2floatingDigits: vi.fn().mockImplementation((amount: number) => amount)
     });
@@ -567,7 +699,8 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       recordReloadSkipped: vi.fn(),
       recordReloadFailed: vi.fn(),
       recordValidationError: vi.fn(),
-      recordSchedulingError: vi.fn()
+      recordSchedulingError: vi.fn(),
+      recordChargeClaimReleaseError: vi.fn()
     });
     const balance = input?.balance ?? 50.0;
     const weeklyCostInDenom = input?.weeklyCostInDenom ?? 50_000_000;
@@ -597,7 +730,8 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       stripeTransactionService,
       drainingDeploymentService,
       deploymentRepository,
-      instrumentationService
+      instrumentationService,
+      billingConfig
     );
 
     return {
@@ -610,6 +744,8 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       paymentMethodService,
       stripeTransactionService,
       instrumentationService,
+      billingConfig,
+      chargeClaim,
       walletSetting,
       walletSettingWithWallet,
       wallet,

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.ts
@@ -1,5 +1,5 @@
 import { createMongoAbility } from "@casl/ability";
-import { addMilliseconds, millisecondsInHour, millisecondsInMinute } from "date-fns";
+import { addMilliseconds, millisecondsInHour, millisecondsInMinute, millisecondsInSecond } from "date-fns";
 import { Err, Ok, Result } from "ts-results";
 import { singleton } from "tsyringe";
 
@@ -212,13 +212,15 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
     }
 
     const cooldownMinutes = this.billingConfig.get("AUTO_RELOAD_CHARGE_COOLDOWN_IN_MIN");
-    const claim = await this.walletSettingRepository.claimForCharge(resources.walletSetting.id, cooldownMinutes);
+    const attempt = await this.walletSettingRepository.claimForCharge(resources.walletSetting.id, cooldownMinutes);
 
-    if (!claim) {
-      const nextCheckAt = this.#calculateChargeWindowReopenDate(cooldownMinutes);
+    if (!attempt.won) {
+      const nextCheckAt = this.#calculateChargeWindowReopenDate(attempt.secondsUntilWindowReopen);
       this.instrumentationService.recordReloadSkipped({ mode, reason: "charge_rate_limited", coverageRatio, logContext: { ...log, nextCheckAt } });
       return { nextCheckAt };
     }
+
+    const claim = attempt.claim;
 
     try {
       await this.stripeTransactionService.createPaymentIntent({
@@ -322,8 +324,12 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
     }
   }
 
-  #calculateChargeWindowReopenDate(cooldownMinutes: number): Date {
-    return addMilliseconds(new Date(), cooldownMinutes * millisecondsInMinute + this.#CHARGE_WINDOW_REOPEN_BUFFER_IN_MS);
+  /**
+   * Defers by the cooldown still owed rather than a fresh full one: a check that loses the claim
+   * late in the window would otherwise wait out nearly two cooldowns before retrying.
+   */
+  #calculateChargeWindowReopenDate(secondsUntilWindowReopen: number): Date {
+    return addMilliseconds(new Date(), secondsUntilWindowReopen * millisecondsInSecond + this.#CHARGE_WINDOW_REOPEN_BUFFER_IN_MS);
   }
 
   #calculateNextCheckDate(): Date {

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.ts
@@ -1,5 +1,5 @@
 import { createMongoAbility } from "@casl/ability";
-import { addMilliseconds, millisecondsInHour } from "date-fns";
+import { addMilliseconds, millisecondsInHour, millisecondsInMinute } from "date-fns";
 import { Err, Ok, Result } from "ts-results";
 import { singleton } from "tsyringe";
 
@@ -7,8 +7,9 @@ import { STANDARD_TOP_UP_MIN_AMOUNT_USD } from "@src/billing/config";
 import { WalletBalanceReloadCheck } from "@src/billing/events/wallet-balance-reload-check";
 import type { GetBalancesResponseOutput } from "@src/billing/http-schemas/balance.schema";
 import { centsToUsd } from "@src/billing/lib/currency/currency";
-import { UserWalletOutput, WalletSettingOutput, WalletSettingRepository } from "@src/billing/repositories";
+import { ChargeClaim, UserWalletOutput, WalletSettingOutput, WalletSettingRepository } from "@src/billing/repositories";
 import { BalancesService } from "@src/billing/services/balances/balances.service";
+import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import { type PaymentMethod, PaymentMethodService } from "@src/billing/services/payment-method/payment-method.service";
 import { AUTO_RECHARGE_METADATA_KEY, StripeTransactionService } from "@src/billing/services/stripe-transaction/stripe-transaction.service";
 import { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
@@ -34,6 +35,7 @@ type Resources = {
 };
 type AllResources = Resources & { balance: GetBalancesResponseOutput["data"]["total"]; paymentMethod: PaymentMethod };
 type ReloadContext = AllResources & { job: JobMeta; triggeredByDeployment: boolean };
+type ReloadOutcome = { nextCheckAt: Date } | undefined;
 
 const millisecondsInDay = 24 * millisecondsInHour;
 
@@ -53,6 +55,9 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
 
   #MIN_RELOAD_AMOUNT_IN_USD = 20;
 
+  /** Scheduling the deferred check slightly past the window reopen avoids a boundary re-skip. */
+  #CHARGE_WINDOW_REOPEN_BUFFER_IN_MS = millisecondsInMinute;
+
   constructor(
     private readonly walletSettingRepository: WalletSettingRepository,
     private readonly balancesService: BalancesService,
@@ -61,7 +66,8 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
     private readonly stripeTransactionService: StripeTransactionService,
     private readonly drainingDeploymentService: DrainingDeploymentService,
     private readonly deploymentRepository: DeploymentRepository,
-    private readonly instrumentationService: WalletBalanceReloadCheckInstrumentationService
+    private readonly instrumentationService: WalletBalanceReloadCheckInstrumentationService,
+    private readonly billingConfig: BillingConfigService
   ) {}
 
   async handle(payload: JobPayload<WalletBalanceReloadCheck>, job: JobMeta): Promise<void> {
@@ -72,8 +78,8 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
       const resourcesResult = await this.#collectResources(payload);
 
       if (resourcesResult.ok) {
-        await this.#tryToReload({ ...resourcesResult.val, job, triggeredByDeployment: payload.triggeredByDeployment ?? false });
-        await this.#scheduleNextCheck(resourcesResult.val);
+        const reloadOutcome = await this.#tryToReload({ ...resourcesResult.val, job, triggeredByDeployment: payload.triggeredByDeployment ?? false });
+        await this.#scheduleNextCheck(resourcesResult.val, reloadOutcome?.nextCheckAt);
         success = true;
       } else {
         this.instrumentationService.recordValidationError(resourcesResult.val.event, resourcesResult.val, payload.userId);
@@ -171,7 +177,7 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
     });
   }
 
-  async #tryToReload(resources: ReloadContext): Promise<void> {
+  async #tryToReload(resources: ReloadContext): Promise<ReloadOutcome> {
     if (resources.walletSetting.autoReloadMode === "threshold") {
       return this.#tryToReloadOnFixedThreshold(resources);
     }
@@ -179,7 +185,7 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
     return this.#tryToReloadOnPredictedSpend(resources);
   }
 
-  async #tryToReloadOnFixedThreshold(resources: ReloadContext): Promise<void> {
+  async #tryToReloadOnFixedThreshold(resources: ReloadContext): Promise<ReloadOutcome> {
     const { balance } = resources;
     const mode = resources.walletSetting.autoReloadMode;
     const threshold = centsToUsd(resources.walletSetting.autoReloadThreshold);
@@ -205,6 +211,15 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
       }
     }
 
+    const cooldownMinutes = this.billingConfig.get("AUTO_RELOAD_CHARGE_COOLDOWN_IN_MIN");
+    const claim = await this.walletSettingRepository.claimForCharge(resources.walletSetting.id, cooldownMinutes);
+
+    if (!claim) {
+      const nextCheckAt = this.#calculateChargeWindowReopenDate(cooldownMinutes);
+      this.instrumentationService.recordReloadSkipped({ mode, reason: "charge_rate_limited", coverageRatio, logContext: { ...log, nextCheckAt } });
+      return { nextCheckAt };
+    }
+
     try {
       await this.stripeTransactionService.createPaymentIntent({
         userId: resources.user.id,
@@ -218,12 +233,13 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
       });
       this.instrumentationService.recordReloadTriggered({ mode, amount: reloadAmount, coverageRatio, logContext: log });
     } catch (error) {
+      await this.#releaseChargeClaim(claim);
       this.instrumentationService.recordReloadFailed({ mode, error, logContext: log });
       throw error;
     }
   }
 
-  async #tryToReloadOnPredictedSpend(resources: ReloadContext): Promise<void> {
+  async #tryToReloadOnPredictedSpend(resources: ReloadContext): Promise<ReloadOutcome> {
     const mode = resources.walletSetting.autoReloadMode;
     const reloadTargetDate = addMilliseconds(new Date(), this.#RELOAD_COVERAGE_PERIOD_IN_MS);
     const costUntilTargetDateInDenom = await this.drainingDeploymentService.calculateAllDeploymentCostUntilDate(resources.wallet.address, reloadTargetDate);
@@ -279,16 +295,35 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
     }
   }
 
-  async #scheduleNextCheck(resources: Resources): Promise<void> {
+  async #scheduleNextCheck(resources: Resources, nextCheckAt?: Date): Promise<void> {
+    const defaultNextCheckDate = this.#calculateNextCheckDate();
+    const startAfter = nextCheckAt && nextCheckAt < defaultNextCheckDate ? nextCheckAt : defaultNextCheckDate;
+
     try {
       await this.walletReloadJobService.scheduleForWalletSetting(resources.walletSetting, {
-        startAfter: this.#calculateNextCheckDate().toISOString(),
+        startAfter: startAfter.toISOString(),
         withCleanup: true
       });
     } catch (error) {
       this.instrumentationService.recordSchedulingError(resources.wallet.address, error);
       throw error;
     }
+  }
+
+  /**
+   * Releases best-effort: a rejected release must not replace the payment error the caller is
+   * about to record and rethrow, which retries and alerting classify.
+   */
+  async #releaseChargeClaim(claim: ChargeClaim): Promise<void> {
+    try {
+      await this.walletSettingRepository.releaseChargeClaim(claim);
+    } catch (error) {
+      this.instrumentationService.recordChargeClaimReleaseError(claim.id, error);
+    }
+  }
+
+  #calculateChargeWindowReopenDate(cooldownMinutes: number): Date {
+    return addMilliseconds(new Date(), cooldownMinutes * millisecondsInMinute + this.#CHARGE_WINDOW_REOPEN_BUFFER_IN_MS);
   }
 
   #calculateNextCheckDate(): Date {

--- a/apps/api/test/seeders/wallet-setting.seeder.ts
+++ b/apps/api/test/seeders/wallet-setting.seeder.ts
@@ -11,6 +11,7 @@ export const generateWalletSetting = (overrides: Partial<WalletSettingOutput>) =
     autoReloadMode: "prediction" as const,
     autoReloadThreshold: faker.number.int({ min: 500, max: 100000 }),
     autoReloadAmount: faker.number.int({ min: 2000, max: 100000 }),
+    lastAutoChargeAt: null,
     createdAt: faker.date.recent(),
     updatedAt: faker.date.recent(),
     ...overrides


### PR DESCRIPTION
## Why

Fixes CON-904

In threshold mode, auto reload charges the card whenever the balance is at or below the threshold. Nothing limits how often that can happen: the pg-boss singleton key only dedups queued jobs and the Stripe idempotency key is scoped to a single job, so automatic deployment funding can drain the balance in lumps and trigger a burst of identical card charges within minutes. CON-843 measures those bursts; this adds the guard it anticipated.

## What

- New `AUTO_RELOAD_CHARGE_COOLDOWN_IN_MIN` billing env var (default 60, so one automatic charge per hour; 0 disables the cap).
- Before charging in threshold mode, the reload check takes an atomic claim on the new `wallet_settings.last_auto_charge_at` column (same guarded-UPDATE pattern as `deployment_settings.last_funded_at`). Losing the claim records a `charge_rate_limited` skip and reschedules the check for the moment the window reopens instead of the daily safety net, so the reload still happens, just later. A failed charge attempt releases the claim.
- Prediction mode and manual top-ups are untouched.

Notes:

- The migration is a single nullable-column ADD on `wallet_settings`, safe to run on the production db.
- The new column shows up in the raw `/v1/wallet-settings` response JSON like the other internal columns already do; the OpenAPI schema and generated client types are unchanged.
- Deleting wallet settings via the API removes the row and resets the window. Auto reload is disabled in between, so that path is not a practical bypass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable cooldown for automatic wallet charges, defaulting to 60 minutes.
  * Prevented duplicate automatic charges when multiple reload checks occur at the same time.
  * Failed automatic charges can be retried after releasing the active charge claim.
  * Added cooldown-aware rescheduling so wallets are checked again when eligible.
  * Manual top-ups and prediction-based charges remain exempt from the cooldown.

* **Documentation**
  * Documented automatic charge cooldown behavior and retry handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->