### PR TITLE
fix(deployment): reject an SDL too large to store instead of deploying it unrecorded

### DIFF
--- a/apps/api/drizzle/0043_store_deployment_sdl.sql
+++ b/apps/api/drizzle/0043_store_deployment_sdl.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "deployment_settings" ADD COLUMN "sdl" text;--> statement-breakpoint
+ALTER TABLE "deployment_settings" ADD COLUMN "manifest_version" varchar(64);

--- a/apps/api/drizzle/meta/0043_snapshot.json
+++ b/apps/api/drizzle/meta/0043_snapshot.json
@@ -1,0 +1,1528 @@
+{
+  "id": "7d238aae-847e-4efe-b5aa-2959bb86e3b6",
+  "prevId": "1afa9fce-1a48-48fd-9ba0-90b37793c4e2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.user_wallets": {
+      "name": "user_wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_allowance": {
+          "name": "deployment_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "fee_allowance": {
+          "name": "fee_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "trial": {
+          "name": "trial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits_low_notified_at": {
+          "name": "credits_low_notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_wallets_user_id_userSetting_id_fk": {
+          "name": "user_wallets_user_id_userSetting_id_fk",
+          "tableFrom": "user_wallets",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_wallets_user_id_unique": {
+          "name": "user_wallets_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "user_wallets_address_unique": {
+          "name": "user_wallets_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_methods": {
+      "name": "payment_methods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_method_id": {
+          "name": "payment_method_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_validated": {
+          "name": "is_validated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payment_methods_fingerprint_payment_method_id_unique": {
+          "name": "payment_methods_fingerprint_payment_method_id_unique",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_default_unique": {
+          "name": "payment_methods_user_id_is_default_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"payment_methods\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_fingerprint_idx": {
+          "name": "payment_methods_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_idx": {
+          "name": "payment_methods_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_validated_idx": {
+          "name": "payment_methods_user_id_is_validated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_validated",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_fingerprint_payment_method_id_idx": {
+          "name": "payment_methods_user_id_fingerprint_payment_method_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_methods_user_id_userSetting_id_fk": {
+          "name": "payment_methods_user_id_userSetting_id_fk",
+          "tableFrom": "payment_methods",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_transactions": {
+      "name": "stripe_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "stripe_transaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "stripe_transaction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created'"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_refunded": {
+          "name": "amount_refunded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bonus_amount": {
+          "name": "bonus_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_charge_id": {
+          "name": "stripe_charge_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_coupon_id": {
+          "name": "stripe_coupon_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_promotion_code_id": {
+          "name": "stripe_promotion_code_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_idempotency_key": {
+          "name": "stripe_idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method_type": {
+          "name": "payment_method_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_brand": {
+          "name": "card_brand",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_last4": {
+          "name": "card_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_url": {
+          "name": "receipt_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_transactions_stripe_invoice_id_unique": {
+          "name": "stripe_transactions_stripe_invoice_id_unique",
+          "columns": [
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stripe_transactions\".\"stripe_invoice_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_idempotency_key_unique": {
+          "name": "stripe_transactions_stripe_idempotency_key_unique",
+          "columns": [
+            {
+              "expression": "stripe_idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stripe_transactions\".\"stripe_idempotency_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_user_id_idx": {
+          "name": "stripe_transactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_payment_intent_id_idx": {
+          "name": "stripe_transactions_stripe_payment_intent_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_payment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_charge_id_idx": {
+          "name": "stripe_transactions_stripe_charge_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_coupon_id_idx": {
+          "name": "stripe_transactions_stripe_coupon_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_coupon_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_promotion_code_id_idx": {
+          "name": "stripe_transactions_stripe_promotion_code_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_promotion_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_status_idx": {
+          "name": "stripe_transactions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_created_at_idx": {
+          "name": "stripe_transactions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_user_id_created_at_idx": {
+          "name": "stripe_transactions_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_transactions_user_id_userSetting_id_fk": {
+          "name": "stripe_transactions_user_id_userSetting_id_fk",
+          "tableFrom": "stripe_transactions",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_settings": {
+      "name": "wallet_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_reload_enabled": {
+          "name": "auto_reload_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_reload_mode": {
+          "name": "auto_reload_mode",
+          "type": "auto_reload_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'prediction'"
+        },
+        "auto_reload_threshold": {
+          "name": "auto_reload_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2000
+        },
+        "auto_reload_amount": {
+          "name": "auto_reload_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10000
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_settings_user_id_idx": {
+          "name": "wallet_settings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_settings_wallet_id_user_wallets_id_fk": {
+          "name": "wallet_settings_wallet_id_user_wallets_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "user_wallets",
+          "columnsFrom": [
+            "wallet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wallet_settings_user_id_userSetting_id_fk": {
+          "name": "wallet_settings_user_id_userSetting_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallet_settings_wallet_id_unique": {
+          "name": "wallet_settings_wallet_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wallet_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.userSetting": {
+      "name": "userSetting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscribedToNewsletter": {
+          "name": "subscribedToNewsletter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "youtubeUsername": {
+          "name": "youtubeUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitterUsername": {
+          "name": "twitterUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "githubUsername": {
+          "name": "githubUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_ip": {
+          "name": "last_ip",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_user_agent": {
+          "name": "last_user_agent",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fingerprint": {
+          "name": "last_fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboardingSkippedAt": {
+          "name": "onboardingSkippedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "userSetting_userId_unique": {
+          "name": "userSetting_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        },
+        "userSetting_username_unique": {
+          "name": "userSetting_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.template": {
+      "name": "template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "copiedFromId": {
+          "name": "copiedFromId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cpu": {
+          "name": "cpu",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ram": {
+          "name": "ram",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage": {
+          "name": "storage",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sdl": {
+          "name": "sdl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "template_userId_idx": {
+          "name": "template_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.templateFavorite": {
+      "name": "templateFavorite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "templateId": {
+          "name": "templateId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addedDate": {
+          "name": "addedDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "templateFavorite_userId_templateId_unique": {
+          "name": "templateFavorite_userId_templateId_unique",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "templateId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "templateFavorite_templateId_template_id_fk": {
+          "name": "templateFavorite_templateId_template_id_fk",
+          "tableFrom": "templateFavorite",
+          "tableTo": "template",
+          "columnsFrom": [
+            "templateId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_settings": {
+      "name": "deployment_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dseq": {
+          "name": "dseq",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_top_up_enabled": {
+          "name": "auto_top_up_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closed": {
+          "name": "closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_funded_at": {
+          "name": "last_funded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_limit_hours": {
+          "name": "runtime_limit_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sdl": {
+          "name": "sdl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manifest_version": {
+          "name": "manifest_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_ends_at": {
+          "name": "runtime_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_ending_notified_for": {
+          "name": "runtime_ending_notified_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "id_auto_top_up_enabled_closed_idx": {
+          "name": "id_auto_top_up_enabled_closed_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auto_top_up_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "closed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_settings_user_id_userSetting_id_fk": {
+          "name": "deployment_settings_user_id_userSetting_id_fk",
+          "tableFrom": "deployment_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dseq_user_id_idx": {
+          "name": "dseq_user_id_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "dseq",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_key": {
+          "name": "hashed_key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_format": {
+          "name": "key_format",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_user_id_userSetting_id_fk": {
+          "name": "api_keys_user_id_userSetting_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_hashed_key_unique": {
+          "name": "api_keys_hashed_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hashed_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_verification_codes": {
+      "name": "email_verification_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_verification_codes_user_id_idx": {
+          "name": "email_verification_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_verification_codes_user_id_userSetting_id_fk": {
+          "name": "email_verification_codes_user_id_userSetting_id_fk",
+          "tableFrom": "email_verification_codes",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.data_keys": {
+      "name": "data_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wrapped_key": {
+          "name": "wrapped_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wrapped_by_kid": {
+          "name": "wrapped_by_kid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "data_keys_wrapped_by_kid_idx": {
+          "name": "data_keys_wrapped_by_kid_idx",
+          "columns": [
+            {
+              "expression": "wrapped_by_kid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "data_keys_user_id_userSetting_id_fk": {
+          "name": "data_keys_user_id_userSetting_id_fk",
+          "tableFrom": "data_keys",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "data_keys_user_id_unique": {
+          "name": "data_keys_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.stripe_transaction_status": {
+      "name": "stripe_transaction_status",
+      "schema": "public",
+      "values": [
+        "created",
+        "pending",
+        "requires_action",
+        "succeeded",
+        "failed",
+        "refunded",
+        "canceled"
+      ]
+    },
+    "public.stripe_transaction_type": {
+      "name": "stripe_transaction_type",
+      "schema": "public",
+      "values": [
+        "payment_intent",
+        "coupon_claim",
+        "manual_credit"
+      ]
+    },
+    "public.auto_reload_mode": {
+      "name": "auto_reload_mode",
+      "schema": "public",
+      "values": [
+        "prediction",
+        "threshold"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -302,6 +302,13 @@
       "when": 1787641216046,
       "tag": "0042_warn_before_runtime_limit",
       "breakpoints": true
+    },
+    {
+      "idx": 43,
+      "version": "7",
+      "when": 1787670520752,
+      "tag": "0043_store_deployment_sdl",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/deployment/config/sdl.config.ts
+++ b/apps/api/src/deployment/config/sdl.config.ts
@@ -2,10 +2,15 @@
  * Upper bound on the SDL the console stores for a deployment. The column it is written to is `text`
  * and so bounds nothing itself, which makes this the only thing keeping a pathological SDL from
  * filling the database — and, because the document is measured against it before being serialized
- * rather than after, from filling memory on the way there. An SDL that does not fit is dropped, not
- * rejected: it still deploys, it is simply not remembered. Requests stay bounded separately, by the
- * 512 KB body limit `createRoute` puts on every route that can carry a body. Counted in characters
- * rather than bytes, since it is compared against a JavaScript string length. Sized roughly twenty
- * times above any SDL a real deployment needs.
+ * rather than after, from filling memory on the way there.
+ *
+ * An SDL that does not fit is rejected with a 400 and nothing is created, rather than deployed with no
+ * record of what it is. A deployment the console cannot describe is one nobody can later reproduce,
+ * redeploy, or attach sealed secrets to, so the two are never allowed to disagree.
+ *
+ * Requests stay bounded separately, by the 512 KB body limit `createRoute` puts on every route that can
+ * carry a body — this bounds the stripped document, which is a different thing and smaller. Counted in
+ * characters rather than bytes, since it is compared against a JavaScript string length. Sized roughly
+ * twenty times above any SDL a real deployment needs.
  */
 export const SDL_MAX_LENGTH = 128 * 1024;

--- a/apps/api/src/deployment/config/sdl.config.ts
+++ b/apps/api/src/deployment/config/sdl.config.ts
@@ -1,0 +1,11 @@
+/**
+ * Upper bound on the SDL the console stores for a deployment. The column it is written to is `text`
+ * and so bounds nothing itself, which makes this the only thing keeping a pathological SDL from
+ * filling the database — and, because the document is measured against it before being serialized
+ * rather than after, from filling memory on the way there. An SDL that does not fit is dropped, not
+ * rejected: it still deploys, it is simply not remembered. Requests stay bounded separately, by the
+ * 512 KB body limit `createRoute` puts on every route that can carry a body. Counted in characters
+ * rather than bytes, since it is compared against a JavaScript string length. Sized roughly twenty
+ * times above any SDL a real deployment needs.
+ */
+export const SDL_MAX_LENGTH = 128 * 1024;

--- a/apps/api/src/deployment/model-schemas/deployment-setting/deployment-setting.schema.ts
+++ b/apps/api/src/deployment/model-schemas/deployment-setting/deployment-setting.schema.ts
@@ -1,5 +1,5 @@
 import { sql } from "drizzle-orm";
-import { boolean, index, integer, pgTable, timestamp, unique, uuid, varchar } from "drizzle-orm/pg-core";
+import { boolean, index, integer, pgTable, text, timestamp, unique, uuid, varchar } from "drizzle-orm/pg-core";
 
 import { Users } from "@src/user/model-schemas";
 
@@ -18,6 +18,8 @@ export const DeploymentSettings = pgTable(
     closed: boolean("closed").notNull().default(false),
     lastFundedAt: timestamp("last_funded_at"),
     runtimeLimitHours: integer("runtime_limit_hours"),
+    sdl: text("sdl"),
+    manifestVersion: varchar("manifest_version", { length: 64 }),
     runtimeEndsAt: timestamp("runtime_ends_at", { withTimezone: true }),
     runtimeEndingNotifiedFor: timestamp("runtime_ending_notified_for", { withTimezone: true }),
     createdAt: timestamp("created_at").defaultNow(),

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
@@ -281,15 +281,6 @@ describe(DeploymentSettingRepository.name, () => {
       });
     });
 
-    it("records an sdl the caller chose not to store as nothing at all", async () => {
-      const { deploymentSettingRepository, user } = await setup();
-      const dseq = newDseq();
-
-      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: null, manifestVersion: "BAUG" });
-
-      expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq })).toMatchObject({ sdl: null, manifestVersion: "BAUG" });
-    });
-
     it("records the runtime limit its creator chose in the same write", async () => {
       const { deploymentSettingRepository, user } = await setup();
       const dseq = newDseq();

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest";
 import { AbilityService } from "@src/auth/services/ability/ability.service";
 import type { ApiPgDatabase } from "@src/core";
 import { POSTGRES_DB, resolveTable } from "@src/core";
+import { SDL_MAX_LENGTH } from "@src/deployment/config/sdl.config";
 import { MAX_RUNTIME_LIMIT_INCREMENT_HOURS } from "@src/deployment/http-schemas/runtime-limit";
 import type { UserOutput } from "@src/user/repositories";
 import { UserRepository } from "@src/user/repositories";
@@ -264,6 +265,85 @@ describe(DeploymentSettingRepository.name, () => {
       expect(claimed).toBe(false);
     });
   });
+
+  describe("upsertDefinition", () => {
+    it("records the sdl and the manifest version of a deployment with no row yet", async () => {
+      const { deploymentSettingRepository, user } = await setup();
+      const dseq = newDseq();
+
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: "version: '2.0'", manifestVersion: "BAUG" });
+
+      expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq })).toMatchObject({
+        sdl: "version: '2.0'",
+        manifestVersion: "BAUG",
+        autoTopUpEnabled: true,
+        runtimeLimitHours: null
+      });
+    });
+
+    it("records an sdl the caller chose not to store as nothing at all", async () => {
+      const { deploymentSettingRepository, user } = await setup();
+      const dseq = newDseq();
+
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: null, manifestVersion: "BAUG" });
+
+      expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq })).toMatchObject({ sdl: null, manifestVersion: "BAUG" });
+    });
+
+    it("records the runtime limit its creator chose in the same write", async () => {
+      const { deploymentSettingRepository, user } = await setup();
+      const dseq = newDseq();
+
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: "version: '2.0'", manifestVersion: "BAUG", runtimeLimitHours: 6 });
+
+      expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq })).toMatchObject({ sdl: "version: '2.0'", runtimeLimitHours: 6 });
+    });
+
+    it("overwrites the definition of a row a settings read created first", async () => {
+      const { deploymentSettingRepository, user } = await setup();
+      const dseq = newDseq();
+      await deploymentSettingRepository.create({ userId: user.id, dseq, autoTopUpEnabled: false });
+
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: "version: '2.0'", manifestVersion: "BAUG" });
+
+      expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq })).toMatchObject({ sdl: "version: '2.0'", autoTopUpEnabled: false });
+    });
+
+    it("leaves a runtime limit already on the row alone when none is given", async () => {
+      const { deploymentSettingRepository, user } = await setup();
+      const dseq = newDseq();
+      await deploymentSettingRepository.create({ userId: user.id, dseq, autoTopUpEnabled: true, runtimeLimitHours: 6 });
+
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: "version: '2.0'", manifestVersion: "BAUG" });
+
+      expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq })).toMatchObject({ runtimeLimitHours: 6 });
+    });
+
+    it("keeps the definitions of two deployments of the same user apart", async () => {
+      const { deploymentSettingRepository, user } = await setup();
+      const [first, second] = [newDseq(), newDseq()];
+
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq: first, sdl: "first", manifestVersion: "BAUG" });
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq: second, sdl: "second", manifestVersion: "BQYH" });
+
+      expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq: first })).toMatchObject({ sdl: "first", manifestVersion: "BAUG" });
+      expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq: second })).toMatchObject({ sdl: "second", manifestVersion: "BQYH" });
+    });
+
+    it("stores an sdl of the largest size the console will keep", async () => {
+      const { deploymentSettingRepository, user } = await setup();
+      const dseq = newDseq();
+      const sdl = "x".repeat(SDL_MAX_LENGTH);
+
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl, manifestVersion: "BAUG" });
+
+      expect((await deploymentSettingRepository.findOneBy({ userId: user.id, dseq }))?.sdl).toHaveLength(SDL_MAX_LENGTH);
+    });
+  });
+
+  function newDseq() {
+    return faker.number.int({ min: 100000, max: 999999 }).toString();
+  }
 
   async function setup() {
     const userRepository = container.resolve(UserRepository);

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -252,17 +252,35 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
   }
 
   /**
-   * Persists a runtime limit chosen at deployment creation. Upserts on the (dseq, userId) unique so a
-   * concurrent lazy row creation from a settings read cannot drop the limit; the conflict branch only
-   * writes the limit and leaves the row's other fields as the earlier writer set them.
+   * Records what a deployment is, at the moment it is created: the SDL it was given, stripped of its
+   * secrets, the manifest version it commits on chain, and the runtime limit its creator chose. One
+   * statement, so a deployment can never end up remembering half of itself, and so the sealed secrets
+   * a later phase adds land in the same write as the SDL they belong to.
+   *
+   * Upserts on the (dseq, userId) unique because a settings read creates a row lazily, and because the
+   * caller retries a create that failed to broadcast. The conflict branch leaves every field it does
+   * not name as the earlier writer set them, and an absent runtime limit counts as unnamed: drizzle
+   * drops undefined out of the set clause, so creating without a limit cannot clear one already there.
    */
-  async upsertRuntimeLimit({ userId, dseq, runtimeLimitHours }: { userId: string; dseq: string; runtimeLimitHours: number }): Promise<void> {
+  async upsertDefinition({
+    userId,
+    dseq,
+    sdl,
+    manifestVersion,
+    runtimeLimitHours
+  }: {
+    userId: string;
+    dseq: string;
+    sdl: string | null;
+    manifestVersion: string;
+    runtimeLimitHours?: number;
+  }): Promise<void> {
     await this.cursor
       .insert(this.table)
-      .values({ userId, dseq, autoTopUpEnabled: true, runtimeLimitHours })
+      .values({ userId, dseq, autoTopUpEnabled: AUTO_TOP_UP_ENABLED_BY_DEFAULT, sdl, manifestVersion, runtimeLimitHours })
       .onConflictDoUpdate({
         target: [this.table.dseq, this.table.userId],
-        set: { runtimeLimitHours, updatedAt: sql`now()` }
+        set: { sdl, manifestVersion, runtimeLimitHours, updatedAt: sql`now()` }
       });
   }
 

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -253,7 +253,7 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
 
   /**
    * Records what a deployment is, at the moment it is created: the SDL it was given, stripped of its
-   * secrets, the manifest version it commits on chain, and the runtime limit its creator chose. One
+   * secrets and small enough to keep, the manifest version it commits on chain, and the runtime limit its creator chose. One
    * statement, so a deployment can never end up remembering half of itself, and so the sealed secrets
    * a later phase adds land in the same write as the SDL they belong to.
    *
@@ -271,7 +271,7 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
   }: {
     userId: string;
     dseq: string;
-    sdl: string | null;
+    sdl: string;
     manifestVersion: string;
     runtimeLimitHours?: number;
   }): Promise<void> {

--- a/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.spec.ts
@@ -580,6 +580,8 @@ describe(DeploymentSettingService.name, () => {
       closed: false,
       lastFundedAt: null,
       runtimeLimitHours: null,
+      sdl: null,
+      manifestVersion: null,
       runtimeEndsAt: null,
       runtimeEndingNotifiedFor: null,
       createdAt: faker.date.past().toISOString(),

--- a/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.ts
+++ b/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.ts
@@ -26,7 +26,10 @@ import { TopUpManagedDeploymentsInstrumentationService } from "../top-up-managed
 /** The fields a PATCH may change. A null `runtimeLimitHours` removes the limit; an absent one leaves it alone. */
 type DeploymentSettingChange = Pick<DeploymentSettingsInput, "autoTopUpEnabled" | "runtimeLimitHours">;
 
-type DeploymentSettingWithEstimatedTopUpAmount = Omit<DeploymentSettingsOutput, "lastFundedAt" | "runtimeEndingNotifiedFor" | "runtimeEndsAt"> & {
+type DeploymentSettingWithEstimatedTopUpAmount = Omit<
+  DeploymentSettingsOutput,
+  "lastFundedAt" | "runtimeEndingNotifiedFor" | "sdl" | "manifestVersion" | "runtimeEndsAt"
+> & {
   estimatedTopUpAmount: number;
   topUpFrequencyMs: number;
   runtimeEndsAt: string | null;
@@ -76,10 +79,19 @@ export class DeploymentSettingService {
     return await this.withEstimatedTopUpAmount(await this.deploymentSettingRepository.accessibleBy(this.authService.ability, "create").create(params));
   }
 
-  async create(input: DeploymentSettingsInput): Promise<DeploymentSettingWithEstimatedTopUpAmount> {
+  /**
+   * Takes the same reconciling path as `upsert` rather than inserting blind, because by the time this
+   * runs the row usually exists: creating a deployment records what it is, on the very row this
+   * endpoint writes. A caller doing `POST /v1/deployments` and then `POST /v1/deployment-settings` for
+   * the same dseq would otherwise hit the (dseq, userId) unique and get a 500 for a request that used
+   * to succeed.
+   */
+  async create(input: FindDeploymentSettingParams & DeploymentSettingChange): Promise<DeploymentSettingWithEstimatedTopUpAmount> {
     this.#assertFundingStaysOn(input.autoTopUpEnabled);
 
-    const result = await this.withEstimatedTopUpAmount(await this.deploymentSettingRepository.accessibleBy(this.authService.ability, "create").create(input));
+    const { userId, dseq, ...change } = input;
+    const { setting } = await this.#writeReconcilingConcurrentCreate({ userId, dseq }, change);
+    const result = await this.withEstimatedTopUpAmount(setting);
 
     if (result.autoTopUpEnabled) {
       await this.walletReloadJobService.scheduleImmediate({ userId: result.userId });
@@ -314,7 +326,12 @@ export class DeploymentSettingService {
     }
   }
 
-  /** `lastFundedAt` and `runtimeEndingNotifiedFor` are internal sweep markers and stay out of the API payload. */
+  /**
+   * `lastFundedAt` and `runtimeEndingNotifiedFor` are internal sweep markers and stay out of the API
+   * payload. So do `sdl` and `manifestVersion`: they are what the console remembers a deployment by,
+   * not something it hands back, and the response schema is types only — whatever this returns is
+   * what ships.
+   */
   async withEstimatedTopUpAmount(params: DeploymentSettingsOutput): Promise<DeploymentSettingWithEstimatedTopUpAmount>;
   async withEstimatedTopUpAmount(params: undefined): Promise<undefined>;
   async withEstimatedTopUpAmount(params?: DeploymentSettingsOutput): Promise<DeploymentSettingWithEstimatedTopUpAmount | undefined> {
@@ -322,7 +339,7 @@ export class DeploymentSettingService {
       return undefined;
     }
 
-    const { lastFundedAt, runtimeEndingNotifiedFor, runtimeEndsAt, ...rest } = params;
+    const { lastFundedAt, runtimeEndingNotifiedFor, sdl, manifestVersion, runtimeEndsAt, ...rest } = params;
     const setting = { ...rest, runtimeEndsAt: runtimeEndsAt?.toISOString() ?? null };
 
     if (!setting.autoTopUpEnabled) {

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -1,5 +1,6 @@
 import { DeploymentReclamation, MsgAccountDeposit } from "@akashnetwork/chain-sdk/private-types/akash.v1";
 import { MsgCloseDeployment, MsgCreateDeployment, MsgUpdateDeployment } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
+import { faker } from "@faker-js/faker";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { mock, type MockProxy } from "vitest-mock-extended";
 
@@ -10,6 +11,7 @@ import type { RpcMessageService } from "@src/billing/services/rpc-message-servic
 import type { WalletReaderService } from "@src/billing/services/wallet-reader/wallet-reader.service";
 import type { LoggerService } from "@src/core";
 import type { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
+import { SDL_MAX_LENGTH } from "@src/deployment/config/sdl.config";
 import type { GetDeploymentResponse } from "@src/deployment/http-schemas/deployment.schema";
 import type { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import type { SdlService } from "@src/deployment/services/sdl/sdl.service";
@@ -20,6 +22,80 @@ import type { StaleManagedDeploymentsCleanerService } from "../stale-managed-dep
 import { DeploymentWriterService } from "./deployment-writer.service";
 
 import { mockConfigService } from "@test/mocks/config-service.mock";
+
+const ENV_VALUE = faker.string.alphanumeric(24);
+const REGISTRY_PASSWORD = faker.internet.password();
+
+/** A complete SDL around a service body, plus an optional placement profile nothing references. */
+function sdlAround(serviceBody: string, extraPlacement = ""): string {
+  return `version: "2.0"
+services:
+  web:
+    image: nginx
+${serviceBody}    expose:
+      - port: 3000
+        as: 80
+        to:
+          - global: true
+profiles:
+  compute:
+    web:
+      resources:
+        cpu:
+          units: 0.5
+        memory:
+          size: 512Mi
+        storage:
+          - size: 512Mi
+  placement:
+    dcloud:
+      pricing:
+        web:
+          denom: uakt
+          amount: 1000
+${extraPlacement}deployment:
+  web:
+    dcloud:
+      profile: web
+      count: 1`;
+}
+
+/** A valid SDL carrying an env value and a registry password, so a test can look for them afterwards. */
+const SDL_WITH_SECRETS = sdlAround(`    credentials:
+      host: registry.example.test
+      username: registry-user
+      password: ${REGISTRY_PASSWORD}
+    env:
+      - API_TOKEN=${ENV_VALUE}
+`);
+
+/**
+ * The shape that turns a small request into an enormous document: one anchored scalar aliased many
+ * times over. js-yaml loads every alias back as an independent string, so serializing writes the
+ * scalar out in full each time.
+ */
+const SDL_ALIASING_ONE_SCALAR = sdlAround(`    args:
+      - &payload ${"x".repeat(4096)}
+${Array.from({ length: 511 }, () => "      - *payload").join("\n")}
+`);
+
+/**
+ * The other shape, and the one that costs the most to measure: aliases pointing at aliases, doubling
+ * the node count per level. It hides under an unreferenced placement profile's `attributes`, the SDL's
+ * one free-form position, where the manifest generator never looks — 1.3 KB expanding to 2^24 elements.
+ */
+const SDL_ALIASING_A_DAG = sdlAround(
+  "",
+  `    unused:
+      attributes:
+        a0: &a0 []
+${Array.from({ length: 24 }, (_, level) => `        a${level + 1}: &a${level + 1} [*a${level}, *a${level}]`).join("\n")}
+      pricing:
+        web:
+          denom: uakt
+          amount: 1000
+`
+);
 
 describe(DeploymentWriterService.name, () => {
   const wallet: WalletInitialized = {
@@ -124,44 +200,134 @@ describe(DeploymentWriterService.name, () => {
       expect(rpcMessageService.getCreateDeploymentMsg.mock.calls[0][0].reclamation).toBeUndefined();
     });
 
-    it("persists the runtime limit after the create tx succeeds", async () => {
+    it("records the runtime limit alongside the definition", async () => {
       const { service, deploymentSettingRepository } = setup();
-      const dseq = 1748400000000;
-      vi.spyOn(Date, "now").mockReturnValue(dseq);
+      vi.spyOn(Date, "now").mockReturnValue(1748400000000);
 
-      await service.create({ userId: "user-1", sdl: "valid-sdl", deposit: 5, runtimeLimitHours: 6 });
+      await service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, deposit: 5, runtimeLimitHours: 6 });
 
-      expect(deploymentSettingRepository.upsertRuntimeLimit).toHaveBeenCalledWith({
+      expect(deploymentSettingRepository.upsertDefinition).toHaveBeenCalledWith(expect.objectContaining({ dseq: "1748400000000", runtimeLimitHours: 6 }));
+    });
+
+    it("records no runtime limit when none is requested", async () => {
+      const { service, deploymentSettingRepository } = setup();
+
+      await service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, deposit: 5 });
+
+      expect(deploymentSettingRepository.upsertDefinition).toHaveBeenCalledWith(expect.objectContaining({ runtimeLimitHours: undefined }));
+    });
+
+    it("records the sdl and the manifest version it commits on chain", async () => {
+      const { service, deploymentSettingRepository } = setup();
+      vi.spyOn(Date, "now").mockReturnValue(1748400000000);
+
+      await service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, deposit: 5 });
+
+      expect(deploymentSettingRepository.upsertDefinition).toHaveBeenCalledWith({
         userId: wallet.userId,
         dseq: "1748400000000",
-        runtimeLimitHours: 6
+        sdl: expect.stringContaining("API_TOKEN="),
+        manifestVersion: "BAUG",
+        runtimeLimitHours: undefined
       });
     });
 
-    it("persists no runtime limit when none is requested", async () => {
+    it("records an sdl carrying none of the submitted env values", async () => {
       const { service, deploymentSettingRepository } = setup();
 
-      await service.create({ userId: "user-1", sdl: "valid-sdl", deposit: 5 });
+      await service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, deposit: 5 });
 
-      expect(deploymentSettingRepository.upsertRuntimeLimit).not.toHaveBeenCalled();
+      expect(recordedSdlOf(deploymentSettingRepository)).not.toContain(ENV_VALUE);
     });
 
-    it("persists no runtime limit when the create tx fails", async () => {
+    it("records an sdl carrying none of the submitted registry credentials", async () => {
+      const { service, deploymentSettingRepository } = setup();
+
+      await service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, deposit: 5 });
+
+      expect(recordedSdlOf(deploymentSettingRepository)).not.toContain(REGISTRY_PASSWORD);
+    });
+
+    it("records the definition before broadcasting the create tx", async () => {
+      const { service, signerService, deploymentSettingRepository } = setup();
+
+      await service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, deposit: 5 });
+
+      expect(deploymentSettingRepository.upsertDefinition.mock.invocationCallOrder[0]).toBeLessThan(
+        signerService.executeDerivedDecodedTxByUserId.mock.invocationCallOrder[0]
+      );
+    });
+
+    it("keeps the recorded definition when the create tx fails to broadcast", async () => {
       const { service, signerService, deploymentSettingRepository } = setup();
       signerService.executeDerivedDecodedTxByUserId.mockRejectedValue(new Error("tx failed"));
 
-      await expect(service.create({ userId: "user-1", sdl: "valid-sdl", deposit: 5, runtimeLimitHours: 6 })).rejects.toThrow("tx failed");
+      await expect(service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, deposit: 5, runtimeLimitHours: 6 })).rejects.toThrow("tx failed");
 
-      expect(deploymentSettingRepository.upsertRuntimeLimit).not.toHaveBeenCalled();
+      expect(deploymentSettingRepository.upsertDefinition).toHaveBeenCalledTimes(1);
     });
 
-    it("surfaces a runtime limit persistence failure instead of silently dropping the limit", async () => {
+    it("broadcasts nothing when the definition cannot be recorded", async () => {
+      const { service, signerService, deploymentSettingRepository } = setup();
+      deploymentSettingRepository.upsertDefinition.mockRejectedValue(new Error("db down"));
+
+      await expect(service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, deposit: 5 })).rejects.toThrow("db down");
+
+      expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
+    });
+
+    it("reports a failure to record the definition without logging the sdl", async () => {
       const { service, deploymentSettingRepository, logger } = setup();
-      deploymentSettingRepository.upsertRuntimeLimit.mockRejectedValue(new Error("db down"));
+      deploymentSettingRepository.upsertDefinition.mockRejectedValue(new Error("db down"));
 
-      await expect(service.create({ userId: "user-1", sdl: "valid-sdl", deposit: 5, runtimeLimitHours: 6 })).rejects.toThrow("db down");
+      await expect(service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, deposit: 5, runtimeLimitHours: 6 })).rejects.toThrow("db down");
 
-      expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "RUNTIME_LIMIT_PERSISTENCE_FAILED", runtimeLimitHours: 6 }));
+      expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "DEPLOYMENT_DEFINITION_PERSISTENCE_FAILED", runtimeLimitHours: 6 }));
+      expect(loggedTextOf(logger)).not.toContain("API_TOKEN");
+    });
+
+    it("still creates the deployment when its sdl is too large to store", async () => {
+      const { service, signerService } = setup();
+
+      const result = await service.create({ userId: "user-1", sdl: SDL_ALIASING_ONE_SCALAR, deposit: 5 });
+
+      expect(result.dseq).toEqual(expect.any(String));
+      expect(signerService.executeDerivedDecodedTxByUserId).toHaveBeenCalledTimes(1);
+    });
+
+    it("records no sdl when an aliased scalar would serialize past the maximum stored length", async () => {
+      const { service, deploymentSettingRepository } = setup();
+
+      await service.create({ userId: "user-1", sdl: SDL_ALIASING_ONE_SCALAR, deposit: 5 });
+
+      expect(deploymentSettingRepository.upsertDefinition).toHaveBeenCalledWith(expect.objectContaining({ sdl: null, manifestVersion: "BAUG" }));
+    });
+
+    it("records no sdl for an sdl whose aliases form a doubling graph, without stalling on it", async () => {
+      const { service, deploymentSettingRepository, logger, signerService } = setup();
+
+      await service.create({ userId: "user-1", sdl: SDL_ALIASING_A_DAG, deposit: 5 });
+
+      expect(deploymentSettingRepository.upsertDefinition).toHaveBeenCalledWith(expect.objectContaining({ sdl: null, manifestVersion: "BAUG" }));
+      expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "DEPLOYMENT_SDL_TOO_LARGE_TO_STORE" }));
+      expect(signerService.executeDerivedDecodedTxByUserId).toHaveBeenCalledTimes(1);
+    }, 5000);
+
+    it("reports an sdl too large to store by its length alone", async () => {
+      const { service, logger } = setup();
+
+      await service.create({ userId: "user-1", sdl: SDL_ALIASING_ONE_SCALAR, deposit: 5 });
+
+      expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "DEPLOYMENT_SDL_TOO_LARGE_TO_STORE", maxLength: SDL_MAX_LENGTH }));
+      expect(loggedTextOf(logger)).not.toContain("API_TOKEN");
+    });
+
+    it("never hands the sdl to the logger on a successful create", async () => {
+      const { service, logger } = setup();
+
+      await service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, deposit: 5 });
+
+      expect(loggedTextOf(logger)).not.toContain("API_TOKEN");
     });
 
     it("reclaims trial orphans with age 0 before signing the create when the wallet is trialing", async () => {
@@ -383,6 +549,20 @@ describe(DeploymentWriterService.name, () => {
       expect(providerService.sendManifest).toHaveBeenCalledWith(expect.objectContaining({ provider: "provider-2" }));
     });
   });
+
+  function recordedSdlOf(deploymentSettingRepository: MockProxy<DeploymentSettingRepository>): string {
+    const { sdl } = deploymentSettingRepository.upsertDefinition.mock.calls[0][0];
+    expect(sdl).not.toBeNull();
+    return sdl as string;
+  }
+
+  /** Everything the logger was handed, flattened, so a test can assert the sdl reached none of it. */
+  function loggedTextOf(logger: MockProxy<LoggerService>): string {
+    return [logger.error, logger.warn, logger.info, logger.debug]
+      .flatMap(method => method.mock.calls)
+      .map(call => JSON.stringify(call))
+      .join("");
+  }
 
   function setup(input?: { isManagedDepositEnabled?: boolean; defaultDeposit?: number }) {
     const signerService = mock<ManagedSignerService>();

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -79,6 +79,11 @@ const SDL_ALIASING_ONE_SCALAR = sdlAround(`    args:
 ${Array.from({ length: 511 }, () => "      - *payload").join("\n")}
 `);
 
+/** An SDL with no anchors at all whose serialized length alone puts it past what the console stores. */
+const SDL_TOO_LONG_WITHOUT_ALIASES = sdlAround(`    args:
+${Array.from({ length: 40 }, () => `      - ${"z".repeat(4096)}`).join("\n")}
+`);
+
 /**
  * The other shape, and the one that costs the most to measure: aliases pointing at aliases, doubling
  * the node count per level. It hides under an unreferenced placement profile's `attributes`, the SDL's
@@ -286,40 +291,49 @@ describe(DeploymentWriterService.name, () => {
       expect(loggedTextOf(logger)).not.toContain("API_TOKEN");
     });
 
-    it("still creates the deployment when its sdl is too large to store", async () => {
-      const { service, signerService } = setup();
+    it("rejects an sdl the exact serialized length puts past the maximum", async () => {
+      const { service } = setup();
 
-      const result = await service.create({ userId: "user-1", sdl: SDL_ALIASING_ONE_SCALAR, deposit: 5 });
-
-      expect(result.dseq).toEqual(expect.any(String));
-      expect(signerService.executeDerivedDecodedTxByUserId).toHaveBeenCalledTimes(1);
+      await expect(service.create({ userId: "user-1", sdl: SDL_TOO_LONG_WITHOUT_ALIASES, deposit: 5 })).rejects.toMatchObject({ status: 400 });
     });
 
-    it("records no sdl when an aliased scalar would serialize past the maximum stored length", async () => {
-      const { service, deploymentSettingRepository } = setup();
+    it("rejects an sdl whose aliased scalar the estimate puts past the maximum", async () => {
+      const { service } = setup();
 
-      await service.create({ userId: "user-1", sdl: SDL_ALIASING_ONE_SCALAR, deposit: 5 });
-
-      expect(deploymentSettingRepository.upsertDefinition).toHaveBeenCalledWith(expect.objectContaining({ sdl: null, manifestVersion: "BAUG" }));
+      await expect(service.create({ userId: "user-1", sdl: SDL_ALIASING_ONE_SCALAR, deposit: 5 })).rejects.toMatchObject({ status: 400 });
     });
 
-    it("records no sdl for an sdl whose aliases form a doubling graph, without stalling on it", async () => {
-      const { service, deploymentSettingRepository, logger, signerService } = setup();
+    it("rejects an sdl whose aliases form a doubling graph, without stalling on it", async () => {
+      const { service } = setup();
 
-      await service.create({ userId: "user-1", sdl: SDL_ALIASING_A_DAG, deposit: 5 });
-
-      expect(deploymentSettingRepository.upsertDefinition).toHaveBeenCalledWith(expect.objectContaining({ sdl: null, manifestVersion: "BAUG" }));
-      expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "DEPLOYMENT_SDL_TOO_LARGE_TO_STORE" }));
-      expect(signerService.executeDerivedDecodedTxByUserId).toHaveBeenCalledTimes(1);
+      await expect(service.create({ userId: "user-1", sdl: SDL_ALIASING_A_DAG, deposit: 5 })).rejects.toMatchObject({ status: 400 });
     }, 5000);
 
-    it("reports an sdl too large to store by its length alone", async () => {
+    it("records nothing for an sdl it rejects", async () => {
+      const { service, deploymentSettingRepository } = setup();
+
+      await expect(service.create({ userId: "user-1", sdl: SDL_ALIASING_ONE_SCALAR, deposit: 5 })).rejects.toThrow();
+
+      expect(deploymentSettingRepository.upsertDefinition).not.toHaveBeenCalled();
+    });
+
+    it("broadcasts nothing for an sdl it rejects", async () => {
+      const { service, signerService } = setup();
+
+      await expect(service.create({ userId: "user-1", sdl: SDL_ALIASING_ONE_SCALAR, deposit: 5 })).rejects.toThrow();
+
+      expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
+    });
+
+    it("says nothing about the sdl beyond its length when rejecting it", async () => {
       const { service, logger } = setup();
 
-      await service.create({ userId: "user-1", sdl: SDL_ALIASING_ONE_SCALAR, deposit: 5 });
+      const rejection = (await service.create({ userId: "user-1", sdl: SDL_ALIASING_ONE_SCALAR, deposit: 5 }).catch((error: Error) => error)) as Error;
 
-      expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "DEPLOYMENT_SDL_TOO_LARGE_TO_STORE", maxLength: SDL_MAX_LENGTH }));
-      expect(loggedTextOf(logger)).not.toContain("API_TOKEN");
+      expect(rejection.message).not.toContain("payload");
+      expect(rejection.message).toContain(String(SDL_MAX_LENGTH));
+      expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "DEPLOYMENT_SDL_TOO_LARGE", maxLength: SDL_MAX_LENGTH }));
+      expect(loggedTextOf(logger)).not.toContain("payload");
     });
 
     it("never hands the sdl to the logger on a successful create", async () => {

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -10,6 +10,7 @@ import { WalletReaderService } from "@src/billing/services/wallet-reader/wallet-
 import { LoggerService } from "@src/core";
 import { FeatureFlags } from "@src/core/services/feature-flags/feature-flags";
 import { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
+import { SDL_MAX_LENGTH } from "@src/deployment/config/sdl.config";
 import {
   CreateDeploymentRequest,
   CreateDeploymentResponse,
@@ -18,6 +19,7 @@ import {
 } from "@src/deployment/http-schemas/deployment.schema";
 import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import { SdlService } from "@src/deployment/services/sdl/sdl.service";
+import { stripSdlSecrets } from "@src/deployment/utils/sdl-secret-stripping/sdl-secret-stripping";
 import { ProviderService } from "@src/provider/services/provider/provider.service";
 import { denomToUdenom } from "@src/utils/math";
 import { DeploymentConfigService } from "../deployment-config/deployment-config.service";
@@ -53,6 +55,14 @@ export class DeploymentWriterService {
     const dseq = Date.now();
     const manifestVersion = await this.sdlService.generateManifestVersion(manifest.groups);
 
+    await this.recordDefinition({
+      userId: wallet.userId,
+      dseq: dseq.toString(),
+      submittedSdl: input.sdl,
+      manifestVersion,
+      runtimeLimitHours: input.runtimeLimitHours
+    });
+
     const message = this.rpcMessageService.getCreateDeploymentMsg({
       owner: wallet.address,
       dseq,
@@ -65,10 +75,6 @@ export class DeploymentWriterService {
 
     const result = await this.signerService.executeDerivedDecodedTxByUserId(wallet.userId, [message]);
 
-    if (input.runtimeLimitHours) {
-      await this.persistRuntimeLimit({ userId: wallet.userId, dseq: dseq.toString(), runtimeLimitHours: input.runtimeLimitHours });
-    }
-
     return {
       dseq: dseq.toString(),
       manifest: manifestToSortedJSON(manifest.groups),
@@ -77,17 +83,60 @@ export class DeploymentWriterService {
   }
 
   /**
-   * Runs after the create tx so a failed create leaves no settings row for the funding sweep to visit
-   * forever. A persistence failure surfaces as an error rather than best-effort: until switching modes
-   * ships, a silently dropped limit would leave the deployment funded indefinitely with no way back.
+   * Records what the deployment is before the create tx is broadcast, never after. The reverse order
+   * would let a successful broadcast produce a deployment with no remembered definition, which becomes
+   * unrecoverable once a later phase stores sealed secrets in the same write. A broadcast that then
+   * fails leaves a record for a deployment that does not exist on chain, which costs one row the
+   * draining sweep skips on every pass, and which the next create — always on a fresh dseq — ignores.
+   *
+   * A failure here surfaces as an error rather than best-effort, and nothing is broadcast: the user
+   * retries and gets both the deployment and its record, instead of a deployment the console cannot
+   * describe. An SDL merely too large to store is not such a failure — see `storableSdl`.
+   *
+   * The stored SDL deliberately does not hash to the stored manifest version, and no future reader
+   * should expect it to. The version is taken over the manifest the generator produced, which rewrites
+   * the denom and appends the allowed auditors to its own parse; the stored SDL is the one the user
+   * submitted, stripped. They describe the same deployment, not the same bytes.
    */
-  private async persistRuntimeLimit(input: { userId: string; dseq: string; runtimeLimitHours: number }): Promise<void> {
+  private async recordDefinition(input: {
+    userId: string;
+    dseq: string;
+    submittedSdl: string;
+    manifestVersion: Uint8Array;
+    runtimeLimitHours?: number;
+  }): Promise<void> {
+    const { submittedSdl, manifestVersion, ...rest } = input;
+
     try {
-      await this.deploymentSettingRepository.upsertRuntimeLimit(input);
+      await this.deploymentSettingRepository.upsertDefinition({
+        ...rest,
+        sdl: this.storableSdl(submittedSdl, rest.dseq),
+        manifestVersion: Buffer.from(manifestVersion).toString("base64")
+      });
     } catch (error) {
-      this.logger.error({ event: "RUNTIME_LIMIT_PERSISTENCE_FAILED", ...input, error });
+      this.logger.error({ event: "DEPLOYMENT_DEFINITION_PERSISTENCE_FAILED", ...rest, error });
       throw error;
     }
+  }
+
+  /**
+   * The submitted SDL with its secrets taken out, or nothing at all when it is too large to store. The
+   * column is `text` and so bounds nothing itself, which makes this the only thing standing between a
+   * pathological SDL and the database.
+   *
+   * Being too large is ordinary input, not a failure: the deployment goes ahead without a stored
+   * definition rather than failing over something only the console wants. It is reported by its length
+   * alone — never the SDL or any part of it, the whole point of stripping being that user content does
+   * not end up somewhere it was not meant to be, and a log is exactly that.
+   */
+  private storableSdl(submittedSdl: string, dseq: string): string | null {
+    const { sdl, length } = stripSdlSecrets(submittedSdl, SDL_MAX_LENGTH);
+
+    if (sdl === null) {
+      this.logger.warn({ event: "DEPLOYMENT_SDL_TOO_LARGE_TO_STORE", dseq, length, maxLength: SDL_MAX_LENGTH });
+    }
+
+    return sdl;
   }
 
   /**

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -53,12 +53,13 @@ export class DeploymentWriterService {
     }
 
     const dseq = Date.now();
+    const sdl = this.strippedSdlWithinLimit(input.sdl, dseq.toString());
     const manifestVersion = await this.sdlService.generateManifestVersion(manifest.groups);
 
     await this.recordDefinition({
       userId: wallet.userId,
       dseq: dseq.toString(),
-      submittedSdl: input.sdl,
+      sdl,
       manifestVersion,
       runtimeLimitHours: input.runtimeLimitHours
     });
@@ -91,50 +92,49 @@ export class DeploymentWriterService {
    *
    * A failure here surfaces as an error rather than best-effort, and nothing is broadcast: the user
    * retries and gets both the deployment and its record, instead of a deployment the console cannot
-   * describe. An SDL merely too large to store is not such a failure — see `storableSdl`.
+   * describe.
    *
    * The stored SDL deliberately does not hash to the stored manifest version, and no future reader
    * should expect it to. The version is taken over the manifest the generator produced, which rewrites
    * the denom and appends the allowed auditors to its own parse; the stored SDL is the one the user
    * submitted, stripped. They describe the same deployment, not the same bytes.
    */
-  private async recordDefinition(input: {
-    userId: string;
-    dseq: string;
-    submittedSdl: string;
-    manifestVersion: Uint8Array;
-    runtimeLimitHours?: number;
-  }): Promise<void> {
-    const { submittedSdl, manifestVersion, ...rest } = input;
+  private async recordDefinition(input: { userId: string; dseq: string; sdl: string; manifestVersion: Uint8Array; runtimeLimitHours?: number }): Promise<void> {
+    const { manifestVersion, ...rest } = input;
 
     try {
       await this.deploymentSettingRepository.upsertDefinition({
         ...rest,
-        sdl: this.storableSdl(submittedSdl, rest.dseq),
         manifestVersion: Buffer.from(manifestVersion).toString("base64")
       });
     } catch (error) {
-      this.logger.error({ event: "DEPLOYMENT_DEFINITION_PERSISTENCE_FAILED", ...rest, error });
+      const { sdl, ...loggable } = rest;
+      this.logger.error({ event: "DEPLOYMENT_DEFINITION_PERSISTENCE_FAILED", ...loggable, error });
       throw error;
     }
   }
 
   /**
-   * The submitted SDL with its secrets taken out, or nothing at all when it is too large to store. The
-   * column is `text` and so bounds nothing itself, which makes this the only thing standing between a
-   * pathological SDL and the database.
+   * The submitted SDL with its secrets taken out, or a 400 when it is larger than the console will
+   * store. Rejecting rather than deploying-without-a-record is what keeps a deployment and the record
+   * of what it is from ever disagreeing: a deployment the console cannot describe is one nobody can
+   * later reproduce, redeploy, or attach sealed secrets to.
    *
-   * Being too large is ordinary input, not a failure: the deployment goes ahead without a stored
-   * definition rather than failing over something only the console wants. It is reported by its length
-   * alone — never the SDL or any part of it, the whole point of stripping being that user content does
-   * not end up somewhere it was not meant to be, and a log is exactly that.
+   * It runs before the definition is written and before anything is broadcast, so a rejected request
+   * leaves no row behind and nothing on chain.
+   *
+   * Neither the log nor the error says anything about the SDL beyond how long it is. The whole point of
+   * stripping is that user content does not end up somewhere it was not meant to be, and an error body
+   * travels further than a log does.
    */
-  private storableSdl(submittedSdl: string, dseq: string): string | null {
+  private strippedSdlWithinLimit(submittedSdl: string, dseq: string): string {
     const { sdl, length } = stripSdlSecrets(submittedSdl, SDL_MAX_LENGTH);
 
     if (sdl === null) {
-      this.logger.warn({ event: "DEPLOYMENT_SDL_TOO_LARGE_TO_STORE", dseq, length, maxLength: SDL_MAX_LENGTH });
+      this.logger.warn({ event: "DEPLOYMENT_SDL_TOO_LARGE", dseq, length, maxLength: SDL_MAX_LENGTH });
     }
+
+    assert(sdl !== null, 400, `SDL is too large: it exceeds the maximum of ${SDL_MAX_LENGTH} characters once stored`);
 
     return sdl;
   }

--- a/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.spec.ts
+++ b/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.spec.ts
@@ -372,6 +372,8 @@ describe(InitialDeploymentFundingService.name, () => {
       closed: false,
       lastFundedAt: null,
       runtimeLimitHours: null,
+      sdl: null,
+      manifestVersion: null,
       runtimeEndsAt: null,
       runtimeEndingNotifiedFor: null,
       createdAt: new Date("2026-08-20T00:00:00.000Z").toISOString(),

--- a/apps/api/src/deployment/utils/sdl-secret-stripping/sdl-secret-stripping.spec.ts
+++ b/apps/api/src/deployment/utils/sdl-secret-stripping/sdl-secret-stripping.spec.ts
@@ -1,0 +1,245 @@
+import type { SDLInput } from "@akashnetwork/chain-sdk";
+import { yaml } from "@akashnetwork/chain-sdk";
+import { faker } from "@faker-js/faker";
+import { dump } from "js-yaml";
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { BillingConfig } from "@src/billing/providers";
+import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
+import { BlockedGpuService } from "@src/deployment/services/blocked-gpu/blocked-gpu.service";
+import { SdlService } from "@src/deployment/services/sdl/sdl.service";
+import { stripSdlSecrets } from "./sdl-secret-stripping";
+
+import { mockConfigService } from "@test/mocks/config-service.mock";
+
+const IMAGE = "ghcr.io/akash-network/hello-akash-world:2.1.0";
+
+/** Generous enough that every test but the size ones is measuring stripping rather than the limit. */
+const MAX_LENGTH = 128 * 1024;
+
+describe(stripSdlSecrets.name, () => {
+  describe("environment values", () => {
+    it("keeps the variable name and drops its value", () => {
+      const token = faker.string.alphanumeric(24);
+
+      const stripped = strip(sdlWith({ web: { env: [`API_TOKEN=${token}`] } }));
+
+      expect(stripped.services.web.env).toEqual(["API_TOKEN="]);
+    });
+
+    it("drops a value that itself contains an equals sign", () => {
+      const password = faker.internet.password();
+
+      const stripped = strip(sdlWith({ web: { env: [`DATABASE_URL=postgres://u:${password}@h:5432/db?ssl=true&a=b`] } }));
+
+      expect(stripped.services.web.env).toEqual(["DATABASE_URL="]);
+    });
+
+    it("leaves an entry that names no value alone", () => {
+      const stripped = strip(sdlWith({ web: { env: ["INHERITED_FROM_HOST"] } }));
+
+      expect(stripped.services.web.env).toEqual(["INHERITED_FROM_HOST"]);
+    });
+
+    it("leaves an explicitly null env list alone", () => {
+      const stripped = strip(sdlWith({ web: { env: null } }));
+
+      expect(stripped.services.web.env).toBeNull();
+    });
+
+    it("leaves a service that declares no env alone", () => {
+      const stripped = strip(sdlWith({ web: {} }));
+
+      expect(stripped.services.web).not.toHaveProperty("env");
+    });
+
+    it("strips the env of every service, not only the first", () => {
+      const stripped = strip(sdlWith({ web: { env: [`A=${faker.string.alphanumeric(8)}`] }, worker: { env: [`B=${faker.string.alphanumeric(8)}`] } }));
+
+      expect(stripped.services.web.env).toEqual(["A="]);
+      expect(stripped.services.worker.env).toEqual(["B="]);
+    });
+  });
+
+  describe("private registry credentials", () => {
+    it("removes the whole block, not just the password", () => {
+      const stripped = strip(
+        sdlWith({
+          web: {
+            credentials: { host: "registry.example.test", username: faker.string.alphanumeric(10), password: faker.internet.password() }
+          }
+        })
+      );
+
+      expect(stripped.services.web).not.toHaveProperty("credentials");
+    });
+
+    it("removes the block of every service that declares one", () => {
+      const credentials = { host: "registry.example.test", username: faker.string.alphanumeric(10), password: faker.internet.password() };
+
+      const stripped = strip(sdlWith({ web: { credentials }, worker: { credentials } }));
+
+      expect(stripped.services.web).not.toHaveProperty("credentials");
+      expect(stripped.services.worker).not.toHaveProperty("credentials");
+    });
+  });
+
+  describe("a value that is also an ordinary part of the SDL", () => {
+    it("keeps a service whose name another service's env value happens to equal", () => {
+      const stripped = strip(sdlWith({ wordpress: { env: ["WORDPRESS_DB_HOST=db"] }, db: { env: ["MYSQL_DATABASE=wordpress"] } }));
+
+      expect(Object.keys(stripped.services)).toEqual(["wordpress", "db"]);
+      expect(stripped.services.db.image).toBe(IMAGE);
+      expect(Object.keys(stripped.deployment)).toEqual(["wordpress", "db"]);
+      expect(Object.keys(stripped.profiles.compute)).toEqual(["wordpress", "db"]);
+    });
+
+    it("keeps a placement denom an env value happens to equal", () => {
+      const stripped = strip(sdlWith({ web: { env: ["DENOM=uakt"] } }));
+
+      expect(stripped.profiles.placement.dcloud.pricing.web.denom).toBe("uakt");
+    });
+
+    it("keeps an image an env value happens to equal", () => {
+      const stripped = strip(sdlWith({ web: { image: "nginx", env: ["IMAGE_NAME=nginx"] } }));
+
+      expect(stripped.services.web.image).toBe("nginx");
+    });
+
+    it("keeps a map key an env value happens to equal", () => {
+      const stripped = strip(sdlWith({ web: { env: ["PROFILE=dcloud"] } }));
+
+      expect(stripped.profiles.placement).toHaveProperty("dcloud");
+    });
+  });
+
+  describe("a copy of a value the SDL made for itself", () => {
+    it("keeps the copy an aliased env list left in args, stripping only where the value is declared", () => {
+      const token = faker.string.alphanumeric(12);
+      const sharedEnv = [`API_TOKEN=${token}`];
+
+      const stripped = strip(dump(sdlDocument({ web: { env: sharedEnv, args: sharedEnv } })));
+
+      expect(stripped.services.web.env).toEqual(["API_TOKEN="]);
+      expect(stripped.services.web.args).toEqual(["API_TOKEN="]);
+    });
+
+    it("keeps a value typed out a second time in args, which the env declaration cannot reach", () => {
+      const token = faker.string.alphanumeric(12);
+
+      const stripped = strip(sdlWith({ web: { env: [`API_TOKEN=${token}`], args: [`--token=${token}`] } }));
+
+      expect(stripped.services.web.env).toEqual(["API_TOKEN="]);
+      expect(stripped.services.web.args).toEqual([`--token=${token}`]);
+    });
+  });
+
+  describe("the stripped output", () => {
+    it("stays an SDL the manifest generator still accepts", () => {
+      const submitted = sdlWith({ web: { env: [`API_TOKEN=${faker.string.alphanumeric(12)}`] } });
+
+      expect(manifestFrom(storedSdlOf(submitted)).ok).toBe(true);
+    });
+
+    it("stays an SDL the manifest generator accepts when an env value equals the service name", () => {
+      const submitted = sdlWith({ wordpress: { env: ["WORDPRESS_DB_HOST=db"] }, db: {} });
+
+      expect(manifestFrom(storedSdlOf(submitted)).ok).toBe(true);
+    });
+
+    it("stays an SDL the manifest generator accepts when an env value equals the denom", () => {
+      const submitted = sdlWith({ web: { env: ["DENOM=uakt"] } });
+
+      expect(manifestFrom(storedSdlOf(submitted)).ok).toBe(true);
+    });
+
+    it("still generates a manifest for an SDL that declares no env at all", () => {
+      expect(manifestFrom(storedSdlOf(sdlWith({ web: {} }))).ok).toBe(true);
+    });
+
+    it("strips an already stripped SDL to the same thing again", () => {
+      const once = storedSdlOf(sdlWith({ web: { env: [`API_TOKEN=${faker.string.alphanumeric(12)}`] } }));
+
+      expect(storedSdlOf(once)).toBe(once);
+    });
+  });
+
+  describe("an SDL too large to store", () => {
+    it("returns nothing rather than the document, reporting the size it measured", () => {
+      const result = stripSdlSecrets(sdlWith({ web: { args: ["x".repeat(2048)] } }), 512);
+
+      expect(result.sdl).toBeNull();
+      expect(result.length).toBeGreaterThan(512);
+    });
+
+    it("refuses a document whose aliases multiply a scalar past the limit without serializing it", () => {
+      const result = stripSdlSecrets(sdlAliasingOneScalar({ scalarLength: 4096, aliasCount: 512 }), 8192);
+
+      expect(result.sdl).toBeNull();
+      expect(result.length).toBeGreaterThan(8192);
+    });
+
+    it("measures an aliased scalar once per alias, as serializing it would write it", () => {
+      const oneAlias = stripSdlSecrets(sdlAliasingOneScalar({ scalarLength: 4096, aliasCount: 1 }), 8192).length;
+      const manyAliases = stripSdlSecrets(sdlAliasingOneScalar({ scalarLength: 4096, aliasCount: 512 }), 8192).length;
+
+      expect(manyAliases).toBeGreaterThan(oneAlias);
+    });
+
+    it("returns a document that fits", () => {
+      expect(stripSdlSecrets(sdlWith({ web: {} }), MAX_LENGTH).sdl).toContain("services:");
+    });
+  });
+
+  type ServiceOverrides = Record<string, unknown>;
+
+  function strip(rawSdl: string) {
+    return yaml.raw<SDLInput>(storedSdlOf(rawSdl));
+  }
+
+  function storedSdlOf(rawSdl: string): string {
+    const { sdl } = stripSdlSecrets(rawSdl, MAX_LENGTH);
+    expect(sdl).not.toBeNull();
+    return sdl as string;
+  }
+
+  /** JSON is a subset of YAML, so building the fixture as an object keeps indentation out of the tests. */
+  function sdlWith(services: Record<string, ServiceOverrides>): string {
+    return JSON.stringify(sdlDocument(services));
+  }
+
+  function sdlDocument(services: Record<string, ServiceOverrides>) {
+    const names = Object.keys(services);
+
+    return {
+      version: "2.0",
+      services: Object.fromEntries(
+        Object.entries(services).map(([name, overrides]) => [name, { image: IMAGE, expose: [{ port: 3000, as: 80, to: [{ global: true }] }], ...overrides }])
+      ),
+      profiles: {
+        compute: Object.fromEntries(names.map(name => [name, { resources: { cpu: { units: 0.5 }, memory: { size: "512Mi" }, storage: [{ size: "512Mi" }] } }])),
+        placement: { dcloud: { pricing: Object.fromEntries(names.map(name => [name, { denom: "uakt", amount: 1000 }])) } }
+      },
+      deployment: Object.fromEntries(names.map(name => [name, { dcloud: { profile: name, count: 1 } }]))
+    };
+  }
+
+  /**
+   * An SDL whose `args` point one anchored scalar at itself many times over. js-yaml emits it as an
+   * anchor and N aliases, but loads it back as N independent strings, so serializing writes the scalar
+   * out in full every time — the shape that turns a small request into a huge document.
+   */
+  function sdlAliasingOneScalar({ scalarLength, aliasCount }: { scalarLength: number; aliasCount: number }): string {
+    const args = ["    args:", `      - &payload ${"x".repeat(scalarLength)}`, ...Array.from({ length: aliasCount - 1 }, () => "      - *payload")];
+
+    return dump(sdlDocument({ web: {} })).replace(`    image: ${IMAGE}`, [`    image: ${IMAGE}`, ...args].join("\n"));
+  }
+
+  function manifestFrom(rawSdl: string) {
+    const config = mock<BillingConfig>({ DEPLOYMENT_GRANT_DENOM: "uakt", MANAGED_WALLET_LEASE_ALLOWED_AUDITORS: [] });
+    const blockedGpuService = new BlockedGpuService(mockConfigService<BillingConfigService>({ MANAGED_WALLET_TRIAL_BLOCKED_GPU_MODELS: [] }));
+
+    return new SdlService(config, blockedGpuService).generateManifest(rawSdl);
+  }
+});

--- a/apps/api/src/deployment/utils/sdl-secret-stripping/sdl-secret-stripping.spec.ts
+++ b/apps/api/src/deployment/utils/sdl-secret-stripping/sdl-secret-stripping.spec.ts
@@ -173,11 +173,16 @@ describe(stripSdlSecrets.name, () => {
       expect(result.length).toBeGreaterThan(512);
     });
 
-    it("refuses a document whose aliases multiply a scalar past the limit without serializing it", () => {
-      const result = stripSdlSecrets(sdlAliasingOneScalar({ scalarLength: 4096, aliasCount: 512 }), 8192);
+    it("refuses a document whose aliases multiply a scalar past the limit, stopping at the budget rather than serializing it", () => {
+      const scalarLength = 4096;
+      const aliasCount = 512;
+      const lengthIfItHadBeenSerialized = scalarLength * aliasCount;
+
+      const result = stripSdlSecrets(sdlAliasingOneScalar({ scalarLength, aliasCount }), 8192);
 
       expect(result.sdl).toBeNull();
       expect(result.length).toBeGreaterThan(8192);
+      expect(result.length).toBeLessThan(lengthIfItHadBeenSerialized);
     });
 
     it("measures an aliased scalar once per alias, as serializing it would write it", () => {
@@ -185,6 +190,29 @@ describe(stripSdlSecrets.name, () => {
       const manyAliases = stripSdlSecrets(sdlAliasingOneScalar({ scalarLength: 4096, aliasCount: 512 }), 8192).length;
 
       expect(manyAliases).toBeGreaterThan(oneAlias);
+    });
+
+    it("stores a document with no anchors that fits, without consulting the estimate", () => {
+      const stripped = stripSdlSecrets(sdlWith({ web: { env: [`API_TOKEN=${faker.string.alphanumeric(12)}`] } }), MAX_LENGTH);
+
+      expect(stripped.sdl).toContain("API_TOKEN=");
+      expect(stripped.length).toBe(stripped.sdl?.length);
+    });
+
+    it("stores nothing for a document with no anchors that serializes past the limit", () => {
+      const result = stripSdlSecrets(sdlWith({ web: { args: ["x".repeat(4096)] } }), 512);
+
+      expect(result.sdl).toBeNull();
+      expect(result.length).toBeGreaterThan(512);
+    });
+
+    it("stores a document whose scalars merely contain an ampersand and an asterisk", () => {
+      const submitted = sdlWith({ web: { args: ["sh", "-c", "start && tail -f *.log"], env: [`TOKEN=${faker.string.alphanumeric(8)}&x*y`] } });
+
+      const stripped = strip(submitted);
+
+      expect(stripped.services.web.args).toEqual(["sh", "-c", "start && tail -f *.log"]);
+      expect(stripped.services.web.env).toEqual(["TOKEN="]);
     });
 
     it("returns a document that fits", () => {

--- a/apps/api/src/deployment/utils/sdl-secret-stripping/sdl-secret-stripping.ts
+++ b/apps/api/src/deployment/utils/sdl-secret-stripping/sdl-secret-stripping.ts
@@ -38,10 +38,12 @@ export function stripSdlSecrets(rawSdl: string, maxLength: number): StrippedSdl 
     delete service.credentials;
   }
 
-  const estimatedLength = estimateSerializedLength(sdl, maxLength);
+  if (mayShareNodes(rawSdl)) {
+    const estimatedLength = estimateSerializedLength(sdl, maxLength);
 
-  if (estimatedLength > maxLength) {
-    return { sdl: null, length: estimatedLength };
+    if (estimatedLength > maxLength) {
+      return { sdl: null, length: estimatedLength };
+    }
   }
 
   const stripped = dump(sdl, { lineWidth: -1 });
@@ -87,6 +89,38 @@ function withoutValue(entry: string): string {
 }
 
 /**
+ * Whether this document could possibly contain a node reachable more than once. Sharing is what the
+ * estimator exists to price, and a document without it cannot serialize to more than a constant factor
+ * over the text it arrived as — which the body limit already caps at 512 KB. Sharing is necessary for
+ * amplification rather than sufficient, which is all a guard that only ever adds work needs to be right
+ * about.
+ *
+ * Sharing comes from one place: a YAML alias. An alias needs an anchor to point at, so a document that
+ * shares anything has to spell both `&` and `*` somewhere in its bytes — and a document missing either
+ * character is a pure tree, whose serialized form is bounded by an input the body limit already caps at
+ * 512 KB. That is the whole argument, and it holds without knowing anything about YAML's grammar: no
+ * assumption about quoting, flow style, block scalars, indentation or comments, because it never asks
+ * *where* the characters are.
+ *
+ * Requiring both is what keeps it honest rather than merely cheap. Testing only `*` would send an
+ * ordinary `command: ["sh", "-c", "a && b"]` down the estimator path for nothing; testing only `&`
+ * would do the same for a `--include=*.log`. Requiring both narrows it to documents that could
+ * genuinely alias, while still deciding on presence alone.
+ *
+ * This deliberately reads the raw text and not the parsed tree. An anchored *scalar* loads into an
+ * ordinary string primitive and loses the identity a reference-walk would look for, so a tree walk
+ * would report no sharing for exactly the document that amplifies worst. It also reads the submitted
+ * text rather than the stripped document, both because the stripped one does not exist yet and because
+ * stripping removes values, never sharing.
+ *
+ * False positives cost nothing — they take the path every document took before this existed. A false
+ * negative would hand an amplifying document straight to `dump`, which is the failure this guards.
+ */
+function mayShareNodes(rawSdl: string): boolean {
+  return rawSdl.includes("&") && rawSdl.includes("*");
+}
+
+/**
  * What serializing this document would cost, measured on the parsed tree instead of by serializing it.
  * Serializing first and measuring after is what a document built out of YAML aliases exploits: an
  * anchored scalar loads as an ordinary string and loses the identity that would let js-yaml re-emit it
@@ -94,8 +128,16 @@ function withoutValue(entry: string): string {
  * the body limit can reach a gigabyte that way, and the size guard never gets to run because the
  * process is already dead.
  *
- * Walking the tree costs nothing by comparison: it allocates no strings, and it follows each alias as
- * the serializer would rather than collapsing them, which is what makes the total an honest upper bound.
+ * Walking the tree costs nothing by comparison: it allocates no strings, and it follows every alias
+ * rather than collapsing them, which is what keeps the total an upper bound.
+ *
+ * An upper bound, and a loose one, because js-yaml only re-expands *some* aliases. An anchored scalar
+ * loads into a string primitive whose identity is gone, so the serializer has no way to know it was
+ * aliased and writes it out again every time; an anchored mapping or sequence keeps its identity and is
+ * re-emitted as one anchor and N aliases. This walk cannot tell the two apart from the parsed tree, so
+ * it charges every alias as though it were a scalar. That errs toward refusing to store, never toward
+ * an unbounded serialize — but it does mean a document sharing large *objects* can be measured far
+ * above what it would actually serialize to, and refused when it would have fitted.
  *
  * Following aliases rather than memoizing them is also what makes termination something this has to
  * earn. Aliases form a DAG, not a tree, so a document can double its node count per level and be walked

--- a/apps/api/src/deployment/utils/sdl-secret-stripping/sdl-secret-stripping.ts
+++ b/apps/api/src/deployment/utils/sdl-secret-stripping/sdl-secret-stripping.ts
@@ -1,0 +1,149 @@
+import type { SDLInput } from "@akashnetwork/chain-sdk";
+import { yaml } from "@akashnetwork/chain-sdk";
+import { dump } from "js-yaml";
+
+type SdlServiceDefinition = SDLInput["services"][string];
+
+/**
+ * The stripped SDL, or nothing when storing it would cost more than the caller allows. `length` is
+ * what the stripped document was measured at — an estimate once it exceeds the limit, since measuring
+ * stops there rather than running a pathological document to completion.
+ */
+export type StrippedSdl = { sdl: string | null; length: number };
+
+/**
+ * The submitted SDL with the value of every `env` entry and every private registry `credentials` block
+ * removed. Variable names survive, so the stored definition still describes what the deployment expects
+ * to be given.
+ *
+ * Both are removed where they are declared and nowhere else. An SDL that copies a secret somewhere else
+ * itself — through a YAML anchor aliased into `args`, say — keeps that copy. Chasing those was tried and
+ * withdrawn: it means collecting the secrets and deleting every string in the document equal to one,
+ * which cannot tell a secret apart from an ordinary value that happens to match it. `DENOM=uakt` took
+ * out `denom: uakt`, and a service named `db` referenced by another service's `WORDPRESS_DB_HOST=db`
+ * took out the whole service. An SDL smuggling its own secret into `args` is a leak its author wrote on
+ * purpose; quietly destroying an ordinary two-service SDL is a bug the author cannot even see.
+ *
+ * Only a validated SDL may be passed here: the caller runs it through the manifest generator first,
+ * which rejects unknown root properties and so bounds where a service, and with it an env list, can hide.
+ *
+ * The result is re-serialized YAML and so never byte-identical to what arrived. It must never stand in
+ * for the raw SDL anywhere a hash is taken over it.
+ */
+export function stripSdlSecrets(rawSdl: string, maxLength: number): StrippedSdl {
+  const sdl = yaml.raw<SDLInput>(rawSdl);
+
+  for (const service of serviceDefinitionsOf(sdl)) {
+    stripEnvValues(service);
+    delete service.credentials;
+  }
+
+  const estimatedLength = estimateSerializedLength(sdl, maxLength);
+
+  if (estimatedLength > maxLength) {
+    return { sdl: null, length: estimatedLength };
+  }
+
+  const stripped = dump(sdl, { lineWidth: -1 });
+
+  return stripped.length > maxLength ? { sdl: null, length: stripped.length } : { sdl: stripped, length: stripped.length };
+}
+
+function serviceDefinitionsOf(sdl: SDLInput | undefined): SdlServiceDefinition[] {
+  const services = sdl?.services;
+
+  if (!services || typeof services !== "object") {
+    return [];
+  }
+
+  return Object.values(services).filter((service): service is SdlServiceDefinition => !!service && typeof service === "object");
+}
+
+/**
+ * An `env` that is not a list is left alone rather than treated as an error. The SDL schema only allows
+ * the list form, so the manifest generator the caller runs first rejects a map before it can reach
+ * here; this is the one shape where the stripper no-ops instead of failing loudly, and it is worth
+ * knowing about if that validation ever loosens.
+ */
+function stripEnvValues(service: SdlServiceDefinition): void {
+  const env = service.env;
+
+  if (!Array.isArray(env)) {
+    return;
+  }
+
+  env.forEach((entry, index) => {
+    if (typeof entry === "string") {
+      env[index] = withoutValue(entry);
+    }
+  });
+}
+
+/** Keeps the variable name and drops its value. An entry that declares no value is left as it is. */
+function withoutValue(entry: string): string {
+  const valueStart = entry.indexOf("=");
+
+  return valueStart === -1 ? entry : entry.slice(0, valueStart + 1);
+}
+
+/**
+ * What serializing this document would cost, measured on the parsed tree instead of by serializing it.
+ * Serializing first and measuring after is what a document built out of YAML aliases exploits: an
+ * anchored scalar loads as an ordinary string and loses the identity that would let js-yaml re-emit it
+ * as an alias, so every alias of a 100 KB scalar is written out in full. A request comfortably inside
+ * the body limit can reach a gigabyte that way, and the size guard never gets to run because the
+ * process is already dead.
+ *
+ * Walking the tree costs nothing by comparison: it allocates no strings, and it follows each alias as
+ * the serializer would rather than collapsing them, which is what makes the total an honest upper bound.
+ *
+ * Following aliases rather than memoizing them is also what makes termination something this has to
+ * earn. Aliases form a DAG, not a tree, so a document can double its node count per level and be walked
+ * exponentially many times from a few hundred bytes of YAML. What bounds it is that *every* node adds
+ * at least one character before its children are visited — a scalar its own length, a map entry its
+ * key, and an array its element count, which is what the `- ` markers really cost. The running total
+ * therefore rises at least once per node, so the walk stops after `budget` nodes however the document
+ * is shaped. An array charging nothing was enough to break this: an array-only DAG kept the total near
+ * zero while the node count doubled, and a 1.3 KB document took seconds.
+ *
+ * The ancestor set terminates on the true cycle `&a [*a]` parses into, which is otherwise endless. It
+ * is a path set rather than a seen set on purpose: memoizing would collapse the aliases whose cost this
+ * is trying to measure.
+ */
+function estimateSerializedLength(document: unknown, budget: number): number {
+  const ancestors = new Set<object>();
+  let total = 0;
+
+  function visit(node: unknown): void {
+    if (total > budget) {
+      return;
+    }
+
+    if (node === null || typeof node !== "object") {
+      total += String(node).length + 1;
+      return;
+    }
+
+    if (ancestors.has(node)) {
+      return;
+    }
+
+    ancestors.add(node);
+
+    if (Array.isArray(node)) {
+      total += node.length + 1;
+      node.forEach(visit);
+    } else {
+      for (const [key, value] of Object.entries(node)) {
+        total += key.length + 1;
+        visit(value);
+      }
+    }
+
+    ancestors.delete(node);
+  }
+
+  visit(document);
+
+  return total;
+}

--- a/apps/api/test/functional/deployment-setting.spec.ts
+++ b/apps/api/test/functional/deployment-setting.spec.ts
@@ -58,6 +58,23 @@ describe("Deployment Settings", () => {
       });
     });
 
+    it("hands back none of what the console remembers the deployment by", async () => {
+      const { token, user } = await setup();
+      const dseq = faker.number.int({ min: 1, max: 1000000 }).toString();
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: "version: '2.0'", manifestVersion: "BAUG" });
+
+      const response = await app.request(`/v1/deployment-settings/${user.id}/${dseq}`, {
+        headers: {
+          authorization: `Bearer ${token}`
+        }
+      });
+
+      expect(response.status).toBe(200);
+      const { data } = (await response.json()) as { data: Record<string, unknown> };
+      expect(data).not.toHaveProperty("sdl");
+      expect(data).not.toHaveProperty("manifestVersion");
+    });
+
     it("enables auto top-up on a lazily created row without consulting the owner's wallet", async () => {
       const { token, user } = await setup({ hasManagedWallet: false });
       const dseq = faker.number.int({ min: 1, max: 1000000 }).toString();
@@ -151,6 +168,42 @@ describe("Deployment Settings", () => {
       });
 
       expect(response.status).toBe(401);
+    });
+
+    it("succeeds for a deployment whose creation already recorded its definition", async () => {
+      const { token, user } = await setup();
+      const dseq = faker.number.int({ min: 1, max: 1000000 }).toString();
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: "version: '2.0'", manifestVersion: "BAUG" });
+
+      const response = await app.request("/v1/deployment-settings", {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${token}`,
+          "content-type": "application/json"
+        },
+        body: JSON.stringify({ data: { userId: user.id, dseq, autoTopUpEnabled: true } })
+      });
+
+      expect(response.status).toBe(201);
+      const { data } = (await response.json()) as { data: { dseq: string; autoTopUpEnabled: boolean } };
+      expect(data).toMatchObject({ dseq, autoTopUpEnabled: true });
+    });
+
+    it("leaves the recorded definition alone when settings are created for the same deployment", async () => {
+      const { token, user } = await setup();
+      const dseq = faker.number.int({ min: 1, max: 1000000 }).toString();
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: "version: '2.0'", manifestVersion: "BAUG" });
+
+      await app.request("/v1/deployment-settings", {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${token}`,
+          "content-type": "application/json"
+        },
+        body: JSON.stringify({ data: { userId: user.id, dseq, autoTopUpEnabled: true } })
+      });
+
+      expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq })).toMatchObject({ sdl: "version: '2.0'", manifestVersion: "BAUG" });
     });
 
     it("returns 403 when creating deployment settings for another user", async () => {

--- a/apps/api/test/functional/deployments.spec.ts
+++ b/apps/api/test/functional/deployments.spec.ts
@@ -31,6 +31,8 @@ import { createLeaseStatus } from "@test/seeders/lease-status.seeder";
 import { createUser } from "@test/seeders/user.seeder";
 import { createUserWallet } from "@test/seeders/user-wallet.seeder";
 
+const OVERSIZED_FILLER = "z".repeat(4096);
+
 describe("Deployments API", () => {
   const userRepository = container.resolve(UserRepository);
   const apiKeyAuthService = container.resolve(ApiKeyAuthService);
@@ -702,6 +704,42 @@ describe("Deployments API", () => {
 
       expect(response.status).toBe(400);
     });
+
+    it("returns 400 for an sdl too large to store", async () => {
+      const { userApiKeySecret } = await mockPersistedUser();
+
+      const response = await postOversizedDeployment(userApiKeySecret);
+
+      expect(response.status).toBe(400);
+    });
+
+    it("says nothing about the sdl in the 400 it returns", async () => {
+      const { userApiKeySecret } = await mockPersistedUser();
+
+      const response = await postOversizedDeployment(userApiKeySecret);
+
+      expect(await response.text()).not.toContain(OVERSIZED_FILLER);
+    });
+
+    it("records nothing and broadcasts nothing for an sdl too large to store", async () => {
+      const { userApiKeySecret, user } = await mockPersistedUser();
+
+      await postOversizedDeployment(userApiKeySecret);
+
+      expect(await container.resolve(DeploymentSettingRepository).findOneBy({ userId: user.id })).toBeUndefined();
+      expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
+    });
+
+    function postOversizedDeployment(userApiKeySecret: string) {
+      const yml = fs.readFileSync(path.resolve(__dirname, "../mocks/hello-world-sdl.yml"), "utf8");
+      const args = Array.from({ length: 40 }, () => `      - ${OVERSIZED_FILLER}`).join("\n");
+
+      return app.request("/v1/deployments", {
+        method: "POST",
+        body: JSON.stringify({ data: { sdl: yml.replace("    expose:", `    args:\n${args}\n    expose:`) } }),
+        headers: new Headers({ "Content-Type": "application/json", "x-api-key": userApiKeySecret })
+      });
+    }
 
     async function createDeploymentWithSecrets() {
       const { userApiKeySecret, user } = await mockPersistedUser();

--- a/apps/api/test/functional/deployments.spec.ts
+++ b/apps/api/test/functional/deployments.spec.ts
@@ -15,6 +15,7 @@ import { ManagedSignerService } from "@src/billing/services";
 import { CORE_CONFIG } from "@src/core";
 import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import { DeploymentReaderService } from "@src/deployment/services/deployment-reader/deployment-reader.service";
+import { SdlService } from "@src/deployment/services/sdl/sdl.service";
 import { ProviderService } from "@src/provider/services/provider/provider.service";
 import { app } from "@src/rest-app";
 import type { RestAkashDeploymentInfoResponse } from "@src/types/rest";
@@ -127,7 +128,11 @@ describe("Deployments API", () => {
     return { user, userApiKeySecret, wallets };
   }
 
-  /** Persists a real user row so the create path can write FK-bound rows like deployment settings. */
+  /**
+   * Persists a real user row, which every create needs: creating a deployment now records what that
+   * deployment is, and that record is FK-bound to the user. `mockUser` fakes the user for read paths
+   * that never write.
+   */
   async function mockPersistedUser() {
     const dbUser = await userRepository.create({ userId: faker.string.uuid() });
     const userApiKeySecret = faker.word.noun();
@@ -479,7 +484,7 @@ describe("Deployments API", () => {
 
   describe("POST /v1/deployments", () => {
     it("creates a deployment", async () => {
-      const { userApiKeySecret } = await mockUser();
+      const { userApiKeySecret } = await mockPersistedUser();
       const yml = fs.readFileSync(path.resolve(__dirname, "../mocks/hello-world-sdl.yml"), "utf8");
 
       const response = await app.request("/v1/deployments", {
@@ -562,7 +567,7 @@ describe("Deployments API", () => {
     });
 
     it("creates a deployment without a deposit", async () => {
-      const { userApiKeySecret } = await mockUser();
+      const { userApiKeySecret } = await mockPersistedUser();
       const yml = fs.readFileSync(path.resolve(__dirname, "../mocks/hello-world-sdl.yml"), "utf8");
 
       const response = await app.request("/v1/deployments", {
@@ -598,6 +603,50 @@ describe("Deployments API", () => {
 
       const setting = await container.resolve(DeploymentSettingRepository).findOneBy({ userId: user.id, dseq: result.data.dseq });
       expect(setting).toMatchObject({ autoTopUpEnabled: true, runtimeLimitHours: 6, runtimeEndsAt: null });
+    });
+
+    it("records the sdl it was given", async () => {
+      const { setting } = await createDeploymentWithSecrets();
+
+      expect(setting?.sdl).toContain("ghcr.io/akash-network/hello-akash-world");
+    });
+
+    it("records an sdl naming every env variable the submitted one declared", async () => {
+      const { setting } = await createDeploymentWithSecrets();
+
+      expect(setting?.sdl).toContain("API_TOKEN=");
+      expect(setting?.sdl).toContain("DATABASE_URL=");
+      expect(setting?.sdl).toContain("INHERITED_FROM_HOST");
+    });
+
+    it("records an sdl carrying none of the submitted env values", async () => {
+      const { setting } = await createDeploymentWithSecrets();
+
+      expect(setting?.sdl).not.toContain("PLACEHOLDER_API_TOKEN");
+      expect(setting?.sdl).not.toContain("PLACEHOLDER_DB_PASSWORD");
+      expect(setting?.sdl).not.toContain("db.example.test");
+    });
+
+    it("records an sdl carrying none of the submitted registry credentials", async () => {
+      const { setting } = await createDeploymentWithSecrets();
+
+      expect(setting?.sdl).not.toContain("PLACEHOLDER_REGISTRY_USERNAME");
+      expect(setting?.sdl).not.toContain("PLACEHOLDER_REGISTRY_PASSWORD");
+      expect(setting?.sdl).not.toContain("registry.example.test");
+      expect(setting?.sdl).not.toContain("credentials");
+    });
+
+    it("records an sdl that is still a deployable SDL", async () => {
+      const { setting } = await createDeploymentWithSecrets();
+
+      expect(container.resolve(SdlService).generateManifest(setting?.sdl ?? "").ok).toBe(true);
+    });
+
+    it("records the manifest version it commits on chain", async () => {
+      const { setting } = await createDeploymentWithSecrets();
+
+      expect(setting?.manifestVersion).toMatch(/^[A-Za-z0-9+/]+={0,2}$/);
+      expect(Buffer.from(setting?.manifestVersion ?? "", "base64")).toHaveLength(32);
     });
 
     it("returns 400 for a non-integer runtime limit", async () => {
@@ -653,6 +702,22 @@ describe("Deployments API", () => {
 
       expect(response.status).toBe(400);
     });
+
+    async function createDeploymentWithSecrets() {
+      const { userApiKeySecret, user } = await mockPersistedUser();
+      const yml = fs.readFileSync(path.resolve(__dirname, "../mocks/hello-world-sdl-with-secrets.yml"), "utf8");
+
+      const response = await app.request("/v1/deployments", {
+        method: "POST",
+        body: JSON.stringify({ data: { sdl: yml } }),
+        headers: new Headers({ "Content-Type": "application/json", "x-api-key": userApiKeySecret })
+      });
+
+      expect(response.status).toBe(201);
+      const result = (await response.json()) as { data: { dseq: string } };
+
+      return { setting: await container.resolve(DeploymentSettingRepository).findOneBy({ userId: user.id, dseq: result.data.dseq }) };
+    }
   });
 
   describe("DELETE /v1/deployments/{dseq}", () => {

--- a/apps/api/test/mocks/hello-world-sdl-with-secrets.yml
+++ b/apps/api/test/mocks/hello-world-sdl-with-secrets.yml
@@ -1,0 +1,40 @@
+---
+version: "2.0"
+services:
+  web:
+    image: ghcr.io/akash-network/hello-akash-world:2.1.0
+    credentials:
+      host: registry.example.test
+      username: PLACEHOLDER_REGISTRY_USERNAME
+      password: PLACEHOLDER_REGISTRY_PASSWORD
+      email: placeholder@example.test
+    env:
+      - API_TOKEN=PLACEHOLDER_API_TOKEN
+      - DATABASE_URL=postgres://placeholder:PLACEHOLDER_DB_PASSWORD@db.example.test:5432/app?ssl=true
+      - INHERITED_FROM_HOST
+    expose:
+      - port: 3000
+        as: 80
+        to:
+          - global: true
+profiles:
+  compute:
+    web:
+      resources:
+        cpu:
+          units: 0.5
+        memory:
+          size: 512Mi
+        storage:
+          - size: 512Mi
+  placement:
+    dcloud:
+      pricing:
+        web:
+          denom: uakt
+          amount: 1000
+deployment:
+  web:
+    dcloud:
+      profile: web
+      count: 1


### PR DESCRIPTION
> Stacked on #3662. Base is `feat/deployment-store-sdl-without-secrets`, so this PR shows only the slice.

## Why

ref CON-855

Two changes to how an oversized SDL is handled, one of which reverses a decision made in #3662.

**An SDL too large to store is now rejected with a 400, and nothing is created.** #3662 stores `null`,
warns, and lets the deployment proceed. That quietly produces a deployment the console cannot
describe — one nobody can later reproduce, redeploy, or attach sealed secrets to. Refusing the request
is what keeps a deployment and the record of what it is from ever disagreeing.

**Size is now measured exactly for any SDL that cannot alias.** `estimateSerializedLength` is an
approximation; `dump().length` is exact. Now that an over-count means a rejected deployment rather than
a quietly missing record, running the estimator on a document that cannot amplify is a user-visible
failure mode for no benefit.

## What

### Oversize → 400

The check runs **before the definition write and before anything is broadcast**, so a rejected request
leaves no orphan row behind and nothing reaches the chain.

"Anything" includes the **trial reclamation**, and getting that ordering right needed a fix. A trialing
wallet's create first reclaims escrow from its own lease-less deployments, and that reclamation
broadcasts `MsgCloseDeployment`. The oversize check originally landed four lines below it, which made
this reachable at will: a trialing user with deployment A still collecting bids posts a second create
with an oversized SDL, gets a 400 — and A is closed on chain with its fees spent.

That was novel to this slice. The base branch deliberately puts every user-input rejection *above* the
reclamation — the wallet lookup, the manifest parse, the deposit check. #3662 added one failure below
it, but that is an infrastructure fault (a DB error from `recordDefinition`). This slice introduced the
first **deterministic, user-triggerable** rejection after it, which is what turned an ordering detail
into reachable state loss.

The check now sits with the other rejections, above the reclamation. `dseq` moved up with it — it is a
bare `Date.now()` and the reclamation takes only `wallet`, so neither depends on the other. The
reclamation's own JSDoc now carries the invariant: *nothing that can reject the caller may be added
below this line.* It uses `http-assert` (the assertion wrapper over
`http-errors` already imported in this file) per CLAUDE.md, not a custom error class.

Neither the log nor the error body says anything about the SDL beyond how long it is — an error body
travels further than a log does. The log keeps the shape it had, renamed to `DEPLOYMENT_SDL_TOO_LARGE`
since it no longer describes a storage decision.

`sdl` **stays nullable**. Rows created lazily by a settings read still carry no SDL, and rows written
before this shipped still have to work. The repository's `upsertDefinition` parameter is narrowed from
`string | null` to `string`, because after this change no caller can pass `null` — that is a type
change, not a column change.

### Estimate only when the SDL can alias

```ts
function mayShareNodes(rawSdl: string): boolean {
  return rawSdl.includes("&") && rawSdl.includes("*");
}
```

Amplification is alias-driven, and an alias needs an anchor to point at — so any document that shares a
node must spell **both** `&` and `*` somewhere in its bytes, so a document missing either cannot alias.
Skipping the estimator is therefore safe *with respect to alias amplification*, which is the only thing
the estimator was ever built to price — and that is the whole of the claim. It is deliberately **not** a
claim that an alias-free document cannot serialize to far more than it arrived as; one can, since flow
style spells a nesting level in about four characters and block style re-spells it as two spaces per
level on every emitted line. The estimator never priced indentation either, so that is a property of the
SDL surface rather than of this guard, and the base branch behaves identically. Documents that could alias keep exactly the behaviour they had, and the post-serialize length
check remains the authority on both paths.

I chose "both present" over a bare presence test on either character. It is still a pure presence test —
no assumption about quoting, flow style, block scalars, indentation or comments, and it never asks
*where* the characters are — but it avoids sending an ordinary `command: ["sh", "-c", "a && b"]` or an
`--include=*.log` down the estimator path for nothing. The soundness rests on a YAML invariant, not on
parsing cleverness. Sharing is *necessary* for amplification rather than sufficient, which is all a guard
that only ever adds work needs to be right about.

**Detection is textual, on the raw submitted string** — deliberately not a walk of the parsed tree
looking for shared object references. An anchored *scalar* loads into an ordinary string primitive and
loses the identity such a walk would look for, so a reference walk reports "no sharing" for exactly the
document that amplifies worst. That is the original amplification defect; a tree walk here would
reintroduce it.

## Known and accepted, not missed

Two things a reviewer should read as deliberate decisions rather than gaps.

### The estimate can reject a heavily-aliased SDL that would have fitted — accepted

This PR also corrects the estimator's own JSDoc, which was half-wrong. js-yaml re-expands an aliased
**scalar**, because identity is lost when it loads into an ordinary string primitive, but re-emits an
aliased **mapping or sequence** as one anchor plus N references, because identity survives. The parsed
tree cannot distinguish the two cases, so `estimateSerializedLength` prices every alias as a full scalar
copy.

Measured on the alias-DAG fixture in this PR:

| | measured |
|---|---|
| estimator | 131,156 (stops at the budget) |
| actual `dump` | **1,542 bytes, in 1 ms** |

That is ~85× on a pathological input. On a realistic one the over-count is roughly the alias count
against shared blocks — typically **2–10×**, for an SDL that shares an env list or a resources block
across services.

**Consequence:** a heavily-aliased SDL carrying more than roughly **13 KB of aliased content** can be
rejected with a 400 saying it is too large when it is not. The limit is 128 KB, already ~25× above a
typical SDL, so this is unlikely — but it is reachable, and since the previous slice it is a hard
rejection rather than a silently missing record.

**Workaround for a user who hits it:** remove the anchors from the SDL. The expanded document is what
gets stored either way, so nothing is lost but the aliasing.

**The fix, if it is ever wanted:** charge objects and arrays once via a seen-set and scalars per
occurrence. That models js-yaml exactly, makes the estimate tight rather than loose, and leaves the
scalar-amplification bound — the one that motivated the estimator in the first place — fully intact.

Deliberately not built. Raised, measured, and accepted on cost/benefit.

### A `deployment_settings` row can still legitimately have no SDL

The oversize branch is no longer a source of a null `sdl`, but it was never the only one.
`DeploymentSettingService.createWithDefaults` still creates rows with no SDL when a settings read
arrives for a deployment the console never recorded — one created before this shipped, or created
outside the managed path.

This matters for the **sealed-secrets phase**: a row can carry secrets while having no definition to
bind them to, so that phase cannot assume `sdl` is present just because the row exists.

The column stays nullable for exactly this reason. Only the repository's `upsertDefinition` parameter
narrowed to `string`, since after this change no caller passes `null`.

## Tests

The two rejection mechanisms are tested separately so it is clear which produced each 400:

- `SDL_TOO_LONG_WITHOUT_ALIASES` — no anchors, rejected on its exact serialized length
- `SDL_ALIASING_ONE_SCALAR` — rejected on the estimate
- `SDL_ALIASING_A_DAG` — rejected on the estimate, still in milliseconds
- rejection writes no `deployment_settings` row and reaches no signer
- rejection does not reclaim trial orphans — `cleanUpForWallet` is never called for a trialing wallet
  whose SDL is refused, which is the F1 regression
- the rejection message names no part of the SDL, and neither does the log
- functional: oversize → 400, no row written, `executeDerivedDecodedTxByUserId` never called, and the
  response body contains none of the SDL's filler
- a no-anchor SDL takes the dump path and stores correctly; an SDL whose scalars merely contain `&` and
  `*` is a conservative positive and still stores fine

**The alias guard is proven load-bearing.** The pre-existing amplification assertion did not actually
discriminate between the paths (`sdl` came back `null` either way, because the post-dump check also
catches it), so it now asserts the reported length stays near the budget rather than reaching the
serialized size. With the guard forced off, the unit assertion fails with
`expected 2102265 to be less than 2097152` — the estimate had become the real 2 MB serialization.

## Demo

Both rejection paths, against a real Postgres with the production classes:

```output
--- no anchors, rejected on its exact serialized length ---
request body                  : 161.1 KB
response status               : 400
message names no sdl content  : true
deployment_settings rows      : 0
broadcasts to the chain       : 0
--- anchored scalar, rejected on the estimate ---
request body                  : 11.1 KB
response status               : 400
message names no sdl content  : true
deployment_settings rows      : 0
broadcasts to the chain       : 0
```


