### PR TITLE
fix(deployment): stop alerting when auto top-up hits a closed deployment

### DIFF
--- a/apps/api/src/billing/services/chain-error/chain-error.service.spec.ts
+++ b/apps/api/src/billing/services/chain-error/chain-error.service.spec.ts
@@ -291,6 +291,43 @@ describe(ChainErrorService.name, () => {
     });
   });
 
+  describe("getFailedMessageIndex", () => {
+    it("reads the index from a raw chain message", () => {
+      const { service } = setup();
+      const err = new Error("Query failed with (6): rpc error: code = Unknown desc = failed to execute message; message index: 2: deployment closed");
+
+      expect(service.getFailedMessageIndex(err)).toBe(2);
+    });
+
+    it("reads the index off the original error once toAppError has replaced the message", async () => {
+      const { service } = setup();
+      const rawError = new Error("Query failed with (6): rpc error: code = Unknown desc = failed to execute message; message index: 2: Deployment closed");
+      const appError = await service.toAppError(rawError, []);
+
+      expect(appError.message).toBe("Deployment closed");
+      expect(service.getFailedMessageIndex(appError)).toBe(2);
+    });
+
+    it("returns zero rather than collapsing the first message into a missing index", () => {
+      const { service } = setup();
+
+      expect(service.getFailedMessageIndex(new Error("failed to execute message; message index: 0: deployment closed"))).toBe(0);
+    });
+
+    it("returns undefined when the message carries no index", () => {
+      const { service } = setup();
+
+      expect(service.getFailedMessageIndex(new Error("Deployment closed"))).toBeUndefined();
+    });
+
+    it("falls back to the error's own message when originalError is not an error", () => {
+      const { service } = setup();
+      const err = Object.assign(new Error("failed to execute message; message index: 1: deployment closed"), { originalError: "not an error" });
+
+      expect(service.getFailedMessageIndex(err)).toBe(1);
+    });
+  });
+
   describe("isUnsettleableDeploymentError", () => {
     it("returns true for the escrow settlement underflow panic", () => {
       const { service } = setup();

--- a/apps/api/src/billing/services/chain-error/chain-error.service.ts
+++ b/apps/api/src/billing/services/chain-error/chain-error.service.ts
@@ -126,6 +126,28 @@ export class ChainErrorService {
     return /account closed|deployment closed/i.test(error.message);
   }
 
+  /**
+   * `toAppError` replaces the raw chain message with a mapped one, so on that path the index survives only
+   * on `originalError`, which is read first because it is the rawest message available.
+   */
+  public getFailedMessageIndex(error: Error): number | undefined {
+    const originalError = (error as { originalError?: unknown }).originalError;
+
+    return this.parseMessageIndex(originalError instanceof Error ? originalError.message : undefined) ?? this.parseMessageIndex(error.message);
+  }
+
+  private parseMessageIndex(message: string | undefined): number | undefined {
+    const match = message?.match(/message index: (\d+)/)?.[1];
+
+    if (match === undefined) {
+      return undefined;
+    }
+
+    const index = parseInt(match, 10);
+
+    return Number.isNaN(index) ? undefined : index;
+  }
+
   public isUnsettleableDeploymentError(error: Error): boolean {
     const originalError = (error as { originalError?: unknown }).originalError;
     const messages = [error.message, originalError instanceof Error ? originalError.message : undefined];
@@ -180,12 +202,12 @@ export class ChainErrorService {
   }
 
   private getMessagePrefix(error: Error, messages: readonly EncodeObject[]) {
-    const messageIndexStr = error.message.match(/message index: (\d+)/)?.[1];
-    if (!messageIndexStr) {
+    const messageIndex = this.getFailedMessageIndex(error);
+
+    if (messageIndex === undefined) {
       return "";
     }
 
-    const messageIndex = parseInt(messageIndexStr);
     const messageType = messages[messageIndex]?.typeUrl;
 
     if (!messageType) {

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
@@ -65,6 +65,46 @@ describe(DeploymentSettingRepository.name, () => {
     });
   });
 
+  describe("markAsClosed", () => {
+    it("closes only the rows it is given", async () => {
+      const { deploymentSettingRepository, settingId, createSetting, readClosed } = await setup();
+      const untouchedId = await createSetting();
+
+      await deploymentSettingRepository.markAsClosed([settingId]);
+
+      expect(await readClosed(settingId)).toBe(true);
+      expect(await readClosed(untouchedId)).toBe(false);
+    });
+
+    it("closes every row of a batch", async () => {
+      const { deploymentSettingRepository, settingId, createSetting, readClosed } = await setup();
+      const otherId = await createSetting();
+
+      await deploymentSettingRepository.markAsClosed([settingId, otherId]);
+
+      expect(await readClosed(settingId)).toBe(true);
+      expect(await readClosed(otherId)).toBe(true);
+    });
+
+    it("does nothing when given no ids", async () => {
+      const { deploymentSettingRepository, settingId, readClosed } = await setup();
+
+      await deploymentSettingRepository.markAsClosed([]);
+
+      expect(await readClosed(settingId)).toBe(false);
+    });
+
+    it("leaves a funding claim marker intact so a late release still matches it", async () => {
+      const { deploymentSettingRepository, settingId } = await setup();
+
+      const claims = await deploymentSettingRepository.claimForFunding([settingId], COOLDOWN_MINUTES);
+      await deploymentSettingRepository.markAsClosed([settingId]);
+      await deploymentSettingRepository.releaseFundingClaim(claims);
+
+      expect(await deploymentSettingRepository.claimForFunding([settingId], COOLDOWN_MINUTES)).toEqual([{ id: settingId, claimedAt: expect.any(String) }]);
+    });
+  });
+
   describe("releaseFundingClaim", () => {
     it("makes a claimed deployment immediately claimable again", async () => {
       const { deploymentSettingRepository, settingId } = await setup();
@@ -401,6 +441,12 @@ describe(DeploymentSettingRepository.name, () => {
       return setting;
     }
 
+    async function readClosed(id: string) {
+      const [row] = await db.select({ closed: deploymentSettingsTable.closed }).from(deploymentSettingsTable).where(eq(deploymentSettingsTable.id, id));
+
+      return row.closed;
+    }
+
     async function backdateLastFundedAt(id: string, minutesAgo: number) {
       await db
         .update(deploymentSettingsTable)
@@ -420,7 +466,8 @@ describe(DeploymentSettingRepository.name, () => {
       createSetting,
       createLimitedSetting,
       createAnchoredSetting,
-      backdateLastFundedAt
+      backdateLastFundedAt,
+      readClosed
     };
   }
 });

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -370,6 +370,14 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
     return row?.runtimeEndsAt ?? null;
   }
 
+  async markAsClosed(ids: string[]): Promise<void> {
+    if (!ids.length) {
+      return;
+    }
+
+    await this.updateManyById(ids, { closed: true });
+  }
+
   /**
    * Atomically claims deployments for auto-funding, returning only the claims this caller won.
    * A deployment is claimable when it has never been funded or its last funding is older than

--- a/apps/api/src/deployment/repositories/lease/lease.repository.ts
+++ b/apps/api/src/deployment/repositories/lease/lease.repository.ts
@@ -11,6 +11,7 @@ export interface DrainingDeploymentOutput {
   blockRate: number;
   predictedClosedHeight: number;
   closedHeight?: number;
+  isClosed?: boolean;
 }
 
 export interface DatabaseLeaseListParams {

--- a/apps/api/src/deployment/services/draining-deployment-rpc/draining-deployment-rpc.service.spec.ts
+++ b/apps/api/src/deployment/services/draining-deployment-rpc/draining-deployment-rpc.service.spec.ts
@@ -198,6 +198,39 @@ describe(DrainingDeploymentRpcService.name, () => {
     expect(createLogger).toHaveBeenCalledWith({ context: DrainingDeploymentRpcService.name });
   });
 
+  describe("when the escrow account is no longer open", () => {
+    it.each(["closed", "overdrawn"])("flags a %s escrow account so its setting can be marked closed", async escrowState => {
+      const { service, owner, dseqs, closureHeight } = setup({
+        inputs: [{ leases: [{ blockRate: 10 }], deployment: { escrowState, funds: 0, transferred: 0 } }]
+      });
+
+      const result = await service.findManyByDseqAndOwner(closureHeight, owner, dseqs);
+
+      expect(result).toEqual([expect.objectContaining({ dseq: Number(dseqs[0]), isClosed: true })]);
+    });
+
+    it("keeps an open escrow account unflagged", async () => {
+      const { service, owner, dseqs, closureHeight } = setup({
+        inputs: [{ leases: [{ blockRate: 100 }], deployment: { escrowState: "open" } }]
+      });
+
+      const result = await service.findManyByDseqAndOwner(closureHeight, owner, dseqs);
+
+      expect(result).toEqual([expect.objectContaining({ dseq: Number(dseqs[0]) })]);
+      expect(result[0]).not.toHaveProperty("isClosed");
+    });
+
+    it("keeps a flagged deployment that an open lease would place beyond the closure window", async () => {
+      const { service, owner, dseqs } = setup({
+        inputs: [{ leases: [{ blockRate: 1 }], deployment: { escrowState: "closed", funds: 10_000_000, transferred: 0 } }]
+      });
+
+      const result = await service.findManyByDseqAndOwner(1, owner, dseqs);
+
+      expect(result).toEqual([expect.objectContaining({ dseq: Number(dseqs[0]), isClosed: true })]);
+    });
+  });
+
   function setup({
     inputs = []
   }: {
@@ -213,6 +246,7 @@ describe(DrainingDeploymentRpcService.name, () => {
         createdHeight?: number;
         funds?: number;
         transferred?: number;
+        escrowState?: string;
       };
     }>;
   } = {}) {
@@ -263,6 +297,7 @@ describe(DrainingDeploymentRpcService.name, () => {
         if ("escrow_account" in deploymentInfo) {
           deploymentInfo.escrow_account.state.funds = [{ denom: "uakt", amount: String(funds) }];
           deploymentInfo.escrow_account.state.transferred = [{ denom: "uakt", amount: String(transferred) }];
+          deploymentInfo.escrow_account.state.state = input.deployment.escrowState ?? "open";
         }
         deployments.push(deployment);
       }

--- a/apps/api/src/deployment/services/draining-deployment-rpc/draining-deployment-rpc.service.ts
+++ b/apps/api/src/deployment/services/draining-deployment-rpc/draining-deployment-rpc.service.ts
@@ -5,6 +5,9 @@ import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
 import { DrainingDeploymentOutput } from "@src/deployment/repositories/lease/lease.repository";
 import { DrainingDeploymentLeaseSource, RpcDeploymentInfo } from "@src/deployment/types/draining-deployment";
 
+/** The chain rejects a deposit into any escrow account that is not open, so every other state means closed to us. */
+const OPEN_ESCROW_ACCOUNT_STATE = "open";
+
 @singleton()
 export class DrainingDeploymentRpcService implements DrainingDeploymentLeaseSource {
   private readonly loggerService: ReturnType<CreateLogger>;
@@ -20,7 +23,8 @@ export class DrainingDeploymentRpcService implements DrainingDeploymentLeaseSour
   /**
    * Finds draining deployments by owner and dseqs from RPC.
    * Fetches lease and deployment data, calculates block rates, and predicts closure heights.
-   * Returns only deployments that are predicted to close before or at the closure height.
+   * Returns deployments predicted to close before or at the closure height, plus any whose escrow
+   * account is no longer open so the caller can mark their settings closed.
    *
    * @param closureHeight - The block height threshold for filtering draining deployments
    * @param owner - The owner address to query deployments for
@@ -40,7 +44,7 @@ export class DrainingDeploymentRpcService implements DrainingDeploymentLeaseSour
 
     this.loggerService.debug({ event: "RPC_RESOURCES_FETCHED", dseqSet, leases, deployments, result: outputs });
 
-    return outputs.filter(output => output.predictedClosedHeight <= closureHeight);
+    return outputs.filter(output => output.isClosed || output.predictedClosedHeight <= closureHeight);
   }
 
   /**
@@ -92,7 +96,8 @@ export class DrainingDeploymentRpcService implements DrainingDeploymentLeaseSour
         .map(deployment => ({
           dseq: deployment.deployment.id.dseq,
           createdHeight: Number(deployment.deployment.created_at),
-          escrowBalance: this.#sumAmounts(deployment.escrow_account.state.funds) + this.#sumAmounts(deployment.escrow_account.state.transferred)
+          escrowBalance: this.#sumAmounts(deployment.escrow_account.state.funds) + this.#sumAmounts(deployment.escrow_account.state.transferred),
+          isEscrowOpen: deployment.escrow_account.state.state === OPEN_ESCROW_ACCOUNT_STATE
         }));
 
       allItems.push(...filteredItems);
@@ -175,6 +180,8 @@ export class DrainingDeploymentRpcService implements DrainingDeploymentLeaseSour
   /**
    * Adds predicted closure heights to draining deployments.
    * Calculates closure height based on escrow balance and block rate.
+   * Flags deployments whose escrow account is no longer open before the balance and rate checks,
+   * which would otherwise drop a drained-and-closed deployment before it can be marked closed.
    * Filters out deployments with missing data, zero balance,
    * or invalid block rates, logging warnings for each case.
    *
@@ -196,6 +203,10 @@ export class DrainingDeploymentRpcService implements DrainingDeploymentLeaseSour
           owner: drainingDeployment.owner
         });
         return acc;
+      }
+
+      if (!deployment.isEscrowOpen) {
+        return [...acc, { ...drainingDeployment, predictedClosedHeight: 0, isClosed: true }];
       }
 
       if (deployment.escrowBalance <= 0) {

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
@@ -87,7 +87,7 @@ describe(DrainingDeploymentService.name, () => {
 
       expect(leaseRepository.findManyByDseqAndOwner).not.toHaveBeenCalled();
       expect(loggerService.error).not.toHaveBeenCalled();
-      expect(deploymentSettingRepository.updateManyById).toHaveBeenCalledWith(expect.arrayContaining([expect.any(String)]), { closed: true });
+      expect(deploymentSettingRepository.markAsClosed).toHaveBeenCalledWith(expect.arrayContaining([expect.any(String)]));
 
       expect(callback).toHaveBeenCalledTimes(deploymentSettings.length);
       [activeBatches[0][0], activeBatches[1][0]].forEach(deployment => {
@@ -207,6 +207,27 @@ describe(DrainingDeploymentService.name, () => {
       );
     });
 
+    it("marks a deployment whose escrow account is no longer open even though its lease still reads open", async () => {
+      const { service, deploymentSettingRepository, currentHeight } = setup();
+      const sink = mock<DeploymentTopUpInstrumentation>();
+      const address = createAkashAddress();
+      const activeSetting = createAutoTopUpDeployment({ address, dseq: "3001" });
+      const closedSetting = createAutoTopUpDeployment({ address, dseq: "3002" });
+
+      deploymentSettingRepository.findAutoTopUpDeploymentsByOwner.mockResolvedValue([activeSetting, closedSetting]);
+      vi.spyOn(service, "findLeases").mockResolvedValue([
+        createDrainingDeployment({ dseq: Number(activeSetting.dseq), owner: address, predictedClosedHeight: currentHeight + 500 }),
+        createDrainingDeployment({ dseq: Number(closedSetting.dseq), owner: address, predictedClosedHeight: currentHeight + 500, isClosed: true })
+      ]);
+
+      const result = await service.findDrainingDeploymentsForOwner(address, sink, currentHeight);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].dseq).toBe(activeSetting.dseq);
+      expect(deploymentSettingRepository.markAsClosed).toHaveBeenCalledWith([closedSetting.id]);
+      expect(sink.recordDeploymentsMarkedClosed).toHaveBeenCalledWith(1);
+    });
+
     it("marks closed deployments as closed and excludes them from the result", async () => {
       const { service, deploymentSettingRepository, currentHeight, instrumentation } = setup();
       const sink = mock<DeploymentTopUpInstrumentation>();
@@ -229,7 +250,7 @@ describe(DrainingDeploymentService.name, () => {
 
       expect(result).toHaveLength(1);
       expect(result[0].dseq).toBe(activeSetting.dseq);
-      expect(deploymentSettingRepository.updateManyById).toHaveBeenCalledWith([closedSetting.id], { closed: true });
+      expect(deploymentSettingRepository.markAsClosed).toHaveBeenCalledWith([closedSetting.id]);
       expect(sink.recordDeploymentsMarkedClosed).toHaveBeenCalledWith(1);
       expect(instrumentation.recordDeploymentsMarkedClosed).not.toHaveBeenCalled();
     });

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
@@ -147,7 +147,7 @@ export class DrainingDeploymentService {
           return acc;
         }
 
-        if (deployment.closedHeight) {
+        if (deployment.isClosed || deployment.closedHeight) {
           acc[1].push(deploymentSetting.id);
         } else {
           acc[0].push({
@@ -162,7 +162,7 @@ export class DrainingDeploymentService {
     );
 
     if (missingIds.length) {
-      await this.deploymentSettingRepository.updateManyById(missingIds, { closed: true });
+      await this.deploymentSettingRepository.markAsClosed(missingIds);
       instrumentation.recordDeploymentsMarkedClosed(missingIds.length);
     }
 

--- a/apps/api/src/deployment/services/top-up-managed-deployments/deployment-top-up-instrumentation.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/deployment-top-up-instrumentation.ts
@@ -29,4 +29,7 @@ export interface DeploymentTopUpInstrumentation {
   recordMasterWalletInsufficientFundsError(details: { owner: string; items: FundingMessageItem[]; error: unknown }): void;
   recordClaimReleaseError(details: { owner: string; deploymentIds: string[]; error: unknown }): void;
   recordDeploymentsMarkedClosed(count: number): void;
+  recordDeploymentClosedOnChain(details: { owner: string; deployment: DrainingDeployment; messageIndex?: number; error: unknown }): void;
+  recordDeploymentCloseMarkFailed(details: { owner: string; deployment: DrainingDeployment; error: unknown }): void;
+  recordClosedDeploymentRetryLimit(details: { owner: string; remainingCount: number }): void;
 }

--- a/apps/api/src/deployment/services/top-up-managed-deployments/fund-draining-deployments-instrumentation.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/fund-draining-deployments-instrumentation.service.spec.ts
@@ -196,6 +196,50 @@ describe(FundDrainingDeploymentsInstrumentationService.name, () => {
     });
   });
 
+  describe("recordDeploymentClosedOnChain", () => {
+    it("credits the marked-closed counter and warns rather than reporting a chain tx error", () => {
+      const { service, deploymentsMarkedClosed, chainTxErrors } = setup();
+      const deployment = mock<DrainingDeployment>({ dseq: "42", address: "akash1owner" });
+      const error = new Error("Deployment closed");
+
+      service.recordDeploymentClosedOnChain({ owner: "akash1owner", deployment, messageIndex: 0, error });
+
+      expect(deploymentsMarkedClosed.add).toHaveBeenCalledWith(1);
+      expect(chainTxErrors.add).not.toHaveBeenCalled();
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ event: "FUND_DRAINING_DEPLOYMENT_CLOSED_ON_CHAIN", owner: "akash1owner", dseq: "42", messageIndex: 0, error })
+      );
+      expect(mockLogger.error).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("recordDeploymentCloseMarkFailed", () => {
+    it("warns without claiming the deployment was marked closed", () => {
+      const { service, deploymentsMarkedClosed } = setup();
+      const deployment = mock<DrainingDeployment>({ dseq: "42", address: "akash1owner" });
+
+      service.recordDeploymentCloseMarkFailed({ owner: "akash1owner", deployment, error: new Error("connection terminated") });
+
+      expect(deploymentsMarkedClosed.add).not.toHaveBeenCalled();
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "FUND_DRAINING_DEPLOYMENT_CLOSE_MARK_FAILED", dseq: "42" }));
+      expect(mockLogger.error).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("recordClosedDeploymentRetryLimit", () => {
+    it("warns without counting the deployments it left unfunded as errors", () => {
+      const { service, chainTxErrors } = setup();
+
+      service.recordClosedDeploymentRetryLimit({ owner: "akash1owner", remainingCount: 2 });
+
+      expect(chainTxErrors.add).not.toHaveBeenCalled();
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ event: "FUND_DRAINING_CLOSED_DEPLOYMENT_RETRY_LIMIT", owner: "akash1owner", remainingCount: 2 })
+      );
+      expect(mockLogger.error).not.toHaveBeenCalled();
+    });
+  });
+
   describe("recordDeploymentPreparation", () => {
     it("records no instrument and does not throw on the stateless path", () => {
       const { service, jobCompletions } = setup();

--- a/apps/api/src/deployment/services/top-up-managed-deployments/fund-draining-deployments-instrumentation.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/fund-draining-deployments-instrumentation.service.ts
@@ -220,6 +220,48 @@ export class FundDrainingDeploymentsInstrumentationService implements Deployment
     this.emitLog("error", { event: "FUND_DRAINING_CREDITS_LOW_SCHEDULE_ERROR", walletId, error });
   }
 
+  recordDeploymentClosedOnChain({
+    owner,
+    deployment,
+    messageIndex,
+    error
+  }: {
+    owner: string;
+    deployment: DrainingDeployment;
+    messageIndex?: number;
+    error: unknown;
+  }): void {
+    this.recordDeploymentsMarkedClosed(1);
+
+    this.emitLog("warn", {
+      event: "FUND_DRAINING_DEPLOYMENT_CLOSED_ON_CHAIN",
+      owner,
+      dseq: deployment.dseq,
+      address: deployment.address,
+      messageIndex,
+      error
+    });
+  }
+
+  /** The count stays uncredited so telemetry never reports a row as closed that the database still has open. */
+  recordDeploymentCloseMarkFailed({ owner, deployment, error }: { owner: string; deployment: DrainingDeployment; error: unknown }): void {
+    this.emitLog("warn", {
+      event: "FUND_DRAINING_DEPLOYMENT_CLOSE_MARK_FAILED",
+      owner,
+      dseq: deployment.dseq,
+      address: deployment.address,
+      error
+    });
+  }
+
+  recordClosedDeploymentRetryLimit({ owner, remainingCount }: { owner: string; remainingCount: number }): void {
+    this.emitLog("warn", {
+      event: "FUND_DRAINING_CLOSED_DEPLOYMENT_RETRY_LIMIT",
+      owner,
+      remainingCount
+    });
+  }
+
   /**
    * The cron records blocks-until-predicted-close against a run-scoped start height. The stateless
    * event-driven path has no per-run start height, so there is nothing meaningful to record here.

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.spec.ts
@@ -72,6 +72,63 @@ describe(TopUpManagedDeploymentsInstrumentationService.name, () => {
     });
   });
 
+  describe("recordDeploymentClosedOnChain", () => {
+    it("warns, credits the marked-closed count, and leaves the run reporting success", () => {
+      const { service, logger, summarizer, countersByName } = setup();
+      service.start(100, { dryRun: false });
+      const deployment = createDrainingDeployment();
+      const error = new Error("Deployment closed");
+
+      service.recordDeploymentClosedOnChain({ owner: deployment.address, deployment, messageIndex: 1, error });
+      service.finish("success", 200);
+
+      expect(summarizer.get("deploymentsMarkedClosedCount")).toBe(1);
+      expect(summarizer.get("deploymentTopUpErrorCount")).toBe(0);
+      expect(summarizer.get("walletsTopUpErrorCount")).toBe(0);
+      expect(countersByName["auto_top_up_deployments_marked_closed_total"].add).toHaveBeenCalledWith(1);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: "TOP_UP_DEPLOYMENT_CLOSED_ON_CHAIN",
+          dseq: deployment.dseq,
+          address: deployment.address,
+          messageIndex: 1,
+          message: "Deployment closed"
+        })
+      );
+      expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "TOP_UP_DEPLOYMENTS_SUMMARY" }));
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("recordDeploymentCloseMarkFailed", () => {
+    it("warns without claiming the deployment was marked closed", () => {
+      const { service, logger, summarizer } = setup();
+      service.start(100, { dryRun: false });
+      const deployment = createDrainingDeployment();
+
+      service.recordDeploymentCloseMarkFailed({ owner: deployment.address, deployment, error: new Error("connection terminated") });
+
+      expect(summarizer.get("deploymentsMarkedClosedCount")).toBe(0);
+      expect(summarizer.get("deploymentTopUpErrorCount")).toBe(0);
+      expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "TOP_UP_DEPLOYMENT_CLOSE_MARK_FAILED", dseq: deployment.dseq }));
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("recordClosedDeploymentRetryLimit", () => {
+    it("warns without counting the deployments it left unfunded as errors", () => {
+      const { service, logger, summarizer } = setup();
+      service.start(100, { dryRun: false });
+      const owner = createDrainingDeployment().address;
+
+      service.recordClosedDeploymentRetryLimit({ owner, remainingCount: 2 });
+
+      expect(summarizer.get("deploymentTopUpErrorCount")).toBe(0);
+      expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "TOP_UP_CLOSED_DEPLOYMENT_RETRY_LIMIT", owner, remainingCount: 2 }));
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+  });
+
   describe("recordMessagePreparationError", () => {
     it("tracks insufficient balance separately", () => {
       const { service, logger, summarizer } = setup();

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.ts
@@ -241,6 +241,51 @@ export class TopUpManagedDeploymentsInstrumentationService implements Deployment
     });
   }
 
+  recordDeploymentClosedOnChain({
+    owner,
+    deployment,
+    messageIndex,
+    error
+  }: {
+    owner: string;
+    deployment: DrainingDeployment;
+    messageIndex?: number;
+    error: unknown;
+  }): void {
+    this.recordDeploymentsMarkedClosed(1);
+
+    this.logger.warn({
+      event: "TOP_UP_DEPLOYMENT_CLOSED_ON_CHAIN",
+      owner,
+      dseq: deployment.dseq,
+      address: deployment.address,
+      messageIndex,
+      ...this.serializeError(error),
+      dryRun: this.options?.dryRun
+    });
+  }
+
+  /** The count stays uncredited so the summary never reports a row as closed that the database still has open. */
+  recordDeploymentCloseMarkFailed({ owner, deployment, error }: { owner: string; deployment: DrainingDeployment; error: unknown }): void {
+    this.logger.warn({
+      event: "TOP_UP_DEPLOYMENT_CLOSE_MARK_FAILED",
+      owner,
+      dseq: deployment.dseq,
+      address: deployment.address,
+      ...this.serializeError(error),
+      dryRun: this.options?.dryRun
+    });
+  }
+
+  recordClosedDeploymentRetryLimit({ owner, remainingCount }: { owner: string; remainingCount: number }): void {
+    this.logger.warn({
+      event: "TOP_UP_CLOSED_DEPLOYMENT_RETRY_LIMIT",
+      owner,
+      remainingCount,
+      dryRun: this.options?.dryRun
+    });
+  }
+
   recordDeploymentPreparation(ownerAddress: string, predictedClosedHeight: number): void {
     this.topUpSummarizer.inc("deploymentCount");
     this.topUpSummarizer.trackWallet(ownerAddress);

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.integration.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.integration.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { UserWalletRepository } from "@src/billing/repositories";
 import { BalancesService } from "@src/billing/services/balances/balances.service";
+import { ChainErrorService } from "@src/billing/services/chain-error/chain-error.service";
 import { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
 import type { ApiPgDatabase } from "@src/core";
 import { CORE_CONFIG, POSTGRES_DB, resolveTable } from "@src/core";
@@ -27,6 +28,10 @@ const NEARLY_DRAINED_ESCROW_AMOUNT = "1000";
 const ALLOWANCE_ABOVE_HEADROOM_BELOW_A_COOLDOWN = 20000;
 
 type DepositMessage = { value: { deposit?: { amount?: { amount: string } } } };
+
+function dseqOf(message: unknown): string {
+  return String((message as { value: { id: { xid: string } } }).value.id.xid).split("/")[1];
+}
 
 /** Flattens every deposit message broadcast across all txs into the numeric amounts they carry. */
 function depositedAmounts(executeDerivedTx: { mock: { calls: unknown[][] } }): number[] {
@@ -86,6 +91,53 @@ describe(TopUpManagedDeploymentsService.name, () => {
 
       const closedSetting = await findSetting(address, closedOnChainDseq);
       expect(closedSetting?.closed).toBe(true);
+    });
+
+    // The chain rejects a batched deposit because one of its deployments closed between the sweep reading
+    // the chain and broadcasting. That deployment's setting is closed and the rest of the batch still lands.
+    it("drops a deployment the chain rejects as closed and funds the rest of the batch in the same pass", async () => {
+      const {
+        topUpService,
+        executeDerivedTx,
+        chainErrorService,
+        createUserWithWallet,
+        createDeploymentSetting,
+        findSetting,
+        mockLeasesForOwner,
+        mockDeploymentsForOwner,
+        stubGetFreshLimits
+      } = await setup();
+      const { user, address } = await createUserWithWallet();
+      const firstDseq = "400001";
+      const secondDseq = "400002";
+
+      await createDeploymentSetting(user.id, firstDseq);
+      await createDeploymentSetting(user.id, secondDseq);
+
+      mockLeasesForOwner(address, [createActiveLease(address, firstDseq), createActiveLease(address, secondDseq)], { persist: true });
+      mockDeploymentsForOwner(address, [createActiveDeployment(address, firstDseq), createActiveDeployment(address, secondDseq)], { persist: true });
+      stubGetFreshLimits({ [address]: 10000000 });
+
+      let closedDseq: string | undefined;
+      executeDerivedTx.mockImplementationOnce(async (_walletId, messages) => {
+        closedDseq = dseqOf(messages[1]);
+        throw await chainErrorService.toAppError(
+          new Error(
+            "Query failed with (6): rpc error: code = Unknown desc = failed to execute message; message index: 1: Deployment closed with gas used: '33317': unknown request"
+          ),
+          messages
+        );
+      });
+
+      const result = await topUpService.topUpDeployments({ dryRun: false });
+
+      expect(result.ok).toBe(true);
+      expect(executeDerivedTx).toHaveBeenCalledTimes(2);
+
+      const survivingDseq = closedDseq === firstDseq ? secondDseq : firstDseq;
+      expect(executeDerivedTx.mock.calls[1][1].map(dseqOf)).toEqual([survivingDseq]);
+      expect((await findSetting(address, closedDseq as string))?.closed).toBe(true);
+      expect((await findSetting(address, survivingDseq))?.closed).toBe(false);
     });
 
     // Owner has two active deployments on chain. One has low escrow and is predicted
@@ -565,6 +617,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
     const topUpService = container.resolve(TopUpManagedDeploymentsService);
     const signerService = container.resolve(ManagedSignerService);
     const balances = container.resolve(BalancesService);
+    const chainErrorService = container.resolve(ChainErrorService);
 
     nock(apiNodeUrl)
       .get("/cosmos/base/tendermint/v1beta1/blocks/latest")
@@ -656,6 +709,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
     return {
       topUpService,
       executeDerivedTx,
+      chainErrorService,
       createUserWithWallet,
       createDeploymentSetting,
       findSetting,

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.integration.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.integration.ts
@@ -93,8 +93,6 @@ describe(TopUpManagedDeploymentsService.name, () => {
       expect(closedSetting?.closed).toBe(true);
     });
 
-    // The chain rejects a batched deposit because one of its deployments closed between the sweep reading
-    // the chain and broadcasting. That deployment's setting is closed and the rest of the batch still lands.
     it("drops a deployment the chain rejects as closed and funds the rest of the batch in the same pass", async () => {
       const {
         topUpService,

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
@@ -1522,10 +1522,37 @@ describe(TopUpManagedDeploymentsService.name, () => {
 
       await expect(service.topUpDeployments({ dryRun: false })).resolves.toEqual(expect.objectContaining({ ok: true }));
 
-      expect(managedSignerService.executeDerivedTx).toHaveBeenCalledTimes(4);
-      expect(deploymentSettingRepository.markAsClosed).toHaveBeenCalledTimes(4);
-      expect(instrumentation.recordClosedDeploymentRetryLimit).toHaveBeenCalledWith({ owner, remainingCount: 2 });
+      expect(managedSignerService.executeDerivedTx).toHaveBeenCalledTimes(3);
+      expect(deploymentSettingRepository.markAsClosed).toHaveBeenCalledTimes(3);
+      expect(instrumentation.recordClosedDeploymentRetryLimit).toHaveBeenCalledWith({ owner, remainingCount: 3 });
       expect(instrumentation.recordChainTxError).not.toHaveBeenCalled();
+    });
+
+    it("reports a fee grant refill failure as a chain tx error", async () => {
+      const { service, chainErrorService, managedSignerService, instrumentation, owner } = setupDrainingOwner({ deploymentCount: 2 });
+      const error = new Error("fee grant refill failed");
+
+      chainErrorService.isMasterWalletInsufficientFundsError.mockResolvedValue(false);
+      managedSignerService.ensureFeeGrants.mockRejectedValue(error);
+
+      await expect(service.topUpDeployments({ dryRun: false })).resolves.toEqual(expect.objectContaining({ ok: true }));
+
+      expect(managedSignerService.executeDerivedTx).not.toHaveBeenCalled();
+      expect(instrumentation.recordChainTxError).toHaveBeenCalledWith(expect.objectContaining({ owner, error }));
+      expect(instrumentation.recordMasterWalletInsufficientFundsError).not.toHaveBeenCalled();
+    });
+
+    it("reports master wallet insufficient funds when the fee grant refill drains the master wallet", async () => {
+      const { service, chainErrorService, managedSignerService, instrumentation, owner } = setupDrainingOwner({ deploymentCount: 2 });
+      const error = new Error("insufficient funds: 10uakt is smaller than 20uakt");
+
+      chainErrorService.isMasterWalletInsufficientFundsError.mockResolvedValue(true);
+      managedSignerService.ensureFeeGrants.mockRejectedValue(error);
+
+      await expect(service.topUpDeployments({ dryRun: false })).resolves.toEqual(expect.objectContaining({ err: true, val: [error] }));
+
+      expect(instrumentation.recordChainTxError).toHaveBeenCalledWith(expect.objectContaining({ owner, error }));
+      expect(instrumentation.recordMasterWalletInsufficientFundsError).toHaveBeenCalledWith(expect.objectContaining({ owner, error }));
     });
 
     it("neither broadcasts nor marks anything closed on a dry run", async () => {
@@ -1572,11 +1599,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
       const walletId = faker.number.int({ min: 1000000, max: 9999999 });
       const deployments = createDrainingDeployments(owner, walletId, input.deploymentCount);
 
-      context.drainingDeploymentService.findDrainingDeploymentsByOwner.mockImplementation(() =>
-        (async function* () {
-          yield { address: owner, walletId, deployments };
-        })()
-      );
+      mockOwnerYields(context.drainingDeploymentService, createOwnerYield(deployments));
       context.drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(1000000);
       context.cachedBalanceService.get.mockResolvedValue(createMockCachedBalance(() => 1000000));
 

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
@@ -689,6 +689,8 @@ describe(TopUpManagedDeploymentsService.name, () => {
       const error = new Error(`insufficient funds: 10uakt is smaller than 20uakt`);
 
       chainErrorService.isMasterWalletInsufficientFundsError.mockResolvedValue(false);
+      chainErrorService.isDeploymentClosedError.mockReturnValue(false);
+      chainErrorService.getFailedMessageIndex.mockReturnValue(undefined);
       const mockTx = mock<IndexedTx>({
         code: 0,
         hash: "tx-hash",
@@ -1386,6 +1388,226 @@ describe(TopUpManagedDeploymentsService.name, () => {
     }
   });
 
+  describe("when the chain reports a deployment closed", () => {
+    it("marks the closed deployment, drops it, and funds the rest of the batch in the same pass", async () => {
+      const { service, chainErrorService, managedSignerService, deploymentSettingRepository, instrumentation, owner, walletId, deployments } =
+        setupDrainingOwner({ deploymentCount: 3 });
+      const error = createDeploymentClosedError(1);
+
+      chainErrorService.isDeploymentClosedError.mockReturnValue(true);
+      chainErrorService.getFailedMessageIndex.mockReturnValue(1);
+      managedSignerService.executeDerivedTx.mockRejectedValueOnce(error);
+
+      await expect(service.topUpDeployments({ dryRun: false })).resolves.toEqual(expect.objectContaining({ ok: true }));
+
+      expect(managedSignerService.executeDerivedTx).toHaveBeenCalledTimes(2);
+      expect(managedSignerService.executeDerivedTx).toHaveBeenLastCalledWith(walletId, [
+        expect.objectContaining({ value: expect.objectContaining({ id: { scope: Scope.deployment, xid: `${owner}/${deployments[0].dseq}` } }) }),
+        expect.objectContaining({ value: expect.objectContaining({ id: { scope: Scope.deployment, xid: `${owner}/${deployments[2].dseq}` } }) })
+      ]);
+      expect(deploymentSettingRepository.markAsClosed).toHaveBeenCalledWith([deployments[1].id]);
+      expect(instrumentation.recordDeploymentClosedOnChain).toHaveBeenCalledWith({
+        owner,
+        deployment: expect.objectContaining({ id: deployments[1].id }),
+        messageIndex: 1,
+        error
+      });
+      expect(instrumentation.recordChainTxError).not.toHaveBeenCalled();
+      expect(instrumentation.recordDeposit.mock.calls[0][0].items).toHaveLength(2);
+      expect(instrumentation.finish).toHaveBeenCalledWith("success", CURRENT_BLOCK_HEIGHT);
+    });
+
+    it("resolves each retry's message index against the shrunken batch rather than the original one", async () => {
+      const { service, chainErrorService, managedSignerService, deploymentSettingRepository, instrumentation, deployments } = setupDrainingOwner({
+        deploymentCount: 4
+      });
+
+      chainErrorService.isDeploymentClosedError.mockReturnValue(true);
+      chainErrorService.getFailedMessageIndex.mockReturnValueOnce(0).mockReturnValueOnce(1);
+      managedSignerService.executeDerivedTx.mockRejectedValueOnce(createDeploymentClosedError(0)).mockRejectedValueOnce(createDeploymentClosedError(1));
+
+      await service.topUpDeployments({ dryRun: false });
+
+      expect(managedSignerService.executeDerivedTx).toHaveBeenCalledTimes(3);
+      expect(deploymentSettingRepository.markAsClosed).toHaveBeenNthCalledWith(1, [deployments[0].id]);
+      expect(deploymentSettingRepository.markAsClosed).toHaveBeenNthCalledWith(2, [deployments[2].id]);
+      expect(instrumentation.recordDeposit.mock.calls[0][0].items.map(item => item.deployment.id)).toEqual([deployments[1].id, deployments[3].id]);
+    });
+
+    it("marks every deployment closed and reports no error when the whole batch is closed", async () => {
+      const { service, chainErrorService, managedSignerService, deploymentSettingRepository, instrumentation, deployments } = setupDrainingOwner({
+        deploymentCount: 2
+      });
+
+      chainErrorService.isDeploymentClosedError.mockReturnValue(true);
+      chainErrorService.getFailedMessageIndex.mockReturnValue(0);
+      managedSignerService.executeDerivedTx.mockRejectedValue(createDeploymentClosedError(0));
+
+      await expect(service.topUpDeployments({ dryRun: false })).resolves.toEqual(expect.objectContaining({ ok: true }));
+
+      expect(deploymentSettingRepository.markAsClosed).toHaveBeenNthCalledWith(1, [deployments[0].id]);
+      expect(deploymentSettingRepository.markAsClosed).toHaveBeenNthCalledWith(2, [deployments[1].id]);
+      expect(instrumentation.recordDeposit).not.toHaveBeenCalled();
+      expect(instrumentation.recordChainTxError).not.toHaveBeenCalled();
+      expect(instrumentation.finish).toHaveBeenCalledWith("success", CURRENT_BLOCK_HEIGHT);
+    });
+
+    it("drops a deployment a broadcast tx reverted on rather than only a rejected estimate", async () => {
+      const { service, chainErrorService, managedSignerService, deploymentSettingRepository, instrumentation, deployments } = setupDrainingOwner({
+        deploymentCount: 2
+      });
+
+      chainErrorService.isDeploymentClosedError.mockReturnValue(true);
+      chainErrorService.getFailedMessageIndex.mockReturnValue(0);
+      managedSignerService.executeDerivedTx.mockResolvedValueOnce(
+        mock<IndexedTx>({ code: 8, hash: "tx-hash", rawLog: "failed to execute message; message index: 0: Deployment closed" })
+      );
+
+      await service.topUpDeployments({ dryRun: false });
+
+      expect(managedSignerService.executeDerivedTx).toHaveBeenCalledTimes(2);
+      expect(deploymentSettingRepository.markAsClosed).toHaveBeenCalledWith([deployments[0].id]);
+      expect(instrumentation.recordChainTxError).not.toHaveBeenCalled();
+    });
+
+    it("reports a chain tx error and marks nothing when the failing message cannot be located in the batch", async () => {
+      const { service, chainErrorService, managedSignerService, deploymentSettingRepository, instrumentation } = setupDrainingOwner({
+        deploymentCount: 2
+      });
+      const error = createDeploymentClosedError(7);
+
+      chainErrorService.isDeploymentClosedError.mockReturnValue(true);
+      chainErrorService.getFailedMessageIndex.mockReturnValue(7);
+      managedSignerService.executeDerivedTx.mockRejectedValue(error);
+
+      await service.topUpDeployments({ dryRun: false });
+
+      expect(managedSignerService.executeDerivedTx).toHaveBeenCalledTimes(1);
+      expect(deploymentSettingRepository.markAsClosed).not.toHaveBeenCalled();
+      expect(instrumentation.recordDeploymentClosedOnChain).not.toHaveBeenCalled();
+      expect(instrumentation.recordChainTxError).toHaveBeenCalledWith(expect.objectContaining({ error }));
+    });
+
+    it("keeps funding the rest of the batch when the closed deployment cannot be written to the database", async () => {
+      const { service, chainErrorService, managedSignerService, deploymentSettingRepository, instrumentation, owner, deployments } = setupDrainingOwner({
+        deploymentCount: 2
+      });
+      const markError = new Error("connection terminated");
+
+      chainErrorService.isDeploymentClosedError.mockReturnValue(true);
+      chainErrorService.getFailedMessageIndex.mockReturnValue(0);
+      managedSignerService.executeDerivedTx.mockRejectedValueOnce(createDeploymentClosedError(0));
+      deploymentSettingRepository.markAsClosed.mockRejectedValue(markError);
+
+      await expect(service.topUpDeployments({ dryRun: false })).resolves.toEqual(expect.objectContaining({ ok: true }));
+
+      expect(managedSignerService.executeDerivedTx).toHaveBeenCalledTimes(2);
+      expect(instrumentation.recordDeploymentCloseMarkFailed).toHaveBeenCalledWith({
+        owner,
+        deployment: expect.objectContaining({ id: deployments[0].id }),
+        error: markError
+      });
+      expect(instrumentation.recordDeploymentClosedOnChain).not.toHaveBeenCalled();
+      expect(instrumentation.recordChainTxError).not.toHaveBeenCalled();
+    });
+
+    it("stops retrying once too many deployments of one owner turn out closed, without reporting an error", async () => {
+      const { service, chainErrorService, managedSignerService, deploymentSettingRepository, instrumentation, owner } = setupDrainingOwner({
+        deploymentCount: 6
+      });
+
+      chainErrorService.isDeploymentClosedError.mockReturnValue(true);
+      chainErrorService.getFailedMessageIndex.mockReturnValue(0);
+      managedSignerService.executeDerivedTx.mockRejectedValue(createDeploymentClosedError(0));
+
+      await expect(service.topUpDeployments({ dryRun: false })).resolves.toEqual(expect.objectContaining({ ok: true }));
+
+      expect(managedSignerService.executeDerivedTx).toHaveBeenCalledTimes(4);
+      expect(deploymentSettingRepository.markAsClosed).toHaveBeenCalledTimes(4);
+      expect(instrumentation.recordClosedDeploymentRetryLimit).toHaveBeenCalledWith({ owner, remainingCount: 2 });
+      expect(instrumentation.recordChainTxError).not.toHaveBeenCalled();
+    });
+
+    it("neither broadcasts nor marks anything closed on a dry run", async () => {
+      const { service, managedSignerService, deploymentSettingRepository } = setupDrainingOwner({ deploymentCount: 2 });
+
+      await service.topUpDeployments({ dryRun: true });
+
+      expect(managedSignerService.executeDerivedTx).not.toHaveBeenCalled();
+      expect(deploymentSettingRepository.markAsClosed).not.toHaveBeenCalled();
+    });
+
+    it("reports to the event-driven instrumentation when immediate funding hits a closed deployment", async () => {
+      const {
+        service,
+        chainErrorService,
+        drainingDeploymentService,
+        cachedBalanceService,
+        managedSignerService,
+        deploymentSettingRepository,
+        instrumentation,
+        fundDrainingInstrumentation
+      } = setup();
+      const owner = createAkashAddress();
+      const walletId = faker.number.int({ min: 1000000, max: 9999999 });
+      const deployments = createDrainingDeployments(owner, walletId, 2);
+
+      drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue(deployments);
+      drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(1000000);
+      cachedBalanceService.getFresh.mockResolvedValue(createMockCachedBalance(() => 1000000));
+      chainErrorService.isDeploymentClosedError.mockReturnValue(true);
+      chainErrorService.getFailedMessageIndex.mockReturnValue(0);
+      managedSignerService.executeDerivedTx.mockRejectedValueOnce(createDeploymentClosedError(0));
+
+      await service.topUpDrainingDeploymentsForOwner({ walletId, address: owner });
+
+      expect(deploymentSettingRepository.markAsClosed).toHaveBeenCalledWith([deployments[0].id]);
+      expect(fundDrainingInstrumentation.recordDeploymentClosedOnChain).toHaveBeenCalledWith(expect.objectContaining({ owner, messageIndex: 0 }));
+      expect(instrumentation.recordDeploymentClosedOnChain).not.toHaveBeenCalled();
+    });
+
+    function setupDrainingOwner(input: { deploymentCount: number }) {
+      const context = setup();
+      const owner = createAkashAddress();
+      const walletId = faker.number.int({ min: 1000000, max: 9999999 });
+      const deployments = createDrainingDeployments(owner, walletId, input.deploymentCount);
+
+      context.drainingDeploymentService.findDrainingDeploymentsByOwner.mockImplementation(() =>
+        (async function* () {
+          yield { address: owner, walletId, deployments };
+        })()
+      );
+      context.drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(1000000);
+      context.cachedBalanceService.get.mockResolvedValue(createMockCachedBalance(() => 1000000));
+
+      return { ...context, owner, walletId, deployments };
+    }
+  });
+
+  function createDeploymentClosedError(messageIndex: number) {
+    const error: Error & { originalError?: Error } = new Error("Deployment closed");
+    error.originalError = new Error(
+      `Query failed with (6): rpc error: code = Unknown desc = failed to execute message; message index: ${messageIndex}: Deployment closed`
+    );
+    return error;
+  }
+
+  function createDrainingDeployments(owner: string, walletId: number, count: number): DrainingDeployment[] {
+    return Array.from({ length: count }, () => {
+      const setting = createAutoTopUpDeployment({ address: owner, walletId });
+      return {
+        ...setting,
+        ...createDrainingDeployment({
+          dseq: Number(setting.dseq),
+          owner,
+          predictedClosedHeight: CURRENT_BLOCK_HEIGHT + 1500,
+          denom: DEPLOYMENT_GRANT_DENOM
+        }),
+        dseq: setting.dseq
+      } as DrainingDeployment;
+    });
+  }
+
   function setupWithWalletReloadJobs(input?: { currentBlockHeight?: number; feeAllowance?: number }) {
     const walletSettingRepository = mock<WalletSettingRepository>();
     const userWalletRepository = mock<UserWalletRepository>();
@@ -1432,6 +1654,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
     const deploymentSettingRepository = mock<DeploymentSettingRepository>();
     deploymentSettingRepository.claimForFunding.mockImplementation(async (ids: string[]) => ids.map(createFundingClaim));
     deploymentSettingRepository.releaseFundingClaim.mockResolvedValue(undefined);
+    deploymentSettingRepository.markAsClosed.mockResolvedValue(undefined);
     deploymentSettingRepository.findAutoTopUpDeploymentsByOwnerIteratively.mockImplementation(() => (async function* () {})());
     const deploymentConfig = mockConfigService<DeploymentConfigService>({ AUTO_TOP_UP_DEDUP_COOLDOWN_IN_MIN: DEDUP_COOLDOWN_IN_MIN });
     const balancesService = mock<BalancesService>();

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
@@ -421,7 +421,14 @@ export class TopUpManagedDeploymentsService {
     }
 
     const { address, walletIsTrialing: isTrialing, walletCreatedAt: createdAt, walletActivatedAt: activatedAt } = ownerInputs[0].deployment;
-    const feeAllowance = await this.managedSignerService.ensureFeeGrants({ address, isTrialing, createdAt, activatedAt });
+    let feeAllowance: number;
+
+    try {
+      feeAllowance = await this.managedSignerService.ensureFeeGrants({ address, isTrialing, createdAt, activatedAt });
+    } catch (error: unknown) {
+      await this.#recordOwnerFundingFailure({ owner, items: ownerInputs, error, instrumentation });
+      return false;
+    }
 
     if (feeAllowance <= 0) {
       instrumentation.recordChainTxError({
@@ -447,26 +454,40 @@ export class TopUpManagedDeploymentsService {
       const closedIndex = this.#findClosedDeploymentIndex(failure, remaining);
 
       if (closedIndex === undefined) {
-        instrumentation.recordChainTxError({ owner, items: remaining, error: failure });
-
-        if (failure instanceof Error && (await this.chainErrorService.isMasterWalletInsufficientFundsError(failure))) {
-          instrumentation.recordMasterWalletInsufficientFundsError({ owner, items: remaining, error: failure });
-          throw failure;
-        }
-
+        await this.#recordOwnerFundingFailure({ owner, items: remaining, error: failure, instrumentation });
         return false;
       }
 
       await this.#markDeploymentClosed({ owner, item: remaining[closedIndex], messageIndex: closedIndex, error: failure, instrumentation });
       remaining = remaining.filter((_, index) => index !== closedIndex);
 
-      if (++closedDeploymentsDropped > MAX_CLOSED_DEPLOYMENT_DROPS && remaining.length) {
+      if (++closedDeploymentsDropped >= MAX_CLOSED_DEPLOYMENT_DROPS && remaining.length) {
         instrumentation.recordClosedDeploymentRetryLimit({ owner, remainingCount: remaining.length });
         return false;
       }
     }
 
     return false;
+  }
+
+  /** Runs the master-wallet classification for every failure that stops an owner's funding, whichever chain call raised it. */
+  async #recordOwnerFundingFailure({
+    owner,
+    items,
+    error,
+    instrumentation
+  }: {
+    owner: string;
+    items: CollectedMessage[];
+    error: unknown;
+    instrumentation: DeploymentTopUpInstrumentation;
+  }): Promise<void> {
+    instrumentation.recordChainTxError({ owner, items, error });
+
+    if (error instanceof Error && (await this.chainErrorService.isMasterWalletInsufficientFundsError(error))) {
+      instrumentation.recordMasterWalletInsufficientFundsError({ owner, items, error });
+      throw error;
+    }
   }
 
   /** Returns the failure rather than throwing it so the caller classifies a rejected estimate and a reverted tx alike. */

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
@@ -21,6 +21,9 @@ import type { DeploymentTopUpInstrumentation } from "./deployment-top-up-instrum
 import { FundDrainingDeploymentsInstrumentationService } from "./fund-draining-deployments-instrumentation.service";
 import { TopUpManagedDeploymentsInstrumentationService } from "./top-up-managed-deployments-instrumentation.service";
 
+/** Bounds how long one owner's backlog of closed deployments can hold the sweep, which converges over the passes that follow. */
+const MAX_CLOSED_DEPLOYMENT_DROPS = 3;
+
 type DepositSize = {
   affordableAmount: number;
   runwayMinutes: number;
@@ -400,56 +403,127 @@ export class TopUpManagedDeploymentsService {
     return isCapped && runwayMinutes < this.deploymentConfig.get("AUTO_TOP_UP_DEDUP_COOLDOWN_IN_MIN");
   }
 
+  /**
+   * Re-broadcasting without a closed deployment is safe only because both classified shapes prove the tx was
+   * rejected whole: a fee estimation never broadcasts, and a non-zero tx code means every message reverted.
+   * The closed deployment keeps the balance it reserved, which only leaves the survivors a smaller allowance
+   * than they were already sized against before the batch was sent.
+   */
   private async topUpForOwner(
     owner: string,
     ownerInputs: CollectedMessage[],
     options: DryRunOptions,
     instrumentation: DeploymentTopUpInstrumentation
   ): Promise<boolean> {
-    const walletId = ownerInputs[0].deployment.walletId;
+    if (options.dryRun) {
+      this.#recordDeposit(instrumentation, { owner, items: ownerInputs });
+      return true;
+    }
 
-    try {
-      if (!options.dryRun) {
-        const { address, walletIsTrialing: isTrialing, walletCreatedAt: createdAt, walletActivatedAt: activatedAt } = ownerInputs[0].deployment;
-        const feeAllowance = await this.managedSignerService.ensureFeeGrants({ address, isTrialing, createdAt, activatedAt });
+    const { address, walletIsTrialing: isTrialing, walletCreatedAt: createdAt, walletActivatedAt: activatedAt } = ownerInputs[0].deployment;
+    const feeAllowance = await this.managedSignerService.ensureFeeGrants({ address, isTrialing, createdAt, activatedAt });
 
-        if (feeAllowance <= 0) {
-          instrumentation.recordChainTxError({
-            owner,
-            items: ownerInputs,
-            error: new Error(`Fee grant missing for wallet ${owner}, unable to top up deployments`)
-          });
-          return false;
-        }
-
-        const tx = await this.managedSignerService.executeDerivedTx(
-          walletId,
-          ownerInputs.map(i => i.message)
-        );
-
-        if (tx.code !== COSMOS_TX_CODE_OK) {
-          instrumentation.recordChainTxError({
-            owner,
-            items: ownerInputs,
-            error: new Error(`Deposit tx ${tx.hash} failed on-chain with code ${tx.code}: ${tx.rawLog}`)
-          });
-          return false;
-        }
-      }
-    } catch (error: unknown) {
-      instrumentation.recordChainTxError({ owner, items: ownerInputs, error });
-
-      if (error instanceof Error && (await this.chainErrorService.isMasterWalletInsufficientFundsError(error))) {
-        instrumentation.recordMasterWalletInsufficientFundsError({ owner, items: ownerInputs, error });
-        throw error;
-      }
-
+    if (feeAllowance <= 0) {
+      instrumentation.recordChainTxError({
+        owner,
+        items: ownerInputs,
+        error: new Error(`Fee grant missing for wallet ${owner}, unable to top up deployments`)
+      });
       return false;
     }
 
-    this.#recordDeposit(instrumentation, { owner, items: ownerInputs });
+    const walletId = ownerInputs[0].deployment.walletId;
+    let remaining = ownerInputs;
+    let closedDeploymentsDropped = 0;
 
-    return true;
+    while (remaining.length) {
+      const failure = await this.#depositForOwner(walletId, remaining);
+
+      if (!failure) {
+        this.#recordDeposit(instrumentation, { owner, items: remaining });
+        return true;
+      }
+
+      const closedIndex = this.#findClosedDeploymentIndex(failure, remaining);
+
+      if (closedIndex === undefined) {
+        instrumentation.recordChainTxError({ owner, items: remaining, error: failure });
+
+        if (failure instanceof Error && (await this.chainErrorService.isMasterWalletInsufficientFundsError(failure))) {
+          instrumentation.recordMasterWalletInsufficientFundsError({ owner, items: remaining, error: failure });
+          throw failure;
+        }
+
+        return false;
+      }
+
+      await this.#markDeploymentClosed({ owner, item: remaining[closedIndex], messageIndex: closedIndex, error: failure, instrumentation });
+      remaining = remaining.filter((_, index) => index !== closedIndex);
+
+      if (++closedDeploymentsDropped > MAX_CLOSED_DEPLOYMENT_DROPS && remaining.length) {
+        instrumentation.recordClosedDeploymentRetryLimit({ owner, remainingCount: remaining.length });
+        return false;
+      }
+    }
+
+    return false;
+  }
+
+  /** Returns the failure rather than throwing it so the caller classifies a rejected estimate and a reverted tx alike. */
+  async #depositForOwner(walletId: number, items: CollectedMessage[]): Promise<unknown> {
+    try {
+      const tx = await this.managedSignerService.executeDerivedTx(
+        walletId,
+        items.map(item => item.message)
+      );
+
+      if (tx.code !== COSMOS_TX_CODE_OK) {
+        return new Error(`Deposit tx ${tx.hash} failed on-chain with code ${tx.code}: ${tx.rawLog}`);
+      }
+
+      return undefined;
+    } catch (error: unknown) {
+      return error;
+    }
+  }
+
+  /** An index outside the batch is not resolved to a neighbour: closing the wrong deployment is worse than alerting. */
+  #findClosedDeploymentIndex(error: unknown, items: CollectedMessage[]): number | undefined {
+    if (!(error instanceof Error) || !this.chainErrorService.isDeploymentClosedError(error)) {
+      return undefined;
+    }
+
+    const messageIndex = this.chainErrorService.getFailedMessageIndex(error);
+
+    if (messageIndex !== undefined) {
+      return messageIndex >= 0 && messageIndex < items.length ? messageIndex : undefined;
+    }
+
+    return items.length === 1 ? 0 : undefined;
+  }
+
+  /** A failed write is reported rather than thrown, which would strand the survivors the retry exists to fund. */
+  async #markDeploymentClosed({
+    owner,
+    item,
+    messageIndex,
+    error,
+    instrumentation
+  }: {
+    owner: string;
+    item: CollectedMessage;
+    messageIndex: number;
+    error: unknown;
+    instrumentation: DeploymentTopUpInstrumentation;
+  }): Promise<void> {
+    try {
+      await this.deploymentSettingRepository.markAsClosed([item.deployment.id]);
+    } catch (markError: unknown) {
+      instrumentation.recordDeploymentCloseMarkFailed({ owner, deployment: item.deployment, error: markError });
+      return;
+    }
+
+    instrumentation.recordDeploymentClosedOnChain({ owner, deployment: item.deployment, messageIndex, error });
   }
 
   /**

--- a/apps/api/src/deployment/types/draining-deployment.ts
+++ b/apps/api/src/deployment/types/draining-deployment.ts
@@ -10,6 +10,7 @@ export type RpcDeploymentInfo = {
   dseq: string;
   escrowBalance: number;
   createdHeight: number;
+  isEscrowOpen: boolean;
 };
 
 export interface DrainingDeploymentLeaseSource {

--- a/apps/api/test/seeders/draining-deployment.seeder.ts
+++ b/apps/api/test/seeders/draining-deployment.seeder.ts
@@ -10,7 +10,8 @@ export function createDrainingDeployment({
   blockRate = faker.number.int({ min: 1, max: 100 }),
   predictedClosedHeight = faker.number.int({ min: 1, max: 99999999 }),
   owner = faker.string.alpha(),
-  closedHeight = undefined
+  closedHeight = undefined,
+  isClosed = undefined
 }: Partial<DrainingDeploymentOutput> = {}): DrainingDeploymentOutput {
   return {
     dseq,
@@ -18,6 +19,7 @@ export function createDrainingDeployment({
     blockRate,
     predictedClosedHeight,
     owner,
-    closedHeight
+    closedHeight,
+    isClosed
   };
 }


### PR DESCRIPTION
## Why

Fixes CON-90

The hourly `top-up-deployments` cron batches every one of an owner's deposit messages into a single chain tx. If one of those deployments is already closed on chain, fee estimation rejects the whole tx with `failed to execute message; message index: 0: Deployment closed`.

Today that gets treated as an ordinary chain failure. `recordChainTxError` counts every deployment in the batch as a top-up error, so one closed deployment poisons all of its owner's healthy deployments for that pass. A non-zero `deploymentTopUpErrorCount` then makes the run summary log at error level, which is what pages us. And the `deployment_settings` row is never flipped to `closed = true`, so the same deployment fails again every hour, forever.

The pre-flight guard that should have caught this only marks a setting closed when its lease row reports a `closedHeight`. It never looks at the deployment's escrow account state, and `#addPredictedClosedHeight` drops any deployment whose escrow balance is `<= 0`. So a drained-and-closed deployment falls out of the result set, hits the `if (!deployment) return acc` branch, and is silently skipped instead of marked closed.

## What

Two layers: stop building the bad message in the first place, and recover when one gets built anyway.

### Prevention

`DrainingDeploymentRpcService` now reads `escrow_account.state.state` and flags any non-open account as closed. The flag is set before the no-balance and invalid-rate early returns that were dropping these rows on the floor. This mirrors the rule the chain itself applies, since `MsgAccountDeposit` rejects any account whose state is not open. `DrainingDeploymentService` routes the flag into the same marking path the lease `closedHeight` already used.

### Recovery

Prevention can't cover a deployment that closes between the sweep reading the chain and broadcasting, and it can't help when the indexer-DB fallback serves stale lease data. For those, `topUpForOwner` identifies the culprit from the chain error's `message index`, marks its setting closed, drops it, and re-broadcasts the remaining messages in the same pass. It's capped at 3 drops per owner so one owner's backlog can't stall the sweep; the rows marked during a pass persist, so it converges over the passes that follow.

Re-broadcasting is safe only because both classified error shapes prove the tx was rejected atomically: a fee estimation never broadcasts, and a non-zero tx code means every message reverted. Shapes that could mean "maybe landed" (the tx-signer's not-found-on-chain message, an axios timeout) never contain "deployment closed", so they can't reach the retry branch.

### Supporting changes

`ChainErrorService.getFailedMessageIndex` reads `originalError` first, because `toAppError` overwrites the raw message with "Deployment closed" and the index survives only there. `DeploymentSettingRepository.markAsClosed` gives the two existing ad-hoc `updateManyById(ids, { closed: true })` call sites one name. Three new instrumentation records feed the existing marked-closed counter and emit warns, deliberately leaving `deploymentTopUpErrorCount` and `walletsTopUpErrorCount` alone so the summary stays at info and the run reports success.

### Two judgment calls worth a look

A `markAsClosed` database failure is swallowed rather than thrown. Throwing would release every claim, skip the wallet reload, strand the survivors, and push the run to failure, which is worse than the bug being fixed. It emits `TOP_UP_DEPLOYMENT_CLOSE_MARK_FAILED` and deliberately does not credit the marked-closed count.

The closed deployment keeps the balance it reserved. Giving it back would mean re-entering `collectMessages` for the survivors, and they were already sized against the smaller allowance before the batch was sent. It sorts itself out on the next pass.

### Testing

1985 unit, 323 functional and 61 integration tests pass. Lint is clean, and `tsc --noEmit` diffed against the baseline shows no new errors. A mutation check (indexing into `ownerInputs` instead of `remaining`) fails three of the new tests, so the re-indexing coverage is doing real work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Automatically detects deployments with closed escrow accounts and marks them closed.
  - Retries funding for remaining active deployments when a batch includes a closed deployment.
  - Adds safeguards to limit repeated retries for closed deployments.
  - Provides clearer operational tracking for successful closures, failures, and retry limits.

- **Bug Fixes**
  - Improved identification of failed transactions, including wrapped and malformed errors.
  - Preserves funding behavior and error reporting when wallet funds are insufficient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
