### PR TITLE
test(deployment): stop asserting flag-gated summary tiles in the redesign e2e

### DIFF
--- a/apps/deploy-web/tests/ui/deployment-detail-preview.spec.ts
+++ b/apps/deploy-web/tests/ui/deployment-detail-preview.spec.ts
@@ -4,6 +4,14 @@ import { ConfigureDeploymentPage } from "./pages/ConfigureDeploymentPage";
 
 const REDESIGN_TABS = ["Details", "Logs", "Events", "Shell", "Update", "Settings"];
 
+/**
+ * Summary tiles that render whatever the escrow-abstraction flags say. BALANCE, AUTO TOP-UP and RUNTIME LIMIT share a
+ * slot that swaps with those flags and with the deployment's runtime limit, and e2e cannot pin flags on a deployed
+ * environment, so that slot is left to DeploymentDetailHeader.spec.tsx. vCPU is left out because the placement card
+ * repeats it, which would trip strict mode.
+ */
+const FLAG_INDEPENDENT_SUMMARY_TILES = ["COST", "GPU", "MEMORY", "STORAGE"];
+
 test.describe("Deployment detail redesign preview", () => {
   test.use({ userType: "existing" });
 
@@ -35,8 +43,11 @@ test.describe("Deployment detail redesign preview", () => {
     });
 
     await test.step("renders the summary header and full tab bar", async () => {
-      await expect(page.getByText("TOTAL SERVICES")).toBeVisible({ timeout: 30_000 });
-      await expect(page.getByText("AUTO TOP-UP")).toBeVisible();
+      await expect(page.getByText("TOTAL SERVICES", { exact: true })).toBeVisible({ timeout: 30_000 });
+
+      for (const tile of FLAG_INDEPENDENT_SUMMARY_TILES) {
+        await expect(page.getByText(tile, { exact: true })).toBeVisible();
+      }
 
       for (const tab of REDESIGN_TABS) {
         await expect(page.getByRole("tab", { name: tab })).toBeVisible();


### PR DESCRIPTION
## Why

The beta e2e suite has been red since #3651 landed. The deployment-detail preview spec asserts that the header shows an `AUTO TOP-UP` tile, but #3651 hides that tile (along with `BALANCE`) behind `useIsEscrowAbstracted()`, and both of the flags it reads are on in beta. The tile is simply not on the page any more, so the test fails before it gets to any of its other assertions.

Failing run: https://github.com/akash-network/console/actions/runs/32858216418/job/97835678508 (the Slack alert blamed #3658, but that is just the PR attached to the release commit).

The page snapshot from that run's artifact shows what beta actually renders:

```
TOTAL SERVICES 1  |  COST $2.46/month
GPU —  |  vCPU 1  |  MEMORY 2.15 GB  |  STORAGE 10.74 GB
```

That third slot in the top row now has three possible states: `RUNTIME LIMIT` when the deployment has one, `AUTO TOP-UP` when it doesn't and escrow isn't abstracted, and nothing at all when it is. E2E runs against a deployed environment and can't pin Unleash flags, so the slot isn't assertable from here at all. `DeploymentDetailHeader.spec.tsx` already covers all three branches.

## What

Swaps the `AUTO TOP-UP` assertion for the summary tiles that render no matter what the flags say: `COST`, `GPU`, `MEMORY`, `STORAGE`. That still proves the whole summary card painted, which is what the original assertion was reaching for, without coupling the test to a flag.

`vCPU` is left out on purpose because the placement card repeats it and a second match would trip Playwright strict mode. `TOTAL SERVICES` keeps its long timeout since it doubles as the "header has painted" gate.

Test-only change. The rest of the spec (tabs, `Placements`, the `?tab=EVENTS` param) was verified against the same snapshot and is still accurate; the test just never reached it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved deployment detail preview coverage to verify all summary tiles that should remain visible regardless of escrow settings.
  * Added exact validation for the “TOTAL SERVICES” tile and updated checks for consistent tile visibility.
  * Replaced the previous “AUTO TOP-UP” assertion with broader summary-tile validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->