### PR TITLE
feat(provider): re-verify dead providers and expose ongoing outages

### DIFF
--- a/apps/provider-inventory/CONTEXT.md
+++ b/apps/provider-inventory/CONTEXT.md
@@ -34,6 +34,18 @@ A named pool of persistent storage on a provider (e.g. `beta1` for HDD, `beta2` 
 **RAM storage class**:
 A volume with `attributes.class = "ram"`. Allocated against node memory, not against ephemeral or persistent storage pools. **Persistent + RAM is invalid** and rejected by request validation.
 
+**incident**:
+One continuous stretch of a provider not answering, stored as a row in `provider_incidents`. Opened when the **streamer** exhausts its retries, closed on the first stream message after recovery. `ended_at IS NULL` means the provider is unreachable right now; `last_attempt_at` is when it was last dialled and is what tells a live outage from one left behind by a stalled streamer.
+_Avoid_: downtime, outage record
+
+**dead provider**:
+A provider still registered on chain whose **incident** has been open longer than `DEAD_PROVIDER_UPDATED_THRESHOLD_MS` and whose chain record has not changed since. Dropped from the regular **discovery loop** so it cannot crowd out healthy providers, and re-dialled once every `DEAD_PROVIDER_RETRY_INTERVAL_MS` so a recovery still closes its incident.
+_Avoid_: gone provider, stale provider
+
+**ongoing outage**:
+What `GET /v1/provider-outages` reports — an open **incident** older than the age the caller asks for, paired with the provider's address and `host_uri`. Consumers (today: `apps/api`) use it to decide whether a deployment's provider has been dark long enough to act on.
+_Avoid_: incident feed
+
 ### Requests
 
 **GroupSpec**:

--- a/apps/provider-inventory/drizzle/0005_add_incident_last_attempt_at.sql
+++ b/apps/provider-inventory/drizzle/0005_add_incident_last_attempt_at.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "provider_incidents" ADD COLUMN "last_attempt_at" timestamp with time zone DEFAULT now() NOT NULL;

--- a/apps/provider-inventory/drizzle/meta/0005_snapshot.json
+++ b/apps/provider-inventory/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,276 @@
+{
+  "id": "0b2a57b2-9434-4cf1-bd7a-70a068b7d993",
+  "prevId": "d65bf4ae-2ed9-4979-a847-fd2673014509",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.provider_incidents": {
+      "name": "provider_incidents",
+      "schema": "",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uniq_provider_incidents_open_per_provider": {
+          "name": "uniq_provider_incidents_open_per_provider",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "ended_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_incidents_provider": {
+          "name": "idx_incidents_provider",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_inventory": {
+      "name": "provider_inventory",
+      "schema": "",
+      "columns": {
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "host_uri": {
+          "name": "host_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_online": {
+          "name": "is_online",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_online_since": {
+          "name": "is_online_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inventory": {
+          "name": "inventory",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "total_available_cpu": {
+          "name": "total_available_cpu",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "total_available_memory": {
+          "name": "total_available_memory",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "total_available_gpu": {
+          "name": "total_available_gpu",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "total_available_eph": {
+          "name": "total_available_eph",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "total_available_persistent": {
+          "name": "total_available_persistent",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "total_available_leased_ip": {
+          "name": "total_available_leased_ip",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "max_node_free_cpu": {
+          "name": "max_node_free_cpu",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "max_node_free_memory": {
+          "name": "max_node_free_memory",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "max_node_free_gpu": {
+          "name": "max_node_free_gpu",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "reclamation_window": {
+          "name": "reclamation_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gpu_models": {
+          "name": "gpu_models",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "storage_classes": {
+          "name": "storage_classes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "self_attributes": {
+          "name": "self_attributes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "signed_attributes": {
+          "name": "signed_attributes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "audited_by": {
+          "name": "audited_by",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_provider_inventory_online": {
+          "name": "idx_provider_inventory_online",
+          "columns": [
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "is_online AND is_online_since IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/provider-inventory/drizzle/meta/_journal.json
+++ b/apps/provider-inventory/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1781690088926,
       "tag": "0004_add_reclamation_window",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1787764005445,
+      "tag": "0005_add_incident_last_attempt_at",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/provider-inventory/src/config/env.config.ts
+++ b/apps/provider-inventory/src/config/env.config.ts
@@ -33,6 +33,11 @@ export const envSchema = z.object({
     .nonnegative()
     .default(2 * 24 * 60 * ONE_MINUTE),
   OFFLINE_PROVIDER_RETRY_MAX_ATTEMPTS: z.number({ coerce: true }).int().positive().default(2),
+  DEAD_PROVIDER_RETRY_INTERVAL_MS: z
+    .number({ coerce: true })
+    .int()
+    .nonnegative()
+    .default(60 * ONE_MINUTE),
   INCIDENT_RETENTION_DAYS: z.number({ coerce: true }).int().positive().default(31),
   INCIDENT_CLEANUP_INTERVAL_MS: z
     .number({ coerce: true })

--- a/apps/provider-inventory/src/controllers/provider-outages/provider-outages.controller.ts
+++ b/apps/provider-inventory/src/controllers/provider-outages/provider-outages.controller.ts
@@ -1,7 +1,7 @@
 import { singleton } from "tsyringe";
 
+import type { ProviderOutagesRequest, ProviderOutagesResponse } from "@src/http-schemas/provider-outages.schema";
 import { ProviderIncidentRepository } from "@src/repositories/provider-incident/provider-incident.repository";
-import type { ProviderOutagesRequest, ProviderOutagesResponse } from "../../http-schemas/provider-outages.schema";
 
 @singleton()
 export class ProviderOutagesController {

--- a/apps/provider-inventory/src/controllers/provider-outages/provider-outages.controller.ts
+++ b/apps/provider-inventory/src/controllers/provider-outages/provider-outages.controller.ts
@@ -1,0 +1,26 @@
+import { singleton } from "tsyringe";
+
+import { ProviderIncidentRepository } from "@src/repositories/provider-incident/provider-incident.repository";
+import type { ProviderOutagesRequest, ProviderOutagesResponse } from "../../http-schemas/provider-outages.schema";
+
+@singleton()
+export class ProviderOutagesController {
+  readonly #incidentRepository: ProviderIncidentRepository;
+
+  constructor(incidentRepository: ProviderIncidentRepository) {
+    this.#incidentRepository = incidentRepository;
+  }
+
+  async getOngoingOutages(request: ProviderOutagesRequest): Promise<ProviderOutagesResponse> {
+    const outages = await this.#incidentRepository.findOutagesStartedBefore(request.minAgeDays);
+
+    return {
+      outages: outages.map(outage => ({
+        provider: outage.provider,
+        hostUri: outage.hostUri,
+        startedAt: outage.startedAt.toISOString(),
+        lastAttemptAt: outage.lastAttemptAt.toISOString()
+      }))
+    };
+  }
+}

--- a/apps/provider-inventory/src/http-schemas/provider-outages.schema.ts
+++ b/apps/provider-inventory/src/http-schemas/provider-outages.schema.ts
@@ -1,10 +1,13 @@
 import { z } from "@hono/zod-openapi";
 
+const MAX_OUTAGE_AGE_DAYS = 365;
+
 export const ProviderOutagesRequestSchema = z.object({
   minAgeDays: z
     .number({ coerce: true })
     .int()
     .nonnegative()
+    .max(MAX_OUTAGE_AGE_DAYS)
     .openapi({ description: "Only return outages that started at least this many days ago", example: 3 })
 });
 export type ProviderOutagesRequest = z.infer<typeof ProviderOutagesRequestSchema>;

--- a/apps/provider-inventory/src/http-schemas/provider-outages.schema.ts
+++ b/apps/provider-inventory/src/http-schemas/provider-outages.schema.ts
@@ -4,11 +4,8 @@ const MAX_OUTAGE_AGE_DAYS = 365;
 
 export const ProviderOutagesRequestSchema = z.object({
   minAgeDays: z
-    .number({ coerce: true })
-    .int()
-    .nonnegative()
-    .max(MAX_OUTAGE_AGE_DAYS)
-    .openapi({ description: "Only return outages that started at least this many days ago", example: 3 })
+    .preprocess(value => (value === "" ? undefined : value), z.number({ coerce: true }).int().nonnegative().max(MAX_OUTAGE_AGE_DAYS))
+    .openapi({ description: "Only return outages that started at least this many days ago", example: 3, param: { required: true } })
 });
 export type ProviderOutagesRequest = z.infer<typeof ProviderOutagesRequestSchema>;
 

--- a/apps/provider-inventory/src/http-schemas/provider-outages.schema.ts
+++ b/apps/provider-inventory/src/http-schemas/provider-outages.schema.ts
@@ -1,0 +1,25 @@
+import { z } from "@hono/zod-openapi";
+
+export const ProviderOutagesRequestSchema = z.object({
+  minAgeDays: z
+    .number({ coerce: true })
+    .int()
+    .nonnegative()
+    .openapi({ description: "Only return outages that started at least this many days ago", example: 3 })
+});
+export type ProviderOutagesRequest = z.infer<typeof ProviderOutagesRequestSchema>;
+
+const ProviderOutageSchema = z.object({
+  provider: z.string().openapi({ description: "Provider address", example: "akash1q7spv2cw06yszgfp4f9ed59lkka6ytn8g4tkjf" }),
+  hostUri: z.string().openapi({ description: "Provider HTTPS endpoint", example: "https://provider.europlots.com:8443" }),
+  startedAt: z.string().datetime().openapi({ description: "When the provider stopped answering", example: "2026-01-01T00:00:00.000Z" }),
+  lastAttemptAt: z.string().datetime().openapi({
+    description: "When the provider was last dialled while still unreachable; a value far in the past means the outage record is stale",
+    example: "2026-01-08T12:00:00.000Z"
+  })
+});
+
+export const ProviderOutagesResponseSchema = z.object({
+  outages: z.array(ProviderOutageSchema)
+});
+export type ProviderOutagesResponse = z.infer<typeof ProviderOutagesResponseSchema>;

--- a/apps/provider-inventory/src/model-schemas/provider-incident/provider-incident.schema.ts
+++ b/apps/provider-inventory/src/model-schemas/provider-incident/provider-incident.schema.ts
@@ -6,6 +6,8 @@ export const providerIncidents = pgTable(
   {
     provider: text("provider").notNull(),
     startedAt: timestamp("started_at", { withTimezone: true }).notNull().defaultNow(),
+    /** Last time the provider was dialled while this incident was open. Lets consumers tell a live outage from one left behind by a stalled service. */
+    lastAttemptAt: timestamp("last_attempt_at", { withTimezone: true }).notNull().defaultNow(),
     endedAt: timestamp("ended_at", { withTimezone: true })
   },
   table => ({

--- a/apps/provider-inventory/src/repositories/provider-incident/provider-incident.repository.integration.ts
+++ b/apps/provider-inventory/src/repositories/provider-incident/provider-incident.repository.integration.ts
@@ -4,6 +4,7 @@ import { container } from "tsyringe";
 import { describe, expect, it } from "vitest";
 
 import { providerIncidents } from "@src/model-schemas/provider-incident/provider-incident.schema";
+import { providerInventory } from "@src/model-schemas/provider-inventory/provider-inventory.schema";
 import { DRIZZLE_DB } from "@src/providers/drizzle.provider";
 import { ProviderIncidentRepository } from "./provider-incident.repository";
 
@@ -34,6 +35,40 @@ describe(ProviderIncidentRepository.name, () => {
       expect(rows).toHaveLength(1);
       expect(rows[0].endedAt).toBeNull();
       expect(rows[0].startedAt.toISOString()).toBe(firstRow.startedAt.toISOString());
+    });
+
+    it("records the new attempt on the incident that is already open", async () => {
+      const { repository, db } = setup();
+      await seedIncident(db, {
+        provider: "akash1a",
+        startedAt: atDaysAgoUtc(9, 10),
+        lastAttemptAt: atDaysAgoUtc(7, 10),
+        endedAt: null
+      });
+
+      await repository.openIncident("akash1a");
+
+      const [row] = await db.select().from(providerIncidents);
+      expect(row.startedAt.toISOString()).toBe(atDaysAgoUtc(9, 10).toISOString());
+      expect(row.lastAttemptAt.getTime()).toBeGreaterThan(Date.now() - 60_000);
+    });
+
+    it("leaves a closed incident's attempt time alone when opening a new outage", async () => {
+      const { repository, db } = setup();
+      const closedLastAttemptAt = atDaysAgoUtc(5, 10);
+      await seedIncident(db, {
+        provider: "akash1a",
+        startedAt: atDaysAgoUtc(5, 9),
+        lastAttemptAt: closedLastAttemptAt,
+        endedAt: atDaysAgoUtc(5, 11)
+      });
+
+      await repository.openIncident("akash1a");
+
+      const rows = await db.select().from(providerIncidents).where(eq(providerIncidents.provider, "akash1a"));
+      const [closed] = rows.filter(r => r.endedAt !== null);
+      expect(rows).toHaveLength(2);
+      expect(closed.lastAttemptAt.toISOString()).toBe(closedLastAttemptAt.toISOString());
     });
 
     it("opens a new incident for a fresh outage and leaves the prior closed incident intact", async () => {
@@ -105,33 +140,34 @@ describe(ProviderIncidentRepository.name, () => {
     });
   });
 
-  describe("getOfflineSince", () => {
-    it("returns the open incident's started_at for a provider with an open incident", async () => {
+  describe("getOpenIncidents", () => {
+    it("returns the open incident of a provider that is currently unreachable", async () => {
       const { repository, db } = setup();
       const startedAt = new Date("2026-01-01T00:00:00Z");
-      await seedIncident(db, { provider: "akash1a", startedAt, endedAt: null });
+      const lastAttemptAt = new Date("2026-01-03T00:00:00Z");
+      await seedIncident(db, { provider: "akash1a", startedAt, lastAttemptAt, endedAt: null });
 
-      const result = await repository.getOfflineSince(["akash1a"]);
+      const result = await repository.getOpenIncidents(["akash1a"]);
 
-      expect(result.get("akash1a")?.toISOString()).toBe(startedAt.toISOString());
+      expect(result.get("akash1a")).toEqual({ startedAt, lastAttemptAt });
     });
 
-    it("returns the open incident's started_at even when an earlier closed incident exists", async () => {
+    it("returns the open incident even when an earlier closed incident exists", async () => {
       const { repository, db } = setup();
       const openStartedAt = new Date("2026-02-01T00:00:00Z");
       await seedClosed(db, { provider: "akash1a", startedAt: new Date("2026-01-01T00:00:00Z"), endedAt: new Date("2026-01-01T00:05:00Z") });
       await seedIncident(db, { provider: "akash1a", startedAt: openStartedAt, endedAt: null });
 
-      const result = await repository.getOfflineSince(["akash1a"]);
+      const result = await repository.getOpenIncidents(["akash1a"]);
 
-      expect(result.get("akash1a")?.toISOString()).toBe(openStartedAt.toISOString());
+      expect(result.get("akash1a")?.startedAt.toISOString()).toBe(openStartedAt.toISOString());
     });
 
     it("omits providers whose only incident is already closed", async () => {
       const { repository, db } = setup();
       await seedClosed(db, { provider: "akash1a", endedAt: new Date("2026-01-01T00:05:00Z") });
 
-      const result = await repository.getOfflineSince(["akash1a"]);
+      const result = await repository.getOpenIncidents(["akash1a"]);
 
       expect(result.has("akash1a")).toBe(false);
     });
@@ -140,7 +176,7 @@ describe(ProviderIncidentRepository.name, () => {
       const { repository, db } = setup();
       await seedIncident(db, { provider: "akash1a", startedAt: new Date("2026-01-01T00:00:00Z"), endedAt: null });
 
-      const result = await repository.getOfflineSince(["akash1a", "akash1unknown"]);
+      const result = await repository.getOpenIncidents(["akash1a", "akash1unknown"]);
 
       expect([...result.keys()]).toEqual(["akash1a"]);
     });
@@ -148,9 +184,64 @@ describe(ProviderIncidentRepository.name, () => {
     it("returns an empty map for an empty list", async () => {
       const { repository } = setup();
 
-      const result = await repository.getOfflineSince([]);
+      const result = await repository.getOpenIncidents([]);
 
       expect(result.size).toBe(0);
+    });
+  });
+
+  describe("findOutagesStartedBefore", () => {
+    it("returns ongoing outages older than the requested age, with the provider's host", async () => {
+      const { repository, db } = setup();
+      const startedAt = atDaysAgoUtc(5, 10);
+      const lastAttemptAt = atDaysAgoUtc(0, 10);
+      await seedProvider(db, { owner: "akash1a", hostUri: "https://provider.a:8443" });
+      await seedIncident(db, { provider: "akash1a", startedAt, lastAttemptAt, endedAt: null });
+
+      const outages = await repository.findOutagesStartedBefore(3);
+
+      expect(outages).toEqual([{ provider: "akash1a", hostUri: "https://provider.a:8443", startedAt, lastAttemptAt }]);
+    });
+
+    it("omits outages that are younger than the requested age", async () => {
+      const { repository, db } = setup();
+      await seedProvider(db, { owner: "akash1a" });
+      await seedIncident(db, { provider: "akash1a", startedAt: atDaysAgoUtc(1, 10), endedAt: null });
+
+      const outages = await repository.findOutagesStartedBefore(3);
+
+      expect(outages).toEqual([]);
+    });
+
+    it("omits providers whose outage has already ended", async () => {
+      const { repository, db } = setup();
+      await seedProvider(db, { owner: "akash1a" });
+      await seedClosed(db, { provider: "akash1a", startedAt: atDaysAgoUtc(9, 10), endedAt: atDaysAgoUtc(1, 10) });
+
+      const outages = await repository.findOutagesStartedBefore(3);
+
+      expect(outages).toEqual([]);
+    });
+
+    it("omits outages of providers that are no longer in the inventory", async () => {
+      const { repository, db } = setup();
+      await seedIncident(db, { provider: "akash1gone", startedAt: atDaysAgoUtc(9, 10), endedAt: null });
+
+      const outages = await repository.findOutagesStartedBefore(3);
+
+      expect(outages).toEqual([]);
+    });
+
+    it("returns the longest outages first", async () => {
+      const { repository, db } = setup();
+      await seedProvider(db, { owner: "akash1a" });
+      await seedProvider(db, { owner: "akash1b" });
+      await seedIncident(db, { provider: "akash1a", startedAt: atDaysAgoUtc(5, 10), endedAt: null });
+      await seedIncident(db, { provider: "akash1b", startedAt: atDaysAgoUtc(9, 10), endedAt: null });
+
+      const outages = await repository.findOutagesStartedBefore(3);
+
+      expect(outages.map(o => o.provider)).toEqual(["akash1b", "akash1a"]);
     });
   });
 
@@ -295,13 +386,24 @@ interface SeedClosedInput {
 }
 
 async function seedClosed(db: PostgresJsDatabase, input: SeedClosedInput): Promise<void> {
+  const startedAt = input.startedAt ?? new Date(input.endedAt.getTime() - 60_000);
   await db.insert(providerIncidents).values({
     provider: input.provider,
-    startedAt: input.startedAt ?? new Date(input.endedAt.getTime() - 60_000),
+    startedAt,
+    lastAttemptAt: startedAt,
     endedAt: input.endedAt
   });
 }
 
-async function seedIncident(db: PostgresJsDatabase, input: { provider: string; startedAt: Date; endedAt: Date | null }): Promise<void> {
-  await db.insert(providerIncidents).values({ provider: input.provider, startedAt: input.startedAt, endedAt: input.endedAt });
+async function seedIncident(db: PostgresJsDatabase, input: { provider: string; startedAt: Date; lastAttemptAt?: Date; endedAt: Date | null }): Promise<void> {
+  await db.insert(providerIncidents).values({
+    provider: input.provider,
+    startedAt: input.startedAt,
+    lastAttemptAt: input.lastAttemptAt ?? input.startedAt,
+    endedAt: input.endedAt
+  });
+}
+
+async function seedProvider(db: PostgresJsDatabase, input: { owner: string; hostUri?: string }): Promise<void> {
+  await db.insert(providerInventory).values({ owner: input.owner, hostUri: input.hostUri ?? `https://${input.owner}:8443` });
 }

--- a/apps/provider-inventory/src/repositories/provider-incident/provider-incident.repository.ts
+++ b/apps/provider-inventory/src/repositories/provider-incident/provider-incident.repository.ts
@@ -85,11 +85,7 @@ export class ProviderIncidentRepository {
     `;
   }
 
-  /**
-   * Opens an incident for a provider that just failed to answer, or — when one is already open —
-   * records that the provider was dialled again, which is how consumers tell an outage that is
-   * still being observed from one abandoned by a stalled service.
-   */
+  /** Re-dialling an open incident bumps lastAttemptAt, which is how consumers tell a live outage from one abandoned by a stalled service. */
   async openIncident(provider: string): Promise<void> {
     await this.driver
       .getDb()

--- a/apps/provider-inventory/src/repositories/provider-incident/provider-incident.repository.ts
+++ b/apps/provider-inventory/src/repositories/provider-incident/provider-incident.repository.ts
@@ -1,7 +1,8 @@
-import { and, eq, getTableName, inArray, isNotNull, isNull, lt, sql } from "drizzle-orm";
+import { and, eq, getTableName, inArray, isNotNull, isNull, lt, lte, sql } from "drizzle-orm";
 import { inject, singleton } from "tsyringe";
 
 import { providerIncidents } from "@src/model-schemas/provider-incident/provider-incident.schema";
+import { providerInventory } from "@src/model-schemas/provider-inventory/provider-inventory.schema";
 import { type Database, PG_CLIENT } from "@src/providers/postgres.provider";
 import { DbDriver } from "../db-driver/db-driver";
 
@@ -11,6 +12,18 @@ export interface RecentIncidentRow {
   provider: string;
   startedAt: string;
   endedAt: string | null;
+}
+
+export interface OpenIncident {
+  startedAt: Date;
+  lastAttemptAt: Date;
+}
+
+export interface ProviderOutageRow {
+  provider: string;
+  hostUri: string;
+  startedAt: Date;
+  lastAttemptAt: Date;
 }
 
 export interface DailyDowntimeRow {
@@ -72,8 +85,21 @@ export class ProviderIncidentRepository {
     `;
   }
 
+  /**
+   * Opens an incident for a provider that just failed to answer, or — when one is already open —
+   * records that the provider was dialled again, which is how consumers tell an outage that is
+   * still being observed from one abandoned by a stalled service.
+   */
   async openIncident(provider: string): Promise<void> {
-    await this.driver.getDb().insert(providerIncidents).values({ provider }).onConflictDoNothing().returning({ provider: providerIncidents.provider });
+    await this.driver
+      .getDb()
+      .insert(providerIncidents)
+      .values({ provider })
+      .onConflictDoUpdate({
+        target: providerIncidents.provider,
+        targetWhere: isNull(providerIncidents.endedAt),
+        set: { lastAttemptAt: sql`now()` }
+      });
   }
 
   async closeIncident(provider: string | string[]): Promise<void> {
@@ -88,20 +114,39 @@ export class ProviderIncidentRepository {
       .where(and(where, isNull(providerIncidents.endedAt)));
   }
 
-  async getOfflineSince(providers: string[]): Promise<Map<string, Date>> {
+  async getOpenIncidents(providers: string[]): Promise<Map<string, OpenIncident>> {
     if (providers.length === 0) return new Map();
 
     const rows = await this.driver
       .getDb()
-      .select({ provider: providerIncidents.provider, startedAt: providerIncidents.startedAt })
+      .select({
+        provider: providerIncidents.provider,
+        startedAt: providerIncidents.startedAt,
+        lastAttemptAt: providerIncidents.lastAttemptAt
+      })
       .from(providerIncidents)
       .where(and(inArray(providerIncidents.provider, providers), isNull(providerIncidents.endedAt)));
 
-    const result = new Map<string, Date>();
+    const result = new Map<string, OpenIncident>();
     for (const row of rows) {
-      result.set(row.provider, row.startedAt);
+      result.set(row.provider, { startedAt: row.startedAt, lastAttemptAt: row.lastAttemptAt });
     }
     return result;
+  }
+
+  async findOutagesStartedBefore(minAgeDays: number): Promise<ProviderOutageRow[]> {
+    return await this.driver
+      .getDb()
+      .select({
+        provider: providerIncidents.provider,
+        hostUri: providerInventory.hostUri,
+        startedAt: providerIncidents.startedAt,
+        lastAttemptAt: providerIncidents.lastAttemptAt
+      })
+      .from(providerIncidents)
+      .innerJoin(providerInventory, eq(providerInventory.owner, providerIncidents.provider))
+      .where(and(isNull(providerIncidents.endedAt), lte(providerIncidents.startedAt, sql`now() - make_interval(days => ${minAgeDays})`)))
+      .orderBy(providerIncidents.startedAt);
   }
 
   async deleteEndedBefore(retentionDays: number): Promise<number> {

--- a/apps/provider-inventory/src/rest-app.ts
+++ b/apps/provider-inventory/src/rest-app.ts
@@ -5,7 +5,7 @@ import { Hono } from "hono";
 import { container } from "tsyringe";
 
 import { APP_CONFIG } from "@src/providers/app-config.provider";
-import { bidScreeningRouter, healthzRouter } from "@src/routes";
+import { bidScreeningRouter, healthzRouter, providerOutagesRouter } from "@src/routes";
 import { HonoErrorHandlerService } from "@src/services/hono-error-handler/hono-error-handler.service";
 import { startServer } from "@src/services/start-server/start-server";
 import type { AppEnv } from "@src/types/app-context";
@@ -16,6 +16,7 @@ export async function bootstrap(): Promise<void> {
   app.use(container.resolve(HttpLoggerInterceptor).intercept());
   app.route("/", healthzRouter);
   app.route("/", bidScreeningRouter);
+  app.route("/", providerOutagesRouter);
   app.onError(container.resolve(HonoErrorHandlerService).handle);
 
   await startServer(app, createOtelLogger({ context: "REST" }), process, {

--- a/apps/provider-inventory/src/routes/index.ts
+++ b/apps/provider-inventory/src/routes/index.ts
@@ -1,2 +1,3 @@
 export { healthzRouter } from "./healthz/healthz.router";
 export { bidScreeningRouter } from "./bid-screening/bid-screening.router";
+export { providerOutagesRouter } from "./provider-outages/provider-outages.router";

--- a/apps/provider-inventory/src/routes/provider-outages/provider-outages.router.ts
+++ b/apps/provider-inventory/src/routes/provider-outages/provider-outages.router.ts
@@ -1,0 +1,38 @@
+import { container } from "tsyringe";
+
+import { ProviderOutagesController } from "@src/controllers/provider-outages/provider-outages.controller";
+import { ProviderOutagesRequestSchema, ProviderOutagesResponseSchema } from "@src/http-schemas/provider-outages.schema";
+import { createRoute } from "@src/lib/create-route/create-route";
+import { OpenApiHonoHandler } from "@src/lib/open-api-hono-handler/open-api-hono-handler";
+
+export const providerOutagesRouter = new OpenApiHonoHandler();
+
+const getProviderOutagesRoute = createRoute({
+  method: "get",
+  path: "/v1/provider-outages",
+  summary: "List providers that are currently unreachable",
+  tags: ["Provider Outages"],
+  security: [],
+  request: {
+    query: ProviderOutagesRequestSchema
+  },
+  responses: {
+    200: {
+      description: "Returns ongoing outages that started at least minAgeDays ago",
+      content: {
+        "application/json": {
+          schema: ProviderOutagesResponseSchema
+        }
+      }
+    },
+    400: {
+      description: "Invalid query parameters"
+    }
+  }
+});
+
+providerOutagesRouter.openapi(getProviderOutagesRoute, async function routeGetProviderOutages(c) {
+  const request = c.req.valid("query");
+  const response = await container.resolve(ProviderOutagesController).getOngoingOutages(request);
+  return c.json(response, 200);
+});

--- a/apps/provider-inventory/src/services/discovery-scheduler/discovery-scheduler.service.spec.ts
+++ b/apps/provider-inventory/src/services/discovery-scheduler/discovery-scheduler.service.spec.ts
@@ -3,7 +3,7 @@ import { mock } from "vitest-mock-extended";
 
 import type { EnvConfig } from "@src/providers/app-config.provider";
 import type { LoggerFactory } from "@src/providers/logger-factory.provider";
-import type { ProviderIncidentRepository } from "@src/repositories/provider-incident/provider-incident.repository";
+import type { OpenIncident, ProviderIncidentRepository } from "@src/repositories/provider-incident/provider-incident.repository";
 import type { ProviderInventory, ProviderInventoryRepository } from "@src/repositories/provider-inventory/provider-inventory.repository";
 import type { ChainProviderPollerService } from "@src/services/chain-provider-poller/chain-provider-poller.service";
 import type { StreamLifecycleManagerService } from "@src/services/stream-lifecycle-manager/stream-lifecycle-manager.service";
@@ -12,6 +12,7 @@ import type { TimerService } from "../timer/timer.service";
 import { DiscoverySchedulerService } from "./discovery-scheduler.service";
 
 const DEAD_PROVIDER_UPDATED_THRESHOLD_MS = 10 * 24 * 60 * 60 * 1000;
+const DEAD_PROVIDER_RETRY_INTERVAL_MS = 60 * 60 * 1000;
 
 describe(DiscoverySchedulerService.name, () => {
   beforeEach(() => {
@@ -84,17 +85,20 @@ describe(DiscoverySchedulerService.name, () => {
   it("forwards the provider's offline-since timestamp to lifecycle.start", async () => {
     const offline = createProvider({ owner: "offline", hostUri: "https://offline:8443" });
     const offlineSince = new Date(Date.now() - 60_000);
-    const { lifecycle } = setup({ providers: [offline], offlineSince: new Map([[offline.owner, offlineSince]]) });
+    const { lifecycle } = setup({ providers: [offline], openIncidents: openIncidents({ offline: { startedAt: offlineSince } }) });
 
     await vi.advanceTimersByTimeAsync(0);
 
     expect(lifecycle.start).toHaveBeenCalledWith({ ...offline, offlineSince }, expect.any(AbortSignal));
   });
 
-  it("skips a provider whose open incident is older than the dead-provider threshold", async () => {
+  it("skips a dead provider that was dialled within the retry interval", async () => {
     const dead = createProvider({ owner: "dead", hostUri: "https://dead:8443" });
-    const offlineSince = new Date(Date.now() - DEAD_PROVIDER_UPDATED_THRESHOLD_MS - 1_000);
-    const { lifecycle, logger } = setup({ providers: [dead], offlineSince: new Map([[dead.owner, offlineSince]]) });
+    const startedAt = new Date(Date.now() - DEAD_PROVIDER_UPDATED_THRESHOLD_MS - 1_000);
+    const { lifecycle, logger } = setup({
+      providers: [dead],
+      openIncidents: openIncidents({ dead: { startedAt, lastAttemptAt: new Date(Date.now() - 60_000) } })
+    });
 
     await vi.advanceTimersByTimeAsync(0);
 
@@ -102,10 +106,37 @@ describe(DiscoverySchedulerService.name, () => {
     expect(logger.debug).toHaveBeenCalledWith(expect.objectContaining({ event: "DISCOVERY_SKIP_PROVIDER", owner: "dead" }));
   });
 
+  it("re-verifies a dead provider that has not been dialled for the retry interval", async () => {
+    const dead = createProvider({ owner: "dead", hostUri: "https://dead:8443" });
+    const startedAt = new Date(Date.now() - DEAD_PROVIDER_UPDATED_THRESHOLD_MS - 1_000);
+    const lastAttemptAt = new Date(Date.now() - DEAD_PROVIDER_RETRY_INTERVAL_MS - 1_000);
+    const { lifecycle, logger } = setup({ providers: [dead], openIncidents: openIncidents({ dead: { startedAt, lastAttemptAt } }) });
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(lifecycle.start).toHaveBeenCalledWith({ ...dead, offlineSince: startedAt }, expect.any(AbortSignal));
+    expect(logger.debug).toHaveBeenCalledWith(expect.objectContaining({ event: "DISCOVERY_REVERIFY_DEAD_PROVIDER", owner: "dead" }));
+  });
+
+  it("does not re-verify a dead provider that is already being dialled", async () => {
+    const dead = createProvider({ owner: "dead", hostUri: "https://dead:8443" });
+    const startedAt = new Date(Date.now() - DEAD_PROVIDER_UPDATED_THRESHOLD_MS - 1_000);
+    const lastAttemptAt = new Date(Date.now() - DEAD_PROVIDER_RETRY_INTERVAL_MS - 1_000);
+    const { lifecycle } = setup({
+      providers: [dead],
+      watched: new Map([["dead", { hostUri: "https://dead:8443" }]]),
+      openIncidents: openIncidents({ dead: { startedAt, lastAttemptAt } })
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(lifecycle.start).not.toHaveBeenCalled();
+  });
+
   it("retries a dead provider instead of skipping it when its on-chain record changed this tick", async () => {
     const dead = createProvider({ owner: "dead", hostUri: "https://dead:8443" });
     const offlineSince = new Date(Date.now() - DEAD_PROVIDER_UPDATED_THRESHOLD_MS - 1_000);
-    const { writer, lifecycle, logger } = setup({ providers: [dead], offlineSince: new Map([[dead.owner, offlineSince]]) });
+    const { writer, lifecycle, logger } = setup({ providers: [dead], openIncidents: openIncidents({ dead: { startedAt: offlineSince } }) });
     writer.bulkUpsertProviders.mockResolvedValue([{ owner: dead.owner }]);
 
     await vi.advanceTimersByTimeAsync(0);
@@ -118,7 +149,7 @@ describe(DiscoverySchedulerService.name, () => {
     // dead detection keys off open incidents only — a provider with no open incident is never skipped,
     // regardless of how stale its inventory row is
     const provider = createProvider({ owner: "healthy", hostUri: "https://healthy:8443" });
-    const { lifecycle, logger } = setup({ providers: [provider], offlineSince: new Map() });
+    const { lifecycle, logger } = setup({ providers: [provider], openIncidents: new Map() });
 
     await vi.advanceTimersByTimeAsync(0);
 
@@ -130,11 +161,11 @@ describe(DiscoverySchedulerService.name, () => {
     // A dead provider is still on-chain, so its inventory row and open incident must be preserved.
     // Deleting them (via stopAndDelete) would reset dead-detection and re-monitor it as brand-new next tick.
     const dead = createProvider({ owner: "dead", hostUri: "https://dead:8443" });
-    const offlineSince = new Date(Date.now() - DEAD_PROVIDER_UPDATED_THRESHOLD_MS - 1_000);
+    const startedAt = new Date(Date.now() - DEAD_PROVIDER_UPDATED_THRESHOLD_MS - 1_000);
     const { lifecycle } = setup({
       providers: [dead],
       watched: new Map([["dead", { hostUri: "https://dead:8443" }]]),
-      offlineSince: new Map([[dead.owner, offlineSince]])
+      openIncidents: openIncidents({ dead: { startedAt, lastAttemptAt: new Date(Date.now() - 60_000) } })
     });
 
     await vi.advanceTimersByTimeAsync(0);
@@ -164,7 +195,7 @@ describe(DiscoverySchedulerService.name, () => {
     const { lifecycle } = setup({
       providers: [updated],
       watched: new Map([["moving", { hostUri: "https://old:8443" }]]),
-      offlineSince: new Map([[updated.owner, offlineSince]])
+      openIncidents: openIncidents({ moving: { startedAt: offlineSince } })
     });
 
     await vi.advanceTimersByTimeAsync(0);
@@ -338,7 +369,7 @@ describe(DiscoverySchedulerService.name, () => {
     onlineOwners?: Pick<ProviderInventory, "owner" | "hostUri">[];
     autoStart?: boolean;
     watched?: Map<string, { hostUri: string }>;
-    offlineSince?: Map<string, Date>;
+    openIncidents?: Map<string, OpenIncident>;
   }) {
     const poller = mock<ChainProviderPollerService>();
     const writer = mock<ProviderInventoryRepository>();
@@ -348,7 +379,7 @@ describe(DiscoverySchedulerService.name, () => {
     lifecycle.stopAndDelete.mockResolvedValue();
     lifecycle.waitForPendingConnections.mockResolvedValue();
     writer.bulkUpsertProviders.mockResolvedValue([]);
-    incidentRepository.getOfflineSince.mockResolvedValue(input?.offlineSince ?? new Map());
+    incidentRepository.getOpenIncidents.mockResolvedValue(input?.openIncidents ?? new Map());
     incidentRepository.deleteEndedBefore.mockResolvedValue(0);
 
     const onlineOwners = input?.onlineOwners ?? [];
@@ -371,6 +402,7 @@ describe(DiscoverySchedulerService.name, () => {
       STREAM_RECONNECT_MAX_DELAY_MS: 300_000,
       STREAM_FIRST_MESSAGE_TIMEOUT_MS: 10_000,
       DEAD_PROVIDER_UPDATED_THRESHOLD_MS,
+      DEAD_PROVIDER_RETRY_INTERVAL_MS,
       REST_API_NODE_URL: "http://localhost:1317",
       INCIDENT_RETENTION_DAYS: 31,
       INCIDENT_CLEANUP_INTERVAL_MS: 24 * 60 * 60 * 1000
@@ -417,6 +449,12 @@ function asyncIterableThatThrows<T>(error: Error): AsyncGenerator<T> {
       return this;
     }
   } as AsyncGenerator<T>;
+}
+
+function openIncidents(byOwner: Record<string, { startedAt: Date; lastAttemptAt?: Date }>): Map<string, OpenIncident> {
+  return new Map(
+    Object.entries(byOwner).map(([owner, incident]) => [owner, { startedAt: incident.startedAt, lastAttemptAt: incident.lastAttemptAt ?? new Date() }])
+  );
 }
 
 function createProvider(overrides?: Partial<ChainProvider>): ChainProvider {

--- a/apps/provider-inventory/src/services/discovery-scheduler/discovery-scheduler.service.ts
+++ b/apps/provider-inventory/src/services/discovery-scheduler/discovery-scheduler.service.ts
@@ -108,14 +108,15 @@ export class DiscoverySchedulerService {
       let restartedProvidersCount = 0;
       let totalProviders = 0;
       let deadProvidersCount = 0;
+      let reverifiedProvidersCount = 0;
       for await (const providers of this.#poller.poll({ signal, batchSize: 500 })) {
         if (signal?.aborted) break;
 
         // important to upsert before starting new stream,
         // otherwise stream will have nothing to update in the db
-        const [updatedProviders, offlineSincePerProvider] = await Promise.all([
+        const [updatedProviders, openIncidentPerProvider] = await Promise.all([
           this.#upsertProviders(providers),
-          this.#incidentRepository.getOfflineSince(providers.map(p => p.owner))
+          this.#incidentRepository.getOpenIncidents(providers.map(p => p.owner))
         ]);
         for (const provider of providers) {
           totalProviders++;
@@ -126,19 +127,32 @@ export class DiscoverySchedulerService {
           providersToStop.delete(provider.owner);
 
           const observedProvider = watchedProviders.get(provider.owner);
-          const offlineSince = offlineSincePerProvider.get(provider.owner);
+          const openIncident = openIncidentPerProvider.get(provider.owner);
+          const offlineSince = openIncident?.startedAt;
 
           if (
             !updatedProviders?.has(provider.owner) &&
-            offlineSince &&
-            Date.now() - offlineSince.getTime() >= this.#config.DEAD_PROVIDER_UPDATED_THRESHOLD_MS
+            openIncident &&
+            Date.now() - openIncident.startedAt.getTime() >= this.#config.DEAD_PROVIDER_UPDATED_THRESHOLD_MS
           ) {
-            this.#logger.debug({
-              event: "DISCOVERY_SKIP_PROVIDER",
-              owner: provider.owner,
-              reason: "provider has an open incident older than the dead-provider threshold"
-            });
             deadProvidersCount++;
+            const isDueForReverification = Date.now() - openIncident.lastAttemptAt.getTime() >= this.#config.DEAD_PROVIDER_RETRY_INTERVAL_MS;
+
+            if (isDueForReverification && !observedProvider) {
+              this.#logger.debug({
+                event: "DISCOVERY_REVERIFY_DEAD_PROVIDER",
+                owner: provider.owner,
+                lastAttemptAt: openIncident.lastAttemptAt
+              });
+              void this.#lifecycle.start({ ...provider, offlineSince: openIncident.startedAt }, signal);
+              reverifiedProvidersCount++;
+            } else {
+              this.#logger.debug({
+                event: "DISCOVERY_SKIP_PROVIDER",
+                owner: provider.owner,
+                reason: observedProvider ? "dead provider is already being dialled" : "dead provider was dialled recently enough"
+              });
+            }
             continue;
           }
 
@@ -164,6 +178,7 @@ export class DiscoverySchedulerService {
         stoppedCount: providersToStop.size,
         startedCount: startedProvidersCount,
         restartedCount: restartedProvidersCount,
+        reverifiedCount: reverifiedProvidersCount,
         completedInMs: Date.now() - startedAt
       });
 
@@ -180,6 +195,7 @@ export class DiscoverySchedulerService {
         stoppedCount: providersToStop.size,
         startedCount: startedProvidersCount,
         restartedCount: restartedProvidersCount,
+        reverifiedCount: reverifiedProvidersCount,
         completedInMs: Date.now() - startedAt
       });
     } catch (error) {

--- a/apps/provider-inventory/test/functional/provider-outages.spec.ts
+++ b/apps/provider-inventory/test/functional/provider-outages.spec.ts
@@ -73,6 +73,14 @@ describe("GET /v1/provider-outages", () => {
     expect(response.status).toBe(400);
   });
 
+  it("rejects an age too large for postgres to turn into an interval", async () => {
+    const { request } = await setup();
+
+    const response = await request("/v1/provider-outages?minAgeDays=9007199254740991");
+
+    expect(response.status).toBe(400);
+  });
+
   async function setup() {
     const app = new Hono<AppEnv>();
     app.route("/", providerOutagesRouter);

--- a/apps/provider-inventory/test/functional/provider-outages.spec.ts
+++ b/apps/provider-inventory/test/functional/provider-outages.spec.ts
@@ -1,0 +1,105 @@
+import { serve } from "@hono/node-server";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import { Hono } from "hono";
+import type { AddressInfo } from "node:net";
+import { container } from "tsyringe";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { providerIncidents } from "@src/model-schemas/provider-incident/provider-incident.schema";
+import { providerInventory } from "@src/model-schemas/provider-inventory/provider-inventory.schema";
+import { DRIZZLE_DB } from "@src/providers/drizzle.provider";
+import { providerOutagesRouter } from "@src/routes";
+import { HonoErrorHandlerService } from "@src/services/hono-error-handler/hono-error-handler.service";
+import type { AppEnv } from "@src/types/app-context";
+import { testDb } from "../setup-functional-tests";
+
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+describe("GET /v1/provider-outages", () => {
+  let stopServer: () => Promise<void>;
+
+  beforeEach(async () => {
+    await testDb.truncate();
+  });
+
+  afterEach(async () => {
+    await stopServer?.();
+  });
+
+  it("returns providers that have been unreachable for at least the requested number of days", async () => {
+    const { request, db } = await setup();
+    const startedAt = daysAgo(5);
+    const lastAttemptAt = daysAgo(0);
+    await seedOutage(db, { provider: "akash1dark", hostUri: "https://dark:8443", startedAt, lastAttemptAt });
+
+    const response = await request("/v1/provider-outages?minAgeDays=3");
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      outages: [
+        {
+          provider: "akash1dark",
+          hostUri: "https://dark:8443",
+          startedAt: startedAt.toISOString(),
+          lastAttemptAt: lastAttemptAt.toISOString()
+        }
+      ]
+    });
+  });
+
+  it("leaves out providers whose outage is younger than the requested number of days", async () => {
+    const { request, db } = await setup();
+    await seedOutage(db, { provider: "akash1recent", startedAt: daysAgo(1) });
+
+    const response = await request("/v1/provider-outages?minAgeDays=3");
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ outages: [] });
+  });
+
+  it("rejects a request that does not say how old the outages must be", async () => {
+    const { request } = await setup();
+
+    const response = await request("/v1/provider-outages");
+
+    expect(response.status).toBe(400);
+  });
+
+  it("rejects a non-numeric age", async () => {
+    const { request } = await setup();
+
+    const response = await request("/v1/provider-outages?minAgeDays=forever");
+
+    expect(response.status).toBe(400);
+  });
+
+  async function setup() {
+    const app = new Hono<AppEnv>();
+    app.route("/", providerOutagesRouter);
+    app.onError(container.resolve(HonoErrorHandlerService).handle);
+
+    const server = serve({ fetch: app.fetch, port: 0 });
+    await new Promise<void>(resolve => server.once("listening", resolve));
+    const { port } = server.address() as AddressInfo;
+    stopServer = () => new Promise<void>(resolve => server.close(() => resolve()));
+
+    return {
+      db: container.resolve<PostgresJsDatabase>(DRIZZLE_DB),
+      request: (path: string) => fetch(`http://127.0.0.1:${port}${path}`)
+    };
+  }
+});
+
+function daysAgo(days: number): Date {
+  return new Date(Date.now() - days * DAY_IN_MS);
+}
+
+async function seedOutage(db: PostgresJsDatabase, input: { provider: string; hostUri?: string; startedAt: Date; lastAttemptAt?: Date }): Promise<void> {
+  await db.insert(providerInventory).values({ owner: input.provider, hostUri: input.hostUri ?? `https://${input.provider}:8443` });
+  await db.insert(providerIncidents).values({
+    provider: input.provider,
+    startedAt: input.startedAt,
+    lastAttemptAt: input.lastAttemptAt ?? input.startedAt,
+    endedAt: null
+  });
+}

--- a/apps/provider-inventory/test/functional/provider-outages.spec.ts
+++ b/apps/provider-inventory/test/functional/provider-outages.spec.ts
@@ -73,6 +73,14 @@ describe("GET /v1/provider-outages", () => {
     expect(response.status).toBe(400);
   });
 
+  it("rejects an empty age rather than reading it as no age filter at all", async () => {
+    const { request } = await setup();
+
+    const response = await request("/v1/provider-outages?minAgeDays=");
+
+    expect(response.status).toBe(400);
+  });
+
   it("rejects an age too large for postgres to turn into an interval", async () => {
     const { request } = await setup();
 


### PR DESCRIPTION
## Why

Closes CON-907. Unblocks CON-900 (warn owners about dark providers) and CON-901 (auto-close deployments on them).

Discovery gives up on a provider once its incident has been open for two days and its chain record hasn't changed. Nothing ever dials it again, so if the provider comes back nobody finds out: the incident stays open forever and the provider is written off permanently. CON-900/901 are about to make real decisions — emails, and eventually closing someone's deployment and refunding escrow — off that record, so it has to reflect reality first.

There was also no way for `apps/api` to ask which providers are currently dark.

## What

**Dead providers get re-dialled once an hour** (`DEAD_PROVIDER_RETRY_INTERVAL_MS`, default 1h). Each dial stamps `last_attempt_at` on the open incident; recovery closes the incident through the existing first-message path and the provider goes back to normal monitoring. The `OFFLINE_PROVIDER_RETRY_MAX_ATTEMPTS = 2` short-circuit still applies, so a re-verification is two short dials, not a full retry cycle. Providers that are already being dialled are skipped, so the hourly cadence can't stack duplicate streams on one owner.

**`last_attempt_at` on `provider_incidents`** (additive migration, `NOT NULL DEFAULT now()` — existing open rows become truthful within an hour of deploy). Consumers use it to tell an outage that is still being observed from one abandoned by a stalled streamer, and refuse to act on stale data.

**`GET /v1/provider-outages?minAgeDays=<int>`** returns open incidents older than the requested age, joined to the inventory for `host_uri`: `{ outages: [{ provider, hostUri, startedAt, lastAttemptAt }] }`, longest outage first. Internal, unauthenticated, same as `/v1/bid-screening`.

The new domain terms — incident, dead provider, ongoing outage — are recorded in `apps/provider-inventory/CONTEXT.md`.

### Load

Re-verification is bounded by the existing stream-connection semaphore (100 concurrent, each permit held at most `STREAM_FIRST_MESSAGE_TIMEOUT_MS` = 10s), so ~1800 dead providers work out to a few minutes of extra dialling spread over one tick per hour. Healthy providers keep their existing priority.

### Rollout

No helm change: the new interval is a zod default. The migration is a single `ADD COLUMN` with a default.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public endpoint to retrieve ongoing provider outages filtered by minimum outage age.
  * Outage responses include provider details, endpoint, outage start time, and latest verification attempt.
  * Dead providers are automatically rechecked after a configurable interval.

* **Bug Fixes**
  * Existing incidents now record subsequent verification attempts, improving outage status accuracy.
  * Improved handling of empty outage-age filters and invalid request values.

* **Documentation**
  * Added definitions for incidents, dead providers, and ongoing outages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->