### PR TITLE
feat(deployment): warn owners when their provider goes dark

### DIFF
--- a/.helm/console-api-prod-mainnet-values.yaml
+++ b/.helm/console-api-prod-mainnet-values.yaml
@@ -47,6 +47,19 @@ jobs:
       - ./dist/console.js
       - notify-expiring-deployments
       - --dry-run
+  # Ships in dry-run for a bake period: --dry-run only logs UNREACHABLE_PROVIDER_DEPLOYMENT_WOULD_NOTIFY.
+  # The first live run catches up on every outage already past the threshold, so check the volume in
+  # those logs before dropping the flag.
+  # Offset from the two runtime-limit sweeps so no two of them hit deployment_settings on the same minute.
+  - name: notify-unreachable-provider-deployments
+    schedule: "11,41 * * * *" # every 30 minutes
+    command:
+      - node
+      - --require
+      - ./dist/instrumentation.js
+      - ./dist/console.js
+      - notify-unreachable-provider-deployments
+      - --dry-run
   - name: mint-act
     schedule: "*/10 * * * *" # every 10 minutes
     concurrencyPolicy: Forbid

--- a/.helm/console-api-staging-sandbox-values.yaml
+++ b/.helm/console-api-staging-sandbox-values.yaml
@@ -34,6 +34,15 @@ jobs:
       - ./dist/instrumentation.js
       - ./dist/console.js
       - notify-expiring-deployments
+  # Offset from the two runtime-limit sweeps so no two of them hit deployment_settings on the same minute.
+  - name: notify-unreachable-provider-deployments
+    schedule: "11,41 * * * *" # every 30 minutes
+    command:
+      - node
+      - --require
+      - ./dist/instrumentation.js
+      - ./dist/console.js
+      - notify-unreachable-provider-deployments
 
 replicas: 2
 

--- a/apps/api/drizzle/0045_mark_provider_unreachable_notice.sql
+++ b/apps/api/drizzle/0045_mark_provider_unreachable_notice.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "deployment_settings" ADD COLUMN "provider_unreachable_notified_for" timestamp with time zone;

--- a/apps/api/drizzle/meta/0045_snapshot.json
+++ b/apps/api/drizzle/meta/0045_snapshot.json
@@ -1,0 +1,1540 @@
+{
+  "id": "9b8b2670-3ddf-4478-99f6-d25378df7b47",
+  "prevId": "0c5ec86e-303d-464c-b336-1e65cf1e5a45",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.user_wallets": {
+      "name": "user_wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_allowance": {
+          "name": "deployment_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "fee_allowance": {
+          "name": "fee_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "trial": {
+          "name": "trial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits_low_notified_at": {
+          "name": "credits_low_notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_wallets_user_id_userSetting_id_fk": {
+          "name": "user_wallets_user_id_userSetting_id_fk",
+          "tableFrom": "user_wallets",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_wallets_user_id_unique": {
+          "name": "user_wallets_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "user_wallets_address_unique": {
+          "name": "user_wallets_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_methods": {
+      "name": "payment_methods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_method_id": {
+          "name": "payment_method_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_validated": {
+          "name": "is_validated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payment_methods_fingerprint_payment_method_id_unique": {
+          "name": "payment_methods_fingerprint_payment_method_id_unique",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_default_unique": {
+          "name": "payment_methods_user_id_is_default_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"payment_methods\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_fingerprint_idx": {
+          "name": "payment_methods_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_idx": {
+          "name": "payment_methods_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_validated_idx": {
+          "name": "payment_methods_user_id_is_validated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_validated",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_fingerprint_payment_method_id_idx": {
+          "name": "payment_methods_user_id_fingerprint_payment_method_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_methods_user_id_userSetting_id_fk": {
+          "name": "payment_methods_user_id_userSetting_id_fk",
+          "tableFrom": "payment_methods",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_transactions": {
+      "name": "stripe_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "stripe_transaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "stripe_transaction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created'"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_refunded": {
+          "name": "amount_refunded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bonus_amount": {
+          "name": "bonus_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_charge_id": {
+          "name": "stripe_charge_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_coupon_id": {
+          "name": "stripe_coupon_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_promotion_code_id": {
+          "name": "stripe_promotion_code_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_idempotency_key": {
+          "name": "stripe_idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method_type": {
+          "name": "payment_method_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_brand": {
+          "name": "card_brand",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_last4": {
+          "name": "card_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_url": {
+          "name": "receipt_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_transactions_stripe_invoice_id_unique": {
+          "name": "stripe_transactions_stripe_invoice_id_unique",
+          "columns": [
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stripe_transactions\".\"stripe_invoice_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_idempotency_key_unique": {
+          "name": "stripe_transactions_stripe_idempotency_key_unique",
+          "columns": [
+            {
+              "expression": "stripe_idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stripe_transactions\".\"stripe_idempotency_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_user_id_idx": {
+          "name": "stripe_transactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_payment_intent_id_idx": {
+          "name": "stripe_transactions_stripe_payment_intent_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_payment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_charge_id_idx": {
+          "name": "stripe_transactions_stripe_charge_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_coupon_id_idx": {
+          "name": "stripe_transactions_stripe_coupon_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_coupon_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_promotion_code_id_idx": {
+          "name": "stripe_transactions_stripe_promotion_code_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_promotion_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_status_idx": {
+          "name": "stripe_transactions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_created_at_idx": {
+          "name": "stripe_transactions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_user_id_created_at_idx": {
+          "name": "stripe_transactions_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_transactions_user_id_userSetting_id_fk": {
+          "name": "stripe_transactions_user_id_userSetting_id_fk",
+          "tableFrom": "stripe_transactions",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_settings": {
+      "name": "wallet_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_reload_enabled": {
+          "name": "auto_reload_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_reload_mode": {
+          "name": "auto_reload_mode",
+          "type": "auto_reload_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'prediction'"
+        },
+        "auto_reload_threshold": {
+          "name": "auto_reload_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2000
+        },
+        "auto_reload_amount": {
+          "name": "auto_reload_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10000
+        },
+        "last_auto_charge_at": {
+          "name": "last_auto_charge_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_settings_user_id_idx": {
+          "name": "wallet_settings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_settings_wallet_id_user_wallets_id_fk": {
+          "name": "wallet_settings_wallet_id_user_wallets_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "user_wallets",
+          "columnsFrom": [
+            "wallet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wallet_settings_user_id_userSetting_id_fk": {
+          "name": "wallet_settings_user_id_userSetting_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallet_settings_wallet_id_unique": {
+          "name": "wallet_settings_wallet_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wallet_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.userSetting": {
+      "name": "userSetting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscribedToNewsletter": {
+          "name": "subscribedToNewsletter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "youtubeUsername": {
+          "name": "youtubeUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitterUsername": {
+          "name": "twitterUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "githubUsername": {
+          "name": "githubUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_ip": {
+          "name": "last_ip",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_user_agent": {
+          "name": "last_user_agent",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fingerprint": {
+          "name": "last_fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboardingSkippedAt": {
+          "name": "onboardingSkippedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "userSetting_userId_unique": {
+          "name": "userSetting_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        },
+        "userSetting_username_unique": {
+          "name": "userSetting_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.template": {
+      "name": "template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "copiedFromId": {
+          "name": "copiedFromId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cpu": {
+          "name": "cpu",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ram": {
+          "name": "ram",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage": {
+          "name": "storage",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sdl": {
+          "name": "sdl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "template_userId_idx": {
+          "name": "template_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.templateFavorite": {
+      "name": "templateFavorite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "templateId": {
+          "name": "templateId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addedDate": {
+          "name": "addedDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "templateFavorite_userId_templateId_unique": {
+          "name": "templateFavorite_userId_templateId_unique",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "templateId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "templateFavorite_templateId_template_id_fk": {
+          "name": "templateFavorite_templateId_template_id_fk",
+          "tableFrom": "templateFavorite",
+          "tableTo": "template",
+          "columnsFrom": [
+            "templateId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_settings": {
+      "name": "deployment_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dseq": {
+          "name": "dseq",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_top_up_enabled": {
+          "name": "auto_top_up_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closed": {
+          "name": "closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_funded_at": {
+          "name": "last_funded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_limit_hours": {
+          "name": "runtime_limit_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sdl": {
+          "name": "sdl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manifest_version": {
+          "name": "manifest_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_ends_at": {
+          "name": "runtime_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_ending_notified_for": {
+          "name": "runtime_ending_notified_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_unreachable_notified_for": {
+          "name": "provider_unreachable_notified_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "id_auto_top_up_enabled_closed_idx": {
+          "name": "id_auto_top_up_enabled_closed_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auto_top_up_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "closed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_settings_user_id_userSetting_id_fk": {
+          "name": "deployment_settings_user_id_userSetting_id_fk",
+          "tableFrom": "deployment_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dseq_user_id_idx": {
+          "name": "dseq_user_id_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "dseq",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_key": {
+          "name": "hashed_key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_format": {
+          "name": "key_format",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_user_id_userSetting_id_fk": {
+          "name": "api_keys_user_id_userSetting_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_hashed_key_unique": {
+          "name": "api_keys_hashed_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hashed_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_verification_codes": {
+      "name": "email_verification_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_verification_codes_user_id_idx": {
+          "name": "email_verification_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_verification_codes_user_id_userSetting_id_fk": {
+          "name": "email_verification_codes_user_id_userSetting_id_fk",
+          "tableFrom": "email_verification_codes",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.data_keys": {
+      "name": "data_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wrapped_key": {
+          "name": "wrapped_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wrapped_by_kid": {
+          "name": "wrapped_by_kid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "data_keys_wrapped_by_kid_idx": {
+          "name": "data_keys_wrapped_by_kid_idx",
+          "columns": [
+            {
+              "expression": "wrapped_by_kid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "data_keys_user_id_userSetting_id_fk": {
+          "name": "data_keys_user_id_userSetting_id_fk",
+          "tableFrom": "data_keys",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "data_keys_user_id_unique": {
+          "name": "data_keys_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.stripe_transaction_status": {
+      "name": "stripe_transaction_status",
+      "schema": "public",
+      "values": [
+        "created",
+        "pending",
+        "requires_action",
+        "succeeded",
+        "failed",
+        "refunded",
+        "canceled"
+      ]
+    },
+    "public.stripe_transaction_type": {
+      "name": "stripe_transaction_type",
+      "schema": "public",
+      "values": [
+        "payment_intent",
+        "coupon_claim",
+        "manual_credit"
+      ]
+    },
+    "public.auto_reload_mode": {
+      "name": "auto_reload_mode",
+      "schema": "public",
+      "values": [
+        "prediction",
+        "threshold"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -316,6 +316,13 @@
       "when": 1787674771013,
       "tag": "0044_wallet_settings_last_auto_charge_at",
       "breakpoints": true
+    },
+    {
+      "idx": 45,
+      "version": "7",
+      "when": 1787764821094,
+      "tag": "0045_mark_provider_unreachable_notice",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/app/console.ts
+++ b/apps/api/src/app/console.ts
@@ -71,6 +71,16 @@ program
   });
 
 program
+  .command("notify-unreachable-provider-deployments")
+  .description("Warn users whose deployments run on a provider that has been unreachable for days")
+  .option("-d, --dry-run", "Log which users would be warned without sending any email", false)
+  .action(async (options, command) => {
+    await executeCliHandler(command.name(), async () => {
+      return container.resolve(TopUpDeploymentsController).notifyUnreachableProviderDeployments(options);
+    });
+  });
+
+program
   .command("cleanup-provider-deployments")
   .description("Close trial deployments for a provider")
   .option("-c, --concurrency <number>", "How many wallets are processed concurrently", value => z.number({ coerce: true }).optional().default(10).parse(value))

--- a/apps/api/src/deployment/config/env.config.spec.ts
+++ b/apps/api/src/deployment/config/env.config.spec.ts
@@ -134,12 +134,20 @@ describe("deployment envSchema", () => {
     });
   });
 
-  describe("PROVIDER_OUTAGE_FRESHNESS_WINDOW_IN_H", () => {
-    it("defaults to trusting outages the inventory re-checked within 3 hours", () => {
+  describe("PROVIDER_UNREACHABLE_NOTIFY_AFTER_DAYS", () => {
+    it("defaults to warning after 3 dark days and trusting outages re-checked within 3 hours", () => {
       const result = envSchema.safeParse(setup());
 
       expect(result.success).toBe(true);
+      expect(result.success && result.data.PROVIDER_UNREACHABLE_NOTIFY_AFTER_DAYS).toBe(3);
       expect(result.success && result.data.PROVIDER_OUTAGE_FRESHNESS_WINDOW_IN_H).toBe(3);
+    });
+
+    it("rejects warning after zero days, which would report every blip", () => {
+      const result = envSchema.safeParse(setup({ PROVIDER_UNREACHABLE_NOTIFY_AFTER_DAYS: 0 }));
+
+      expect(result.success).toBe(false);
+      expect(!result.success && result.error.issues.some(issue => issue.path[0] === "PROVIDER_UNREACHABLE_NOTIFY_AFTER_DAYS")).toBe(true);
     });
 
     it("rejects an unbounded freshness window, which would trust an outage record nobody maintains", () => {

--- a/apps/api/src/deployment/config/env.config.ts
+++ b/apps/api/src/deployment/config/env.config.ts
@@ -90,6 +90,8 @@ export const envSchema = z
      * warned about almost as soon as it is set, which tells the user nothing they did not just decide.
      */
     RUNTIME_LIMIT_WARNING_MIN_LIMIT_IN_H: z.number({ coerce: true }).positive().finite().optional().default(12),
+    /** Long enough that a provider working through an outage is not announced as dead to the owners running on it. */
+    PROVIDER_UNREACHABLE_NOTIFY_AFTER_DAYS: z.number({ coerce: true }).positive().finite().optional().default(3),
     /** An outage the inventory has not re-checked within this window describes the past, not the present, so the sweeps refuse it. */
     PROVIDER_OUTAGE_FRESHNESS_WINDOW_IN_H: z.number({ coerce: true }).positive().finite().optional().default(3),
     /** Base URL of the provider inventory service, which owns the record of who is currently unreachable. */

--- a/apps/api/src/deployment/controllers/deployment/top-up-deployments.controller.spec.ts
+++ b/apps/api/src/deployment/controllers/deployment/top-up-deployments.controller.spec.ts
@@ -5,6 +5,7 @@ import type { DeploymentCloseJobService } from "@src/deployment/services/deploym
 import type { ExpiringDeploymentsNotifierService } from "@src/deployment/services/expiring-deployments-notifier/expiring-deployments-notifier.service";
 import type { StaleManagedDeploymentsCleanerService } from "@src/deployment/services/stale-managed-deployments-cleaner/stale-managed-deployments-cleaner.service";
 import type { TopUpManagedDeploymentsService } from "@src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service";
+import type { UnreachableProviderDeploymentsNotifierService } from "@src/deployment/services/unreachable-provider-deployments-notifier/unreachable-provider-deployments-notifier.service";
 import { TopUpDeploymentsController } from "./top-up-deployments.controller";
 
 describe(TopUpDeploymentsController.name, () => {
@@ -64,16 +65,29 @@ describe(TopUpDeploymentsController.name, () => {
     });
   });
 
+  describe("notifyUnreachableProviderDeployments", () => {
+    it("delegates to the service that warns owners of deployments on unreachable providers", async () => {
+      const { controller, unreachableProviderDeploymentsNotifierService } = setup();
+      const options = { dryRun: false };
+
+      await controller.notifyUnreachableProviderDeployments(options);
+
+      expect(unreachableProviderDeploymentsNotifierService.notifyUnreachableProviderDeployments).toHaveBeenCalledWith(options);
+    });
+  });
+
   function setup() {
     const topUpManagedDeploymentsService = mock<TopUpManagedDeploymentsService>();
     const staleDeploymentsCleanerService = mock<StaleManagedDeploymentsCleanerService>();
     const deploymentCloseJobService = mock<DeploymentCloseJobService>();
     const expiringDeploymentsNotifierService = mock<ExpiringDeploymentsNotifierService>();
+    const unreachableProviderDeploymentsNotifierService = mock<UnreachableProviderDeploymentsNotifierService>();
     const controller = new TopUpDeploymentsController(
       topUpManagedDeploymentsService,
       staleDeploymentsCleanerService,
       deploymentCloseJobService,
-      expiringDeploymentsNotifierService
+      expiringDeploymentsNotifierService,
+      unreachableProviderDeploymentsNotifierService
     );
 
     return {
@@ -81,7 +95,8 @@ describe(TopUpDeploymentsController.name, () => {
       topUpManagedDeploymentsService,
       staleDeploymentsCleanerService,
       deploymentCloseJobService,
-      expiringDeploymentsNotifierService
+      expiringDeploymentsNotifierService,
+      unreachableProviderDeploymentsNotifierService
     };
   }
 });

--- a/apps/api/src/deployment/controllers/deployment/top-up-deployments.controller.ts
+++ b/apps/api/src/deployment/controllers/deployment/top-up-deployments.controller.ts
@@ -5,6 +5,7 @@ import { DeploymentCloseJobService } from "@src/deployment/services/deployment-c
 import { ExpiringDeploymentsNotifierService } from "@src/deployment/services/expiring-deployments-notifier/expiring-deployments-notifier.service";
 import { StaleManagedDeploymentsCleanerService } from "@src/deployment/services/stale-managed-deployments-cleaner/stale-managed-deployments-cleaner.service";
 import { TopUpManagedDeploymentsService } from "@src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service";
+import { UnreachableProviderDeploymentsNotifierService } from "@src/deployment/services/unreachable-provider-deployments-notifier/unreachable-provider-deployments-notifier.service";
 import { CleanUpStaleDeploymentsParams } from "@src/deployment/types/state-deployments";
 
 @singleton()
@@ -13,7 +14,8 @@ export class TopUpDeploymentsController {
     private readonly topUpManagedDeploymentsService: TopUpManagedDeploymentsService,
     private readonly staleDeploymentsCleanerService: StaleManagedDeploymentsCleanerService,
     private readonly deploymentCloseJobService: DeploymentCloseJobService,
-    private readonly expiringDeploymentsNotifierService: ExpiringDeploymentsNotifierService
+    private readonly expiringDeploymentsNotifierService: ExpiringDeploymentsNotifierService,
+    private readonly unreachableProviderDeploymentsNotifierService: UnreachableProviderDeploymentsNotifierService
   ) {}
 
   /** The reconcile goes first because it only needs the database, so a chain-RPC failure in the sweep cannot skip it for the hour. */
@@ -28,5 +30,9 @@ export class TopUpDeploymentsController {
 
   async notifyExpiringDeployments(options: DryRunOptions) {
     return await this.expiringDeploymentsNotifierService.notifyExpiringDeployments(options);
+  }
+
+  async notifyUnreachableProviderDeployments(options: DryRunOptions) {
+    return await this.unreachableProviderDeploymentsNotifierService.notifyUnreachableProviderDeployments(options);
   }
 }

--- a/apps/api/src/deployment/model-schemas/deployment-setting/deployment-setting.schema.ts
+++ b/apps/api/src/deployment/model-schemas/deployment-setting/deployment-setting.schema.ts
@@ -22,6 +22,7 @@ export const DeploymentSettings = pgTable(
     manifestVersion: varchar("manifest_version", { length: 64 }),
     runtimeEndsAt: timestamp("runtime_ends_at", { withTimezone: true }),
     runtimeEndingNotifiedFor: timestamp("runtime_ending_notified_for", { withTimezone: true }),
+    providerUnreachableNotifiedFor: timestamp("provider_unreachable_notified_for", { withTimezone: true }),
     createdAt: timestamp("created_at").defaultNow(),
     updatedAt: timestamp("updated_at").defaultNow()
   },

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
@@ -16,6 +16,8 @@ import { DeploymentSettingRepository } from "./deployment-setting.repository";
 import { createAkashAddress } from "@test/seeders/akash-address.seeder";
 
 const COOLDOWN_MINUTES = 60;
+const OUTAGE_STARTED_AT = "2026-08-01T00:00:00.000Z";
+const LATER_OUTAGE_STARTED_AT = "2026-08-20T00:00:00.000Z";
 const WARNING_WINDOW = { leadHours: 6, minLimitHours: 12 };
 
 /** Rows created with a `Date` store exactly that value, so its ISO form is the marker the claim matches on. */
@@ -310,6 +312,89 @@ describe(DeploymentSettingRepository.name, () => {
       const claimed = await deploymentSettingRepository.claimRuntimeEndingNotification(setting.id, markerFor(staleDeadline));
 
       expect(claimed).toBe(false);
+    });
+  });
+
+  describe("claimProviderUnreachableNotification", () => {
+    it("awards the claim to exactly one caller across concurrent attempts", async () => {
+      const { deploymentSettingRepository, user } = await setup();
+      const claim = { userId: user.id, dseq: newDseq(), downSinceMarker: OUTAGE_STARTED_AT };
+
+      const results = await Promise.all(Array.from({ length: 5 }, () => deploymentSettingRepository.claimProviderUnreachableNotification(claim)));
+
+      expect(results.filter(Boolean)).toHaveLength(1);
+    });
+
+    it("refuses a second claim for the same outage", async () => {
+      const { deploymentSettingRepository, user } = await setup();
+      const claim = { userId: user.id, dseq: newDseq(), downSinceMarker: OUTAGE_STARTED_AT };
+      await deploymentSettingRepository.claimProviderUnreachableNotification(claim);
+
+      const claimed = await deploymentSettingRepository.claimProviderUnreachableNotification(claim);
+
+      expect(claimed).toBe(false);
+    });
+
+    it("claims again once the provider recovers and goes dark a second time", async () => {
+      const { deploymentSettingRepository, user } = await setup();
+      const dseq = newDseq();
+      await deploymentSettingRepository.claimProviderUnreachableNotification({ userId: user.id, dseq, downSinceMarker: OUTAGE_STARTED_AT });
+
+      const claimed = await deploymentSettingRepository.claimProviderUnreachableNotification({
+        userId: user.id,
+        dseq,
+        downSinceMarker: LATER_OUTAGE_STARTED_AT
+      });
+
+      expect(claimed).toBe(true);
+    });
+
+    it("records the outage on a deployment that has no settings row yet, without turning funding on", async () => {
+      const { deploymentSettingRepository, user } = await setup();
+      const dseq = newDseq();
+
+      await deploymentSettingRepository.claimProviderUnreachableNotification({ userId: user.id, dseq, downSinceMarker: OUTAGE_STARTED_AT });
+
+      const setting = await deploymentSettingRepository.findOneBy({ userId: user.id, dseq });
+      expect(setting).toMatchObject({ autoTopUpEnabled: false });
+      expect(setting?.providerUnreachableNotifiedFor?.toISOString()).toBe(OUTAGE_STARTED_AT);
+    });
+
+    it("leaves the funding setting of an existing row alone", async () => {
+      const { deploymentSettingRepository, user, createLimitedSetting } = await setup();
+      const setting = await createLimitedSetting(24, { autoTopUpEnabled: true });
+
+      await deploymentSettingRepository.claimProviderUnreachableNotification({
+        userId: user.id,
+        dseq: setting.dseq,
+        downSinceMarker: OUTAGE_STARTED_AT
+      });
+
+      const updated = await deploymentSettingRepository.findOneBy({ userId: user.id, dseq: setting.dseq });
+      expect(updated).toMatchObject({ autoTopUpEnabled: true });
+    });
+  });
+
+  describe("releaseProviderUnreachableClaim", () => {
+    it("lets the next sweep report the same outage again", async () => {
+      const { deploymentSettingRepository, user } = await setup();
+      const claim = { userId: user.id, dseq: newDseq(), downSinceMarker: OUTAGE_STARTED_AT };
+      await deploymentSettingRepository.claimProviderUnreachableNotification(claim);
+
+      await deploymentSettingRepository.releaseProviderUnreachableClaim(claim);
+
+      expect(await deploymentSettingRepository.claimProviderUnreachableNotification(claim)).toBe(true);
+    });
+
+    it("leaves a stamp written for a later outage untouched", async () => {
+      const { deploymentSettingRepository, user } = await setup();
+      const dseq = newDseq();
+      await deploymentSettingRepository.claimProviderUnreachableNotification({ userId: user.id, dseq, downSinceMarker: LATER_OUTAGE_STARTED_AT });
+
+      await deploymentSettingRepository.releaseProviderUnreachableClaim({ userId: user.id, dseq, downSinceMarker: OUTAGE_STARTED_AT });
+
+      const setting = await deploymentSettingRepository.findOneBy({ userId: user.id, dseq });
+      expect(setting?.providerUnreachableNotifiedFor?.toISOString()).toBe(LATER_OUTAGE_STARTED_AT);
     });
   });
 

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -421,24 +421,7 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
       .where(or(...claims.map(claim => and(eq(this.table.id, claim.id), eq(this.table.lastFundedAt, sql`${claim.claimedAt}::timestamp`)))));
   }
 
-  /**
-   * Claims the right to tell one owner that their deployment's provider has gone dark, returning false
-   * when this outage has already been reported. The marker is the moment the outage started, so a
-   * provider that recovers and fails again re-arms the warning for the new outage while a single long
-   * outage is only ever reported once.
-   *
-   * Inserts the row when a deployment has no settings yet — created before settings existed, or created
-   * outside the web app — because the warning has to be remembered somewhere and this is where it lives.
-   * Such a row is written with funding off: an outage bookmark must not be the thing that enrols a
-   * deployment into automatic funding.
-   *
-   * The marker is matched as text for the same reason `releaseFundingClaim` does: a `Date` drops the
-   * sub-millisecond digits Postgres keeps, so a round-tripped value would never match itself.
-   *
-   * Claimed before the email is sent rather than stamped after: the sweep runs many times an hour while
-   * an outage lasts days, so a send that succeeded but failed to stamp would mail the same owner on
-   * every pass. A send that fails hands the claim back through `releaseProviderUnreachableClaim`.
-   */
+  /** Claimed before the email goes out, not stamped after, because the sweep runs many times an hour while an outage lasts days. */
   async claimProviderUnreachableNotification({ userId, dseq, downSinceMarker }: { userId: string; dseq: string; downSinceMarker: string }): Promise<boolean> {
     const [claimed] = await this.cursor
       .insert(this.table)
@@ -458,11 +441,7 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
     return !!claimed;
   }
 
-  /**
-   * Gives back a claim whose email was never accepted, so the next sweep can report the same outage.
-   * Scoped to the exact outage the claim was taken against, so a release arriving late cannot clear the
-   * stamp a later pass wrote for a newer outage.
-   */
+  /** Scoped to the exact outage the claim was taken against, so a late release cannot clear the stamp a later pass wrote for a newer outage. */
   async releaseProviderUnreachableClaim({ userId, dseq, downSinceMarker }: { userId: string; dseq: string; downSinceMarker: string }): Promise<void> {
     await this.cursor
       .update(this.table)

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -421,6 +421,57 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
       .where(or(...claims.map(claim => and(eq(this.table.id, claim.id), eq(this.table.lastFundedAt, sql`${claim.claimedAt}::timestamp`)))));
   }
 
+  /**
+   * Claims the right to tell one owner that their deployment's provider has gone dark, returning false
+   * when this outage has already been reported. The marker is the moment the outage started, so a
+   * provider that recovers and fails again re-arms the warning for the new outage while a single long
+   * outage is only ever reported once.
+   *
+   * Inserts the row when a deployment has no settings yet — created before settings existed, or created
+   * outside the web app — because the warning has to be remembered somewhere and this is where it lives.
+   * Such a row is written with funding off: an outage bookmark must not be the thing that enrols a
+   * deployment into automatic funding.
+   *
+   * The marker is matched as text for the same reason `releaseFundingClaim` does: a `Date` drops the
+   * sub-millisecond digits Postgres keeps, so a round-tripped value would never match itself.
+   *
+   * Claimed before the email is sent rather than stamped after: the sweep runs many times an hour while
+   * an outage lasts days, so a send that succeeded but failed to stamp would mail the same owner on
+   * every pass. A send that fails hands the claim back through `releaseProviderUnreachableClaim`.
+   */
+  async claimProviderUnreachableNotification({ userId, dseq, downSinceMarker }: { userId: string; dseq: string; downSinceMarker: string }): Promise<boolean> {
+    const [claimed] = await this.cursor
+      .insert(this.table)
+      .values({
+        userId,
+        dseq,
+        autoTopUpEnabled: false,
+        providerUnreachableNotifiedFor: sql`${downSinceMarker}::timestamptz`
+      })
+      .onConflictDoUpdate({
+        target: [this.table.dseq, this.table.userId],
+        set: { providerUnreachableNotifiedFor: sql`${downSinceMarker}::timestamptz`, updatedAt: sql`now()` },
+        setWhere: sql`${this.table.providerUnreachableNotifiedFor} is distinct from ${downSinceMarker}::timestamptz`
+      })
+      .returning({ id: this.table.id });
+
+    return !!claimed;
+  }
+
+  /**
+   * Gives back a claim whose email was never accepted, so the next sweep can report the same outage.
+   * Scoped to the exact outage the claim was taken against, so a release arriving late cannot clear the
+   * stamp a later pass wrote for a newer outage.
+   */
+  async releaseProviderUnreachableClaim({ userId, dseq, downSinceMarker }: { userId: string; dseq: string; downSinceMarker: string }): Promise<void> {
+    await this.cursor
+      .update(this.table)
+      .set({ providerUnreachableNotifiedFor: null, updatedAt: sql`now()` })
+      .where(
+        and(eq(this.table.userId, userId), eq(this.table.dseq, dseq), eq(this.table.providerUnreachableNotifiedFor, sql`${downSinceMarker}::timestamptz`))
+      );
+  }
+
   protected toInput(payload: Partial<DeploymentSettingsInput>): Partial<DeploymentSettingsInput> {
     if (!payload.updatedAt) {
       payload.updatedAt = new Date();

--- a/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.spec.ts
@@ -681,6 +681,7 @@ describe(DeploymentSettingService.name, () => {
       manifestVersion: null,
       runtimeEndsAt: null,
       runtimeEndingNotifiedFor: null,
+      providerUnreachableNotifiedFor: null,
       createdAt: faker.date.past().toISOString(),
       updatedAt: faker.date.past().toISOString(),
       ...overrides

--- a/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.ts
+++ b/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.ts
@@ -29,7 +29,7 @@ type DeploymentSettingChange = Pick<DeploymentSettingsInput, "autoTopUpEnabled" 
 
 type DeploymentSettingWithEstimatedTopUpAmount = Omit<
   DeploymentSettingsOutput,
-  "lastFundedAt" | "runtimeEndingNotifiedFor" | "sdl" | "manifestVersion" | "runtimeEndsAt"
+  "lastFundedAt" | "runtimeEndingNotifiedFor" | "providerUnreachableNotifiedFor" | "sdl" | "manifestVersion" | "runtimeEndsAt"
 > & {
   estimatedTopUpAmount: number;
   topUpFrequencyMs: number;
@@ -363,8 +363,8 @@ export class DeploymentSettingService {
   }
 
   /**
-   * `lastFundedAt` and `runtimeEndingNotifiedFor` are internal sweep markers and stay out of the API
-   * payload. So do `sdl` and `manifestVersion`: they are what the console remembers a deployment by,
+   * `lastFundedAt`, `runtimeEndingNotifiedFor` and `providerUnreachableNotifiedFor` are internal sweep markers and stay
+   * out of the API payload. So do `sdl` and `manifestVersion`: they are what the console remembers a deployment by,
    * not something it hands back, and the response schema is types only — whatever this returns is
    * what ships.
    */
@@ -375,7 +375,7 @@ export class DeploymentSettingService {
       return undefined;
     }
 
-    const { lastFundedAt, runtimeEndingNotifiedFor, sdl, manifestVersion, runtimeEndsAt, ...rest } = params;
+    const { lastFundedAt, runtimeEndingNotifiedFor, providerUnreachableNotifiedFor, sdl, manifestVersion, runtimeEndsAt, ...rest } = params;
     const setting = { ...rest, runtimeEndsAt: runtimeEndsAt?.toISOString() ?? null };
 
     if (!setting.autoTopUpEnabled) {

--- a/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.spec.ts
+++ b/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.spec.ts
@@ -469,6 +469,7 @@ describe(InitialDeploymentFundingService.name, () => {
       manifestVersion: null,
       runtimeEndsAt: null,
       runtimeEndingNotifiedFor: null,
+      providerUnreachableNotifiedFor: null,
       createdAt: new Date("2026-08-20T00:00:00.000Z").toISOString(),
       updatedAt: new Date("2026-08-20T00:00:00.000Z").toISOString(),
       ...overrides

--- a/apps/api/src/deployment/services/unreachable-provider-deployments-notifier/unreachable-provider-deployments-notifier.service.integration.ts
+++ b/apps/api/src/deployment/services/unreachable-provider-deployments-notifier/unreachable-provider-deployments-notifier.service.integration.ts
@@ -1,0 +1,132 @@
+import { faker } from "@faker-js/faker";
+import { container } from "tsyringe";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { UserWalletRepository } from "@src/billing/repositories";
+import { CHAIN_DB } from "@src/chain";
+import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import { NotificationService } from "@src/notifications/services/notification/notification.service";
+import { UserRepository } from "@src/user/repositories";
+import { ProviderOutagesHttpService } from "../provider-outages-http/provider-outages-http.service";
+import { UnreachableProviderDeploymentsNotifierService } from "./unreachable-provider-deployments-notifier.service";
+
+import { createAkashAddress, createDeployment, createDeploymentGroup, createLease, createProvider } from "@test/seeders";
+
+const DOWN_SINCE = "2026-07-24T00:00:00.000Z";
+const SECOND_OUTAGE_SINCE = "2026-08-20T00:00:00.000Z";
+
+describe(UnreachableProviderDeploymentsNotifierService.name, () => {
+  beforeAll(async () => {
+    await container.resolve(CHAIN_DB).authenticate();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("emails the owner once and remembers the outage it reported", async () => {
+    const { service, createNotification, deploymentSettingRepository, deployment, user } = await setup();
+
+    const result = await service.notifyUnreachableProviderDeployments({ dryRun: false });
+
+    expect(result.ok).toBe(true);
+    expect(createNotification).toHaveBeenCalledTimes(1);
+    const setting = await deploymentSettingRepository.findOneBy({ userId: user.id, dseq: deployment.dseq });
+    expect(setting?.providerUnreachableNotifiedFor?.toISOString()).toBe(DOWN_SINCE);
+  });
+
+  it("stays quiet while the same outage drags on", async () => {
+    const { service, createNotification } = await setup();
+
+    await service.notifyUnreachableProviderDeployments({ dryRun: false });
+    await service.notifyUnreachableProviderDeployments({ dryRun: false });
+
+    expect(createNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it("emails again when the provider recovers and goes dark a second time", async () => {
+    const { service, createNotification, setOutageStart } = await setup();
+    await service.notifyUnreachableProviderDeployments({ dryRun: false });
+
+    setOutageStart(SECOND_OUTAGE_SINCE);
+    await service.notifyUnreachableProviderDeployments({ dryRun: false });
+
+    expect(createNotification).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries on the next sweep when the email is rejected", async () => {
+    const { service, createNotification } = await setup();
+    createNotification.mockRejectedValueOnce(new Error("novu is down"));
+
+    const failed = await service.notifyUnreachableProviderDeployments({ dryRun: false });
+    const retried = await service.notifyUnreachableProviderDeployments({ dryRun: false });
+
+    expect(failed.err).toBe(true);
+    expect(retried.ok).toBe(true);
+    expect(createNotification).toHaveBeenCalledTimes(2);
+  });
+
+  it("leaves a self-custody deployment alone", async () => {
+    const { service, createNotification } = await setup({ managed: false });
+
+    await service.notifyUnreachableProviderDeployments({ dryRun: false });
+
+    expect(createNotification).not.toHaveBeenCalled();
+  });
+
+  it("writes nothing on a dry run", async () => {
+    const { service, createNotification, deploymentSettingRepository, deployment, user } = await setup();
+
+    await service.notifyUnreachableProviderDeployments({ dryRun: true });
+
+    expect(createNotification).not.toHaveBeenCalled();
+    expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq: deployment.dseq })).toBeUndefined();
+  });
+
+  async function setup(input: { managed?: boolean } = {}) {
+    const userRepository = container.resolve(UserRepository);
+    const userWalletRepository = container.resolve(UserWalletRepository);
+    const deploymentSettingRepository = container.resolve(DeploymentSettingRepository);
+
+    const owner = createAkashAddress();
+    const user = await userRepository.create({ userId: faker.string.uuid(), email: "owner@example.com" });
+
+    if (input.managed !== false) {
+      const { wallet } = await userWalletRepository.getOrCreate({ userId: user.id });
+      await userWalletRepository.updateById(wallet.id, { address: owner });
+    }
+
+    const provider = await createProvider();
+    const deployment = await createDeployment({ owner, dseq: faker.string.numeric(10) });
+    const group = await createDeploymentGroup({ deploymentId: deployment.id, owner, dseq: deployment.dseq, gseq: 1 });
+    await createLease({
+      deploymentId: deployment.id,
+      deploymentGroupId: group.id,
+      owner,
+      dseq: deployment.dseq,
+      gseq: 1,
+      oseq: 1,
+      providerAddress: provider.owner,
+      closedHeight: undefined
+    });
+
+    let startedAt = DOWN_SINCE;
+    const providerOutagesHttpService = container.resolve(ProviderOutagesHttpService);
+    vi.spyOn(providerOutagesHttpService, "findOutagesOlderThanDays").mockImplementation(async () => [
+      { provider: provider.owner, hostUri: provider.hostUri, startedAt }
+    ]);
+
+    const createNotification = vi.spyOn(container.resolve(NotificationService), "createNotification").mockResolvedValue(undefined);
+
+    return {
+      service: container.resolve(UnreachableProviderDeploymentsNotifierService),
+      deploymentSettingRepository,
+      createNotification,
+      deployment,
+      user,
+      setOutageStart: (value: string) => {
+        startedAt = value;
+      }
+    };
+  }
+});

--- a/apps/api/src/deployment/services/unreachable-provider-deployments-notifier/unreachable-provider-deployments-notifier.service.spec.ts
+++ b/apps/api/src/deployment/services/unreachable-provider-deployments-notifier/unreachable-provider-deployments-notifier.service.spec.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { UserWalletRepository } from "@src/billing/repositories";
+import type { CreateLogger } from "@src/core";
+import type { DeploymentSettingRepository, DeploymentSettingsOutput } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import type { ActiveLeaseOnProvider, LeaseRepository } from "@src/deployment/repositories/lease/lease.repository";
+import type { DeploymentConfigService } from "@src/deployment/services/deployment-config/deployment-config.service";
+import type { ProviderOutage, ProviderOutagesHttpService } from "@src/deployment/services/provider-outages-http/provider-outages-http.service";
+import type { NotificationService } from "@src/notifications/services/notification/notification.service";
+import type { UserOutput, UserRepository } from "@src/user/repositories";
+import { UnreachableProviderDeploymentsNotifierService } from "./unreachable-provider-deployments-notifier.service";
+
+import { mockConfigService } from "@test/mocks/config-service.mock";
+
+const NOTIFY_AFTER_DAYS = 3;
+const DEPLOY_WEB_BASE_URL = "https://console.akash.network";
+const OWNER = "akash1owner";
+const DSEQ = "1784768430632";
+const DARK_PROVIDER = "akash1dark";
+const HEALTHY_PROVIDER = "akash1healthy";
+const DOWN_SINCE = "2026-07-24T00:00:00.000Z";
+const LONGER_OUTAGE_SINCE = "2026-07-01T00:00:00.000Z";
+
+describe(UnreachableProviderDeploymentsNotifierService.name, () => {
+  it("asks for outages at least the configured number of days old", async () => {
+    const { service, providerOutagesHttpService } = setup({});
+
+    await service.notifyUnreachableProviderDeployments({ dryRun: false });
+
+    expect(providerOutagesHttpService.findOutagesOlderThanDays).toHaveBeenCalledWith(NOTIFY_AFTER_DAYS);
+  });
+
+  it("emails the owner naming the deployment, the host and where to close it", async () => {
+    const { service, notificationService } = setup({
+      outages: [anOutage({})],
+      leases: [aLease({})]
+    });
+
+    await service.notifyUnreachableProviderDeployments({ dryRun: false });
+
+    expect(notificationService.createNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          description: expect.stringContaining(DSEQ)
+        })
+      })
+    );
+    const [{ payload }] = notificationService.createNotification.mock.calls[0];
+    expect(payload.description).toContain("https://dark:8443");
+    expect(payload.description).toContain(`${DEPLOY_WEB_BASE_URL}/deployments/${DSEQ}`);
+  });
+
+  it("claims the outage before sending so a repeat sweep cannot email twice", async () => {
+    const { service, deploymentSettingRepository } = setup({
+      outages: [anOutage({})],
+      leases: [aLease({})]
+    });
+
+    await service.notifyUnreachableProviderDeployments({ dryRun: false });
+
+    expect(deploymentSettingRepository.claimProviderUnreachableNotification).toHaveBeenCalledWith({
+      userId: "user-1",
+      dseq: DSEQ,
+      downSinceMarker: DOWN_SINCE
+    });
+  });
+
+  it("warns about a deployment as soon as one of its leases is dark", async () => {
+    const { service, notificationService } = setup({
+      outages: [anOutage({})],
+      leases: [aLease({}), aLease({ providerAddress: HEALTHY_PROVIDER })]
+    });
+
+    await service.notifyUnreachableProviderDeployments({ dryRun: false });
+
+    expect(notificationService.createNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports the longest of several outages so the age names the real problem", async () => {
+    const { service, deploymentSettingRepository } = setup({
+      outages: [anOutage({}), anOutage({ provider: HEALTHY_PROVIDER, hostUri: "https://other:8443", startedAt: LONGER_OUTAGE_SINCE })],
+      leases: [aLease({}), aLease({ providerAddress: HEALTHY_PROVIDER })]
+    });
+
+    await service.notifyUnreachableProviderDeployments({ dryRun: false });
+
+    expect(deploymentSettingRepository.claimProviderUnreachableNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ downSinceMarker: LONGER_OUTAGE_SINCE })
+    );
+  });
+
+  it("leaves self-custody deployments alone", async () => {
+    const { service, notificationService, deploymentSettingRepository } = setup({
+      outages: [anOutage({})],
+      leases: [aLease({})],
+      wallet: null
+    });
+
+    await service.notifyUnreachableProviderDeployments({ dryRun: false });
+
+    expect(notificationService.createNotification).not.toHaveBeenCalled();
+    expect(deploymentSettingRepository.claimProviderUnreachableNotification).not.toHaveBeenCalled();
+  });
+
+  it("does not claim an outage for an owner with no email to send to", async () => {
+    const { service, notificationService, deploymentSettingRepository } = setup({
+      outages: [anOutage({})],
+      leases: [aLease({})],
+      user: mock<UserOutput>({ id: "user-1", email: null })
+    });
+
+    await service.notifyUnreachableProviderDeployments({ dryRun: false });
+
+    expect(notificationService.createNotification).not.toHaveBeenCalled();
+    expect(deploymentSettingRepository.claimProviderUnreachableNotification).not.toHaveBeenCalled();
+  });
+
+  it("skips an outage already reported for this deployment without touching the claim", async () => {
+    const { service, notificationService, deploymentSettingRepository } = setup({
+      outages: [anOutage({})],
+      leases: [aLease({})],
+      setting: mock<DeploymentSettingsOutput>({ providerUnreachableNotifiedFor: new Date(DOWN_SINCE) })
+    });
+
+    await service.notifyUnreachableProviderDeployments({ dryRun: false });
+
+    expect(notificationService.createNotification).not.toHaveBeenCalled();
+    expect(deploymentSettingRepository.claimProviderUnreachableNotification).not.toHaveBeenCalled();
+  });
+
+  it("sends nothing on a dry run", async () => {
+    const { service, notificationService, deploymentSettingRepository } = setup({
+      outages: [anOutage({})],
+      leases: [aLease({})]
+    });
+
+    await service.notifyUnreachableProviderDeployments({ dryRun: true });
+
+    expect(notificationService.createNotification).not.toHaveBeenCalled();
+    expect(deploymentSettingRepository.claimProviderUnreachableNotification).not.toHaveBeenCalled();
+  });
+
+  it("sends nothing when another pass took the claim first", async () => {
+    const { service, notificationService } = setup({
+      outages: [anOutage({})],
+      leases: [aLease({})],
+      claimed: false
+    });
+
+    await service.notifyUnreachableProviderDeployments({ dryRun: false });
+
+    expect(notificationService.createNotification).not.toHaveBeenCalled();
+  });
+
+  it("gives the claim back and reports the failure when the email is rejected", async () => {
+    const { service, notificationService, deploymentSettingRepository } = setup({
+      outages: [anOutage({})],
+      leases: [aLease({})]
+    });
+    notificationService.createNotification.mockRejectedValue(new Error("novu is down"));
+
+    const result = await service.notifyUnreachableProviderDeployments({ dryRun: false });
+
+    expect(result.err).toBe(true);
+    expect(deploymentSettingRepository.releaseProviderUnreachableClaim).toHaveBeenCalledWith({
+      userId: "user-1",
+      dseq: DSEQ,
+      downSinceMarker: DOWN_SINCE
+    });
+  });
+
+  it("keeps warning the other owners after one email fails", async () => {
+    const { service, notificationService } = setup({
+      outages: [anOutage({})],
+      leases: [aLease({}), aLease({ owner: "akash1other", dseq: "999" })]
+    });
+    notificationService.createNotification.mockRejectedValueOnce(new Error("novu is down"));
+
+    const result = await service.notifyUnreachableProviderDeployments({ dryRun: false });
+
+    expect(notificationService.createNotification).toHaveBeenCalledTimes(2);
+    expect(result.err).toBe(true);
+  });
+
+  it("does nothing at all when the outage record cannot be trusted", async () => {
+    const { service, providerOutagesHttpService, leaseRepository, notificationService } = setup({});
+    providerOutagesHttpService.findOutagesOlderThanDays.mockRejectedValue(new Error("stale"));
+
+    await expect(service.notifyUnreachableProviderDeployments({ dryRun: false })).rejects.toThrow("stale");
+    expect(leaseRepository.findActiveLeasesOfDeploymentsOnProviders).not.toHaveBeenCalled();
+    expect(notificationService.createNotification).not.toHaveBeenCalled();
+  });
+
+  function setup(input: {
+    outages?: ProviderOutage[];
+    leases?: ActiveLeaseOnProvider[];
+    wallet?: { userId: string } | null;
+    user?: UserOutput;
+    setting?: DeploymentSettingsOutput;
+    claimed?: boolean;
+  }) {
+    const providerOutagesHttpService = mock<ProviderOutagesHttpService>();
+    providerOutagesHttpService.findOutagesOlderThanDays.mockResolvedValue(input.outages ?? []);
+
+    const leaseRepository = mock<LeaseRepository>();
+    leaseRepository.findActiveLeasesOfDeploymentsOnProviders.mockResolvedValue(input.leases ?? []);
+
+    const userWalletRepository = mock<UserWalletRepository>();
+    userWalletRepository.findOneByAddress.mockResolvedValue(
+      input.wallet === null ? undefined : mock<Awaited<ReturnType<UserWalletRepository["findOneByAddress"]>>>({ userId: "user-1" })
+    );
+
+    const deploymentSettingRepository = mock<DeploymentSettingRepository>();
+    deploymentSettingRepository.findOneBy.mockResolvedValue(input.setting);
+    deploymentSettingRepository.claimProviderUnreachableNotification.mockResolvedValue(input.claimed ?? true);
+
+    const userRepository = mock<UserRepository>();
+    userRepository.findById.mockResolvedValue(input.user ?? mock<UserOutput>({ id: "user-1", email: "owner@example.com" }));
+
+    const notificationService = mock<NotificationService>();
+    const config = mockConfigService<DeploymentConfigService>({
+      PROVIDER_UNREACHABLE_NOTIFY_AFTER_DAYS: NOTIFY_AFTER_DAYS,
+      DEPLOY_WEB_BASE_URL
+    });
+    const createLogger = (() => mock<ReturnType<CreateLogger>>()) as unknown as CreateLogger;
+
+    const service = new UnreachableProviderDeploymentsNotifierService(
+      providerOutagesHttpService,
+      leaseRepository,
+      userWalletRepository,
+      deploymentSettingRepository,
+      userRepository,
+      notificationService,
+      config,
+      createLogger
+    );
+
+    return { service, providerOutagesHttpService, leaseRepository, userWalletRepository, deploymentSettingRepository, userRepository, notificationService };
+  }
+});
+
+function anOutage(overrides: Partial<ProviderOutage>): ProviderOutage {
+  return {
+    provider: overrides.provider ?? DARK_PROVIDER,
+    hostUri: overrides.hostUri ?? "https://dark:8443",
+    startedAt: overrides.startedAt ?? DOWN_SINCE
+  };
+}
+
+function aLease(overrides: Partial<ActiveLeaseOnProvider>): ActiveLeaseOnProvider {
+  return {
+    owner: overrides.owner ?? OWNER,
+    dseq: overrides.dseq ?? DSEQ,
+    providerAddress: overrides.providerAddress ?? DARK_PROVIDER
+  };
+}

--- a/apps/api/src/deployment/services/unreachable-provider-deployments-notifier/unreachable-provider-deployments-notifier.service.spec.ts
+++ b/apps/api/src/deployment/services/unreachable-provider-deployments-notifier/unreachable-provider-deployments-notifier.service.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { UserWalletRepository } from "@src/billing/repositories";
@@ -223,7 +223,7 @@ describe(UnreachableProviderDeploymentsNotifierService.name, () => {
       PROVIDER_UNREACHABLE_NOTIFY_AFTER_DAYS: NOTIFY_AFTER_DAYS,
       DEPLOY_WEB_BASE_URL
     });
-    const createLogger = (() => mock<ReturnType<CreateLogger>>()) as unknown as CreateLogger;
+    const createLogger = vi.fn<CreateLogger>(() => mock<ReturnType<CreateLogger>>());
 
     const service = new UnreachableProviderDeploymentsNotifierService(
       providerOutagesHttpService,

--- a/apps/api/src/deployment/services/unreachable-provider-deployments-notifier/unreachable-provider-deployments-notifier.service.ts
+++ b/apps/api/src/deployment/services/unreachable-provider-deployments-notifier/unreachable-provider-deployments-notifier.service.ts
@@ -20,17 +20,7 @@ interface DarkDeployment {
   downSince: string;
 }
 
-/**
- * Tells owners that the provider hosting their deployment has stopped answering, which today nothing
- * does: escrow keeps draining toward a provider that is no longer serving the workload, and the owner
- * finds out only when they happen to open the deployment.
- *
- * One email per outage. A provider that recovers and goes dark again is worth telling the owner about
- * a second time; a single outage dragging on for weeks is not.
- *
- * Managed wallets only. A self-custody deployment has no account behind its address, so there is no
- * one to email.
- */
+/** Managed wallets only, since a self-custody deployment has no account behind its address and so nobody to email. */
 @singleton()
 export class UnreachableProviderDeploymentsNotifierService {
   private readonly logger: ReturnType<CreateLogger>;
@@ -79,11 +69,7 @@ export class UnreachableProviderDeploymentsNotifierService {
     return errors.length > 0 ? Err(errors) : Ok(undefined);
   }
 
-  /**
-   * A deployment counts as dark as soon as one of its leases sits on an unreachable provider — a
-   * workload split across providers is already broken when one of them disappears. Where several are
-   * dark, the longest outage is the one reported, so the age the owner reads is the age of the problem.
-   */
+  /** One dark lease is enough, and where several are dark the longest outage is reported so the age the owner reads is the age of the problem. */
   async #findDarkDeployments(outages: ProviderOutage[]): Promise<DarkDeployment[]> {
     if (outages.length === 0) return [];
 
@@ -201,11 +187,7 @@ export class UnreachableProviderDeploymentsNotifierService {
     return true;
   }
 
-  /**
-   * A claim whose email never went out is given back so the next sweep retries it. A failed release is
-   * logged rather than thrown: it would replace the send error the caller reports, and the cost is one
-   * owner warned late or not at all, which is what the claim was already risking.
-   */
+  /** A failed release is logged rather than thrown, because it would replace the send error the caller reports. */
   async #releaseClaim(deployment: DarkDeployment, claim: { userId: string; dseq: string; downSinceMarker: string }): Promise<void> {
     try {
       await this.deploymentSettingRepository.releaseProviderUnreachableClaim(claim);

--- a/apps/api/src/deployment/services/unreachable-provider-deployments-notifier/unreachable-provider-deployments-notifier.service.ts
+++ b/apps/api/src/deployment/services/unreachable-provider-deployments-notifier/unreachable-provider-deployments-notifier.service.ts
@@ -1,0 +1,225 @@
+import { Err, Ok, Result } from "ts-results";
+import { inject, singleton } from "tsyringe";
+
+import { UserWalletRepository } from "@src/billing/repositories";
+import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
+import type { DryRunOptions } from "@src/core/types/console";
+import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import { type ActiveLeaseOnProvider, LeaseRepository } from "@src/deployment/repositories/lease/lease.repository";
+import { DeploymentConfigService } from "@src/deployment/services/deployment-config/deployment-config.service";
+import { type ProviderOutage, ProviderOutagesHttpService } from "@src/deployment/services/provider-outages-http/provider-outages-http.service";
+import { NotificationService } from "@src/notifications/services/notification/notification.service";
+import { providerUnreachableNotification } from "@src/notifications/services/notification-templates/provider-unreachable-notification";
+import { UserRepository } from "@src/user/repositories";
+
+/** A deployment with at least one lease on a provider that has gone dark, and the outage to tell its owner about. */
+interface DarkDeployment {
+  owner: string;
+  dseq: string;
+  hostUri: string;
+  downSince: string;
+}
+
+/**
+ * Tells owners that the provider hosting their deployment has stopped answering, which today nothing
+ * does: escrow keeps draining toward a provider that is no longer serving the workload, and the owner
+ * finds out only when they happen to open the deployment.
+ *
+ * One email per outage. A provider that recovers and goes dark again is worth telling the owner about
+ * a second time; a single outage dragging on for weeks is not.
+ *
+ * Managed wallets only. A self-custody deployment has no account behind its address, so there is no
+ * one to email.
+ */
+@singleton()
+export class UnreachableProviderDeploymentsNotifierService {
+  private readonly logger: ReturnType<CreateLogger>;
+
+  constructor(
+    private readonly providerOutagesHttpService: ProviderOutagesHttpService,
+    private readonly leaseRepository: LeaseRepository,
+    private readonly userWalletRepository: UserWalletRepository,
+    private readonly deploymentSettingRepository: DeploymentSettingRepository,
+    private readonly userRepository: UserRepository,
+    private readonly notificationService: NotificationService,
+    private readonly config: DeploymentConfigService,
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
+  ) {
+    this.logger = createLogger({ context: UnreachableProviderDeploymentsNotifierService.name });
+  }
+
+  async notifyUnreachableProviderDeployments({ dryRun }: DryRunOptions): Promise<Result<void, unknown[]>> {
+    const outages = await this.providerOutagesHttpService.findOutagesOlderThanDays(this.config.get("PROVIDER_UNREACHABLE_NOTIFY_AFTER_DAYS"));
+    const deployments = await this.#findDarkDeployments(outages);
+
+    this.logger.info({ event: "UNREACHABLE_PROVIDER_DEPLOYMENTS_SWEEP_START", outages: outages.length, count: deployments.length, dryRun });
+
+    const errors: unknown[] = [];
+    let notifiedCount = 0;
+
+    for (const deployment of deployments) {
+      try {
+        if (await this.#notifyOwner(deployment, dryRun)) {
+          notifiedCount++;
+        }
+      } catch (error) {
+        this.logger.error({ event: "UNREACHABLE_PROVIDER_DEPLOYMENT_NOTIFY_FAILED", dseq: deployment.dseq, owner: deployment.owner, error });
+        errors.push(error);
+      }
+    }
+
+    this.logger.info({
+      event: "UNREACHABLE_PROVIDER_DEPLOYMENTS_SWEEP_END",
+      found: deployments.length,
+      notified: notifiedCount,
+      failed: errors.length,
+      dryRun
+    });
+
+    return errors.length > 0 ? Err(errors) : Ok(undefined);
+  }
+
+  /**
+   * A deployment counts as dark as soon as one of its leases sits on an unreachable provider — a
+   * workload split across providers is already broken when one of them disappears. Where several are
+   * dark, the longest outage is the one reported, so the age the owner reads is the age of the problem.
+   */
+  async #findDarkDeployments(outages: ProviderOutage[]): Promise<DarkDeployment[]> {
+    if (outages.length === 0) return [];
+
+    const outageByProvider = new Map(outages.map(outage => [outage.provider, outage]));
+    const leases = await this.leaseRepository.findActiveLeasesOfDeploymentsOnProviders([...outageByProvider.keys()]);
+    const darkByDeployment = new Map<string, DarkDeployment>();
+
+    for (const lease of leases) {
+      const outage = outageByProvider.get(lease.providerAddress);
+      if (!outage) continue;
+
+      const key = this.#deploymentKey(lease);
+      const known = darkByDeployment.get(key);
+      if (known && known.downSince <= outage.startedAt) continue;
+
+      darkByDeployment.set(key, {
+        owner: lease.owner,
+        dseq: lease.dseq,
+        hostUri: outage.hostUri,
+        downSince: outage.startedAt
+      });
+    }
+
+    return [...darkByDeployment.values()];
+  }
+
+  #deploymentKey(lease: ActiveLeaseOnProvider): string {
+    return `${lease.owner}/${lease.dseq}`;
+  }
+
+  async #notifyOwner(deployment: DarkDeployment, dryRun: boolean): Promise<boolean> {
+    const wallet = await this.userWalletRepository.findOneByAddress(deployment.owner);
+
+    if (!wallet) {
+      this.logger.debug({
+        event: "UNREACHABLE_PROVIDER_DEPLOYMENT_SKIPPED",
+        reason: "NOT_A_MANAGED_WALLET",
+        dseq: deployment.dseq,
+        owner: deployment.owner
+      });
+      return false;
+    }
+
+    const setting = await this.deploymentSettingRepository.findOneBy({ userId: wallet.userId, dseq: deployment.dseq });
+
+    if (setting?.providerUnreachableNotifiedFor?.toISOString() === deployment.downSince) {
+      this.logger.debug({
+        event: "UNREACHABLE_PROVIDER_DEPLOYMENT_SKIPPED",
+        reason: "ALREADY_NOTIFIED",
+        dseq: deployment.dseq,
+        owner: deployment.owner
+      });
+      return false;
+    }
+
+    const user = await this.userRepository.findById(wallet.userId);
+
+    if (!user?.email) {
+      this.logger.warn({
+        event: "UNREACHABLE_PROVIDER_DEPLOYMENT_SKIPPED",
+        reason: "USER_HAS_NO_EMAIL",
+        dseq: deployment.dseq,
+        userId: wallet.userId
+      });
+      return false;
+    }
+
+    if (dryRun) {
+      this.logger.info({
+        event: "UNREACHABLE_PROVIDER_DEPLOYMENT_WOULD_NOTIFY",
+        dseq: deployment.dseq,
+        owner: deployment.owner,
+        hostUri: deployment.hostUri,
+        downSince: deployment.downSince
+      });
+      return false;
+    }
+
+    const claim = { userId: wallet.userId, dseq: deployment.dseq, downSinceMarker: deployment.downSince };
+    const claimed = await this.deploymentSettingRepository.claimProviderUnreachableNotification(claim);
+
+    if (!claimed) {
+      this.logger.info({
+        event: "UNREACHABLE_PROVIDER_DEPLOYMENT_SKIPPED",
+        reason: "ALREADY_NOTIFIED",
+        dseq: deployment.dseq,
+        owner: deployment.owner
+      });
+      return false;
+    }
+
+    try {
+      await this.notificationService.createNotification(
+        providerUnreachableNotification(user, {
+          dseq: deployment.dseq,
+          owner: deployment.owner,
+          hostUri: deployment.hostUri,
+          downSince: deployment.downSince,
+          deploymentUrl: this.#deploymentUrl(deployment.dseq)
+        })
+      );
+    } catch (error) {
+      await this.#releaseClaim(deployment, claim);
+      throw error;
+    }
+
+    this.logger.info({
+      event: "UNREACHABLE_PROVIDER_DEPLOYMENT_NOTIFIED",
+      dseq: deployment.dseq,
+      owner: deployment.owner,
+      hostUri: deployment.hostUri,
+      downSince: deployment.downSince
+    });
+
+    return true;
+  }
+
+  /**
+   * A claim whose email never went out is given back so the next sweep retries it. A failed release is
+   * logged rather than thrown: it would replace the send error the caller reports, and the cost is one
+   * owner warned late or not at all, which is what the claim was already risking.
+   */
+  async #releaseClaim(deployment: DarkDeployment, claim: { userId: string; dseq: string; downSinceMarker: string }): Promise<void> {
+    try {
+      await this.deploymentSettingRepository.releaseProviderUnreachableClaim(claim);
+    } catch (error) {
+      this.logger.error({
+        event: "UNREACHABLE_PROVIDER_DEPLOYMENT_CLAIM_RELEASE_FAILED",
+        dseq: deployment.dseq,
+        owner: deployment.owner,
+        error
+      });
+    }
+  }
+
+  #deploymentUrl(dseq: string): string {
+    return `${this.config.get("DEPLOY_WEB_BASE_URL")}/deployments/${dseq}`;
+  }
+}

--- a/apps/api/src/notifications/services/notification-templates/provider-unreachable-notification.spec.ts
+++ b/apps/api/src/notifications/services/notification-templates/provider-unreachable-notification.spec.ts
@@ -1,0 +1,41 @@
+import { subDays } from "date-fns";
+import { describe, expect, it } from "vitest";
+
+import { providerUnreachableNotification } from "./provider-unreachable-notification";
+
+import { createUser } from "@test/seeders/user.seeder";
+
+const DEPLOYMENT_URL = "https://console.akash.network/deployments/654321";
+
+describe(providerUnreachableNotification.name, () => {
+  it("returns a notification naming the deployment, the provider and how long it has been dark", () => {
+    const user = createUser({ id: "user-123", email: "user@example.com" });
+    const downSince = subDays(new Date(), 5);
+
+    const result = providerUnreachableNotification(user, {
+      dseq: "654321",
+      owner: "akash1owner",
+      hostUri: "https://provider.akash.cmolls.de:8443",
+      downSince: downSince.toISOString(),
+      deploymentUrl: DEPLOYMENT_URL
+    });
+
+    expect(result.notificationId).toBe(`providerUnreachable.${downSince.toISOString()}.654321.akash1owner`);
+    expect(result.payload.summary).toBe("Your Akash deployment's provider is unreachable");
+    expect(result.payload.description).toContain("<strong>654321</strong>");
+    expect(result.payload.description).toContain("<strong>https://provider.akash.cmolls.de:8443</strong>");
+    expect(result.payload.description).toContain("5 days");
+    expect(result.payload.description).toContain(`<a href="${DEPLOYMENT_URL}">Close the deployment</a>`);
+    expect(result.user).toEqual({ id: "user-123", email: "user@example.com" });
+  });
+
+  it("keys the notification id on the outage so a provider that recovers and fails again is reported anew", () => {
+    const user = createUser({ id: "user-123", email: "user@example.com" });
+    const vars = { dseq: "654321", owner: "akash1owner", hostUri: "https://dark:8443", deploymentUrl: DEPLOYMENT_URL };
+
+    const first = providerUnreachableNotification(user, { ...vars, downSince: subDays(new Date(), 9).toISOString() });
+    const second = providerUnreachableNotification(user, { ...vars, downSince: subDays(new Date(), 3).toISOString() });
+
+    expect(first.notificationId).not.toBe(second.notificationId);
+  });
+});

--- a/apps/api/src/notifications/services/notification-templates/provider-unreachable-notification.spec.ts
+++ b/apps/api/src/notifications/services/notification-templates/provider-unreachable-notification.spec.ts
@@ -29,6 +29,21 @@ describe(providerUnreachableNotification.name, () => {
     expect(result.user).toEqual({ id: "user-123", email: "user@example.com" });
   });
 
+  it("escapes a host uri the provider declared with markup in it", () => {
+    const user = createUser({ id: "user-123", email: "user@example.com" });
+
+    const result = providerUnreachableNotification(user, {
+      dseq: "654321",
+      owner: "akash1owner",
+      hostUri: '<script>alert("xss")</script>',
+      downSince: subDays(new Date(), 5).toISOString(),
+      deploymentUrl: DEPLOYMENT_URL
+    });
+
+    expect(result.payload.description).not.toContain("<script>");
+    expect(result.payload.description).toContain("&lt;script&gt;");
+  });
+
   it("keys the notification id on the outage so a provider that recovers and fails again is reported anew", () => {
     const user = createUser({ id: "user-123", email: "user@example.com" });
     const vars = { dseq: "654321", owner: "akash1owner", hostUri: "https://dark:8443", deploymentUrl: DEPLOYMENT_URL };

--- a/apps/api/src/notifications/services/notification-templates/provider-unreachable-notification.ts
+++ b/apps/api/src/notifications/services/notification-templates/provider-unreachable-notification.ts
@@ -1,0 +1,24 @@
+import { formatDistanceToNow } from "date-fns";
+
+import type { UserOutput } from "@src/user/repositories";
+import type { CreateNotificationInput } from "../notification/notification.service";
+
+export function providerUnreachableNotification(
+  user: UserOutput,
+  vars: { dseq: string; owner: string; hostUri: string; downSince: string; deploymentUrl: string }
+): CreateNotificationInput {
+  const downSince = new Date(vars.downSince);
+
+  return {
+    notificationId: `providerUnreachable.${downSince.toISOString()}.${vars.dseq}.${vars.owner}`,
+    payload: {
+      summary: "Your Akash deployment's provider is unreachable",
+      description:
+        `The provider hosting deployment <strong>${vars.dseq}</strong>, <strong>${vars.hostUri}</strong>, ` +
+        `has not responded for ${formatDistanceToNow(downSince)} and your workload is most likely down. ` +
+        `You are still paying for it. <a href="${vars.deploymentUrl}">Close the deployment</a> to get the remaining ` +
+        `funds back, then redeploy somewhere else.`
+    },
+    user: { id: user.id, email: user.email }
+  };
+}

--- a/apps/api/src/notifications/services/notification-templates/provider-unreachable-notification.ts
+++ b/apps/api/src/notifications/services/notification-templates/provider-unreachable-notification.ts
@@ -1,8 +1,13 @@
 import { formatDistanceToNow } from "date-fns";
+import escapeHtml from "lodash/escape";
 
 import type { UserOutput } from "@src/user/repositories";
 import type { CreateNotificationInput } from "../notification/notification.service";
 
+/**
+ * A provider's host URI is whatever it declared on chain, so it reaches this email as untrusted text
+ * and is escaped before going into the markup.
+ */
 export function providerUnreachableNotification(
   user: UserOutput,
   vars: { dseq: string; owner: string; hostUri: string; downSince: string; deploymentUrl: string }
@@ -14,7 +19,7 @@ export function providerUnreachableNotification(
     payload: {
       summary: "Your Akash deployment's provider is unreachable",
       description:
-        `The provider hosting deployment <strong>${vars.dseq}</strong>, <strong>${vars.hostUri}</strong>, ` +
+        `The provider hosting deployment <strong>${vars.dseq}</strong>, <strong>${escapeHtml(vars.hostUri)}</strong>, ` +
         `has not responded for ${formatDistanceToNow(downSince)} and your workload is most likely down. ` +
         `You are still paying for it. <a href="${vars.deploymentUrl}">Close the deployment</a> to get the remaining ` +
         `funds back, then redeploy somewhere else.`


### PR DESCRIPTION
## Why

Closes CON-900. Stacked on #3696 (and through it, #3695).

A managed-wallet user has had a deployment on provider.akash.cmolls.de since July 24. The provider stopped answering that same day — 303/303 failed uptime checks, host unroutable from several networks. The user opens Console daily, keeps the deployment page open, and has no idea. Escrow keeps draining toward a counterparty that is not even withdrawing it. Nothing in the product says a word.

## What

A sweep every 30 minutes reads the ongoing outages (≥ `PROVIDER_UNREACHABLE_NOTIFY_AFTER_DAYS`, default 3), finds the deployments sitting on those providers, and emails each owner once: which deployment, which host, how long it has been dark, and a link to close it and get the rest of the money back.

**One email per outage, not per sweep.** The claim is the outage's start time, stamped on `deployment_settings.provider_unreachable_notified_for`, taken before the email goes out and handed back if the send fails. A provider that recovers and goes dark again is worth telling the owner about; a single outage dragging on for weeks is not.

**Which deployments count.** A deployment is affected as soon as one of its leases is dark — a workload split across providers is already broken when one disappears. Where several of its providers are dark, the longest outage is the one reported, so the age in the email is the age of the problem.

**Managed wallets only.** A self-custody deployment has no account behind its address, so there is nobody to email. Those are skipped.

## Notes

- **CON-734 interaction:** rows the marker has to create (deployments predating settings, or created outside the web app) are written with `auto_top_up_enabled: false`. An outage bookmark must not be the thing that enrols a deployment into automatic funding. Worth a look from whoever lands always-on funding.
- **Why a CronJob and not pg-boss:** nothing in the API writes when a provider goes dark, so there is no enqueue point to hang a delayed job off. That is the unbounded-recurring-sweep case the contribution guidelines keep CronJobs for.
- **Rollout:** live on staging-sandbox, `--dry-run` on prod-mainnet. The first live run catches up on every outage already past three days, so check the `UNREACHABLE_PROVIDER_DEPLOYMENT_WOULD_NOTIFY` volume before dropping the flag. The cmolls.de case should show up there.
- The migration is a single nullable `ADD COLUMN`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated notifications for deployments affected by prolonged provider outages.
  - Notifications include deployment details, outage duration, provider information, and recommended next steps.
  - Added configurable outage duration threshold, defaulting to three days.
  - Added scheduled processing with dry-run support.
  - Prevented duplicate notifications while allowing re-notification after recovery and a later outage.

- **Bug Fixes**
  - Improved handling of notification failures and concurrent processing to avoid missed or duplicate alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->