### PR TITLE
build(repo): use AEP-86 SDK alpha

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@akashnetwork/akash-api": "1.4.3",
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/console-api-types": "*",
     "@akashnetwork/database": "*",
     "@akashnetwork/env-loader": "*",

--- a/apps/deploy-web/package.json
+++ b/apps/deploy-web/package.json
@@ -26,7 +26,7 @@
     "type-check": "tsc"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/console-api-types": "*",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",

--- a/apps/indexer/package.json
+++ b/apps/indexer/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@akashnetwork/akash-api": "1.4.3",
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/database": "*",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/instrumentation": "*",

--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -36,7 +36,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",
     "@akashnetwork/instrumentation": "*",

--- a/apps/notifications/src/modules/chain/providers/registry.provider.ts
+++ b/apps/notifications/src/modules/chain/providers/registry.provider.ts
@@ -12,18 +12,16 @@ import type { Provider } from "@nestjs/common";
 export const RegistryProvider: Provider<Registry> = {
   provide: Registry,
   useFactory: () => {
-    const akashTypes: ReadonlyArray<[string, GeneratedType]> = [
-      ...Object.values(v1),
-      ...Object.values(v1beta4),
-      ...Object.values(v1beta5),
-      ...Object.values(cosmosv1),
-      ...Object.values(cosmosv1beta1),
-      ...Object.values(cosmosv1alpha1),
-      ...Object.values(cosmosv2alpha1)
-    ]
-      .filter(x => "$type" in x)
-      .map(x => ["/" + x.$type, x as unknown as GeneratedType]);
+    const modules: ReadonlyArray<Record<string, unknown>> = [v1, v1beta4, v1beta5, cosmosv1, cosmosv1beta1, cosmosv1alpha1, cosmosv2alpha1];
+    const akashTypes: ReadonlyArray<[string, GeneratedType]> = modules
+      .flatMap(module => Object.values(module))
+      .filter(hasType)
+      .map(type => ["/" + type.$type, type as unknown as GeneratedType]);
 
     return new Registry(akashTypes);
   }
 };
+
+function hasType(value: unknown): value is { $type: string } {
+  return typeof value === "object" && value !== null && "$type" in value && typeof value.$type === "string";
+}

--- a/apps/provider-inventory/package.json
+++ b/apps/provider-inventory/package.json
@@ -24,7 +24,7 @@
     "test:unit": "vitest run --project unit"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/instrumentation": "*",
     "@akashnetwork/logging": "*",

--- a/apps/provider-inventory/src/mappers/groupspec-mapper/groupspec-mapper.ts
+++ b/apps/provider-inventory/src/mappers/groupspec-mapper/groupspec-mapper.ts
@@ -45,4 +45,10 @@ export function getAttributeFingerprint(attributes: ResourceAttribute[] | undefi
     .join(",");
 }
 
-export type GroupSpecJSON = ToJSON<GroupSpec>;
+type GroupSpecRequirementsJSON = ToJSON<NonNullable<GroupSpec["requirements"]>>;
+
+export type GroupSpecJSON = Omit<ToJSON<GroupSpec>, "requirements"> & {
+  requirements: Omit<GroupSpecRequirementsJSON, "verification"> & {
+    verification?: GroupSpecRequirementsJSON["verification"];
+  };
+};

--- a/apps/provider-proxy/package.json
+++ b/apps/provider-proxy/package.json
@@ -20,7 +20,7 @@
     "test:unit": "vitest run --project unit"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/instrumentation": "*",
     "@akashnetwork/logging": "*",

--- a/apps/stats-web/package.json
+++ b/apps/stats-web/package.json
@@ -14,7 +14,7 @@
     "test:unit": "NODE_ENV=test vitest run"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/logging": "*",
     "@akashnetwork/network-store": "*",

--- a/apps/tx-signer/package.json
+++ b/apps/tx-signer/package.json
@@ -21,7 +21,7 @@
     "test:unit": "vitest run --project unit"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",
     "@akashnetwork/instrumentation": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akash-api": "1.4.3",
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/console-api-types": "*",
         "@akashnetwork/database": "*",
         "@akashnetwork/env-loader": "*",
@@ -542,7 +542,7 @@
       "version": "3.31.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/console-api-types": "*",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
@@ -2168,7 +2168,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akash-api": "1.4.3",
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/database": "*",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/instrumentation": "*",
@@ -2558,7 +2558,7 @@
       "version": "2.16.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
         "@akashnetwork/instrumentation": "*",
@@ -3701,7 +3701,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/instrumentation": "*",
         "@akashnetwork/logging": "*",
@@ -4041,7 +4041,7 @@
       "version": "2.10.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/instrumentation": "*",
         "@akashnetwork/logging": "*",
@@ -4218,7 +4218,7 @@
       "name": "@akashnetwork/stats-web",
       "version": "1.14.1",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/logging": "*",
         "@akashnetwork/network-store": "*",
@@ -4982,7 +4982,7 @@
       "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
         "@akashnetwork/instrumentation": "*",
@@ -5473,9 +5473,9 @@
       }
     },
     "node_modules/@akashnetwork/chain-sdk": {
-      "version": "1.0.0-alpha.41",
-      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.41.tgz",
-      "integrity": "sha512-mr3fGDBSISxl0eZF83+IJLVulGSuJVu+MRj6fG61pi2rgfgnv9QEKpdU3w7wtFFt5saJaJNgsqAlyjGZQecZ1A==",
+      "version": "1.0.0-alpha.43",
+      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.43.tgz",
+      "integrity": "sha512-+XTgpLn3kibMEWBAOkfmOGo2VJcv+VtT5Uvq966Nk5YMyD9HCYUvdDLm1k167Di1S11t66SH06BhoY1M/m2IWg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.12.0",
@@ -45932,7 +45932,7 @@
       "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/net": "*",
         "jotai": "^2.9.2"
       },

--- a/packages/network-store/package.json
+++ b/packages/network-store/package.json
@@ -18,7 +18,7 @@
     "validate:types": "tsc --noEmit && echo"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/net": "*",
     "jotai": "^2.9.2"
   },


### PR DESCRIPTION
## Why

Part of CON-800.

Console needs the published AEP-86 TypeScript contracts and SDL manifest
projection before the application integrations can be reviewed independently.

## What

- update existing Console workspaces from
  `@akashnetwork/chain-sdk@1.0.0-alpha.41` to
  `@akashnetwork/chain-sdk@1.0.0-alpha.43`
- keep the new optional placement verification field optional at the existing
  provider-inventory JSON boundary
- avoid a TypeScript union expansion limit while registering the larger SDK
  message set in notifications

This adds no AEP-86 product behavior. It is the dependency and compatibility
foundation for the split application PRs.