### PR TITLE
fix(deployment): reject an oversized SDL before reclaiming trial orphans

### DIFF
--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -23,6 +23,7 @@ import { DeploymentWriterService } from "./deployment-writer.service";
 
 import { mockConfigService } from "@test/mocks/config-service.mock";
 
+const ALIASED_FILLER = "x".repeat(4096);
 const ENV_VALUE = faker.string.alphanumeric(24);
 const REGISTRY_PASSWORD = faker.internet.password();
 
@@ -75,7 +76,7 @@ const SDL_WITH_SECRETS = sdlAround(`    credentials:
  * scalar out in full each time.
  */
 const SDL_ALIASING_ONE_SCALAR = sdlAround(`    args:
-      - &payload ${"x".repeat(4096)}
+      - &payload ${ALIASED_FILLER}
 ${Array.from({ length: 511 }, () => "      - *payload").join("\n")}
 `);
 
@@ -330,10 +331,11 @@ describe(DeploymentWriterService.name, () => {
 
       const rejection = (await service.create({ userId: "user-1", sdl: SDL_ALIASING_ONE_SCALAR, deposit: 5 }).catch((error: Error) => error)) as Error;
 
+      expect(rejection.message).not.toContain(ALIASED_FILLER);
       expect(rejection.message).not.toContain("payload");
       expect(rejection.message).toContain(String(SDL_MAX_LENGTH));
       expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "DEPLOYMENT_SDL_TOO_LARGE", maxLength: SDL_MAX_LENGTH }));
-      expect(loggedTextOf(logger)).not.toContain("payload");
+      expect(loggedTextOf(logger)).not.toContain(ALIASED_FILLER);
     });
 
     it("never hands the sdl to the logger on a successful create", async () => {
@@ -403,6 +405,14 @@ describe(DeploymentWriterService.name, () => {
       walletReaderService.getWalletByUserId.mockResolvedValue({ ...wallet, isTrialing: true });
 
       await expect(service.create({ userId: "user-1", sdl: "valid-sdl" })).rejects.toMatchObject({ status: 400 });
+      expect(staleDeploymentsCleaner.cleanUpForWallet).not.toHaveBeenCalled();
+    });
+
+    it("does not reclaim trial orphans when an oversized sdl will reject the create", async () => {
+      const { service, staleDeploymentsCleaner, walletReaderService } = setup();
+      walletReaderService.getWalletByUserId.mockResolvedValue({ ...wallet, isTrialing: true });
+
+      await expect(service.create({ userId: "user-1", sdl: SDL_ALIASING_ONE_SCALAR, deposit: 5 })).rejects.toMatchObject({ status: 400 });
       expect(staleDeploymentsCleaner.cleanUpForWallet).not.toHaveBeenCalled();
     });
   });

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -81,33 +81,6 @@ export class DeploymentWriterService {
     };
   }
 
-  /**
-   * Records what the deployment is before anything is broadcast, never after, on both create and
-   * update. The reverse order would let a successful broadcast produce a deployment with no remembered
-   * definition, which becomes unrecoverable once a later phase stores sealed secrets in the same write.
-   * A broadcast that then fails leaves a record for something that is not running: on create the retry
-   * takes a fresh dseq, so the orphaned row survives until the draining sweep collects it; on update
-   * the dseq is the one being updated, so the same request retried — idempotent on both the record and
-   * the chain — puts the two back in step.
-   *
-   * A failure here surfaces as an error rather than best-effort, and nothing is broadcast and no
-   * manifest is re-sent: the user retries and gets both the deployment and its record, instead of a
-   * deployment the console cannot describe.
-   *
-   * An update records unconditionally, including when the manifest version already matches the chain.
-   * A matching version means the manifest is unchanged, not that the submitted document is: comments,
-   * formatting, and everything outside the manifest can still differ, and it is the SDL that is
-   * recorded.
-   *
-   * The write is last-writer-wins, with no compare-and-swap: two concurrent updates of one dseq can
-   * interleave so the row keeps one SDL while the chain runs the other, both succeeding. That is inert
-   * while nothing reads these columns, and needs revisiting when sealed secrets share the write.
-   *
-   * The stored SDL deliberately does not hash to the stored manifest version, and no future reader
-   * should expect it to. The version is taken over the manifest the generator produced, which rewrites
-   * the denom and appends the allowed auditors to its own parse; the stored SDL is the one the user
-   * submitted, stripped. They describe the same deployment, not the same bytes.
-   */
   private async recordDefinition(input: { userId: string; dseq: string; sdl: string; manifestVersion: Uint8Array; runtimeLimitHours?: number }): Promise<void> {
     const { manifestVersion, ...rest } = input;
 
@@ -124,11 +97,12 @@ export class DeploymentWriterService {
   }
 
   #strippedSdlWithinLimit(submittedSdl: string, dseq: string): string {
-    const { sdl, length } = stripSdlSecrets(submittedSdl, SDL_MAX_LENGTH);
+    const { sdl, length, error } = stripSdlSecrets(submittedSdl, SDL_MAX_LENGTH);
 
     if (sdl === null) {
       this.logger.warn({ event: "DEPLOYMENT_SDL_TOO_LARGE", dseq, length, maxLength: SDL_MAX_LENGTH });
       throw new HTTPException(400, {
+        cause: error,
         message: `SDL is too large: it exceeds the maximum of ${SDL_MAX_LENGTH} characters once stored`
       });
     }

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -1,4 +1,5 @@
 import { manifestToSortedJSON } from "@akashnetwork/chain-sdk";
+import { HTTPException } from "hono/http-exception";
 import assert from "http-assert";
 import { singleton } from "tsyringe";
 
@@ -39,6 +40,10 @@ export class DeploymentWriterService {
   ) {}
 
   public async create(input: CreateDeploymentRequest["data"] & { userId: string }): Promise<CreateDeploymentResponse["data"]> {
+    const dseq = Date.now();
+    /** SDL for storage ONLY, stripped of secrets */
+    const sdl = this.#strippedSdlWithinLimit(input.sdl, dseq.toString());
+
     const wallet = await this.walletReaderService.getWalletByUserId(input.userId);
     const manifest = this.#parseManifest(input.sdl, { isTrialing: !!wallet.isTrialing });
     const depositInDollars = this.resolveDepositInDollars(input.deposit);
@@ -47,8 +52,6 @@ export class DeploymentWriterService {
       await this.reclaimTrialOrphanedDeployments(wallet);
     }
 
-    const dseq = Date.now();
-    const sdl = this.strippedSdlWithinLimit(input.sdl, dseq.toString());
     const manifestVersion = await this.sdlService.generateManifestVersion(manifest.groups);
 
     await this.recordDefinition({
@@ -120,28 +123,15 @@ export class DeploymentWriterService {
     }
   }
 
-  /**
-   * The submitted SDL with its secrets taken out, or a 400 when it is larger than the console will
-   * store. Rejecting rather than deploying-without-a-record is what keeps a deployment and the record
-   * of what it is from ever disagreeing: a deployment the console cannot describe is one nobody can
-   * later reproduce, redeploy, or attach sealed secrets to.
-   *
-   * It runs before the definition is written and before anything is broadcast, so a rejected create
-   * leaves no row behind and nothing on chain, and a rejected update leaves the deployment running
-   * exactly what it ran before, still described by the record it already had.
-   *
-   * Neither the log nor the error says anything about the SDL beyond how long it is. The whole point of
-   * stripping is that user content does not end up somewhere it was not meant to be, and an error body
-   * travels further than a log does.
-   */
-  private strippedSdlWithinLimit(submittedSdl: string, dseq: string): string {
+  #strippedSdlWithinLimit(submittedSdl: string, dseq: string): string {
     const { sdl, length } = stripSdlSecrets(submittedSdl, SDL_MAX_LENGTH);
 
     if (sdl === null) {
       this.logger.warn({ event: "DEPLOYMENT_SDL_TOO_LARGE", dseq, length, maxLength: SDL_MAX_LENGTH });
+      throw new HTTPException(400, {
+        message: `SDL is too large: it exceeds the maximum of ${SDL_MAX_LENGTH} characters once stored`
+      });
     }
-
-    assert(sdl !== null, 400, `SDL is too large: it exceeds the maximum of ${SDL_MAX_LENGTH} characters once stored`);
 
     return sdl;
   }
@@ -169,7 +159,8 @@ export class DeploymentWriterService {
    * before the create tx so the freed deployment allowance is available when the create's balance check runs.
    * Best-effort: a cleanup failure never blocks the create, which then proceeds and may 402 exactly as it would today.
    * Age 0 also closes an actively-quoting lease-less deployment of the same trial user, acceptable since a trial
-   * balance cannot fund two deployments at once.
+   * balance cannot fund two deployments at once — but only because every way this request can still be refused has
+   * already been tried. Nothing that can reject the caller may be added below this line.
    */
   private async reclaimTrialOrphanedDeployments(wallet: WalletInitialized): Promise<void> {
     try {
@@ -228,7 +219,7 @@ export class DeploymentWriterService {
   public async updateByUserIdAndDseq(userId: string, dseq: string, input: UpdateDeploymentRequest["data"]): Promise<DeploymentResponse> {
     const wallet = await this.walletReaderService.getWalletByUserId(userId);
     const manifest = this.#parseManifest(input.sdl, { isTrialing: !!wallet.isTrialing });
-    const sdl = this.strippedSdlWithinLimit(input.sdl, dseq);
+    const sdl = this.#strippedSdlWithinLimit(input.sdl, dseq);
 
     const [deployment, manifestVersion] = await Promise.all([
       this.deploymentReaderService.findByWalletAndDseq(wallet, dseq),

--- a/apps/api/src/deployment/utils/sdl-secret-stripping/sdl-secret-stripping.spec.ts
+++ b/apps/api/src/deployment/utils/sdl-secret-stripping/sdl-secret-stripping.spec.ts
@@ -199,11 +199,13 @@ describe(stripSdlSecrets.name, () => {
       expect(stripped.length).toBe(stripped.sdl?.length);
     });
 
-    it("stores nothing for a document with no anchors that serializes past the limit", () => {
-      const result = stripSdlSecrets(sdlWith({ web: { args: ["x".repeat(4096)] } }), 512);
+    it("measures a document with no anchors by serializing it exactly", () => {
+      const submitted = sdlWith({ web: { args: ["x".repeat(4096)] } });
+
+      const result = stripSdlSecrets(submitted, 512);
 
       expect(result.sdl).toBeNull();
-      expect(result.length).toBeGreaterThan(512);
+      expect(result.length).toBe(dump(yaml.raw(submitted), { lineWidth: -1 }).length);
     });
 
     it("stores a document whose scalars merely contain an ampersand and an asterisk", () => {

--- a/apps/api/src/deployment/utils/sdl-secret-stripping/sdl-secret-stripping.ts
+++ b/apps/api/src/deployment/utils/sdl-secret-stripping/sdl-secret-stripping.ts
@@ -89,16 +89,17 @@ function withoutValue(entry: string): string {
 }
 
 /**
- * Whether this document could possibly contain a node reachable more than once. Sharing is what the
- * estimator exists to price, and a document without it cannot serialize to more than a constant factor
- * over the text it arrived as — which the body limit already caps at 512 KB. Sharing is necessary for
- * amplification rather than sufficient, which is all a guard that only ever adds work needs to be right
- * about.
+ * Whether this document could possibly contain a node reachable more than once, which is the one thing
+ * `estimateSerializedLength` exists to price. Skipping the estimator for a document that cannot share a
+ * node is therefore safe *with respect to alias amplification* — and that is the whole of the claim.
+ * It is deliberately not a claim that an alias-free document cannot serialize to much more than it
+ * arrived as: one can, since flow style spells a nesting level in about four characters and block style
+ * re-spells it as two spaces per level on every emitted line. The estimator never priced indentation
+ * either, so that is a property of the SDL surface rather than of this guard.
  *
  * Sharing comes from one place: a YAML alias. An alias needs an anchor to point at, so a document that
- * shares anything has to spell both `&` and `*` somewhere in its bytes — and a document missing either
- * character is a pure tree, whose serialized form is bounded by an input the body limit already caps at
- * 512 KB. That is the whole argument, and it holds without knowing anything about YAML's grammar: no
+ * shares anything has to spell both `&` and `*` somewhere in its bytes, and a document missing either
+ * character cannot alias. That argument holds without knowing anything about YAML's grammar: no
  * assumption about quoting, flow style, block scalars, indentation or comments, because it never asks
  * *where* the characters are.
  *

--- a/apps/api/src/deployment/utils/sdl-secret-stripping/sdl-secret-stripping.ts
+++ b/apps/api/src/deployment/utils/sdl-secret-stripping/sdl-secret-stripping.ts
@@ -9,7 +9,7 @@ type SdlServiceDefinition = SDLInput["services"][string];
  * what the stripped document was measured at — an estimate once it exceeds the limit, since measuring
  * stops there rather than running a pathological document to completion.
  */
-export type StrippedSdl = { sdl: string | null; length: number };
+export type StrippedSdl = { sdl: string | null; length: number; error?: unknown };
 
 /**
  * The submitted SDL with the value of every `env` entry and every private registry `credentials` block
@@ -31,7 +31,12 @@ export type StrippedSdl = { sdl: string | null; length: number };
  * for the raw SDL anywhere a hash is taken over it.
  */
 export function stripSdlSecrets(rawSdl: string, maxLength: number): StrippedSdl {
-  const sdl = yaml.raw<SDLInput>(rawSdl);
+  let sdl: SDLInput;
+  try {
+    sdl = yaml.raw<SDLInput>(rawSdl);
+  } catch (error) {
+    return { sdl: null, length: rawSdl.length, error };
+  }
 
   for (const service of serviceDefinitionsOf(sdl)) {
     stripEnvValues(service);


### PR DESCRIPTION
> **Follow-up to #3664, which merged before this fix landed on it.** #3664 was merged at its then-head
> `022b1ec7`; the reviewer's blocking finding was fixed one commit later and did not make it in. The
> defect below is therefore **live on `main` right now**.

## Why

ref CON-855

A trialing wallet's create reclaims escrow from its own lease-less deployments before deploying, and
that reclamation **broadcasts `MsgCloseDeployment` on chain**
(`stale-managed-deployments-cleaner.service.ts` → `managedSignerService.executeDerivedTx`). Selection is
every open, lease-less deployment of the wallet with `maxLiveBlocks: 0`, which includes one created
seconds ago that is still collecting bids.

The oversize-SDL rejection added in #3664 landed *four lines below* that reclamation. So:

1. a trialing user creates deployment **A**, which is awaiting bids
2. they POST a second create whose stripped SDL exceeds the limit
3. `#parseManifest` passes, the reclamation broadcasts a close for **A**
4. `strippedSdlWithinLimit` throws 400

The user gets a 400, nothing is created, and **A is destroyed with its fees spent**. Repeatable at will.

This was novel to #3664. The base branch deliberately puts every user-input rejection *above* the
reclamation — the wallet lookup, the manifest parse, the deposit check. #3662 added one failure below
it, but that is an infrastructure fault (a DB error from `recordDefinition`). #3664 introduced the first
**deterministic, user-triggerable** rejection after it, which is what turned an ordering detail into
reachable state loss.

#3664's own JSDoc claimed *"It runs before the definition is written and before anything is broadcast,
so a rejected request leaves no row behind and nothing on chain."* The first half was true; the second
was false for a trialing wallet.

## What

The oversize check joins the other rejections, above the reclamation:

```ts
const dseq = Date.now();
const sdl = this.strippedSdlWithinLimit(input.sdl, dseq.toString());

if (wallet.isTrialing) {
  await this.reclaimTrialOrphanedDeployments(wallet);
}
```

`dseq` moves up with it. I verified the independence rather than assuming it: `dseq` is a bare
`Date.now()`, `strippedSdlWithinLimit` uses only `input.sdl` and `dseq` (for the warn log), and
`reclaimTrialOrphanedDeployments` takes only `wallet` — `cleanUpForWallet` selects by `wallet.address`
and block height, and touches neither `dseq` nor the SDL.

The JSDoc now states the invariant rather than nearly-stating it, and the reclamation's own comment
carries the rule that makes it durable: **nothing that can reject the caller may be added below it.**

### Also in this commit

- **Narrowed a false doc claim.** The alias guard's JSDoc said an alias-free document "cannot serialize
  to more than a constant factor over the text it arrived as". That is not true — flow style spells a
  nesting level in ~4 characters and block style re-spells it as 2 spaces per level on every emitted
  line, so an anchor-free 16 KB body can dump to megabytes. The claim is now narrowed to what is
  actually true: skipping the estimator is safe *with respect to alias amplification*, which is the only
  thing the estimator prices. The estimator never priced indentation either, so this is a property of
  the SDL surface, not of the guard, and it is unchanged from before #3664. Doc only — the underlying
  issue is being raised separately.
- **Tightened two assertions that did not pin their mechanism.** The exact-dump test now asserts
  `result.length` equals the real `dump(...).length` instead of merely exceeding the limit, and the unit
  leak assertion now checks for the 4096-char filler rather than only the anchor name.

## Tests

`does not reclaim trial orphans when an oversized sdl will reject the create` — a trialing wallet whose
SDL is refused must never reach `cleanUpForWallet`. It follows the existing sibling
`does not reclaim trial orphans when a missing deposit will reject the create`.

**Proven load-bearing.** Reverting the hoist fails it with exactly the reported symptom:

```
× does not reclaim trial orphans when an oversized sdl will reject the create
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Oversized SDL submissions now return a clear client error before wallet lookup or trial cleanup occurs.
- Error messages and logs no longer expose expanded YAML filler content.
- Reported document sizes are now measured accurately, improving validation feedback.
- YAML parsing failures during size validation are handled without exposing sensitive expanded content.
- Deployment updates now persist SDL and manifest changes before broadcasting, preventing incomplete update states.

## Documentation

- Clarified safeguards and limitations around YAML anchors, aliases, and document-size expansion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->