### PR TITLE
refactor(deployment): open a KMS-wrapped compact JWE in one place

### DIFF
--- a/apps/api/src/deployment/services/kms-wrapped-jwe/kms-wrapped-jwe.service.spec.ts
+++ b/apps/api/src/deployment/services/kms-wrapped-jwe/kms-wrapped-jwe.service.spec.ts
@@ -1,0 +1,238 @@
+import type { protos } from "@google-cloud/kms";
+import crc32c from "fast-crc32c";
+import { grpc } from "google-gax";
+import createError from "http-errors";
+import { CompactEncrypt } from "jose";
+import { constants, generateKeyPairSync, privateDecrypt, randomBytes } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { SdlSecretsKmsClient } from "@src/deployment/providers/kms.provider";
+import { KmsWrappedJweError, KmsWrappedJweService } from "./kms-wrapped-jwe.service";
+
+const KID = "sdl-secrets.v1";
+const VERSION_NAME = "projects/console-test/locations/global/keyRings/console-api/cryptoKeys/sdl-secrets/cryptoKeyVersions/1";
+
+async function expectFailure(open: Promise<unknown>, failure: string) {
+  await expect(open).rejects.toMatchObject({ failure });
+}
+
+function parseFailure(service: KmsWrappedJweService, serialized: string) {
+  try {
+    service.parse(serialized);
+  } catch (error) {
+    return error;
+  }
+
+  return undefined;
+}
+
+describe(KmsWrappedJweService.name, () => {
+  it("returns the exact bytes the wrapped content encryption key protects", async () => {
+    const { service, wrap } = setup();
+    const payload = randomBytes(32);
+
+    const plaintext = await service.open(service.parse(await wrap(payload)));
+
+    expect(plaintext.equals(payload)).toBe(true);
+  });
+
+  it("returns a payload that is not JSON, because what the bytes mean belongs to the caller", async () => {
+    const { service, wrap } = setup();
+
+    const plaintext = await service.open(service.parse(await wrap(Buffer.from([0, 1, 255]))));
+
+    expect([...plaintext]).toEqual([0, 1, 255]);
+  });
+
+  it("parses a header carrying nothing but the algorithm claims, so a wrapped data key is not held to a transport seal's claims", async () => {
+    const { service, wrap } = setup();
+
+    const { header } = service.parse(await wrap(randomBytes(32)));
+
+    expect(header).toEqual({ alg: "RSA-OAEP-256", enc: "A256GCM", kid: KID });
+  });
+
+  it("returns header claims it does not itself validate", async () => {
+    const { service, wrap } = setup();
+
+    const { header } = service.parse(await wrap(randomBytes(32), { sub: "someone", exp: 1 }));
+
+    expect(header).toMatchObject({ sub: "someone", exp: 1 });
+  });
+
+  it("spends no key service call while parsing", async () => {
+    const { service, wrap, kmsClient } = setup();
+
+    service.parse(await wrap(randomBytes(32)));
+
+    expect(kmsClient.asymmetricDecrypt).not.toHaveBeenCalled();
+  });
+
+  it("unwraps the content encryption key with the configured crypto key version", async () => {
+    const { service, wrap, kmsClient } = setup();
+
+    await service.open(service.parse(await wrap(randomBytes(32))));
+
+    expect(kmsClient.asymmetricDecrypt).toHaveBeenCalledWith(expect.objectContaining({ name: VERSION_NAME }));
+  });
+
+  it("spends one key service call per open", async () => {
+    const { service, wrap, kmsClient } = setup();
+    const parsed = service.parse(await wrap(randomBytes(32)));
+
+    await service.open(parsed);
+
+    expect(kmsClient.asymmetricDecrypt).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports what failed without deciding whose fault it is", async () => {
+    const { service } = setup();
+
+    expect(parseFailure(service, "not.a.jwe")).toBeInstanceOf(KmsWrappedJweError);
+    expect(createError.isHttpError(parseFailure(service, "not.a.jwe"))).toBe(false);
+  });
+
+  it("reports anything that is not a compact serialization as malformed", async () => {
+    const { service } = setup();
+
+    expect(parseFailure(service, "not.a.jwe")).toMatchObject({ failure: "MALFORMED" });
+  });
+
+  it("reports a protected header that is not base64url as unreadable", async () => {
+    const { service, wrap } = setup();
+    const parts = (await wrap(randomBytes(32))).split(".");
+    parts[0] = `${parts[0]}!`;
+
+    expect(parseFailure(service, parts.join("."))).toMatchObject({ failure: "HEADER_UNREADABLE" });
+  });
+
+  it("reports a protected header that is not a JSON object as unreadable", async () => {
+    const { service, wrap } = setup();
+    const [, ...rest] = (await wrap(randomBytes(32))).split(".");
+
+    expect(parseFailure(service, [Buffer.from("[]").toString("base64url"), ...rest].join("."))).toMatchObject({ failure: "HEADER_UNREADABLE" });
+  });
+
+  it("reports an encrypted key that is not the length a modulus fixes as invalid", async () => {
+    const { service, wrap } = setup();
+    const parts = (await wrap(randomBytes(32))).split(".");
+    parts[1] = randomBytes(200).toString("base64url");
+
+    expect(parseFailure(service, parts.join("."))).toMatchObject({ failure: "ENCRYPTED_KEY_INVALID" });
+  });
+
+  it("reports a ciphertext that is not base64url as invalid", async () => {
+    const { service, wrap } = setup();
+    const parts = (await wrap(randomBytes(32))).split(".");
+    parts[3] = `${parts[3]}!!!!`;
+
+    expect(parseFailure(service, parts.join("."))).toMatchObject({ failure: "CIPHERTEXT_INVALID" });
+  });
+
+  it("reports an initialization vector that is not the 96 bits A256GCM fixes as invalid", async () => {
+    const { service, wrap } = setup();
+    const parts = (await wrap(randomBytes(32))).split(".");
+    parts[2] = randomBytes(13).toString("base64url");
+
+    expect(parseFailure(service, parts.join("."))).toMatchObject({ failure: "IV_INVALID" });
+  });
+
+  it("reports an authentication tag that is not the 128 bits A256GCM fixes as invalid", async () => {
+    const { service, wrap } = setup();
+    const parts = (await wrap(randomBytes(32))).split(".");
+    parts[4] = Buffer.alloc(5).toString("base64url");
+
+    expect(parseFailure(service, parts.join("."))).toMatchObject({ failure: "TAG_INVALID" });
+  });
+
+  it("reports a key service that rejects the encrypted key separately from one that is unreachable", async () => {
+    const { service, wrap, kmsClient } = setup();
+    kmsClient.asymmetricDecrypt.mockRejectedValue(Object.assign(new Error("3 INVALID_ARGUMENT"), { code: grpc.status.INVALID_ARGUMENT }));
+
+    await expectFailure(service.open(service.parse(await wrap(randomBytes(32)))), "ENCRYPTED_KEY_REJECTED");
+  });
+
+  it("reports an unreachable key service and carries the underlying error for the caller to log", async () => {
+    const { service, wrap, kmsClient } = setup();
+    const unreachable = Object.assign(new Error("14 UNAVAILABLE"), { code: grpc.status.UNAVAILABLE });
+    kmsClient.asymmetricDecrypt.mockRejectedValue(unreachable);
+
+    await expect(service.open(service.parse(await wrap(randomBytes(32))))).rejects.toMatchObject({
+      failure: "KEY_SERVICE_UNREACHABLE",
+      details: { versionName: VERSION_NAME, error: unreachable }
+    });
+  });
+
+  it("reports a key service that could not verify the request checksum", async () => {
+    const { service, wrap, kmsClient } = setup();
+    kmsClient.asymmetricDecrypt.mockResolvedValue([{ plaintext: Buffer.alloc(32), verifiedCiphertextCrc32c: false }]);
+
+    await expectFailure(service.open(service.parse(await wrap(randomBytes(32)))), "KEY_SERVICE_REQUEST_CORRUPTED");
+  });
+
+  it("reports a key service that returned no plaintext", async () => {
+    const { service, wrap, kmsClient } = setup();
+    kmsClient.asymmetricDecrypt.mockResolvedValue([{ verifiedCiphertextCrc32c: true }]);
+
+    await expectFailure(service.open(service.parse(await wrap(randomBytes(32)))), "KEY_SERVICE_PLAINTEXT_MISSING");
+  });
+
+  it("reports a key service whose plaintext fails its own checksum", async () => {
+    const { service, wrap, kmsClient } = setup();
+    kmsClient.asymmetricDecrypt.mockResolvedValue([{ plaintext: Buffer.alloc(32), plaintextCrc32c: { value: "1" }, verifiedCiphertextCrc32c: true }]);
+
+    await expectFailure(service.open(service.parse(await wrap(randomBytes(32)))), "KEY_SERVICE_RESPONSE_CORRUPTED");
+  });
+
+  it("reports an altered ciphertext as an authentication failure", async () => {
+    const { service, wrap } = setup();
+    const parts = (await wrap(randomBytes(32))).split(".");
+    parts[3] = Buffer.from("tampered").toString("base64url");
+
+    await expectFailure(service.open(service.parse(parts.join("."))), "AUTHENTICATION_FAILED");
+  });
+
+  it("reports an altered protected header as an authentication failure, because the header is the additional authenticated data", async () => {
+    const { service, wrap } = setup();
+    const [protectedHeader, ...rest] = (await wrap(randomBytes(32))).split(".");
+    const claims = JSON.parse(Buffer.from(protectedHeader, "base64url").toString());
+    const forged = Buffer.from(JSON.stringify({ ...claims, kid: "sdl-secrets.v9" })).toString("base64url");
+
+    await expectFailure(service.open(service.parse([forged, ...rest].join("."))), "AUTHENTICATION_FAILED");
+  });
+
+  it("reports a content encryption key that is not the length AES-256 requires as an authentication failure", async () => {
+    const { service, wrap, kmsClient } = setup();
+    const shortKey = Buffer.alloc(16);
+    kmsClient.asymmetricDecrypt.mockResolvedValue([
+      { plaintext: shortKey, plaintextCrc32c: { value: String(crc32c.calculate(shortKey)) }, verifiedCiphertextCrc32c: true }
+    ]);
+
+    await expectFailure(service.open(service.parse(await wrap(randomBytes(32)))), "AUTHENTICATION_FAILED");
+  });
+
+  function setup() {
+    const { publicKey, privateKey } = generateKeyPairSync("rsa", { modulusLength: 3072 });
+
+    const wrap = (payload: Buffer, claims?: Record<string, unknown>) =>
+      new CompactEncrypt(payload).setProtectedHeader({ alg: "RSA-OAEP-256", enc: "A256GCM", kid: KID, ...claims }).encrypt(publicKey);
+
+    const kmsClient = mock<SdlSecretsKmsClient>();
+    kmsClient.asymmetricDecrypt.mockImplementation(async request => {
+      const plaintext = privateDecrypt({ key: privateKey, padding: constants.RSA_PKCS1_OAEP_PADDING, oaepHash: "sha256" }, Buffer.from(request.ciphertext));
+
+      return [
+        {
+          plaintext,
+          plaintextCrc32c: { value: String(crc32c.calculate(plaintext)) },
+          verifiedCiphertextCrc32c: true
+        } satisfies protos.google.cloud.kms.v1.IAsymmetricDecryptResponse
+      ];
+    });
+
+    const service = new KmsWrappedJweService({ client: kmsClient, versionName: VERSION_NAME, kid: KID });
+
+    return { service, wrap, kmsClient, privateKey };
+  }
+});

--- a/apps/api/src/deployment/services/kms-wrapped-jwe/kms-wrapped-jwe.service.ts
+++ b/apps/api/src/deployment/services/kms-wrapped-jwe/kms-wrapped-jwe.service.ts
@@ -1,0 +1,202 @@
+import crc32c from "fast-crc32c";
+import { grpc } from "google-gax";
+import { createDecipheriv } from "node:crypto";
+import { inject, singleton } from "tsyringe";
+
+import { SDL_SECRETS_WRAPPED_KEY_BYTES } from "@src/deployment/config/sdl-secrets.config";
+import type { SdlSecretsKmsTarget } from "@src/deployment/providers/kms.provider";
+import { SDL_SECRETS_KMS_TARGET } from "@src/deployment/providers/kms.provider";
+
+export type KmsWrappedJweFailure =
+  | "MALFORMED"
+  | "HEADER_UNREADABLE"
+  | "ENCRYPTED_KEY_INVALID"
+  | "CIPHERTEXT_INVALID"
+  | "IV_INVALID"
+  | "TAG_INVALID"
+  | "ENCRYPTED_KEY_REJECTED"
+  | "KEY_SERVICE_UNREACHABLE"
+  | "KEY_SERVICE_REQUEST_CORRUPTED"
+  | "KEY_SERVICE_PLAINTEXT_MISSING"
+  | "KEY_SERVICE_RESPONSE_CORRUPTED"
+  | "AUTHENTICATION_FAILED";
+
+/** Carries what went wrong without deciding whose fault it is: the same failure is a client error on the transport path and our own corruption at rest. */
+export class KmsWrappedJweError extends Error {
+  constructor(
+    readonly failure: KmsWrappedJweFailure,
+    readonly details: Record<string, unknown> = {}
+  ) {
+    super(failure);
+    this.name = KmsWrappedJweError.name;
+  }
+}
+
+interface JweSegments {
+  protectedHeader: string;
+  encryptedKey: string;
+  iv: string;
+  ciphertext: string;
+  tag: string;
+}
+
+declare const PARSED_BY_KMS_WRAPPED_JWE_SERVICE: unique symbol;
+
+/** Branded so `open` cannot be handed a literal that skipped the free checks and spend an unwrap on garbage. */
+export interface ParsedKmsWrappedJwe {
+  segments: JweSegments;
+  header: Record<string, unknown>;
+  readonly [PARSED_BY_KMS_WRAPPED_JWE_SERVICE]: true;
+}
+
+const COMPACT_JWE_PART_COUNT = 5;
+
+/** Buffer.from silently drops characters outside the alphabet, so a garbled segment would decode to a plausible length. */
+const BASE64URL_SEGMENT = /^[A-Za-z0-9_-]+$/;
+
+/** base64url encodes in quanta of four characters; a leftover of exactly one carries no byte, and Buffer.from discards it as silently as it does a stray character. */
+const BASE64URL_ORPHAN_CHARACTER_REMAINDER = 1;
+
+function isBase64Url(segment: string) {
+  return BASE64URL_SEGMENT.test(segment) && segment.length % 4 !== BASE64URL_ORPHAN_CHARACTER_REMAINDER;
+}
+
+/** A256GCM fixes the initialization vector at 96 bits, and Node accepts any other length without complaint. */
+const CONTENT_ENCRYPTION_IV_BYTES = 12;
+
+/** A256GCM fixes the tag at 128 bits, and Node silently accepts shorter ones — 4 bytes of authentication is not authentication. */
+const CONTENT_ENCRYPTION_TAG_BYTES = 16;
+
+/** gRPC reports the status of a failed call as a numeric `code` on the rejection. */
+function getGrpcStatus(error: unknown) {
+  return error instanceof Error && "code" in error ? error.code : undefined;
+}
+
+/** Validates nothing in the header, because what a header must say differs by caller and a wrapped data key carries none of a transport seal's claims. */
+@singleton()
+export class KmsWrappedJweService {
+  constructor(@inject(SDL_SECRETS_KMS_TARGET) private readonly kmsTarget: SdlSecretsKmsTarget) {}
+
+  /** Everything here is free and nothing in `open` is, so a serialization whose own segments cannot be used never spends an unwrap. */
+  parse(serialized: string): ParsedKmsWrappedJwe {
+    const parts = serialized.split(".");
+
+    if (parts.length !== COMPACT_JWE_PART_COUNT) {
+      throw new KmsWrappedJweError("MALFORMED", { partCount: parts.length });
+    }
+
+    const [protectedHeader, encryptedKey, iv, ciphertext, tag] = parts;
+    const segments = { protectedHeader, encryptedKey, iv, ciphertext, tag };
+
+    this.#assertSegmentsAreWellFormed(segments);
+
+    return { segments, header: this.#parseHeader(protectedHeader) } as ParsedKmsWrappedJwe;
+  }
+
+  async open({ segments }: ParsedKmsWrappedJwe): Promise<Buffer> {
+    const contentEncryptionKey = await this.#unwrapContentEncryptionKey(segments.encryptedKey);
+
+    return this.#openContent(segments, contentEncryptionKey);
+  }
+
+  #assertSegmentsAreWellFormed({ protectedHeader, encryptedKey, iv, ciphertext, tag }: JweSegments) {
+    this.#assertSegmentIsBase64Url(protectedHeader, "HEADER_UNREADABLE");
+    this.#assertSegmentIsBase64Url(ciphertext, "CIPHERTEXT_INVALID");
+
+    const wrappedKeyBytes = this.#decodedByteLength(encryptedKey);
+
+    if (!SDL_SECRETS_WRAPPED_KEY_BYTES.has(wrappedKeyBytes)) {
+      throw new KmsWrappedJweError("ENCRYPTED_KEY_INVALID", { wrappedKeyBytes });
+    }
+
+    this.#assertSegmentDecodesTo(iv, CONTENT_ENCRYPTION_IV_BYTES, "IV_INVALID");
+    this.#assertSegmentDecodesTo(tag, CONTENT_ENCRYPTION_TAG_BYTES, "TAG_INVALID");
+  }
+
+  #assertSegmentIsBase64Url(segment: string, failure: KmsWrappedJweFailure) {
+    if (!isBase64Url(segment)) {
+      throw new KmsWrappedJweError(failure);
+    }
+  }
+
+  #assertSegmentDecodesTo(segment: string, expectedBytes: number, failure: KmsWrappedJweFailure) {
+    const decodedBytes = this.#decodedByteLength(segment);
+
+    if (decodedBytes !== expectedBytes) {
+      throw new KmsWrappedJweError(failure, { decodedBytes, expectedBytes });
+    }
+  }
+
+  #decodedByteLength(segment: string) {
+    return isBase64Url(segment) ? Buffer.from(segment, "base64url").length : 0;
+  }
+
+  #parseHeader(protectedHeader: string): Record<string, unknown> {
+    const header = this.#decodeHeaderJson(protectedHeader);
+
+    if (!header || typeof header !== "object" || Array.isArray(header)) {
+      throw new KmsWrappedJweError("HEADER_UNREADABLE");
+    }
+
+    return header as Record<string, unknown>;
+  }
+
+  #decodeHeaderJson(protectedHeader: string): unknown {
+    try {
+      return JSON.parse(Buffer.from(protectedHeader, "base64url").toString("utf8"));
+    } catch {
+      return null;
+    }
+  }
+
+  /** `jose` cannot delegate key unwrapping to a remote service, which is why the encrypted key is handed to Cloud KMS here rather than opened by a stock library. */
+  async #unwrapContentEncryptionKey(encryptedKey: string): Promise<Buffer> {
+    const response = await this.#asymmetricDecrypt(Buffer.from(encryptedKey, "base64url"));
+
+    if (!response.verifiedCiphertextCrc32c) {
+      throw new KmsWrappedJweError("KEY_SERVICE_REQUEST_CORRUPTED");
+    }
+
+    if (!response.plaintext) {
+      throw new KmsWrappedJweError("KEY_SERVICE_PLAINTEXT_MISSING");
+    }
+
+    const contentEncryptionKey = Buffer.from(response.plaintext as Uint8Array);
+
+    if (crc32c.calculate(contentEncryptionKey) !== Number(response.plaintextCrc32c?.value)) {
+      throw new KmsWrappedJweError("KEY_SERVICE_RESPONSE_CORRUPTED");
+    }
+
+    return contentEncryptionKey;
+  }
+
+  async #asymmetricDecrypt(ciphertext: Buffer) {
+    try {
+      const [response] = await this.kmsTarget.client.asymmetricDecrypt({
+        name: this.kmsTarget.versionName,
+        ciphertext,
+        ciphertextCrc32c: { value: crc32c.calculate(ciphertext) }
+      });
+
+      return response;
+    } catch (error) {
+      if (getGrpcStatus(error) === grpc.status.INVALID_ARGUMENT) {
+        throw new KmsWrappedJweError("ENCRYPTED_KEY_REJECTED");
+      }
+
+      throw new KmsWrappedJweError("KEY_SERVICE_UNREACHABLE", { versionName: this.kmsTarget.versionName, error });
+    }
+  }
+
+  #openContent({ protectedHeader, iv, ciphertext, tag }: JweSegments, contentEncryptionKey: Buffer): Buffer {
+    try {
+      const decipher = createDecipheriv("aes-256-gcm", contentEncryptionKey, Buffer.from(iv, "base64url"));
+      decipher.setAAD(Buffer.from(protectedHeader, "ascii"));
+      decipher.setAuthTag(Buffer.from(tag, "base64url"));
+
+      return Buffer.concat([decipher.update(Buffer.from(ciphertext, "base64url")), decipher.final()]);
+    } catch {
+      throw new KmsWrappedJweError("AUTHENTICATION_FAILED");
+    }
+  }
+}

--- a/apps/api/src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service.spec.ts
@@ -10,6 +10,7 @@ import type { AuthService } from "@src/auth/services/auth.service";
 import type { CreateLogger } from "@src/core";
 import { SDL_SECRETS_MAX_SEAL_LIFETIME_MS } from "@src/deployment/config/sdl-secrets.config";
 import type { SdlSecretsKmsClient } from "@src/deployment/providers/kms.provider";
+import { KmsWrappedJweService } from "@src/deployment/services/kms-wrapped-jwe/kms-wrapped-jwe.service";
 import type { UserOutput } from "@src/user/repositories";
 import { SdlSecretsUnsealerService } from "./sdl-secrets-unsealer.service";
 
@@ -203,6 +204,22 @@ describe(SdlSecretsUnsealerService.name, () => {
     await expect(open(await seal({ nested: { deep: "value" } }))).rejects.toMatchObject({ status: 400 });
   });
 
+  it("rejects a payload that is not JSON at all as an invalid payload rather than a tampered seal", async () => {
+    const { open, sealRaw, logger } = setup();
+
+    await expect(open(await sealRaw("not json at all"))).rejects.toMatchObject({ status: 400 });
+    expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "SDL_SECRETS_SEAL_PAYLOAD_INVALID" }));
+  });
+
+  it("reports a genuinely altered ciphertext as a tampered seal rather than an invalid payload", async () => {
+    const { open, seal, logger } = setup();
+    const parts = (await seal({ TOKEN: "t" })).split(".");
+    parts[3] = Buffer.from("tampered").toString("base64url");
+
+    await expect(open(parts.join("."))).rejects.toThrow();
+    expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "SDL_SECRETS_SEAL_TAMPERED" }));
+  });
+
   it("fails with 503 when KMS is unreachable", async () => {
     const { open, seal, kmsClient, logger } = setup();
     kmsClient.asymmetricDecrypt.mockRejectedValue(Object.assign(new Error("14 UNAVAILABLE"), { code: grpc.status.UNAVAILABLE }));
@@ -355,10 +372,10 @@ describe(SdlSecretsUnsealerService.name, () => {
     const jwk = { ...publicKey.export({ format: "jwk" }), use: "enc", alg: "RSA-OAEP-256" };
     const clientSecrets = { DB_URL: `postgres://app:${randomUUID()}@db.internal/app`, API_TOKEN: randomBytes(20).toString("hex") };
 
-    const seal = async (secrets: unknown, claims?: Record<string, unknown>) =>
-      new CompactEncrypt(new TextEncoder().encode(JSON.stringify(secrets)))
-        .setProtectedHeader(sealClaims(claims) as never)
-        .encrypt(await importJWK(jwk, "RSA-OAEP-256"));
+    const sealRaw = async (plaintext: string, claims?: Record<string, unknown>) =>
+      new CompactEncrypt(new TextEncoder().encode(plaintext)).setProtectedHeader(sealClaims(claims) as never).encrypt(await importJWK(jwk, "RSA-OAEP-256"));
+
+    const seal = async (secrets: unknown, claims?: Record<string, unknown>) => await sealRaw(JSON.stringify(secrets), claims);
 
     /**
      * Builds a compact JWE from the same stock primitives and AAD convention the service decodes
@@ -402,9 +419,9 @@ describe(SdlSecretsUnsealerService.name, () => {
     const createLogger: CreateLogger = () => logger;
 
     const kmsTarget = { client: kmsClient, versionName: VERSION_NAME, kid: KID };
-    const service = new SdlSecretsUnsealerService(kmsTarget, authService, createLogger);
+    const service = new SdlSecretsUnsealerService(kmsTarget, new KmsWrappedJweService(kmsTarget), authService, createLogger);
     const open = (seal: string, sdl = SDL) => service.open({ seal, sdl });
 
-    return { open, kmsClient, authService, logger, seal, assembleSeal, privateKey, clientSecrets };
+    return { open, kmsClient, authService, logger, seal, sealRaw, assembleSeal, privateKey, clientSecrets };
   }
 });

--- a/apps/api/src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service.spec.ts
@@ -216,7 +216,7 @@ describe(SdlSecretsUnsealerService.name, () => {
     const parts = (await seal({ TOKEN: "t" })).split(".");
     parts[3] = Buffer.from("tampered").toString("base64url");
 
-    await expect(open(parts.join("."))).rejects.toThrow();
+    await expect(open(parts.join("."))).rejects.toMatchObject({ status: 400 });
     expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "SDL_SECRETS_SEAL_TAMPERED" }));
   });
 

--- a/apps/api/src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service.ts
+++ b/apps/api/src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service.ts
@@ -1,19 +1,14 @@
-import crc32c from "fast-crc32c";
-import { grpc } from "google-gax";
 import createError from "http-errors";
-import { createDecipheriv, createHash } from "node:crypto";
+import { createHash } from "node:crypto";
 import { inject, singleton } from "tsyringe";
 
 import { AuthService } from "@src/auth/services/auth.service";
 import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
-import {
-  SDL_SECRETS_CONTENT_ENCRYPTION,
-  SDL_SECRETS_MAX_SEAL_LIFETIME_MS,
-  SDL_SECRETS_SEAL_ALGORITHM,
-  SDL_SECRETS_WRAPPED_KEY_BYTES
-} from "@src/deployment/config/sdl-secrets.config";
+import { SDL_SECRETS_CONTENT_ENCRYPTION, SDL_SECRETS_MAX_SEAL_LIFETIME_MS, SDL_SECRETS_SEAL_ALGORITHM } from "@src/deployment/config/sdl-secrets.config";
 import type { SdlSecretsKmsTarget } from "@src/deployment/providers/kms.provider";
 import { SDL_SECRETS_KMS_TARGET } from "@src/deployment/providers/kms.provider";
+import type { KmsWrappedJweFailure, ParsedKmsWrappedJwe } from "@src/deployment/services/kms-wrapped-jwe/kms-wrapped-jwe.service";
+import { KmsWrappedJweError, KmsWrappedJweService } from "@src/deployment/services/kms-wrapped-jwe/kms-wrapped-jwe.service";
 
 export type SdlSecrets = Record<string, string>;
 
@@ -26,56 +21,50 @@ interface SealHeader {
   sdlHash?: unknown;
 }
 
-interface SealParts {
-  protectedHeader: string;
-  encryptedKey: string;
-  iv: string;
-  ciphertext: string;
-  tag: string;
+interface SealRejection {
+  status: number;
+  event: string;
+  message: string;
+  isServiceFault?: true;
 }
 
-const COMPACT_JWE_PART_COUNT = 5;
-
-/** Buffer.from silently drops characters outside the alphabet, so a garbled segment would decode to a plausible length. */
-const BASE64URL_SEGMENT = /^[A-Za-z0-9_-]+$/;
-
-/** base64url encodes in quanta of four characters; a leftover of exactly one carries no byte, and Buffer.from discards it as silently as it does a stray character. */
-const BASE64URL_ORPHAN_CHARACTER_REMAINDER = 1;
-
-function isBase64Url(segment: string) {
-  return BASE64URL_SEGMENT.test(segment) && segment.length % 4 !== BASE64URL_ORPHAN_CHARACTER_REMAINDER;
-}
-
-/** A256GCM fixes the initialization vector at 96 bits, and Node accepts any other length without complaint. */
-const CONTENT_ENCRYPTION_IV_BYTES = 12;
-
-/** A256GCM fixes the tag at 128 bits, and Node silently accepts shorter ones — 4 bytes of authentication is not authentication. */
-const CONTENT_ENCRYPTION_TAG_BYTES = 16;
+/** How a hostile or stale client input is reported: every shape failure blames the caller, and only an unreachable key service is our fault. */
+const SEAL_REJECTIONS: Record<KmsWrappedJweFailure, SealRejection> = {
+  MALFORMED: { status: 400, event: "SDL_SECRETS_SEAL_MALFORMED", message: "Sealed secrets must be a compact JWE" },
+  HEADER_UNREADABLE: { status: 400, event: "SDL_SECRETS_SEAL_HEADER_UNREADABLE", message: "Sealed secrets carry an unreadable protected header" },
+  ENCRYPTED_KEY_INVALID: { status: 400, event: "SDL_SECRETS_SEAL_ENCRYPTED_KEY_INVALID", message: "Sealed secrets carry a malformed encrypted key" },
+  CIPHERTEXT_INVALID: { status: 400, event: "SDL_SECRETS_SEAL_CIPHERTEXT_INVALID", message: "Sealed secrets carry a malformed ciphertext" },
+  IV_INVALID: { status: 400, event: "SDL_SECRETS_SEAL_IV_INVALID", message: "Sealed secrets carry a malformed initialization vector" },
+  TAG_INVALID: { status: 400, event: "SDL_SECRETS_SEAL_TAG_INVALID", message: "Sealed secrets carry a malformed authentication tag" },
+  ENCRYPTED_KEY_REJECTED: {
+    status: 400,
+    event: "SDL_SECRETS_SEAL_ENCRYPTED_KEY_REJECTED",
+    message: "Sealed secrets carry an encrypted key this key version cannot open"
+  },
+  KEY_SERVICE_REQUEST_CORRUPTED: { status: 503, event: "SDL_SECRETS_CEK_REQUEST_CORRUPTED", message: "SDL secrets could not be unsealed" },
+  KEY_SERVICE_PLAINTEXT_MISSING: { status: 503, event: "SDL_SECRETS_CEK_MISSING", message: "SDL secrets could not be unsealed" },
+  KEY_SERVICE_RESPONSE_CORRUPTED: { status: 503, event: "SDL_SECRETS_CEK_RESPONSE_CORRUPTED", message: "SDL secrets could not be unsealed" },
+  KEY_SERVICE_UNREACHABLE: {
+    status: 503,
+    event: "SDL_SECRETS_CEK_UNWRAP_FAILED",
+    message: "Unable to reach the SDL secrets key management service",
+    isServiceFault: true
+  },
+  AUTHENTICATION_FAILED: { status: 400, event: "SDL_SECRETS_SEAL_TAMPERED", message: "Sealed secrets failed authentication" }
+};
 
 function isSdlBound(header: SealHeader) {
   return header.sdlHash !== undefined;
 }
 
-/** gRPC reports the status of a failed call as a numeric `code` on the rejection. */
-function getGrpcStatus(error: unknown) {
-  return error instanceof Error && "code" in error ? error.code : undefined;
-}
-
-/**
- * Opens a transport seal — one JWE holding all of a deployment's secrets.
- *
- * `jose` cannot delegate key unwrapping to a remote service, so the compact serialization is taken
- * apart by hand and each piece handed to a stock primitive. The only hand-written logic is the
- * split: the encrypted key goes to Cloud KMS, and the content is opened with AES-256-GCM using the
- * protected header's own ASCII as the additional authenticated data. That last detail is what makes
- * the header claims tamper-evident — altering `sub`, `exp` or `sdlHash` breaks the GCM tag.
- */
+/** Holds only what makes a seal a seal — the claims a client must prove and the flat string payload — because the wire format lives in `KmsWrappedJweService`. */
 @singleton()
 export class SdlSecretsUnsealerService {
   readonly #loggerService: ReturnType<CreateLogger>;
 
   constructor(
     @inject(SDL_SECRETS_KMS_TARGET) private readonly kmsTarget: SdlSecretsKmsTarget,
+    private readonly wrappedJweService: KmsWrappedJweService,
     private readonly authService: AuthService,
     @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
@@ -83,13 +72,11 @@ export class SdlSecretsUnsealerService {
   }
 
   async open({ seal, sdl }: { seal: string; sdl: string }): Promise<SdlSecrets> {
-    const parts = this.#splitSeal(seal);
-    this.#assertSegmentsAreWellFormed(parts);
-    const header = this.#validateHeader(parts.protectedHeader);
+    const parsed = this.#parseSeal(seal);
+    const header = this.#validateHeader(parsed.header);
     this.#assertSdlBinding(header, sdl);
 
-    const contentEncryptionKey = await this.#unwrapContentEncryptionKey(parts.encryptedKey);
-    const secrets = this.#decryptSecrets(parts, contentEncryptionKey);
+    const secrets = this.#parseSecrets(await this.#openSeal(parsed));
 
     this.#loggerService.info({
       event: "SDL_SECRETS_SEAL_OPENED",
@@ -101,22 +88,38 @@ export class SdlSecretsUnsealerService {
     return secrets;
   }
 
-  #splitSeal(seal: string): SealParts {
-    const parts = seal.split(".");
+  #parseSeal(seal: string): ParsedKmsWrappedJwe {
+    try {
+      return this.wrappedJweService.parse(seal);
+    } catch (error) {
+      throw this.#rejectWrappedJweFailure(error);
+    }
+  }
 
-    if (parts.length !== COMPACT_JWE_PART_COUNT) {
-      throw this.#reject(400, "SDL_SECRETS_SEAL_MALFORMED", "Sealed secrets must be a compact JWE", { partCount: parts.length });
+  async #openSeal(parsed: ParsedKmsWrappedJwe): Promise<Buffer> {
+    try {
+      return await this.wrappedJweService.open(parsed);
+    } catch (error) {
+      throw this.#rejectWrappedJweFailure(error);
+    }
+  }
+
+  #rejectWrappedJweFailure(error: unknown) {
+    if (!(error instanceof KmsWrappedJweError)) return error;
+
+    const { status, event, message, isServiceFault } = SEAL_REJECTIONS[error.failure];
+
+    if (isServiceFault) {
+      this.#loggerService.error({ event, ...error.details });
+
+      return createError(status, message);
     }
 
-    const [protectedHeader, encryptedKey, iv, ciphertext, tag] = parts;
-
-    return { protectedHeader, encryptedKey, iv, ciphertext, tag };
+    return this.#reject(status, event, message, error.details);
   }
 
   /** Everything here is free; nothing below it is. A malformed or stale seal must never reach Cloud KMS. */
-  #validateHeader(protectedHeader: string) {
-    const header = this.#parseHeader(protectedHeader);
-
+  #validateHeader(header: SealHeader) {
     if (header.alg !== SDL_SECRETS_SEAL_ALGORITHM || header.enc !== SDL_SECRETS_CONTENT_ENCRYPTION) {
       throw this.#reject(400, "SDL_SECRETS_SEAL_ALGORITHM_UNSUPPORTED", `Seals must use ${SDL_SECRETS_SEAL_ALGORITHM} and ${SDL_SECRETS_CONTENT_ENCRYPTION}`, {
         alg: header.alg,
@@ -169,125 +172,22 @@ export class SdlSecretsUnsealerService {
     }
   }
 
-  /** Also free, and for the same reason: a seal whose own segments cannot be used must never spend an unwrap. */
-  #assertSegmentsAreWellFormed({ protectedHeader, encryptedKey, iv, ciphertext, tag }: SealParts) {
-    this.#assertSegmentIsBase64Url(protectedHeader, "SDL_SECRETS_SEAL_HEADER_UNREADABLE", "Sealed secrets carry an unreadable protected header");
-    this.#assertSegmentIsBase64Url(ciphertext, "SDL_SECRETS_SEAL_CIPHERTEXT_INVALID", "Sealed secrets carry a malformed ciphertext");
-
-    const wrappedKeyBytes = this.#decodedByteLength(encryptedKey);
-
-    if (!SDL_SECRETS_WRAPPED_KEY_BYTES.has(wrappedKeyBytes)) {
-      throw this.#reject(400, "SDL_SECRETS_SEAL_ENCRYPTED_KEY_INVALID", "Sealed secrets carry a malformed encrypted key", { wrappedKeyBytes });
-    }
-
-    this.#assertSegmentDecodesTo(iv, CONTENT_ENCRYPTION_IV_BYTES, "SDL_SECRETS_SEAL_IV_INVALID", "Sealed secrets carry a malformed initialization vector");
-    this.#assertSegmentDecodesTo(tag, CONTENT_ENCRYPTION_TAG_BYTES, "SDL_SECRETS_SEAL_TAG_INVALID", "Sealed secrets carry a malformed authentication tag");
-  }
-
-  #assertSegmentIsBase64Url(segment: string, event: string, message: string) {
-    if (!isBase64Url(segment)) {
-      throw this.#reject(400, event, message, {});
-    }
-  }
-
-  #assertSegmentDecodesTo(segment: string, expectedBytes: number, event: string, message: string) {
-    const decodedBytes = this.#decodedByteLength(segment);
-
-    if (decodedBytes !== expectedBytes) {
-      throw this.#reject(400, event, message, { decodedBytes, expectedBytes });
-    }
-  }
-
-  #decodedByteLength(segment: string) {
-    return isBase64Url(segment) ? Buffer.from(segment, "base64url").length : 0;
-  }
-
-  #parseHeader(protectedHeader: string): SealHeader {
-    const header = this.#decodeHeaderJson(protectedHeader);
-
-    if (!header || typeof header !== "object" || Array.isArray(header)) {
-      throw this.#reject(400, "SDL_SECRETS_SEAL_HEADER_UNREADABLE", "Sealed secrets carry an unreadable protected header", {});
-    }
-
-    return header;
-  }
-
-  #decodeHeaderJson(protectedHeader: string): unknown {
-    try {
-      return JSON.parse(Buffer.from(protectedHeader, "base64url").toString("utf8"));
-    } catch {
-      return null;
-    }
-  }
-
-  async #unwrapContentEncryptionKey(encryptedKey: string): Promise<Buffer> {
-    const ciphertext = Buffer.from(encryptedKey, "base64url");
-
-    const response = await this.#asymmetricDecrypt(ciphertext);
-
-    if (!response.verifiedCiphertextCrc32c) {
-      throw this.#reject(503, "SDL_SECRETS_CEK_REQUEST_CORRUPTED", "SDL secrets could not be unsealed", {});
-    }
-
-    if (!response.plaintext) {
-      throw this.#reject(503, "SDL_SECRETS_CEK_MISSING", "SDL secrets could not be unsealed", {});
-    }
-
-    const contentEncryptionKey = Buffer.from(response.plaintext as Uint8Array);
-
-    if (crc32c.calculate(contentEncryptionKey) !== Number(response.plaintextCrc32c?.value)) {
-      throw this.#reject(503, "SDL_SECRETS_CEK_RESPONSE_CORRUPTED", "SDL secrets could not be unsealed", {});
-    }
-
-    return contentEncryptionKey;
-  }
-
-  async #asymmetricDecrypt(ciphertext: Buffer) {
-    try {
-      const [response] = await this.kmsTarget.client.asymmetricDecrypt({
-        name: this.kmsTarget.versionName,
-        ciphertext,
-        ciphertextCrc32c: { value: crc32c.calculate(ciphertext) }
-      });
-
-      return response;
-    } catch (error) {
-      if (getGrpcStatus(error) === grpc.status.INVALID_ARGUMENT) {
-        throw this.#reject(400, "SDL_SECRETS_SEAL_ENCRYPTED_KEY_REJECTED", "Sealed secrets carry an encrypted key this key version cannot open", {});
-      }
-
-      this.#loggerService.error({ event: "SDL_SECRETS_CEK_UNWRAP_FAILED", versionName: this.kmsTarget.versionName, error });
-
-      throw createError(503, "Unable to reach the SDL secrets key management service");
-    }
-  }
-
-  #decryptSecrets({ protectedHeader, iv, ciphertext, tag }: SealParts, contentEncryptionKey: Buffer): SdlSecrets {
-    try {
-      const decipher = createDecipheriv("aes-256-gcm", contentEncryptionKey, Buffer.from(iv, "base64url"));
-      decipher.setAAD(Buffer.from(protectedHeader, "ascii"));
-      decipher.setAuthTag(Buffer.from(tag, "base64url"));
-
-      const plaintext = Buffer.concat([decipher.update(Buffer.from(ciphertext, "base64url")), decipher.final()]);
-
-      return this.#parseSecrets(plaintext);
-    } catch (error) {
-      if (createError.isHttpError(error)) {
-        throw error;
-      }
-
-      throw this.#reject(400, "SDL_SECRETS_SEAL_TAMPERED", "Sealed secrets failed authentication", {});
-    }
-  }
-
   #parseSecrets(plaintext: Buffer): SdlSecrets {
-    const secrets = JSON.parse(plaintext.toString("utf8"));
+    const secrets = this.#decodeSecretsJson(plaintext);
 
     if (!secrets || typeof secrets !== "object" || Array.isArray(secrets) || Object.values(secrets).some(value => typeof value !== "string")) {
       throw this.#reject(400, "SDL_SECRETS_SEAL_PAYLOAD_INVALID", "Sealed secrets must be a flat object of string values", {});
     }
 
-    return secrets;
+    return secrets as SdlSecrets;
+  }
+
+  #decodeSecretsJson(plaintext: Buffer): unknown {
+    try {
+      return JSON.parse(plaintext.toString("utf8"));
+    } catch {
+      return null;
+    }
   }
 
   #reject(status: number, event: string, message: string, details: Record<string, unknown>) {


### PR DESCRIPTION
## Why

Part of CON-852.

Two paths now need to open a compact JWE whose content encryption key only Cloud KMS can unwrap: the
transport seal a client sends, and a wrapped data key coming back out of our own `data_keys` table. All of
that logic lived inside `SdlSecretsUnsealerService`, so the second caller would have had to duplicate it.

This is the first of three stacked PRs. It is a pure refactor and ships no new behaviour. Its base is
`main`.

## What

Extracts the wire-format half of `SdlSecretsUnsealerService` into `KmsWrappedJweService`:

- the five-segment compact split
- the segment well-formedness checks (base64url, RSA-modulus-sized encrypted key, 96-bit IV, 128-bit tag)
- the crc32c-verified `asymmetricDecrypt` of the encrypted key
- the AES-256-GCM open that uses the protected header's ASCII as the additional authenticated data

What deliberately did **not** move: claim validation. `alg`/`enc`, `kid`, `sub`, `exp` and the SDL binding
stay in the unsealer, and the primitive validates nothing in the header, because what a header must say
differs by caller — a wrapped data key carries none of a transport seal's claims. The flat-string payload
shape also stays with the unsealer; the primitive returns raw bytes.

Two design points worth a reviewer's attention:

**The seam is two-phase on purpose.** `parse()` is free and `open()` is not, so each caller can validate
whatever it needs *between* the two and a malformed or stale input never reaches Cloud KMS. That ordering
was load-bearing in the original and is preserved on both paths.

**The primitive never decides whose fault a failure is.** It throws a `KmsWrappedJweError` carrying a
failure discriminant and never an `http-errors` instance. The transport path maps the 12 discriminants to
its existing statuses, event names, messages and log levels through one record literal; the at-rest path
(next PR in the stack) maps the same discriminants to 5xx, because a corrupted row of ours is not a
client's mistake. Merging the two error vocabularies into the primitive would have been the wrong
abstraction.

`ParsedKmsWrappedJwe` is branded with a `unique symbol`, so `open()` cannot be handed a structurally
compatible literal that skipped every free check and spend a KMS unwrap on garbage. Bypassing the seam is
a type error.

### Behaviour change to be aware of

One deliberate change, status unchanged: a decrypted payload that is **not valid JSON at all** now logs
`SDL_SECRETS_SEAL_PAYLOAD_INVALID` instead of `SDL_SECRETS_SEAL_TAMPERED`. Both are still `400`. The new
event is more accurate — the GCM tag verified, so nothing was tampered with — and it makes the tamper
signal more precise, since a genuinely altered ciphertext still reports `TAMPERED`.

**Please check no dashboard or alert keys off `SDL_SECRETS_SEAL_TAMPERED` volume**, as its rate will drop
slightly if any client has ever sent a well-sealed non-JSON payload. Both events are now pinned by tests,
which they were not before.

No other observable change. No API contract, no schema, no migration, no config, no dependency.

### Verification

The transport spec is the proof that behaviour was relocated rather than moved: **41 → 43 tests, none
dropped and none loosened**, and the only edit to existing test code is one line of constructor wiring.
The two added tests pin both sides of the event split above.

`KmsWrappedJweService` gets its own 23-test spec covering the contract the transport spec cannot observe:
that `open()` returns raw bytes rather than JSON, that a header carrying only algorithm claims parses
fine, that `parse()` spends no key-service call, that failures are discriminants and not HTTP errors, and
that an unreachable key service carries the underlying error for the caller to log.

Both are driven by a locally generated RSA-3072 keypair performing real RSA-OAEP-256 decryption and real
crc32c — no network, no emulator, no CI dependency added.

### Scope

This stack ships **no caller** for any of it. `SdlSecretsUnsealerService` had zero callers before this PR
and still has zero; the storage column and the write path that will use both services are a later slice,
because they need the HTTP layer and a schema change that CON-852 explicitly excludes. Please don't read
the absence of a caller as an omission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added secure handling for wrapped encrypted secret payloads.
  * Added validation for encrypted payload structure, integrity, authentication, and key-service responses.
  * Added clearer classification of invalid payloads, authentication failures, and key-service errors.

* **Bug Fixes**
  * Improved preservation of raw binary payloads during decryption.
  * Invalid JSON secrets are now distinguished from tampered or otherwise invalid ciphertext.

* **Tests**
  * Expanded coverage for successful decryption, malformed inputs, integrity checks, authentication failures, and error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->