### PR TITLE
feat(deployment): close deployments whose provider never comes back

### DIFF
--- a/.helm/console-api-prod-mainnet-values.yaml
+++ b/.helm/console-api-prod-mainnet-values.yaml
@@ -60,6 +60,19 @@ jobs:
       - ./dist/console.js
       - notify-unreachable-provider-deployments
       - --dry-run
+  # Ships in dry-run and stays that way until the warning email above has been live for longer than the
+  # gap between the two thresholds (14 - 3 = 11 days), so no owner's first word about an outage is the
+  # closure notice. Check that every UNREACHABLE_PROVIDER_DEPLOYMENT_WOULD_CLOSE was warned first.
+  # Offset from the sweeps above so no two of them hit deployment_settings on the same minute.
+  - name: close-unreachable-provider-deployments
+    schedule: "26 * * * *" # hourly
+    command:
+      - node
+      - --require
+      - ./dist/instrumentation.js
+      - ./dist/console.js
+      - close-unreachable-provider-deployments
+      - --dry-run
   - name: mint-act
     schedule: "*/10 * * * *" # every 10 minutes
     concurrencyPolicy: Forbid

--- a/.helm/console-api-staging-sandbox-values.yaml
+++ b/.helm/console-api-staging-sandbox-values.yaml
@@ -43,6 +43,15 @@ jobs:
       - ./dist/instrumentation.js
       - ./dist/console.js
       - notify-unreachable-provider-deployments
+  # Offset from the sweeps above so no two of them hit deployment_settings on the same minute.
+  - name: close-unreachable-provider-deployments
+    schedule: "26 * * * *" # hourly
+    command:
+      - node
+      - --require
+      - ./dist/instrumentation.js
+      - ./dist/console.js
+      - close-unreachable-provider-deployments
 
 replicas: 2
 

--- a/apps/api/src/app/console.ts
+++ b/apps/api/src/app/console.ts
@@ -81,6 +81,16 @@ program
   });
 
 program
+  .command("close-unreachable-provider-deployments")
+  .description("Close deployments whose every provider has been unreachable for weeks")
+  .option("-d, --dry-run", "Log which deployments would be closed without broadcasting", false)
+  .action(async (options, command) => {
+    await executeCliHandler(command.name(), async () => {
+      return container.resolve(TopUpDeploymentsController).closeUnreachableProviderDeployments(options);
+    });
+  });
+
+program
   .command("cleanup-provider-deployments")
   .description("Close trial deployments for a provider")
   .option("-c, --concurrency <number>", "How many wallets are processed concurrently", value => z.number({ coerce: true }).optional().default(10).parse(value))

--- a/apps/api/src/app/providers/jobs.provider.ts
+++ b/apps/api/src/app/providers/jobs.provider.ts
@@ -11,6 +11,7 @@ import { NotificationHandler } from "@src/notifications/services/notification-ha
 import { AutoRechargeSucceededHandler } from "../services/auto-recharge-succeeded/auto-recharge-succeeded.handler";
 import { CloseExpiredDeploymentHandler } from "../services/close-expired-deployment/close-expired-deployment.handler";
 import { CloseTrialDeploymentHandler } from "../services/close-trial-deployment/close-trial-deployment.handler";
+import { CloseUnreachableProviderDeploymentHandler } from "../services/close-unreachable-provider-deployment/close-unreachable-provider-deployment.handler";
 import { EnableDeploymentAlertHandler } from "../services/enable-deployment-alert/enable-deployment-alert.handler";
 import { FirstPurchaseBonusGrantedHandler } from "../services/first-purchase-bonus-granted/first-purchase-bonus-granted.handler";
 import { FundDeploymentHandler } from "../services/fund-deployment/fund-deployment.handler";
@@ -27,6 +28,7 @@ export async function startJobQueues(): Promise<void> {
     container.resolve(NotificationHandler),
     container.resolve(CloseTrialDeploymentHandler),
     container.resolve(CloseExpiredDeploymentHandler),
+    container.resolve(CloseUnreachableProviderDeploymentHandler),
     container.resolve(TrialDeploymentLeaseCreatedHandler),
     container.resolve(EnableDeploymentAlertHandler),
     container.resolve(FundDeploymentHandler),

--- a/apps/api/src/app/services/close-unreachable-provider-deployment/close-unreachable-provider-deployment.handler.integration.ts
+++ b/apps/api/src/app/services/close-unreachable-provider-deployment/close-unreachable-provider-deployment.handler.integration.ts
@@ -53,12 +53,12 @@ describe(CloseUnreachableProviderDeploymentHandler.name, () => {
     expect(close).not.toHaveBeenCalled();
   });
 
-  it("records a close the chain had already settled without telling the owner about it", async () => {
+  it("still tells the owner when the close had already landed on chain", async () => {
     const { handler, enqueue, deploymentSettingRepository, deployment, user } = await setup({ alreadyClosedOnChain: true });
 
     await handler.handle({ owner: deployment.owner, dseq: deployment.dseq, version: 1 });
 
-    expect(enqueue).not.toHaveBeenCalled();
+    expect(enqueue).toHaveBeenCalledTimes(1);
     const setting = await deploymentSettingRepository.findOneBy({ userId: user.id, dseq: deployment.dseq });
     expect(setting?.closed).toBe(true);
   });

--- a/apps/api/src/app/services/close-unreachable-provider-deployment/close-unreachable-provider-deployment.handler.integration.ts
+++ b/apps/api/src/app/services/close-unreachable-provider-deployment/close-unreachable-provider-deployment.handler.integration.ts
@@ -1,0 +1,116 @@
+import { faker } from "@faker-js/faker";
+import { container } from "tsyringe";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { UserWalletRepository } from "@src/billing/repositories";
+import { CHAIN_DB } from "@src/chain";
+import { JobQueueService } from "@src/core";
+import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import { DeploymentWriterService } from "@src/deployment/services/deployment-writer/deployment-writer.service";
+import { ProviderOutagesHttpService } from "@src/deployment/services/provider-outages-http/provider-outages-http.service";
+import { UserRepository } from "@src/user/repositories";
+import { CloseUnreachableProviderDeploymentHandler } from "./close-unreachable-provider-deployment.handler";
+
+import { createAkashAddress, createDeployment, createDeploymentGroup, createLease, createProvider } from "@test/seeders";
+
+const DOWN_SINCE = "2026-07-24T00:00:00.000Z";
+
+describe(CloseUnreachableProviderDeploymentHandler.name, () => {
+  beforeAll(async () => {
+    await container.resolve(CHAIN_DB).authenticate();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("closes a still fully dark deployment, records it and tells the owner", async () => {
+    const { handler, close, enqueue, deploymentSettingRepository, deployment, user } = await setup();
+
+    await handler.handle({ owner: deployment.owner, dseq: deployment.dseq, version: 1 });
+
+    expect(close).toHaveBeenCalledWith(expect.objectContaining({ address: deployment.owner }), deployment.dseq);
+    expect(enqueue).toHaveBeenCalledTimes(1);
+    const setting = await deploymentSettingRepository.findOneBy({ userId: user.id, dseq: deployment.dseq });
+    expect(setting?.closed).toBe(true);
+  });
+
+  it("closes nothing once one of the deployment's providers answers again", async () => {
+    const { handler, close, enqueue, deploymentSettingRepository, deployment, user } = await setup({ alsoOnHealthyProvider: true });
+
+    await handler.handle({ owner: deployment.owner, dseq: deployment.dseq, version: 1 });
+
+    expect(close).not.toHaveBeenCalled();
+    expect(enqueue).not.toHaveBeenCalled();
+    expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq: deployment.dseq })).toBeUndefined();
+  });
+
+  it("closes nothing when the deployment has no active lease left", async () => {
+    const { handler, close, deployment } = await setup({ leaseAlreadyClosed: true });
+
+    await handler.handle({ owner: deployment.owner, dseq: deployment.dseq, version: 1 });
+
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  it("records a close the chain had already settled without telling the owner about it", async () => {
+    const { handler, enqueue, deploymentSettingRepository, deployment, user } = await setup({ alreadyClosedOnChain: true });
+
+    await handler.handle({ owner: deployment.owner, dseq: deployment.dseq, version: 1 });
+
+    expect(enqueue).not.toHaveBeenCalled();
+    const setting = await deploymentSettingRepository.findOneBy({ userId: user.id, dseq: deployment.dseq });
+    expect(setting?.closed).toBe(true);
+  });
+
+  async function setup(input: { alsoOnHealthyProvider?: boolean; leaseAlreadyClosed?: boolean; alreadyClosedOnChain?: boolean } = {}) {
+    const userRepository = container.resolve(UserRepository);
+    const userWalletRepository = container.resolve(UserWalletRepository);
+    const deploymentSettingRepository = container.resolve(DeploymentSettingRepository);
+
+    const owner = createAkashAddress();
+    const user = await userRepository.create({ userId: faker.string.uuid(), email: "owner@example.com" });
+    const { wallet } = await userWalletRepository.getOrCreate({ userId: user.id });
+    await userWalletRepository.updateById(wallet.id, { address: owner });
+
+    const darkProvider = await createProvider();
+    const deployment = await createDeployment({ owner, dseq: faker.string.numeric(10) });
+    await seedLease(deployment, darkProvider.owner, 1, input.leaseAlreadyClosed ? 10_000 : undefined);
+
+    if (input.alsoOnHealthyProvider) {
+      const healthyProvider = await createProvider();
+      await seedLease(deployment, healthyProvider.owner, 2);
+    }
+
+    vi.spyOn(container.resolve(ProviderOutagesHttpService), "findOutagesOlderThanDays").mockResolvedValue([
+      { provider: darkProvider.owner, hostUri: darkProvider.hostUri, startedAt: DOWN_SINCE }
+    ]);
+
+    const close = vi.spyOn(container.resolve(DeploymentWriterService), "close").mockResolvedValue(!input.alreadyClosedOnChain);
+    const enqueue = vi.spyOn(container.resolve(JobQueueService), "enqueue").mockResolvedValue("job-id");
+
+    return {
+      handler: container.resolve(CloseUnreachableProviderDeploymentHandler),
+      deploymentSettingRepository,
+      close,
+      enqueue,
+      deployment,
+      user
+    };
+  }
+});
+
+async function seedLease(deployment: { id: string; owner: string; dseq: string }, providerAddress: string, gseq: number, closedHeight?: number) {
+  const group = await createDeploymentGroup({ deploymentId: deployment.id, owner: deployment.owner, dseq: deployment.dseq, gseq });
+
+  await createLease({
+    deploymentId: deployment.id,
+    deploymentGroupId: group.id,
+    owner: deployment.owner,
+    dseq: deployment.dseq,
+    gseq,
+    oseq: 1,
+    providerAddress,
+    closedHeight
+  });
+}

--- a/apps/api/src/app/services/close-unreachable-provider-deployment/close-unreachable-provider-deployment.handler.spec.ts
+++ b/apps/api/src/app/services/close-unreachable-provider-deployment/close-unreachable-provider-deployment.handler.spec.ts
@@ -1,0 +1,203 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { UserWalletRepository } from "@src/billing/repositories";
+import type { ChainErrorService } from "@src/billing/services/chain-error/chain-error.service";
+import type { CreateLogger, JobPayload, JobQueueService } from "@src/core";
+import type { TxService } from "@src/core/services/tx/tx.service";
+import type { CloseUnreachableProviderDeploymentCommand } from "@src/deployment/commands/close-unreachable-provider-deployment.command";
+import type { DarkDeployment } from "@src/deployment/lib/dark-deployment/dark-deployment";
+import type { DeploymentSettingRepository, DeploymentSettingsOutput } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import type { DeploymentConfigService } from "@src/deployment/services/deployment-config/deployment-config.service";
+import type { DeploymentWriterService } from "@src/deployment/services/deployment-writer/deployment-writer.service";
+import type { UnreachableProviderDeploymentsCloserService } from "@src/deployment/services/unreachable-provider-deployments-closer/unreachable-provider-deployments-closer.service";
+import { CloseUnreachableProviderDeploymentHandler } from "./close-unreachable-provider-deployment.handler";
+
+import { mockConfigService } from "@test/mocks/config-service.mock";
+import { createUserWallet } from "@test/seeders/user-wallet.seeder";
+
+const DEPLOY_WEB_BASE_URL = "https://console.akash.network";
+const OWNER = "akash1owner";
+const DSEQ = "1784768430632";
+const HOST_URI = "https://dark:8443";
+const DOWN_SINCE = "2026-07-01T00:00:00.000Z";
+const NOW = "2026-07-31T00:00:00.000Z";
+const DAYS_DOWN = 30;
+const WALLET_ID = 7;
+const USER_ID = "user-1";
+
+describe(CloseUnreachableProviderDeploymentHandler.name, () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("closes a deployment whose every provider is still dark and records it", async () => {
+    const { handler, deploymentWriterService, deploymentSettingRepository } = setup();
+
+    await handler.handle(aPayload());
+
+    expect(deploymentWriterService.close).toHaveBeenCalledWith(expect.objectContaining({ address: OWNER }), DSEQ);
+    expect(deploymentSettingRepository.markClosed).toHaveBeenCalledWith({ userId: USER_ID, dseq: DSEQ });
+  });
+
+  it("tells the owner which host went dark and for how long", async () => {
+    vi.useFakeTimers({ now: new Date(NOW) });
+    const { handler, jobQueueService } = setup();
+
+    await handler.handle(aPayload());
+
+    expect(jobQueueService.enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          template: "providerUnreachableClosed",
+          userId: USER_ID,
+          vars: expect.objectContaining({ dseq: DSEQ, hostUri: HOST_URI, downForDays: DAYS_DOWN, redeployUrl: `${DEPLOY_WEB_BASE_URL}/new-deployment` })
+        })
+      }),
+      { singletonKey: `notification.providerUnreachableClosed.${DSEQ}.${WALLET_ID}` }
+    );
+  });
+
+  it("records the close and queues the email in one transaction", async () => {
+    const { handler, txService } = setup();
+
+    await handler.handle(aPayload());
+
+    expect(txService.transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves a self-custody deployment alone", async () => {
+    const { handler, deploymentWriterService } = setup({ wallet: null });
+
+    await handler.handle(aPayload());
+
+    expect(deploymentWriterService.close).not.toHaveBeenCalled();
+  });
+
+  it("skips a deployment already recorded as closed", async () => {
+    const { handler, deploymentWriterService, closeJobService } = setup({ setting: mock<DeploymentSettingsOutput>({ closed: true }) });
+
+    await handler.handle(aPayload());
+
+    expect(deploymentWriterService.close).not.toHaveBeenCalled();
+    expect(closeJobService.findStillDarkDeployment).not.toHaveBeenCalled();
+  });
+
+  it("closes nothing once a provider hosting the deployment answers again", async () => {
+    const { handler, deploymentWriterService, deploymentSettingRepository, jobQueueService } = setup({ stillDark: null });
+
+    await handler.handle(aPayload());
+
+    expect(deploymentWriterService.close).not.toHaveBeenCalled();
+    expect(deploymentSettingRepository.markClosed).not.toHaveBeenCalled();
+    expect(jobQueueService.enqueue).not.toHaveBeenCalled();
+  });
+
+  it("tries again later when the chain will not settle the escrow yet", async () => {
+    const { handler, closeJobService, deploymentSettingRepository, jobQueueService } = setup({
+      closeError: new Error("escrow not settled"),
+      isUnsettleable: true
+    });
+
+    await handler.handle(aPayload());
+
+    expect(closeJobService.schedule).toHaveBeenCalledWith({ owner: OWNER, dseq: DSEQ }, { startAfter: expect.any(Date) });
+    expect(deploymentSettingRepository.markClosed).not.toHaveBeenCalled();
+    expect(jobQueueService.enqueue).not.toHaveBeenCalled();
+  });
+
+  it("throws any other close failure so the queue retries it", async () => {
+    const { handler, closeJobService } = setup({ closeError: new Error("broadcast failed") });
+
+    await expect(handler.handle(aPayload())).rejects.toThrow("broadcast failed");
+    expect(closeJobService.schedule).not.toHaveBeenCalled();
+  });
+
+  it("records a close that had already happened on chain without telling the owner about it", async () => {
+    const { handler, deploymentSettingRepository, jobQueueService } = setup({ alreadyClosedOnChain: true });
+
+    await handler.handle(aPayload());
+
+    expect(deploymentSettingRepository.markClosed).toHaveBeenCalledWith({ userId: USER_ID, dseq: DSEQ });
+    expect(jobQueueService.enqueue).not.toHaveBeenCalled();
+  });
+
+  it("throws when recording the close fails so the queue retries it", async () => {
+    const { handler, deploymentSettingRepository } = setup();
+    deploymentSettingRepository.markClosed.mockRejectedValue(new Error("connection terminated"));
+
+    await expect(handler.handle(aPayload())).rejects.toThrow("connection terminated");
+  });
+
+  function aPayload(): JobPayload<CloseUnreachableProviderDeploymentCommand> {
+    return { owner: OWNER, dseq: DSEQ, version: 1 };
+  }
+
+  function setup(
+    input: {
+      wallet?: null;
+      setting?: DeploymentSettingsOutput;
+      stillDark?: DarkDeployment | null;
+      closeError?: Error;
+      isUnsettleable?: boolean;
+      alreadyClosedOnChain?: boolean;
+    } = {}
+  ) {
+    const userWalletRepository = mock<UserWalletRepository>();
+    userWalletRepository.findOneByAddress.mockResolvedValue(
+      input.wallet === null ? undefined : createUserWallet({ id: WALLET_ID, userId: USER_ID, address: OWNER })
+    );
+
+    const deploymentSettingRepository = mock<DeploymentSettingRepository>();
+    deploymentSettingRepository.findOneBy.mockResolvedValue(input.setting);
+
+    const deploymentWriterService = mock<DeploymentWriterService>();
+    if (input.closeError) {
+      deploymentWriterService.close.mockRejectedValue(input.closeError);
+    } else {
+      deploymentWriterService.close.mockResolvedValue(!input.alreadyClosedOnChain);
+    }
+
+    const closeJobService = mock<UnreachableProviderDeploymentsCloserService>();
+    closeJobService.findStillDarkDeployment.mockResolvedValue(
+      input.stillDark === undefined ? { owner: OWNER, dseq: DSEQ, hostUri: HOST_URI, downSince: DOWN_SINCE } : input.stillDark
+    );
+
+    const chainErrorService = mock<ChainErrorService>();
+    chainErrorService.isUnsettleableDeploymentError.mockReturnValue(input.isUnsettleable ?? false);
+
+    const jobQueueService = mock<JobQueueService>();
+    jobQueueService.enqueue.mockResolvedValue("job-id");
+
+    const txService = mock<TxService>();
+    txService.transaction.mockImplementation(async callback => await callback());
+
+    const config = mockConfigService<DeploymentConfigService>({ DEPLOY_WEB_BASE_URL });
+    const logger = mock<ReturnType<CreateLogger>>();
+    const createLogger = vi.fn<CreateLogger>(() => logger);
+
+    const handler = new CloseUnreachableProviderDeploymentHandler(
+      userWalletRepository,
+      deploymentSettingRepository,
+      deploymentWriterService,
+      closeJobService,
+      chainErrorService,
+      jobQueueService,
+      txService,
+      config,
+      createLogger
+    );
+
+    return {
+      handler,
+      userWalletRepository,
+      deploymentSettingRepository,
+      deploymentWriterService,
+      closeJobService,
+      chainErrorService,
+      jobQueueService,
+      txService,
+      logger
+    };
+  }
+});

--- a/apps/api/src/app/services/close-unreachable-provider-deployment/close-unreachable-provider-deployment.handler.spec.ts
+++ b/apps/api/src/app/services/close-unreachable-provider-deployment/close-unreachable-provider-deployment.handler.spec.ts
@@ -113,12 +113,21 @@ describe(CloseUnreachableProviderDeploymentHandler.name, () => {
     expect(closeJobService.schedule).not.toHaveBeenCalled();
   });
 
-  it("records a close that had already happened on chain without telling the owner about it", async () => {
+  it("still tells the owner when the close had already landed on chain, since a retry of its own broadcast looks the same", async () => {
     const { handler, deploymentSettingRepository, jobQueueService } = setup({ alreadyClosedOnChain: true });
 
     await handler.handle(aPayload());
 
     expect(deploymentSettingRepository.markClosed).toHaveBeenCalledWith({ userId: USER_ID, dseq: DSEQ });
+    expect(jobQueueService.enqueue).toHaveBeenCalledTimes(1);
+  });
+
+  it("queues the email in the same transaction as the record, so neither can land without the other", async () => {
+    const { handler, deploymentSettingRepository, jobQueueService, txService } = setup();
+    txService.transaction.mockRejectedValue(new Error("deadlock detected"));
+
+    await expect(handler.handle(aPayload())).rejects.toThrow("deadlock detected");
+    expect(deploymentSettingRepository.markClosed).not.toHaveBeenCalled();
     expect(jobQueueService.enqueue).not.toHaveBeenCalled();
   });
 

--- a/apps/api/src/app/services/close-unreachable-provider-deployment/close-unreachable-provider-deployment.handler.ts
+++ b/apps/api/src/app/services/close-unreachable-provider-deployment/close-unreachable-provider-deployment.handler.ts
@@ -1,0 +1,134 @@
+import { differenceInDays, minutesToMilliseconds } from "date-fns";
+import { inject, singleton } from "tsyringe";
+
+import { UserWalletRepository } from "@src/billing/repositories";
+import { ChainErrorService } from "@src/billing/services/chain-error/chain-error.service";
+import { type CreateLogger, type JobHandler, type JobPayload, JobQueueService, LOGGER_FACTORY } from "@src/core";
+import { TxService } from "@src/core/services/tx/tx.service";
+import { CloseUnreachableProviderDeploymentCommand } from "@src/deployment/commands/close-unreachable-provider-deployment.command";
+import type { DarkDeployment } from "@src/deployment/lib/dark-deployment/dark-deployment";
+import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import { DeploymentConfigService } from "@src/deployment/services/deployment-config/deployment-config.service";
+import { DeploymentWriterService } from "@src/deployment/services/deployment-writer/deployment-writer.service";
+import {
+  type CloseUnreachableProviderDeploymentTarget,
+  UnreachableProviderDeploymentsCloserService
+} from "@src/deployment/services/unreachable-provider-deployments-closer/unreachable-provider-deployments-closer.service";
+import { NotificationJob } from "@src/notifications/services/notification-handler/notification.handler";
+
+/** How long a close the chain is not ready to settle waits before it is tried again. */
+const RETRY_DELAY_MS = minutesToMilliseconds(15);
+
+/** The job carries only the deployment's identity, so one that waited out a long escrow retry decides on what is true when it runs. */
+@singleton()
+export class CloseUnreachableProviderDeploymentHandler implements JobHandler<CloseUnreachableProviderDeploymentCommand> {
+  public readonly accepts = CloseUnreachableProviderDeploymentCommand;
+
+  public readonly concurrency = 2;
+
+  /** The per-deployment singletonKey plus this policy keeps a duplicate from broadcasting a close concurrently with the job it duplicates. */
+  public readonly policy = "singleton";
+
+  private readonly logger: ReturnType<CreateLogger>;
+
+  constructor(
+    private readonly userWalletRepository: UserWalletRepository,
+    private readonly deploymentSettingRepository: DeploymentSettingRepository,
+    private readonly deploymentWriterService: DeploymentWriterService,
+    private readonly closeJobService: UnreachableProviderDeploymentsCloserService,
+    private readonly chainErrorService: ChainErrorService,
+    private readonly jobQueueService: JobQueueService,
+    private readonly txService: TxService,
+    private readonly config: DeploymentConfigService,
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
+  ) {
+    this.logger = createLogger({ context: CloseUnreachableProviderDeploymentHandler.name });
+  }
+
+  async handle(payload: JobPayload<CloseUnreachableProviderDeploymentCommand>): Promise<void> {
+    const { owner, dseq } = payload;
+
+    const wallet = await this.userWalletRepository.findOneByAddress(owner);
+
+    if (!wallet?.address) {
+      this.logger.debug({ event: "UNREACHABLE_PROVIDER_DEPLOYMENT_CLOSE_SKIPPED", reason: "NOT_A_MANAGED_WALLET", dseq, owner });
+      return;
+    }
+
+    const setting = await this.deploymentSettingRepository.findOneBy({ userId: wallet.userId, dseq });
+
+    if (setting?.closed) {
+      this.logger.debug({ event: "UNREACHABLE_PROVIDER_DEPLOYMENT_CLOSE_SKIPPED", reason: "ALREADY_CLOSED", dseq, owner });
+      return;
+    }
+
+    const deployment = await this.closeJobService.findStillDarkDeployment({ owner, dseq });
+
+    if (!deployment) {
+      this.logger.info({ event: "UNREACHABLE_PROVIDER_DEPLOYMENT_CLOSE_SKIPPED", reason: "NO_LONGER_FULLY_DARK", dseq, owner });
+      return;
+    }
+
+    let closedByUs: boolean;
+
+    try {
+      closedByUs = await this.deploymentWriterService.close({ ...wallet, address: wallet.address }, dseq);
+    } catch (error) {
+      if (error instanceof Error && this.chainErrorService.isUnsettleableDeploymentError(error)) {
+        this.logger.warn({
+          event: "UNREACHABLE_PROVIDER_DEPLOYMENT_UNSETTLEABLE",
+          reason: "Deployment escrow cannot be settled yet; chain rejects close until it settles",
+          dseq,
+          owner
+        });
+        await this.#retryLater({ owner, dseq });
+        return;
+      }
+      throw error;
+    }
+
+    await this.#recordAndNotify(deployment, wallet, closedByUs);
+
+    if (!closedByUs) {
+      this.logger.debug({ event: "UNREACHABLE_PROVIDER_DEPLOYMENT_CLOSE_SKIPPED", reason: "ALREADY_CLOSED_ON_CHAIN", dseq, owner });
+      return;
+    }
+
+    this.logger.info({
+      event: "UNREACHABLE_PROVIDER_DEPLOYMENT_CLOSED",
+      dseq,
+      owner,
+      hostUri: deployment.hostUri,
+      downSince: deployment.downSince
+    });
+  }
+
+  /** One transaction, so a deployment is never recorded as closed without the email explaining it queued alongside. */
+  async #recordAndNotify(deployment: DarkDeployment, wallet: { id: number; userId: string }, closedByUs: boolean): Promise<void> {
+    await this.txService.transaction(async () => {
+      await this.deploymentSettingRepository.markClosed({ userId: wallet.userId, dseq: deployment.dseq });
+
+      if (!closedByUs) return;
+
+      await this.jobQueueService.enqueue(
+        new NotificationJob({
+          template: "providerUnreachableClosed",
+          userId: wallet.userId,
+          vars: {
+            dseq: deployment.dseq,
+            owner: deployment.owner,
+            hostUri: deployment.hostUri,
+            downForDays: differenceInDays(new Date(), new Date(deployment.downSince)),
+            redeployUrl: `${this.config.get("DEPLOY_WEB_BASE_URL")}/new-deployment`
+          }
+        }),
+        { singletonKey: `notification.providerUnreachableClosed.${deployment.dseq}.${wallet.id}` }
+      );
+    });
+  }
+
+  /** A fresh job rather than a throw, so an escrow the chain will not settle keeps retrying past the queue's retry budget. */
+  async #retryLater(target: CloseUnreachableProviderDeploymentTarget): Promise<void> {
+    await this.closeJobService.schedule(target, { startAfter: new Date(Date.now() + RETRY_DELAY_MS) });
+  }
+}

--- a/apps/api/src/app/services/close-unreachable-provider-deployment/close-unreachable-provider-deployment.handler.ts
+++ b/apps/api/src/app/services/close-unreachable-provider-deployment/close-unreachable-provider-deployment.handler.ts
@@ -19,7 +19,7 @@ import { NotificationJob } from "@src/notifications/services/notification-handle
 /** How long a close the chain is not ready to settle waits before it is tried again. */
 const RETRY_DELAY_MS = minutesToMilliseconds(15);
 
-/** The job carries only the deployment's identity, so one that waited out a long escrow retry decides on what is true when it runs. */
+/** Whether the deployment is still ours to close is re-read here, so a job that waited out a long escrow retry decides on what is true when it runs. */
 @singleton()
 export class CloseUnreachableProviderDeploymentHandler implements JobHandler<CloseUnreachableProviderDeploymentCommand> {
   public readonly accepts = CloseUnreachableProviderDeploymentCommand;
@@ -87,11 +87,10 @@ export class CloseUnreachableProviderDeploymentHandler implements JobHandler<Clo
       throw error;
     }
 
-    await this.#recordAndNotify(deployment, wallet, closedByUs);
+    await this.#recordAndNotify(deployment, wallet);
 
     if (!closedByUs) {
-      this.logger.debug({ event: "UNREACHABLE_PROVIDER_DEPLOYMENT_CLOSE_SKIPPED", reason: "ALREADY_CLOSED_ON_CHAIN", dseq, owner });
-      return;
+      this.logger.info({ event: "UNREACHABLE_PROVIDER_DEPLOYMENT_CLOSE_LANDED_ELSEWHERE", dseq, owner });
     }
 
     this.logger.info({
@@ -103,12 +102,10 @@ export class CloseUnreachableProviderDeploymentHandler implements JobHandler<Clo
     });
   }
 
-  /** One transaction, so a deployment is never recorded as closed without the email explaining it queued alongside. */
-  async #recordAndNotify(deployment: DarkDeployment, wallet: { id: number; userId: string }, closedByUs: boolean): Promise<void> {
+  /** One transaction, so a deployment is never recorded as closed without the email explaining it queued alongside, and never told twice. */
+  async #recordAndNotify(deployment: DarkDeployment, wallet: { id: number; userId: string }): Promise<void> {
     await this.txService.transaction(async () => {
       await this.deploymentSettingRepository.markClosed({ userId: wallet.userId, dseq: deployment.dseq });
-
-      if (!closedByUs) return;
 
       await this.jobQueueService.enqueue(
         new NotificationJob({

--- a/apps/api/src/deployment/commands/close-unreachable-provider-deployment.command.ts
+++ b/apps/api/src/deployment/commands/close-unreachable-provider-deployment.command.ts
@@ -1,0 +1,16 @@
+import type { Job } from "@src/core";
+import { JOB_NAME } from "@src/core";
+
+export class CloseUnreachableProviderDeploymentCommand implements Job {
+  static readonly [JOB_NAME] = "CloseUnreachableProviderDeploymentCommand";
+
+  public readonly name = CloseUnreachableProviderDeploymentCommand[JOB_NAME];
+  public readonly version = 1;
+
+  constructor(
+    public readonly data: {
+      owner: string;
+      dseq: string;
+    }
+  ) {}
+}

--- a/apps/api/src/deployment/config/env.config.spec.ts
+++ b/apps/api/src/deployment/config/env.config.spec.ts
@@ -150,6 +150,27 @@ describe("deployment envSchema", () => {
       expect(!result.success && result.error.issues.some(issue => issue.path[0] === "PROVIDER_UNREACHABLE_NOTIFY_AFTER_DAYS")).toBe(true);
     });
 
+    it("defaults to closing after 14 dark days", () => {
+      const result = envSchema.safeParse(setup());
+
+      expect(result.success).toBe(true);
+      expect(result.success && result.data.PROVIDER_UNREACHABLE_CLOSE_AFTER_DAYS).toBe(14);
+    });
+
+    it("rejects closing on the same day the owner is warned", () => {
+      const result = envSchema.safeParse(setup({ PROVIDER_UNREACHABLE_NOTIFY_AFTER_DAYS: 5, PROVIDER_UNREACHABLE_CLOSE_AFTER_DAYS: 5 }));
+
+      expect(result.success).toBe(false);
+      expect(!result.success && result.error.issues[0].path).toEqual(["PROVIDER_UNREACHABLE_CLOSE_AFTER_DAYS"]);
+    });
+
+    it("rejects closing before the owner has been warned", () => {
+      const result = envSchema.safeParse(setup({ PROVIDER_UNREACHABLE_NOTIFY_AFTER_DAYS: 5, PROVIDER_UNREACHABLE_CLOSE_AFTER_DAYS: 4 }));
+
+      expect(result.success).toBe(false);
+      expect(!result.success && result.error.issues[0].path).toEqual(["PROVIDER_UNREACHABLE_CLOSE_AFTER_DAYS"]);
+    });
+
     it("rejects an unbounded freshness window, which would trust an outage record nobody maintains", () => {
       const result = envSchema.safeParse(setup({ PROVIDER_OUTAGE_FRESHNESS_WINDOW_IN_H: Infinity }));
 

--- a/apps/api/src/deployment/config/env.config.ts
+++ b/apps/api/src/deployment/config/env.config.ts
@@ -92,6 +92,8 @@ export const envSchema = z
     RUNTIME_LIMIT_WARNING_MIN_LIMIT_IN_H: z.number({ coerce: true }).positive().finite().optional().default(12),
     /** Long enough that a provider working through an outage is not announced as dead to the owners running on it. */
     PROVIDER_UNREACHABLE_NOTIFY_AFTER_DAYS: z.number({ coerce: true }).positive().finite().optional().default(3),
+    /** Must stay above the warning threshold so an owner is always told before anything of theirs is closed. */
+    PROVIDER_UNREACHABLE_CLOSE_AFTER_DAYS: z.number({ coerce: true }).positive().finite().optional().default(14),
     /** An outage the inventory has not re-checked within this window describes the past, not the present, so the sweeps refuse it. */
     PROVIDER_OUTAGE_FRESHNESS_WINDOW_IN_H: z.number({ coerce: true }).positive().finite().optional().default(3),
     /** Base URL of the provider inventory service, which owns the record of who is currently unreachable. */
@@ -112,6 +114,14 @@ export const envSchema = z
         code: z.ZodIssueCode.custom,
         path: ["RUNTIME_LIMIT_WARNING_MIN_LIMIT_IN_H"],
         message: `RUNTIME_LIMIT_WARNING_MIN_LIMIT_IN_H (${env.RUNTIME_LIMIT_WARNING_MIN_LIMIT_IN_H}) must be at least twice RUNTIME_LIMIT_WARNING_LEAD_IN_H (${env.RUNTIME_LIMIT_WARNING_LEAD_IN_H}), otherwise the shortest warned limit is warned about almost as soon as it is set`
+      });
+    }
+
+    if (env.PROVIDER_UNREACHABLE_CLOSE_AFTER_DAYS <= env.PROVIDER_UNREACHABLE_NOTIFY_AFTER_DAYS) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["PROVIDER_UNREACHABLE_CLOSE_AFTER_DAYS"],
+        message: `PROVIDER_UNREACHABLE_CLOSE_AFTER_DAYS (${env.PROVIDER_UNREACHABLE_CLOSE_AFTER_DAYS}) must be greater than PROVIDER_UNREACHABLE_NOTIFY_AFTER_DAYS (${env.PROVIDER_UNREACHABLE_NOTIFY_AFTER_DAYS}), otherwise a deployment can be closed before its owner has been warned`
       });
     }
 

--- a/apps/api/src/deployment/controllers/deployment/top-up-deployments.controller.spec.ts
+++ b/apps/api/src/deployment/controllers/deployment/top-up-deployments.controller.spec.ts
@@ -5,6 +5,7 @@ import type { DeploymentCloseJobService } from "@src/deployment/services/deploym
 import type { ExpiringDeploymentsNotifierService } from "@src/deployment/services/expiring-deployments-notifier/expiring-deployments-notifier.service";
 import type { StaleManagedDeploymentsCleanerService } from "@src/deployment/services/stale-managed-deployments-cleaner/stale-managed-deployments-cleaner.service";
 import type { TopUpManagedDeploymentsService } from "@src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service";
+import type { UnreachableProviderDeploymentsCloserService } from "@src/deployment/services/unreachable-provider-deployments-closer/unreachable-provider-deployments-closer.service";
 import type { UnreachableProviderDeploymentsNotifierService } from "@src/deployment/services/unreachable-provider-deployments-notifier/unreachable-provider-deployments-notifier.service";
 import { TopUpDeploymentsController } from "./top-up-deployments.controller";
 
@@ -76,18 +77,31 @@ describe(TopUpDeploymentsController.name, () => {
     });
   });
 
+  describe("closeUnreachableProviderDeployments", () => {
+    it("delegates to the service that closes deployments left on unreachable providers", async () => {
+      const { controller, unreachableProviderDeploymentsCloserService } = setup();
+      const options = { dryRun: false };
+
+      await controller.closeUnreachableProviderDeployments(options);
+
+      expect(unreachableProviderDeploymentsCloserService.closeUnreachableProviderDeployments).toHaveBeenCalledWith(options);
+    });
+  });
+
   function setup() {
     const topUpManagedDeploymentsService = mock<TopUpManagedDeploymentsService>();
     const staleDeploymentsCleanerService = mock<StaleManagedDeploymentsCleanerService>();
     const deploymentCloseJobService = mock<DeploymentCloseJobService>();
     const expiringDeploymentsNotifierService = mock<ExpiringDeploymentsNotifierService>();
     const unreachableProviderDeploymentsNotifierService = mock<UnreachableProviderDeploymentsNotifierService>();
+    const unreachableProviderDeploymentsCloserService = mock<UnreachableProviderDeploymentsCloserService>();
     const controller = new TopUpDeploymentsController(
       topUpManagedDeploymentsService,
       staleDeploymentsCleanerService,
       deploymentCloseJobService,
       expiringDeploymentsNotifierService,
-      unreachableProviderDeploymentsNotifierService
+      unreachableProviderDeploymentsNotifierService,
+      unreachableProviderDeploymentsCloserService
     );
 
     return {
@@ -96,7 +110,8 @@ describe(TopUpDeploymentsController.name, () => {
       staleDeploymentsCleanerService,
       deploymentCloseJobService,
       expiringDeploymentsNotifierService,
-      unreachableProviderDeploymentsNotifierService
+      unreachableProviderDeploymentsNotifierService,
+      unreachableProviderDeploymentsCloserService
     };
   }
 });

--- a/apps/api/src/deployment/controllers/deployment/top-up-deployments.controller.ts
+++ b/apps/api/src/deployment/controllers/deployment/top-up-deployments.controller.ts
@@ -5,6 +5,7 @@ import { DeploymentCloseJobService } from "@src/deployment/services/deployment-c
 import { ExpiringDeploymentsNotifierService } from "@src/deployment/services/expiring-deployments-notifier/expiring-deployments-notifier.service";
 import { StaleManagedDeploymentsCleanerService } from "@src/deployment/services/stale-managed-deployments-cleaner/stale-managed-deployments-cleaner.service";
 import { TopUpManagedDeploymentsService } from "@src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service";
+import { UnreachableProviderDeploymentsCloserService } from "@src/deployment/services/unreachable-provider-deployments-closer/unreachable-provider-deployments-closer.service";
 import { UnreachableProviderDeploymentsNotifierService } from "@src/deployment/services/unreachable-provider-deployments-notifier/unreachable-provider-deployments-notifier.service";
 import { CleanUpStaleDeploymentsParams } from "@src/deployment/types/state-deployments";
 
@@ -15,7 +16,8 @@ export class TopUpDeploymentsController {
     private readonly staleDeploymentsCleanerService: StaleManagedDeploymentsCleanerService,
     private readonly deploymentCloseJobService: DeploymentCloseJobService,
     private readonly expiringDeploymentsNotifierService: ExpiringDeploymentsNotifierService,
-    private readonly unreachableProviderDeploymentsNotifierService: UnreachableProviderDeploymentsNotifierService
+    private readonly unreachableProviderDeploymentsNotifierService: UnreachableProviderDeploymentsNotifierService,
+    private readonly unreachableProviderDeploymentsCloserService: UnreachableProviderDeploymentsCloserService
   ) {}
 
   /** The reconcile goes first because it only needs the database, so a chain-RPC failure in the sweep cannot skip it for the hour. */
@@ -34,5 +36,9 @@ export class TopUpDeploymentsController {
 
   async notifyUnreachableProviderDeployments(options: DryRunOptions) {
     return await this.unreachableProviderDeploymentsNotifierService.notifyUnreachableProviderDeployments(options);
+  }
+
+  async closeUnreachableProviderDeployments(options: DryRunOptions) {
+    return await this.unreachableProviderDeploymentsCloserService.closeUnreachableProviderDeployments(options);
   }
 }

--- a/apps/api/src/deployment/lib/dark-deployment/dark-deployment.spec.ts
+++ b/apps/api/src/deployment/lib/dark-deployment/dark-deployment.spec.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import type { ActiveLeaseOnProvider } from "@src/deployment/repositories/lease/lease.repository";
+import type { ProviderOutage } from "@src/deployment/services/provider-outages-http/provider-outages-http.service";
+import { resolveFullyDarkDeployment } from "./dark-deployment";
+
+const OWNER = "akash1owner";
+const DSEQ = "1784768430632";
+const DARK_PROVIDER = "akash1dark";
+const DARKER_PROVIDER = "akash1darker";
+const HEALTHY_PROVIDER = "akash1healthy";
+const DOWN_SINCE = "2026-07-24T00:00:00.000Z";
+const LONGER_OUTAGE_SINCE = "2026-07-01T00:00:00.000Z";
+
+describe("resolveFullyDarkDeployment", () => {
+  it("resolves a deployment whose only lease sits on an unreachable provider", () => {
+    const result = resolveFullyDarkDeployment([aLease({})], outageMap([anOutage({})]));
+
+    expect(result).toEqual({ owner: OWNER, dseq: DSEQ, hostUri: "https://dark:8443", downSince: DOWN_SINCE });
+  });
+
+  it("resolves nothing while one lease still sits on a provider that answers", () => {
+    const result = resolveFullyDarkDeployment([aLease({}), aLease({ providerAddress: HEALTHY_PROVIDER })], outageMap([anOutage({})]));
+
+    expect(result).toBeNull();
+  });
+
+  it("resolves nothing for a deployment with no active leases left", () => {
+    const result = resolveFullyDarkDeployment([], outageMap([anOutage({})]));
+
+    expect(result).toBeNull();
+  });
+
+  it("names the host down longest and pairs it with that same host's outage start", () => {
+    const leases = [aLease({}), aLease({ providerAddress: DARKER_PROVIDER })];
+    const outages = outageMap([anOutage({}), anOutage({ provider: DARKER_PROVIDER, hostUri: "https://darker:8443", startedAt: LONGER_OUTAGE_SINCE })]);
+
+    const result = resolveFullyDarkDeployment(leases, outages);
+
+    expect(result).toEqual({ owner: OWNER, dseq: DSEQ, hostUri: "https://darker:8443", downSince: LONGER_OUTAGE_SINCE });
+  });
+
+  it("names the host down longest regardless of the order the leases arrive in", () => {
+    const leases = [aLease({ providerAddress: DARKER_PROVIDER }), aLease({})];
+    const outages = outageMap([anOutage({}), anOutage({ provider: DARKER_PROVIDER, hostUri: "https://darker:8443", startedAt: LONGER_OUTAGE_SINCE })]);
+
+    const result = resolveFullyDarkDeployment(leases, outages);
+
+    expect(result?.hostUri).toBe("https://darker:8443");
+    expect(result?.downSince).toBe(LONGER_OUTAGE_SINCE);
+  });
+});
+
+function outageMap(outages: ProviderOutage[]): Map<string, ProviderOutage> {
+  return new Map(outages.map(outage => [outage.provider, outage]));
+}
+
+function anOutage(overrides: Partial<ProviderOutage>): ProviderOutage {
+  return {
+    provider: overrides.provider ?? DARK_PROVIDER,
+    hostUri: overrides.hostUri ?? "https://dark:8443",
+    startedAt: overrides.startedAt ?? DOWN_SINCE
+  };
+}
+
+function aLease(overrides: Partial<ActiveLeaseOnProvider>): ActiveLeaseOnProvider {
+  return {
+    owner: overrides.owner ?? OWNER,
+    dseq: overrides.dseq ?? DSEQ,
+    providerAddress: overrides.providerAddress ?? DARK_PROVIDER
+  };
+}

--- a/apps/api/src/deployment/lib/dark-deployment/dark-deployment.ts
+++ b/apps/api/src/deployment/lib/dark-deployment/dark-deployment.ts
@@ -1,0 +1,27 @@
+import type { ActiveLeaseOnProvider } from "@src/deployment/repositories/lease/lease.repository";
+import type { ProviderOutage } from "@src/deployment/services/provider-outages-http/provider-outages-http.service";
+
+export interface DarkDeployment {
+  owner: string;
+  dseq: string;
+  hostUri: string;
+  downSince: string;
+}
+
+/** The host named is the one down longest, so the outage age reported beside it belongs to that same host. */
+export function resolveFullyDarkDeployment(leases: ActiveLeaseOnProvider[], outageByProvider: Map<string, ProviderOutage>): DarkDeployment | null {
+  if (leases.length === 0) return null;
+
+  const outages: ProviderOutage[] = [];
+
+  for (const lease of leases) {
+    const outage = outageByProvider.get(lease.providerAddress);
+    if (!outage) return null;
+    outages.push(outage);
+  }
+
+  const [{ owner, dseq }] = leases;
+  const longestOutage = outages.reduce((longest, outage) => (outage.startedAt < longest.startedAt ? outage : longest));
+
+  return { owner, dseq, hostUri: longestOutage.hostUri, downSince: longestOutage.startedAt };
+}

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
@@ -398,6 +398,28 @@ describe(DeploymentSettingRepository.name, () => {
     });
   });
 
+  describe("markClosed", () => {
+    it("records a deployment that had no settings row as closed, without turning funding on", async () => {
+      const { deploymentSettingRepository, user } = await setup();
+      const dseq = newDseq();
+
+      await deploymentSettingRepository.markClosed({ userId: user.id, dseq });
+
+      const setting = await deploymentSettingRepository.findOneBy({ userId: user.id, dseq });
+      expect(setting).toMatchObject({ closed: true, autoTopUpEnabled: false });
+    });
+
+    it("closes an existing row without disturbing its funding setting", async () => {
+      const { deploymentSettingRepository, user, createLimitedSetting } = await setup();
+      const setting = await createLimitedSetting(24, { autoTopUpEnabled: true });
+
+      await deploymentSettingRepository.markClosed({ userId: user.id, dseq: setting.dseq });
+
+      const updated = await deploymentSettingRepository.findOneBy({ userId: user.id, dseq: setting.dseq });
+      expect(updated).toMatchObject({ closed: true, autoTopUpEnabled: true });
+    });
+  });
+
   describe("upsertDefinition", () => {
     it("records the sdl and the manifest version of a deployment with no row yet", async () => {
       const { deploymentSettingRepository, user } = await setup();

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -451,6 +451,22 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
       );
   }
 
+  /**
+   * Records that a deployment is closed, creating the row when the deployment has none — a deployment
+   * created before settings existed, or outside the web app, still has to be remembered as closed or
+   * every later sweep would try to close it again. Such a row is written with funding off, since a
+   * closed deployment has nothing to fund.
+   */
+  async markClosed({ userId, dseq }: { userId: string; dseq: string }): Promise<void> {
+    await this.cursor
+      .insert(this.table)
+      .values({ userId, dseq, autoTopUpEnabled: false, closed: true })
+      .onConflictDoUpdate({
+        target: [this.table.dseq, this.table.userId],
+        set: { closed: true, updatedAt: sql`now()` }
+      });
+  }
+
   protected toInput(payload: Partial<DeploymentSettingsInput>): Partial<DeploymentSettingsInput> {
     if (!payload.updatedAt) {
       payload.updatedAt = new Date();

--- a/apps/api/src/deployment/repositories/lease/lease.repository.integration.ts
+++ b/apps/api/src/deployment/repositories/lease/lease.repository.integration.ts
@@ -68,6 +68,44 @@ describe(LeaseRepository.name, () => {
     });
   });
 
+  describe("findActiveLeasesOfDeployment", () => {
+    it("returns every active lease of the deployment, dark provider or not", async () => {
+      const { repository } = setup();
+      const [darkProvider, healthyProvider] = await Promise.all([seedProvider(), seedProvider()]);
+      const deployment = await seedDeployment();
+      await seedLease(deployment, { providerAddress: darkProvider, gseq: 1 });
+      await seedLease(deployment, { providerAddress: healthyProvider, gseq: 2 });
+
+      const found = await repository.findActiveLeasesOfDeployment(deployment.owner, deployment.dseq);
+
+      expect(found.map(lease => lease.providerAddress).sort()).toEqual([darkProvider, healthyProvider].sort());
+    });
+
+    it("ignores leases that have already been closed", async () => {
+      const { repository } = setup();
+      const darkProvider = await seedProvider();
+      const deployment = await seedDeployment();
+      await seedLease(deployment, { providerAddress: darkProvider, closedHeight: 10_000 });
+
+      const found = await repository.findActiveLeasesOfDeployment(deployment.owner, deployment.dseq);
+
+      expect(found).toEqual([]);
+    });
+
+    it("leaves out the leases of other deployments the owner holds", async () => {
+      const { repository } = setup();
+      const darkProvider = await seedProvider();
+      const deployment = await seedDeployment();
+      const otherDeployment = await seedDeployment();
+      await seedLease(deployment, { providerAddress: darkProvider });
+      await seedLease(otherDeployment, { providerAddress: darkProvider });
+
+      const found = await repository.findActiveLeasesOfDeployment(deployment.owner, deployment.dseq);
+
+      expect(found).toEqual([{ owner: deployment.owner, dseq: deployment.dseq, providerAddress: darkProvider }]);
+    });
+  });
+
   function setup() {
     return { repository: container.resolve(LeaseRepository) };
   }

--- a/apps/api/src/deployment/repositories/lease/lease.repository.ts
+++ b/apps/api/src/deployment/repositories/lease/lease.repository.ts
@@ -61,6 +61,19 @@ export class LeaseRepository implements DrainingDeploymentLeaseSource {
     );
   }
 
+  /** Every active lease of a single deployment, so a close can re-check that all of them are still dark before it broadcasts. */
+  async findActiveLeasesOfDeployment(owner: string, dseq: string): Promise<ActiveLeaseOnProvider[]> {
+    return await this.#chainDb.query<ActiveLeaseOnProvider>(
+      `/* lease:activeOfDeployment */
+      SELECT l."owner", l."dseq"::text AS "dseq", l."providerAddress"
+      FROM lease l
+      WHERE l."closedHeight" IS NULL
+        AND l."owner" = :owner
+        AND l."dseq" = :dseq`,
+      { type: QueryTypes.SELECT, replacements: { owner, dseq } }
+    );
+  }
+
   async findOneByDseqAndOwner(dseq: string, owner: string): Promise<DrainingDeploymentOutput | null> {
     const leases = await Lease.findAll({
       where: { dseq, owner },

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -549,7 +549,7 @@ describe(DeploymentWriterService.name, () => {
       const closeMsg = { typeUrl: "/close", value: MsgCloseDeployment.fromPartial({}) };
       rpcMessageService.getCloseDeploymentMsg.mockReturnValue(closeMsg);
 
-      await service.close(wallet, "100");
+      await expect(service.close(wallet, "100")).resolves.toBe(true);
 
       expect(rpcMessageService.getCloseDeploymentMsg).toHaveBeenCalledWith(wallet.address, "100");
       expect(signerService.executeDecodedTxByUserWallet).toHaveBeenCalledWith(wallet, [closeMsg]);
@@ -562,20 +562,20 @@ describe(DeploymentWriterService.name, () => {
         deployment: { ...deploymentData.deployment, state: "closed" }
       });
 
-      await service.close(wallet, "100");
+      await expect(service.close(wallet, "100")).resolves.toBe(false);
 
       expect(rpcMessageService.getCloseDeploymentMsg).not.toHaveBeenCalled();
       expect(signerService.executeDecodedTxByUserWallet).not.toHaveBeenCalled();
     });
 
-    it("treats a failed close tx as success when a re-read shows the deployment already closed", async () => {
+    it("reports a close it did not make when a re-read shows the deployment already closed", async () => {
       const { service, signerService, deploymentReaderService } = setup();
       signerService.executeDecodedTxByUserWallet.mockRejectedValue(new Error("deployment already closed"));
       deploymentReaderService.findByWalletAndDseq
         .mockResolvedValueOnce(deploymentData)
         .mockResolvedValueOnce({ ...deploymentData, deployment: { ...deploymentData.deployment, state: "closed" } });
 
-      await expect(service.close(wallet, "100")).resolves.toBeUndefined();
+      await expect(service.close(wallet, "100")).resolves.toBe(false);
     });
 
     it("re-throws the original close error when a re-read shows the deployment is still open", async () => {

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -205,7 +205,7 @@ export class DeploymentWriterService {
     }
   }
 
-  public async closeByUserIdAndDseq(userId: string, dseq: string): Promise<void> {
+  public async closeByUserIdAndDseq(userId: string, dseq: string): Promise<boolean> {
     const wallet = await this.walletReaderService.getWalletByUserId(userId);
     return this.close(wallet, dseq);
   }
@@ -214,19 +214,21 @@ export class DeploymentWriterService {
    * Idempotent close: an already-`closed` deployment is a no-op. The state read is a check→broadcast window, so a
    * concurrent close (a user cancel racing the cleanup cron, or two overlapping cleanup runs) can settle it between
    * the read and the broadcast; the losing tx then fails on an already-closed deployment. Re-read once on failure and
-   * treat a now-closed deployment as success, otherwise surface the original error.
+   * treat a now-closed deployment as success, otherwise surface the original error. Returns false when the
+   * deployment was already closed, so a caller can tell a close it performed from one that had already happened.
    */
-  public async close(wallet: WalletInitialized, dseq: string): Promise<void> {
+  public async close(wallet: WalletInitialized, dseq: string): Promise<boolean> {
     const deployment = await this.deploymentReaderService.findByWalletAndDseq(wallet, dseq);
-    if (deployment.deployment.state === "closed") return;
+    if (deployment.deployment.state === "closed") return false;
     const message = this.rpcMessageService.getCloseDeploymentMsg(wallet.address, deployment.deployment.id.dseq);
     try {
       await this.signerService.executeDecodedTxByUserWallet(wallet, [message]);
     } catch (error) {
       const latest = await this.deploymentReaderService.findByWalletAndDseq(wallet, dseq).catch(() => null);
-      if (latest?.deployment.state === "closed") return;
+      if (latest?.deployment.state === "closed") return false;
       throw error;
     }
+    return true;
   }
 
   public async deposit(options: { userId: string; dseq: string; amount: number }): Promise<DeploymentResponse> {

--- a/apps/api/src/deployment/services/unreachable-provider-deployments-closer/unreachable-provider-deployments-closer.service.integration.ts
+++ b/apps/api/src/deployment/services/unreachable-provider-deployments-closer/unreachable-provider-deployments-closer.service.integration.ts
@@ -1,0 +1,117 @@
+import { faker } from "@faker-js/faker";
+import { container } from "tsyringe";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { UserWalletRepository } from "@src/billing/repositories";
+import { CHAIN_DB } from "@src/chain";
+import { JobQueueService } from "@src/core";
+import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import { DeploymentWriterService } from "@src/deployment/services/deployment-writer/deployment-writer.service";
+import { UserRepository } from "@src/user/repositories";
+import { ProviderOutagesHttpService } from "../provider-outages-http/provider-outages-http.service";
+import { UnreachableProviderDeploymentsCloserService } from "./unreachable-provider-deployments-closer.service";
+
+import { createAkashAddress, createDeployment, createDeploymentGroup, createLease, createProvider } from "@test/seeders";
+
+const DOWN_SINCE = "2026-07-24T00:00:00.000Z";
+
+describe(UnreachableProviderDeploymentsCloserService.name, () => {
+  beforeAll(async () => {
+    await container.resolve(CHAIN_DB).authenticate();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("closes a fully dark deployment, records it and tells the owner", async () => {
+    const { service, close, enqueue, deploymentSettingRepository, deployment, user } = await setup();
+
+    const result = await service.closeUnreachableProviderDeployments({ dryRun: false });
+
+    expect(result.ok).toBe(true);
+    expect(close).toHaveBeenCalledWith(expect.objectContaining({ address: deployment.owner }), deployment.dseq);
+    expect(enqueue).toHaveBeenCalledTimes(1);
+    const setting = await deploymentSettingRepository.findOneBy({ userId: user.id, dseq: deployment.dseq });
+    expect(setting?.closed).toBe(true);
+  });
+
+  it("leaves the deployment alone on a second sweep", async () => {
+    const { service, close } = await setup();
+
+    await service.closeUnreachableProviderDeployments({ dryRun: false });
+    await service.closeUnreachableProviderDeployments({ dryRun: false });
+
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves a deployment with a surviving lease on a healthy provider alone", async () => {
+    const { service, close } = await setup({ alsoOnHealthyProvider: true });
+
+    await service.closeUnreachableProviderDeployments({ dryRun: false });
+
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  it("writes nothing on a dry run", async () => {
+    const { service, close, enqueue, deploymentSettingRepository, deployment, user } = await setup();
+
+    await service.closeUnreachableProviderDeployments({ dryRun: true });
+
+    expect(close).not.toHaveBeenCalled();
+    expect(enqueue).not.toHaveBeenCalled();
+    expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq: deployment.dseq })).toBeUndefined();
+  });
+
+  async function setup(input: { alsoOnHealthyProvider?: boolean } = {}) {
+    const userRepository = container.resolve(UserRepository);
+    const userWalletRepository = container.resolve(UserWalletRepository);
+    const deploymentSettingRepository = container.resolve(DeploymentSettingRepository);
+
+    const owner = createAkashAddress();
+    const user = await userRepository.create({ userId: faker.string.uuid(), email: "owner@example.com" });
+    const { wallet } = await userWalletRepository.getOrCreate({ userId: user.id });
+    await userWalletRepository.updateById(wallet.id, { address: owner });
+
+    const darkProvider = await createProvider();
+    const deployment = await createDeployment({ owner, dseq: faker.string.numeric(10) });
+    await seedLease(deployment, darkProvider.owner, 1);
+
+    if (input.alsoOnHealthyProvider) {
+      const healthyProvider = await createProvider();
+      await seedLease(deployment, healthyProvider.owner, 2);
+    }
+
+    const providerOutagesHttpService = container.resolve(ProviderOutagesHttpService);
+    vi.spyOn(providerOutagesHttpService, "findOutagesOlderThanDays").mockResolvedValue([
+      { provider: darkProvider.owner, hostUri: darkProvider.hostUri, startedAt: DOWN_SINCE }
+    ]);
+
+    const close = vi.spyOn(container.resolve(DeploymentWriterService), "close").mockResolvedValue(undefined);
+    const enqueue = vi.spyOn(container.resolve(JobQueueService), "enqueue").mockResolvedValue("job-id");
+
+    return {
+      service: container.resolve(UnreachableProviderDeploymentsCloserService),
+      deploymentSettingRepository,
+      close,
+      enqueue,
+      deployment,
+      user
+    };
+  }
+});
+
+async function seedLease(deployment: { id: string; owner: string; dseq: string }, providerAddress: string, gseq: number) {
+  const group = await createDeploymentGroup({ deploymentId: deployment.id, owner: deployment.owner, dseq: deployment.dseq, gseq });
+
+  await createLease({
+    deploymentId: deployment.id,
+    deploymentGroupId: group.id,
+    owner: deployment.owner,
+    dseq: deployment.dseq,
+    gseq,
+    oseq: 1,
+    providerAddress,
+    closedHeight: undefined
+  });
+}

--- a/apps/api/src/deployment/services/unreachable-provider-deployments-closer/unreachable-provider-deployments-closer.service.integration.ts
+++ b/apps/api/src/deployment/services/unreachable-provider-deployments-closer/unreachable-provider-deployments-closer.service.integration.ts
@@ -87,7 +87,7 @@ describe(UnreachableProviderDeploymentsCloserService.name, () => {
       { provider: darkProvider.owner, hostUri: darkProvider.hostUri, startedAt: DOWN_SINCE }
     ]);
 
-    const close = vi.spyOn(container.resolve(DeploymentWriterService), "close").mockResolvedValue(undefined);
+    const close = vi.spyOn(container.resolve(DeploymentWriterService), "close").mockResolvedValue(true);
     const enqueue = vi.spyOn(container.resolve(JobQueueService), "enqueue").mockResolvedValue("job-id");
 
     return {

--- a/apps/api/src/deployment/services/unreachable-provider-deployments-closer/unreachable-provider-deployments-closer.service.integration.ts
+++ b/apps/api/src/deployment/services/unreachable-provider-deployments-closer/unreachable-provider-deployments-closer.service.integration.ts
@@ -6,7 +6,6 @@ import { UserWalletRepository } from "@src/billing/repositories";
 import { CHAIN_DB } from "@src/chain";
 import { JobQueueService } from "@src/core";
 import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
-import { DeploymentWriterService } from "@src/deployment/services/deployment-writer/deployment-writer.service";
 import { UserRepository } from "@src/user/repositories";
 import { ProviderOutagesHttpService } from "../provider-outages-http/provider-outages-http.service";
 import { UnreachableProviderDeploymentsCloserService } from "./unreachable-provider-deployments-closer.service";
@@ -24,43 +23,41 @@ describe(UnreachableProviderDeploymentsCloserService.name, () => {
     vi.restoreAllMocks();
   });
 
-  it("closes a fully dark deployment, records it and tells the owner", async () => {
-    const { service, close, enqueue, deploymentSettingRepository, deployment, user } = await setup();
+  it("hands a fully dark deployment to its own close job", async () => {
+    const { service, enqueue, deployment } = await setup();
 
     const result = await service.closeUnreachableProviderDeployments({ dryRun: false });
 
     expect(result.ok).toBe(true);
-    expect(close).toHaveBeenCalledWith(expect.objectContaining({ address: deployment.owner }), deployment.dseq);
-    expect(enqueue).toHaveBeenCalledTimes(1);
-    const setting = await deploymentSettingRepository.findOneBy({ userId: user.id, dseq: deployment.dseq });
-    expect(setting?.closed).toBe(true);
-  });
-
-  it("leaves the deployment alone on a second sweep", async () => {
-    const { service, close } = await setup();
-
-    await service.closeUnreachableProviderDeployments({ dryRun: false });
-    await service.closeUnreachableProviderDeployments({ dryRun: false });
-
-    expect(close).toHaveBeenCalledTimes(1);
+    expect(enqueue).toHaveBeenCalledWith(expect.objectContaining({ data: { owner: deployment.owner, dseq: deployment.dseq } }), {
+      singletonKey: `CloseUnreachableProviderDeploymentCommand.${deployment.owner}.${deployment.dseq}`
+    });
   });
 
   it("leaves a deployment with a surviving lease on a healthy provider alone", async () => {
-    const { service, close } = await setup({ alsoOnHealthyProvider: true });
+    const { service, enqueue } = await setup({ alsoOnHealthyProvider: true });
 
     await service.closeUnreachableProviderDeployments({ dryRun: false });
 
-    expect(close).not.toHaveBeenCalled();
+    expect(enqueue).not.toHaveBeenCalled();
   });
 
-  it("writes nothing on a dry run", async () => {
-    const { service, close, enqueue, deploymentSettingRepository, deployment, user } = await setup();
+  it("schedules nothing on a dry run", async () => {
+    const { service, enqueue, deploymentSettingRepository, deployment, user } = await setup();
 
     await service.closeUnreachableProviderDeployments({ dryRun: true });
 
-    expect(close).not.toHaveBeenCalled();
     expect(enqueue).not.toHaveBeenCalled();
     expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq: deployment.dseq })).toBeUndefined();
+  });
+
+  it("leaves a deployment already recorded as closed alone", async () => {
+    const { service, enqueue, deploymentSettingRepository, deployment, user } = await setup();
+    await deploymentSettingRepository.markClosed({ userId: user.id, dseq: deployment.dseq });
+
+    await service.closeUnreachableProviderDeployments({ dryRun: false });
+
+    expect(enqueue).not.toHaveBeenCalled();
   });
 
   async function setup(input: { alsoOnHealthyProvider?: boolean } = {}) {
@@ -87,13 +84,13 @@ describe(UnreachableProviderDeploymentsCloserService.name, () => {
       { provider: darkProvider.owner, hostUri: darkProvider.hostUri, startedAt: DOWN_SINCE }
     ]);
 
-    const close = vi.spyOn(container.resolve(DeploymentWriterService), "close").mockResolvedValue(true);
-    const enqueue = vi.spyOn(container.resolve(JobQueueService), "enqueue").mockResolvedValue("job-id");
+    const jobQueueService = container.resolve(JobQueueService);
+    const enqueue = vi.spyOn(jobQueueService, "enqueue").mockResolvedValue("job-id");
+    vi.spyOn(jobQueueService, "findPendingSingletonKeys").mockResolvedValue(new Set());
 
     return {
       service: container.resolve(UnreachableProviderDeploymentsCloserService),
       deploymentSettingRepository,
-      close,
       enqueue,
       deployment,
       user

--- a/apps/api/src/deployment/services/unreachable-provider-deployments-closer/unreachable-provider-deployments-closer.service.spec.ts
+++ b/apps/api/src/deployment/services/unreachable-provider-deployments-closer/unreachable-provider-deployments-closer.service.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { UserWalletRepository } from "@src/billing/repositories";
@@ -22,8 +22,14 @@ const OTHER_DARK_PROVIDER = "akash1darker";
 const HEALTHY_PROVIDER = "akash1healthy";
 const DOWN_SINCE = "2026-07-24T00:00:00.000Z";
 const LONGER_OUTAGE_SINCE = "2026-07-01T00:00:00.000Z";
+const NOW = "2026-07-31T00:00:00.000Z";
+const DAYS_SINCE_LONGER_OUTAGE = 30;
 
 describe(UnreachableProviderDeploymentsCloserService.name, () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("asks for outages at least the configured number of days old", async () => {
     const { service, providerOutagesHttpService } = setup({});
 
@@ -56,7 +62,8 @@ describe(UnreachableProviderDeploymentsCloserService.name, () => {
     expect(deploymentWriterService.close).not.toHaveBeenCalled();
   });
 
-  it("closes a deployment spread across several providers once all of them are dark, naming the one gone longest", async () => {
+  it("closes a deployment spread across several providers once all of them are dark, naming the one gone longest and for how long", async () => {
+    vi.useFakeTimers({ now: new Date(NOW) });
     const { service, deploymentWriterService, jobQueueService } = setup({
       outages: [anOutage({}), anOutage({ provider: OTHER_DARK_PROVIDER, hostUri: "https://darker:8443", startedAt: LONGER_OUTAGE_SINCE })],
       leases: [aLease({}), aLease({ providerAddress: OTHER_DARK_PROVIDER })]
@@ -66,7 +73,11 @@ describe(UnreachableProviderDeploymentsCloserService.name, () => {
 
     expect(deploymentWriterService.close).toHaveBeenCalledTimes(1);
     expect(jobQueueService.enqueue).toHaveBeenCalledWith(
-      expect.objectContaining({ data: expect.objectContaining({ vars: expect.objectContaining({ hostUri: "https://darker:8443" }) }) }),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          vars: expect.objectContaining({ hostUri: "https://darker:8443", downForDays: DAYS_SINCE_LONGER_OUTAGE })
+        })
+      }),
       expect.anything()
     );
   });

--- a/apps/api/src/deployment/services/unreachable-provider-deployments-closer/unreachable-provider-deployments-closer.service.spec.ts
+++ b/apps/api/src/deployment/services/unreachable-provider-deployments-closer/unreachable-provider-deployments-closer.service.spec.ts
@@ -225,7 +225,7 @@ describe(UnreachableProviderDeploymentsCloserService.name, () => {
       PROVIDER_UNREACHABLE_CLOSE_AFTER_DAYS: CLOSE_AFTER_DAYS,
       DEPLOY_WEB_BASE_URL
     });
-    const createLogger = (() => mock<ReturnType<CreateLogger>>()) as unknown as CreateLogger;
+    const createLogger = vi.fn<CreateLogger>(() => mock<ReturnType<CreateLogger>>());
 
     const service = new UnreachableProviderDeploymentsCloserService(
       providerOutagesHttpService,

--- a/apps/api/src/deployment/services/unreachable-provider-deployments-closer/unreachable-provider-deployments-closer.service.spec.ts
+++ b/apps/api/src/deployment/services/unreachable-provider-deployments-closer/unreachable-provider-deployments-closer.service.spec.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { UserWalletRepository } from "@src/billing/repositories";
+import type { ChainErrorService } from "@src/billing/services/chain-error/chain-error.service";
+import type { CreateLogger, JobQueueService } from "@src/core";
+import type { DeploymentSettingRepository, DeploymentSettingsOutput } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import type { ActiveLeaseOnProvider, LeaseRepository } from "@src/deployment/repositories/lease/lease.repository";
+import type { DeploymentConfigService } from "@src/deployment/services/deployment-config/deployment-config.service";
+import type { DeploymentWriterService } from "@src/deployment/services/deployment-writer/deployment-writer.service";
+import type { ProviderOutage, ProviderOutagesHttpService } from "@src/deployment/services/provider-outages-http/provider-outages-http.service";
+import { UnreachableProviderDeploymentsCloserService } from "./unreachable-provider-deployments-closer.service";
+
+import { mockConfigService } from "@test/mocks/config-service.mock";
+
+const CLOSE_AFTER_DAYS = 14;
+const DEPLOY_WEB_BASE_URL = "https://console.akash.network";
+const OWNER = "akash1owner";
+const DSEQ = "1784768430632";
+const DARK_PROVIDER = "akash1dark";
+const OTHER_DARK_PROVIDER = "akash1darker";
+const HEALTHY_PROVIDER = "akash1healthy";
+const DOWN_SINCE = "2026-07-24T00:00:00.000Z";
+const LONGER_OUTAGE_SINCE = "2026-07-01T00:00:00.000Z";
+
+describe(UnreachableProviderDeploymentsCloserService.name, () => {
+  it("asks for outages at least the configured number of days old", async () => {
+    const { service, providerOutagesHttpService } = setup({});
+
+    await service.closeUnreachableProviderDeployments({ dryRun: false });
+
+    expect(providerOutagesHttpService.findOutagesOlderThanDays).toHaveBeenCalledWith(CLOSE_AFTER_DAYS);
+  });
+
+  it("closes a deployment whose every lease sits on an unreachable provider", async () => {
+    const { service, deploymentWriterService, deploymentSettingRepository } = setup({
+      outages: [anOutage({})],
+      leases: [aLease({})]
+    });
+
+    const result = await service.closeUnreachableProviderDeployments({ dryRun: false });
+
+    expect(result.ok).toBe(true);
+    expect(deploymentWriterService.close).toHaveBeenCalledWith(expect.objectContaining({ address: OWNER }), DSEQ);
+    expect(deploymentSettingRepository.markClosed).toHaveBeenCalledWith({ userId: "user-1", dseq: DSEQ });
+  });
+
+  it("leaves a deployment alone while one of its leases is still on a provider that answers", async () => {
+    const { service, deploymentWriterService } = setup({
+      outages: [anOutage({})],
+      leases: [aLease({}), aLease({ providerAddress: HEALTHY_PROVIDER })]
+    });
+
+    await service.closeUnreachableProviderDeployments({ dryRun: false });
+
+    expect(deploymentWriterService.close).not.toHaveBeenCalled();
+  });
+
+  it("closes a deployment spread across several providers once all of them are dark, naming the one gone longest", async () => {
+    const { service, deploymentWriterService, jobQueueService } = setup({
+      outages: [anOutage({}), anOutage({ provider: OTHER_DARK_PROVIDER, hostUri: "https://darker:8443", startedAt: LONGER_OUTAGE_SINCE })],
+      leases: [aLease({}), aLease({ providerAddress: OTHER_DARK_PROVIDER })]
+    });
+
+    await service.closeUnreachableProviderDeployments({ dryRun: false });
+
+    expect(deploymentWriterService.close).toHaveBeenCalledTimes(1);
+    expect(jobQueueService.enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ vars: expect.objectContaining({ hostUri: "https://darker:8443" }) }) }),
+      expect.anything()
+    );
+  });
+
+  it("tells the owner their deployment was closed and why", async () => {
+    const { service, jobQueueService } = setup({
+      outages: [anOutage({})],
+      leases: [aLease({})]
+    });
+
+    await service.closeUnreachableProviderDeployments({ dryRun: false });
+
+    expect(jobQueueService.enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          template: "providerUnreachableClosed",
+          userId: "user-1",
+          vars: expect.objectContaining({ dseq: DSEQ, hostUri: "https://dark:8443" })
+        })
+      }),
+      { singletonKey: `notification.providerUnreachableClosed.${DSEQ}.7` }
+    );
+  });
+
+  it("leaves self-custody deployments alone", async () => {
+    const { service, deploymentWriterService } = setup({
+      outages: [anOutage({})],
+      leases: [aLease({})],
+      wallet: null
+    });
+
+    await service.closeUnreachableProviderDeployments({ dryRun: false });
+
+    expect(deploymentWriterService.close).not.toHaveBeenCalled();
+  });
+
+  it("skips a deployment already recorded as closed", async () => {
+    const { service, deploymentWriterService } = setup({
+      outages: [anOutage({})],
+      leases: [aLease({})],
+      setting: mock<DeploymentSettingsOutput>({ closed: true })
+    });
+
+    await service.closeUnreachableProviderDeployments({ dryRun: false });
+
+    expect(deploymentWriterService.close).not.toHaveBeenCalled();
+  });
+
+  it("closes nothing on a dry run", async () => {
+    const { service, deploymentWriterService, deploymentSettingRepository, jobQueueService } = setup({
+      outages: [anOutage({})],
+      leases: [aLease({})]
+    });
+
+    await service.closeUnreachableProviderDeployments({ dryRun: true });
+
+    expect(deploymentWriterService.close).not.toHaveBeenCalled();
+    expect(deploymentSettingRepository.markClosed).not.toHaveBeenCalled();
+    expect(jobQueueService.enqueue).not.toHaveBeenCalled();
+  });
+
+  it("moves on when the chain will not settle the escrow yet", async () => {
+    const { service, deploymentWriterService, chainErrorService, deploymentSettingRepository } = setup({
+      outages: [anOutage({})],
+      leases: [aLease({})]
+    });
+    deploymentWriterService.close.mockRejectedValue(new Error("escrow not settled"));
+    chainErrorService.isUnsettleableDeploymentError.mockReturnValue(true);
+
+    const result = await service.closeUnreachableProviderDeployments({ dryRun: false });
+
+    expect(result.ok).toBe(true);
+    expect(deploymentSettingRepository.markClosed).not.toHaveBeenCalled();
+  });
+
+  it("keeps closing the other deployments after one close fails", async () => {
+    const { service, deploymentWriterService } = setup({
+      outages: [anOutage({})],
+      leases: [aLease({}), aLease({ owner: "akash1other", dseq: "999" })]
+    });
+    deploymentWriterService.close.mockRejectedValueOnce(new Error("broadcast failed"));
+
+    const result = await service.closeUnreachableProviderDeployments({ dryRun: false });
+
+    expect(deploymentWriterService.close).toHaveBeenCalledTimes(2);
+    expect(result.err).toBe(true);
+  });
+
+  it("reports a queue that refuses the closure email without undoing the close", async () => {
+    const { service, jobQueueService, deploymentSettingRepository } = setup({
+      outages: [anOutage({})],
+      leases: [aLease({})]
+    });
+    jobQueueService.enqueue.mockRejectedValue(new Error("queue is down"));
+
+    const result = await service.closeUnreachableProviderDeployments({ dryRun: false });
+
+    expect(result.err).toBe(true);
+    expect(deploymentSettingRepository.markClosed).toHaveBeenCalledWith({ userId: "user-1", dseq: DSEQ });
+  });
+
+  it("closes nothing when the outage record cannot be trusted", async () => {
+    const { service, providerOutagesHttpService, leaseRepository, deploymentWriterService } = setup({});
+    providerOutagesHttpService.findOutagesOlderThanDays.mockRejectedValue(new Error("stale"));
+
+    await expect(service.closeUnreachableProviderDeployments({ dryRun: false })).rejects.toThrow("stale");
+    expect(leaseRepository.findActiveLeasesOfDeploymentsOnProviders).not.toHaveBeenCalled();
+    expect(deploymentWriterService.close).not.toHaveBeenCalled();
+  });
+
+  function setup(input: { outages?: ProviderOutage[]; leases?: ActiveLeaseOnProvider[]; wallet?: null; setting?: DeploymentSettingsOutput }) {
+    const providerOutagesHttpService = mock<ProviderOutagesHttpService>();
+    providerOutagesHttpService.findOutagesOlderThanDays.mockResolvedValue(input.outages ?? []);
+
+    const leaseRepository = mock<LeaseRepository>();
+    leaseRepository.findActiveLeasesOfDeploymentsOnProviders.mockResolvedValue(input.leases ?? []);
+
+    const userWalletRepository = mock<UserWalletRepository>();
+    userWalletRepository.findOneByAddress.mockImplementation(async address =>
+      input.wallet === null ? undefined : mock<Awaited<ReturnType<UserWalletRepository["findOneByAddress"]>>>({ id: 7, userId: "user-1", address })
+    );
+
+    const deploymentSettingRepository = mock<DeploymentSettingRepository>();
+    deploymentSettingRepository.findOneBy.mockResolvedValue(input.setting);
+
+    const deploymentWriterService = mock<DeploymentWriterService>();
+    const chainErrorService = mock<ChainErrorService>();
+    chainErrorService.isUnsettleableDeploymentError.mockReturnValue(false);
+    const jobQueueService = mock<JobQueueService>();
+
+    const config = mockConfigService<DeploymentConfigService>({
+      PROVIDER_UNREACHABLE_CLOSE_AFTER_DAYS: CLOSE_AFTER_DAYS,
+      DEPLOY_WEB_BASE_URL
+    });
+    const createLogger = (() => mock<ReturnType<CreateLogger>>()) as unknown as CreateLogger;
+
+    const service = new UnreachableProviderDeploymentsCloserService(
+      providerOutagesHttpService,
+      leaseRepository,
+      userWalletRepository,
+      deploymentSettingRepository,
+      deploymentWriterService,
+      chainErrorService,
+      jobQueueService,
+      config,
+      createLogger
+    );
+
+    return {
+      service,
+      providerOutagesHttpService,
+      leaseRepository,
+      userWalletRepository,
+      deploymentSettingRepository,
+      deploymentWriterService,
+      chainErrorService,
+      jobQueueService
+    };
+  }
+});
+
+function anOutage(overrides: Partial<ProviderOutage>): ProviderOutage {
+  return {
+    provider: overrides.provider ?? DARK_PROVIDER,
+    hostUri: overrides.hostUri ?? "https://dark:8443",
+    startedAt: overrides.startedAt ?? DOWN_SINCE
+  };
+}
+
+function aLease(overrides: Partial<ActiveLeaseOnProvider>): ActiveLeaseOnProvider {
+  return {
+    owner: overrides.owner ?? OWNER,
+    dseq: overrides.dseq ?? DSEQ,
+    providerAddress: overrides.providerAddress ?? DARK_PROVIDER
+  };
+}

--- a/apps/api/src/deployment/services/unreachable-provider-deployments-closer/unreachable-provider-deployments-closer.service.spec.ts
+++ b/apps/api/src/deployment/services/unreachable-provider-deployments-closer/unreachable-provider-deployments-closer.service.spec.ts
@@ -201,7 +201,26 @@ describe(UnreachableProviderDeploymentsCloserService.name, () => {
     expect(deploymentWriterService.close).not.toHaveBeenCalled();
   });
 
-  function setup(input: { outages?: ProviderOutage[]; leases?: ActiveLeaseOnProvider[]; wallet?: null; setting?: DeploymentSettingsOutput }) {
+  it("does not tell the owner about a close that had already happened on chain", async () => {
+    const { service, jobQueueService, deploymentSettingRepository } = setup({
+      outages: [anOutage({})],
+      leases: [aLease({})],
+      alreadyClosedOnChain: true
+    });
+
+    await service.closeUnreachableProviderDeployments({ dryRun: false });
+
+    expect(jobQueueService.enqueue).not.toHaveBeenCalled();
+    expect(deploymentSettingRepository.markClosed).toHaveBeenCalled();
+  });
+
+  function setup(input: {
+    outages?: ProviderOutage[];
+    leases?: ActiveLeaseOnProvider[];
+    wallet?: null;
+    setting?: DeploymentSettingsOutput;
+    alreadyClosedOnChain?: boolean;
+  }) {
     const providerOutagesHttpService = mock<ProviderOutagesHttpService>();
     providerOutagesHttpService.findOutagesOlderThanDays.mockResolvedValue(input.outages ?? []);
 
@@ -217,6 +236,7 @@ describe(UnreachableProviderDeploymentsCloserService.name, () => {
     deploymentSettingRepository.findOneBy.mockResolvedValue(input.setting);
 
     const deploymentWriterService = mock<DeploymentWriterService>();
+    deploymentWriterService.close.mockResolvedValue(!input.alreadyClosedOnChain);
     const chainErrorService = mock<ChainErrorService>();
     chainErrorService.isUnsettleableDeploymentError.mockReturnValue(false);
     const jobQueueService = mock<JobQueueService>();

--- a/apps/api/src/deployment/services/unreachable-provider-deployments-closer/unreachable-provider-deployments-closer.service.spec.ts
+++ b/apps/api/src/deployment/services/unreachable-provider-deployments-closer/unreachable-provider-deployments-closer.service.spec.ts
@@ -1,20 +1,17 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { UserWalletRepository } from "@src/billing/repositories";
-import type { ChainErrorService } from "@src/billing/services/chain-error/chain-error.service";
 import type { CreateLogger, JobQueueService } from "@src/core";
 import type { DeploymentSettingRepository, DeploymentSettingsOutput } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import type { ActiveLeaseOnProvider, LeaseRepository } from "@src/deployment/repositories/lease/lease.repository";
 import type { DeploymentConfigService } from "@src/deployment/services/deployment-config/deployment-config.service";
-import type { DeploymentWriterService } from "@src/deployment/services/deployment-writer/deployment-writer.service";
 import type { ProviderOutage, ProviderOutagesHttpService } from "@src/deployment/services/provider-outages-http/provider-outages-http.service";
 import { UnreachableProviderDeploymentsCloserService } from "./unreachable-provider-deployments-closer.service";
 
 import { mockConfigService } from "@test/mocks/config-service.mock";
 
 const CLOSE_AFTER_DAYS = 14;
-const DEPLOY_WEB_BASE_URL = "https://console.akash.network";
 const OWNER = "akash1owner";
 const DSEQ = "1784768430632";
 const DARK_PROVIDER = "akash1dark";
@@ -22,210 +19,171 @@ const OTHER_DARK_PROVIDER = "akash1darker";
 const HEALTHY_PROVIDER = "akash1healthy";
 const DOWN_SINCE = "2026-07-24T00:00:00.000Z";
 const LONGER_OUTAGE_SINCE = "2026-07-01T00:00:00.000Z";
-const NOW = "2026-07-31T00:00:00.000Z";
-const DAYS_SINCE_LONGER_OUTAGE = 30;
+const SINGLETON_KEY = `CloseUnreachableProviderDeploymentCommand.${OWNER}.${DSEQ}`;
 
 describe(UnreachableProviderDeploymentsCloserService.name, () => {
-  afterEach(() => {
-    vi.useRealTimers();
-  });
+  describe("closeUnreachableProviderDeployments", () => {
+    it("asks for outages at least the configured number of days old", async () => {
+      const { service, providerOutagesHttpService } = setup({});
 
-  it("asks for outages at least the configured number of days old", async () => {
-    const { service, providerOutagesHttpService } = setup({});
+      await service.closeUnreachableProviderDeployments({ dryRun: false });
 
-    await service.closeUnreachableProviderDeployments({ dryRun: false });
-
-    expect(providerOutagesHttpService.findOutagesOlderThanDays).toHaveBeenCalledWith(CLOSE_AFTER_DAYS);
-  });
-
-  it("closes a deployment whose every lease sits on an unreachable provider", async () => {
-    const { service, deploymentWriterService, deploymentSettingRepository } = setup({
-      outages: [anOutage({})],
-      leases: [aLease({})]
+      expect(providerOutagesHttpService.findOutagesOlderThanDays).toHaveBeenCalledWith(CLOSE_AFTER_DAYS);
     });
 
-    const result = await service.closeUnreachableProviderDeployments({ dryRun: false });
+    it("hands a fully dark deployment to its own close job", async () => {
+      const { service, jobQueueService } = setup({ outages: [anOutage({})], leases: [aLease({})] });
 
-    expect(result.ok).toBe(true);
-    expect(deploymentWriterService.close).toHaveBeenCalledWith(expect.objectContaining({ address: OWNER }), DSEQ);
-    expect(deploymentSettingRepository.markClosed).toHaveBeenCalledWith({ userId: "user-1", dseq: DSEQ });
-  });
+      const result = await service.closeUnreachableProviderDeployments({ dryRun: false });
 
-  it("leaves a deployment alone while one of its leases is still on a provider that answers", async () => {
-    const { service, deploymentWriterService } = setup({
-      outages: [anOutage({})],
-      leases: [aLease({}), aLease({ providerAddress: HEALTHY_PROVIDER })]
+      expect(result.ok).toBe(true);
+      expect(jobQueueService.enqueue).toHaveBeenCalledWith(expect.objectContaining({ data: { owner: OWNER, dseq: DSEQ } }), { singletonKey: SINGLETON_KEY });
     });
 
-    await service.closeUnreachableProviderDeployments({ dryRun: false });
+    it("schedules nothing while one of its leases is still on a provider that answers", async () => {
+      const { service, jobQueueService } = setup({ outages: [anOutage({})], leases: [aLease({}), aLease({ providerAddress: HEALTHY_PROVIDER })] });
 
-    expect(deploymentWriterService.close).not.toHaveBeenCalled();
-  });
+      await service.closeUnreachableProviderDeployments({ dryRun: false });
 
-  it("closes a deployment spread across several providers once all of them are dark, naming the one gone longest and for how long", async () => {
-    vi.useFakeTimers({ now: new Date(NOW) });
-    const { service, deploymentWriterService, jobQueueService } = setup({
-      outages: [anOutage({}), anOutage({ provider: OTHER_DARK_PROVIDER, hostUri: "https://darker:8443", startedAt: LONGER_OUTAGE_SINCE })],
-      leases: [aLease({}), aLease({ providerAddress: OTHER_DARK_PROVIDER })]
+      expect(jobQueueService.enqueue).not.toHaveBeenCalled();
     });
 
-    await service.closeUnreachableProviderDeployments({ dryRun: false });
+    it("schedules a deployment spread across several providers once all of them are dark", async () => {
+      const { service, jobQueueService } = setup({
+        outages: [anOutage({}), anOutage({ provider: OTHER_DARK_PROVIDER, startedAt: LONGER_OUTAGE_SINCE })],
+        leases: [aLease({}), aLease({ providerAddress: OTHER_DARK_PROVIDER })]
+      });
 
-    expect(deploymentWriterService.close).toHaveBeenCalledTimes(1);
-    expect(jobQueueService.enqueue).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({
-          vars: expect.objectContaining({ hostUri: "https://darker:8443", downForDays: DAYS_SINCE_LONGER_OUTAGE })
-        })
-      }),
-      expect.anything()
-    );
-  });
+      await service.closeUnreachableProviderDeployments({ dryRun: false });
 
-  it("tells the owner their deployment was closed and why", async () => {
-    const { service, jobQueueService } = setup({
-      outages: [anOutage({})],
-      leases: [aLease({})]
+      expect(jobQueueService.enqueue).toHaveBeenCalledTimes(1);
     });
 
-    await service.closeUnreachableProviderDeployments({ dryRun: false });
+    it("leaves self-custody deployments alone", async () => {
+      const { service, jobQueueService } = setup({ outages: [anOutage({})], leases: [aLease({})], wallet: null });
 
-    expect(jobQueueService.enqueue).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({
-          template: "providerUnreachableClosed",
-          userId: "user-1",
-          vars: expect.objectContaining({ dseq: DSEQ, hostUri: "https://dark:8443" })
-        })
-      }),
-      { singletonKey: `notification.providerUnreachableClosed.${DSEQ}.7` }
-    );
-  });
+      await service.closeUnreachableProviderDeployments({ dryRun: false });
 
-  it("leaves self-custody deployments alone", async () => {
-    const { service, deploymentWriterService } = setup({
-      outages: [anOutage({})],
-      leases: [aLease({})],
-      wallet: null
+      expect(jobQueueService.enqueue).not.toHaveBeenCalled();
     });
 
-    await service.closeUnreachableProviderDeployments({ dryRun: false });
+    it("skips a deployment already recorded as closed", async () => {
+      const { service, jobQueueService } = setup({
+        outages: [anOutage({})],
+        leases: [aLease({})],
+        setting: mock<DeploymentSettingsOutput>({ closed: true })
+      });
 
-    expect(deploymentWriterService.close).not.toHaveBeenCalled();
-  });
+      await service.closeUnreachableProviderDeployments({ dryRun: false });
 
-  it("skips a deployment already recorded as closed", async () => {
-    const { service, deploymentWriterService } = setup({
-      outages: [anOutage({})],
-      leases: [aLease({})],
-      setting: mock<DeploymentSettingsOutput>({ closed: true })
+      expect(jobQueueService.enqueue).not.toHaveBeenCalled();
     });
 
-    await service.closeUnreachableProviderDeployments({ dryRun: false });
+    it("leaves a deployment that already holds a pending close job alone", async () => {
+      const { service, jobQueueService } = setup({ outages: [anOutage({})], leases: [aLease({})], pendingKeys: [SINGLETON_KEY] });
 
-    expect(deploymentWriterService.close).not.toHaveBeenCalled();
-  });
+      await service.closeUnreachableProviderDeployments({ dryRun: false });
 
-  it("closes nothing on a dry run", async () => {
-    const { service, deploymentWriterService, deploymentSettingRepository, jobQueueService } = setup({
-      outages: [anOutage({})],
-      leases: [aLease({})]
+      expect(jobQueueService.enqueue).not.toHaveBeenCalled();
     });
 
-    await service.closeUnreachableProviderDeployments({ dryRun: true });
+    it("schedules nothing on a dry run", async () => {
+      const { service, jobQueueService } = setup({ outages: [anOutage({})], leases: [aLease({})] });
 
-    expect(deploymentWriterService.close).not.toHaveBeenCalled();
-    expect(deploymentSettingRepository.markClosed).not.toHaveBeenCalled();
-    expect(jobQueueService.enqueue).not.toHaveBeenCalled();
-  });
+      const result = await service.closeUnreachableProviderDeployments({ dryRun: true });
 
-  it("moves on when the chain will not settle the escrow yet", async () => {
-    const { service, deploymentWriterService, chainErrorService, deploymentSettingRepository } = setup({
-      outages: [anOutage({})],
-      leases: [aLease({})]
-    });
-    deploymentWriterService.close.mockRejectedValue(new Error("escrow not settled"));
-    chainErrorService.isUnsettleableDeploymentError.mockReturnValue(true);
-
-    const result = await service.closeUnreachableProviderDeployments({ dryRun: false });
-
-    expect(result.ok).toBe(true);
-    expect(deploymentSettingRepository.markClosed).not.toHaveBeenCalled();
-  });
-
-  it("keeps closing the other deployments after one close fails", async () => {
-    const { service, deploymentWriterService } = setup({
-      outages: [anOutage({})],
-      leases: [aLease({}), aLease({ owner: "akash1other", dseq: "999" })]
-    });
-    deploymentWriterService.close.mockRejectedValueOnce(new Error("broadcast failed"));
-
-    const result = await service.closeUnreachableProviderDeployments({ dryRun: false });
-
-    expect(deploymentWriterService.close).toHaveBeenCalledTimes(2);
-    expect(result.err).toBe(true);
-  });
-
-  it("still tells the owner when recording the close fails", async () => {
-    const { service, deploymentSettingRepository, jobQueueService } = setup({
-      outages: [anOutage({})],
-      leases: [aLease({})]
-    });
-    deploymentSettingRepository.markClosed.mockRejectedValue(new Error("connection terminated"));
-
-    const result = await service.closeUnreachableProviderDeployments({ dryRun: false });
-
-    expect(result.err).toBe(true);
-    expect(jobQueueService.enqueue).toHaveBeenCalledTimes(1);
-  });
-
-  it("reports a queue that refuses the closure email without undoing the close", async () => {
-    const { service, jobQueueService, deploymentSettingRepository } = setup({
-      outages: [anOutage({})],
-      leases: [aLease({})]
-    });
-    jobQueueService.enqueue.mockRejectedValue(new Error("queue is down"));
-
-    const result = await service.closeUnreachableProviderDeployments({ dryRun: false });
-
-    expect(result.err).toBe(true);
-    expect(deploymentSettingRepository.markClosed).toHaveBeenCalledWith({ userId: "user-1", dseq: DSEQ });
-  });
-
-  it("closes nothing when the outage record cannot be trusted", async () => {
-    const { service, providerOutagesHttpService, leaseRepository, deploymentWriterService } = setup({});
-    providerOutagesHttpService.findOutagesOlderThanDays.mockRejectedValue(new Error("stale"));
-
-    await expect(service.closeUnreachableProviderDeployments({ dryRun: false })).rejects.toThrow("stale");
-    expect(leaseRepository.findActiveLeasesOfDeploymentsOnProviders).not.toHaveBeenCalled();
-    expect(deploymentWriterService.close).not.toHaveBeenCalled();
-  });
-
-  it("does not tell the owner about a close that had already happened on chain", async () => {
-    const { service, jobQueueService, deploymentSettingRepository } = setup({
-      outages: [anOutage({})],
-      leases: [aLease({})],
-      alreadyClosedOnChain: true
+      expect(result.ok).toBe(true);
+      expect(jobQueueService.enqueue).not.toHaveBeenCalled();
+      expect(jobQueueService.findPendingSingletonKeys).not.toHaveBeenCalled();
     });
 
-    await service.closeUnreachableProviderDeployments({ dryRun: false });
+    it("reports which deployments it would close on a dry run", async () => {
+      const { service, logger } = setup({ outages: [anOutage({})], leases: [aLease({})] });
 
-    expect(jobQueueService.enqueue).not.toHaveBeenCalled();
-    expect(deploymentSettingRepository.markClosed).toHaveBeenCalled();
+      await service.closeUnreachableProviderDeployments({ dryRun: true });
+
+      expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "UNREACHABLE_PROVIDER_DEPLOYMENT_WOULD_CLOSE", dseq: DSEQ, owner: OWNER }));
+    });
+
+    it("keeps scheduling the other deployments after one enqueue fails", async () => {
+      const { service, jobQueueService } = setup({ outages: [anOutage({})], leases: [aLease({}), aLease({ owner: "akash1other", dseq: "999" })] });
+      jobQueueService.enqueue.mockRejectedValueOnce(new Error("queue is down"));
+
+      const result = await service.closeUnreachableProviderDeployments({ dryRun: false });
+
+      expect(jobQueueService.enqueue).toHaveBeenCalledTimes(2);
+      expect(result.err).toBe(true);
+    });
+
+    it("schedules nothing when the outage record cannot be trusted", async () => {
+      const { service, providerOutagesHttpService, leaseRepository, jobQueueService } = setup({});
+      providerOutagesHttpService.findOutagesOlderThanDays.mockRejectedValue(new Error("stale"));
+
+      await expect(service.closeUnreachableProviderDeployments({ dryRun: false })).rejects.toThrow("stale");
+      expect(leaseRepository.findActiveLeasesOfDeploymentsOnProviders).not.toHaveBeenCalled();
+      expect(jobQueueService.enqueue).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("schedule", () => {
+    it("throws when the queue refuses to create the job", async () => {
+      const { service, jobQueueService } = setup({});
+      jobQueueService.enqueue.mockResolvedValue(null);
+
+      await expect(service.schedule({ owner: OWNER, dseq: DSEQ })).rejects.toThrow(DSEQ);
+    });
+
+    it("never asks the queue to start a job in the past", async () => {
+      const { service, jobQueueService } = setup({});
+
+      await service.schedule({ owner: OWNER, dseq: DSEQ }, { startAfter: new Date("2020-01-01T00:00:00.000Z") });
+
+      const [, options] = jobQueueService.enqueue.mock.calls[0];
+      expect(new Date(options!.startAfter as string).getTime()).toBeGreaterThan(new Date("2020-01-01T00:00:00.000Z").getTime());
+    });
+  });
+
+  describe("findStillDarkDeployment", () => {
+    it("resolves the deployment while every one of its leases is still dark", async () => {
+      const { service } = setup({ outages: [anOutage({})], deploymentLeases: [aLease({})] });
+
+      const result = await service.findStillDarkDeployment({ owner: OWNER, dseq: DSEQ });
+
+      expect(result).toEqual({ owner: OWNER, dseq: DSEQ, hostUri: "https://dark:8443", downSince: DOWN_SINCE });
+    });
+
+    it("resolves nothing once one of its providers answers again", async () => {
+      const { service } = setup({ outages: [anOutage({})], deploymentLeases: [aLease({}), aLease({ providerAddress: HEALTHY_PROVIDER })] });
+
+      const result = await service.findStillDarkDeployment({ owner: OWNER, dseq: DSEQ });
+
+      expect(result).toBeNull();
+    });
+
+    it("resolves nothing without asking about outages when the deployment has no active leases left", async () => {
+      const { service, providerOutagesHttpService } = setup({ outages: [anOutage({})], deploymentLeases: [] });
+
+      const result = await service.findStillDarkDeployment({ owner: OWNER, dseq: DSEQ });
+
+      expect(result).toBeNull();
+      expect(providerOutagesHttpService.findOutagesOlderThanDays).not.toHaveBeenCalled();
+    });
   });
 
   function setup(input: {
     outages?: ProviderOutage[];
     leases?: ActiveLeaseOnProvider[];
+    deploymentLeases?: ActiveLeaseOnProvider[];
     wallet?: null;
     setting?: DeploymentSettingsOutput;
-    alreadyClosedOnChain?: boolean;
+    pendingKeys?: string[];
   }) {
     const providerOutagesHttpService = mock<ProviderOutagesHttpService>();
     providerOutagesHttpService.findOutagesOlderThanDays.mockResolvedValue(input.outages ?? []);
 
     const leaseRepository = mock<LeaseRepository>();
     leaseRepository.findActiveLeasesOfDeploymentsOnProviders.mockResolvedValue(input.leases ?? []);
+    leaseRepository.findActiveLeasesOfDeployment.mockResolvedValue(input.deploymentLeases ?? []);
 
     const userWalletRepository = mock<UserWalletRepository>();
     userWalletRepository.findOneByAddress.mockImplementation(async address =>
@@ -235,40 +193,25 @@ describe(UnreachableProviderDeploymentsCloserService.name, () => {
     const deploymentSettingRepository = mock<DeploymentSettingRepository>();
     deploymentSettingRepository.findOneBy.mockResolvedValue(input.setting);
 
-    const deploymentWriterService = mock<DeploymentWriterService>();
-    deploymentWriterService.close.mockResolvedValue(!input.alreadyClosedOnChain);
-    const chainErrorService = mock<ChainErrorService>();
-    chainErrorService.isUnsettleableDeploymentError.mockReturnValue(false);
     const jobQueueService = mock<JobQueueService>();
+    jobQueueService.enqueue.mockResolvedValue("job-id");
+    jobQueueService.findPendingSingletonKeys.mockResolvedValue(new Set(input.pendingKeys ?? []));
 
-    const config = mockConfigService<DeploymentConfigService>({
-      PROVIDER_UNREACHABLE_CLOSE_AFTER_DAYS: CLOSE_AFTER_DAYS,
-      DEPLOY_WEB_BASE_URL
-    });
-    const createLogger = vi.fn<CreateLogger>(() => mock<ReturnType<CreateLogger>>());
+    const config = mockConfigService<DeploymentConfigService>({ PROVIDER_UNREACHABLE_CLOSE_AFTER_DAYS: CLOSE_AFTER_DAYS });
+    const logger = mock<ReturnType<CreateLogger>>();
+    const createLogger = vi.fn<CreateLogger>(() => logger);
 
     const service = new UnreachableProviderDeploymentsCloserService(
       providerOutagesHttpService,
       leaseRepository,
       userWalletRepository,
       deploymentSettingRepository,
-      deploymentWriterService,
-      chainErrorService,
       jobQueueService,
       config,
       createLogger
     );
 
-    return {
-      service,
-      providerOutagesHttpService,
-      leaseRepository,
-      userWalletRepository,
-      deploymentSettingRepository,
-      deploymentWriterService,
-      chainErrorService,
-      jobQueueService
-    };
+    return { service, providerOutagesHttpService, leaseRepository, userWalletRepository, deploymentSettingRepository, jobQueueService, logger };
   }
 });
 

--- a/apps/api/src/deployment/services/unreachable-provider-deployments-closer/unreachable-provider-deployments-closer.service.spec.ts
+++ b/apps/api/src/deployment/services/unreachable-provider-deployments-closer/unreachable-provider-deployments-closer.service.spec.ts
@@ -166,6 +166,19 @@ describe(UnreachableProviderDeploymentsCloserService.name, () => {
     expect(result.err).toBe(true);
   });
 
+  it("still tells the owner when recording the close fails", async () => {
+    const { service, deploymentSettingRepository, jobQueueService } = setup({
+      outages: [anOutage({})],
+      leases: [aLease({})]
+    });
+    deploymentSettingRepository.markClosed.mockRejectedValue(new Error("connection terminated"));
+
+    const result = await service.closeUnreachableProviderDeployments({ dryRun: false });
+
+    expect(result.err).toBe(true);
+    expect(jobQueueService.enqueue).toHaveBeenCalledTimes(1);
+  });
+
   it("reports a queue that refuses the closure email without undoing the close", async () => {
     const { service, jobQueueService, deploymentSettingRepository } = setup({
       outages: [anOutage({})],

--- a/apps/api/src/deployment/services/unreachable-provider-deployments-closer/unreachable-provider-deployments-closer.service.spec.ts
+++ b/apps/api/src/deployment/services/unreachable-provider-deployments-closer/unreachable-provider-deployments-closer.service.spec.ts
@@ -115,6 +115,19 @@ describe(UnreachableProviderDeploymentsCloserService.name, () => {
       expect(result.err).toBe(true);
     });
 
+    it("keeps screening the other deployments after one lookup fails", async () => {
+      const { service, userWalletRepository, jobQueueService } = setup({
+        outages: [anOutage({})],
+        leases: [aLease({}), aLease({ owner: "akash1other", dseq: "999" })]
+      });
+      userWalletRepository.findOneByAddress.mockRejectedValueOnce(new Error("connection reset"));
+
+      const result = await service.closeUnreachableProviderDeployments({ dryRun: false });
+
+      expect(jobQueueService.enqueue).toHaveBeenCalledTimes(1);
+      expect(result.err).toBe(true);
+    });
+
     it("schedules nothing when the outage record cannot be trusted", async () => {
       const { service, providerOutagesHttpService, leaseRepository, jobQueueService } = setup({});
       providerOutagesHttpService.findOutagesOlderThanDays.mockRejectedValue(new Error("stale"));

--- a/apps/api/src/deployment/services/unreachable-provider-deployments-closer/unreachable-provider-deployments-closer.service.ts
+++ b/apps/api/src/deployment/services/unreachable-provider-deployments-closer/unreachable-provider-deployments-closer.service.ts
@@ -170,7 +170,7 @@ export class UnreachableProviderDeploymentsCloserService {
       throw error;
     }
 
-    await this.deploymentSettingRepository.markClosed({ userId: wallet.userId, dseq: deployment.dseq });
+    await this.#recordClosed(deployment, wallet, errors);
 
     this.logger.info({
       event: "UNREACHABLE_PROVIDER_DEPLOYMENT_CLOSED",
@@ -183,6 +183,24 @@ export class UnreachableProviderDeploymentsCloserService {
     await this.#notifyOwner(deployment, wallet, errors);
 
     return true;
+  }
+
+  /**
+   * Marking the setting happens after the close, so a database that refuses it is collected rather than
+   * thrown: the owner would otherwise lose the email explaining a close that already happened.
+   */
+  async #recordClosed(deployment: DarkDeployment, wallet: { userId: string }, errors: unknown[]): Promise<void> {
+    try {
+      await this.deploymentSettingRepository.markClosed({ userId: wallet.userId, dseq: deployment.dseq });
+    } catch (error) {
+      this.logger.error({
+        event: "UNREACHABLE_PROVIDER_DEPLOYMENT_CLOSE_RECORD_FAILED",
+        dseq: deployment.dseq,
+        owner: deployment.owner,
+        error
+      });
+      errors.push(error);
+    }
   }
 
   /**

--- a/apps/api/src/deployment/services/unreachable-provider-deployments-closer/unreachable-provider-deployments-closer.service.ts
+++ b/apps/api/src/deployment/services/unreachable-provider-deployments-closer/unreachable-provider-deployments-closer.service.ts
@@ -50,25 +50,25 @@ export class UnreachableProviderDeploymentsCloserService {
     const pendingKeys = dryRun ? new Set<string>() : await this.jobQueueService.findPendingSingletonKeys(CloseUnreachableProviderDeploymentCommand[JOB_NAME]);
 
     for (const deployment of deployments) {
-      if (!(await this.#isCloseable(deployment))) continue;
-
-      if (dryRun) {
-        this.logger.info({
-          event: "UNREACHABLE_PROVIDER_DEPLOYMENT_WOULD_CLOSE",
-          dseq: deployment.dseq,
-          owner: deployment.owner,
-          hostUri: deployment.hostUri,
-          downSince: deployment.downSince
-        });
-        continue;
-      }
-
-      if (pendingKeys.has(UnreachableProviderDeploymentsCloserService.singletonKey(deployment))) {
-        alreadyScheduledCount++;
-        continue;
-      }
-
       try {
+        if (!(await this.#isCloseable(deployment))) continue;
+
+        if (dryRun) {
+          this.logger.info({
+            event: "UNREACHABLE_PROVIDER_DEPLOYMENT_WOULD_CLOSE",
+            dseq: deployment.dseq,
+            owner: deployment.owner,
+            hostUri: deployment.hostUri,
+            downSince: deployment.downSince
+          });
+          continue;
+        }
+
+        if (pendingKeys.has(UnreachableProviderDeploymentsCloserService.singletonKey(deployment))) {
+          alreadyScheduledCount++;
+          continue;
+        }
+
         await this.schedule(deployment);
         scheduledCount++;
       } catch (error) {

--- a/apps/api/src/deployment/services/unreachable-provider-deployments-closer/unreachable-provider-deployments-closer.service.ts
+++ b/apps/api/src/deployment/services/unreachable-provider-deployments-closer/unreachable-provider-deployments-closer.service.ts
@@ -1,0 +1,219 @@
+import { differenceInDays } from "date-fns";
+import { Err, Ok, Result } from "ts-results";
+import { inject, singleton } from "tsyringe";
+
+import { UserWalletRepository } from "@src/billing/repositories";
+import { ChainErrorService } from "@src/billing/services/chain-error/chain-error.service";
+import { type CreateLogger, JobQueueService, LOGGER_FACTORY } from "@src/core";
+import type { DryRunOptions } from "@src/core/types/console";
+import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import { type ActiveLeaseOnProvider, LeaseRepository } from "@src/deployment/repositories/lease/lease.repository";
+import { DeploymentConfigService } from "@src/deployment/services/deployment-config/deployment-config.service";
+import { DeploymentWriterService } from "@src/deployment/services/deployment-writer/deployment-writer.service";
+import { type ProviderOutage, ProviderOutagesHttpService } from "@src/deployment/services/provider-outages-http/provider-outages-http.service";
+import { NotificationJob } from "@src/notifications/services/notification-handler/notification.handler";
+
+/** A deployment whose every active lease sits on a provider that stopped answering. */
+interface DarkDeployment {
+  owner: string;
+  dseq: string;
+  hostUri: string;
+  downSince: string;
+}
+
+/**
+ * Closes deployments whose provider has been gone for weeks. Left alone, the chain only closes such a
+ * deployment when its escrow finally drains, so the owner keeps paying a provider that stopped serving
+ * long ago for as long as the money lasts. Closing settles the escrow and returns the remainder.
+ *
+ * Only when the whole deployment is dark. A deployment still holding a lease on a provider that answers
+ * may well be doing useful work, and closing it would take that away over a problem the owner can see
+ * and act on themselves.
+ *
+ * Owners are warned first: `PROVIDER_UNREACHABLE_CLOSE_AFTER_DAYS` is held above the warning threshold
+ * by the config schema, so nobody's first word about an outage is the closure email.
+ */
+@singleton()
+export class UnreachableProviderDeploymentsCloserService {
+  private readonly logger: ReturnType<CreateLogger>;
+
+  constructor(
+    private readonly providerOutagesHttpService: ProviderOutagesHttpService,
+    private readonly leaseRepository: LeaseRepository,
+    private readonly userWalletRepository: UserWalletRepository,
+    private readonly deploymentSettingRepository: DeploymentSettingRepository,
+    private readonly deploymentWriterService: DeploymentWriterService,
+    private readonly chainErrorService: ChainErrorService,
+    private readonly jobQueueService: JobQueueService,
+    private readonly config: DeploymentConfigService,
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
+  ) {
+    this.logger = createLogger({ context: UnreachableProviderDeploymentsCloserService.name });
+  }
+
+  async closeUnreachableProviderDeployments({ dryRun }: DryRunOptions): Promise<Result<void, unknown[]>> {
+    const outages = await this.providerOutagesHttpService.findOutagesOlderThanDays(this.config.get("PROVIDER_UNREACHABLE_CLOSE_AFTER_DAYS"));
+    const deployments = await this.#findFullyDarkDeployments(outages);
+
+    this.logger.info({ event: "UNREACHABLE_PROVIDER_DEPLOYMENTS_CLOSE_SWEEP_START", outages: outages.length, count: deployments.length, dryRun });
+
+    const errors: unknown[] = [];
+    let closedCount = 0;
+
+    for (const deployment of deployments) {
+      try {
+        if (await this.#closeDeployment(deployment, dryRun, errors)) {
+          closedCount++;
+        }
+      } catch (error) {
+        this.logger.error({ event: "UNREACHABLE_PROVIDER_DEPLOYMENT_CLOSE_FAILED", dseq: deployment.dseq, owner: deployment.owner, error });
+        errors.push(error);
+      }
+    }
+
+    this.logger.info({
+      event: "UNREACHABLE_PROVIDER_DEPLOYMENTS_CLOSE_SWEEP_END",
+      found: deployments.length,
+      closed: closedCount,
+      failed: errors.length,
+      dryRun
+    });
+
+    return errors.length > 0 ? Err(errors) : Ok(undefined);
+  }
+
+  /**
+   * A deployment qualifies only when every one of its active leases sits on an unreachable provider.
+   * `downSince` is the latest of those outages — the moment the deployment as a whole went dark — while
+   * the host named in the email is the one that has been gone longest.
+   */
+  async #findFullyDarkDeployments(outages: ProviderOutage[]): Promise<DarkDeployment[]> {
+    if (outages.length === 0) return [];
+
+    const outageByProvider = new Map(outages.map(outage => [outage.provider, outage]));
+    const leases = await this.leaseRepository.findActiveLeasesOfDeploymentsOnProviders([...outageByProvider.keys()]);
+    const leasesByDeployment = new Map<string, ActiveLeaseOnProvider[]>();
+
+    for (const lease of leases) {
+      const key = `${lease.owner}/${lease.dseq}`;
+      leasesByDeployment.set(key, [...(leasesByDeployment.get(key) ?? []), lease]);
+    }
+
+    const dark: DarkDeployment[] = [];
+
+    for (const deploymentLeases of leasesByDeployment.values()) {
+      const deploymentOutages = deploymentLeases.map(lease => outageByProvider.get(lease.providerAddress));
+      if (deploymentOutages.some(outage => !outage)) continue;
+
+      const [{ owner, dseq }] = deploymentLeases;
+      const started = (deploymentOutages as ProviderOutage[]).map(outage => outage.startedAt).sort();
+
+      dark.push({
+        owner,
+        dseq,
+        hostUri: (deploymentOutages as ProviderOutage[]).find(outage => outage.startedAt === started[0])!.hostUri,
+        downSince: started[started.length - 1]
+      });
+    }
+
+    return dark;
+  }
+
+  async #closeDeployment(deployment: DarkDeployment, dryRun: boolean, errors: unknown[]): Promise<boolean> {
+    const wallet = await this.userWalletRepository.findOneByAddress(deployment.owner);
+
+    if (!wallet?.address) {
+      this.logger.debug({
+        event: "UNREACHABLE_PROVIDER_DEPLOYMENT_CLOSE_SKIPPED",
+        reason: "NOT_A_MANAGED_WALLET",
+        dseq: deployment.dseq,
+        owner: deployment.owner
+      });
+      return false;
+    }
+
+    const setting = await this.deploymentSettingRepository.findOneBy({ userId: wallet.userId, dseq: deployment.dseq });
+
+    if (setting?.closed) {
+      this.logger.debug({
+        event: "UNREACHABLE_PROVIDER_DEPLOYMENT_CLOSE_SKIPPED",
+        reason: "ALREADY_CLOSED",
+        dseq: deployment.dseq,
+        owner: deployment.owner
+      });
+      return false;
+    }
+
+    if (dryRun) {
+      this.logger.info({
+        event: "UNREACHABLE_PROVIDER_DEPLOYMENT_WOULD_CLOSE",
+        dseq: deployment.dseq,
+        owner: deployment.owner,
+        hostUri: deployment.hostUri,
+        downSince: deployment.downSince
+      });
+      return false;
+    }
+
+    try {
+      await this.deploymentWriterService.close({ ...wallet, address: wallet.address }, deployment.dseq);
+    } catch (error) {
+      if (error instanceof Error && this.chainErrorService.isUnsettleableDeploymentError(error)) {
+        this.logger.warn({
+          event: "UNREACHABLE_PROVIDER_DEPLOYMENT_UNSETTLEABLE",
+          reason: "Deployment escrow cannot be settled yet; chain rejects close until it settles",
+          dseq: deployment.dseq,
+          owner: deployment.owner
+        });
+        return false;
+      }
+      throw error;
+    }
+
+    await this.deploymentSettingRepository.markClosed({ userId: wallet.userId, dseq: deployment.dseq });
+
+    this.logger.info({
+      event: "UNREACHABLE_PROVIDER_DEPLOYMENT_CLOSED",
+      dseq: deployment.dseq,
+      owner: deployment.owner,
+      hostUri: deployment.hostUri,
+      downSince: deployment.downSince
+    });
+
+    await this.#notifyOwner(deployment, wallet, errors);
+
+    return true;
+  }
+
+  /**
+   * The deployment is already closed on chain by the time this runs, so a queue that refuses the job is
+   * collected rather than thrown: reversing the close is not on the table, and the sweep must not report
+   * a close that happened as a close that failed.
+   */
+  async #notifyOwner(deployment: DarkDeployment, wallet: { id: number; userId: string }, errors: unknown[]): Promise<void> {
+    try {
+      await this.jobQueueService.enqueue(
+        new NotificationJob({
+          template: "providerUnreachableClosed",
+          userId: wallet.userId,
+          vars: {
+            dseq: deployment.dseq,
+            owner: deployment.owner,
+            hostUri: deployment.hostUri,
+            downForDays: differenceInDays(new Date(), new Date(deployment.downSince)),
+            redeployUrl: `${this.config.get("DEPLOY_WEB_BASE_URL")}/new-deployment`
+          }
+        }),
+        { singletonKey: `notification.providerUnreachableClosed.${deployment.dseq}.${wallet.id}` }
+      );
+    } catch (error) {
+      this.logger.error({
+        event: "UNREACHABLE_PROVIDER_DEPLOYMENT_CLOSE_NOTIFICATION_FAILED",
+        dseq: deployment.dseq,
+        owner: deployment.owner,
+        error
+      });
+      errors.push(error);
+    }
+  }
+}

--- a/apps/api/src/deployment/services/unreachable-provider-deployments-closer/unreachable-provider-deployments-closer.service.ts
+++ b/apps/api/src/deployment/services/unreachable-provider-deployments-closer/unreachable-provider-deployments-closer.service.ts
@@ -140,8 +140,10 @@ export class UnreachableProviderDeploymentsCloserService {
       return false;
     }
 
+    let closedByUs: boolean;
+
     try {
-      await this.deploymentWriterService.close({ ...wallet, address: wallet.address }, deployment.dseq);
+      closedByUs = await this.deploymentWriterService.close({ ...wallet, address: wallet.address }, deployment.dseq);
     } catch (error) {
       if (error instanceof Error && this.chainErrorService.isUnsettleableDeploymentError(error)) {
         this.logger.warn({
@@ -156,6 +158,16 @@ export class UnreachableProviderDeploymentsCloserService {
     }
 
     await this.#recordClosed(deployment, wallet, errors);
+
+    if (!closedByUs) {
+      this.logger.debug({
+        event: "UNREACHABLE_PROVIDER_DEPLOYMENT_CLOSE_SKIPPED",
+        reason: "ALREADY_CLOSED_ON_CHAIN",
+        dseq: deployment.dseq,
+        owner: deployment.owner
+      });
+      return false;
+    }
 
     this.logger.info({
       event: "UNREACHABLE_PROVIDER_DEPLOYMENT_CLOSED",

--- a/apps/api/src/deployment/services/unreachable-provider-deployments-closer/unreachable-provider-deployments-closer.service.ts
+++ b/apps/api/src/deployment/services/unreachable-provider-deployments-closer/unreachable-provider-deployments-closer.service.ts
@@ -21,18 +21,7 @@ interface DarkDeployment {
   downSince: string;
 }
 
-/**
- * Closes deployments whose provider has been gone for weeks. Left alone, the chain only closes such a
- * deployment when its escrow finally drains, so the owner keeps paying a provider that stopped serving
- * long ago for as long as the money lasts. Closing settles the escrow and returns the remainder.
- *
- * Only when the whole deployment is dark. A deployment still holding a lease on a provider that answers
- * may well be doing useful work, and closing it would take that away over a problem the owner can see
- * and act on themselves.
- *
- * Owners are warned first: `PROVIDER_UNREACHABLE_CLOSE_AFTER_DAYS` is held above the warning threshold
- * by the config schema, so nobody's first word about an outage is the closure email.
- */
+/** Only fully dark deployments are closed, because one lease still answering may well be doing useful work the owner can see. */
 @singleton()
 export class UnreachableProviderDeploymentsCloserService {
   private readonly logger: ReturnType<CreateLogger>;
@@ -82,11 +71,7 @@ export class UnreachableProviderDeploymentsCloserService {
     return errors.length > 0 ? Err(errors) : Ok(undefined);
   }
 
-  /**
-   * A deployment qualifies only when every one of its active leases sits on an unreachable provider.
-   * Where several are dark, the longest outage is the one reported, so the host named and the age
-   * beside it come from the same outage.
-   */
+  /** Where several leases are dark, the longest outage is the one reported, so the host named and the age beside it come from the same outage. */
   async #findFullyDarkDeployments(outages: ProviderOutage[]): Promise<DarkDeployment[]> {
     if (outages.length === 0) return [];
 
@@ -185,10 +170,7 @@ export class UnreachableProviderDeploymentsCloserService {
     return true;
   }
 
-  /**
-   * Marking the setting happens after the close, so a database that refuses it is collected rather than
-   * thrown: the owner would otherwise lose the email explaining a close that already happened.
-   */
+  /** A database that refuses the marking is collected rather than thrown, or the owner loses the email explaining a close that already happened. */
   async #recordClosed(deployment: DarkDeployment, wallet: { userId: string }, errors: unknown[]): Promise<void> {
     try {
       await this.deploymentSettingRepository.markClosed({ userId: wallet.userId, dseq: deployment.dseq });
@@ -203,11 +185,7 @@ export class UnreachableProviderDeploymentsCloserService {
     }
   }
 
-  /**
-   * The deployment is already closed on chain by the time this runs, so a queue that refuses the job is
-   * collected rather than thrown: reversing the close is not on the table, and the sweep must not report
-   * a close that happened as a close that failed.
-   */
+  /** The close is already on chain by the time this runs, so a queue that refuses the job is collected rather than thrown. */
   async #notifyOwner(deployment: DarkDeployment, wallet: { id: number; userId: string }, errors: unknown[]): Promise<void> {
     try {
       await this.jobQueueService.enqueue(

--- a/apps/api/src/deployment/services/unreachable-provider-deployments-closer/unreachable-provider-deployments-closer.service.ts
+++ b/apps/api/src/deployment/services/unreachable-provider-deployments-closer/unreachable-provider-deployments-closer.service.ts
@@ -84,8 +84,8 @@ export class UnreachableProviderDeploymentsCloserService {
 
   /**
    * A deployment qualifies only when every one of its active leases sits on an unreachable provider.
-   * `downSince` is the latest of those outages — the moment the deployment as a whole went dark — while
-   * the host named in the email is the one that has been gone longest.
+   * Where several are dark, the longest outage is the one reported, so the host named and the age
+   * beside it come from the same outage.
    */
   async #findFullyDarkDeployments(outages: ProviderOutage[]): Promise<DarkDeployment[]> {
     if (outages.length === 0) return [];
@@ -106,13 +106,13 @@ export class UnreachableProviderDeploymentsCloserService {
       if (deploymentOutages.some(outage => !outage)) continue;
 
       const [{ owner, dseq }] = deploymentLeases;
-      const started = (deploymentOutages as ProviderOutage[]).map(outage => outage.startedAt).sort();
+      const longestOutage = (deploymentOutages as ProviderOutage[]).reduce((longest, outage) => (outage.startedAt < longest.startedAt ? outage : longest));
 
       dark.push({
         owner,
         dseq,
-        hostUri: (deploymentOutages as ProviderOutage[]).find(outage => outage.startedAt === started[0])!.hostUri,
-        downSince: started[started.length - 1]
+        hostUri: longestOutage.hostUri,
+        downSince: longestOutage.startedAt
       });
     }
 

--- a/apps/api/src/deployment/services/unreachable-provider-deployments-closer/unreachable-provider-deployments-closer.service.ts
+++ b/apps/api/src/deployment/services/unreachable-provider-deployments-closer/unreachable-provider-deployments-closer.service.ts
@@ -1,27 +1,22 @@
-import { differenceInDays } from "date-fns";
 import { Err, Ok, Result } from "ts-results";
 import { inject, singleton } from "tsyringe";
 
 import { UserWalletRepository } from "@src/billing/repositories";
-import { ChainErrorService } from "@src/billing/services/chain-error/chain-error.service";
-import { type CreateLogger, JobQueueService, LOGGER_FACTORY } from "@src/core";
+import { type CreateLogger, JOB_NAME, JobQueueService, LOGGER_FACTORY } from "@src/core";
 import type { DryRunOptions } from "@src/core/types/console";
+import { CloseUnreachableProviderDeploymentCommand } from "@src/deployment/commands/close-unreachable-provider-deployment.command";
+import { type DarkDeployment, resolveFullyDarkDeployment } from "@src/deployment/lib/dark-deployment/dark-deployment";
 import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import { type ActiveLeaseOnProvider, LeaseRepository } from "@src/deployment/repositories/lease/lease.repository";
 import { DeploymentConfigService } from "@src/deployment/services/deployment-config/deployment-config.service";
-import { DeploymentWriterService } from "@src/deployment/services/deployment-writer/deployment-writer.service";
 import { type ProviderOutage, ProviderOutagesHttpService } from "@src/deployment/services/provider-outages-http/provider-outages-http.service";
-import { NotificationJob } from "@src/notifications/services/notification-handler/notification.handler";
 
-/** A deployment whose every active lease sits on a provider that stopped answering. */
-interface DarkDeployment {
+export type CloseUnreachableProviderDeploymentTarget = {
   owner: string;
   dseq: string;
-  hostUri: string;
-  downSince: string;
-}
+};
 
-/** Only fully dark deployments are closed, because one lease still answering may well be doing useful work the owner can see. */
+/** Only fully dark deployments qualify, because one lease still answering may well be doing useful work the owner can see. */
 @singleton()
 export class UnreachableProviderDeploymentsCloserService {
   private readonly logger: ReturnType<CreateLogger>;
@@ -31,8 +26,6 @@ export class UnreachableProviderDeploymentsCloserService {
     private readonly leaseRepository: LeaseRepository,
     private readonly userWalletRepository: UserWalletRepository,
     private readonly deploymentSettingRepository: DeploymentSettingRepository,
-    private readonly deploymentWriterService: DeploymentWriterService,
-    private readonly chainErrorService: ChainErrorService,
     private readonly jobQueueService: JobQueueService,
     private readonly config: DeploymentConfigService,
     @inject(LOGGER_FACTORY) createLogger: CreateLogger
@@ -40,6 +33,11 @@ export class UnreachableProviderDeploymentsCloserService {
     this.logger = createLogger({ context: UnreachableProviderDeploymentsCloserService.name });
   }
 
+  static singletonKey(target: CloseUnreachableProviderDeploymentTarget): string {
+    return `${CloseUnreachableProviderDeploymentCommand[JOB_NAME]}.${target.owner}.${target.dseq}`;
+  }
+
+  /** A dry run enqueues nothing, which gates the whole pipeline because this sweep is the only thing that creates these jobs. */
   async closeUnreachableProviderDeployments({ dryRun }: DryRunOptions): Promise<Result<void, unknown[]>> {
     const outages = await this.providerOutagesHttpService.findOutagesOlderThanDays(this.config.get("PROVIDER_UNREACHABLE_CLOSE_AFTER_DAYS"));
     const deployments = await this.#findFullyDarkDeployments(outages);
@@ -47,15 +45,34 @@ export class UnreachableProviderDeploymentsCloserService {
     this.logger.info({ event: "UNREACHABLE_PROVIDER_DEPLOYMENTS_CLOSE_SWEEP_START", outages: outages.length, count: deployments.length, dryRun });
 
     const errors: unknown[] = [];
-    let closedCount = 0;
+    let scheduledCount = 0;
+    let alreadyScheduledCount = 0;
+    const pendingKeys = dryRun ? new Set<string>() : await this.jobQueueService.findPendingSingletonKeys(CloseUnreachableProviderDeploymentCommand[JOB_NAME]);
 
     for (const deployment of deployments) {
+      if (!(await this.#isCloseable(deployment))) continue;
+
+      if (dryRun) {
+        this.logger.info({
+          event: "UNREACHABLE_PROVIDER_DEPLOYMENT_WOULD_CLOSE",
+          dseq: deployment.dseq,
+          owner: deployment.owner,
+          hostUri: deployment.hostUri,
+          downSince: deployment.downSince
+        });
+        continue;
+      }
+
+      if (pendingKeys.has(UnreachableProviderDeploymentsCloserService.singletonKey(deployment))) {
+        alreadyScheduledCount++;
+        continue;
+      }
+
       try {
-        if (await this.#closeDeployment(deployment, dryRun, errors)) {
-          closedCount++;
-        }
+        await this.schedule(deployment);
+        scheduledCount++;
       } catch (error) {
-        this.logger.error({ event: "UNREACHABLE_PROVIDER_DEPLOYMENT_CLOSE_FAILED", dseq: deployment.dseq, owner: deployment.owner, error });
+        this.logger.error({ event: "UNREACHABLE_PROVIDER_DEPLOYMENT_CLOSE_SCHEDULE_FAILED", dseq: deployment.dseq, owner: deployment.owner, error });
         errors.push(error);
       }
     }
@@ -63,7 +80,8 @@ export class UnreachableProviderDeploymentsCloserService {
     this.logger.info({
       event: "UNREACHABLE_PROVIDER_DEPLOYMENTS_CLOSE_SWEEP_END",
       found: deployments.length,
-      closed: closedCount,
+      scheduled: scheduledCount,
+      alreadyScheduled: alreadyScheduledCount,
       failed: errors.length,
       dryRun
     });
@@ -71,40 +89,35 @@ export class UnreachableProviderDeploymentsCloserService {
     return errors.length > 0 ? Err(errors) : Ok(undefined);
   }
 
-  /** Where several leases are dark, the longest outage is the one reported, so the host named and the age beside it come from the same outage. */
-  async #findFullyDarkDeployments(outages: ProviderOutage[]): Promise<DarkDeployment[]> {
-    if (outages.length === 0) return [];
+  /** A duplicate that slips past the pending-key check is harmless: the handler re-reads the outage and the row, so it closes nothing twice. */
+  async schedule(target: CloseUnreachableProviderDeploymentTarget, options: { startAfter?: Date } = {}): Promise<string> {
+    const startAfter = options.startAfter && new Date(Math.max(options.startAfter.getTime(), Date.now()));
 
-    const outageByProvider = new Map(outages.map(outage => [outage.provider, outage]));
-    const leases = await this.leaseRepository.findActiveLeasesOfDeploymentsOnProviders([...outageByProvider.keys()]);
-    const leasesByDeployment = new Map<string, ActiveLeaseOnProvider[]>();
+    const createdJobId = await this.jobQueueService.enqueue(new CloseUnreachableProviderDeploymentCommand({ owner: target.owner, dseq: target.dseq }), {
+      singletonKey: UnreachableProviderDeploymentsCloserService.singletonKey(target),
+      ...(startAfter && { startAfter: startAfter.toISOString() })
+    });
 
-    for (const lease of leases) {
-      const key = `${lease.owner}/${lease.dseq}`;
-      leasesByDeployment.set(key, [...(leasesByDeployment.get(key) ?? []), lease]);
+    if (!createdJobId) {
+      throw new Error(`Failed to schedule unreachable-provider close for deployment ${target.dseq} of ${target.owner}`);
     }
 
-    const dark: DarkDeployment[] = [];
-
-    for (const deploymentLeases of leasesByDeployment.values()) {
-      const deploymentOutages = deploymentLeases.map(lease => outageByProvider.get(lease.providerAddress));
-      if (deploymentOutages.some(outage => !outage)) continue;
-
-      const [{ owner, dseq }] = deploymentLeases;
-      const longestOutage = (deploymentOutages as ProviderOutage[]).reduce((longest, outage) => (outage.startedAt < longest.startedAt ? outage : longest));
-
-      dark.push({
-        owner,
-        dseq,
-        hostUri: longestOutage.hostUri,
-        downSince: longestOutage.startedAt
-      });
-    }
-
-    return dark;
+    return createdJobId;
   }
 
-  async #closeDeployment(deployment: DarkDeployment, dryRun: boolean, errors: unknown[]): Promise<boolean> {
+  /** Re-checked per job because the unsettleable-escrow path can retry for hours, and closing a deployment whose provider came back cannot be undone. */
+  async findStillDarkDeployment(target: CloseUnreachableProviderDeploymentTarget): Promise<DarkDeployment | null> {
+    const leases = await this.leaseRepository.findActiveLeasesOfDeployment(target.owner, target.dseq);
+
+    if (leases.length === 0) return null;
+
+    const outages = await this.providerOutagesHttpService.findOutagesOlderThanDays(this.config.get("PROVIDER_UNREACHABLE_CLOSE_AFTER_DAYS"));
+
+    return resolveFullyDarkDeployment(leases, new Map(outages.map(outage => [outage.provider, outage])));
+  }
+
+  /** Screens out what the handler would skip anyway, so a dry run's count is the count that would really be closed. */
+  async #isCloseable(deployment: DarkDeployment): Promise<boolean> {
     const wallet = await this.userWalletRepository.findOneByAddress(deployment.owner);
 
     if (!wallet?.address) {
@@ -129,99 +142,23 @@ export class UnreachableProviderDeploymentsCloserService {
       return false;
     }
 
-    if (dryRun) {
-      this.logger.info({
-        event: "UNREACHABLE_PROVIDER_DEPLOYMENT_WOULD_CLOSE",
-        dseq: deployment.dseq,
-        owner: deployment.owner,
-        hostUri: deployment.hostUri,
-        downSince: deployment.downSince
-      });
-      return false;
-    }
-
-    let closedByUs: boolean;
-
-    try {
-      closedByUs = await this.deploymentWriterService.close({ ...wallet, address: wallet.address }, deployment.dseq);
-    } catch (error) {
-      if (error instanceof Error && this.chainErrorService.isUnsettleableDeploymentError(error)) {
-        this.logger.warn({
-          event: "UNREACHABLE_PROVIDER_DEPLOYMENT_UNSETTLEABLE",
-          reason: "Deployment escrow cannot be settled yet; chain rejects close until it settles",
-          dseq: deployment.dseq,
-          owner: deployment.owner
-        });
-        return false;
-      }
-      throw error;
-    }
-
-    await this.#recordClosed(deployment, wallet, errors);
-
-    if (!closedByUs) {
-      this.logger.debug({
-        event: "UNREACHABLE_PROVIDER_DEPLOYMENT_CLOSE_SKIPPED",
-        reason: "ALREADY_CLOSED_ON_CHAIN",
-        dseq: deployment.dseq,
-        owner: deployment.owner
-      });
-      return false;
-    }
-
-    this.logger.info({
-      event: "UNREACHABLE_PROVIDER_DEPLOYMENT_CLOSED",
-      dseq: deployment.dseq,
-      owner: deployment.owner,
-      hostUri: deployment.hostUri,
-      downSince: deployment.downSince
-    });
-
-    await this.#notifyOwner(deployment, wallet, errors);
-
     return true;
   }
 
-  /** A database that refuses the marking is collected rather than thrown, or the owner loses the email explaining a close that already happened. */
-  async #recordClosed(deployment: DarkDeployment, wallet: { userId: string }, errors: unknown[]): Promise<void> {
-    try {
-      await this.deploymentSettingRepository.markClosed({ userId: wallet.userId, dseq: deployment.dseq });
-    } catch (error) {
-      this.logger.error({
-        event: "UNREACHABLE_PROVIDER_DEPLOYMENT_CLOSE_RECORD_FAILED",
-        dseq: deployment.dseq,
-        owner: deployment.owner,
-        error
-      });
-      errors.push(error);
-    }
-  }
+  async #findFullyDarkDeployments(outages: ProviderOutage[]): Promise<DarkDeployment[]> {
+    if (outages.length === 0) return [];
 
-  /** The close is already on chain by the time this runs, so a queue that refuses the job is collected rather than thrown. */
-  async #notifyOwner(deployment: DarkDeployment, wallet: { id: number; userId: string }, errors: unknown[]): Promise<void> {
-    try {
-      await this.jobQueueService.enqueue(
-        new NotificationJob({
-          template: "providerUnreachableClosed",
-          userId: wallet.userId,
-          vars: {
-            dseq: deployment.dseq,
-            owner: deployment.owner,
-            hostUri: deployment.hostUri,
-            downForDays: differenceInDays(new Date(), new Date(deployment.downSince)),
-            redeployUrl: `${this.config.get("DEPLOY_WEB_BASE_URL")}/new-deployment`
-          }
-        }),
-        { singletonKey: `notification.providerUnreachableClosed.${deployment.dseq}.${wallet.id}` }
-      );
-    } catch (error) {
-      this.logger.error({
-        event: "UNREACHABLE_PROVIDER_DEPLOYMENT_CLOSE_NOTIFICATION_FAILED",
-        dseq: deployment.dseq,
-        owner: deployment.owner,
-        error
-      });
-      errors.push(error);
+    const outageByProvider = new Map(outages.map(outage => [outage.provider, outage]));
+    const leases = await this.leaseRepository.findActiveLeasesOfDeploymentsOnProviders([...outageByProvider.keys()]);
+    const leasesByDeployment = new Map<string, ActiveLeaseOnProvider[]>();
+
+    for (const lease of leases) {
+      const key = `${lease.owner}/${lease.dseq}`;
+      leasesByDeployment.set(key, [...(leasesByDeployment.get(key) ?? []), lease]);
     }
+
+    return [...leasesByDeployment.values()]
+      .map(deploymentLeases => resolveFullyDarkDeployment(deploymentLeases, outageByProvider))
+      .filter(deployment => !!deployment);
   }
 }

--- a/apps/api/src/deployment/services/unreachable-provider-deployments-notifier/unreachable-provider-deployments-notifier.service.spec.ts
+++ b/apps/api/src/deployment/services/unreachable-provider-deployments-notifier/unreachable-provider-deployments-notifier.service.spec.ts
@@ -78,6 +78,30 @@ describe(UnreachableProviderDeploymentsNotifierService.name, () => {
     expect(notificationService.createNotification).toHaveBeenCalledTimes(1);
   });
 
+  it("promises an automatic close when every lease of the deployment is dark", async () => {
+    const { service, notificationService } = setup({
+      outages: [anOutage({})],
+      leases: [aLease({})]
+    });
+
+    await service.notifyUnreachableProviderDeployments({ dryRun: false });
+
+    const [{ payload }] = notificationService.createNotification.mock.calls[0];
+    expect(payload.description).toContain(`${CLOSE_AFTER_DAYS} days`);
+  });
+
+  it("promises no automatic close when the deployment still holds a lease on a healthy provider", async () => {
+    const { service, notificationService } = setup({
+      outages: [anOutage({})],
+      leases: [aLease({}), aLease({ providerAddress: HEALTHY_PROVIDER })]
+    });
+
+    await service.notifyUnreachableProviderDeployments({ dryRun: false });
+
+    const [{ payload }] = notificationService.createNotification.mock.calls[0];
+    expect(payload.description).not.toContain("we will close the deployment for you");
+  });
+
   it("reports the longest of several outages so the age names the real problem", async () => {
     const { service, deploymentSettingRepository } = setup({
       outages: [anOutage({}), anOutage({ provider: HEALTHY_PROVIDER, hostUri: "https://other:8443", startedAt: LONGER_OUTAGE_SINCE })],

--- a/apps/api/src/deployment/services/unreachable-provider-deployments-notifier/unreachable-provider-deployments-notifier.service.spec.ts
+++ b/apps/api/src/deployment/services/unreachable-provider-deployments-notifier/unreachable-provider-deployments-notifier.service.spec.ts
@@ -78,7 +78,7 @@ describe(UnreachableProviderDeploymentsNotifierService.name, () => {
     expect(notificationService.createNotification).toHaveBeenCalledTimes(1);
   });
 
-  it("promises an automatic close when every lease of the deployment is dark", async () => {
+  it("tells the owner how long the deployment has before it is closed for them", async () => {
     const { service, notificationService } = setup({
       outages: [anOutage({})],
       leases: [aLease({})]
@@ -88,18 +88,6 @@ describe(UnreachableProviderDeploymentsNotifierService.name, () => {
 
     const [{ payload }] = notificationService.createNotification.mock.calls[0];
     expect(payload.description).toContain(`${CLOSE_AFTER_DAYS} days`);
-  });
-
-  it("promises no automatic close when the deployment still holds a lease on a healthy provider", async () => {
-    const { service, notificationService } = setup({
-      outages: [anOutage({})],
-      leases: [aLease({}), aLease({ providerAddress: HEALTHY_PROVIDER })]
-    });
-
-    await service.notifyUnreachableProviderDeployments({ dryRun: false });
-
-    const [{ payload }] = notificationService.createNotification.mock.calls[0];
-    expect(payload.description).not.toContain("we will close the deployment for you");
   });
 
   it("reports the longest of several outages so the age names the real problem", async () => {

--- a/apps/api/src/deployment/services/unreachable-provider-deployments-notifier/unreachable-provider-deployments-notifier.service.spec.ts
+++ b/apps/api/src/deployment/services/unreachable-provider-deployments-notifier/unreachable-provider-deployments-notifier.service.spec.ts
@@ -14,6 +14,7 @@ import { UnreachableProviderDeploymentsNotifierService } from "./unreachable-pro
 import { mockConfigService } from "@test/mocks/config-service.mock";
 
 const NOTIFY_AFTER_DAYS = 3;
+const CLOSE_AFTER_DAYS = 14;
 const DEPLOY_WEB_BASE_URL = "https://console.akash.network";
 const OWNER = "akash1owner";
 const DSEQ = "1784768430632";
@@ -221,6 +222,7 @@ describe(UnreachableProviderDeploymentsNotifierService.name, () => {
     const notificationService = mock<NotificationService>();
     const config = mockConfigService<DeploymentConfigService>({
       PROVIDER_UNREACHABLE_NOTIFY_AFTER_DAYS: NOTIFY_AFTER_DAYS,
+      PROVIDER_UNREACHABLE_CLOSE_AFTER_DAYS: CLOSE_AFTER_DAYS,
       DEPLOY_WEB_BASE_URL
     });
     const createLogger = vi.fn<CreateLogger>(() => mock<ReturnType<CreateLogger>>());

--- a/apps/api/src/deployment/services/unreachable-provider-deployments-notifier/unreachable-provider-deployments-notifier.service.ts
+++ b/apps/api/src/deployment/services/unreachable-provider-deployments-notifier/unreachable-provider-deployments-notifier.service.ts
@@ -18,7 +18,6 @@ interface DarkDeployment {
   dseq: string;
   hostUri: string;
   downSince: string;
-  isFullyDark: boolean;
 }
 
 /** Managed wallets only, since a self-custody deployment has no account behind its address and so nobody to email. */
@@ -96,8 +95,7 @@ export class UnreachableProviderDeploymentsNotifierService {
         owner,
         dseq,
         hostUri: longestOutage.hostUri,
-        downSince: longestOutage.startedAt,
-        isFullyDark: deploymentOutages.length === deploymentLeases.length
+        downSince: longestOutage.startedAt
       });
     }
 
@@ -176,7 +174,7 @@ export class UnreachableProviderDeploymentsNotifierService {
           owner: deployment.owner,
           hostUri: deployment.hostUri,
           downSince: deployment.downSince,
-          closeAfterDays: deployment.isFullyDark ? this.config.get("PROVIDER_UNREACHABLE_CLOSE_AFTER_DAYS") : undefined,
+          closeAfterDays: this.config.get("PROVIDER_UNREACHABLE_CLOSE_AFTER_DAYS"),
           deploymentUrl: this.#deploymentUrl(deployment.dseq)
         })
       );

--- a/apps/api/src/deployment/services/unreachable-provider-deployments-notifier/unreachable-provider-deployments-notifier.service.ts
+++ b/apps/api/src/deployment/services/unreachable-provider-deployments-notifier/unreachable-provider-deployments-notifier.service.ts
@@ -18,6 +18,7 @@ interface DarkDeployment {
   dseq: string;
   hostUri: string;
   downSince: string;
+  isFullyDark: boolean;
 }
 
 /** Managed wallets only, since a self-custody deployment has no account behind its address and so nobody to email. */
@@ -75,25 +76,32 @@ export class UnreachableProviderDeploymentsNotifierService {
 
     const outageByProvider = new Map(outages.map(outage => [outage.provider, outage]));
     const leases = await this.leaseRepository.findActiveLeasesOfDeploymentsOnProviders([...outageByProvider.keys()]);
-    const darkByDeployment = new Map<string, DarkDeployment>();
+    const leasesByDeployment = new Map<string, ActiveLeaseOnProvider[]>();
 
     for (const lease of leases) {
-      const outage = outageByProvider.get(lease.providerAddress);
-      if (!outage) continue;
-
       const key = this.#deploymentKey(lease);
-      const known = darkByDeployment.get(key);
-      if (known && known.downSince <= outage.startedAt) continue;
+      leasesByDeployment.set(key, [...(leasesByDeployment.get(key) ?? []), lease]);
+    }
 
-      darkByDeployment.set(key, {
-        owner: lease.owner,
-        dseq: lease.dseq,
-        hostUri: outage.hostUri,
-        downSince: outage.startedAt
+    const dark: DarkDeployment[] = [];
+
+    for (const deploymentLeases of leasesByDeployment.values()) {
+      const deploymentOutages = deploymentLeases.map(lease => outageByProvider.get(lease.providerAddress)).filter(outage => !!outage);
+      if (deploymentOutages.length === 0) continue;
+
+      const [{ owner, dseq }] = deploymentLeases;
+      const longestOutage = deploymentOutages.reduce((longest, outage) => (outage.startedAt < longest.startedAt ? outage : longest));
+
+      dark.push({
+        owner,
+        dseq,
+        hostUri: longestOutage.hostUri,
+        downSince: longestOutage.startedAt,
+        isFullyDark: deploymentOutages.length === deploymentLeases.length
       });
     }
 
-    return [...darkByDeployment.values()];
+    return dark;
   }
 
   #deploymentKey(lease: ActiveLeaseOnProvider): string {
@@ -168,7 +176,7 @@ export class UnreachableProviderDeploymentsNotifierService {
           owner: deployment.owner,
           hostUri: deployment.hostUri,
           downSince: deployment.downSince,
-          closeAfterDays: this.config.get("PROVIDER_UNREACHABLE_CLOSE_AFTER_DAYS"),
+          closeAfterDays: deployment.isFullyDark ? this.config.get("PROVIDER_UNREACHABLE_CLOSE_AFTER_DAYS") : undefined,
           deploymentUrl: this.#deploymentUrl(deployment.dseq)
         })
       );

--- a/apps/api/src/deployment/services/unreachable-provider-deployments-notifier/unreachable-provider-deployments-notifier.service.ts
+++ b/apps/api/src/deployment/services/unreachable-provider-deployments-notifier/unreachable-provider-deployments-notifier.service.ts
@@ -168,6 +168,7 @@ export class UnreachableProviderDeploymentsNotifierService {
           owner: deployment.owner,
           hostUri: deployment.hostUri,
           downSince: deployment.downSince,
+          closeAfterDays: this.config.get("PROVIDER_UNREACHABLE_CLOSE_AFTER_DAYS"),
           deploymentUrl: this.#deploymentUrl(deployment.dseq)
         })
       );

--- a/apps/api/src/notifications/services/notification-handler/notification.handler.ts
+++ b/apps/api/src/notifications/services/notification-handler/notification.handler.ts
@@ -14,6 +14,7 @@ import { afterTrialEndsNotification } from "../notification-templates/after-tria
 import { beforeCloseTrialDeploymentNotification } from "../notification-templates/before-close-trial-deployment";
 import { beforeTrialEndsNotification } from "../notification-templates/before-trial-ends-notification";
 import { firstPurchaseBonusGrantedNotification } from "../notification-templates/first-purchase-bonus-granted-notification";
+import { providerUnreachableClosedNotification } from "../notification-templates/provider-unreachable-closed";
 import { startTrialNotification } from "../notification-templates/start-trial-notification";
 import { trialDeploymentClosedNotification } from "../notification-templates/trial-deployment-closed";
 import { trialEndedNotification } from "../notification-templates/trial-ended-notification";
@@ -27,7 +28,8 @@ const notificationTemplates = {
   beforeCloseTrialDeployment: beforeCloseTrialDeploymentNotification,
   trialDeploymentClosed: trialDeploymentClosedNotification,
   trialFirstDeploymentLeaseCreated: trialFirstDeploymentLeaseCreatedNotification,
-  firstPurchaseBonusGranted: firstPurchaseBonusGrantedNotification
+  firstPurchaseBonusGranted: firstPurchaseBonusGrantedNotification,
+  providerUnreachableClosed: providerUnreachableClosedNotification
 };
 
 type NotificationTemplates = typeof notificationTemplates;

--- a/apps/api/src/notifications/services/notification-templates/provider-unreachable-closed.spec.ts
+++ b/apps/api/src/notifications/services/notification-templates/provider-unreachable-closed.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { providerUnreachableClosedNotification } from "./provider-unreachable-closed";
+
+import { createUser } from "@test/seeders/user.seeder";
+
+const REDEPLOY_URL = "https://console.akash.network/new-deployment";
+
+describe(providerUnreachableClosedNotification.name, () => {
+  it("tells the owner which deployment was closed, why, and that the money came back", () => {
+    const user = createUser({ id: "user-123", email: "user@example.com" });
+
+    const result = providerUnreachableClosedNotification(user, {
+      dseq: "654321",
+      owner: "akash1owner",
+      hostUri: "https://provider.akash.cmolls.de:8443",
+      downForDays: 14,
+      redeployUrl: REDEPLOY_URL
+    });
+
+    expect(result.notificationId).toBe("providerUnreachableClosed.654321.akash1owner");
+    expect(result.payload.summary).toBe("Your Akash deployment was closed: provider unreachable");
+    expect(result.payload.description).toContain("<strong>654321</strong>");
+    expect(result.payload.description).toContain("<strong>https://provider.akash.cmolls.de:8443</strong>");
+    expect(result.payload.description).toContain("14 days ago");
+    expect(result.payload.description).toContain("returned");
+    expect(result.payload.description).toContain(`<a href="${REDEPLOY_URL}">Deploy it again</a>`);
+    expect(result.user).toEqual({ id: "user-123", email: "user@example.com" });
+  });
+
+  it("escapes a host uri the provider declared with markup in it", () => {
+    const user = createUser({ id: "user-123", email: "user@example.com" });
+
+    const result = providerUnreachableClosedNotification(user, {
+      dseq: "654321",
+      owner: "akash1owner",
+      hostUri: '<script>alert("xss")</script>',
+      downForDays: 14,
+      redeployUrl: REDEPLOY_URL
+    });
+
+    expect(result.payload.description).not.toContain("<script>");
+    expect(result.payload.description).toContain("&lt;script&gt;");
+  });
+});

--- a/apps/api/src/notifications/services/notification-templates/provider-unreachable-closed.ts
+++ b/apps/api/src/notifications/services/notification-templates/provider-unreachable-closed.ts
@@ -1,0 +1,26 @@
+import escapeHtml from "lodash/escape";
+
+import type { UserOutput } from "@src/user/repositories";
+import type { CreateNotificationInput } from "../notification/notification.service";
+
+/**
+ * A provider's host URI is whatever it declared on chain, so it reaches this email as untrusted text
+ * and is escaped before going into the markup.
+ */
+export function providerUnreachableClosedNotification(
+  user: UserOutput,
+  vars: { dseq: string; owner: string; hostUri: string; downForDays: number; redeployUrl: string }
+): CreateNotificationInput {
+  return {
+    notificationId: `providerUnreachableClosed.${vars.dseq}.${vars.owner}`,
+    payload: {
+      summary: "Your Akash deployment was closed: provider unreachable",
+      description:
+        `Deployment <strong>${vars.dseq}</strong> has been closed. Its provider, ` +
+        `<strong>${escapeHtml(vars.hostUri)}</strong>, stopped responding ${vars.downForDays} days ago and never came back, ` +
+        `so the deployment was costing you money without running anything. What was left of its funds has been returned ` +
+        `to your account. <a href="${vars.redeployUrl}">Deploy it again</a> whenever you are ready.`
+    },
+    user: { id: user.id, email: user.email }
+  };
+}

--- a/apps/api/src/notifications/services/notification-templates/provider-unreachable-notification.spec.ts
+++ b/apps/api/src/notifications/services/notification-templates/provider-unreachable-notification.spec.ts
@@ -32,6 +32,21 @@ describe(providerUnreachableNotification.name, () => {
     expect(result.user).toEqual({ id: "user-123", email: "user@example.com" });
   });
 
+  it("leaves out the closure promise when only part of the deployment is dark", () => {
+    const user = createUser({ id: "user-123", email: "user@example.com" });
+
+    const result = providerUnreachableNotification(user, {
+      dseq: "654321",
+      owner: "akash1owner",
+      hostUri: "https://dark:8443",
+      downSince: subDays(new Date(), 5).toISOString(),
+      deploymentUrl: DEPLOYMENT_URL
+    });
+
+    expect(result.payload.description).not.toContain("we will close the deployment for you");
+    expect(result.payload.description).toContain(`<a href="${DEPLOYMENT_URL}">Close the deployment</a>`);
+  });
+
   it("escapes a host uri the provider declared with markup in it", () => {
     const user = createUser({ id: "user-123", email: "user@example.com" });
 

--- a/apps/api/src/notifications/services/notification-templates/provider-unreachable-notification.spec.ts
+++ b/apps/api/src/notifications/services/notification-templates/provider-unreachable-notification.spec.ts
@@ -32,7 +32,7 @@ describe(providerUnreachableNotification.name, () => {
     expect(result.user).toEqual({ id: "user-123", email: "user@example.com" });
   });
 
-  it("leaves out the closure promise when only part of the deployment is dark", () => {
+  it("makes the closure promise conditional on every provider staying dark", () => {
     const user = createUser({ id: "user-123", email: "user@example.com" });
 
     const result = providerUnreachableNotification(user, {
@@ -40,11 +40,11 @@ describe(providerUnreachableNotification.name, () => {
       owner: "akash1owner",
       hostUri: "https://dark:8443",
       downSince: subDays(new Date(), 5).toISOString(),
+      closeAfterDays: CLOSE_AFTER_DAYS,
       deploymentUrl: DEPLOYMENT_URL
     });
 
-    expect(result.payload.description).not.toContain("we will close the deployment for you");
-    expect(result.payload.description).toContain(`<a href="${DEPLOYMENT_URL}">Close the deployment</a>`);
+    expect(result.payload.description).toContain("If every provider hosting this deployment is still unreachable");
   });
 
   it("escapes a host uri the provider declared with markup in it", () => {

--- a/apps/api/src/notifications/services/notification-templates/provider-unreachable-notification.spec.ts
+++ b/apps/api/src/notifications/services/notification-templates/provider-unreachable-notification.spec.ts
@@ -6,6 +6,7 @@ import { providerUnreachableNotification } from "./provider-unreachable-notifica
 import { createUser } from "@test/seeders/user.seeder";
 
 const DEPLOYMENT_URL = "https://console.akash.network/deployments/654321";
+const CLOSE_AFTER_DAYS = 14;
 
 describe(providerUnreachableNotification.name, () => {
   it("returns a notification naming the deployment, the provider and how long it has been dark", () => {
@@ -17,6 +18,7 @@ describe(providerUnreachableNotification.name, () => {
       owner: "akash1owner",
       hostUri: "https://provider.akash.cmolls.de:8443",
       downSince: downSince.toISOString(),
+      closeAfterDays: CLOSE_AFTER_DAYS,
       deploymentUrl: DEPLOYMENT_URL
     });
 
@@ -26,6 +28,7 @@ describe(providerUnreachableNotification.name, () => {
     expect(result.payload.description).toContain("<strong>https://provider.akash.cmolls.de:8443</strong>");
     expect(result.payload.description).toContain("5 days");
     expect(result.payload.description).toContain(`<a href="${DEPLOYMENT_URL}">Close the deployment</a>`);
+    expect(result.payload.description).toContain("we will close the deployment for you");
     expect(result.user).toEqual({ id: "user-123", email: "user@example.com" });
   });
 
@@ -37,6 +40,7 @@ describe(providerUnreachableNotification.name, () => {
       owner: "akash1owner",
       hostUri: '<script>alert("xss")</script>',
       downSince: subDays(new Date(), 5).toISOString(),
+      closeAfterDays: CLOSE_AFTER_DAYS,
       deploymentUrl: DEPLOYMENT_URL
     });
 
@@ -46,7 +50,7 @@ describe(providerUnreachableNotification.name, () => {
 
   it("keys the notification id on the outage so a provider that recovers and fails again is reported anew", () => {
     const user = createUser({ id: "user-123", email: "user@example.com" });
-    const vars = { dseq: "654321", owner: "akash1owner", hostUri: "https://dark:8443", deploymentUrl: DEPLOYMENT_URL };
+    const vars = { dseq: "654321", owner: "akash1owner", hostUri: "https://dark:8443", closeAfterDays: CLOSE_AFTER_DAYS, deploymentUrl: DEPLOYMENT_URL };
 
     const first = providerUnreachableNotification(user, { ...vars, downSince: subDays(new Date(), 9).toISOString() });
     const second = providerUnreachableNotification(user, { ...vars, downSince: subDays(new Date(), 3).toISOString() });

--- a/apps/api/src/notifications/services/notification-templates/provider-unreachable-notification.ts
+++ b/apps/api/src/notifications/services/notification-templates/provider-unreachable-notification.ts
@@ -10,9 +10,13 @@ import type { CreateNotificationInput } from "../notification/notification.servi
  */
 export function providerUnreachableNotification(
   user: UserOutput,
-  vars: { dseq: string; owner: string; hostUri: string; downSince: string; closeAfterDays: number; deploymentUrl: string }
+  vars: { dseq: string; owner: string; hostUri: string; downSince: string; closeAfterDays?: number; deploymentUrl: string }
 ): CreateNotificationInput {
   const downSince = new Date(vars.downSince);
+  const closurePromise =
+    vars.closeAfterDays === undefined
+      ? ""
+      : ` If the provider is still unreachable ${vars.closeAfterDays} days after it went down, we will close the deployment for you and return what is left.`;
 
   return {
     notificationId: `providerUnreachable.${downSince.toISOString()}.${vars.dseq}.${vars.owner}`,
@@ -22,8 +26,7 @@ export function providerUnreachableNotification(
         `The provider hosting deployment <strong>${vars.dseq}</strong>, <strong>${escapeHtml(vars.hostUri)}</strong>, ` +
         `has not responded for ${formatDistanceToNow(downSince)} and your workload is most likely down. ` +
         `You are still paying for it. <a href="${vars.deploymentUrl}">Close the deployment</a> to get the remaining ` +
-        `funds back, then redeploy somewhere else. If the provider is still unreachable ${vars.closeAfterDays} days ` +
-        `after it went down, we will close the deployment for you and return what is left.`
+        `funds back, then redeploy somewhere else.${closurePromise}`
     },
     user: { id: user.id, email: user.email }
   };

--- a/apps/api/src/notifications/services/notification-templates/provider-unreachable-notification.ts
+++ b/apps/api/src/notifications/services/notification-templates/provider-unreachable-notification.ts
@@ -10,13 +10,9 @@ import type { CreateNotificationInput } from "../notification/notification.servi
  */
 export function providerUnreachableNotification(
   user: UserOutput,
-  vars: { dseq: string; owner: string; hostUri: string; downSince: string; closeAfterDays?: number; deploymentUrl: string }
+  vars: { dseq: string; owner: string; hostUri: string; downSince: string; closeAfterDays: number; deploymentUrl: string }
 ): CreateNotificationInput {
   const downSince = new Date(vars.downSince);
-  const closurePromise =
-    vars.closeAfterDays === undefined
-      ? ""
-      : ` If the provider is still unreachable ${vars.closeAfterDays} days after it went down, we will close the deployment for you and return what is left.`;
 
   return {
     notificationId: `providerUnreachable.${downSince.toISOString()}.${vars.dseq}.${vars.owner}`,
@@ -26,7 +22,8 @@ export function providerUnreachableNotification(
         `The provider hosting deployment <strong>${vars.dseq}</strong>, <strong>${escapeHtml(vars.hostUri)}</strong>, ` +
         `has not responded for ${formatDistanceToNow(downSince)} and your workload is most likely down. ` +
         `You are still paying for it. <a href="${vars.deploymentUrl}">Close the deployment</a> to get the remaining ` +
-        `funds back, then redeploy somewhere else.${closurePromise}`
+        `funds back, then redeploy somewhere else. If every provider hosting this deployment is still unreachable ` +
+        `${vars.closeAfterDays} days after it went down, we will close the deployment for you and return what is left.`
     },
     user: { id: user.id, email: user.email }
   };

--- a/apps/api/src/notifications/services/notification-templates/provider-unreachable-notification.ts
+++ b/apps/api/src/notifications/services/notification-templates/provider-unreachable-notification.ts
@@ -10,7 +10,7 @@ import type { CreateNotificationInput } from "../notification/notification.servi
  */
 export function providerUnreachableNotification(
   user: UserOutput,
-  vars: { dseq: string; owner: string; hostUri: string; downSince: string; deploymentUrl: string }
+  vars: { dseq: string; owner: string; hostUri: string; downSince: string; closeAfterDays: number; deploymentUrl: string }
 ): CreateNotificationInput {
   const downSince = new Date(vars.downSince);
 
@@ -22,7 +22,8 @@ export function providerUnreachableNotification(
         `The provider hosting deployment <strong>${vars.dseq}</strong>, <strong>${escapeHtml(vars.hostUri)}</strong>, ` +
         `has not responded for ${formatDistanceToNow(downSince)} and your workload is most likely down. ` +
         `You are still paying for it. <a href="${vars.deploymentUrl}">Close the deployment</a> to get the remaining ` +
-        `funds back, then redeploy somewhere else.`
+        `funds back, then redeploy somewhere else. If the provider is still unreachable ${vars.closeAfterDays} days ` +
+        `after it went down, we will close the deployment for you and return what is left.`
     },
     user: { id: user.id, email: user.email }
   };


### PR DESCRIPTION
## Why

Closes CON-901. Stacked on #3697 (and through it, #3696 and #3695).

Warning the owner only helps someone who acts on it. When the provider never comes back and the owner does nothing, the deployment stays open until the escrow drains — weeks of paying a counterparty that stopped serving, for a workload that no longer exists. The user in the original case was a month into exactly that.

## What

An hourly sweep finds the deployments where **every one of its active leases** sits on a provider dark for at least `PROVIDER_UNREACHABLE_CLOSE_AFTER_DAYS` (default 14), and hands each one to its own `CloseUnreachableProviderDeploymentCommand`, the way #3698 handles expired-deployment closes. Closing settles the escrow, so the remainder returns to the owner's deployment allowance on its own. They get an email naming the deployment, the provider, how long it was gone, and a link to deploy again.

**Discovery stays a sweep, execution does not.** The outage belongs to provider-inventory, over HTTP and in its own database, so no write in this app can enqueue a job when a provider goes dark. What a job buys is the execution: each deployment gets retry with backoff of its own, and an escrow the chain will not settle yet is retried every 15 minutes by a fresh job instead of waiting out the hour to the next sweep.

**The job re-reads the outage before it broadcasts.** It carries only the owner and dseq, so a job that waited out a long escrow retry decides on what is true when it runs rather than on what the sweep saw. Closing a deployment whose provider came back in the meantime cannot be undone.

**Every lease, not just one.** A deployment still holding a lease on a provider that answers may well be doing useful work; taking that away over a problem the owner can see and act on themselves is not ours to do. Warning is one dark lease; closing is all of them.

**Owners are warned first.** The config schema refuses a close threshold at or below the warning threshold, so nobody's first word about an outage can be the closure notice. The warning email from #3697 now says the closure is coming and when.

**Closing is recorded even for deployments with no settings row** (created before settings existed, or outside the web app) — otherwise every later sweep would broadcast another close for the same deployment.

**Recording the close and queueing the email share one transaction.** `enqueue` joins the ambient transaction, so a deployment can never be recorded as closed without the email that explains it, and never told twice: any later attempt returns early on the recorded close. A failure there throws into the queue's retry budget rather than being collected. Note this is what keeps the email single, not the `singletonKey` on it: the notification queue declares no policy, so it is `standard`, where `singletonKey` does not dedupe.

## Notes

- **Rollout:** unchanged, and no new env var. `--dry-run` enqueues nothing, and this sweep is the only thing that creates these jobs, so the existing flag still gates the whole pipeline. The dry run also screens out self-custody and already-closed deployments, so its count stays the count that would really be closed. Live on staging-sandbox, `--dry-run` on prod-mainnet; keep it there until #3697's warning has been live longer than the gap between the thresholds (14 − 3 = 11 days), and check that every `UNREACHABLE_PROVIDER_DEPLOYMENT_WOULD_CLOSE` deployment was warned first.
- Managed wallets only, same as the warning sweep — closing a self-custody deployment is not something Console has the authority to do.
- No migration. The column this uses came with #3697.


