### PR TITLE
refactor(observability): inject the logger factory in core, app, deployment and billing services

### DIFF
--- a/apps/api/src/app/services/auto-recharge-succeeded/auto-recharge-succeeded.handler.spec.ts
+++ b/apps/api/src/app/services/auto-recharge-succeeded/auto-recharge-succeeded.handler.spec.ts
@@ -6,7 +6,7 @@ import type { UserWalletRepository } from "@src/billing/repositories";
 import type { BalancesService } from "@src/billing/services/balances/balances.service";
 import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import type { EventPayload } from "@src/core";
-import type { LoggerService } from "@src/core/providers/logging.provider";
+import type { CreateLogger } from "@src/core/providers/logging.provider";
 import type { NotificationService } from "@src/notifications/services/notification/notification.service";
 import { autoRechargeSucceededNotification } from "@src/notifications/services/notification-templates/auto-recharge-succeeded-notification";
 import type { UserRepository } from "@src/user/repositories";
@@ -71,6 +71,12 @@ describe(AutoRechargeSucceededHandler.name, () => {
     expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "AUTO_RECHARGE_SUCCESS_EMAIL_SKIPPED", reason: "Wallet address not found" }));
   });
 
+  it("creates the logger with the service context", () => {
+    const { createLogger } = setup({ user: null });
+
+    expect(createLogger).toHaveBeenCalledWith({ context: AutoRechargeSucceededHandler.name });
+  });
+
   function setup(input: {
     user: ReturnType<typeof createUser> | null;
     wallet?: ReturnType<typeof createUserWallet>;
@@ -93,8 +99,10 @@ describe(AutoRechargeSucceededHandler.name, () => {
       billingConfig: mock<BillingConfigService>({
         get: vi.fn().mockReturnValue(input.paymentLink ?? "https://console.akash.network/billing?openPayment=true")
       }),
-      logger: mock<LoggerService>()
+      logger: mock<ReturnType<CreateLogger>>()
     };
+
+    const createLogger = vi.fn<CreateLogger>(() => mocks.logger);
 
     const handler = new AutoRechargeSucceededHandler(
       mocks.notificationService,
@@ -102,9 +110,9 @@ describe(AutoRechargeSucceededHandler.name, () => {
       mocks.userWalletRepository,
       mocks.balancesService,
       mocks.billingConfig,
-      mocks.logger
+      createLogger
     );
 
-    return { handler, ...mocks };
+    return { handler, createLogger, ...mocks };
   }
 });

--- a/apps/api/src/app/services/auto-recharge-succeeded/auto-recharge-succeeded.handler.ts
+++ b/apps/api/src/app/services/auto-recharge-succeeded/auto-recharge-succeeded.handler.ts
@@ -1,10 +1,10 @@
-import { singleton } from "tsyringe";
+import { inject, singleton } from "tsyringe";
 
 import { AutoRechargeSucceeded } from "@src/billing/events/auto-recharge-succeeded";
 import { UserWalletRepository } from "@src/billing/repositories";
 import { BalancesService } from "@src/billing/services/balances/balances.service";
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
-import { EventPayload, JobHandler, LoggerService } from "@src/core";
+import { type CreateLogger, EventPayload, JobHandler, LOGGER_FACTORY } from "@src/core";
 import { NotificationService } from "@src/notifications/services/notification/notification.service";
 import { autoRechargeSucceededNotification } from "@src/notifications/services/notification-templates/auto-recharge-succeeded-notification";
 import { UserRepository } from "@src/user/repositories";
@@ -15,14 +15,18 @@ export class AutoRechargeSucceededHandler implements JobHandler<AutoRechargeSucc
 
   public readonly concurrency = 2;
 
+  private readonly logger: ReturnType<CreateLogger>;
+
   constructor(
     private readonly notificationService: NotificationService,
     private readonly userRepository: UserRepository,
     private readonly userWalletRepository: UserWalletRepository,
     private readonly balancesService: BalancesService,
     private readonly billingConfig: BillingConfigService,
-    private readonly logger: LoggerService
-  ) {}
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
+  ) {
+    this.logger = createLogger({ context: AutoRechargeSucceededHandler.name });
+  }
 
   async handle(payload: EventPayload<AutoRechargeSucceeded>): Promise<void> {
     const user = await this.userRepository.findById(payload.userId);

--- a/apps/api/src/app/services/close-trial-deployment/close-trial-deployment.handler.spec.ts
+++ b/apps/api/src/app/services/close-trial-deployment/close-trial-deployment.handler.spec.ts
@@ -7,7 +7,7 @@ import type { UserWalletRepository } from "@src/billing/repositories";
 import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import { ChainErrorService } from "@src/billing/services/chain-error/chain-error.service";
 import type { TxManagerService } from "@src/billing/services/tx-manager/tx-manager.service";
-import type { LoggerService } from "@src/core/providers/logging.provider";
+import type { CreateLogger } from "@src/core/providers/logging.provider";
 import { JOB_NAME, type JobPayload, type JobQueueService } from "@src/core/services/job-queue/job-queue.service";
 import type { GetDeploymentResponse } from "@src/deployment/http-schemas/deployment.schema";
 import type { DeploymentWriterService } from "@src/deployment/services/deployment-writer/deployment-writer.service";
@@ -281,6 +281,12 @@ describe(CloseTrialDeploymentHandler.name, () => {
     });
   });
 
+  it("creates the logger with the service context", () => {
+    const { createLogger } = setup();
+
+    expect(createLogger).toHaveBeenCalledWith({ context: CloseTrialDeploymentHandler.name });
+  });
+
   function setup(input?: {
     findWalletById?: UserWalletRepository["findById"];
     enqueueJob?: JobQueueService["enqueue"];
@@ -301,7 +307,7 @@ describe(CloseTrialDeploymentHandler.name, () => {
             })
           )
       }),
-      logger: mock<LoggerService>(),
+      logger: mock<ReturnType<CreateLogger>>(),
       jobQueueService: mock<JobQueueService>({
         enqueue: input?.enqueueJob ?? vi.fn().mockResolvedValue(undefined)
       }),
@@ -317,9 +323,11 @@ describe(CloseTrialDeploymentHandler.name, () => {
       chainErrorService: new ChainErrorService(mock<BalanceHttpService>(), mock<BillingConfigService>(), mock<TxManagerService>())
     };
 
+    const createLogger = vi.fn<CreateLogger>(() => mocks.logger);
+
     const handler = new CloseTrialDeploymentHandler(
       mocks.userWalletRepository,
-      mocks.logger,
+      createLogger,
       mocks.jobQueueService,
       mocks.deploymentWriterService,
       mocks.deploymentService,
@@ -327,6 +335,6 @@ describe(CloseTrialDeploymentHandler.name, () => {
       mocks.chainErrorService
     );
 
-    return { handler, ...mocks };
+    return { handler, createLogger, ...mocks };
   }
 });

--- a/apps/api/src/app/services/close-trial-deployment/close-trial-deployment.handler.ts
+++ b/apps/api/src/app/services/close-trial-deployment/close-trial-deployment.handler.ts
@@ -1,10 +1,10 @@
 import { DeploymentHttpService } from "@akashnetwork/http-sdk";
-import { singleton } from "tsyringe";
+import { inject, singleton } from "tsyringe";
 
 import { UserWalletRepository } from "@src/billing/repositories";
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import { ChainErrorService } from "@src/billing/services/chain-error/chain-error.service";
-import { Job, JOB_NAME, JobHandler, JobPayload, JobQueueService, LoggerService } from "@src/core";
+import { type CreateLogger, Job, JOB_NAME, JobHandler, JobPayload, JobQueueService, LOGGER_FACTORY } from "@src/core";
 import { DeploymentWriterService } from "@src/deployment/services/deployment-writer/deployment-writer.service";
 import { RESOLVED_MARKER } from "@src/notifications/services/notification-data-resolver/notification-data-resolver.service";
 import { NotificationJob } from "@src/notifications/services/notification-handler/notification.handler";
@@ -28,15 +28,19 @@ export class CloseTrialDeploymentHandler implements JobHandler<CloseTrialDeploym
 
   public readonly concurrency = 2;
 
+  private readonly logger: ReturnType<CreateLogger>;
+
   constructor(
     private readonly userWalletRepository: UserWalletRepository,
-    private readonly logger: LoggerService,
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger,
     private readonly jobQueueService: JobQueueService,
     private readonly deploymentWriterService: DeploymentWriterService,
     private readonly deploymentService: DeploymentHttpService,
     private readonly billingConfig: BillingConfigService,
     private readonly chainErrorService: ChainErrorService
-  ) {}
+  ) {
+    this.logger = createLogger({ context: CloseTrialDeploymentHandler.name });
+  }
 
   async handle(payload: JobPayload<CloseTrialDeployment>): Promise<void> {
     const wallet = await this.userWalletRepository.findById(payload.walletId);

--- a/apps/api/src/app/services/enable-deployment-alert/enable-deployment-alert.handler.spec.ts
+++ b/apps/api/src/app/services/enable-deployment-alert/enable-deployment-alert.handler.spec.ts
@@ -3,7 +3,7 @@ import { mock } from "vitest-mock-extended";
 
 import type { EnableDeploymentAlertCommand } from "@src/billing/commands/enable-deployment-alert.command";
 import type { JobPayload } from "@src/core";
-import type { LoggerService } from "@src/core/providers/logging.provider";
+import type { CreateLogger } from "@src/core/providers/logging.provider";
 import type { NotificationService } from "@src/notifications/services/notification/notification.service";
 import { EnableDeploymentAlertHandler } from "./enable-deployment-alert.handler";
 
@@ -27,17 +27,24 @@ describe(EnableDeploymentAlertHandler.name, () => {
     });
   });
 
-  function setup(params?: { notificationService?: Partial<NotificationService>; logger?: Partial<LoggerService> }) {
+  it("creates the logger with the service context", () => {
+    const { createLogger } = setup();
+
+    expect(createLogger).toHaveBeenCalledWith({ context: EnableDeploymentAlertHandler.name });
+  });
+
+  function setup(params?: { notificationService?: Partial<NotificationService>; logger?: Partial<ReturnType<CreateLogger>> }) {
     const notificationService = mock<NotificationService>({
       autoEnableDeploymentAlert: vi.fn().mockResolvedValue(undefined),
       ...params?.notificationService
     });
-    const logger = mock<LoggerService>({
+    const logger = mock<ReturnType<CreateLogger>>({
       ...params?.logger
     });
+    const createLogger = vi.fn<CreateLogger>(() => logger);
 
-    const handler = new EnableDeploymentAlertHandler(notificationService, logger);
+    const handler = new EnableDeploymentAlertHandler(notificationService, createLogger);
 
-    return { handler, notificationService, logger };
+    return { handler, notificationService, logger, createLogger };
   }
 });

--- a/apps/api/src/app/services/enable-deployment-alert/enable-deployment-alert.handler.ts
+++ b/apps/api/src/app/services/enable-deployment-alert/enable-deployment-alert.handler.ts
@@ -1,8 +1,8 @@
-import { singleton } from "tsyringe";
+import { inject, singleton } from "tsyringe";
 
 import { EnableDeploymentAlertCommand } from "@src/billing/commands/enable-deployment-alert.command";
 import type { JobHandler, JobPayload } from "@src/core";
-import { LoggerService } from "@src/core/providers/logging.provider";
+import { type CreateLogger, LOGGER_FACTORY } from "@src/core/providers/logging.provider";
 import { NotificationService } from "@src/notifications/services/notification/notification.service";
 
 @singleton()
@@ -11,10 +11,14 @@ export class EnableDeploymentAlertHandler implements JobHandler<EnableDeployment
 
   public readonly concurrency = 2;
 
+  private readonly logger: ReturnType<CreateLogger>;
+
   constructor(
     private readonly notificationService: NotificationService,
-    private readonly logger: LoggerService
-  ) {}
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
+  ) {
+    this.logger = createLogger({ context: EnableDeploymentAlertHandler.name });
+  }
 
   async handle(payload: JobPayload<EnableDeploymentAlertCommand>): Promise<void> {
     this.logger.debug({ event: "ENABLE_DEPLOYMENT_ALERT", userId: payload.userId, dseq: payload.dseq });

--- a/apps/api/src/app/services/first-purchase-bonus-granted/first-purchase-bonus-granted.handler.spec.ts
+++ b/apps/api/src/app/services/first-purchase-bonus-granted/first-purchase-bonus-granted.handler.spec.ts
@@ -3,7 +3,7 @@ import { mock } from "vitest-mock-extended";
 
 import type { FirstPurchaseBonusGranted } from "@src/billing/events/first-purchase-bonus-granted";
 import type { EventPayload } from "@src/core";
-import type { LoggerService } from "@src/core/providers/logging.provider";
+import type { CreateLogger } from "@src/core/providers/logging.provider";
 import type { NotificationService } from "@src/notifications/services/notification/notification.service";
 import { firstPurchaseBonusGrantedNotification } from "@src/notifications/services/notification-templates/first-purchase-bonus-granted-notification";
 import type { UserRepository } from "@src/user/repositories";
@@ -45,6 +45,12 @@ describe(FirstPurchaseBonusGrantedHandler.name, () => {
     expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "FIRST_PURCHASE_BONUS_EMAIL_SKIPPED" }));
   });
 
+  it("creates the logger with the service context", () => {
+    const { createLogger } = setup();
+
+    expect(createLogger).toHaveBeenCalledWith({ context: FirstPurchaseBonusGrantedHandler.name });
+  });
+
   function setup(input?: { findUserById?: UserRepository["findById"] }) {
     const mocks = {
       notificationService: mock<NotificationService>({
@@ -53,11 +59,13 @@ describe(FirstPurchaseBonusGrantedHandler.name, () => {
       userRepository: mock<UserRepository>({
         findById: input?.findUserById ?? vi.fn()
       }),
-      logger: mock<LoggerService>()
+      logger: mock<ReturnType<CreateLogger>>()
     };
 
-    const handler = new FirstPurchaseBonusGrantedHandler(mocks.notificationService, mocks.userRepository, mocks.logger);
+    const createLogger = vi.fn<CreateLogger>(() => mocks.logger);
 
-    return { handler, ...mocks };
+    const handler = new FirstPurchaseBonusGrantedHandler(mocks.notificationService, mocks.userRepository, createLogger);
+
+    return { handler, createLogger, ...mocks };
   }
 });

--- a/apps/api/src/app/services/first-purchase-bonus-granted/first-purchase-bonus-granted.handler.ts
+++ b/apps/api/src/app/services/first-purchase-bonus-granted/first-purchase-bonus-granted.handler.ts
@@ -1,7 +1,7 @@
-import { singleton } from "tsyringe";
+import { inject, singleton } from "tsyringe";
 
 import { FirstPurchaseBonusGranted } from "@src/billing/events/first-purchase-bonus-granted";
-import { EventPayload, JobHandler, LoggerService } from "@src/core";
+import { type CreateLogger, EventPayload, JobHandler, LOGGER_FACTORY } from "@src/core";
 import { NotificationService } from "@src/notifications/services/notification/notification.service";
 import { firstPurchaseBonusGrantedNotification } from "@src/notifications/services/notification-templates/first-purchase-bonus-granted-notification";
 import { UserRepository } from "@src/user/repositories";
@@ -12,11 +12,15 @@ export class FirstPurchaseBonusGrantedHandler implements JobHandler<FirstPurchas
 
   public readonly concurrency = 2;
 
+  private readonly logger: ReturnType<CreateLogger>;
+
   constructor(
     private readonly notificationService: NotificationService,
     private readonly userRepository: UserRepository,
-    private readonly logger: LoggerService
-  ) {}
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
+  ) {
+    this.logger = createLogger({ context: FirstPurchaseBonusGrantedHandler.name });
+  }
 
   async handle(payload: EventPayload<FirstPurchaseBonusGranted>): Promise<void> {
     const user = await this.userRepository.findById(payload.userId);

--- a/apps/api/src/app/services/trial-deployment-lease-created/trial-deployment-lease-created.handler.spec.ts
+++ b/apps/api/src/app/services/trial-deployment-lease-created/trial-deployment-lease-created.handler.spec.ts
@@ -7,7 +7,7 @@ import type { UserWalletRepository } from "@src/billing/repositories";
 import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import type { EventPayload } from "@src/core";
 import { DOMAIN_EVENT_NAME } from "@src/core";
-import type { LoggerService } from "@src/core/providers/logging.provider";
+import type { CreateLogger } from "@src/core/providers/logging.provider";
 import type { JobQueueService } from "@src/core/services/job-queue/job-queue.service";
 import { NotificationJob } from "@src/notifications/services/notification-handler/notification.handler";
 import { CloseTrialDeployment } from "../close-trial-deployment/close-trial-deployment.handler";
@@ -204,6 +204,12 @@ describe(TrialDeploymentLeaseCreatedHandler.name, () => {
     );
   });
 
+  it("creates the logger with the service context", () => {
+    const { createLogger } = setup();
+
+    expect(createLogger).toHaveBeenCalledWith({ context: TrialDeploymentLeaseCreatedHandler.name });
+  });
+
   function setup(input?: {
     findWalletById?: UserWalletRepository["findById"];
     enqueueJob?: JobQueueService["enqueue"];
@@ -213,7 +219,7 @@ describe(TrialDeploymentLeaseCreatedHandler.name, () => {
       userWalletRepository: mock<UserWalletRepository>({
         findById: input?.findWalletById ?? vi.fn()
       }),
-      logger: mock<LoggerService>(),
+      logger: mock<ReturnType<CreateLogger>>(),
       jobQueueService: mock<JobQueueService>({
         enqueue: input?.enqueueJob ?? vi.fn().mockResolvedValue(undefined)
       }),
@@ -222,8 +228,10 @@ describe(TrialDeploymentLeaseCreatedHandler.name, () => {
       })
     };
 
-    const handler = new TrialDeploymentLeaseCreatedHandler(mocks.userWalletRepository, mocks.logger, mocks.jobQueueService, mocks.billingConfig);
+    const createLogger = vi.fn<CreateLogger>(() => mocks.logger);
 
-    return { handler, ...mocks };
+    const handler = new TrialDeploymentLeaseCreatedHandler(mocks.userWalletRepository, createLogger, mocks.jobQueueService, mocks.billingConfig);
+
+    return { handler, createLogger, ...mocks };
   }
 });

--- a/apps/api/src/app/services/trial-deployment-lease-created/trial-deployment-lease-created.handler.ts
+++ b/apps/api/src/app/services/trial-deployment-lease-created/trial-deployment-lease-created.handler.ts
@@ -1,10 +1,10 @@
 import { addHours } from "date-fns";
-import { singleton } from "tsyringe";
+import { inject, singleton } from "tsyringe";
 
 import { TrialDeploymentLeaseCreated } from "@src/billing/events/trial-deployment-lease-created";
 import { UserWalletRepository } from "@src/billing/repositories";
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
-import { DOMAIN_EVENT_NAME, EventPayload, JobHandler, JobQueueService, LoggerService } from "@src/core";
+import { type CreateLogger, DOMAIN_EVENT_NAME, EventPayload, JobHandler, JobQueueService, LOGGER_FACTORY } from "@src/core";
 import { RESOLVED_MARKER } from "@src/notifications/services/notification-data-resolver/notification-data-resolver.service";
 import { NotificationJob } from "@src/notifications/services/notification-handler/notification.handler";
 import { CloseTrialDeployment } from "../close-trial-deployment/close-trial-deployment.handler";
@@ -15,12 +15,16 @@ export class TrialDeploymentLeaseCreatedHandler implements JobHandler<TrialDeplo
 
   public readonly concurrency = 2;
 
+  private readonly logger: ReturnType<CreateLogger>;
+
   constructor(
     private readonly userWalletRepository: UserWalletRepository,
-    private readonly logger: LoggerService,
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger,
     private readonly jobQueueService: JobQueueService,
     private readonly billingConfig: BillingConfigService
-  ) {}
+  ) {
+    this.logger = createLogger({ context: TrialDeploymentLeaseCreatedHandler.name });
+  }
 
   async handle(payload: EventPayload<TrialDeploymentLeaseCreated>): Promise<void> {
     const wallet = await this.userWalletRepository.findById(payload.walletId);

--- a/apps/api/src/app/services/trial-started/trial-started.handler.spec.ts
+++ b/apps/api/src/app/services/trial-started/trial-started.handler.spec.ts
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
-import type { LoggerService } from "@src/core/providers/logging.provider";
+import type { CreateLogger } from "@src/core/providers/logging.provider";
 import type { JobQueueService } from "@src/core/services/job-queue/job-queue.service";
 import type { NotificationService } from "@src/notifications/services/notification/notification.service";
 import { NotificationJob } from "@src/notifications/services/notification-handler/notification.handler";
@@ -217,6 +217,12 @@ describe(TrialStartedHandler.name, () => {
     });
   });
 
+  it("creates the logger with the service context", () => {
+    const { createLogger } = setup();
+
+    expect(createLogger).toHaveBeenCalledWith({ context: TrialStartedHandler.name });
+  });
+
   function setup(input?: {
     findUserById?: UserRepository["findById"];
     createNotification?: NotificationService["createNotification"];
@@ -235,7 +241,7 @@ describe(TrialStartedHandler.name, () => {
       userRepository: mock<UserRepository>({
         findById: input?.findUserById ?? vi.fn()
       }),
-      logger: mock<LoggerService>(),
+      logger: mock<ReturnType<CreateLogger>>(),
       coreConfig: mockConfig<BillingConfigService>({
         TRIAL_ALLOWANCE_EXPIRATION_DAYS: input?.trialExpirationDays ?? 30,
         CONSOLE_WEB_PAYMENT_LINK: paymentLink,
@@ -243,8 +249,10 @@ describe(TrialStartedHandler.name, () => {
       })
     };
 
-    const handler = new TrialStartedHandler(mocks.notificationService, mocks.jobQueueManager, mocks.userRepository, mocks.logger, mocks.coreConfig);
+    const createLogger = vi.fn<CreateLogger>(() => mocks.logger);
 
-    return { handler, ...mocks, paymentLink };
+    const handler = new TrialStartedHandler(mocks.notificationService, mocks.jobQueueManager, mocks.userRepository, createLogger, mocks.coreConfig);
+
+    return { handler, createLogger, ...mocks, paymentLink };
   }
 });

--- a/apps/api/src/app/services/trial-started/trial-started.handler.ts
+++ b/apps/api/src/app/services/trial-started/trial-started.handler.ts
@@ -1,9 +1,9 @@
 import { addDays, subDays } from "date-fns";
-import { singleton } from "tsyringe";
+import { inject, singleton } from "tsyringe";
 
 import { TrialStarted } from "@src/billing/events/trial-started";
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
-import { EventPayload, JobHandler, JobQueueService, LoggerService } from "@src/core";
+import { type CreateLogger, EventPayload, JobHandler, JobQueueService, LOGGER_FACTORY } from "@src/core";
 import { NotificationService } from "@src/notifications/services/notification/notification.service";
 import { RESOLVED_MARKER } from "@src/notifications/services/notification-data-resolver/notification-data-resolver.service";
 import { NotificationJob } from "@src/notifications/services/notification-handler/notification.handler";
@@ -16,13 +16,17 @@ export class TrialStartedHandler implements JobHandler<TrialStarted> {
 
   public readonly concurrency = 2;
 
+  private readonly logger: ReturnType<CreateLogger>;
+
   constructor(
     private readonly notificationService: NotificationService,
     private readonly jobQueueManager: JobQueueService,
     private readonly userRepository: UserRepository,
-    private readonly logger: LoggerService,
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger,
     private readonly billingConfig: BillingConfigService
-  ) {}
+  ) {
+    this.logger = createLogger({ context: TrialStartedHandler.name });
+  }
 
   async handle(payload: EventPayload<TrialStarted>): Promise<void> {
     const user = await this.userRepository.findById(payload.userId);

--- a/apps/api/src/billing/controllers/stripe/stripe.controller.spec.ts
+++ b/apps/api/src/billing/controllers/stripe/stripe.controller.spec.ts
@@ -2,7 +2,7 @@ import { faker } from "@faker-js/faker";
 import createError from "http-errors";
 import type Stripe from "stripe";
 import { container } from "tsyringe";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import { AuthService } from "@src/auth/services/auth.service";
@@ -19,7 +19,7 @@ import type { TopUpService } from "@src/billing/services/top-up/top-up.service";
 import type { TransactionReportingService } from "@src/billing/services/transaction-reporting/transaction-reporting.service";
 import type { TrialActivationJobService } from "@src/billing/services/trial-activation-job/trial-activation-job.service";
 import type { WalletSettingService } from "@src/billing/services/wallet-settings/wallet-settings.service";
-import type { LoggerService } from "@src/core/providers/logging.provider";
+import type { CreateLogger } from "@src/core/providers/logging.provider";
 import { StripeController } from "./stripe.controller";
 
 import { generateDatabaseStripeTransaction } from "@test/seeders/database-stripe-transaction.seeder";
@@ -344,6 +344,12 @@ describe(StripeController.name, () => {
     });
   });
 
+  it("creates the logger with the service context", () => {
+    const { createLogger } = setup();
+
+    expect(createLogger).toHaveBeenCalledWith({ context: StripeController.name });
+  });
+
   function setup() {
     const user = createUser();
     const payingUser: PayingUser = { ...user, stripeCustomerId: user.stripeCustomerId! };
@@ -362,7 +368,8 @@ describe(StripeController.name, () => {
     const trialActivationJobService = mock<TrialActivationJobService>();
     const transactionReporting = mock<TransactionReportingService>();
     const walletSettingService = mock<WalletSettingService>();
-    const logger = mock<LoggerService>();
+    const logger = mock<ReturnType<CreateLogger>>();
+    const createLogger = vi.fn<CreateLogger>(() => logger);
     const controller = new StripeController(
       stripe,
       stripeTransaction,
@@ -376,7 +383,7 @@ describe(StripeController.name, () => {
       couponRedemptionService,
       customerService,
       walletSettingService,
-      logger
+      createLogger
     );
     container.register(AuthService, { useValue: authService });
 
@@ -394,6 +401,7 @@ describe(StripeController.name, () => {
       trialActivationJobService,
       walletSettingService,
       logger,
+      createLogger,
       user
     };
   }

--- a/apps/api/src/billing/controllers/stripe/stripe.controller.ts
+++ b/apps/api/src/billing/controllers/stripe/stripe.controller.ts
@@ -1,7 +1,7 @@
 import { HTTPException } from "hono/http-exception";
 import assert from "http-assert";
 import Stripe from "stripe";
-import { singleton } from "tsyringe";
+import { inject, singleton } from "tsyringe";
 import type { infer as ZodInfer } from "zod";
 
 import { AuthService, Protected } from "@src/auth/services/auth.service";
@@ -31,10 +31,12 @@ import { TopUpService } from "@src/billing/services/top-up/top-up.service";
 import { TransactionReportingService } from "@src/billing/services/transaction-reporting/transaction-reporting.service";
 import { TrialActivationJobService } from "@src/billing/services/trial-activation-job/trial-activation-job.service";
 import { WalletSettingService } from "@src/billing/services/wallet-settings/wallet-settings.service";
-import { LoggerService } from "@src/core/providers/logging.provider";
+import { type CreateLogger, LOGGER_FACTORY } from "@src/core/providers/logging.provider";
 
 @singleton()
 export class StripeController {
+  private readonly logger: ReturnType<CreateLogger>;
+
   constructor(
     private readonly stripe: StripeService,
     private readonly stripeTransaction: StripeTransactionService,
@@ -48,9 +50,9 @@ export class StripeController {
     private readonly couponRedemptionService: CouponRedemptionService,
     private readonly customerService: CustomerService,
     private readonly walletSettingService: WalletSettingService,
-    private readonly logger: LoggerService
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
-    this.logger.setContext(StripeController.name);
+    this.logger = createLogger({ context: StripeController.name });
   }
 
   @Protected([{ action: "read", subject: "StripePayment" }])

--- a/apps/api/src/billing/services/external-signer-http-sdk/external-signer-http-sdk.service.ts
+++ b/apps/api/src/billing/services/external-signer-http-sdk/external-signer-http-sdk.service.ts
@@ -6,7 +6,7 @@ import { inject, singleton } from "tsyringe";
 import type { SignAndBroadcastOptions } from "@src/billing/lib/batch-signing-client/batch-signing-client.service";
 import { TYPE_REGISTRY } from "@src/billing/providers/type-registry.provider";
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
-import { LoggerService } from "@src/core";
+import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
 
 type SignAndBroadcastRequestMessage = {
   typeUrl: string;
@@ -33,12 +33,14 @@ type SignAndBroadcastResponse = {
 
 @singleton()
 export class ExternalSignerHttpSdkService {
+  private readonly logger: ReturnType<CreateLogger>;
+
   constructor(
     private readonly billingConfigService: BillingConfigService,
-    private readonly logger: LoggerService,
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger,
     @inject(TYPE_REGISTRY) private readonly registry: Registry
   ) {
-    this.logger.setContext(ExternalSignerHttpSdkService.name);
+    this.logger = createLogger({ context: ExternalSignerHttpSdkService.name });
   }
 
   async signAndBroadcastWithFundingWallet(messages: readonly EncodeObject[]) {

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
@@ -21,7 +21,7 @@ import type { ManagedUserWalletService } from "@src/billing/services/managed-use
 import type { TrialActivationJobService } from "@src/billing/services/trial-activation-job/trial-activation-job.service";
 import type { TrialValidationService } from "@src/billing/services/trial-validation/trial-validation.service";
 import type { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
-import type { LoggerService } from "@src/core";
+import type { CreateLogger } from "@src/core";
 import type { DomainEventsService } from "@src/core/services/domain-events/domain-events.service";
 import type { FeatureFlagValue } from "@src/core/services/feature-flags/feature-flags";
 import type { UserOutput, UserRepository } from "@src/user/repositories";
@@ -851,6 +851,12 @@ describe(ManagedSignerService.name, () => {
     };
   }
 
+  it("creates the logger with the service context", () => {
+    const { createLogger } = setup();
+
+    expect(createLogger).toHaveBeenCalledWith({ context: ManagedSignerService.name });
+  });
+
   function setupForCreate(input: { deploymentLimit: number } & Omit<NonNullable<Parameters<typeof setup>[0]>, "retrieveDeploymentLimit">) {
     const { deploymentLimit, ...rest } = input;
 
@@ -929,8 +935,7 @@ describe(ManagedSignerService.name, () => {
         refillWalletFees: vi.fn()
       }),
       trialActivationJobService: mock<TrialActivationJobService>(),
-      logger: mock<LoggerService>({
-        setContext: vi.fn(),
+      logger: mock<ReturnType<CreateLogger>>({
         error: vi.fn(),
         warn: vi.fn()
       })
@@ -939,6 +944,8 @@ describe(ManagedSignerService.name, () => {
     const registryMock = mock<Registry>({
       decode: input?.decode ?? vi.fn()
     });
+
+    const createLogger = vi.fn<CreateLogger>(() => mocks.logger);
 
     const service = new ManagedSignerService(
       registryMock,
@@ -955,9 +962,9 @@ describe(ManagedSignerService.name, () => {
       mocks.walletReloadJobService,
       mocks.managedUserWalletService,
       mocks.trialActivationJobService,
-      mocks.logger
+      createLogger
     );
 
-    return { service, registry: registryMock, ...mocks };
+    return { service, registry: registryMock, createLogger, ...mocks };
   }
 });

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
@@ -9,7 +9,7 @@ import { context, trace } from "@opentelemetry/api";
 import assert from "http-assert";
 import { BadRequest, isHttpError } from "http-errors";
 import pick from "lodash/pick";
-import { singleton } from "tsyringe";
+import { inject, singleton } from "tsyringe";
 
 import { AuthService } from "@src/auth/services/auth.service";
 import { EnableDeploymentAlertCommand } from "@src/billing/commands/enable-deployment-alert.command";
@@ -21,7 +21,7 @@ import { ManagedUserWalletService } from "@src/billing/services/managed-user-wal
 import { TrialActivationJobService } from "@src/billing/services/trial-activation-job/trial-activation-job.service";
 import { TxManagerService } from "@src/billing/services/tx-manager/tx-manager.service";
 import { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
-import { LoggerService } from "@src/core";
+import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
 import { DomainEventsService } from "@src/core/services/domain-events/domain-events.service";
 import { UserRepository } from "@src/user/repositories";
 import { COSMOS_TX_CODE_OK } from "@src/utils/constants";
@@ -40,6 +40,8 @@ const INSUFFICIENT_DEPOSIT_BALANCE_RELOADING_MESSAGE =
 
 @singleton()
 export class ManagedSignerService {
+  private readonly logger: ReturnType<CreateLogger>;
+
   constructor(
     @InjectTypeRegistry() private readonly registry: Registry,
     private readonly billingConfigService: BillingConfigService,
@@ -55,9 +57,9 @@ export class ManagedSignerService {
     private readonly walletReloadJobService: WalletReloadJobService,
     private readonly managedUserWalletService: ManagedUserWalletService,
     private readonly trialActivationJobService: TrialActivationJobService,
-    private readonly logger: LoggerService
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
-    this.logger.setContext(ManagedSignerService.name);
+    this.logger = createLogger({ context: ManagedSignerService.name });
   }
 
   @Trace()

--- a/apps/api/src/billing/services/managed-user-wallet/managed-user-wallet.service.spec.ts
+++ b/apps/api/src/billing/services/managed-user-wallet/managed-user-wallet.service.spec.ts
@@ -3,12 +3,12 @@ import type { EncodeObject } from "@cosmjs/proto-signing";
 import { faker } from "@faker-js/faker";
 import addDays from "date-fns/addDays";
 import subDays from "date-fns/subDays";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { BillingConfig } from "@src/billing/providers";
 import type { TxManagerService } from "@src/billing/services/tx-manager/tx-manager.service";
-import type { LoggerService } from "@src/core/providers/logging.provider";
+import type { CreateLogger } from "@src/core/providers/logging.provider";
 import type { ManagedSignerService } from "../managed-signer/managed-signer.service";
 import type { RpcMessageService } from "../rpc-message-service/rpc-message.service";
 import { ManagedUserWalletService } from "./managed-user-wallet.service";
@@ -154,6 +154,12 @@ describe(ManagedUserWalletService.name, () => {
     });
   });
 
+  it("creates the logger with the service context", () => {
+    const { createLogger } = setup();
+
+    expect(createLogger).toHaveBeenCalledWith({ context: ManagedUserWalletService.name });
+  });
+
   function setup() {
     const config: BillingConfig = {
       TRIAL_DEPLOYMENT_ALLOWANCE_AMOUNT: 500000,
@@ -167,7 +173,8 @@ describe(ManagedUserWalletService.name, () => {
     const rpcMessageService = mock<RpcMessageService>();
     const authzHttpService = mock<AuthzHttpService>();
     const signer = mock<ManagedSignerService>();
-    const logger = mock<LoggerService>();
+    const logger = mock<ReturnType<CreateLogger>>();
+    const createLogger = vi.fn<CreateLogger>(() => logger);
 
     txManagerService.getFundingWalletAddress.mockResolvedValue(createAkashAddress());
     authzHttpService.hasFeeAllowance.mockResolvedValue(false);
@@ -175,8 +182,8 @@ describe(ManagedUserWalletService.name, () => {
     rpcMessageService.getRevokeAllowanceMsg.mockReturnValue({ typeUrl: "/fee-revoke", value: {} } as unknown as EncodeObject);
     signer.executeFundingTx.mockResolvedValue({ code: 0, hash: "hash", rawLog: "[]" } as never);
 
-    const service = new ManagedUserWalletService(config, txManagerService, rpcMessageService, authzHttpService, logger);
+    const service = new ManagedUserWalletService(config, txManagerService, rpcMessageService, authzHttpService, createLogger);
 
-    return { service, signer, config, txManagerService, rpcMessageService, authzHttpService, logger };
+    return { service, signer, config, txManagerService, rpcMessageService, authzHttpService, logger, createLogger };
   }
 });

--- a/apps/api/src/billing/services/managed-user-wallet/managed-user-wallet.service.ts
+++ b/apps/api/src/billing/services/managed-user-wallet/managed-user-wallet.service.ts
@@ -8,12 +8,12 @@ import isAfter from "date-fns/isAfter";
 import subDays from "date-fns/subDays";
 import assert from "http-assert";
 import { BadGateway } from "http-errors";
-import { singleton } from "tsyringe";
+import { inject, singleton } from "tsyringe";
 
 import { type BillingConfig, InjectBillingConfig } from "@src/billing/providers";
 import type { UserWalletOutput } from "@src/billing/repositories";
 import { TxManagerService } from "@src/billing/services/tx-manager/tx-manager.service";
-import { LoggerService } from "@src/core/providers/logging.provider";
+import { type CreateLogger, LOGGER_FACTORY } from "@src/core/providers/logging.provider";
 import type { ManagedSignerService } from "../managed-signer/managed-signer.service";
 import { RpcMessageService, SpendingAuthorizationMsgOptions } from "../rpc-message-service/rpc-message.service";
 
@@ -40,13 +40,17 @@ export class ManagedUserWalletService {
     }
   );
 
+  private readonly logger: ReturnType<CreateLogger>;
+
   constructor(
     @InjectBillingConfig() private readonly config: BillingConfig,
     private readonly txManagerService: TxManagerService,
     private readonly rpcMessageService: RpcMessageService,
     private readonly authzHttpService: AuthzHttpService,
-    private readonly logger: LoggerService
-  ) {}
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
+  ) {
+    this.logger = createLogger({ context: ManagedUserWalletService.name });
+  }
 
   async createAndAuthorizeTrialSpending(signer: ManagedSignerService, { addressIndex }: { addressIndex: number }) {
     const address = await this.txManagerService.getDerivedWalletAddress(addressIndex);

--- a/apps/api/src/billing/services/remaining-credits/remaining-credits.service.spec.ts
+++ b/apps/api/src/billing/services/remaining-credits/remaining-credits.service.spec.ts
@@ -3,7 +3,7 @@ import { mock } from "vitest-mock-extended";
 
 import type { UserWalletRepository } from "@src/billing/repositories";
 import type { BalancesService } from "@src/billing/services/balances/balances.service";
-import type { LoggerService } from "@src/core/providers/logging.provider";
+import type { CreateLogger } from "@src/core/providers/logging.provider";
 import { RemainingCreditsService } from "./remaining-credits.service";
 
 import { createUser } from "@test/seeders/user.seeder";
@@ -61,6 +61,12 @@ describe(RemainingCreditsService.name, () => {
     });
   });
 
+  it("creates the logger with the service context", () => {
+    const { createLogger } = setup();
+
+    expect(createLogger).toHaveBeenCalledWith({ context: RemainingCreditsService.name });
+  });
+
   function setup(input?: { findOneByUserId?: UserWalletRepository["findOneByUserId"]; retrieveDeploymentLimit?: BalancesService["retrieveDeploymentLimit"] }) {
     const mocks = {
       userWalletRepository: mock<UserWalletRepository>({
@@ -69,11 +75,13 @@ describe(RemainingCreditsService.name, () => {
       balanceService: mock<BalancesService>({
         retrieveDeploymentLimit: input?.retrieveDeploymentLimit ?? vi.fn()
       }),
-      logger: mock<LoggerService>()
+      logger: mock<ReturnType<CreateLogger>>()
     };
 
-    const service = new RemainingCreditsService(mocks.balanceService, mocks.userWalletRepository, mocks.logger);
+    const createLogger = vi.fn<CreateLogger>(() => mocks.logger);
 
-    return { service, ...mocks };
+    const service = new RemainingCreditsService(mocks.balanceService, mocks.userWalletRepository, createLogger);
+
+    return { service, createLogger, ...mocks };
   }
 });

--- a/apps/api/src/billing/services/remaining-credits/remaining-credits.service.ts
+++ b/apps/api/src/billing/services/remaining-credits/remaining-credits.service.ts
@@ -1,8 +1,8 @@
-import { injectable } from "tsyringe";
+import { inject, injectable } from "tsyringe";
 
 import { UserWalletRepository } from "@src/billing/repositories";
 import { BalancesService } from "@src/billing/services/balances/balances.service";
-import { LoggerService } from "@src/core/providers/logging.provider";
+import { type CreateLogger, LOGGER_FACTORY } from "@src/core/providers/logging.provider";
 import type { Resolver } from "@src/core/providers/resolvers.provider";
 import { DATA_RESOLVER } from "@src/core/providers/resolvers.provider";
 import { UserOutput } from "@src/user/repositories";
@@ -12,12 +12,14 @@ import { udenomToDenom } from "@src/utils/math";
 export class RemainingCreditsService implements Resolver {
   readonly key = "remainingCredits";
 
+  private readonly loggerService: ReturnType<CreateLogger>;
+
   constructor(
     private readonly balanceService: BalancesService,
     private readonly userWalletRepository: UserWalletRepository,
-    private readonly loggerService: LoggerService
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
-    loggerService.setContext(RemainingCreditsService.name);
+    this.loggerService = createLogger({ context: RemainingCreditsService.name });
   }
 
   async resolve(user: UserOutput) {

--- a/apps/api/src/billing/services/trial-activation-job/trial-activation-job.service.spec.ts
+++ b/apps/api/src/billing/services/trial-activation-job/trial-activation-job.service.spec.ts
@@ -1,9 +1,9 @@
 import { faker } from "@faker-js/faker";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import { ActivateTrial } from "@src/billing/events/activate-trial";
-import type { JobQueueService, LoggerService } from "@src/core";
+import type { CreateLogger, JobQueueService } from "@src/core";
 import { TrialActivationJobService } from "./trial-activation-job.service";
 
 describe(TrialActivationJobService.name, () => {
@@ -45,13 +45,20 @@ describe(TrialActivationJobService.name, () => {
     });
   });
 
+  it("creates the logger with the service context", () => {
+    const { createLogger } = setup();
+
+    expect(createLogger).toHaveBeenCalledWith({ context: TrialActivationJobService.name });
+  });
+
   function setup(input?: { enqueueError?: Error }) {
     const jobQueueService = mock<JobQueueService>();
     if (input?.enqueueError) {
       jobQueueService.enqueue.mockRejectedValue(input.enqueueError);
     }
-    const logger = mock<LoggerService>();
-    const service = new TrialActivationJobService(jobQueueService, logger);
-    return { service, jobQueueService, logger };
+    const logger = mock<ReturnType<CreateLogger>>();
+    const createLogger = vi.fn<CreateLogger>(() => logger);
+    const service = new TrialActivationJobService(jobQueueService, createLogger);
+    return { service, jobQueueService, logger, createLogger };
   }
 });

--- a/apps/api/src/billing/services/trial-activation-job/trial-activation-job.service.ts
+++ b/apps/api/src/billing/services/trial-activation-job/trial-activation-job.service.ts
@@ -1,17 +1,19 @@
 import createError from "http-errors";
-import { singleton } from "tsyringe";
+import { inject, singleton } from "tsyringe";
 
 import { ActivateTrial } from "@src/billing/events/activate-trial";
-import { JobQueueService, LoggerService } from "@src/core";
+import { type CreateLogger, JobQueueService, LOGGER_FACTORY } from "@src/core";
 import type { UserOutput } from "@src/user/repositories";
 
 @singleton()
 export class TrialActivationJobService {
+  private readonly logger: ReturnType<CreateLogger>;
+
   constructor(
     private readonly jobQueueService: JobQueueService,
-    private readonly logger: LoggerService
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
-    this.logger.setContext(TrialActivationJobService.name);
+    this.logger = createLogger({ context: TrialActivationJobService.name });
   }
 
   /**

--- a/apps/api/src/billing/services/tx-manager/tx-manager.service.spec.ts
+++ b/apps/api/src/billing/services/tx-manager/tx-manager.service.spec.ts
@@ -6,7 +6,7 @@ import { mock } from "vitest-mock-extended";
 import type { SignAndBroadcastOptions } from "@src/billing/lib/batch-signing-client/batch-signing-client.service";
 import type { Wallet } from "@src/billing/lib/wallet/wallet";
 import type { ExternalSignerHttpSdkService } from "@src/billing/services/external-signer-http-sdk/external-signer-http-sdk.service";
-import type { LoggerService } from "@src/core";
+import type { CreateLogger } from "@src/core";
 import { TxManagerService } from "./tx-manager.service";
 
 import { createAkashAddress } from "@test/seeders";
@@ -83,6 +83,12 @@ describe(TxManagerService.name, () => {
     });
   });
 
+  it("creates the logger with the service context", () => {
+    const { createLogger } = setup();
+
+    expect(createLogger).toHaveBeenCalledWith({ context: TxManagerService.name });
+  });
+
   function setup(input?: {
     fundingWalletAddress?: string;
     derivedWalletAddress?: string;
@@ -110,7 +116,8 @@ describe(TxManagerService.name, () => {
       }
     };
 
-    const logger = mock<LoggerService>();
+    const logger = mock<ReturnType<CreateLogger>>();
+    const createLogger = vi.fn<CreateLogger>(() => logger);
     const externalSignerHttpSdkService = mock<ExternalSignerHttpSdkService>({
       signAndBroadcastWithFundingWallet: vi
         .fn()
@@ -120,7 +127,7 @@ describe(TxManagerService.name, () => {
         .mockResolvedValue(input?.externalDerivedResult ?? mock<IndexedTx>({ code: 0, hash: "default-hash", rawLog: "success" }))
     });
 
-    const service = new TxManagerService(walletResources, logger, externalSignerHttpSdkService);
+    const service = new TxManagerService(walletResources, createLogger, externalSignerHttpSdkService);
 
     return {
       service,
@@ -128,6 +135,7 @@ describe(TxManagerService.name, () => {
       derivedWallet,
       walletFactory,
       logger,
+      createLogger,
       externalSignerHttpSdkService
     };
   }

--- a/apps/api/src/billing/services/tx-manager/tx-manager.service.ts
+++ b/apps/api/src/billing/services/tx-manager/tx-manager.service.ts
@@ -5,7 +5,7 @@ import type { SignAndBroadcastOptions } from "@src/billing/lib/batch-signing-cli
 import { Wallet } from "@src/billing/lib/wallet/wallet";
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import { ExternalSignerHttpSdkService } from "@src/billing/services/external-signer-http-sdk/external-signer-http-sdk.service";
-import { LoggerService } from "@src/core";
+import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
 
 export type WalletFactory = (walletIndex?: number) => Wallet;
 type WalletVersionConfig = {
@@ -54,12 +54,14 @@ type WalletOptions = {
 export class TxManagerService {
   readonly #DEFAULT_WALLET_VERSION: WalletVersion = "v2";
 
+  private readonly logger: ReturnType<CreateLogger>;
+
   constructor(
     @inject(WALLET_RESOURCES) private readonly walletResources: WalletResources,
-    private readonly logger: LoggerService,
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger,
     private readonly externalSignerHttpSdkService: ExternalSignerHttpSdkService
   ) {
-    this.logger.setContext(TxManagerService.name);
+    this.logger = createLogger({ context: TxManagerService.name });
   }
 
   #getWalletResources(options?: WalletOptions): WalletVersionConfig {

--- a/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.spec.ts
+++ b/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.spec.ts
@@ -6,7 +6,7 @@ import type { UserWalletRepository, WalletSettingRepository } from "@src/billing
 import type { BalancesService } from "@src/billing/services/balances/balances.service";
 import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import type { JobPayload } from "@src/core";
-import type { LoggerService } from "@src/core/providers/logging.provider";
+import type { CreateLogger } from "@src/core/providers/logging.provider";
 import type { DrainingDeploymentService } from "@src/deployment/services/draining-deployment/draining-deployment.service";
 import type { NotificationService } from "@src/notifications/services/notification/notification.service";
 import { creditsRunningLowNotification } from "@src/notifications/services/notification-templates/credits-running-low-notification";
@@ -203,6 +203,12 @@ describe(WalletCreditsLowCheckHandler.name, () => {
     expect(userWalletRepository.updateById).toHaveBeenCalledWith(expect.any(Number), { creditsLowNotifiedAt: expect.any(Date) });
   });
 
+  it("creates the logger with the service context", () => {
+    const { createLogger } = setup();
+
+    expect(createLogger).toHaveBeenCalledWith({ context: WalletCreditsLowCheckHandler.name });
+  });
+
   function setup(input?: {
     autoReloadEnabled?: boolean;
     walletSettingNotFound?: boolean;
@@ -246,7 +252,8 @@ describe(WalletCreditsLowCheckHandler.name, () => {
     const billingConfig = mockConfigService<BillingConfigService>({
       CONSOLE_WEB_PAYMENT_LINK: paymentLink
     });
-    const logger = mock<LoggerService>();
+    const logger = mock<ReturnType<CreateLogger>>();
+    const createLogger = vi.fn<CreateLogger>(() => logger);
 
     walletSettingRepository.findByUserId.mockResolvedValue(input?.walletSettingNotFound ? undefined : walletSetting);
 
@@ -264,7 +271,7 @@ describe(WalletCreditsLowCheckHandler.name, () => {
       drainingDeploymentService,
       notificationService,
       billingConfig,
-      logger
+      createLogger
     );
 
     return {
@@ -277,6 +284,7 @@ describe(WalletCreditsLowCheckHandler.name, () => {
       notificationService,
       billingConfig,
       logger,
+      createLogger,
       user,
       wallet,
       walletSetting,

--- a/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.ts
+++ b/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.ts
@@ -1,10 +1,10 @@
-import { singleton } from "tsyringe";
+import { inject, singleton } from "tsyringe";
 
 import { WalletCreditsLowCheck } from "@src/billing/events/wallet-credits-low-check";
 import { isWalletInitialized, type UserWalletOutput, UserWalletRepository, WalletSettingRepository } from "@src/billing/repositories";
 import { BalancesService } from "@src/billing/services/balances/balances.service";
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
-import { type JobHandler, type JobPayload, LoggerService } from "@src/core";
+import { type CreateLogger, type JobHandler, type JobPayload, LOGGER_FACTORY } from "@src/core";
 import { DrainingDeploymentService } from "@src/deployment/services/draining-deployment/draining-deployment.service";
 import { NotificationService } from "@src/notifications/services/notification/notification.service";
 import { creditsRunningLowNotification } from "@src/notifications/services/notification-templates/credits-running-low-notification";
@@ -22,6 +22,8 @@ export class WalletCreditsLowCheckHandler implements JobHandler<WalletCreditsLow
 
   public readonly policy = "singleton";
 
+  private readonly logger: ReturnType<CreateLogger>;
+
   constructor(
     private readonly walletSettingRepository: WalletSettingRepository,
     private readonly userWalletRepository: UserWalletRepository,
@@ -30,8 +32,10 @@ export class WalletCreditsLowCheckHandler implements JobHandler<WalletCreditsLow
     private readonly drainingDeploymentService: DrainingDeploymentService,
     private readonly notificationService: NotificationService,
     private readonly billingConfig: BillingConfigService,
-    private readonly logger: LoggerService
-  ) {}
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
+  ) {
+    this.logger = createLogger({ context: WalletCreditsLowCheckHandler.name });
+  }
 
   async handle(payload: JobPayload<WalletCreditsLowCheck>): Promise<void> {
     const resources = await this.#getValidWalletResources(payload.userId);

--- a/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.spec.ts
+++ b/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.spec.ts
@@ -1,12 +1,12 @@
 import { faker } from "@faker-js/faker";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import { WalletBalanceReloadCheck } from "@src/billing/events/wallet-balance-reload-check";
 import { WalletCreditsLowCheck } from "@src/billing/events/wallet-credits-low-check";
 import type { UserWalletRepository, WalletSettingRepository } from "@src/billing/repositories";
 import type { JobQueueService } from "@src/core";
-import type { LoggerService } from "@src/core/providers/logging.provider";
+import type { CreateLogger } from "@src/core/providers/logging.provider";
 import { WalletReloadJobService } from "./wallet-reload-job.service";
 
 import { createUserWallet } from "@test/seeders/user-wallet.seeder";
@@ -367,20 +367,28 @@ describe(WalletReloadJobService.name, () => {
     expect((job as WalletCreditsLowCheck).data).toEqual({ userId });
   }
 
+  it("creates the logger with the service context", () => {
+    const { createLogger } = setup();
+
+    expect(createLogger).toHaveBeenCalledWith({ context: WalletReloadJobService.name });
+  });
+
   function setup() {
     const walletSettingRepository = mock<WalletSettingRepository>();
     const userWalletRepository = mock<UserWalletRepository>();
     const jobQueueService = mock<JobQueueService>();
-    const logger = mock<LoggerService>();
+    const logger = mock<ReturnType<CreateLogger>>();
+    const createLogger = vi.fn<CreateLogger>(() => logger);
 
-    const service = new WalletReloadJobService(walletSettingRepository, userWalletRepository, jobQueueService, logger);
+    const service = new WalletReloadJobService(walletSettingRepository, userWalletRepository, jobQueueService, createLogger);
 
     return {
       service,
       walletSettingRepository,
       userWalletRepository,
       jobQueueService,
-      logger
+      logger,
+      createLogger
     };
   }
 });

--- a/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.ts
+++ b/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.ts
@@ -1,20 +1,22 @@
-import { singleton } from "tsyringe";
+import { inject, singleton } from "tsyringe";
 
 import { WalletBalanceReloadCheck } from "@src/billing/events/wallet-balance-reload-check";
 import { WalletCreditsLowCheck } from "@src/billing/events/wallet-credits-low-check";
 import { UserWalletRepository, WalletSettingOutput, WalletSettingRepository } from "@src/billing/repositories";
 import { EnqueueOptions, JobQueueService } from "@src/core";
-import { LoggerService } from "@src/core/providers/logging.provider";
+import { type CreateLogger, LOGGER_FACTORY } from "@src/core/providers/logging.provider";
 
 @singleton()
 export class WalletReloadJobService {
+  private readonly logger: ReturnType<CreateLogger>;
+
   constructor(
     private readonly walletSettingRepository: WalletSettingRepository,
     private readonly userWalletRepository: UserWalletRepository,
     private readonly jobQueueService: JobQueueService,
-    private readonly logger: LoggerService
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
-    this.logger.setContext(WalletReloadJobService.name);
+    this.logger = createLogger({ context: WalletReloadJobService.name });
   }
 
   async scheduleImmediate(input: WalletReloadImmediateInput, options?: { triggeredByDeployment?: boolean }): Promise<boolean> {

--- a/apps/api/src/billing/services/wallet-settings/wallet-settings.service.integration.ts
+++ b/apps/api/src/billing/services/wallet-settings/wallet-settings.service.integration.ts
@@ -10,7 +10,7 @@ import type { UserWalletRepository, WalletSettingOutput, WalletSettingRepository
 import type { PaymentMethodService } from "@src/billing/services/payment-method/payment-method.service";
 import { type PaymentMethod } from "@src/billing/services/payment-method/payment-method.service";
 import type { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
-import type { LoggerService } from "@src/core/providers/logging.provider";
+import type { CreateLogger } from "@src/core/providers/logging.provider";
 import type { UserRepository } from "@src/user/repositories";
 import { WalletSettingService } from "./wallet-settings.service";
 
@@ -332,7 +332,8 @@ describe(WalletSettingService.name, () => {
     const walletReloadJobService = mock<WalletReloadJobService>({
       scheduleForWalletSetting: vi.fn().mockResolvedValue(jobId)
     });
-    const logger = mock<LoggerService>();
+    const logger = mock<ReturnType<CreateLogger>>();
+    const createLogger = vi.fn<CreateLogger>(() => logger);
     const service = new WalletSettingService(
       walletSettingRepository,
       userWalletRepository,
@@ -340,7 +341,7 @@ describe(WalletSettingService.name, () => {
       paymentMethodService,
       authService,
       walletReloadJobService,
-      logger
+      createLogger
     );
 
     return {

--- a/apps/api/src/billing/services/wallet-settings/wallet-settings.service.spec.ts
+++ b/apps/api/src/billing/services/wallet-settings/wallet-settings.service.spec.ts
@@ -7,7 +7,7 @@ import type { AuthService } from "@src/auth/services/auth.service";
 import type { UserWalletRepository, WalletSettingRepository } from "@src/billing/repositories";
 import type { PaymentMethod, PaymentMethodService } from "@src/billing/services/payment-method/payment-method.service";
 import type { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
-import type { LoggerService } from "@src/core/providers/logging.provider";
+import type { CreateLogger } from "@src/core/providers/logging.provider";
 import type { UserRepository } from "@src/user/repositories";
 import { WalletSettingService } from "./wallet-settings.service";
 
@@ -57,6 +57,12 @@ describe(WalletSettingService.name, () => {
     });
   });
 
+  it("creates the logger with the service context", () => {
+    const { createLogger } = setup();
+
+    expect(createLogger).toHaveBeenCalledWith({ context: WalletSettingService.name });
+  });
+
   function setup() {
     const user = createUser();
     const userWithStripe = { ...user, stripeCustomerId: faker.string.uuid() };
@@ -82,7 +88,8 @@ describe(WalletSettingService.name, () => {
     const walletReloadJobService = mock<WalletReloadJobService>({
       scheduleForWalletSetting: vi.fn().mockResolvedValue(jobId)
     });
-    const logger = mock<LoggerService>();
+    const logger = mock<ReturnType<CreateLogger>>();
+    const createLogger = vi.fn<CreateLogger>(() => logger);
     const service = new WalletSettingService(
       walletSettingRepository,
       userWalletRepository,
@@ -90,7 +97,7 @@ describe(WalletSettingService.name, () => {
       paymentMethodService,
       authService,
       walletReloadJobService,
-      logger
+      createLogger
     );
 
     return {
@@ -101,7 +108,8 @@ describe(WalletSettingService.name, () => {
       userWalletRepository,
       walletReloadJobService,
       jobId,
-      service
+      service,
+      createLogger
     };
   }
 });

--- a/apps/api/src/billing/services/wallet-settings/wallet-settings.service.ts
+++ b/apps/api/src/billing/services/wallet-settings/wallet-settings.service.ts
@@ -1,5 +1,5 @@
 import assert from "http-assert";
-import { singleton } from "tsyringe";
+import { inject, singleton } from "tsyringe";
 
 import { AuthService } from "@src/auth/services/auth.service";
 import { centsToUsd, usdToCents } from "@src/billing/lib/currency/currency";
@@ -7,7 +7,7 @@ import { UserWalletRepository, type WalletSettingOutput, WalletSettingRepository
 import { PaymentMethodService } from "@src/billing/services/payment-method/payment-method.service";
 import { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
 import { WithTransaction } from "@src/core";
-import { LoggerService } from "@src/core/providers/logging.provider";
+import { type CreateLogger, LOGGER_FACTORY } from "@src/core/providers/logging.provider";
 import { isUniqueViolation } from "@src/core/repositories/base.repository";
 import { UserOutput, UserRepository } from "@src/user/repositories";
 
@@ -20,6 +20,8 @@ export interface WalletSettingInput {
 
 @singleton()
 export class WalletSettingService {
+  private readonly logger: ReturnType<CreateLogger>;
+
   constructor(
     private readonly walletSettingRepository: WalletSettingRepository,
     private readonly userWalletRepository: UserWalletRepository,
@@ -27,9 +29,9 @@ export class WalletSettingService {
     private readonly paymentMethodService: PaymentMethodService,
     private readonly authService: AuthService,
     private readonly walletReloadJobService: WalletReloadJobService,
-    private readonly logger: LoggerService
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
-    this.logger.setContext(WalletSettingService.name);
+    this.logger = createLogger({ context: WalletSettingService.name });
   }
 
   async getWalletSetting(userId: string): Promise<WalletSettingOutput | undefined> {

--- a/apps/api/src/core/providers/eventloop-monitoring.provider.ts
+++ b/apps/api/src/core/providers/eventloop-monitoring.provider.ts
@@ -6,12 +6,12 @@ import { DisposableRegistry } from "@src/core/lib/disposable-registry/disposable
 import type { AppInitializer } from "./app-initializer";
 import { APP_INITIALIZER, ON_APP_START } from "./app-initializer";
 import { CORE_CONFIG } from "./config.provider";
-import { LoggerService } from "./logging.provider";
+import { LOGGER_FACTORY } from "./logging.provider";
 
 container.register(APP_INITIALIZER, {
   useFactory: instancePerContainerCachingFactory(
     DisposableRegistry.registerFromFactory<AppInitializer>(c => {
-      const logger = c.resolve(LoggerService);
+      const logger = c.resolve(LOGGER_FACTORY)({ context: "EVENTLOOP_MONITORING" });
       let disposable: ReturnType<typeof blockedAt> | null = null;
       return {
         async [ON_APP_START]() {

--- a/apps/api/src/core/services/analytics/analytics.service.spec.ts
+++ b/apps/api/src/core/services/analytics/analytics.service.spec.ts
@@ -3,15 +3,15 @@ import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { Amplitude } from "@src/core/providers/amplitude.provider";
-import type { LoggerService } from "@src/core/providers/logging.provider";
+import type { CreateLogger } from "@src/core/providers/logging.provider";
 import { AnalyticsService } from "./analytics.service";
 
 describe(AnalyticsService.name, () => {
   describe("constructor", () => {
-    it("sets logger context", () => {
-      const { logger } = setup();
+    it("creates the logger with the service context", () => {
+      const { createLogger } = setup();
 
-      expect(logger.setContext).toHaveBeenCalledWith("AnalyticsService");
+      expect(createLogger).toHaveBeenCalledWith({ context: AnalyticsService.name });
     });
   });
 
@@ -96,12 +96,14 @@ describe(AnalyticsService.name, () => {
     const amplitude = mock<Amplitude>({
       Identify: IdentifyConstructor
     });
-    const logger = mock<LoggerService>();
-    const service = new AnalyticsService(amplitude, logger);
+    const logger = mock<ReturnType<CreateLogger>>();
+    const createLogger = vi.fn<CreateLogger>(() => logger);
+    const service = new AnalyticsService(amplitude, createLogger);
 
     return {
       amplitude,
       logger,
+      createLogger,
       service
     };
   }

--- a/apps/api/src/core/services/analytics/analytics.service.ts
+++ b/apps/api/src/core/services/analytics/analytics.service.ts
@@ -1,17 +1,19 @@
 import { inject, singleton } from "tsyringe";
 
 import { AMPLITUDE, type Amplitude } from "@src/core/providers/amplitude.provider";
-import { LoggerService } from "@src/core/providers/logging.provider";
+import { type CreateLogger, LOGGER_FACTORY } from "@src/core/providers/logging.provider";
 
 type AnalyticsEvent = "user_registered" | "balance_top_up" | "balance_refund" | "first_purchase_bonus_granted";
 
 @singleton()
 export class AnalyticsService {
+  private readonly loggerService: ReturnType<CreateLogger>;
+
   constructor(
     @inject(AMPLITUDE) private readonly amplitude: Amplitude,
-    private readonly loggerService: LoggerService
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
-    loggerService.setContext(AnalyticsService.name);
+    this.loggerService = createLogger({ context: AnalyticsService.name });
   }
 
   identify(userId: string, userProperties: Record<string, unknown> = {}) {

--- a/apps/api/src/core/services/domain-events/domain-events.service.spec.ts
+++ b/apps/api/src/core/services/domain-events/domain-events.service.spec.ts
@@ -1,7 +1,7 @@
-import type { LoggerService } from "@akashnetwork/logging";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
+import type { CreateLogger } from "../../providers/logging.provider";
 import type { JobQueueService } from "../job-queue/job-queue.service";
 import type { DomainEvent } from "./domain-events.service";
 import { DomainEventsService } from "./domain-events.service";
@@ -27,10 +27,17 @@ describe(DomainEventsService.name, () => {
     });
   });
 
+  it("creates the logger with the service context", () => {
+    const { createLogger } = setup();
+
+    expect(createLogger).toHaveBeenCalledWith({ context: DomainEventsService.name });
+  });
+
   function setup() {
     const jobQueueManager = mock<JobQueueService>();
-    const logger = mock<LoggerService>();
-    const service = new DomainEventsService(jobQueueManager, logger);
-    return { service, jobQueueManager, logger };
+    const logger = mock<ReturnType<CreateLogger>>();
+    const createLogger = vi.fn<CreateLogger>(() => logger);
+    const service = new DomainEventsService(jobQueueManager, createLogger);
+    return { service, jobQueueManager, logger, createLogger };
   }
 });

--- a/apps/api/src/core/services/domain-events/domain-events.service.ts
+++ b/apps/api/src/core/services/domain-events/domain-events.service.ts
@@ -1,6 +1,6 @@
-import { singleton } from "tsyringe";
+import { inject, singleton } from "tsyringe";
 
-import { LoggerService } from "../../providers/logging.provider";
+import { type CreateLogger, LOGGER_FACTORY } from "../../providers/logging.provider";
 import { EnqueueOptions, Job, JOB_NAME, JobPayload, JobQueueService } from "../job-queue/job-queue.service";
 
 export { JOB_NAME as DOMAIN_EVENT_NAME };
@@ -10,10 +10,14 @@ export type EventPayload<T extends DomainEvent> = JobPayload<T>;
 
 @singleton()
 export class DomainEventsService {
+  private readonly logger: ReturnType<CreateLogger>;
+
   constructor(
     private readonly jobQueueManager: JobQueueService,
-    private readonly logger: LoggerService
-  ) {}
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
+  ) {
+    this.logger = createLogger({ context: DomainEventsService.name });
+  }
 
   async publish(event: DomainEvent, options?: EnqueueOptions): Promise<string | null> {
     try {

--- a/apps/api/src/core/services/error/error.service.spec.ts
+++ b/apps/api/src/core/services/error/error.service.spec.ts
@@ -1,10 +1,10 @@
 import "@test/mocks/logger-service.mock";
 
-import type { LoggerService } from "@akashnetwork/logging";
 import { faker } from "@faker-js/faker";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
+import type { CreateLogger } from "../../providers/logging.provider";
 import { ErrorService } from "./error.service";
 
 describe(ErrorService.name, () => {
@@ -48,9 +48,16 @@ describe(ErrorService.name, () => {
     expect(actual).toBeUndefined();
   });
 
+  it("creates the logger with the service context", () => {
+    const { createLogger } = setup();
+
+    expect(createLogger).toHaveBeenCalledWith({ context: ErrorService.name });
+  });
+
   function setup() {
-    const logger = mock<LoggerService>();
-    const service = new ErrorService(logger);
-    return { service, logger };
+    const logger = mock<ReturnType<CreateLogger>>();
+    const createLogger = vi.fn<CreateLogger>(() => logger);
+    const service = new ErrorService(createLogger);
+    return { service, logger, createLogger };
   }
 });

--- a/apps/api/src/core/services/error/error.service.ts
+++ b/apps/api/src/core/services/error/error.service.ts
@@ -1,11 +1,13 @@
-import { singleton } from "tsyringe";
+import { inject, singleton } from "tsyringe";
 
-import { LoggerService } from "../../providers/logging.provider";
+import { type CreateLogger, LOGGER_FACTORY } from "../../providers/logging.provider";
 
 @singleton()
 export class ErrorService {
-  constructor(private readonly logger: LoggerService) {
-    this.logger.setContext(ErrorService.name);
+  private readonly logger: ReturnType<CreateLogger>;
+
+  constructor(@inject(LOGGER_FACTORY) createLogger: CreateLogger) {
+    this.logger = createLogger({ context: ErrorService.name });
   }
 
   async execWithErrorHandler<T>(extraLog: Record<string, unknown>, cb: () => Promise<T>, onError?: (error: unknown) => void): Promise<T | undefined> {

--- a/apps/api/src/core/services/job-queue/job-queue.service.spec.ts
+++ b/apps/api/src/core/services/job-queue/job-queue.service.spec.ts
@@ -4,7 +4,7 @@ import type { Sql } from "postgres";
 import { describe, expect, it, vi } from "vitest";
 import { mock, mockDeep } from "vitest-mock-extended";
 
-import type { LoggerService } from "@src/core/providers/logging.provider";
+import type { CreateLogger } from "@src/core/providers/logging.provider";
 import type { CoreConfigService } from "../core-config/core-config.service";
 import type { ExecutionContextService } from "../execution-context/execution-context.service";
 import type { TxService } from "../tx/tx.service";
@@ -394,9 +394,15 @@ describe(JobQueueService.name, () => {
     });
   });
 
+  it("creates the logger with the service context", () => {
+    const { createLogger } = setup();
+
+    expect(createLogger).toHaveBeenCalledWith({ context: JobQueueService.name });
+  });
+
   function setup(input?: { pgBoss?: PgBoss; postgresDbUri?: string }) {
     const mocks = {
-      logger: mock<LoggerService>(),
+      logger: mock<ReturnType<CreateLogger>>(),
       coreConfig: mock<CoreConfigService>({
         get: vi.fn().mockReturnValue(input?.postgresDbUri ?? "postgresql://localhost:5432/test")
       }),
@@ -419,15 +425,17 @@ describe(JobQueueService.name, () => {
       txService: mock<TxService>()
     };
 
+    const createLogger = vi.fn<CreateLogger>(() => mocks.logger);
+
     const service = new JobQueueService(
-      mocks.logger,
+      createLogger,
       mocks.coreConfig,
       mocks.executionContextService,
       mocks.txService,
       input && Object.hasOwn(input, "pgBoss") ? input?.pgBoss : mocks.pgBoss
     );
 
-    return { service, ...mocks };
+    return { service, createLogger, ...mocks };
   }
 
   class TestJob implements Job {

--- a/apps/api/src/core/services/job-queue/job-queue.service.ts
+++ b/apps/api/src/core/services/job-queue/job-queue.service.ts
@@ -4,7 +4,7 @@ import { Job as PgBossJob, PgBoss, Queue as PgBossQueue, SendOptions as PgBossSe
 import type { Sql } from "postgres";
 import { Disposable, inject, InjectionToken, singleton } from "tsyringe";
 
-import { LoggerService } from "@src/core/providers/logging.provider";
+import { type CreateLogger, LOGGER_FACTORY } from "@src/core/providers/logging.provider";
 import { CoreConfigService } from "../core-config/core-config.service";
 import { ExecutionContextService } from "../execution-context/execution-context.service";
 import { TxService } from "../tx/tx.service";
@@ -16,14 +16,16 @@ export class JobQueueService implements Disposable {
   private readonly pgBoss: PgBoss;
   private handlers?: JobHandler<Job>[];
   private readonly tracer = trace.getTracer("job-queue");
+  private readonly logger: ReturnType<CreateLogger>;
 
   constructor(
-    private readonly logger: LoggerService,
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger,
     private readonly coreConfig: CoreConfigService,
     private readonly executionContextService: ExecutionContextService,
     private readonly txService: TxService,
     @inject(PG_BOSS_TOKEN, { isOptional: true }) pgBoss?: PgBoss
   ) {
+    this.logger = createLogger({ context: JobQueueService.name });
     this.pgBoss =
       pgBoss ??
       new PgBoss({

--- a/apps/api/src/deployment/services/active-deployments-count/active-deployments-count.service.spec.ts
+++ b/apps/api/src/deployment/services/active-deployments-count/active-deployments-count.service.spec.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { UserWalletRepository } from "@src/billing/repositories";
-import type { LoggerService } from "@src/core/providers/logging.provider";
+import type { CreateLogger } from "@src/core/providers/logging.provider";
 import type { DeploymentRepository } from "@src/deployment/repositories/deployment/deployment.repository";
 import { ActiveDeploymentsCountService } from "./active-deployments-count.service";
 
@@ -61,6 +61,12 @@ describe(ActiveDeploymentsCountService.name, () => {
     });
   });
 
+  it("creates the logger with the service context", () => {
+    const { createLogger } = setup();
+
+    expect(createLogger).toHaveBeenCalledWith({ context: ActiveDeploymentsCountService.name });
+  });
+
   function setup(input?: { findOneByUserId?: UserWalletRepository["findOneByUserId"]; countActiveByOwner?: DeploymentRepository["countActiveByOwner"] }) {
     const mocks = {
       userWalletRepository: mock<UserWalletRepository>({
@@ -69,11 +75,13 @@ describe(ActiveDeploymentsCountService.name, () => {
       deploymentRepository: mock<DeploymentRepository>({
         countActiveByOwner: input?.countActiveByOwner ?? vi.fn()
       }),
-      logger: mock<LoggerService>()
+      logger: mock<ReturnType<CreateLogger>>()
     };
 
-    const service = new ActiveDeploymentsCountService(mocks.deploymentRepository, mocks.userWalletRepository, mocks.logger);
+    const createLogger = vi.fn<CreateLogger>(() => mocks.logger);
 
-    return { service, ...mocks };
+    const service = new ActiveDeploymentsCountService(mocks.deploymentRepository, mocks.userWalletRepository, createLogger);
+
+    return { service, createLogger, ...mocks };
   }
 });

--- a/apps/api/src/deployment/services/active-deployments-count/active-deployments-count.service.ts
+++ b/apps/api/src/deployment/services/active-deployments-count/active-deployments-count.service.ts
@@ -1,7 +1,7 @@
-import { injectable } from "tsyringe";
+import { inject, injectable } from "tsyringe";
 
 import { UserWalletRepository } from "@src/billing/repositories";
-import { LoggerService } from "@src/core/providers/logging.provider";
+import { type CreateLogger, LOGGER_FACTORY } from "@src/core/providers/logging.provider";
 import type { Resolver } from "@src/core/providers/resolvers.provider";
 import { DATA_RESOLVER } from "@src/core/providers/resolvers.provider";
 import { DeploymentRepository } from "@src/deployment/repositories/deployment/deployment.repository";
@@ -11,12 +11,14 @@ import { UserOutput } from "@src/user/repositories";
 export class ActiveDeploymentsCountService implements Resolver {
   readonly key = "activeDeployments";
 
+  private readonly loggerService: ReturnType<CreateLogger>;
+
   constructor(
     private readonly deploymentRepository: DeploymentRepository,
     private readonly userWalletRepository: UserWalletRepository,
-    private readonly loggerService: LoggerService
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
-    loggerService.setContext(ActiveDeploymentsCountService.name);
+    this.loggerService = createLogger({ context: ActiveDeploymentsCountService.name });
   }
 
   async resolve(user: UserOutput) {

--- a/apps/api/src/deployment/services/cached-balance/cached-balance.service.spec.ts
+++ b/apps/api/src/deployment/services/cached-balance/cached-balance.service.spec.ts
@@ -1,8 +1,8 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { BalancesService } from "@src/billing/services/balances/balances.service";
-import type { LoggerService } from "@src/core";
+import type { CreateLogger } from "@src/core";
 import type { DeploymentConfigService } from "@src/deployment/services/deployment-config/deployment-config.service";
 import { CachedBalanceService } from "./cached-balance.service";
 
@@ -171,15 +171,22 @@ describe(CachedBalanceService.name, () => {
     });
   });
 
+  it("creates the logger with the service context", () => {
+    const { createLogger } = setup();
+
+    expect(createLogger).toHaveBeenCalledWith({ context: CachedBalanceService.name });
+  });
+
   function setup(input?: { headroomInUsd?: number }) {
     const balancesService = mock<BalancesService>();
     const deploymentConfig = mockConfigService<DeploymentConfigService>({
       AUTO_TOP_UP_BALANCE_HEADROOM_IN_USD: input?.headroomInUsd ?? 0
     });
-    const logger = mock<LoggerService>();
+    const logger = mock<ReturnType<CreateLogger>>();
+    const createLogger = vi.fn<CreateLogger>(() => logger);
 
-    const service = new CachedBalanceService(balancesService, deploymentConfig, logger);
+    const service = new CachedBalanceService(balancesService, deploymentConfig, createLogger);
 
-    return { service, balancesService, deploymentConfig, logger };
+    return { service, balancesService, deploymentConfig, logger, createLogger };
   }
 });

--- a/apps/api/src/deployment/services/cached-balance/cached-balance.service.ts
+++ b/apps/api/src/deployment/services/cached-balance/cached-balance.service.ts
@@ -1,8 +1,8 @@
-import { singleton } from "tsyringe";
+import { inject, singleton } from "tsyringe";
 
 import { BalancesService } from "@src/billing/services/balances/balances.service";
 import { memoizeAsync } from "@src/caching/helpers";
-import { LoggerService } from "@src/core";
+import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
 import { DeploymentConfigService } from "@src/deployment/services/deployment-config/deployment-config.service";
 import { denomToUdenom } from "@src/utils/math";
 
@@ -51,12 +51,14 @@ export class CachedBalance {
 export class CachedBalanceService {
   public get = memoizeAsync((address: string) => this.buildForAddress(address), { cacheItemLimit: 10_000 });
 
+  private readonly logger: ReturnType<CreateLogger>;
+
   constructor(
     private readonly balancesService: BalancesService,
     private readonly deploymentConfig: DeploymentConfigService,
-    private readonly logger: LoggerService
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
-    this.logger.setContext(CachedBalanceService.name);
+    this.logger = createLogger({ context: CachedBalanceService.name });
   }
 
   /**

--- a/apps/api/src/deployment/services/deployment-reader/deployment-reader.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-reader/deployment-reader.service.spec.ts
@@ -8,7 +8,7 @@ import { mock } from "vitest-mock-extended";
 import type { AuthService } from "@src/auth/services/auth.service";
 import type { WalletInitialized } from "@src/billing/repositories";
 import type { WalletReaderService } from "@src/billing/services/wallet-reader/wallet-reader.service";
-import type { LoggerService } from "@src/core/providers/logging.provider";
+import type { CreateLogger } from "@src/core/providers/logging.provider";
 import type { DeploymentSettingRepository, DeploymentSettingsOutput } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import type { FallbackDeploymentReaderService } from "@src/deployment/services/fallback-deployment-reader/fallback-deployment-reader.service";
 import type { FallbackLeaseReaderService } from "@src/deployment/services/fallback-lease-reader/fallback-lease-reader.service";
@@ -304,6 +304,12 @@ describe(DeploymentReaderService.name, () => {
     });
   }
 
+  it("creates the logger with the service context", () => {
+    const { createLogger } = setup();
+
+    expect(createLogger).toHaveBeenCalledWith({ context: DeploymentReaderService.name });
+  });
+
   function setup(
     input: {
       wallet?: WalletInitialized;
@@ -345,7 +351,7 @@ describe(DeploymentReaderService.name, () => {
       walletReaderService: mock<WalletReaderService>({
         getWalletByUserId: vi.fn().mockResolvedValue(wallet)
       }),
-      logger: mock<LoggerService>()
+      logger: mock<ReturnType<CreateLogger>>()
     };
 
     const recorded = input.recorded === undefined ? { sdl: "version: '2.0'", manifestVersion: "BAUG" } : input.recorded;
@@ -356,6 +362,7 @@ describe(DeploymentReaderService.name, () => {
       accessibleBy: vi.fn().mockReturnValue(scopedDeploymentSettingRepository)
     });
     const authService = mock<AuthService>({ ability: mock<AuthService["ability"]>() });
+    const createLogger = vi.fn<CreateLogger>(() => mocks.logger);
 
     const service = new DeploymentReaderService(
       mocks.providerService,
@@ -367,9 +374,9 @@ describe(DeploymentReaderService.name, () => {
       mocks.walletReaderService,
       deploymentSettingRepository,
       authService,
-      mocks.logger
+      createLogger
     );
 
-    return { service, ...mocks, wallet, deploymentSettingRepository, scopedDeploymentSettingRepository, authService };
+    return { service, createLogger, ...mocks, wallet, deploymentSettingRepository, scopedDeploymentSettingRepository, authService };
   }
 });

--- a/apps/api/src/deployment/services/deployment-reader/deployment-reader.service.ts
+++ b/apps/api/src/deployment/services/deployment-reader/deployment-reader.service.ts
@@ -16,13 +16,13 @@ import { AxiosError } from "axios";
 import assert from "http-assert";
 import { InternalServerError } from "http-errors";
 import { Op } from "sequelize";
-import { singleton } from "tsyringe";
+import { inject, singleton } from "tsyringe";
 
 import { AuthService } from "@src/auth/services/auth.service";
 import type { WalletInitialized } from "@src/billing/repositories";
 import { WalletReaderService } from "@src/billing/services/wallet-reader/wallet-reader.service";
 import { Memoize } from "@src/caching/helpers";
-import { LoggerService } from "@src/core";
+import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
 import { ConsoleSettings, DeploymentResponse, GetDeploymentResponse, ListDeploymentsItem } from "@src/deployment/http-schemas/deployment.schema";
 import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import { FallbackLeaseReaderService } from "@src/deployment/services/fallback-lease-reader/fallback-lease-reader.service";
@@ -35,6 +35,8 @@ import { MessageService } from "../message-service/message.service";
 
 @singleton()
 export class DeploymentReaderService {
+  private readonly logger: ReturnType<CreateLogger>;
+
   constructor(
     private readonly providerService: ProviderService,
     private readonly deploymentHttpService: DeploymentHttpService,
@@ -45,8 +47,10 @@ export class DeploymentReaderService {
     private readonly walletReaderService: WalletReaderService,
     private readonly deploymentSettingRepository: DeploymentSettingRepository,
     private readonly authService: AuthService,
-    private readonly logger: LoggerService
-  ) {}
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
+  ) {
+    this.logger = createLogger({ context: DeploymentReaderService.name });
+  }
 
   public async findByUserIdAndDseq(userId: string, dseq: string): Promise<GetDeploymentResponse["data"]> {
     const wallet = await this.walletReaderService.getWalletByUserId(userId);

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -9,7 +9,7 @@ import type { BillingConfigService } from "@src/billing/services/billing-config/
 import type { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
 import type { RpcMessageService } from "@src/billing/services/rpc-message-service/rpc-message.service";
 import type { WalletReaderService } from "@src/billing/services/wallet-reader/wallet-reader.service";
-import type { LoggerService } from "@src/core";
+import type { CreateLogger } from "@src/core";
 import type { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
 import { SDL_MAX_LENGTH } from "@src/deployment/config/sdl.config";
 import type { DeploymentResponse } from "@src/deployment/http-schemas/deployment.schema";
@@ -651,12 +651,18 @@ describe(DeploymentWriterService.name, () => {
   }
 
   /** Everything the logger was handed, flattened, so a test can assert the sdl reached none of it. */
-  function loggedTextOf(logger: MockProxy<LoggerService>): string {
+  function loggedTextOf(logger: MockProxy<ReturnType<CreateLogger>>): string {
     return [logger.error, logger.warn, logger.info, logger.debug]
       .flatMap(method => method.mock.calls)
       .map(call => JSON.stringify(call))
       .join("");
   }
+
+  it("creates the logger with the service context", () => {
+    const { createLogger } = setup();
+
+    expect(createLogger).toHaveBeenCalledWith({ context: DeploymentWriterService.name });
+  });
 
   function setup(input?: { isManagedDepositEnabled?: boolean; defaultDeposit?: number }) {
     const signerService = mock<ManagedSignerService>();
@@ -669,7 +675,8 @@ describe(DeploymentWriterService.name, () => {
     const deploymentReaderService = mock<DeploymentReaderService>();
     const walletReaderService = mock<WalletReaderService>();
     const staleDeploymentsCleaner = mock<StaleManagedDeploymentsCleanerService>();
-    const logger = mock<LoggerService>();
+    const logger = mock<ReturnType<CreateLogger>>();
+    const createLogger = vi.fn<CreateLogger>(() => logger);
     const deploymentConfig: MockProxy<DeploymentConfigService> = mockConfigService<DeploymentConfigService>({
       DEPLOYMENT_DEFAULT_DEPOSIT: input?.defaultDeposit ?? 0.5
     });
@@ -691,7 +698,7 @@ describe(DeploymentWriterService.name, () => {
       deploymentReaderService,
       walletReaderService,
       staleDeploymentsCleaner,
-      logger,
+      createLogger,
       deploymentConfig,
       featureFlagsService,
       deploymentSettingRepository
@@ -708,6 +715,7 @@ describe(DeploymentWriterService.name, () => {
       walletReaderService,
       staleDeploymentsCleaner,
       logger,
+      createLogger,
       deploymentConfig,
       featureFlagsService,
       deploymentSettingRepository

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -1,14 +1,14 @@
 import { manifestToSortedJSON } from "@akashnetwork/chain-sdk";
 import { HTTPException } from "hono/http-exception";
 import assert from "http-assert";
-import { singleton } from "tsyringe";
+import { inject, singleton } from "tsyringe";
 
 import type { UserWalletOutput, WalletInitialized } from "@src/billing/repositories";
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
 import { RpcMessageService } from "@src/billing/services/rpc-message-service/rpc-message.service";
 import { WalletReaderService } from "@src/billing/services/wallet-reader/wallet-reader.service";
-import { LoggerService } from "@src/core";
+import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
 import { FeatureFlags } from "@src/core/services/feature-flags/feature-flags";
 import { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
 import { SDL_MAX_LENGTH } from "@src/deployment/config/sdl.config";
@@ -24,6 +24,8 @@ import { StaleManagedDeploymentsCleanerService } from "../stale-managed-deployme
 
 @singleton()
 export class DeploymentWriterService {
+  private readonly logger: ReturnType<CreateLogger>;
+
   constructor(
     private readonly signerService: ManagedSignerService,
     private readonly rpcMessageService: RpcMessageService,
@@ -33,11 +35,13 @@ export class DeploymentWriterService {
     private readonly deploymentReaderService: DeploymentReaderService,
     private readonly walletReaderService: WalletReaderService,
     private readonly staleDeploymentsCleaner: StaleManagedDeploymentsCleanerService,
-    private readonly logger: LoggerService,
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger,
     private readonly deploymentConfig: DeploymentConfigService,
     private readonly featureFlagsService: FeatureFlagsService,
     private readonly deploymentSettingRepository: DeploymentSettingRepository
-  ) {}
+  ) {
+    this.logger = createLogger({ context: DeploymentWriterService.name });
+  }
 
   public async create(input: CreateDeploymentRequest["data"] & { userId: string }): Promise<CreateDeploymentResponse["data"]> {
     const dseq = Date.now();

--- a/apps/api/src/deployment/services/draining-deployment-rpc/draining-deployment-rpc.service.spec.ts
+++ b/apps/api/src/deployment/services/draining-deployment-rpc/draining-deployment-rpc.service.spec.ts
@@ -2,10 +2,10 @@ import "@test/mocks/logger-service.mock";
 
 import type { DeploymentHttpService, DeploymentListResponse, LeaseHttpService } from "@akashnetwork/http-sdk";
 import { faker } from "@faker-js/faker";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
-import type { LoggerService } from "@src/core";
+import type { CreateLogger } from "@src/core";
 import { DrainingDeploymentRpcService } from "./draining-deployment-rpc.service";
 
 import { createAkashAddress } from "@test/seeders";
@@ -194,6 +194,12 @@ describe(DrainingDeploymentRpcService.name, () => {
     });
   });
 
+  it("creates the logger with the service context", () => {
+    const { createLogger } = setup();
+
+    expect(createLogger).toHaveBeenCalledWith({ context: DrainingDeploymentRpcService.name });
+  });
+
   function setup({
     inputs = []
   }: {
@@ -214,7 +220,8 @@ describe(DrainingDeploymentRpcService.name, () => {
   } = {}) {
     const leaseHttpService = mock<LeaseHttpService>();
     const deploymentHttpService = mock<DeploymentHttpService>();
-    const loggerService = mock<LoggerService>();
+    const loggerService = mock<ReturnType<CreateLogger>>();
+    const createLogger = vi.fn<CreateLogger>(() => loggerService);
 
     const owner = createAkashAddress();
     const closureHeight = 1000000;
@@ -276,13 +283,14 @@ describe(DrainingDeploymentRpcService.name, () => {
       pagination: { next_key: null, total: String(deploymentList.length) }
     } as unknown as DeploymentListResponse);
 
-    const service = new DrainingDeploymentRpcService(leaseHttpService, deploymentHttpService, loggerService);
+    const service = new DrainingDeploymentRpcService(leaseHttpService, deploymentHttpService, createLogger);
 
     return {
       service,
       leaseHttpService,
       deploymentHttpService,
       loggerService,
+      createLogger,
       owner,
       dseqs,
       closureHeight

--- a/apps/api/src/deployment/services/draining-deployment-rpc/draining-deployment-rpc.service.ts
+++ b/apps/api/src/deployment/services/draining-deployment-rpc/draining-deployment-rpc.service.ts
@@ -1,18 +1,20 @@
 import { DeploymentHttpService, LeaseHttpService, type RpcLease } from "@akashnetwork/http-sdk";
-import { singleton } from "tsyringe";
+import { inject, singleton } from "tsyringe";
 
-import { LoggerService } from "@src/core";
+import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
 import { DrainingDeploymentOutput } from "@src/deployment/repositories/lease/lease.repository";
 import { DrainingDeploymentLeaseSource, RpcDeploymentInfo } from "@src/deployment/types/draining-deployment";
 
 @singleton()
 export class DrainingDeploymentRpcService implements DrainingDeploymentLeaseSource {
+  private readonly loggerService: ReturnType<CreateLogger>;
+
   constructor(
     private readonly leaseHttpService: LeaseHttpService,
     private readonly deploymentHttpService: DeploymentHttpService,
-    private readonly loggerService: LoggerService
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
-    loggerService.setContext(DrainingDeploymentRpcService.name);
+    this.loggerService = createLogger({ context: DrainingDeploymentRpcService.name });
   }
 
   /**

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
@@ -11,7 +11,7 @@ import { mock } from "vitest-mock-extended";
 import type { UserWalletRepository } from "@src/billing/repositories";
 import type { BalancesService } from "@src/billing/services/balances/balances.service";
 import type { BlockHttpService } from "@src/chain/services/block-http/block-http.service";
-import type { LoggerService } from "@src/core";
+import type { CreateLogger } from "@src/core";
 import type { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import type { DrainingDeploymentOutput, LeaseRepository } from "@src/deployment/repositories/lease/lease.repository";
 import { averageBlockCountInAnHour } from "@src/utils/constants";
@@ -1090,6 +1090,12 @@ describe(DrainingDeploymentService.name, () => {
     }
   });
 
+  it("creates the logger with the service context", () => {
+    const { createLogger } = setup();
+
+    expect(createLogger).toHaveBeenCalledWith({ context: DrainingDeploymentService.name });
+  });
+
   function setup() {
     const currentHeight = 1000000;
 
@@ -1100,7 +1106,8 @@ describe(DrainingDeploymentService.name, () => {
     const userWalletRepository = mock<UserWalletRepository>();
     const deploymentSettingRepository = mock<DeploymentSettingRepository>();
     const rpcService = mock<DrainingDeploymentRpcService>();
-    const loggerService = mock<LoggerService>();
+    const loggerService = mock<ReturnType<CreateLogger>>();
+    const createLogger = vi.fn<CreateLogger>(() => loggerService);
     const balancesService = mock<BalancesService>();
 
     rpcService.findManyByDseqAndOwner.mockResolvedValue([]);
@@ -1118,7 +1125,7 @@ describe(DrainingDeploymentService.name, () => {
       userWalletRepository,
       deploymentSettingRepository,
       config,
-      loggerService,
+      createLogger,
       rpcService,
       balancesService,
       instrumentation
@@ -1132,6 +1139,7 @@ describe(DrainingDeploymentService.name, () => {
       deploymentSettingRepository,
       rpcService,
       loggerService,
+      createLogger,
       balancesService,
       config,
       currentHeight,

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
@@ -1,12 +1,12 @@
 import { AnyAbility } from "@casl/ability";
 import { millisecondsInHour } from "date-fns/constants";
 import keyBy from "lodash/keyBy";
-import { singleton } from "tsyringe";
+import { inject, singleton } from "tsyringe";
 
 import { UserWalletRepository } from "@src/billing/repositories";
 import { BalancesService } from "@src/billing/services/balances/balances.service";
 import { BlockHttpService } from "@src/chain/services/block-http/block-http.service";
-import { LoggerService } from "@src/core";
+import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
 import type { DryRunOptions } from "@src/core/types/console";
 import { AutoTopUpDeployment, DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import { DrainingDeploymentOutput, LeaseRepository } from "@src/deployment/repositories/lease/lease.repository";
@@ -26,18 +26,20 @@ export type WeeklyCoverage = {
 
 @singleton()
 export class DrainingDeploymentService {
+  private readonly loggerService: ReturnType<CreateLogger>;
+
   constructor(
     private readonly blockHttpService: BlockHttpService,
     private readonly leaseRepository: LeaseRepository,
     private readonly userWalletRepository: UserWalletRepository,
     private readonly deploymentSettingRepository: DeploymentSettingRepository,
     private readonly config: DeploymentConfigService,
-    private readonly loggerService: LoggerService,
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger,
     private readonly rpcService: DrainingDeploymentRpcService,
     private readonly balancesService: BalancesService,
     private readonly instrumentation: TopUpManagedDeploymentsInstrumentationService
   ) {
-    loggerService.setContext(DrainingDeploymentService.name);
+    this.loggerService = createLogger({ context: DrainingDeploymentService.name });
   }
 
   /**

--- a/apps/api/src/deployment/services/expired-deployments-closer/expired-deployments-closer.service.spec.ts
+++ b/apps/api/src/deployment/services/expired-deployments-closer/expired-deployments-closer.service.spec.ts
@@ -1,10 +1,10 @@
 import { faker } from "@faker-js/faker";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { UserWalletRepository } from "@src/billing/repositories";
 import type { ChainErrorService } from "@src/billing/services/chain-error/chain-error.service";
-import type { LoggerService } from "@src/core";
+import type { CreateLogger } from "@src/core";
 import type { DeploymentSettingRepository, ExpiredRuntimeDeployment } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import type { DeploymentWriterService } from "@src/deployment/services/deployment-writer/deployment-writer.service";
 import { ExpiredDeploymentsCloserService } from "./expired-deployments-closer.service";
@@ -94,12 +94,19 @@ describe(ExpiredDeploymentsCloserService.name, () => {
     };
   }
 
+  it("creates the logger with the service context", () => {
+    const { createLogger } = setup({ expired: [] });
+
+    expect(createLogger).toHaveBeenCalledWith({ context: ExpiredDeploymentsCloserService.name });
+  });
+
   function setup(input: { expired: ExpiredRuntimeDeployment[]; walletAddress?: string | null; closeError?: Error; isUnsettleable?: boolean }) {
     const deploymentSettingRepository = mock<DeploymentSettingRepository>();
     const userWalletRepository = mock<UserWalletRepository>();
     const deploymentWriterService = mock<DeploymentWriterService>();
     const chainErrorService = mock<ChainErrorService>();
-    const logger = mock<LoggerService>();
+    const logger = mock<ReturnType<CreateLogger>>();
+    const createLogger = vi.fn<CreateLogger>(() => logger);
 
     deploymentSettingRepository.findExpiredRuntimeDeployments.mockResolvedValue(input.expired);
     userWalletRepository.findById.mockImplementation(async walletId => {
@@ -115,8 +122,14 @@ describe(ExpiredDeploymentsCloserService.name, () => {
       deploymentWriterService.close.mockRejectedValue(input.closeError);
     }
 
-    const service = new ExpiredDeploymentsCloserService(deploymentSettingRepository, userWalletRepository, deploymentWriterService, chainErrorService, logger);
+    const service = new ExpiredDeploymentsCloserService(
+      deploymentSettingRepository,
+      userWalletRepository,
+      deploymentWriterService,
+      chainErrorService,
+      createLogger
+    );
 
-    return { service, deploymentSettingRepository, userWalletRepository, deploymentWriterService, chainErrorService, logger };
+    return { service, deploymentSettingRepository, userWalletRepository, deploymentWriterService, chainErrorService, logger, createLogger };
   }
 });

--- a/apps/api/src/deployment/services/expired-deployments-closer/expired-deployments-closer.service.ts
+++ b/apps/api/src/deployment/services/expired-deployments-closer/expired-deployments-closer.service.ts
@@ -1,9 +1,9 @@
 import { Err, Ok, Result } from "ts-results";
-import { singleton } from "tsyringe";
+import { inject, singleton } from "tsyringe";
 
 import { UserWalletRepository } from "@src/billing/repositories";
 import { ChainErrorService } from "@src/billing/services/chain-error/chain-error.service";
-import { LoggerService } from "@src/core";
+import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
 import type { DryRunOptions } from "@src/core/types/console";
 import { DeploymentSettingRepository, type ExpiredRuntimeDeployment } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import { DeploymentWriterService } from "@src/deployment/services/deployment-writer/deployment-writer.service";
@@ -22,14 +22,16 @@ import { DeploymentWriterService } from "@src/deployment/services/deployment-wri
  */
 @singleton()
 export class ExpiredDeploymentsCloserService {
+  private readonly logger: ReturnType<CreateLogger>;
+
   constructor(
     private readonly deploymentSettingRepository: DeploymentSettingRepository,
     private readonly userWalletRepository: UserWalletRepository,
     private readonly deploymentWriterService: DeploymentWriterService,
     private readonly chainErrorService: ChainErrorService,
-    private readonly logger: LoggerService
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
-    this.logger.setContext(ExpiredDeploymentsCloserService.name);
+    this.logger = createLogger({ context: ExpiredDeploymentsCloserService.name });
   }
 
   async closeExpiredDeployments({ dryRun }: DryRunOptions): Promise<Result<void, unknown[]>> {

--- a/apps/api/src/deployment/services/expiring-deployments-notifier/expiring-deployments-notifier.service.spec.ts
+++ b/apps/api/src/deployment/services/expiring-deployments-notifier/expiring-deployments-notifier.service.spec.ts
@@ -1,8 +1,8 @@
 import { faker } from "@faker-js/faker";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
-import type { LoggerService } from "@src/core";
+import type { CreateLogger } from "@src/core";
 import type { DeploymentSettingRepository, ExpiringRuntimeDeployment } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import type { DeploymentConfigService } from "@src/deployment/services/deployment-config/deployment-config.service";
 import type { NotificationService } from "@src/notifications/services/notification/notification.service";
@@ -134,6 +134,12 @@ describe(ExpiringDeploymentsNotifierService.name, () => {
     };
   }
 
+  it("creates the logger with the service context", () => {
+    const { createLogger } = setup({ expiring: [] });
+
+    expect(createLogger).toHaveBeenCalledWith({ context: ExpiringDeploymentsNotifierService.name });
+  });
+
   function setup(input: {
     expiring: ExpiringRuntimeDeployment | ExpiringRuntimeDeployment[];
     claimed?: boolean;
@@ -156,7 +162,8 @@ describe(ExpiringDeploymentsNotifierService.name, () => {
       RUNTIME_LIMIT_WARNING_MIN_LIMIT_IN_H: 12,
       DEPLOY_WEB_BASE_URL: "https://console.example.com"
     });
-    const logger = mock<LoggerService>();
+    const logger = mock<ReturnType<CreateLogger>>();
+    const createLogger = vi.fn<CreateLogger>(() => logger);
 
     deploymentSettingRepository.findExpiringRuntimeDeployments.mockResolvedValue(expiring);
     deploymentSettingRepository.claimRuntimeEndingNotification.mockResolvedValue(input.claimed ?? true);
@@ -171,8 +178,8 @@ describe(ExpiringDeploymentsNotifierService.name, () => {
       });
     }
 
-    const service = new ExpiringDeploymentsNotifierService(deploymentSettingRepository, userRepository, notificationService, config, logger);
+    const service = new ExpiringDeploymentsNotifierService(deploymentSettingRepository, userRepository, notificationService, config, createLogger);
 
-    return { service, deploymentSettingRepository, userRepository, notificationService, config, logger, expiring, users };
+    return { service, deploymentSettingRepository, userRepository, notificationService, config, logger, createLogger, expiring, users };
   }
 });

--- a/apps/api/src/deployment/services/expiring-deployments-notifier/expiring-deployments-notifier.service.ts
+++ b/apps/api/src/deployment/services/expiring-deployments-notifier/expiring-deployments-notifier.service.ts
@@ -1,7 +1,7 @@
 import { Err, Ok, Result } from "ts-results";
-import { singleton } from "tsyringe";
+import { inject, singleton } from "tsyringe";
 
-import { LoggerService } from "@src/core";
+import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
 import type { DryRunOptions } from "@src/core/types/console";
 import { DeploymentConfigService } from "@src/deployment/services/deployment-config/deployment-config.service";
 import { NotificationService } from "@src/notifications/services/notification/notification.service";
@@ -20,14 +20,16 @@ import { DeploymentSettingRepository, type ExpiringRuntimeDeployment } from "../
  */
 @singleton()
 export class ExpiringDeploymentsNotifierService {
+  private readonly logger: ReturnType<CreateLogger>;
+
   constructor(
     private readonly deploymentSettingRepository: DeploymentSettingRepository,
     private readonly userRepository: UserRepository,
     private readonly notificationService: NotificationService,
     private readonly config: DeploymentConfigService,
-    private readonly logger: LoggerService
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
-    this.logger.setContext(ExpiringDeploymentsNotifierService.name);
+    this.logger = createLogger({ context: ExpiringDeploymentsNotifierService.name });
   }
 
   async notifyExpiringDeployments({ dryRun }: DryRunOptions): Promise<Result<void, unknown[]>> {

--- a/apps/api/src/deployment/services/stale-managed-deployments-cleaner/stale-managed-deployments-cleaner.service.spec.ts
+++ b/apps/api/src/deployment/services/stale-managed-deployments-cleaner/stale-managed-deployments-cleaner.service.spec.ts
@@ -11,7 +11,7 @@ import { ChainErrorService } from "@src/billing/services/chain-error/chain-error
 import type { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
 import type { TxManagerService } from "@src/billing/services/tx-manager/tx-manager.service";
 import type { BlockRepository } from "@src/chain/repositories/block.repository";
-import type { CreateLogger, LoggerService } from "@src/core/providers/logging.provider";
+import type { CreateLogger } from "@src/core/providers/logging.provider";
 import { ErrorService } from "@src/core/services/error/error.service";
 import type { DeploymentRepository } from "@src/deployment/repositories/deployment/deployment.repository";
 import { StaleManagedDeploymentsCleanerService } from "./stale-managed-deployments-cleaner.service";
@@ -118,6 +118,12 @@ describe(StaleManagedDeploymentsCleanerService.name, () => {
     return createError(400, "Deployment escrow cannot be settled yet", { originalError: new Error(UNSETTLEABLE_PANIC) });
   }
 
+  it("creates the logger with the service context", () => {
+    const { createLogger } = setup();
+
+    expect(createLogger).toHaveBeenCalledWith({ context: StaleManagedDeploymentsCleanerService.name });
+  });
+
   it("creates the error service logger with the service context", () => {
     const { createErrorLogger } = setup();
 
@@ -140,7 +146,8 @@ describe(StaleManagedDeploymentsCleanerService.name, () => {
     });
     const managedUserWalletService = mock<ManagedUserWalletService>();
     const config = mock<BillingConfig>({ FEE_ALLOWANCE_REFILL_AMOUNT: 1000 });
-    const logger = mock<LoggerService>();
+    const logger = mock<ReturnType<CreateLogger>>();
+    const createLogger = vi.fn<CreateLogger>(() => logger);
     const errorLogger = mock<ReturnType<CreateLogger>>();
     const createErrorLogger = vi.fn<CreateLogger>(() => errorLogger);
     const errorService = new ErrorService(createErrorLogger);
@@ -159,7 +166,7 @@ describe(StaleManagedDeploymentsCleanerService.name, () => {
       managedUserWalletService,
       errorService,
       chainErrorService,
-      logger
+      createLogger
     );
 
     return {
@@ -173,6 +180,7 @@ describe(StaleManagedDeploymentsCleanerService.name, () => {
       managedUserWalletService,
       chainErrorService,
       logger,
+      createLogger,
       errorLogger,
       createErrorLogger
     };

--- a/apps/api/src/deployment/services/stale-managed-deployments-cleaner/stale-managed-deployments-cleaner.service.spec.ts
+++ b/apps/api/src/deployment/services/stale-managed-deployments-cleaner/stale-managed-deployments-cleaner.service.spec.ts
@@ -11,7 +11,7 @@ import { ChainErrorService } from "@src/billing/services/chain-error/chain-error
 import type { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
 import type { TxManagerService } from "@src/billing/services/tx-manager/tx-manager.service";
 import type { BlockRepository } from "@src/chain/repositories/block.repository";
-import type { LoggerService } from "@src/core/providers/logging.provider";
+import type { CreateLogger, LoggerService } from "@src/core/providers/logging.provider";
 import { ErrorService } from "@src/core/services/error/error.service";
 import type { DeploymentRepository } from "@src/deployment/repositories/deployment/deployment.repository";
 import { StaleManagedDeploymentsCleanerService } from "./stale-managed-deployments-cleaner.service";
@@ -118,6 +118,12 @@ describe(StaleManagedDeploymentsCleanerService.name, () => {
     return createError(400, "Deployment escrow cannot be settled yet", { originalError: new Error(UNSETTLEABLE_PANIC) });
   }
 
+  it("creates the error service logger with the service context", () => {
+    const { createErrorLogger } = setup();
+
+    expect(createErrorLogger).toHaveBeenCalledWith({ context: ErrorService.name });
+  });
+
   function setup(input?: { currentHeight?: number; staleDeployments?: { dseq: number }[]; executeDerivedTx?: ManagedSignerService["executeDerivedTx"] }) {
     const wallet = createUserWallet({ id: 123, address: "akash1test" });
 
@@ -135,8 +141,9 @@ describe(StaleManagedDeploymentsCleanerService.name, () => {
     const managedUserWalletService = mock<ManagedUserWalletService>();
     const config = mock<BillingConfig>({ FEE_ALLOWANCE_REFILL_AMOUNT: 1000 });
     const logger = mock<LoggerService>();
-    const errorLogger = mock<LoggerService>();
-    const errorService = new ErrorService(errorLogger);
+    const errorLogger = mock<ReturnType<CreateLogger>>();
+    const createErrorLogger = vi.fn<CreateLogger>(() => errorLogger);
+    const errorService = new ErrorService(createErrorLogger);
     const chainErrorService = new ChainErrorService(mock<BalanceHttpService>(), mock<BillingConfigService>(), mock<TxManagerService>());
 
     blockRepository.getLatestProcessedHeight.mockResolvedValue(input?.currentHeight ?? 1_000_000);
@@ -166,7 +173,8 @@ describe(StaleManagedDeploymentsCleanerService.name, () => {
       managedUserWalletService,
       chainErrorService,
       logger,
-      errorLogger
+      errorLogger,
+      createErrorLogger
     };
   }
 });

--- a/apps/api/src/deployment/services/stale-managed-deployments-cleaner/stale-managed-deployments-cleaner.service.ts
+++ b/apps/api/src/deployment/services/stale-managed-deployments-cleaner/stale-managed-deployments-cleaner.service.ts
@@ -1,6 +1,6 @@
 import type { EncodeObject } from "@cosmjs/proto-signing";
 import { secondsInMinute } from "date-fns/constants";
-import { singleton } from "tsyringe";
+import { inject, singleton } from "tsyringe";
 
 import { type BillingConfig, InjectBillingConfig } from "@src/billing/providers";
 import { UserWalletOutput, UserWalletRepository } from "@src/billing/repositories";
@@ -8,7 +8,7 @@ import { ManagedUserWalletService, RpcMessageService } from "@src/billing/servic
 import { ChainErrorService } from "@src/billing/services/chain-error/chain-error.service";
 import { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
 import { BlockRepository } from "@src/chain/repositories/block.repository";
-import { LoggerService } from "@src/core";
+import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
 import { ErrorService } from "@src/core/services/error/error.service";
 import { DeploymentRepository } from "@src/deployment/repositories/deployment/deployment.repository";
 import { CleanUpStaleDeploymentsParams } from "@src/deployment/types/state-deployments";
@@ -17,6 +17,8 @@ import { averageBlockTime } from "@src/utils/constants";
 @singleton()
 export class StaleManagedDeploymentsCleanerService {
   private readonly MAX_LIVE_BLOCKS = Math.floor((10 * secondsInMinute) / averageBlockTime);
+
+  private readonly logger: ReturnType<CreateLogger>;
 
   constructor(
     private readonly userWalletRepository: UserWalletRepository,
@@ -28,9 +30,9 @@ export class StaleManagedDeploymentsCleanerService {
     private readonly managedUserWalletService: ManagedUserWalletService,
     private readonly errorService: ErrorService,
     private readonly chainErrorService: ChainErrorService,
-    private readonly logger: LoggerService
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
-    this.logger.setContext(StaleManagedDeploymentsCleanerService.name);
+    this.logger = createLogger({ context: StaleManagedDeploymentsCleanerService.name });
   }
 
   async cleanup(options: CleanUpStaleDeploymentsParams) {

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.spec.ts
@@ -2,10 +2,10 @@ import "@test/mocks/logger-service.mock";
 
 import { faker } from "@faker-js/faker";
 import type { Counter } from "@opentelemetry/api";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
-import type { LoggerService, MetricsService } from "@src/core";
+import type { CreateLogger, MetricsService } from "@src/core";
 import { TopUpSummarizer } from "@src/deployment/lib/top-up-summarizer/top-up-summarizer";
 import type { DrainingDeployment } from "@src/deployment/types/draining-deployment";
 import { TopUpManagedDeploymentsInstrumentationService } from "./top-up-managed-deployments-instrumentation.service";
@@ -217,6 +217,12 @@ describe(TopUpManagedDeploymentsInstrumentationService.name, () => {
     };
   }
 
+  it("creates the logger with the service context", () => {
+    const { createLogger } = setup();
+
+    expect(createLogger).toHaveBeenCalledWith({ context: TopUpManagedDeploymentsInstrumentationService.name });
+  });
+
   function setup() {
     const countersByName: Record<string, Counter> = {};
     const metricsService = mock<MetricsService>();
@@ -229,10 +235,11 @@ describe(TopUpManagedDeploymentsInstrumentationService.name, () => {
     metricsService.createHistogram.mockReturnValue(mock());
 
     const summarizer = new TopUpSummarizer();
-    const logger = mock<LoggerService>();
+    const logger = mock<ReturnType<CreateLogger>>();
+    const createLogger = vi.fn<CreateLogger>(() => logger);
 
-    const service = new TopUpManagedDeploymentsInstrumentationService(metricsService, summarizer, logger);
+    const service = new TopUpManagedDeploymentsInstrumentationService(metricsService, summarizer, createLogger);
 
-    return { service, metricsService, countersByName, summarizer, logger };
+    return { service, metricsService, countersByName, summarizer, logger, createLogger };
   }
 });

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.ts
@@ -1,8 +1,8 @@
 import type { Counter, Histogram, Meter } from "@opentelemetry/api";
-import { Lifecycle, scoped } from "tsyringe";
+import { inject, Lifecycle, scoped } from "tsyringe";
 
 import { DepositDeploymentMsgOptions } from "@src/billing/services";
-import { LoggerService, MetricsService } from "@src/core";
+import { type CreateLogger, LOGGER_FACTORY, MetricsService } from "@src/core";
 import type { DryRunOptions } from "@src/core/types/console";
 import { TopUpSummarizer } from "@src/deployment/lib/top-up-summarizer/top-up-summarizer";
 import { DrainingDeployment } from "@src/deployment/types/draining-deployment";
@@ -21,15 +21,16 @@ export class TopUpManagedDeploymentsInstrumentationService implements Deployment
   private readonly predictedCloseBlocks: Histogram;
   private readonly insufficientBalanceWithAutoReload: Counter;
   private readonly settingToggles: Counter;
+  private readonly logger: ReturnType<CreateLogger>;
   private startTime: number | undefined;
   private options: DryRunOptions | undefined;
 
   constructor(
     private readonly metricsService: MetricsService,
     private readonly topUpSummarizer: TopUpSummarizer,
-    private readonly logger: LoggerService
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
-    this.logger.setContext(TopUpManagedDeploymentsInstrumentationService.name);
+    this.logger = createLogger({ context: TopUpManagedDeploymentsInstrumentationService.name });
 
     this.meter = this.metricsService.getMeter("auto-top-up", "1.0.0");
 

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
@@ -3,7 +3,7 @@ import "@test/mocks/logger-service.mock";
 import { Scope, Source } from "@akashnetwork/chain-sdk/private-types/akash.v1";
 import type { IndexedTx } from "@cosmjs/stargate";
 import { faker } from "@faker-js/faker";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import { WalletBalanceReloadCheck } from "@src/billing/events/wallet-balance-reload-check";
@@ -16,7 +16,7 @@ import type { ManagedSignerService } from "@src/billing/services/managed-signer/
 import { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
 import type { BlockHttpService } from "@src/chain/services/block-http/block-http.service";
 import type { JobQueueService } from "@src/core";
-import type { LoggerService } from "@src/core/providers/logging.provider";
+import type { CreateLogger } from "@src/core/providers/logging.provider";
 import type { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import type { DeploymentConfigService } from "@src/deployment/services/deployment-config/deployment-config.service";
 import type { DrainingDeployment, DrainingDeploymentService } from "@src/deployment/services/draining-deployment/draining-deployment.service";
@@ -1001,9 +1001,10 @@ describe(TopUpManagedDeploymentsService.name, () => {
     const walletSettingRepository = mock<WalletSettingRepository>();
     const userWalletRepository = mock<UserWalletRepository>();
     const jobQueueService = mock<JobQueueService>();
-    const logger = mock<LoggerService>();
+    const logger = mock<ReturnType<CreateLogger>>();
+    const createLogger = vi.fn<CreateLogger>(() => logger);
     jobQueueService.enqueue.mockResolvedValue(faker.string.uuid());
-    const walletReloadService = new WalletReloadJobService(walletSettingRepository, userWalletRepository, jobQueueService, logger);
+    const walletReloadService = new WalletReloadJobService(walletSettingRepository, userWalletRepository, jobQueueService, createLogger);
 
     return {
       ...setup({ ...input, walletReloadService }),


### PR DESCRIPTION
## Why

Part of CON-905

`LoggerService` in `apps/api/src/core/providers/logging.provider.ts` has been marked
`@deprecated use LOGGER_FACTORY token instead` for a while, and 50 services across
`apps/api` were still injecting it. This PR converts `core`, `app`, `deployment` and `billing` to the `LOGGER_FACTORY`
pattern, as three reviewable commits.

Eleven services in `apps/api/src` were already migrated, so this follows an
established in-repo pattern rather than introducing one. The designated reference is
`apps/api/src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service.ts`.

The `LoggerService` class itself is removed in the follow-up PR, once every caller is
converted. Splitting that way means `main` never has a state where the class is gone
while callers still reference it.

## What

Per service:

```diff
-import { LoggerService } from "@src/core";
+import { type CreateLogger, LOGGER_FACTORY } from "@src/core";

-    private readonly logger: LoggerService
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
+  private readonly logger: ReturnType<CreateLogger>;
-    this.logger.setContext(MyService.name);
+    this.logger = createLogger({ context: MyService.name });
```

Existing logger member names and `private readonly` / `#private` styles were kept per
file, so method bodies stay out of the diff entirely.

### Behavioural change: one additive log field

`createOtelLogger({ context })` is byte-identical to the deprecated class plus
`setContext()` — same `mixin: collectOtel`, same level, formatters, serializers and
timestamp. Verified in `packages/logging`: `initPino()` sets `mixin: LoggerService.mixin`
but then spreads `...additionalOptions` after it, so the instance mixin wins; and
`options.context` routes through the same `setContext()` -> `pino.child({ context })` path.

20 of the converted services already called `setContext(X.name)`, so their output is
unchanged. The rest previously logged with **no `context` field** and now gain one:

```
{"level":"info","time":"...","pid":...,"event":"BEFORE_no_context_field"}
{"level":"info","time":"...","pid":...,"context":"DeploymentWriterService","event":"AFTER_context_field_present"}
```

This is purely additive — no field renamed or removed, no level change — so alerts keyed
on `event` are unaffected. Dashboards grouping by `context` will see new buckets.

### Tests

Spec doubles follow the already-migrated specs, with one addition: the stub is a
`vi.fn<CreateLogger>` so the context string is actually asserted.

```ts
const logger = mock<ReturnType<CreateLogger>>();
const createLogger = vi.fn<CreateLogger>(() => logger);
// ...
expect(createLogger).toHaveBeenCalledWith({ context: MyService.name });
```

Without this, nothing could observe a context string, and because every context is a
`string`, `tsc` cannot catch a wrong one either — a copy-pasted context would mislabel
every log line from a service and pass CI. Each slice was mutation-tested by
deliberately mislabelling one context and confirming the assertion fails.

Assertion bodies are otherwise unchanged. `expect(logger.error).toHaveBeenCalledWith(...)`
assertions are byte-identical to before; only how the double is built changed.

### Validation

`apps/api`, per slice and on the final tree:

| Check | Result |
|---|---|
| `npm run lint -- --quiet` | exit 0 |
| `npx tsc -p tsconfig.build.json` | 0 errors |
| `npx tsc --noEmit` | 40 errors, identical to the pre-existing baseline on `main` |
| `npm test` (unit + functional + integration) | 216 files / 2351 tests passed |

Test count rose from 2322 to 2351; the +29 are the new context assertions.

`npx tsc --noEmit` is already red on `main` (40 errors, all in `.spec.ts` / config files).
That baseline was captured before any edit and is unchanged by this PR. The typecheck CI
actually runs is `tsc -p tsconfig.build.json`, which is green.

No endpoint, UI, CLI, or migration changes, so there is nothing to demo beyond the log
shape shown above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved log organization across billing, deployment, trial, event, and payment-processing services.
  - Log messages now include clearer service-specific context, making operational events and errors easier to identify and troubleshoot.
  - Existing processing, deployment, wallet, and notification behavior remains unchanged.

- **Tests**
  - Expanded automated coverage to verify that service and handler logs use the correct context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->