### PR TITLE
feat(deployment): record the sdl and manifest version on deployment update

### DIFF
--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
@@ -310,6 +310,16 @@ describe(DeploymentSettingRepository.name, () => {
       expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq })).toMatchObject({ runtimeLimitHours: 6 });
     });
 
+    it("replaces a definition an earlier write recorded", async () => {
+      const { deploymentSettingRepository, user } = await setup();
+      const dseq = newDseq();
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: "version: '2.0'", manifestVersion: "BAUG" });
+
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: "version: '2.1'", manifestVersion: "BQYH" });
+
+      expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq })).toMatchObject({ sdl: "version: '2.1'", manifestVersion: "BQYH" });
+    });
+
     it("keeps the definitions of two deployments of the same user apart", async () => {
       const { deploymentSettingRepository, user } = await setup();
       const [first, second] = [newDseq(), newDseq()];

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -252,15 +252,18 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
   }
 
   /**
-   * Records what a deployment is, at the moment it is created: the SDL it was given, stripped of its
-   * secrets and small enough to keep, the manifest version it commits on chain, and the runtime limit its creator chose. One
-   * statement, so a deployment can never end up remembering half of itself, and so the sealed secrets
-   * a later phase adds land in the same write as the SDL they belong to.
+   * Records what a deployment is, at the moment it is created and again every time it is updated: the
+   * SDL it was given, stripped of its secrets and small enough to keep, the manifest version it commits
+   * on chain, and the runtime limit its creator chose. One statement, so a deployment can never end up
+   * remembering half of itself, and so the sealed secrets a later phase adds land in the same write as
+   * the SDL they belong to.
    *
-   * Upserts on the (dseq, userId) unique because a settings read creates a row lazily, and because the
-   * caller retries a create that failed to broadcast. The conflict branch leaves every field it does
-   * not name as the earlier writer set them, and an absent runtime limit counts as unnamed: drizzle
-   * drops undefined out of the set clause, so creating without a limit cannot clear one already there.
+   * Upserts on the (dseq, userId) unique because a settings read creates a row lazily, because the
+   * caller retries a create that failed to broadcast, and because an update of a deployment that
+   * predates any record has to produce the row a create would have. The conflict branch leaves every
+   * field it does not name as the earlier writer set them, and an absent runtime limit counts as
+   * unnamed: drizzle drops undefined out of the set clause, so neither creating nor updating without a
+   * limit can clear one already there.
    */
   async upsertDefinition({
     userId,

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -562,6 +562,76 @@ describe(DeploymentWriterService.name, () => {
       expect(providerService.sendManifest).toHaveBeenCalledWith(expect.objectContaining({ provider: "provider-1" }));
       expect(providerService.sendManifest).toHaveBeenCalledWith(expect.objectContaining({ provider: "provider-2" }));
     });
+
+    it("records the sdl and the manifest version it re-commits", async () => {
+      const { service, deploymentSettingRepository } = setup();
+
+      await service.updateByUserIdAndDseq("user-1", "100", { sdl: SDL_WITH_SECRETS });
+
+      expect(deploymentSettingRepository.upsertDefinition).toHaveBeenCalledWith({
+        userId: wallet.userId,
+        dseq: "100",
+        sdl: expect.stringContaining("API_TOKEN="),
+        manifestVersion: "BAUG"
+      });
+    });
+
+    it("records an sdl carrying none of the submitted env values", async () => {
+      const { service, deploymentSettingRepository } = setup();
+
+      await service.updateByUserIdAndDseq("user-1", "100", { sdl: SDL_WITH_SECRETS });
+
+      expect(recordedSdlOf(deploymentSettingRepository)).not.toContain(ENV_VALUE);
+    });
+
+    it("records an sdl carrying none of the submitted registry credentials", async () => {
+      const { service, deploymentSettingRepository } = setup();
+
+      await service.updateByUserIdAndDseq("user-1", "100", { sdl: SDL_WITH_SECRETS });
+
+      expect(recordedSdlOf(deploymentSettingRepository)).not.toContain(REGISTRY_PASSWORD);
+    });
+
+    it("records the definition even when the manifest version already matches the chain", async () => {
+      const { service, sdlService, signerService, deploymentSettingRepository } = setup();
+      sdlService.generateManifestVersion.mockResolvedValue(new Uint8Array([1, 2, 3]));
+
+      await service.updateByUserIdAndDseq("user-1", "100", { sdl: SDL_WITH_SECRETS });
+
+      expect(deploymentSettingRepository.upsertDefinition).toHaveBeenCalledWith(expect.objectContaining({ dseq: "100", manifestVersion: "AQID" }));
+      expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
+    });
+
+    it("records the definition before it broadcasts or re-sends the manifest", async () => {
+      const { service, signerService, providerService, deploymentSettingRepository } = setup();
+      deploymentSettingRepository.upsertDefinition.mockRejectedValue(new Error("db down"));
+
+      await expect(service.updateByUserIdAndDseq("user-1", "100", { sdl: SDL_WITH_SECRETS })).rejects.toThrow("db down");
+
+      expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
+      expect(providerService.sendManifest).not.toHaveBeenCalled();
+    });
+
+    it("rejects an sdl too large to store without touching the deployment", async () => {
+      const { service, signerService, providerService, deploymentSettingRepository } = setup();
+
+      await expect(service.updateByUserIdAndDseq("user-1", "100", { sdl: SDL_TOO_LONG_WITHOUT_ALIASES })).rejects.toMatchObject({ status: 400 });
+
+      expect(deploymentSettingRepository.upsertDefinition).not.toHaveBeenCalled();
+      expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
+      expect(providerService.sendManifest).not.toHaveBeenCalled();
+    });
+
+    it("reports a failure to record the definition without logging the sdl", async () => {
+      const { service, deploymentSettingRepository, logger } = setup();
+      deploymentSettingRepository.upsertDefinition.mockRejectedValue(new Error("db down"));
+
+      await expect(service.updateByUserIdAndDseq("user-1", "100", { sdl: SDL_WITH_SECRETS })).rejects.toThrow("db down");
+
+      expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "DEPLOYMENT_DEFINITION_PERSISTENCE_FAILED", dseq: "100" }));
+      expect(loggedTextOf(logger)).not.toContain(ENV_VALUE);
+      expect(loggedTextOf(logger)).not.toContain("API_TOKEN");
+    });
   });
 
   function recordedSdlOf(deploymentSettingRepository: MockProxy<DeploymentSettingRepository>): string {

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -84,15 +84,26 @@ export class DeploymentWriterService {
   }
 
   /**
-   * Records what the deployment is before the create tx is broadcast, never after. The reverse order
-   * would let a successful broadcast produce a deployment with no remembered definition, which becomes
-   * unrecoverable once a later phase stores sealed secrets in the same write. A broadcast that then
-   * fails leaves a record for a deployment that does not exist on chain, which costs one row the
-   * draining sweep skips on every pass, and which the next create — always on a fresh dseq — ignores.
+   * Records what the deployment is before anything is broadcast, never after, on both create and
+   * update. The reverse order would let a successful broadcast produce a deployment with no remembered
+   * definition, which becomes unrecoverable once a later phase stores sealed secrets in the same write.
+   * A broadcast that then fails leaves a record for something that is not running: on create the retry
+   * takes a fresh dseq, so the orphaned row survives until the draining sweep collects it; on update
+   * the dseq is the one being updated, so the same request retried — idempotent on both the record and
+   * the chain — puts the two back in step.
    *
-   * A failure here surfaces as an error rather than best-effort, and nothing is broadcast: the user
-   * retries and gets both the deployment and its record, instead of a deployment the console cannot
-   * describe.
+   * A failure here surfaces as an error rather than best-effort, and nothing is broadcast and no
+   * manifest is re-sent: the user retries and gets both the deployment and its record, instead of a
+   * deployment the console cannot describe.
+   *
+   * An update records unconditionally, including when the manifest version already matches the chain.
+   * A matching version means the manifest is unchanged, not that the submitted document is: comments,
+   * formatting, and everything outside the manifest can still differ, and it is the SDL that is
+   * recorded.
+   *
+   * The write is last-writer-wins, with no compare-and-swap: two concurrent updates of one dseq can
+   * interleave so the row keeps one SDL while the chain runs the other, both succeeding. That is inert
+   * while nothing reads these columns, and needs revisiting when sealed secrets share the write.
    *
    * The stored SDL deliberately does not hash to the stored manifest version, and no future reader
    * should expect it to. The version is taken over the manifest the generator produced, which rewrites
@@ -120,8 +131,9 @@ export class DeploymentWriterService {
    * of what it is from ever disagreeing: a deployment the console cannot describe is one nobody can
    * later reproduce, redeploy, or attach sealed secrets to.
    *
-   * It runs before the definition is written and before anything is broadcast, so a rejected request
-   * leaves no row behind and nothing on chain.
+   * It runs before the definition is written and before anything is broadcast, so a rejected create
+   * leaves no row behind and nothing on chain, and a rejected update leaves the deployment running
+   * exactly what it ran before, still described by the record it already had.
    *
    * Neither the log nor the error says anything about the SDL beyond how long it is. The whole point of
    * stripping is that user content does not end up somewhere it was not meant to be, and an error body
@@ -221,11 +233,14 @@ export class DeploymentWriterService {
   public async updateByUserIdAndDseq(userId: string, dseq: string, input: UpdateDeploymentRequest["data"]): Promise<GetDeploymentResponse["data"]> {
     const wallet = await this.walletReaderService.getWalletByUserId(userId);
     const manifest = this.#parseManifest(input.sdl, { isTrialing: !!wallet.isTrialing });
+    const sdl = this.strippedSdlWithinLimit(input.sdl, dseq);
 
     const [deployment, manifestVersion] = await Promise.all([
       this.deploymentReaderService.findByWalletAndDseq(wallet, dseq),
       this.sdlService.generateManifestVersion(manifest.groups)
     ]);
+
+    await this.recordDefinition({ userId: wallet.userId, dseq, sdl, manifestVersion });
 
     await this.ensureDeploymentIsUpToDate(wallet, dseq, manifestVersion, deployment);
     const auth = { walletId: wallet.id };

--- a/apps/api/test/functional/deployments.spec.ts
+++ b/apps/api/test/functional/deployments.spec.ts
@@ -131,9 +131,9 @@ describe("Deployments API", () => {
   }
 
   /**
-   * Persists a real user row, which every create needs: creating a deployment now records what that
-   * deployment is, and that record is FK-bound to the user. `mockUser` fakes the user for read paths
-   * that never write.
+   * Persists a real user row, which every create and every SDL update needs: creating or updating a
+   * deployment now records what that deployment is, and that record is FK-bound to the user. `mockUser`
+   * fakes the user, and only suits paths that never record a definition.
    */
   async function mockPersistedUser() {
     const dbUser = await userRepository.create({ userId: faker.string.uuid() });
@@ -963,7 +963,7 @@ describe("Deployments API", () => {
 
   describe("PUT /v1/deployments/{dseq}", () => {
     it("should update a deployment successfully", async () => {
-      const { userApiKeySecret, wallets } = await mockUser();
+      const { userApiKeySecret, wallets } = await mockPersistedUser();
       const dseq = "1234";
       await setupDeploymentInfoMock(wallets, dseq);
 
@@ -1064,6 +1064,92 @@ describe("Deployments API", () => {
       const result = (await response.json()) as { message: string };
       expect(result.message).toContain("Invalid SDL");
     });
+
+    it("replaces the sdl and the manifest version an earlier write recorded", async () => {
+      const { userApiKeySecret, user, dseq } = await setupUpdatableDeployment();
+      const deploymentSettingRepository = container.resolve(DeploymentSettingRepository);
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: "version: '2.0'", manifestVersion: "AAAA" });
+
+      const response = await putDeployment({ userApiKeySecret, dseq, sdlMock: "hello-world-sdl.yml" });
+
+      expect(response.status).toBe(200);
+      const setting = await deploymentSettingRepository.findOneBy({ userId: user.id, dseq });
+      expect(setting?.sdl).toContain("ghcr.io/akash-network/hello-akash-world");
+      expect(setting?.manifestVersion).not.toBe("AAAA");
+      expect(Buffer.from(setting?.manifestVersion ?? "", "base64")).toHaveLength(32);
+    });
+
+    it("records the definition of a deployment updated before it had one", async () => {
+      const { userApiKeySecret, user, dseq } = await setupUpdatableDeployment();
+      const deploymentSettingRepository = container.resolve(DeploymentSettingRepository);
+      expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq })).toBeUndefined();
+
+      const response = await putDeployment({ userApiKeySecret, dseq, sdlMock: "hello-world-sdl.yml" });
+
+      expect(response.status).toBe(200);
+      expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq })).toMatchObject({
+        sdl: expect.stringContaining("ghcr.io/akash-network/hello-akash-world"),
+        manifestVersion: expect.stringMatching(/^[A-Za-z0-9+/]+={0,2}$/)
+      });
+    });
+
+    it("records an sdl naming every env variable the submitted one declared", async () => {
+      const { setting } = await updateDeploymentWithSecrets();
+
+      expect(setting?.sdl).toContain("API_TOKEN=");
+      expect(setting?.sdl).toContain("DATABASE_URL=");
+      expect(setting?.sdl).toContain("INHERITED_FROM_HOST");
+    });
+
+    it("records an sdl carrying none of the submitted env values", async () => {
+      const { setting } = await updateDeploymentWithSecrets();
+
+      expect(setting?.sdl).not.toContain("PLACEHOLDER_API_TOKEN");
+      expect(setting?.sdl).not.toContain("PLACEHOLDER_DB_PASSWORD");
+      expect(setting?.sdl).not.toContain("db.example.test");
+    });
+
+    it("records an sdl carrying none of the submitted registry credentials", async () => {
+      const { setting } = await updateDeploymentWithSecrets();
+
+      expect(setting?.sdl).not.toContain("PLACEHOLDER_REGISTRY_PASSWORD");
+      expect(setting?.sdl).not.toContain("registry.example.test");
+      expect(setting?.sdl).not.toContain("credentials");
+    });
+
+    it("records an sdl that is still a deployable SDL", async () => {
+      const { setting } = await updateDeploymentWithSecrets();
+
+      expect(container.resolve(SdlService).generateManifest(setting?.sdl ?? "").ok).toBe(true);
+    });
+
+    async function setupUpdatableDeployment() {
+      const { userApiKeySecret, user, wallets } = await mockPersistedUser();
+      const dseq = "1234";
+      await setupDeploymentInfoMock(wallets, dseq);
+
+      return { userApiKeySecret, user, dseq };
+    }
+
+    function putDeployment({ userApiKeySecret, dseq, sdlMock }: { userApiKeySecret: string; dseq: string; sdlMock: string }) {
+      const yml = fs.readFileSync(path.resolve(__dirname, `../mocks/${sdlMock}`), "utf8");
+
+      return app.request(`/v1/deployments/${dseq}`, {
+        method: "PUT",
+        body: JSON.stringify({ data: { sdl: yml } }),
+        headers: new Headers({ "Content-Type": "application/json", "x-api-key": userApiKeySecret })
+      });
+    }
+
+    async function updateDeploymentWithSecrets() {
+      const { userApiKeySecret, user, dseq } = await setupUpdatableDeployment();
+
+      const response = await putDeployment({ userApiKeySecret, dseq, sdlMock: "hello-world-sdl-with-secrets.yml" });
+
+      expect(response.status).toBe(200);
+
+      return { setting: await container.resolve(DeploymentSettingRepository).findOneBy({ userId: user.id, dseq }) };
+    }
   });
 
   describe("GET /v1/addresses/{address}/deployments/{skip}/{limit}", () => {


### PR DESCRIPTION
## Why

Closes CON-856

Creating a deployment already recorded what that deployment is. Updating one did not.

So the moment a user changed their SDL, the console's record went stale against what the providers were actually running, and stayed stale for the rest of the deployment's life. Anything built on that record — reproducing a deployment, redeploying it, showing a user what they are running, and the sealed secrets work that will share the same row — would have been reading the SDL the deployment was *created* with, not the one it is running.

This closes that gap: an update now records the SDL it applies, the same way a create does.

## What

`DeploymentWriterService.updateByUserIdAndDseq` now strips the submitted SDL's secrets, rejects it with a `400` when it is too large to store (`SDL_MAX_LENGTH`, 128 KiB), and records it together with the manifest version it re-commits — **before** it broadcasts and **before** it re-sends the manifest. This mirrors the create path exactly; no create-path semantics moved.

Notable decisions, all documented in the `recordDefinition` JSDoc:

- **The record is written first, never after.** The reverse order would let a successful broadcast produce a deployment with no remembered definition, which becomes unrecoverable once a later phase stores sealed secrets in the same write.
- **A record that cannot be written fails the whole update.** Nothing is broadcast and no manifest is re-sent, so the deployment keeps running the SDL the console still correctly describes. The user retries and gets both.
- **The write is an upsert**, so a deployment updated before it ever had a record gains the same row a create would have produced. Drizzle drops `undefined` out of the set clause, so updating without a runtime limit cannot clear one already there.
- **It records unconditionally**, including on the branch where the manifest version already matches the chain. A matching version means the *manifest* is unchanged, not that the submitted *document* is — comments, formatting, and everything outside the manifest can still differ, and it is the SDL that is recorded.
- **The stored SDL deliberately does not hash to the stored manifest version.** The version is taken over the manifest the generator produced (which rewrites the denom and appends allowed auditors); the stored SDL is the one the user submitted, stripped. They describe the same deployment, not the same bytes.
- **The write is last-writer-wins, with no compare-and-swap.** Two concurrent updates of one dseq can interleave so the row keeps one SDL while the chain runs the other. This is inert while nothing reads these columns, and is called out in the JSDoc as needing revisiting when sealed secrets share the write.

### Behaviour changes worth flagging

- `PUT` on a deployment now returns **`400`** for an SDL larger than 128 KiB, where it previously succeeded. This is deliberate and matches create: deploying without a record is what lets the deployment and the record of it disagree. Neither the log nor the error body echoes the SDL — only its length.
- `PUT` is now a **write path**, so it requires a persisted user row (the record is FK-bound to the user). The functional-test helper JSDoc was widened to say so.

### Not included

- **No migration.** The `sdl` and `manifest_version` columns already exist from the create-path change (`09c510f9`).
- **No CAS / optimistic locking** — out of scope, recorded as a known property instead.
- **No orphan cleanup.** On create, a retry takes a fresh dseq, so a row orphaned by a failed broadcast survives until the draining sweep collects it. That sweep is separate in-flight work; this PR restores the JSDoc sentence describing that behaviour rather than implying retries self-heal it.

### Tests

- Unit: records the SDL and the manifest version it re-commits; strips env values and registry credentials; records even when the manifest version already matches; records before broadcasting or re-sending the manifest; rejects an oversized SDL without touching the deployment; reports a persistence failure without logging the SDL.
- Integration: `upsertDefinition` conflict-branch behaviour.
- Functional: the full `PUT` path against a real database.

Full suite for `apps/api`: **215 files, 2290 tests passing**. Lint clean. `tsc --noEmit` unchanged at the pre-existing 40-error baseline, none in changed files.

---

# Recording a deployment's SDL when it is updated

*2026-08-25T20:45:07Z by Showboat 0.6.1*
<!-- showboat-id: 1f75dc3b-1fa0-4afb-a385-3ae586d137a2 -->

Creating a deployment already recorded what it is. Updating one did not, so the moment a user changed their SDL the console's record went stale against what the providers were actually running.

This demo drives the real `DeploymentWriterService.updateByUserIdAndDseq` against a real Postgres and the real `DeploymentSettingRepository`; only the chain signer, the provider client and the deployment reader are stubbed. Everything shown below is a row read back out of the database after the update returned.

Every block runs in `/tmp/console-iso`, a git worktree checked out at the commit under review, so nothing unrelated in the main working tree can affect what it shows.

## The harness

A scratch integration file, written into the worktree for the duration of the demo and deleted at the end. It is not part of the change.

```bash
cd /tmp/console-iso/apps/api
cat > src/deployment/services/deployment-writer/demo-record-on-update.integration.ts <<'TSEOF'
import { container } from "tsyringe";
import { describe, it } from "vitest";
import { mock } from "vitest-mock-extended";

import type { WalletInitialized } from "@src/billing/repositories";
import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
import type { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
import type { RpcMessageService } from "@src/billing/services/rpc-message-service/rpc-message.service";
import type { WalletReaderService } from "@src/billing/services/wallet-reader/wallet-reader.service";
import type { LoggerService } from "@src/core";
import { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
import type { GetDeploymentResponse } from "@src/deployment/http-schemas/deployment.schema";
import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
import { SdlService } from "@src/deployment/services/sdl/sdl.service";
import type { ProviderService } from "@src/provider/services/provider/provider.service";
import { UserRepository } from "@src/user/repositories";
import { DeploymentConfigService } from "../deployment-config/deployment-config.service";
import type { DeploymentReaderService } from "../deployment-reader/deployment-reader.service";
import type { StaleManagedDeploymentsCleanerService } from "../stale-managed-deployments-cleaner/stale-managed-deployments-cleaner.service";
import { DeploymentWriterService } from "./deployment-writer.service";

const DSEQ = "424242";
const SCENARIO = process.env.DEMO_SCENARIO ?? "all";

function say(line: string) {
  process.stdout.write(`DEMO| ${line}\n`);
}

function sdlWith(image: string, apiToken: string) {
  return `version: "2.0"
services:
  web:
    image: ${image}
    env:
      - API_TOKEN=${apiToken}
    expose:
      - port: 3000
        as: 80
        to:
          - global: true
profiles:
  compute:
    web:
      resources:
        cpu:
          units: 0.5
        memory:
          size: 512Mi
        storage:
          - size: 512Mi
  placement:
    dcloud:
      pricing:
        web:
          denom: uakt
          amount: 1000
deployment:
  web:
    dcloud:
      profile: web
      count: 1`;
}

describe("recording a deployment's definition when it is updated", () => {
  it("shows what the console remembers before and after an update", async () => {
    const { service, deploymentSettingRepository, userId } = await setup();

    if (SCENARIO === "rowless" || SCENARIO === "all") {
      say(`A deployment the console has never recorded: dseq ${DSEQ}`);
      say(`  stored row before the update: ${JSON.stringify(await deploymentSettingRepository.findOneBy({ userId, dseq: DSEQ }))}`);

      await service.updateByUserIdAndDseq(userId, DSEQ, { sdl: sdlWith("nginx:1.0", "DEMO_TOKEN_ONE") });

      const created = await deploymentSettingRepository.findOneBy({ userId, dseq: DSEQ });
      say(`  stored row after the update: exists=${!!created} autoTopUpEnabled=${created?.autoTopUpEnabled} runtimeLimitHours=${created?.runtimeLimitHours}`);
      say(`  recorded image: ${created?.sdl?.match(/image: \S+/)?.[0]}`);
      say(`  recorded manifest version decodes to ${Buffer.from(created?.manifestVersion ?? "", "base64").length} bytes`);
    }

    if (SCENARIO === "replaces" || SCENARIO === "all") {
      await service.updateByUserIdAndDseq(userId, DSEQ, { sdl: sdlWith("nginx:1.0", "DEMO_TOKEN_ONE") });
      const before = await deploymentSettingRepository.findOneBy({ userId, dseq: DSEQ });
      say("The same deployment updated again, to a different image:");
      say(`  recorded image before: ${before?.sdl?.match(/image: \S+/)?.[0]}`);
      say(`  recorded manifest version before: ${before?.manifestVersion}`);

      await service.updateByUserIdAndDseq(userId, DSEQ, { sdl: sdlWith("nginx:2.0", "DEMO_TOKEN_TWO") });

      const after = await deploymentSettingRepository.findOneBy({ userId, dseq: DSEQ });
      say(`  recorded image after:  ${after?.sdl?.match(/image: \S+/)?.[0]}`);
      say(`  recorded manifest version after:  ${after?.manifestVersion}`);
      say(`  the row is still one row, not two: ${before?.id === after?.id}`);
    }

    if (SCENARIO === "secrets" || SCENARIO === "all") {
      await service.updateByUserIdAndDseq(userId, DSEQ, { sdl: sdlWith("nginx:3.0", "DEMO_TOKEN_THREE") });
      const recorded = await deploymentSettingRepository.findOneBy({ userId, dseq: DSEQ });

      say("What the recorded SDL keeps of the env the user submitted:");
      say(`  names the variable:            ${recorded?.sdl?.includes("API_TOKEN=")}`);
      say(`  carries its submitted value:   ${recorded?.sdl?.includes("DEMO_TOKEN_THREE")}`);
      say(`  the recorded env block reads:  ${JSON.stringify(recorded?.sdl?.match(/- API_TOKEN=\S*/)?.[0] ?? "- API_TOKEN=")}`);
      say(`  and is still a deployable SDL: ${container.resolve(SdlService).generateManifest(recorded?.sdl ?? "").ok}`);
    }
  });

  async function setup() {
    const userRepository = container.resolve(UserRepository);
    const deploymentSettingRepository = container.resolve(DeploymentSettingRepository);
    const user = await userRepository.create({ userId: "11111111-2222-3333-4444-555555555555" });

    const wallet = mock<WalletInitialized>({ id: 1, userId: user.id, address: "akash1demoaddress" });
    const walletReaderService = mock<WalletReaderService>();
    walletReaderService.getWalletByUserId.mockResolvedValue(wallet);

    const deploymentReaderService = mock<DeploymentReaderService>();
    deploymentReaderService.findByWalletAndDseq.mockResolvedValue(
      mock<GetDeploymentResponse["data"]>({
        deployment: { id: { owner: wallet.address, dseq: DSEQ }, state: "active", hash: "an-older-hash", created_at: "2026-01-01" },
        leases: []
      })
    );

    const service = new DeploymentWriterService(
      mock<ManagedSignerService>(),
      mock<RpcMessageService>(),
      container.resolve(SdlService),
      container.resolve(BillingConfigService),
      mock<ProviderService>(),
      deploymentReaderService,
      walletReaderService,
      mock<StaleManagedDeploymentsCleanerService>(),
      mock<LoggerService>(),
      container.resolve(DeploymentConfigService),
      container.resolve(FeatureFlagsService),
      deploymentSettingRepository
    );

    return { service, deploymentSettingRepository, userId: user.id };
  }
});
TSEOF
echo "harness written"
```

```output
harness written
```

## A deployment updated before it had a record gains one

Deployments that predate the console recording anything have no settings row at all. Updating one now produces the same row a create would have produced — auto top-up on by default, no runtime limit, and a 32-byte manifest version.

```bash
cd /tmp/console-iso/apps/api && DEMO_SCENARIO=rowless npx vitest run --project integration src/deployment/services/deployment-writer/demo-record-on-update.integration.ts --reporter=dot 2>&1 | sed -n "s/^DEMO| //p"
```

```output
A deployment the console has never recorded: dseq 424242
  stored row before the update: undefined
  stored row after the update: exists=true autoTopUpEnabled=true runtimeLimitHours=null
  recorded image: image: nginx:1.0
  recorded manifest version decodes to 32 bytes
```

## Updating again replaces what the console remembers

The second update overwrites the first one's SDL and manifest version in place — one row per deployment, not one row per update.

```bash
cd /tmp/console-iso/apps/api && DEMO_SCENARIO=replaces npx vitest run --project integration src/deployment/services/deployment-writer/demo-record-on-update.integration.ts --reporter=dot 2>&1 | sed -n "s/^DEMO| //p"
```

```output
The same deployment updated again, to a different image:
  recorded image before: image: nginx:1.0
  recorded manifest version before: p96GI1v8WvaHnhU1sVPVRBLql5b2ePVOhmyL2yhz+R0=
  recorded image after:  image: nginx:2.0
  recorded manifest version after:  E6rb+9+8Fk1wOrEih/ugrazScBMBgdvQrTH+w26st6M=
  the row is still one row, not two: true
```

## The recorded SDL keeps the variable's name and none of its value

The submitted SDL sets `API_TOKEN` to a value. What lands in the database names the variable and drops what it was set to, and what is left is still a document the manifest generator accepts.

```bash
cd /tmp/console-iso/apps/api && DEMO_SCENARIO=secrets npx vitest run --project integration src/deployment/services/deployment-writer/demo-record-on-update.integration.ts --reporter=dot 2>&1 | sed -n "s/^DEMO| //p"
```

```output
What the recorded SDL keeps of the env the user submitted:
  names the variable:            true
  carries its submitted value:   false
  the recorded env block reads:  "- API_TOKEN="
  and is still a deployable SDL: true
```

## Cleanup

```bash
cd /tmp/console-iso/apps/api && rm -f src/deployment/services/deployment-writer/demo-record-on-update.integration.ts && git status --short src/deployment/services/deployment-writer/ && echo "no scratch file left behind"
```

```output
no scratch file left behind
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployment updates now save the submitted SDL and manifest version, including updates where no previous deployment settings exist.
  * Definitions are recorded even when the manifest version remains unchanged.
* **Bug Fixes**
  * Sensitive values are removed from stored deployment definitions.
  * Invalid or oversized SDL submissions are rejected safely.
  * Deployment updates now persist reliably before synchronization and provider notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->