### PR TITLE
feat(provider): add shared verification policy evaluator

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@akashnetwork/akash-api": "1.4.3",
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/console-api-types": "*",
     "@akashnetwork/database": "*",
     "@akashnetwork/env-loader": "*",

--- a/apps/deploy-web/package.json
+++ b/apps/deploy-web/package.json
@@ -26,7 +26,7 @@
     "type-check": "tsc"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/console-api-types": "*",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",

--- a/apps/indexer/package.json
+++ b/apps/indexer/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@akashnetwork/akash-api": "1.4.3",
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/database": "*",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/instrumentation": "*",

--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -36,7 +36,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",
     "@akashnetwork/instrumentation": "*",

--- a/apps/notifications/src/modules/chain/providers/registry.provider.ts
+++ b/apps/notifications/src/modules/chain/providers/registry.provider.ts
@@ -12,18 +12,16 @@ import type { Provider } from "@nestjs/common";
 export const RegistryProvider: Provider<Registry> = {
   provide: Registry,
   useFactory: () => {
-    const akashTypes: ReadonlyArray<[string, GeneratedType]> = [
-      ...Object.values(v1),
-      ...Object.values(v1beta4),
-      ...Object.values(v1beta5),
-      ...Object.values(cosmosv1),
-      ...Object.values(cosmosv1beta1),
-      ...Object.values(cosmosv1alpha1),
-      ...Object.values(cosmosv2alpha1)
-    ]
-      .filter(x => "$type" in x)
-      .map(x => ["/" + x.$type, x as unknown as GeneratedType]);
+    const modules: ReadonlyArray<Record<string, unknown>> = [v1, v1beta4, v1beta5, cosmosv1, cosmosv1beta1, cosmosv1alpha1, cosmosv2alpha1];
+    const akashTypes: ReadonlyArray<[string, GeneratedType]> = modules
+      .flatMap(module => Object.values(module))
+      .filter(hasType)
+      .map(type => ["/" + type.$type, type as unknown as GeneratedType]);
 
     return new Registry(akashTypes);
   }
 };
+
+function hasType(value: unknown): value is { $type: string } {
+  return typeof value === "object" && value !== null && "$type" in value && typeof value.$type === "string";
+}

--- a/apps/provider-inventory/package.json
+++ b/apps/provider-inventory/package.json
@@ -24,7 +24,7 @@
     "test:unit": "vitest run --project unit"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/instrumentation": "*",
     "@akashnetwork/logging": "*",

--- a/apps/provider-inventory/src/mappers/groupspec-mapper/groupspec-mapper.ts
+++ b/apps/provider-inventory/src/mappers/groupspec-mapper/groupspec-mapper.ts
@@ -45,4 +45,10 @@ export function getAttributeFingerprint(attributes: ResourceAttribute[] | undefi
     .join(",");
 }
 
-export type GroupSpecJSON = ToJSON<GroupSpec>;
+type GroupSpecRequirementsJSON = ToJSON<NonNullable<GroupSpec["requirements"]>>;
+
+export type GroupSpecJSON = Omit<ToJSON<GroupSpec>, "requirements"> & {
+  requirements: Omit<GroupSpecRequirementsJSON, "verification"> & {
+    verification?: GroupSpecRequirementsJSON["verification"];
+  };
+};

--- a/apps/provider-proxy/package.json
+++ b/apps/provider-proxy/package.json
@@ -20,7 +20,7 @@
     "test:unit": "vitest run --project unit"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/instrumentation": "*",
     "@akashnetwork/logging": "*",

--- a/apps/stats-web/package.json
+++ b/apps/stats-web/package.json
@@ -14,7 +14,7 @@
     "test:unit": "NODE_ENV=test vitest run"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/logging": "*",
     "@akashnetwork/network-store": "*",

--- a/apps/tx-signer/package.json
+++ b/apps/tx-signer/package.json
@@ -21,7 +21,7 @@
     "test:unit": "vitest run --project unit"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",
     "@akashnetwork/instrumentation": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5657,6 +5657,10 @@
       "resolved": "apps/provider-proxy",
       "link": true
     },
+    "node_modules/@akashnetwork/provider-verification": {
+      "resolved": "packages/provider-verification",
+      "link": true
+    },
     "node_modules/@akashnetwork/react-query-proxy": {
       "resolved": "packages/react-query-proxy",
       "link": true
@@ -45947,6 +45951,19 @@
       "devDependencies": {
         "@akashnetwork/dev-config": "*",
         "vitest": "^4.0.0"
+      }
+    },
+    "packages/provider-verification": {
+      "name": "@akashnetwork/provider-verification",
+      "version": "0.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43"
+      },
+      "devDependencies": {
+        "@akashnetwork/dev-config": "*",
+        "typescript": "~5.8.2",
+        "vitest": "^4.1.5"
       }
     },
     "packages/react-query-proxy": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akash-api": "1.4.3",
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/console-api-types": "*",
         "@akashnetwork/database": "*",
         "@akashnetwork/env-loader": "*",
@@ -542,7 +542,7 @@
       "version": "3.31.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/console-api-types": "*",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
@@ -2168,7 +2168,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akash-api": "1.4.3",
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/database": "*",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/instrumentation": "*",
@@ -2558,7 +2558,7 @@
       "version": "2.16.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
         "@akashnetwork/instrumentation": "*",
@@ -3701,7 +3701,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/instrumentation": "*",
         "@akashnetwork/logging": "*",
@@ -4041,7 +4041,7 @@
       "version": "2.10.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/instrumentation": "*",
         "@akashnetwork/logging": "*",
@@ -4218,7 +4218,7 @@
       "name": "@akashnetwork/stats-web",
       "version": "1.14.1",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/logging": "*",
         "@akashnetwork/network-store": "*",
@@ -4982,7 +4982,7 @@
       "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
         "@akashnetwork/instrumentation": "*",
@@ -5473,9 +5473,9 @@
       }
     },
     "node_modules/@akashnetwork/chain-sdk": {
-      "version": "1.0.0-alpha.41",
-      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.41.tgz",
-      "integrity": "sha512-mr3fGDBSISxl0eZF83+IJLVulGSuJVu+MRj6fG61pi2rgfgnv9QEKpdU3w7wtFFt5saJaJNgsqAlyjGZQecZ1A==",
+      "version": "1.0.0-alpha.43",
+      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.43.tgz",
+      "integrity": "sha512-+XTgpLn3kibMEWBAOkfmOGo2VJcv+VtT5Uvq966Nk5YMyD9HCYUvdDLm1k167Di1S11t66SH06BhoY1M/m2IWg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.12.0",
@@ -45932,7 +45932,7 @@
       "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/net": "*",
         "jotai": "^2.9.2"
       },

--- a/packages/network-store/package.json
+++ b/packages/network-store/package.json
@@ -18,7 +18,7 @@
     "validate:types": "tsc --noEmit && echo"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/net": "*",
     "jotai": "^2.9.2"
   },

--- a/packages/provider-verification/package.json
+++ b/packages/provider-verification/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@akashnetwork/provider-verification",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Shared AEP-86 provider verification policy evaluation",
+  "license": "Apache-2.0",
+  "author": "Akash Network",
+  "type": "module",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "default": "./src/index.ts"
+    }
+  },
+  "main": "src/index.ts",
+  "scripts": {
+    "format": "prettier --write ./*.{ts,json} **/*.{ts,json}",
+    "lint": "eslint .",
+    "test": "vitest run",
+    "validate:types": "tsc -p tsconfig.build.json --noEmit && echo"
+  },
+  "dependencies": {
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43"
+  },
+  "devDependencies": {
+    "@akashnetwork/dev-config": "*",
+    "typescript": "~5.8.2",
+    "vitest": "^4.1.5"
+  }
+}

--- a/packages/provider-verification/src/index.ts
+++ b/packages/provider-verification/src/index.ts
@@ -1,0 +1,12 @@
+export {
+  deriveProviderVerificationSummary,
+  evaluateProviderVerification,
+  type ProviderVerificationCompleteness,
+  type ProviderVerificationEvaluation,
+  type ProviderVerificationFacts,
+  type ProviderVerificationFailure,
+  type ProviderVerificationSummary,
+  type SnapshotComplianceState
+} from "./providerVerification.js";
+export * from "./providerVerificationQueryClient.js";
+export * from "./providerTierState.js";

--- a/packages/provider-verification/src/providerTierState.spec.ts
+++ b/packages/provider-verification/src/providerTierState.spec.ts
@@ -1,0 +1,149 @@
+import type { AttestationRecord, ProviderSnapshotRecord, ProviderVerificationGraceRecord } from "@akashnetwork/chain-sdk/private-types/akash.v1";
+import { AttestationStatus, VerificationGraceStatus, VerificationTier } from "@akashnetwork/chain-sdk/private-types/akash.v1";
+import { describe, expect, it } from "vitest";
+
+import { deriveProviderTierState, detectProviderTierDemotion } from "./providerTierState.js";
+import type { ProviderVerificationFacts } from "./providerVerification.js";
+
+const observedAt = new Date("2026-08-24T12:00:00.000Z");
+
+describe(deriveProviderTierState.name, () => {
+  it("uses active grace for the effective tier", () => {
+    expect(
+      deriveProviderTierState(
+        facts({
+          attestations: [attestation(VerificationTier.verification_tier_identified)],
+          graces: [grace(VerificationTier.verification_tier_established)],
+          snapshot: snapshot({ complianceDeadline: new Date("2026-08-25T12:00:00.000Z") })
+        })
+      )
+    ).toEqual({
+      effectiveTier: VerificationTier.verification_tier_established,
+      maxPlacementTier: VerificationTier.verification_tier_established,
+      snapshotState: "current"
+    });
+  });
+
+  it.each(["not_posted", "stale", "suspended"] as const)("clamps L2+ placement eligibility to L1 when the snapshot is %s", snapshotState => {
+    const snapshotByState = {
+      not_posted: null,
+      stale: snapshot({ complianceDeadline: observedAt }),
+      suspended: snapshot({ complianceDeadline: new Date("2026-08-25T12:00:00.000Z"), suspended: true })
+    };
+
+    expect(
+      deriveProviderTierState(facts({ attestations: [attestation(VerificationTier.verification_tier_trusted)], snapshot: snapshotByState[snapshotState] }))
+    ).toMatchObject({
+      effectiveTier: VerificationTier.verification_tier_trusted,
+      maxPlacementTier: VerificationTier.verification_tier_identified,
+      snapshotState
+    });
+  });
+
+  it("does not require a snapshot for L1", () => {
+    expect(deriveProviderTierState(facts({ attestations: [attestation(VerificationTier.verification_tier_identified)] }))).toMatchObject({
+      effectiveTier: VerificationTier.verification_tier_identified,
+      maxPlacementTier: VerificationTier.verification_tier_identified,
+      snapshotState: "not_posted"
+    });
+  });
+});
+
+describe(detectProviderTierDemotion.name, () => {
+  it("reports independent tier and snapshot eligibility decreases", () => {
+    const currentSnapshot = {
+      effectiveTier: VerificationTier.verification_tier_established,
+      maxPlacementTier: VerificationTier.verification_tier_established,
+      snapshotState: "current" as const
+    };
+
+    expect(
+      detectProviderTierDemotion(currentSnapshot, {
+        ...currentSnapshot,
+        maxPlacementTier: VerificationTier.verification_tier_identified,
+        snapshotState: "stale"
+      })
+    ).toEqual(["snapshot_eligibility"]);
+    expect(
+      detectProviderTierDemotion(currentSnapshot, {
+        effectiveTier: VerificationTier.verification_tier_verified,
+        maxPlacementTier: VerificationTier.verification_tier_verified,
+        snapshotState: "current"
+      })
+    ).toEqual(["tier_gate", "snapshot_eligibility"]);
+  });
+
+  it("does not emit on an upgrade or unchanged state", () => {
+    const previous = {
+      effectiveTier: VerificationTier.verification_tier_identified,
+      maxPlacementTier: VerificationTier.verification_tier_identified,
+      snapshotState: "not_posted" as const
+    };
+
+    expect(detectProviderTierDemotion(previous, previous)).toEqual([]);
+    expect(
+      detectProviderTierDemotion(previous, {
+        effectiveTier: VerificationTier.verification_tier_verified,
+        maxPlacementTier: VerificationTier.verification_tier_verified,
+        snapshotState: "current"
+      })
+    ).toEqual([]);
+  });
+});
+
+function facts(overrides: Partial<ProviderVerificationFacts> = {}): ProviderVerificationFacts {
+  return {
+    attestations: [],
+    graces: [],
+    snapshot: null,
+    completeness: { attestations: true, graces: true, snapshot: true },
+    observedAt,
+    observedHeight: "100",
+    ...overrides
+  };
+}
+
+function attestation(tier: VerificationTier): AttestationRecord {
+  return {
+    provider: "akash1provider",
+    auditor: "akash1auditor",
+    tier,
+    capabilities: [],
+    evidenceHash: new Uint8Array(),
+    fee: undefined,
+    feeStatus: 0,
+    createdAt: undefined,
+    expiresAt: undefined,
+    status: AttestationStatus.attestation_status_valid,
+    voidedReason: 0,
+    deposit: undefined,
+    depositStatus: 0,
+    auditEscrowId: 0n,
+    faultAttribution: 0
+  };
+}
+
+function grace(preservedTier: VerificationTier): ProviderVerificationGraceRecord {
+  return {
+    id: 1n,
+    provider: "akash1provider",
+    preservedTier,
+    sourceDiscrepancyIds: [],
+    startedAt: undefined,
+    expiresAt: undefined,
+    status: VerificationGraceStatus.verification_grace_status_active
+  };
+}
+
+function snapshot(overrides: Partial<ProviderSnapshotRecord> = {}): ProviderSnapshotRecord {
+  return {
+    provider: "akash1provider",
+    snapshotHash: new Uint8Array(),
+    resourceSummary: undefined,
+    postedAt: undefined,
+    snapshotTimestamp: undefined,
+    complianceDeadline: new Date("2026-08-25T12:00:00.000Z"),
+    suspended: false,
+    ...overrides
+  };
+}

--- a/packages/provider-verification/src/providerTierState.ts
+++ b/packages/provider-verification/src/providerTierState.ts
@@ -1,0 +1,32 @@
+import { VerificationTier } from "@akashnetwork/chain-sdk/private-types/akash.v1";
+
+import { deriveProviderVerificationSummary, type ProviderVerificationFacts, type SnapshotComplianceState } from "./providerVerification.js";
+
+export type ProviderTierDemotionChange = "tier_gate" | "snapshot_eligibility";
+
+export interface ProviderTierState {
+  effectiveTier: VerificationTier;
+  maxPlacementTier: VerificationTier;
+  snapshotState: SnapshotComplianceState;
+}
+
+export function deriveProviderTierState(facts: ProviderVerificationFacts): ProviderTierState {
+  const summary = deriveProviderVerificationSummary(facts);
+  const maxPlacementTier =
+    summary.tierGateTier < VerificationTier.verification_tier_verified || summary.snapshotState === "current"
+      ? summary.tierGateTier
+      : VerificationTier.verification_tier_identified;
+
+  return {
+    effectiveTier: summary.tierGateTier,
+    maxPlacementTier,
+    snapshotState: summary.snapshotState
+  };
+}
+
+export function detectProviderTierDemotion(previous: ProviderTierState, current: ProviderTierState): ProviderTierDemotionChange[] {
+  const changes: ProviderTierDemotionChange[] = [];
+  if (current.effectiveTier < previous.effectiveTier) changes.push("tier_gate");
+  if (current.maxPlacementTier < previous.maxPlacementTier) changes.push("snapshot_eligibility");
+  return changes;
+}

--- a/packages/provider-verification/src/providerVerification.spec.ts
+++ b/packages/provider-verification/src/providerVerification.spec.ts
@@ -1,0 +1,267 @@
+import type { AttestationRecord, ProviderVerificationGraceRecord, VerificationRequirement } from "@akashnetwork/chain-sdk/private-types/akash.v1";
+import {
+  AttestationStatus,
+  AuditorSelectionMode,
+  CapabilityFlag,
+  VerificationGraceStatus,
+  VerificationTier
+} from "@akashnetwork/chain-sdk/private-types/akash.v1";
+import { describe, expect, it } from "vitest";
+
+import { deriveProviderVerificationSummary, evaluateProviderVerification, type ProviderVerificationFacts } from "./providerVerification.js";
+
+const observedAt = new Date("2026-08-24T12:00:00.000Z");
+
+describe("deriveProviderVerificationSummary", () => {
+  it("matches the market keeper by using stored-valid attestations regardless of auditor lifecycle or expires_at", () => {
+    const facts = createFacts({
+      attestations: [
+        createAttestation({ auditor: "auditor-b", tier: VerificationTier.verification_tier_verified, capabilities: [CapabilityFlag.capability_bare_metal] }),
+        createAttestation({
+          auditor: "auditor-a",
+          tier: VerificationTier.verification_tier_established,
+          capabilities: [CapabilityFlag.capability_persistent_storage]
+        }),
+        createAttestation({
+          auditor: "auditor-c",
+          status: AttestationStatus.attestation_status_expired,
+          tier: VerificationTier.verification_tier_trusted,
+          capabilities: [CapabilityFlag.capability_confidential_computing]
+        })
+      ]
+    });
+
+    expect(deriveProviderVerificationSummary(facts)).toMatchObject({
+      bestStatusValidTier: VerificationTier.verification_tier_established,
+      tierGateTier: VerificationTier.verification_tier_established,
+      capabilities: [CapabilityFlag.capability_persistent_storage, CapabilityFlag.capability_bare_metal],
+      validAttestationCount: 2,
+      validAuditors: ["auditor-a", "auditor-b"]
+    });
+  });
+
+  it("uses active grace only for the tier gate", () => {
+    const facts = createFacts({
+      attestations: [createAttestation({ tier: VerificationTier.verification_tier_identified, capabilities: [CapabilityFlag.capability_persistent_storage] })],
+      graces: [createGrace(VerificationTier.verification_tier_established)]
+    });
+
+    expect(deriveProviderVerificationSummary(facts)).toMatchObject({
+      bestStatusValidTier: VerificationTier.verification_tier_identified,
+      tierGateTier: VerificationTier.verification_tier_established,
+      capabilities: [CapabilityFlag.capability_persistent_storage]
+    });
+  });
+});
+
+describe("evaluateProviderVerification", () => {
+  it("does not enforce a vacuous requirement", () => {
+    const result = evaluateProviderVerification({
+      moduleActive: null,
+      requirement: createRequirement({ minTier: VerificationTier.verification_tier_unspecified }),
+      facts: createFacts()
+    });
+
+    expect(result.outcome).toBe("pass");
+  });
+
+  it("does not enforce verification while the chain module is inactive", () => {
+    const result = evaluateProviderVerification({
+      moduleActive: false,
+      requirement: createRequirement({ minTier: VerificationTier.verification_tier_trusted }),
+      facts: createFacts({ completeness: { attestations: false, graces: false, snapshot: false } })
+    });
+
+    expect(result.outcome).toBe("pass");
+  });
+
+  it("returns unknown instead of excluding a provider when required facts are incomplete", () => {
+    const result = evaluateProviderVerification({
+      moduleActive: true,
+      requirement: createRequirement({ minTier: VerificationTier.verification_tier_verified }),
+      facts: createFacts({ completeness: { attestations: true, graces: false, snapshot: false } })
+    });
+
+    expect(result).toMatchObject({ outcome: "unknown", incompleteFacts: ["graces", "snapshot"] });
+  });
+
+  it("checks snapshot before tier and retains the full failure set", () => {
+    const result = evaluateProviderVerification({
+      moduleActive: true,
+      requirement: createRequirement({
+        minTier: VerificationTier.verification_tier_verified,
+        requiredCapabilities: [CapabilityFlag.capability_persistent_storage],
+        minAuditorCount: 2
+      }),
+      facts: createFacts()
+    });
+
+    expect(result.outcome).toBe("fail");
+    if (result.outcome !== "fail") throw new Error("expected failure");
+    expect(result.firstFailure.code).toBe("snapshot_not_posted");
+    expect(result.failures.map(failure => failure.code)).toEqual([
+      "snapshot_not_posted",
+      "insufficient_tier",
+      "missing_capability",
+      "insufficient_auditor_count"
+    ]);
+  });
+
+  it("matches capability union and tier-qualified auditor semantics", () => {
+    const result = evaluateProviderVerification({
+      moduleActive: true,
+      requirement: createRequirement({
+        minTier: VerificationTier.verification_tier_verified,
+        requiredCapabilities: [CapabilityFlag.capability_persistent_storage, CapabilityFlag.capability_bare_metal],
+        requiredAuditors: ["auditor-l2", "auditor-l1"],
+        auditorMode: AuditorSelectionMode.auditor_selection_mode_any,
+        minAuditorCount: 1
+      }),
+      facts: createFacts({
+        attestations: [
+          createAttestation({ auditor: "auditor-l2", tier: VerificationTier.verification_tier_verified, capabilities: [CapabilityFlag.capability_bare_metal] }),
+          createAttestation({
+            auditor: "auditor-l1",
+            tier: VerificationTier.verification_tier_identified,
+            capabilities: [CapabilityFlag.capability_persistent_storage]
+          })
+        ],
+        snapshot: { complianceDeadline: new Date("2026-08-25T12:00:00.000Z"), suspended: false }
+      })
+    });
+
+    expect(result).toMatchObject({ outcome: "pass", qualifiedAuditors: ["auditor-l2"] });
+  });
+
+  it("treats unspecified auditor mode as any and reports all missing auditors for all mode", () => {
+    const facts = createFacts({ attestations: [createAttestation({ auditor: "auditor-a" })] });
+    const anyResult = evaluateProviderVerification({
+      moduleActive: true,
+      requirement: createRequirement({ requiredAuditors: ["auditor-a", "auditor-b"] }),
+      facts
+    });
+    const allResult = evaluateProviderVerification({
+      moduleActive: true,
+      requirement: createRequirement({ requiredAuditors: ["auditor-a", "auditor-b"], auditorMode: AuditorSelectionMode.auditor_selection_mode_all }),
+      facts
+    });
+
+    expect(anyResult.outcome).toBe("pass");
+    expect(allResult).toMatchObject({
+      outcome: "fail",
+      firstFailure: { code: "required_auditor_not_found", missing: ["auditor-b"] }
+    });
+  });
+
+  it("does not add a provider-bond check that the market BidFilter does not perform", () => {
+    const result = evaluateProviderVerification({
+      moduleActive: true,
+      requirement: createRequirement({ minTier: VerificationTier.verification_tier_verified }),
+      facts: createFacts({
+        attestations: [createAttestation({ tier: VerificationTier.verification_tier_verified })],
+        snapshot: { complianceDeadline: new Date("2026-08-25T12:00:00.000Z"), suspended: false }
+      })
+    });
+
+    expect(result.outcome).toBe("pass");
+  });
+
+  it("uses the snapshot compliance deadline even before suspension is persisted", () => {
+    const result = evaluateProviderVerification({
+      moduleActive: true,
+      requirement: createRequirement({ minTier: VerificationTier.verification_tier_verified }),
+      facts: createFacts({
+        attestations: [createAttestation({ tier: VerificationTier.verification_tier_verified })],
+        snapshot: { complianceDeadline: observedAt, suspended: false }
+      })
+    });
+
+    expect(result).toMatchObject({ outcome: "fail", firstFailure: { code: "snapshot_stale" } });
+  });
+
+  it("does not let an active grace bypass L2 snapshot suspension", () => {
+    const result = evaluateProviderVerification({
+      moduleActive: true,
+      requirement: createRequirement({ minTier: VerificationTier.verification_tier_verified }),
+      facts: createFacts({
+        graces: [createGrace(VerificationTier.verification_tier_verified)],
+        snapshot: { complianceDeadline: new Date("2026-08-25T12:00:00.000Z"), suspended: true }
+      })
+    });
+
+    expect(result).toMatchObject({
+      outcome: "fail",
+      firstFailure: { code: "snapshot_suspended" },
+      failures: [{ code: "snapshot_suspended" }]
+    });
+  });
+
+  it("keeps eligibility when a partial bond slash leaves the attestation valid", () => {
+    const result = evaluateProviderVerification({
+      moduleActive: true,
+      requirement: createRequirement({ minTier: VerificationTier.verification_tier_verified }),
+      facts: createFacts({
+        attestations: [createAttestation({ tier: VerificationTier.verification_tier_verified })],
+        snapshot: { complianceDeadline: new Date("2026-08-25T12:00:00.000Z"), suspended: false }
+      })
+    });
+
+    expect(result.outcome).toBe("pass");
+  });
+});
+
+function createFacts(overrides: Partial<ProviderVerificationFacts> = {}): ProviderVerificationFacts {
+  return {
+    attestations: [],
+    graces: [],
+    snapshot: null,
+    completeness: { attestations: true, graces: true, snapshot: true },
+    observedAt,
+    observedHeight: "100",
+    ...overrides
+  };
+}
+
+function createAttestation(overrides: Partial<AttestationRecord> = {}): AttestationRecord {
+  return {
+    provider: "provider",
+    auditor: "auditor",
+    tier: VerificationTier.verification_tier_identified,
+    capabilities: [],
+    evidenceHash: new Uint8Array(),
+    fee: undefined,
+    feeStatus: 0,
+    createdAt: new Date("2025-01-01T00:00:00.000Z"),
+    expiresAt: new Date("2025-01-02T00:00:00.000Z"),
+    status: AttestationStatus.attestation_status_valid,
+    voidedReason: 0,
+    deposit: undefined,
+    depositStatus: 0,
+    auditEscrowId: 1n,
+    faultAttribution: 0,
+    ...overrides
+  };
+}
+
+function createGrace(preservedTier: VerificationTier): ProviderVerificationGraceRecord {
+  return {
+    id: 1n,
+    provider: "provider",
+    preservedTier,
+    sourceDiscrepancyIds: [1n],
+    startedAt: observedAt,
+    expiresAt: new Date("2026-08-25T12:00:00.000Z"),
+    status: VerificationGraceStatus.verification_grace_status_active
+  };
+}
+
+function createRequirement(overrides: Partial<VerificationRequirement> = {}): VerificationRequirement {
+  return {
+    minTier: VerificationTier.verification_tier_identified,
+    requiredCapabilities: [],
+    requiredAuditors: [],
+    auditorMode: AuditorSelectionMode.auditor_selection_mode_unspecified,
+    minAuditorCount: 0,
+    ...overrides
+  };
+}

--- a/packages/provider-verification/src/providerVerification.ts
+++ b/packages/provider-verification/src/providerVerification.ts
@@ -1,0 +1,191 @@
+import type {
+  AttestationRecord,
+  ProviderSnapshotRecord,
+  ProviderVerificationGraceRecord,
+  VerificationRequirement
+} from "@akashnetwork/chain-sdk/private-types/akash.v1";
+import {
+  AttestationStatus,
+  AuditorSelectionMode,
+  CapabilityFlag,
+  VerificationGraceStatus,
+  VerificationTier
+} from "@akashnetwork/chain-sdk/private-types/akash.v1";
+
+type AttestationFact = Pick<AttestationRecord, "auditor" | "capabilities" | "status" | "tier">;
+type GraceFact = Pick<ProviderVerificationGraceRecord, "preservedTier" | "status">;
+type SnapshotFact = Pick<ProviderSnapshotRecord, "complianceDeadline" | "suspended">;
+
+export interface ProviderVerificationCompleteness {
+  attestations: boolean;
+  graces: boolean;
+  snapshot: boolean;
+}
+
+export interface ProviderVerificationFacts {
+  attestations: readonly AttestationFact[];
+  graces: readonly GraceFact[];
+  snapshot: SnapshotFact | null;
+  completeness: ProviderVerificationCompleteness;
+  observedAt: Date;
+  observedHeight: string;
+}
+
+export type SnapshotComplianceState = "unknown" | "not_posted" | "current" | "stale" | "suspended";
+
+export interface ProviderVerificationSummary {
+  bestStatusValidTier: VerificationTier;
+  tierGateTier: VerificationTier;
+  capabilities: CapabilityFlag[];
+  validAttestationCount: number;
+  validAuditors: string[];
+  snapshotState: SnapshotComplianceState;
+  observedHeight: string;
+}
+
+export type ProviderVerificationFailure =
+  | { code: "snapshot_not_posted" }
+  | { code: "snapshot_suspended" }
+  | { code: "snapshot_stale" }
+  | { code: "insufficient_tier"; actual: VerificationTier; required: VerificationTier }
+  | { code: "missing_capability"; capability: CapabilityFlag }
+  | { code: "insufficient_auditor_count"; actual: number; required: number }
+  | { code: "required_auditor_not_found"; mode: AuditorSelectionMode; missing: string[] };
+
+interface EvaluationBase {
+  summary: ProviderVerificationSummary;
+  qualifiedAuditors: string[];
+}
+
+export type ProviderVerificationEvaluation =
+  | (EvaluationBase & { outcome: "pass"; firstFailure: null; failures: [] })
+  | (EvaluationBase & {
+      outcome: "fail";
+      firstFailure: ProviderVerificationFailure;
+      failures: ProviderVerificationFailure[];
+    })
+  | (EvaluationBase & { outcome: "unknown"; firstFailure: null; failures: []; incompleteFacts: Array<keyof ProviderVerificationCompleteness | "params"> });
+
+interface EvaluateProviderVerificationInput {
+  moduleActive: boolean | null;
+  requirement: VerificationRequirement | null;
+  facts: ProviderVerificationFacts;
+}
+
+export function deriveProviderVerificationSummary(facts: ProviderVerificationFacts): ProviderVerificationSummary {
+  const validAttestations = facts.attestations.filter(attestation => attestation.status === AttestationStatus.attestation_status_valid);
+  const bestStatusValidTier = validAttestations.reduce(
+    (best, attestation) => betterTier(best, attestation.tier),
+    VerificationTier.verification_tier_unspecified
+  );
+  const tierGateTier = facts.graces
+    .filter(grace => grace.status === VerificationGraceStatus.verification_grace_status_active)
+    .reduce((best, grace) => betterTier(best, grace.preservedTier), bestStatusValidTier);
+  const capabilities = uniqueSorted(
+    validAttestations.flatMap(attestation => attestation.capabilities).filter(capability => capability !== CapabilityFlag.capability_unspecified)
+  );
+  const validAuditors = uniqueSorted(validAttestations.map(attestation => attestation.auditor).filter(Boolean));
+
+  return {
+    bestStatusValidTier,
+    tierGateTier,
+    capabilities,
+    validAttestationCount: validAttestations.length,
+    validAuditors,
+    snapshotState: deriveSnapshotState(facts),
+    observedHeight: facts.observedHeight
+  };
+}
+
+export function evaluateProviderVerification({ moduleActive, requirement, facts }: EvaluateProviderVerificationInput): ProviderVerificationEvaluation {
+  const summary = deriveProviderVerificationSummary(facts);
+  const noRequirement = !requirement || requirement.minTier === VerificationTier.verification_tier_unspecified;
+
+  if (noRequirement || moduleActive === false) {
+    return pass(summary, []);
+  }
+
+  const incompleteFacts: Array<keyof ProviderVerificationCompleteness | "params"> = [];
+  if (moduleActive === null) incompleteFacts.push("params");
+  if (!facts.completeness.attestations) incompleteFacts.push("attestations");
+  if (!facts.completeness.graces) incompleteFacts.push("graces");
+  if (requiresSnapshot(requirement.minTier) && !facts.completeness.snapshot) incompleteFacts.push("snapshot");
+
+  const qualifiedAuditors = qualifiedAuditorsForTier(facts.attestations, requirement.minTier);
+  if (incompleteFacts.length > 0) {
+    return { outcome: "unknown", firstFailure: null, failures: [], incompleteFacts, qualifiedAuditors, summary };
+  }
+
+  const failures: ProviderVerificationFailure[] = [];
+  if (requiresSnapshot(requirement.minTier)) {
+    if (summary.snapshotState === "not_posted") failures.push({ code: "snapshot_not_posted" });
+    if (summary.snapshotState === "suspended") failures.push({ code: "snapshot_suspended" });
+    if (summary.snapshotState === "stale") failures.push({ code: "snapshot_stale" });
+  }
+
+  if (summary.tierGateTier < requirement.minTier) {
+    failures.push({ code: "insufficient_tier", actual: summary.tierGateTier, required: requirement.minTier });
+  }
+
+  for (const capability of requirement.requiredCapabilities) {
+    if (capability !== CapabilityFlag.capability_unspecified && !summary.capabilities.includes(capability)) {
+      failures.push({ code: "missing_capability", capability });
+    }
+  }
+
+  if (qualifiedAuditors.length < requirement.minAuditorCount) {
+    failures.push({ code: "insufficient_auditor_count", actual: qualifiedAuditors.length, required: requirement.minAuditorCount });
+  }
+
+  const requiredAuditorFailure = evaluateRequiredAuditors(requirement, qualifiedAuditors);
+  if (requiredAuditorFailure) failures.push(requiredAuditorFailure);
+
+  return failures.length === 0 ? pass(summary, qualifiedAuditors) : { outcome: "fail", firstFailure: failures[0], failures, qualifiedAuditors, summary };
+}
+
+function deriveSnapshotState(facts: ProviderVerificationFacts): SnapshotComplianceState {
+  if (!facts.completeness.snapshot) return "unknown";
+  if (!facts.snapshot) return "not_posted";
+  if (facts.snapshot.suspended) return "suspended";
+  if (!facts.snapshot.complianceDeadline || facts.snapshot.complianceDeadline <= facts.observedAt) return "stale";
+  return "current";
+}
+
+function requiresSnapshot(tier: VerificationTier): boolean {
+  return tier >= VerificationTier.verification_tier_verified;
+}
+
+function betterTier(left: VerificationTier, right: VerificationTier): VerificationTier {
+  return right > left ? right : left;
+}
+
+function qualifiedAuditorsForTier(attestations: readonly AttestationFact[], minTier: VerificationTier): string[] {
+  return uniqueSorted(
+    attestations
+      .filter(attestation => attestation.status === AttestationStatus.attestation_status_valid && attestation.tier >= minTier)
+      .map(attestation => attestation.auditor)
+      .filter(Boolean)
+  );
+}
+
+function evaluateRequiredAuditors(
+  requirement: VerificationRequirement,
+  qualifiedAuditors: readonly string[]
+): Extract<ProviderVerificationFailure, { code: "required_auditor_not_found" }> | null {
+  if (requirement.requiredAuditors.length === 0) return null;
+
+  const available = new Set(qualifiedAuditors);
+  const missing = requirement.requiredAuditors.filter(auditor => !available.has(auditor));
+  const allRequired = requirement.auditorMode === AuditorSelectionMode.auditor_selection_mode_all;
+  const satisfied = allRequired ? missing.length === 0 : requirement.requiredAuditors.some(auditor => available.has(auditor));
+
+  return satisfied ? null : { code: "required_auditor_not_found", mode: requirement.auditorMode, missing };
+}
+
+function uniqueSorted<T extends number | string>(values: readonly T[]): T[] {
+  return [...new Set(values)].sort((left, right) => (left < right ? -1 : left > right ? 1 : 0));
+}
+
+function pass(summary: ProviderVerificationSummary, qualifiedAuditors: string[]): ProviderVerificationEvaluation {
+  return { outcome: "pass", firstFailure: null, failures: [], qualifiedAuditors, summary };
+}

--- a/packages/provider-verification/src/providerVerificationQueryClient.spec.ts
+++ b/packages/provider-verification/src/providerVerificationQueryClient.spec.ts
@@ -1,0 +1,176 @@
+import { SDKError, SDKErrorCode } from "@akashnetwork/chain-sdk/web";
+import { describe, expect, it, vi } from "vitest";
+
+import { type ProviderQueries, ProviderVerificationQueryClient, type VerificationQueries } from "./providerVerificationQueryClient.js";
+
+const height = "1234";
+const options = { headers: { "x-cosmos-block-height": height } };
+
+describe(ProviderVerificationQueryClient.name, () => {
+  it("pins and paginates global queries at one height", async () => {
+    const getAuditors = vi
+      .fn()
+      .mockResolvedValueOnce({ auditors: [{ address: "akash1auditor1" }], pagination: { nextKey: Uint8Array.from([1]), total: 0n } })
+      .mockResolvedValueOnce({ auditors: [{ address: "akash1auditor2" }], pagination: { nextKey: new Uint8Array(), total: 0n } });
+    const getDiscrepancies = vi.fn().mockResolvedValue({ discrepancies: [], pagination: { nextKey: new Uint8Array(), total: 0n } });
+    const getParams = vi.fn().mockResolvedValue({ params: { verificationModuleActive: true } });
+    const client = createClient({ getAuditors, getDiscrepancies, getParams });
+
+    const result = await client.getGlobalState(height);
+
+    expect(result).toMatchObject({
+      auditors: [{ address: "akash1auditor1" }, { address: "akash1auditor2" }],
+      discrepancies: [],
+      observedHeight: height,
+      params: { verificationModuleActive: true }
+    });
+    expect(getParams).toHaveBeenCalledWith({}, options);
+    expect(getAuditors).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ pagination: expect.objectContaining({ key: new Uint8Array(), limit: 100n }) }),
+      options
+    );
+    expect(getAuditors).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ pagination: expect.objectContaining({ key: Uint8Array.from([1]), limit: 100n }) }),
+      options
+    );
+    expect(getDiscrepancies).toHaveBeenCalledWith(expect.any(Object), options);
+  });
+
+  it("returns one height-consistent provider state and maps missing optional records to null", async () => {
+    const getProviderAttestations = vi
+      .fn()
+      .mockResolvedValue({ attestations: [{ auditor: "akash1auditor" }], pagination: { nextKey: new Uint8Array(), total: 0n } });
+    const getProviderAuditEscrows = vi.fn().mockResolvedValue({ escrows: [], pagination: { nextKey: new Uint8Array(), total: 0n } });
+    const getProviderBond = vi.fn().mockResolvedValue({
+      bond: { provider: "akash1provider" },
+      requiredForCurrentTier: { amount: "500", denom: "uakt" }
+    });
+    const getProviderVerificationGrace = vi.fn().mockResolvedValue({ grace: undefined });
+    const getProviderSnapshot = vi.fn().mockResolvedValue({ snapshot: { provider: "akash1provider" } });
+    const getProviderMaintenances = vi.fn().mockResolvedValue({ maintenance: [], pagination: { nextKey: new Uint8Array(), total: 0n } });
+    const client = createClient(
+      {
+        getProviderAttestations,
+        getProviderAuditEscrows,
+        getProviderBond,
+        getProviderVerificationGrace,
+        getProviderSnapshot
+      },
+      { getProviderMaintenances }
+    );
+
+    const result = await client.getProviderState("akash1provider", height);
+
+    expect(result).toMatchObject({
+      provider: "akash1provider",
+      attestations: [{ auditor: "akash1auditor" }],
+      auditEscrows: [],
+      bond: { provider: "akash1provider" },
+      requiredBondForCurrentTier: { amount: "500", denom: "uakt" },
+      grace: null,
+      snapshot: { provider: "akash1provider" },
+      maintenances: [],
+      observedHeight: height
+    });
+    for (const query of [
+      getProviderAttestations,
+      getProviderAuditEscrows,
+      getProviderBond,
+      getProviderVerificationGrace,
+      getProviderSnapshot,
+      getProviderMaintenances
+    ]) {
+      expect(query.mock.calls[0].at(-1)).toEqual(options);
+    }
+  });
+
+  it("does not hide transport failures", async () => {
+    const client = createClient({ getProviderBond: vi.fn().mockRejectedValue(new SDKError("unavailable", SDKErrorCode.Unavailable)) });
+
+    await expect(client.getProviderState("akash1provider", height)).rejects.toMatchObject({ code: SDKErrorCode.Unavailable });
+  });
+
+  it("queries only placement facts for provider screening", async () => {
+    const getProviderAttestations = vi
+      .fn()
+      .mockResolvedValue({ attestations: [{ auditor: "akash1auditor" }], pagination: { nextKey: new Uint8Array(), total: 0n } });
+    const getProviderVerificationGrace = vi.fn().mockResolvedValue({ grace: undefined });
+    const getProviderSnapshot = vi.fn().mockResolvedValue({ snapshot: { provider: "akash1provider" } });
+    const getProviderAuditEscrows = vi.fn().mockRejectedValue(new SDKError("unavailable", SDKErrorCode.Unavailable));
+    const getProviderBond = vi.fn();
+    const getProviderMaintenances = vi.fn();
+    const client = createClient(
+      { getProviderAttestations, getProviderVerificationGrace, getProviderSnapshot, getProviderAuditEscrows, getProviderBond },
+      { getProviderMaintenances }
+    );
+
+    await expect(client.getProviderScreeningState("akash1provider", height)).resolves.toMatchObject({
+      provider: "akash1provider",
+      attestations: [{ auditor: "akash1auditor" }],
+      grace: null,
+      snapshot: { provider: "akash1provider" },
+      observedHeight: height
+    });
+    expect(getProviderAuditEscrows).not.toHaveBeenCalled();
+    expect(getProviderBond).not.toHaveBeenCalled();
+    expect(getProviderMaintenances).not.toHaveBeenCalled();
+  });
+
+  it("maps a missing provider bond response to absent bond facts", async () => {
+    const client = createClient({ getProviderBond: vi.fn().mockRejectedValue(new SDKError("missing", SDKErrorCode.NotFound)) });
+
+    const result = await client.getProviderState("akash1provider", height);
+
+    expect(result.bond).toBeNull();
+    expect(result.requiredBondForCurrentTier).toBeNull();
+  });
+
+  it("pins singular reconciliation queries and preserves uint64 identities", async () => {
+    const getAuditEscrow = vi.fn().mockResolvedValue({ escrow: { id: 9007199254740993n } });
+    const getDiscrepancy = vi.fn().mockResolvedValue({ discrepancy: { id: 9007199254740995n } });
+    const getAuditor = vi.fn().mockResolvedValue({ auditor: { address: "akash1auditor" } });
+    const client = createClient({ getAuditEscrow, getAuditor, getDiscrepancy });
+
+    await expect(client.getAuditEscrow("9007199254740993", height)).resolves.toMatchObject({ id: 9007199254740993n });
+    await expect(client.getDiscrepancy("9007199254740995", height)).resolves.toMatchObject({ id: 9007199254740995n });
+    await expect(client.getAuditor("akash1auditor", height)).resolves.toMatchObject({ address: "akash1auditor" });
+
+    expect(getAuditEscrow).toHaveBeenCalledWith({ id: 9007199254740993n }, options);
+    expect(getDiscrepancy).toHaveBeenCalledWith({ id: 9007199254740995n }, options);
+    expect(getAuditor).toHaveBeenCalledWith({ auditor: "akash1auditor" }, options);
+  });
+
+  it("rejects malformed uint64 identifiers before calling the SDK", async () => {
+    const getAuditEscrow = vi.fn();
+    const client = createClient({ getAuditEscrow });
+
+    await expect(client.getAuditEscrow("-1", height)).rejects.toThrow("Invalid uint64 identifier");
+    expect(getAuditEscrow).not.toHaveBeenCalled();
+  });
+});
+
+function createClient(verification: Partial<VerificationQueries> = {}, provider: Partial<ProviderQueries> = {}) {
+  const emptyPage = { pagination: { nextKey: new Uint8Array(), total: 0n } };
+  const verificationQueries = {
+    getAuditors: vi.fn().mockResolvedValue({ auditors: [], ...emptyPage }),
+    getAuditor: vi.fn().mockResolvedValue({ auditor: undefined }),
+    getAuditEscrow: vi.fn().mockResolvedValue({ escrow: undefined }),
+    getDiscrepancy: vi.fn().mockResolvedValue({ discrepancy: undefined }),
+    getDiscrepancies: vi.fn().mockResolvedValue({ discrepancies: [], ...emptyPage }),
+    getParams: vi.fn().mockResolvedValue({ params: undefined }),
+    getProviderAttestations: vi.fn().mockResolvedValue({ attestations: [], ...emptyPage }),
+    getProviderAuditEscrows: vi.fn().mockResolvedValue({ escrows: [], ...emptyPage }),
+    getProviderBond: vi.fn().mockResolvedValue({ bond: undefined, requiredForCurrentTier: undefined }),
+    getProviderSnapshot: vi.fn().mockResolvedValue({ snapshot: undefined }),
+    getProviderVerificationGrace: vi.fn().mockResolvedValue({ grace: undefined }),
+    ...verification
+  } as VerificationQueries;
+  const providerQueries = {
+    getProviderMaintenances: vi.fn().mockResolvedValue({ maintenance: [], ...emptyPage }),
+    ...provider
+  } as ProviderQueries;
+
+  return new ProviderVerificationQueryClient(verificationQueries, providerQueries);
+}

--- a/packages/provider-verification/src/providerVerificationQueryClient.ts
+++ b/packages/provider-verification/src/providerVerificationQueryClient.ts
@@ -1,0 +1,230 @@
+import type {
+  AttestationRecord,
+  AuditEscrowRecord,
+  AuditorRecord,
+  DiscrepancyEvent,
+  ProviderBondRecord,
+  ProviderSnapshotRecord,
+  ProviderVerificationGraceRecord,
+  Verification_Params
+} from "@akashnetwork/chain-sdk/private-types/akash.v1";
+import { AttestationStatus, AuditEscrowStatus, AuditorStatus, DiscrepancyStatus } from "@akashnetwork/chain-sdk/private-types/akash.v1";
+import type { ProviderMaintenanceWithStatus } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
+import { ProviderMaintenanceStatus } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
+import type { Coin } from "@akashnetwork/chain-sdk/private-types/cosmos.v1beta1";
+import { createChainNodeWebSDK, SDKError, SDKErrorCode } from "@akashnetwork/chain-sdk/web";
+
+type ChainNodeWebSDK = ReturnType<typeof createChainNodeWebSDK>;
+export type VerificationQueries = Pick<
+  ChainNodeWebSDK["akash"]["verification"]["v1"],
+  | "getAuditors"
+  | "getAuditor"
+  | "getAuditEscrow"
+  | "getDiscrepancy"
+  | "getDiscrepancies"
+  | "getParams"
+  | "getProviderAttestations"
+  | "getProviderAuditEscrows"
+  | "getProviderBond"
+  | "getProviderSnapshot"
+  | "getProviderVerificationGrace"
+>;
+export type ProviderQueries = Pick<ChainNodeWebSDK["akash"]["provider"]["v1beta4"], "getProviderMaintenances">;
+
+interface Pagination {
+  nextKey: Uint8Array;
+}
+
+export interface ProviderVerificationGlobalState {
+  params: Verification_Params | null;
+  auditors: AuditorRecord[];
+  discrepancies: DiscrepancyEvent[];
+  observedHeight: string;
+}
+
+export interface ProviderVerificationScreeningState {
+  provider: string;
+  attestations: AttestationRecord[];
+  grace: ProviderVerificationGraceRecord | null;
+  snapshot: ProviderSnapshotRecord | null;
+  observedHeight: string;
+}
+
+export interface ProviderVerificationProviderState extends ProviderVerificationScreeningState {
+  auditEscrows: AuditEscrowRecord[];
+  bond: ProviderBondRecord | null;
+  requiredBondForCurrentTier: Coin | null;
+  maintenances: ProviderMaintenanceWithStatus[];
+}
+
+export class ProviderVerificationQueryClient {
+  constructor(
+    private readonly verification: VerificationQueries,
+    private readonly provider: ProviderQueries
+  ) {}
+
+  async getAuditor(auditor: string, height: string): Promise<AuditorRecord | null> {
+    return optionalRecord(
+      () => this.verification.getAuditor({ auditor }, queryOptions(height)),
+      response => response.auditor
+    );
+  }
+
+  async getAuditEscrow(id: string, height: string): Promise<AuditEscrowRecord | null> {
+    return optionalRecord(
+      () => this.verification.getAuditEscrow({ id: parseUint64(id) }, queryOptions(height)),
+      response => response.escrow
+    );
+  }
+
+  async getDiscrepancy(id: string, height: string): Promise<DiscrepancyEvent | null> {
+    return optionalRecord(
+      () => this.verification.getDiscrepancy({ id: parseUint64(id) }, queryOptions(height)),
+      response => response.discrepancy
+    );
+  }
+
+  async getGlobalState(height: string): Promise<ProviderVerificationGlobalState> {
+    const options = queryOptions(height);
+    const [paramsResponse, auditors, discrepancies] = await Promise.all([
+      this.verification.getParams({}, options),
+      collectPages(async pagination => {
+        const response = await this.verification.getAuditors({ pagination, statusFilter: AuditorStatus.auditor_status_unspecified }, options);
+
+        return { items: response.auditors, pagination: response.pagination };
+      }),
+      collectPages(async pagination => {
+        const response = await this.verification.getDiscrepancies({ pagination, statusFilter: DiscrepancyStatus.discrepancy_status_unspecified }, options);
+
+        return { items: response.discrepancies, pagination: response.pagination };
+      })
+    ]);
+
+    return {
+      params: paramsResponse.params ?? null,
+      auditors,
+      discrepancies,
+      observedHeight: height
+    };
+  }
+
+  async getProviderState(provider: string, height: string): Promise<ProviderVerificationProviderState> {
+    const options = queryOptions(height);
+    const [screening, auditEscrows, bondResponse, maintenances] = await Promise.all([
+      this.getProviderScreeningState(provider, height),
+      collectPages(async pagination => {
+        const response = await this.verification.getProviderAuditEscrows(
+          { pagination, provider, statusFilter: AuditEscrowStatus.audit_escrow_status_unspecified },
+          options
+        );
+
+        return { items: response.escrows, pagination: response.pagination };
+      }),
+      optionalResponse(() => this.verification.getProviderBond({ provider }, options)),
+      collectPages(async pagination => {
+        const response = await this.provider.getProviderMaintenances(
+          { pagination, provider, statusFilter: ProviderMaintenanceStatus.provider_maintenance_status_unspecified },
+          options
+        );
+
+        return { items: response.maintenance, pagination: response.pagination };
+      })
+    ]);
+
+    return {
+      ...screening,
+      auditEscrows,
+      bond: bondResponse?.bond ?? null,
+      requiredBondForCurrentTier: bondResponse?.requiredForCurrentTier ?? null,
+      maintenances
+    };
+  }
+
+  async getProviderScreeningState(provider: string, height: string): Promise<ProviderVerificationScreeningState> {
+    const options = queryOptions(height);
+    const [attestations, grace, snapshot] = await Promise.all([
+      collectPages(async pagination => {
+        const response = await this.verification.getProviderAttestations(
+          { pagination, provider, statusFilter: AttestationStatus.attestation_status_unspecified },
+          options
+        );
+
+        return { items: response.attestations, pagination: response.pagination };
+      }),
+      optionalRecord(
+        () => this.verification.getProviderVerificationGrace({ provider }, options),
+        response => response.grace
+      ),
+      optionalRecord(
+        () => this.verification.getProviderSnapshot({ provider }, options),
+        response => response.snapshot
+      )
+    ]);
+
+    return {
+      provider,
+      attestations,
+      grace,
+      snapshot,
+      observedHeight: height
+    };
+  }
+}
+
+export function createProviderVerificationQueryClient(baseUrl: string): ProviderVerificationQueryClient {
+  const sdk = createChainNodeWebSDK({ query: { baseUrl } });
+  return new ProviderVerificationQueryClient(sdk.akash.verification.v1, sdk.akash.provider.v1beta4);
+}
+
+function queryOptions(height: string) {
+  return { headers: { "x-cosmos-block-height": height } };
+}
+
+async function collectPages<T>(
+  fetchPage: (pagination: ReturnType<typeof pageRequest>) => Promise<{ items: T[]; pagination: Pagination | undefined }>
+): Promise<T[]> {
+  const items: T[] = [];
+  let nextKey: Uint8Array<ArrayBufferLike> = new Uint8Array();
+
+  do {
+    const response = await fetchPage(pageRequest(nextKey));
+    items.push(...response.items);
+    nextKey = response.pagination?.nextKey ?? new Uint8Array();
+  } while (nextKey.length > 0);
+
+  return items;
+}
+
+function pageRequest(key: Uint8Array<ArrayBufferLike>) {
+  return {
+    key,
+    offset: 0n,
+    limit: 100n,
+    countTotal: false,
+    reverse: false
+  };
+}
+
+function parseUint64(value: string): bigint {
+  if (!/^\d+$/.test(value)) throw new Error(`Invalid uint64 identifier: ${value}`);
+  const parsed = BigInt(value);
+  if (parsed > 18_446_744_073_709_551_615n) throw new Error(`Invalid uint64 identifier: ${value}`);
+  return parsed;
+}
+
+async function optionalRecord<TResponse, TRecord>(
+  query: () => Promise<TResponse>,
+  select: (response: TResponse) => TRecord | undefined
+): Promise<TRecord | null> {
+  const response = await optionalResponse(query);
+  return response ? (select(response) ?? null) : null;
+}
+
+async function optionalResponse<TResponse>(query: () => Promise<TResponse>): Promise<TResponse | null> {
+  try {
+    return await query();
+  } catch (error) {
+    if (error instanceof SDKError && error.code === SDKErrorCode.NotFound) return null;
+    throw error;
+  }
+}

--- a/packages/provider-verification/tsconfig.build.json
+++ b/packages/provider-verification/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@akashnetwork/dev-config/tsconfig.base-node.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "noImplicitAny": true,
+    "strict": true,
+    "target": "ES2022"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/provider-verification/tsconfig.json
+++ b/packages/provider-verification/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/provider-verification/vitest.config.ts
+++ b/packages/provider-verification/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    name: "provider-verification",
+    include: ["**/*.spec.ts"],
+    environment: "node"
+  }
+});


### PR DESCRIPTION
## Why

Part of CON-800.

Indexer, API, and provider-inventory need one implementation of AEP-86 tier,
capability, auditor-policy, and snapshot eligibility rules.

Depends on #3713. The dependency commit will disappear from this diff after
that PR merges.

## What

Add the private `@akashnetwork/provider-verification` workspace package with:

- normalized tier and capability evaluation
- required-auditor and minimum-count policy checks
- snapshot and grace-state handling
- a shared verification query client
- focused unit-test matrices for policy and query behavior
