### PR TITLE
fix(analytics): stop sending Amplitude events from localhost and test runs

### DIFF
--- a/apps/deploy-web/src/services/analytics/analytics.service.spec.ts
+++ b/apps/deploy-web/src/services/analytics/analytics.service.spec.ts
@@ -400,12 +400,103 @@ describe(AnalyticsService.name, () => {
     });
   });
 
+  describe("untrackable hosts", () => {
+    it.each(["localhost", "127.0.0.1", "0.0.0.0", "::1", "[::1]", "console.localhost", "mymachine.local"])(
+      "does not initialize Amplitude on %s even when enabled",
+      hostname => {
+        const init = vi.fn();
+        const identify = vi.fn();
+        const service = setup({
+          amplitude: { init, identify },
+          hostname,
+          options: {
+            amplitude: { enabled: true, apiKey: mockAmplitudeApiKey },
+            ga: { enabled: false, measurementId: mockGaMeasurementId }
+          }
+        });
+
+        service.identify({ id: faker.string.uuid() });
+
+        expect(init).not.toHaveBeenCalled();
+        expect(identify).not.toHaveBeenCalled();
+      }
+    );
+
+    it("does not track Amplitude events on localhost", () => {
+      const track = vi.fn();
+      const service = setup({
+        amplitude: { track },
+        hostname: "localhost",
+        options: {
+          amplitude: { enabled: true, apiKey: mockAmplitudeApiKey },
+          ga: { enabled: false, measurementId: mockGaMeasurementId }
+        }
+      });
+
+      service.track("create_deployment");
+
+      expect(track).not.toHaveBeenCalled();
+    });
+
+    it("does not initialize Amplitude when the hostname is unavailable", () => {
+      const init = vi.fn();
+      const service = setup({
+        amplitude: { init },
+        hostname: "",
+        options: {
+          amplitude: { enabled: true, apiKey: mockAmplitudeApiKey },
+          ga: { enabled: false, measurementId: mockGaMeasurementId }
+        }
+      });
+
+      service.identify({ id: faker.string.uuid() });
+
+      expect(init).not.toHaveBeenCalled();
+    });
+
+    it("still forwards events to GA on localhost so local GTM debugging keeps working", () => {
+      const dataLayer: Record<string, unknown>[] = [];
+      const service = setup({
+        dataLayer,
+        hostname: "localhost",
+        options: {
+          amplitude: { enabled: true, apiKey: mockAmplitudeApiKey },
+          ga: { enabled: true, measurementId: mockGaMeasurementId }
+        }
+      });
+
+      service.track("create_deployment");
+
+      expect(dataLayer).toHaveLength(1);
+    });
+
+    it.each(["console.akash.network", "console-beta.akash.network", "8zv824gmq5zw-console-beta.akash.network"])(
+      "initializes Amplitude on the real host %s",
+      hostname => {
+        const init = vi.fn();
+        const service = setup({
+          amplitude: { init },
+          hostname,
+          options: {
+            amplitude: { enabled: true, apiKey: mockAmplitudeApiKey },
+            ga: { enabled: false, measurementId: mockGaMeasurementId }
+          }
+        });
+
+        service.identify({ id: faker.string.uuid() });
+
+        expect(init).toHaveBeenCalledWith(mockAmplitudeApiKey, undefined, undefined);
+      }
+    );
+  });
+
   function setup(params: {
     amplitude?: Mocked<Amplitude>;
     dataLayer?: Record<string, unknown>[];
     options?: AnalyticsOptions;
     storage?: Pick<Storage, "getItem" | "setItem">;
     locationSearch?: string;
+    hostname?: string;
   }) {
     const amplitude = {
       init: vi.fn(),
@@ -433,7 +524,8 @@ describe(AnalyticsService.name, () => {
       amplitude,
       () => dataLayer,
       storage,
-      () => params.locationSearch ?? ""
+      () => params.locationSearch ?? "",
+      () => params.hostname ?? "console.akash.network"
     );
   }
 });

--- a/apps/deploy-web/src/services/analytics/analytics.service.spec.ts
+++ b/apps/deploy-web/src/services/analytics/analytics.service.spec.ts
@@ -401,7 +401,7 @@ describe(AnalyticsService.name, () => {
   });
 
   describe("untrackable hosts", () => {
-    it.each(["localhost", "127.0.0.1", "0.0.0.0", "::1", "[::1]", "console.localhost", "mymachine.local"])(
+    it.each(["localhost", "127.0.0.1", "127.0.0.2", "127.1.2.3", "0.0.0.0", "::1", "[::1]", "console.localhost", "mymachine.local"])(
       "does not initialize Amplitude on %s even when enabled",
       hostname => {
         const init = vi.fn();
@@ -470,7 +470,7 @@ describe(AnalyticsService.name, () => {
       expect(dataLayer).toHaveLength(1);
     });
 
-    it.each(["console.akash.network", "console-beta.akash.network", "8zv824gmq5zw-console-beta.akash.network"])(
+    it.each(["console.akash.network", "console-beta.akash.network", "8zv824gmq5zw-console-beta.akash.network", "127-console.akash.network"])(
       "initializes Amplitude on the real host %s",
       hostname => {
         const init = vi.fn();

--- a/apps/deploy-web/src/services/analytics/analytics.service.ts
+++ b/apps/deploy-web/src/services/analytics/analytics.service.ts
@@ -168,10 +168,13 @@ const isBrowser = typeof window !== "undefined";
  * Hosts that never belong to a real user: dev servers and jsdom test runs both report one of these, and every
  * device they invent is billed as a tracked user against the Amplitude MTU quota even though nobody is using the app.
  */
-const UNTRACKABLE_HOSTNAMES = new Set(["localhost", "127.0.0.1", "0.0.0.0", "::1", "[::1]"]);
+const UNTRACKABLE_HOSTNAMES = new Set(["localhost", "0.0.0.0", "::1", "[::1]"]);
+
+/** The whole 127.0.0.0/8 range is loopback, so a dev server bound to any of it is still nobody. */
+const IPV4_LOOPBACK = /^127(?:\.\d{1,3}){3}$/;
 
 function isTrackableHostname(hostname: string): boolean {
-  if (!hostname || UNTRACKABLE_HOSTNAMES.has(hostname)) {
+  if (!hostname || UNTRACKABLE_HOSTNAMES.has(hostname) || IPV4_LOOPBACK.test(hostname)) {
     return false;
   }
 

--- a/apps/deploy-web/src/services/analytics/analytics.service.ts
+++ b/apps/deploy-web/src/services/analytics/analytics.service.ts
@@ -164,6 +164,20 @@ const UTM_PARAM_KEYS = ["utm_source", "utm_medium", "utm_campaign", "utm_term", 
 
 const isBrowser = typeof window !== "undefined";
 
+/**
+ * Hosts that never belong to a real user: dev servers and jsdom test runs both report one of these, and every
+ * device they invent is billed as a tracked user against the Amplitude MTU quota even though nobody is using the app.
+ */
+const UNTRACKABLE_HOSTNAMES = new Set(["localhost", "127.0.0.1", "0.0.0.0", "::1", "[::1]"]);
+
+function isTrackableHostname(hostname: string): boolean {
+  if (!hostname || UNTRACKABLE_HOSTNAMES.has(hostname)) {
+    return false;
+  }
+
+  return !hostname.endsWith(".localhost") && !hostname.endsWith(".local");
+}
+
 export type Amplitude = Pick<typeof amplitude, "init" | "Identify" | "identify" | "track" | "setUserId" | "add" | "flush">;
 
 export class AnalyticsService {
@@ -183,9 +197,10 @@ export class AnalyticsService {
     private readonly amplitudeClient: Amplitude = amplitude,
     private readonly getDataLayer: () => Record<string, unknown>[] | undefined = () => (isBrowser ? window.dataLayer : undefined),
     private readonly storage: Pick<Storage, "getItem" | "setItem"> | undefined = isBrowser ? window.localStorage : undefined,
-    private readonly getLocationSearch: () => string = () => (isBrowser ? window.location.search : "")
+    private readonly getLocationSearch: () => string = () => (isBrowser ? window.location.search : ""),
+    private readonly getHostname: () => string = () => (isBrowser ? window.location.hostname : "")
   ) {
-    this.isAmplitudeEnabled = this.options.amplitude.enabled;
+    this.isAmplitudeEnabled = this.options.amplitude.enabled && isTrackableHostname(this.getHostname());
     this.utmProperties = this.captureFirstTouchUtm();
   }
 


### PR DESCRIPTION
## Why

We hit 100% of the Amplitude plan capacity in August (10,596 MTU against a 10,000 quota). Amplitude bills **monthly tracked users**, not events, so the overage is about how many distinct identities we let into the tool.

Auditing the last 30 days across all five projects, **43% of billed users came from `localhost`**:

| Project | Domain | Users | Events |
|---|---|---|---|
| Beta | `localhost` | **5,013** | 106,564 |
| Beta | `console-beta.akash.network` | 1,185 | 26,856 |
| Prod | `localhost` | 200 | 5,614 |

That traffic is not people. Of 6,710 tracked users in the Beta project, only 603 created an account and 243 ever created a deployment, while `navigate_tab` fired 299 times there against 11,283 in production. The daily shape is machine-like too: a burst peaking at 953 users in a single day that does not pause for weekends (Sunday 9 Aug produced 726 users). `log_collector_enabled` fired 27,471 times across 4,148 Beta users, against 17 times in production.

The mechanism is our own config. `env/.env.staging` enables Amplitude with the Beta key, `test:unit` and `test:cov` both run with `DEPLOYMENT_ENV=staging`, `AnalyticsService` gated only on the env flag and defaulted to the real browser client, and jsdom reports hostname `localhost` with a fresh device id per process.

## What

`isAmplitudeEnabled` now requires a trackable hostname in addition to the env flag, so the SDK never initialises on `localhost`, a loopback address, or a `.local`/`.localhost` host. Real deploys are unaffected, including PR preview hosts.

- Injected `getHostname` as a constructor dependency, matching the existing injectable seams, so the guard is unit-testable.
- Added coverage for each untrackable host, for the no-hostname case, and for real hosts still initialising.
- **GA is deliberately left alone.** It is a separate meter and local GTM debugging still works; there is a test pinning that behaviour.

Not fixed here, tracked separately: server-side `email_sent` identities (815 users who never opened the app) and the `log_collector_*` volume.

### Verification
- `npm run test:unit` in `apps/deploy-web`: 366 files, 3608 tests passing
- `npm run lint -- --quiet`: clean
- `npx tsc --noEmit`: 92 pre-existing errors, 0 new (verified against the `origin/main` baseline)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Amplitude analytics is disabled on local, loopback, and other untrackable hostnames.
  * Google Analytics event forwarding continues according to its existing configuration.
  * Amplitude remains enabled on supported production hosts.

* **Tests**
  * Added coverage for analytics behavior across supported and unsupported host environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->