### PR TITLE
chore(ci): report security-scan once per scanned commit

### DIFF
--- a/.github/workflows/all-ci-unsafe.yml
+++ b/.github/workflows/all-ci-unsafe.yml
@@ -11,8 +11,10 @@ on:
     types: [completed]
   # pull_request: # uncomment to test this workflow in PR
 
+# Keyed on the scanned commit, not the branch: a branch-wide key lets a newer commit's scan cancel an
+# older commit's scan mid-flight, orphaning the check run it already created as permanently pending.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch || github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_sha || github.event.pull_request.head.sha }}
   cancel-in-progress: true
 
 permissions:
@@ -53,6 +55,17 @@ jobs:
       - name: Decide whether to run scan
         id: decide
         run: | # shell
+          # A cancelled CI run is superseded by a newer one whose own scan reports this commit's verdict;
+          # reporting here as well would race that scan for the same check name on the same commit.
+          if [ "${PARENT_WORKFLOW_CONCLUSION}" == "cancelled" ]; then
+            echo "run_scan=false" >> "$GITHUB_OUTPUT"
+            echo "report_check=false" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=Upstream CI was cancelled, so the superseding CI run reports instead" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "report_check=true" >> "$GITHUB_OUTPUT"
+
           if [ "${PARENT_WORKFLOW_CONCLUSION}" != "success" ]; then
             echo "run_scan=false" >> "$GITHUB_OUTPUT"
             echo "skip_reason=Upstream CI conclusion is '${PARENT_WORKFLOW_CONCLUSION}'" >> "$GITHUB_OUTPUT"
@@ -68,8 +81,16 @@ jobs:
           echo "run_scan=true" >> "$GITHUB_OUTPUT"
           echo "skip_reason=" >> "$GITHUB_OUTPUT"
 
+      - name: Note skipped check run
+        if: ${{ steps.decide.outputs.report_check != 'true' }}
+        env:
+          SKIP_REASON: ${{ steps.decide.outputs.skip_reason }}
+        run: | # shell
+          echo "No \`security-scan\` check reported for ${PARENT_WORKFLOW_HEAD_SHA}: ${SKIP_REASON}" >> "$GITHUB_STEP_SUMMARY"
+
       - name: Create check run
         id: create_check
+        if: ${{ steps.decide.outputs.report_check == 'true' }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: | # js
@@ -252,7 +273,7 @@ jobs:
   finalize:
     runs-on: ubuntu-latest
     needs: [create-check-run, static-analyses, codeql-scan, apps-deps-scan]
-    if: ${{ always() && needs.create-check-run.result == 'success' }}
+    if: ${{ always() && needs.create-check-run.result == 'success' && needs.create-check-run.outputs.check_run_id != '' }}
     steps:
       - name: Final conclusion and summary
         id: final


### PR DESCRIPTION
## Why

The `security-scan` check on a PR could show a state that contradicts the Security Scan run in the Actions tab: a stale failure, or a spinner that never resolves. It reproduces on stacked PRs, where it happens on nearly every stack rebase.

Force-pushing a stack updates a child PR's base ref and head ref within the same second, so GitHub fires two `pull_request.synchronize` events for that PR. Both start CI on the *same* commit, and CI's own `concurrency` + `cancel-in-progress` kills the first. Observed on #3706:

```
base_ref_force_pushed  05:50:59
head_ref_force_pushed  05:51:00

CI 33043818863  cancelled  sha=9a7c3001  created 05:51:02
CI 33043819299  success    sha=9a7c3001  created 05:51:03
```

`workflow_run: types: [completed]` fires for the cancelled run too, and `create-check-run` created its check run unconditionally, so that commit ended up with two `security-scan` check runs:

```
id=98424748779  success  06:00:31 → 06:03:35  "Static analysis: passed"
id=98423165600  failure  05:51:14 → 05:51:20  "Blocked: Upstream CI conclusion is 'cancelled'"
```

GitHub surfaces only the newest check run per name, so whichever of the two finalized last decided what the PR displayed. There is a second failure mode behind the same duplication: the concurrency group was keyed on the branch, so a newer commit's scan could cancel an older commit's scan *after* it had created its check run — and a cancelled workflow takes `finalize` down with it despite `always()` (e.g. runs 32999534705, 32993991902, where `create-check-run` and `finalize` are both `cancelled`), leaving that check run `in_progress` forever with nothing left to complete it.

## What

- Skip creating the `security-scan` check run when upstream CI was cancelled. A cancelled CI run is always superseded, and the superseding run's scan reports the verdict for that commit — so there is nothing to report and no one to race. The reason is written to the job summary instead.
- Key the Security Scan concurrency group on the scanned commit (`workflow_run.head_sha`) rather than the branch, so scans of different commits can no longer cancel each other. Re-runs of the same commit still de-duplicate.
- Guard `finalize` on a non-empty `check_run_id`, so it doesn't try to complete a check run that was never created.

No change to what gets scanned, or to how a failing or skipped upstream CI is reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI scan handling so checks for individual commits are not cancelled by newer scans.
  * Prevented scan and status reporting when an upstream CI run is cancelled.
  * Added clearer skip reasons and workflow summary information for cancelled runs.
  * Ensured check results are finalized only when a check was successfully created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->