### PR TITLE
fix(auth): stop the turnstile widget fighting cloudflare's own retry

### DIFF
--- a/apps/deploy-web/eslint.config.mjs
+++ b/apps/deploy-web/eslint.config.mjs
@@ -20,7 +20,8 @@ export default [
     }
   },
   {
-    files: ["tests/ui/**/*.ts", "tests/ui/**/*.tsx"],
+    // matched with a leading **/ so the override still applies when lint-staged runs eslint from the git root
+    files: ["**/tests/ui/**/*.ts", "**/tests/ui/**/*.tsx"],
     rules: {
       "react-hooks/rules-of-hooks": "off"
     }

--- a/apps/deploy-web/eslint.config.mjs
+++ b/apps/deploy-web/eslint.config.mjs
@@ -19,8 +19,8 @@ export default [
       ]
     }
   },
+  /** Globs are anchored with a leading double star so this override still applies when lint-staged runs eslint from the git root. */
   {
-    // matched with a leading **/ so the override still applies when lint-staged runs eslint from the git root
     files: ["**/tests/ui/**/*.ts", "**/tests/ui/**/*.tsx"],
     rules: {
       "react-hooks/rules-of-hooks": "off"

--- a/apps/deploy-web/src/components/turnstile/Turnstile.spec.tsx
+++ b/apps/deploy-web/src/components/turnstile/Turnstile.spec.tsx
@@ -331,25 +331,41 @@ describe(Turnstile.name, () => {
       }
     });
 
-    it("abandons a pending challenge on unmount rather than reporting it wedged 2 minutes later", async () => {
+    it("drops a pending challenge on unmount without reporting it wedged 2 minutes later", async () => {
       const { turnstileRef, errorHandler, unmount } = await setup({ enabled: true });
       vi.useFakeTimers();
 
       try {
-        let rejection: unknown;
-        const promise = turnstileRef.current!.renderAndWaitResponse().catch(error => {
-          rejection = error;
-        });
+        const settled = vi.fn();
+        turnstileRef.current!.renderAndWaitResponse().then(settled, settled);
         await act(async () => {
           unmount();
         });
-        await promise;
         await act(async () => {
           await vi.advanceTimersByTimeAsync(CHALLENGE_DEADLINE_MS);
         });
 
-        expect(rejection).toMatchObject({ reason: "dismissed" });
         expect(errorHandler.reportError).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("does not reject on unmount, so an abandoned page cannot report a captcha error the visitor never saw", async () => {
+      const { turnstileRef, unmount } = await setup({ enabled: true });
+      vi.useFakeTimers();
+
+      try {
+        const settled = vi.fn();
+        turnstileRef.current!.renderAndWaitResponse().then(settled, settled);
+        await act(async () => {
+          unmount();
+        });
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(CHALLENGE_DEADLINE_MS);
+        });
+
+        expect(settled).not.toHaveBeenCalled();
       } finally {
         vi.useRealTimers();
       }

--- a/apps/deploy-web/src/components/turnstile/Turnstile.spec.tsx
+++ b/apps/deploy-web/src/components/turnstile/Turnstile.spec.tsx
@@ -67,6 +67,21 @@ describe(Turnstile.name, () => {
     expect(errorHandler.reportError).toHaveBeenCalledTimes(1);
   });
 
+  it("reports the first failure of every run, not only of the first one", async () => {
+    const { ReactTurnstile, latestProps } = createTurnstileMock();
+    const { turnstileRef, errorHandler } = await setup({ enabled: true, components: { ReactTurnstile } });
+
+    for (let run = 0; run < 2; run++) {
+      turnstileRef.current!.renderAndWaitResponse().catch(() => undefined);
+      await act(async () => {
+        latestProps.current?.onError?.("network-error");
+        await wait(0);
+      });
+    }
+
+    expect(errorHandler.reportError).toHaveBeenCalledTimes(2);
+  });
+
   it("never restarts the widget when errors alternate with interactive prompts", async () => {
     const { ReactTurnstile, instance, latestProps } = createTurnstileMock();
     await setup({ enabled: true, components: { ReactTurnstile } });
@@ -296,7 +311,7 @@ describe(Turnstile.name, () => {
     });
 
     it("rejects a challenge that never settles instead of hanging the caller", async () => {
-      const { turnstileRef } = await setup({ enabled: true });
+      const { turnstileRef, errorHandler } = await setup({ enabled: true });
       vi.useFakeTimers();
 
       try {
@@ -310,6 +325,7 @@ describe(Turnstile.name, () => {
         await promise;
 
         expect(rejection).toMatchObject({ reason: "timeout" });
+        expect(errorHandler.reportError).toHaveBeenCalledWith(expect.objectContaining({ tags: { event: "TURNSTILE_CHALLENGE_WEDGED" } }));
       } finally {
         vi.useRealTimers();
       }

--- a/apps/deploy-web/src/components/turnstile/Turnstile.spec.tsx
+++ b/apps/deploy-web/src/components/turnstile/Turnstile.spec.tsx
@@ -5,11 +5,13 @@ import { setTimeout as wait } from "node:timers/promises";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
+import type { ErrorHandlerService } from "@src/services/error-handler/error-handler.service";
 import type { TurnstileRef } from "./Turnstile";
-import { COMPONENTS, Turnstile } from "./Turnstile";
+import { CHALLENGE_DEADLINE_MS, COMPONENTS, Turnstile } from "./Turnstile";
 
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { MockComponents } from "@tests/unit/mocks";
+import { TestContainerProvider } from "@tests/unit/TestContainerProvider";
 
 describe(Turnstile.name, () => {
   it("does not render if turnstile is disabled", async () => {
@@ -24,21 +26,64 @@ describe(Turnstile.name, () => {
     expect(screen.queryByText("Turnstile")).toBeInTheDocument();
   });
 
-  it("resets actual widget on error", async () => {
-    const turnstileInstance = mock<TurnstileInstance>();
-    const ReactTurnstile = forwardRef<TurnstileInstance | undefined, TurnstileProps>((props, ref) => {
-      useForwardedRef(ref, turnstileInstance);
-      useEffect(() => {
-        props.onError?.("test");
-      }, []);
-      return <div>Turnstile</div>;
-    });
+  it("leaves the widget in place on error so Cloudflare's own retry can recover", async () => {
+    const { ReactTurnstile, instance, latestProps } = createTurnstileMock();
     await setup({ enabled: true, components: { ReactTurnstile } });
 
-    expect(turnstileInstance.remove).toHaveBeenCalled();
-    expect(turnstileInstance.render).toHaveBeenCalled();
-    expect(turnstileInstance.execute).toHaveBeenCalled();
+    await act(async () => {
+      latestProps.current?.onError?.("network-error");
+      await wait(0);
+    });
+
+    expect(instance.remove).not.toHaveBeenCalled();
+    expect(instance.render).not.toHaveBeenCalled();
+    expect(instance.execute).not.toHaveBeenCalled();
     expect(screen.queryByText("Some error occurred")).toBeInTheDocument();
+  });
+
+  it("reports challenge failures so they are visible in production", async () => {
+    const { ReactTurnstile, latestProps } = createTurnstileMock();
+    const { errorHandler } = await setup({ enabled: true, components: { ReactTurnstile } });
+
+    await act(async () => {
+      latestProps.current?.onError?.("network-error");
+      await wait(0);
+    });
+
+    expect(errorHandler.reportError).toHaveBeenCalledWith(expect.objectContaining({ error: "network-error", tags: { event: "TURNSTILE_CHALLENGE_FAILED" } }));
+  });
+
+  it("reports only the first failure of a run so Cloudflare's retries cannot storm Sentry", async () => {
+    const { ReactTurnstile, latestProps } = createTurnstileMock();
+    const { errorHandler } = await setup({ enabled: true, components: { ReactTurnstile } });
+
+    for (let attempt = 0; attempt < 3; attempt++) {
+      await act(async () => {
+        latestProps.current?.onError?.("network-error");
+        await wait(0);
+      });
+    }
+
+    expect(errorHandler.reportError).toHaveBeenCalledTimes(1);
+  });
+
+  it("never restarts the widget when errors alternate with interactive prompts", async () => {
+    const { ReactTurnstile, instance, latestProps } = createTurnstileMock();
+    await setup({ enabled: true, components: { ReactTurnstile } });
+
+    for (let attempt = 0; attempt < 3; attempt++) {
+      await act(async () => {
+        latestProps.current?.onError?.("network-error");
+        await wait(0);
+      });
+      await act(async () => {
+        latestProps.current?.onBeforeInteractive?.();
+        await wait(0);
+      });
+    }
+
+    expect(instance.remove).not.toHaveBeenCalled();
+    expect(instance.execute).not.toHaveBeenCalled();
   });
 
   it('resets actual widget on "Retry" button click', async () => {
@@ -233,6 +278,43 @@ describe(Turnstile.name, () => {
       expect(abandoned).not.toHaveBeenCalled();
     });
 
+    it("resolves once Cloudflare refreshes an expired token", async () => {
+      const { ReactTurnstile, latestProps } = createTurnstileMock();
+      const { turnstileRef } = await setup({ enabled: true, components: { ReactTurnstile } });
+
+      const promise = turnstileRef.current!.renderAndWaitResponse();
+      await act(async () => {
+        latestProps.current?.onExpire?.("stale-token");
+        await wait(0);
+      });
+      await act(async () => {
+        latestProps.current?.onSuccess?.("refreshed-token");
+        await wait(0);
+      });
+
+      await expect(promise).resolves.toEqual({ token: "refreshed-token" });
+    });
+
+    it("rejects a challenge that never settles instead of hanging the caller", async () => {
+      const { turnstileRef } = await setup({ enabled: true });
+      vi.useFakeTimers();
+
+      try {
+        let rejection: unknown;
+        const promise = turnstileRef.current!.renderAndWaitResponse().catch(error => {
+          rejection = error;
+        });
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(CHALLENGE_DEADLINE_MS);
+        });
+        await promise;
+
+        expect(rejection).toMatchObject({ reason: "timeout" });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it("resolves with disabled token when turnstile is disabled", async () => {
       const { turnstileRef } = await setup({ enabled: false });
 
@@ -243,25 +325,28 @@ describe(Turnstile.name, () => {
 
   async function setup(input?: { enabled?: boolean; siteKey?: string; onDismissed?: () => void; components?: Partial<typeof COMPONENTS> }) {
     const turnstileRef = { current: null as TurnstileRef | null };
+    const errorHandler = mock<ErrorHandlerService>();
 
     const result = render(
-      <Turnstile
-        ref={turnstileRef}
-        enabled={!!input?.enabled}
-        siteKey="unittest-site-key"
-        onDismissed={input?.onDismissed}
-        components={MockComponents(COMPONENTS, {
-          ReactTurnstile: forwardRef<TurnstileInstance | undefined, TurnstileProps>((_, ref) => {
-            useForwardedRef(ref);
-            return <div>Turnstile</div>;
-          }),
-          ...input?.components
-        })}
-      />
+      <TestContainerProvider services={{ errorHandler: () => errorHandler }}>
+        <Turnstile
+          ref={turnstileRef}
+          enabled={!!input?.enabled}
+          siteKey="unittest-site-key"
+          onDismissed={input?.onDismissed}
+          components={MockComponents(COMPONENTS, {
+            ReactTurnstile: forwardRef<TurnstileInstance | undefined, TurnstileProps>((_, ref) => {
+              useForwardedRef(ref);
+              return <div>Turnstile</div>;
+            }),
+            ...input?.components
+          })}
+        />
+      </TestContainerProvider>
     );
     await act(() => wait(0));
 
-    return { ...result, turnstileRef };
+    return { ...result, turnstileRef, errorHandler };
   }
 
   const ButtonMock = forwardRef<HTMLButtonElement, React.ComponentProps<typeof COMPONENTS.Button>>((props, ref) => (
@@ -269,6 +354,17 @@ describe(Turnstile.name, () => {
       {props.children}
     </button>
   ));
+
+  function createTurnstileMock(instance: TurnstileInstance = mock<TurnstileInstance>()) {
+    const latestProps: { current: TurnstileProps | undefined } = { current: undefined };
+    const ReactTurnstile = forwardRef<TurnstileInstance | undefined, TurnstileProps>((props, ref) => {
+      useForwardedRef(ref, instance);
+      latestProps.current = props;
+      return <div>Turnstile</div>;
+    });
+
+    return { ReactTurnstile, instance, latestProps };
+  }
 
   function useForwardedRef<T>(ref: React.ForwardedRef<T>, instance: T = mock<T>()) {
     useEffect(() => {

--- a/apps/deploy-web/src/components/turnstile/Turnstile.spec.tsx
+++ b/apps/deploy-web/src/components/turnstile/Turnstile.spec.tsx
@@ -331,6 +331,30 @@ describe(Turnstile.name, () => {
       }
     });
 
+    it("abandons a pending challenge on unmount rather than reporting it wedged 2 minutes later", async () => {
+      const { turnstileRef, errorHandler, unmount } = await setup({ enabled: true });
+      vi.useFakeTimers();
+
+      try {
+        let rejection: unknown;
+        const promise = turnstileRef.current!.renderAndWaitResponse().catch(error => {
+          rejection = error;
+        });
+        await act(async () => {
+          unmount();
+        });
+        await promise;
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(CHALLENGE_DEADLINE_MS);
+        });
+
+        expect(rejection).toMatchObject({ reason: "dismissed" });
+        expect(errorHandler.reportError).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it("resolves with disabled token when turnstile is disabled", async () => {
       const { turnstileRef } = await setup({ enabled: false });
 

--- a/apps/deploy-web/src/components/turnstile/Turnstile.tsx
+++ b/apps/deploy-web/src/components/turnstile/Turnstile.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { RefObject } from "react";
-import { forwardRef, useCallback, useImperativeHandle, useMemo, useRef, useState } from "react";
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
 import { MdInfo } from "react-icons/md";
 import { Button } from "@akashnetwork/ui/components";
 import type { TurnstileInstance } from "@marsidev/react-turnstile";
@@ -85,6 +85,9 @@ export const Turnstile = forwardRef<TurnstileRef, TurnstileProps>(function Turns
   useWhen(status === "dismissed", () => {
     turnstileRef.current?.remove();
   });
+  useEffect(function abandonPendingChallengeOnUnmount() {
+    return () => abandonPendingChallenge.current?.();
+  }, []);
 
   useImperativeHandle(
     ref || externalTurnstileRef,

--- a/apps/deploy-web/src/components/turnstile/Turnstile.tsx
+++ b/apps/deploy-web/src/components/turnstile/Turnstile.tsx
@@ -59,7 +59,7 @@ export const Turnstile = forwardRef<TurnstileRef, TurnstileProps>(function Turns
   const { errorHandler } = useServices();
 
   const hasReportedFailure = useRef(false);
-  /** Cloudflare keeps retrying every 8s, so only the first anomaly of a run is reported: enough to diagnose, without one Sentry event per retry per stuck visitor. */
+  /** Cloudflare keeps retrying every 8s, so only the first anomaly of a run is reported: enough to diagnose, without one Sentry event per retry per stuck visitor. A run ends at the next success or the next challenge the caller asks for. */
   const reportChallengeFailure = useCallback(
     (error: unknown, event: string) => {
       if (hasReportedFailure.current) return;
@@ -98,6 +98,7 @@ export const Turnstile = forwardRef<TurnstileRef, TurnstileProps>(function Turns
         }
 
         abandonPendingChallenge.current?.();
+        hasReportedFailure.current = false;
         resetWidget();
         return new Promise((resolve, reject) => {
           const stopWaiting = () => {
@@ -122,6 +123,7 @@ export const Turnstile = forwardRef<TurnstileRef, TurnstileProps>(function Turns
           };
           const deadline = setTimeout(() => {
             stopWaiting();
+            reportChallengeFailure(new Error("Turnstile challenge never settled"), "TURNSTILE_CHALLENGE_WEDGED");
             reject({ reason: "timeout" });
           }, CHALLENGE_DEADLINE_MS);
 
@@ -130,7 +132,7 @@ export const Turnstile = forwardRef<TurnstileRef, TurnstileProps>(function Turns
         });
       }
     }),
-    [resetWidget, enabled]
+    [resetWidget, enabled, reportChallengeFailure]
   );
 
   if (!enabled) {

--- a/apps/deploy-web/src/components/turnstile/Turnstile.tsx
+++ b/apps/deploy-web/src/components/turnstile/Turnstile.tsx
@@ -10,12 +10,23 @@ import { motion } from "framer-motion";
 import { RefreshCwIcon, Undo2 } from "lucide-react";
 import dynamic from "next/dynamic";
 
+import { useServices } from "@src/context/ServicesProvider";
 import { useWhen } from "@src/hooks/useWhen";
 import { getInjectedConfig } from "@src/utils/getInjectedConfig/getInjectedConfig";
 
 type TurnstileStatus = "uninitialized" | "solved" | "interactive" | "expired" | "error" | "dismissed";
 
 const VISIBILITY_STATUSES: TurnstileStatus[] = ["interactive", "error"];
+
+/**
+ * Cloudflare recovers from a failed or expired challenge on its own, so the widget must never be torn down and
+ * rebuilt from our side: doing so restarts the challenge with no backoff, and an error -> interactive -> error
+ * cycle then flaps forever until the page is hard reloaded.
+ */
+const RECOVERY_OPTIONS = { retry: "auto", retryInterval: 8_000, refreshExpired: "auto" } as const;
+
+/** Bounds how long a caller waits on those retries, so a wedged challenge surfaces an error instead of hanging the form. */
+export const CHALLENGE_DEADLINE_MS = 120_000;
 
 export const COMPONENTS = {
   ReactTurnstile,
@@ -45,6 +56,18 @@ export const Turnstile = forwardRef<TurnstileRef, TurnstileProps>(function Turns
   const isVisible = useMemo(() => enabled && VISIBILITY_STATUSES.includes(status), [enabled, status]);
   const eventBus = useRef<EventTarget>(new EventTarget());
   const injectedConfig = getInjectedConfig();
+  const { errorHandler } = useServices();
+
+  const hasReportedFailure = useRef(false);
+  /** Cloudflare keeps retrying every 8s, so only the first anomaly of a run is reported: enough to diagnose, without one Sentry event per retry per stuck visitor. */
+  const reportChallengeFailure = useCallback(
+    (error: unknown, event: string) => {
+      if (hasReportedFailure.current) return;
+      hasReportedFailure.current = true;
+      errorHandler.reportError({ error, severity: "warning", tags: { event } });
+    },
+    [errorHandler]
+  );
 
   const resetWidget = useCallback(() => {
     turnstileRef.current?.remove();
@@ -59,9 +82,6 @@ export const Turnstile = forwardRef<TurnstileRef, TurnstileProps>(function Turns
     abandonPendingChallenge.current?.();
   }, [onDismissed]);
 
-  useWhen(status === "error" || status === "expired", () => {
-    resetWidget();
-  });
   useWhen(status === "dismissed", () => {
     turnstileRef.current?.remove();
   });
@@ -81,6 +101,7 @@ export const Turnstile = forwardRef<TurnstileRef, TurnstileProps>(function Turns
         resetWidget();
         return new Promise((resolve, reject) => {
           const stopWaiting = () => {
+            clearTimeout(deadline);
             eventBus.current.removeEventListener("success", successListener);
             eventBus.current.removeEventListener("error", errorListener);
             abandonPendingChallenge.current = undefined;
@@ -99,6 +120,11 @@ export const Turnstile = forwardRef<TurnstileRef, TurnstileProps>(function Turns
             stopWaiting();
             reject({ reason: "dismissed" });
           };
+          const deadline = setTimeout(() => {
+            stopWaiting();
+            reject({ reason: "timeout" });
+          }, CHALLENGE_DEADLINE_MS);
+
           eventBus.current.addEventListener("success", successListener);
           eventBus.current.addEventListener("error", errorListener);
         });
@@ -133,17 +159,17 @@ export const Turnstile = forwardRef<TurnstileRef, TurnstileProps>(function Turns
               className="flex-1"
               ref={turnstileRef}
               siteKey={injectedConfig?.NEXT_PUBLIC_TURNSTILE_SITE_KEY ?? siteKey}
-              options={{ execution: "execute", size: "normal" }}
+              options={{ execution: "execute", size: "normal", ...RECOVERY_OPTIONS }}
               onError={error => {
                 setStatus("error");
+                reportChallengeFailure(error, "TURNSTILE_CHALLENGE_FAILED");
                 eventBus.current.dispatchEvent(new CustomEvent("error", { detail: { error, reason: "error" } }));
               }}
-              onExpire={() => {
-                setStatus("expired");
-                eventBus.current.dispatchEvent(new CustomEvent("expired", { detail: { reason: "expired" } }));
-              }}
+              onExpire={() => setStatus("expired")}
+              onTimeout={() => reportChallengeFailure(new Error("Turnstile challenge timed out"), "TURNSTILE_CHALLENGE_TIMED_OUT")}
               onSuccess={token => {
                 setStatus("solved");
+                hasReportedFailure.current = false;
                 eventBus.current.dispatchEvent(new CustomEvent("success", { detail: { token } }));
               }}
               onBeforeInteractive={() => setStatus("interactive")}

--- a/apps/deploy-web/src/components/turnstile/Turnstile.tsx
+++ b/apps/deploy-web/src/components/turnstile/Turnstile.tsx
@@ -75,6 +75,7 @@ export const Turnstile = forwardRef<TurnstileRef, TurnstileProps>(function Turns
     turnstileRef.current?.execute();
   }, []);
   const abandonPendingChallenge = useRef<(() => void) | undefined>(undefined);
+  const stopWaitingForChallenge = useRef<(() => void) | undefined>(undefined);
   /** Notifies the parent before rejecting so it can drop the abandoned attempt instead of rendering it as a failure. */
   const hideWidget = useCallback(() => {
     setStatus("dismissed");
@@ -85,8 +86,13 @@ export const Turnstile = forwardRef<TurnstileRef, TurnstileProps>(function Turns
   useWhen(status === "dismissed", () => {
     turnstileRef.current?.remove();
   });
-  useEffect(function abandonPendingChallengeOnUnmount() {
-    return () => abandonPendingChallenge.current?.();
+  /**
+   * Unmounting is not a dismissal, so the deadline is dropped without settling the promise: the caller awaiting it is
+   * going away with us. Rejecting instead would surface as a mutation error and reach the global MutationCache
+   * reporter as an untagged non-Error, one Sentry event for every visitor who navigates off mid-challenge.
+   */
+  useEffect(function stopWaitingForChallengeOnUnmount() {
+    return () => stopWaitingForChallenge.current?.();
   }, []);
 
   useImperativeHandle(
@@ -109,6 +115,7 @@ export const Turnstile = forwardRef<TurnstileRef, TurnstileProps>(function Turns
             eventBus.current.removeEventListener("success", successListener);
             eventBus.current.removeEventListener("error", errorListener);
             abandonPendingChallenge.current = undefined;
+            stopWaitingForChallenge.current = undefined;
           };
           const successListener = (event: Event) => {
             stopWaiting();
@@ -124,6 +131,7 @@ export const Turnstile = forwardRef<TurnstileRef, TurnstileProps>(function Turns
             stopWaiting();
             reject({ reason: "dismissed" });
           };
+          stopWaitingForChallenge.current = stopWaiting;
           const deadline = setTimeout(() => {
             stopWaiting();
             reportChallengeFailure(new Error("Turnstile challenge never settled"), "TURNSTILE_CHALLENGE_WEDGED");

--- a/apps/deploy-web/tests/ui/actions/auth.ts
+++ b/apps/deploy-web/tests/ui/actions/auth.ts
@@ -13,12 +13,8 @@ export type AuthType = "passwordless" | "email-password";
 
 const DETECT_TIMEOUT_MS = 30_000;
 
-/**
- * Leaving /login waits on a Turnstile solve, the app's auth API route and Auth0 in sequence, which on beta regularly
- * outruns the 15s actionTimeout: 8 of 27 tests in the 2026-08-25 run retried on this gate alone, and the global
- * teardown failed its escrow sweep with it, leaving deployments draining.
- */
-const SIGN_IN_TIMEOUT_MS = 45_000;
+/** Leaving /login waits on the Turnstile solve, the app's auth API route and Auth0 in sequence. */
+const SIGN_IN_TIMEOUT_MS = 15_000;
 
 export function generateTestPassword(): string {
   return `E2e!${crypto.randomUUID()}`;

--- a/apps/deploy-web/tests/ui/fixture/base-test.ts
+++ b/apps/deploy-web/tests/ui/fixture/base-test.ts
@@ -74,14 +74,17 @@ async function closeDeploymentsLeftBehind(page: Page) {
   }
 }
 
+/**
+ * Cloudflare's always-pass, invisible dummy sitekey. The visible always-pass variant (1x...AA) can still enter an
+ * interactive challenge that no test ever solves, which stalls sign-in until the whole budget burns.
+ * https://developers.cloudflare.com/turnstile/troubleshooting/testing/#dummy-sitekeys-and-secret-keys
+ */
+const ALWAYS_PASS_INVISIBLE_SITE_KEY = "1x00000000000000000000BB";
+
 export async function injectUIConfig(page: Page) {
-  await page.addInitScript(() => {
-    (window as any).__AK_INJECTED_CONFIG__ = Object.freeze({
-      // always pass, invisible turnstile site key: https://developers.cloudflare.com/turnstile/troubleshooting/testing/#dummy-sitekeys-and-secret-keys
-      // the visible variant (…AA) can still enter an interactive challenge that no test ever solves, stalling sign-in forever
-      NEXT_PUBLIC_TURNSTILE_SITE_KEY: "1x00000000000000000000BB"
-    });
-  });
+  await page.addInitScript(siteKey => {
+    (window as any).__AK_INJECTED_CONFIG__ = Object.freeze({ NEXT_PUBLIC_TURNSTILE_SITE_KEY: siteKey });
+  }, ALWAYS_PASS_INVISIBLE_SITE_KEY);
 }
 
 /**

--- a/apps/deploy-web/tests/ui/fixture/base-test.ts
+++ b/apps/deploy-web/tests/ui/fixture/base-test.ts
@@ -77,8 +77,9 @@ async function closeDeploymentsLeftBehind(page: Page) {
 export async function injectUIConfig(page: Page) {
   await page.addInitScript(() => {
     (window as any).__AK_INJECTED_CONFIG__ = Object.freeze({
-      // always pass turnstile site key: https://developers.cloudflare.com/turnstile/troubleshooting/testing/#dummy-sitekeys-and-secret-keys
-      NEXT_PUBLIC_TURNSTILE_SITE_KEY: "1x00000000000000000000AA"
+      // always pass, invisible turnstile site key: https://developers.cloudflare.com/turnstile/troubleshooting/testing/#dummy-sitekeys-and-secret-keys
+      // the visible variant (…AA) can still enter an interactive challenge that no test ever solves, stalling sign-in forever
+      NEXT_PUBLIC_TURNSTILE_SITE_KEY: "1x00000000000000000000BB"
     });
   });
 }


### PR DESCRIPTION
## Why

A session expired while a laptop slept overnight. The redirect to `/login` was correct, but the captcha overlay on that page kept failing and re-rendering on a loop, and nothing except a hard refresh got past it.

Our widget was fighting Cloudflare's own recovery. Turnstile retries a failed challenge every 8s and refreshes an expired token by itself. `retry: auto`, `retry-interval: 8000` and `refresh-expired: auto` are all defaults and we passed none of them, so all of that was already running. On top of it the component had a reset-on-error effect calling `remove()`, `render()` and `execute()` with no backoff, tearing down Cloudflare's in-flight retry each time.

That effect keys on a boolean, so an `error -> interactive -> error` cycle re-arms it on every transition. One transient failure flaps forever, and a network blip in the first seconds after a wake is enough to start it. Since the reset also calls `execute()`, an error at mount escalates into a full interactive challenge on a login page the visitor has not touched yet.

Two more bugs turned up in the same component. `onExpire` dispatched an `"expired"` event that nothing listens for, so `renderAndWaitResponse()` never settled and the submit button sat on `Loading...` forever. That is the same never-settling promise which stalled the beta e2e sign-in. Separately, Turnstile errors were never reported anywhere, so none of this was visible in Sentry.

Precedent: #3107 pinned the widget size after a Cloudflare `api.js` update broke login.

## What

In `Turnstile.tsx`, I dropped the reset-on-error effect and let Cloudflare recover on its own, quietly and with backoff. Its recovery settings are now stated explicitly in `options` so nobody adds a manual reset back. `renderAndWaitResponse()` is bounded by a 120s deadline that rejects with `{ reason: "timeout" }`, so a wedged challenge surfaces through `RemoteApiError` instead of hanging the form. The dead `"expired"` dispatch is gone and `onTimeout` is wired up.

Failures now go to Sentry through `errorHandler.reportError`, but only the first of each run. Cloudflare keeps retrying every 8s, and one event per retry per stuck visitor is how you end up with a 27k-event group.

On the e2e side, the fixture injected `1x00000000000000000000AA`, the visible always-pass dummy sitekey, which can still enter an interactive challenge that no test solves. It now uses the invisible variant `1x00000000000000000000BB`, and `SIGN_IN_TIMEOUT_MS` goes back to 15s.

The first commit fixes an unrelated pre-commit trap I hit on the way. The eslint override disabling `react-hooks/rules-of-hooks` for Playwright fixtures was anchored at `tests/ui/**`, which only matches when eslint runs inside `apps/deploy-web`. lint-staged runs it from the git root, so the override never applied and every commit touching `apps/deploy-web/tests/ui` was rejected, including files it had not modified. Reproducible on `main`.

### Reproducing the loop

Cloudflare publishes an always-blocks dummy sitekey, and `getInjectedConfig` lets you swap the key at runtime. Run this before `/login` mounts:

```js
window.__AK_INJECTED_CONFIG__ = Object.freeze({ NEXT_PUBLIC_TURNSTILE_SITE_KEY: "2x00000000000000000000AB" });
```

Before the fix the overlay flaps continuously. After it, you get one widget, retries roughly 8s apart, then a stable error state with the reload and dismiss buttons.

The unit tests cover the same thing without a browser. `never restarts the widget when errors alternate with interactive prompts` fails on `main` with `remove` called three times.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved verification challenge recovery with automatic retries and refreshes after expiration.
  * Prevented duplicate error reports and unnecessary widget restarts.
  * Added a 120-second timeout for pending verification responses.

* **Tests**
  * Expanded coverage for challenge failures, retries, expiration, refreshes, and timeouts.
  * Improved UI test configuration and shortened sign-in test timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->