### PR TITLE
refactor(dx): export only what consumers import from http-sdk

### DIFF
--- a/apps/api/src/address/services/address/address.service.spec.ts
+++ b/apps/api/src/address/services/address/address.service.spec.ts
@@ -1,4 +1,4 @@
-import type { CosmosHttpService } from "@akashnetwork/http-sdk/src/cosmos/cosmos-http.service";
+import type { CosmosHttpService } from "@akashnetwork/http-sdk";
 import { AxiosError } from "axios";
 import { describe, expect, it } from "vitest";
 import type { MockProxy } from "vitest-mock-extended";

--- a/packages/http-sdk/src/api-key/index.ts
+++ b/packages/http-sdk/src/api-key/index.ts
@@ -1,2 +1,0 @@
-export * from "./api-key-http.service";
-export * from "./api-key-http.types";

--- a/packages/http-sdk/src/auth/index.ts
+++ b/packages/http-sdk/src/auth/index.ts
@@ -1,2 +1,0 @@
-export * from "./auth-http.service";
-export * from "./auth-http.types";

--- a/packages/http-sdk/src/cosmos/index.ts
+++ b/packages/http-sdk/src/cosmos/index.ts
@@ -1,2 +1,0 @@
-export * from "./cosmos-http.service";
-export * from "./types";

--- a/packages/http-sdk/src/index.ts
+++ b/packages/http-sdk/src/index.ts
@@ -1,29 +1,39 @@
-export * from "./http/http.service";
-export * from "./authz/authz-http.service";
-export * from "./api-http/api-http.service";
-export * from "./tx-http/tx-http.service";
-export * from "./managed-wallet-http/managed-wallet-http.service";
-export * from "./balance/balance-http.service";
-export * from "./types/denom.type";
-export * from "./template/template-http.service";
-export * from "./usage/usage-http.service";
-export * from "./auth";
-export * from "./deployment-setting/deployment-setting-http.service";
-export * from "./api-key";
-export * from "./bid/bid-http.service";
-export * from "./deployment/deployment-http.service";
-export * from "./deployment/managed-deployment-http.service";
-export * from "./lease/lease-http.service";
-export * from "./lease/lease-state";
-export * from "./utils/isHttpError";
-export * from "./git-hub/git-hub-http.service";
-export * from "./cosmos";
-export * from "./stripe/stripe.service";
-export * from "./stripe/stripe.types";
-export { createHttpClient, type HttpClient, type HttpClientOptions } from "./utils/httpClient";
+export { AuthzHttpService, type DepositDeploymentGrant, type ExactDepositDeploymentGrant } from "./authz/authz-http.service";
+export { type ApiKeyResponse } from "./api-key/api-key-http.types";
+export { ApiKeyHttpService } from "./api-key/api-key-http.service";
+export { AuthHttpService } from "./auth/auth-http.service";
+export { SendVerificationCodeResponseSchema, type VerifyEmailResponse, VerifyEmailResponseSchema } from "./auth/auth-http.types";
+export { type Balance, BalanceHttpService } from "./balance/balance-http.service";
+export { type Bid, BidHttpService, type DeploymentResource } from "./bid/bid-http.service";
+export { CosmosHttpService } from "./cosmos/cosmos-http.service";
+export { type RestCosmosStakingValidatorResponse } from "./cosmos/types";
 export {
-  createFetchAdapter,
-  type FetchAdapterOptions,
-  isNetworkOrIdempotentRequestError,
-  isRetriableError
-} from "./utils/createFetchAdapter/createFetchAdapter";
+  type DeploymentInfo,
+  DeploymentInfoSchema,
+  DeploymentHttpService,
+  type DeploymentListResponse,
+  type FindAllParams
+} from "./deployment/deployment-http.service";
+export { ManagedDeploymentHttpService } from "./deployment/managed-deployment-http.service";
+export { DeploymentSettingHttpService, type UpdateDeploymentSettingInput } from "./deployment-setting/deployment-setting-http.service";
+export { GitHubHttpService, type ProviderAttributesSchema } from "./git-hub/git-hub-http.service";
+export { LeaseHttpService, type LeaseListParams, type RestAkashLeaseListResponse, type RpcLease } from "./lease/lease-http.service";
+export { isLeaseLive, LIVE_LEASE_STATES } from "./lease/lease-state";
+export { type ApiManagedWalletOutput, ManagedWalletHttpService } from "./managed-wallet-http/managed-wallet-http.service";
+export { StripeService } from "./stripe/stripe.service";
+export type {
+  ApplyCouponParams,
+  BillingTransaction,
+  ConfirmPaymentParams,
+  ConfirmPaymentResponse,
+  PaymentMethod,
+  SetupIntentResponse,
+  ThreeDSecureAuthParams
+} from "./stripe/stripe.types";
+export { type TemplateCategory, TemplateHttpService, type TemplateOutput, type TemplateOutputSummary } from "./template/template-http.service";
+export { TxHttpService, type TxOutput } from "./tx-http/tx-http.service";
+export { type Denom } from "./types/denom.type";
+export { UsageHttpService } from "./usage/usage-http.service";
+export { createFetchAdapter, isNetworkOrIdempotentRequestError, isRetriableError } from "./utils/createFetchAdapter/createFetchAdapter";
+export { createHttpClient, type HttpClient, type HttpClientOptions } from "./utils/httpClient";
+export { isHttpError } from "./utils/isHttpError";


### PR DESCRIPTION
## Why

Part of CON-906.

The barrel re-exported whole modules, so every internal helper and response type was public whether or not anything imported it — **137 exported symbols against 57 that consumers actually use**. Listing the 57 explicitly makes the surface auditable and turns a newly orphaned export into a visible diff instead of something that lingers unnoticed.

`@akashnetwork/http-sdk` is **repo-internal and unpublished** — `npm view` 404s, there is no `publishConfig`, and no workflow publishes it (`all-release.yml` releases apps as Docker images and treats `packages/*` only as change-detection inputs). So narrowing the public surface cannot break an external consumer.

**Slice 5 of 5.** Base: [#3691](https://github.com/akash-network/console/pull/3691). Measured size: **74**.

## What

- `index.ts` now lists 57 named exports. **No `export *` remains.**
- The base classes stay internal on the same grounds: nothing outside the package constructs `HttpService` or `ApiHttpService`, and they only need to be public again once something does. Same for `extractData`, `ApiOutput`, `sdkLogger`, `loadWithPagination`, `hasQueryParam`.
- The per-directory barrels (`api-key/`, `auth/`, `cosmos/`) had no consumers other than the root one, so the root re-exports from the modules themselves and they are deleted.
- The console-api spec that reached past the barrel into `@akashnetwork/http-sdk/src/cosmos/...` now imports from the package root like everything else. **No deep imports into `http-sdk/src` remain anywhere.** This also fixes a pre-existing `TS2307`, so `apps/api` ends one `tsc` error *below* baseline.

Export set and import set were verified equal in both directions: 57 exported, 57 imported, nothing exported-but-unused, nothing imported-but-missing.

### Verification

All green (exit 0): `packages/http-sdk` 36 tests / 0 `tsc` errors, `apps/api` 2369, `apps/deploy-web` 3575, `apps/notifications` 251, `apps/tx-signer` 108 / 0 `tsc` errors; lint clean in all five.

### Demo

None — internal refactor with no endpoint, UI, CLI or migration to exercise.

---

## Deferred / follow-up

This stack completes the **"cleanup unused http-sdk"** half of CON-906. The **"migrate the rest"** half is deliberately not finished, hence `Part of` rather than a closing keyword. What remains:

### Blocked: `AuthzHttpService` cannot move to chain-sdk

Both authz grants and feegrant allowances carry their body inside a `google.protobuf.Any`. The SDK decodes with `Any.fromJSON`, which reads proto-JSON `type_url`/`value`; cosmos grpc-gateway emits the canonical `{"@type": ...}` form. The shapes don't overlap, so results decode to `{ typeUrl: "", value: Uint8Array(0) }` — **no error, silently empty**.

Consumers: `managed-user-wallet`, `balances` (console-api) and `wallet-balances` (deploy-web, **browser** — so the Node-only `createChainNodeSDK` escape hatch is unavailable).

Nothing here touches that path; it behaves exactly as before. But the risk is worth recording: migrating it carelessly would show a user's granted deployment balance as **0** and could cause the API to re-issue grants that already exist, both silently. Fixing it means teaching the SDK's JSON decoder the `@type` form — an upstream change to `@akashnetwork/chain-sdk`.

**Consequence:** `packages/http-sdk` cannot be deleted outright while this service lives there.

### Backlog

- **B0 (gates Wave B)** — a wrapped `fetch` for `createApiSdk` carrying OTEL trace propagation, the 401 → session-expiry interceptor, and retry. The generated client has none of the three; migrating endpoints without it drops them.
- **Wave B — console-api**, cheapest first: `ManagedDeploymentHttpService`, `UsageHttpService`, Stripe (payment methods; coupons/confirm/prices; CSV), `ApiKeyHttpService`, `AuthHttpService`, `ManagedWalletHttpService`, `DeploymentSettingHttpService`, `TxHttpService`. Most need an `operationId` added to the console-api route first — `gen-operations.ts` skips routes without one. Open questions: CSV export needs a Blob (the generated client returns a string) and four endpoints use `withCredentials`, which it never sets.
- **Wave C — chain**: `BalanceHttpService`, `BidHttpService`, `CosmosHttpService` (needs splitting — `stats.service.ts` is 621 LOC + 962 LOC spec), `LeaseHttpService`, `DeploymentHttpService` (its error model flips from a 4xx union to a throw), plus the blocked `AuthzHttpService`.
- **Staying put**: `TemplateHttpService` (static templates CDN, not console-api), `GitHubHttpService` (raw.githubusercontent), `createHttpClient` / `createFetchAdapter` (generic axios + retry for non-Akash hosts), `isLeaseLive`. No equivalent exists in either SDK.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the SDK’s public exports for clearer, more predictable access to supported services, utilities, schemas, and types.
  - Removed unintended exposure of internal HTTP modules and unsupported adapter options.
  - Updated internal type usage to rely on the package’s public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->