### PR TITLE
feat(deployment): return a deployment's console settings from its read endpoint

### DIFF
--- a/apps/api/src/deployment/controllers/lease/lease.controller.ts
+++ b/apps/api/src/deployment/controllers/lease/lease.controller.ts
@@ -1,7 +1,7 @@
 import { singleton } from "tsyringe";
 
 import { AuthService, Protected } from "@src/auth/services/auth.service";
-import { type GetDeploymentResponse } from "@src/deployment/http-schemas/deployment.schema";
+import { type CreateLeaseResponse } from "@src/deployment/http-schemas/deployment.schema";
 import { type CreateLeaseRequest } from "@src/deployment/http-schemas/lease.schema";
 import { type FallbackLeaseListResponse } from "@src/deployment/http-schemas/lease-rpc.schema";
 import { DatabaseLeaseListParams } from "@src/deployment/repositories/lease/lease.repository";
@@ -17,7 +17,7 @@ export class LeaseController {
   ) {}
 
   @Protected([{ action: "sign", subject: "UserWallet" }])
-  async createLeasesAndSendManifest(input: CreateLeaseRequest): Promise<GetDeploymentResponse> {
+  async createLeasesAndSendManifest(input: CreateLeaseRequest): Promise<CreateLeaseResponse> {
     const result = await this.leaseService.createLeasesAndSendManifest({
       ...input,
       userId: this.authService.currentUser.id

--- a/apps/api/src/deployment/http-schemas/deployment.schema.ts
+++ b/apps/api/src/deployment/http-schemas/deployment.schema.ts
@@ -78,7 +78,25 @@ const DeploymentLeaseListItemSchema = DeploymentResponseSchema.extend({
   leases: z.array(DeploymentLeaseSchema.omit({ status: true }))
 });
 
+const ConsoleSettingsSchema = z.object({
+  sdl: z.string().openapi({
+    description: "The SDL the console stored for this deployment. Re-serialized YAML, so not byte-identical to the submitted document."
+  }),
+  manifestVersion: z.string().openapi({
+    description: "Base64 of the manifest version this deployment commits on chain. Deliberately not a hash of the `sdl` above."
+  })
+});
+
 export const GetDeploymentResponseSchema = z.object({
+  data: DeploymentResponseSchema.extend({
+    consoleSettings: ConsoleSettingsSchema.nullable().openapi({
+      description: "What the console recorded for this deployment, or null when it recorded nothing."
+    })
+  })
+});
+
+/** POST /v1/leases answers with the deployment as the chain describes it, without the console's own record. */
+export const CreateLeaseResponseSchema = z.object({
   data: DeploymentResponseSchema
 });
 
@@ -283,6 +301,9 @@ export const GetWeeklyDeploymentCostResponseSchema = z.object({
   })
 });
 
+export type DeploymentResponse = z.infer<typeof DeploymentResponseSchema>;
+export type CreateLeaseResponse = z.infer<typeof CreateLeaseResponseSchema>;
+export type ConsoleSettings = z.infer<typeof ConsoleSettingsSchema>;
 export type GetDeploymentResponse = z.infer<typeof GetDeploymentResponseSchema>;
 export type CreateDeploymentRequest = z.infer<typeof CreateDeploymentRequestSchema>;
 export type CreateDeploymentResponse = z.infer<typeof CreateDeploymentResponseSchema>;

--- a/apps/api/src/deployment/routes/leases/leases.router.ts
+++ b/apps/api/src/deployment/routes/leases/leases.router.ts
@@ -4,7 +4,7 @@ import { createRoute } from "@src/core/lib/create-route/create-route";
 import { OpenApiHonoHandler } from "@src/core/services/open-api-hono-handler/open-api-hono-handler";
 import { SECURITY_BEARER_OR_API_KEY, SECURITY_NONE } from "@src/core/services/openapi-docs/openapi-security";
 import { LeaseController } from "@src/deployment/controllers/lease/lease.controller";
-import { GetDeploymentResponseSchema } from "@src/deployment/http-schemas/deployment.schema";
+import { CreateLeaseResponseSchema } from "@src/deployment/http-schemas/deployment.schema";
 import { CreateLeaseRequestSchema } from "@src/deployment/http-schemas/lease.schema";
 import { FallbackLeaseListQuerySchema, FallbackLeaseListResponseSchema } from "@src/deployment/http-schemas/lease-rpc.schema";
 
@@ -31,7 +31,7 @@ const createLeaseRoute = createRoute({
       description: "Leases created and manifest sent",
       content: {
         "application/json": {
-          schema: GetDeploymentResponseSchema
+          schema: CreateLeaseResponseSchema
         }
       }
     }

--- a/apps/api/src/deployment/services/deployment-reader/deployment-reader.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-reader/deployment-reader.service.spec.ts
@@ -5,9 +5,11 @@ import { AxiosError } from "axios";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
+import type { AuthService } from "@src/auth/services/auth.service";
 import type { WalletInitialized } from "@src/billing/repositories";
 import type { WalletReaderService } from "@src/billing/services/wallet-reader/wallet-reader.service";
 import type { LoggerService } from "@src/core/providers/logging.provider";
+import type { DeploymentSettingRepository, DeploymentSettingsOutput } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import type { FallbackDeploymentReaderService } from "@src/deployment/services/fallback-deployment-reader/fallback-deployment-reader.service";
 import type { FallbackLeaseReaderService } from "@src/deployment/services/fallback-lease-reader/fallback-lease-reader.service";
 import type { MessageService } from "@src/deployment/services/message-service/message.service";
@@ -20,6 +22,57 @@ import { createLeaseApiResponse } from "@test/seeders/lease-api-response.seeder"
 import { createUserWallet } from "@test/seeders/user-wallet.seeder";
 
 describe(DeploymentReaderService.name, () => {
+  describe("findByUserIdAndDseq", () => {
+    it("returns what the console recorded alongside the deployment", async () => {
+      const { service, wallet } = setup({ recorded: { sdl: "version: '2.0'", manifestVersion: "BAUG" } });
+
+      const result = await service.findByUserIdAndDseq(wallet.userId, "12345");
+
+      expect(result.consoleSettings).toEqual({ sdl: "version: '2.0'", manifestVersion: "BAUG" });
+    });
+
+    it("returns no console settings when nothing was recorded for the deployment", async () => {
+      const { service, wallet } = setup({ recorded: null });
+
+      const result = await service.findByUserIdAndDseq(wallet.userId, "12345");
+
+      expect(result.consoleSettings).toBeNull();
+    });
+
+    it("returns no console settings for a settings row that carries no sdl", async () => {
+      const { service, wallet } = setup({ recorded: { sdl: null, manifestVersion: null } });
+
+      const result = await service.findByUserIdAndDseq(wallet.userId, "12345");
+
+      expect(result.consoleSettings).toBeNull();
+    });
+
+    it("reads the console settings under the caller's own ability and user id", async () => {
+      const { service, wallet, deploymentSettingRepository, scopedDeploymentSettingRepository, authService } = setup();
+
+      await service.findByUserIdAndDseq(wallet.userId, "12345");
+
+      expect(deploymentSettingRepository.accessibleBy).toHaveBeenCalledWith(authService.ability, "read");
+      expect(scopedDeploymentSettingRepository.findOneBy).toHaveBeenCalledWith({ userId: wallet.userId, dseq: "12345" });
+    });
+
+    it("reads the console settings without waiting for the chain to answer", async () => {
+      const { service, wallet, deploymentHttpService, scopedDeploymentSettingRepository } = setup();
+      const deploymentInfo = createDeploymentInfoSeed();
+      let settingsWereReadBeforeTheChainAnswered = false;
+
+      deploymentHttpService.findByOwnerAndDseq.mockImplementation(async () => {
+        await Promise.resolve();
+        settingsWereReadBeforeTheChainAnswered = scopedDeploymentSettingRepository.findOneBy.mock.calls.length > 0;
+        return deploymentInfo;
+      });
+
+      await service.findByUserIdAndDseq(wallet.userId, "12345");
+
+      expect(settingsWereReadBeforeTheChainAnswered).toBe(true);
+    });
+  });
+
   describe("findByWalletAndDseq", () => {
     it("falls back to database for deployment data when blockchain node is unreachable", async () => {
       const wallet = createUserWallet() as WalletInitialized;
@@ -258,6 +311,7 @@ describe(DeploymentReaderService.name, () => {
       fallbackDeploymentList?: ReturnType<typeof createDeploymentListResponseSeed>;
       fallbackLeases?: ReturnType<typeof createLeaseApiResponse>[];
       leases?: ReturnType<typeof createLeaseApiResponse>[];
+      recorded?: Pick<DeploymentSettingsOutput, "sdl" | "manifestVersion"> | null;
     } = {}
   ) {
     const defaultWallet = createUserWallet() as WalletInitialized;
@@ -294,6 +348,15 @@ describe(DeploymentReaderService.name, () => {
       logger: mock<LoggerService>()
     };
 
+    const recorded = input.recorded === undefined ? { sdl: "version: '2.0'", manifestVersion: "BAUG" } : input.recorded;
+    const scopedDeploymentSettingRepository = mock<DeploymentSettingRepository>({
+      findOneBy: vi.fn().mockResolvedValue(recorded ? mock<DeploymentSettingsOutput>(recorded) : undefined)
+    });
+    const deploymentSettingRepository = mock<DeploymentSettingRepository>({
+      accessibleBy: vi.fn().mockReturnValue(scopedDeploymentSettingRepository)
+    });
+    const authService = mock<AuthService>({ ability: mock<AuthService["ability"]>() });
+
     const service = new DeploymentReaderService(
       mocks.providerService,
       mocks.deploymentHttpService,
@@ -302,9 +365,11 @@ describe(DeploymentReaderService.name, () => {
       mocks.fallbackLeaseReaderService,
       mocks.messageService,
       mocks.walletReaderService,
+      deploymentSettingRepository,
+      authService,
       mocks.logger
     );
 
-    return { service, ...mocks };
+    return { service, ...mocks, wallet, deploymentSettingRepository, scopedDeploymentSettingRepository, authService };
   }
 });

--- a/apps/api/src/deployment/services/deployment-reader/deployment-reader.service.ts
+++ b/apps/api/src/deployment/services/deployment-reader/deployment-reader.service.ts
@@ -18,11 +18,13 @@ import { InternalServerError } from "http-errors";
 import { Op } from "sequelize";
 import { singleton } from "tsyringe";
 
+import { AuthService } from "@src/auth/services/auth.service";
 import type { WalletInitialized } from "@src/billing/repositories";
 import { WalletReaderService } from "@src/billing/services/wallet-reader/wallet-reader.service";
 import { Memoize } from "@src/caching/helpers";
 import { LoggerService } from "@src/core";
-import { GetDeploymentResponse, ListDeploymentsItem } from "@src/deployment/http-schemas/deployment.schema";
+import { ConsoleSettings, DeploymentResponse, GetDeploymentResponse, ListDeploymentsItem } from "@src/deployment/http-schemas/deployment.schema";
+import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import { FallbackLeaseReaderService } from "@src/deployment/services/fallback-lease-reader/fallback-lease-reader.service";
 import { ProviderService } from "@src/provider/services/provider/provider.service";
 import { ProviderList } from "@src/types/provider";
@@ -41,15 +43,43 @@ export class DeploymentReaderService {
     private readonly fallbackLeaseReaderService: FallbackLeaseReaderService,
     private readonly messageService: MessageService,
     private readonly walletReaderService: WalletReaderService,
+    private readonly deploymentSettingRepository: DeploymentSettingRepository,
+    private readonly authService: AuthService,
     private readonly logger: LoggerService
   ) {}
 
   public async findByUserIdAndDseq(userId: string, dseq: string): Promise<GetDeploymentResponse["data"]> {
     const wallet = await this.walletReaderService.getWalletByUserId(userId);
-    return this.findByWalletAndDseq(wallet, dseq);
+    const [deployment, consoleSettings] = await Promise.all([this.findByWalletAndDseq(wallet, dseq), this.findConsoleSettings(userId, dseq)]);
+
+    return { ...deployment, consoleSettings };
   }
 
-  public async findByWalletAndDseq(wallet: WalletInitialized, dseq: string): Promise<GetDeploymentResponse["data"]> {
+  /**
+   * What the console recorded for this deployment, or null when it recorded nothing. The chain knows only the
+   * manifest, so the SDL that produced it is ours to remember or lose; this is what lets a deployment created on
+   * one device be read back on another.
+   *
+   * Scoped twice over, because the (dseq, userId) unique means two users holding the same dseq is an ordinary
+   * state rather than a collision: the query names the caller's own id, and `accessibleBy` ANDs the same
+   * condition into the SQL from the caller's ability. Either alone would be enough today; together they mean a
+   * later refactor has to defeat both to leak one user's SDL to another.
+   *
+   * A row with no `sdl` is reported as nothing recorded rather than as a partial record. Settings reads create
+   * rows lazily and deployments predating the recording leave both columns null, so an absent SDL is the common
+   * case and not a broken one.
+   */
+  private async findConsoleSettings(userId: string, dseq: string): Promise<ConsoleSettings | null> {
+    const setting = await this.deploymentSettingRepository.accessibleBy(this.authService.ability, "read").findOneBy({ userId, dseq });
+
+    if (!setting?.sdl || !setting.manifestVersion) {
+      return null;
+    }
+
+    return { sdl: setting.sdl, manifestVersion: setting.manifestVersion };
+  }
+
+  public async findByWalletAndDseq(wallet: WalletInitialized, dseq: string): Promise<DeploymentResponse> {
     const { address: owner } = wallet;
     const deploymentResponse = await this.getDeployment(owner, dseq);
     assert(deploymentResponse, 404, "Deployment not found");

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -12,7 +12,7 @@ import type { WalletReaderService } from "@src/billing/services/wallet-reader/wa
 import type { LoggerService } from "@src/core";
 import type { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
 import { SDL_MAX_LENGTH } from "@src/deployment/config/sdl.config";
-import type { GetDeploymentResponse } from "@src/deployment/http-schemas/deployment.schema";
+import type { DeploymentResponse } from "@src/deployment/http-schemas/deployment.schema";
 import type { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import type { SdlService } from "@src/deployment/services/sdl/sdl.service";
 import type { ProviderService } from "@src/provider/services/provider/provider.service";
@@ -117,7 +117,7 @@ describe(DeploymentWriterService.name, () => {
     groupSpecs: [{ name: "test-group", resources: [] }]
   };
 
-  const deploymentData: GetDeploymentResponse["data"] = {
+  const deploymentData: DeploymentResponse = {
     deployment: {
       id: { owner: wallet.address, dseq: "100" },
       state: "active",

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -11,12 +11,7 @@ import { LoggerService } from "@src/core";
 import { FeatureFlags } from "@src/core/services/feature-flags/feature-flags";
 import { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
 import { SDL_MAX_LENGTH } from "@src/deployment/config/sdl.config";
-import {
-  CreateDeploymentRequest,
-  CreateDeploymentResponse,
-  GetDeploymentResponse,
-  UpdateDeploymentRequest
-} from "@src/deployment/http-schemas/deployment.schema";
+import { CreateDeploymentRequest, CreateDeploymentResponse, DeploymentResponse, UpdateDeploymentRequest } from "@src/deployment/http-schemas/deployment.schema";
 import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import { SdlService } from "@src/deployment/services/sdl/sdl.service";
 import { stripSdlSecrets } from "@src/deployment/utils/sdl-secret-stripping/sdl-secret-stripping";
@@ -196,7 +191,7 @@ export class DeploymentWriterService {
     }
   }
 
-  public async deposit(options: { userId: string; dseq: string; amount: number }): Promise<GetDeploymentResponse["data"]> {
+  public async deposit(options: { userId: string; dseq: string; amount: number }): Promise<DeploymentResponse> {
     if (this.isManagedDepositEnabled()) {
       this.logger.warn({ event: "DEPRECATED_DEPOSIT_DEPLOYMENT_ENDPOINT_USED", userId: options.userId, dseq: options.dseq });
     }
@@ -218,7 +213,7 @@ export class DeploymentWriterService {
     return await this.deploymentReaderService.findByWalletAndDseq(wallet, options.dseq);
   }
 
-  public async updateByUserIdAndDseq(userId: string, dseq: string, input: UpdateDeploymentRequest["data"]): Promise<GetDeploymentResponse["data"]> {
+  public async updateByUserIdAndDseq(userId: string, dseq: string, input: UpdateDeploymentRequest["data"]): Promise<DeploymentResponse> {
     const wallet = await this.walletReaderService.getWalletByUserId(userId);
     const manifest = this.#parseManifest(input.sdl, { isTrialing: !!wallet.isTrialing });
 
@@ -240,12 +235,7 @@ export class DeploymentWriterService {
     return manifestResult.value;
   }
 
-  private async ensureDeploymentIsUpToDate(
-    wallet: UserWalletOutput,
-    dseq: string,
-    manifestVersion: Uint8Array,
-    deployment: GetDeploymentResponse["data"]
-  ): Promise<void> {
+  private async ensureDeploymentIsUpToDate(wallet: UserWalletOutput, dseq: string, manifestVersion: Uint8Array, deployment: DeploymentResponse): Promise<void> {
     if (Buffer.from(manifestVersion).toString("base64") !== deployment.deployment.hash) {
       const message = this.rpcMessageService.getUpdateDeploymentMsg({
         owner: wallet.address!,
@@ -264,7 +254,7 @@ export class DeploymentWriterService {
   }: {
     dseq: string;
     manifest: string;
-    leases: GetDeploymentResponse["data"]["leases"];
+    leases: DeploymentResponse["leases"];
     auth: { walletId: number };
   }): Promise<void> {
     const leaseProviders = new Set(leases.map(lease => lease.id.provider));

--- a/apps/api/src/deployment/services/lease/lease.service.ts
+++ b/apps/api/src/deployment/services/lease/lease.service.ts
@@ -4,7 +4,7 @@ import { singleton } from "tsyringe";
 
 import { ManagedSignerService, RpcMessageService } from "@src/billing/services";
 import { WalletReaderService } from "@src/billing/services/wallet-reader/wallet-reader.service";
-import { GetDeploymentResponse } from "@src/deployment/http-schemas/deployment.schema";
+import { DeploymentResponse } from "@src/deployment/http-schemas/deployment.schema";
 import { CreateLeaseRequest } from "@src/deployment/http-schemas/lease.schema";
 import { ProviderService } from "@src/provider/services/provider/provider.service";
 import { DeploymentReaderService } from "../deployment-reader/deployment-reader.service";
@@ -21,7 +21,7 @@ export class LeaseService {
   ) {}
 
   @Trace()
-  public async createLeasesAndSendManifest({ leases, manifest, userId }: CreateLeaseRequest & { userId: string }): Promise<GetDeploymentResponse["data"]> {
+  public async createLeasesAndSendManifest({ leases, manifest, userId }: CreateLeaseRequest & { userId: string }): Promise<DeploymentResponse> {
     const wallet = await this.walletReaderService.getWalletByUserId(userId);
     const dseq = leases[0].dseq;
 

--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -4190,12 +4190,32 @@
                             "id",
                             "state"
                           ]
+                        },
+                        "consoleSettings": {
+                          "type": "object",
+                          "nullable": true,
+                          "properties": {
+                            "sdl": {
+                              "type": "string",
+                              "description": "The SDL the console stored for this deployment. Re-serialized YAML, so not byte-identical to the submitted document."
+                            },
+                            "manifestVersion": {
+                              "type": "string",
+                              "description": "Base64 of the manifest version this deployment commits on chain. Deliberately not a hash of the `sdl` above."
+                            }
+                          },
+                          "required": [
+                            "sdl",
+                            "manifestVersion"
+                          ],
+                          "description": "What the console recorded for this deployment, or null when it recorded nothing."
                         }
                       },
                       "required": [
                         "deployment",
                         "leases",
-                        "escrow_account"
+                        "escrow_account",
+                        "consoleSettings"
                       ]
                     }
                   },

--- a/apps/api/test/e2e/managed-api-deployment-flow.spec.ts
+++ b/apps/api/test/e2e/managed-api-deployment-flow.spec.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 import type { ListBidsResponse } from "@src/bid/http-schemas/bid.schema";
 import type {
   CreateDeploymentResponse,
+  CreateLeaseResponse,
   DepositDeploymentResponse,
   GetDeploymentResponse,
   UpdateDeploymentResponse
@@ -196,7 +197,7 @@ describe("Managed Wallet API Deployment Flow", () => {
     apiKey: string,
     deployment: CreateDeploymentResponse["data"],
     bid: ListBidsResponse["data"][number]
-  ): Promise<GetDeploymentResponse["data"] | undefined> {
+  ): Promise<CreateLeaseResponse["data"] | undefined> {
     const body = {
       manifest: deployment.manifest,
       leases: [
@@ -209,7 +210,7 @@ describe("Managed Wallet API Deployment Flow", () => {
       ]
     };
 
-    const { data } = await requestApi<GetDeploymentResponse>("/v1/leases", {
+    const { data } = await requestApi<CreateLeaseResponse>("/v1/leases", {
       method: "POST",
       headers: {
         "content-type": "application/json",

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -7078,6 +7078,25 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                   "properties": {
                     "data": {
                       "properties": {
+                        "consoleSettings": {
+                          "description": "What the console recorded for this deployment, or null when it recorded nothing.",
+                          "nullable": true,
+                          "properties": {
+                            "manifestVersion": {
+                              "description": "Base64 of the manifest version this deployment commits on chain. Deliberately not a hash of the \`sdl\` above.",
+                              "type": "string",
+                            },
+                            "sdl": {
+                              "description": "The SDL the console stored for this deployment. Re-serialized YAML, so not byte-identical to the submitted document.",
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "sdl",
+                            "manifestVersion",
+                          ],
+                          "type": "object",
+                        },
                         "deployment": {
                           "properties": {
                             "created_at": {
@@ -7430,6 +7449,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                         "deployment",
                         "leases",
                         "escrow_account",
+                        "consoleSettings",
                       ],
                       "type": "object",
                     },

--- a/apps/api/test/functional/deployments.spec.ts
+++ b/apps/api/test/functional/deployments.spec.ts
@@ -275,8 +275,100 @@ describe("Deployments API", () => {
       expect(result.data).toEqual({
         deployment: expect.any(Object),
         escrow_account: expect.any(Object),
-        leases: expect.arrayContaining([expect.any(Object)])
+        leases: expect.arrayContaining([expect.any(Object)]),
+        consoleSettings: null
       });
+    });
+
+    it("returns what the console recorded for the deployment", async () => {
+      const dseq = "1234";
+      const { userApiKeySecret, user, wallets } = await mockPersistedUser();
+      await setupDeploymentInfoMock(wallets, dseq);
+      const sdl = `version: '2.0' # ${faker.string.uuid()}`;
+      await container.resolve(DeploymentSettingRepository).upsertDefinition({ userId: user.id, dseq, sdl, manifestVersion: "BAUG" });
+
+      const response = await app.request(`/v1/deployments/${dseq}`, {
+        method: "GET",
+        headers: new Headers({ "Content-Type": "application/json", "x-api-key": userApiKeySecret })
+      });
+
+      expect(response.status).toBe(200);
+      const result = (await response.json()) as { data: { consoleSettings: unknown } };
+      expect(result.data.consoleSettings).toEqual({ sdl, manifestVersion: "BAUG" });
+    });
+
+    it("reads a deployment for which the console recorded nothing", async () => {
+      const dseq = "1234";
+      const { userApiKeySecret, wallets } = await mockPersistedUser();
+      await setupDeploymentInfoMock(wallets, dseq);
+
+      const response = await app.request(`/v1/deployments/${dseq}`, {
+        method: "GET",
+        headers: new Headers({ "Content-Type": "application/json", "x-api-key": userApiKeySecret })
+      });
+
+      expect(response.status).toBe(200);
+      const result = (await response.json()) as { data: { deployment: unknown; consoleSettings: unknown } };
+      expect(result.data.deployment).toEqual(expect.any(Object));
+      expect(result.data.consoleSettings).toBeNull();
+    });
+
+    it("reads a deployment whose settings row carries no sdl", async () => {
+      const dseq = "1234";
+      const { userApiKeySecret, user, wallets } = await mockPersistedUser();
+      await setupDeploymentInfoMock(wallets, dseq);
+      await container.resolve(DeploymentSettingRepository).create({ userId: user.id, dseq });
+
+      const response = await app.request(`/v1/deployments/${dseq}`, {
+        method: "GET",
+        headers: new Headers({ "Content-Type": "application/json", "x-api-key": userApiKeySecret })
+      });
+
+      expect(response.status).toBe(200);
+      const result = (await response.json()) as { data: { consoleSettings: unknown } };
+      expect(result.data.consoleSettings).toBeNull();
+    });
+
+    it("hands back none of what another user recorded for the same dseq", async () => {
+      const dseq = "1234";
+      const owner = await mockPersistedUser();
+      const otherUsersSdl = `version: '2.0' # ${faker.string.uuid()}`;
+      await container.resolve(DeploymentSettingRepository).upsertDefinition({ userId: owner.user.id, dseq, sdl: otherUsersSdl, manifestVersion: "BAUG" });
+      const reader = await mockPersistedUser();
+      await setupDeploymentInfoMock(reader.wallets, dseq);
+
+      const response = await app.request(`/v1/deployments/${dseq}`, {
+        method: "GET",
+        headers: new Headers({ "Content-Type": "application/json", "x-api-key": reader.userApiKeySecret })
+      });
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect((body as { data: { consoleSettings: unknown } }).data.consoleSettings).toBeNull();
+      expect(JSON.stringify(body)).not.toContain(otherUsersSdl);
+    });
+
+    it("hands each user their own console settings for the same dseq", async () => {
+      const dseq = "1234";
+      const deploymentSettingRepository = container.resolve(DeploymentSettingRepository);
+      const first = await mockPersistedUser();
+      const firstSdl = `version: '2.0' # ${faker.string.uuid()}`;
+      await deploymentSettingRepository.upsertDefinition({ userId: first.user.id, dseq, sdl: firstSdl, manifestVersion: "BAUG" });
+      const second = await mockPersistedUser();
+      const secondSdl = `version: '2.0' # ${faker.string.uuid()}`;
+      await deploymentSettingRepository.upsertDefinition({ userId: second.user.id, dseq, sdl: secondSdl, manifestVersion: "BAUH" });
+      await setupDeploymentInfoMock(second.wallets, dseq);
+
+      const readAs = async (apiKey: string) => {
+        const response = await app.request(`/v1/deployments/${dseq}`, {
+          method: "GET",
+          headers: new Headers({ "Content-Type": "application/json", "x-api-key": apiKey })
+        });
+        return (await response.json()) as { data: { consoleSettings: { sdl: string } | null } };
+      };
+
+      expect((await readAs(first.userApiKeySecret)).data.consoleSettings).toEqual({ sdl: firstSdl, manifestVersion: "BAUG" });
+      expect((await readAs(second.userApiKeySecret)).data.consoleSettings).toEqual({ sdl: secondSdl, manifestVersion: "BAUH" });
     });
 
     it("returns 404 for an error in deployment info", async () => {

--- a/apps/api/test/functional/deployments.spec.ts
+++ b/apps/api/test/functional/deployments.spec.ts
@@ -281,7 +281,7 @@ describe("Deployments API", () => {
     });
 
     it("returns what the console recorded for the deployment", async () => {
-      const dseq = "1234";
+      const dseq = faker.string.numeric({ length: 8, allowLeadingZeros: false });
       const { userApiKeySecret, user, wallets } = await mockPersistedUser();
       await setupDeploymentInfoMock(wallets, dseq);
       const sdl = `version: '2.0' # ${faker.string.uuid()}`;
@@ -298,7 +298,7 @@ describe("Deployments API", () => {
     });
 
     it("reads a deployment for which the console recorded nothing", async () => {
-      const dseq = "1234";
+      const dseq = faker.string.numeric({ length: 8, allowLeadingZeros: false });
       const { userApiKeySecret, wallets } = await mockPersistedUser();
       await setupDeploymentInfoMock(wallets, dseq);
 
@@ -314,7 +314,7 @@ describe("Deployments API", () => {
     });
 
     it("reads a deployment whose settings row carries no sdl", async () => {
-      const dseq = "1234";
+      const dseq = faker.string.numeric({ length: 8, allowLeadingZeros: false });
       const { userApiKeySecret, user, wallets } = await mockPersistedUser();
       await setupDeploymentInfoMock(wallets, dseq);
       await container.resolve(DeploymentSettingRepository).create({ userId: user.id, dseq });
@@ -330,7 +330,7 @@ describe("Deployments API", () => {
     });
 
     it("hands back none of what another user recorded for the same dseq", async () => {
-      const dseq = "1234";
+      const dseq = faker.string.numeric({ length: 8, allowLeadingZeros: false });
       const owner = await mockPersistedUser();
       const otherUsersSdl = `version: '2.0' # ${faker.string.uuid()}`;
       await container.resolve(DeploymentSettingRepository).upsertDefinition({ userId: owner.user.id, dseq, sdl: otherUsersSdl, manifestVersion: "BAUG" });
@@ -349,7 +349,7 @@ describe("Deployments API", () => {
     });
 
     it("hands each user their own console settings for the same dseq", async () => {
-      const dseq = "1234";
+      const dseq = faker.string.numeric({ length: 8, allowLeadingZeros: false });
       const deploymentSettingRepository = container.resolve(DeploymentSettingRepository);
       const first = await mockPersistedUser();
       const firstSdl = `version: '2.0' # ${faker.string.uuid()}`;

--- a/packages/console-api-types/src/schema-placement.assert.ts
+++ b/packages/console-api-types/src/schema-placement.assert.ts
@@ -1,0 +1,48 @@
+import type { operations } from "./schema";
+
+/**
+ * Guards which operation carries `consoleSettings` in the generated schema.
+ *
+ * `getDeployment`, `updateDeployment`, `depositDeployment` and `createLease` all answer with the same
+ * inline deployment shape, so their generated blocks are byte-identical for hundreds of lines. A field
+ * added to that schema by hand, or by any patch that matches on surrounding context rather than on the
+ * operation it belongs to, can land on the wrong one and still compile, still appear exactly once, and
+ * still satisfy `validate:types` — none of which is sensitive to *which* operation it landed on. That
+ * is not hypothetical: it happened, and nothing but a positional check caught it.
+ *
+ * Only the read carries what the console recorded for a deployment. The three that write never return it,
+ * so promising it there would have TypeScript describe a property that is `undefined` at runtime.
+ */
+type OkResponseData<T> = T extends { responses: { 200: { content: { "application/json": { data: infer D } } } } } ? D : never;
+
+type Carries<T, K extends string> = K extends keyof OkResponseData<T> ? true : false;
+
+type Resolves<T> = [OkResponseData<T>] extends [never] ? false : true;
+
+type Asserts<T extends true> = T;
+type Refutes<T extends false> = T;
+
+export type ConsoleSettingsIsOnTheDeploymentRead = Asserts<Carries<operations["getDeployment"], "consoleSettings">>;
+export type ConsoleSettingsIsNotOnTheDeploymentUpdate = Refutes<Carries<operations["updateDeployment"], "consoleSettings">>;
+export type ConsoleSettingsIsNotOnTheDeposit = Refutes<Carries<operations["depositDeployment"], "consoleSettings">>;
+export type ConsoleSettingsIsNotOnTheLeaseCreate = Refutes<Carries<operations["createLease"], "consoleSettings">>;
+
+/**
+ * `Carries` answers on `keyof`, which degrades in two opposite directions, so neither check below is
+ * redundant with the other and neither is redundant with the four above.
+ *
+ * An extraction that matches nothing yields `never`, and `keyof never` is `string | number | symbol`, so
+ * every key appears present. The three `Refutes` are what fail then — the read's own assertions would
+ * pass for the wrong reason. `Resolves` is therefore the only thing standing between a `getDeployment`
+ * that stops resolving on its own and a file that compiles green while guarding nothing.
+ *
+ * An extraction that matches but is keyless — `data: unknown`, say — yields `keyof` of `never`, so every
+ * key appears absent and the three `Refutes` pass vacuously. The `escrow_account` probes are what fail
+ * then, on a key every deployment response has always had.
+ */
+export type TheDeploymentReadResolves = Asserts<Resolves<operations["getDeployment"]>>;
+
+export type TheDeploymentReadIsKeyed = Asserts<Carries<operations["getDeployment"], "escrow_account">>;
+export type TheDeploymentUpdateIsKeyed = Asserts<Carries<operations["updateDeployment"], "escrow_account">>;
+export type TheDepositIsKeyed = Asserts<Carries<operations["depositDeployment"], "escrow_account">>;
+export type TheLeaseCreateIsKeyed = Asserts<Carries<operations["createLease"], "escrow_account">>;

--- a/packages/console-api-types/src/schema.d.ts
+++ b/packages/console-api-types/src/schema.d.ts
@@ -7861,6 +7861,13 @@ export interface operations {
                   }[];
                 };
               };
+              /** @description What the console recorded for this deployment, or null when it recorded nothing. */
+              consoleSettings: {
+                /** @description The SDL the console stored for this deployment. Re-serialized YAML, so not byte-identical to the submitted document. */
+                sdl: string;
+                /** @description Base64 of the manifest version this deployment commits on chain. Deliberately not a hash of the `sdl` above. */
+                manifestVersion: string;
+              } | null;
             };
           };
         };


### PR DESCRIPTION
## Why

Closes CON-858

A deployment created on one device could not be inspected from another. The chain stores the
manifest and never the SDL that produced it, so once the browser that submitted a deployment cleared
its site data, what that deployment *was* had been lost. #3662 started recording it at creation;
this hands it back on the existing single-deployment read, so a deployment can be inspected from a
second device, or after clearing site data.

### Scope — this PR meets acceptance criteria 1, 2 and 3. Criterion 4 is NOT implemented.

> **Criterion 4: "The response makes clear that env values are absent rather than empty" — not implemented.**

It was **dropped by explicit direction from the repo owner at the plan gate**, to be solved in later
work. It is not a technical blocker, and it was not descoped for cost: three viable encodings were
costed and all fit this PR's budget. The shape is a product decision that should not be settled
incidentally by whoever ships the read endpoint.

**The practical gap.** The SDL is returned exactly as stored, with env values already removed at
creation by the existing stripper — each variable keeps its name and loses everything after the `=`.
Nothing in the payload distinguishes a value the console removed from one the author genuinely left
empty. A consumer seeing `API_TOKEN=` cannot tell which it is, and could round-trip that SDL into a
new deployment believing the blank was intentional, deploying a service whose credentials are
silently empty. That surfaces at runtime in the provider's logs, not at deploy time.

The exposure is bounded to the deployment's own owner, since the read is user-scoped — so this is a
correctness and usability gap, not a disclosure one. **This PR should not be read as completing the
feature.**

**Cost note for the follow-up, which is cheaper than it looks:** a *per-service list of redacted env
names needs no migration.* It is derivable at read time from the stored SDL, because an entry ending
in `=` had a value removed while an entry with no `=` was declared without one — the
`INHERITED_FROM_HOST` case the stripper preserves deliberately. That derivation is exact for every
SDL the current stripper produced. Only a *stored* signal — one that records what a particular strip
actually found — needs a new column and a backfill, because `stripSdlSecrets` strips unconditionally
and persists nothing about what it removed.

## What

`GET /v1/deployments/{dseq}` now returns a `consoleSettings` block beside the chain-shaped
`deployment`, `leases` and `escrow_account`:

```jsonc
"consoleSettings": { "sdl": "…", "manifestVersion": "…" }   // or null
```

Returned unconditionally, `null` when nothing was recorded — which covers a missing settings row, a
row created lazily by a settings read, and any row predating the recording. That is the common case,
not a broken one.

**No breaking change, no migration.** One field added to one response.

### How it is scoped to the owner

The deployment itself comes from the chain, so scoping runs session user id → CASL-filtered wallet
row → chain lookup keyed on that wallet's address. The recorded settings, by contrast, live in our
database and are per-user, so they get their own scoping — twice over. `(dseq, user_id)` is the
unique on `deployment_settings`, which makes two users holding the same dseq an ordinary state rather
than a collision, so a dseq-only lookup would be a real leak. The query names the caller's own id and
`accessibleBy` ANDs the same condition into the SQL from the caller's ability; a later refactor has
to defeat both. Nothing on this path is memoized — the memoized sibling read is `SECURITY_NONE` and
keyed on `(owner, dseq)`, which is exactly the shape a user-scoped read must not borrow.

### Deliberately unchanged

`findByWalletAndDseq` is untouched, so lease creation, deposit, update and the list keep the payload
they had, and the list issues no settings query at all — the field cannot become an N+1.
`POST /v1/leases` shared this response schema and now has its own over the same unchanged base, which
is why the regenerated OpenAPI document moves on one route only.

### Tests

Five unit and five functional. The important one asserts cross-user isolation and was mutation-tested:
removing both scoping layers fails exactly that test and its sibling, and nothing else. Each test takes
its own dseq, because a functional database is truncated per file rather than per test and a shared
dseq would let that assertion depend on which row an unordered lookup returned rather than on the
security property.

### Contract artifacts

The committed OpenAPI document and generated types described a response the API no longer returns, so
`deploy-web` could not see the new field. Only this endpoint's delta is regenerated here.

`schema-placement.assert.ts` is new: `getDeployment`, `updateDeployment`, `depositDeployment` and
`createLease` answer with byte-identical inline shapes, so a field can be added to the wrong one and
still compile, still appear once, and still pass the package's type gate. It asserts from both sides
which operation carries the field, and guards the two ways its own `keyof` probe can degrade. It runs
in CI via `validate:types`. This caught a real misplacement during review.

## Follow-ups this surfaced

1. **Pre-existing contract drift.** The committed artifacts lag `main` by several merged routes:
   roughly **376 lines** in `schema.d.ts` and **112** in `openapi.json`, plus the `notifications`
   artifacts. Deliberately left out of this PR — it wants a standalone mechanical regeneration commit.
   Note that a raw `npm run sdk:gen` looks ~19,000 lines worse than it is, because the generator emits
   four-space output that only lint-staged later reformats.
2. **No CI gate compares the committed artifacts to the routes they derive from.** That is the root
   cause of (1) — the drift accumulated silently and nothing failed.

## Demo

### Reading a deployment's remembered definition back from the console

*2026-08-25T20:39:52Z by Showboat 0.6.1*
<!-- showboat-id: aaf367fb-31e3-4c3b-8e4a-7272de42eaed -->

A deployment created on one device could not be inspected from another. The chain stores the
manifest, never the SDL that produced it, so once the browser that submitted it cleared its site
data the definition was gone. Since #3662 the console records it at creation; this change hands it
back on the existing single-deployment read.

`GET /v1/deployments/{dseq}` now carries a `consoleSettings` block next to the chain-shaped
`deployment`, `leases` and `escrow_account` fields:

    "consoleSettings": { "sdl": "...", "manifestVersion": "..." }   // or null

The three behaviours below are the acceptance criteria, exercised against the real route through
the real router, controller, service and repository, with only the blockchain node stubbed.

#### The shape of the change

One field on one route. The read is user-scoped, and the scoping is the interesting part: the
`(dseq, user_id)` unique on `deployment_settings` means two users legitimately holding the same
dseq is an ordinary state, not a collision — so a dseq-only lookup would be a real leak.

```bash
sed -n "81,101p" apps/api/src/deployment/http-schemas/deployment.schema.ts
```

```output
const ConsoleSettingsSchema = z.object({
  sdl: z.string().openapi({
    description: "The SDL the console stored for this deployment. Re-serialized YAML, so not byte-identical to the submitted document."
  }),
  manifestVersion: z.string().openapi({
    description: "Base64 of the manifest version this deployment commits on chain. Deliberately not a hash of the `sdl` above."
  })
});

export const GetDeploymentResponseSchema = z.object({
  data: DeploymentResponseSchema.extend({
    consoleSettings: ConsoleSettingsSchema.nullable().openapi({
      description: "What the console recorded for this deployment, or null when it recorded nothing."
    })
  })
});

/** POST /v1/leases answers with the deployment as the chain describes it, without the console's own record. */
export const CreateLeaseResponseSchema = z.object({
  data: DeploymentResponseSchema
});
```

```bash
sed -n "51,84p" apps/api/src/deployment/services/deployment-reader/deployment-reader.service.ts
```

```output
  public async findByUserIdAndDseq(userId: string, dseq: string): Promise<GetDeploymentResponse["data"]> {
    const wallet = await this.walletReaderService.getWalletByUserId(userId);
    const [deployment, consoleSettings] = await Promise.all([this.findByWalletAndDseq(wallet, dseq), this.findConsoleSettings(userId, dseq)]);

    return { ...deployment, consoleSettings };
  }

  /**
   * What the console recorded for this deployment, or null when it recorded nothing. The chain knows only the
   * manifest, so the SDL that produced it is ours to remember or lose; this is what lets a deployment created on
   * one device be read back on another.
   *
   * Scoped twice over, because the (dseq, userId) unique means two users holding the same dseq is an ordinary
   * state rather than a collision: the query names the caller's own id, and `accessibleBy` ANDs the same
   * condition into the SQL from the caller's ability. Either alone would be enough today; together they mean a
   * later refactor has to defeat both to leak one user's SDL to another.
   *
   * A row with no `sdl` is reported as nothing recorded rather than as a partial record. Settings reads create
   * rows lazily and deployments predating the recording leave both columns null, so an absent SDL is the common
   * case and not a broken one.
   */
  private async findConsoleSettings(userId: string, dseq: string): Promise<ConsoleSettings | null> {
    const setting = await this.deploymentSettingRepository.accessibleBy(this.authService.ability, "read").findOneBy({ userId, dseq });

    if (!setting?.sdl || !setting.manifestVersion) {
      return null;
    }

    return { sdl: setting.sdl, manifestVersion: setting.manifestVersion };
  }

  public async findByWalletAndDseq(wallet: WalletInitialized, dseq: string): Promise<DeploymentResponse> {
    const { address: owner } = wallet;
    const deploymentResponse = await this.getDeployment(owner, dseq);
```

#### The endpoint, exercised

Two users, Alice and Bob, each with their own wallet and their own deployment. The blockchain node
is stubbed so both addresses have a deployment at dseq `20250825`; everything else — auth, the
router, the CASL row filter, Postgres — is real.

Scenarios A and B are acceptance criteria 1 and 2. Scenario C is criterion 3: the same dseq, a
record for each user, and neither can see the other's.

```bash
set -e
SPEC="$PWD/apps/api/test/functional/zz-demo-console-settings.spec.ts"
cp .work/deployment-remembered-definition-read/demo-driver.spec.ts.txt "$SPEC"
trap 'rm -f "$SPEC"' EXIT
( cd apps/api && npx vitest run test/functional/zz-demo-console-settings.spec.ts --project functional 2>&1 | sed -n '/^<<<DEMO/,/^DEMO>>>/p' )
```

```output
<<<DEMO
A. Alice reads her own deployment 20250825 — the console remembers what she deployed
  GET /v1/deployments/20250825  ->  200
  owner           : akash1alice000000000000000000000000000q7xk2v
  consoleSettings : {
                      "sdl": "version: '2.0'\nservices:\n  web:\n    image: ghcr.io/akash-network/hello-akash-world\n    env:\n      - API_TOKEN=",
                      "manifestVersion": "l6ZQ4kQfXTVYzn0Yc0dq2sRt9qYQ2p3xVn8gGkT1abc="
                    }
DEMO>>>
<<<DEMO
B. Bob reads his deployment 20250825 — the console recorded nothing for it
  GET /v1/deployments/20250825  ->  200
  owner           : akash1bob0000000000000000000000000000009mzp4t
  consoleSettings : null
DEMO>>>
<<<DEMO
C. Same dseq 20250825, both users now have a record — each sees only their own
  GET /v1/deployments/20250825  ->  200
  owner           : akash1alice000000000000000000000000000q7xk2v
  consoleSettings : {
                      "sdl": "version: '2.0'\nservices:\n  web:\n    image: ghcr.io/akash-network/hello-akash-world\n    env:\n      - API_TOKEN=",
                      "manifestVersion": "l6ZQ4kQfXTVYzn0Yc0dq2sRt9qYQ2p3xVn8gGkT1abc="
                    }
DEMO>>>
<<<DEMO
   ... and Bob, same dseq, same request
  GET /v1/deployments/20250825  ->  200
  owner           : akash1bob0000000000000000000000000000009mzp4t
  consoleSettings : {
                      "sdl": "version: '2.0' # bob's own, entirely different",
                      "manifestVersion": "BOBxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx="
                    }
DEMO>>>
```

#### What the tests hold down

The cross-user isolation test is the one that matters. It seeds a record for the owner, reads as a
different user, and asserts on the whole serialized body rather than just the field — so a leak
through *any* field fails it, not only through `consoleSettings`.

```bash
sed -n '/hands back none of what another user recorded/,/^    });$/p' apps/api/test/functional/deployments.spec.ts
```

```output
    it("hands back none of what another user recorded for the same dseq", async () => {
      const dseq = faker.string.numeric({ length: 8, allowLeadingZeros: false });
      const owner = await mockPersistedUser();
      const otherUsersSdl = `version: '2.0' # ${faker.string.uuid()}`;
      await container.resolve(DeploymentSettingRepository).upsertDefinition({ userId: owner.user.id, dseq, sdl: otherUsersSdl, manifestVersion: "BAUG" });
      const reader = await mockPersistedUser();
      await setupDeploymentInfoMock(reader.wallets, dseq);

      const response = await app.request(`/v1/deployments/${dseq}`, {
        method: "GET",
        headers: new Headers({ "Content-Type": "application/json", "x-api-key": reader.userApiKeySecret })
      });

      expect(response.status).toBe(200);
      const body = await response.json();
      expect((body as { data: { consoleSettings: unknown } }).data.consoleSettings).toBeNull();
      expect(JSON.stringify(body)).not.toContain(otherUsersSdl);
    });
```

```bash
cd apps/api && npx vitest run test/functional/deployments.spec.ts src/deployment/services/deployment-reader --project functional --project unit 2>&1 | grep -E "(Test Files|Tests) +[0-9]+ passed"
```

```output
 Test Files  2 passed (2)
      Tests  73 passed (73)
```

#### Scope, and what is deliberately not here

`POST /v1/leases` shares the deployment payload but keeps its own schema, so it is unchanged — as
are the list, deposit and update routes. Only the single-deployment read gained the field, which is
also why there is no N+1: the list route issues no settings query at all.

**Acceptance criterion 4 — "the response makes clear that env values are absent rather than empty"
— is not implemented.** It was dropped by explicit direction, to be solved in later work; it is not
a technical blocker. The `sdl` above shows `API_TOKEN=` with the value already removed by the
existing stripper, and nothing in the payload distinguishes that from a value the author genuinely
left empty. A consumer could round-trip this SDL into a new deployment believing the blank was
intentional. Recorded in full, with notes for whoever picks it up, in `deferred.md`.

```bash
sed -n "/## What the gap means/,/^## Notes/p" .work/deployment-remembered-definition-read/deferred.md
```

```output
#### What the gap means in practice for a user

A consumer reading `API_TOKEN=` back from `GET /v1/deployments/{dseq}` cannot tell whether the
author wrote an empty value or whether the console removed it. The likely harm is a round trip: the
consumer feeds that SDL into a new deployment believing the empty value was intentional, and
deploys a service whose credentials are silently blank. The failure surfaces at runtime, in the
provider's logs, not at deploy time.

The exposure is bounded to the deployment's own owner — the read is user-scoped (see the
cross-user isolation test) — so this is a correctness and usability gap, not a disclosure one.

#### Notes for whoever picks this up
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployment details now include stored console settings, including SDL and manifest version, when available.
  * Console settings are scoped to the requesting user and return as unavailable when incomplete or absent.
  * Lease creation responses now return deployment information specific to lease creation.

* **Bug Fixes**
  * Improved deployment response consistency across read, update, deposit, and lease operations.

* **Tests**
  * Added coverage for settings availability, authorization boundaries, missing values, and response schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->