### PR TITLE
docs(dx): prefer pg-boss over cron jobs for scheduled and double-write work

### DIFF
--- a/.claude/instructions/prefer-pg-boss-over-cron-jobs.md
+++ b/.claude/instructions/prefer-pg-boss-over-cron-jobs.md
@@ -1,0 +1,10 @@
+## Prefer pg-boss over cron jobs for double writes and time-specific executions
+
+## Description
+- For work that must happen alongside a database write (a double write) or at/after a specific time, always prefer a pg-boss job over adding a new Kubernetes CronJob or CLI sweep command whenever possible.
+- In `apps/api`, use `JobQueueService` (`apps/api/src/core/services/job-queue/job-queue.service.ts`): define a job + handler, and enqueue it where the triggering write happens.
+- Why pg-boss:
+  - Jobs live in the same Postgres database, so `enqueue` joins the ambient transaction of the domain write: the job and the write commit or roll back together, eliminating dual-write inconsistency.
+  - Delayed / time-specific execution is built in (`startAfter` in enqueue options), so no additional cron job, helm values entry, or deploy pipeline change is needed.
+  - Retries with backoff, queue policies, and observability come from the existing `JobQueueService` setup instead of per-cron-job wiring.
+- Reach for a CronJob only when a queue job genuinely cannot express the work (e.g. an unbounded recurring sweep over rows that were never touched by an enqueue-capable code path).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,6 +217,11 @@ See detailed guidelines:
 See detailed guidelines:
 @./.claude/instructions/use-mock-instead-of-as-unknown-as-in-tests.md
 
+## Prefer pg-boss over cron jobs for double writes and time-specific executions
+
+See detailed guidelines:
+@./.claude/instructions/prefer-pg-boss-over-cron-jobs.md
+
 ## Writing Tests
 
 Always use the `/console-tests` skill when writing, fixing, reviewing, or refactoring tests in this repo.


### PR DESCRIPTION
## Why

The runtime-limit close sweep in #3630 shipped as a Kubernetes CronJob, which meant helm values in two environments and a dry-run rollout just to run a periodic task. We already run pg-boss in the API and it fits most of this work better: an enqueue joins the domain write's transaction, so the job and the write commit or roll back together, and `startAfter` handles delayed execution without any deploy wiring. This records that preference in the contribution guidelines so the next scheduled or double-write task defaults to pg-boss instead of another CronJob.

## What

Adds `.claude/instructions/prefer-pg-boss-over-cron-jobs.md` and links it from `CLAUDE.md`, following the existing instruction-file convention.