### PR TITLE
feat(indexer): add provider verification schema

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@akashnetwork/akash-api": "1.4.3",
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/console-api-types": "*",
     "@akashnetwork/database": "*",
     "@akashnetwork/env-loader": "*",

--- a/apps/deploy-web/package.json
+++ b/apps/deploy-web/package.json
@@ -26,7 +26,7 @@
     "type-check": "tsc"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/console-api-types": "*",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",

--- a/apps/indexer/drizzle/0010_add_provider_verification.sql
+++ b/apps/indexer/drizzle/0010_add_provider_verification.sql
@@ -1,0 +1,296 @@
+CREATE TABLE IF NOT EXISTS "verification_auditor" (
+  "address" varchar(255) PRIMARY KEY NOT NULL,
+  "status" integer NOT NULL,
+  "max_attestation_tier" integer NOT NULL,
+  "bond_denom" varchar(255) NOT NULL,
+  "bond_amount" numeric(30, 0) NOT NULL,
+  "bond_status" integer NOT NULL,
+  "metadata_hash" bytea,
+  "registered_at" timestamp with time zone NOT NULL,
+  "renewal_deadline" timestamp with time zone NOT NULL,
+  "discrepancy_count" numeric(20, 0) NOT NULL,
+  "bond_unbonding_completion_time" timestamp with time zone,
+  "observed_height" integer NOT NULL,
+  "observed_block_time" timestamp with time zone NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "verification_auditor_status" ON "verification_auditor" ("status");
+CREATE INDEX IF NOT EXISTS "verification_auditor_renewal_deadline" ON "verification_auditor" ("renewal_deadline");
+
+CREATE TABLE IF NOT EXISTS "verification_attestation" (
+  "provider" varchar(255) NOT NULL,
+  "auditor" varchar(255) NOT NULL,
+  "tier" integer NOT NULL,
+  "evidence_hash" bytea NOT NULL,
+  "fee_denom" varchar(255) NOT NULL,
+  "fee_amount" numeric(30, 0) NOT NULL,
+  "fee_status" integer NOT NULL,
+  "created_at" timestamp with time zone NOT NULL,
+  "expires_at" timestamp with time zone NOT NULL,
+  "status" integer NOT NULL,
+  "voided_reason" integer NOT NULL,
+  "deposit_denom" varchar(255) NOT NULL,
+  "deposit_amount" numeric(30, 0) NOT NULL,
+  "deposit_status" integer NOT NULL,
+  "audit_escrow_id" numeric(20, 0) NOT NULL,
+  "fault_attribution" integer NOT NULL,
+  "observed_height" integer NOT NULL,
+  "observed_block_time" timestamp with time zone NOT NULL,
+  CONSTRAINT "verification_attestation_provider_auditor" PRIMARY KEY ("provider", "auditor")
+);
+
+CREATE INDEX IF NOT EXISTS "verification_attestation_provider_status_tier" ON "verification_attestation" ("provider", "status", "tier");
+CREATE INDEX IF NOT EXISTS "verification_attestation_expires_at_status" ON "verification_attestation" ("expires_at", "status");
+CREATE INDEX IF NOT EXISTS "verification_attestation_audit_escrow_id" ON "verification_attestation" ("audit_escrow_id");
+
+CREATE TABLE IF NOT EXISTS "verification_attestation_capability" (
+  "provider" varchar(255) NOT NULL,
+  "auditor" varchar(255) NOT NULL,
+  "capability" integer NOT NULL,
+  "observed_height" integer NOT NULL,
+  "observed_block_time" timestamp with time zone NOT NULL,
+  CONSTRAINT "verification_attestation_capability_identity" PRIMARY KEY ("provider", "auditor", "capability"),
+  CONSTRAINT "verification_attestation_capability_attestation_fkey"
+    FOREIGN KEY ("provider", "auditor") REFERENCES "verification_attestation" ("provider", "auditor") ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS "verification_attestation_capability_capability_provider"
+  ON "verification_attestation_capability" ("capability", "provider");
+
+CREATE TABLE IF NOT EXISTS "verification_audit_escrow" (
+  "id" numeric(20, 0) PRIMARY KEY NOT NULL,
+  "provider" varchar(255) NOT NULL,
+  "consumed_by_auditor" varchar(255) NOT NULL,
+  "requested_tier" integer NOT NULL,
+  "fee_denom" varchar(255) NOT NULL,
+  "fee_amount" numeric(30, 0) NOT NULL,
+  "fee_status" integer NOT NULL,
+  "provider_deposit_denom" varchar(255) NOT NULL,
+  "provider_deposit_amount" numeric(30, 0) NOT NULL,
+  "provider_deposit_status" integer NOT NULL,
+  "status" integer NOT NULL,
+  "opened_at" timestamp with time zone NOT NULL,
+  "consumed_at" timestamp with time zone,
+  "expires_at" timestamp with time zone NOT NULL,
+  "metadata_hash" bytea,
+  "settlement_reason" integer NOT NULL,
+  "fault_attribution" integer NOT NULL,
+  "observed_height" integer NOT NULL,
+  "observed_block_time" timestamp with time zone NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "verification_audit_escrow_provider_status" ON "verification_audit_escrow" ("provider", "status");
+CREATE INDEX IF NOT EXISTS "verification_audit_escrow_expires_at_status" ON "verification_audit_escrow" ("expires_at", "status");
+
+CREATE TABLE IF NOT EXISTS "verification_audit_escrow_capability" (
+  "audit_escrow_id" numeric(20, 0) NOT NULL,
+  "capability" integer NOT NULL,
+  "observed_height" integer NOT NULL,
+  "observed_block_time" timestamp with time zone NOT NULL,
+  CONSTRAINT "verification_audit_escrow_capability_identity" PRIMARY KEY ("audit_escrow_id", "capability"),
+  CONSTRAINT "verification_audit_escrow_capability_escrow_fkey"
+    FOREIGN KEY ("audit_escrow_id") REFERENCES "verification_audit_escrow" ("id") ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS "verification_audit_escrow_capability_capability" ON "verification_audit_escrow_capability" ("capability");
+
+CREATE TABLE IF NOT EXISTS "verification_discrepancy" (
+  "id" numeric(20, 0) PRIMARY KEY NOT NULL,
+  "provider" varchar(255) NOT NULL,
+  "auditor_a" varchar(255) NOT NULL,
+  "auditor_a_tier" integer NOT NULL,
+  "auditor_b" varchar(255) NOT NULL,
+  "auditor_b_tier" integer NOT NULL,
+  "detected_at" timestamp with time zone NOT NULL,
+  "resolution_status" integer NOT NULL,
+  "resolution_proposal_id" numeric(20, 0) NOT NULL,
+  "grace_record_id" numeric(20, 0) NOT NULL,
+  "resolution_reason" integer NOT NULL,
+  "fault_attribution" integer NOT NULL,
+  "resolution_evidence_hash" bytea,
+  "observed_height" integer NOT NULL,
+  "observed_block_time" timestamp with time zone NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "verification_discrepancy_provider_resolution_status" ON "verification_discrepancy" ("provider", "resolution_status");
+CREATE INDEX IF NOT EXISTS "verification_discrepancy_auditor_a" ON "verification_discrepancy" ("auditor_a");
+CREATE INDEX IF NOT EXISTS "verification_discrepancy_auditor_b" ON "verification_discrepancy" ("auditor_b");
+
+CREATE TABLE IF NOT EXISTS "verification_grace" (
+  "id" numeric(20, 0) PRIMARY KEY NOT NULL,
+  "provider" varchar(255) NOT NULL,
+  "preserved_tier" integer NOT NULL,
+  "started_at" timestamp with time zone NOT NULL,
+  "expires_at" timestamp with time zone NOT NULL,
+  "status" integer NOT NULL,
+  "observed_height" integer NOT NULL,
+  "observed_block_time" timestamp with time zone NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "verification_grace_provider_status" ON "verification_grace" ("provider", "status");
+CREATE INDEX IF NOT EXISTS "verification_grace_expires_at_status" ON "verification_grace" ("expires_at", "status");
+
+CREATE TABLE IF NOT EXISTS "verification_grace_discrepancy" (
+  "grace_id" numeric(20, 0) NOT NULL,
+  "discrepancy_id" numeric(20, 0) NOT NULL,
+  "observed_height" integer NOT NULL,
+  "observed_block_time" timestamp with time zone NOT NULL,
+  CONSTRAINT "verification_grace_discrepancy_identity" PRIMARY KEY ("grace_id", "discrepancy_id"),
+  CONSTRAINT "verification_grace_discrepancy_grace_fkey"
+    FOREIGN KEY ("grace_id") REFERENCES "verification_grace" ("id") ON DELETE CASCADE,
+  CONSTRAINT "verification_grace_discrepancy_discrepancy_fkey"
+    FOREIGN KEY ("discrepancy_id") REFERENCES "verification_discrepancy" ("id") ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS "verification_grace_discrepancy_discrepancy_id" ON "verification_grace_discrepancy" ("discrepancy_id");
+
+CREATE TABLE IF NOT EXISTS "verification_provider_bond" (
+  "provider" varchar(255) PRIMARY KEY NOT NULL,
+  "bonded_denom" varchar(255) NOT NULL,
+  "bonded_amount" numeric(30, 0) NOT NULL,
+  "required_for_current_tier_denom" varchar(255) NOT NULL,
+  "required_for_current_tier_amount" numeric(30, 0) NOT NULL,
+  "slashed" boolean NOT NULL,
+  "last_slash_time" timestamp with time zone,
+  "observed_height" integer NOT NULL,
+  "observed_block_time" timestamp with time zone NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS "verification_provider_bond_unbonding" (
+  "provider" varchar(255) NOT NULL,
+  "entry_index" integer NOT NULL,
+  "denom" varchar(255) NOT NULL,
+  "amount" numeric(30, 0) NOT NULL,
+  "completion_time" timestamp with time zone NOT NULL,
+  "observed_height" integer NOT NULL,
+  "observed_block_time" timestamp with time zone NOT NULL,
+  CONSTRAINT "verification_provider_bond_unbonding_identity" PRIMARY KEY ("provider", "entry_index"),
+  CONSTRAINT "verification_provider_bond_unbonding_bond_fkey"
+    FOREIGN KEY ("provider") REFERENCES "verification_provider_bond" ("provider") ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS "verification_provider_bond_unbonding_completion_time"
+  ON "verification_provider_bond_unbonding" ("completion_time");
+
+CREATE TABLE IF NOT EXISTS "verification_provider_observation" (
+  "provider" varchar(255) PRIMARY KEY NOT NULL,
+  "observed_height" integer NOT NULL,
+  "observed_block_time" timestamp with time zone NOT NULL,
+  "effective_tier" integer NOT NULL,
+  "max_placement_tier" integer NOT NULL,
+  "snapshot_state" varchar(255) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS "verification_provider_tier_stream" (
+  "id" smallint PRIMARY KEY NOT NULL,
+  "stream_id" uuid NOT NULL DEFAULT gen_random_uuid()
+);
+
+INSERT INTO "verification_provider_tier_stream" ("id")
+VALUES (1)
+ON CONFLICT ("id") DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS "verification_provider_tier_demotion" (
+  "id" bigserial PRIMARY KEY NOT NULL,
+  "provider" varchar(255) NOT NULL,
+  "previous_effective_tier" integer NOT NULL,
+  "previous_max_placement_tier" integer NOT NULL,
+  "previous_snapshot_state" varchar(255) NOT NULL,
+  "current_effective_tier" integer NOT NULL,
+  "current_max_placement_tier" integer NOT NULL,
+  "current_snapshot_state" varchar(255) NOT NULL,
+  "changes" varchar(255)[] NOT NULL,
+  "observed_height" integer NOT NULL,
+  "observed_block_time" timestamp with time zone NOT NULL,
+  "created_at" timestamp with time zone NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS "verification_provider_tier_demotion_provider_id"
+  ON "verification_provider_tier_demotion" ("provider", "id");
+CREATE INDEX IF NOT EXISTS "verification_provider_tier_demotion_observed_height"
+  ON "verification_provider_tier_demotion" ("observed_height");
+
+CREATE TABLE IF NOT EXISTS "verification_provider_snapshot" (
+  "provider" varchar(255) PRIMARY KEY NOT NULL,
+  "snapshot_hash" bytea NOT NULL,
+  "total_gpus" integer NOT NULL,
+  "total_vcpus" integer NOT NULL,
+  "total_memory_mb" numeric(20, 0) NOT NULL,
+  "total_storage_mb" numeric(20, 0) NOT NULL,
+  "active_leases" integer NOT NULL,
+  "software_version" varchar(255) NOT NULL,
+  "software_signature" bytea,
+  "software_identity_version" varchar(255),
+  "software_artifact_ref" text,
+  "software_digest_algorithm" varchar(255),
+  "software_digest" bytea,
+  "software_signature_type" varchar(255),
+  "software_identity_signature" bytea,
+  "software_signature_ref" text,
+  "software_public_key_ref" text,
+  "posted_at" timestamp with time zone NOT NULL,
+  "snapshot_timestamp" timestamp with time zone NOT NULL,
+  "compliance_deadline" timestamp with time zone NOT NULL,
+  "suspended" boolean NOT NULL,
+  "observed_height" integer NOT NULL,
+  "observed_block_time" timestamp with time zone NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "verification_provider_snapshot_compliance_deadline_suspended"
+  ON "verification_provider_snapshot" ("compliance_deadline", "suspended");
+CREATE INDEX IF NOT EXISTS "verification_provider_snapshot_snapshot_timestamp" ON "verification_provider_snapshot" ("snapshot_timestamp");
+
+CREATE TABLE IF NOT EXISTS "provider_maintenance" (
+  "provider" varchar(255) NOT NULL,
+  "id" numeric(20, 0) NOT NULL,
+  "maintenance_type" integer NOT NULL,
+  "starts_at" timestamp with time zone NOT NULL,
+  "expected_ends_at" timestamp with time zone NOT NULL,
+  "opened_at" timestamp with time zone NOT NULL,
+  "closed_at" timestamp with time zone,
+  "metadata_hash" bytea,
+  "status" integer NOT NULL,
+  "observed_height" integer NOT NULL,
+  "observed_block_time" timestamp with time zone NOT NULL,
+  CONSTRAINT "provider_maintenance_provider_id" PRIMARY KEY ("provider", "id")
+);
+
+CREATE INDEX IF NOT EXISTS "provider_maintenance_provider_status" ON "provider_maintenance" ("provider", "status");
+CREATE INDEX IF NOT EXISTS "provider_maintenance_starts_at_expected_ends_at" ON "provider_maintenance" ("starts_at", "expected_ends_at");
+
+CREATE TABLE IF NOT EXISTS "verification_params" (
+  "id" smallint PRIMARY KEY NOT NULL,
+  "params" jsonb NOT NULL,
+  "observed_height" integer NOT NULL,
+  "observed_block_time" timestamp with time zone NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS "verification_reconcile_target" (
+  "target_type" varchar(255) NOT NULL,
+  "target_key" varchar(255) NOT NULL,
+  "requested_height" integer NOT NULL,
+  "invalidated" boolean NOT NULL DEFAULT true,
+  "claimed_at" timestamp with time zone,
+  "attempt_count" integer NOT NULL DEFAULT 0,
+  "next_attempt_at" timestamp with time zone,
+  "last_error" text,
+  CONSTRAINT "verification_reconcile_target_identity" PRIMARY KEY ("target_type", "target_key")
+);
+
+CREATE INDEX IF NOT EXISTS "verification_reconcile_target_claimed_at_next_attempt_at"
+  ON "verification_reconcile_target" ("claimed_at" NULLS FIRST, "next_attempt_at" NULLS FIRST);
+CREATE INDEX IF NOT EXISTS "verification_reconcile_target_requested_height" ON "verification_reconcile_target" ("requested_height");
+
+CREATE TABLE IF NOT EXISTS "verification_block_event" (
+  "id" uuid PRIMARY KEY NOT NULL DEFAULT gen_random_uuid(),
+  "height" integer NOT NULL,
+  "index" integer NOT NULL,
+  "type" varchar(255) NOT NULL,
+  "data" jsonb NOT NULL,
+  "is_processed" boolean NOT NULL DEFAULT false,
+  CONSTRAINT "verification_block_event_height_fkey"
+    FOREIGN KEY ("height") REFERENCES "block" ("height") ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "verification_block_event_height_index" ON "verification_block_event" ("height", "index");
+CREATE INDEX IF NOT EXISTS "verification_block_event_height_is_processed" ON "verification_block_event" ("height", "is_processed");

--- a/apps/indexer/drizzle/meta/_journal.json
+++ b/apps/indexer/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1763000000000,
       "tag": "0009_drop_monitored_value",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1787570000000,
+      "tag": "0010_add_provider_verification",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/indexer/drizzle/relations.ts
+++ b/apps/indexer/drizzle/relations.ts
@@ -11,8 +11,23 @@ import {
   provider,
   providerAttribute,
   providerAttributeSignature,
+  providerMaintenance,
   providerSnapshot,
-  transaction
+  transaction,
+  verificationAttestation,
+  verificationAttestationCapability,
+  verificationAuditEscrow,
+  verificationAuditEscrowCapability,
+  verificationAuditor,
+  verificationBlockEvent,
+  verificationDiscrepancy,
+  verificationGrace,
+  verificationGraceDiscrepancy,
+  verificationProviderBond,
+  verificationProviderBondUnbonding,
+  verificationProviderObservation,
+  verificationProviderSnapshot,
+  verificationProviderTierDemotion
 } from "./schema";
 
 export const deploymentGroupRelations = relations(deploymentGroup, ({ one, many }) => ({
@@ -36,11 +51,20 @@ export const providerAttributeSignatureRelations = relations(providerAttributeSi
   })
 }));
 
-export const providerRelations = relations(provider, ({ many }) => ({
+export const providerRelations = relations(provider, ({ one, many }) => ({
   providerAttributeSignatures: many(providerAttributeSignature),
   leases: many(lease),
   providerAttributes: many(providerAttribute),
-  providerSnapshots: many(providerSnapshot)
+  providerSnapshots: many(providerSnapshot),
+  verificationAttestations: many(verificationAttestation),
+  verificationAuditEscrows: many(verificationAuditEscrow),
+  verificationDiscrepancies: many(verificationDiscrepancy),
+  verificationGraceRecords: many(verificationGrace),
+  verificationBond: one(verificationProviderBond),
+  verificationObservation: one(verificationProviderObservation),
+  verificationSnapshot: one(verificationProviderSnapshot),
+  verificationTierDemotions: many(verificationProviderTierDemotion),
+  maintenanceRecords: many(providerMaintenance)
 }));
 
 export const leaseRelations = relations(lease, ({ one }) => ({
@@ -93,7 +117,8 @@ export const messageRelations = relations(message, ({ one, many }) => ({
 
 export const blockRelations = relations(block, ({ many }) => ({
   messages: many(message),
-  transactions: many(transaction)
+  transactions: many(transaction),
+  verificationBlockEvents: many(verificationBlockEvent)
 }));
 
 export const transactionRelations = relations(transaction, ({ one, many }) => ({
@@ -113,5 +138,120 @@ export const addressReferenceRelations = relations(addressReference, ({ one }) =
   transaction: one(transaction, {
     fields: [addressReference.transactionId],
     references: [transaction.id]
+  })
+}));
+
+export const verificationAuditorRelations = relations(verificationAuditor, ({ many }) => ({
+  attestations: many(verificationAttestation)
+}));
+
+export const verificationAttestationRelations = relations(verificationAttestation, ({ one, many }) => ({
+  provider: one(provider, {
+    fields: [verificationAttestation.provider],
+    references: [provider.owner]
+  }),
+  auditor: one(verificationAuditor, {
+    fields: [verificationAttestation.auditor],
+    references: [verificationAuditor.address]
+  }),
+  capabilities: many(verificationAttestationCapability)
+}));
+
+export const verificationAttestationCapabilityRelations = relations(verificationAttestationCapability, ({ one }) => ({
+  attestation: one(verificationAttestation, {
+    fields: [verificationAttestationCapability.provider, verificationAttestationCapability.auditor],
+    references: [verificationAttestation.provider, verificationAttestation.auditor]
+  })
+}));
+
+export const verificationAuditEscrowRelations = relations(verificationAuditEscrow, ({ one, many }) => ({
+  provider: one(provider, {
+    fields: [verificationAuditEscrow.provider],
+    references: [provider.owner]
+  }),
+  capabilities: many(verificationAuditEscrowCapability)
+}));
+
+export const verificationAuditEscrowCapabilityRelations = relations(verificationAuditEscrowCapability, ({ one }) => ({
+  auditEscrow: one(verificationAuditEscrow, {
+    fields: [verificationAuditEscrowCapability.audit_escrow_id],
+    references: [verificationAuditEscrow.id]
+  })
+}));
+
+export const verificationDiscrepancyRelations = relations(verificationDiscrepancy, ({ one, many }) => ({
+  provider: one(provider, {
+    fields: [verificationDiscrepancy.provider],
+    references: [provider.owner]
+  }),
+  graceRecords: many(verificationGraceDiscrepancy)
+}));
+
+export const verificationGraceRelations = relations(verificationGrace, ({ one, many }) => ({
+  provider: one(provider, {
+    fields: [verificationGrace.provider],
+    references: [provider.owner]
+  }),
+  sourceDiscrepancies: many(verificationGraceDiscrepancy)
+}));
+
+export const verificationGraceDiscrepancyRelations = relations(verificationGraceDiscrepancy, ({ one }) => ({
+  grace: one(verificationGrace, {
+    fields: [verificationGraceDiscrepancy.grace_id],
+    references: [verificationGrace.id]
+  }),
+  discrepancy: one(verificationDiscrepancy, {
+    fields: [verificationGraceDiscrepancy.discrepancy_id],
+    references: [verificationDiscrepancy.id]
+  })
+}));
+
+export const verificationProviderBondRelations = relations(verificationProviderBond, ({ one, many }) => ({
+  provider: one(provider, {
+    fields: [verificationProviderBond.provider],
+    references: [provider.owner]
+  }),
+  unbondingEntries: many(verificationProviderBondUnbonding)
+}));
+
+export const verificationProviderBondUnbondingRelations = relations(verificationProviderBondUnbonding, ({ one }) => ({
+  providerBond: one(verificationProviderBond, {
+    fields: [verificationProviderBondUnbonding.provider],
+    references: [verificationProviderBond.provider]
+  })
+}));
+
+export const verificationProviderObservationRelations = relations(verificationProviderObservation, ({ one }) => ({
+  provider: one(provider, {
+    fields: [verificationProviderObservation.provider],
+    references: [provider.owner]
+  })
+}));
+
+export const verificationProviderTierDemotionRelations = relations(verificationProviderTierDemotion, ({ one }) => ({
+  provider: one(provider, {
+    fields: [verificationProviderTierDemotion.provider],
+    references: [provider.owner]
+  })
+}));
+
+export const verificationProviderSnapshotRelations = relations(verificationProviderSnapshot, ({ one }) => ({
+  provider: one(provider, {
+    fields: [verificationProviderSnapshot.provider],
+    references: [provider.owner]
+  })
+}));
+
+export const providerMaintenanceRelations = relations(providerMaintenance, ({ one }) => ({
+  provider: one(provider, {
+    fields: [providerMaintenance.provider],
+    references: [provider.owner]
+  })
+}));
+
+export const verificationBlockEventRelations = relations(verificationBlockEvent, ({ one }) => ({
+  block: one(block, {
+    fields: [verificationBlockEvent.height],
+    references: [block.height]
   })
 }));

--- a/apps/indexer/drizzle/schema.ts
+++ b/apps/indexer/drizzle/schema.ts
@@ -1,6 +1,7 @@
 import { sql } from "drizzle-orm";
 import {
   bigint,
+  bigserial,
   boolean,
   customType,
   doublePrecision,
@@ -10,6 +11,7 @@ import {
   jsonb,
   numeric,
   pgTable,
+  primaryKey,
   serial,
   smallint,
   text,
@@ -727,5 +729,443 @@ export const bmeStatusChange = pgTable(
       foreignColumns: [block.height],
       name: "bme_status_change_height_fkey"
     })
+  ]
+);
+
+export const verificationAuditor = pgTable(
+  "verification_auditor",
+  {
+    address: varchar({ length: 255 }).primaryKey().notNull(),
+    status: integer().notNull(),
+    max_attestation_tier: integer().notNull(),
+    bond_denom: varchar({ length: 255 }).notNull(),
+    bond_amount: numeric({ precision: 30, scale: 0 }).notNull(),
+    bond_status: integer().notNull(),
+    metadata_hash: bytea("metadata_hash"),
+    registered_at: timestamp({ withTimezone: true, mode: "string" }).notNull(),
+    renewal_deadline: timestamp({ withTimezone: true, mode: "string" }).notNull(),
+    discrepancy_count: numeric({ precision: 20, scale: 0 }).notNull(),
+    bond_unbonding_completion_time: timestamp({ withTimezone: true, mode: "string" }),
+    observed_height: integer().notNull(),
+    observed_block_time: timestamp({ withTimezone: true, mode: "string" }).notNull()
+  },
+  table => [
+    index("verification_auditor_status").using("btree", table.status.asc().nullsLast().op("int4_ops")),
+    index("verification_auditor_renewal_deadline").using("btree", table.renewal_deadline.asc().nullsLast().op("timestamptz_ops"))
+  ]
+);
+
+export const verificationAttestation = pgTable(
+  "verification_attestation",
+  {
+    provider: varchar({ length: 255 }).notNull(),
+    auditor: varchar({ length: 255 }).notNull(),
+    tier: integer().notNull(),
+    evidence_hash: bytea("evidence_hash").notNull(),
+    fee_denom: varchar({ length: 255 }).notNull(),
+    fee_amount: numeric({ precision: 30, scale: 0 }).notNull(),
+    fee_status: integer().notNull(),
+    created_at: timestamp({ withTimezone: true, mode: "string" }).notNull(),
+    expires_at: timestamp({ withTimezone: true, mode: "string" }).notNull(),
+    status: integer().notNull(),
+    voided_reason: integer().notNull(),
+    deposit_denom: varchar({ length: 255 }).notNull(),
+    deposit_amount: numeric({ precision: 30, scale: 0 }).notNull(),
+    deposit_status: integer().notNull(),
+    audit_escrow_id: numeric({ precision: 20, scale: 0 }).notNull(),
+    fault_attribution: integer().notNull(),
+    observed_height: integer().notNull(),
+    observed_block_time: timestamp({ withTimezone: true, mode: "string" }).notNull()
+  },
+  table => [
+    primaryKey({ columns: [table.provider, table.auditor], name: "verification_attestation_provider_auditor" }),
+    index("verification_attestation_provider_status_tier").using(
+      "btree",
+      table.provider.asc().nullsLast().op("text_ops"),
+      table.status.asc().nullsLast().op("int4_ops"),
+      table.tier.asc().nullsLast().op("int4_ops")
+    ),
+    index("verification_attestation_expires_at_status").using(
+      "btree",
+      table.expires_at.asc().nullsLast().op("timestamptz_ops"),
+      table.status.asc().nullsLast().op("int4_ops")
+    ),
+    index("verification_attestation_audit_escrow_id").using("btree", table.audit_escrow_id.asc().nullsLast().op("numeric_ops"))
+  ]
+);
+
+export const verificationAttestationCapability = pgTable(
+  "verification_attestation_capability",
+  {
+    provider: varchar({ length: 255 }).notNull(),
+    auditor: varchar({ length: 255 }).notNull(),
+    capability: integer().notNull(),
+    observed_height: integer().notNull(),
+    observed_block_time: timestamp({ withTimezone: true, mode: "string" }).notNull()
+  },
+  table => [
+    primaryKey({
+      columns: [table.provider, table.auditor, table.capability],
+      name: "verification_attestation_capability_identity"
+    }),
+    index("verification_attestation_capability_capability_provider").using(
+      "btree",
+      table.capability.asc().nullsLast().op("int4_ops"),
+      table.provider.asc().nullsLast().op("text_ops")
+    ),
+    foreignKey({
+      columns: [table.provider, table.auditor],
+      foreignColumns: [verificationAttestation.provider, verificationAttestation.auditor],
+      name: "verification_attestation_capability_attestation_fkey"
+    }).onDelete("cascade")
+  ]
+);
+
+export const verificationAuditEscrow = pgTable(
+  "verification_audit_escrow",
+  {
+    id: numeric({ precision: 20, scale: 0 }).primaryKey().notNull(),
+    provider: varchar({ length: 255 }).notNull(),
+    consumed_by_auditor: varchar({ length: 255 }).notNull(),
+    requested_tier: integer().notNull(),
+    fee_denom: varchar({ length: 255 }).notNull(),
+    fee_amount: numeric({ precision: 30, scale: 0 }).notNull(),
+    fee_status: integer().notNull(),
+    provider_deposit_denom: varchar({ length: 255 }).notNull(),
+    provider_deposit_amount: numeric({ precision: 30, scale: 0 }).notNull(),
+    provider_deposit_status: integer().notNull(),
+    status: integer().notNull(),
+    opened_at: timestamp({ withTimezone: true, mode: "string" }).notNull(),
+    consumed_at: timestamp({ withTimezone: true, mode: "string" }),
+    expires_at: timestamp({ withTimezone: true, mode: "string" }).notNull(),
+    metadata_hash: bytea("metadata_hash"),
+    settlement_reason: integer().notNull(),
+    fault_attribution: integer().notNull(),
+    observed_height: integer().notNull(),
+    observed_block_time: timestamp({ withTimezone: true, mode: "string" }).notNull()
+  },
+  table => [
+    index("verification_audit_escrow_provider_status").using(
+      "btree",
+      table.provider.asc().nullsLast().op("text_ops"),
+      table.status.asc().nullsLast().op("int4_ops")
+    ),
+    index("verification_audit_escrow_expires_at_status").using(
+      "btree",
+      table.expires_at.asc().nullsLast().op("timestamptz_ops"),
+      table.status.asc().nullsLast().op("int4_ops")
+    )
+  ]
+);
+
+export const verificationAuditEscrowCapability = pgTable(
+  "verification_audit_escrow_capability",
+  {
+    audit_escrow_id: numeric({ precision: 20, scale: 0 }).notNull(),
+    capability: integer().notNull(),
+    observed_height: integer().notNull(),
+    observed_block_time: timestamp({ withTimezone: true, mode: "string" }).notNull()
+  },
+  table => [
+    primaryKey({
+      columns: [table.audit_escrow_id, table.capability],
+      name: "verification_audit_escrow_capability_identity"
+    }),
+    index("verification_audit_escrow_capability_capability").using("btree", table.capability.asc().nullsLast().op("int4_ops")),
+    foreignKey({
+      columns: [table.audit_escrow_id],
+      foreignColumns: [verificationAuditEscrow.id],
+      name: "verification_audit_escrow_capability_escrow_fkey"
+    }).onDelete("cascade")
+  ]
+);
+
+export const verificationDiscrepancy = pgTable(
+  "verification_discrepancy",
+  {
+    id: numeric({ precision: 20, scale: 0 }).primaryKey().notNull(),
+    provider: varchar({ length: 255 }).notNull(),
+    auditor_a: varchar({ length: 255 }).notNull(),
+    auditor_a_tier: integer().notNull(),
+    auditor_b: varchar({ length: 255 }).notNull(),
+    auditor_b_tier: integer().notNull(),
+    detected_at: timestamp({ withTimezone: true, mode: "string" }).notNull(),
+    resolution_status: integer().notNull(),
+    resolution_proposal_id: numeric({ precision: 20, scale: 0 }).notNull(),
+    grace_record_id: numeric({ precision: 20, scale: 0 }).notNull(),
+    resolution_reason: integer().notNull(),
+    fault_attribution: integer().notNull(),
+    resolution_evidence_hash: bytea("resolution_evidence_hash"),
+    observed_height: integer().notNull(),
+    observed_block_time: timestamp({ withTimezone: true, mode: "string" }).notNull()
+  },
+  table => [
+    index("verification_discrepancy_provider_resolution_status").using(
+      "btree",
+      table.provider.asc().nullsLast().op("text_ops"),
+      table.resolution_status.asc().nullsLast().op("int4_ops")
+    ),
+    index("verification_discrepancy_auditor_a").using("btree", table.auditor_a.asc().nullsLast().op("text_ops")),
+    index("verification_discrepancy_auditor_b").using("btree", table.auditor_b.asc().nullsLast().op("text_ops"))
+  ]
+);
+
+export const verificationGrace = pgTable(
+  "verification_grace",
+  {
+    id: numeric({ precision: 20, scale: 0 }).primaryKey().notNull(),
+    provider: varchar({ length: 255 }).notNull(),
+    preserved_tier: integer().notNull(),
+    started_at: timestamp({ withTimezone: true, mode: "string" }).notNull(),
+    expires_at: timestamp({ withTimezone: true, mode: "string" }).notNull(),
+    status: integer().notNull(),
+    observed_height: integer().notNull(),
+    observed_block_time: timestamp({ withTimezone: true, mode: "string" }).notNull()
+  },
+  table => [
+    index("verification_grace_provider_status").using("btree", table.provider.asc().nullsLast().op("text_ops"), table.status.asc().nullsLast().op("int4_ops")),
+    index("verification_grace_expires_at_status").using(
+      "btree",
+      table.expires_at.asc().nullsLast().op("timestamptz_ops"),
+      table.status.asc().nullsLast().op("int4_ops")
+    )
+  ]
+);
+
+export const verificationGraceDiscrepancy = pgTable(
+  "verification_grace_discrepancy",
+  {
+    grace_id: numeric({ precision: 20, scale: 0 }).notNull(),
+    discrepancy_id: numeric({ precision: 20, scale: 0 }).notNull(),
+    observed_height: integer().notNull(),
+    observed_block_time: timestamp({ withTimezone: true, mode: "string" }).notNull()
+  },
+  table => [
+    primaryKey({
+      columns: [table.grace_id, table.discrepancy_id],
+      name: "verification_grace_discrepancy_identity"
+    }),
+    index("verification_grace_discrepancy_discrepancy_id").using("btree", table.discrepancy_id.asc().nullsLast().op("numeric_ops")),
+    foreignKey({
+      columns: [table.grace_id],
+      foreignColumns: [verificationGrace.id],
+      name: "verification_grace_discrepancy_grace_fkey"
+    }).onDelete("cascade"),
+    foreignKey({
+      columns: [table.discrepancy_id],
+      foreignColumns: [verificationDiscrepancy.id],
+      name: "verification_grace_discrepancy_discrepancy_fkey"
+    }).onDelete("cascade")
+  ]
+);
+
+export const verificationProviderBond = pgTable("verification_provider_bond", {
+  provider: varchar({ length: 255 }).primaryKey().notNull(),
+  bonded_denom: varchar({ length: 255 }).notNull(),
+  bonded_amount: numeric({ precision: 30, scale: 0 }).notNull(),
+  required_for_current_tier_denom: varchar({ length: 255 }).notNull(),
+  required_for_current_tier_amount: numeric({ precision: 30, scale: 0 }).notNull(),
+  slashed: boolean().notNull(),
+  last_slash_time: timestamp({ withTimezone: true, mode: "string" }),
+  observed_height: integer().notNull(),
+  observed_block_time: timestamp({ withTimezone: true, mode: "string" }).notNull()
+});
+
+export const verificationProviderBondUnbonding = pgTable(
+  "verification_provider_bond_unbonding",
+  {
+    provider: varchar({ length: 255 }).notNull(),
+    entry_index: integer().notNull(),
+    denom: varchar({ length: 255 }).notNull(),
+    amount: numeric({ precision: 30, scale: 0 }).notNull(),
+    completion_time: timestamp({ withTimezone: true, mode: "string" }).notNull(),
+    observed_height: integer().notNull(),
+    observed_block_time: timestamp({ withTimezone: true, mode: "string" }).notNull()
+  },
+  table => [
+    primaryKey({
+      columns: [table.provider, table.entry_index],
+      name: "verification_provider_bond_unbonding_identity"
+    }),
+    index("verification_provider_bond_unbonding_completion_time").using("btree", table.completion_time.asc().nullsLast().op("timestamptz_ops")),
+    foreignKey({
+      columns: [table.provider],
+      foreignColumns: [verificationProviderBond.provider],
+      name: "verification_provider_bond_unbonding_bond_fkey"
+    }).onDelete("cascade")
+  ]
+);
+
+export const verificationProviderObservation = pgTable("verification_provider_observation", {
+  provider: varchar({ length: 255 }).primaryKey().notNull(),
+  observed_height: integer().notNull(),
+  observed_block_time: timestamp({ withTimezone: true, mode: "string" }).notNull(),
+  effective_tier: integer().notNull(),
+  max_placement_tier: integer().notNull(),
+  snapshot_state: varchar({ length: 255 }).notNull()
+});
+
+export const verificationProviderTierStream = pgTable("verification_provider_tier_stream", {
+  id: smallint().primaryKey().notNull(),
+  stream_id: uuid()
+    .default(sql`gen_random_uuid()`)
+    .notNull()
+});
+
+export const verificationProviderTierDemotion = pgTable(
+  "verification_provider_tier_demotion",
+  {
+    id: bigserial({ mode: "bigint" }).primaryKey().notNull(),
+    provider: varchar({ length: 255 }).notNull(),
+    previous_effective_tier: integer().notNull(),
+    previous_max_placement_tier: integer().notNull(),
+    previous_snapshot_state: varchar({ length: 255 }).notNull(),
+    current_effective_tier: integer().notNull(),
+    current_max_placement_tier: integer().notNull(),
+    current_snapshot_state: varchar({ length: 255 }).notNull(),
+    changes: varchar({ length: 255 }).array().notNull(),
+    observed_height: integer().notNull(),
+    observed_block_time: timestamp({ withTimezone: true, mode: "string" }).notNull(),
+    created_at: timestamp({ withTimezone: true, mode: "string" }).defaultNow().notNull()
+  },
+  table => [
+    index("verification_provider_tier_demotion_provider_id").using(
+      "btree",
+      table.provider.asc().nullsLast().op("text_ops"),
+      table.id.asc().nullsLast().op("int8_ops")
+    ),
+    index("verification_provider_tier_demotion_observed_height").using("btree", table.observed_height.asc().nullsLast().op("int4_ops"))
+  ]
+);
+
+export const verificationProviderSnapshot = pgTable(
+  "verification_provider_snapshot",
+  {
+    provider: varchar({ length: 255 }).primaryKey().notNull(),
+    snapshot_hash: bytea("snapshot_hash").notNull(),
+    total_gpus: integer().notNull(),
+    total_vcpus: integer().notNull(),
+    total_memory_mb: numeric({ precision: 20, scale: 0 }).notNull(),
+    total_storage_mb: numeric({ precision: 20, scale: 0 }).notNull(),
+    active_leases: integer().notNull(),
+    software_version: varchar({ length: 255 }).notNull(),
+    software_signature: bytea("software_signature"),
+    software_identity_version: varchar({ length: 255 }),
+    software_artifact_ref: text(),
+    software_digest_algorithm: varchar({ length: 255 }),
+    software_digest: bytea("software_digest"),
+    software_signature_type: varchar({ length: 255 }),
+    software_identity_signature: bytea("software_identity_signature"),
+    software_signature_ref: text(),
+    software_public_key_ref: text(),
+    posted_at: timestamp({ withTimezone: true, mode: "string" }).notNull(),
+    snapshot_timestamp: timestamp({ withTimezone: true, mode: "string" }).notNull(),
+    compliance_deadline: timestamp({ withTimezone: true, mode: "string" }).notNull(),
+    suspended: boolean().notNull(),
+    observed_height: integer().notNull(),
+    observed_block_time: timestamp({ withTimezone: true, mode: "string" }).notNull()
+  },
+  table => [
+    index("verification_provider_snapshot_compliance_deadline_suspended").using(
+      "btree",
+      table.compliance_deadline.asc().nullsLast().op("timestamptz_ops"),
+      table.suspended.asc().nullsLast().op("bool_ops")
+    ),
+    index("verification_provider_snapshot_snapshot_timestamp").using("btree", table.snapshot_timestamp.asc().nullsLast().op("timestamptz_ops"))
+  ]
+);
+
+export const providerMaintenance = pgTable(
+  "provider_maintenance",
+  {
+    provider: varchar({ length: 255 }).notNull(),
+    id: numeric({ precision: 20, scale: 0 }).notNull(),
+    maintenance_type: integer().notNull(),
+    starts_at: timestamp({ withTimezone: true, mode: "string" }).notNull(),
+    expected_ends_at: timestamp({ withTimezone: true, mode: "string" }).notNull(),
+    opened_at: timestamp({ withTimezone: true, mode: "string" }).notNull(),
+    closed_at: timestamp({ withTimezone: true, mode: "string" }),
+    metadata_hash: bytea("metadata_hash"),
+    status: integer().notNull(),
+    observed_height: integer().notNull(),
+    observed_block_time: timestamp({ withTimezone: true, mode: "string" }).notNull()
+  },
+  table => [
+    primaryKey({ columns: [table.provider, table.id], name: "provider_maintenance_provider_id" }),
+    index("provider_maintenance_provider_status").using(
+      "btree",
+      table.provider.asc().nullsLast().op("text_ops"),
+      table.status.asc().nullsLast().op("int4_ops")
+    ),
+    index("provider_maintenance_starts_at_expected_ends_at").using(
+      "btree",
+      table.starts_at.asc().nullsLast().op("timestamptz_ops"),
+      table.expected_ends_at.asc().nullsLast().op("timestamptz_ops")
+    )
+  ]
+);
+
+export const verificationParams = pgTable("verification_params", {
+  id: smallint().primaryKey().notNull(),
+  params: jsonb().notNull(),
+  observed_height: integer().notNull(),
+  observed_block_time: timestamp({ withTimezone: true, mode: "string" }).notNull()
+});
+
+export const verificationReconcileTarget = pgTable(
+  "verification_reconcile_target",
+  {
+    target_type: varchar({ length: 255 }).notNull(),
+    target_key: varchar({ length: 255 }).notNull(),
+    requested_height: integer().notNull(),
+    invalidated: boolean().default(true).notNull(),
+    claimed_at: timestamp({ withTimezone: true, mode: "string" }),
+    attempt_count: integer().default(0).notNull(),
+    next_attempt_at: timestamp({ withTimezone: true, mode: "string" }),
+    last_error: text()
+  },
+  table => [
+    primaryKey({
+      columns: [table.target_type, table.target_key],
+      name: "verification_reconcile_target_identity"
+    }),
+    index("verification_reconcile_target_claimed_at_next_attempt_at").using(
+      "btree",
+      table.claimed_at.asc().nullsFirst().op("timestamptz_ops"),
+      table.next_attempt_at.asc().nullsFirst().op("timestamptz_ops")
+    ),
+    index("verification_reconcile_target_requested_height").using("btree", table.requested_height.asc().nullsLast().op("int4_ops"))
+  ]
+);
+
+export const verificationBlockEvent = pgTable(
+  "verification_block_event",
+  {
+    id: uuid()
+      .primaryKey()
+      .notNull()
+      .default(sql`gen_random_uuid()`),
+    height: integer().notNull(),
+    index: integer().notNull(),
+    type: varchar({ length: 255 }).notNull(),
+    data: jsonb().notNull(),
+    is_processed: boolean().default(false).notNull()
+  },
+  table => [
+    uniqueIndex("verification_block_event_height_index").using(
+      "btree",
+      table.height.asc().nullsLast().op("int4_ops"),
+      table.index.asc().nullsLast().op("int4_ops")
+    ),
+    index("verification_block_event_height_is_processed").using(
+      "btree",
+      table.height.asc().nullsLast().op("int4_ops"),
+      table.is_processed.asc().nullsLast().op("bool_ops")
+    ),
+    foreignKey({
+      columns: [table.height],
+      foreignColumns: [block.height],
+      name: "verification_block_event_height_fkey"
+    }).onDelete("cascade")
   ]
 );

--- a/apps/indexer/package.json
+++ b/apps/indexer/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@akashnetwork/akash-api": "1.4.3",
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/database": "*",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/instrumentation": "*",

--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -36,7 +36,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",
     "@akashnetwork/instrumentation": "*",

--- a/apps/notifications/src/modules/chain/providers/registry.provider.ts
+++ b/apps/notifications/src/modules/chain/providers/registry.provider.ts
@@ -12,18 +12,16 @@ import type { Provider } from "@nestjs/common";
 export const RegistryProvider: Provider<Registry> = {
   provide: Registry,
   useFactory: () => {
-    const akashTypes: ReadonlyArray<[string, GeneratedType]> = [
-      ...Object.values(v1),
-      ...Object.values(v1beta4),
-      ...Object.values(v1beta5),
-      ...Object.values(cosmosv1),
-      ...Object.values(cosmosv1beta1),
-      ...Object.values(cosmosv1alpha1),
-      ...Object.values(cosmosv2alpha1)
-    ]
-      .filter(x => "$type" in x)
-      .map(x => ["/" + x.$type, x as unknown as GeneratedType]);
+    const modules: ReadonlyArray<Record<string, unknown>> = [v1, v1beta4, v1beta5, cosmosv1, cosmosv1beta1, cosmosv1alpha1, cosmosv2alpha1];
+    const akashTypes: ReadonlyArray<[string, GeneratedType]> = modules
+      .flatMap(module => Object.values(module))
+      .filter(hasType)
+      .map(type => ["/" + type.$type, type as unknown as GeneratedType]);
 
     return new Registry(akashTypes);
   }
 };
+
+function hasType(value: unknown): value is { $type: string } {
+  return typeof value === "object" && value !== null && "$type" in value && typeof value.$type === "string";
+}

--- a/apps/provider-inventory/package.json
+++ b/apps/provider-inventory/package.json
@@ -24,7 +24,7 @@
     "test:unit": "vitest run --project unit"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/instrumentation": "*",
     "@akashnetwork/logging": "*",

--- a/apps/provider-inventory/src/mappers/groupspec-mapper/groupspec-mapper.ts
+++ b/apps/provider-inventory/src/mappers/groupspec-mapper/groupspec-mapper.ts
@@ -45,4 +45,10 @@ export function getAttributeFingerprint(attributes: ResourceAttribute[] | undefi
     .join(",");
 }
 
-export type GroupSpecJSON = ToJSON<GroupSpec>;
+type GroupSpecRequirementsJSON = ToJSON<NonNullable<GroupSpec["requirements"]>>;
+
+export type GroupSpecJSON = Omit<ToJSON<GroupSpec>, "requirements"> & {
+  requirements: Omit<GroupSpecRequirementsJSON, "verification"> & {
+    verification?: GroupSpecRequirementsJSON["verification"];
+  };
+};

--- a/apps/provider-proxy/package.json
+++ b/apps/provider-proxy/package.json
@@ -20,7 +20,7 @@
     "test:unit": "vitest run --project unit"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/instrumentation": "*",
     "@akashnetwork/logging": "*",

--- a/apps/stats-web/package.json
+++ b/apps/stats-web/package.json
@@ -14,7 +14,7 @@
     "test:unit": "NODE_ENV=test vitest run"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/logging": "*",
     "@akashnetwork/network-store": "*",

--- a/apps/tx-signer/package.json
+++ b/apps/tx-signer/package.json
@@ -21,7 +21,7 @@
     "test:unit": "vitest run --project unit"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",
     "@akashnetwork/instrumentation": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21799,7 +21799,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-8yQrvS6sMpSwIovhPOwfyNf2Wz6v/B62LFSVYQ85+Rq3tLsBIG7rP5geMxaijTUxSkrO6RzN/IRuIAADYQsleA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -44976,7 +44975,8 @@
         "sequelize-typescript": "^2.1.5"
       },
       "devDependencies": {
-        "@akashnetwork/dev-config": "*"
+        "@akashnetwork/dev-config": "*",
+        "vitest": "^4.1.5"
       }
     },
     "packages/dev-config": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akash-api": "1.4.3",
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/console-api-types": "*",
         "@akashnetwork/database": "*",
         "@akashnetwork/env-loader": "*",
@@ -542,7 +542,7 @@
       "version": "3.31.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/console-api-types": "*",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
@@ -2168,7 +2168,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akash-api": "1.4.3",
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/database": "*",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/instrumentation": "*",
@@ -2558,7 +2558,7 @@
       "version": "2.16.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
         "@akashnetwork/instrumentation": "*",
@@ -3701,7 +3701,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/instrumentation": "*",
         "@akashnetwork/logging": "*",
@@ -4041,7 +4041,7 @@
       "version": "2.10.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/instrumentation": "*",
         "@akashnetwork/logging": "*",
@@ -4218,7 +4218,7 @@
       "name": "@akashnetwork/stats-web",
       "version": "1.14.1",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/logging": "*",
         "@akashnetwork/network-store": "*",
@@ -4982,7 +4982,7 @@
       "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
         "@akashnetwork/instrumentation": "*",
@@ -5473,9 +5473,9 @@
       }
     },
     "node_modules/@akashnetwork/chain-sdk": {
-      "version": "1.0.0-alpha.41",
-      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.41.tgz",
-      "integrity": "sha512-mr3fGDBSISxl0eZF83+IJLVulGSuJVu+MRj6fG61pi2rgfgnv9QEKpdU3w7wtFFt5saJaJNgsqAlyjGZQecZ1A==",
+      "version": "1.0.0-alpha.43",
+      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.43.tgz",
+      "integrity": "sha512-+XTgpLn3kibMEWBAOkfmOGo2VJcv+VtT5Uvq966Nk5YMyD9HCYUvdDLm1k167Di1S11t66SH06BhoY1M/m2IWg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.12.0",
@@ -45932,7 +45932,7 @@
       "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/net": "*",
         "jotai": "^2.9.2"
       },

--- a/packages/database/chainDefinitions.spec.ts
+++ b/packages/database/chainDefinitions.spec.ts
@@ -1,0 +1,35 @@
+import { netConfig } from "@akashnetwork/net";
+import { describe, expect, it } from "vitest";
+
+import { chainDefinitions, resolveAkashSandboxChainOverride } from "./chainDefinitions";
+
+describe("Akash sandbox chain definition", () => {
+  it("preserves the standard sandbox configuration by default", () => {
+    expect(chainDefinitions.akashSandbox).toMatchObject({
+      chainId: "sandbox-2",
+      rpcNodes: netConfig.getAllBaseRpcUrls("sandbox"),
+      apiUrl: netConfig.getBaseAPIUrl("sandbox"),
+      genesisFileUrl: `https://raw.githubusercontent.com/akash-network/net/main/${netConfig.mapped("sandbox")}/genesis.json`
+    });
+  });
+
+  it("parses a complete private sandbox configuration", () => {
+    expect(
+      resolveAkashSandboxChainOverride({
+        chainId: "aep-86",
+        rpcUrl: "https://rpc.aep86.example.com",
+        restApiUrl: "https://rest.aep86.example.com",
+        genesisUrl: "https://aep86.example.com/genesis.json"
+      })
+    ).toEqual({
+      chainId: "aep-86",
+      rpcUrl: "https://rpc.aep86.example.com",
+      restApiUrl: "https://rest.aep86.example.com",
+      genesisUrl: "https://aep86.example.com/genesis.json"
+    });
+  });
+
+  it("rejects a partial private sandbox configuration", () => {
+    expect(() => resolveAkashSandboxChainOverride({ chainId: "aep-86" })).toThrow("must be set together");
+  });
+});

--- a/packages/database/chainDefinitions.ts
+++ b/packages/database/chainDefinitions.ts
@@ -16,11 +16,29 @@ import {
   Provider,
   ProviderAttribute,
   ProviderAttributeSignature,
+  ProviderMaintenance,
   ProviderSnapshot,
   ProviderSnapshotNode,
   ProviderSnapshotNodeCPU,
   ProviderSnapshotNodeGPU,
-  ProviderSnapshotStorage
+  ProviderSnapshotStorage,
+  VerificationAttestation,
+  VerificationAttestationCapability,
+  VerificationAuditEscrow,
+  VerificationAuditEscrowCapability,
+  VerificationAuditor,
+  VerificationBlockEvent,
+  VerificationDiscrepancy,
+  VerificationGrace,
+  VerificationGraceDiscrepancy,
+  VerificationParams,
+  VerificationProviderBond,
+  VerificationProviderBondUnbonding,
+  VerificationProviderObservation,
+  VerificationProviderSnapshot,
+  VerificationProviderTierDemotion,
+  VerificationProviderTierStream,
+  VerificationReconcileTarget
 } from "./dbSchemas/akash";
 import type { Block, Message } from "./dbSchemas/base";
 dotenv.config({ path: ".env.local" });
@@ -36,8 +54,10 @@ export const IBC_USDC_DENOMS = [
 ];
 
 export interface ChainDef {
+  chainId: string;
   code: string;
   rpcNodes: string[];
+  apiUrl: string;
   cosmosDirectoryId: string;
   connectionString: string | undefined;
   genesisFileUrl: string;
@@ -54,17 +74,62 @@ export interface ChainDef {
   customModels?: ModelCtor<Model<any, any>>[];
 }
 
+interface AkashSandboxChainOverrideInput {
+  chainId?: string;
+  genesisUrl?: string;
+  restApiUrl?: string;
+  rpcUrl?: string;
+}
+
+export interface AkashSandboxChainOverride {
+  chainId: string;
+  genesisUrl: string;
+  restApiUrl: string;
+  rpcUrl: string;
+}
+
+const AKASH_SANDBOX_OVERRIDE_ENV_NAMES = [
+  "NEXT_PUBLIC_AKASH_SANDBOX_CHAIN_ID",
+  "NEXT_PUBLIC_AKASH_SANDBOX_RPC_URL",
+  "NEXT_PUBLIC_AKASH_SANDBOX_REST_API_URL",
+  "NEXT_PUBLIC_AKASH_SANDBOX_GENESIS_URL"
+] as const;
+
+export function resolveAkashSandboxChainOverride(input: AkashSandboxChainOverrideInput): AkashSandboxChainOverride | undefined {
+  const configuredValues = Object.values(input).filter(value => Boolean(value?.trim()));
+  if (configuredValues.length === 0) return undefined;
+  if (configuredValues.length !== AKASH_SANDBOX_OVERRIDE_ENV_NAMES.length) {
+    throw new Error(`${AKASH_SANDBOX_OVERRIDE_ENV_NAMES.join(", ")} must be set together`);
+  }
+
+  return {
+    chainId: requireValue(input.chainId, AKASH_SANDBOX_OVERRIDE_ENV_NAMES[0]),
+    rpcUrl: requireHttpUrl(input.rpcUrl, AKASH_SANDBOX_OVERRIDE_ENV_NAMES[1]),
+    restApiUrl: requireHttpUrl(input.restApiUrl, AKASH_SANDBOX_OVERRIDE_ENV_NAMES[2]),
+    genesisUrl: requireHttpUrl(input.genesisUrl, AKASH_SANDBOX_OVERRIDE_ENV_NAMES[3])
+  };
+}
+
+const akashSandboxOverride = resolveAkashSandboxChainOverride({
+  chainId: process.env.NEXT_PUBLIC_AKASH_SANDBOX_CHAIN_ID,
+  rpcUrl: process.env.NEXT_PUBLIC_AKASH_SANDBOX_RPC_URL,
+  restApiUrl: process.env.NEXT_PUBLIC_AKASH_SANDBOX_REST_API_URL,
+  genesisUrl: process.env.NEXT_PUBLIC_AKASH_SANDBOX_GENESIS_URL
+});
+
 export const chainDefinitions: { [key: string]: ChainDef } = {
   akash: {
+    chainId: "akashnet-2",
     code: "akash",
     rpcNodes: netConfig.getAllBaseRpcUrls("mainnet"),
+    apiUrl: netConfig.getBaseAPIUrl("mainnet"),
     cosmosDirectoryId: "akash",
     connectionString: process.env.AKASH_DATABASE_CS,
     genesisFileUrl: `https://raw.githubusercontent.com/akash-network/net/main/${netConfig.mapped("mainnet")}/genesis.json`,
     coinGeckoId: "akash-network",
     logoUrlSVG: "https://raw.githubusercontent.com/cosmos/chain-registry/master/akash/images/akt.svg",
     logoUrlPNG: "https://console.akash.network/images/chains/akash.png",
-    customIndexers: ["AkashStatsIndexer", "BmeIndexer"],
+    customIndexers: ["AkashStatsIndexer", "BmeIndexer", "ProviderVerificationIndexer"],
     bech32Prefix: "akash",
     denom: "akt",
     udenom: "uakt",
@@ -81,6 +146,7 @@ export const chainDefinitions: { [key: string]: ChainDef } = {
       Provider,
       ProviderAttribute,
       ProviderAttributeSignature,
+      ProviderMaintenance,
       ProviderSnapshot,
       ProviderSnapshotNode,
       ProviderSnapshotNodeCPU,
@@ -88,20 +154,39 @@ export const chainDefinitions: { [key: string]: ChainDef } = {
       ProviderSnapshotStorage,
       BmeLedgerRecord,
       BmeRawEvent,
-      BmeStatusChange
+      BmeStatusChange,
+      VerificationAttestation,
+      VerificationAttestationCapability,
+      VerificationAuditEscrow,
+      VerificationAuditEscrowCapability,
+      VerificationAuditor,
+      VerificationBlockEvent,
+      VerificationDiscrepancy,
+      VerificationGrace,
+      VerificationGraceDiscrepancy,
+      VerificationParams,
+      VerificationProviderBond,
+      VerificationProviderBondUnbonding,
+      VerificationProviderObservation,
+      VerificationProviderSnapshot,
+      VerificationProviderTierDemotion,
+      VerificationProviderTierStream,
+      VerificationReconcileTarget
     ]
   },
   get akashTestnet() {
     return {
+      chainId: "testnet-8",
       code: "akash-testnet",
       rpcNodes: netConfig.getAllBaseRpcUrls("testnet"),
+      apiUrl: netConfig.getBaseAPIUrl("testnet"),
       cosmosDirectoryId: "akash",
       connectionString: process.env.AKASH_TESTNET_DATABASE_CS,
       genesisFileUrl: `https://raw.githubusercontent.com/akash-network/net/main/${netConfig.mapped("testnet")}/genesis.json`,
       coinGeckoId: "akash-network",
       logoUrlSVG: "https://raw.githubusercontent.com/cosmos/chain-registry/master/akash/images/akt.svg",
       logoUrlPNG: "https://console.akash.network/images/chains/akash.png",
-      customIndexers: ["AkashStatsIndexer", "BmeIndexer"],
+      customIndexers: ["AkashStatsIndexer", "BmeIndexer", "ProviderVerificationIndexer"],
       bech32Prefix: "akash",
       denom: "act",
       udenom: "uact",
@@ -118,6 +203,7 @@ export const chainDefinitions: { [key: string]: ChainDef } = {
         Provider,
         ProviderAttribute,
         ProviderAttributeSignature,
+        ProviderMaintenance,
         ProviderSnapshot,
         ProviderSnapshotNode,
         ProviderSnapshotNodeCPU,
@@ -125,20 +211,39 @@ export const chainDefinitions: { [key: string]: ChainDef } = {
         ProviderSnapshotStorage,
         BmeLedgerRecord,
         BmeRawEvent,
-        BmeStatusChange
+        BmeStatusChange,
+        VerificationAttestation,
+        VerificationAttestationCapability,
+        VerificationAuditEscrow,
+        VerificationAuditEscrowCapability,
+        VerificationAuditor,
+        VerificationBlockEvent,
+        VerificationDiscrepancy,
+        VerificationGrace,
+        VerificationGraceDiscrepancy,
+        VerificationParams,
+        VerificationProviderBond,
+        VerificationProviderBondUnbonding,
+        VerificationProviderObservation,
+        VerificationProviderSnapshot,
+        VerificationProviderTierDemotion,
+        VerificationProviderTierStream,
+        VerificationReconcileTarget
       ]
     };
   },
   akashSandbox: {
+    chainId: akashSandboxOverride?.chainId ?? "sandbox-2",
     code: "akash-sandbox",
-    rpcNodes: netConfig.getAllBaseRpcUrls("sandbox"),
+    rpcNodes: akashSandboxOverride ? [akashSandboxOverride.rpcUrl] : netConfig.getAllBaseRpcUrls("sandbox"),
+    apiUrl: akashSandboxOverride?.restApiUrl ?? netConfig.getBaseAPIUrl("sandbox"),
     cosmosDirectoryId: "akash",
     connectionString: process.env.AKASH_SANDBOX_DATABASE_CS,
-    genesisFileUrl: `https://raw.githubusercontent.com/akash-network/net/main/${netConfig.mapped("sandbox")}/genesis.json`,
+    genesisFileUrl: akashSandboxOverride?.genesisUrl ?? `https://raw.githubusercontent.com/akash-network/net/main/${netConfig.mapped("sandbox")}/genesis.json`,
     coinGeckoId: "akash-network",
     logoUrlSVG: "https://raw.githubusercontent.com/cosmos/chain-registry/master/akash/images/akt.svg",
     logoUrlPNG: "https://console.akash.network/images/chains/akash.png",
-    customIndexers: ["AkashStatsIndexer", "BmeIndexer"],
+    customIndexers: ["AkashStatsIndexer", "BmeIndexer", "ProviderVerificationIndexer"],
     bech32Prefix: "akash",
     denom: "akt",
     udenom: "uakt",
@@ -155,6 +260,7 @@ export const chainDefinitions: { [key: string]: ChainDef } = {
       Provider,
       ProviderAttribute,
       ProviderAttributeSignature,
+      ProviderMaintenance,
       ProviderSnapshot,
       ProviderSnapshotNode,
       ProviderSnapshotNodeCPU,
@@ -162,9 +268,39 @@ export const chainDefinitions: { [key: string]: ChainDef } = {
       ProviderSnapshotStorage,
       BmeLedgerRecord,
       BmeRawEvent,
-      BmeStatusChange
+      BmeStatusChange,
+      VerificationAttestation,
+      VerificationAttestationCapability,
+      VerificationAuditEscrow,
+      VerificationAuditEscrowCapability,
+      VerificationAuditor,
+      VerificationBlockEvent,
+      VerificationDiscrepancy,
+      VerificationGrace,
+      VerificationGraceDiscrepancy,
+      VerificationParams,
+      VerificationProviderBond,
+      VerificationProviderBondUnbonding,
+      VerificationProviderObservation,
+      VerificationProviderSnapshot,
+      VerificationProviderTierDemotion,
+      VerificationProviderTierStream,
+      VerificationReconcileTarget
     ]
   }
 };
 
 export const activeChain = chainDefinitions[process.env.ACTIVE_CHAIN || "akash"];
+
+function requireValue(value: string | undefined, name: string): string {
+  const trimmedValue = value?.trim();
+  if (!trimmedValue) throw new Error(`${name} must not be empty`);
+  return trimmedValue;
+}
+
+function requireHttpUrl(value: string | undefined, name: string): string {
+  const url = requireValue(value, name);
+  const protocol = new URL(url).protocol;
+  if (protocol !== "http:" && protocol !== "https:") throw new Error(`${name} must use http or https`);
+  return url;
+}

--- a/packages/database/dbSchemas/akash/index.ts
+++ b/packages/database/dbSchemas/akash/index.ts
@@ -14,6 +14,24 @@ export { Bid } from "./bid";
 export { BmeLedgerRecord } from "./bmeLedgerRecord";
 export { BmeRawEvent } from "./bmeRawEvent";
 export { BmeStatusChange } from "./bmeStatusChange";
+export { ProviderMaintenance } from "./providerMaintenance";
+export { VerificationAttestation } from "./verificationAttestation";
+export { VerificationAttestationCapability } from "./verificationAttestationCapability";
+export { VerificationAuditEscrow } from "./verificationAuditEscrow";
+export { VerificationAuditEscrowCapability } from "./verificationAuditEscrowCapability";
+export { VerificationAuditor } from "./verificationAuditor";
+export { VerificationBlockEvent } from "./verificationBlockEvent";
+export { VerificationDiscrepancy } from "./verificationDiscrepancy";
+export { VerificationGrace } from "./verificationGrace";
+export { VerificationGraceDiscrepancy } from "./verificationGraceDiscrepancy";
+export { VerificationParams } from "./verificationParams";
+export { VerificationProviderBond } from "./verificationProviderBond";
+export { VerificationProviderBondUnbonding } from "./verificationProviderBondUnbonding";
+export { VerificationProviderObservation } from "./verificationProviderObservation";
+export { VerificationProviderSnapshot } from "./verificationProviderSnapshot";
+export { VerificationProviderTierDemotion } from "./verificationProviderTierDemotion";
+export { VerificationProviderTierStream } from "./verificationProviderTierStream";
+export { VerificationReconcileTarget } from "./verificationReconcileTarget";
 
 // Overrides
 export { AkashBlock } from "./akashBlock";

--- a/packages/database/dbSchemas/akash/provider.ts
+++ b/packages/database/dbSchemas/akash/provider.ts
@@ -1,11 +1,19 @@
 import { DataTypes } from "sequelize";
-import { BelongsTo, Column, Default, HasMany, Model, PrimaryKey, Table } from "sequelize-typescript";
+import { BelongsTo, Column, Default, HasMany, HasOne, Model, PrimaryKey, Table } from "sequelize-typescript";
 
 import { Required } from "../decorators/requiredDecorator";
 import { AkashBlock } from "./akashBlock";
 import { ProviderAttribute } from "./providerAttribute";
 import { ProviderAttributeSignature } from "./providerAttributeSignature";
+import { ProviderMaintenance } from "./providerMaintenance"; // eslint-disable-line import-x/no-cycle
 import { ProviderSnapshot } from "./providerSnapshot";
+import { VerificationAttestation } from "./verificationAttestation"; // eslint-disable-line import-x/no-cycle
+import { VerificationAuditEscrow } from "./verificationAuditEscrow"; // eslint-disable-line import-x/no-cycle
+import { VerificationDiscrepancy } from "./verificationDiscrepancy"; // eslint-disable-line import-x/no-cycle
+import { VerificationGrace } from "./verificationGrace"; // eslint-disable-line import-x/no-cycle
+import { VerificationProviderBond } from "./verificationProviderBond"; // eslint-disable-line import-x/no-cycle
+import { VerificationProviderObservation } from "./verificationProviderObservation"; // eslint-disable-line import-x/no-cycle
+import { VerificationProviderSnapshot } from "./verificationProviderSnapshot"; // eslint-disable-line import-x/no-cycle
 
 /**
  * Provider model for Akash
@@ -147,6 +155,14 @@ export class Provider extends Model {
    * The provider snapshots associated with the provider
    */
   @HasMany(() => ProviderSnapshot, "owner") providerSnapshots!: ProviderSnapshot[];
+  @HasMany(() => VerificationAttestation, { foreignKey: "provider", constraints: false }) verificationAttestations!: VerificationAttestation[];
+  @HasMany(() => VerificationAuditEscrow, { foreignKey: "provider", constraints: false }) verificationAuditEscrows!: VerificationAuditEscrow[];
+  @HasMany(() => VerificationDiscrepancy, { foreignKey: "provider", constraints: false }) verificationDiscrepancies!: VerificationDiscrepancy[];
+  @HasMany(() => VerificationGrace, { foreignKey: "provider", constraints: false }) verificationGraceRecords!: VerificationGrace[];
+  @HasMany(() => ProviderMaintenance, { foreignKey: "provider", constraints: false }) maintenanceRecords!: ProviderMaintenance[];
+  @HasOne(() => VerificationProviderBond, { foreignKey: "provider", constraints: false }) verificationBond?: VerificationProviderBond;
+  @HasOne(() => VerificationProviderObservation, { foreignKey: "provider", constraints: false }) verificationObservation?: VerificationProviderObservation;
+  @HasOne(() => VerificationProviderSnapshot, { foreignKey: "provider", constraints: false }) verificationSnapshot?: VerificationProviderSnapshot;
   /**
    * The block at which the provider was created
    */

--- a/packages/database/dbSchemas/akash/providerMaintenance.ts
+++ b/packages/database/dbSchemas/akash/providerMaintenance.ts
@@ -1,0 +1,26 @@
+import { DataTypes } from "sequelize";
+import { BelongsTo, Column, Model, PrimaryKey, Table } from "sequelize-typescript";
+
+import { Required } from "../decorators/requiredDecorator";
+import { Provider } from "./provider"; // eslint-disable-line import-x/no-cycle
+
+@Table({
+  tableName: "provider_maintenance",
+  underscored: true,
+  indexes: [{ fields: ["provider", "status"] }, { fields: ["starts_at", "expected_ends_at"] }]
+})
+export class ProviderMaintenance extends Model {
+  @Required @PrimaryKey @Column provider!: string;
+  @Required @PrimaryKey @Column(DataTypes.DECIMAL(20, 0)) id!: string;
+  @Required @Column maintenanceType!: number;
+  @Required @Column(DataTypes.DATE) startsAt!: Date;
+  @Required @Column(DataTypes.DATE) expectedEndsAt!: Date;
+  @Required @Column(DataTypes.DATE) openedAt!: Date;
+  @Column(DataTypes.DATE) closedAt?: Date;
+  @Column(DataTypes.BLOB) metadataHash?: Buffer;
+  @Required @Column status!: number;
+  @Required @Column observedHeight!: number;
+  @Required @Column(DataTypes.DATE) observedBlockTime!: Date;
+
+  @BelongsTo(() => Provider, { foreignKey: "provider", targetKey: "owner", constraints: false }) providerRecord!: Provider;
+}

--- a/packages/database/dbSchemas/akash/verificationAttestation.ts
+++ b/packages/database/dbSchemas/akash/verificationAttestation.ts
@@ -1,0 +1,35 @@
+import { DataTypes } from "sequelize";
+import { BelongsTo, Column, Model, PrimaryKey, Table } from "sequelize-typescript";
+
+import { Required } from "../decorators/requiredDecorator";
+import { Provider } from "./provider"; // eslint-disable-line import-x/no-cycle
+import { VerificationAuditor } from "./verificationAuditor"; // eslint-disable-line import-x/no-cycle
+
+@Table({
+  tableName: "verification_attestation",
+  underscored: true,
+  indexes: [{ fields: ["provider", "status", "tier"] }, { fields: ["expires_at", "status"] }, { fields: ["audit_escrow_id"] }]
+})
+export class VerificationAttestation extends Model {
+  @Required @PrimaryKey @Column provider!: string;
+  @Required @PrimaryKey @Column auditor!: string;
+  @Required @Column tier!: number;
+  @Required @Column(DataTypes.BLOB) evidenceHash!: Buffer;
+  @Required @Column feeDenom!: string;
+  @Required @Column(DataTypes.DECIMAL(30, 0)) feeAmount!: string;
+  @Required @Column feeStatus!: number;
+  @Required @Column(DataTypes.DATE) createdAt!: Date;
+  @Required @Column(DataTypes.DATE) expiresAt!: Date;
+  @Required @Column status!: number;
+  @Required @Column voidedReason!: number;
+  @Required @Column depositDenom!: string;
+  @Required @Column(DataTypes.DECIMAL(30, 0)) depositAmount!: string;
+  @Required @Column depositStatus!: number;
+  @Required @Column(DataTypes.DECIMAL(20, 0)) auditEscrowId!: string;
+  @Required @Column faultAttribution!: number;
+  @Required @Column observedHeight!: number;
+  @Required @Column(DataTypes.DATE) observedBlockTime!: Date;
+
+  @BelongsTo(() => Provider, { foreignKey: "provider", targetKey: "owner", constraints: false }) providerRecord!: Provider;
+  @BelongsTo(() => VerificationAuditor, { foreignKey: "auditor", targetKey: "address", constraints: false }) auditorRecord!: VerificationAuditor;
+}

--- a/packages/database/dbSchemas/akash/verificationAttestationCapability.ts
+++ b/packages/database/dbSchemas/akash/verificationAttestationCapability.ts
@@ -1,0 +1,17 @@
+import { DataTypes } from "sequelize";
+import { Column, Model, PrimaryKey, Table } from "sequelize-typescript";
+
+import { Required } from "../decorators/requiredDecorator";
+
+@Table({
+  tableName: "verification_attestation_capability",
+  underscored: true,
+  indexes: [{ fields: ["capability", "provider"] }]
+})
+export class VerificationAttestationCapability extends Model {
+  @Required @PrimaryKey @Column provider!: string;
+  @Required @PrimaryKey @Column auditor!: string;
+  @Required @PrimaryKey @Column capability!: number;
+  @Required @Column observedHeight!: number;
+  @Required @Column(DataTypes.DATE) observedBlockTime!: Date;
+}

--- a/packages/database/dbSchemas/akash/verificationAuditEscrow.ts
+++ b/packages/database/dbSchemas/akash/verificationAuditEscrow.ts
@@ -1,0 +1,36 @@
+import { DataTypes } from "sequelize";
+import { BelongsTo, Column, HasMany, Model, PrimaryKey, Table } from "sequelize-typescript";
+
+import { Required } from "../decorators/requiredDecorator";
+import { Provider } from "./provider"; // eslint-disable-line import-x/no-cycle
+import { VerificationAuditEscrowCapability } from "./verificationAuditEscrowCapability"; // eslint-disable-line import-x/no-cycle
+
+@Table({
+  tableName: "verification_audit_escrow",
+  underscored: true,
+  indexes: [{ fields: ["provider", "status"] }, { fields: ["expires_at", "status"] }]
+})
+export class VerificationAuditEscrow extends Model {
+  @Required @PrimaryKey @Column(DataTypes.DECIMAL(20, 0)) id!: string;
+  @Required @Column provider!: string;
+  @Required @Column consumedByAuditor!: string;
+  @Required @Column requestedTier!: number;
+  @Required @Column feeDenom!: string;
+  @Required @Column(DataTypes.DECIMAL(30, 0)) feeAmount!: string;
+  @Required @Column feeStatus!: number;
+  @Required @Column providerDepositDenom!: string;
+  @Required @Column(DataTypes.DECIMAL(30, 0)) providerDepositAmount!: string;
+  @Required @Column providerDepositStatus!: number;
+  @Required @Column status!: number;
+  @Required @Column(DataTypes.DATE) openedAt!: Date;
+  @Column(DataTypes.DATE) consumedAt?: Date;
+  @Required @Column(DataTypes.DATE) expiresAt!: Date;
+  @Column(DataTypes.BLOB) metadataHash?: Buffer;
+  @Required @Column settlementReason!: number;
+  @Required @Column faultAttribution!: number;
+  @Required @Column observedHeight!: number;
+  @Required @Column(DataTypes.DATE) observedBlockTime!: Date;
+
+  @BelongsTo(() => Provider, { foreignKey: "provider", targetKey: "owner", constraints: false }) providerRecord!: Provider;
+  @HasMany(() => VerificationAuditEscrowCapability, "auditEscrowId") capabilities!: VerificationAuditEscrowCapability[];
+}

--- a/packages/database/dbSchemas/akash/verificationAuditEscrowCapability.ts
+++ b/packages/database/dbSchemas/akash/verificationAuditEscrowCapability.ts
@@ -1,0 +1,19 @@
+import { DataTypes } from "sequelize";
+import { BelongsTo, Column, Model, PrimaryKey, Table } from "sequelize-typescript";
+
+import { Required } from "../decorators/requiredDecorator";
+import { VerificationAuditEscrow } from "./verificationAuditEscrow"; // eslint-disable-line import-x/no-cycle
+
+@Table({
+  tableName: "verification_audit_escrow_capability",
+  underscored: true,
+  indexes: [{ fields: ["capability"] }]
+})
+export class VerificationAuditEscrowCapability extends Model {
+  @Required @PrimaryKey @Column(DataTypes.DECIMAL(20, 0)) auditEscrowId!: string;
+  @Required @PrimaryKey @Column capability!: number;
+  @Required @Column observedHeight!: number;
+  @Required @Column(DataTypes.DATE) observedBlockTime!: Date;
+
+  @BelongsTo(() => VerificationAuditEscrow, "auditEscrowId") auditEscrow!: VerificationAuditEscrow;
+}

--- a/packages/database/dbSchemas/akash/verificationAuditor.ts
+++ b/packages/database/dbSchemas/akash/verificationAuditor.ts
@@ -1,0 +1,28 @@
+import { DataTypes } from "sequelize";
+import { Column, HasMany, Model, PrimaryKey, Table } from "sequelize-typescript";
+
+import { Required } from "../decorators/requiredDecorator";
+import { VerificationAttestation } from "./verificationAttestation"; // eslint-disable-line import-x/no-cycle
+
+@Table({
+  tableName: "verification_auditor",
+  underscored: true,
+  indexes: [{ fields: ["status"] }, { fields: ["renewal_deadline"] }]
+})
+export class VerificationAuditor extends Model {
+  @Required @PrimaryKey @Column address!: string;
+  @Required @Column status!: number;
+  @Required @Column maxAttestationTier!: number;
+  @Required @Column bondDenom!: string;
+  @Required @Column(DataTypes.DECIMAL(30, 0)) bondAmount!: string;
+  @Required @Column bondStatus!: number;
+  @Column(DataTypes.BLOB) metadataHash?: Buffer;
+  @Required @Column(DataTypes.DATE) registeredAt!: Date;
+  @Required @Column(DataTypes.DATE) renewalDeadline!: Date;
+  @Required @Column(DataTypes.DECIMAL(20, 0)) discrepancyCount!: string;
+  @Column(DataTypes.DATE) bondUnbondingCompletionTime?: Date;
+  @Required @Column observedHeight!: number;
+  @Required @Column(DataTypes.DATE) observedBlockTime!: Date;
+
+  @HasMany(() => VerificationAttestation, { foreignKey: "auditor", constraints: false }) attestations!: VerificationAttestation[];
+}

--- a/packages/database/dbSchemas/akash/verificationBlockEvent.ts
+++ b/packages/database/dbSchemas/akash/verificationBlockEvent.ts
@@ -1,0 +1,21 @@
+import { DataTypes, UUIDV4 } from "sequelize";
+import { BelongsTo, Column, Default, Model, PrimaryKey, Table } from "sequelize-typescript";
+
+import { Block } from "../base/block";
+import { Required } from "../decorators/requiredDecorator";
+
+/** Durable staging for verification invalidation signals from finalize_block_events. */
+@Table({
+  tableName: "verification_block_event",
+  underscored: true,
+  indexes: [{ unique: true, fields: ["height", "index"] }, { fields: ["height", "is_processed"] }]
+})
+export class VerificationBlockEvent extends Model {
+  @Required @PrimaryKey @Default(UUIDV4) @Column(DataTypes.UUID) id!: string;
+  @Required @Column height!: number;
+  @BelongsTo(() => Block, "height") block!: Block;
+  @Required @Column index!: number;
+  @Required @Column type!: string;
+  @Required @Column(DataTypes.JSONB) data!: Record<string, string | null>;
+  @Required @Default(false) @Column isProcessed!: boolean;
+}

--- a/packages/database/dbSchemas/akash/verificationDiscrepancy.ts
+++ b/packages/database/dbSchemas/akash/verificationDiscrepancy.ts
@@ -1,0 +1,30 @@
+import { DataTypes } from "sequelize";
+import { BelongsTo, Column, Model, PrimaryKey, Table } from "sequelize-typescript";
+
+import { Required } from "../decorators/requiredDecorator";
+import { Provider } from "./provider"; // eslint-disable-line import-x/no-cycle
+
+@Table({
+  tableName: "verification_discrepancy",
+  underscored: true,
+  indexes: [{ fields: ["provider", "resolution_status"] }, { fields: ["auditor_a"] }, { fields: ["auditor_b"] }]
+})
+export class VerificationDiscrepancy extends Model {
+  @Required @PrimaryKey @Column(DataTypes.DECIMAL(20, 0)) id!: string;
+  @Required @Column provider!: string;
+  @Required @Column auditorA!: string;
+  @Required @Column auditorATier!: number;
+  @Required @Column auditorB!: string;
+  @Required @Column auditorBTier!: number;
+  @Required @Column(DataTypes.DATE) detectedAt!: Date;
+  @Required @Column resolutionStatus!: number;
+  @Required @Column(DataTypes.DECIMAL(20, 0)) resolutionProposalId!: string;
+  @Required @Column(DataTypes.DECIMAL(20, 0)) graceRecordId!: string;
+  @Required @Column resolutionReason!: number;
+  @Required @Column faultAttribution!: number;
+  @Column(DataTypes.BLOB) resolutionEvidenceHash?: Buffer;
+  @Required @Column observedHeight!: number;
+  @Required @Column(DataTypes.DATE) observedBlockTime!: Date;
+
+  @BelongsTo(() => Provider, { foreignKey: "provider", targetKey: "owner", constraints: false }) providerRecord!: Provider;
+}

--- a/packages/database/dbSchemas/akash/verificationGrace.ts
+++ b/packages/database/dbSchemas/akash/verificationGrace.ts
@@ -1,0 +1,25 @@
+import { DataTypes } from "sequelize";
+import { BelongsTo, Column, HasMany, Model, PrimaryKey, Table } from "sequelize-typescript";
+
+import { Required } from "../decorators/requiredDecorator";
+import { Provider } from "./provider"; // eslint-disable-line import-x/no-cycle
+import { VerificationGraceDiscrepancy } from "./verificationGraceDiscrepancy"; // eslint-disable-line import-x/no-cycle
+
+@Table({
+  tableName: "verification_grace",
+  underscored: true,
+  indexes: [{ fields: ["provider", "status"] }, { fields: ["expires_at", "status"] }]
+})
+export class VerificationGrace extends Model {
+  @Required @PrimaryKey @Column(DataTypes.DECIMAL(20, 0)) id!: string;
+  @Required @Column provider!: string;
+  @Required @Column preservedTier!: number;
+  @Required @Column(DataTypes.DATE) startedAt!: Date;
+  @Required @Column(DataTypes.DATE) expiresAt!: Date;
+  @Required @Column status!: number;
+  @Required @Column observedHeight!: number;
+  @Required @Column(DataTypes.DATE) observedBlockTime!: Date;
+
+  @BelongsTo(() => Provider, { foreignKey: "provider", targetKey: "owner", constraints: false }) providerRecord!: Provider;
+  @HasMany(() => VerificationGraceDiscrepancy, "graceId") sourceDiscrepancies!: VerificationGraceDiscrepancy[];
+}

--- a/packages/database/dbSchemas/akash/verificationGraceDiscrepancy.ts
+++ b/packages/database/dbSchemas/akash/verificationGraceDiscrepancy.ts
@@ -1,0 +1,21 @@
+import { DataTypes } from "sequelize";
+import { BelongsTo, Column, Model, PrimaryKey, Table } from "sequelize-typescript";
+
+import { Required } from "../decorators/requiredDecorator";
+import { VerificationDiscrepancy } from "./verificationDiscrepancy"; // eslint-disable-line import-x/no-cycle
+import { VerificationGrace } from "./verificationGrace";
+
+@Table({
+  tableName: "verification_grace_discrepancy",
+  underscored: true,
+  indexes: [{ fields: ["discrepancy_id"] }]
+})
+export class VerificationGraceDiscrepancy extends Model {
+  @Required @PrimaryKey @Column(DataTypes.DECIMAL(20, 0)) graceId!: string;
+  @Required @PrimaryKey @Column(DataTypes.DECIMAL(20, 0)) discrepancyId!: string;
+  @Required @Column observedHeight!: number;
+  @Required @Column(DataTypes.DATE) observedBlockTime!: Date;
+
+  @BelongsTo(() => VerificationGrace, "graceId") grace!: VerificationGrace;
+  @BelongsTo(() => VerificationDiscrepancy, "discrepancyId") discrepancy!: VerificationDiscrepancy;
+}

--- a/packages/database/dbSchemas/akash/verificationParams.ts
+++ b/packages/database/dbSchemas/akash/verificationParams.ts
@@ -1,0 +1,15 @@
+import { DataTypes } from "sequelize";
+import { Column, Model, PrimaryKey, Table } from "sequelize-typescript";
+
+import { Required } from "../decorators/requiredDecorator";
+
+@Table({
+  tableName: "verification_params",
+  underscored: true
+})
+export class VerificationParams extends Model {
+  @Required @PrimaryKey @Column(DataTypes.SMALLINT) id!: number;
+  @Required @Column(DataTypes.JSONB) params!: Record<string, unknown>;
+  @Required @Column observedHeight!: number;
+  @Required @Column(DataTypes.DATE) observedBlockTime!: Date;
+}

--- a/packages/database/dbSchemas/akash/verificationProviderBond.ts
+++ b/packages/database/dbSchemas/akash/verificationProviderBond.ts
@@ -1,0 +1,25 @@
+import { DataTypes } from "sequelize";
+import { BelongsTo, Column, HasMany, Model, PrimaryKey, Table } from "sequelize-typescript";
+
+import { Required } from "../decorators/requiredDecorator";
+import { Provider } from "./provider"; // eslint-disable-line import-x/no-cycle
+import { VerificationProviderBondUnbonding } from "./verificationProviderBondUnbonding"; // eslint-disable-line import-x/no-cycle
+
+@Table({
+  tableName: "verification_provider_bond",
+  underscored: true
+})
+export class VerificationProviderBond extends Model {
+  @Required @PrimaryKey @Column provider!: string;
+  @Required @Column bondedDenom!: string;
+  @Required @Column(DataTypes.DECIMAL(30, 0)) bondedAmount!: string;
+  @Required @Column requiredForCurrentTierDenom!: string;
+  @Required @Column(DataTypes.DECIMAL(30, 0)) requiredForCurrentTierAmount!: string;
+  @Required @Column slashed!: boolean;
+  @Column(DataTypes.DATE) lastSlashTime?: Date;
+  @Required @Column observedHeight!: number;
+  @Required @Column(DataTypes.DATE) observedBlockTime!: Date;
+
+  @BelongsTo(() => Provider, { foreignKey: "provider", targetKey: "owner", constraints: false }) providerRecord!: Provider;
+  @HasMany(() => VerificationProviderBondUnbonding, "provider") unbondingEntries!: VerificationProviderBondUnbonding[];
+}

--- a/packages/database/dbSchemas/akash/verificationProviderBondUnbonding.ts
+++ b/packages/database/dbSchemas/akash/verificationProviderBondUnbonding.ts
@@ -1,0 +1,22 @@
+import { DataTypes } from "sequelize";
+import { BelongsTo, Column, Model, PrimaryKey, Table } from "sequelize-typescript";
+
+import { Required } from "../decorators/requiredDecorator";
+import { VerificationProviderBond } from "./verificationProviderBond"; // eslint-disable-line import-x/no-cycle
+
+@Table({
+  tableName: "verification_provider_bond_unbonding",
+  underscored: true,
+  indexes: [{ fields: ["completion_time"] }]
+})
+export class VerificationProviderBondUnbonding extends Model {
+  @Required @PrimaryKey @Column provider!: string;
+  @Required @PrimaryKey @Column entryIndex!: number;
+  @Required @Column denom!: string;
+  @Required @Column(DataTypes.DECIMAL(30, 0)) amount!: string;
+  @Required @Column(DataTypes.DATE) completionTime!: Date;
+  @Required @Column observedHeight!: number;
+  @Required @Column(DataTypes.DATE) observedBlockTime!: Date;
+
+  @BelongsTo(() => VerificationProviderBond, "provider") providerBond!: VerificationProviderBond;
+}

--- a/packages/database/dbSchemas/akash/verificationProviderObservation.ts
+++ b/packages/database/dbSchemas/akash/verificationProviderObservation.ts
@@ -1,0 +1,20 @@
+import { DataTypes } from "sequelize";
+import { BelongsTo, Column, Model, PrimaryKey, Table } from "sequelize-typescript";
+
+import { Required } from "../decorators/requiredDecorator";
+import { Provider } from "./provider"; // eslint-disable-line import-x/no-cycle
+
+@Table({
+  tableName: "verification_provider_observation",
+  underscored: true
+})
+export class VerificationProviderObservation extends Model {
+  @Required @PrimaryKey @Column provider!: string;
+  @Required @Column observedHeight!: number;
+  @Required @Column(DataTypes.DATE) observedBlockTime!: Date;
+  @Required @Column effectiveTier!: number;
+  @Required @Column maxPlacementTier!: number;
+  @Required @Column snapshotState!: string;
+
+  @BelongsTo(() => Provider, { foreignKey: "provider", targetKey: "owner", constraints: false }) providerRecord!: Provider;
+}

--- a/packages/database/dbSchemas/akash/verificationProviderSnapshot.ts
+++ b/packages/database/dbSchemas/akash/verificationProviderSnapshot.ts
@@ -1,0 +1,38 @@
+import { DataTypes } from "sequelize";
+import { BelongsTo, Column, Model, PrimaryKey, Table } from "sequelize-typescript";
+
+import { Required } from "../decorators/requiredDecorator";
+import { Provider } from "./provider"; // eslint-disable-line import-x/no-cycle
+
+@Table({
+  tableName: "verification_provider_snapshot",
+  underscored: true,
+  indexes: [{ fields: ["compliance_deadline", "suspended"] }, { fields: ["snapshot_timestamp"] }]
+})
+export class VerificationProviderSnapshot extends Model {
+  @Required @PrimaryKey @Column provider!: string;
+  @Required @Column(DataTypes.BLOB) snapshotHash!: Buffer;
+  @Required @Column totalGpus!: number;
+  @Required @Column totalVcpus!: number;
+  @Required @Column(DataTypes.DECIMAL(20, 0)) totalMemoryMb!: string;
+  @Required @Column(DataTypes.DECIMAL(20, 0)) totalStorageMb!: string;
+  @Required @Column activeLeases!: number;
+  @Required @Column softwareVersion!: string;
+  @Column(DataTypes.BLOB) softwareSignature?: Buffer;
+  @Column softwareIdentityVersion?: string;
+  @Column softwareArtifactRef?: string;
+  @Column softwareDigestAlgorithm?: string;
+  @Column(DataTypes.BLOB) softwareDigest?: Buffer;
+  @Column softwareSignatureType?: string;
+  @Column(DataTypes.BLOB) softwareIdentitySignature?: Buffer;
+  @Column softwareSignatureRef?: string;
+  @Column softwarePublicKeyRef?: string;
+  @Required @Column(DataTypes.DATE) postedAt!: Date;
+  @Required @Column(DataTypes.DATE) snapshotTimestamp!: Date;
+  @Required @Column(DataTypes.DATE) complianceDeadline!: Date;
+  @Required @Column suspended!: boolean;
+  @Required @Column observedHeight!: number;
+  @Required @Column(DataTypes.DATE) observedBlockTime!: Date;
+
+  @BelongsTo(() => Provider, { foreignKey: "provider", targetKey: "owner", constraints: false }) providerRecord!: Provider;
+}

--- a/packages/database/dbSchemas/akash/verificationProviderTierDemotion.ts
+++ b/packages/database/dbSchemas/akash/verificationProviderTierDemotion.ts
@@ -1,0 +1,27 @@
+import { DataTypes } from "sequelize";
+import { AutoIncrement, BelongsTo, Column, Default, Model, PrimaryKey, Table } from "sequelize-typescript";
+
+import { Required } from "../decorators/requiredDecorator";
+import { Provider } from "./provider";
+
+@Table({
+  tableName: "verification_provider_tier_demotion",
+  underscored: true,
+  indexes: [{ fields: ["provider", "id"] }, { fields: ["observed_height"] }]
+})
+export class VerificationProviderTierDemotion extends Model {
+  @Required @AutoIncrement @PrimaryKey @Column(DataTypes.BIGINT) id!: string;
+  @Required @Column provider!: string;
+  @Required @Column previousEffectiveTier!: number;
+  @Required @Column previousMaxPlacementTier!: number;
+  @Required @Column previousSnapshotState!: string;
+  @Required @Column currentEffectiveTier!: number;
+  @Required @Column currentMaxPlacementTier!: number;
+  @Required @Column currentSnapshotState!: string;
+  @Required @Column(DataTypes.ARRAY(DataTypes.STRING)) changes!: string[];
+  @Required @Column observedHeight!: number;
+  @Required @Column(DataTypes.DATE) observedBlockTime!: Date;
+  @Required @Default(DataTypes.NOW) @Column(DataTypes.DATE) createdAt!: Date;
+
+  @BelongsTo(() => Provider, { foreignKey: "provider", targetKey: "owner", constraints: false }) providerRecord!: Provider;
+}

--- a/packages/database/dbSchemas/akash/verificationProviderTierStream.ts
+++ b/packages/database/dbSchemas/akash/verificationProviderTierStream.ts
@@ -1,0 +1,13 @@
+import { DataTypes } from "sequelize";
+import { Column, Default, Model, PrimaryKey, Table } from "sequelize-typescript";
+
+import { Required } from "../decorators/requiredDecorator";
+
+@Table({
+  tableName: "verification_provider_tier_stream",
+  underscored: true
+})
+export class VerificationProviderTierStream extends Model {
+  @Required @PrimaryKey @Column(DataTypes.SMALLINT) id!: number;
+  @Required @Default(DataTypes.UUIDV4) @Column(DataTypes.UUID) streamId!: string;
+}

--- a/packages/database/dbSchemas/akash/verificationReconcileTarget.ts
+++ b/packages/database/dbSchemas/akash/verificationReconcileTarget.ts
@@ -1,0 +1,20 @@
+import { DataTypes } from "sequelize";
+import { Column, Default, Model, PrimaryKey, Table } from "sequelize-typescript";
+
+import { Required } from "../decorators/requiredDecorator";
+
+@Table({
+  tableName: "verification_reconcile_target",
+  underscored: true,
+  indexes: [{ fields: ["claimed_at", "next_attempt_at"] }, { fields: ["requested_height"] }]
+})
+export class VerificationReconcileTarget extends Model {
+  @Required @PrimaryKey @Column targetType!: string;
+  @Required @PrimaryKey @Column targetKey!: string;
+  @Required @Column requestedHeight!: number;
+  @Required @Default(true) @Column invalidated!: boolean;
+  @Column(DataTypes.DATE) claimedAt?: Date;
+  @Required @Default(0) @Column attemptCount!: number;
+  @Column(DataTypes.DATE) nextAttemptAt?: Date;
+  @Column(DataTypes.TEXT) lastError?: string;
+}

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -14,6 +14,8 @@
   "scripts": {
     "format": "prettier --write ./*.{ts,json} **/*.{ts,json}",
     "lint": "eslint .",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "validate:types": "tsc -p tsconfig.build.json --noEmit && echo"
   },
   "dependencies": {
@@ -23,6 +25,7 @@
     "sequelize-typescript": "^2.1.5"
   },
   "devDependencies": {
-    "@akashnetwork/dev-config": "*"
+    "@akashnetwork/dev-config": "*",
+    "vitest": "^4.1.5"
   }
 }

--- a/packages/network-store/package.json
+++ b/packages/network-store/package.json
@@ -18,7 +18,7 @@
     "validate:types": "tsc --noEmit && echo"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/net": "*",
     "jotai": "^2.9.2"
   },


### PR DESCRIPTION
## Why

Part of CON-800.

Console needs durable, queryable AEP-86 state before the indexer and API can
consume verification events.

Depends on #3713.

## What

- add shared database definitions for attestations, auditors, bonds, snapshots,
  escrows, discrepancies, grace state, maintenance, and reconciliation targets
- register the new Akash chain definitions
- add the corresponding additive indexer migration
- keep generated Drizzle SQL, schema, and relations in a separate commit
