### PR TITLE
test(deployment): fix the red beta e2e run and its login flakiness

### DIFF
--- a/apps/deploy-web/tests/ui/actions/auth.ts
+++ b/apps/deploy-web/tests/ui/actions/auth.ts
@@ -13,6 +13,13 @@ export type AuthType = "passwordless" | "email-password";
 
 const DETECT_TIMEOUT_MS = 30_000;
 
+/**
+ * Leaving /login waits on a Turnstile solve, the app's auth API route and Auth0 in sequence, which on beta regularly
+ * outruns the 15s actionTimeout: 8 of 27 tests in the 2026-08-25 run retried on this gate alone, and the global
+ * teardown failed its escrow sweep with it, leaving deployments draining.
+ */
+const SIGN_IN_TIMEOUT_MS = 45_000;
+
 export function generateTestPassword(): string {
   return `E2e!${crypto.randomUUID()}`;
 }
@@ -63,7 +70,7 @@ export async function loginExistingUser(page: Page): Promise<void> {
   await page.goto(`${testEnvConfig.BASE_URL}/login?auth=password`);
   await signInWithPassword(page, { email, password });
 
-  await page.waitForURL(url => !url.pathname.includes("/login"), { timeout: 15_000 });
+  await page.waitForURL(url => !url.pathname.includes("/login"), { timeout: SIGN_IN_TIMEOUT_MS });
   await new AppNav(page).accountMenuButton().waitFor({ timeout: 30_000 });
 }
 

--- a/apps/deploy-web/tests/ui/deployment-detail.spec.ts
+++ b/apps/deploy-web/tests/ui/deployment-detail.spec.ts
@@ -48,7 +48,13 @@ test.describe("Deployment detail", () => {
       }
     });
 
+    await test.step("lands on the Events tab so the workload's first events are in view", async () => {
+      await expect(page.getByRole("tab", { name: "Events" })).toHaveAttribute("aria-selected", "true");
+    });
+
     await test.step("shows the placements & services overview on the Details tab", async () => {
+      await page.getByRole("tab", { name: "Details" }).click();
+
       await expect(page.getByText("Placements", { exact: true })).toBeVisible({ timeout: 30_000 });
 
       const service = page.getByRole("button", { name: /service-1/ });

--- a/apps/deploy-web/tests/ui/pages/AuthPagePasswordless.ts
+++ b/apps/deploy-web/tests/ui/pages/AuthPagePasswordless.ts
@@ -2,6 +2,12 @@ import type { Page } from "@playwright/test";
 
 import { testEnvConfig } from "../fixture/test-env.config";
 
+/**
+ * The verify screen appears only once the OTP request reaches Auth0 and the email is dispatched, which outruns the
+ * 15s actionTimeout on beta.
+ */
+const VERIFY_SCREEN_TIMEOUT_MS = 45_000;
+
 export class AuthPagePasswordless {
   constructor(readonly page: Page) {}
 
@@ -19,7 +25,7 @@ export class AuthPagePasswordless {
   }
 
   async waitForVerifyScreen() {
-    await this.page.getByLabel("Verification code digit 1").waitFor({ state: "visible" });
+    await this.page.getByLabel("Verification code digit 1").waitFor({ state: "visible", timeout: VERIFY_SCREEN_TIMEOUT_MS });
   }
 
   async waitForRedirectAwayFromLogin() {

--- a/apps/deploy-web/tests/ui/passwordless-login.spec.ts
+++ b/apps/deploy-web/tests/ui/passwordless-login.spec.ts
@@ -50,7 +50,7 @@ test.describe("Passwordless auth", () => {
   });
 
   test("returns to the email step when the browser back button is pressed on the verify screen", async ({ page }) => {
-    test.setTimeout(60 * 1000);
+    test.setTimeout(3 * 60 * 1000);
 
     const auth = new AuthPagePasswordless(page);
     await auth.goto();


### PR DESCRIPTION
## Why

The console-web e2e run on beta ([32876351244](https://github.com/akash-network/console/actions/runs/32876351244)) is red. Of 27 tests, 1 failed outright and 10 were flaky. Two unrelated causes.

**The hard failure came from #3661.** `DeploymentPlacements` only renders its `Placements` heading on the Details tab, but deploying redirects to `?tab=EVENTS` so the user sees the workload's first events. The failure artifact confirms it: the deployment is Running, the header tiles and all six tabs render, and `tab "Events" [selected]`. The spec used to land on Details implicitly, via a `page.goto` on the preview route that carried no tab query — #3661 retired that route and dropped the navigation with it, leaving nothing to activate Details. The app is fine here; the spec is what broke.

**The 10 flaky tests are all one thing:** auth round-trips running past `actionTimeout: 15_000`, at exactly two gates — `loginExistingUser`'s `waitForURL` (8 tests) and `waitForVerifyScreen` (2 tests). Snapshots show the submit button still on `Loading...` with no error alert, so the Turnstile solve → auth route → Auth0 chain simply hadn't returned. They all pass on retry, so it's a budget mismatch rather than a broken flow — but it burns ~8 min of retries per run, and it also broke the global teardown's escrow sweep (`could not sweep the test account`), which leaves beta deployments draining.

## What

Test-only, two commits.

`test(deployment)` — activate the Details tab before asserting placements, the way `DeploymentDetailPage.expectRunning()` already does, and assert the post-deploy landing tab so a future change there fails loudly instead of quietly skipping the assertions that follow. The final tab-query step now clicks Events from a genuine `DETAILS` state, so `onValueChange` actually fires.

`test(auth)` — budget both auth gates at 45s behind named constants, matching the `*_TIMEOUT_MS` convention already in these files, and raise the one per-test cap (60s) that would otherwise have become the new binding constraint. Left `inbox-code.strategy.ts`'s 10s submit budget alone: it never appeared in the flake list and it races an error-alert locator, so changing it would shift semantics with nothing to justify it.

The captcha bypass turned out to be working as designed — the fixture injects Cloudflare's always-pass dummy sitekey plus the `x-testing-client-token` header — so nothing changed there.

### Verifying

PR CI doesn't run this suite; `reusable-deploy-test.yml` is only reachable from the deploy pipeline. Its `actions/checkout` takes no `ref`, so it runs specs from the dispatched branch against the already-deployed image, which means no new release is needed after merge:

```
gh workflow run reusable-deploy-app.yml --repo akash-network/console --ref main \
  -f app=console-web -f image_tag=console-web/v3.176.1
```

Locally: `tsc --noEmit` holds at the pre-existing 93 errors with an identical error set, `eslint .` is clean, the `unit-e2e-helpers` vitest project passes (33 tests), and `playwright test --list` still resolves all 27 tests.
