### PR TITLE
fix(deployment): stop the balance floor stranding the tail of a balance

### DIFF
--- a/apps/api/src/deployment/lib/top-up-summarizer/top-up-summarizer.spec.ts
+++ b/apps/api/src/deployment/lib/top-up-summarizer/top-up-summarizer.spec.ts
@@ -1,20 +1,16 @@
 import "reflect-metadata";
 
-import { beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { TopUpSummarizer } from "./top-up-summarizer";
 
 import { createAkashAddress } from "@test/seeders";
 
 describe(TopUpSummarizer.name, () => {
-  let summarizer: TopUpSummarizer;
-
-  beforeEach(() => {
-    summarizer = new TopUpSummarizer();
-  });
-
   describe("inc", () => {
     it("should increment counters", () => {
+      const { summarizer } = setup();
+
       summarizer.inc("deploymentCount");
       summarizer.inc("deploymentTopUpCount");
       summarizer.inc("deploymentTopUpErrorCount");
@@ -27,6 +23,8 @@ describe(TopUpSummarizer.name, () => {
     });
 
     it("should increment by specified value", () => {
+      const { summarizer } = setup();
+
       summarizer.inc("deploymentCount", 2);
       expect(summarizer.get("deploymentCount")).toBe(2);
     });
@@ -37,6 +35,8 @@ describe(TopUpSummarizer.name, () => {
     const WALLET_2 = createAkashAddress();
 
     it("should track unique wallets", () => {
+      const { summarizer } = setup();
+
       summarizer.trackWallet(WALLET_1);
       summarizer.trackWallet(WALLET_2);
       summarizer.trackWallet(WALLET_1); // Duplicate
@@ -45,6 +45,8 @@ describe(TopUpSummarizer.name, () => {
     });
 
     it("should track successful wallets", () => {
+      const { summarizer } = setup();
+
       summarizer.trackWallet(WALLET_1);
       summarizer.trackWallet(WALLET_2);
       summarizer.trackSuccessfulWallet(WALLET_1);
@@ -56,6 +58,8 @@ describe(TopUpSummarizer.name, () => {
     });
 
     it("should track failed wallets", () => {
+      const { summarizer } = setup();
+
       summarizer.trackWallet(WALLET_1);
       summarizer.trackWallet(WALLET_2);
       summarizer.trackFailedWallet(WALLET_1);
@@ -66,6 +70,8 @@ describe(TopUpSummarizer.name, () => {
     });
 
     it("should track mixed success and failure", () => {
+      const { summarizer } = setup();
+
       summarizer.trackWallet(WALLET_1);
       summarizer.trackWallet(WALLET_2);
       summarizer.trackSuccessfulWallet(WALLET_1);
@@ -79,6 +85,8 @@ describe(TopUpSummarizer.name, () => {
 
   describe("addTopUpAmount", () => {
     it("should accumulate top-up amounts", () => {
+      const { summarizer } = setup();
+
       summarizer.addTopUpAmount(100);
       summarizer.addTopUpAmount(200);
 
@@ -88,6 +96,8 @@ describe(TopUpSummarizer.name, () => {
 
   describe("set", () => {
     it("should set block heights", () => {
+      const { summarizer } = setup();
+
       summarizer.set("startBlockHeight", 1000);
       summarizer.set("endBlockHeight", 2000);
 
@@ -98,6 +108,8 @@ describe(TopUpSummarizer.name, () => {
 
   describe("ensurePredictedClosedHeight", () => {
     it("should track minimum predicted closed height", () => {
+      const { summarizer } = setup();
+
       summarizer.ensurePredictedClosedHeight(2000);
       summarizer.ensurePredictedClosedHeight(1000);
 
@@ -105,6 +117,8 @@ describe(TopUpSummarizer.name, () => {
     });
 
     it("should track maximum predicted closed height", () => {
+      const { summarizer } = setup();
+
       summarizer.ensurePredictedClosedHeight(1000);
       summarizer.ensurePredictedClosedHeight(2000);
 
@@ -112,6 +126,8 @@ describe(TopUpSummarizer.name, () => {
     });
 
     it("should handle single height", () => {
+      const { summarizer } = setup();
+
       summarizer.ensurePredictedClosedHeight(1000);
 
       expect(summarizer.get("minPredictedClosedHeight")).toBe(1000);
@@ -121,6 +137,8 @@ describe(TopUpSummarizer.name, () => {
 
   describe("summarize", () => {
     it("should return complete summary", () => {
+      const { summarizer } = setup();
+
       const WALLET_1 = createAkashAddress();
       const WALLET_2 = createAkashAddress();
 
@@ -160,6 +178,8 @@ describe(TopUpSummarizer.name, () => {
     });
 
     it("should handle empty state", () => {
+      const { summarizer } = setup();
+
       expect(summarizer.summarize()).toEqual({
         deploymentCount: 0,
         deploymentTopUpCount: 0,
@@ -179,4 +199,8 @@ describe(TopUpSummarizer.name, () => {
       });
     });
   });
+
+  function setup() {
+    return { summarizer: new TopUpSummarizer() };
+  }
 });

--- a/apps/api/src/deployment/lib/top-up-summarizer/top-up-summarizer.spec.ts
+++ b/apps/api/src/deployment/lib/top-up-summarizer/top-up-summarizer.spec.ts
@@ -129,6 +129,7 @@ describe(TopUpSummarizer.name, () => {
       summarizer.inc("deploymentTopUpErrorCount");
       summarizer.inc("insufficientBalanceCount");
       summarizer.inc("depositsBelowUsefulRunwayCount");
+      summarizer.inc("headroomConcessionCount");
       summarizer.set("startBlockHeight", 1000);
       summarizer.set("endBlockHeight", 2000);
       summarizer.ensurePredictedClosedHeight(1500);
@@ -146,6 +147,7 @@ describe(TopUpSummarizer.name, () => {
         deploymentsMarkedClosedCount: 0,
         insufficientBalanceCount: 1,
         depositsBelowUsefulRunwayCount: 1,
+        headroomConcessionCount: 1,
         walletsCount: 2,
         walletsTopUpCount: 1,
         walletsTopUpErrorCount: 1,
@@ -165,6 +167,7 @@ describe(TopUpSummarizer.name, () => {
         deploymentsMarkedClosedCount: 0,
         insufficientBalanceCount: 0,
         depositsBelowUsefulRunwayCount: 0,
+        headroomConcessionCount: 0,
         walletsCount: 0,
         walletsTopUpCount: 0,
         walletsTopUpErrorCount: 0,

--- a/apps/api/src/deployment/lib/top-up-summarizer/top-up-summarizer.ts
+++ b/apps/api/src/deployment/lib/top-up-summarizer/top-up-summarizer.ts
@@ -7,6 +7,7 @@ interface TopUpSummary {
   deploymentsMarkedClosedCount: number;
   insufficientBalanceCount: number;
   depositsBelowUsefulRunwayCount: number;
+  headroomConcessionCount: number;
   walletsCount: number;
   walletsTopUpCount: number;
   walletsTopUpErrorCount: number;
@@ -26,6 +27,8 @@ export class TopUpSummarizer {
   private insufficientBalanceCount = 0;
 
   private depositsBelowUsefulRunwayCount = 0;
+
+  private headroomConcessionCount = 0;
 
   private deploymentTopUpErrorCount = 0;
 
@@ -56,6 +59,7 @@ export class TopUpSummarizer {
       | "deploymentsMarkedClosedCount"
       | "insufficientBalanceCount"
       | "depositsBelowUsefulRunwayCount"
+      | "headroomConcessionCount"
     >,
     value = 1
   ) {
@@ -115,6 +119,7 @@ export class TopUpSummarizer {
       deploymentsMarkedClosedCount: this.deploymentsMarkedClosedCount,
       insufficientBalanceCount: this.insufficientBalanceCount,
       depositsBelowUsefulRunwayCount: this.depositsBelowUsefulRunwayCount,
+      headroomConcessionCount: this.headroomConcessionCount,
       walletsCount: this.walletAddresses.size,
       walletsTopUpCount: this.successfulWalletAddresses.size,
       walletsTopUpErrorCount: this.failedWalletAddresses.size,

--- a/apps/api/src/deployment/services/cached-balance/cached-balance.service.spec.ts
+++ b/apps/api/src/deployment/services/cached-balance/cached-balance.service.spec.ts
@@ -10,6 +10,9 @@ import { mockConfigService } from "@test/mocks/config-service.mock";
 import { createAkashAddress } from "@test/seeders";
 
 describe(CachedBalanceService.name, () => {
+  /** Mirrors the `DEPLOYMENT_DEFAULT_DEPOSIT` default: the smallest deposit the platform makes, in dollars. */
+  const DEFAULT_DEPOSIT_IN_USD = 0.5;
+
   describe("get", () => {
     const address = createAkashAddress();
     const DEPLOYMENT_LIMIT = 1000;
@@ -168,6 +171,80 @@ describe(CachedBalanceService.name, () => {
       expect(balance.headroomWaived).toBe(false);
     });
 
+    it("waives the headroom when what sits above it is too small to be a deposit", async () => {
+      const { service, balancesService } = setup({ headroomInUsd: 5 });
+      balancesService.getFreshLimits.mockResolvedValue({ deployment: 5_300_000, fee: 100 });
+
+      const balance = await service.getFresh(address);
+
+      expect(balance.spendable).toBe(5_300_000);
+      expect(balance.headroomWaived).toBe(true);
+    });
+
+    it("keeps the headroom when what sits above it is exactly a deposit", async () => {
+      const { service, balancesService } = setup({ headroomInUsd: 5 });
+      balancesService.getFreshLimits.mockResolvedValue({ deployment: 5_500_000, fee: 100 });
+
+      const balance = await service.getFresh(address);
+
+      expect(balance.spendable).toBe(500_000);
+      expect(balance.headroomWaived).toBe(false);
+    });
+
+    it("reports a disabled headroom as unwaived even on a balance below a single deposit", async () => {
+      const { service, balancesService } = setup({ headroomInUsd: 0 });
+      balancesService.getFreshLimits.mockResolvedValue({ deployment: 100_000, fee: 100 });
+
+      const balance = await service.getFresh(address);
+
+      expect(balance.spendable).toBe(100_000);
+      expect(balance.headroomWaived).toBe(false);
+    });
+
+    it("yields the headroom on demand so the whole balance becomes spendable", async () => {
+      const { service, balancesService } = setup({ headroomInUsd: 5 });
+      balancesService.getFreshLimits.mockResolvedValue({ deployment: 10_000_000, fee: 100 });
+
+      const balance = await service.getFresh(address);
+      balance.waiveHeadroom();
+
+      expect(balance.spendable).toBe(10_000_000);
+      expect(balance.headroomWaived).toBe(true);
+    });
+
+    it("previews what yielding the headroom would release without yielding it", async () => {
+      const { service, balancesService } = setup({ headroomInUsd: 5 });
+      balancesService.getFreshLimits.mockResolvedValue({ deployment: 10_000_000, fee: 100 });
+
+      const balance = await service.getFresh(address);
+
+      expect(balance.previewSufficientAmountWithoutHeadroom(10_000_000)).toBe(10_000_000);
+      expect(balance.previewSufficientAmount(10_000_000)).toBe(5_000_000);
+      expect(balance.headroomWaived).toBe(false);
+    });
+
+    it("previews the same amount with and without a disabled headroom", async () => {
+      const { service, balancesService } = setup({ headroomInUsd: 0 });
+      balancesService.getFreshLimits.mockResolvedValue({ deployment: 10_000_000, fee: 100 });
+
+      const balance = await service.getFresh(address);
+
+      expect(balance.previewSufficientAmountWithoutHeadroom(10_000_000)).toBe(10_000_000);
+      expect(balance.previewSufficientAmount(10_000_000)).toBe(10_000_000);
+    });
+
+    it("keeps what a batch already reserved out of the balance the yielded headroom releases", async () => {
+      const { service, balancesService } = setup({ headroomInUsd: 5 });
+      balancesService.getFreshLimits.mockResolvedValue({ deployment: 10_000_000, fee: 100 });
+
+      const balance = await service.getFresh(address);
+      balance.reserveSufficientAmount(3_000_000);
+      balance.waiveHeadroom();
+
+      expect(balance.spendable).toBe(7_000_000);
+      expect(balance.previewSufficientAmountWithoutHeadroom(10_000_000)).toBe(7_000_000);
+    });
+
     it("logs the headroom decision so the floor can be tuned from data", async () => {
       const { service, balancesService, logger } = setup({ headroomInUsd: 5 });
       balancesService.getFreshLimits.mockResolvedValue({ deployment: 6_000_000, fee: 100 });
@@ -179,6 +256,7 @@ describe(CachedBalanceService.name, () => {
         address,
         available: 6_000_000,
         headroom: 5_000_000,
+        minDeposit: 500_000,
         spendable: 1_000_000,
         waived: false
       });
@@ -191,10 +269,11 @@ describe(CachedBalanceService.name, () => {
     expect(createLogger).toHaveBeenCalledWith({ context: CachedBalanceService.name });
   });
 
-  function setup(input?: { headroomInUsd?: number }) {
+  function setup(input?: { headroomInUsd?: number; defaultDepositInUsd?: number }) {
     const balancesService = mock<BalancesService>();
     const deploymentConfig = mockConfigService<DeploymentConfigService>({
-      AUTO_TOP_UP_BALANCE_HEADROOM_IN_USD: input?.headroomInUsd ?? 0
+      AUTO_TOP_UP_BALANCE_HEADROOM_IN_USD: input?.headroomInUsd ?? 0,
+      DEPLOYMENT_DEFAULT_DEPOSIT: input?.defaultDepositInUsd ?? DEFAULT_DEPOSIT_IN_USD
     });
     const logger = mock<ReturnType<CreateLogger>>();
     const createLogger = vi.fn<CreateLogger>(() => logger);

--- a/apps/api/src/deployment/services/cached-balance/cached-balance.service.spec.ts
+++ b/apps/api/src/deployment/services/cached-balance/cached-balance.service.spec.ts
@@ -10,7 +10,6 @@ import { mockConfigService } from "@test/mocks/config-service.mock";
 import { createAkashAddress } from "@test/seeders";
 
 describe(CachedBalanceService.name, () => {
-  /** Mirrors the `DEPLOYMENT_DEFAULT_DEPOSIT` default: the smallest deposit the platform makes, in dollars. */
   const DEFAULT_DEPOSIT_IN_USD = 0.5;
 
   describe("get", () => {

--- a/apps/api/src/deployment/services/cached-balance/cached-balance.service.ts
+++ b/apps/api/src/deployment/services/cached-balance/cached-balance.service.ts
@@ -12,13 +12,7 @@ export class CachedBalance {
   #headroomWaived: boolean;
   #reserved = 0;
 
-  /**
-   * The headroom is kept only while what sits above it is worth depositing. A remainder below `minDeposit`
-   * cannot be a deposit at all, so the floor yields whole rather than being handed out as dust, and it yields
-   * for the same reason once the balance no longer covers it: keeping running deployments alive outranks
-   * reserving room for a new one. The floor is resolved once, from the balance the funding pass started with,
-   * so a batch cannot chip it away one deployment at a time; `waiveHeadroom` is the only other way past it.
-   */
+  /** The floor is kept only while what sits above it is at least `minDeposit`, and is resolved once per funding pass. */
   constructor(available: number, { headroom, minDeposit }: { headroom: number; minDeposit: number }) {
     this.#available = available;
     this.#headroom = headroom;
@@ -37,11 +31,7 @@ export class CachedBalance {
     return this.#headroomWaived;
   }
 
-  /**
-   * Yields the floor for the rest of the pass, leaving the whole balance spendable. The floor exists to keep
-   * a new deployment possible, which is worth nothing when withholding it closes the deployment it was
-   * withheld from, so a caller concedes it rather than skip a deposit the floor alone made too small.
-   */
+  /** Yields the floor for the rest of the pass, so no deposit is ever lost to it. */
   public waiveHeadroom(): void {
     this.#headroomWaived = true;
   }
@@ -54,10 +44,7 @@ export class CachedBalance {
     return Math.min(desiredAmount, this.spendable);
   }
 
-  /**
-   * What the same preview would hand out with the floor yielded, so a caller can weigh a concession before
-   * making it: the floor is only worth giving up when giving it up changes the answer.
-   */
+  /** Lets a caller weigh a floor concession before making it. */
   public previewSufficientAmountWithoutHeadroom(desiredAmount: number) {
     return Math.min(desiredAmount, this.#available - this.#reserved);
   }
@@ -98,10 +85,7 @@ export class CachedBalanceService {
     return this.buildForAddress(address);
   }
 
-  /**
-   * The floor's minimum useful deposit is the platform's own default deposit: the smallest amount it will ever
-   * deposit, already held at or above the chain's `min_deposits`, so a remainder below it is not a deposit.
-   */
+  /** The floor's minimum is the platform's own default deposit, the smallest amount it will ever deposit. */
   private async buildForAddress(address: string): Promise<CachedBalance> {
     const limits = await this.balancesService.getFreshLimits({ address });
     const headroom = denomToUdenom(this.deploymentConfig.get("AUTO_TOP_UP_BALANCE_HEADROOM_IN_USD"));

--- a/apps/api/src/deployment/services/cached-balance/cached-balance.service.ts
+++ b/apps/api/src/deployment/services/cached-balance/cached-balance.service.ts
@@ -8,18 +8,21 @@ import { denomToUdenom } from "@src/utils/math";
 
 export class CachedBalance {
   readonly #available: number;
-  readonly #headroomWaived: boolean;
-  #spendable: number;
+  readonly #headroom: number;
+  #headroomWaived: boolean;
+  #reserved = 0;
 
   /**
-   * The headroom yields the moment the balance cannot cover it: keeping running deployments alive outranks
-   * reserving room for a new one. It is resolved once, from the balance the funding pass started with, so a
-   * batch cannot chip the floor away one deployment at a time.
+   * The headroom is kept only while what sits above it is worth depositing. A remainder below `minDeposit`
+   * cannot be a deposit at all, so the floor yields whole rather than being handed out as dust, and it yields
+   * for the same reason once the balance no longer covers it: keeping running deployments alive outranks
+   * reserving room for a new one. The floor is resolved once, from the balance the funding pass started with,
+   * so a batch cannot chip it away one deployment at a time; `waiveHeadroom` is the only other way past it.
    */
-  constructor(available: number, headroom: number) {
+  constructor(available: number, { headroom, minDeposit }: { headroom: number; minDeposit: number }) {
     this.#available = available;
-    this.#headroomWaived = headroom > 0 && available <= headroom;
-    this.#spendable = available > headroom ? available - headroom : available;
+    this.#headroom = headroom;
+    this.#headroomWaived = headroom > 0 && available - headroom < minDeposit;
   }
 
   public get available() {
@@ -27,7 +30,7 @@ export class CachedBalance {
   }
 
   public get spendable() {
-    return this.#spendable;
+    return (this.#headroomWaived ? this.#available : this.#available - this.#headroom) - this.#reserved;
   }
 
   public get headroomWaived() {
@@ -35,21 +38,38 @@ export class CachedBalance {
   }
 
   /**
+   * Yields the floor for the rest of the pass, leaving the whole balance spendable. The floor exists to keep
+   * a new deployment possible, which is worth nothing when withholding it closes the deployment it was
+   * withheld from, so a caller concedes it rather than skip a deposit the floor alone made too small.
+   */
+  public waiveHeadroom(): void {
+    this.#headroomWaived = true;
+  }
+
+  /**
    * What `reserveSufficientAmount` would hand out, without taking it, so a caller can decline a deposit
    * before the allowance is spoken for and leave it to the rest of the owner's batch.
    */
   public previewSufficientAmount(desiredAmount: number) {
-    return Math.min(desiredAmount, this.#spendable);
+    return Math.min(desiredAmount, this.spendable);
+  }
+
+  /**
+   * What the same preview would hand out with the floor yielded, so a caller can weigh a concession before
+   * making it: the floor is only worth giving up when giving it up changes the answer.
+   */
+  public previewSufficientAmountWithoutHeadroom(desiredAmount: number) {
+    return Math.min(desiredAmount, this.#available - this.#reserved);
   }
 
   public reserveSufficientAmount(desiredAmount: number) {
     const value = this.previewSufficientAmount(desiredAmount);
 
     if (value <= 0) {
-      throw new Error(`Insufficient balance: ${this.#spendable} < ${desiredAmount}`);
+      throw new Error(`Insufficient balance: ${this.spendable} < ${desiredAmount}`);
     }
 
-    this.#spendable -= value;
+    this.#reserved += value;
 
     return value;
   }
@@ -78,16 +98,22 @@ export class CachedBalanceService {
     return this.buildForAddress(address);
   }
 
+  /**
+   * The floor's minimum useful deposit is the platform's own default deposit: the smallest amount it will ever
+   * deposit, already held at or above the chain's `min_deposits`, so a remainder below it is not a deposit.
+   */
   private async buildForAddress(address: string): Promise<CachedBalance> {
     const limits = await this.balancesService.getFreshLimits({ address });
     const headroom = denomToUdenom(this.deploymentConfig.get("AUTO_TOP_UP_BALANCE_HEADROOM_IN_USD"));
-    const balance = new CachedBalance(limits.deployment, headroom);
+    const minDeposit = denomToUdenom(this.deploymentConfig.get("DEPLOYMENT_DEFAULT_DEPOSIT"));
+    const balance = new CachedBalance(limits.deployment, { headroom, minDeposit });
 
     this.logger.info({
       event: "AUTO_TOP_UP_BALANCE_HEADROOM",
       address,
       available: balance.available,
       headroom,
+      minDeposit,
       spendable: balance.spendable,
       waived: balance.headroomWaived
     });

--- a/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.spec.ts
+++ b/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.spec.ts
@@ -23,6 +23,8 @@ import { createUserWallet } from "@test/seeders/user-wallet.seeder";
 describe(InitialDeploymentFundingService.name, () => {
   const CURRENT_HEIGHT = 1000;
   const LOOK_AHEAD_HEIGHT = CURRENT_HEIGHT + 600 * 24;
+  /** Mirrors the `DEPLOYMENT_DEFAULT_DEPOSIT` default of $0.50: the smallest deposit worth holding a floor for. */
+  const MIN_DEPOSIT = 500_000;
 
   it("throws when the lease is not visible on chain yet", async () => {
     const { service, drainingDeploymentService, managedSignerService } = setup();
@@ -227,7 +229,7 @@ describe(InitialDeploymentFundingService.name, () => {
     const { service, drainingDeploymentService, rpcMessageService, cachedBalanceService } = setup();
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
     drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(500000);
-    cachedBalanceService.getFresh.mockResolvedValue(new CachedBalance(200000, 0));
+    cachedBalanceService.getFresh.mockResolvedValue(new CachedBalance(200000, { headroom: 0, minDeposit: MIN_DEPOSIT }));
 
     await service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" });
 
@@ -238,7 +240,7 @@ describe(InitialDeploymentFundingService.name, () => {
     const { service, drainingDeploymentService, managedSignerService, instrumentation, cachedBalanceService } = setup();
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
     drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(500000);
-    cachedBalanceService.getFresh.mockResolvedValue(new CachedBalance(0, 0));
+    cachedBalanceService.getFresh.mockResolvedValue(new CachedBalance(0, { headroom: 0, minDeposit: MIN_DEPOSIT }));
 
     await service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" });
 
@@ -253,7 +255,7 @@ describe(InitialDeploymentFundingService.name, () => {
     const { service, drainingDeploymentService, rpcMessageService, cachedBalanceService } = setup();
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
     drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(10_000_000);
-    cachedBalanceService.getFresh.mockResolvedValue(new CachedBalance(10_000_000, 5_000_000));
+    cachedBalanceService.getFresh.mockResolvedValue(new CachedBalance(10_000_000, { headroom: 5_000_000, minDeposit: MIN_DEPOSIT }));
 
     await service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" });
 
@@ -264,7 +266,7 @@ describe(InitialDeploymentFundingService.name, () => {
     const { service, drainingDeploymentService, rpcMessageService, cachedBalanceService } = setup();
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
     drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(10_000_000);
-    cachedBalanceService.getFresh.mockResolvedValue(new CachedBalance(4_000_000, 5_000_000));
+    cachedBalanceService.getFresh.mockResolvedValue(new CachedBalance(4_000_000, { headroom: 5_000_000, minDeposit: MIN_DEPOSIT }));
 
     await service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" });
 
@@ -275,11 +277,22 @@ describe(InitialDeploymentFundingService.name, () => {
     const { service, drainingDeploymentService, rpcMessageService, cachedBalanceService } = setup();
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
     drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(10_000_000);
-    cachedBalanceService.getFresh.mockResolvedValue(new CachedBalance(5_000_000, 5_000_000));
+    cachedBalanceService.getFresh.mockResolvedValue(new CachedBalance(5_000_000, { headroom: 5_000_000, minDeposit: MIN_DEPOSIT }));
 
     await service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" });
 
     expect(rpcMessageService.getDepositDeploymentMsg).toHaveBeenCalledWith(expect.objectContaining({ amount: 5_000_000 }));
+  });
+
+  it("funds the full balance when what sits above the headroom is too small to be a deposit", async () => {
+    const { service, drainingDeploymentService, rpcMessageService, cachedBalanceService } = setup();
+    drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment()]);
+    drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(10_000_000);
+    cachedBalanceService.getFresh.mockResolvedValue(new CachedBalance(5_300_000, { headroom: 5_000_000, minDeposit: MIN_DEPOSIT }));
+
+    await service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" });
+
+    expect(rpcMessageService.getDepositDeploymentMsg).toHaveBeenCalledWith(expect.objectContaining({ amount: 5_300_000 }));
   });
 
   it("skips funding when the wallet is not found", async () => {
@@ -410,7 +423,7 @@ describe(InitialDeploymentFundingService.name, () => {
     const createLogger: CreateLogger = () => logger;
 
     blockHttpService.getCurrentHeight.mockResolvedValue(CURRENT_HEIGHT);
-    cachedBalanceService.getFresh.mockResolvedValue(new CachedBalance(1000000, 0));
+    cachedBalanceService.getFresh.mockResolvedValue(new CachedBalance(1000000, { headroom: 0, minDeposit: MIN_DEPOSIT }));
     userWalletRepository.findById.mockResolvedValue(createUserWallet({ id: 1, address: "akash1owner" }));
     managedSignerService.ensureFeeGrants.mockResolvedValue(100000);
     managedSignerService.executeDerivedTx.mockResolvedValue({ code: 0, hash: "TESTHASH", rawLog: "[]" });

--- a/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.spec.ts
+++ b/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.spec.ts
@@ -23,7 +23,6 @@ import { createUserWallet } from "@test/seeders/user-wallet.seeder";
 describe(InitialDeploymentFundingService.name, () => {
   const CURRENT_HEIGHT = 1000;
   const LOOK_AHEAD_HEIGHT = CURRENT_HEIGHT + 600 * 24;
-  /** Mirrors the `DEPLOYMENT_DEFAULT_DEPOSIT` default of $0.50: the smallest deposit worth holding a floor for. */
   const MIN_DEPOSIT = 500_000;
 
   it("throws when the lease is not visible on chain yet", async () => {

--- a/apps/api/src/deployment/services/top-up-managed-deployments/deployment-top-up-instrumentation.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/deployment-top-up-instrumentation.ts
@@ -14,6 +14,14 @@ export interface DeploymentTopUpInstrumentation {
   recordInvalidDepositAmount(details: { desiredAmount: number; dseq: string; address: string; blockRate: number }): void;
   recordRuntimeLimitReached(details: { dseq: string; address: string; runtimeEndsAt: Date }): void;
   recordDepositBelowUsefulRunway(details: { dseq: string; address: string; desiredAmount: number; affordableAmount: number; runwayMinutes: number }): void;
+  recordHeadroomConceded(details: {
+    dseq: string;
+    address: string;
+    desiredAmount: number;
+    flooredAmount: number;
+    affordableAmount: number;
+    runwayMinutes: number;
+  }): void;
   recordMessagePreparationError(details: { deployment: DrainingDeployment; error: unknown }): void;
   recordSkipped(details: { owner: string; deploymentCount: number }): void;
   recordDeposit(details: { owner: string; items: FundingMessageItem[] }): void;

--- a/apps/api/src/deployment/services/top-up-managed-deployments/fund-draining-deployments-instrumentation.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/fund-draining-deployments-instrumentation.service.spec.ts
@@ -167,6 +167,25 @@ describe(FundDrainingDeploymentsInstrumentationService.name, () => {
     });
   });
 
+  describe("recordHeadroomConceded", () => {
+    it("increments the concession counter and warns with the amounts either side of it", () => {
+      const { service, headroomConcessions } = setup();
+      const details = {
+        dseq: "900001",
+        address: "akash1owner",
+        desiredAmount: 50_000_000,
+        flooredAmount: 600_000,
+        affordableAmount: 5_600_000,
+        runwayMinutes: 2880
+      };
+
+      service.recordHeadroomConceded(details);
+
+      expect(headroomConcessions.add).toHaveBeenCalledWith(1);
+      expect(mockLogger.warn).toHaveBeenCalledWith({ event: "FUND_DRAINING_HEADROOM_CONCEDED", ...details });
+    });
+  });
+
   describe("recordDeploymentsMarkedClosed", () => {
     it("increments the marked-closed counter by the given count", () => {
       const { service, deploymentsMarkedClosed } = setup();
@@ -270,6 +289,7 @@ describe(FundDrainingDeploymentsInstrumentationService.name, () => {
       masterWalletInsufficientFunds: counters["fund_draining_deployments_master_wallet_insufficient_funds_total"],
       deploymentsMarkedClosed: counters["fund_draining_deployments_deployments_marked_closed_total"],
       claimReleaseErrors: counters["fund_draining_deployments_claim_release_errors_total"],
+      headroomConcessions: counters["fund_draining_deployments_headroom_concessions_total"],
       jobDuration: histograms["fund_draining_deployments_job_duration_ms"],
       depositAmount: histograms["fund_draining_deployments_deposit_amount"]
     };

--- a/apps/api/src/deployment/services/top-up-managed-deployments/fund-draining-deployments-instrumentation.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/fund-draining-deployments-instrumentation.service.ts
@@ -43,6 +43,7 @@ export class FundDrainingDeploymentsInstrumentationService implements Deployment
   private readonly masterWalletInsufficientFunds: Counter;
   private readonly deploymentsMarkedClosed: Counter;
   private readonly claimReleaseErrors: Counter;
+  private readonly headroomConcessions: Counter;
 
   private readonly logger = createOtelLogger({ context: "FundDrainingDeploymentsService" });
 
@@ -98,6 +99,10 @@ export class FundDrainingDeploymentsInstrumentationService implements Deployment
     this.claimReleaseErrors = this.metricsService.createCounter(this.meter, "fund_draining_deployments_claim_release_errors_total", {
       description: "Total number of failed attempts to release an immediate funding claim after a deposit did not land"
     });
+
+    this.headroomConcessions = this.metricsService.createCounter(this.meter, "fund_draining_deployments_headroom_concessions_total", {
+      description: "Total number of immediate funding deposits sized from the whole balance because keeping the headroom would have skipped them"
+    });
   }
 
   recordJobSucceeded(durationMs: number): void {
@@ -143,6 +148,18 @@ export class FundDrainingDeploymentsInstrumentationService implements Deployment
   recordDepositBelowUsefulRunway(details: { dseq: string; address: string; desiredAmount: number; affordableAmount: number; runwayMinutes: number }): void {
     this.skips.add(1, { reason: "below_useful_runway" satisfies FundDrainingSkipReason });
     this.emitLog("warn", { event: "FUND_DRAINING_DEPOSIT_BELOW_USEFUL_RUNWAY", ...details });
+  }
+
+  recordHeadroomConceded(details: {
+    dseq: string;
+    address: string;
+    desiredAmount: number;
+    flooredAmount: number;
+    affordableAmount: number;
+    runwayMinutes: number;
+  }): void {
+    this.headroomConcessions.add(1);
+    this.emitLog("warn", { event: "FUND_DRAINING_HEADROOM_CONCEDED", ...details });
   }
 
   recordMessagePreparationError({ deployment, error }: { deployment: DrainingDeployment; error: unknown }): void {

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.spec.ts
@@ -128,6 +128,46 @@ describe(TopUpManagedDeploymentsInstrumentationService.name, () => {
     });
   });
 
+  describe("recordHeadroomConceded", () => {
+    it("counts the concession, warns with the amounts either side of it, and carries the dry-run flag", () => {
+      const { service, logger, summarizer, countersByName } = setup();
+      service.start(100, { dryRun: false });
+      const deployment = createDrainingDeployment();
+      const details = {
+        dseq: deployment.dseq,
+        address: deployment.address,
+        desiredAmount: 50_000_000,
+        flooredAmount: 600_000,
+        affordableAmount: 5_600_000,
+        runwayMinutes: 2880
+      };
+
+      service.recordHeadroomConceded(details);
+
+      expect(summarizer.get("headroomConcessionCount")).toBe(1);
+      expect(countersByName["auto_top_up_headroom_concessions_total"].add).toHaveBeenCalledWith(1);
+      expect(logger.warn).toHaveBeenCalledWith({ event: "AUTO_TOP_UP_HEADROOM_CONCEDED", ...details, dryRun: false });
+    });
+
+    it("counts the concession without emitting a metric in dry run mode", () => {
+      const { service, summarizer, countersByName } = setup();
+      service.start(100, { dryRun: true });
+      const deployment = createDrainingDeployment();
+
+      service.recordHeadroomConceded({
+        dseq: deployment.dseq,
+        address: deployment.address,
+        desiredAmount: 50_000_000,
+        flooredAmount: 600_000,
+        affordableAmount: 5_600_000,
+        runwayMinutes: 2880
+      });
+
+      expect(summarizer.get("headroomConcessionCount")).toBe(1);
+      expect(countersByName["auto_top_up_headroom_concessions_total"].add).not.toHaveBeenCalled();
+    });
+  });
+
   describe("recordDeploymentPreparation", () => {
     it("records predicted close blocks when start height is set", () => {
       const { service, summarizer } = setup();

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.ts
@@ -21,6 +21,7 @@ export class TopUpManagedDeploymentsInstrumentationService implements Deployment
   private readonly predictedCloseBlocks: Histogram;
   private readonly insufficientBalanceWithAutoReload: Counter;
   private readonly depositsBelowUsefulRunway: Counter;
+  private readonly headroomConcessions: Counter;
   private readonly settingToggles: Counter;
   private readonly logger: ReturnType<CreateLogger>;
   private startTime: number | undefined;
@@ -75,6 +76,10 @@ export class TopUpManagedDeploymentsInstrumentationService implements Deployment
 
     this.depositsBelowUsefulRunway = this.metricsService.createCounter(this.meter, "auto_top_up_deposits_below_useful_runway_total", {
       description: "Total number of deposits declined because the credits available bought less runway than the dedup cooldown"
+    });
+
+    this.headroomConcessions = this.metricsService.createCounter(this.meter, "auto_top_up_headroom_concessions_total", {
+      description: "Total number of deposits sized from the whole balance because keeping the headroom would have skipped them"
     });
 
     this.settingToggles = this.metricsService.createCounter(this.meter, "auto_top_up_setting_toggles_total", {
@@ -163,6 +168,22 @@ export class TopUpManagedDeploymentsInstrumentationService implements Deployment
 
     this.execWhenEnabled(() => {
       this.chainTxErrors.add(1);
+    });
+  }
+
+  recordHeadroomConceded(details: {
+    dseq: string;
+    address: string;
+    desiredAmount: number;
+    flooredAmount: number;
+    affordableAmount: number;
+    runwayMinutes: number;
+  }): void {
+    this.topUpSummarizer.inc("headroomConcessionCount");
+    this.logger.warn({ event: "AUTO_TOP_UP_HEADROOM_CONCEDED", ...details, dryRun: this.options?.dryRun });
+
+    this.execWhenEnabled(() => {
+      this.headroomConcessions.add(1);
     });
   }
 

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.integration.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.integration.ts
@@ -23,6 +23,13 @@ const BLOCK_RATE = 50;
 const ESCROW_AMOUNT = "50000";
 /** Mirrors the `AUTO_TOP_UP_BALANCE_HEADROOM_IN_USD` default of $5, in the grant denom's micro units. */
 const HEADROOM_UDENOM = 5000000;
+/** Escrow left on a deployment that closes in well under the funding cooldown, so any capped deposit is declined. */
+const NEARLY_DRAINED_ESCROW_AMOUNT = "1000";
+/**
+ * Credits above the headroom floor that buy under an hour of runway at `BLOCK_RATE`, so keeping the floor
+ * would leave the deployment unfunded rather than merely underfunded.
+ */
+const ALLOWANCE_ABOVE_HEADROOM_BELOW_A_COOLDOWN = 20000;
 
 type DepositMessage = { value: { deposit?: { amount?: { amount: string } } } };
 
@@ -387,6 +394,27 @@ describe(TopUpManagedDeploymentsService.name, () => {
       expect(depositedAmounts(executeDerivedTx)).toEqual([500000]);
     });
 
+    it("spends into the headroom floor rather than leave a deployment minutes from closing unfunded", async () => {
+      const { topUpService, executeDerivedTx, createUserWithWallet, createDeploymentSetting, mockLeasesForOwner, mockDeploymentsForOwner, stubGetFreshLimits } =
+        await setup();
+      const { user, address } = await createUserWithWallet();
+      const drainingDseq = "900003";
+      const available = HEADROOM_UDENOM + ALLOWANCE_ABOVE_HEADROOM_BELOW_A_COOLDOWN;
+
+      await createDeploymentSetting(user.id, drainingDseq);
+
+      mockLeasesForOwner(address, [createActiveLease(address, drainingDseq)]);
+      mockDeploymentsForOwner(address, [createActiveDeployment(address, drainingDseq, NEARLY_DRAINED_ESCROW_AMOUNT)]);
+      stubGetFreshLimits({ [address]: available });
+
+      await topUpService.topUpDeployments({ dryRun: false });
+
+      const [deposited] = depositedAmounts(executeDerivedTx);
+      expect(executeDerivedTx).toHaveBeenCalledOnce();
+      expect(deposited).toBeGreaterThan(ALLOWANCE_ABOVE_HEADROOM_BELOW_A_COOLDOWN);
+      expect(deposited).toBeLessThanOrEqual(available);
+    });
+
     it("funds a draining deployment from the whole balance when it sits below the headroom floor", async () => {
       const { topUpService, executeDerivedTx, createUserWithWallet, createDeploymentSetting, mockLeasesForOwner, mockDeploymentsForOwner, stubGetFreshLimits } =
         await setup();
@@ -511,12 +539,12 @@ describe(TopUpManagedDeploymentsService.name, () => {
     });
   }
 
-  function createActiveDeployment(owner: string, dseq: string) {
+  function createActiveDeployment(owner: string, dseq: string, escrowAmount = ESCROW_AMOUNT) {
     return createDeploymentInfoSeed({
       owner,
       dseq,
       state: "active",
-      amount: ESCROW_AMOUNT,
+      amount: escrowAmount,
       denom: DENOM,
       createdAt: String(CURRENT_HEIGHT - 1000)
     });

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.integration.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.integration.ts
@@ -23,12 +23,7 @@ const BLOCK_RATE = 50;
 const ESCROW_AMOUNT = "50000";
 /** Mirrors the `AUTO_TOP_UP_BALANCE_HEADROOM_IN_USD` default of $5, in the grant denom's micro units. */
 const HEADROOM_UDENOM = 5000000;
-/** Escrow left on a deployment that closes in well under the funding cooldown, so any capped deposit is declined. */
 const NEARLY_DRAINED_ESCROW_AMOUNT = "1000";
-/**
- * Credits above the headroom floor that buy under an hour of runway at `BLOCK_RATE`, so keeping the floor
- * would leave the deployment unfunded rather than merely underfunded.
- */
 const ALLOWANCE_ABOVE_HEADROOM_BELOW_A_COOLDOWN = 20000;
 
 type DepositMessage = { value: { deposit?: { amount?: { amount: string } } } };

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
@@ -37,15 +37,22 @@ describe(TopUpManagedDeploymentsService.name, () => {
   const DEDUP_COOLDOWN_IN_MIN = 60;
   /** A deposit that reaches the 48h target runway, so it is never declined for being too small to outlast the cooldown. */
   const RUNWAY_MINUTES_AT_TARGET = 48 * 60;
+  /** Mirrors the `DEPLOYMENT_DEFAULT_DEPOSIT` default of $0.50: the smallest deposit worth holding a floor for. */
+  const MIN_DEPOSIT = 500_000;
+  const HEADROOM = 5_000_000;
 
   function createFundingClaim(id: string) {
     return { id, claimedAt: CLAIMED_AT };
   }
 
-  /** Mirrors `CachedBalance`: one allowance answers both the preview and the reservation, and reserving nothing throws. */
+  /**
+   * Mirrors `CachedBalance` with no headroom held: one allowance answers every preview and the reservation,
+   * and reserving nothing throws.
+   */
   function createMockCachedBalance(affordableAmount: (desiredAmount: number) => number) {
     const balance = mock<CachedBalance>();
     balance.previewSufficientAmount.mockImplementation(affordableAmount);
+    balance.previewSufficientAmountWithoutHeadroom.mockImplementation(affordableAmount);
     balance.reserveSufficientAmount.mockImplementation(desiredAmount => {
       const amount = affordableAmount(desiredAmount);
 
@@ -790,6 +797,75 @@ describe(TopUpManagedDeploymentsService.name, () => {
       expect(walletReloadService.scheduleImmediate).not.toHaveBeenCalled();
     });
 
+    it("yields the balance headroom rather than decline a deposit the headroom alone made too small", async () => {
+      const { service, drainingDeploymentService, cachedBalanceService, managedSignerService, fundDrainingInstrumentation } = setup();
+      const owner = createAkashAddress();
+      const walletId = faker.number.int({ min: 1000000, max: 9999999 });
+      const deployment = createDrainingFor(owner, walletId);
+      const available = HEADROOM + 600_000;
+      const desiredAmount = 50_000_000;
+
+      drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([deployment]);
+      drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(desiredAmount);
+      drainingDeploymentService.calculateRunwayMinutesAfterDeposit.mockImplementation((_deployment, amount) =>
+        amount >= available ? RUNWAY_MINUTES_AT_TARGET : DEDUP_COOLDOWN_IN_MIN - 1
+      );
+      cachedBalanceService.getFresh.mockResolvedValue(new CachedBalance(available, { headroom: HEADROOM, minDeposit: MIN_DEPOSIT }));
+
+      await service.topUpDrainingDeploymentsForOwner({ walletId, address: owner });
+
+      const [, messages] = managedSignerService.executeDerivedTx.mock.calls[0];
+      expect(messages[0].value.deposit?.amount?.amount).toBe(String(available));
+      expect(fundDrainingInstrumentation.recordHeadroomConceded).toHaveBeenCalledWith({
+        dseq: deployment.dseq,
+        address: deployment.address,
+        desiredAmount,
+        flooredAmount: 600_000,
+        affordableAmount: available,
+        runwayMinutes: RUNWAY_MINUTES_AT_TARGET
+      });
+      expect(fundDrainingInstrumentation.recordDepositBelowUsefulRunway).not.toHaveBeenCalled();
+    });
+
+    it("keeps the balance headroom when the deposit it allows is already worth making", async () => {
+      const { service, drainingDeploymentService, cachedBalanceService, managedSignerService, fundDrainingInstrumentation } = setup();
+      const owner = createAkashAddress();
+      const walletId = faker.number.int({ min: 1000000, max: 9999999 });
+      const deployment = createDrainingFor(owner, walletId);
+      const available = HEADROOM + 600_000;
+
+      drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([deployment]);
+      drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(50_000_000);
+      drainingDeploymentService.calculateRunwayMinutesAfterDeposit.mockReturnValue(RUNWAY_MINUTES_AT_TARGET);
+      cachedBalanceService.getFresh.mockResolvedValue(new CachedBalance(available, { headroom: HEADROOM, minDeposit: MIN_DEPOSIT }));
+
+      await service.topUpDrainingDeploymentsForOwner({ walletId, address: owner });
+
+      const [, messages] = managedSignerService.executeDerivedTx.mock.calls[0];
+      expect(messages[0].value.deposit?.amount?.amount).toBe("600000");
+      expect(fundDrainingInstrumentation.recordHeadroomConceded).not.toHaveBeenCalled();
+    });
+
+    it("holds the balance headroom when yielding it would not make the deposit worth making either", async () => {
+      const { service, drainingDeploymentService, cachedBalanceService, managedSignerService, fundDrainingInstrumentation } = setup();
+      const owner = createAkashAddress();
+      const walletId = faker.number.int({ min: 1000000, max: 9999999 });
+      const deployment = createDrainingFor(owner, walletId);
+
+      drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([deployment]);
+      drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(50_000_000);
+      drainingDeploymentService.calculateRunwayMinutesAfterDeposit.mockReturnValue(DEDUP_COOLDOWN_IN_MIN - 1);
+      cachedBalanceService.getFresh.mockResolvedValue(new CachedBalance(HEADROOM + 600_000, { headroom: HEADROOM, minDeposit: MIN_DEPOSIT }));
+
+      await service.topUpDrainingDeploymentsForOwner({ walletId, address: owner });
+
+      expect(fundDrainingInstrumentation.recordHeadroomConceded).not.toHaveBeenCalled();
+      expect(fundDrainingInstrumentation.recordDepositBelowUsefulRunway).toHaveBeenCalledWith(
+        expect.objectContaining({ dseq: deployment.dseq, affordableAmount: 600_000 })
+      );
+      expect(managedSignerService.executeDerivedTx).not.toHaveBeenCalled();
+    });
+
     it("releases the claim of a deposit it declined so credits landing later can fund it", async () => {
       const { service, drainingDeploymentService, cachedBalanceService, deploymentSettingRepository } = setup();
       const owner = createAkashAddress();
@@ -874,7 +950,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
       drainingDeploymentService.calculateRunwayMinutesAfterDeposit.mockImplementation(deployment =>
         deployment === declined ? DEDUP_COOLDOWN_IN_MIN - 1 : RUNWAY_MINUTES_AT_TARGET
       );
-      cachedBalanceService.getFresh.mockResolvedValue(new CachedBalance(ALLOWANCE, NO_HEADROOM));
+      cachedBalanceService.getFresh.mockResolvedValue(new CachedBalance(ALLOWANCE, { headroom: NO_HEADROOM, minDeposit: MIN_DEPOSIT }));
 
       await service.topUpDrainingDeploymentsForOwner({ walletId, address: owner });
 

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
@@ -37,7 +37,6 @@ describe(TopUpManagedDeploymentsService.name, () => {
   const DEDUP_COOLDOWN_IN_MIN = 60;
   /** A deposit that reaches the 48h target runway, so it is never declined for being too small to outlast the cooldown. */
   const RUNWAY_MINUTES_AT_TARGET = 48 * 60;
-  /** Mirrors the `DEPLOYMENT_DEFAULT_DEPOSIT` default of $0.50: the smallest deposit worth holding a floor for. */
   const MIN_DEPOSIT = 500_000;
   const HEADROOM = 5_000_000;
 
@@ -45,10 +44,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
     return { id, claimedAt: CLAIMED_AT };
   }
 
-  /**
-   * Mirrors `CachedBalance` with no headroom held: one allowance answers every preview and the reservation,
-   * and reserving nothing throws.
-   */
+  /** Mirrors `CachedBalance` with no floor held: one allowance answers every preview and the reservation. */
   function createMockCachedBalance(affordableAmount: (desiredAmount: number) => number) {
     const balance = mock<CachedBalance>();
     balance.previewSufficientAmount.mockImplementation(affordableAmount);
@@ -825,6 +821,48 @@ describe(TopUpManagedDeploymentsService.name, () => {
         runwayMinutes: RUNWAY_MINUTES_AT_TARGET
       });
       expect(fundDrainingInstrumentation.recordDepositBelowUsefulRunway).not.toHaveBeenCalled();
+    });
+
+    it("yields the balance headroom to a deployment the rest of the batch left nothing for", async () => {
+      const { service, drainingDeploymentService, cachedBalanceService, managedSignerService, fundDrainingInstrumentation } = setup();
+      const owner = createAkashAddress();
+      const walletId = faker.number.int({ min: 1000000, max: 9999999 });
+      const first = createDrainingFor(owner, walletId);
+      const second = createDrainingFor(owner, walletId);
+      const aboveHeadroom = 5_600_000;
+      const secondDesiredAmount = 3_000_000;
+
+      drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([first, second]);
+      drainingDeploymentService.calculateAmountToTargetRunway.mockImplementation(deployment => (deployment === first ? aboveHeadroom : secondDesiredAmount));
+      cachedBalanceService.getFresh.mockResolvedValue(new CachedBalance(HEADROOM + aboveHeadroom, { headroom: HEADROOM, minDeposit: MIN_DEPOSIT }));
+
+      await service.topUpDrainingDeploymentsForOwner({ walletId, address: owner });
+
+      const [, messages] = managedSignerService.executeDerivedTx.mock.calls[0];
+      expect(messages.map(message => message.value.deposit?.amount?.amount)).toEqual([String(aboveHeadroom), String(secondDesiredAmount)]);
+      expect(fundDrainingInstrumentation.recordHeadroomConceded).toHaveBeenCalledWith(
+        expect.objectContaining({ dseq: second.dseq, flooredAmount: 0, affordableAmount: secondDesiredAmount })
+      );
+      expect(fundDrainingInstrumentation.recordMessagePreparationError).not.toHaveBeenCalled();
+    });
+
+    it("reports an exhausted allowance as insufficient balance when yielding the headroom releases nothing", async () => {
+      const { service, drainingDeploymentService, cachedBalanceService, managedSignerService, fundDrainingInstrumentation } = setup();
+      const owner = createAkashAddress();
+      const walletId = faker.number.int({ min: 1000000, max: 9999999 });
+      const deployment = createDrainingFor(owner, walletId);
+
+      drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([deployment]);
+      drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(3_000_000);
+      cachedBalanceService.getFresh.mockResolvedValue(new CachedBalance(0, { headroom: HEADROOM, minDeposit: MIN_DEPOSIT }));
+
+      await service.topUpDrainingDeploymentsForOwner({ walletId, address: owner });
+
+      expect(fundDrainingInstrumentation.recordHeadroomConceded).not.toHaveBeenCalled();
+      expect(fundDrainingInstrumentation.recordMessagePreparationError).toHaveBeenCalledWith(
+        expect.objectContaining({ error: expect.objectContaining({ message: expect.stringContaining("Insufficient balance") }) })
+      );
+      expect(managedSignerService.executeDerivedTx).not.toHaveBeenCalled();
     });
 
     it("keeps the balance headroom when the deposit it allows is already worth making", async () => {

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
@@ -270,12 +270,7 @@ export class TopUpManagedDeploymentsService {
     return messageInputs.filter(x => !!x);
   }
 
-  /**
-   * The balance floor must never be what makes a deposit too small to be worth making. Holding credits back
-   * for a create the owner has not asked for, while the deployment they were withheld from closes, leaves an
-   * idle balance and nothing running. So when the floored amount lands below useful runway the floor yields
-   * for the rest of the pass and the deposit is sized again from the whole balance.
-   */
+  /** The floor must never be the reason a deposit is not made, so it yields when the floored amount falls short. */
   #sizeDeposit({
     balance,
     deployment,
@@ -291,7 +286,7 @@ export class TopUpManagedDeploymentsService {
   }): DepositSize {
     const floored = this.#describeDeposit({ deployment, currentHeight, affordableAmount: balance.previewSufficientAmount(desiredAmount) });
 
-    if (!this.#isCappedBelowUsefulRunway({ desiredAmount, ...floored })) {
+    if (!this.#fallsShortOfUsefulDeposit({ desiredAmount, ...floored })) {
       return floored;
     }
 
@@ -301,7 +296,7 @@ export class TopUpManagedDeploymentsService {
       affordableAmount: balance.previewSufficientAmountWithoutHeadroom(desiredAmount)
     });
 
-    if (this.#isCappedBelowUsefulRunway({ desiredAmount, ...conceded })) {
+    if (this.#fallsShortOfUsefulDeposit({ desiredAmount, ...conceded })) {
       return floored;
     }
 
@@ -317,6 +312,11 @@ export class TopUpManagedDeploymentsService {
     });
 
     return conceded;
+  }
+
+  /** An amount of zero falls short too: insufficient balance is the right answer only once the floor has yielded. */
+  #fallsShortOfUsefulDeposit(deposit: { desiredAmount: number; affordableAmount: number; runwayMinutes: number }): boolean {
+    return deposit.affordableAmount <= 0 || this.#isCappedBelowUsefulRunway(deposit);
   }
 
   #describeDeposit({

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
@@ -19,6 +19,11 @@ import type { DeploymentTopUpInstrumentation } from "./deployment-top-up-instrum
 import { FundDrainingDeploymentsInstrumentationService } from "./fund-draining-deployments-instrumentation.service";
 import { TopUpManagedDeploymentsInstrumentationService } from "./top-up-managed-deployments-instrumentation.service";
 
+type DepositSize = {
+  affordableAmount: number;
+  runwayMinutes: number;
+};
+
 type CollectedMessage = {
   message: { typeUrl: string; value: MsgAccountDeposit };
   input: DepositDeploymentMsgOptions;
@@ -223,8 +228,7 @@ export class TopUpManagedDeploymentsService {
             });
             return;
           }
-          const affordableAmount = balance.previewSufficientAmount(desiredAmount);
-          const runwayMinutes = this.drainingDeploymentService.calculateRunwayMinutesAfterDeposit(deployment, affordableAmount, currentHeight);
+          const { affordableAmount, runwayMinutes } = this.#sizeDeposit({ balance, deployment, desiredAmount, currentHeight, instrumentation });
 
           if (this.#isCappedBelowUsefulRunway({ desiredAmount, affordableAmount, runwayMinutes })) {
             instrumentation.recordDepositBelowUsefulRunway({
@@ -264,6 +268,70 @@ export class TopUpManagedDeploymentsService {
     );
 
     return messageInputs.filter(x => !!x);
+  }
+
+  /**
+   * The balance floor must never be what makes a deposit too small to be worth making. Holding credits back
+   * for a create the owner has not asked for, while the deployment they were withheld from closes, leaves an
+   * idle balance and nothing running. So when the floored amount lands below useful runway the floor yields
+   * for the rest of the pass and the deposit is sized again from the whole balance.
+   */
+  #sizeDeposit({
+    balance,
+    deployment,
+    desiredAmount,
+    currentHeight,
+    instrumentation
+  }: {
+    balance: CachedBalance;
+    deployment: DrainingDeployment;
+    desiredAmount: number;
+    currentHeight: number;
+    instrumentation: DeploymentTopUpInstrumentation;
+  }): DepositSize {
+    const floored = this.#describeDeposit({ deployment, currentHeight, affordableAmount: balance.previewSufficientAmount(desiredAmount) });
+
+    if (!this.#isCappedBelowUsefulRunway({ desiredAmount, ...floored })) {
+      return floored;
+    }
+
+    const conceded = this.#describeDeposit({
+      deployment,
+      currentHeight,
+      affordableAmount: balance.previewSufficientAmountWithoutHeadroom(desiredAmount)
+    });
+
+    if (this.#isCappedBelowUsefulRunway({ desiredAmount, ...conceded })) {
+      return floored;
+    }
+
+    balance.waiveHeadroom();
+
+    instrumentation.recordHeadroomConceded({
+      dseq: deployment.dseq,
+      address: deployment.address,
+      desiredAmount,
+      flooredAmount: floored.affordableAmount,
+      affordableAmount: conceded.affordableAmount,
+      runwayMinutes: conceded.runwayMinutes
+    });
+
+    return conceded;
+  }
+
+  #describeDeposit({
+    deployment,
+    affordableAmount,
+    currentHeight
+  }: {
+    deployment: DrainingDeployment;
+    affordableAmount: number;
+    currentHeight: number;
+  }): DepositSize {
+    return {
+      affordableAmount,
+      runwayMinutes: this.drainingDeploymentService.calculateRunwayMinutesAfterDeposit(deployment, affordableAmount, currentHeight)
+    };
   }
 
   /**


### PR DESCRIPTION
## Why

The $5 auto-funding balance floor (CON-882) avoided holding credits back forever by waiving itself once the balance fell to it. Deposits always took the whole sliver above the floor, so a balance landed exactly on the floor in one pass and was spent on the next.

#3682 removed that escape hatch. A credit-capped deposit that buys less runway than the dedup cooldown is now skipped, and skipping leaves the balance where it was. So when the sliver above the floor buys under an hour, which is the case for any deployment burning fast enough, every pass reaches the same verdict:

| pass | available | floored deposit | outcome |
|---|---|---|---|
| N | $5.60 | $0.60, worth 4 min of runway | skipped, under the 60 min cooldown |
| N+1 | $5.60 | same decision | skipped |
| ... | $5.60 | same decision | deployment closes with $5.60 unspent |

The balance never moves, so `available <= headroom` never becomes true and the waiver never fires. The owner ends up with an idle floor and nothing running, and the only way to spend those credits is to create another deployment. Both rules are right on their own: the floor should not be handed out as dust, and a deposit too small to outlast its own cooldown is worse than none. Together they withhold credits from a deployment and then let it close.

Ref CON-882
Ref CON-889

## What

The floor is now kept only while what sits above it is worth depositing, which is checked two ways.

Up front, on cost: `CachedBalance` carves the floor out only when the remainder is at least `DEPLOYMENT_DEFAULT_DEPOSIT` ($0.50). That is the smallest deposit the platform makes and it already sits at or above the chain's `min_deposits`, so a remainder below it cannot be a deposit at all. One predicate now covers the old `available <= headroom` case too, since a non-positive remainder is also below a deposit.

On demand, on runway: `#sizeDeposit` weighs a concession before making it. If the floored amount is capped below useful runway and yielding the floor clears the cooldown bar, the floor is conceded for the rest of the pass and the deposit is sized from the whole balance. If yielding would not clear the bar either, the floor is kept and the deposit is skipped exactly as #3682 intended, so the floor is never given away on a false premise.

`CachedBalance` tracks what the pass has reserved and derives `spendable` from it, so yielding the floor mid-batch keeps the batch's accounting intact. Concessions are counted and logged on both funding paths (`auto_top_up_headroom_concessions_total`, `fund_draining_deployments_headroom_concessions_total`, and `headroomConcessionCount` in the run summary), so how often the floor gets in the way can be read from data rather than guessed at.

### Behaviour delta

| available | before | after |
|---|---|---|
| $200 / $6.00 / $5.50 | floor kept | unchanged |
| $5.30, remainder under one deposit | $0.30 deposited, waived next pass | floor waived up front, whole $5.30 spendable |
| $5.60, sliver buys under the cooldown | skipped every pass, deployment closes with $5.60 idle | floor conceded, deposit sized from the whole balance |
| $5.60, sliver buys over the cooldown | $0.60 deposited | unchanged |
| $5.60, whole balance still under the cooldown | skipped | unchanged, floor kept |
| $4.00 | waived | unchanged |

Every case in CON-882's agreed-rule table keeps its answer. `initial-deployment-funding` needs no concession: it has no skip rule, so its deposit always lands and the floor cannot close a deployment there.

### Testing

`apps/api` unit (1867), functional (323) and the `top-up-managed-deployments` integration suite (17) all pass, plus lint and tsc. New coverage:

- `cached-balance.service.spec.ts`: remainder below and exactly at one deposit, a disabled floor on a sub-deposit balance, the on-demand yield, a yield after a batch reservation, and both previews.
- `top-up-managed-deployments.service.spec.ts`: floor conceded when it alone made the deposit too small, kept when the floored deposit is already useful, kept when yielding would not help either.
- `top-up-managed-deployments.service.integration.ts`: a nearly drained deployment with credits just above the floor is funded past the floor instead of being left to close.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved automatic funding decisions for deployments nearing shutdown.
  * Deposits can use available headroom when this provides useful additional runway.
  * Added support for minimum deposit thresholds and reserved balances.
  * Added previews of funding amounts without applying headroom.

* **Monitoring**
  * Added tracking, summaries, metrics, and warning logs for headroom concessions.

* **Bug Fixes**
  * Improved deposit calculations when balances are low, reservations exist, or headroom is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->