### PR TITLE
docs(dx): cap JSDoc at one line and ban derivation prose

### DIFF
--- a/.claude/instructions/clean-code-over-comments.md
+++ b/.claude/instructions/clean-code-over-comments.md
@@ -6,7 +6,10 @@
 - **Names replace comments.** Prefer a verbose, intention-revealing name over a short name plus a comment: `secondsUntilBidExpiry`, not `t` with a `// seconds until bid expires`. Name functions by behavior, not by trigger: `redirectToSocialLogin`, not `onOAuthClick`. A name that needs a comment to be understood is the wrong name.
 - **One name per callback.** When a callback is bound to a named `const` (a `useCallback`, `useMemo`, event handler, or any assignment), the `const` carries the behavior name and the body stays an anonymous arrow — don't *also* name the function expression, and don't name the `const` after its trigger or the prop it feeds. One name is enough, and it names the *behavior*. Keep a named function expression only for a callback that has no binding name of its own: `useEffect(function redirectWhenSignedOut() {…})`, a `return function teardown() {…}` cleanup, or an inline `items.map(function renderRow() {…})`.
 - **Structure replaces comments.** A function that needs internal section-comments to navigate wants to be several named functions. Separate concerns at every level — orchestration vs. detail, one reason to change per unit — so each piece is small enough to need no narration. Don't over-fragment though: single-statement operations stay inline; extract only multi-line sequences that earn a name.
-- **JSDoc the non-obvious.** Module-level helper functions and "magic" constants (colors, fallbacks, multipliers, timeouts) get a 1–2 line JSDoc stating what/why. Skip it when the name is already fully self-describing.
+- **Default to no JSDoc.** A JSDoc block is an exception you have to justify, not a box to fill in. A magic constant earns one only when a reader who might change the value would otherwise get it wrong *and* no name can carry the point — reach for `MIN_`/`MAX_` prefixes, a named type, or a `satisfies` clause before reaching for prose. Skip it whenever the name already says it.
+- **One line, hard cap.** A JSDoc block is a single sentence on one line. A second sentence needs a reason; a third is never right. No paragraphs, no blank lines inside the block, no bullet lists. If the *why* doesn't fit on one line, it isn't a comment — it's a PR description or a refactor that makes the constraint structural.
+- **The constraint, not the derivation.** State only the fact a future editor would break — what the value must stay above, what upstream bug the workaround exists for. How you got there is not part of it: drop the alternatives you rejected, what you verified it against, how the numbers multiply out, which test covers it, and what happens in every other scenario. That belongs in the PR description or nowhere.
+- **Tests get no JSDoc at all.** No block on a `describe`, an `it`, a fixture, or a `setup` function. A test whose purpose needs explaining wants a better test name or a smaller test.
 
 ## Examples
 
@@ -18,6 +21,11 @@ const BID_EXPIRY_SECONDS = 320;
 function getSecondsUntilBidExpiry(createdAt: Date) {
   return BID_EXPIRY_SECONDS - differenceInSeconds(new Date(), createdAt);
 }
+```
+
+```typescript
+/** pg-boss defaults its backoff multiplier to 0, which would collapse every retry gap after the first to zero. */
+const MIN_RECHECK_BACKOFF_SECONDS = 30;
 ```
 
 ```typescript
@@ -48,6 +56,27 @@ function getTime(createdAt: Date) {
   const elapsed = differenceInSeconds(new Date(), createdAt); // seconds since creation
   return t - elapsed;
 }
+```
+
+```typescript
+/**
+ * First gap between chain re-checks, doubling from there. pg-boss multiplies its backoff by this value and
+ * defaults it to 0, which collapses every later gap to zero however high the cap is set — so it must be
+ * positive for the horizon below to exist at all.
+ *
+ * With 48 attempts and the cap below, this spans about 21.5 to 22 hours depending on jitter, sized to outlast
+ * a chain-node outage rather than a blip. Checking too early costs retries rather than rows, since the
+ * presence check enforces its own margin on top.
+ */
+const MIN_RECHECK_BACKOFF_SECONDS = 30;
+```
+
+```typescript
+/**
+ * Covers the compensation against a real database and a real chain response, because both halves of its
+ * decision are about things a mock cannot get wrong on its behalf.
+ */
+describe("deployment setting compensation", () => {
 ```
 
 ```typescript


### PR DESCRIPTION
## Why

too much comments

## What

The "magic constants get a 1-2 line JSDoc" carve-out read as a box to fill in, so every "why is this value 30" got answered with the reasoning that produced it: rejected alternatives, what was verified, how the numbers multiply out.

Replace it with a default of no JSDoc, a hard one-line cap, a split between the constraint and its derivation, and no JSDoc on tests at all.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated code-writing guidance to discourage unnecessary JSDoc comments.
  * Clarified when concise documentation is appropriate for non-obvious constraints.
  * Added examples covering magic constants and test-related documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->