### PR TITLE
feat(deployment): encrypt a secret value under its owner's data key

### DIFF
--- a/apps/api/src/secret/config/secret-at-rest.config.ts
+++ b/apps/api/src/secret/config/secret-at-rest.config.ts
@@ -1,2 +1,7 @@
 /** The only message a caller gets when stored secrets cannot be read: the error handler echoes `message` for every `http-errors` instance regardless of `expose`. */
 export const SECRET_UNREADABLE_ERROR_MESSAGE = "Unable to read stored secrets";
+
+/** The data key is already the per-owner key rotation re-wraps, so a value is encrypted directly under it rather than under a per-value key wrapped by it. */
+export const SECRET_AT_REST_KEY_MANAGEMENT = "dir";
+
+export const SECRET_AT_REST_CONTENT_ENCRYPTION = "A256GCM";

--- a/apps/api/src/secret/services/secret-cipher/secret-cipher.service.integration.ts
+++ b/apps/api/src/secret/services/secret-cipher/secret-cipher.service.integration.ts
@@ -31,7 +31,7 @@ describe(SecretCipherService.name, () => {
     const clientSecrets = {
       DB_URL: `postgres://app:${randomUUID()}@db.internal/app`,
       API_TOKEN: randomBytes(20).toString("hex"),
-      PRIVATE_KEY: "-----BEGIN KEY-----\nдані 🔐\n-----END KEY-----\n",
+      PRIVATE_KEY: `-----BEGIN KEY-----\nдані: ${randomUUID()} 🔐\n-----END KEY-----\n`,
       EMPTY: ""
     };
 

--- a/apps/api/src/secret/services/secret-cipher/secret-cipher.service.integration.ts
+++ b/apps/api/src/secret/services/secret-cipher/secret-cipher.service.integration.ts
@@ -1,0 +1,224 @@
+import type { protos } from "@google-cloud/kms";
+import crc32c from "fast-crc32c";
+import { compactDecrypt, CompactEncrypt, decodeProtectedHeader } from "jose";
+import { constants, generateKeyPairSync, privateDecrypt, randomBytes, randomUUID } from "node:crypto";
+import { container } from "tsyringe";
+import { afterEach, describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { AuthService } from "@src/auth/services/auth.service";
+import type { CreateLogger } from "@src/core/providers/logging.provider";
+import { ExecutionContextService } from "@src/core/services/execution-context/execution-context.service";
+import type { SdlSecretsKmsClient } from "@src/deployment/providers/kms.provider";
+import { KmsWrappedJweService } from "@src/deployment/services/kms-wrapped-jwe/kms-wrapped-jwe.service";
+import type { SdlSecretsSealingKeyService } from "@src/deployment/services/sdl-secrets-sealing-key/sdl-secrets-sealing-key.service";
+import { SdlSecretsUnsealerService } from "@src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service";
+import { DataKeyRepository } from "@src/secret/repositories/data-key/data-key.repository";
+import { DataKeyService } from "@src/secret/services/data-key/data-key.service";
+import { DataKeyUnwrapperService } from "@src/secret/services/data-key-unwrapper/data-key-unwrapper.service";
+import type { UserOutput } from "@src/user/repositories";
+import { UserRepository } from "@src/user/repositories";
+import { SecretCipherService } from "./secret-cipher.service";
+
+const KID = "sdl-secrets.v1";
+const VERSION_NAME = "projects/console-test/locations/global/keyRings/console-api/cryptoKeys/sdl-secrets/cryptoKeyVersions/1";
+const SDL = 'version: "2.0"\nservices:\n  web:\n    image: nginx\n';
+
+describe(SecretCipherService.name, () => {
+  it("returns the exact values a client sealed after they have been encrypted at rest and decrypted back", async () => {
+    const { cipher, openSeal, sealAs, createTestUser, inRequest } = setup();
+    const user = await createTestUser();
+    const clientSecrets = {
+      DB_URL: `postgres://app:${randomUUID()}@db.internal/app`,
+      API_TOKEN: randomBytes(20).toString("hex"),
+      PRIVATE_KEY: "-----BEGIN KEY-----\nдані 🔐\n-----END KEY-----\n",
+      EMPTY: ""
+    };
+
+    const roundTripped = await inRequest(user, async () => {
+      const opened = await openSeal(await sealAs(user, clientSecrets));
+      const stored = await Promise.all(Object.entries(opened).map(async ([name, value]) => [name, await cipher.encrypt(user.id, value)] as const));
+
+      return Object.fromEntries(await Promise.all(stored.map(async ([name, encrypted]) => [name, await cipher.decrypt(user.id, encrypted)] as const)));
+    });
+
+    expect(roundTripped).toEqual(clientSecrets);
+  });
+
+  it("records the user's own data key record in every value it stores", async () => {
+    const { cipher, createTestUser, inRequest, dataKeyRepository } = setup();
+    const user = await createTestUser();
+
+    const stored = await inRequest(user, async () => await Promise.all(["a", "b", "c"].map(async value => await cipher.encrypt(user.id, value))));
+    const dataKey = await dataKeyRepository.findByUserId(user.id);
+
+    expect(stored.map(encrypted => decodeProtectedHeader(encrypted).kid)).toEqual([dataKey!.id, dataKey!.id, dataKey!.id]);
+    expect(stored.map(encrypted => decodeProtectedHeader(encrypted).alg)).toEqual(["dir", "dir", "dir"]);
+  });
+
+  it("unwraps the data key once for a request that encrypts and decrypts twelve values", async () => {
+    const { cipher, createTestUser, inRequest, kmsClient } = setup();
+    const user = await createTestUser();
+    const values = Array.from({ length: 12 }, (_, index) => `secret-${index}`);
+
+    const roundTripped = await inRequest(user, async () => {
+      const stored = await Promise.all(values.map(async value => await cipher.encrypt(user.id, value)));
+
+      return await Promise.all(stored.map(async encrypted => await cipher.decrypt(user.id, encrypted)));
+    });
+
+    expect(roundTripped).toEqual(values);
+    expect(kmsClient.asymmetricDecrypt).toHaveBeenCalledTimes(1);
+  });
+
+  it("unwraps the data key again in the request that follows the one that unwrapped it", async () => {
+    const { cipher, createTestUser, inRequest, kmsClient } = setup();
+    const user = await createTestUser();
+
+    const encrypted = await inRequest(user, async () => await cipher.encrypt(user.id, "value"));
+
+    await expect(inRequest(user, async () => await cipher.decrypt(user.id, encrypted))).resolves.toBe("value");
+    expect(kmsClient.asymmetricDecrypt).toHaveBeenCalledTimes(2);
+  });
+
+  it("holds no data key once the request that unwrapped one has ended", async () => {
+    const { cipher, createTestUser, inRequest, executionContextService } = setup();
+    const user = await createTestUser();
+
+    const heldDuringRequest = await inRequest(user, async () => {
+      await cipher.encrypt(user.id, "value");
+
+      return executionContextService.get("HELD_DATA_KEYS");
+    });
+    const heldInNextRequest = await inRequest(user, async () => executionContextService.get("HELD_DATA_KEYS"));
+
+    expect(heldDuringRequest?.size).toBe(1);
+    expect(heldInNextRequest).toBeUndefined();
+  });
+
+  it("refuses to decrypt one user's stored value for another user", async () => {
+    const { cipher, createTestUser, inRequest } = setup();
+    const [owner, other] = await Promise.all([createTestUser(), createTestUser()]);
+
+    const encryptedForOwner = await inRequest(owner, async () => await cipher.encrypt(owner.id, "owner-only"));
+
+    await expect(inRequest(other, async () => await cipher.decrypt(other.id, encryptedForOwner))).rejects.toMatchObject({ status: 500 });
+  });
+
+  it("fails authentication when one user's stored value is opened with another user's data key", async () => {
+    const { cipher, createTestUser, inRequest, dataKeyOf } = setup();
+    const [owner, other] = await Promise.all([createTestUser(), createTestUser()]);
+
+    const encryptedForOwner = await inRequest(owner, async () => await cipher.encrypt(owner.id, "owner-only"));
+    await inRequest(other, async () => await cipher.encrypt(other.id, "other-only"));
+
+    await expect(compactDecrypt(encryptedForOwner, await dataKeyOf(other))).rejects.toMatchObject({ code: "ERR_JWE_DECRYPTION_FAILED" });
+    await expect(compactDecrypt(encryptedForOwner, await dataKeyOf(owner))).resolves.toMatchObject({ protectedHeader: { alg: "dir" } });
+  });
+
+  it("reads a value back through a service that shares nothing with the one that stored it", async () => {
+    const { cipher, buildCipher, createTestUser, inRequest } = setup();
+    const user = await createTestUser();
+
+    const encrypted = await inRequest(user, async () => await cipher.encrypt(user.id, "durable"));
+
+    await expect(inRequest(user, async () => await buildCipher().decrypt(user.id, encrypted))).resolves.toBe("durable");
+  });
+
+  it("creates the data key row on first use for a user that never had one", async () => {
+    const { cipher, createTestUser, inRequest, dataKeyRepository } = setup();
+    const user = await createTestUser();
+
+    expect(await dataKeyRepository.findByUserId(user.id)).toBeUndefined();
+
+    await inRequest(user, async () => await cipher.encrypt(user.id, "value"));
+
+    expect(await dataKeyRepository.findByUserId(user.id)).toMatchObject({ userId: user.id, wrappedByKid: KID });
+  });
+
+  const pendingCleanups: Array<() => Promise<void>> = [];
+  afterEach(async () => {
+    await Promise.all(pendingCleanups.splice(0).map(async runCleanup => await runCleanup()));
+  });
+
+  function setup() {
+    const { publicKey, privateKey } = generateKeyPairSync("rsa", { modulusLength: 3072 });
+    const { n, e } = publicKey.export({ format: "jwk" });
+    const sealingKeyService = mock<SdlSecretsSealingKeyService>();
+    sealingKeyService.peekSealingKey.mockReturnValue({ kid: KID, publicKey, jwk: { kty: "RSA", n: n!, e: e!, use: "enc", alg: "RSA-OAEP-256" } });
+
+    const kmsClient = mock<SdlSecretsKmsClient>();
+    kmsClient.asymmetricDecrypt.mockImplementation(async request => {
+      const plaintext = privateDecrypt({ key: privateKey, padding: constants.RSA_PKCS1_OAEP_PADDING, oaepHash: "sha256" }, Buffer.from(request.ciphertext));
+
+      return [
+        {
+          plaintext,
+          plaintextCrc32c: { value: String(crc32c.calculate(plaintext)) },
+          verifiedCiphertextCrc32c: true
+        } satisfies protos.google.cloud.kms.v1.IAsymmetricDecryptResponse
+      ];
+    });
+
+    const createLogger: CreateLogger = () => mock<ReturnType<CreateLogger>>();
+    const kmsTarget = { client: kmsClient, versionName: VERSION_NAME, kid: KID };
+    const wrappedJweService = new KmsWrappedJweService(kmsTarget);
+    const dataKeyRepository = container.resolve(DataKeyRepository);
+    const userRepository = container.resolve(UserRepository);
+    const executionContextService = container.resolve(ExecutionContextService);
+    const dataKeyService = new DataKeyService(dataKeyRepository, sealingKeyService, createLogger);
+    const authService = mock<AuthService>();
+
+    const buildCipher = () =>
+      new SecretCipherService(new DataKeyUnwrapperService(dataKeyService, executionContextService, wrappedJweService, kmsTarget, createLogger), createLogger);
+
+    const unsealer = new SdlSecretsUnsealerService(kmsTarget, wrappedJweService, authService, createLogger);
+    const createdUserIds: string[] = [];
+
+    pendingCleanups.push(async () => {
+      if (createdUserIds.length > 0) {
+        await userRepository.deleteById(createdUserIds);
+      }
+    });
+
+    async function createTestUser() {
+      const user = await userRepository.create({});
+      createdUserIds.push(user.id);
+
+      return user;
+    }
+
+    const sealAs = async (user: UserOutput, secrets: Record<string, string>) =>
+      await new CompactEncrypt(new TextEncoder().encode(JSON.stringify(secrets)))
+        .setProtectedHeader({ alg: "RSA-OAEP-256", enc: "A256GCM", kid: KID, sub: user.id, exp: Math.floor(Date.now() / 1000) + 300 } as never)
+        .encrypt(publicKey);
+
+    const openSeal = async (seal: string) => await unsealer.open({ seal, sdl: SDL });
+
+    const inRequest = <R>(user: UserOutput, cb: () => Promise<R>) =>
+      executionContextService.runWithContext(async () => {
+        authService.currentUser = user;
+
+        return await cb();
+      });
+
+    const dataKeyOf = async (user: UserOutput) => {
+      const dataKey = await dataKeyRepository.findByUserId(user.id);
+
+      return Buffer.from((await compactDecrypt(dataKey!.wrappedKey, privateKey)).plaintext);
+    };
+
+    return {
+      cipher: buildCipher(),
+      buildCipher,
+      openSeal,
+      sealAs,
+      createTestUser,
+      inRequest,
+      kmsClient,
+      executionContextService,
+      dataKeyRepository,
+      dataKeyOf
+    };
+  }
+});

--- a/apps/api/src/secret/services/secret-cipher/secret-cipher.service.spec.ts
+++ b/apps/api/src/secret/services/secret-cipher/secret-cipher.service.spec.ts
@@ -1,0 +1,155 @@
+import { CompactEncrypt, decodeProtectedHeader } from "jose";
+import { randomBytes, randomUUID } from "node:crypto";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { CreateLogger } from "@src/core/providers/logging.provider";
+import type { DataKeyUnwrapperService } from "@src/secret/services/data-key-unwrapper/data-key-unwrapper.service";
+import { SecretCipherService } from "./secret-cipher.service";
+
+const DATA_KEY_ID = "2b0f1e3c-8a4d-4c22-9f10-7d5e6a1b2c3d";
+const OTHER_DATA_KEY_ID = "9c8b7a65-4321-4def-8abc-0123456789ab";
+const USER_ID = "3f2b6f7a-1c1d-4b0e-8b8a-9a0f5f5c2b11";
+
+describe(SecretCipherService.name, () => {
+  it("returns the value it was given after a round trip", async () => {
+    const { service } = setup();
+    const value = `postgres://app:${randomUUID()}@db.internal/app`;
+
+    const encrypted = await service.encrypt(USER_ID, value);
+
+    await expect(service.decrypt(USER_ID, encrypted)).resolves.toBe(value);
+  });
+
+  it("preserves a value carrying multibyte characters, newlines and quotes", async () => {
+    const { service } = setup();
+    const value = '-----BEGIN KEY-----\nдані\n"quoted"\t🔐\n-----END KEY-----\n';
+
+    const encrypted = await service.encrypt(USER_ID, value);
+
+    await expect(service.decrypt(USER_ID, encrypted)).resolves.toBe(value);
+  });
+
+  it("preserves an empty value", async () => {
+    const { service } = setup();
+
+    const encrypted = await service.encrypt(USER_ID, "");
+
+    await expect(service.decrypt(USER_ID, encrypted)).resolves.toBe("");
+  });
+
+  it("records the data key record that encrypted the value", async () => {
+    const { service } = setup();
+
+    const encrypted = await service.encrypt(USER_ID, "value");
+
+    expect(decodeProtectedHeader(encrypted).kid).toBe(DATA_KEY_ID);
+  });
+
+  it("declares the key management and content encryption it uses", async () => {
+    const { service } = setup();
+
+    const encrypted = await service.encrypt(USER_ID, "value");
+
+    expect(decodeProtectedHeader(encrypted)).toMatchObject({ alg: "dir", enc: "A256GCM" });
+  });
+
+  it("does not record the key version that wrapped the data key", async () => {
+    const { service } = setup();
+
+    const encrypted = await service.encrypt(USER_ID, "value");
+
+    expect(Object.keys(decodeProtectedHeader(encrypted))).toEqual(["alg", "enc", "kid"]);
+  });
+
+  it("encrypts the same value differently every time", async () => {
+    const { service } = setup();
+
+    const [first, second] = await Promise.all([service.encrypt(USER_ID, "value"), service.encrypt(USER_ID, "value")]);
+
+    expect(first).not.toBe(second);
+  });
+
+  it("rejects a value recorded against a different data key record", async () => {
+    const { service, key } = setup();
+    const encryptedForAnotherRecord = await setup({ dataKeyId: OTHER_DATA_KEY_ID, key }).service.encrypt(USER_ID, "value");
+
+    await expect(service.decrypt(USER_ID, encryptedForAnotherRecord)).rejects.toMatchObject({ status: 500 });
+  });
+
+  it("spends no unwrap on a value recorded against a different data key record", async () => {
+    const { service, unwrap, key } = setup();
+    const encryptedForAnotherRecord = await setup({ dataKeyId: OTHER_DATA_KEY_ID, key }).service.encrypt(USER_ID, "value");
+
+    await expect(service.decrypt(USER_ID, encryptedForAnotherRecord)).rejects.toThrow();
+
+    expect(unwrap).not.toHaveBeenCalled();
+  });
+
+  it("rejects a value encrypted under a different key even when it names the same record", async () => {
+    const { service } = setup();
+    const encryptedUnderAnotherKey = await setup({ key: randomBytes(32) }).service.encrypt(USER_ID, "value");
+
+    await expect(service.decrypt(USER_ID, encryptedUnderAnotherKey)).rejects.toMatchObject({ status: 500 });
+  });
+
+  it("rejects a value whose ciphertext was altered", async () => {
+    const { service } = setup();
+    const parts = (await service.encrypt(USER_ID, "value")).split(".");
+    parts[3] = Buffer.from("tampered").toString("base64url");
+
+    await expect(service.decrypt(USER_ID, parts.join("."))).rejects.toMatchObject({ status: 500 });
+  });
+
+  it("rejects a value whose recorded data key was rewritten in place", async () => {
+    const { service } = setup();
+    const [, ...rest] = (await service.encrypt(USER_ID, "value")).split(".");
+    const forged = Buffer.from(JSON.stringify({ alg: "dir", enc: "A256GCM", kid: DATA_KEY_ID, tampered: true })).toString("base64url");
+
+    await expect(service.decrypt(USER_ID, [forged, ...rest].join("."))).rejects.toMatchObject({ status: 500 });
+  });
+
+  it("rejects a value declaring a key management algorithm it does not use", async () => {
+    const { service, key } = setup();
+    const wrapped = await new CompactEncrypt(new TextEncoder().encode("value"))
+      .setProtectedHeader({ alg: "A256GCMKW", enc: "A256GCM", kid: DATA_KEY_ID })
+      .encrypt(key);
+
+    await expect(service.decrypt(USER_ID, wrapped)).rejects.toMatchObject({ status: 500 });
+  });
+
+  it("rejects a value declaring a content encryption it does not use", async () => {
+    const { service, key } = setup();
+    const wrapped = await new CompactEncrypt(new TextEncoder().encode("value"))
+      .setProtectedHeader({ alg: "dir", enc: "A128CBC-HS256", kid: DATA_KEY_ID })
+      .encrypt(key);
+
+    await expect(service.decrypt(USER_ID, wrapped)).rejects.toMatchObject({ status: 500 });
+  });
+
+  it("rejects a value that is not a compact JWE", async () => {
+    const { service, logger } = setup();
+
+    await expect(service.decrypt(USER_ID, "not-a-jwe")).rejects.toMatchObject({ status: 500 });
+    expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "SECRET_VALUE_HEADER_UNREADABLE" }));
+  });
+
+  it("asks for the owner's data key rather than a key of its own", async () => {
+    const { service, dataKeyUnwrapperService } = setup();
+
+    await service.encrypt(USER_ID, "value");
+
+    expect(dataKeyUnwrapperService.getDataKey).toHaveBeenCalledWith(USER_ID);
+  });
+
+  function setup(input?: { dataKeyId?: string; key?: Buffer }) {
+    const key = input?.key ?? randomBytes(32);
+    const unwrap = vi.fn(async () => key);
+    const dataKeyUnwrapperService = mock<DataKeyUnwrapperService>();
+    dataKeyUnwrapperService.getDataKey.mockResolvedValue({ id: input?.dataKeyId ?? DATA_KEY_ID, unwrap });
+    const logger = mock<ReturnType<CreateLogger>>();
+    const service = new SecretCipherService(dataKeyUnwrapperService, () => logger);
+
+    return { service, dataKeyUnwrapperService, unwrap, key, logger };
+  }
+});

--- a/apps/api/src/secret/services/secret-cipher/secret-cipher.service.spec.ts
+++ b/apps/api/src/secret/services/secret-cipher/secret-cipher.service.spec.ts
@@ -127,6 +127,29 @@ describe(SecretCipherService.name, () => {
     await expect(service.decrypt(USER_ID, wrapped)).rejects.toMatchObject({ status: 500 });
   });
 
+  it("spends no unwrap on a value declaring a key management algorithm it does not use", async () => {
+    const { service, unwrap, key, logger } = setup();
+    const wrapped = await new CompactEncrypt(new TextEncoder().encode("value"))
+      .setProtectedHeader({ alg: "A256GCMKW", enc: "A256GCM", kid: DATA_KEY_ID })
+      .encrypt(key);
+
+    await expect(service.decrypt(USER_ID, wrapped)).rejects.toThrow();
+
+    expect(unwrap).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "SECRET_VALUE_ALGORITHM_UNSUPPORTED" }));
+  });
+
+  it("spends no unwrap on a value declaring a content encryption it does not use", async () => {
+    const { service, unwrap, key } = setup();
+    const wrapped = await new CompactEncrypt(new TextEncoder().encode("value"))
+      .setProtectedHeader({ alg: "dir", enc: "A128CBC-HS256", kid: DATA_KEY_ID })
+      .encrypt(key);
+
+    await expect(service.decrypt(USER_ID, wrapped)).rejects.toThrow();
+
+    expect(unwrap).not.toHaveBeenCalled();
+  });
+
   it("rejects a value that is not a compact JWE", async () => {
     const { service, logger } = setup();
 

--- a/apps/api/src/secret/services/secret-cipher/secret-cipher.service.ts
+++ b/apps/api/src/secret/services/secret-cipher/secret-cipher.service.ts
@@ -6,6 +6,9 @@ import { type CreateLogger, LOGGER_FACTORY } from "@src/core/providers/logging.p
 import { SECRET_AT_REST_CONTENT_ENCRYPTION, SECRET_AT_REST_KEY_MANAGEMENT, SECRET_UNREADABLE_ERROR_MESSAGE } from "@src/secret/config/secret-at-rest.config";
 import { DataKeyUnwrapperService } from "@src/secret/services/data-key-unwrapper/data-key-unwrapper.service";
 
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
 /** The protected header names the data key record and is itself the additional authenticated data, so the recorded name cannot be swapped without breaking the tag. */
 @singleton()
 export class SecretCipherService {
@@ -21,21 +24,21 @@ export class SecretCipherService {
   async encrypt(userId: string, value: string): Promise<string> {
     const dataKey = await this.dataKeyUnwrapperService.getDataKey(userId);
 
-    return await new CompactEncrypt(new TextEncoder().encode(value))
+    return await new CompactEncrypt(textEncoder.encode(value))
       .setProtectedHeader({ alg: SECRET_AT_REST_KEY_MANAGEMENT, enc: SECRET_AT_REST_CONTENT_ENCRYPTION, kid: dataKey.id })
       .encrypt(await dataKey.unwrap());
   }
 
   /** The recorded data key is checked before the key is unwrapped, so reading a value the user cannot own costs no key-service call. */
   async decrypt(userId: string, encrypted: string): Promise<string> {
-    const dataKey = await this.dataKeyUnwrapperService.getDataKey(userId);
     const kid = this.#readDataKeyId(encrypted, userId);
+    const dataKey = await this.dataKeyUnwrapperService.getDataKey(userId);
 
     if (kid !== dataKey.id) {
       throw this.#rejectUnreadable("SECRET_VALUE_DATA_KEY_MISMATCH", { userId, received: kid, expected: dataKey.id });
     }
 
-    return new TextDecoder().decode(await this.#open(encrypted, await dataKey.unwrap(), userId));
+    return textDecoder.decode(await this.#open(encrypted, await dataKey.unwrap(), userId));
   }
 
   #readDataKeyId(encrypted: string, userId: string) {

--- a/apps/api/src/secret/services/secret-cipher/secret-cipher.service.ts
+++ b/apps/api/src/secret/services/secret-cipher/secret-cipher.service.ts
@@ -31,7 +31,7 @@ export class SecretCipherService {
 
   /** The recorded data key is checked before the key is unwrapped, so reading a value the user cannot own costs no key-service call. */
   async decrypt(userId: string, encrypted: string): Promise<string> {
-    const kid = this.#readDataKeyId(encrypted, userId);
+    const { kid } = this.#readSupportedHeader(encrypted, userId);
     const dataKey = await this.dataKeyUnwrapperService.getDataKey(userId);
 
     if (kid !== dataKey.id) {
@@ -41,9 +41,19 @@ export class SecretCipherService {
     return textDecoder.decode(await this.#open(encrypted, await dataKey.unwrap(), userId));
   }
 
-  #readDataKeyId(encrypted: string, userId: string) {
+  #readSupportedHeader(encrypted: string, userId: string) {
+    const header = this.#decodeHeader(encrypted, userId);
+
+    if (header.alg !== SECRET_AT_REST_KEY_MANAGEMENT || header.enc !== SECRET_AT_REST_CONTENT_ENCRYPTION) {
+      throw this.#rejectUnreadable("SECRET_VALUE_ALGORITHM_UNSUPPORTED", { userId, alg: header.alg, enc: header.enc });
+    }
+
+    return header;
+  }
+
+  #decodeHeader(encrypted: string, userId: string) {
     try {
-      return decodeProtectedHeader(encrypted).kid;
+      return decodeProtectedHeader(encrypted);
     } catch {
       throw this.#rejectUnreadable("SECRET_VALUE_HEADER_UNREADABLE", { userId });
     }

--- a/apps/api/src/secret/services/secret-cipher/secret-cipher.service.ts
+++ b/apps/api/src/secret/services/secret-cipher/secret-cipher.service.ts
@@ -1,0 +1,67 @@
+import createError from "http-errors";
+import { compactDecrypt, CompactEncrypt, decodeProtectedHeader } from "jose";
+import { inject, singleton } from "tsyringe";
+
+import { type CreateLogger, LOGGER_FACTORY } from "@src/core/providers/logging.provider";
+import { SECRET_AT_REST_CONTENT_ENCRYPTION, SECRET_AT_REST_KEY_MANAGEMENT, SECRET_UNREADABLE_ERROR_MESSAGE } from "@src/secret/config/secret-at-rest.config";
+import { DataKeyUnwrapperService } from "@src/secret/services/data-key-unwrapper/data-key-unwrapper.service";
+
+/** The protected header names the data key record and is itself the additional authenticated data, so the recorded name cannot be swapped without breaking the tag. */
+@singleton()
+export class SecretCipherService {
+  readonly #loggerService: ReturnType<CreateLogger>;
+
+  constructor(
+    private readonly dataKeyUnwrapperService: DataKeyUnwrapperService,
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
+  ) {
+    this.#loggerService = createLogger({ context: SecretCipherService.name });
+  }
+
+  async encrypt(userId: string, value: string): Promise<string> {
+    const dataKey = await this.dataKeyUnwrapperService.getDataKey(userId);
+
+    return await new CompactEncrypt(new TextEncoder().encode(value))
+      .setProtectedHeader({ alg: SECRET_AT_REST_KEY_MANAGEMENT, enc: SECRET_AT_REST_CONTENT_ENCRYPTION, kid: dataKey.id })
+      .encrypt(await dataKey.unwrap());
+  }
+
+  /** The recorded data key is checked before the key is unwrapped, so reading a value the user cannot own costs no key-service call. */
+  async decrypt(userId: string, encrypted: string): Promise<string> {
+    const dataKey = await this.dataKeyUnwrapperService.getDataKey(userId);
+    const kid = this.#readDataKeyId(encrypted, userId);
+
+    if (kid !== dataKey.id) {
+      throw this.#rejectUnreadable("SECRET_VALUE_DATA_KEY_MISMATCH", { userId, received: kid, expected: dataKey.id });
+    }
+
+    return new TextDecoder().decode(await this.#open(encrypted, await dataKey.unwrap(), userId));
+  }
+
+  #readDataKeyId(encrypted: string, userId: string) {
+    try {
+      return decodeProtectedHeader(encrypted).kid;
+    } catch {
+      throw this.#rejectUnreadable("SECRET_VALUE_HEADER_UNREADABLE", { userId });
+    }
+  }
+
+  async #open(encrypted: string, key: Buffer, userId: string): Promise<Uint8Array> {
+    try {
+      const { plaintext } = await compactDecrypt(encrypted, key, {
+        keyManagementAlgorithms: [SECRET_AT_REST_KEY_MANAGEMENT],
+        contentEncryptionAlgorithms: [SECRET_AT_REST_CONTENT_ENCRYPTION]
+      });
+
+      return plaintext;
+    } catch (error) {
+      throw this.#rejectUnreadable("SECRET_VALUE_UNREADABLE", { userId, error });
+    }
+  }
+
+  #rejectUnreadable(event: string, details: Record<string, unknown>) {
+    this.#loggerService.error({ event, ...details });
+
+    return createError(500, SECRET_UNREADABLE_ERROR_MESSAGE);
+  }
+}


### PR DESCRIPTION
## Why

> **Base branch: `feat/encrypt-decrypt-secrets`, not `main`.**
> This is PR 3 of 3 in a stack. Review it after PRs 1 and 2. The size label therefore measures only the
> incremental diff on top of PR 2, not the whole stack.

Part of CON-852.

Sealing values in transit protects them on the way in; it does nothing for what a database backup holds.
This is the layer that makes a stolen snapshot, a read replica, a read-only injection or a stolen disk
yield nothing useful, and it closes the round trip the rest of the phase builds toward: a client seals
values, the API opens the seal, re-encrypts under the owner's data key, and can decrypt back to exactly
the original values.

## What

`SecretCipherService.encrypt(userId, value)` / `.decrypt(userId, encrypted)` — one compact JWE per value,
encrypted directly under the owner's data key, using the unwrapper from PR 2 so a request encrypting many
values still pays for one key-service call.

### The at-rest format

`alg: "dir"`, `enc: "A256GCM"`, and a protected header of exactly `{ alg, enc, kid }`.

**Why `dir` rather than `A256GCMKW`.** `A256GCMKW` would generate a per-value content encryption key and
wrap it under the data key. That buys nothing here: the data key is already a per-owner key, and it is
already the thing rotation re-wraps — in one small `data_keys` row rather than across every value it
protects. `dir` uses the data key directly as the content encryption key, which is one less layer to get
wrong and about 60 bytes smaller per value.

**Why `kid` carries `data_keys.id` and deliberately not `wrappedByKid`.** `kid` names the data key
*record* that encrypted the value. The KMS key version alias is a different fact: it says which version
wrapped the data key, not which key encrypted the value. Recording it per value would go stale the moment
rotation re-wraps a data key, because re-wrapping changes `wrappedByKid` without changing the data key
itself — so every value's copy would be wrong while the values stayed perfectly readable. It is already
authoritative inside `data_keys.wrapped_key`'s own header and indexed in the `wrapped_by_kid` column, and
one hop from `kid` reaches it. So: one field, not both, and no format-version field either — `alg` + `enc`
+ `kid` is already self-describing.

The JOSE spec makes the protected header the additional authenticated data, so the recorded record name is
tamper-evident: it cannot be swapped without breaking the GCM tag.

### Reading

`decrypt` compares the header's `kid` against the user's own data key record **before** unwrapping
anything, so reading a value the caller cannot own costs no key-service call. A value stored for one user
therefore fails twice for another: once on the recorded record, and again on authentication if the first
check were ever bypassed. Both allow-lists (`dir` only, `A256GCM` only) are passed to `compactDecrypt`, so
a blob declaring a different algorithm is refused rather than opened.

### Acceptance criteria this PR proves

| Criterion | Test |
|---|---|
| An integration test against a real database and the local key implementation proves the round trip preserves values exactly | `secret-cipher.service.integration.ts` › *"returns the exact values a client sealed after they have been encrypted at rest and decrypted back"* — real Postgres, a real client seal, the real unsealer, then encrypt and decrypt at rest |
| An at-rest value records which data-key record encrypted it | integration › *"records the user's own data key record in every value it stores"*; unit › *"records the data key record that encrypted the value"*, *"does not record the key version that wrapped the data key"* |
| A request handling multiple values performs at most one unwrap | integration › *"unwraps the data key once for a request that encrypts and decrypts twelve values"* |
| An unwrapped key is not reachable after its request ends | integration › *"holds no data key once the request that unwrapped one has ended"*, *"unwraps the data key again in the request that follows the one that unwrapped it"* |
| Key-service calls per deployment do not grow with the number of secrets | the same twelve-value test — twelve values, one call |
| A value stored for one user cannot be decrypted with a different user's data key | integration › *"refuses to decrypt one user's stored value for another user"* **and** *"fails authentication when one user's stored value is opened with another user's data key"*, which opens the blob with the other user's real data key through stock `jose` so the refusal is proven cryptographic and not merely a metadata check |
| No test asserts on ciphertext bytes | Satisfied by construction — see below |

The `kid` policy check is mutation-tested: removing it fails two tests. Both algorithm allow-lists are
mutation-tested individually: removing either fails its own test.

**On not asserting ciphertext.** Every assertion is on round-tripped plaintext, decoded header metadata,
rejection status, logged event, or key-service call counts. No test asserts ciphertext bytes, and none
asserts a ciphertext *length* either — length tracks plaintext size, so a length assertion would be a byte
assertion wearing a disguise. The one blob-to-blob comparison asserts only that two encryptions of the same
value differ, which is an assertion about non-determinism rather than about bytes.

Round-trip coverage includes multibyte characters, newlines, quotes and the empty string, plus a test that
a value stored by one service instance is readable by a freshly constructed one, so nothing depends on
in-process state beyond the row.

The integration test uses a locally generated RSA-3072 keypair driving real RSA-OAEP-256 decryption and
real crc32c against a real database — no network, no emulator, no CI dependency added. Test credentials are
generated, never literals.

### Scope

**No caller.** No route, no controller, no storage column, no change to `DeploymentWriterService`. Storage
and wiring are a later slice, because they need the HTTP layer and a schema change CON-852 explicitly
excludes. No API contract, no schema, no migration, no config, no dependency. Please don't read the absence
of a caller as an omission — the round trip is proven end to end by the integration test rather than by a
production call site.

Two notes recorded for whoever writes that caller: `encrypt`/`decrypt` reach the key service on first use
in a request, so unwrap before `BEGIN` rather than holding a database transaction open across a KMS round
trip; and `decrypt` can create a `data_keys` row for a user who has none, so a pure read path can write.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added authenticated encryption and decryption for stored secrets.
  - Added user-specific data-key handling to isolate protected data.
  - Added validation for encryption metadata and supported encryption algorithms.
  - Added consistent handling for unreadable or invalid encrypted secrets.
  - Configured AES-256-GCM encryption for protected secret data.

- **Tests**
  - Added comprehensive coverage for encryption, decryption, key isolation, tampering, invalid input, and persistence scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->