### PR TITLE
fix(deployment): unify byte units, runtime countdown and the cost tooltip on the detail page

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfidentialComputeResources.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfidentialComputeResources.spec.tsx
@@ -34,11 +34,11 @@ describe(ConfidentialComputeResources.name, () => {
     expect(screen.getByText("Available to your container")).toBeInTheDocument();
 
     expect(screen.getByText("0.5 CPU")).toBeInTheDocument();
-    expect(screen.getByText("256 MiB")).toBeInTheDocument();
+    expect(screen.getByText("268.44 MB")).toBeInTheDocument();
     expect(screen.getByText("0.1 CPU")).toBeInTheDocument();
-    expect(screen.getByText("64 MiB")).toBeInTheDocument();
+    expect(screen.getByText("67.11 MB")).toBeInTheDocument();
     expect(screen.getByText("0.4 CPU")).toBeInTheDocument();
-    expect(screen.getByText("192 MiB")).toBeInTheDocument();
+    expect(screen.getByText("201.33 MB")).toBeInTheDocument();
   });
 
   it("warns when the declared resources are at or below the attestation sidecar reservation", () => {
@@ -69,8 +69,8 @@ describe(ConfidentialComputeResources.name, () => {
     };
     setup({ carveouts: [cpuCarveout, second] });
 
-    expect(screen.getByText("0.5 CPU · 256 MiB")).toBeInTheDocument();
-    expect(screen.getByText("8 CPU · 32 GiB · 1 GPU")).toBeInTheDocument();
+    expect(screen.getByText("0.5 CPU · 268.44 MB")).toBeInTheDocument();
+    expect(screen.getByText("8 CPU · 34.36 GB · 1 GPU")).toBeInTheDocument();
   });
 
   it("notes the replica count when a resource unit runs more than one pod", () => {

--- a/apps/deploy-web/src/components/deployments/ConfidentialComputeResources.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfidentialComputeResources.tsx
@@ -6,7 +6,7 @@ import { Info } from "lucide-react";
 import type { TeeResourceCarveout } from "@src/utils/confidentialCompute";
 import { MIN_PRIMARY_CPU_MILLICORES, MIN_PRIMARY_MEMORY_BYTES } from "@src/utils/confidentialCompute";
 import { roundDecimal } from "@src/utils/mathHelpers";
-import { bytesToShrink } from "@src/utils/unitUtils";
+import { formatByteSize } from "@src/utils/unitUtils";
 
 export type Props = {
   carveouts: TeeResourceCarveout[];
@@ -17,14 +17,9 @@ export const DEPENDENCIES = { CustomTooltip };
 
 const formatCpu = (millicores: number) => `${roundDecimal(millicores / 1000, 2)} CPU`;
 
-const formatMemory = (bytes: number) => {
-  const { value, unit } = bytesToShrink(bytes, true);
-  return `${roundDecimal(value, 2)} ${unit}`;
-};
-
 /** Self-describing label for a resource unit (on-chain groups carry no service names). */
 const formatUnitLabel = (carveout: TeeResourceCarveout) => {
-  const parts = [formatCpu(carveout.requested.cpu), formatMemory(carveout.requested.memory)];
+  const parts = [formatCpu(carveout.requested.cpu), formatByteSize(carveout.requested.memory)];
   if (carveout.gpuUnits > 0) parts.push(`${carveout.gpuUnits} GPU`);
   return parts.join(" · ");
 };
@@ -36,7 +31,7 @@ function ResourceLine({ label, cpu, memory }: { label: string; cpu: number; memo
       {/* Keep each value intact (e.g. "0.01 CPU") and pinned right so a wrapping label can't break the numbers across lines. */}
       <span className="flex shrink-0 items-center gap-3 whitespace-nowrap text-right font-medium tabular-nums">
         <span>{formatCpu(cpu)}</span>
-        <span>{formatMemory(memory)}</span>
+        <span>{formatByteSize(memory)}</span>
       </span>
     </div>
   );

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.spec.tsx
@@ -84,17 +84,17 @@ describe("DeploymentDetailHeader", () => {
     try {
       setup({ runtimeLimitHours: 12, runtimeEndsAt: "2026-08-21T14:00:00.000Z" });
 
-      expect(screen.getByText("12h · ~2h left")).toBeInTheDocument();
+      expect(screen.getByText("12h · 2h left")).toBeInTheDocument();
 
       await act(async () => {
         await vi.advanceTimersByTimeAsync(61 * 60 * 1000);
       });
-      expect(screen.getByText("12h · ~1h left")).toBeInTheDocument();
+      expect(screen.getByText("12h · 59m left")).toBeInTheDocument();
 
       await act(async () => {
         await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
       });
-      expect(screen.getByText("12h · reached")).toBeInTheDocument();
+      expect(screen.getByText("12h · limit reached")).toBeInTheDocument();
     } finally {
       vi.useRealTimers();
     }

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.spec.tsx
@@ -179,6 +179,16 @@ describe("DeploymentDetailHeader", () => {
     expect(CostRate).toHaveBeenCalledWith(expect.objectContaining({ perBlockUDenom: 4000, gpuCount: 2 }), {});
   });
 
+  it("hangs the cost breakdown tooltip off the COST label rather than the value", () => {
+    const { CostRate, CostBreakdownTooltip } = setup({
+      leases: [buildPricedLease({ state: "active", amount: "4000", gpuAmount: 2 })]
+    });
+
+    expect(screen.getByText("COST").parentElement).toHaveTextContent("cost-tooltip");
+    expect(CostBreakdownTooltip).toHaveBeenCalledWith(expect.objectContaining({ perBlockUDenom: 4000, gpuCount: 2 }), {});
+    expect(CostRate).toHaveBeenCalledWith(expect.objectContaining({ hideBreakdownTooltip: true }), {});
+  });
+
   it("leaves closed leases out of the cost, so a partly torn-down deployment doesn't over-report", () => {
     const { CostRate } = setup({
       leases: [buildPricedLease({ state: "active", amount: "4000", gpuAmount: 1 }), buildPricedLease({ state: "closed", amount: "9000", gpuAmount: 1 })]
@@ -187,10 +197,11 @@ describe("DeploymentDetailHeader", () => {
     expect(CostRate).toHaveBeenCalledWith(expect.objectContaining({ perBlockUDenom: 4000, gpuCount: 1 }), {});
   });
 
-  it("shows no cost when every lease is closed", () => {
-    const { CostRate } = setup({ leases: [buildPricedLease({ state: "closed", amount: "9000", gpuAmount: 1 })] });
+  it("shows no cost and no breakdown tooltip when every lease is closed", () => {
+    const { CostRate, CostBreakdownTooltip } = setup({ leases: [buildPricedLease({ state: "closed", amount: "9000", gpuAmount: 1 })] });
 
     expect(CostRate).not.toHaveBeenCalled();
+    expect(CostBreakdownTooltip).not.toHaveBeenCalled();
   });
 
   it("keeps redeploy off the header now that it lives on the update tab", () => {
@@ -281,6 +292,7 @@ describe("DeploymentDetailHeader", () => {
         })
       });
     const CostRate = vi.fn(() => <div>cost-rate</div>);
+    const CostBreakdownTooltip = vi.fn(() => <span>cost-tooltip</span>);
     const DeploymentVisitControl = vi.fn(() => <div>visit</div>);
 
     const deployment = mock<DeploymentDto>({
@@ -312,12 +324,13 @@ describe("DeploymentDetailHeader", () => {
           ConfidentialComputeBadge,
           GpuInterconnectBadge,
           CostRate,
+          CostBreakdownTooltip,
           DeploymentVisitControl,
           ...input.dependencies
         })}
       />
     );
 
-    return { changeDeploymentName, CostRate, PriceValue };
+    return { changeDeploymentName, CostRate, CostBreakdownTooltip, PriceValue };
   }
 });

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.spec.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import yaml from "js-yaml";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
@@ -185,6 +186,7 @@ describe("DeploymentDetailHeader", () => {
     });
 
     expect(screen.getByText("COST").parentElement).toHaveTextContent("cost-tooltip");
+    expect(screen.getByText("COST").parentElement?.querySelector("svg")).toBeInTheDocument();
     expect(CostBreakdownTooltip).toHaveBeenCalledWith(expect.objectContaining({ perBlockUDenom: 4000, gpuCount: 2 }), {});
     expect(CostRate).toHaveBeenCalledWith(expect.objectContaining({ hideBreakdownTooltip: true }), {});
   });
@@ -292,7 +294,7 @@ describe("DeploymentDetailHeader", () => {
         })
       });
     const CostRate = vi.fn(() => <div>cost-rate</div>);
-    const CostBreakdownTooltip = vi.fn(() => <span>cost-tooltip</span>);
+    const CostBreakdownTooltip = vi.fn(({ children }: { children?: ReactNode }) => <span>cost-tooltip{children}</span>);
     const DeploymentVisitControl = vi.fn(() => <div>visit</div>);
 
     const deployment = mock<DeploymentDto>({

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.tsx
@@ -23,7 +23,7 @@ import type { ApiProviderList } from "@src/types/provider";
 import { isLeaseLive } from "@src/utils/leaseUtils";
 import { roundDecimal, udenomToDenom } from "@src/utils/mathHelpers";
 import { formatRuntimeLimit } from "@src/utils/runtimeLimitUtils";
-import { bytesToShrink } from "@src/utils/unitUtils";
+import { formatByteSize } from "@src/utils/unitUtils";
 import {
   countPlacementServices,
   formatGpuLabel,
@@ -88,8 +88,6 @@ export const DeploymentDetailHeader: FC<DeploymentDetailHeaderProps> = ({ deploy
 
   const name = getDeploymentName(deployment.dseq) || `Deployment #${deployment.dseq}`;
   const servicesCount = countPlacementServices(leases ?? [], servicesByPlacement, manifestServices);
-  const memory = bytesToShrink(deployment.memoryAmount);
-  const storage = bytesToShrink(deployment.storageAmount);
 
   return (
     <div className="flex flex-col gap-6 py-6 lg:flex-row lg:items-start lg:justify-between">
@@ -167,8 +165,8 @@ export const DeploymentDetailHeader: FC<DeploymentDetailHeaderProps> = ({ deploy
           <div className="grid grid-cols-4 gap-x-10">
             <SummaryItem label="GPU">{formatGpuLabel(deployment.gpuAmount ?? 0, getDeploymentGpuModels(deployment.groups))}</SummaryItem>
             <SummaryItem label="vCPU">{roundDecimal(deployment.cpuAmount, 2)}</SummaryItem>
-            <SummaryItem label="MEMORY">{`${roundDecimal(memory.value, 2)} ${memory.unit}`}</SummaryItem>
-            <SummaryItem label="STORAGE">{`${roundDecimal(storage.value, 2)} ${storage.unit}`}</SummaryItem>
+            <SummaryItem label="MEMORY">{formatByteSize(deployment.memoryAmount)}</SummaryItem>
+            <SummaryItem label="STORAGE">{formatByteSize(deployment.storageAmount)}</SummaryItem>
           </div>
         </CardContent>
       </Card>

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.tsx
@@ -7,6 +7,7 @@ import { CheckCircle, EditPencil, InfoCircle } from "iconoir-react";
 
 import { useLocalNotes } from "@src/components/LocalNoteManager";
 import { ConfidentialComputeBadge } from "@src/components/shared/ConfidentialComputeBadge";
+import { CostBreakdownTooltip } from "@src/components/shared/CostBreakdownTooltip";
 import { CostRate } from "@src/components/shared/CostRate";
 import { GpuInterconnectBadge } from "@src/components/shared/GpuInterconnectBadge";
 import { PriceValue } from "@src/components/shared/PriceValue";
@@ -43,6 +44,7 @@ export const DEPENDENCIES = {
   useDeclaredTeeTypes,
   useDeclaredGpuInterconnect,
   CostRate,
+  CostBreakdownTooltip,
   PriceValue,
   DeploymentVisitControl,
   CustomTooltip,
@@ -117,8 +119,19 @@ export const DeploymentDetailHeader: FC<DeploymentDetailHeaderProps> = ({ deploy
         <CardContent className="flex flex-col gap-5 p-6">
           <div className="grid grid-cols-4 gap-x-10">
             <SummaryItem label="TOTAL SERVICES">{servicesCount}</SummaryItem>
-            <SummaryItem label="COST">
-              {costPerBlockUDenom ? <d.CostRate perBlockUDenom={costPerBlockUDenom} denom={denom} gpuCount={liveGpuCount} /> : "—"}
+            <SummaryItem
+              label={
+                <span className="inline-flex items-center gap-1">
+                  COST
+                  {!!costPerBlockUDenom && (
+                    <d.CostBreakdownTooltip perBlockUDenom={costPerBlockUDenom} denom={denom} gpuCount={liveGpuCount}>
+                      <InfoCircle width={12} height={12} className="text-muted-foreground" />
+                    </d.CostBreakdownTooltip>
+                  )}
+                </span>
+              }
+            >
+              {costPerBlockUDenom ? <d.CostRate perBlockUDenom={costPerBlockUDenom} denom={denom} gpuCount={liveGpuCount} hideBreakdownTooltip /> : "—"}
             </SummaryItem>
             {!isEscrowAbstracted && (
               <SummaryItem label="BALANCE">

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.tsx
@@ -14,7 +14,7 @@ import { isLeaseLive } from "@src/utils/leaseUtils";
 import { roundDecimal } from "@src/utils/mathHelpers";
 import { providerDisplayName } from "@src/utils/providerUtils";
 import { isProviderReclaimed, isReclaiming } from "@src/utils/reclamationUtils";
-import { bytesToShrink } from "@src/utils/unitUtils";
+import { formatByteSize } from "@src/utils/unitUtils";
 import { UrlService } from "@src/utils/urlUtils";
 import { ConfidentialComputeResources } from "../../ConfidentialComputeResources";
 import { DownloadAttestationEvidence } from "../../DownloadAttestationEvidence";
@@ -177,12 +177,10 @@ export const PlacementCard: FC<PlacementCardProps> = ({
 };
 
 function buildPlacementStats(lease: LeaseDto, serviceCount: number, gpuModels: string[]): PlacementStat[] {
-  const memory = bytesToShrink(lease.memoryAmount);
-  const storage = bytesToShrink(lease.storageAmount);
   const stats: PlacementStat[] = [
     { label: "vCPU", value: roundDecimal(lease.cpuAmount, 2) },
-    { label: "Memory", value: `${roundDecimal(memory.value, 2)} ${memory.unit}` },
-    { label: "Storage", value: `${roundDecimal(storage.value, 2)} ${storage.unit}` }
+    { label: "Memory", value: formatByteSize(lease.memoryAmount) },
+    { label: "Storage", value: formatByteSize(lease.storageAmount) }
   ];
   if (lease.gpuAmount && lease.gpuAmount > 0) {
     stats.push({ label: "GPU", value: formatGpuLabel(lease.gpuAmount, gpuModels) });

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementServiceRow.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementServiceRow.spec.tsx
@@ -158,7 +158,7 @@ describe(PlacementServiceRow.name, () => {
     setup({
       detail: {
         image: "ghcr.io/acmecorp/llm-gateway:0.9.4",
-        resources: { gpuUnits: 0, cpu: 1, memory: { value: 2, unit: "Gi" }, storage: { value: 10, unit: "Gi" } }
+        resources: { gpuUnits: 0, cpu: 1, memory: 2 * 1024 ** 3, storage: 10 * 1024 ** 3 }
       }
     });
 
@@ -168,7 +168,7 @@ describe(PlacementServiceRow.name, () => {
     expect(screen.getByText("ghcr.io/acmecorp/llm-gateway:0.9.4")).toBeInTheDocument();
     expect(screen.getByText("vCPU")).toBeInTheDocument();
     expect(screen.getByText("Memory")).toBeInTheDocument();
-    expect(screen.getByText("2 Gi")).toBeInTheDocument();
+    expect(screen.getByText("2.15 GB")).toBeInTheDocument();
     expect(screen.getByText("Storage")).toBeInTheDocument();
   });
 

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementServiceRow.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementServiceRow.tsx
@@ -6,6 +6,7 @@ import { Box, Globe, Label, NavArrowDown, NavArrowRight } from "iconoir-react";
 
 import type { ForwardedPort, LeaseServiceStatus, ServiceIp } from "@src/queries/useLeaseQuery";
 import type { LeaseDto } from "@src/types/deployment";
+import { formatByteSize } from "@src/utils/unitUtils";
 import { StatusBadge } from "../DeploymentStatusBadge";
 import type { ManifestServiceDetail, ManifestServiceResources } from "./placementModel";
 import { formatReplicaCount, getServiceStatus } from "./placementModel";
@@ -147,6 +148,6 @@ function buildServiceStats(resources: ManifestServiceResources): PlacementStat[]
   return stats;
 }
 
-function formatSize(size: ManifestServiceResources["memory"]): string {
-  return size ? `${size.value} ${size.unit}`.trim() : "—";
+function formatSize(bytes: ManifestServiceResources["memory"]): string {
+  return bytes === undefined ? "—" : formatByteSize(bytes);
 }

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/placementModel.spec.ts
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/placementModel.spec.ts
@@ -27,7 +27,7 @@ describe("placementModel", () => {
       const result = parseManifestServices(manifest);
 
       expect(result.web.image).toBe("nginx:latest");
-      expect(result.web.resources).toEqual({ cpu: 2, gpuUnits: 0, memory: { value: 512, unit: "Mi" }, storage: { value: 1, unit: "Gi" } });
+      expect(result.web.resources).toEqual({ cpu: 2, gpuUnits: 0, memory: 512 * 1024 ** 2, storage: 1024 ** 3 });
     });
 
     it("reads gpu units from the compute profile", () => {
@@ -69,8 +69,8 @@ describe("placementModel", () => {
       expect(parseManifestServices(manifest).web.resources).toEqual({
         cpu: 1,
         gpuUnits: 0,
-        memory: { value: 256, unit: "Mi" },
-        storage: { value: 1, unit: "Gi" }
+        memory: 256 * 1024 ** 2,
+        storage: 1024 ** 3
       });
     });
 

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/placementModel.ts
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/placementModel.ts
@@ -6,17 +6,15 @@ import type { DeploymentGroup, LeaseDto } from "@src/types/deployment";
 import { getGpusFromAttributes } from "@src/utils/deploymentUtils";
 import { isLeaseLive } from "@src/utils/leaseUtils";
 import { parseSvcCommand } from "@src/utils/sdl/sdlImport";
-
-export interface ResourceSize {
-  value: number;
-  unit: string;
-}
+import { sizeStringToBytes } from "@src/utils/unitUtils";
 
 export interface ManifestServiceResources {
   cpu?: number;
   gpuUnits: number;
-  memory?: ResourceSize;
-  storage?: ResourceSize;
+  /** Bytes, normalized from the SDL's own suffix so the page renders one unit family everywhere. */
+  memory?: number;
+  /** Bytes, normalized from the SDL's own suffix so the page renders one unit family everywhere. */
+  storage?: number;
 }
 
 export interface ManifestEnvVar {
@@ -228,15 +226,11 @@ function toCommandString(value: unknown): string {
   return parseSvcCommand(value as string | (string | number | boolean)[]).replace(/\n/g, " ");
 }
 
-function parseSize(size: unknown): ResourceSize | undefined {
-  if (typeof size === "number") return { value: size, unit: "" };
+function parseSize(size: unknown): number | undefined {
+  if (typeof size === "number") return size;
   if (typeof size !== "string") return undefined;
 
-  const value = parseFloat(size);
-  if (Number.isNaN(value)) return undefined;
-
-  const unit = size.match(/[a-zA-Z]+/)?.[0] ?? "";
-  return { value, unit };
+  return sizeStringToBytes(size);
 }
 
 function toNumber(value: unknown): number | undefined {

--- a/apps/deploy-web/src/components/shared/CostBreakdownTooltip.spec.tsx
+++ b/apps/deploy-web/src/components/shared/CostBreakdownTooltip.spec.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { IntlProvider } from "react-intl";
 import { TooltipProvider } from "@akashnetwork/ui/components";
 import { describe, expect, it } from "vitest";
@@ -30,13 +31,23 @@ describe(CostBreakdownTooltip.name, () => {
     expect(screen.queryAllByText(/per month/i)).toHaveLength(0);
   });
 
-  function setup(input: { gpuCount: number }) {
+  it("renders a custom trigger in place of the default info icon", async () => {
+    const { user } = setup({ gpuCount: 0, trigger: <button>breakdown</button> });
+
+    await user.hover(screen.getByRole("button", { name: "breakdown" }));
+
+    expect(await screen.findAllByText(/per hour/i)).not.toHaveLength(0);
+  });
+
+  function setup(input: { gpuCount: number; trigger?: ReactNode }) {
     const user = userEvent.setup();
     const { container } = render(
       <TestContainerProvider>
         <IntlProvider locale="en">
           <TooltipProvider>
-            <CostBreakdownTooltip perBlockValue={0.0001} denom="uakt" gpuCount={input.gpuCount} />
+            <CostBreakdownTooltip perBlockUDenom={100} denom="uakt" gpuCount={input.gpuCount}>
+              {input.trigger}
+            </CostBreakdownTooltip>
           </TooltipProvider>
         </IntlProvider>
       </TestContainerProvider>

--- a/apps/deploy-web/src/components/shared/CostBreakdownTooltip.tsx
+++ b/apps/deploy-web/src/components/shared/CostBreakdownTooltip.tsx
@@ -1,23 +1,27 @@
-import type { FC } from "react";
+import type { FC, ReactNode } from "react";
 import { CustomTooltip } from "@akashnetwork/ui/components";
 import { InfoCircle } from "iconoir-react";
 
+import { PRICE_DISPLAY_PRECISION, udenomToDenom } from "@src/utils/mathHelpers";
 import { perBlockToHourly } from "@src/utils/priceUtils";
 import { PriceValue } from "./PriceValue";
 
 interface Props {
-  perBlockValue: number;
+  /** Per-block price in udenom, straight off the chain — a bid price, or the summed price of live leases. */
+  perBlockUDenom: number | string;
   denom: string;
   gpuCount: number;
+  children?: ReactNode;
 }
 
 /**
- * Cost breakdown hung off a `CostRate`, which already shows the monthly rate (and the hourly rate for GPU
+ * Cost breakdown hung off a cost figure that already shows the monthly rate (and the hourly rate for GPU
  * specs), so this only surfaces the rates that aren't already visible: the hourly rate for CPU-only specs, the
- * per-hour-per-GPU rate for GPU specs, and the daily rate.
+ * per-hour-per-GPU rate for GPU specs, and the daily rate. The trigger defaults to a small info icon and can be
+ * overridden through `children`.
  */
-export const CostBreakdownTooltip: FC<Props> = ({ perBlockValue, denom, gpuCount }) => {
-  const hourlyValue = perBlockToHourly(perBlockValue);
+export const CostBreakdownTooltip: FC<Props> = ({ perBlockUDenom, denom, gpuCount, children }) => {
+  const hourlyValue = perBlockToHourly(udenomToDenom(perBlockUDenom, PRICE_DISPLAY_PRECISION));
   const dailyValue = hourlyValue * 24;
   const hasGpu = gpuCount > 0;
   const hourlyPerGpuValue = hasGpu ? hourlyValue / gpuCount : 0;
@@ -53,7 +57,7 @@ export const CostBreakdownTooltip: FC<Props> = ({ perBlockValue, denom, gpuCount
         </div>
       }
     >
-      <InfoCircle className="ml-2 text-xs text-muted-foreground" />
+      {children ?? <InfoCircle className="ml-2 text-xs text-muted-foreground" />}
     </CustomTooltip>
   );
 };

--- a/apps/deploy-web/src/components/shared/CostRate.spec.tsx
+++ b/apps/deploy-web/src/components/shared/CostRate.spec.tsx
@@ -47,13 +47,25 @@ describe(CostRate.name, () => {
     expect(screen.queryAllByText(/per hour \/ GPU/i)).toHaveLength(0);
   });
 
-  function setup(input: { gpuCount: number; perBlockUDenom?: number }) {
+  it("omits the breakdown tooltip when the consumer renders it elsewhere", () => {
+    const { trigger } = setup({ gpuCount: 2, hideBreakdownTooltip: true });
+
+    expect(trigger).toBeNull();
+    expect(screen.getByText("$590.36")).toBeInTheDocument();
+  });
+
+  function setup(input: { gpuCount: number; perBlockUDenom?: number; hideBreakdownTooltip?: boolean }) {
     const user = userEvent.setup();
     const { container } = render(
       <TestContainerProvider>
         <IntlProvider locale="en">
           <TooltipProvider>
-            <CostRate perBlockUDenom={input.perBlockUDenom ?? ONE_ACT_PER_BLOCK} denom="uact" gpuCount={input.gpuCount} />
+            <CostRate
+              perBlockUDenom={input.perBlockUDenom ?? ONE_ACT_PER_BLOCK}
+              denom="uact"
+              gpuCount={input.gpuCount}
+              hideBreakdownTooltip={input.hideBreakdownTooltip}
+            />
           </TooltipProvider>
         </IntlProvider>
       </TestContainerProvider>

--- a/apps/deploy-web/src/components/shared/CostRate.tsx
+++ b/apps/deploy-web/src/components/shared/CostRate.tsx
@@ -11,6 +11,8 @@ interface Props {
   denom: string;
   gpuCount: number;
   className?: string;
+  /** For consumers that render the breakdown tooltip elsewhere, e.g. next to a stat label. */
+  hideBreakdownTooltip?: boolean;
 }
 
 /**
@@ -18,7 +20,7 @@ interface Props {
  * that scale) with the monthly rate beneath it; a CPU-only spec shows just the monthly rate so an inexpensive
  * deployment doesn't read as `$0.00/hr`. The info tooltip fills in the rates that aren't already shown.
  */
-export const CostRate: FC<Props> = ({ perBlockUDenom, denom, gpuCount, className }) => {
+export const CostRate: FC<Props> = ({ perBlockUDenom, denom, gpuCount, className, hideBreakdownTooltip }) => {
   const showAsHourly = gpuCount > 0;
   const perBlockValue = udenomToDenom(perBlockUDenom, PRICE_DISPLAY_PRECISION);
 
@@ -26,7 +28,7 @@ export const CostRate: FC<Props> = ({ perBlockUDenom, denom, gpuCount, className
     <div className={cn("flex min-w-0 flex-col", className)}>
       <span className="inline-flex items-center">
         <PricePerTimeUnit denom={denom} perBlockValue={perBlockValue} showAsHourly={showAsHourly} abbreviated />
-        <CostBreakdownTooltip perBlockValue={perBlockValue} denom={denom} gpuCount={gpuCount} />
+        {!hideBreakdownTooltip && <CostBreakdownTooltip perBlockUDenom={perBlockUDenom} denom={denom} gpuCount={gpuCount} />}
       </span>
       {showAsHourly && (
         <PricePerTimeUnit className="text-xs font-normal text-muted-foreground" denom={denom} perBlockValue={perBlockValue} showAsHourly={false} abbreviated />

--- a/apps/deploy-web/src/hooks/useTickingNow.ts
+++ b/apps/deploy-web/src/hooks/useTickingNow.ts
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 /**
  * Default cadence between re-renders.
  *
- * Labels built on this hook typically display whole minutes ("2m left") or whole hours ("~5h left"), so one
+ * Labels built on this hook typically display whole minutes ("45m left") or hours and minutes ("2h 10m left"), so one
  * update per minute keeps them honest — including flipping to an expired state within a minute of crossing
  * the deadline — while avoiding the per-second churn a visibly-running countdown like `useQuoteExpiry` needs.
  */
@@ -15,7 +15,7 @@ export const DEFAULT_TICK_INTERVAL_MS = 60_000;
  * Some views compute text from `Date.now()` at render time but never refetch data — no query polling and
  * refetch-on-focus disabled — so once mounted, that text freezes at whatever was true on first render until
  * an unrelated re-render happens. A user who leaves such a page open keeps seeing a stale verdict long after
- * reality moved on (e.g. "~1h left" after the deadline already passed). This hook fixes that: while
+ * reality moved on (e.g. "1h left" after the deadline already passed). This hook fixes that: while
  * `enabled`, an interval pushes `Date.now()` into state every `intervalMs`, re-rendering the component so
  * anything formatted from the returned clock stays current.
  *

--- a/apps/deploy-web/src/utils/deploymentData/helpers.ts
+++ b/apps/deploy-web/src/utils/deploymentData/helpers.ts
@@ -8,44 +8,6 @@ export class CustomValidationError extends Error {
   }
 }
 
-const specSuffixes = {
-  Ki: 1024,
-  Mi: 1024 * 1024,
-  Gi: 1024 * 1024 * 1024,
-  Ti: 1024 * 1024 * 1024 * 1024,
-  Pi: 1024 * 1024 * 1024 * 1024 * 1024,
-  Ei: 1024 * 1024 * 1024 * 1024 * 1024 * 1024,
-  K: 1000,
-  M: 1000 * 1000,
-  G: 1000 * 1000 * 1000,
-  T: 1000 * 1000 * 1000 * 1000,
-  P: 1000 * 1000 * 1000 * 1000 * 1000,
-  E: 1000 * 1000 * 1000 * 1000 * 1000 * 1000,
-  Kb: 1000,
-  Mb: 1000 * 1000,
-  Gb: 1000 * 1000 * 1000,
-  Tb: 1000 * 1000 * 1000 * 1000,
-  Pb: 1000 * 1000 * 1000 * 1000 * 1000,
-  Eb: 1000 * 1000 * 1000 * 1000 * 1000 * 1000
-};
-
-export function parseSizeStr(str: string) {
-  try {
-    const suffix = Object.keys(specSuffixes).find(s => str.toLowerCase().endsWith(s.toLowerCase()));
-
-    if (suffix) {
-      const suffixPos = str.length - suffix.length;
-      const numberStr = str.substring(0, suffixPos);
-      return (parseFloat(numberStr) * specSuffixes[suffix as keyof typeof specSuffixes]).toString();
-    } else {
-      return parseFloat(str);
-    }
-  } catch (err) {
-    console.error(err);
-    throw new Error("Error while parsing size: " + str, { cause: err });
-  }
-}
-
 export function parseSdlInput(yamlJson: string | SDLInput): SDLInput {
   return typeof yamlJson === "string" ? yaml.raw<SDLInput>(yamlJson) : yamlJson;
 }

--- a/apps/deploy-web/src/utils/runtimeLimitUtils.spec.ts
+++ b/apps/deploy-web/src/utils/runtimeLimitUtils.spec.ts
@@ -7,12 +7,45 @@ describe(formatRuntimeLimit.name, () => {
     expect(formatRuntimeLimit(12, null)).toBe("12h");
   });
 
-  it("shows the remaining time while the countdown runs", () => {
+  it("shows whole hours remaining when the deadline lands on the hour", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-08-21T12:00:00.000Z"));
 
     try {
-      expect(formatRuntimeLimit(12, "2026-08-21T17:00:00.000Z")).toBe("12h · ~5h left");
+      expect(formatRuntimeLimit(12, "2026-08-21T17:00:00.000Z")).toBe("12h · 5h left");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("adds the minutes when the remaining time is not a whole number of hours", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-21T12:00:00.000Z"));
+
+    try {
+      expect(formatRuntimeLimit(12, "2026-08-21T14:10:00.000Z")).toBe("12h · 2h 10m left");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("counts in minutes alone once under an hour remains", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-21T12:00:00.000Z"));
+
+    try {
+      expect(formatRuntimeLimit(12, "2026-08-21T12:45:00.000Z")).toBe("12h · 45m left");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("still reads a full minute through the final seconds", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-21T12:00:00.000Z"));
+
+    try {
+      expect(formatRuntimeLimit(12, "2026-08-21T12:00:01.000Z")).toBe("12h · 1m left");
     } finally {
       vi.useRealTimers();
     }
@@ -23,7 +56,7 @@ describe(formatRuntimeLimit.name, () => {
     vi.setSystemTime(new Date("2026-08-21T12:00:00.000Z"));
 
     try {
-      expect(formatRuntimeLimit(12, "2026-08-21T11:00:00.000Z")).toBe("12h · reached");
+      expect(formatRuntimeLimit(12, "2026-08-21T11:00:00.000Z")).toBe("12h · limit reached");
     } finally {
       vi.useRealTimers();
     }

--- a/apps/deploy-web/src/utils/runtimeLimitUtils.ts
+++ b/apps/deploy-web/src/utils/runtimeLimitUtils.ts
@@ -13,8 +13,8 @@ export const MAX_RUNTIME_LIMIT_HOURS = 8760;
  *
  * The wall clock is read through the `now` parameter rather than `Date.now()` directly. That keeps the
  * output deterministic under fake timers in tests and lets callers stay fresh on pages that never refetch
- * by passing a ticking clock (`useTickingNow`) — without one, the "~Xh left" / "reached" verdict would
- * freeze at first render.
+ * by passing a ticking clock (`useTickingNow`) — without one, the "2h 10m left" / "limit reached" verdict
+ * would freeze at first render.
  *
  * @param runtimeLimitHours The limit the user requested, shown as-is (e.g. "12h").
  * @param runtimeEndsAt When the deployment is closed automatically, ISO-encoded; null while the countdown
@@ -26,9 +26,27 @@ export function formatRuntimeLimit(runtimeLimitHours: number, runtimeEndsAt: str
   if (!runtimeEndsAt) {
     return limit;
   }
-  const hoursRemaining = (new Date(runtimeEndsAt).getTime() - now) / (1000 * 60 * 60);
-  if (hoursRemaining <= 0) {
-    return `${limit} · reached`;
+  const millisecondsRemaining = new Date(runtimeEndsAt).getTime() - now;
+  if (millisecondsRemaining <= 0) {
+    return `${limit} · limit reached`;
   }
-  return `${limit} · ~${Math.ceil(hoursRemaining)}h left`;
+  return `${limit} · ${formatTimeRemaining(millisecondsRemaining)} left`;
+}
+
+const MILLISECONDS_PER_MINUTE = 60 * 1000;
+const MINUTES_PER_HOUR = 60;
+
+/**
+ * The remaining time as the coarsest honest reading: minutes alone below an hour, hours alone on the hour,
+ * both otherwise. Rounding up at the minute keeps the final seconds reading "1m" rather than "0m", and never
+ * overstates by more than a minute — unlike rounding up whole hours, which sold 2h10m as "~3h".
+ */
+function formatTimeRemaining(milliseconds: number): string {
+  const totalMinutes = Math.ceil(milliseconds / MILLISECONDS_PER_MINUTE);
+  const hours = Math.floor(totalMinutes / MINUTES_PER_HOUR);
+  const minutes = totalMinutes % MINUTES_PER_HOUR;
+
+  if (hours === 0) return `${minutes}m`;
+  if (minutes === 0) return `${hours}h`;
+  return `${hours}h ${minutes}m`;
 }

--- a/apps/deploy-web/src/utils/unitUtils.spec.ts
+++ b/apps/deploy-web/src/utils/unitUtils.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { formatByteSize, sizeStringToBytes } from "./unitUtils";
+import { bytesToShrink, formatByteSize, sizeStringToBytes } from "./unitUtils";
 
 describe(sizeStringToBytes.name, () => {
   it("converts a binary suffix to bytes", () => {
@@ -31,6 +31,27 @@ describe(sizeStringToBytes.name, () => {
   });
 });
 
+describe(bytesToShrink.name, () => {
+  it("picks the unit the amount fits into", () => {
+    expect(bytesToShrink(536870912)).toEqual({ value: 536.870912, unit: "MB" });
+    expect(bytesToShrink(536870912, true)).toEqual({ value: 512, unit: "MiB" });
+  });
+
+  it("keeps an amount smaller than the first unit in bytes", () => {
+    expect(bytesToShrink(512)).toEqual({ value: 512, unit: "Bytes" });
+    expect(bytesToShrink(0.5)).toEqual({ value: 0.5, unit: "Bytes" });
+    expect(bytesToShrink(0)).toEqual({ value: 0, unit: "Bytes" });
+  });
+
+  it("keeps an amount larger than the last unit in that unit", () => {
+    expect(bytesToShrink(1000 ** 9)).toEqual({ value: 1000, unit: "YB" });
+  });
+
+  it("carries the sign through", () => {
+    expect(bytesToShrink(-2000)).toEqual({ value: -2, unit: "kB" });
+  });
+});
+
 describe(formatByteSize.name, () => {
   it("labels bytes with the largest decimal unit that fits", () => {
     expect(formatByteSize(536870912)).toBe("536.87 MB");
@@ -38,7 +59,9 @@ describe(formatByteSize.name, () => {
     expect(formatByteSize(1000000)).toBe("1 MB");
   });
 
-  it("labels an empty amount", () => {
+  it("labels amounts too small for a larger unit in bytes", () => {
     expect(formatByteSize(0)).toBe("0 Bytes");
+    expect(formatByteSize(512)).toBe("512 Bytes");
+    expect(formatByteSize(0.5)).toBe("0.5 Bytes");
   });
 });

--- a/apps/deploy-web/src/utils/unitUtils.spec.ts
+++ b/apps/deploy-web/src/utils/unitUtils.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { formatByteSize, sizeStringToBytes } from "./unitUtils";
+
+describe(sizeStringToBytes.name, () => {
+  it("converts a binary suffix to bytes", () => {
+    expect(sizeStringToBytes("512Mi")).toBe(536870912);
+    expect(sizeStringToBytes("1Gi")).toBe(1073741824);
+  });
+
+  it("converts a decimal suffix to bytes", () => {
+    expect(sizeStringToBytes("2G")).toBe(2000000000);
+    expect(sizeStringToBytes("500Mb")).toBe(500000000);
+  });
+
+  it("converts a fractional amount", () => {
+    expect(sizeStringToBytes("1.5Gi")).toBe(1610612736);
+  });
+
+  it("treats a suffixless value as bytes", () => {
+    expect(sizeStringToBytes("1048576")).toBe(1048576);
+  });
+
+  it("treats an unrecognized suffix as bytes so a stray unit still renders a number", () => {
+    expect(sizeStringToBytes("512foo")).toBe(512);
+  });
+
+  it("returns undefined when the value carries no number", () => {
+    expect(sizeStringToBytes("Mi")).toBeUndefined();
+    expect(sizeStringToBytes("")).toBeUndefined();
+  });
+});
+
+describe(formatByteSize.name, () => {
+  it("labels bytes with the largest decimal unit that fits", () => {
+    expect(formatByteSize(536870912)).toBe("536.87 MB");
+    expect(formatByteSize(1073741824)).toBe("1.07 GB");
+    expect(formatByteSize(1000000)).toBe("1 MB");
+  });
+
+  it("labels an empty amount", () => {
+    expect(formatByteSize(0)).toBe("0 Bytes");
+  });
+});

--- a/apps/deploy-web/src/utils/unitUtils.ts
+++ b/apps/deploy-web/src/utils/unitUtils.ts
@@ -1,5 +1,52 @@
+import { roundDecimal } from "./mathHelpers";
+
 export const byteUnits = ["Bytes", "kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
 export const bibyteUnits = ["Bytes", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"];
+
+/** Byte multiplier for every size suffix an SDL may use: the binary `Mi` family and the decimal `M` / `Mb` ones. */
+const sizeSuffixBytes: Record<string, number> = {
+  Ki: 1024,
+  Mi: 1024 ** 2,
+  Gi: 1024 ** 3,
+  Ti: 1024 ** 4,
+  Pi: 1024 ** 5,
+  Ei: 1024 ** 6,
+  K: 1000,
+  M: 1000 ** 2,
+  G: 1000 ** 3,
+  T: 1000 ** 4,
+  P: 1000 ** 5,
+  E: 1000 ** 6,
+  Kb: 1000,
+  Mb: 1000 ** 2,
+  Gb: 1000 ** 3,
+  Tb: 1000 ** 4,
+  Pb: 1000 ** 5,
+  Eb: 1000 ** 6
+};
+
+/** Longest suffix first so `Mi` and `Mb` are matched before the `M` they both start with. */
+const sizeSuffixesLongestFirst = Object.keys(sizeSuffixBytes).sort((a, b) => b.length - a.length);
+
+/**
+ * Bytes for an SDL size string — a binary suffix (`512Mi`), a decimal one (`2G`, `500Mb`), or a bare number
+ * already in bytes. Undefined when the value carries no number at all, so callers can fall back to a placeholder
+ * instead of rendering NaN. An unrecognized suffix leaves the leading number to stand as raw bytes.
+ */
+export function sizeStringToBytes(size: string): number | undefined {
+  const suffix = sizeSuffixesLongestFirst.find(candidate => size.toLowerCase().endsWith(candidate.toLowerCase()));
+  const value = parseFloat(suffix ? size.slice(0, -suffix.length) : size);
+
+  if (Number.isNaN(value)) return undefined;
+
+  return suffix ? value * sizeSuffixBytes[suffix] : value;
+}
+
+/** A byte count as a decimal-unit label, e.g. `536.87 MB`. The one byte format the deployment detail page uses. */
+export function formatByteSize(bytes: number): string {
+  const { value, unit } = bytesToShrink(bytes);
+  return `${roundDecimal(value, 2)} ${unit}`;
+}
 
 export function bytesToShrink(value: number, bibyte?: boolean) {
   const multiplier = bibyte ? 1024 : 1000;

--- a/apps/deploy-web/src/utils/unitUtils.ts
+++ b/apps/deploy-web/src/utils/unitUtils.ts
@@ -50,21 +50,14 @@ export function formatByteSize(bytes: number): string {
 
 export function bytesToShrink(value: number, bibyte?: boolean) {
   const multiplier = bibyte ? 1024 : 1000;
-  let finalValue = 0;
-  let finalUnit = bibyte ? bibyteUnits[0] : byteUnits[0];
+  const units = bibyte ? bibyteUnits : byteUnits;
   const isNegative = value < 0;
-  const _value = Math.abs(value);
+  const magnitude = Math.abs(value);
+  /** Clamped to the unit list: anything below one unit stays in bytes, anything above the last unit stays in it. */
+  const unitIndex = magnitude === 0 ? 0 : Math.min(Math.max(Math.floor(Math.log(magnitude) / Math.log(multiplier)), 0), units.length - 1);
+  const finalValue = magnitude / Math.pow(multiplier, unitIndex);
 
-  if (_value !== 0) {
-    const i = parseInt(Math.floor(Math.log(_value) / Math.log(multiplier)).toString());
-
-    if (i !== 0) {
-      finalValue = _value / Math.pow(multiplier, i);
-      finalUnit = bibyte ? bibyteUnits[i] : byteUnits[i];
-    }
-  }
-
-  return { value: isNegative ? -finalValue : finalValue, unit: finalUnit };
+  return { value: isNegative ? -finalValue : finalValue, unit: units[unitIndex] };
 }
 
 export function toBytes(size: number, type: string, bibyte?: boolean) {


### PR DESCRIPTION
## Why

Three display problems on the deployment detail page, all found while going over the page.

The page showed byte amounts in three vocabularies at once. The header summary and the placement cards rendered decimal MB ("536.87 MB"), an expanded service row echoed the SDL's own suffix straight back ("512 Mi"), and the confidential-compute card formatted in binary MiB ("256 MiB").

The runtime limit was not just inconsistent, it was wrong. Remaining time was computed in fractional hours and rounded up, so a deployment with 2h10m left claimed "~3h left", and anything under an hour read "~1h left" until it flipped to "reached". The tilde was covering for a bad number.

The COST tile was the odd one out in the header. RUNTIME LIMIT and AUTO TOP-UP hang a small 12px info icon off their label, but the cost's price-breakdown icon sat next to the $/hr value with its own larger styling, so two tiles in the same row placed the same affordance in two different spots.

## What

Byte units (first commit):

- SDL sizes are normalized to bytes when the manifest is parsed, so the model no longer carries a display-shaped `{ value, unit }` pair
- every byte value on the page goes through one `formatByteSize` helper: header tile, placement card, expanded service row, confidential-compute card
- the suffix table that conversion needs already sat in `deploymentData/helpers` as dead code, so it moved to `unitUtils` next to `bytesToShrink` instead of being written a second time
- a `512Mi` service now reads 536.87 MB, and a 256 MiB carveout reads 268.44 MB. That is the arithmetic the header was already doing, so the page now agrees with itself
- the Configure page keeps binary units on purpose. There they mirror what you typed into the form

Runtime limit (second commit):

- counts whole minutes and shows the coarsest honest reading: `24h · 2h 10m left`, `24h · 45m left`, `24h · 1m left`, `24h · limit reached`
- rounding up at the minute keeps the last seconds from reading `0m`, and it never overstates by more than a minute
- the two places that render it (the header tile and Settings > Billing) share the same function, so they moved together

Cost tooltip (third commit):

- the price-breakdown icon moved from beside the $/hr value to beside the COST label, with the same 12px icon and spacing the RUNTIME LIMIT and AUTO TOP-UP labels use
- `CostBreakdownTooltip` now takes the raw per-block udenom (so consumers stop duplicating the conversion) and accepts a custom trigger; `CostRate` grew a `hideBreakdownTooltip` prop so the marketplace providers table keeps its inline icon unchanged
- the icon only renders while there is a live cost, so the "—" state carries no orphan tooltip

Tests: a new `unitUtils.spec.ts` covers the conversion and the formatter, the placement, confidential-compute, header and runtime-limit specs were moved to the new strings, and the tooltip move added specs to `CostRate`, `CostBreakdownTooltip` and the header. The full deploy-web unit suite passes (3584 tests), lint is clean, and `tsc` reports the same 92 pre-existing errors as a cold run on main.

One thing worth a look in review: the header's `SummaryItem` is `whitespace-nowrap` inside a four-column grid, and `24h · 12h 30m left` is wider than anything that tile has had to hold so far.
