### PR TITLE
fix(dx): stop the service worker serving day-old html documents

### DIFF
--- a/apps/deploy-web/next.config.js
+++ b/apps/deploy-web/next.config.js
@@ -8,6 +8,13 @@ const defaultCache = require("next-pwa/cache");
 const withPWA = require("next-pwa")({
   dest: "public",
   disable: isDev,
+  /**
+   * next-pwa registers a start-url route ahead of every other rule, handled by a plugin that rewrites an
+   * opaqueredirect into a fake empty 200 -- so the "/" -> "/login" redirect gets stored as a blank document and
+   * served back on the next visit. dynamicStartUrl drops that route; cacheStartUrl stops "/" being precached too.
+   */
+  cacheStartUrl: false,
+  dynamicStartUrl: false,
   runtimeCaching: [
     {
       urlPattern: ({ url }) => {
@@ -16,6 +23,20 @@ const withPWA = require("next-pwa")({
       },
       handler: "NetworkOnly",
       options: { cacheName: "third-party-network-only" }
+    },
+    /**
+     * Must precede defaultCache, whose catch-all "others" rule is a 24h NetworkFirst that also matches navigations:
+     * on a slow network its 10s timeout serves a day-old document whose /_next/static/<buildId> chunks 404 after a
+     * deploy, and only a hard reload escapes it. The app needs a live session and API to render anything useful, so
+     * an honest network error beats a stale shell.
+     */
+    {
+      urlPattern: ({ url, request }) => {
+        const isSameOrigin = self.origin === url.origin; // eslint-disable-line no-undef
+        return isSameOrigin && request.destination === "document";
+      },
+      handler: "NetworkOnly",
+      options: { cacheName: "html-network-only" }
     },
     ...defaultCache
   ]


### PR DESCRIPTION
## Why

Same overnight-sleep report as the PR below this one. The captcha loop was the visible failure, but there is a second reason a hard refresh was needed instead of a normal reload: the service worker can serve a day-old `/login` document.

`next-pwa` spreads its default runtime caching wholesale, and the catch-all `others` rule is a 24h `NetworkFirst` matching every same-origin non-API GET, navigations included:

```js
handler: "NetworkFirst",
options: { cacheName: "others", networkTimeoutSeconds: 10, expiration: { maxEntries: 32, maxAgeSeconds: 86400 } }
```

When the network is slow, as it is for the first seconds after a laptop wakes, that 10s timeout expires and the worker serves a cached document. If a deploy landed overnight, the document's `/_next/static/<buildId>` chunks are gone. A normal reload hits the same worker, so only a hard refresh escapes.

The same defaults carry the known start-url bug. Its `cacheWillUpdate` rewrites an `opaqueredirect` into a fake empty 200 and caches that, which is exactly what the `/` to `/login` redirect produces.

## What

Registered a `NetworkOnly` rule for document requests ahead of the defaults, and dropped the start-url route.

One thing worth knowing if you touch this again: the start-url route is gated on `dynamicStartUrl`, not `cacheStartUrl`, and it is `unshift`ed ahead of every other rule. Setting only `cacheStartUrl: false` leaves it in place and in front of the new rule, which is what my first attempt did.

Pages are no longer served offline. The app needs a live session and a live API to render anything useful, so an honest network error beats a stale shell. Static assets keep their caching.

### Verification

Built and compared the generated `public/sw.js`:

| | before | after |
| --- | --- | --- |
| `start-url` route | present | gone |
| `html-network-only` | absent | registered 2nd, ahead of `others` |
