### PR TITLE
feat(deployment): delete a deployment setting no chain deployment backs

### DIFF
--- a/apps/api/src/app/providers/jobs.provider.ts
+++ b/apps/api/src/app/providers/jobs.provider.ts
@@ -6,6 +6,7 @@ import { WalletCreditsLowCheckHandler } from "@src/billing/services/wallet-credi
 import type { AppInitializer } from "@src/core/providers/app-initializer";
 import { APP_INITIALIZER, ON_APP_START } from "@src/core/providers/app-initializer";
 import { JobQueueService } from "@src/core/services/job-queue/job-queue.service";
+import { DeleteUnbackedDeploymentSettingHandler } from "@src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler";
 import { NotificationHandler } from "@src/notifications/services/notification-handler/notification.handler";
 import { AutoRechargeSucceededHandler } from "../services/auto-recharge-succeeded/auto-recharge-succeeded.handler";
 import { CloseTrialDeploymentHandler } from "../services/close-trial-deployment/close-trial-deployment.handler";
@@ -33,7 +34,8 @@ container.register(APP_INITIALIZER, {
         container.resolve(WalletCreditsLowCheckHandler),
         container.resolve(FirstPurchaseBonusGrantedHandler),
         container.resolve(AutoRechargeSucceededHandler),
-        container.resolve(ActivateTrialHandler)
+        container.resolve(ActivateTrialHandler),
+        container.resolve(DeleteUnbackedDeploymentSettingHandler)
       ]);
     }
   } satisfies AppInitializer

--- a/apps/api/src/chain/providers/chain-sdk.provider.ts
+++ b/apps/api/src/chain/providers/chain-sdk.provider.ts
@@ -5,6 +5,25 @@ import { container, instancePerContainerCachingFactory } from "tsyringe";
 
 import { CORE_CONFIG } from "@src/core";
 
+/**
+ * Deadline for a single chain query. Without one the SDK adds no abort signal at all, so a black-holed
+ * connection hangs its caller indefinitely — a background job until pg-boss expires it a quarter of an hour
+ * later, and a request until the client gives up. Matches the 30s the REST services already pass to
+ * `httpClient.get`, and is a ceiling rather than a target: every query behind this token is a point read.
+ */
+const QUERY_TIMEOUT_MS = 30_000;
+
+type QueryTransportOptions = NonNullable<Parameters<typeof createChainNodeWebSDK>[0]["query"]["transportOptions"]>;
+
+/**
+ * `createGrpcGatewayTransport` reads `defaultTimeoutMs` off the transport options it is handed, but
+ * `ChainNodeWebSDKOptions` declares that bag as `{ retry?: RetryOptions }` only. Verified against a live
+ * endpoint: a 2s value aborts after ~2s with `DeadlineExceeded`, so the runtime honours the option and the
+ * published type is simply behind it. Asserted once, here, so a dependency bump that widens the type turns
+ * this into a redundant assertion rather than leaving the timeout silently unset.
+ */
+const TRANSPORT_OPTIONS = { defaultTimeoutMs: QUERY_TIMEOUT_MS } as unknown as QueryTransportOptions;
+
 export const CHAIN_SDK = Symbol("CHAIN_SDK") as InjectionToken<ChainNodeWebSDK>;
 export type ChainSDK = ChainNodeWebSDK;
 
@@ -13,7 +32,8 @@ container.register(CHAIN_SDK, {
     const { REST_API_NODE_URL } = c.resolve(CORE_CONFIG);
     return createChainNodeWebSDK({
       query: {
-        baseUrl: REST_API_NODE_URL
+        baseUrl: REST_API_NODE_URL,
+        transportOptions: TRANSPORT_OPTIONS
       }
     });
   })

--- a/apps/api/src/chain/providers/chain-sdk.provider.ts
+++ b/apps/api/src/chain/providers/chain-sdk.provider.ts
@@ -19,10 +19,13 @@ type QueryTransportOptions = NonNullable<Parameters<typeof createChainNodeWebSDK
  * `createGrpcGatewayTransport` reads `defaultTimeoutMs` off the transport options it is handed, but
  * `ChainNodeWebSDKOptions` declares that bag as `{ retry?: RetryOptions }` only. Verified against a live
  * endpoint: a 2s value aborts after ~2s with `DeadlineExceeded`, so the runtime honours the option and the
- * published type is simply behind it. Asserted once, here, so a dependency bump that widens the type turns
- * this into a redundant assertion rather than leaving the timeout silently unset.
+ * published type is simply behind it.
+ *
+ * Widened by intersection rather than asserted, so only this one field escapes checking: every other option in
+ * the bag stays type-checked, and a misspelling like `defaultTimeoutMS` is a compile error instead of an option
+ * silently doing nothing.
  */
-const TRANSPORT_OPTIONS = { defaultTimeoutMs: QUERY_TIMEOUT_MS } as unknown as QueryTransportOptions;
+const TRANSPORT_OPTIONS: QueryTransportOptions & { defaultTimeoutMs: number } = { defaultTimeoutMs: QUERY_TIMEOUT_MS };
 
 export const CHAIN_SDK = Symbol("CHAIN_SDK") as InjectionToken<ChainNodeWebSDK>;
 export type ChainSDK = ChainNodeWebSDK;

--- a/apps/api/src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler.integration.ts
+++ b/apps/api/src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler.integration.ts
@@ -1,22 +1,36 @@
 import { faker } from "@faker-js/faker";
+import { addMinutes } from "date-fns";
 import { eq } from "drizzle-orm";
 import nock from "nock";
 import { container } from "tsyringe";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { ApiPgDatabase } from "@src/core";
-import { CORE_CONFIG, JobQueueService, POSTGRES_DB, resolveTable } from "@src/core";
+import { JobQueueService, POSTGRES_DB, resolveTable } from "@src/core";
+import { CoreConfigService } from "@src/core/services/core-config/core-config.service";
 import { UserRepository } from "@src/user/repositories";
 import { DeleteUnbackedDeploymentSetting, DeleteUnbackedDeploymentSettingHandler } from "./delete-unbacked-deployment-setting.handler";
 
 import { createAkashAddress } from "@test/seeders/akash-address.seeder";
 
 const DEPLOYMENT_INFO_PATH = "/akash/deployment/v1beta4/deployments/info";
+const LATEST_BLOCK_PATH = "/cosmos/base/tendermint/v1beta1/blocks/latest";
+const BLOCK_HEIGHT_HEADER = "x-cosmos-block-height";
+
+/** Comfortably past the margin the presence check requires between the row and the block it will trust. */
+const CHAIN_MINUTES_AHEAD = 30;
+const CHAIN_HEIGHT = "28343549";
 
 /** The response two independent mainnet REST nodes returned for a deployment that was never created. */
 const ABSENT_FROM_CHAIN = {
   status: 404,
   body: { code: 5, message: "codespace deployment code 4: Deployment not found", details: [] }
+};
+
+/** What a node behind the pinned height actually answers, captured against mainnet. Note it is not code 5. */
+const HEIGHT_ABOVE_THEIR_CHAIN = {
+  status: 500,
+  body: { code: 2, message: "codespace sdk code 26: invalid height: cannot query with height in the future; please provide a valid height", details: [] }
 };
 
 /** The shape of a real answer, trimmed to the fields the presence check can see. */
@@ -102,6 +116,43 @@ describe(DeleteUnbackedDeploymentSettingHandler.name, () => {
     expect(await findSetting(settingId)).toBeDefined();
   });
 
+  it("pins the lookup to the height it proved is past the row", async () => {
+    const { payload, handler, answerChainWith, pinnedHeights } = await setup();
+    answerChainWith(ABSENT_FROM_CHAIN);
+
+    await handler.handle(payload);
+
+    expect(pinnedHeights()).toEqual([CHAIN_HEIGHT]);
+  });
+
+  it("keeps a setting and throws when the answering node has not reached the pinned height", async () => {
+    const { settingId, payload, handler, answerChainWith, findSetting } = await setup();
+    answerChainWith(HEIGHT_ABOVE_THEIR_CHAIN);
+
+    await expect(handler.handle(payload)).rejects.toThrow();
+
+    expect(await findSetting(settingId)).toBeDefined();
+  });
+
+  it("keeps a setting and throws when the chain has not progressed past the row", async () => {
+    const { settingId, payload, handler, answerChainWith, findSetting } = await setup({ chainMinutesAhead: -1 });
+    answerChainWith(ABSENT_FROM_CHAIN);
+
+    await expect(handler.handle(payload)).rejects.toThrow(/not past/);
+
+    expect(await findSetting(settingId)).toBeDefined();
+  });
+
+  it("keeps a setting and throws when the latest block cannot be read", async () => {
+    const { settingId, payload, handler, answerChainWith, failLatestBlock, findSetting } = await setup();
+    answerChainWith(ABSENT_FROM_CHAIN);
+    failLatestBlock();
+
+    await expect(handler.handle(payload)).rejects.toThrow();
+
+    expect(await findSetting(settingId)).toBeDefined();
+  });
+
   it("deletes the setting once across two deliveries of the same compensation", async () => {
     const { settingId, payload, handler, answerChainWith, findSetting } = await setup();
     answerChainWith(ABSENT_FROM_CHAIN, 2);
@@ -112,10 +163,10 @@ describe(DeleteUnbackedDeploymentSettingHandler.name, () => {
     expect(await findSetting(settingId)).toBeUndefined();
   });
 
-  async function setup() {
+  async function setup(input: { chainMinutesAhead?: number } = {}) {
     const db = container.resolve<ApiPgDatabase>(POSTGRES_DB);
     const deploymentSettingsTable = resolveTable("DeploymentSettings");
-    const restApiNodeUrl = container.resolve<{ REST_API_NODE_URL: string }>(CORE_CONFIG).REST_API_NODE_URL;
+    const restApiNodeUrl = container.resolve(CoreConfigService).get("REST_API_NODE_URL");
     const jobQueue = await bootstrapJobQueue();
 
     const owner = createAkashAddress();
@@ -126,16 +177,47 @@ describe(DeleteUnbackedDeploymentSettingHandler.name, () => {
       .values({ userId: user.id, dseq, autoTopUpEnabled: true, sdl: 'version: "2.0"', manifestVersion: "BAUG" })
       .returning();
 
+    answerLatestBlockWith(addMinutes(new Date(setting.createdAt ?? new Date()), input.chainMinutesAhead ?? CHAIN_MINUTES_AHEAD));
+
     /**
      * Matches the exact deployment the compensation is about, so a lookup that asked for anything else finds no
      * interceptor and fails the test rather than quietly receiving the answer meant for another deployment.
      */
+    const pinned: string[] = [];
+
+    function answerLatestBlockWith(time: Date) {
+      nock(restApiNodeUrl)
+        .persist()
+        .get(LATEST_BLOCK_PATH)
+        .query(true)
+        .reply(200, { block_id: {}, block: { header: { height: CHAIN_HEIGHT, time: time.toISOString(), chain_id: "akashnet-2" } } });
+    }
+
+    function failLatestBlock() {
+      nock.cleanAll();
+      nock(restApiNodeUrl)
+        .persist()
+        .get(LATEST_BLOCK_PATH)
+        .query(true)
+        .replyWithError(Object.assign(new Error("socket hang up"), { code: "ECONNRESET" }));
+      nock(restApiNodeUrl).get(DEPLOYMENT_INFO_PATH).query(true).reply(ABSENT_FROM_CHAIN.status, ABSENT_FROM_CHAIN.body);
+    }
+
+    function pinnedHeights() {
+      return pinned;
+    }
+
     function answerChainWith({ status, body }: { status: number; body: unknown }, times = 1) {
       nock(restApiNodeUrl)
         .get(DEPLOYMENT_INFO_PATH)
         .query({ "id.owner": owner, "id.dseq": dseq })
         .times(times)
-        .reply(status, body as nock.Body);
+        .reply(function reply(this: nock.ReplyFnContext) {
+          const header = this.req.headers[BLOCK_HEIGHT_HEADER] as string | string[] | undefined;
+          pinned.push(Array.isArray(header) ? header[0] : header ?? "(none)");
+
+          return [status, body as nock.Body];
+        });
     }
 
     function failChainWith(error: Error) {
@@ -156,6 +238,8 @@ describe(DeleteUnbackedDeploymentSettingHandler.name, () => {
       settingId: setting.id,
       answerChainWith,
       failChainWith,
+      failLatestBlock,
+      pinnedHeights,
       findSetting,
       enqueueCompensation: () => jobQueue.enqueue(new DeleteUnbackedDeploymentSetting({ deploymentSettingId: setting.id, owner, dseq })),
       startWorkers: () => jobQueue.startWorkers({ concurrency: 1, pollingIntervalSeconds: 0.5 })

--- a/apps/api/src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler.integration.ts
+++ b/apps/api/src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler.integration.ts
@@ -3,7 +3,7 @@ import { addMinutes } from "date-fns";
 import { eq } from "drizzle-orm";
 import nock from "nock";
 import { container } from "tsyringe";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 
 import type { ApiPgDatabase } from "@src/core";
 import { JobQueueService, POSTGRES_DB, resolveTable } from "@src/core";
@@ -68,6 +68,15 @@ function bootstrapJobQueue() {
 describe(DeleteUnbackedDeploymentSettingHandler.name, () => {
   afterEach(() => {
     nock.cleanAll();
+  });
+
+  /**
+   * A worker left running outlives the interceptors: the compensation it retried becomes due a minute later
+   * with nock torn down, and issues a real request to `REST_API_NODE_URL` — egress from CI to a third-party
+   * mainnet endpoint, and a flake that only shows up on a slow run.
+   */
+  afterAll(async () => {
+    if (jobQueueReady) await (await jobQueueReady).dispose();
   });
 
   it("deletes a setting no deployment backs, run the way a worker runs it", async () => {

--- a/apps/api/src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler.integration.ts
+++ b/apps/api/src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler.integration.ts
@@ -1,0 +1,164 @@
+import { faker } from "@faker-js/faker";
+import { eq } from "drizzle-orm";
+import nock from "nock";
+import { container } from "tsyringe";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { ApiPgDatabase } from "@src/core";
+import { CORE_CONFIG, JobQueueService, POSTGRES_DB, resolveTable } from "@src/core";
+import { UserRepository } from "@src/user/repositories";
+import { DeleteUnbackedDeploymentSetting, DeleteUnbackedDeploymentSettingHandler } from "./delete-unbacked-deployment-setting.handler";
+
+import { createAkashAddress } from "@test/seeders/akash-address.seeder";
+
+const DEPLOYMENT_INFO_PATH = "/akash/deployment/v1beta4/deployments/info";
+
+/** The response two independent mainnet REST nodes returned for a deployment that was never created. */
+const ABSENT_FROM_CHAIN = {
+  status: 404,
+  body: { code: 5, message: "codespace deployment code 4: Deployment not found", details: [] }
+};
+
+/** The shape of a real answer, trimmed to the fields the presence check can see. */
+function presentOnChain(owner: string, dseq: string) {
+  return {
+    status: 200,
+    body: {
+      deployment: { id: { owner, dseq }, state: "active", hash: "bLTCo5xFV2obtovLJ/rUZDHLkzAbB8vlXpF2iJGKpaY=", created_at: "16122572", reclamation: null },
+      groups: [],
+      escrow_account: null
+    }
+  };
+}
+
+let jobQueueReady: Promise<JobQueueService> | undefined;
+
+/** pg-boss owns its own schema and creates it on start, so the queue this suite uses is bootstrapped once per file. */
+function bootstrapJobQueue() {
+  jobQueueReady ??= (async () => {
+    const jobQueue = container.resolve(JobQueueService);
+    await jobQueue.setup();
+    await jobQueue.registerHandlers([container.resolve(DeleteUnbackedDeploymentSettingHandler)]);
+
+    return jobQueue;
+  })();
+
+  return jobQueueReady;
+}
+
+/**
+ * Covers the compensation against a real database and a real chain response, because both halves of its decision
+ * are about things a mock cannot get wrong on its behalf: what the node actually replies for a deployment that
+ * does not exist, and whether the delete reaches the row.
+ */
+describe(DeleteUnbackedDeploymentSettingHandler.name, () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  it("deletes a setting no deployment backs, run the way a worker runs it", async () => {
+    const { settingId, answerChainWith, enqueueCompensation, startWorkers, findSetting } = await setup();
+    answerChainWith(ABSENT_FROM_CHAIN);
+
+    await enqueueCompensation();
+    await startWorkers();
+
+    await vi.waitFor(async () => expect(await findSetting(settingId)).toBeUndefined(), { timeout: 20_000, interval: 250 });
+  });
+
+  it("keeps a setting the chain does have a deployment for", async () => {
+    const { owner, dseq, settingId, payload, handler, answerChainWith, findSetting } = await setup();
+    answerChainWith(presentOnChain(owner, dseq));
+
+    await handler.handle(payload);
+
+    expect(await findSetting(settingId)).toBeDefined();
+  });
+
+  it("keeps a setting and throws when the node answers with an error, so the queue retries", async () => {
+    const { settingId, payload, handler, answerChainWith, findSetting } = await setup();
+    answerChainWith({ status: 503, body: { code: 14, message: "upstream connect error", details: [] } });
+
+    await expect(handler.handle(payload)).rejects.toThrow();
+
+    expect(await findSetting(settingId)).toBeDefined();
+  });
+
+  it("keeps a setting and throws when the node cannot be reached at all", async () => {
+    const { settingId, payload, handler, failChainWith, findSetting } = await setup();
+    failChainWith(Object.assign(new Error("socket hang up"), { code: "ECONNRESET" }));
+
+    await expect(handler.handle(payload)).rejects.toThrow();
+
+    expect(await findSetting(settingId)).toBeDefined();
+  });
+
+  it("keeps a setting and throws when the node answers with something unparseable", async () => {
+    const { settingId, payload, handler, answerChainWith, findSetting } = await setup();
+    answerChainWith({ status: 502, body: "<html>Bad Gateway</html>" });
+
+    await expect(handler.handle(payload)).rejects.toThrow();
+
+    expect(await findSetting(settingId)).toBeDefined();
+  });
+
+  it("deletes the setting once across two deliveries of the same compensation", async () => {
+    const { settingId, payload, handler, answerChainWith, findSetting } = await setup();
+    answerChainWith(ABSENT_FROM_CHAIN, 2);
+
+    await handler.handle(payload);
+    await handler.handle(payload);
+
+    expect(await findSetting(settingId)).toBeUndefined();
+  });
+
+  async function setup() {
+    const db = container.resolve<ApiPgDatabase>(POSTGRES_DB);
+    const deploymentSettingsTable = resolveTable("DeploymentSettings");
+    const restApiNodeUrl = container.resolve<{ REST_API_NODE_URL: string }>(CORE_CONFIG).REST_API_NODE_URL;
+    const jobQueue = await bootstrapJobQueue();
+
+    const owner = createAkashAddress();
+    const dseq = faker.number.int({ min: 100000, max: 999999 }).toString();
+    const user = await container.resolve(UserRepository).create({});
+    const [setting] = await db
+      .insert(deploymentSettingsTable)
+      .values({ userId: user.id, dseq, autoTopUpEnabled: true, sdl: 'version: "2.0"', manifestVersion: "BAUG" })
+      .returning();
+
+    /**
+     * Matches the exact deployment the compensation is about, so a lookup that asked for anything else finds no
+     * interceptor and fails the test rather than quietly receiving the answer meant for another deployment.
+     */
+    function answerChainWith({ status, body }: { status: number; body: unknown }, times = 1) {
+      nock(restApiNodeUrl)
+        .get(DEPLOYMENT_INFO_PATH)
+        .query({ "id.owner": owner, "id.dseq": dseq })
+        .times(times)
+        .reply(status, body as nock.Body);
+    }
+
+    function failChainWith(error: Error) {
+      nock(restApiNodeUrl).get(DEPLOYMENT_INFO_PATH).query({ "id.owner": owner, "id.dseq": dseq }).replyWithError(error);
+    }
+
+    async function findSetting(id: string) {
+      const [row] = await db.select().from(deploymentSettingsTable).where(eq(deploymentSettingsTable.id, id));
+
+      return row;
+    }
+
+    return {
+      handler: container.resolve(DeleteUnbackedDeploymentSettingHandler),
+      payload: { deploymentSettingId: setting.id, owner, dseq, version: 1 as const },
+      owner,
+      dseq,
+      settingId: setting.id,
+      answerChainWith,
+      failChainWith,
+      findSetting,
+      enqueueCompensation: () => jobQueue.enqueue(new DeleteUnbackedDeploymentSetting({ deploymentSettingId: setting.id, owner, dseq })),
+      startWorkers: () => jobQueue.startWorkers({ concurrency: 1, pollingIntervalSeconds: 0.5 })
+    };
+  }
+});

--- a/apps/api/src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler.spec.ts
+++ b/apps/api/src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler.spec.ts
@@ -16,6 +16,20 @@ import { createAkashAddress } from "@test/seeders/akash-address.seeder";
 
 const OWNER = createAkashAddress();
 const DSEQ = "1748400000000";
+const RECORDED_AT = new Date("2026-01-01T00:00:00.000Z");
+
+/**
+ * `createdAt` is declared `string` on the repository's output type but arrives from drizzle as a `Date`, and a
+ * row can carry none at all. Both are shapes the handler has to survive, so the fixture states them as they
+ * really are rather than as the type does — the one place this file needs to step outside it.
+ */
+function settingRecordedAt(input: { id: string; dseq: string; recordedAt: Date | null }) {
+  return mock<DeploymentSettingsOutput>({
+    id: input.id,
+    dseq: input.dseq,
+    createdAt: input.recordedAt as unknown as DeploymentSettingsOutput["createdAt"]
+  });
+}
 
 describe(DeleteUnbackedDeploymentSettingHandler.name, () => {
   it("deletes the setting when the chain does not have the deployment", async () => {
@@ -84,12 +98,21 @@ describe(DeleteUnbackedDeploymentSettingHandler.name, () => {
     expect(deploymentPresenceService.isOnChain).not.toHaveBeenCalled();
   });
 
-  it("asks the chain about the deployment the payload names", async () => {
+  it("asks the chain about the deployment the payload names, judged against when the row was written", async () => {
     const { handler, payload, deploymentPresenceService } = setup({ isOnChain: true });
 
     await handler.handle(payload);
 
-    expect(deploymentPresenceService.isOnChain).toHaveBeenCalledWith({ owner: OWNER, dseq: DSEQ });
+    expect(deploymentPresenceService.isOnChain).toHaveBeenCalledWith({ owner: OWNER, dseq: DSEQ, recordedAt: RECORDED_AT });
+  });
+
+  it("keeps a setting whose stored creation time is missing, since no chain answer could be judged against it", async () => {
+    const { handler, payload, deploymentSettingRepository, deploymentPresenceService } = setup({ isOnChain: false, recordedAt: null });
+
+    await handler.handle(payload);
+
+    expect(deploymentSettingRepository.deleteById).not.toHaveBeenCalled();
+    expect(deploymentPresenceService.isOnChain).not.toHaveBeenCalled();
   });
 
   it("accepts the job the create enqueues", () => {
@@ -98,7 +121,7 @@ describe(DeleteUnbackedDeploymentSettingHandler.name, () => {
     expect(handler.accepts).toBe(DeleteUnbackedDeploymentSetting);
   });
 
-  it("keys a compensation by the setting's owner and dseq", () => {
+  it("keys a compensation by the owning user and the dseq", () => {
     expect(unbackedDeploymentSettingKeyFor({ userId: "user-1", dseq: DSEQ })).toBe(`deleteUnbackedDeploymentSetting.user-1.${DSEQ}`);
   });
 
@@ -108,11 +131,12 @@ describe(DeleteUnbackedDeploymentSettingHandler.name, () => {
     expect(createLogger).toHaveBeenCalledWith({ context: DeleteUnbackedDeploymentSettingHandler.name });
   });
 
-  function setup(input: { isOnChain?: boolean; chainLookupRejectsWith?: unknown; settingExists?: boolean; storedDseq?: string }) {
+  function setup(input: { isOnChain?: boolean; chainLookupRejectsWith?: unknown; settingExists?: boolean; storedDseq?: string; recordedAt?: Date | null }) {
     const deploymentSettingId = faker.string.uuid();
+    const recordedAt = input.recordedAt === undefined ? RECORDED_AT : input.recordedAt;
     const deploymentSettingRepository = mock<DeploymentSettingRepository>();
     deploymentSettingRepository.findById.mockResolvedValue(
-      input.settingExists === false ? undefined : mock<DeploymentSettingsOutput>({ id: deploymentSettingId, dseq: input.storedDseq ?? DSEQ })
+      input.settingExists === false ? undefined : settingRecordedAt({ id: deploymentSettingId, dseq: input.storedDseq ?? DSEQ, recordedAt })
     );
 
     const deploymentPresenceService = mock<DeploymentPresenceService>();

--- a/apps/api/src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler.spec.ts
+++ b/apps/api/src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler.spec.ts
@@ -1,0 +1,137 @@
+import { SDKError, SDKErrorCode } from "@akashnetwork/chain-sdk/web";
+import { faker } from "@faker-js/faker";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { CreateLogger } from "@src/core";
+import type { DeploymentSettingRepository, DeploymentSettingsOutput } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import type { DeploymentPresenceService } from "@src/deployment/services/deployment-presence/deployment-presence.service";
+import {
+  DeleteUnbackedDeploymentSetting,
+  DeleteUnbackedDeploymentSettingHandler,
+  unbackedDeploymentSettingKeyFor
+} from "./delete-unbacked-deployment-setting.handler";
+
+import { createAkashAddress } from "@test/seeders/akash-address.seeder";
+
+const OWNER = createAkashAddress();
+const DSEQ = "1748400000000";
+
+describe(DeleteUnbackedDeploymentSettingHandler.name, () => {
+  it("deletes the setting when the chain does not have the deployment", async () => {
+    const { handler, payload, deploymentSettingRepository } = setup({ isOnChain: false });
+
+    await handler.handle(payload);
+
+    expect(deploymentSettingRepository.deleteById).toHaveBeenCalledWith(payload.deploymentSettingId);
+  });
+
+  it("keeps the setting when the chain does have the deployment", async () => {
+    const { handler, payload, deploymentSettingRepository } = setup({ isOnChain: true });
+
+    await handler.handle(payload);
+
+    expect(deploymentSettingRepository.deleteById).not.toHaveBeenCalled();
+  });
+
+  it("keeps the setting and lets a node that could not be reached surface, so the queue retries", async () => {
+    const unreachable = new SDKError("[unknown] fetch failed", SDKErrorCode.Unknown);
+    const { handler, payload, deploymentSettingRepository } = setup({ chainLookupRejectsWith: unreachable });
+
+    await expect(handler.handle(payload)).rejects.toThrow(unreachable);
+
+    expect(deploymentSettingRepository.deleteById).not.toHaveBeenCalled();
+  });
+
+  it("keeps the setting and lets an unrecognised failure surface, so the queue retries", async () => {
+    const { handler, payload, deploymentSettingRepository } = setup({ chainLookupRejectsWith: new Error("Deployment not found") });
+
+    await expect(handler.handle(payload)).rejects.toThrow("Deployment not found");
+
+    expect(deploymentSettingRepository.deleteById).not.toHaveBeenCalled();
+  });
+
+  it("names the setting it could not check, so a compensation that exhausts its retries is traceable", async () => {
+    const { handler, payload, logger } = setup({ chainLookupRejectsWith: new Error("fetch failed") });
+
+    await expect(handler.handle(payload)).rejects.toThrow();
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "UNBACKED_DEPLOYMENT_SETTING_CHAIN_LOOKUP_FAILED",
+        deploymentSettingId: payload.deploymentSettingId,
+        owner: OWNER,
+        dseq: DSEQ
+      })
+    );
+  });
+
+  it("does nothing when the setting is already gone, so a repeated delivery is harmless", async () => {
+    const { handler, payload, deploymentSettingRepository, deploymentPresenceService } = setup({ settingExists: false });
+
+    await handler.handle(payload);
+
+    expect(deploymentSettingRepository.deleteById).not.toHaveBeenCalled();
+    expect(deploymentPresenceService.isOnChain).not.toHaveBeenCalled();
+  });
+
+  it("keeps a setting whose stored dseq is not the one the chain was asked about", async () => {
+    const { handler, payload, deploymentSettingRepository, deploymentPresenceService } = setup({ isOnChain: false, storedDseq: "1748400000001" });
+
+    await handler.handle(payload);
+
+    expect(deploymentSettingRepository.deleteById).not.toHaveBeenCalled();
+    expect(deploymentPresenceService.isOnChain).not.toHaveBeenCalled();
+  });
+
+  it("asks the chain about the deployment the payload names", async () => {
+    const { handler, payload, deploymentPresenceService } = setup({ isOnChain: true });
+
+    await handler.handle(payload);
+
+    expect(deploymentPresenceService.isOnChain).toHaveBeenCalledWith({ owner: OWNER, dseq: DSEQ });
+  });
+
+  it("accepts the job the create enqueues", () => {
+    const { handler } = setup({ isOnChain: true });
+
+    expect(handler.accepts).toBe(DeleteUnbackedDeploymentSetting);
+  });
+
+  it("keys a compensation by the setting's owner and dseq", () => {
+    expect(unbackedDeploymentSettingKeyFor({ userId: "user-1", dseq: DSEQ })).toBe(`deleteUnbackedDeploymentSetting.user-1.${DSEQ}`);
+  });
+
+  it("creates the logger with the handler context", () => {
+    const { createLogger } = setup({ isOnChain: true });
+
+    expect(createLogger).toHaveBeenCalledWith({ context: DeleteUnbackedDeploymentSettingHandler.name });
+  });
+
+  function setup(input: { isOnChain?: boolean; chainLookupRejectsWith?: unknown; settingExists?: boolean; storedDseq?: string }) {
+    const deploymentSettingId = faker.string.uuid();
+    const deploymentSettingRepository = mock<DeploymentSettingRepository>();
+    deploymentSettingRepository.findById.mockResolvedValue(
+      input.settingExists === false ? undefined : mock<DeploymentSettingsOutput>({ id: deploymentSettingId, dseq: input.storedDseq ?? DSEQ })
+    );
+
+    const deploymentPresenceService = mock<DeploymentPresenceService>();
+    deploymentPresenceService.isOnChain.mockImplementation(async () => {
+      if (input.chainLookupRejectsWith) throw input.chainLookupRejectsWith;
+      return input.isOnChain ?? true;
+    });
+
+    const logger = mock<ReturnType<CreateLogger>>();
+    const createLogger = vi.fn<CreateLogger>(() => logger);
+    const handler = new DeleteUnbackedDeploymentSettingHandler(deploymentSettingRepository, deploymentPresenceService, createLogger);
+
+    return {
+      handler,
+      payload: { deploymentSettingId, owner: OWNER, dseq: DSEQ, version: 1 as const },
+      deploymentSettingRepository,
+      deploymentPresenceService,
+      logger,
+      createLogger
+    };
+  }
+});

--- a/apps/api/src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler.ts
+++ b/apps/api/src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler.ts
@@ -1,0 +1,90 @@
+import { inject, singleton } from "tsyringe";
+
+import { type CreateLogger, type Job, JOB_NAME, type JobHandler, type JobPayload, LOGGER_FACTORY } from "@src/core";
+import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import { DeploymentPresenceService } from "@src/deployment/services/deployment-presence/deployment-presence.service";
+
+/**
+ * Compensates a deployment setting whose create transaction may never have reached the chain. Written in the
+ * same transaction as the row itself and cancelled the moment the broadcast succeeds, so it only ever runs for
+ * a create that failed, or crashed between broadcasting and cancelling.
+ */
+export class DeleteUnbackedDeploymentSetting implements Job {
+  static readonly [JOB_NAME] = "DeleteUnbackedDeploymentSetting";
+  readonly name = DeleteUnbackedDeploymentSetting[JOB_NAME];
+  readonly version = 1;
+
+  constructor(
+    public readonly data: {
+      deploymentSettingId: string;
+      owner: string;
+      dseq: string;
+    }
+  ) {}
+}
+
+/**
+ * Derives the compensation's key from the row's natural key, so the create that enqueued it can cancel it
+ * after a successful broadcast without carrying a job id through the signing round trip.
+ */
+export function unbackedDeploymentSettingKeyFor({ userId, dseq }: { userId: string; dseq: string }): string {
+  return `deleteUnbackedDeploymentSetting.${userId}.${dseq}`;
+}
+
+@singleton()
+export class DeleteUnbackedDeploymentSettingHandler implements JobHandler<DeleteUnbackedDeploymentSetting> {
+  public readonly accepts = DeleteUnbackedDeploymentSetting;
+
+  public readonly concurrency = 2;
+
+  private readonly logger: ReturnType<CreateLogger>;
+
+  constructor(
+    private readonly deploymentSettingRepository: DeploymentSettingRepository,
+    private readonly deploymentPresenceService: DeploymentPresenceService,
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
+  ) {
+    this.logger = createLogger({ context: DeleteUnbackedDeploymentSettingHandler.name });
+  }
+
+  /**
+   * Running is not evidence that the deployment is missing — the broadcast may have landed and the process died
+   * before cancelling, or the cancellation itself may have failed — so the chain is asked every time and is the
+   * only thing that authorises the delete. Anything short of a chain answer escapes, because the queue retrying
+   * costs a row's extra lifetime while a wrong delete costs the only stored copy of its SDL and its runtime limit.
+   *
+   * The repository is used unscoped on purpose. Job execution runs under an empty ability, and `accessibleBy`
+   * builds a `DrizzleAbility` that refuses in a field initializer, so a scoped read would throw before any SQL ran.
+   */
+  async handle(payload: JobPayload<DeleteUnbackedDeploymentSetting>): Promise<void> {
+    const { deploymentSettingId, owner, dseq } = payload;
+    const setting = await this.deploymentSettingRepository.findById(deploymentSettingId);
+
+    if (!setting) {
+      this.logger.info({ event: "UNBACKED_DEPLOYMENT_SETTING_ALREADY_GONE", deploymentSettingId, owner, dseq });
+      return;
+    }
+
+    if (setting.dseq !== dseq) {
+      this.logger.error({ event: "UNBACKED_DEPLOYMENT_SETTING_DSEQ_MISMATCH", deploymentSettingId, owner, dseq, storedDseq: setting.dseq });
+      return;
+    }
+
+    if (await this.isOnChain({ deploymentSettingId, owner, dseq })) {
+      this.logger.info({ event: "UNBACKED_DEPLOYMENT_SETTING_IS_BACKED", deploymentSettingId, owner, dseq });
+      return;
+    }
+
+    await this.deploymentSettingRepository.deleteById(deploymentSettingId);
+    this.logger.info({ event: "UNBACKED_DEPLOYMENT_SETTING_DELETED", deploymentSettingId, owner, dseq });
+  }
+
+  private async isOnChain({ deploymentSettingId, owner, dseq }: { deploymentSettingId: string; owner: string; dseq: string }): Promise<boolean> {
+    try {
+      return await this.deploymentPresenceService.isOnChain({ owner, dseq });
+    } catch (error) {
+      this.logger.error({ event: "UNBACKED_DEPLOYMENT_SETTING_CHAIN_LOOKUP_FAILED", deploymentSettingId, owner, dseq, error });
+      throw error;
+    }
+  }
+}

--- a/apps/api/src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler.ts
+++ b/apps/api/src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler.ts
@@ -35,8 +35,6 @@ export function unbackedDeploymentSettingKeyFor({ userId, dseq }: { userId: stri
 export class DeleteUnbackedDeploymentSettingHandler implements JobHandler<DeleteUnbackedDeploymentSetting> {
   public readonly accepts = DeleteUnbackedDeploymentSetting;
 
-  public readonly concurrency = 2;
-
   private readonly logger: ReturnType<CreateLogger>;
 
   constructor(
@@ -49,9 +47,14 @@ export class DeleteUnbackedDeploymentSettingHandler implements JobHandler<Delete
 
   /**
    * Running is not evidence that the deployment is missing — the broadcast may have landed and the process died
-   * before cancelling, or the cancellation itself may have failed — so the chain is asked every time and is the
-   * only thing that authorises the delete. Anything short of a chain answer escapes, because the queue retrying
-   * costs a row's extra lifetime while a wrong delete costs the only stored copy of its SDL and its runtime limit.
+   * before cancelling, and `cancelCreatedBy` only cancels a job still in state `created`, so a compensation a
+   * worker has already picked up cannot be called off at all. What keeps a live deployment's row safe in that
+   * window is not the cancellation but the two things below, and anything short of a chain answer escapes,
+   * because the queue retrying costs a row's extra lifetime while a wrong delete costs the only stored copy of
+   * its SDL and its runtime limit.
+   *
+   * The row's own `createdAt` is what the chain answer is judged against, which is why it is read here rather
+   * than taken from the payload: the guard has to be anchored to when the record was actually written.
    *
    * The repository is used unscoped on purpose. Job execution runs under an empty ability, and `accessibleBy`
    * builds a `DrizzleAbility` that refuses in a field initializer, so a scoped read would throw before any SQL ran.
@@ -70,7 +73,12 @@ export class DeleteUnbackedDeploymentSettingHandler implements JobHandler<Delete
       return;
     }
 
-    if (await this.isOnChain({ deploymentSettingId, owner, dseq })) {
+    if (!setting.createdAt) {
+      this.logger.error({ event: "UNBACKED_DEPLOYMENT_SETTING_UNDATED", deploymentSettingId, owner, dseq });
+      return;
+    }
+
+    if (await this.isOnChain({ deploymentSettingId, owner, dseq, recordedAt: new Date(setting.createdAt) })) {
       this.logger.info({ event: "UNBACKED_DEPLOYMENT_SETTING_IS_BACKED", deploymentSettingId, owner, dseq });
       return;
     }
@@ -79,9 +87,19 @@ export class DeleteUnbackedDeploymentSettingHandler implements JobHandler<Delete
     this.logger.info({ event: "UNBACKED_DEPLOYMENT_SETTING_DELETED", deploymentSettingId, owner, dseq });
   }
 
-  private async isOnChain({ deploymentSettingId, owner, dseq }: { deploymentSettingId: string; owner: string; dseq: string }): Promise<boolean> {
+  private async isOnChain({
+    deploymentSettingId,
+    owner,
+    dseq,
+    recordedAt
+  }: {
+    deploymentSettingId: string;
+    owner: string;
+    dseq: string;
+    recordedAt: Date;
+  }): Promise<boolean> {
     try {
-      return await this.deploymentPresenceService.isOnChain({ owner, dseq });
+      return await this.deploymentPresenceService.isOnChain({ owner, dseq, recordedAt });
     } catch (error) {
       this.logger.error({ event: "UNBACKED_DEPLOYMENT_SETTING_CHAIN_LOOKUP_FAILED", deploymentSettingId, owner, dseq, error });
       throw error;

--- a/apps/api/src/deployment/services/deployment-presence/deployment-presence.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-presence/deployment-presence.service.spec.ts
@@ -1,0 +1,92 @@
+import type { QueryDeploymentResponse } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
+import { SDKError, SDKErrorCode } from "@akashnetwork/chain-sdk/web";
+import { describe, expect, it } from "vitest";
+import { mockDeep } from "vitest-mock-extended";
+
+import type { ChainSDK } from "@src/chain/providers/chain-sdk.provider";
+import { DeploymentPresenceService } from "./deployment-presence.service";
+
+const OWNER = "akash100dwtg4hqnd240x583spjwnk4kanp559xwtvmg";
+const DSEQ = "16122570";
+
+/** The shapes a real node produced for each outcome, captured against mainnet REST and replayed here. */
+const CHAIN_ANSWERS = {
+  absent: new SDKError("[not_found] codespace deployment code 4: Deployment not found", SDKErrorCode.NotFound),
+  unroutableQueryVersion: new SDKError("[unimplemented] Not Implemented", SDKErrorCode.Unimplemented),
+  unreachableNode: new SDKError("[unknown] fetch failed", SDKErrorCode.Unknown),
+  timedOut: new SDKError("[deadline_exceeded] the operation timed out", SDKErrorCode.DeadlineExceeded),
+  malformedOwner: new SDKError("[invalid_argument] invalid owner address", SDKErrorCode.InvalidArgument)
+};
+
+describe(DeploymentPresenceService.name, () => {
+  it("reports a deployment the chain answers for as on chain", async () => {
+    const { service } = setup({ answers: mockDeep<QueryDeploymentResponse>() });
+
+    await expect(service.isOnChain({ owner: OWNER, dseq: DSEQ })).resolves.toBe(true);
+  });
+
+  it("reports a deployment the chain says it does not have as absent", async () => {
+    const { service } = setup({ rejectsWith: CHAIN_ANSWERS.absent });
+
+    await expect(service.isOnChain({ owner: OWNER, dseq: DSEQ })).resolves.toBe(false);
+  });
+
+  it("asks the chain for the deployment the caller named, with dseq as a number", async () => {
+    const { service, chainSdk } = setup({ answers: mockDeep<QueryDeploymentResponse>() });
+
+    await service.isOnChain({ owner: OWNER, dseq: DSEQ });
+
+    expect(chainSdk.akash.deployment.v1beta4.getDeployment).toHaveBeenCalledWith({ id: { owner: OWNER, dseq: 16122570n } });
+  });
+
+  it("refuses to answer when the node cannot be reached", async () => {
+    const { service } = setup({ rejectsWith: CHAIN_ANSWERS.unreachableNode });
+
+    await expect(service.isOnChain({ owner: OWNER, dseq: DSEQ })).rejects.toThrow(CHAIN_ANSWERS.unreachableNode);
+  });
+
+  it("refuses to answer when the request timed out", async () => {
+    const { service } = setup({ rejectsWith: CHAIN_ANSWERS.timedOut });
+
+    await expect(service.isOnChain({ owner: OWNER, dseq: DSEQ })).rejects.toThrow(CHAIN_ANSWERS.timedOut);
+  });
+
+  it("refuses to answer when the node does not serve this query version", async () => {
+    const { service } = setup({ rejectsWith: CHAIN_ANSWERS.unroutableQueryVersion });
+
+    await expect(service.isOnChain({ owner: OWNER, dseq: DSEQ })).rejects.toThrow(CHAIN_ANSWERS.unroutableQueryVersion);
+  });
+
+  it("refuses to answer when the node rejected the request as malformed", async () => {
+    const { service } = setup({ rejectsWith: CHAIN_ANSWERS.malformedOwner });
+
+    await expect(service.isOnChain({ owner: OWNER, dseq: DSEQ })).rejects.toThrow(CHAIN_ANSWERS.malformedOwner);
+  });
+
+  it("refuses to answer on an error shape it does not recognise", async () => {
+    const { service } = setup({ rejectsWith: new Error("Deployment not found") });
+
+    await expect(service.isOnChain({ owner: OWNER, dseq: DSEQ })).rejects.toThrow("Deployment not found");
+  });
+
+  it("refuses to answer when something other than an error was thrown", async () => {
+    const { service } = setup({ rejectsWith: { code: SDKErrorCode.NotFound, message: "Deployment not found" } });
+
+    await expect(service.isOnChain({ owner: OWNER, dseq: DSEQ })).rejects.toEqual({
+      code: SDKErrorCode.NotFound,
+      message: "Deployment not found"
+    });
+  });
+
+  function setup(input: { answers?: QueryDeploymentResponse; rejectsWith?: unknown }) {
+    const chainSdk = mockDeep<ChainSDK>();
+    chainSdk.akash.deployment.v1beta4.getDeployment.mockImplementation(async () => {
+      if (input.answers) return input.answers;
+      throw input.rejectsWith;
+    });
+
+    const service = new DeploymentPresenceService(chainSdk);
+
+    return { service, chainSdk };
+  }
+});

--- a/apps/api/src/deployment/services/deployment-presence/deployment-presence.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-presence/deployment-presence.service.spec.ts
@@ -1,5 +1,7 @@
 import type { QueryDeploymentResponse } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
+import type { GetLatestBlockResponse } from "@akashnetwork/chain-sdk/private-types/cosmos.v1beta1";
 import { SDKError, SDKErrorCode } from "@akashnetwork/chain-sdk/web";
+import { addMinutes, subMinutes } from "date-fns";
 import { describe, expect, it } from "vitest";
 import { mockDeep } from "vitest-mock-extended";
 
@@ -8,13 +10,20 @@ import { DeploymentPresenceService } from "./deployment-presence.service";
 
 const OWNER = "akash100dwtg4hqnd240x583spjwnk4kanp559xwtvmg";
 const DSEQ = "16122570";
+const RECORDED_AT = new Date("2026-01-01T00:00:00.000Z");
+const CHAIN_HEIGHT = 28343549n;
+
+/** The margin the service requires between the record and the block it will trust, kept in step with it. */
+const MARGIN_IN_MIN = 10;
 
 /** The shapes a real node produced for each outcome, captured against mainnet REST and replayed here. */
 const CHAIN_ANSWERS = {
   absent: new SDKError("[not_found] codespace deployment code 4: Deployment not found", SDKErrorCode.NotFound),
+  heightAboveTheirChain: new SDKError("[unknown] codespace sdk code 26: invalid height: cannot query with height in the future", SDKErrorCode.Unknown),
+  heightPruned: new SDKError("[unknown] codespace sdk code 38: not found: failed to load state at height", SDKErrorCode.Unknown),
   unroutableQueryVersion: new SDKError("[unimplemented] Not Implemented", SDKErrorCode.Unimplemented),
   unreachableNode: new SDKError("[unknown] fetch failed", SDKErrorCode.Unknown),
-  timedOut: new SDKError("[deadline_exceeded] the operation timed out", SDKErrorCode.DeadlineExceeded),
+  timedOut: new SDKError("[deadline_exceeded] The operation was aborted due to timeout", SDKErrorCode.DeadlineExceeded),
   malformedOwner: new SDKError("[invalid_argument] invalid owner address", SDKErrorCode.InvalidArgument)
 };
 
@@ -22,64 +31,128 @@ describe(DeploymentPresenceService.name, () => {
   it("reports a deployment the chain answers for as on chain", async () => {
     const { service } = setup({ answers: mockDeep<QueryDeploymentResponse>() });
 
-    await expect(service.isOnChain({ owner: OWNER, dseq: DSEQ })).resolves.toBe(true);
+    await expect(service.isOnChain({ owner: OWNER, dseq: DSEQ, recordedAt: RECORDED_AT })).resolves.toBe(true);
   });
 
   it("reports a deployment the chain says it does not have as absent", async () => {
     const { service } = setup({ rejectsWith: CHAIN_ANSWERS.absent });
 
-    await expect(service.isOnChain({ owner: OWNER, dseq: DSEQ })).resolves.toBe(false);
+    await expect(service.isOnChain({ owner: OWNER, dseq: DSEQ, recordedAt: RECORDED_AT })).resolves.toBe(false);
   });
 
   it("asks the chain for the deployment the caller named, with dseq as a number", async () => {
     const { service, chainSdk } = setup({ answers: mockDeep<QueryDeploymentResponse>() });
 
-    await service.isOnChain({ owner: OWNER, dseq: DSEQ });
+    await service.isOnChain({ owner: OWNER, dseq: DSEQ, recordedAt: RECORDED_AT });
 
-    expect(chainSdk.akash.deployment.v1beta4.getDeployment).toHaveBeenCalledWith({ id: { owner: OWNER, dseq: 16122570n } });
+    expect(chainSdk.akash.deployment.v1beta4.getDeployment).toHaveBeenCalledWith({ id: { owner: OWNER, dseq: 16122570n } }, expect.anything());
+  });
+
+  it("pins the lookup to the height it proved is past the record, so a shorter chain must refuse it", async () => {
+    const { service, chainSdk } = setup({ rejectsWith: CHAIN_ANSWERS.absent });
+
+    await service.isOnChain({ owner: OWNER, dseq: DSEQ, recordedAt: RECORDED_AT });
+
+    expect(chainSdk.akash.deployment.v1beta4.getDeployment).toHaveBeenCalledWith(expect.anything(), {
+      header: { "x-cosmos-block-height": CHAIN_HEIGHT.toString() }
+    });
+  });
+
+  it("refuses to answer when the chain has not yet progressed past the record", async () => {
+    const { service } = setup({ rejectsWith: CHAIN_ANSWERS.absent, chainTime: subMinutes(RECORDED_AT, 1) });
+
+    await expect(service.isOnChain({ owner: OWNER, dseq: DSEQ, recordedAt: RECORDED_AT })).rejects.toThrow(/not past/);
+  });
+
+  it("refuses to answer when the chain has progressed past the record but not past the margin", async () => {
+    const { service } = setup({ rejectsWith: CHAIN_ANSWERS.absent, chainTime: addMinutes(RECORDED_AT, MARGIN_IN_MIN - 1) });
+
+    await expect(service.isOnChain({ owner: OWNER, dseq: DSEQ, recordedAt: RECORDED_AT })).rejects.toThrow(/not past/);
+  });
+
+  it("looks the deployment up at all only once the chain is past the margin", async () => {
+    const { service, chainSdk } = setup({ rejectsWith: CHAIN_ANSWERS.absent, chainTime: addMinutes(RECORDED_AT, MARGIN_IN_MIN - 1) });
+
+    await service.isOnChain({ owner: OWNER, dseq: DSEQ, recordedAt: RECORDED_AT }).catch(() => undefined);
+
+    expect(chainSdk.akash.deployment.v1beta4.getDeployment).not.toHaveBeenCalled();
+  });
+
+  it("refuses to answer when the chain does not report a latest block time", async () => {
+    const { service } = setup({ rejectsWith: CHAIN_ANSWERS.absent, chainTime: null });
+
+    await expect(service.isOnChain({ owner: OWNER, dseq: DSEQ, recordedAt: RECORDED_AT })).rejects.toThrow(/did not report a latest block time/);
+  });
+
+  it("refuses to answer when the latest block cannot be read", async () => {
+    const { service } = setup({ rejectsWith: CHAIN_ANSWERS.absent, latestBlockRejectsWith: CHAIN_ANSWERS.unreachableNode });
+
+    await expect(service.isOnChain({ owner: OWNER, dseq: DSEQ, recordedAt: RECORDED_AT })).rejects.toThrow(CHAIN_ANSWERS.unreachableNode);
+  });
+
+  it("refuses to answer when the answering node has not reached the pinned height", async () => {
+    const { service } = setup({ rejectsWith: CHAIN_ANSWERS.heightAboveTheirChain });
+
+    await expect(service.isOnChain({ owner: OWNER, dseq: DSEQ, recordedAt: RECORDED_AT })).rejects.toThrow(CHAIN_ANSWERS.heightAboveTheirChain);
+  });
+
+  it("refuses to answer when the answering node has pruned the pinned height", async () => {
+    const { service } = setup({ rejectsWith: CHAIN_ANSWERS.heightPruned });
+
+    await expect(service.isOnChain({ owner: OWNER, dseq: DSEQ, recordedAt: RECORDED_AT })).rejects.toThrow(CHAIN_ANSWERS.heightPruned);
   });
 
   it("refuses to answer when the node cannot be reached", async () => {
     const { service } = setup({ rejectsWith: CHAIN_ANSWERS.unreachableNode });
 
-    await expect(service.isOnChain({ owner: OWNER, dseq: DSEQ })).rejects.toThrow(CHAIN_ANSWERS.unreachableNode);
+    await expect(service.isOnChain({ owner: OWNER, dseq: DSEQ, recordedAt: RECORDED_AT })).rejects.toThrow(CHAIN_ANSWERS.unreachableNode);
   });
 
   it("refuses to answer when the request timed out", async () => {
     const { service } = setup({ rejectsWith: CHAIN_ANSWERS.timedOut });
 
-    await expect(service.isOnChain({ owner: OWNER, dseq: DSEQ })).rejects.toThrow(CHAIN_ANSWERS.timedOut);
+    await expect(service.isOnChain({ owner: OWNER, dseq: DSEQ, recordedAt: RECORDED_AT })).rejects.toThrow(CHAIN_ANSWERS.timedOut);
   });
 
   it("refuses to answer when the node does not serve this query version", async () => {
     const { service } = setup({ rejectsWith: CHAIN_ANSWERS.unroutableQueryVersion });
 
-    await expect(service.isOnChain({ owner: OWNER, dseq: DSEQ })).rejects.toThrow(CHAIN_ANSWERS.unroutableQueryVersion);
+    await expect(service.isOnChain({ owner: OWNER, dseq: DSEQ, recordedAt: RECORDED_AT })).rejects.toThrow(CHAIN_ANSWERS.unroutableQueryVersion);
   });
 
   it("refuses to answer when the node rejected the request as malformed", async () => {
     const { service } = setup({ rejectsWith: CHAIN_ANSWERS.malformedOwner });
 
-    await expect(service.isOnChain({ owner: OWNER, dseq: DSEQ })).rejects.toThrow(CHAIN_ANSWERS.malformedOwner);
+    await expect(service.isOnChain({ owner: OWNER, dseq: DSEQ, recordedAt: RECORDED_AT })).rejects.toThrow(CHAIN_ANSWERS.malformedOwner);
   });
 
   it("refuses to answer on an error shape it does not recognise", async () => {
     const { service } = setup({ rejectsWith: new Error("Deployment not found") });
 
-    await expect(service.isOnChain({ owner: OWNER, dseq: DSEQ })).rejects.toThrow("Deployment not found");
+    await expect(service.isOnChain({ owner: OWNER, dseq: DSEQ, recordedAt: RECORDED_AT })).rejects.toThrow("Deployment not found");
   });
 
   it("refuses to answer when something other than an error was thrown", async () => {
     const { service } = setup({ rejectsWith: { code: SDKErrorCode.NotFound, message: "Deployment not found" } });
 
-    await expect(service.isOnChain({ owner: OWNER, dseq: DSEQ })).rejects.toEqual({
+    await expect(service.isOnChain({ owner: OWNER, dseq: DSEQ, recordedAt: RECORDED_AT })).rejects.toEqual({
       code: SDKErrorCode.NotFound,
       message: "Deployment not found"
     });
   });
 
-  function setup(input: { answers?: QueryDeploymentResponse; rejectsWith?: unknown }) {
+  function setup(input: { answers?: QueryDeploymentResponse; rejectsWith?: unknown; chainTime?: Date | null; latestBlockRejectsWith?: unknown }) {
+    const chainTime = input.chainTime === undefined ? addMinutes(RECORDED_AT, MARGIN_IN_MIN + 1) : input.chainTime;
     const chainSdk = mockDeep<ChainSDK>();
+
+    chainSdk.cosmos.base.tendermint.v1beta1.getLatestBlock.mockImplementation(async () => {
+      if (input.latestBlockRejectsWith) throw input.latestBlockRejectsWith;
+
+      return mockDeep<GetLatestBlockResponse>({
+        block: { header: { height: CHAIN_HEIGHT, time: chainTime ?? undefined } }
+      });
+    });
+
     chainSdk.akash.deployment.v1beta4.getDeployment.mockImplementation(async () => {
       if (input.answers) return input.answers;
       throw input.rejectsWith;

--- a/apps/api/src/deployment/services/deployment-presence/deployment-presence.service.ts
+++ b/apps/api/src/deployment/services/deployment-presence/deployment-presence.service.ts
@@ -1,18 +1,52 @@
 import { SDKError, SDKErrorCode } from "@akashnetwork/chain-sdk/web";
+import { addMinutes } from "date-fns";
 import { inject, singleton } from "tsyringe";
 
 import { CHAIN_SDK, type ChainSDK } from "@src/chain/providers/chain-sdk.provider";
+
+/** Derived from the SDK's own signature rather than a deep import, since it publishes no `CallOptions`. */
+type QueryOptions = NonNullable<Parameters<ChainSDK["akash"]["deployment"]["v1beta4"]["getDeployment"]>[1]>;
+
+/** Cosmos' gRPC gateway serves a query at the height named by this request header instead of the latest one. */
+const BLOCK_HEIGHT_HEADER = "x-cosmos-block-height";
+
+/**
+ * How far past a record's creation the chain must have progressed before an absence is believed. It absorbs
+ * the gap between the database clock that stamped the record and the consensus clock that stamps blocks, plus
+ * the block or two a create needs to be included.
+ *
+ * It is also a floor no configuration can undermine: a grace period shortened below it does not start
+ * deleting early, it just makes the compensation retry until the chain has moved far enough on.
+ */
+const CHAIN_PROGRESS_MARGIN_IN_MIN = 10;
 
 /**
  * The one error a missing deployment produces, and the only one that may be read as an answer rather than a
  * failure to get one. Verified against two independent mainnet REST nodes: an absent deployment returns
  * `HTTP 404 {"code":5,...}`, which the SDK's grpc-gateway transport turns into an `SDKError` carrying
  * `NotFound`. Every other outcome carries a different code — a malformed owner is `InvalidArgument`, a node
- * that does not serve this query version is `Unimplemented`, an unreachable host or a DNS failure is
- * `Unknown`, and a timeout is `DeadlineExceeded` — so none of them can be mistaken for an answer.
+ * that does not serve this query version is `Unimplemented`, an unreachable host is `Unknown`, a timeout is
+ * `DeadlineExceeded`, and a node asked for a height it does not have is `Unknown` — so none of them can be
+ * mistaken for an answer.
  */
 function isDeploymentAbsent(error: unknown): boolean {
   return error instanceof SDKError && error.code === SDKErrorCode.NotFound;
+}
+
+/**
+ * Pins a query to one block height.
+ *
+ * The transport reads custom request headers off `header`
+ * (`requestHeaderWithCompression(..., callOptions?.header, ...)`), while the `CallOptions` it inherits from
+ * connectrpc declares only `headers`. Verified against a live endpoint by pinning a height the node cannot
+ * have: the singular spelling is refused, the plural one is silently dropped and the query answers at the
+ * latest height instead. Spelling this as an intersection rather than the declared field is therefore
+ * load-bearing — the typed field would leave the pin off the wire and the guard inert.
+ */
+function atBlockHeight(height: bigint): QueryOptions {
+  const pinned: QueryOptions & { header: Record<string, string> } = { header: { [BLOCK_HEIGHT_HEADER]: height.toString() } };
+
+  return pinned;
 }
 
 @singleton()
@@ -30,14 +64,50 @@ export class DeploymentPresenceService {
    * because the cost of the two mistakes is not symmetric — believing a live deployment gone destroys the only
    * copy of its SDL and silently drops its runtime limit, while believing a gone deployment live merely leaves
    * a row nothing reads.
+   *
+   * `recordedAt` is when the caller wrote down the thing whose existence is in question, and it is what makes
+   * a `false` here trustworthy. `REST_API_NODE_URL` is a pooled third-party endpoint on mainnet, so successive
+   * queries can be served by different members at different heights and one that is hours behind reports a
+   * live deployment absent — truthfully, for its own height. So absence is established in two steps that
+   * together leave no room for a stale answer:
+   *
+   * 1. read the pool's latest block and refuse to proceed unless its timestamp is past `recordedAt` plus a
+   *    margin, which establishes that a height exists at which the deployment would already be visible;
+   * 2. ask for the deployment **pinned to that height**, so any member that has not reached it must refuse
+   *    the query rather than answer from its own shorter chain.
+   *
+   * Step 2 is what makes this sound rather than merely less likely to be wrong. A lagging member cannot
+   * produce `NotFound` for a height above its own — it answers `Unknown` ("cannot query with height in the
+   * future"), which is rethrown and retried, most likely onto a different member.
    */
-  async isOnChain({ owner, dseq }: { owner: string; dseq: string }): Promise<boolean> {
+  async isOnChain({ owner, dseq, recordedAt }: { owner: string; dseq: string; recordedAt: Date }): Promise<boolean> {
+    const height = await this.#heightPast(recordedAt);
+
     try {
-      await this.#chainSdk.akash.deployment.v1beta4.getDeployment({ id: { owner, dseq: BigInt(dseq) } });
+      await this.#chainSdk.akash.deployment.v1beta4.getDeployment({ id: { owner, dseq: BigInt(dseq) } }, atBlockHeight(height));
       return true;
     } catch (error) {
       if (isDeploymentAbsent(error)) return false;
       throw error;
     }
+  }
+
+  async #heightPast(recordedAt: Date): Promise<bigint> {
+    const { block } = await this.#chainSdk.cosmos.base.tendermint.v1beta1.getLatestBlock();
+    const header = block?.header;
+
+    if (!header?.time) {
+      throw new Error("Chain did not report a latest block time, so no height can be shown to be past the record");
+    }
+
+    const mustBePast = addMinutes(recordedAt, CHAIN_PROGRESS_MARGIN_IN_MIN);
+
+    if (header.time <= mustBePast) {
+      throw new Error(
+        `Chain has only reached ${header.time.toISOString()}, which is not past ${mustBePast.toISOString()}, so an absent deployment cannot be told from an unindexed one`
+      );
+    }
+
+    return header.height;
   }
 }

--- a/apps/api/src/deployment/services/deployment-presence/deployment-presence.service.ts
+++ b/apps/api/src/deployment/services/deployment-presence/deployment-presence.service.ts
@@ -11,9 +11,18 @@ type QueryOptions = NonNullable<Parameters<ChainSDK["akash"]["deployment"]["v1be
 const BLOCK_HEIGHT_HEADER = "x-cosmos-block-height";
 
 /**
- * How far past a record's creation the chain must have progressed before an absence is believed. It absorbs
- * the gap between the database clock that stamped the record and the consensus clock that stamps blocks, plus
- * the block or two a create needs to be included.
+ * How far past a record's creation the chain must have progressed before an absence is believed.
+ *
+ * This is not a guess about clock skew: a create is broadcast as an *unordered* cosmos tx carrying
+ * `timeoutTimestamp = now + UNORDERED_TX_TTL_MS` (tx-signer, default 30s), so the chain itself refuses to
+ * include a create tx more than that long after it was signed, and with the signer's retry ceiling the hard
+ * bound on inclusion is around two and a half minutes. Ten minutes is roughly four times a bound the chain
+ * enforces, and the remainder absorbs the gap between the database clock that stamped the record and the
+ * consensus clock that stamps blocks.
+ *
+ * That makes this constant load-bearing on `UNORDERED_TX_TTL_MS` in **another service**, silently: raising
+ * that TTL past about nine minutes would let a create land later than this margin allows, and nothing here —
+ * no test, no type, no log — would notice. Change one and check the other.
  *
  * It is also a floor no configuration can undermine: a grace period shortened below it does not start
  * deleting early, it just makes the compensation retry until the chain has moved far enough on.

--- a/apps/api/src/deployment/services/deployment-presence/deployment-presence.service.ts
+++ b/apps/api/src/deployment/services/deployment-presence/deployment-presence.service.ts
@@ -1,0 +1,43 @@
+import { SDKError, SDKErrorCode } from "@akashnetwork/chain-sdk/web";
+import { inject, singleton } from "tsyringe";
+
+import { CHAIN_SDK, type ChainSDK } from "@src/chain/providers/chain-sdk.provider";
+
+/**
+ * The one error a missing deployment produces, and the only one that may be read as an answer rather than a
+ * failure to get one. Verified against two independent mainnet REST nodes: an absent deployment returns
+ * `HTTP 404 {"code":5,...}`, which the SDK's grpc-gateway transport turns into an `SDKError` carrying
+ * `NotFound`. Every other outcome carries a different code — a malformed owner is `InvalidArgument`, a node
+ * that does not serve this query version is `Unimplemented`, an unreachable host or a DNS failure is
+ * `Unknown`, and a timeout is `DeadlineExceeded` — so none of them can be mistaken for an answer.
+ */
+function isDeploymentAbsent(error: unknown): boolean {
+  return error instanceof SDKError && error.code === SDKErrorCode.NotFound;
+}
+
+@singleton()
+export class DeploymentPresenceService {
+  readonly #chainSdk: ChainSDK;
+
+  constructor(@inject(CHAIN_SDK) chainSdk: ChainSDK) {
+    this.#chainSdk = chainSdk;
+  }
+
+  /**
+   * Whether the chain holds this deployment, in any state. Answers only when the chain answered: any outcome
+   * this cannot positively read as "absent" is rethrown, so a caller that deletes on `false` can never delete
+   * because a node was unreachable. A response the node served is read as present without inspecting its body,
+   * because the cost of the two mistakes is not symmetric — believing a live deployment gone destroys the only
+   * copy of its SDL and silently drops its runtime limit, while believing a gone deployment live merely leaves
+   * a row nothing reads.
+   */
+  async isOnChain({ owner, dseq }: { owner: string; dseq: string }): Promise<boolean> {
+    try {
+      await this.#chainSdk.akash.deployment.v1beta4.getDeployment({ id: { owner, dseq: BigInt(dseq) } });
+      return true;
+    } catch (error) {
+      if (isDeploymentAbsent(error)) return false;
+      throw error;
+    }
+  }
+}


### PR DESCRIPTION
## Why

A deployment setting is written just before the create tx is broadcast, so a broadcast that never lands leaves a row on a dseq the chain has never heard of — and **nothing in the codebase can reach those rows**:

- `StaleManagedDeploymentsCleanerService` starts from on-chain deployments and closes the lease-less ones; a dseq that was never broadcast is not among them
- the funding sweep looks each remembered dseq up by lease and skips whatever it finds nothing for, on every pass, forever (`draining-deployment.service.ts`, the `if (!deployment) return acc` branch)

Left alone they only accumulate.

This PR is **the compensation that deletes such a row, and the chain check that is its sole authority to do so.** The producer that enqueues it — the transactional outbox in `DeploymentWriterService` — is the stacked follow-up below.

## What

`DeleteUnbackedDeploymentSetting`, a delayed, dseq-keyed job, and its handler. Plus `DeploymentPresenceService`, which asks the chain whether a deployment exists and is the whole reason this is safe.

> **Note for reviewers: the job has no producer until slice 2.** It is not dead code, it is the first half of a stack. Its behaviour is fully exercised here — including end to end through a real pg-boss worker against real Postgres.

### The chain check is the only thing allowed to delete

A compensation firing is **not** evidence that the deployment is missing. Slice 2 cancels the job the moment the broadcast succeeds, but the process can die in between, or the cancellation itself can fail. So the handler asks the chain every time, and deletes only on a positively-identified "not there".

### An absent answer is believed only at a height past the record

`REST_API_NODE_URL` on mainnet is `https://rpc.akt.dev/rest` — a **pooled** third-party endpoint, several
independent nodes with no read-your-writes guarantee. And the SDK lifts its error code straight from the
response **body** with no reference to `response.status`. So a naive predicate is not "the chain says this
deployment does not exist", it is "some upstream returned a non-2xx whose JSON body has `code: 5`" — and a
pool member two hours behind reports a live deployment absent, *truthfully, for its own height*.

That is the exact path this design exists to serve: broadcast lands → process dies before the cancellation →
at +60 min the compensation asks the pool → an unlucky draw deletes a live deployment's row.

Absence is therefore established in two steps:

1. read the pool's latest block and **refuse to proceed** unless its timestamp is past the row's `createdAt`
   plus a margin, which establishes that a height exists at which the deployment would already be visible;
2. ask for the deployment **pinned to that height** via the `x-cosmos-block-height` request header.

**Step 2 is what makes this sound rather than merely less likely to be wrong.** A member that has not
reached the pinned height cannot answer from its shorter chain — it must refuse. Verified live against
mainnet, and the refusal is emphatically *not* the not-found code:

| pinned height | outcome |
|---|---|
| latest, deployment present | resolves `200` |
| latest, deployment absent | `SDKError` `NotFound` (5) |
| above the node's chain | `SDKError` `Unknown` (2) — *"cannot query with height in the future"* |
| below the node's pruning window | `SDKError` `Unknown` (2) — *"failed to load state at height"* |

Both refusals are rethrown and retried, most likely onto a different member. Two requests landing on
different pool members no longer matters, because the answer that authorises the delete is bound to a height.

**The 10-minute margin is a multiple of a bound the chain enforces, not a guess.** A create is broadcast as an
*unordered* cosmos tx carrying `timeoutTimestamp = now + UNORDERED_TX_TTL_MS` (tx-signer, default **30 s**), so
the chain itself refuses to include a create tx later than that after signing; with the signer's retry ceiling
the hard bound on inclusion is ≈2.5 min. Ten minutes is roughly 4x that, and the remainder absorbs the gap
between the database clock that stamps the row and the consensus clock that stamps blocks.

That makes this constant **load-bearing on `UNORDERED_TX_TTL_MS` in another service, silently** — raising that
TTL past ~9 min would let a create land later than the margin allows, and no test, type or log would notice.
The JSDoc names it so the next person changing it has a chance.

It is a module constant rather than a config knob deliberately: a correctness floor, not something to tune. It
also makes the design robust to a misconfigured grace — shortening the grace does not start deleting early, it
just makes the compensation retry until the chain has moved far enough on.

#### The header spelling is load-bearing, and the typed one is wrong

The transport reads custom request headers off `callOptions.header` (singular), while the `CallOptions` it
inherits from connectrpc declares only `headers` (plural). Probed live by pinning a height the node cannot
have:

```
header  (singular): THREW code=2 (Unknown) -> pin WAS honoured
headers (plural)  : RESOLVED               -> pin was IGNORED
```

Using the **typed** field would have put nothing on the wire and left the whole guard inert. The intersection
type in `atBlockHeight` is there for that reason, and a mutation to the plural spelling fails two tests —
including an integration test that reads the header off the wire.

### Chain queries now have a deadline

`chain-sdk.provider.ts` passed only `{ query: { baseUrl } }`, so there was no `defaultTimeoutMs` and
`createAbortSignal` added no timeout signal at all: a black-holed connection hung its caller until pg-boss
expired the job 15 minutes later. Now 30s, matching what the REST services already pass to `httpClient.get`.
Verified live that the runtime honours the option (a 2s value aborts at ~2s with `DeadlineExceeded`) — the
published type does not mention it, so the option is **widened by intersection rather than asserted**, which
keeps every other option in the bag type-checked. That matters for the same reason the header spelling did:

| under intersection | under the old `as unknown as` |
|---|---|
| `defaultTimeoutMS` (typo) → `TS2561: Did you mean to write 'defaultTimeoutMs'?` | compiles, silently does nothing |
| `retry: "nonsense"` → `TS2322: Type 'string' is not assignable to type 'RetryOptions'` | compiles |

This benefits all seven `CHAIN_SDK` consumers, none of which is harmed by a 30s ceiling on a point read.

### Which error means "not there" — established against real nodes, not guessed

The SDK throws for both "no such deployment" and "I could not reach the node", so the two arrive through the same channel and telling them apart is the load-bearing decision in this PR.

Probed live against **two independent mainnet REST nodes** (`api.akashnet.net` and `rpc.akt.dev/rest`), then again through the SDK itself:

| situation | HTTP | body | reaches us as |
|---|---|---|---|
| deployment absent | `404` | `{"code":5,"message":"codespace deployment code 4: Deployment not found"}` | `SDKError` code `NotFound` (5) |
| deployment present | `200` | the deployment | resolves |
| node does not serve this query version | `501` | `{"code":12,...}` | `SDKError` code `Unimplemented` (12) |
| host unreachable / DNS failure | — | — | `SDKError` code `Unknown` (2) |
| request timed out | — | — | `SDKError` code `DeadlineExceeded` (4) |
| owner address malformed | `400` | `{"code":3,...}` | `SDKError` code `InvalidArgument` (3) |
| height above the node's chain | `500` | `{"code":2,...}` | `SDKError` code `Unknown` (2) |

The transport does this in one place — `createGrpcGatewayTransport` reads `code` off the error body and defaults to `Unknown`, and `createAbortSignal` wraps everything else — so `code === NotFound` is narrow and nothing else can land on it. The predicate is therefore exactly:

```ts
error instanceof SDKError && error.code === SDKErrorCode.NotFound
```

**Everything else is rethrown out of the handler** so pg-boss retries with backoff. Note the polarity: failing closed here means *letting the error escape*, not swallowing it. `DeploymentPresenceService.isOnChain` never returns `false` for a failure it could not classify.

A response the node served is read as present **without inspecting its body**, because the two mistakes do not cost the same: believing a live deployment gone destroys the only stored copy of its SDL and silently drops its runtime limit, while believing a gone deployment live merely leaves a row nothing reads.

Uses `ChainSDK` (`@akashnetwork/chain-sdk`) rather than the internal `http-sdk` `DeploymentHttpService`, per the standing migration direction, via the point lookup `akash.deployment.v1beta4.getDeployment` (`/akash/deployment/v1beta4/deployments/info`).

### The repository is used unscoped, and must be

Job execution sets `ABILITY` to an empty `createMongoAbility()`. `DeploymentSettingRepository.accessibleBy` builds a `DrizzleAbility` that calls `throwUnlessCan` in a field initializer, so a scoped read would throw `ForbiddenError` before any SQL ran and the compensation would never delete anything. **That is pinned by a test that runs through the real worker**, not by calling the handler directly — routing the read through `accessibleBy` makes it hang until timeout and three tests fail.

### Idempotency is structural

The handler re-reads the row by id, re-checks that its stored dseq is the one the chain was asked about, and deletes by id. A second delivery finds no row and returns. Nothing is targeted by dseq alone.

## Tests

Every assertion below was mutation-checked: the production line was deliberately broken and the test confirmed RED.

**`deployment-presence.service.spec.ts`** — the classification matrix above plus the freshness guard, 17 tests.

| mutation | result |
|---|---|
| `isDeploymentAbsent` → `return true` (any throw is not-found) | **6 fail** |
| drop the code check, any `SDKError` is not-found | **4 fail** |
| remove the absent branch (never absent) | **1 fails** |
| use the **typed** `headers` spelling (pin silently dropped) | **2 fail** |
| drop the pin entirely (query the latest height) | **3 fail** |
| drop the freshness check (trust any height) | **4 fail** |
| remove the margin (require only past `createdAt`) | **2 fail** |
| treat a missing block time as fresh | **1 fails** |

**`delete-unbacked-deployment-setting.handler.spec.ts`** — 11 tests.

| mutation | result |
|---|---|
| remove the chain check entirely (delete whenever the job fires) | **5 fail** |
| classifier failure returns `false` instead of throwing (swallow and delete) | **3 fail** |
| invert the presence branch (delete when present) | **2 fail** |
| drop the already-gone guard | **1 fails** |
| drop the dseq re-verification | **1 fails** |

**`delete-unbacked-deployment-setting.handler.integration.ts`** — real Postgres, real pg-boss, and the **real chain responses replayed byte-for-byte** through `nock` (the 404/`code:5` body above, a 200, a 503, a 502 with an unparseable body, and an `ECONNRESET`). The interceptor matches the exact `id.owner`/`id.dseq`, so a lookup that asked for anything else finds no interceptor and fails.

| mutation | result |
|---|---|
| route the repository through `accessibleBy` (the ability trap) | **3 fail**, incl. the worker test timing out at 20s |
| classifier treats any throw as absent | **3 fail** |
| any `SDKError` treated as absent | **3 fail** |
| remove the chain check | **4 fail** |
| use the typed `headers` spelling | **1 fails** — reads the pin off the wire |
| drop the freshness check | **1 fails** |

Plus three new cases: the lookup is pinned to the proved height; a node behind that height keeps the row and
throws; a chain not yet past the row keeps the row and throws.

**Not covered by a test, deliberately:** the 30s query timeout in the provider. Its only observable is the
SDK instance's internal transport, and asserting it would need `vi.mock` on the SDK module, which this repo's
conventions rule out. It is verified by live probe instead, and if the option were ever dropped the behaviour
reverts to today's unbounded wait — a hang, not a wrong delete.

**Integration workers are stopped in teardown.** A worker left running outlives the interceptors: the
compensation it retried came due a minute later with nock gone and issued a real request to
`REST_API_NODE_URL` — egress from CI to a third-party mainnet endpoint, and a flake that only showed on a slow
run.

One honest gap: dropping the already-gone guard does **not** fail the integration suite, because deleting a row by an id that is gone is a no-op either way — idempotency is structural, and the guard only buys a clearer log line. The unit suite covers it.

## Checks

In `apps/api`, on this branch alone:

- `npm test` → **219 files passed / 2405 tests passed**
- `npm run lint -- --quiet` → clean
- `npx tsc --noEmit` → 41 errors, byte-identical to the pre-existing baseline on `main` (all in unrelated files)

## One review item deliberately not done

`DeploymentSettingsOutput` declares `createdAt: string` while the schema is a nullable `timestamp` and drizzle
returns `Date | null`. Runtime is correct, but the lie is why the test fixture needs one `as unknown as` and
why the handler's null guard reads as near-unreachable.

I tried the correction and **stopped**: it cascades into the public HTTP contract. `deployment-setting.controller.ts`
returns the repository row straight through at six sites to a response schema typed `createdAt: z.string().datetime()`,
so correcting the type produces 14 errors across that controller, its spec, and two unrelated specs — it only
works today because `JSON.stringify` happens to render a `Date` as the right wire format. Fixing that is a
change to how a public endpoint builds its payload, which does not belong in a cleanup round. Recorded for a
separate PR; the cast stays, isolated in one documented fixture helper.

## Stack

This is **slice 1 of 2**.

- **Slice 1 (this PR)** — the compensation, its chain check, and its registration. `size: L`.
- **Slice 2** — the transactional outbox that produces it: the setting write and the enqueue in one transaction, the cancellation on a successful broadcast, the grace period and the retry horizon. `size: L`: https://github.com/akash-network/console/pull/3686

**Merge slice 1 first.** Until slice 2 lands, the queue exists and nothing enqueues onto it.
