### PR TITLE
fix(deployment): report marked-closed deployments in the run summary

### DIFF
--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
@@ -17,7 +17,6 @@ import type { DeploymentCloseJobService } from "../deployment-close-job/deployme
 import type { DeploymentConfigService } from "../deployment-config/deployment-config.service";
 import type { DrainingDeploymentRpcService } from "../draining-deployment-rpc/draining-deployment-rpc.service";
 import type { DeploymentTopUpInstrumentation } from "../top-up-managed-deployments/deployment-top-up-instrumentation";
-import type { TopUpManagedDeploymentsInstrumentationService } from "../top-up-managed-deployments/top-up-managed-deployments-instrumentation.service";
 import { DrainingDeploymentService } from "./draining-deployment.service";
 
 import { mockConfigService } from "@test/mocks/config-service.mock";
@@ -82,7 +81,7 @@ describe(DrainingDeploymentService.name, () => {
       );
 
       const callback = vi.fn();
-      for await (const result of service.findDrainingDeploymentsByOwner(currentHeight)) {
+      for await (const result of service.findDrainingDeploymentsByOwner(currentHeight, mock<DeploymentTopUpInstrumentation>())) {
         callback(result);
       }
 
@@ -126,7 +125,7 @@ describe(DrainingDeploymentService.name, () => {
       const findLeasesSpy = vi.spyOn(service, "findLeases").mockResolvedValue([farFromClosure]);
 
       const callback = vi.fn();
-      for await (const result of service.findDrainingDeploymentsByOwner(currentHeight)) {
+      for await (const result of service.findDrainingDeploymentsByOwner(currentHeight, mock<DeploymentTopUpInstrumentation>())) {
         callback(result);
       }
 
@@ -142,6 +141,65 @@ describe(DrainingDeploymentService.name, () => {
         activeDeployments: [expect.objectContaining({ dseq: setting.dseq, predictedClosedHeight: farFromClosure.predictedClosedHeight })],
         drainingDeployments: []
       });
+    });
+
+    it("reports marked-closed deployments to the caller's instrumentation", async () => {
+      const { service, deploymentSettingRepository, currentHeight } = setup();
+      const sink = mock<DeploymentTopUpInstrumentation>();
+      const address = createAkashAddress();
+      const closedSetting = createAutoTopUpDeployment({ address, dseq: "4001" });
+
+      deploymentSettingRepository.findAutoTopUpDeploymentsByOwnerIteratively.mockImplementation(() =>
+        (async function* () {
+          yield { address, walletId: closedSetting.walletId, deploymentSettings: [closedSetting] };
+        })()
+      );
+      vi.spyOn(service, "findLeases").mockResolvedValue([
+        createDrainingDeployment({
+          dseq: Number(closedSetting.dseq),
+          owner: address,
+          predictedClosedHeight: currentHeight + 500,
+          closedHeight: currentHeight - 100
+        })
+      ]);
+
+      const callback = vi.fn();
+      for await (const result of service.findDrainingDeploymentsByOwner(currentHeight, sink)) {
+        callback(result);
+      }
+
+      expect(deploymentSettingRepository.markAsClosed).toHaveBeenCalledWith([closedSetting.id]);
+      expect(sink.recordDeploymentsMarkedClosed).toHaveBeenCalledWith(1);
+      expect(callback).toHaveBeenCalledWith(expect.objectContaining({ address, drainingDeployments: [] }));
+    });
+
+    it("marks no deployment closed during a dry run", async () => {
+      const { service, deploymentSettingRepository, currentHeight } = setup();
+      const sink = mock<DeploymentTopUpInstrumentation>();
+      const address = createAkashAddress();
+      const closedSetting = createAutoTopUpDeployment({ address, dseq: "4002" });
+
+      deploymentSettingRepository.findAutoTopUpDeploymentsByOwnerIteratively.mockImplementation(() =>
+        (async function* () {
+          yield { address, walletId: closedSetting.walletId, deploymentSettings: [closedSetting] };
+        })()
+      );
+      vi.spyOn(service, "findLeases").mockResolvedValue([
+        createDrainingDeployment({
+          dseq: Number(closedSetting.dseq),
+          owner: address,
+          predictedClosedHeight: currentHeight + 500,
+          closedHeight: currentHeight - 100
+        })
+      ]);
+
+      const callback = vi.fn();
+      for await (const result of service.findDrainingDeploymentsByOwner(currentHeight, sink, { dryRun: true })) {
+        callback(result);
+      }
+
+      expect(deploymentSettingRepository.markAsClosed).not.toHaveBeenCalled();
+      expect(sink.recordDeploymentsMarkedClosed).not.toHaveBeenCalled();
     });
 
     it("does not persist a runtime countdown during a dry run and still returns a calculated deadline", async () => {
@@ -164,7 +222,7 @@ describe(DrainingDeploymentService.name, () => {
         ]);
 
         const callback = vi.fn();
-        for await (const result of service.findDrainingDeploymentsByOwner(currentHeight, { dryRun: true })) {
+        for await (const result of service.findDrainingDeploymentsByOwner(currentHeight, mock<DeploymentTopUpInstrumentation>(), { dryRun: true })) {
           callback(result);
         }
 
@@ -230,7 +288,7 @@ describe(DrainingDeploymentService.name, () => {
     });
 
     it("marks closed deployments as closed and excludes them from the result", async () => {
-      const { service, deploymentSettingRepository, currentHeight, instrumentation } = setup();
+      const { service, deploymentSettingRepository, currentHeight } = setup();
       const sink = mock<DeploymentTopUpInstrumentation>();
       const address = createAkashAddress();
       const activeSetting = createAutoTopUpDeployment({ address, dseq: "2001" });
@@ -253,7 +311,6 @@ describe(DrainingDeploymentService.name, () => {
       expect(result[0].dseq).toBe(activeSetting.dseq);
       expect(deploymentSettingRepository.markAsClosed).toHaveBeenCalledWith([closedSetting.id]);
       expect(sink.recordDeploymentsMarkedClosed).toHaveBeenCalledWith(1);
-      expect(instrumentation.recordDeploymentsMarkedClosed).not.toHaveBeenCalled();
     });
 
     it("drops a deployment already funded to its runtime deadline and records the skip", async () => {
@@ -422,7 +479,7 @@ describe(DrainingDeploymentService.name, () => {
       ]);
 
       const callback = vi.fn();
-      for await (const result of service.findDrainingDeploymentsByOwner(currentHeight, { dryRun: true })) {
+      for await (const result of service.findDrainingDeploymentsByOwner(currentHeight, mock<DeploymentTopUpInstrumentation>(), { dryRun: true })) {
         callback(result);
       }
 
@@ -1331,8 +1388,6 @@ describe(DrainingDeploymentService.name, () => {
       AUTO_TOP_UP_TARGET_RUNWAY_IN_H: 48
     });
 
-    const instrumentation = mock<TopUpManagedDeploymentsInstrumentationService>();
-
     const service = new DrainingDeploymentService(
       blockHttpService,
       leaseRepository,
@@ -1342,8 +1397,7 @@ describe(DrainingDeploymentService.name, () => {
       config,
       createLogger,
       rpcService,
-      balancesService,
-      instrumentation
+      balancesService
     );
 
     return {
@@ -1358,8 +1412,7 @@ describe(DrainingDeploymentService.name, () => {
       createLogger,
       balancesService,
       config,
-      currentHeight,
-      instrumentation
+      currentHeight
     };
   }
 });

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
@@ -16,7 +16,6 @@ import { DeploymentCloseJobService } from "../deployment-close-job/deployment-cl
 import { DeploymentConfigService } from "../deployment-config/deployment-config.service";
 import { DrainingDeploymentRpcService } from "../draining-deployment-rpc/draining-deployment-rpc.service";
 import type { DeploymentTopUpInstrumentation } from "../top-up-managed-deployments/deployment-top-up-instrumentation";
-import { TopUpManagedDeploymentsInstrumentationService } from "../top-up-managed-deployments/top-up-managed-deployments-instrumentation.service";
 
 export type { DrainingDeployment } from "@src/deployment/types/draining-deployment";
 
@@ -55,20 +54,23 @@ export class DrainingDeploymentService {
     private readonly config: DeploymentConfigService,
     @inject(LOGGER_FACTORY) createLogger: CreateLogger,
     private readonly rpcService: DrainingDeploymentRpcService,
-    private readonly balancesService: BalancesService,
-    private readonly instrumentation: TopUpManagedDeploymentsInstrumentationService
+    private readonly balancesService: BalancesService
   ) {
     this.loggerService = createLogger({ context: DrainingDeploymentService.name });
   }
 
   /** Yields owners with nothing draining too, so the sweep can price their credits-low coverage without re-querying per owner. */
-  async *findDrainingDeploymentsByOwner(currentHeight: number, options: DryRunOptions = { dryRun: false }): AsyncGenerator<AutoTopUpOwnerDeployments> {
+  async *findDrainingDeploymentsByOwner(
+    currentHeight: number,
+    instrumentation: DeploymentTopUpInstrumentation,
+    options: DryRunOptions = { dryRun: false }
+  ): AsyncGenerator<AutoTopUpOwnerDeployments> {
     for await (const { address, walletId, deploymentSettings } of this.deploymentSettingRepository.findAutoTopUpDeploymentsByOwnerIteratively()) {
       const { activeDeployments, drainingDeployments } = await this.#resolveOwnerDeployments(
         deploymentSettings,
         address,
         currentHeight,
-        this.instrumentation,
+        instrumentation,
         options.dryRun
       );
 
@@ -113,7 +115,7 @@ export class DrainingDeploymentService {
     dryRun: boolean
   ): Promise<{ activeDeployments: DrainingDeployment[]; drainingDeployments: DrainingDeployment[] }> {
     const expectedClosureHeight = this.#getExpectedClosureHeight(currentHeight);
-    const activeDeployments = await this.#resolveActiveDeployments(deploymentSettings, address, instrumentation);
+    const activeDeployments = await this.#resolveActiveDeployments(deploymentSettings, address, instrumentation, dryRun);
     const drainingDeployments = await this.#dropDeploymentsFundedToRuntimeLimit(
       activeDeployments.filter(deployment => deployment.predictedClosedHeight <= expectedClosureHeight),
       currentHeight,
@@ -127,7 +129,8 @@ export class DrainingDeploymentService {
   async #resolveActiveDeployments(
     deploymentSettings: AutoTopUpDeployment[],
     address: string,
-    instrumentation: DeploymentTopUpInstrumentation
+    instrumentation: DeploymentTopUpInstrumentation,
+    dryRun: boolean
   ): Promise<DrainingDeployment[]> {
     if (deploymentSettings.length === 0) {
       return [];
@@ -163,7 +166,7 @@ export class DrainingDeploymentService {
       [[], []]
     );
 
-    if (missingIds.length) {
+    if (missingIds.length && !dryRun) {
       await this.deploymentSettingRepository.markAsClosed(missingIds);
       instrumentation.recordDeploymentsMarkedClosed(missingIds.length);
     }

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.integration.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.integration.ts
@@ -9,6 +9,7 @@ import { ChainErrorService } from "@src/billing/services/chain-error/chain-error
 import { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
 import type { ApiPgDatabase } from "@src/core";
 import { CORE_CONFIG, POSTGRES_DB, resolveTable } from "@src/core";
+import { TopUpSummarizer } from "@src/deployment/lib/top-up-summarizer/top-up-summarizer";
 import { UserRepository } from "@src/user/repositories";
 import { averageBlockCountInAnHour } from "@src/utils/constants";
 import { TopUpManagedDeploymentsService } from "./top-up-managed-deployments.service";
@@ -76,6 +77,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
       mockLeasesForOwner(address, [createActiveLease(address, drainingDseq), createClosedLease(address, closedOnChainDseq)]);
       mockDeploymentsForOwner(address, [createActiveDeployment(address, drainingDseq), createClosedDeployment(address, closedOnChainDseq)]);
       stubGetFreshLimits({ [address]: 10000000 });
+      const inc = vi.spyOn(TopUpSummarizer.prototype, "inc");
 
       await topUpService.topUpDeployments({ dryRun: false });
 
@@ -91,6 +93,8 @@ describe(TopUpManagedDeploymentsService.name, () => {
 
       const closedSetting = await findSetting(address, closedOnChainDseq);
       expect(closedSetting?.closed).toBe(true);
+      expect(inc).toHaveBeenCalledWith("deploymentsMarkedClosedCount", 1);
+      expect(inc).toHaveBeenCalledWith("deploymentTopUpCount", 1);
     });
 
     it("drops a deployment the chain rejects as closed and funds the rest of the batch in the same pass", async () => {

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
@@ -214,7 +214,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
     });
 
     it("sizes every owner in the sweep from a single block height", async () => {
-      const { service, drainingDeploymentService, cachedBalanceService, blockHttpService } = setup();
+      const { service, drainingDeploymentService, cachedBalanceService, blockHttpService, instrumentation } = setup();
       const deployments = createManyAutoTopUpDeployments(3);
 
       drainingDeploymentService.findDrainingDeploymentsByOwner.mockImplementation(() =>
@@ -239,7 +239,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
 
       await service.topUpDeployments({ dryRun: false });
 
-      expect(drainingDeploymentService.findDrainingDeploymentsByOwner).toHaveBeenCalledWith(CURRENT_BLOCK_HEIGHT, { dryRun: false });
+      expect(drainingDeploymentService.findDrainingDeploymentsByOwner).toHaveBeenCalledWith(CURRENT_BLOCK_HEIGHT, instrumentation, { dryRun: false });
       expect(drainingDeploymentService.calculateAmountToTargetRunway).toHaveBeenCalledTimes(deployments.length);
       drainingDeploymentService.calculateAmountToTargetRunway.mock.calls.forEach(([, height]) => {
         expect(height).toBe(CURRENT_BLOCK_HEIGHT);

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
@@ -64,7 +64,7 @@ export class TopUpManagedDeploymentsService {
     const errors: unknown[] = [];
 
     try {
-      for await (const owner of this.drainingDeploymentService.findDrainingDeploymentsByOwner(currentHeight, options)) {
+      for await (const owner of this.drainingDeploymentService.findDrainingDeploymentsByOwner(currentHeight, this.instrumentation, options)) {
         try {
           if (owner.drainingDeployments.length) {
             const balance = await this.cachedBalanceService.get(owner.address);


### PR DESCRIPTION
## Why

Fixes CON-911

Every `TOP_UP_DEPLOYMENTS_SUMMARY` in prod reports `deploymentsMarkedClosedCount: 0`, while `auto_top_up_deployments_marked_closed_total` counted 25 to 75 per run on the same pods. Anyone reading the summary to understand a run gets a wrong number.

The cause is a tsyringe instance split. `TopUpManagedDeploymentsInstrumentationService` and the `TopUpSummarizer` inside it are ResolutionScoped, and the cron process constructs the two relevant singletons in different top-level resolutions: the jobs provider resolves `FundDeploymentHandler` first, which constructs `DrainingDeploymentService` and captures instrumentation instance A, then a later resolution constructs `TopUpManagedDeploymentsService`, which captures instance B. Marked-closed deployments were recorded into instance A. The summary is emitted from instance B's summarizer, so the count never reached it. The OTel counter is process-global and stayed correct, which is why the metric and the log disagreed on every run. Introduced by #3607, which threaded an instrumentation parameter through `findDrainingDeploymentsForOwner` but left `findDrainingDeploymentsByOwner` on the injected instance.

## What

`findDrainingDeploymentsByOwner` now takes the instrumentation as a parameter, the way `findDrainingDeploymentsForOwner` already does, and the sweep passes its own instance. The injected instrumentation is deleted from `DrainingDeploymentService` entirely, so there is no second identity left to drift.

Two side effects of the same split also go away:

- Dry runs no longer increment `auto_top_up_deployments_marked_closed_total`. Instance A never received `start()`, so its dry-run gate was permanently open.
- `TOP_UP_RUNTIME_LIMIT_REACHED`, recorded from the same path, now carries the run's dry-run flag.

Tests: a byOwner mirror of the existing ForOwner sink test (fails on the base branch, passes here), the sweep spec now pins that the service passes its own instrumentation, and the marks-closed integration test asserts the logged summary carries the count.

Stacked on #3711; will retarget when it merges.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Deployment top-up processing now consistently records closed and funded deployments during a run.
  * Draining deployment checks now receive and report through the active run instrumentation.
* **Tests**
  * Added coverage confirming closed and funded deployment reporting.
  * Updated service tests to validate instrumentation during draining and top-up operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->