### PR TITLE
feat(billing): raise auto recharge minimums to a $10 threshold and $25 amount

### DIFF
--- a/apps/api/src/billing/config/index.ts
+++ b/apps/api/src/billing/config/index.ts
@@ -4,4 +4,4 @@ export const appConfig = {
   USDC_IBC_DENOMS
 };
 
-export { STANDARD_TOP_UP_MIN_AMOUNT_USD } from "./top-up.config";
+export { AUTO_RELOAD_AMOUNT_MIN_USD, AUTO_RELOAD_THRESHOLD_MIN_USD, STANDARD_TOP_UP_MIN_AMOUNT_USD } from "./top-up.config";

--- a/apps/api/src/billing/config/top-up.config.ts
+++ b/apps/api/src/billing/config/top-up.config.ts
@@ -1,2 +1,8 @@
-/** Minimum USD amount accepted by a standard (non-trial) paid top-up, shared by trial validation, wallet-settings input validation, and the auto-reload charge clamp. */
+/** Minimum USD amount accepted by a standard (non-trial) paid top-up, shared by trial validation and one-time top-ups. */
 export const STANDARD_TOP_UP_MIN_AMOUNT_USD = 20;
+
+/** Mirrors RunPod's auto-pay floor: the lowest balance a user may set as the auto recharge trigger. */
+export const AUTO_RELOAD_THRESHOLD_MIN_USD = 10;
+
+/** Mirrors RunPod's auto-pay floor: the lowest amount a single auto recharge may charge, independent of the one-time top-up minimum. */
+export const AUTO_RELOAD_AMOUNT_MIN_USD = 25;

--- a/apps/api/src/billing/http-schemas/wallet.schema.ts
+++ b/apps/api/src/billing/http-schemas/wallet.schema.ts
@@ -1,8 +1,6 @@
 import { z } from "@hono/zod-openapi";
 
-import { STANDARD_TOP_UP_MIN_AMOUNT_USD } from "@src/billing/config";
-
-const AUTO_RELOAD_THRESHOLD_MIN_USD = 5;
+import { AUTO_RELOAD_AMOUNT_MIN_USD, AUTO_RELOAD_THRESHOLD_MIN_USD } from "@src/billing/config";
 
 /** Upper bounds stop an oversized value from being charged verbatim to the card. */
 const AUTO_RELOAD_THRESHOLD_MAX_USD = 10_000;
@@ -49,12 +47,12 @@ export const WalletSettingsInputSchema = z.object({
     }),
   autoReloadAmount: z
     .number()
-    .min(STANDARD_TOP_UP_MIN_AMOUNT_USD)
+    .min(AUTO_RELOAD_AMOUNT_MIN_USD)
     .max(AUTO_RELOAD_AMOUNT_MAX_USD)
     .multipleOf(0.01)
     .optional()
     .openapi({
-      description: `USD amount charged on each automatic top-up (minimum ${STANDARD_TOP_UP_MIN_AMOUNT_USD}, maximum ${AUTO_RELOAD_AMOUNT_MAX_USD}). Defaults are applied on create when omitted.`
+      description: `USD amount charged on each automatic top-up (minimum ${AUTO_RELOAD_AMOUNT_MIN_USD}, maximum ${AUTO_RELOAD_AMOUNT_MAX_USD}). Defaults are applied on create when omitted.`
     })
 });
 

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.spec.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.spec.ts
@@ -469,7 +469,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       expect(stripeTransactionService.createPaymentIntent).toHaveBeenCalledWith(expect.objectContaining({ amount: 100 }));
     });
 
-    it("clamps the charge to the $20 minimum when the stored amount is below it", async () => {
+    it("clamps the charge to the $25 minimum when the stored amount is below it", async () => {
       const { handler, stripeTransactionService, job, jobMeta } = setup({
         autoReloadMode: "threshold",
         balance: 5,
@@ -479,7 +479,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
 
       await handler.handle(job, jobMeta);
 
-      expect(stripeTransactionService.createPaymentIntent).toHaveBeenCalledWith(expect.objectContaining({ amount: 20 }));
+      expect(stripeTransactionService.createPaymentIntent).toHaveBeenCalledWith(expect.objectContaining({ amount: 25 }));
     });
 
     it("records the failure and rethrows when the payment intent fails", async () => {

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.ts
@@ -3,7 +3,7 @@ import { addMilliseconds, millisecondsInHour } from "date-fns";
 import { Err, Ok, Result } from "ts-results";
 import { singleton } from "tsyringe";
 
-import { STANDARD_TOP_UP_MIN_AMOUNT_USD } from "@src/billing/config";
+import { AUTO_RELOAD_AMOUNT_MIN_USD } from "@src/billing/config";
 import { WalletBalanceReloadCheck } from "@src/billing/events/wallet-balance-reload-check";
 import type { GetBalancesResponseOutput } from "@src/billing/http-schemas/balance.schema";
 import { centsToUsd } from "@src/billing/lib/currency/currency";
@@ -183,7 +183,7 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
     const { balance } = resources;
     const mode = resources.walletSetting.autoReloadMode;
     const threshold = centsToUsd(resources.walletSetting.autoReloadThreshold);
-    const reloadAmount = Math.max(centsToUsd(resources.walletSetting.autoReloadAmount), STANDARD_TOP_UP_MIN_AMOUNT_USD);
+    const reloadAmount = Math.max(centsToUsd(resources.walletSetting.autoReloadAmount), AUTO_RELOAD_AMOUNT_MIN_USD);
     const log = {
       walletAddress: resources.wallet.address,
       balance,

--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -203,15 +203,15 @@
                       },
                       "autoReloadThreshold": {
                         "type": "number",
-                        "minimum": 5,
+                        "minimum": 10,
                         "maximum": 10000,
-                        "description": "USD credit balance at or below which an automatic top-up is triggered (minimum 5, maximum 10000). Defaults are applied on create when omitted."
+                        "description": "USD credit balance at or below which an automatic top-up is triggered (minimum 10, maximum 10000). Defaults are applied on create when omitted."
                       },
                       "autoReloadAmount": {
                         "type": "number",
-                        "minimum": 20,
+                        "minimum": 25,
                         "maximum": 10000,
-                        "description": "USD amount charged on each automatic top-up (minimum 20, maximum 10000). Defaults are applied on create when omitted."
+                        "description": "USD amount charged on each automatic top-up (minimum 25, maximum 10000). Defaults are applied on create when omitted."
                       }
                     },
                     "required": [
@@ -314,15 +314,15 @@
                       },
                       "autoReloadThreshold": {
                         "type": "number",
-                        "minimum": 5,
+                        "minimum": 10,
                         "maximum": 10000,
-                        "description": "USD credit balance at or below which an automatic top-up is triggered (minimum 5, maximum 10000). Defaults are applied on create when omitted."
+                        "description": "USD credit balance at or below which an automatic top-up is triggered (minimum 10, maximum 10000). Defaults are applied on create when omitted."
                       },
                       "autoReloadAmount": {
                         "type": "number",
-                        "minimum": 20,
+                        "minimum": 25,
                         "maximum": 10000,
-                        "description": "USD amount charged on each automatic top-up (minimum 20, maximum 10000). Defaults are applied on create when omitted."
+                        "description": "USD amount charged on each automatic top-up (minimum 25, maximum 10000). Defaults are applied on create when omitted."
                       }
                     },
                     "required": [

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -15271,9 +15271,9 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                   "data": {
                     "properties": {
                       "autoReloadAmount": {
-                        "description": "USD amount charged on each automatic top-up (minimum 20, maximum 10000). Defaults are applied on create when omitted.",
+                        "description": "USD amount charged on each automatic top-up (minimum 25, maximum 10000). Defaults are applied on create when omitted.",
                         "maximum": 10000,
-                        "minimum": 20,
+                        "minimum": 25,
                         "type": "number",
                       },
                       "autoReloadEnabled": {
@@ -15288,9 +15288,9 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                         "type": "string",
                       },
                       "autoReloadThreshold": {
-                        "description": "USD credit balance at or below which an automatic top-up is triggered (minimum 5, maximum 10000). Defaults are applied on create when omitted.",
+                        "description": "USD credit balance at or below which an automatic top-up is triggered (minimum 10, maximum 10000). Defaults are applied on create when omitted.",
                         "maximum": 10000,
-                        "minimum": 5,
+                        "minimum": 10,
                         "type": "number",
                       },
                     },
@@ -15382,9 +15382,9 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                   "data": {
                     "properties": {
                       "autoReloadAmount": {
-                        "description": "USD amount charged on each automatic top-up (minimum 20, maximum 10000). Defaults are applied on create when omitted.",
+                        "description": "USD amount charged on each automatic top-up (minimum 25, maximum 10000). Defaults are applied on create when omitted.",
                         "maximum": 10000,
-                        "minimum": 20,
+                        "minimum": 25,
                         "type": "number",
                       },
                       "autoReloadEnabled": {
@@ -15399,9 +15399,9 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                         "type": "string",
                       },
                       "autoReloadThreshold": {
-                        "description": "USD credit balance at or below which an automatic top-up is triggered (minimum 5, maximum 10000). Defaults are applied on create when omitted.",
+                        "description": "USD credit balance at or below which an automatic top-up is triggered (minimum 10, maximum 10000). Defaults are applied on create when omitted.",
                         "maximum": 10000,
-                        "minimum": 5,
+                        "minimum": 10,
                         "type": "number",
                       },
                     },

--- a/apps/api/test/functional/wallet-settings.spec.ts
+++ b/apps/api/test/functional/wallet-settings.spec.ts
@@ -36,7 +36,7 @@ describe("Wallet Settings", () => {
       const response = await app.request("/v1/wallet-settings", {
         method: "PUT",
         headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
-        body: JSON.stringify({ data: { autoReloadEnabled: true, autoReloadAmount: 5 } })
+        body: JSON.stringify({ data: { autoReloadEnabled: true, autoReloadAmount: 24.99 } })
       });
 
       expect(response.status).toBe(400);
@@ -48,7 +48,7 @@ describe("Wallet Settings", () => {
       const response = await app.request("/v1/wallet-settings", {
         method: "PUT",
         headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
-        body: JSON.stringify({ data: { autoReloadEnabled: true, autoReloadThreshold: 1 } })
+        body: JSON.stringify({ data: { autoReloadEnabled: true, autoReloadThreshold: 9.99 } })
       });
 
       expect(response.status).toBe(400);

--- a/apps/deploy-web/src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup.spec.tsx
@@ -35,10 +35,10 @@ describe(AutoTopUpSettingsPopup.name, () => {
     const upsertMutate = vi.fn();
     setup({ upsertMutate });
 
-    fireEvent.change(amountInput(), { target: { value: "5" } });
+    fireEvent.change(amountInput(), { target: { value: "24.99" } });
     await submit();
 
-    expect(screen.getByText(/Minimum amount is \$20/)).toBeInTheDocument();
+    expect(screen.getByText(/Minimum amount is \$25/)).toBeInTheDocument();
     expect(upsertMutate).not.toHaveBeenCalled();
   });
 
@@ -46,11 +46,18 @@ describe(AutoTopUpSettingsPopup.name, () => {
     const upsertMutate = vi.fn();
     setup({ upsertMutate });
 
-    fireEvent.change(thresholdInput(), { target: { value: "1" } });
+    fireEvent.change(thresholdInput(), { target: { value: "9.99" } });
     await submit();
 
-    expect(screen.getByText(/Minimum threshold is \$5/)).toBeInTheDocument();
+    expect(screen.getByText(/Minimum threshold is \$10/)).toBeInTheDocument();
     expect(upsertMutate).not.toHaveBeenCalled();
+  });
+
+  it("raises stored values below the minimums to the minimums when prefilling", () => {
+    setup({ threshold: 5, amount: 20 });
+
+    expect(thresholdInput().value).toBe("10");
+    expect(amountInput().value).toBe("25");
   });
 
   it("blocks submit and shows an error when the amount is above the maximum", async () => {
@@ -137,10 +144,12 @@ describe(AutoTopUpSettingsPopup.name, () => {
     );
   });
 
-  it("saves prediction mode even when a stored threshold is below the threshold-mode minimum", async () => {
+  it("saves prediction mode even when the entered threshold is below the threshold-mode minimum", async () => {
     const upsertMutate = vi.fn();
-    setup({ mode: "prediction", threshold: 1, amount: 1, upsertMutate });
+    setup({ mode: "threshold", upsertMutate });
 
+    fireEvent.change(thresholdInput(), { target: { value: "1" } });
+    fireEvent.click(modeRadio(/predicted spend/i));
     await submit();
 
     expect(upsertMutate).toHaveBeenCalledWith({ data: { autoReloadEnabled: true, autoReloadMode: "prediction" } }, expect.anything());

--- a/apps/deploy-web/src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup.tsx
@@ -30,14 +30,14 @@ export const DEFAULT_AUTO_RELOAD_MODE: AutoReloadMode = "threshold";
 export const DEFAULT_AUTO_RELOAD_THRESHOLD = 20;
 export const DEFAULT_AUTO_RELOAD_AMOUNT = 100;
 
-/** Matches AkashML's minimum credit-balance threshold. */
-const AUTO_RELOAD_THRESHOLD_MIN_USD = 5;
+/** Mirrors the API's AUTO_RELOAD_THRESHOLD_MIN_USD, itself matching RunPod's auto-pay threshold floor. */
+const AUTO_RELOAD_THRESHOLD_MIN_USD = 10;
 
 /** Mirrors the max bound on both fields in the backend's WalletSettingsInputSchema so over-limit values fail inline instead of as a generic 400. */
 const AUTO_RELOAD_MAX_USD = 10_000;
 
-/** Mirrors STANDARD_TOP_UP_MIN_AMOUNT_USD — the fixed floor the backend applies to every recurring auto-top-up charge, independent of the trial-aware one-time top-up minimum. */
-const AUTO_RELOAD_AMOUNT_MIN_USD = 20;
+/** Mirrors the API's AUTO_RELOAD_AMOUNT_MIN_USD — the floor applied to every recurring auto-top-up charge, independent of the trial-aware one-time top-up minimum. */
+const AUTO_RELOAD_AMOUNT_MIN_USD = 25;
 
 const MODE_OPTIONS: Array<{ value: AutoReloadMode; id: string; title: string; description: string; recommended?: boolean }> = [
   {
@@ -119,8 +119,8 @@ export const AutoTopUpSettingsPopup: React.FC<AutoTopUpSettingsPopupProps> = ({
   const defaultValues = useMemo<AutoTopUpFormValues>(
     () => ({
       autoReloadMode: mode ?? DEFAULT_AUTO_RELOAD_MODE,
-      autoReloadThreshold: threshold ?? DEFAULT_AUTO_RELOAD_THRESHOLD,
-      autoReloadAmount: amount ?? DEFAULT_AUTO_RELOAD_AMOUNT
+      autoReloadThreshold: Math.max(threshold ?? DEFAULT_AUTO_RELOAD_THRESHOLD, AUTO_RELOAD_THRESHOLD_MIN_USD),
+      autoReloadAmount: Math.max(amount ?? DEFAULT_AUTO_RELOAD_AMOUNT, AUTO_RELOAD_AMOUNT_MIN_USD)
     }),
     [mode, threshold, amount]
   );

--- a/packages/console-api-types/src/schema.d.ts
+++ b/packages/console-api-types/src/schema.d.ts
@@ -7183,9 +7183,9 @@ export interface operations {
              * @enum {string}
              */
             autoReloadMode?: "threshold" | "prediction";
-            /** @description USD credit balance at or below which an automatic top-up is triggered (minimum 5, maximum 10000). Defaults are applied on create when omitted. */
+            /** @description USD credit balance at or below which an automatic top-up is triggered (minimum 10, maximum 10000). Defaults are applied on create when omitted. */
             autoReloadThreshold?: number;
-            /** @description USD amount charged on each automatic top-up (minimum 20, maximum 10000). Defaults are applied on create when omitted. */
+            /** @description USD amount charged on each automatic top-up (minimum 25, maximum 10000). Defaults are applied on create when omitted. */
             autoReloadAmount?: number;
           };
         };
@@ -7240,9 +7240,9 @@ export interface operations {
              * @enum {string}
              */
             autoReloadMode?: "threshold" | "prediction";
-            /** @description USD credit balance at or below which an automatic top-up is triggered (minimum 5, maximum 10000). Defaults are applied on create when omitted. */
+            /** @description USD credit balance at or below which an automatic top-up is triggered (minimum 10, maximum 10000). Defaults are applied on create when omitted. */
             autoReloadThreshold?: number;
-            /** @description USD amount charged on each automatic top-up (minimum 20, maximum 10000). Defaults are applied on create when omitted. */
+            /** @description USD amount charged on each automatic top-up (minimum 25, maximum 10000). Defaults are applied on create when omitted. */
             autoReloadAmount?: number;
           };
         };


### PR DESCRIPTION
## Why

The auto recharge dialog let people set a trigger threshold as low as $5 and a charge amount as low as $20, and that $20 was really the one-time top-up floor (`STANDARD_TOP_UP_MIN_AMOUNT_USD`) borrowed for a second purpose. RunPod's auto-pay requires $10 and $25, and we want the same floors so a recurring charge is big enough to be worth making.

Fixed-threshold auto recharge is not in production yet, so the runtime charge floor can move with it without changing what any live account gets charged.

## What

- Adds `AUTO_RELOAD_THRESHOLD_MIN_USD` (10) and `AUTO_RELOAD_AMOUNT_MIN_USD` (25) to the billing config. The auto recharge amount no longer borrows the one-time top-up minimum, which stays at $20 for one-time top-ups and trial validation.
- `WalletSettingsInputSchema` validates against the new constants, and its OpenAPI descriptions interpolate them, so the published minimums move too.
- The threshold-mode charge clamp in `wallet-balance-reload-check` floors at $25. Prediction mode keeps its own separate $20 minimum.
- The dialog mirrors both constants and raises a stored below-minimum value up to the floor when it opens, so an account saved at $5/$20 doesn't open with a Save that fails validation the user has to go hunting for.
- Specs now use boundary values ($9.99 and $24.99) so the floors are actually pinned rather than just cleared.

No migration: the `wallet_setting` column defaults (2000¢ threshold, 10000¢ amount) already clear both floors. Deployment-level auto top-up is untouched.

Verified: `AutoTopUpSettingsPopup` 22 passed and the whole `billing-usage` folder 334 passed in deploy-web; `src/billing` unit 505 passed and the `wallet-settings` functional suite 6 passed in api; lint quiet and `tsc --noEmit` at its existing baseline in both apps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased automatic top-up minimums: $10 for the balance threshold and $25 for the reload amount.
  * Existing settings below these limits are automatically adjusted to the new minimums.
  * Prediction-based auto-top-up settings can still be saved without threshold validation.

* **Documentation**
  * Updated API and wallet settings documentation to reflect the new minimum values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->