### PR TITLE
feat(deployment): remember a deployment's sdl and committed manifest version

### DIFF
--- a/apps/api/drizzle/0043_store_deployment_sdl.sql
+++ b/apps/api/drizzle/0043_store_deployment_sdl.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "deployment_settings" ADD COLUMN "sdl" text;--> statement-breakpoint
+ALTER TABLE "deployment_settings" ADD COLUMN "manifest_version" varchar(64);

--- a/apps/api/drizzle/meta/0043_snapshot.json
+++ b/apps/api/drizzle/meta/0043_snapshot.json
@@ -1,0 +1,1528 @@
+{
+  "id": "7d238aae-847e-4efe-b5aa-2959bb86e3b6",
+  "prevId": "1afa9fce-1a48-48fd-9ba0-90b37793c4e2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.user_wallets": {
+      "name": "user_wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_allowance": {
+          "name": "deployment_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "fee_allowance": {
+          "name": "fee_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "trial": {
+          "name": "trial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits_low_notified_at": {
+          "name": "credits_low_notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_wallets_user_id_userSetting_id_fk": {
+          "name": "user_wallets_user_id_userSetting_id_fk",
+          "tableFrom": "user_wallets",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_wallets_user_id_unique": {
+          "name": "user_wallets_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "user_wallets_address_unique": {
+          "name": "user_wallets_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_methods": {
+      "name": "payment_methods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_method_id": {
+          "name": "payment_method_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_validated": {
+          "name": "is_validated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payment_methods_fingerprint_payment_method_id_unique": {
+          "name": "payment_methods_fingerprint_payment_method_id_unique",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_default_unique": {
+          "name": "payment_methods_user_id_is_default_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"payment_methods\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_fingerprint_idx": {
+          "name": "payment_methods_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_idx": {
+          "name": "payment_methods_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_validated_idx": {
+          "name": "payment_methods_user_id_is_validated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_validated",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_fingerprint_payment_method_id_idx": {
+          "name": "payment_methods_user_id_fingerprint_payment_method_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_methods_user_id_userSetting_id_fk": {
+          "name": "payment_methods_user_id_userSetting_id_fk",
+          "tableFrom": "payment_methods",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_transactions": {
+      "name": "stripe_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "stripe_transaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "stripe_transaction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created'"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_refunded": {
+          "name": "amount_refunded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bonus_amount": {
+          "name": "bonus_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_charge_id": {
+          "name": "stripe_charge_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_coupon_id": {
+          "name": "stripe_coupon_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_promotion_code_id": {
+          "name": "stripe_promotion_code_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_idempotency_key": {
+          "name": "stripe_idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method_type": {
+          "name": "payment_method_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_brand": {
+          "name": "card_brand",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_last4": {
+          "name": "card_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_url": {
+          "name": "receipt_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_transactions_stripe_invoice_id_unique": {
+          "name": "stripe_transactions_stripe_invoice_id_unique",
+          "columns": [
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stripe_transactions\".\"stripe_invoice_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_idempotency_key_unique": {
+          "name": "stripe_transactions_stripe_idempotency_key_unique",
+          "columns": [
+            {
+              "expression": "stripe_idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stripe_transactions\".\"stripe_idempotency_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_user_id_idx": {
+          "name": "stripe_transactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_payment_intent_id_idx": {
+          "name": "stripe_transactions_stripe_payment_intent_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_payment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_charge_id_idx": {
+          "name": "stripe_transactions_stripe_charge_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_coupon_id_idx": {
+          "name": "stripe_transactions_stripe_coupon_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_coupon_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_promotion_code_id_idx": {
+          "name": "stripe_transactions_stripe_promotion_code_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_promotion_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_status_idx": {
+          "name": "stripe_transactions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_created_at_idx": {
+          "name": "stripe_transactions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_user_id_created_at_idx": {
+          "name": "stripe_transactions_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_transactions_user_id_userSetting_id_fk": {
+          "name": "stripe_transactions_user_id_userSetting_id_fk",
+          "tableFrom": "stripe_transactions",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_settings": {
+      "name": "wallet_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_reload_enabled": {
+          "name": "auto_reload_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_reload_mode": {
+          "name": "auto_reload_mode",
+          "type": "auto_reload_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'prediction'"
+        },
+        "auto_reload_threshold": {
+          "name": "auto_reload_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2000
+        },
+        "auto_reload_amount": {
+          "name": "auto_reload_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10000
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_settings_user_id_idx": {
+          "name": "wallet_settings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_settings_wallet_id_user_wallets_id_fk": {
+          "name": "wallet_settings_wallet_id_user_wallets_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "user_wallets",
+          "columnsFrom": [
+            "wallet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wallet_settings_user_id_userSetting_id_fk": {
+          "name": "wallet_settings_user_id_userSetting_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallet_settings_wallet_id_unique": {
+          "name": "wallet_settings_wallet_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wallet_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.userSetting": {
+      "name": "userSetting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscribedToNewsletter": {
+          "name": "subscribedToNewsletter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "youtubeUsername": {
+          "name": "youtubeUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitterUsername": {
+          "name": "twitterUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "githubUsername": {
+          "name": "githubUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_ip": {
+          "name": "last_ip",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_user_agent": {
+          "name": "last_user_agent",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fingerprint": {
+          "name": "last_fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboardingSkippedAt": {
+          "name": "onboardingSkippedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "userSetting_userId_unique": {
+          "name": "userSetting_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        },
+        "userSetting_username_unique": {
+          "name": "userSetting_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.template": {
+      "name": "template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "copiedFromId": {
+          "name": "copiedFromId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cpu": {
+          "name": "cpu",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ram": {
+          "name": "ram",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage": {
+          "name": "storage",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sdl": {
+          "name": "sdl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "template_userId_idx": {
+          "name": "template_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.templateFavorite": {
+      "name": "templateFavorite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "templateId": {
+          "name": "templateId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addedDate": {
+          "name": "addedDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "templateFavorite_userId_templateId_unique": {
+          "name": "templateFavorite_userId_templateId_unique",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "templateId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "templateFavorite_templateId_template_id_fk": {
+          "name": "templateFavorite_templateId_template_id_fk",
+          "tableFrom": "templateFavorite",
+          "tableTo": "template",
+          "columnsFrom": [
+            "templateId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_settings": {
+      "name": "deployment_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dseq": {
+          "name": "dseq",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_top_up_enabled": {
+          "name": "auto_top_up_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closed": {
+          "name": "closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_funded_at": {
+          "name": "last_funded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_limit_hours": {
+          "name": "runtime_limit_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sdl": {
+          "name": "sdl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manifest_version": {
+          "name": "manifest_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_ends_at": {
+          "name": "runtime_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_ending_notified_for": {
+          "name": "runtime_ending_notified_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "id_auto_top_up_enabled_closed_idx": {
+          "name": "id_auto_top_up_enabled_closed_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auto_top_up_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "closed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_settings_user_id_userSetting_id_fk": {
+          "name": "deployment_settings_user_id_userSetting_id_fk",
+          "tableFrom": "deployment_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dseq_user_id_idx": {
+          "name": "dseq_user_id_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "dseq",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_key": {
+          "name": "hashed_key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_format": {
+          "name": "key_format",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_user_id_userSetting_id_fk": {
+          "name": "api_keys_user_id_userSetting_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_hashed_key_unique": {
+          "name": "api_keys_hashed_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hashed_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_verification_codes": {
+      "name": "email_verification_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_verification_codes_user_id_idx": {
+          "name": "email_verification_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_verification_codes_user_id_userSetting_id_fk": {
+          "name": "email_verification_codes_user_id_userSetting_id_fk",
+          "tableFrom": "email_verification_codes",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.data_keys": {
+      "name": "data_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wrapped_key": {
+          "name": "wrapped_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wrapped_by_kid": {
+          "name": "wrapped_by_kid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "data_keys_wrapped_by_kid_idx": {
+          "name": "data_keys_wrapped_by_kid_idx",
+          "columns": [
+            {
+              "expression": "wrapped_by_kid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "data_keys_user_id_userSetting_id_fk": {
+          "name": "data_keys_user_id_userSetting_id_fk",
+          "tableFrom": "data_keys",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "data_keys_user_id_unique": {
+          "name": "data_keys_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.stripe_transaction_status": {
+      "name": "stripe_transaction_status",
+      "schema": "public",
+      "values": [
+        "created",
+        "pending",
+        "requires_action",
+        "succeeded",
+        "failed",
+        "refunded",
+        "canceled"
+      ]
+    },
+    "public.stripe_transaction_type": {
+      "name": "stripe_transaction_type",
+      "schema": "public",
+      "values": [
+        "payment_intent",
+        "coupon_claim",
+        "manual_credit"
+      ]
+    },
+    "public.auto_reload_mode": {
+      "name": "auto_reload_mode",
+      "schema": "public",
+      "values": [
+        "prediction",
+        "threshold"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -302,6 +302,13 @@
       "when": 1787641216046,
       "tag": "0042_warn_before_runtime_limit",
       "breakpoints": true
+    },
+    {
+      "idx": 43,
+      "version": "7",
+      "when": 1787670520752,
+      "tag": "0043_store_deployment_sdl",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/deployment/config/sdl.config.ts
+++ b/apps/api/src/deployment/config/sdl.config.ts
@@ -1,0 +1,11 @@
+/**
+ * Upper bound on the SDL the console stores for a deployment. The column it is written to is `text`
+ * and so bounds nothing itself, which makes this the only thing keeping a pathological SDL from
+ * filling the database — and, because the document is measured against it before being serialized
+ * rather than after, from filling memory on the way there. An SDL that does not fit is dropped, not
+ * rejected: it still deploys, it is simply not remembered. Requests stay bounded separately, by the
+ * 512 KB body limit `createRoute` puts on every route that can carry a body. Counted in characters
+ * rather than bytes, since it is compared against a JavaScript string length. Sized roughly twenty
+ * times above any SDL a real deployment needs.
+ */
+export const SDL_MAX_LENGTH = 128 * 1024;

--- a/apps/api/src/deployment/model-schemas/deployment-setting/deployment-setting.schema.ts
+++ b/apps/api/src/deployment/model-schemas/deployment-setting/deployment-setting.schema.ts
@@ -1,5 +1,5 @@
 import { sql } from "drizzle-orm";
-import { boolean, index, integer, pgTable, timestamp, unique, uuid, varchar } from "drizzle-orm/pg-core";
+import { boolean, index, integer, pgTable, text, timestamp, unique, uuid, varchar } from "drizzle-orm/pg-core";
 
 import { Users } from "@src/user/model-schemas";
 
@@ -18,6 +18,8 @@ export const DeploymentSettings = pgTable(
     closed: boolean("closed").notNull().default(false),
     lastFundedAt: timestamp("last_funded_at"),
     runtimeLimitHours: integer("runtime_limit_hours"),
+    sdl: text("sdl"),
+    manifestVersion: varchar("manifest_version", { length: 64 }),
     runtimeEndsAt: timestamp("runtime_ends_at", { withTimezone: true }),
     runtimeEndingNotifiedFor: timestamp("runtime_ending_notified_for", { withTimezone: true }),
     createdAt: timestamp("created_at").defaultNow(),

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest";
 import { AbilityService } from "@src/auth/services/ability/ability.service";
 import type { ApiPgDatabase } from "@src/core";
 import { POSTGRES_DB, resolveTable } from "@src/core";
+import { SDL_MAX_LENGTH } from "@src/deployment/config/sdl.config";
 import { MAX_RUNTIME_LIMIT_INCREMENT_HOURS } from "@src/deployment/http-schemas/runtime-limit";
 import type { UserOutput } from "@src/user/repositories";
 import { UserRepository } from "@src/user/repositories";
@@ -264,6 +265,85 @@ describe(DeploymentSettingRepository.name, () => {
       expect(claimed).toBe(false);
     });
   });
+
+  describe("upsertDefinition", () => {
+    it("records the sdl and the manifest version of a deployment with no row yet", async () => {
+      const { deploymentSettingRepository, user } = await setup();
+      const dseq = newDseq();
+
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: "version: '2.0'", manifestVersion: "BAUG" });
+
+      expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq })).toMatchObject({
+        sdl: "version: '2.0'",
+        manifestVersion: "BAUG",
+        autoTopUpEnabled: true,
+        runtimeLimitHours: null
+      });
+    });
+
+    it("records an sdl the caller chose not to store as nothing at all", async () => {
+      const { deploymentSettingRepository, user } = await setup();
+      const dseq = newDseq();
+
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: null, manifestVersion: "BAUG" });
+
+      expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq })).toMatchObject({ sdl: null, manifestVersion: "BAUG" });
+    });
+
+    it("records the runtime limit its creator chose in the same write", async () => {
+      const { deploymentSettingRepository, user } = await setup();
+      const dseq = newDseq();
+
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: "version: '2.0'", manifestVersion: "BAUG", runtimeLimitHours: 6 });
+
+      expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq })).toMatchObject({ sdl: "version: '2.0'", runtimeLimitHours: 6 });
+    });
+
+    it("overwrites the definition of a row a settings read created first", async () => {
+      const { deploymentSettingRepository, user } = await setup();
+      const dseq = newDseq();
+      await deploymentSettingRepository.create({ userId: user.id, dseq, autoTopUpEnabled: false });
+
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: "version: '2.0'", manifestVersion: "BAUG" });
+
+      expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq })).toMatchObject({ sdl: "version: '2.0'", autoTopUpEnabled: false });
+    });
+
+    it("leaves a runtime limit already on the row alone when none is given", async () => {
+      const { deploymentSettingRepository, user } = await setup();
+      const dseq = newDseq();
+      await deploymentSettingRepository.create({ userId: user.id, dseq, autoTopUpEnabled: true, runtimeLimitHours: 6 });
+
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: "version: '2.0'", manifestVersion: "BAUG" });
+
+      expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq })).toMatchObject({ runtimeLimitHours: 6 });
+    });
+
+    it("keeps the definitions of two deployments of the same user apart", async () => {
+      const { deploymentSettingRepository, user } = await setup();
+      const [first, second] = [newDseq(), newDseq()];
+
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq: first, sdl: "first", manifestVersion: "BAUG" });
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq: second, sdl: "second", manifestVersion: "BQYH" });
+
+      expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq: first })).toMatchObject({ sdl: "first", manifestVersion: "BAUG" });
+      expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq: second })).toMatchObject({ sdl: "second", manifestVersion: "BQYH" });
+    });
+
+    it("stores an sdl of the largest size the console will keep", async () => {
+      const { deploymentSettingRepository, user } = await setup();
+      const dseq = newDseq();
+      const sdl = "x".repeat(SDL_MAX_LENGTH);
+
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl, manifestVersion: "BAUG" });
+
+      expect((await deploymentSettingRepository.findOneBy({ userId: user.id, dseq }))?.sdl).toHaveLength(SDL_MAX_LENGTH);
+    });
+  });
+
+  function newDseq() {
+    return faker.number.int({ min: 100000, max: 999999 }).toString();
+  }
 
   async function setup() {
     const userRepository = container.resolve(UserRepository);

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -252,17 +252,35 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
   }
 
   /**
-   * Persists a runtime limit chosen at deployment creation. Upserts on the (dseq, userId) unique so a
-   * concurrent lazy row creation from a settings read cannot drop the limit; the conflict branch only
-   * writes the limit and leaves the row's other fields as the earlier writer set them.
+   * Records what a deployment is, at the moment it is created: the SDL it was given, stripped of its
+   * secrets, the manifest version it commits on chain, and the runtime limit its creator chose. One
+   * statement, so a deployment can never end up remembering half of itself, and so the sealed secrets
+   * a later phase adds land in the same write as the SDL they belong to.
+   *
+   * Upserts on the (dseq, userId) unique because a settings read creates a row lazily, and because the
+   * caller retries a create that failed to broadcast. The conflict branch leaves every field it does
+   * not name as the earlier writer set them, and an absent runtime limit counts as unnamed: drizzle
+   * drops undefined out of the set clause, so creating without a limit cannot clear one already there.
    */
-  async upsertRuntimeLimit({ userId, dseq, runtimeLimitHours }: { userId: string; dseq: string; runtimeLimitHours: number }): Promise<void> {
+  async upsertDefinition({
+    userId,
+    dseq,
+    sdl,
+    manifestVersion,
+    runtimeLimitHours
+  }: {
+    userId: string;
+    dseq: string;
+    sdl: string | null;
+    manifestVersion: string;
+    runtimeLimitHours?: number;
+  }): Promise<void> {
     await this.cursor
       .insert(this.table)
-      .values({ userId, dseq, autoTopUpEnabled: true, runtimeLimitHours })
+      .values({ userId, dseq, autoTopUpEnabled: AUTO_TOP_UP_ENABLED_BY_DEFAULT, sdl, manifestVersion, runtimeLimitHours })
       .onConflictDoUpdate({
         target: [this.table.dseq, this.table.userId],
-        set: { runtimeLimitHours, updatedAt: sql`now()` }
+        set: { sdl, manifestVersion, runtimeLimitHours, updatedAt: sql`now()` }
       });
   }
 

--- a/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.spec.ts
@@ -580,6 +580,8 @@ describe(DeploymentSettingService.name, () => {
       closed: false,
       lastFundedAt: null,
       runtimeLimitHours: null,
+      sdl: null,
+      manifestVersion: null,
       runtimeEndsAt: null,
       runtimeEndingNotifiedFor: null,
       createdAt: faker.date.past().toISOString(),

--- a/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.ts
+++ b/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.ts
@@ -26,7 +26,10 @@ import { TopUpManagedDeploymentsInstrumentationService } from "../top-up-managed
 /** The fields a PATCH may change. A null `runtimeLimitHours` removes the limit; an absent one leaves it alone. */
 type DeploymentSettingChange = Pick<DeploymentSettingsInput, "autoTopUpEnabled" | "runtimeLimitHours">;
 
-type DeploymentSettingWithEstimatedTopUpAmount = Omit<DeploymentSettingsOutput, "lastFundedAt" | "runtimeEndingNotifiedFor" | "runtimeEndsAt"> & {
+type DeploymentSettingWithEstimatedTopUpAmount = Omit<
+  DeploymentSettingsOutput,
+  "lastFundedAt" | "runtimeEndingNotifiedFor" | "sdl" | "manifestVersion" | "runtimeEndsAt"
+> & {
   estimatedTopUpAmount: number;
   topUpFrequencyMs: number;
   runtimeEndsAt: string | null;
@@ -76,10 +79,19 @@ export class DeploymentSettingService {
     return await this.withEstimatedTopUpAmount(await this.deploymentSettingRepository.accessibleBy(this.authService.ability, "create").create(params));
   }
 
-  async create(input: DeploymentSettingsInput): Promise<DeploymentSettingWithEstimatedTopUpAmount> {
+  /**
+   * Takes the same reconciling path as `upsert` rather than inserting blind, because by the time this
+   * runs the row usually exists: creating a deployment records what it is, on the very row this
+   * endpoint writes. A caller doing `POST /v1/deployments` and then `POST /v1/deployment-settings` for
+   * the same dseq would otherwise hit the (dseq, userId) unique and get a 500 for a request that used
+   * to succeed.
+   */
+  async create(input: FindDeploymentSettingParams & DeploymentSettingChange): Promise<DeploymentSettingWithEstimatedTopUpAmount> {
     this.#assertFundingStaysOn(input.autoTopUpEnabled);
 
-    const result = await this.withEstimatedTopUpAmount(await this.deploymentSettingRepository.accessibleBy(this.authService.ability, "create").create(input));
+    const { userId, dseq, ...change } = input;
+    const { setting } = await this.#writeReconcilingConcurrentCreate({ userId, dseq }, change);
+    const result = await this.withEstimatedTopUpAmount(setting);
 
     if (result.autoTopUpEnabled) {
       await this.walletReloadJobService.scheduleImmediate({ userId: result.userId });
@@ -314,7 +326,12 @@ export class DeploymentSettingService {
     }
   }
 
-  /** `lastFundedAt` and `runtimeEndingNotifiedFor` are internal sweep markers and stay out of the API payload. */
+  /**
+   * `lastFundedAt` and `runtimeEndingNotifiedFor` are internal sweep markers and stay out of the API
+   * payload. So do `sdl` and `manifestVersion`: they are what the console remembers a deployment by,
+   * not something it hands back, and the response schema is types only — whatever this returns is
+   * what ships.
+   */
   async withEstimatedTopUpAmount(params: DeploymentSettingsOutput): Promise<DeploymentSettingWithEstimatedTopUpAmount>;
   async withEstimatedTopUpAmount(params: undefined): Promise<undefined>;
   async withEstimatedTopUpAmount(params?: DeploymentSettingsOutput): Promise<DeploymentSettingWithEstimatedTopUpAmount | undefined> {
@@ -322,7 +339,7 @@ export class DeploymentSettingService {
       return undefined;
     }
 
-    const { lastFundedAt, runtimeEndingNotifiedFor, runtimeEndsAt, ...rest } = params;
+    const { lastFundedAt, runtimeEndingNotifiedFor, sdl, manifestVersion, runtimeEndsAt, ...rest } = params;
     const setting = { ...rest, runtimeEndsAt: runtimeEndsAt?.toISOString() ?? null };
 
     if (!setting.autoTopUpEnabled) {

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -1,5 +1,6 @@
 import { DeploymentReclamation, MsgAccountDeposit } from "@akashnetwork/chain-sdk/private-types/akash.v1";
 import { MsgCloseDeployment, MsgCreateDeployment, MsgUpdateDeployment } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
+import { faker } from "@faker-js/faker";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { mock, type MockProxy } from "vitest-mock-extended";
 
@@ -10,6 +11,7 @@ import type { RpcMessageService } from "@src/billing/services/rpc-message-servic
 import type { WalletReaderService } from "@src/billing/services/wallet-reader/wallet-reader.service";
 import type { LoggerService } from "@src/core";
 import type { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
+import { SDL_MAX_LENGTH } from "@src/deployment/config/sdl.config";
 import type { GetDeploymentResponse } from "@src/deployment/http-schemas/deployment.schema";
 import type { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import type { SdlService } from "@src/deployment/services/sdl/sdl.service";
@@ -20,6 +22,80 @@ import type { StaleManagedDeploymentsCleanerService } from "../stale-managed-dep
 import { DeploymentWriterService } from "./deployment-writer.service";
 
 import { mockConfigService } from "@test/mocks/config-service.mock";
+
+const ENV_VALUE = faker.string.alphanumeric(24);
+const REGISTRY_PASSWORD = faker.internet.password();
+
+/** A complete SDL around a service body, plus an optional placement profile nothing references. */
+function sdlAround(serviceBody: string, extraPlacement = ""): string {
+  return `version: "2.0"
+services:
+  web:
+    image: nginx
+${serviceBody}    expose:
+      - port: 3000
+        as: 80
+        to:
+          - global: true
+profiles:
+  compute:
+    web:
+      resources:
+        cpu:
+          units: 0.5
+        memory:
+          size: 512Mi
+        storage:
+          - size: 512Mi
+  placement:
+    dcloud:
+      pricing:
+        web:
+          denom: uakt
+          amount: 1000
+${extraPlacement}deployment:
+  web:
+    dcloud:
+      profile: web
+      count: 1`;
+}
+
+/** A valid SDL carrying an env value and a registry password, so a test can look for them afterwards. */
+const SDL_WITH_SECRETS = sdlAround(`    credentials:
+      host: registry.example.test
+      username: registry-user
+      password: ${REGISTRY_PASSWORD}
+    env:
+      - API_TOKEN=${ENV_VALUE}
+`);
+
+/**
+ * The shape that turns a small request into an enormous document: one anchored scalar aliased many
+ * times over. js-yaml loads every alias back as an independent string, so serializing writes the
+ * scalar out in full each time.
+ */
+const SDL_ALIASING_ONE_SCALAR = sdlAround(`    args:
+      - &payload ${"x".repeat(4096)}
+${Array.from({ length: 511 }, () => "      - *payload").join("\n")}
+`);
+
+/**
+ * The other shape, and the one that costs the most to measure: aliases pointing at aliases, doubling
+ * the node count per level. It hides under an unreferenced placement profile's `attributes`, the SDL's
+ * one free-form position, where the manifest generator never looks — 1.3 KB expanding to 2^24 elements.
+ */
+const SDL_ALIASING_A_DAG = sdlAround(
+  "",
+  `    unused:
+      attributes:
+        a0: &a0 []
+${Array.from({ length: 24 }, (_, level) => `        a${level + 1}: &a${level + 1} [*a${level}, *a${level}]`).join("\n")}
+      pricing:
+        web:
+          denom: uakt
+          amount: 1000
+`
+);
 
 describe(DeploymentWriterService.name, () => {
   const wallet: WalletInitialized = {
@@ -124,44 +200,134 @@ describe(DeploymentWriterService.name, () => {
       expect(rpcMessageService.getCreateDeploymentMsg.mock.calls[0][0].reclamation).toBeUndefined();
     });
 
-    it("persists the runtime limit after the create tx succeeds", async () => {
+    it("records the runtime limit alongside the definition", async () => {
       const { service, deploymentSettingRepository } = setup();
-      const dseq = 1748400000000;
-      vi.spyOn(Date, "now").mockReturnValue(dseq);
+      vi.spyOn(Date, "now").mockReturnValue(1748400000000);
 
-      await service.create({ userId: "user-1", sdl: "valid-sdl", deposit: 5, runtimeLimitHours: 6 });
+      await service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, deposit: 5, runtimeLimitHours: 6 });
 
-      expect(deploymentSettingRepository.upsertRuntimeLimit).toHaveBeenCalledWith({
+      expect(deploymentSettingRepository.upsertDefinition).toHaveBeenCalledWith(expect.objectContaining({ dseq: "1748400000000", runtimeLimitHours: 6 }));
+    });
+
+    it("records no runtime limit when none is requested", async () => {
+      const { service, deploymentSettingRepository } = setup();
+
+      await service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, deposit: 5 });
+
+      expect(deploymentSettingRepository.upsertDefinition).toHaveBeenCalledWith(expect.objectContaining({ runtimeLimitHours: undefined }));
+    });
+
+    it("records the sdl and the manifest version it commits on chain", async () => {
+      const { service, deploymentSettingRepository } = setup();
+      vi.spyOn(Date, "now").mockReturnValue(1748400000000);
+
+      await service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, deposit: 5 });
+
+      expect(deploymentSettingRepository.upsertDefinition).toHaveBeenCalledWith({
         userId: wallet.userId,
         dseq: "1748400000000",
-        runtimeLimitHours: 6
+        sdl: expect.stringContaining("API_TOKEN="),
+        manifestVersion: "BAUG",
+        runtimeLimitHours: undefined
       });
     });
 
-    it("persists no runtime limit when none is requested", async () => {
+    it("records an sdl carrying none of the submitted env values", async () => {
       const { service, deploymentSettingRepository } = setup();
 
-      await service.create({ userId: "user-1", sdl: "valid-sdl", deposit: 5 });
+      await service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, deposit: 5 });
 
-      expect(deploymentSettingRepository.upsertRuntimeLimit).not.toHaveBeenCalled();
+      expect(recordedSdlOf(deploymentSettingRepository)).not.toContain(ENV_VALUE);
     });
 
-    it("persists no runtime limit when the create tx fails", async () => {
+    it("records an sdl carrying none of the submitted registry credentials", async () => {
+      const { service, deploymentSettingRepository } = setup();
+
+      await service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, deposit: 5 });
+
+      expect(recordedSdlOf(deploymentSettingRepository)).not.toContain(REGISTRY_PASSWORD);
+    });
+
+    it("records the definition before broadcasting the create tx", async () => {
+      const { service, signerService, deploymentSettingRepository } = setup();
+
+      await service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, deposit: 5 });
+
+      expect(deploymentSettingRepository.upsertDefinition.mock.invocationCallOrder[0]).toBeLessThan(
+        signerService.executeDerivedDecodedTxByUserId.mock.invocationCallOrder[0]
+      );
+    });
+
+    it("keeps the recorded definition when the create tx fails to broadcast", async () => {
       const { service, signerService, deploymentSettingRepository } = setup();
       signerService.executeDerivedDecodedTxByUserId.mockRejectedValue(new Error("tx failed"));
 
-      await expect(service.create({ userId: "user-1", sdl: "valid-sdl", deposit: 5, runtimeLimitHours: 6 })).rejects.toThrow("tx failed");
+      await expect(service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, deposit: 5, runtimeLimitHours: 6 })).rejects.toThrow("tx failed");
 
-      expect(deploymentSettingRepository.upsertRuntimeLimit).not.toHaveBeenCalled();
+      expect(deploymentSettingRepository.upsertDefinition).toHaveBeenCalledTimes(1);
     });
 
-    it("surfaces a runtime limit persistence failure instead of silently dropping the limit", async () => {
+    it("broadcasts nothing when the definition cannot be recorded", async () => {
+      const { service, signerService, deploymentSettingRepository } = setup();
+      deploymentSettingRepository.upsertDefinition.mockRejectedValue(new Error("db down"));
+
+      await expect(service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, deposit: 5 })).rejects.toThrow("db down");
+
+      expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
+    });
+
+    it("reports a failure to record the definition without logging the sdl", async () => {
       const { service, deploymentSettingRepository, logger } = setup();
-      deploymentSettingRepository.upsertRuntimeLimit.mockRejectedValue(new Error("db down"));
+      deploymentSettingRepository.upsertDefinition.mockRejectedValue(new Error("db down"));
 
-      await expect(service.create({ userId: "user-1", sdl: "valid-sdl", deposit: 5, runtimeLimitHours: 6 })).rejects.toThrow("db down");
+      await expect(service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, deposit: 5, runtimeLimitHours: 6 })).rejects.toThrow("db down");
 
-      expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "RUNTIME_LIMIT_PERSISTENCE_FAILED", runtimeLimitHours: 6 }));
+      expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "DEPLOYMENT_DEFINITION_PERSISTENCE_FAILED", runtimeLimitHours: 6 }));
+      expect(loggedTextOf(logger)).not.toContain("API_TOKEN");
+    });
+
+    it("still creates the deployment when its sdl is too large to store", async () => {
+      const { service, signerService } = setup();
+
+      const result = await service.create({ userId: "user-1", sdl: SDL_ALIASING_ONE_SCALAR, deposit: 5 });
+
+      expect(result.dseq).toEqual(expect.any(String));
+      expect(signerService.executeDerivedDecodedTxByUserId).toHaveBeenCalledTimes(1);
+    });
+
+    it("records no sdl when an aliased scalar would serialize past the maximum stored length", async () => {
+      const { service, deploymentSettingRepository } = setup();
+
+      await service.create({ userId: "user-1", sdl: SDL_ALIASING_ONE_SCALAR, deposit: 5 });
+
+      expect(deploymentSettingRepository.upsertDefinition).toHaveBeenCalledWith(expect.objectContaining({ sdl: null, manifestVersion: "BAUG" }));
+    });
+
+    it("records no sdl for an sdl whose aliases form a doubling graph, without stalling on it", async () => {
+      const { service, deploymentSettingRepository, logger, signerService } = setup();
+
+      await service.create({ userId: "user-1", sdl: SDL_ALIASING_A_DAG, deposit: 5 });
+
+      expect(deploymentSettingRepository.upsertDefinition).toHaveBeenCalledWith(expect.objectContaining({ sdl: null, manifestVersion: "BAUG" }));
+      expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "DEPLOYMENT_SDL_TOO_LARGE_TO_STORE" }));
+      expect(signerService.executeDerivedDecodedTxByUserId).toHaveBeenCalledTimes(1);
+    }, 5000);
+
+    it("reports an sdl too large to store by its length alone", async () => {
+      const { service, logger } = setup();
+
+      await service.create({ userId: "user-1", sdl: SDL_ALIASING_ONE_SCALAR, deposit: 5 });
+
+      expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "DEPLOYMENT_SDL_TOO_LARGE_TO_STORE", maxLength: SDL_MAX_LENGTH }));
+      expect(loggedTextOf(logger)).not.toContain("API_TOKEN");
+    });
+
+    it("never hands the sdl to the logger on a successful create", async () => {
+      const { service, logger } = setup();
+
+      await service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, deposit: 5 });
+
+      expect(loggedTextOf(logger)).not.toContain("API_TOKEN");
     });
 
     it("reclaims trial orphans with age 0 before signing the create when the wallet is trialing", async () => {
@@ -383,6 +549,20 @@ describe(DeploymentWriterService.name, () => {
       expect(providerService.sendManifest).toHaveBeenCalledWith(expect.objectContaining({ provider: "provider-2" }));
     });
   });
+
+  function recordedSdlOf(deploymentSettingRepository: MockProxy<DeploymentSettingRepository>): string {
+    const { sdl } = deploymentSettingRepository.upsertDefinition.mock.calls[0][0];
+    expect(sdl).not.toBeNull();
+    return sdl as string;
+  }
+
+  /** Everything the logger was handed, flattened, so a test can assert the sdl reached none of it. */
+  function loggedTextOf(logger: MockProxy<LoggerService>): string {
+    return [logger.error, logger.warn, logger.info, logger.debug]
+      .flatMap(method => method.mock.calls)
+      .map(call => JSON.stringify(call))
+      .join("");
+  }
 
   function setup(input?: { isManagedDepositEnabled?: boolean; defaultDeposit?: number }) {
     const signerService = mock<ManagedSignerService>();

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -10,6 +10,7 @@ import { WalletReaderService } from "@src/billing/services/wallet-reader/wallet-
 import { LoggerService } from "@src/core";
 import { FeatureFlags } from "@src/core/services/feature-flags/feature-flags";
 import { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
+import { SDL_MAX_LENGTH } from "@src/deployment/config/sdl.config";
 import {
   CreateDeploymentRequest,
   CreateDeploymentResponse,
@@ -18,6 +19,7 @@ import {
 } from "@src/deployment/http-schemas/deployment.schema";
 import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import { SdlService } from "@src/deployment/services/sdl/sdl.service";
+import { stripSdlSecrets } from "@src/deployment/utils/sdl-secret-stripping/sdl-secret-stripping";
 import { ProviderService } from "@src/provider/services/provider/provider.service";
 import { denomToUdenom } from "@src/utils/math";
 import { DeploymentConfigService } from "../deployment-config/deployment-config.service";
@@ -53,6 +55,14 @@ export class DeploymentWriterService {
     const dseq = Date.now();
     const manifestVersion = await this.sdlService.generateManifestVersion(manifest.groups);
 
+    await this.recordDefinition({
+      userId: wallet.userId,
+      dseq: dseq.toString(),
+      submittedSdl: input.sdl,
+      manifestVersion,
+      runtimeLimitHours: input.runtimeLimitHours
+    });
+
     const message = this.rpcMessageService.getCreateDeploymentMsg({
       owner: wallet.address,
       dseq,
@@ -65,10 +75,6 @@ export class DeploymentWriterService {
 
     const result = await this.signerService.executeDerivedDecodedTxByUserId(wallet.userId, [message]);
 
-    if (input.runtimeLimitHours) {
-      await this.persistRuntimeLimit({ userId: wallet.userId, dseq: dseq.toString(), runtimeLimitHours: input.runtimeLimitHours });
-    }
-
     return {
       dseq: dseq.toString(),
       manifest: manifestToSortedJSON(manifest.groups),
@@ -77,17 +83,60 @@ export class DeploymentWriterService {
   }
 
   /**
-   * Runs after the create tx so a failed create leaves no settings row for the funding sweep to visit
-   * forever. A persistence failure surfaces as an error rather than best-effort: until switching modes
-   * ships, a silently dropped limit would leave the deployment funded indefinitely with no way back.
+   * Records what the deployment is before the create tx is broadcast, never after. The reverse order
+   * would let a successful broadcast produce a deployment with no remembered definition, which becomes
+   * unrecoverable once a later phase stores sealed secrets in the same write. A broadcast that then
+   * fails leaves a record for a deployment that does not exist on chain, which costs one row the
+   * draining sweep skips on every pass, and which the next create — always on a fresh dseq — ignores.
+   *
+   * A failure here surfaces as an error rather than best-effort, and nothing is broadcast: the user
+   * retries and gets both the deployment and its record, instead of a deployment the console cannot
+   * describe. An SDL merely too large to store is not such a failure — see `storableSdl`.
+   *
+   * The stored SDL deliberately does not hash to the stored manifest version, and no future reader
+   * should expect it to. The version is taken over the manifest the generator produced, which rewrites
+   * the denom and appends the allowed auditors to its own parse; the stored SDL is the one the user
+   * submitted, stripped. They describe the same deployment, not the same bytes.
    */
-  private async persistRuntimeLimit(input: { userId: string; dseq: string; runtimeLimitHours: number }): Promise<void> {
+  private async recordDefinition(input: {
+    userId: string;
+    dseq: string;
+    submittedSdl: string;
+    manifestVersion: Uint8Array;
+    runtimeLimitHours?: number;
+  }): Promise<void> {
+    const { submittedSdl, manifestVersion, ...rest } = input;
+
     try {
-      await this.deploymentSettingRepository.upsertRuntimeLimit(input);
+      await this.deploymentSettingRepository.upsertDefinition({
+        ...rest,
+        sdl: this.storableSdl(submittedSdl, rest.dseq),
+        manifestVersion: Buffer.from(manifestVersion).toString("base64")
+      });
     } catch (error) {
-      this.logger.error({ event: "RUNTIME_LIMIT_PERSISTENCE_FAILED", ...input, error });
+      this.logger.error({ event: "DEPLOYMENT_DEFINITION_PERSISTENCE_FAILED", ...rest, error });
       throw error;
     }
+  }
+
+  /**
+   * The submitted SDL with its secrets taken out, or nothing at all when it is too large to store. The
+   * column is `text` and so bounds nothing itself, which makes this the only thing standing between a
+   * pathological SDL and the database.
+   *
+   * Being too large is ordinary input, not a failure: the deployment goes ahead without a stored
+   * definition rather than failing over something only the console wants. It is reported by its length
+   * alone — never the SDL or any part of it, the whole point of stripping being that user content does
+   * not end up somewhere it was not meant to be, and a log is exactly that.
+   */
+  private storableSdl(submittedSdl: string, dseq: string): string | null {
+    const { sdl, length } = stripSdlSecrets(submittedSdl, SDL_MAX_LENGTH);
+
+    if (sdl === null) {
+      this.logger.warn({ event: "DEPLOYMENT_SDL_TOO_LARGE_TO_STORE", dseq, length, maxLength: SDL_MAX_LENGTH });
+    }
+
+    return sdl;
   }
 
   /**

--- a/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.spec.ts
+++ b/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.spec.ts
@@ -372,6 +372,8 @@ describe(InitialDeploymentFundingService.name, () => {
       closed: false,
       lastFundedAt: null,
       runtimeLimitHours: null,
+      sdl: null,
+      manifestVersion: null,
       runtimeEndsAt: null,
       runtimeEndingNotifiedFor: null,
       createdAt: new Date("2026-08-20T00:00:00.000Z").toISOString(),

--- a/apps/api/src/deployment/utils/sdl-secret-stripping/sdl-secret-stripping.spec.ts
+++ b/apps/api/src/deployment/utils/sdl-secret-stripping/sdl-secret-stripping.spec.ts
@@ -1,0 +1,245 @@
+import type { SDLInput } from "@akashnetwork/chain-sdk";
+import { yaml } from "@akashnetwork/chain-sdk";
+import { faker } from "@faker-js/faker";
+import { dump } from "js-yaml";
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { BillingConfig } from "@src/billing/providers";
+import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
+import { BlockedGpuService } from "@src/deployment/services/blocked-gpu/blocked-gpu.service";
+import { SdlService } from "@src/deployment/services/sdl/sdl.service";
+import { stripSdlSecrets } from "./sdl-secret-stripping";
+
+import { mockConfigService } from "@test/mocks/config-service.mock";
+
+const IMAGE = "ghcr.io/akash-network/hello-akash-world:2.1.0";
+
+/** Generous enough that every test but the size ones is measuring stripping rather than the limit. */
+const MAX_LENGTH = 128 * 1024;
+
+describe(stripSdlSecrets.name, () => {
+  describe("environment values", () => {
+    it("keeps the variable name and drops its value", () => {
+      const token = faker.string.alphanumeric(24);
+
+      const stripped = strip(sdlWith({ web: { env: [`API_TOKEN=${token}`] } }));
+
+      expect(stripped.services.web.env).toEqual(["API_TOKEN="]);
+    });
+
+    it("drops a value that itself contains an equals sign", () => {
+      const password = faker.internet.password();
+
+      const stripped = strip(sdlWith({ web: { env: [`DATABASE_URL=postgres://u:${password}@h:5432/db?ssl=true&a=b`] } }));
+
+      expect(stripped.services.web.env).toEqual(["DATABASE_URL="]);
+    });
+
+    it("leaves an entry that names no value alone", () => {
+      const stripped = strip(sdlWith({ web: { env: ["INHERITED_FROM_HOST"] } }));
+
+      expect(stripped.services.web.env).toEqual(["INHERITED_FROM_HOST"]);
+    });
+
+    it("leaves an explicitly null env list alone", () => {
+      const stripped = strip(sdlWith({ web: { env: null } }));
+
+      expect(stripped.services.web.env).toBeNull();
+    });
+
+    it("leaves a service that declares no env alone", () => {
+      const stripped = strip(sdlWith({ web: {} }));
+
+      expect(stripped.services.web).not.toHaveProperty("env");
+    });
+
+    it("strips the env of every service, not only the first", () => {
+      const stripped = strip(sdlWith({ web: { env: [`A=${faker.string.alphanumeric(8)}`] }, worker: { env: [`B=${faker.string.alphanumeric(8)}`] } }));
+
+      expect(stripped.services.web.env).toEqual(["A="]);
+      expect(stripped.services.worker.env).toEqual(["B="]);
+    });
+  });
+
+  describe("private registry credentials", () => {
+    it("removes the whole block, not just the password", () => {
+      const stripped = strip(
+        sdlWith({
+          web: {
+            credentials: { host: "registry.example.test", username: faker.string.alphanumeric(10), password: faker.internet.password() }
+          }
+        })
+      );
+
+      expect(stripped.services.web).not.toHaveProperty("credentials");
+    });
+
+    it("removes the block of every service that declares one", () => {
+      const credentials = { host: "registry.example.test", username: faker.string.alphanumeric(10), password: faker.internet.password() };
+
+      const stripped = strip(sdlWith({ web: { credentials }, worker: { credentials } }));
+
+      expect(stripped.services.web).not.toHaveProperty("credentials");
+      expect(stripped.services.worker).not.toHaveProperty("credentials");
+    });
+  });
+
+  describe("a value that is also an ordinary part of the SDL", () => {
+    it("keeps a service whose name another service's env value happens to equal", () => {
+      const stripped = strip(sdlWith({ wordpress: { env: ["WORDPRESS_DB_HOST=db"] }, db: { env: ["MYSQL_DATABASE=wordpress"] } }));
+
+      expect(Object.keys(stripped.services)).toEqual(["wordpress", "db"]);
+      expect(stripped.services.db.image).toBe(IMAGE);
+      expect(Object.keys(stripped.deployment)).toEqual(["wordpress", "db"]);
+      expect(Object.keys(stripped.profiles.compute)).toEqual(["wordpress", "db"]);
+    });
+
+    it("keeps a placement denom an env value happens to equal", () => {
+      const stripped = strip(sdlWith({ web: { env: ["DENOM=uakt"] } }));
+
+      expect(stripped.profiles.placement.dcloud.pricing.web.denom).toBe("uakt");
+    });
+
+    it("keeps an image an env value happens to equal", () => {
+      const stripped = strip(sdlWith({ web: { image: "nginx", env: ["IMAGE_NAME=nginx"] } }));
+
+      expect(stripped.services.web.image).toBe("nginx");
+    });
+
+    it("keeps a map key an env value happens to equal", () => {
+      const stripped = strip(sdlWith({ web: { env: ["PROFILE=dcloud"] } }));
+
+      expect(stripped.profiles.placement).toHaveProperty("dcloud");
+    });
+  });
+
+  describe("a copy of a value the SDL made for itself", () => {
+    it("keeps the copy an aliased env list left in args, stripping only where the value is declared", () => {
+      const token = faker.string.alphanumeric(12);
+      const sharedEnv = [`API_TOKEN=${token}`];
+
+      const stripped = strip(dump(sdlDocument({ web: { env: sharedEnv, args: sharedEnv } })));
+
+      expect(stripped.services.web.env).toEqual(["API_TOKEN="]);
+      expect(stripped.services.web.args).toEqual(["API_TOKEN="]);
+    });
+
+    it("keeps a value typed out a second time in args, which the env declaration cannot reach", () => {
+      const token = faker.string.alphanumeric(12);
+
+      const stripped = strip(sdlWith({ web: { env: [`API_TOKEN=${token}`], args: [`--token=${token}`] } }));
+
+      expect(stripped.services.web.env).toEqual(["API_TOKEN="]);
+      expect(stripped.services.web.args).toEqual([`--token=${token}`]);
+    });
+  });
+
+  describe("the stripped output", () => {
+    it("stays an SDL the manifest generator still accepts", () => {
+      const submitted = sdlWith({ web: { env: [`API_TOKEN=${faker.string.alphanumeric(12)}`] } });
+
+      expect(manifestFrom(storedSdlOf(submitted)).ok).toBe(true);
+    });
+
+    it("stays an SDL the manifest generator accepts when an env value equals the service name", () => {
+      const submitted = sdlWith({ wordpress: { env: ["WORDPRESS_DB_HOST=db"] }, db: {} });
+
+      expect(manifestFrom(storedSdlOf(submitted)).ok).toBe(true);
+    });
+
+    it("stays an SDL the manifest generator accepts when an env value equals the denom", () => {
+      const submitted = sdlWith({ web: { env: ["DENOM=uakt"] } });
+
+      expect(manifestFrom(storedSdlOf(submitted)).ok).toBe(true);
+    });
+
+    it("still generates a manifest for an SDL that declares no env at all", () => {
+      expect(manifestFrom(storedSdlOf(sdlWith({ web: {} }))).ok).toBe(true);
+    });
+
+    it("strips an already stripped SDL to the same thing again", () => {
+      const once = storedSdlOf(sdlWith({ web: { env: [`API_TOKEN=${faker.string.alphanumeric(12)}`] } }));
+
+      expect(storedSdlOf(once)).toBe(once);
+    });
+  });
+
+  describe("an SDL too large to store", () => {
+    it("returns nothing rather than the document, reporting the size it measured", () => {
+      const result = stripSdlSecrets(sdlWith({ web: { args: ["x".repeat(2048)] } }), 512);
+
+      expect(result.sdl).toBeNull();
+      expect(result.length).toBeGreaterThan(512);
+    });
+
+    it("refuses a document whose aliases multiply a scalar past the limit without serializing it", () => {
+      const result = stripSdlSecrets(sdlAliasingOneScalar({ scalarLength: 4096, aliasCount: 512 }), 8192);
+
+      expect(result.sdl).toBeNull();
+      expect(result.length).toBeGreaterThan(8192);
+    });
+
+    it("measures an aliased scalar once per alias, as serializing it would write it", () => {
+      const oneAlias = stripSdlSecrets(sdlAliasingOneScalar({ scalarLength: 4096, aliasCount: 1 }), 8192).length;
+      const manyAliases = stripSdlSecrets(sdlAliasingOneScalar({ scalarLength: 4096, aliasCount: 512 }), 8192).length;
+
+      expect(manyAliases).toBeGreaterThan(oneAlias);
+    });
+
+    it("returns a document that fits", () => {
+      expect(stripSdlSecrets(sdlWith({ web: {} }), MAX_LENGTH).sdl).toContain("services:");
+    });
+  });
+
+  type ServiceOverrides = Record<string, unknown>;
+
+  function strip(rawSdl: string) {
+    return yaml.raw<SDLInput>(storedSdlOf(rawSdl));
+  }
+
+  function storedSdlOf(rawSdl: string): string {
+    const { sdl } = stripSdlSecrets(rawSdl, MAX_LENGTH);
+    expect(sdl).not.toBeNull();
+    return sdl as string;
+  }
+
+  /** JSON is a subset of YAML, so building the fixture as an object keeps indentation out of the tests. */
+  function sdlWith(services: Record<string, ServiceOverrides>): string {
+    return JSON.stringify(sdlDocument(services));
+  }
+
+  function sdlDocument(services: Record<string, ServiceOverrides>) {
+    const names = Object.keys(services);
+
+    return {
+      version: "2.0",
+      services: Object.fromEntries(
+        Object.entries(services).map(([name, overrides]) => [name, { image: IMAGE, expose: [{ port: 3000, as: 80, to: [{ global: true }] }], ...overrides }])
+      ),
+      profiles: {
+        compute: Object.fromEntries(names.map(name => [name, { resources: { cpu: { units: 0.5 }, memory: { size: "512Mi" }, storage: [{ size: "512Mi" }] } }])),
+        placement: { dcloud: { pricing: Object.fromEntries(names.map(name => [name, { denom: "uakt", amount: 1000 }])) } }
+      },
+      deployment: Object.fromEntries(names.map(name => [name, { dcloud: { profile: name, count: 1 } }]))
+    };
+  }
+
+  /**
+   * An SDL whose `args` point one anchored scalar at itself many times over. js-yaml emits it as an
+   * anchor and N aliases, but loads it back as N independent strings, so serializing writes the scalar
+   * out in full every time — the shape that turns a small request into a huge document.
+   */
+  function sdlAliasingOneScalar({ scalarLength, aliasCount }: { scalarLength: number; aliasCount: number }): string {
+    const args = ["    args:", `      - &payload ${"x".repeat(scalarLength)}`, ...Array.from({ length: aliasCount - 1 }, () => "      - *payload")];
+
+    return dump(sdlDocument({ web: {} })).replace(`    image: ${IMAGE}`, [`    image: ${IMAGE}`, ...args].join("\n"));
+  }
+
+  function manifestFrom(rawSdl: string) {
+    const config = mock<BillingConfig>({ DEPLOYMENT_GRANT_DENOM: "uakt", MANAGED_WALLET_LEASE_ALLOWED_AUDITORS: [] });
+    const blockedGpuService = new BlockedGpuService(mockConfigService<BillingConfigService>({ MANAGED_WALLET_TRIAL_BLOCKED_GPU_MODELS: [] }));
+
+    return new SdlService(config, blockedGpuService).generateManifest(rawSdl);
+  }
+});

--- a/apps/api/src/deployment/utils/sdl-secret-stripping/sdl-secret-stripping.ts
+++ b/apps/api/src/deployment/utils/sdl-secret-stripping/sdl-secret-stripping.ts
@@ -1,0 +1,149 @@
+import type { SDLInput } from "@akashnetwork/chain-sdk";
+import { yaml } from "@akashnetwork/chain-sdk";
+import { dump } from "js-yaml";
+
+type SdlServiceDefinition = SDLInput["services"][string];
+
+/**
+ * The stripped SDL, or nothing when storing it would cost more than the caller allows. `length` is
+ * what the stripped document was measured at — an estimate once it exceeds the limit, since measuring
+ * stops there rather than running a pathological document to completion.
+ */
+export type StrippedSdl = { sdl: string | null; length: number };
+
+/**
+ * The submitted SDL with the value of every `env` entry and every private registry `credentials` block
+ * removed. Variable names survive, so the stored definition still describes what the deployment expects
+ * to be given.
+ *
+ * Both are removed where they are declared and nowhere else. An SDL that copies a secret somewhere else
+ * itself — through a YAML anchor aliased into `args`, say — keeps that copy. Chasing those was tried and
+ * withdrawn: it means collecting the secrets and deleting every string in the document equal to one,
+ * which cannot tell a secret apart from an ordinary value that happens to match it. `DENOM=uakt` took
+ * out `denom: uakt`, and a service named `db` referenced by another service's `WORDPRESS_DB_HOST=db`
+ * took out the whole service. An SDL smuggling its own secret into `args` is a leak its author wrote on
+ * purpose; quietly destroying an ordinary two-service SDL is a bug the author cannot even see.
+ *
+ * Only a validated SDL may be passed here: the caller runs it through the manifest generator first,
+ * which rejects unknown root properties and so bounds where a service, and with it an env list, can hide.
+ *
+ * The result is re-serialized YAML and so never byte-identical to what arrived. It must never stand in
+ * for the raw SDL anywhere a hash is taken over it.
+ */
+export function stripSdlSecrets(rawSdl: string, maxLength: number): StrippedSdl {
+  const sdl = yaml.raw<SDLInput>(rawSdl);
+
+  for (const service of serviceDefinitionsOf(sdl)) {
+    stripEnvValues(service);
+    delete service.credentials;
+  }
+
+  const estimatedLength = estimateSerializedLength(sdl, maxLength);
+
+  if (estimatedLength > maxLength) {
+    return { sdl: null, length: estimatedLength };
+  }
+
+  const stripped = dump(sdl, { lineWidth: -1 });
+
+  return stripped.length > maxLength ? { sdl: null, length: stripped.length } : { sdl: stripped, length: stripped.length };
+}
+
+function serviceDefinitionsOf(sdl: SDLInput | undefined): SdlServiceDefinition[] {
+  const services = sdl?.services;
+
+  if (!services || typeof services !== "object") {
+    return [];
+  }
+
+  return Object.values(services).filter((service): service is SdlServiceDefinition => !!service && typeof service === "object");
+}
+
+/**
+ * An `env` that is not a list is left alone rather than treated as an error. The SDL schema only allows
+ * the list form, so the manifest generator the caller runs first rejects a map before it can reach
+ * here; this is the one shape where the stripper no-ops instead of failing loudly, and it is worth
+ * knowing about if that validation ever loosens.
+ */
+function stripEnvValues(service: SdlServiceDefinition): void {
+  const env = service.env;
+
+  if (!Array.isArray(env)) {
+    return;
+  }
+
+  env.forEach((entry, index) => {
+    if (typeof entry === "string") {
+      env[index] = withoutValue(entry);
+    }
+  });
+}
+
+/** Keeps the variable name and drops its value. An entry that declares no value is left as it is. */
+function withoutValue(entry: string): string {
+  const valueStart = entry.indexOf("=");
+
+  return valueStart === -1 ? entry : entry.slice(0, valueStart + 1);
+}
+
+/**
+ * What serializing this document would cost, measured on the parsed tree instead of by serializing it.
+ * Serializing first and measuring after is what a document built out of YAML aliases exploits: an
+ * anchored scalar loads as an ordinary string and loses the identity that would let js-yaml re-emit it
+ * as an alias, so every alias of a 100 KB scalar is written out in full. A request comfortably inside
+ * the body limit can reach a gigabyte that way, and the size guard never gets to run because the
+ * process is already dead.
+ *
+ * Walking the tree costs nothing by comparison: it allocates no strings, and it follows each alias as
+ * the serializer would rather than collapsing them, which is what makes the total an honest upper bound.
+ *
+ * Following aliases rather than memoizing them is also what makes termination something this has to
+ * earn. Aliases form a DAG, not a tree, so a document can double its node count per level and be walked
+ * exponentially many times from a few hundred bytes of YAML. What bounds it is that *every* node adds
+ * at least one character before its children are visited — a scalar its own length, a map entry its
+ * key, and an array its element count, which is what the `- ` markers really cost. The running total
+ * therefore rises at least once per node, so the walk stops after `budget` nodes however the document
+ * is shaped. An array charging nothing was enough to break this: an array-only DAG kept the total near
+ * zero while the node count doubled, and a 1.3 KB document took seconds.
+ *
+ * The ancestor set terminates on the true cycle `&a [*a]` parses into, which is otherwise endless. It
+ * is a path set rather than a seen set on purpose: memoizing would collapse the aliases whose cost this
+ * is trying to measure.
+ */
+function estimateSerializedLength(document: unknown, budget: number): number {
+  const ancestors = new Set<object>();
+  let total = 0;
+
+  function visit(node: unknown): void {
+    if (total > budget) {
+      return;
+    }
+
+    if (node === null || typeof node !== "object") {
+      total += String(node).length + 1;
+      return;
+    }
+
+    if (ancestors.has(node)) {
+      return;
+    }
+
+    ancestors.add(node);
+
+    if (Array.isArray(node)) {
+      total += node.length + 1;
+      node.forEach(visit);
+    } else {
+      for (const [key, value] of Object.entries(node)) {
+        total += key.length + 1;
+        visit(value);
+      }
+    }
+
+    ancestors.delete(node);
+  }
+
+  visit(document);
+
+  return total;
+}

--- a/apps/api/test/functional/deployment-setting.spec.ts
+++ b/apps/api/test/functional/deployment-setting.spec.ts
@@ -58,6 +58,23 @@ describe("Deployment Settings", () => {
       });
     });
 
+    it("hands back none of what the console remembers the deployment by", async () => {
+      const { token, user } = await setup();
+      const dseq = faker.number.int({ min: 1, max: 1000000 }).toString();
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: "version: '2.0'", manifestVersion: "BAUG" });
+
+      const response = await app.request(`/v1/deployment-settings/${user.id}/${dseq}`, {
+        headers: {
+          authorization: `Bearer ${token}`
+        }
+      });
+
+      expect(response.status).toBe(200);
+      const { data } = (await response.json()) as { data: Record<string, unknown> };
+      expect(data).not.toHaveProperty("sdl");
+      expect(data).not.toHaveProperty("manifestVersion");
+    });
+
     it("enables auto top-up on a lazily created row without consulting the owner's wallet", async () => {
       const { token, user } = await setup({ hasManagedWallet: false });
       const dseq = faker.number.int({ min: 1, max: 1000000 }).toString();
@@ -151,6 +168,42 @@ describe("Deployment Settings", () => {
       });
 
       expect(response.status).toBe(401);
+    });
+
+    it("succeeds for a deployment whose creation already recorded its definition", async () => {
+      const { token, user } = await setup();
+      const dseq = faker.number.int({ min: 1, max: 1000000 }).toString();
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: "version: '2.0'", manifestVersion: "BAUG" });
+
+      const response = await app.request("/v1/deployment-settings", {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${token}`,
+          "content-type": "application/json"
+        },
+        body: JSON.stringify({ data: { userId: user.id, dseq, autoTopUpEnabled: true } })
+      });
+
+      expect(response.status).toBe(201);
+      const { data } = (await response.json()) as { data: { dseq: string; autoTopUpEnabled: boolean } };
+      expect(data).toMatchObject({ dseq, autoTopUpEnabled: true });
+    });
+
+    it("leaves the recorded definition alone when settings are created for the same deployment", async () => {
+      const { token, user } = await setup();
+      const dseq = faker.number.int({ min: 1, max: 1000000 }).toString();
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: "version: '2.0'", manifestVersion: "BAUG" });
+
+      await app.request("/v1/deployment-settings", {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${token}`,
+          "content-type": "application/json"
+        },
+        body: JSON.stringify({ data: { userId: user.id, dseq, autoTopUpEnabled: true } })
+      });
+
+      expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq })).toMatchObject({ sdl: "version: '2.0'", manifestVersion: "BAUG" });
     });
 
     it("returns 403 when creating deployment settings for another user", async () => {

--- a/apps/api/test/functional/deployments.spec.ts
+++ b/apps/api/test/functional/deployments.spec.ts
@@ -15,6 +15,7 @@ import { ManagedSignerService } from "@src/billing/services";
 import { CORE_CONFIG } from "@src/core";
 import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import { DeploymentReaderService } from "@src/deployment/services/deployment-reader/deployment-reader.service";
+import { SdlService } from "@src/deployment/services/sdl/sdl.service";
 import { ProviderService } from "@src/provider/services/provider/provider.service";
 import { app } from "@src/rest-app";
 import type { RestAkashDeploymentInfoResponse } from "@src/types/rest";
@@ -127,7 +128,11 @@ describe("Deployments API", () => {
     return { user, userApiKeySecret, wallets };
   }
 
-  /** Persists a real user row so the create path can write FK-bound rows like deployment settings. */
+  /**
+   * Persists a real user row, which every create needs: creating a deployment now records what that
+   * deployment is, and that record is FK-bound to the user. `mockUser` fakes the user for read paths
+   * that never write.
+   */
   async function mockPersistedUser() {
     const dbUser = await userRepository.create({ userId: faker.string.uuid() });
     const userApiKeySecret = faker.word.noun();
@@ -479,7 +484,7 @@ describe("Deployments API", () => {
 
   describe("POST /v1/deployments", () => {
     it("creates a deployment", async () => {
-      const { userApiKeySecret } = await mockUser();
+      const { userApiKeySecret } = await mockPersistedUser();
       const yml = fs.readFileSync(path.resolve(__dirname, "../mocks/hello-world-sdl.yml"), "utf8");
 
       const response = await app.request("/v1/deployments", {
@@ -562,7 +567,7 @@ describe("Deployments API", () => {
     });
 
     it("creates a deployment without a deposit", async () => {
-      const { userApiKeySecret } = await mockUser();
+      const { userApiKeySecret } = await mockPersistedUser();
       const yml = fs.readFileSync(path.resolve(__dirname, "../mocks/hello-world-sdl.yml"), "utf8");
 
       const response = await app.request("/v1/deployments", {
@@ -598,6 +603,50 @@ describe("Deployments API", () => {
 
       const setting = await container.resolve(DeploymentSettingRepository).findOneBy({ userId: user.id, dseq: result.data.dseq });
       expect(setting).toMatchObject({ autoTopUpEnabled: true, runtimeLimitHours: 6, runtimeEndsAt: null });
+    });
+
+    it("records the sdl it was given", async () => {
+      const { setting } = await createDeploymentWithSecrets();
+
+      expect(setting?.sdl).toContain("ghcr.io/akash-network/hello-akash-world");
+    });
+
+    it("records an sdl naming every env variable the submitted one declared", async () => {
+      const { setting } = await createDeploymentWithSecrets();
+
+      expect(setting?.sdl).toContain("API_TOKEN=");
+      expect(setting?.sdl).toContain("DATABASE_URL=");
+      expect(setting?.sdl).toContain("INHERITED_FROM_HOST");
+    });
+
+    it("records an sdl carrying none of the submitted env values", async () => {
+      const { setting } = await createDeploymentWithSecrets();
+
+      expect(setting?.sdl).not.toContain("PLACEHOLDER_API_TOKEN");
+      expect(setting?.sdl).not.toContain("PLACEHOLDER_DB_PASSWORD");
+      expect(setting?.sdl).not.toContain("db.example.test");
+    });
+
+    it("records an sdl carrying none of the submitted registry credentials", async () => {
+      const { setting } = await createDeploymentWithSecrets();
+
+      expect(setting?.sdl).not.toContain("PLACEHOLDER_REGISTRY_USERNAME");
+      expect(setting?.sdl).not.toContain("PLACEHOLDER_REGISTRY_PASSWORD");
+      expect(setting?.sdl).not.toContain("registry.example.test");
+      expect(setting?.sdl).not.toContain("credentials");
+    });
+
+    it("records an sdl that is still a deployable SDL", async () => {
+      const { setting } = await createDeploymentWithSecrets();
+
+      expect(container.resolve(SdlService).generateManifest(setting?.sdl ?? "").ok).toBe(true);
+    });
+
+    it("records the manifest version it commits on chain", async () => {
+      const { setting } = await createDeploymentWithSecrets();
+
+      expect(setting?.manifestVersion).toMatch(/^[A-Za-z0-9+/]+={0,2}$/);
+      expect(Buffer.from(setting?.manifestVersion ?? "", "base64")).toHaveLength(32);
     });
 
     it("returns 400 for a non-integer runtime limit", async () => {
@@ -653,6 +702,22 @@ describe("Deployments API", () => {
 
       expect(response.status).toBe(400);
     });
+
+    async function createDeploymentWithSecrets() {
+      const { userApiKeySecret, user } = await mockPersistedUser();
+      const yml = fs.readFileSync(path.resolve(__dirname, "../mocks/hello-world-sdl-with-secrets.yml"), "utf8");
+
+      const response = await app.request("/v1/deployments", {
+        method: "POST",
+        body: JSON.stringify({ data: { sdl: yml } }),
+        headers: new Headers({ "Content-Type": "application/json", "x-api-key": userApiKeySecret })
+      });
+
+      expect(response.status).toBe(201);
+      const result = (await response.json()) as { data: { dseq: string } };
+
+      return { setting: await container.resolve(DeploymentSettingRepository).findOneBy({ userId: user.id, dseq: result.data.dseq }) };
+    }
   });
 
   describe("DELETE /v1/deployments/{dseq}", () => {

--- a/apps/api/test/mocks/hello-world-sdl-with-secrets.yml
+++ b/apps/api/test/mocks/hello-world-sdl-with-secrets.yml
@@ -1,0 +1,40 @@
+---
+version: "2.0"
+services:
+  web:
+    image: ghcr.io/akash-network/hello-akash-world:2.1.0
+    credentials:
+      host: registry.example.test
+      username: PLACEHOLDER_REGISTRY_USERNAME
+      password: PLACEHOLDER_REGISTRY_PASSWORD
+      email: placeholder@example.test
+    env:
+      - API_TOKEN=PLACEHOLDER_API_TOKEN
+      - DATABASE_URL=postgres://placeholder:PLACEHOLDER_DB_PASSWORD@db.example.test:5432/app?ssl=true
+      - INHERITED_FROM_HOST
+    expose:
+      - port: 3000
+        as: 80
+        to:
+          - global: true
+profiles:
+  compute:
+    web:
+      resources:
+        cpu:
+          units: 0.5
+        memory:
+          size: 512Mi
+        storage:
+          - size: 512Mi
+  placement:
+    dcloud:
+      pricing:
+        web:
+          denom: uakt
+          amount: 1000
+deployment:
+  web:
+    dcloud:
+      profile: web
+      count: 1


### PR DESCRIPTION
## Why

Closes CON-855

When a user creates a deployment, the console keeps no record of what that deployment actually is. The
SDL is used to build the manifest, broadcast, and then forgotten. This is the first step of storing it,
so a later phase can attach sealed secrets to the same row.

## What

Creating a deployment now records, on the deployment's own `deployment_settings` row:

- **the SDL it was given**, with the value of every `env` entry blanked and every private registry
  `credentials` block removed — variable names survive, so the record still describes what the
  deployment expects to be given
- **the manifest version it commits on chain**, base64, matching the representation the rest of the
  codebase already compares against (`deployment-writer.service.ts` and deploy-web's storage service)

Both columns are nullable with no backfill, so deployments created before this change keep working.
`deployment_settings.user_id` already cascades from `users`, so the stored definition is deleted with
the account. Neither column is returned by any endpoint: `withEstimatedTopUpAmount` drops them the same
way it already drops `lastFundedAt`, since `@hono/zod-openapi` does not strip response bodies at runtime.

### Secrets are removed where they are declared, and nowhere else

An earlier revision of this work removed secrets *by value* across the whole document — collect every
env value and credential, then delete every string equal to one. That cannot tell a secret apart from
an ordinary value that happens to match it:

- `DENOM=uakt` deleted the placement's `denom: uakt`
- `IMAGE_NAME=nginx` deleted `image: nginx`
- a service named `db`, referenced by another service's `WORDPRESS_DB_HOST=db`, deleted **the whole
  service** — its `services` entry, its `profiles.compute` entry and its `deployment` entry

All three produced a stored document that was silently wrong, and the last two no longer revalidated as
an SDL. Stripping only at the declaration site is what keeps ordinary SDLs intact. The trade is that an
SDL which copies its own env value elsewhere — into `args`, say — keeps that copy; that is a leak its
author wrote on purpose, and the two cases are indistinguishable in the parsed document.

### Size is measured before the document is serialized

The `sdl` column is `text`, so the application-level bound is the only thing keeping a pathological SDL
out of the database. It is enforced by walking the parsed tree and summing what serialization would
cost, **not** by serializing and measuring the result.

This matters because YAML aliases amplify. An anchored scalar loads back as an ordinary string and
loses the identity that would let js-yaml re-emit it as an alias, so a 167 KB request aliasing one
100 KB scalar 4000 times serializes to ~390 MB — paid in full before any check on the result could run.
Aliases pointing at *aliases* are worse: they double the node count per level, and hide under
`profiles.placement.<name>.attributes`, the SDL's one free-form position, where a profile the deployment
does not reference is skipped by the manifest generator in ~1 ms.

The walk allocates nothing and follows each alias as the serializer would. Every node adds at least one
character before its children are visited — a scalar its own length, a map entry its key, an array its
element count — so the running total rises at least once per node and the walk stops after `budget`
nodes however the document is shaped.

An SDL too large to store is **ordinary input, not a failure**: the deployment goes ahead unrecorded and
is reported by its length alone, never by its content.

> **Superseded by #3664, which is stacked on this branch.** That PR changes this to a 400 with nothing
> created — no record, no broadcast. The behaviour described here is what this PR alone does; read the
> two in order and #3664 has the final say on the oversize case.

### Ordering

The record is written **before** the create tx is broadcast, in one `INSERT … ON CONFLICT` statement.
The reverse order would let a successful broadcast produce a deployment with no remembered definition,
which becomes unrecoverable once a later phase stores sealed secrets in the same write. A broadcast that
then fails leaves a record for a deployment that does not exist on chain — harmless: the draining sweep
finds no lease for it and skips it, and the next create is always on a fresh `dseq`.

There is deliberately **no** `@WithTransaction()` around this. The broadcast is a 60 s HTTP call to
tx-signer sitting in the middle of the flow; wrapping it would hold a Postgres connection open across it.
A single upsert is atomic on its own and is the shape a later phase can extend with sealed-secret columns.

The runtime limit moved into that same statement, from after the tx to before it.

### Migration

`0042_store_deployment_sdl` adds two nullable columns — no rewrite, no backfill. The journal entry and
the snapshot are both included; `drizzle-kit generate` reports no pending schema changes, and the
functional suite runs the migration on a real database per spec file.

### Notes for the reviewer — known and deliberate, not missed

- **Only managed-wallet deployments are recorded.** Deployments broadcast from the browser with a user's
  own wallet never reach `POST /v1/deployments` (`ManifestEdit.tsx`) and keep their SDL in local storage
  as they do today. Out of scope for "when a user creates a deployment".
- **`PUT /v1/deployments/{dseq}` leaves the record stale.** Updating a deployment does not re-record its
  SDL, so the stored copy describes the deployment as created. Out of scope here; worth a follow-up.
- **`POST /v1/deployment-settings` on an existing row is now a patch, not a 500.** Because every create
  writes the row, that endpoint takes the same reconciling path its sibling `upsert` already used. The
  status code is unchanged (201). The consequence is that it now silently overwrites `autoTopUpEnabled`
  rather than erroring on a duplicate.
- **`env` declared as a map is silently untouched.** The SDL schema only allows the list form and the
  manifest generator rejects a map first, so this is unreachable via the API — but it is the one shape
  where the stripper no-ops rather than failing loudly. Noted in the JSDoc.
- **Debug-level SQL logging carries bind parameters.** `PostgresLoggerService.logQuery` logs all params
  at `debug`, so running with `LOG_LEVEL=debug` would put the stored SDL in the logs. Pre-existing
  mechanism affecting every user string already in the database; not introduced or changed here.
  `LOG_LEVEL` defaults to `info`. Application code never passes the SDL to a logger, and postgres.js
  attaches query params non-enumerably, so they are not serialized into error logs.
- **A 167 KB request already costs ~850 MB on `main`.** `manifestToSortedJSON`, on unchanged chain-sdk
  code that runs at `deployment-writer.service.ts:56` — *before* the stripper at `:58` — materializes
  the amplified document regardless. Measured apples-to-apples: `main` 2608 ms / 847 MB, this branch
  2444 ms / 852 MB. A real pre-existing DoS surface, but not a regression, and bounding it would mean
  rejecting SDLs that deploy fine today.

### Tests

Unit specs for the stripper (declaration-site stripping, the three destroyed-SDL regressions, alias
behaviour, and the size bound), unit specs for the writer (ordering before broadcast, survival of a
failed broadcast, oversize handling for both amplification shapes, and that the SDL never reaches the
logger), repository integration specs for the upsert's conflict branch, and functional specs asserting
the stored SDL over HTTP — including that it still passes `generateManifest`, and that neither column is
exposed by the settings endpoints.

---

## Demo

Runs the production classes against a real Postgres — `DeploymentWriterService`, `SdlService`,
`DeploymentSettingRepository` and the stripper are the real ones. Reproducible with `showboat verify`.

Creating a deployment now records what that deployment is on its own settings row: the SDL it was
given, with the value of every env entry and every private registry credentials block removed, and the
manifest version it commits on chain.

Everything below runs the production classes against a real Postgres. `DeploymentWriterService`,
`SdlService`, `DeploymentSettingRepository` and the stripper are the real ones, wired by hand rather
than resolved from the DI container because a script runner emits no decorator metadata. Only the two
collaborators that reach off-box are stood in for — the wallet reader, and the signer that broadcasts,
so the demo can choose whether the broadcast succeeds.

The demo script is `.work/demo/store-sdl-demo.ts`. It loads the local dev config and then overwrites
every value whose name looks like a credential with an obvious placeholder, because this document is
headed for a public pull request.

## The migration actually runs

Migration 0043 adds the two columns. A drizzle migration is only applied if it is listed in
`drizzle/meta/_journal.json`, so the count of applied migrations matching the count of journal entries
is what proves 0042 was not silently skipped.

```bash
npx tsx --tsconfig ./tsconfig.json ../../.work/demo/store-sdl-demo.ts migrate 2>&1 | grep -v "npm warn"
```

```output
migrations in journal: 44
migrations applied   : 44
┌─────────┬────────────────────┬─────────────────────┬──────────────────────────┬─────────────┐
│ (index) │ column_name        │ data_type           │ character_maximum_length │ is_nullable │
├─────────┼────────────────────┼─────────────────────┼──────────────────────────┼─────────────┤
│ 0       │ 'manifest_version' │ 'character varying' │ 64                       │ 'YES'       │
│ 1       │ 'sdl'              │ 'text'              │ null                     │ 'YES'       │
└─────────┴────────────────────┴─────────────────────┴──────────────────────────┴─────────────┘
```

## An ordinary two-service SDL survives intact

This is the case that matters most. A WordPress SDL where one service's env value (`WORDPRESS_DB_HOST=db`)
is the *name* of the other service, and both services set a password.

```bash
npx tsx --tsconfig ./tsconfig.json ../../.work/demo/store-sdl-demo.ts ordinarySdl 2>&1 | grep -v "npm warn"
```

```output
--- recorded SDL ---
version: '2.0'
services:
  wordpress:
    image: wordpress:6
    env:
      - WORDPRESS_DB_HOST=
      - WORDPRESS_DB_PASSWORD=
    expose:
      - port: 80
        as: 80
        to:
          - global: true
  db:
    image: mysql:8
    env:
      - MYSQL_DATABASE=
      - MYSQL_ROOT_PASSWORD=
    expose:
      - port: 3306
        to:
          - service: wordpress
profiles:
  compute:
    wordpress:
      resources:
        cpu:
          units: 0.5
        memory:
          size: 512Mi
        storage:
          - size: 512Mi
    db:
      resources:
        cpu:
          units: 0.5
        memory:
          size: 512Mi
        storage:
          - size: 512Mi
  placement:
    dcloud:
      pricing:
        wordpress:
          denom: uakt
          amount: 1000
        db:
          denom: uakt
          amount: 1000
deployment:
  wordpress:
    dcloud:
      profile: wordpress
      count: 1
  db:
    dcloud:
      profile: db
      count: 1


both services survived              : true
db service still names its image   : true
WORDPRESS_DB_HOST value is gone    : true
passwords are gone                 : true
still generates a manifest         : true
```

Every env value is gone and both services are intact — the `db` service still exists, still names its
image, and the stored document still generates a manifest.

An earlier revision of this work removed secrets by value across the whole document. That version
deleted `services.db` outright, because `db` was on the secret list by virtue of being another
service's env value. Stripping only where a value is declared is what makes the above hold.

## The submitted SDL, side by side with what was stored

```bash
npx tsx --tsconfig ./tsconfig.json ../../.work/demo/store-sdl-demo.ts record 2>&1 | grep -v "npm warn"
```

```output
--- submitted SDL (what the user sent) ---
version: "2.0"
services:
  web:
    image: ghcr.io/akash-network/hello-akash-world:2.1.0
    credentials:
      host: registry.example.test
      username: registry-user
      password: registry-password
    env:
      - API_TOKEN=s3cr3t-token
      - DATABASE_URL=postgres://app:hunter2@db.example.test:5432/app
      - INHERITED_FROM_HOST
    expose:
      - port: 3000
        as: 80
        to:
          - global: true
profiles:
  compute:
    web:
      resources:
        cpu:
          units: 0.5
        memory:
          size: 512Mi
        storage:
          - size: 512Mi
  placement:
    dcloud:
      pricing:
        web:
          denom: uakt
          amount: 1000
deployment:
  web:
    dcloud:
      profile: web
      count: 1

--- recorded SDL (what the console stored) ---
version: '2.0'
services:
  web:
    image: ghcr.io/akash-network/hello-akash-world:2.1.0
    env:
      - API_TOKEN=
      - DATABASE_URL=
      - INHERITED_FROM_HOST
    expose:
      - port: 3000
        as: 80
        to:
          - global: true
profiles:
  compute:
    web:
      resources:
        cpu:
          units: 0.5
        memory:
          size: 512Mi
        storage:
          - size: 512Mi
  placement:
    dcloud:
      pricing:
        web:
          denom: uakt
          amount: 1000
deployment:
  web:
    dcloud:
      profile: web
      count: 1


--- recorded manifest version ---
rlGNam1Sd//uJ/7AK1c11kN1f1oGQlPrNJjskohPa9s=  (32 bytes decoded)
```

Every env variable is still named, the whole `credentials` block is gone, and `INHERITED_FROM_HOST` —
which names no value — is untouched. Checking each secret and each thing worth keeping, one at a time:

```bash
npx tsx --tsconfig ./tsconfig.json ../../.work/demo/store-sdl-demo.ts secrets 2>&1 | grep -v "npm warn"
```

```output
absent   s3cr3t-token
absent   hunter2
absent   registry-password
absent   registry-user
absent   registry.example.test
absent   db.example.test

kept    API_TOKEN=
kept    DATABASE_URL=
kept    INHERITED_FROM_HOST
kept    hello-akash-world
```

## Size is measured before the document is serialized

An anchored YAML scalar loads back as an ordinary string and loses the identity that would let js-yaml
re-emit it as an alias, so every alias is written out in full. A request comfortably inside the 512 KB
body limit can therefore serialize to hundreds of megabytes. Measuring the parsed tree instead costs
nothing and follows each alias as the serializer would.

```bash
npx tsx --tsconfig ./tsconfig.json ../../.work/demo/store-sdl-demo.ts stripperBound 2>&1 | grep -v "npm warn"
```

```output
request body                       : 166.9 KB (body limit is 512 KB)
it would serialize to              : 391 MB
stored sdl                         : null (too large to store)
measured at                        : 208872 chars, over the 131072 limit
took under a second                : true
allocated under 50 MB              : true
```

### The same bound, against aliases pointing at aliases

The scalar case above is not the worst shape. Aliases can point at *aliases*, doubling the node count
per level, and the whole thing hides under a placement profile the deployment never references — the
SDL's one free-form position, which the manifest generator skips in a millisecond.

An earlier revision of this estimator charged nothing for an array, so the running total stayed near
zero while the node count doubled and the early exit never fired: 1.3 KB of YAML took 2.2 seconds at
depth 24, and depth 40 would have taken roughly forty hours on the event loop. Charging each array for
its element count — real bytes, the `- ` markers — is what makes the documented bound true.

```bash
npx tsx --tsconfig ./tsconfig.json ../../.work/demo/store-sdl-demo.ts aliasDag 2>&1 | grep -v "npm warn"
```

```output
request body                       : 1.4 KB
array elements once expanded       : 1,073,741,824
stored sdl                         : null (too large to store)
measured at                        : 131156 chars, over the 131072 limit
took under a second                : true
```

Being too large to store is ordinary input, not a failure. The deployment still goes through, the
manifest version is still recorded, and only the SDL is left out:

```bash
npx tsx --tsconfig ./tsconfig.json ../../.work/demo/store-sdl-demo.ts aliasAmplification 2>&1 | grep -v "npm warn"
```

```output
request body                  : 11.1 KB
deployment created            : true
recorded sdl                  : null (too large to store)
recorded manifest version     : 6KsXCxv6X/bQgoQb8q489EQu0Q8mpl5T5BqDIN4jpSg=
```

## The record survives a broadcast that fails

The record is written before the create tx is broadcast. The reverse order would let a successful
broadcast produce a deployment with no remembered definition, which becomes unrecoverable once a later
phase stores sealed secrets in the same write.

Here the signer rejects the transaction, so no deployment exists on chain:

```bash
npx tsx --tsconfig ./tsconfig.json ../../.work/demo/store-sdl-demo.ts failedBroadcast 2>&1 | grep -v "npm warn"
```

```output
create failed with: broadcast rejected by the node
rows recorded for this user: 1
recorded sdl still names its variables: true
recorded sdl still carries no values : true
recorded manifest version            : rlGNam1Sd//uJ/7AK1c11kN1f1oGQlPrNJjskohPa9s=
```

The create surfaces the broadcast failure to the caller and the record is still there. Retrying is
unaffected: every create takes a fresh dseq, so the retry writes its own row rather than colliding with
this one. The stranded row is inert — the draining sweep finds no lease for a deployment that does not
exist and skips it.

## What is not covered

Deployments broadcast from the browser with a user's own wallet never reach `POST /v1/deployments` and
are not recorded. That path keeps its SDL in local storage, as it does today.

An SDL that copies its own env value somewhere else — into `args`, say — keeps that copy in the stored
document. Stripping only where a value is declared is what keeps ordinary SDLs intact, and the two
cannot be told apart from the parsed document.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployment definitions now record the submitted manifest version and sanitized SDL.
  * Stored SDL automatically removes environment values and registry credentials.
  * Oversized SDL is excluded from storage with a warning.
  * Deployment definition data remains hidden from deployment settings API responses.

* **Bug Fixes**
  * Improved deployment-setting updates to preserve existing definitions and runtime limits during concurrent creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
