### PR TITLE
feat(deployment): read deployment settings no deployment may back, by page

### DIFF
--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
@@ -93,12 +93,12 @@ describe(DeploymentSettingRepository.name, () => {
     });
   });
 
-  describe("findUnbackedDefinitionCandidates", () => {
+  describe("findUnbackedDeploymentSettings", () => {
     it("returns one page of the newest candidates, not the oldest and not all of them", async () => {
       const { deploymentSettingRepository, rememberDefinitions } = await setup();
       const dseqs = await rememberDefinitions(["oldest", "older", "middle", "newer", "newest"]);
 
-      const page = await deploymentSettingRepository.findUnbackedDefinitionCandidates({ graceHours: 1, pageSize: 3 });
+      const page = await deploymentSettingRepository.findUnbackedDeploymentSettings({ graceHours: 1, pageSize: 3 });
 
       expect(page.map(candidate => candidate.dseq)).toEqual([dseqs.newest, dseqs.newer, dseqs.middle]);
     });
@@ -107,8 +107,8 @@ describe(DeploymentSettingRepository.name, () => {
       const { deploymentSettingRepository, rememberDefinitions } = await setup();
       const dseqs = await rememberDefinitions(["oldest", "older", "middle", "newer", "newest"]);
 
-      const first = await deploymentSettingRepository.findUnbackedDefinitionCandidates({ graceHours: 1, pageSize: 3 });
-      const second = await deploymentSettingRepository.findUnbackedDefinitionCandidates({ graceHours: 1, pageSize: 3, olderThan: first[2] });
+      const first = await deploymentSettingRepository.findUnbackedDeploymentSettings({ graceHours: 1, pageSize: 3 });
+      const second = await deploymentSettingRepository.findUnbackedDeploymentSettings({ graceHours: 1, pageSize: 3, olderThan: first[2] });
 
       expect(second.map(candidate => candidate.dseq)).toEqual([dseqs.older, dseqs.oldest]);
     });
@@ -148,8 +148,8 @@ describe(DeploymentSettingRepository.name, () => {
       const { deploymentSettingRepository, rememberDefinitions } = await setup();
       await rememberDefinitions(["oldest", "newest"]);
 
-      const first = await deploymentSettingRepository.findUnbackedDefinitionCandidates({ graceHours: 1, pageSize: 10 });
-      const exhausted = await deploymentSettingRepository.findUnbackedDefinitionCandidates({ graceHours: 1, pageSize: 10, olderThan: first[1] });
+      const first = await deploymentSettingRepository.findUnbackedDeploymentSettings({ graceHours: 1, pageSize: 10 });
+      const exhausted = await deploymentSettingRepository.findUnbackedDeploymentSettings({ graceHours: 1, pageSize: 10, olderThan: first[1] });
 
       expect(first).toHaveLength(2);
       expect(exhausted).toEqual([]);
@@ -497,7 +497,7 @@ describe(DeploymentSettingRepository.name, () => {
       let olderThan;
 
       while (true) {
-        const page = await deploymentSettingRepository.findUnbackedDefinitionCandidates({ graceHours: 1, pageSize, olderThan });
+        const page = await deploymentSettingRepository.findUnbackedDeploymentSettings({ graceHours: 1, pageSize, olderThan });
 
         if (!page.length) {
           break;

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
@@ -93,6 +93,69 @@ describe(DeploymentSettingRepository.name, () => {
     });
   });
 
+  describe("findUnbackedDefinitionCandidates", () => {
+    it("returns one page of the newest candidates, not the oldest and not all of them", async () => {
+      const { deploymentSettingRepository, rememberDefinitions } = await setup();
+      const dseqs = await rememberDefinitions(["oldest", "older", "middle", "newer", "newest"]);
+
+      const page = await deploymentSettingRepository.findUnbackedDefinitionCandidates({ graceHours: 1, pageSize: 3 });
+
+      expect(page.map(candidate => candidate.dseq)).toEqual([dseqs.newest, dseqs.newer, dseqs.middle]);
+    });
+
+    it("walks the rest through the cursor, returning each record exactly once", async () => {
+      const { deploymentSettingRepository, rememberDefinitions } = await setup();
+      const dseqs = await rememberDefinitions(["oldest", "older", "middle", "newer", "newest"]);
+
+      const first = await deploymentSettingRepository.findUnbackedDefinitionCandidates({ graceHours: 1, pageSize: 3 });
+      const second = await deploymentSettingRepository.findUnbackedDefinitionCandidates({ graceHours: 1, pageSize: 3, olderThan: first[2] });
+
+      expect(second.map(candidate => candidate.dseq)).toEqual([dseqs.older, dseqs.oldest]);
+    });
+
+    /**
+     * `created_at` is `now()` at microsecond precision and a JS `Date` holds milliseconds, so a cursor
+     * carried as a `Date` is the real value truncated down — and the next page, asking for rows strictly
+     * older than it, silently drops every sibling written in the same millisecond. Ties on an identical
+     * timestamp are the other half: they are what the `id` tiebreaker and the secondary ORDER BY exist for.
+     * Both are seeded here, and both straddle a page boundary.
+     *
+     * The tie group is deliberately wider than a page. Postgres promises no order among rows with equal sort
+     * keys, so a fixture whose ties fit inside one page could agree with an id-ordered walk by luck and pass
+     * against a broken ORDER BY. Four tied rows against a page size of two put a boundary inside the group,
+     * which is what makes the walk desynchronise whenever the ordering is not id-descending. Resize one and
+     * you have to resize the other.
+     */
+    it("returns every record exactly once when timestamps collide or differ only in microseconds", async () => {
+      const { rememberDefinitionsAt, walkEveryPage } = await setup();
+      const seeded = await rememberDefinitionsAt([
+        "2026-01-01 00:00:00.700000",
+        "2026-01-01 00:00:00.500000",
+        "2026-01-01 00:00:00.500000",
+        "2026-01-01 00:00:00.500000",
+        "2026-01-01 00:00:00.500000",
+        "2026-01-01 00:00:00.123400",
+        "2026-01-01 00:00:00.123200",
+        "2026-01-01 00:00:00.123000"
+      ]);
+
+      const walked = await walkEveryPage(2);
+
+      expect([...walked].sort()).toEqual([...seeded].sort());
+    });
+
+    it("returns no page at all once the cursor passes the oldest candidate", async () => {
+      const { deploymentSettingRepository, rememberDefinitions } = await setup();
+      await rememberDefinitions(["oldest", "newest"]);
+
+      const first = await deploymentSettingRepository.findUnbackedDefinitionCandidates({ graceHours: 1, pageSize: 10 });
+      const exhausted = await deploymentSettingRepository.findUnbackedDefinitionCandidates({ graceHours: 1, pageSize: 10, olderThan: first[1] });
+
+      expect(first).toHaveLength(2);
+      expect(exhausted).toEqual([]);
+    });
+  });
+
   describe("applyRuntimeLimit", () => {
     it("raises the limit for the row's own user", async () => {
       const { deploymentSettingRepository, user, abilityFor, createLimitedSetting } = await setup();
@@ -401,6 +464,82 @@ describe(DeploymentSettingRepository.name, () => {
       return setting;
     }
 
+    /**
+     * Remembered definitions at exact timestamps, written as text so the microseconds survive: a JS `Date`
+     * is millisecond-only and could not express the collisions these tests exist to cover. Returns the
+     * dseqs in seeding order.
+     */
+    async function rememberDefinitionsAt(timestamps: string[]) {
+      await db.delete(deploymentSettingsTable);
+
+      const dseqs: string[] = [];
+
+      for (const [index, timestamp] of timestamps.entries()) {
+        const dseq = `9100${index}`;
+        dseqs.push(dseq);
+        await db.insert(deploymentSettingsTable).values({
+          userId: user.id,
+          dseq,
+          autoTopUpEnabled: true,
+          closed: false,
+          sdl: "version: '2.0'",
+          manifestVersion: "bWFuaWZlc3Q=",
+          createdAt: sql`${timestamp}::timestamp` as unknown as Date
+        });
+      }
+
+      return dseqs;
+    }
+
+    /** Pages to exhaustion exactly as the sweep does, so a cursor that skips or repeats a row shows up here. */
+    async function walkEveryPage(pageSize: number) {
+      const seen: string[] = [];
+      let olderThan;
+
+      while (true) {
+        const page = await deploymentSettingRepository.findUnbackedDefinitionCandidates({ graceHours: 1, pageSize, olderThan });
+
+        if (!page.length) {
+          break;
+        }
+
+        seen.push(...page.map(candidate => candidate.dseq));
+        olderThan = page[page.length - 1];
+
+        if (page.length < pageSize) {
+          break;
+        }
+      }
+
+      return seen;
+    }
+
+    /**
+     * Remembered definitions written one hour apart, oldest label first, all well past any grace period.
+     * Distinct `created_at` values are the point: they are what makes newest-first observable.
+     */
+    async function rememberDefinitions(labels: string[]) {
+      await db.delete(deploymentSettingsTable);
+
+      const byLabel: Record<string, string> = {};
+
+      for (const [index, label] of labels.entries()) {
+        const dseq = `9000${index}`;
+        byLabel[label] = dseq;
+        await db.insert(deploymentSettingsTable).values({
+          userId: user.id,
+          dseq,
+          autoTopUpEnabled: true,
+          closed: false,
+          sdl: "version: '2.0'",
+          manifestVersion: "bWFuaWZlc3Q=",
+          createdAt: new Date(Date.now() - hoursToMilliseconds(labels.length - index + 1))
+        });
+      }
+
+      return byLabel;
+    }
+
     async function backdateLastFundedAt(id: string, minutesAgo: number) {
       await db
         .update(deploymentSettingsTable)
@@ -420,6 +559,9 @@ describe(DeploymentSettingRepository.name, () => {
       createSetting,
       createLimitedSetting,
       createAnchoredSetting,
+      rememberDefinitions,
+      rememberDefinitionsAt,
+      walkEveryPage,
       backdateLastFundedAt
     };
   }

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -36,6 +36,18 @@ export type ExpiringRuntimeDeployment = ExpiredRuntimeDeployment & {
   runtimeEndsAtMarker: string;
 };
 
+/** A remembered definition old enough to sweep, with the address its dseq would live under on chain. */
+export type UnbackedDefinitionCandidate = {
+  id: string;
+  dseq: string;
+  address: string;
+  /** When the row was written, in text, so paging past it cannot lose the sub-millisecond digits a `Date` drops. */
+  createdAtMarker: string;
+};
+
+/** Where a page of candidates left off. The id breaks ties, so two rows written in the same tick cannot hide each other. */
+export type UnbackedDefinitionCursor = Pick<UnbackedDefinitionCandidate, "id" | "createdAtMarker">;
+
 export type AutoTopUpDeployment = {
   id: string;
   walletId: number;
@@ -285,6 +297,58 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
         target: [this.table.dseq, this.table.userId],
         set: { sdl, manifestVersion, runtimeLimitHours, updatedAt: sql`now()` }
       });
+  }
+
+  /**
+   * One page of remembered definitions old enough that the create tx each was written for has either
+   * reached the chain or never will. Answering which of the two happened needs the chain, so this only
+   * narrows the field: the caller checks every row it returns against the chain before deleting anything.
+   *
+   * `closed = false` is a cheap head start, not the protection for closed deployments — that lives in the
+   * caller asking the chain for every state. `sdl is not null` skips rows a settings read created lazily,
+   * which remember no definition and carry only the choices their owner made.
+   *
+   * Pages newest first, through a `(created_at, id)` keyset rather than an offset: newest first so a run cut
+   * short has still covered where orphans are, and a keyset so that deleting rows as the caller pages cannot
+   * shift the rows underneath it.
+   *
+   * The cursor's timestamp travels as text, for the same reason `runtimeEndsAtMarker` does. `created_at` is
+   * `now()` at microsecond precision and a JS `Date` holds only milliseconds, so a cursor round-tripped
+   * through one is the stored value truncated down — and the next page, asking for rows strictly older than
+   * it, would drop every sibling written in the same millisecond, on this page and on every later one. The
+   * comparison is written as a single row value so it cannot drift out of step with the ORDER BY beside it.
+   */
+  async findUnbackedDefinitionCandidates({
+    graceHours,
+    pageSize,
+    olderThan
+  }: {
+    graceHours: number;
+    pageSize: number;
+    olderThan?: UnbackedDefinitionCursor;
+  }): Promise<UnbackedDefinitionCandidate[]> {
+    const candidates = await this.pg
+      .select({
+        id: this.table.id,
+        dseq: this.table.dseq,
+        address: UserWallets.address,
+        createdAtMarker: sql<string>`to_char(${this.table.createdAt}, 'YYYY-MM-DD"T"HH24:MI:SS.US')`
+      })
+      .from(this.table)
+      .innerJoin(UserWallets, eq(this.table.userId, UserWallets.userId))
+      .where(
+        and(
+          eq(this.table.closed, false),
+          isNotNull(this.table.sdl),
+          isNotNull(UserWallets.address),
+          lt(this.table.createdAt, sql`now() - (${graceHours} * interval '1 hour')`),
+          olderThan ? sql`(${this.table.createdAt}, ${this.table.id}) < (${olderThan.createdAtMarker}::timestamp, ${olderThan.id}::uuid)` : undefined
+        )
+      )
+      .orderBy(desc(this.table.createdAt), desc(this.table.id))
+      .limit(pageSize);
+
+    return candidates as UnbackedDefinitionCandidate[];
   }
 
   /**

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -36,8 +36,8 @@ export type ExpiringRuntimeDeployment = ExpiredRuntimeDeployment & {
   runtimeEndsAtMarker: string;
 };
 
-/** A remembered definition old enough to sweep, with the address its dseq would live under on chain. */
-export type UnbackedDefinitionCandidate = {
+/** A deployment settings row old enough to clean up, with the address its dseq would live under on chain. */
+export type UnbackedDeploymentSetting = {
   id: string;
   dseq: string;
   address: string;
@@ -46,7 +46,7 @@ export type UnbackedDefinitionCandidate = {
 };
 
 /** Where a page of candidates left off. The id breaks ties, so two rows written in the same tick cannot hide each other. */
-export type UnbackedDefinitionCursor = Pick<UnbackedDefinitionCandidate, "id" | "createdAtMarker">;
+export type UnbackedDeploymentSettingCursor = Pick<UnbackedDeploymentSetting, "id" | "createdAtMarker">;
 
 export type AutoTopUpDeployment = {
   id: string;
@@ -300,13 +300,13 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
   }
 
   /**
-   * One page of remembered definitions old enough that the create tx each was written for has either
+   * One page of deployment settings rows old enough that the create tx each was written for has either
    * reached the chain or never will. Answering which of the two happened needs the chain, so this only
    * narrows the field: the caller checks every row it returns against the chain before deleting anything.
    *
    * `closed = false` is a cheap head start, not the protection for closed deployments — that lives in the
    * caller asking the chain for every state. `sdl is not null` skips rows a settings read created lazily,
-   * which remember no definition and carry only the choices their owner made.
+   * which record no SDL at all and carry only the choices their owner made.
    *
    * Pages newest first, through a `(created_at, id)` keyset rather than an offset: newest first so a run cut
    * short has still covered where orphans are, and a keyset so that deleting rows as the caller pages cannot
@@ -318,15 +318,15 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
    * it, would drop every sibling written in the same millisecond, on this page and on every later one. The
    * comparison is written as a single row value so it cannot drift out of step with the ORDER BY beside it.
    */
-  async findUnbackedDefinitionCandidates({
+  async findUnbackedDeploymentSettings({
     graceHours,
     pageSize,
     olderThan
   }: {
     graceHours: number;
     pageSize: number;
-    olderThan?: UnbackedDefinitionCursor;
-  }): Promise<UnbackedDefinitionCandidate[]> {
+    olderThan?: UnbackedDeploymentSettingCursor;
+  }): Promise<UnbackedDeploymentSetting[]> {
     const candidates = await this.pg
       .select({
         id: this.table.id,
@@ -348,7 +348,7 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
       .orderBy(desc(this.table.createdAt), desc(this.table.id))
       .limit(pageSize);
 
-    return candidates as UnbackedDefinitionCandidate[];
+    return candidates as UnbackedDeploymentSetting[];
   }
 
   /**


### PR DESCRIPTION
## Why

A deployment's settings row records what it is — its stripped SDL and the manifest version it commits — written just before the create tx is broadcast. A broadcast that never lands therefore leaves a record on a dseq the chain has never heard of, and **nothing in the codebase can currently find those records**:

- the stale-deployment cleanup (`StaleManagedDeploymentsCleanerService`) starts from on-chain deployments and closes the lease-less ones; a dseq that was never broadcast is not among them
- the funding sweep looks each remembered dseq up by lease and skips whatever it finds nothing for — on every pass, forever (`draining-deployment.service.ts:121-123`)

Left alone they only accumulate. This PR adds the read those rows need. **The cleanup that consumes it is the stacked follow-up below.**

## What

`DeploymentSettingRepository.findUnbackedDeploymentSettings` — one page of deployment settings rows old enough that the create tx each was written for has either reached the chain or never will.

> **Note for reviewers: this method has no caller until slice 2.** It is not dead code, it is the first half of a stack. Its behaviour is fully exercised by the integration tests in this PR, which call it directly against real Postgres.

**Pages rather than caps.** Whether a row is an orphan or a deployment that simply has not been indexed yet is a question only the chain can answer, so this narrows the field and the caller confirms each row before deleting anything. A record the caller never examines would always be among the oldest of its cohort, and because pages come newest first, a cap on how many rows a pass could take would leave the remainder under a waterline that only ever rises — unreachable for good, and worst during the broadcast outage that produces orphans in bulk.

**A keyset, not an offset**, because the caller deletes as it walks and an offset would shift the rows underneath it.

**The cursor's timestamp travels as text**, for the same reason `runtimeEndsAtMarker` already does in this file. `created_at` is `now()` at microsecond precision and a JS `Date` holds only milliseconds, so a cursor round-tripped through one is the stored value truncated *down* — and the next page, asking for rows strictly older than it, would silently drop every sibling written in the same millisecond, on this page and on every later one. The comparison is written as a single row value `(created_at, id) < (marker::timestamp, id::uuid)` so it cannot drift out of step with the `ORDER BY` beside it.

**The predicate.** `closed = false` is only a cheap head start, not the protection for closed deployments — that belongs to the caller, which asks the chain for every state. `sdl is not null` skips rows a settings read created lazily, which remember no definition at all and carry only the choices their owner made.

### Tests

Three integration tests against real Postgres cover page size, newest-first ordering, and cursor exhaustion. A fourth seeds rows that **share a timestamp** and rows that **differ only in microseconds**, walks to exhaustion, and asserts every row appears exactly once.

Each of these mutations fails that suite, confirmed separately:

| Mutation | Result |
|---|---|
| `DESC` → `ASC` | 3 tests fail |
| delete `.limit(pageSize)` | 1 fails: `expected […(5)] to deeply equal ['90004','90003','90002']` |
| drop the `id` tiebreaker from the cursor | 5 of 8 rows returned |
| drop `desc(id)` from `ORDER BY` | 6 of 8 rows returned |
| truncate the marker to milliseconds | 7 of 8 rows returned |

The tie group in that fixture is deliberately **wider than a page**. Postgres promises no order among rows with equal sort keys, so a fixture whose ties fit inside one page could agree with an id-ordered walk by luck and pass against a broken `ORDER BY`. Four tied rows against a page size of two put a boundary inside the group. That constraint is recorded in a JSDoc on the fixture — resize one and you have to resize the other.

## Stack

This is **slice 1 of 2**.

- **Slice 1 (this PR)** — the paged read. `size: M`.
- **Slice 2** — `OrphanedDeploymentSettingsCleanerService`, its config, its CLI subcommand and its cron scheduling, plus the gate decision on closed-deployment rows. `size: L`. Linked below once opened.

**Slice 2 should merge after this one.**

## Checks

In `apps/api`, on this branch alone: `npm test` → `215 passed (215)` files / `2303 passed (2303)` tests, `npm run lint -- --quiet` → clean, `npx tsc --noEmit` → 41 errors, byte-identical to the pre-existing baseline on `main` (all in unrelated files).


## Naming

The method reads deployment settings rows that no on-chain deployment may back, so it is `findUnbackedDeploymentSettings` returning `UnbackedDeploymentSetting`. "Unbacked" is kept deliberately — unlike "definition" it carries the actual meaning, and it is the term the spec uses. "Candidate" is dropped from the type because the method name already implies it of everything returned, but survives in local variable names where it reads better.
