### PR TITLE
fix(deployment): skip a deposit too small to outlast the funding cooldown

### DIFF
--- a/apps/api/src/deployment/lib/top-up-summarizer/top-up-summarizer.spec.ts
+++ b/apps/api/src/deployment/lib/top-up-summarizer/top-up-summarizer.spec.ts
@@ -129,6 +129,7 @@ describe(TopUpSummarizer.name, () => {
       summarizer.inc("deploymentTopUpCount");
       summarizer.inc("deploymentTopUpErrorCount");
       summarizer.inc("insufficientBalanceCount");
+      summarizer.inc("depositsBelowUsefulRunwayCount");
       summarizer.set("startBlockHeight", 1000);
       summarizer.set("endBlockHeight", 2000);
       summarizer.ensurePredictedClosedHeight(1500);
@@ -145,6 +146,7 @@ describe(TopUpSummarizer.name, () => {
         deploymentTopUpErrorCount: 1,
         deploymentsMarkedClosedCount: 0,
         insufficientBalanceCount: 1,
+        depositsBelowUsefulRunwayCount: 1,
         walletsCount: 2,
         walletsTopUpCount: 1,
         walletsTopUpErrorCount: 1,
@@ -163,6 +165,7 @@ describe(TopUpSummarizer.name, () => {
         deploymentTopUpErrorCount: 0,
         deploymentsMarkedClosedCount: 0,
         insufficientBalanceCount: 0,
+        depositsBelowUsefulRunwayCount: 0,
         walletsCount: 0,
         walletsTopUpCount: 0,
         walletsTopUpErrorCount: 0,

--- a/apps/api/src/deployment/lib/top-up-summarizer/top-up-summarizer.ts
+++ b/apps/api/src/deployment/lib/top-up-summarizer/top-up-summarizer.ts
@@ -6,6 +6,7 @@ interface TopUpSummary {
   deploymentTopUpErrorCount: number;
   deploymentsMarkedClosedCount: number;
   insufficientBalanceCount: number;
+  depositsBelowUsefulRunwayCount: number;
   walletsCount: number;
   walletsTopUpCount: number;
   walletsTopUpErrorCount: number;
@@ -23,6 +24,8 @@ export class TopUpSummarizer {
   private deploymentTopUpCount = 0;
 
   private insufficientBalanceCount = 0;
+
+  private depositsBelowUsefulRunwayCount = 0;
 
   private deploymentTopUpErrorCount = 0;
 
@@ -47,7 +50,12 @@ export class TopUpSummarizer {
   inc(
     param: keyof Pick<
       TopUpSummary,
-      "deploymentCount" | "deploymentTopUpCount" | "deploymentTopUpErrorCount" | "deploymentsMarkedClosedCount" | "insufficientBalanceCount"
+      | "deploymentCount"
+      | "deploymentTopUpCount"
+      | "deploymentTopUpErrorCount"
+      | "deploymentsMarkedClosedCount"
+      | "insufficientBalanceCount"
+      | "depositsBelowUsefulRunwayCount"
     >,
     value = 1
   ) {
@@ -106,6 +114,7 @@ export class TopUpSummarizer {
       deploymentTopUpErrorCount: this.deploymentTopUpErrorCount,
       deploymentsMarkedClosedCount: this.deploymentsMarkedClosedCount,
       insufficientBalanceCount: this.insufficientBalanceCount,
+      depositsBelowUsefulRunwayCount: this.depositsBelowUsefulRunwayCount,
       walletsCount: this.walletAddresses.size,
       walletsTopUpCount: this.successfulWalletAddresses.size,
       walletsTopUpErrorCount: this.failedWalletAddresses.size,

--- a/apps/api/src/deployment/services/cached-balance/cached-balance.service.spec.ts
+++ b/apps/api/src/deployment/services/cached-balance/cached-balance.service.spec.ts
@@ -76,6 +76,20 @@ describe(CachedBalanceService.name, () => {
       expect(amount).toBe(1000);
     });
 
+    it("previews the amount a reservation would hand out without spending it", async () => {
+      const { service, balancesService } = setup();
+      balancesService.getFreshLimits.mockResolvedValue({
+        deployment: DEPLOYMENT_LIMIT,
+        fee: 100
+      });
+
+      const balance = await service.get(address);
+
+      expect(balance.previewSufficientAmount(1500)).toBe(1000);
+      expect(balance.previewSufficientAmount(400)).toBe(400);
+      expect(balance.spendable).toBe(1000);
+    });
+
     it("throws when trying to reserve a zero or negative amount", async () => {
       const { service, balancesService } = setup();
       balancesService.getFreshLimits.mockResolvedValue({

--- a/apps/api/src/deployment/services/cached-balance/cached-balance.service.ts
+++ b/apps/api/src/deployment/services/cached-balance/cached-balance.service.ts
@@ -34,8 +34,16 @@ export class CachedBalance {
     return this.#headroomWaived;
   }
 
+  /**
+   * What `reserveSufficientAmount` would hand out, without taking it, so a caller can decline a deposit
+   * before the allowance is spoken for and leave it to the rest of the owner's batch.
+   */
+  public previewSufficientAmount(desiredAmount: number) {
+    return Math.min(desiredAmount, this.#spendable);
+  }
+
   public reserveSufficientAmount(desiredAmount: number) {
-    const value = Math.min(desiredAmount, this.#spendable);
+    const value = this.previewSufficientAmount(desiredAmount);
 
     if (value <= 0) {
       throw new Error(`Insufficient balance: ${this.#spendable} < ${desiredAmount}`);

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
@@ -3,7 +3,7 @@ import "@test/mocks/logger-service.mock";
 import type { AnyAbility } from "@casl/ability";
 import { faker } from "@faker-js/faker";
 import { addWeeks } from "date-fns";
-import { millisecondsInHour } from "date-fns/constants";
+import { millisecondsInHour, minutesInHour } from "date-fns/constants";
 import { groupBy } from "lodash";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
@@ -514,6 +514,61 @@ describe(DrainingDeploymentService.name, () => {
       } finally {
         vi.useRealTimers();
       }
+    });
+  });
+
+  describe("calculateRunwayMinutesAfterDeposit", () => {
+    it("adds the runway a deposit buys to the runway the escrow already covers", () => {
+      const { service, currentHeight } = setup();
+
+      const result = service.calculateRunwayMinutesAfterDeposit(
+        { blockRate: 50, predictedClosedHeight: currentHeight + averageBlockCountInAnHour * 2 },
+        50 * averageBlockCountInAnHour * 3,
+        currentHeight
+      );
+
+      expect(result).toBe(5 * minutesInHour);
+    });
+
+    it("counts only what the deposit buys for a deployment already in arrears", () => {
+      const { service, currentHeight } = setup();
+
+      const result = service.calculateRunwayMinutesAfterDeposit(
+        { blockRate: 50, predictedClosedHeight: currentHeight - averageBlockCountInAnHour * 10 },
+        50 * averageBlockCountInAnHour,
+        currentHeight
+      );
+
+      expect(result).toBe(minutesInHour);
+    });
+
+    it("reports the runway the escrow still covers when nothing is deposited", () => {
+      const { service, currentHeight } = setup();
+
+      const result = service.calculateRunwayMinutesAfterDeposit(
+        { blockRate: 50, predictedClosedHeight: currentHeight + averageBlockCountInAnHour },
+        0,
+        currentHeight
+      );
+
+      expect(result).toBe(minutesInHour);
+    });
+
+    it("returns 0 for a non-positive block rate", () => {
+      const { service, currentHeight } = setup();
+
+      expect(service.calculateRunwayMinutesAfterDeposit({ blockRate: 0, predictedClosedHeight: currentHeight }, 1000, currentHeight)).toBe(0);
+      expect(service.calculateRunwayMinutesAfterDeposit({ blockRate: -5, predictedClosedHeight: currentHeight }, 1000, currentHeight)).toBe(0);
+    });
+
+    it("returns 0 rather than NaN when the predicted close height is missing", () => {
+      const { service, currentHeight } = setup();
+      const withoutPredictedCloseHeight = { blockRate: 50, predictedClosedHeight: undefined } as unknown as Pick<
+        DrainingDeploymentOutput,
+        "blockRate" | "predictedClosedHeight"
+      >;
+
+      expect(service.calculateRunwayMinutesAfterDeposit(withoutPredictedCloseHeight, 1000, currentHeight)).toBe(0);
     });
   });
 

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
@@ -1,5 +1,5 @@
 import { AnyAbility } from "@casl/ability";
-import { millisecondsInHour } from "date-fns/constants";
+import { millisecondsInHour, minutesInHour } from "date-fns/constants";
 import keyBy from "lodash/keyBy";
 import { singleton } from "tsyringe";
 
@@ -260,6 +260,35 @@ export class DrainingDeploymentService {
     const fundedUntil = Math.max(currentHeight, predictedClosedHeight);
 
     return Math.max(0, Math.floor(blockRate * (targetHeight - fundedUntil)));
+  }
+
+  /**
+   * Minutes of runway a deployment holds once a deposit of `amount` lands, counting the runway its escrow
+   * already covers. Shares `calculateAmountToTargetRunway`'s funded-until floor, so a deployment already
+   * in arrears is credited only the runway the deposit itself buys.
+   *
+   * @param deployment - Deployment with its block rate and predicted closure height
+   * @param amount - Deposit amount in credits
+   * @param currentHeight - Block height the funding run is scoped to
+   * @returns Minutes of runway after the deposit, or 0 when the deployment's block rate is unusable
+   */
+  calculateRunwayMinutesAfterDeposit(
+    deployment: Pick<DrainingDeploymentOutput, "blockRate" | "predictedClosedHeight">,
+    amount: number,
+    currentHeight: number
+  ): number {
+    const blockRate = Number(deployment.blockRate);
+    const predictedClosedHeight = Number(deployment.predictedClosedHeight);
+    const isUsable = Number.isFinite(blockRate) && blockRate > 0 && Number.isFinite(predictedClosedHeight);
+
+    if (!isUsable) {
+      return 0;
+    }
+
+    const fundedUntil = Math.max(currentHeight, predictedClosedHeight);
+    const runwayBlocks = fundedUntil - currentHeight + amount / blockRate;
+
+    return (runwayBlocks / averageBlockCountInAnHour) * minutesInHour;
   }
 
   /**

--- a/apps/api/src/deployment/services/top-up-managed-deployments/deployment-top-up-instrumentation.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/deployment-top-up-instrumentation.ts
@@ -13,6 +13,7 @@ export interface DeploymentTopUpInstrumentation {
   recordDeploymentPreparation(ownerAddress: string, predictedClosedHeight: number): void;
   recordInvalidDepositAmount(details: { desiredAmount: number; dseq: string; address: string; blockRate: number }): void;
   recordRuntimeLimitReached(details: { dseq: string; address: string; runtimeEndsAt: Date }): void;
+  recordDepositBelowUsefulRunway(details: { dseq: string; address: string; desiredAmount: number; affordableAmount: number; runwayMinutes: number }): void;
   recordMessagePreparationError(details: { deployment: DrainingDeployment; error: unknown }): void;
   recordSkipped(details: { owner: string; deploymentCount: number }): void;
   recordDeposit(details: { owner: string; items: FundingMessageItem[] }): void;

--- a/apps/api/src/deployment/services/top-up-managed-deployments/fund-draining-deployments-instrumentation.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/fund-draining-deployments-instrumentation.service.ts
@@ -8,7 +8,7 @@ import type { DeploymentTopUpInstrumentation, FundingMessageItem } from "./deplo
 
 export type FundDrainingFailureReason = "master_wallet_insufficient_funds" | "deposit_tx_failed" | "unknown";
 
-export type FundDrainingSkipReason = "nothing_to_fund" | "non_positive_amount" | "runtime_limit_reached";
+export type FundDrainingSkipReason = "nothing_to_fund" | "non_positive_amount" | "runtime_limit_reached" | "below_useful_runway";
 
 export function classifyFailure(error: unknown): FundDrainingFailureReason {
   if (!(error instanceof Error)) {
@@ -138,6 +138,11 @@ export class FundDrainingDeploymentsInstrumentationService implements Deployment
   recordRuntimeLimitReached(details: { dseq: string; address: string; runtimeEndsAt: Date }): void {
     this.skips.add(1, { reason: "runtime_limit_reached" satisfies FundDrainingSkipReason });
     this.emitLog("info", { event: "FUND_DRAINING_RUNTIME_LIMIT_REACHED", ...details });
+  }
+
+  recordDepositBelowUsefulRunway(details: { dseq: string; address: string; desiredAmount: number; affordableAmount: number; runwayMinutes: number }): void {
+    this.skips.add(1, { reason: "below_useful_runway" satisfies FundDrainingSkipReason });
+    this.emitLog("warn", { event: "FUND_DRAINING_DEPOSIT_BELOW_USEFUL_RUNWAY", ...details });
   }
 
   recordMessagePreparationError({ deployment, error }: { deployment: DrainingDeployment; error: unknown }): void {

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.ts
@@ -20,6 +20,7 @@ export class TopUpManagedDeploymentsInstrumentationService implements Deployment
   private readonly depositAmount: Histogram;
   private readonly predictedCloseBlocks: Histogram;
   private readonly insufficientBalanceWithAutoReload: Counter;
+  private readonly depositsBelowUsefulRunway: Counter;
   private readonly settingToggles: Counter;
   private startTime: number | undefined;
   private options: DryRunOptions | undefined;
@@ -69,6 +70,10 @@ export class TopUpManagedDeploymentsInstrumentationService implements Deployment
 
     this.insufficientBalanceWithAutoReload = this.metricsService.createCounter(this.meter, "auto_top_up_insufficient_balance_with_auto_reload_total", {
       description: "Total number of insufficient balance errors where wallet auto-reload is enabled"
+    });
+
+    this.depositsBelowUsefulRunway = this.metricsService.createCounter(this.meter, "auto_top_up_deposits_below_useful_runway_total", {
+      description: "Total number of deposits declined because the credits available bought less runway than the dedup cooldown"
     });
 
     this.settingToggles = this.metricsService.createCounter(this.meter, "auto_top_up_setting_toggles_total", {
@@ -190,6 +195,20 @@ export class TopUpManagedDeploymentsInstrumentationService implements Deployment
         this.messagePreparationErrors.add(1, { error_type: "unknown" });
       });
     }
+  }
+
+  recordDepositBelowUsefulRunway(details: { dseq: string; address: string; desiredAmount: number; affordableAmount: number; runwayMinutes: number }): void {
+    this.topUpSummarizer.inc("depositsBelowUsefulRunwayCount");
+
+    this.logger.warn({
+      event: "DEPOSIT_BELOW_USEFUL_RUNWAY",
+      ...details,
+      dryRun: this.options?.dryRun
+    });
+
+    this.execWhenEnabled(() => {
+      this.depositsBelowUsefulRunway.add(1);
+    });
   }
 
   recordDeploymentsMarkedClosed(count: number): void {

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.integration.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.integration.ts
@@ -448,6 +448,30 @@ describe(TopUpManagedDeploymentsService.name, () => {
       expect(executeDerivedTx).toHaveBeenCalledOnce();
     });
 
+    it("declines a dust deposit the allowance caps below the cooldown, then funds in full once credits arrive", async () => {
+      const { topUpService, executeDerivedTx, createUserWithWallet, createDeploymentSetting, mockLeasesForOwner, mockDeploymentsForOwner, stubGetFreshLimits } =
+        await setup();
+      const { user, wallet, address } = await createUserWithWallet();
+      const dseq = "830001";
+      /** Buys 40 minutes at the seeded block rate, short of the 60-minute dedup cooldown. */
+      const DUST_ALLOWANCE = 20000;
+
+      await createDeploymentSetting(user.id, dseq);
+      mockLeasesForOwner(address, [createActiveLease(address, dseq)], { persist: true });
+      mockDeploymentsForOwner(address, [createActiveDeployment(address, dseq)], { persist: true });
+
+      stubGetFreshLimits({ [address]: DUST_ALLOWANCE });
+      await topUpService.topUpDrainingDeploymentsForOwner({ walletId: wallet.id, address });
+
+      expect(executeDerivedTx).not.toHaveBeenCalled();
+
+      stubGetFreshLimits({ [address]: 10000000 });
+      await topUpService.topUpDrainingDeploymentsForOwner({ walletId: wallet.id, address });
+
+      expect(executeDerivedTx).toHaveBeenCalledOnce();
+      expect(depositedAmounts(executeDerivedTx)).toEqual([BLOCK_RATE * averageBlockCountInAnHour * 48]);
+    });
+
     it("releases the claim of a deposit that landed with a non-OK code so the next pass funds it", async () => {
       const { topUpService, executeDerivedTx, createUserWithWallet, createDeploymentSetting, mockLeasesForOwner, mockDeploymentsForOwner, stubGetFreshLimits } =
         await setup();

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
@@ -21,7 +21,7 @@ import type { DeploymentSettingRepository } from "@src/deployment/repositories/d
 import type { DeploymentConfigService } from "@src/deployment/services/deployment-config/deployment-config.service";
 import type { DrainingDeployment, DrainingDeploymentService } from "@src/deployment/services/draining-deployment/draining-deployment.service";
 import { mockConfigService } from "../../../../test/mocks/config-service.mock";
-import type { CachedBalance, CachedBalanceService } from "../cached-balance/cached-balance.service";
+import { CachedBalance, type CachedBalanceService } from "../cached-balance/cached-balance.service";
 import type { FundDrainingDeploymentsInstrumentationService } from "./fund-draining-deployments-instrumentation.service";
 import { TopUpManagedDeploymentsService } from "./top-up-managed-deployments.service";
 import type { TopUpManagedDeploymentsInstrumentationService } from "./top-up-managed-deployments-instrumentation.service";
@@ -36,14 +36,27 @@ describe(TopUpManagedDeploymentsService.name, () => {
   const CURRENT_BLOCK_HEIGHT = 7481457;
   const CLAIMED_AT = "2026-08-19 06:24:27.123456";
   const SUFFICIENT_FEE_ALLOWANCE = 100001;
+  const DEDUP_COOLDOWN_IN_MIN = 60;
+  /** A deposit that reaches the 48h target runway, so it is never declined for being too small to outlast the cooldown. */
+  const RUNWAY_MINUTES_AT_TARGET = 48 * 60;
 
   function createFundingClaim(id: string) {
     return { id, claimedAt: CLAIMED_AT };
   }
 
-  function createMockCachedBalance(reserveSufficientAmount: (desiredAmount: number) => number) {
+  /** Mirrors `CachedBalance`: one allowance answers both the preview and the reservation, and reserving nothing throws. */
+  function createMockCachedBalance(affordableAmount: (desiredAmount: number) => number) {
     const balance = mock<CachedBalance>();
-    balance.reserveSufficientAmount.mockImplementation(reserveSufficientAmount);
+    balance.previewSufficientAmount.mockImplementation(affordableAmount);
+    balance.reserveSufficientAmount.mockImplementation(desiredAmount => {
+      const amount = affordableAmount(desiredAmount);
+
+      if (amount <= 0) {
+        throw new Error(`Insufficient balance: ${amount} < ${desiredAmount}`);
+      }
+
+      return amount;
+    });
     return balance;
   }
 
@@ -736,12 +749,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
       const owner = createAkashAddress();
       const walletId = faker.number.int({ min: 1000000, max: 9999999 });
       const deployment = createDrainingFor(owner, walletId);
-      const balance = createMockCachedBalance(desiredAmount => {
-        if (desiredAmount <= 0) {
-          throw new Error(`Insufficient balance: 1000000 < ${desiredAmount}`);
-        }
-        return desiredAmount;
-      });
+      const balance = createMockCachedBalance(desiredAmount => desiredAmount);
 
       drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([deployment]);
       drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(0);
@@ -756,6 +764,126 @@ describe(TopUpManagedDeploymentsService.name, () => {
       expect(fundDrainingInstrumentation.recordMessagePreparationError).not.toHaveBeenCalled();
       expect(managedSignerService.executeDerivedTx).not.toHaveBeenCalled();
       expect(walletReloadService.scheduleImmediate).not.toHaveBeenCalled();
+    });
+
+    it("declines a credit-capped deposit that would buy less runway than the dedup cooldown", async () => {
+      const { service, drainingDeploymentService, cachedBalanceService, managedSignerService, walletReloadService, fundDrainingInstrumentation } = setup();
+      const owner = createAkashAddress();
+      const walletId = faker.number.int({ min: 1000000, max: 9999999 });
+      const deployment = createDrainingFor(owner, walletId);
+      const balance = createMockCachedBalance(() => 1000);
+
+      drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([deployment]);
+      drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(1000000);
+      drainingDeploymentService.calculateRunwayMinutesAfterDeposit.mockReturnValue(DEDUP_COOLDOWN_IN_MIN - 1);
+      cachedBalanceService.getFresh.mockResolvedValue(balance);
+
+      await service.topUpDrainingDeploymentsForOwner({ walletId, address: owner });
+
+      expect(fundDrainingInstrumentation.recordDepositBelowUsefulRunway).toHaveBeenCalledWith({
+        dseq: deployment.dseq,
+        address: deployment.address,
+        desiredAmount: 1000000,
+        affordableAmount: 1000,
+        runwayMinutes: DEDUP_COOLDOWN_IN_MIN - 1
+      });
+      expect(balance.reserveSufficientAmount).not.toHaveBeenCalled();
+      expect(managedSignerService.executeDerivedTx).not.toHaveBeenCalled();
+      expect(walletReloadService.scheduleImmediate).not.toHaveBeenCalled();
+    });
+
+    it("releases the claim of a deposit it declined so credits landing later can fund it", async () => {
+      const { service, drainingDeploymentService, cachedBalanceService, deploymentSettingRepository } = setup();
+      const owner = createAkashAddress();
+      const walletId = faker.number.int({ min: 1000000, max: 9999999 });
+      const deployment = createDrainingFor(owner, walletId);
+
+      drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([deployment]);
+      drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(1000000);
+      drainingDeploymentService.calculateRunwayMinutesAfterDeposit.mockReturnValue(DEDUP_COOLDOWN_IN_MIN - 1);
+      cachedBalanceService.getFresh.mockResolvedValue(createMockCachedBalance(() => 1000));
+
+      await service.topUpDrainingDeploymentsForOwner({ walletId, address: owner });
+
+      expect(deploymentSettingRepository.releaseFundingClaim).toHaveBeenCalledWith([createFundingClaim(deployment.id)]);
+    });
+
+    it("deposits a small amount the allowance covers in full, as a deployment close to its runtime limit asks for", async () => {
+      const { service, drainingDeploymentService, cachedBalanceService, managedSignerService, fundDrainingInstrumentation } = setup();
+      const owner = createAkashAddress();
+      const walletId = faker.number.int({ min: 1000000, max: 9999999 });
+      const deployment = createDrainingFor(owner, walletId);
+
+      drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([deployment]);
+      drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(1000);
+      drainingDeploymentService.calculateRunwayMinutesAfterDeposit.mockReturnValue(DEDUP_COOLDOWN_IN_MIN - 1);
+      cachedBalanceService.getFresh.mockResolvedValue(createMockCachedBalance(() => 1000));
+
+      await service.topUpDrainingDeploymentsForOwner({ walletId, address: owner });
+
+      expect(fundDrainingInstrumentation.recordDepositBelowUsefulRunway).not.toHaveBeenCalled();
+      expect(managedSignerService.executeDerivedTx).toHaveBeenCalledOnce();
+    });
+
+    it("deposits a credit-capped amount that still buys more runway than the dedup cooldown", async () => {
+      const { service, drainingDeploymentService, cachedBalanceService, managedSignerService, fundDrainingInstrumentation } = setup();
+      const owner = createAkashAddress();
+      const walletId = faker.number.int({ min: 1000000, max: 9999999 });
+      const deployment = createDrainingFor(owner, walletId);
+
+      drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([deployment]);
+      drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(1000000);
+      drainingDeploymentService.calculateRunwayMinutesAfterDeposit.mockReturnValue(DEDUP_COOLDOWN_IN_MIN);
+      cachedBalanceService.getFresh.mockResolvedValue(createMockCachedBalance(() => 500000));
+
+      await service.topUpDrainingDeploymentsForOwner({ walletId, address: owner });
+
+      expect(fundDrainingInstrumentation.recordDepositBelowUsefulRunway).not.toHaveBeenCalled();
+      expect(managedSignerService.executeDerivedTx).toHaveBeenCalledOnce();
+    });
+
+    it("reports an exhausted allowance as insufficient balance rather than as a declined deposit", async () => {
+      const { service, drainingDeploymentService, cachedBalanceService, managedSignerService, fundDrainingInstrumentation } = setup();
+      const owner = createAkashAddress();
+      const walletId = faker.number.int({ min: 1000000, max: 9999999 });
+      const deployment = createDrainingFor(owner, walletId);
+
+      drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([deployment]);
+      drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(1000000);
+      drainingDeploymentService.calculateRunwayMinutesAfterDeposit.mockReturnValue(0);
+      cachedBalanceService.getFresh.mockResolvedValue(createMockCachedBalance(() => 0));
+
+      await service.topUpDrainingDeploymentsForOwner({ walletId, address: owner });
+
+      expect(fundDrainingInstrumentation.recordDepositBelowUsefulRunway).not.toHaveBeenCalled();
+      expect(fundDrainingInstrumentation.recordMessagePreparationError).toHaveBeenCalledWith(
+        expect.objectContaining({ deployment, error: expect.objectContaining({ message: expect.stringContaining("Insufficient balance") }) })
+      );
+      expect(managedSignerService.executeDerivedTx).not.toHaveBeenCalled();
+    });
+
+    it("leaves the allowance of a declined deposit to the other deployments in the batch", async () => {
+      const { service, drainingDeploymentService, cachedBalanceService, managedSignerService } = setup();
+      const owner = createAkashAddress();
+      const walletId = faker.number.int({ min: 1000000, max: 9999999 });
+      const declined = createDrainingFor(owner, walletId);
+      const funded = createDrainingFor(owner, walletId);
+      const ALLOWANCE = 1000;
+      const NO_HEADROOM = 0;
+
+      drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([declined, funded]);
+      drainingDeploymentService.calculateAmountToTargetRunway.mockImplementation(deployment => (deployment === declined ? ALLOWANCE * 5 : ALLOWANCE));
+      drainingDeploymentService.calculateRunwayMinutesAfterDeposit.mockImplementation(deployment =>
+        deployment === declined ? DEDUP_COOLDOWN_IN_MIN - 1 : RUNWAY_MINUTES_AT_TARGET
+      );
+      cachedBalanceService.getFresh.mockResolvedValue(new CachedBalance(ALLOWANCE, NO_HEADROOM));
+
+      await service.topUpDrainingDeploymentsForOwner({ walletId, address: owner });
+
+      const [, messages] = managedSignerService.executeDerivedTx.mock.calls[0];
+      expect(messages).toHaveLength(1);
+      expect(messages[0].value.id?.xid).toBe(`${funded.address}/${funded.dseq}`);
+      expect(messages[0].value.deposit?.amount?.amount).toBe(String(ALLOWANCE));
     });
 
     it("routes a master-wallet insufficient-funds failure to the immediate-funding instrumentation and rethrows", async () => {
@@ -800,7 +928,10 @@ describe(TopUpManagedDeploymentsService.name, () => {
 
       await service.topUpDrainingDeploymentsForOwner({ walletId, address: owner });
 
-      expect(deploymentSettingRepository.claimForFunding).toHaveBeenCalledWith(expect.arrayContaining([won.id, claimedByAnotherPass.id]), 60);
+      expect(deploymentSettingRepository.claimForFunding).toHaveBeenCalledWith(
+        expect.arrayContaining([won.id, claimedByAnotherPass.id]),
+        DEDUP_COOLDOWN_IN_MIN
+      );
       expect(managedSignerService.executeDerivedTx).toHaveBeenCalledWith(walletId, [
         expect.objectContaining({ value: expect.objectContaining({ id: expect.objectContaining({ xid: expect.stringContaining(`/${won.dseq}`) }) }) })
       ]);
@@ -1029,6 +1160,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
       }
     });
     const drainingDeploymentService = mock<DrainingDeploymentService>();
+    drainingDeploymentService.calculateRunwayMinutesAfterDeposit.mockReturnValue(RUNWAY_MINUTES_AT_TARGET);
     const rpcMessageService = new RpcMessageService(billingConfig);
     const cachedBalanceService = mock<CachedBalanceService>();
     const blockHttpService = mock<BlockHttpService>();
@@ -1042,7 +1174,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
     deploymentSettingRepository.claimForFunding.mockImplementation(async (ids: string[]) => ids.map(createFundingClaim));
     deploymentSettingRepository.releaseFundingClaim.mockResolvedValue(undefined);
     deploymentSettingRepository.findAutoTopUpDeploymentsByOwnerIteratively.mockImplementation(() => (async function* () {})());
-    const deploymentConfig = mockConfigService<DeploymentConfigService>({ AUTO_TOP_UP_DEDUP_COOLDOWN_IN_MIN: 60 });
+    const deploymentConfig = mockConfigService<DeploymentConfigService>({ AUTO_TOP_UP_DEDUP_COOLDOWN_IN_MIN: DEDUP_COOLDOWN_IN_MIN });
 
     const service = new TopUpManagedDeploymentsService(
       managedSignerService,

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
@@ -223,6 +223,20 @@ export class TopUpManagedDeploymentsService {
             });
             return;
           }
+          const affordableAmount = balance.previewSufficientAmount(desiredAmount);
+          const runwayMinutes = this.drainingDeploymentService.calculateRunwayMinutesAfterDeposit(deployment, affordableAmount, currentHeight);
+
+          if (this.#isCappedBelowUsefulRunway({ desiredAmount, affordableAmount, runwayMinutes })) {
+            instrumentation.recordDepositBelowUsefulRunway({
+              dseq: deployment.dseq,
+              address: deployment.address,
+              desiredAmount,
+              affordableAmount,
+              runwayMinutes
+            });
+            return;
+          }
+
           const sufficientAmount = balance.reserveSufficientAmount(desiredAmount);
 
           const messageInput: DepositDeploymentMsgOptions = {
@@ -250,6 +264,31 @@ export class TopUpManagedDeploymentsService {
     );
 
     return messageInputs.filter(x => !!x);
+  }
+
+  /**
+   * A deposit capped by the credits available that buys less runway than the dedup cooldown is worse than
+   * no deposit: it stamps a claim that locks the deployment out of funding for longer than the runway it
+   * just bought, so credits landing in between cannot save it. Left unfunded, the deployment keeps its
+   * claim free for the pass that runs the moment those credits land.
+   *
+   * Only capped deposits are declined. An uncapped one is the complete answer for the deployment however
+   * small it is, which is what a runtime-limited deployment close to its deadline asks for. A deployment
+   * the allowance cannot fund at all is left to `reserveSufficientAmount`, whose insufficient-balance
+   * error is what drives the credits-low telemetry.
+   */
+  #isCappedBelowUsefulRunway({
+    desiredAmount,
+    affordableAmount,
+    runwayMinutes
+  }: {
+    desiredAmount: number;
+    affordableAmount: number;
+    runwayMinutes: number;
+  }): boolean {
+    const isCapped = affordableAmount > 0 && affordableAmount < desiredAmount;
+
+    return isCapped && runwayMinutes < this.deploymentConfig.get("AUTO_TOP_UP_DEDUP_COOLDOWN_IN_MIN");
   }
 
   private async topUpForOwner(


### PR DESCRIPTION
## Why

Auto-funding caps every deposit at the credits available at the time. When that cap bites hard enough, the deployment ends up holding less runway than the dedup cooldown, so the claim its deposit stamped locks it out of funding for longer than it will live. A user who buys credits five minutes later watches the deployment close anyway, with money sitting in the account.

Measured over 30 days of mainnet before the cooldown shipped: of 67 same-deployment deposit pairs landing within an hour of each other, only 2 left less than an hour of runway after the first deposit, and both were dust deposits made from an already-exhausted allowance. So this is a hole in the logic rather than something that has cost anyone yet.

Fixes CON-889

## What

The issue framed this as "let funding retry sooner", which would need a retry marker on the row. This takes the other route: don't make the bad deposit in the first place.

Before the allowance is spoken for, a pass now previews what it can afford and works out how much runway that buys. If the amount is capped by available credits *and* buys less runway than `AUTO_TOP_UP_DEDUP_COOLDOWN_IN_MIN`, the deployment is skipped. Its claim is released by the existing unprepared-claim path, so the job that fires when credits land can fund it properly.

Both flows in the issue hold. A capped deposit followed by a credit purchase now funds the deployment, because the claim was never taken. Overlapping passes still produce exactly one deposit, because the claim mechanism itself is untouched. Deposits inside the cooldown go down rather than up. The cost is that a deployment nobody ever funds closes up to an hour earlier than it would have.

Only capped deposits are declined. An uncapped one is the complete answer for the deployment however small it is, which is what a deployment close to its runtime limit needs, and an allowance that covers nothing still falls through to the insufficient-balance path that drives the credits-low telemetry.

No migration and no new env var. The threshold is the cooldown itself, since the rule is that a deposit has to buy more runway than the lockout it causes.

Supporting pieces:

- `CachedBalance.previewSufficientAmount`, the non-mutating half of `reserveSufficientAmount`, so a declined deployment does not spend from the rest of the owner's batch
- `DrainingDeploymentService.calculateRunwayMinutesAfterDeposit`, sharing the `fundedUntil` floor with `calculateAmountToTargetRunway`
- `recordDepositBelowUsefulRunway` on both instrumentation paths, plus an `auto_top_up_deposits_below_useful_runway_total` counter and a `depositsBelowUsefulRunwayCount` summary field to watch this in prod

## Testing

Unit and integration coverage for the guard, the runway calculation, and the balance preview. I mutation-checked the four behavioural tests by stubbing the guard to `return false`: each one fails without it.

Pre-existing failures on this machine, identical with these changes stashed on `origin/main` and unrelated to this PR: 9 functional (`providers`, `addresses`, `deployments`) and 3 in `user.repository.integration.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Top-up processing now previews affordable amounts and projected runway before reserving funds.
  * Deposits that would provide less than the useful runway threshold are skipped without submitting a transaction or consuming available funds.
  * Eligible deposits can proceed later when sufficient funding is available.
  * Added runway calculations after deposits for more accurate funding decisions.

* **Bug Fixes**
  * Prevented small, ineffective deposits from reducing funds needed by other deployments.

* **Monitoring**
  * Added tracking and logging for deposits skipped because they provide insufficient runway.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->