### PR TITLE
feat(billing): tell users auto recharge charges their card at most once per hour

### DIFF
--- a/apps/deploy-web/src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup.spec.tsx
@@ -121,6 +121,18 @@ describe(AutoTopUpSettingsPopup.name, () => {
     expect(screen.queryByLabelText(/purchase this amount/i)).not.toBeInTheDocument();
   });
 
+  it("tells the user the card is charged at most once per hour in threshold mode", () => {
+    setup({ mode: "threshold" });
+
+    expect(screen.getByText(/charged at most once per hour/i)).toBeInTheDocument();
+  });
+
+  it("hides the hourly charge cap in prediction mode", () => {
+    setup({ mode: "prediction" });
+
+    expect(screen.queryByText(/charged at most once per hour/i)).not.toBeInTheDocument();
+  });
+
   it("saves prediction mode without threshold values", async () => {
     const upsertMutate = vi.fn();
     setup({ mode: "threshold", threshold: 30, amount: 150, upsertMutate });

--- a/apps/deploy-web/src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup.tsx
@@ -39,6 +39,14 @@ const AUTO_RELOAD_MAX_USD = 10_000;
 /** Mirrors the API's AUTO_RELOAD_AMOUNT_MIN_USD — the floor applied to every recurring auto-top-up charge, independent of the trial-aware one-time top-up minimum. */
 const AUTO_RELOAD_AMOUNT_MIN_USD = 25;
 
+/**
+ * Mirrors the API's AUTO_RELOAD_CHARGE_COOLDOWN_IN_MIN, which defaults to 60. Threshold mode takes an hourly per-wallet
+ * charge claim, so a fast-draining balance defers the next top-up rather than charging the card again right away.
+ * Prediction mode and manual top-ups are exempt, so this only belongs in the threshold branch.
+ */
+const CHARGE_COOLDOWN_NOTICE =
+  "Your card is charged at most once per hour. If your balance drops below the threshold again within that hour, the next top-up waits until the hour is up.";
+
 const MODE_OPTIONS: Array<{ value: AutoReloadMode; id: string; title: string; description: string; recommended?: boolean }> = [
   {
     value: "threshold",
@@ -242,6 +250,8 @@ export const AutoTopUpSettingsPopup: React.FC<AutoTopUpSettingsPopupProps> = ({
                   />
                 )}
               />
+
+              <p className="text-sm text-muted-foreground">{CHARGE_COOLDOWN_NOTICE}</p>
             </>
           ) : (
             <p className="text-sm text-muted-foreground">


### PR DESCRIPTION
## Why

Ref CON-904

#3660 capped automatic threshold-mode charges at one per hour, but nothing in the UI says so. A user whose balance drops below their threshold and sees no charge has no way to tell whether the cap held it back or auto recharge is broken. RunPod states the same limit plainly on its Auto-Pay card, which is what prompted this.

## What

One paragraph in the Auto Top-Up settings dialog, threshold mode only:

> Your card is charged at most once per hour. If your balance drops below the threshold again within that hour, the next top-up waits until the hour is up.

The second sentence covers what RunPod's copy leaves out: a rate-limited reload is deferred to when the window reopens, not dropped, so the user knows a charge is still coming.

"Once per hour" lives in a `CHARGE_COOLDOWN_NOTICE` constant with a JSDoc pointing at the API's `AUTO_RELOAD_CHARGE_COOLDOWN_IN_MIN`, the same way that file already mirrors `AUTO_RELOAD_THRESHOLD_MIN_USD` and `AUTO_RELOAD_AMOUNT_MIN_USD`. No API or schema change. It renders only in threshold mode, since prediction mode and manual top-ups are exempt from the cap.

One caveat: the cooldown is an env var, so this copy goes stale if the value ever moves off 60, or gets set to 0 to disable the cap. Exposing it through the wallet-settings response would fix that at the cost of a schema change and an `sdk:gen` run. Happy to do that as a follow-up if reviewers want the guarantee.
