### PR TITLE
refactor(billing): make the low-credit coverage check cheap enough to scale

### DIFF
--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
@@ -1,5 +1,5 @@
 import { MsgAccountDeposit } from "@akashnetwork/chain-sdk/private-types/akash.v1";
-import { MsgCreateDeployment } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
+import { MsgCloseDeployment, MsgCreateDeployment } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
 import { MsgCreateLease } from "@akashnetwork/chain-sdk/private-types/akash.v1beta5";
 import type { LeaseHttpService } from "@akashnetwork/http-sdk";
 import type { MongoAbility } from "@casl/ability";
@@ -738,6 +738,72 @@ describe(ManagedSignerService.name, () => {
       await service.executeDerivedEncodedTxByUserId("user-123", [leaseMessage]);
 
       expect(walletReloadJobService.scheduleImmediate).not.toHaveBeenCalled();
+    });
+
+    it("schedules a credits-low check when a successful transaction closes a deployment", async () => {
+      const wallet = createUserWallet({ userId: "user-123", feeAllowance: 100 });
+      const user = createUser({ userId: "user-123" });
+      const closeMessage = {
+        typeUrl: MsgCloseDeployment.$type,
+        value: Buffer.from(JSON.stringify({ id: { dseq: "123", owner: wallet.address } })).toString("base64")
+      };
+
+      const { service, walletReloadJobService } = setup({
+        findOneByUserId: vi.fn().mockResolvedValue(wallet),
+        findById: vi.fn().mockResolvedValue(user),
+        signAndBroadcastWithDerivedWallet: vi.fn().mockResolvedValue({ code: 0, hash: "tx-hash", rawLog: "success" }),
+        refreshUserWalletLimits: vi.fn().mockResolvedValue(undefined),
+        decode: vi.fn().mockReturnValue({ id: { dseq: "123", owner: wallet.address } })
+      });
+
+      await service.executeDerivedEncodedTxByUserId("user-123", [closeMessage]);
+
+      expect(walletReloadJobService.scheduleCreditsLowCheckIfAutoReloadOff).toHaveBeenCalledWith({ walletId: wallet.id });
+      expect(walletReloadJobService.scheduleImmediate).not.toHaveBeenCalled();
+    });
+
+    it("does not schedule a credits-low check for a transaction without a close message", async () => {
+      const wallet = createUserWallet({ userId: "user-123", feeAllowance: 100, deploymentAllowance: 100 });
+      const user = createUser({ userId: "user-123" });
+      const deploymentMessage = {
+        typeUrl: MsgCreateDeployment.$type,
+        value: Buffer.from(JSON.stringify({ id: { dseq: "123", owner: wallet.address } })).toString("base64")
+      };
+
+      const { service, walletReloadJobService } = setup({
+        findOneByUserId: vi.fn().mockResolvedValue(wallet),
+        findById: vi.fn().mockResolvedValue(user),
+        signAndBroadcastWithDerivedWallet: vi.fn().mockResolvedValue({ code: 0, hash: "tx-hash", rawLog: "success" }),
+        refreshUserWalletLimits: vi.fn().mockResolvedValue(undefined),
+        decode: vi.fn().mockReturnValue({ id: { dseq: "123", owner: wallet.address } })
+      });
+
+      await service.executeDerivedEncodedTxByUserId("user-123", [deploymentMessage]);
+
+      expect(walletReloadJobService.scheduleCreditsLowCheckIfAutoReloadOff).not.toHaveBeenCalled();
+    });
+
+    it("returns the close result even when the credits-low schedule fails", async () => {
+      const wallet = createUserWallet({ userId: "user-123", feeAllowance: 100 });
+      const user = createUser({ userId: "user-123" });
+      const closeMessage = {
+        typeUrl: MsgCloseDeployment.$type,
+        value: Buffer.from(JSON.stringify({ id: { dseq: "123", owner: wallet.address } })).toString("base64")
+      };
+
+      const { service, walletReloadJobService, logger } = setup({
+        findOneByUserId: vi.fn().mockResolvedValue(wallet),
+        findById: vi.fn().mockResolvedValue(user),
+        signAndBroadcastWithDerivedWallet: vi.fn().mockResolvedValue({ code: 0, hash: "tx-hash", rawLog: "success" }),
+        refreshUserWalletLimits: vi.fn().mockResolvedValue(undefined),
+        decode: vi.fn().mockReturnValue({ id: { dseq: "123", owner: wallet.address } })
+      });
+      walletReloadJobService.scheduleCreditsLowCheckIfAutoReloadOff.mockRejectedValue(new Error("connection reset"));
+
+      const result = await service.executeDerivedEncodedTxByUserId("user-123", [closeMessage]);
+
+      expect(result.code).toBe(0);
+      expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "CREDITS_LOW_CHECK_ON_CLOSE_SCHEDULE_FAILED", walletId: wallet.id }));
     });
 
     it("delegates spend-time activation to the guard and surfaces its retriable 409", async () => {

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
@@ -198,12 +198,7 @@ export class ManagedSignerService {
     }
   }
 
-  /**
-   * A close changes the account's running-deployment set, so the credits-low verdict may flip —
-   * typically clearing the low stamp once the burn drops. Every managed close funnels through this
-   * method: the UI broadcasts MsgCloseDeployment via POST /v1/tx, and the deployment writer and
-   * system closers sign through it too. Best-effort so a schedule failure never fails a landed close.
-   */
+  /** Best-effort: a schedule failure must never fail a close that already landed on chain. */
   async #scheduleCreditsLowCheckOnClose(userWallet: UserWalletOutput, messages: EncodeObject[]) {
     if (!messages.some(message => message.typeUrl.endsWith(".MsgCloseDeployment"))) {
       return;

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
@@ -178,6 +178,7 @@ export class ManagedSignerService {
 
     await this.balancesService.refreshUserWalletLimits(userWallet);
     await this.#ensureAutoReloadSchedule(userWallet.userId, messages);
+    await this.#scheduleCreditsLowCheckOnClose(userWallet, messages);
 
     const result = pick(tx, ["code", "hash", "transactionHash", "rawLog"]) as Pick<IndexedTx, "code" | "hash" | "rawLog">;
 
@@ -194,6 +195,24 @@ export class ManagedSignerService {
   async #ensureAutoReloadSchedule(userId: UserWalletOutput["userId"], messages: EncodeObject[]) {
     if (this.#hasSpendingTx(messages)) {
       await this.walletReloadJobService.scheduleImmediate({ userId });
+    }
+  }
+
+  /**
+   * A close changes the account's running-deployment set, so the credits-low verdict may flip —
+   * typically clearing the low stamp once the burn drops. Every managed close funnels through this
+   * method: the UI broadcasts MsgCloseDeployment via POST /v1/tx, and the deployment writer and
+   * system closers sign through it too. Best-effort so a schedule failure never fails a landed close.
+   */
+  async #scheduleCreditsLowCheckOnClose(userWallet: UserWalletOutput, messages: EncodeObject[]) {
+    if (!messages.some(message => message.typeUrl.endsWith(".MsgCloseDeployment"))) {
+      return;
+    }
+
+    try {
+      await this.walletReloadJobService.scheduleCreditsLowCheckIfAutoReloadOff({ walletId: userWallet.id });
+    } catch (error) {
+      this.logger.error({ event: "CREDITS_LOW_CHECK_ON_CLOSE_SCHEDULE_FAILED", walletId: userWallet.id, error });
     }
   }
 

--- a/apps/api/src/billing/services/wallet-credits-low-check/credits-low-transition.ts
+++ b/apps/api/src/billing/services/wallet-credits-low-check/credits-low-transition.ts
@@ -1,0 +1,17 @@
+/**
+ * Whether the credits-low state machine needs to move for these inputs: an un-notified
+ * wallet sitting below a week of coverage needs the warning email; a notified wallet
+ * that recovered or stopped spending needs its stamp cleared.
+ *
+ * Mirrors `WalletCreditsLowCheckHandler`'s decision (zero cost and sufficient balance
+ * clear the stamp, a low un-notified wallet gets the email) so the hourly funding sweep
+ * can skip enqueueing checks that the handler would no-op. Keep the two in lockstep:
+ * a transition this misses is a warning the user never receives.
+ *
+ * Unit-agnostic: pass balance and weekly cost in the same unit (credits or USD).
+ */
+export function needsCreditsLowTransition(input: { balance: number; weeklyCost: number; isNotified: boolean }): boolean {
+  const isLow = input.weeklyCost > 0 && input.balance < input.weeklyCost;
+
+  return isLow !== input.isNotified;
+}

--- a/apps/api/src/billing/services/wallet-credits-low-check/credits-low-transition.ts
+++ b/apps/api/src/billing/services/wallet-credits-low-check/credits-low-transition.ts
@@ -1,15 +1,4 @@
-/**
- * Whether the credits-low state machine needs to move for these inputs: an un-notified
- * wallet sitting below a week of coverage needs the warning email; a notified wallet
- * that recovered or stopped spending needs its stamp cleared.
- *
- * Mirrors `WalletCreditsLowCheckHandler`'s decision (zero cost and sufficient balance
- * clear the stamp, a low un-notified wallet gets the email) so the hourly funding sweep
- * can skip enqueueing checks that the handler would no-op. Keep the two in lockstep:
- * a transition this misses is a warning the user never receives.
- *
- * Unit-agnostic: pass balance and weekly cost in the same unit (credits or USD).
- */
+/** Mirrors `WalletCreditsLowCheckHandler`'s verdict and must stay in lockstep with it; balance and weeklyCost must be in the same unit. */
 export function needsCreditsLowTransition(input: { balance: number; weeklyCost: number; isNotified: boolean }): boolean {
   const isLow = input.weeklyCost > 0 && input.balance < input.weeklyCost;
 

--- a/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.spec.ts
+++ b/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.spec.ts
@@ -14,31 +14,31 @@ import { generateWalletSetting } from "@test/seeders/wallet-setting.seeder";
 
 describe(WalletReloadJobService.name, () => {
   describe("scheduleImmediate", () => {
-    it("enqueues a credits-low check when walletSetting does not exist", async () => {
+    it("schedules nothing when walletSetting does not exist", async () => {
       const { service, walletSettingRepository, jobQueueService } = setup();
       const userId = faker.string.uuid();
       walletSettingRepository.findByUserId.mockResolvedValue(undefined);
-      jobQueueService.enqueue.mockResolvedValue(faker.string.uuid());
 
       const result = await service.scheduleImmediate({ userId });
 
       expect(result).toBe(false);
       expect(walletSettingRepository.findByUserId).toHaveBeenCalledWith(userId);
-      expectCreditsLowCheckScheduled(jobQueueService, userId);
+      expect(jobQueueService.enqueue).not.toHaveBeenCalled();
+      expect(jobQueueService.cancelCreatedBy).not.toHaveBeenCalled();
     });
 
-    it("enqueues a credits-low check when autoReloadEnabled is false", async () => {
+    it("schedules nothing when autoReloadEnabled is false", async () => {
       const { service, walletSettingRepository, jobQueueService } = setup();
       const userId = faker.string.uuid();
       const walletSetting = generateWalletSetting({ autoReloadEnabled: false, userId });
       walletSettingRepository.findByUserId.mockResolvedValue(walletSetting);
-      jobQueueService.enqueue.mockResolvedValue(faker.string.uuid());
 
       const result = await service.scheduleImmediate({ userId });
 
       expect(result).toBe(false);
       expect(walletSettingRepository.findByUserId).toHaveBeenCalledWith(userId);
-      expectCreditsLowCheckScheduled(jobQueueService, walletSetting.userId);
+      expect(jobQueueService.enqueue).not.toHaveBeenCalled();
+      expect(jobQueueService.cancelCreatedBy).not.toHaveBeenCalled();
     });
 
     it("calls scheduleForWalletSetting when conditions are met", async () => {
@@ -104,42 +104,17 @@ describe(WalletReloadJobService.name, () => {
       );
     });
 
-    it("enqueues a credits-low check by walletId when no wallet setting exists", async () => {
+    it("schedules nothing by walletId when no wallet setting exists", async () => {
       const { service, walletSettingRepository, userWalletRepository, jobQueueService } = setup();
       const walletId = faker.number.int({ min: 1, max: 1000000 });
-      const userWallet = createUserWallet({ id: walletId });
       walletSettingRepository.findOneBy.mockResolvedValue(undefined);
-      userWalletRepository.findOneBy.mockResolvedValue(userWallet);
-      jobQueueService.enqueue.mockResolvedValue(faker.string.uuid());
 
       const result = await service.scheduleImmediate({ walletId });
 
       expect(result).toBe(false);
       expect(walletSettingRepository.findOneBy).toHaveBeenCalledWith({ walletId });
-      expect(userWalletRepository.findOneBy).toHaveBeenCalledWith({ id: walletId });
-      expectCreditsLowCheckScheduled(jobQueueService, userWallet.userId);
-    });
-
-    it("does not throw when the job queue is unavailable and a credits-low check is due", async () => {
-      const { service, walletSettingRepository, jobQueueService, logger } = setup();
-      const userId = faker.string.uuid();
-      walletSettingRepository.findByUserId.mockResolvedValue(generateWalletSetting({ autoReloadEnabled: false, userId }));
-      jobQueueService.cancelCreatedBy.mockRejectedValue(new Error("Database not opened. Call open() before executing SQL."));
-
-      await expect(service.scheduleImmediate({ userId })).resolves.toBe(false);
-
-      expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "CREDITS_LOW_CHECK_SCHEDULE_FAILED", userId }));
-    });
-
-    it("does not throw when a credits-low enqueue collides with an existing singleton", async () => {
-      const { service, walletSettingRepository, jobQueueService, logger } = setup();
-      const userId = faker.string.uuid();
-      walletSettingRepository.findByUserId.mockResolvedValue(generateWalletSetting({ autoReloadEnabled: false, userId }));
-      jobQueueService.enqueue.mockResolvedValue(null);
-
-      await expect(service.scheduleImmediate({ userId })).resolves.toBe(false);
-
-      expect(logger.error).not.toHaveBeenCalled();
+      expect(userWalletRepository.findOneBy).not.toHaveBeenCalled();
+      expect(jobQueueService.enqueue).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.ts
+++ b/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.ts
@@ -19,12 +19,7 @@ export class WalletReloadJobService {
     this.logger = createLogger({ context: WalletReloadJobService.name });
   }
 
-  /**
-   * Schedules a balance reload check when Auto Recharge is on and does nothing otherwise.
-   * Deliberately does NOT fall through to a credits-low check: this runs on every managed
-   * spend, and coverage checks are driven by state-change triggers and the hourly funding
-   * sweep instead (CON-896).
-   */
+  /** Deliberately does not fall through to a credits-low check: this runs on every managed spend, which CON-896 moved off that path. */
   async scheduleImmediate(input: WalletReloadImmediateInput, options?: { triggeredByDeployment?: boolean }): Promise<boolean> {
     const walletSetting =
       "userId" in input
@@ -88,11 +83,7 @@ export class WalletReloadJobService {
     await this.jobQueueService.cancelCreatedBy({ name: WalletBalanceReloadCheck.name, singletonKey: `${WalletBalanceReloadCheck.name}.${userId}` });
   }
 
-  /**
-   * Best-effort: a failed schedule is logged instead of thrown so it never fails the
-   * state-change trigger or funding operation behind it, and the hourly funding sweep
-   * re-evaluates every eligible account regardless.
-   */
+  /** Best-effort: a failed schedule is logged rather than thrown, because the hourly funding sweep re-evaluates every eligible account anyway. */
   async scheduleCreditsLowCheck(userId: string, options?: { withCleanup?: boolean }): Promise<string | null> {
     try {
       if (options?.withCleanup) {

--- a/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.ts
+++ b/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.ts
@@ -19,6 +19,12 @@ export class WalletReloadJobService {
     this.logger = createLogger({ context: WalletReloadJobService.name });
   }
 
+  /**
+   * Schedules a balance reload check when Auto Recharge is on and does nothing otherwise.
+   * Deliberately does NOT fall through to a credits-low check: this runs on every managed
+   * spend, and coverage checks are driven by state-change triggers and the hourly funding
+   * sweep instead (CON-896).
+   */
   async scheduleImmediate(input: WalletReloadImmediateInput, options?: { triggeredByDeployment?: boolean }): Promise<boolean> {
     const walletSetting =
       "userId" in input
@@ -30,12 +36,6 @@ export class WalletReloadJobService {
       return true;
     }
 
-    const userId = await this.#resolveUserId(input, walletSetting);
-    if (!userId) {
-      return false;
-    }
-
-    await this.scheduleCreditsLowCheck(userId, { withCleanup: true });
     return false;
   }
 
@@ -90,7 +90,8 @@ export class WalletReloadJobService {
 
   /**
    * Best-effort: a failed schedule is logged instead of thrown so it never fails the
-   * spend or funding operation that triggered it, and the next spend re-schedules the check.
+   * state-change trigger or funding operation behind it, and the hourly funding sweep
+   * re-evaluates every eligible account regardless.
    */
   async scheduleCreditsLowCheck(userId: string, options?: { withCleanup?: boolean }): Promise<string | null> {
     try {

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -38,6 +38,7 @@ export type ExpiringRuntimeDeployment = ExpiredRuntimeDeployment & {
 
 export type AutoTopUpDeployment = {
   id: string;
+  userId: string;
   walletId: number;
   dseq: string;
   address: string;
@@ -45,6 +46,7 @@ export type AutoTopUpDeployment = {
   walletIsTrialing: boolean;
   walletCreatedAt: Date;
   walletActivatedAt: Date | null;
+  walletCreditsLowNotifiedAt: Date | null;
   runtimeLimitHours: number | null;
   runtimeEndsAt: Date | null;
 };
@@ -118,6 +120,7 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
     const deployments = await this.pg
       .select({
         id: this.table.id,
+        userId: this.table.userId,
         dseq: this.table.dseq,
         walletId: UserWallets.id,
         address: UserWallets.address,
@@ -125,6 +128,7 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
         walletIsTrialing: sql<boolean>`coalesce(${UserWallets.isTrialing}, true)`,
         walletCreatedAt: UserWallets.createdAt,
         walletActivatedAt: UserWallets.activatedAt,
+        walletCreditsLowNotifiedAt: UserWallets.creditsLowNotifiedAt,
         runtimeLimitHours: this.table.runtimeLimitHours,
         runtimeEndsAt: this.table.runtimeEndsAt
       })

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
@@ -758,9 +758,24 @@ describe(DrainingDeploymentService.name, () => {
       expect(result).toBe(0);
     });
 
+    it("caps a runtime-limited deployment at its remaining hours like the credits-low threshold", async () => {
+      const blockRate = 50;
+      const runtimeLimitHours = 12;
+      const baseSetup = setup();
+      const { service, userId, ability, balancesService } = await setupCalculateWeeklyCost({
+        deployments: [{ predictedClosedHeight: baseSetup.currentHeight + 1_000_000, blockRate, runtimeLimitHours }],
+        expectedFiatAmount: 3.6
+      });
+
+      const result = await service.calculateWeeklyDeploymentCost(userId, ability);
+
+      expect(balancesService.toFiatAmount).toHaveBeenCalledWith(Math.floor(blockRate * averageBlockCountInAnHour * runtimeLimitHours));
+      expect(result).toBe(3.6);
+    });
+
     async function setupCalculateWeeklyCost(input: {
       userWallet?: ReturnType<typeof createUserWallet> | undefined;
-      deployments: Array<{ predictedClosedHeight: number | null; blockRate: number }>;
+      deployments: Array<{ predictedClosedHeight: number | null; blockRate: number; runtimeLimitHours?: number }>;
       expectedFiatAmount?: number;
     }) {
       const userId = faker.string.uuid();
@@ -771,9 +786,11 @@ describe(DrainingDeploymentService.name, () => {
       const baseSetup = setup();
       baseSetup.userWalletRepository.accessibleBy.mockReturnValue(baseSetup.userWalletRepository);
       baseSetup.userWalletRepository.findOneByUserId.mockResolvedValue(userWallet);
+      baseSetup.userWalletRepository.findOneBy.mockResolvedValue(userWallet);
 
-      baseSetup.deploymentSettingRepository.accessibleBy.mockReturnValue(baseSetup.deploymentSettingRepository);
-      const deploymentSettings = createManyAutoTopUpDeployments(input.deployments.length, { address });
+      const deploymentSettings = input.deployments.map(deployment =>
+        createAutoTopUpDeployment({ address, runtimeLimitHours: deployment.runtimeLimitHours ?? null })
+      );
 
       const drainingDeployments = deploymentSettings.map((setting, idx) => {
         const deployment = input.deployments[idx];

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
@@ -89,14 +89,12 @@ describe(DrainingDeploymentService.name, () => {
       expect(loggerService.error).not.toHaveBeenCalled();
       expect(deploymentSettingRepository.updateManyById).toHaveBeenCalledWith(expect.arrayContaining([expect.any(String)]), { closed: true });
 
-      expect(callback).toHaveBeenCalledTimes(activeBatches.length);
-      activeBatches.forEach((batch, index) => {
-        const deployment = batch[0];
-        expect(callback).toHaveBeenNthCalledWith(
-          index + 1,
+      expect(callback).toHaveBeenCalledTimes(deploymentSettings.length);
+      [activeBatches[0][0], activeBatches[1][0]].forEach(deployment => {
+        expect(callback).toHaveBeenCalledWith(
           expect.objectContaining({
             address: deployment.owner,
-            deployments: expect.arrayContaining([
+            drainingDeployments: expect.arrayContaining([
               expect.objectContaining({
                 dseq: deployment.dseq.toString(),
                 address: deployment.owner
@@ -104,6 +102,44 @@ describe(DrainingDeploymentService.name, () => {
             ])
           })
         );
+      });
+      expect(callback).toHaveBeenCalledWith(expect.objectContaining({ address: addresses[1], activeDeployments: [], drainingDeployments: [] }));
+      expect(callback).toHaveBeenCalledWith(expect.objectContaining({ address: addresses[2], activeDeployments: [], drainingDeployments: [] }));
+    });
+
+    it("yields a non-draining owner with its active deployments and an empty fundable subset", async () => {
+      const { service, deploymentSettingRepository, currentHeight } = setup();
+      const creditsLowNotifiedAt = faker.date.recent();
+      const setting = createAutoTopUpDeployment({ isWalletAutoTopUpEnabled: true, walletIsTrialing: true, walletCreditsLowNotifiedAt: creditsLowNotifiedAt });
+      const farFromClosure = createDrainingDeployment({
+        dseq: Number(setting.dseq),
+        owner: setting.address,
+        predictedClosedHeight: currentHeight + averageBlockCountInAnHour * 24 * 7
+      });
+
+      deploymentSettingRepository.findAutoTopUpDeploymentsByOwnerIteratively.mockImplementation(() =>
+        (async function* () {
+          yield { address: setting.address, walletId: setting.walletId, deploymentSettings: [setting] };
+        })()
+      );
+      const findLeasesSpy = vi.spyOn(service, "findLeases").mockResolvedValue([farFromClosure]);
+
+      const callback = vi.fn();
+      for await (const result of service.findDrainingDeploymentsByOwner(currentHeight)) {
+        callback(result);
+      }
+
+      expect(findLeasesSpy).toHaveBeenCalledWith(Number.MAX_SAFE_INTEGER, setting.address, [setting.dseq]);
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenCalledWith({
+        address: setting.address,
+        walletId: setting.walletId,
+        userId: setting.userId,
+        autoReloadEnabled: true,
+        isTrialing: true,
+        creditsLowNotifiedAt,
+        activeDeployments: [expect.objectContaining({ dseq: setting.dseq, predictedClosedHeight: farFromClosure.predictedClosedHeight })],
+        drainingDeployments: []
       });
     });
 
@@ -136,7 +172,7 @@ describe(DrainingDeploymentService.name, () => {
         expect(callback).toHaveBeenCalledWith(
           expect.objectContaining({
             address,
-            deployments: [
+            drainingDeployments: [
               expect.objectContaining({
                 dseq: setting.dseq,
                 runtimeEndsAt: new Date(Date.now() + runtimeLimitHours * millisecondsInHour)

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
@@ -27,6 +27,17 @@ export type WeeklyCoverage = {
 export type WeeklyBurnSource = Pick<DrainingDeployment, "predictedClosedHeight" | "blockRate"> &
   Partial<Pick<AutoTopUpDeployment, "runtimeLimitHours" | "runtimeEndsAt">>;
 
+export type AutoTopUpOwnerDeployments = {
+  address: string;
+  walletId: number;
+  userId: string;
+  autoReloadEnabled: boolean;
+  isTrialing: boolean;
+  creditsLowNotifiedAt: Date | null;
+  activeDeployments: DrainingDeployment[];
+  drainingDeployments: DrainingDeployment[];
+};
+
 /** Hours in the seven-day window every weekly spending figure is quoted over. */
 const WEEK_HOURS = 24 * 7;
 
@@ -49,36 +60,38 @@ export class DrainingDeploymentService {
   }
 
   /**
-   * Finds draining deployments grouped by owner address.
-   * Iterates through all owners with auto-top-up enabled deployments,
-   * fetches draining deployment data, and marks closed deployments.
-   * Yields batches of active draining deployments per owner.
+   * Iterates every owner with auto-top-up enabled deployments, resolving each owner's full
+   * active-deployment picture once: `drainingDeployments` is the fundable subset inside the
+   * look-ahead window, `activeDeployments` the complete set the credits-low coverage math
+   * prices. Owners with nothing draining are still yielded so the sweep can evaluate their
+   * coverage from data already in hand instead of re-querying per job.
    *
    * The caller passes the block height the whole run is scoped to so the look-ahead window that admits
    * a deployment and the amount that funds it are derived from the same height.
    * A dry run still sizes deposits against a runtime deadline but does not persist one.
    *
-   * @yields Object with owner address and array of draining deployments
+   * @yields Owner wallet state with its active and draining deployments
    */
-  async *findDrainingDeploymentsByOwner(
-    currentHeight: number,
-    options: DryRunOptions = { dryRun: false }
-  ): AsyncGenerator<{ address: string; walletId: number; deployments: DrainingDeployment[] }> {
-    const expectedClosureHeight = this.#getExpectedClosureHeight(currentHeight);
-
+  async *findDrainingDeploymentsByOwner(currentHeight: number, options: DryRunOptions = { dryRun: false }): AsyncGenerator<AutoTopUpOwnerDeployments> {
     for await (const { address, walletId, deploymentSettings } of this.deploymentSettingRepository.findAutoTopUpDeploymentsByOwnerIteratively()) {
-      const deployments = await this.#resolveActiveDrainingDeployments(
+      const { activeDeployments, drainingDeployments } = await this.#resolveOwnerDeployments(
         deploymentSettings,
         address,
-        expectedClosureHeight,
         currentHeight,
         this.instrumentation,
         options.dryRun
       );
 
-      if (deployments.length) {
-        yield { address, walletId, deployments };
-      }
+      yield {
+        address,
+        walletId,
+        userId: deploymentSettings[0].userId,
+        autoReloadEnabled: deploymentSettings[0].isWalletAutoTopUpEnabled,
+        isTrialing: deploymentSettings[0].walletIsTrialing,
+        creditsLowNotifiedAt: deploymentSettings[0].walletCreditsLowNotifiedAt,
+        activeDeployments,
+        drainingDeployments
+      };
     }
   }
 
@@ -93,35 +106,51 @@ export class DrainingDeploymentService {
     currentHeight: number
   ): Promise<DrainingDeployment[]> {
     const deploymentSettings = await this.deploymentSettingRepository.findAutoTopUpDeploymentsByOwner(address);
-    const expectedClosureHeight = this.#getExpectedClosureHeight(currentHeight);
+    const { drainingDeployments } = await this.#resolveOwnerDeployments(deploymentSettings, address, currentHeight, instrumentation, false);
 
-    return this.#resolveActiveDrainingDeployments(deploymentSettings, address, expectedClosureHeight, currentHeight, instrumentation, false);
+    return drainingDeployments;
   }
 
   #getExpectedClosureHeight(currentHeight: number): number {
     return Math.floor(currentHeight + averageBlockCountInAnHour * this.config.get("AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H"));
   }
 
-  async #resolveActiveDrainingDeployments(
+  async #resolveOwnerDeployments(
     deploymentSettings: AutoTopUpDeployment[],
     address: string,
-    expectedClosureHeight: number,
     currentHeight: number,
     instrumentation: DeploymentTopUpInstrumentation,
     dryRun: boolean
+  ): Promise<{ activeDeployments: DrainingDeployment[]; drainingDeployments: DrainingDeployment[] }> {
+    const expectedClosureHeight = this.#getExpectedClosureHeight(currentHeight);
+    const activeDeployments = await this.#resolveActiveDeployments(deploymentSettings, address, instrumentation);
+    const drainingDeployments = await this.#dropDeploymentsFundedToRuntimeLimit(
+      activeDeployments.filter(deployment => deployment.predictedClosedHeight <= expectedClosureHeight),
+      currentHeight,
+      instrumentation,
+      dryRun
+    );
+
+    return { activeDeployments, drainingDeployments };
+  }
+
+  async #resolveActiveDeployments(
+    deploymentSettings: AutoTopUpDeployment[],
+    address: string,
+    instrumentation: DeploymentTopUpInstrumentation
   ): Promise<DrainingDeployment[]> {
     if (deploymentSettings.length === 0) {
       return [];
     }
 
     const dseqs = deploymentSettings.map(deployment => deployment.dseq);
-    const drainingDeployments = await this.findLeases(expectedClosureHeight, address, dseqs);
+    const leases = await this.findLeases(Number.MAX_SAFE_INTEGER, address, dseqs);
 
-    if (!drainingDeployments.length) {
+    if (!leases.length) {
       return [];
     }
 
-    const byDseqOwner = keyBy(drainingDeployments, "dseq");
+    const byDseqOwner = keyBy(leases, "dseq");
     const [active, missingIds] = deploymentSettings.reduce<[DrainingDeployment[], string[]]>(
       (acc, deploymentSetting) => {
         const deployment = byDseqOwner[Number(deploymentSetting.dseq)];
@@ -149,7 +178,7 @@ export class DrainingDeploymentService {
       instrumentation.recordDeploymentsMarkedClosed(missingIds.length);
     }
 
-    return await this.#dropDeploymentsFundedToRuntimeLimit(active, currentHeight, instrumentation, dryRun);
+    return active;
   }
 
   /**

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
@@ -24,6 +24,12 @@ export type WeeklyCoverage = {
   cumulativeDailyCostsUsd: number[];
 };
 
+export type WeeklyBurnSource = Pick<DrainingDeployment, "predictedClosedHeight" | "blockRate"> &
+  Partial<Pick<AutoTopUpDeployment, "runtimeLimitHours" | "runtimeEndsAt">>;
+
+/** Hours in the seven-day window every weekly spending figure is quoted over. */
+const WEEK_HOURS = 24 * 7;
+
 @singleton()
 export class DrainingDeploymentService {
   private readonly loggerService: ReturnType<CreateLogger>;
@@ -344,8 +350,10 @@ export class DrainingDeploymentService {
   }
 
   /**
-   * Calculates the weekly spending for all deployments with auto top-up enabled.
-   * This calculates the cost to keep all deployments running for 7 days, regardless of when they would close.
+   * Weekly auto-top-up spending for a user, in USD — the same figure the credits-low email
+   * threshold uses, so the number shown in the product and the warning can never disagree.
+   * CASL guards the wallet lookup; the per-address coverage query is safe once the wallet
+   * is proven to belong to the caller.
    *
    * @param userId - The user ID to calculate the deployment costs for
    * @param ability - CASL ability instance for authorization checks
@@ -358,28 +366,9 @@ export class DrainingDeploymentService {
       return 0;
     }
 
-    const deploymentSettings = await this.deploymentSettingRepository.accessibleBy(ability, "read").findAutoTopUpDeploymentsByOwner(userWallet.address);
+    const { weeklyCostUsd } = await this.calculateWeeklyCoverageForAddress(userWallet.address);
 
-    if (deploymentSettings.length === 0) {
-      return 0;
-    }
-
-    const currentHeight = await this.blockHttpService.getCurrentHeight();
-    const blocksInAWeek = Math.floor(averageBlockCountInAnHour * 24 * 7);
-    const drainingDeployments = await this.#findDrainingDeployments(deploymentSettings, userWallet.address, Number.MAX_SAFE_INTEGER);
-
-    const weeklyCost = await this.#accumulateDeploymentCost(drainingDeployments, ({ predictedClosedHeight, blockRate }) => {
-      if (predictedClosedHeight && predictedClosedHeight > currentHeight && blockRate > 0) {
-        return Math.floor(blockRate * blocksInAWeek);
-      }
-      return 0;
-    });
-
-    if (weeklyCost === 0) {
-      return 0;
-    }
-
-    return await this.balancesService.toFiatAmount(weeklyCost);
+    return weeklyCostUsd;
   }
 
   /**
@@ -402,17 +391,12 @@ export class DrainingDeploymentService {
     const currentHeight = await this.blockHttpService.getCurrentHeight();
     const leases = await this.#findDrainingDeployments(deploymentSettings, address, Number.MAX_SAFE_INTEGER);
     const settingsByDseq = keyBy(deploymentSettings, s => String(s.dseq));
+    const burns = this.#buildWeeklyBurns(
+      leases.map(lease => ({ ...settingsByDseq[String(lease.dseq)], predictedClosedHeight: lease.predictedClosedHeight, blockRate: lease.blockRate })),
+      currentHeight
+    );
 
-    const burns = leases.flatMap(({ dseq, predictedClosedHeight, blockRate }) => {
-      if (!predictedClosedHeight || predictedClosedHeight <= currentHeight || blockRate <= 0) {
-        return [];
-      }
-
-      const coverageHours = this.#coverageHoursForDeployment(settingsByDseq[String(dseq)], currentHeight);
-      return coverageHours > 0 ? [{ hourlyCredits: blockRate * averageBlockCountInAnHour, coverageHours }] : [];
-    });
-
-    const weeklyCredits = this.#creditsForHours(burns, 24 * 7);
+    const weeklyCredits = this.#creditsForHours(burns, WEEK_HOURS);
     if (weeklyCredits === 0) {
       return noCoverage;
     }
@@ -423,6 +407,29 @@ export class DrainingDeploymentService {
     return { weeklyCostUsd, cumulativeDailyCostsUsd };
   }
 
+  /**
+   * Seven-day burn in credits for deployments whose lease data is already in hand — lets the
+   * hourly funding sweep price an owner's coverage without re-querying settings or leases.
+   * Applies the same runtime-limit capping as `calculateWeeklyCoverageForAddress`; comparing
+   * the result against a credit balance is equivalent to the credits-low handler's USD
+   * comparison because `toFiatAmount` is monotonic (identity for uact), off by at most its
+   * cent rounding.
+   */
+  calculateWeeklyCoverageCredits(deployments: WeeklyBurnSource[], currentHeight: number): number {
+    return this.#creditsForHours(this.#buildWeeklyBurns(deployments, currentHeight), WEEK_HOURS);
+  }
+
+  #buildWeeklyBurns(deployments: WeeklyBurnSource[], currentHeight: number): Array<{ hourlyCredits: number; coverageHours: number }> {
+    return deployments.flatMap(deployment => {
+      if (!deployment.predictedClosedHeight || deployment.predictedClosedHeight <= currentHeight || deployment.blockRate <= 0) {
+        return [];
+      }
+
+      const coverageHours = this.#coverageHoursForDeployment(deployment, currentHeight);
+      return coverageHours > 0 ? [{ hourlyCredits: deployment.blockRate * averageBlockCountInAnHour, coverageHours }] : [];
+    });
+  }
+
   #creditsForHours(burns: Array<{ hourlyCredits: number; coverageHours: number }>, hours: number): number {
     return burns.reduce((total, burn) => total + Math.floor(burn.hourlyCredits * Math.min(hours, burn.coverageHours)), 0);
   }
@@ -431,19 +438,17 @@ export class DrainingDeploymentService {
    * A week of coverage unless the setting has a runtime limit, then remaining
    * hours (0 if the deadline has passed). An unanchored limit is the remaining hours.
    */
-  #coverageHoursForDeployment(setting: AutoTopUpDeployment | undefined, currentHeight: number): number {
-    const weekHours = 24 * 7;
-
-    if (setting?.runtimeEndsAt) {
+  #coverageHoursForDeployment(setting: Partial<Pick<AutoTopUpDeployment, "runtimeLimitHours" | "runtimeEndsAt">>, currentHeight: number): number {
+    if (setting.runtimeEndsAt) {
       const remainingHours = (this.#getRuntimeLimitHeight(setting.runtimeEndsAt, currentHeight) - currentHeight) / averageBlockCountInAnHour;
-      return remainingHours <= 0 ? 0 : Math.min(weekHours, remainingHours);
+      return remainingHours <= 0 ? 0 : Math.min(WEEK_HOURS, remainingHours);
     }
 
-    if (setting?.runtimeLimitHours != null) {
-      return Math.min(weekHours, setting.runtimeLimitHours);
+    if (setting.runtimeLimitHours != null) {
+      return Math.min(WEEK_HOURS, setting.runtimeLimitHours);
     }
 
-    return weekHours;
+    return WEEK_HOURS;
   }
 
   /**

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
@@ -59,19 +59,7 @@ export class DrainingDeploymentService {
     this.loggerService = createLogger({ context: DrainingDeploymentService.name });
   }
 
-  /**
-   * Iterates every owner with auto-top-up enabled deployments, resolving each owner's full
-   * active-deployment picture once: `drainingDeployments` is the fundable subset inside the
-   * look-ahead window, `activeDeployments` the complete set the credits-low coverage math
-   * prices. Owners with nothing draining are still yielded so the sweep can evaluate their
-   * coverage from data already in hand instead of re-querying per job.
-   *
-   * The caller passes the block height the whole run is scoped to so the look-ahead window that admits
-   * a deployment and the amount that funds it are derived from the same height.
-   * A dry run still sizes deposits against a runtime deadline but does not persist one.
-   *
-   * @yields Owner wallet state with its active and draining deployments
-   */
+  /** Yields owners with nothing draining too, so the sweep can price their credits-low coverage without re-querying per owner. */
   async *findDrainingDeploymentsByOwner(currentHeight: number, options: DryRunOptions = { dryRun: false }): AsyncGenerator<AutoTopUpOwnerDeployments> {
     for await (const { address, walletId, deploymentSettings } of this.deploymentSettingRepository.findAutoTopUpDeploymentsByOwnerIteratively()) {
       const { activeDeployments, drainingDeployments } = await this.#resolveOwnerDeployments(
@@ -378,16 +366,7 @@ export class DrainingDeploymentService {
     });
   }
 
-  /**
-   * Weekly auto-top-up spending for a user, in USD — the same figure the credits-low email
-   * threshold uses, so the number shown in the product and the warning can never disagree.
-   * CASL guards the wallet lookup; the per-address coverage query is safe once the wallet
-   * is proven to belong to the caller.
-   *
-   * @param userId - The user ID to calculate the deployment costs for
-   * @param ability - CASL ability instance for authorization checks
-   * @returns The total weekly cost in USD for all deployments with auto top-up enabled
-   */
+  /** CASL scopes only the wallet lookup; the coverage query below is unscoped, which the already-proven-owned address makes safe. */
   async calculateWeeklyDeploymentCost(userId: string, ability: AnyAbility): Promise<number> {
     const userWallet = await this.userWalletRepository.accessibleBy(ability, "read").findOneByUserId(userId);
 
@@ -436,14 +415,7 @@ export class DrainingDeploymentService {
     return { weeklyCostUsd, cumulativeDailyCostsUsd };
   }
 
-  /**
-   * Seven-day burn in credits for deployments whose lease data is already in hand — lets the
-   * hourly funding sweep price an owner's coverage without re-querying settings or leases.
-   * Applies the same runtime-limit capping as `calculateWeeklyCoverageForAddress`; comparing
-   * the result against a credit balance is equivalent to the credits-low handler's USD
-   * comparison because `toFiatAmount` is monotonic (identity for uact), off by at most its
-   * cent rounding.
-   */
+  /** Comparing this against a credit balance stands in for the handler's USD test: `toFiatAmount` is monotonic, off by at most its cent rounding. */
   calculateWeeklyCoverageCredits(deployments: WeeklyBurnSource[], currentHeight: number): number {
     return this.#creditsForHours(this.#buildWeeklyBurns(deployments, currentHeight), WEEK_HOURS);
   }

--- a/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.spec.ts
+++ b/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.spec.ts
@@ -124,6 +124,47 @@ describe(InitialDeploymentFundingService.name, () => {
     expect(instrumentation.recordDeposit).toHaveBeenCalledWith(500000, "uakt", expect.objectContaining({ dseq: "123", address: "akash1owner" }));
   });
 
+  it("schedules a credits-low check after a successful deposit", async () => {
+    const { service, drainingDeploymentService, walletReloadJobService } = setup();
+    drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
+    drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(500000);
+
+    await service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" });
+
+    expect(walletReloadJobService.scheduleCreditsLowCheckIfAutoReloadOff).toHaveBeenCalledWith({ walletId: 1 });
+  });
+
+  it("schedules a credits-low check when funding skips on sufficient runway", async () => {
+    const { service, drainingDeploymentService, walletReloadJobService } = setup();
+    drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment({ predictedClosedHeight: LOOK_AHEAD_HEIGHT + 1 })]);
+
+    await service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" });
+
+    expect(walletReloadJobService.scheduleCreditsLowCheckIfAutoReloadOff).toHaveBeenCalledWith({ walletId: 1 });
+  });
+
+  it("schedules a credits-low check when funding skips on insufficient balance", async () => {
+    const { service, drainingDeploymentService, cachedBalanceService, walletReloadJobService } = setup();
+    drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
+    drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(500000);
+    cachedBalanceService.getFresh.mockResolvedValue(new CachedBalance(0, 0));
+
+    await service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" });
+
+    expect(walletReloadJobService.scheduleCreditsLowCheckIfAutoReloadOff).toHaveBeenCalledWith({ walletId: 1 });
+  });
+
+  it("tolerates a credits-low schedule failure without failing the job", async () => {
+    const { service, drainingDeploymentService, walletReloadJobService, logger } = setup();
+    drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
+    drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(500000);
+    walletReloadJobService.scheduleCreditsLowCheckIfAutoReloadOff.mockRejectedValue(new Error("connection reset"));
+
+    await expect(service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" })).resolves.toBeUndefined();
+
+    expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "INITIAL_FUNDING_CREDITS_LOW_SCHEDULE_FAILED", walletId: 1, dseq: "123" }));
+  });
+
   it("skips funding when auto top-up is disabled for the deployment", async () => {
     const { service, drainingDeploymentService, userWalletRepository, deploymentSettingRepository, managedSignerService, logger } = setup();
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);

--- a/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.ts
+++ b/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.ts
@@ -63,11 +63,7 @@ export class InitialDeploymentFundingService {
     }
   }
 
-  /**
-   * A lease just started, so the account's weekly burn changed and the credits-low verdict may
-   * flip — including when the funding itself skipped (sufficient runway, insufficient balance).
-   * Best-effort for the same reason as the wallet reload: it must never affect the funding outcome.
-   */
+  /** Runs even when funding skipped, since a lease start moves the credits-low verdict either way, and never affects the funding outcome. */
   async #scheduleCreditsLowCheck({ walletId, dseq, address }: FundOnLeaseStartedInput): Promise<void> {
     try {
       await this.walletReloadJobService.scheduleCreditsLowCheckIfAutoReloadOff({ walletId });

--- a/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.ts
+++ b/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.ts
@@ -55,7 +55,32 @@ export class InitialDeploymentFundingService {
    * is terminal — retrying against a closed account can never succeed.
    * Every other early exit is terminal: the hourly cron remains the safety net.
    */
-  async fundOnLeaseStarted({ walletId, address, dseq }: FundOnLeaseStartedInput): Promise<void> {
+  async fundOnLeaseStarted(input: FundOnLeaseStartedInput): Promise<void> {
+    try {
+      await this.#fundOnLeaseStarted(input);
+    } finally {
+      await this.#scheduleCreditsLowCheck(input);
+    }
+  }
+
+  /**
+   * A lease just started, so the account's weekly burn changed and the credits-low verdict may
+   * flip — including when the funding itself skipped (sufficient runway, insufficient balance).
+   * Best-effort for the same reason as the wallet reload: it must never affect the funding outcome.
+   */
+  async #scheduleCreditsLowCheck({ walletId, dseq, address }: FundOnLeaseStartedInput): Promise<void> {
+    try {
+      await this.walletReloadJobService.scheduleCreditsLowCheckIfAutoReloadOff({ walletId });
+    } catch (error) {
+      try {
+        this.logger.error({ event: "INITIAL_FUNDING_CREDITS_LOW_SCHEDULE_FAILED", walletId, dseq, address, error });
+      } catch {
+        return;
+      }
+    }
+  }
+
+  async #fundOnLeaseStarted({ walletId, address, dseq }: FundOnLeaseStartedInput): Promise<void> {
     const [deployment] = await this.drainingDeploymentService.findLeases(Number.MAX_SAFE_INTEGER, address, [dseq]);
 
     if (!deployment) {

--- a/apps/api/src/deployment/services/top-up-managed-deployments/fund-draining-deployments-instrumentation.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/fund-draining-deployments-instrumentation.service.ts
@@ -199,6 +199,10 @@ export class FundDrainingDeploymentsInstrumentationService implements Deployment
     this.deploymentsMarkedClosed.add(count);
   }
 
+  recordCreditsLowScheduleError({ walletId, error }: { walletId: number; error: unknown }): void {
+    this.emitLog("error", { event: "FUND_DRAINING_CREDITS_LOW_SCHEDULE_ERROR", walletId, error });
+  }
+
   /**
    * The cron records blocks-until-predicted-close against a run-scoped start height. The stateless
    * event-driven path has no per-run start height, so there is nothing meaningful to record here.

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.integration.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.integration.ts
@@ -626,6 +626,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
         fee: 5000000,
         deployment: balanceByAddress[wallet.address!] ?? 0
       }));
+      vi.spyOn(balances, "retrieveDeploymentLimit").mockImplementation(async (wallet: { address: string | null }) => balanceByAddress[wallet.address!] ?? 0);
       vi.spyOn(balances, "retrieveAndCalcFeeLimit").mockResolvedValue(5000000);
     }
 

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
@@ -878,6 +878,30 @@ describe(TopUpManagedDeploymentsService.name, () => {
       expect(walletReloadService.scheduleImmediate).not.toHaveBeenCalled();
     });
 
+    it("schedules a credits-low check even when the owner has nothing to fund", async () => {
+      const { service, drainingDeploymentService, walletReloadService } = setup();
+      const owner = createAkashAddress();
+
+      drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([]);
+
+      await service.topUpDrainingDeploymentsForOwner({ walletId: 1, address: owner });
+
+      expect(walletReloadService.scheduleCreditsLowCheckIfAutoReloadOff).toHaveBeenCalledWith({ walletId: 1 });
+    });
+
+    it("records a failed credits-low schedule without failing the funding job", async () => {
+      const { service, drainingDeploymentService, walletReloadService, fundDrainingInstrumentation } = setup();
+      const owner = createAkashAddress();
+      const error = new Error("connection reset");
+
+      drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([]);
+      vi.mocked(walletReloadService.scheduleCreditsLowCheckIfAutoReloadOff).mockRejectedValue(error);
+
+      await expect(service.topUpDrainingDeploymentsForOwner({ walletId: 1, address: owner })).resolves.toBeUndefined();
+
+      expect(fundDrainingInstrumentation.recordCreditsLowScheduleError).toHaveBeenCalledWith({ walletId: 1, error });
+    });
+
     it("records a non-positive-amount skip without reporting a false insufficient-balance error", async () => {
       const { service, drainingDeploymentService, cachedBalanceService, managedSignerService, walletReloadService, fundDrainingInstrumentation } = setup();
       const owner = createAkashAddress();

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
@@ -8,6 +8,7 @@ import { WalletBalanceReloadCheck } from "@src/billing/events/wallet-balance-rel
 import { WalletCreditsLowCheck } from "@src/billing/events/wallet-credits-low-check";
 import type { UserWalletRepository, WalletSettingRepository } from "@src/billing/repositories";
 import { RpcMessageService } from "@src/billing/services";
+import type { BalancesService } from "@src/billing/services/balances/balances.service";
 import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import type { ChainErrorService } from "@src/billing/services/chain-error/chain-error.service";
 import type { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
@@ -17,7 +18,11 @@ import type { JobQueueService } from "@src/core";
 import type { CreateLogger } from "@src/core/providers/logging.provider";
 import type { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import type { DeploymentConfigService } from "@src/deployment/services/deployment-config/deployment-config.service";
-import type { DrainingDeployment, DrainingDeploymentService } from "@src/deployment/services/draining-deployment/draining-deployment.service";
+import type {
+  AutoTopUpOwnerDeployments,
+  DrainingDeployment,
+  DrainingDeploymentService
+} from "@src/deployment/services/draining-deployment/draining-deployment.service";
 import { mockConfigService } from "../../../../test/mocks/config-service.mock";
 import { CachedBalance, type CachedBalanceService } from "../cached-balance/cached-balance.service";
 import type { FundDrainingDeploymentsInstrumentationService } from "./fund-draining-deployments-instrumentation.service";
@@ -27,7 +32,6 @@ import type { TopUpManagedDeploymentsInstrumentationService } from "./top-up-man
 import { createAkashAddress } from "@test/seeders";
 import { createAutoTopUpDeployment, createManyAutoTopUpDeployments } from "@test/seeders/auto-top-up-deployment.seeder";
 import { createDrainingDeployment } from "@test/seeders/draining-deployment.seeder";
-import { generateWalletSetting } from "@test/seeders/wallet-setting.seeder";
 
 describe(TopUpManagedDeploymentsService.name, () => {
   const DEPLOYMENT_GRANT_DENOM = "ibc/170C677610AC31DF0904FFE09CD3B5C657492170E7E52372E48756B71E56F2F1";
@@ -56,6 +60,46 @@ describe(TopUpManagedDeploymentsService.name, () => {
       return amount;
     });
     return balance;
+  }
+
+  function createOwnerYield(deployments: DrainingDeployment[], overrides?: Partial<AutoTopUpOwnerDeployments>): AutoTopUpOwnerDeployments {
+    return {
+      address: deployments[0].address,
+      walletId: deployments[0].walletId,
+      userId: deployments[0].userId,
+      autoReloadEnabled: deployments[0].isWalletAutoTopUpEnabled,
+      isTrialing: deployments[0].walletIsTrialing,
+      creditsLowNotifiedAt: deployments[0].walletCreditsLowNotifiedAt,
+      activeDeployments: deployments,
+      drainingDeployments: deployments,
+      ...overrides
+    };
+  }
+
+  function createNonDrainingOwner(overrides?: Partial<AutoTopUpOwnerDeployments>): AutoTopUpOwnerDeployments {
+    const setting = createAutoTopUpDeployment();
+    const activeDeployment = {
+      ...setting,
+      ...createDrainingDeployment({
+        dseq: Number(setting.dseq),
+        owner: setting.address,
+        predictedClosedHeight: CURRENT_BLOCK_HEIGHT + 1_000_000,
+        denom: DEPLOYMENT_GRANT_DENOM
+      }),
+      dseq: setting.dseq
+    } as DrainingDeployment;
+
+    return createOwnerYield([activeDeployment], { drainingDeployments: [], ...overrides });
+  }
+
+  function mockOwnerYields(drainingDeploymentService: ReturnType<typeof mock<DrainingDeploymentService>>, ...owners: AutoTopUpOwnerDeployments[]) {
+    drainingDeploymentService.findDrainingDeploymentsByOwner.mockImplementation(() =>
+      (async function* () {
+        for (const owner of owners) {
+          yield owner;
+        }
+      })()
+    );
   }
 
   describe("topUpDeployments", () => {
@@ -97,8 +141,8 @@ describe(TopUpManagedDeploymentsService.name, () => {
             {} as Record<string, DrainingDeployment[]>
           );
 
-          for (const [address, items] of Object.entries(byAddress)) {
-            yield { address, walletId: items[0].walletId, deployments: items };
+          for (const items of Object.values(byAddress)) {
+            yield createOwnerYield(items);
           }
         })()
       );
@@ -183,7 +227,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
               }),
               dseq: deployment.dseq
             } as DrainingDeployment;
-            yield { address: deployment.address, walletId: deployment.walletId, deployments: [draining] };
+            yield createOwnerYield([draining]);
           }
         })()
       );
@@ -226,8 +270,8 @@ describe(TopUpManagedDeploymentsService.name, () => {
             {} as Record<string, DrainingDeployment[]>
           );
 
-          for (const [address, items] of Object.entries(byAddress)) {
-            yield { address, walletId: items[0].walletId, deployments: items };
+          for (const items of Object.values(byAddress)) {
+            yield createOwnerYield(items);
           }
         })()
       );
@@ -269,8 +313,8 @@ describe(TopUpManagedDeploymentsService.name, () => {
             {} as Record<string, DrainingDeployment[]>
           );
 
-          for (const [address, items] of Object.entries(byAddress)) {
-            yield { address, walletId: items[0].walletId, deployments: items };
+          for (const items of Object.values(byAddress)) {
+            yield createOwnerYield(items);
           }
         })()
       );
@@ -293,70 +337,174 @@ describe(TopUpManagedDeploymentsService.name, () => {
       expect(managedSignerService.executeDerivedTx).not.toHaveBeenCalled();
     });
 
-    it("does not enqueue a reload job for a non-draining owner with Auto Recharge on", async () => {
-      const { service, drainingDeploymentService, deploymentSettingRepository, jobQueueService, walletSettingRepository, managedSignerService } =
-        setupWithWalletReloadJobs();
-      const owner = createAkashAddress();
-      const walletId = faker.number.int({ min: 1000000, max: 9999999 });
-      const walletSetting = generateWalletSetting({ walletId, autoReloadEnabled: true });
-
-      mockNonDrainingAutoTopUpOwner(drainingDeploymentService, deploymentSettingRepository, owner, walletId);
-      walletSettingRepository.findOneBy.mockResolvedValue(walletSetting);
+    it("skips coverage evaluation for a non-draining owner with Auto Recharge on", async () => {
+      const { service, drainingDeploymentService, walletReloadService, balancesService, managedSignerService } = setup();
+      mockOwnerYields(drainingDeploymentService, createNonDrainingOwner({ autoReloadEnabled: true }));
 
       await service.topUpDeployments({ dryRun: false });
 
-      expect(jobQueueService.enqueue).not.toHaveBeenCalled();
+      expect(walletReloadService.scheduleCreditsLowCheck).not.toHaveBeenCalled();
+      expect(drainingDeploymentService.calculateWeeklyCoverageCredits).not.toHaveBeenCalled();
+      expect(balancesService.retrieveDeploymentLimit).not.toHaveBeenCalled();
       expect(managedSignerService.executeDerivedTx).not.toHaveBeenCalled();
     });
 
-    it("enqueues a credits-low check for a non-draining owner with Auto Recharge off", async () => {
-      const { service, drainingDeploymentService, deploymentSettingRepository, jobQueueService, walletSettingRepository } = setupWithWalletReloadJobs();
-      const owner = createAkashAddress();
-      const walletId = faker.number.int({ min: 1000000, max: 9999999 });
-      const walletSetting = generateWalletSetting({ walletId, autoReloadEnabled: false });
-
-      mockNonDrainingAutoTopUpOwner(drainingDeploymentService, deploymentSettingRepository, owner, walletId);
-      walletSettingRepository.findOneBy.mockResolvedValue(walletSetting);
+    it("skips coverage evaluation for a trialing non-draining owner", async () => {
+      const { service, drainingDeploymentService, walletReloadService } = setup();
+      mockOwnerYields(drainingDeploymentService, createNonDrainingOwner({ isTrialing: true }));
 
       await service.topUpDeployments({ dryRun: false });
 
+      expect(walletReloadService.scheduleCreditsLowCheck).not.toHaveBeenCalled();
+      expect(drainingDeploymentService.calculateWeeklyCoverageCredits).not.toHaveBeenCalled();
+    });
+
+    it("enqueues a credits-low check for a non-draining owner below a week of coverage", async () => {
+      const { service, drainingDeploymentService, balancesService, jobQueueService } = setupWithWalletReloadJobs();
+      const owner = createNonDrainingOwner();
+
+      mockOwnerYields(drainingDeploymentService, owner);
+      drainingDeploymentService.calculateWeeklyCoverageCredits.mockReturnValue(700);
+      balancesService.retrieveDeploymentLimit.mockResolvedValue(100);
+
+      await service.topUpDeployments({ dryRun: false });
+
+      expect(drainingDeploymentService.calculateWeeklyCoverageCredits).toHaveBeenCalledWith(owner.activeDeployments, CURRENT_BLOCK_HEIGHT);
       expect(jobQueueService.enqueue).toHaveBeenCalledWith(
         expect.any(WalletCreditsLowCheck),
         expect.objectContaining({
-          singletonKey: `${WalletCreditsLowCheck.name}.${walletSetting.userId}`
+          singletonKey: `${WalletCreditsLowCheck.name}.${owner.userId}`
         })
       );
       expect(jobQueueService.enqueue).not.toHaveBeenCalledWith(expect.any(WalletBalanceReloadCheck), expect.anything());
     });
 
-    it("keeps a failed credits-low sweep out of the funding run's status and result", async () => {
-      const { service, drainingDeploymentService, deploymentSettingRepository, walletSettingRepository, instrumentation } = setupWithWalletReloadJobs();
-      const owner = createAkashAddress();
-      const walletId = faker.number.int({ min: 1000000, max: 9999999 });
+    it("does not enqueue for a low owner already stamped notified", async () => {
+      const { service, drainingDeploymentService, balancesService, walletReloadService } = setup();
+      mockOwnerYields(drainingDeploymentService, createNonDrainingOwner({ creditsLowNotifiedAt: faker.date.recent() }));
+      drainingDeploymentService.calculateWeeklyCoverageCredits.mockReturnValue(700);
+      balancesService.retrieveDeploymentLimit.mockResolvedValue(100);
+
+      await service.topUpDeployments({ dryRun: false });
+
+      expect(walletReloadService.scheduleCreditsLowCheck).not.toHaveBeenCalled();
+    });
+
+    it("enqueues a clearing check for a notified owner whose balance recovered", async () => {
+      const { service, drainingDeploymentService, balancesService, walletReloadService } = setup();
+      const owner = createNonDrainingOwner({ creditsLowNotifiedAt: faker.date.recent() });
+
+      mockOwnerYields(drainingDeploymentService, owner);
+      drainingDeploymentService.calculateWeeklyCoverageCredits.mockReturnValue(700);
+      balancesService.retrieveDeploymentLimit.mockResolvedValue(1000);
+
+      await service.topUpDeployments({ dryRun: false });
+
+      expect(walletReloadService.scheduleCreditsLowCheck).toHaveBeenCalledWith(owner.userId, { withCleanup: true });
+    });
+
+    it("does not enqueue for a covered owner that was never notified", async () => {
+      const { service, drainingDeploymentService, balancesService, walletReloadService } = setup();
+      mockOwnerYields(drainingDeploymentService, createNonDrainingOwner());
+      drainingDeploymentService.calculateWeeklyCoverageCredits.mockReturnValue(700);
+      balancesService.retrieveDeploymentLimit.mockResolvedValue(1000);
+
+      await service.topUpDeployments({ dryRun: false });
+
+      expect(walletReloadService.scheduleCreditsLowCheck).not.toHaveBeenCalled();
+    });
+
+    it("skips the balance read for a zero-cost owner and only enqueues to clear a stale stamp", async () => {
+      const { service, drainingDeploymentService, balancesService, walletReloadService } = setup();
+      const unnotified = createNonDrainingOwner();
+      const notified = createNonDrainingOwner({ creditsLowNotifiedAt: faker.date.recent() });
+
+      mockOwnerYields(drainingDeploymentService, unnotified, notified);
+      drainingDeploymentService.calculateWeeklyCoverageCredits.mockReturnValue(0);
+
+      await service.topUpDeployments({ dryRun: false });
+
+      expect(balancesService.retrieveDeploymentLimit).not.toHaveBeenCalled();
+      expect(walletReloadService.scheduleCreditsLowCheck).toHaveBeenCalledTimes(1);
+      expect(walletReloadService.scheduleCreditsLowCheck).toHaveBeenCalledWith(notified.userId, { withCleanup: true });
+    });
+
+    it("falls back to enqueueing the check when the inline evaluation fails", async () => {
+      const { service, drainingDeploymentService, balancesService, walletReloadService, instrumentation } = setup();
+      const owner = createNonDrainingOwner();
       const error = new Error("connection reset");
 
-      mockNonDrainingAutoTopUpOwner(drainingDeploymentService, deploymentSettingRepository, owner, walletId);
-      walletSettingRepository.findOneBy.mockRejectedValue(error);
+      mockOwnerYields(drainingDeploymentService, owner);
+      drainingDeploymentService.calculateWeeklyCoverageCredits.mockReturnValue(700);
+      balancesService.retrieveDeploymentLimit.mockRejectedValue(error);
 
       const result = await service.topUpDeployments({ dryRun: false });
 
       expect(result.ok).toBe(true);
-      expect(instrumentation.recordCreditsLowScheduleError).toHaveBeenCalledWith({ walletId, error });
+      expect(instrumentation.recordCreditsLowScheduleError).toHaveBeenCalledWith({ walletId: owner.walletId, error });
+      expect(walletReloadService.scheduleCreditsLowCheck).toHaveBeenCalledWith(owner.userId, { withCleanup: true });
       expect(instrumentation.finish).toHaveBeenCalledWith("success", CURRENT_BLOCK_HEIGHT);
     });
 
-    it("does not schedule extra checks for auto-top-up owners on dry run", async () => {
-      const { service, drainingDeploymentService, deploymentSettingRepository, jobQueueService, walletSettingRepository } = setupWithWalletReloadJobs();
-      const owner = createAkashAddress();
-      const walletId = faker.number.int({ min: 1000000, max: 9999999 });
-      const walletSetting = generateWalletSetting({ walletId, autoReloadEnabled: false });
-
-      mockNonDrainingAutoTopUpOwner(drainingDeploymentService, deploymentSettingRepository, owner, walletId);
-      walletSettingRepository.findOneBy.mockResolvedValue(walletSetting);
+    it("does not evaluate coverage or schedule checks on dry run", async () => {
+      const { service, drainingDeploymentService, balancesService, walletReloadService } = setup();
+      mockOwnerYields(drainingDeploymentService, createNonDrainingOwner());
+      drainingDeploymentService.calculateWeeklyCoverageCredits.mockReturnValue(700);
+      balancesService.retrieveDeploymentLimit.mockResolvedValue(100);
 
       await service.topUpDeployments({ dryRun: true });
 
-      expect(jobQueueService.enqueue).not.toHaveBeenCalled();
+      expect(drainingDeploymentService.calculateWeeklyCoverageCredits).not.toHaveBeenCalled();
+      expect(walletReloadService.scheduleCreditsLowCheck).not.toHaveBeenCalled();
+    });
+
+    it("enqueues a post-funding credits-low check for a funded owner without an inline verdict", async () => {
+      const { service, drainingDeploymentService, cachedBalanceService, balancesService, walletReloadService, managedSignerService } = setup();
+      const deployment = createAutoTopUpDeployment();
+      const draining = {
+        ...deployment,
+        ...createDrainingDeployment({
+          dseq: Number(deployment.dseq),
+          owner: deployment.address,
+          predictedClosedHeight: CURRENT_BLOCK_HEIGHT + 1500,
+          denom: DEPLOYMENT_GRANT_DENOM
+        }),
+        dseq: deployment.dseq
+      } as DrainingDeployment;
+
+      mockOwnerYields(drainingDeploymentService, createOwnerYield([draining]));
+      drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(1000000);
+      cachedBalanceService.get.mockResolvedValue(createMockCachedBalance(() => 1000000));
+
+      await service.topUpDeployments({ dryRun: false });
+
+      expect(managedSignerService.executeDerivedTx).toHaveBeenCalledTimes(1);
+      expect(walletReloadService.scheduleCreditsLowCheck).toHaveBeenCalledWith(deployment.userId, { withCleanup: true });
+      expect(drainingDeploymentService.calculateWeeklyCoverageCredits).not.toHaveBeenCalled();
+      expect(balancesService.retrieveDeploymentLimit).not.toHaveBeenCalled();
+    });
+
+    it("still schedules the credits-low check when funding an owner throws", async () => {
+      const { service, drainingDeploymentService, cachedBalanceService, walletReloadService } = setup();
+      const deployment = createAutoTopUpDeployment();
+      const draining = {
+        ...deployment,
+        ...createDrainingDeployment({
+          dseq: Number(deployment.dseq),
+          owner: deployment.address,
+          predictedClosedHeight: CURRENT_BLOCK_HEIGHT + 1500,
+          denom: DEPLOYMENT_GRANT_DENOM
+        }),
+        dseq: deployment.dseq
+      } as DrainingDeployment;
+
+      mockOwnerYields(drainingDeploymentService, createOwnerYield([draining]));
+      cachedBalanceService.get.mockRejectedValue(new Error("balance fetch failed"));
+
+      const result = await service.topUpDeployments({ dryRun: false });
+
+      expect(result.ok).toBe(false);
+      expect(walletReloadService.scheduleCreditsLowCheck).toHaveBeenCalledWith(deployment.userId, { withCleanup: true });
     });
 
     it("should top up draining deployments for the same owner in the same tx", async () => {
@@ -389,8 +537,8 @@ describe(TopUpManagedDeploymentsService.name, () => {
             {} as Record<string, DrainingDeployment[]>
           );
 
-          for (const [address, items] of Object.entries(byAddress)) {
-            yield { address, walletId: items[0].walletId, deployments: items };
+          for (const items of Object.values(byAddress)) {
+            yield createOwnerYield(items);
           }
         })()
       );
@@ -457,7 +605,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
               dseq: deployment.dseq
             } as DrainingDeployment
           ];
-          yield { address: deployment.address, walletId: deployment.walletId, deployments: items };
+          yield createOwnerYield(items);
         })()
       );
 
@@ -511,8 +659,8 @@ describe(TopUpManagedDeploymentsService.name, () => {
             {} as Record<string, DrainingDeployment[]>
           );
 
-          for (const [address, items] of Object.entries(byAddress)) {
-            yield { address, walletId: items[0].walletId, deployments: items };
+          for (const items of Object.values(byAddress)) {
+            yield createOwnerYield(items);
           }
         })()
       );
@@ -567,8 +715,8 @@ describe(TopUpManagedDeploymentsService.name, () => {
             {} as Record<string, DrainingDeployment[]>
           );
 
-          for (const [address, items] of Object.entries(byAddress)) {
-            yield { address, walletId: items[0].walletId, deployments: items };
+          for (const items of Object.values(byAddress)) {
+            yield createOwnerYield(items);
           }
         })()
       );
@@ -588,17 +736,13 @@ describe(TopUpManagedDeploymentsService.name, () => {
 
       drainingDeploymentService.findDrainingDeploymentsByOwner.mockImplementation(() =>
         (async function* () {
-          yield {
-            address: deployment.address,
-            walletId: deployment.walletId,
-            deployments: [
-              {
-                ...deployment,
-                ...createDrainingDeployment({ dseq: Number(deployment.dseq), owner: deployment.address, predictedClosedHeight }),
-                dseq: deployment.dseq
-              } as DrainingDeployment
-            ]
-          };
+          yield createOwnerYield([
+            {
+              ...deployment,
+              ...createDrainingDeployment({ dseq: Number(deployment.dseq), owner: deployment.address, predictedClosedHeight }),
+              dseq: deployment.dseq
+            } as DrainingDeployment
+          ]);
         })()
       );
       drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(1000000);
@@ -622,17 +766,13 @@ describe(TopUpManagedDeploymentsService.name, () => {
 
       drainingDeploymentService.findDrainingDeploymentsByOwner.mockImplementation(() =>
         (async function* () {
-          yield {
-            address: deployment.address,
-            walletId: deployment.walletId,
-            deployments: [
-              {
-                ...deployment,
-                ...createDrainingDeployment({ dseq: Number(deployment.dseq), owner: deployment.address, predictedClosedHeight }),
-                dseq: deployment.dseq
-              } as DrainingDeployment
-            ]
-          };
+          yield createOwnerYield([
+            {
+              ...deployment,
+              ...createDrainingDeployment({ dseq: Number(deployment.dseq), owner: deployment.address, predictedClosedHeight }),
+              dseq: deployment.dseq
+            } as DrainingDeployment
+          ]);
         })()
       );
       drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(1000000);
@@ -656,17 +796,13 @@ describe(TopUpManagedDeploymentsService.name, () => {
 
       drainingDeploymentService.findDrainingDeploymentsByOwner.mockImplementation(() =>
         (async function* () {
-          yield {
-            address: deployment.address,
-            walletId: deployment.walletId,
-            deployments: [
-              {
-                ...deployment,
-                ...createDrainingDeployment({ dseq: Number(deployment.dseq), owner: deployment.address, predictedClosedHeight }),
-                dseq: deployment.dseq
-              } as DrainingDeployment
-            ]
-          };
+          yield createOwnerYield([
+            {
+              ...deployment,
+              ...createDrainingDeployment({ dseq: Number(deployment.dseq), owner: deployment.address, predictedClosedHeight }),
+              dseq: deployment.dseq
+            } as DrainingDeployment
+          ]);
         })()
       );
       drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(1000000);
@@ -1112,20 +1248,6 @@ describe(TopUpManagedDeploymentsService.name, () => {
     }
   });
 
-  function mockNonDrainingAutoTopUpOwner(
-    drainingDeploymentService: ReturnType<typeof mock<DrainingDeploymentService>>,
-    deploymentSettingRepository: ReturnType<typeof mock<DeploymentSettingRepository>>,
-    owner: string,
-    walletId: number
-  ) {
-    drainingDeploymentService.findDrainingDeploymentsByOwner.mockImplementation(() => (async function* () {})());
-    deploymentSettingRepository.findAutoTopUpDeploymentsByOwnerIteratively.mockImplementation(() =>
-      (async function* () {
-        yield { address: owner, walletId, deploymentSettings: [createAutoTopUpDeployment({ address: owner, walletId })] };
-      })()
-    );
-  }
-
   function setupWithWalletReloadJobs(input?: { currentBlockHeight?: number; feeAllowance?: number }) {
     const walletSettingRepository = mock<WalletSettingRepository>();
     const userWalletRepository = mock<UserWalletRepository>();
@@ -1174,6 +1296,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
     deploymentSettingRepository.releaseFundingClaim.mockResolvedValue(undefined);
     deploymentSettingRepository.findAutoTopUpDeploymentsByOwnerIteratively.mockImplementation(() => (async function* () {})());
     const deploymentConfig = mockConfigService<DeploymentConfigService>({ AUTO_TOP_UP_DEDUP_COOLDOWN_IN_MIN: DEDUP_COOLDOWN_IN_MIN });
+    const balancesService = mock<BalancesService>();
 
     const service = new TopUpManagedDeploymentsService(
       managedSignerService,
@@ -1187,7 +1310,8 @@ describe(TopUpManagedDeploymentsService.name, () => {
       fundDrainingInstrumentation,
       walletReloadService,
       deploymentSettingRepository,
-      deploymentConfig
+      deploymentConfig,
+      balancesService
     );
 
     return {
@@ -1203,7 +1327,8 @@ describe(TopUpManagedDeploymentsService.name, () => {
       fundDrainingInstrumentation,
       walletReloadService,
       deploymentSettingRepository,
-      deploymentConfig
+      deploymentConfig,
+      balancesService
     };
   }
 });

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
@@ -92,16 +92,34 @@ export class TopUpManagedDeploymentsService {
    * about to drain does not wait up to an hour for the next scheduled pass.
    */
   async topUpDrainingDeploymentsForOwner({ walletId, address }: { walletId: number; address: string }): Promise<void> {
-    const currentHeight = await this.blockHttpService.getCurrentHeight();
-    const deployments = await this.drainingDeploymentService.findDrainingDeploymentsForOwner(address, this.fundDrainingInstrumentation, currentHeight);
+    try {
+      const currentHeight = await this.blockHttpService.getCurrentHeight();
+      const deployments = await this.drainingDeploymentService.findDrainingDeploymentsForOwner(address, this.fundDrainingInstrumentation, currentHeight);
 
-    if (!deployments.length) {
-      this.fundDrainingInstrumentation.recordSkipped({ owner: address, deploymentCount: 0 });
-      return;
+      if (!deployments.length) {
+        this.fundDrainingInstrumentation.recordSkipped({ owner: address, deploymentCount: 0 });
+        return;
+      }
+
+      const balance = await this.cachedBalanceService.getFresh(address);
+      await this.#fundOwnerDeployments({ address, walletId, deployments }, { dryRun: false }, balance, this.fundDrainingInstrumentation, currentHeight);
+    } finally {
+      await this.#scheduleCreditsLowCheckOnLandedCredits(walletId);
     }
+  }
 
-    const balance = await this.cachedBalanceService.getFresh(address);
-    await this.#fundOwnerDeployments({ address, walletId, deployments }, { dryRun: false }, balance, this.fundDrainingInstrumentation, currentHeight);
+  /**
+   * Credits just landed on this wallet, so the credits-low verdict may flip — typically clearing
+   * the low stamp. Runs whether or not anything was draining, and best-effort: a schedule failure
+   * must not fail the funding job after a landed deposit, where retries would burn against the
+   * funding-claim cooldown.
+   */
+  async #scheduleCreditsLowCheckOnLandedCredits(walletId: number): Promise<void> {
+    try {
+      await this.walletReloadService.scheduleCreditsLowCheckIfAutoReloadOff({ walletId });
+    } catch (error: unknown) {
+      this.fundDrainingInstrumentation.recordCreditsLowScheduleError({ walletId, error });
+    }
   }
 
   async #fundOwnerDeployments(

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
@@ -3,14 +3,16 @@ import { Err, Ok, Result } from "ts-results";
 import { singleton } from "tsyringe";
 
 import { DepositDeploymentMsgOptions, RpcMessageService } from "@src/billing/services";
+import { BalancesService } from "@src/billing/services/balances/balances.service";
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import { ChainErrorService } from "@src/billing/services/chain-error/chain-error.service";
 import { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
+import { needsCreditsLowTransition } from "@src/billing/services/wallet-credits-low-check/credits-low-transition";
 import { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
 import { BlockHttpService } from "@src/chain/services/block-http/block-http.service";
 import type { DryRunOptions } from "@src/core/types/console";
 import { DeploymentSettingRepository, type FundingClaim } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
-import { DrainingDeployment } from "@src/deployment/services/draining-deployment/draining-deployment.service";
+import { AutoTopUpOwnerDeployments, DrainingDeployment } from "@src/deployment/services/draining-deployment/draining-deployment.service";
 import { DrainingDeploymentService } from "@src/deployment/services/draining-deployment/draining-deployment.service";
 import { COSMOS_TX_CODE_OK } from "@src/utils/constants";
 import { CachedBalance, CachedBalanceService } from "../cached-balance/cached-balance.service";
@@ -39,7 +41,8 @@ export class TopUpManagedDeploymentsService {
     private readonly fundDrainingInstrumentation: FundDrainingDeploymentsInstrumentationService,
     private readonly walletReloadService: WalletReloadJobService,
     private readonly deploymentSettingRepository: DeploymentSettingRepository,
-    private readonly deploymentConfig: DeploymentConfigService
+    private readonly deploymentConfig: DeploymentConfigService,
+    private readonly balancesService: BalancesService
   ) {}
 
   /**
@@ -55,15 +58,23 @@ export class TopUpManagedDeploymentsService {
     try {
       for await (const owner of this.drainingDeploymentService.findDrainingDeploymentsByOwner(currentHeight, options)) {
         try {
-          const balance = await this.cachedBalanceService.get(owner.address);
-          await this.#fundOwnerDeployments(owner, options, balance, this.instrumentation, currentHeight);
+          if (owner.drainingDeployments.length) {
+            const balance = await this.cachedBalanceService.get(owner.address);
+            await this.#fundOwnerDeployments(
+              { address: owner.address, walletId: owner.walletId, deployments: owner.drainingDeployments },
+              options,
+              balance,
+              this.instrumentation,
+              currentHeight
+            );
+          }
         } catch (error: unknown) {
           errors.push(error);
+        } finally {
+          if (!options.dryRun) {
+            await this.#ensureCreditsLowTransitionChecked(owner, currentHeight);
+          }
         }
-      }
-
-      if (!options.dryRun) {
-        await this.#scheduleCreditsLowChecksForAutoTopUpOwners();
       }
     } catch (error: unknown) {
       errors.push(error);
@@ -157,21 +168,51 @@ export class TopUpManagedDeploymentsService {
   }
 
   /**
-   * Best-effort: the sweep only schedules credits-low email checks, so its failures are logged
-   * and kept out of the funding run's status and result, which report on funding alone.
+   * Best-effort: the sweep only schedules credits-low email checks, so failures here are
+   * recorded and kept out of the funding run's status and result, which report on funding
+   * alone. Runs after the funding attempt regardless of its outcome — an owner whose funding
+   * just failed is among the most likely to be low. A funded owner is enqueued without an
+   * inline verdict: the deposits just moved its balance, so the handler recomputes fresh state.
    */
-  async #scheduleCreditsLowChecksForAutoTopUpOwners(): Promise<void> {
+  async #ensureCreditsLowTransitionChecked(owner: AutoTopUpOwnerDeployments, currentHeight: number): Promise<void> {
     try {
-      for await (const owner of this.deploymentSettingRepository.findAutoTopUpDeploymentsByOwnerIteratively()) {
-        try {
-          await this.walletReloadService.scheduleCreditsLowCheckIfAutoReloadOff({ walletId: owner.walletId });
-        } catch (error: unknown) {
-          this.instrumentation.recordCreditsLowScheduleError({ walletId: owner.walletId, error });
-        }
+      if (owner.autoReloadEnabled || owner.isTrialing) {
+        return;
+      }
+
+      if (owner.drainingDeployments.length || (await this.#needsCreditsLowTransition(owner, currentHeight))) {
+        await this.walletReloadService.scheduleCreditsLowCheck(owner.userId, { withCleanup: true });
       }
     } catch (error: unknown) {
-      this.instrumentation.recordCreditsLowScheduleError({ error });
+      this.instrumentation.recordCreditsLowScheduleError({ walletId: owner.walletId, error });
+
+      try {
+        await this.walletReloadService.scheduleCreditsLowCheck(owner.userId, { withCleanup: true });
+      } catch {
+        return;
+      }
     }
+  }
+
+  /**
+   * Decides from data already in hand whether the credits-low state machine needs to move;
+   * anything enqueued is re-verified by the handler against fresh state, so a stale row here
+   * costs at most a no-op job, and an evaluation failure falls back to enqueueing so the
+   * handler's retries absorb transient errors. Compares in credits: `toFiatAmount` is
+   * monotonic (identity for uact), so this matches the handler's USD comparison except
+   * inside its cent-rounding band, where the mismatch is a harmless enqueue.
+   */
+  async #needsCreditsLowTransition(owner: AutoTopUpOwnerDeployments, currentHeight: number): Promise<boolean> {
+    const isNotified = Boolean(owner.creditsLowNotifiedAt);
+    const weeklyCredits = this.drainingDeploymentService.calculateWeeklyCoverageCredits(owner.activeDeployments, currentHeight);
+
+    if (weeklyCredits === 0) {
+      return needsCreditsLowTransition({ balance: 0, weeklyCost: 0, isNotified });
+    }
+
+    const balance = await this.balancesService.retrieveDeploymentLimit({ address: owner.address });
+
+    return needsCreditsLowTransition({ balance, weeklyCost: weeklyCredits, isNotified });
   }
 
   /**

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
@@ -108,12 +108,7 @@ export class TopUpManagedDeploymentsService {
     }
   }
 
-  /**
-   * Credits just landed on this wallet, so the credits-low verdict may flip — typically clearing
-   * the low stamp. Runs whether or not anything was draining, and best-effort: a schedule failure
-   * must not fail the funding job after a landed deposit, where retries would burn against the
-   * funding-claim cooldown.
-   */
+  /** Best-effort after a landed deposit: failing the job here would burn a retry against the funding-claim cooldown. */
   async #scheduleCreditsLowCheckOnLandedCredits(walletId: number): Promise<void> {
     try {
       await this.walletReloadService.scheduleCreditsLowCheckIfAutoReloadOff({ walletId });
@@ -185,13 +180,7 @@ export class TopUpManagedDeploymentsService {
     await this.walletReloadService.scheduleImmediate({ walletId });
   }
 
-  /**
-   * Best-effort: the sweep only schedules credits-low email checks, so failures here are
-   * recorded and kept out of the funding run's status and result, which report on funding
-   * alone. Runs after the funding attempt regardless of its outcome — an owner whose funding
-   * just failed is among the most likely to be low. A funded owner is enqueued without an
-   * inline verdict: the deposits just moved its balance, so the handler recomputes fresh state.
-   */
+  /** Runs after the funding attempt whatever its outcome, since an owner whose funding just failed is among the likeliest to be low. */
   async #ensureCreditsLowTransitionChecked(owner: AutoTopUpOwnerDeployments, currentHeight: number): Promise<void> {
     try {
       if (owner.autoReloadEnabled || owner.isTrialing) {
@@ -212,14 +201,7 @@ export class TopUpManagedDeploymentsService {
     }
   }
 
-  /**
-   * Decides from data already in hand whether the credits-low state machine needs to move;
-   * anything enqueued is re-verified by the handler against fresh state, so a stale row here
-   * costs at most a no-op job, and an evaluation failure falls back to enqueueing so the
-   * handler's retries absorb transient errors. Compares in credits: `toFiatAmount` is
-   * monotonic (identity for uact), so this matches the handler's USD comparison except
-   * inside its cent-rounding band, where the mismatch is a harmless enqueue.
-   */
+  /** Safe to answer from stale rows: the handler re-verifies anything enqueued against fresh state, so a wrong yes costs a no-op job. */
   async #needsCreditsLowTransition(owner: AutoTopUpOwnerDeployments, currentHeight: number): Promise<boolean> {
     const isNotified = Boolean(owner.creditsLowNotifiedAt);
     const weeklyCredits = this.drainingDeploymentService.calculateWeeklyCoverageCredits(owner.activeDeployments, currentHeight);

--- a/apps/api/test/seeders/auto-top-up-deployment.seeder.ts
+++ b/apps/api/test/seeders/auto-top-up-deployment.seeder.ts
@@ -6,6 +6,7 @@ import { createAkashAddress } from "./akash-address.seeder";
 export function createAutoTopUpDeployment(overrides: Partial<AutoTopUpDeployment> = {}): AutoTopUpDeployment {
   return {
     id: faker.string.uuid(),
+    userId: faker.string.uuid(),
     walletId: faker.number.int(),
     dseq: faker.string.numeric(),
     address: createAkashAddress(),
@@ -13,6 +14,7 @@ export function createAutoTopUpDeployment(overrides: Partial<AutoTopUpDeployment
     walletIsTrialing: false,
     walletCreatedAt: faker.date.recent(),
     walletActivatedAt: faker.date.recent(),
+    walletCreditsLowNotifiedAt: null,
     runtimeLimitHours: null,
     runtimeEndsAt: null,
     ...overrides


### PR DESCRIPTION
## Why

The credits-running-low email (#3633) scheduled its coverage check on every managed spending transaction, and every check job rebuilt the account's whole spending picture from scratch: a settings query, a full lease scan over RPC, an authz grant read, and a block-height read. A once-per-low-period email was costing per-transaction work that grows with every paying account.

It also left two calculations of "a week of spending". `/v1/weekly-cost` billed every deployment a flat 168 hours, while the email threshold caps runtime-limited deployments at their remaining hours, so the figure shown in the product and the threshold behind the email could disagree.

Closes CON-896

## What

- `/v1/weekly-cost` now delegates to the same coverage calculation the email threshold uses, so a runtime-limited deployment is billed only its remaining hours in both places. This is the only user-visible change.
- The check now runs only when the answer can change: credits landing (the fund-on-credit job, which now schedules a check even when nothing was draining), a lease starting (initial funding, including its sufficient-runway and insufficient-balance skips), a deployment closing (the managed signer detects `MsgCloseDeployment`, which covers the UI close, the REST close, and the system closers), and Auto Recharge transitions (unchanged). Spending transactions and deployment-settings saves no longer schedule anything.
- The hourly funding sweep evaluates coverage inline instead of enqueueing a job per owner. The owner iteration yields every auto-top-up owner with its full active-lease picture, the transition decision compares credits directly (the fiat conversion is monotonic, so no price lookups are needed), and a job is enqueued only when the state machine has to move: send the email or clear the stamp. Funded owners still get a post-funding job because their balance just moved. The second full owner iteration and its per-owner wallet-setting reads are gone.
- The handler is untouched: same guards, same one-email-per-low-period stamp, same clearing on recovery or on enabling Auto Recharge. Anything the sweep enqueues is re-verified there against fresh state, so a stale row costs at most a no-op job.

Accepted gaps, all covered by the hourly sweep within an hour: refunds move credits out without an event, and the deprecated `/v1/deposit-deployment` endpoint plus the low-level cleanup closers bypass the new triggers.

Permission note: `/v1/weekly-cost` keeps CASL on the wallet lookup; the per-address settings query inside the shared calculation is unscoped, since the wallet lookup already proves ownership.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved credits-low monitoring after deployment funding, transaction completion, and scheduled top-ups.
  * Funding calculations now account for active and draining deployments, runtime limits, and available balances.
* **Bug Fixes**
  * Scheduling failures are logged without interrupting successful funding or transaction processing.
  * Unnecessary credits-low checks are avoided when Auto Recharge is unavailable or disabled.
  * Credits-low status now reflects changing wallet balances and weekly spending needs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->