### PR TITLE
feat(indexer): ingest provider verification state

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@akashnetwork/akash-api": "1.4.3",
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/console-api-types": "*",
     "@akashnetwork/database": "*",
     "@akashnetwork/env-loader": "*",

--- a/apps/deploy-web/package.json
+++ b/apps/deploy-web/package.json
@@ -26,7 +26,7 @@
     "type-check": "tsc"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/console-api-types": "*",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",

--- a/apps/indexer/drizzle/0010_add_provider_verification.sql
+++ b/apps/indexer/drizzle/0010_add_provider_verification.sql
@@ -1,0 +1,296 @@
+CREATE TABLE IF NOT EXISTS "verification_auditor" (
+  "address" varchar(255) PRIMARY KEY NOT NULL,
+  "status" integer NOT NULL,
+  "max_attestation_tier" integer NOT NULL,
+  "bond_denom" varchar(255) NOT NULL,
+  "bond_amount" numeric(30, 0) NOT NULL,
+  "bond_status" integer NOT NULL,
+  "metadata_hash" bytea,
+  "registered_at" timestamp with time zone NOT NULL,
+  "renewal_deadline" timestamp with time zone NOT NULL,
+  "discrepancy_count" numeric(20, 0) NOT NULL,
+  "bond_unbonding_completion_time" timestamp with time zone,
+  "observed_height" integer NOT NULL,
+  "observed_block_time" timestamp with time zone NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "verification_auditor_status" ON "verification_auditor" ("status");
+CREATE INDEX IF NOT EXISTS "verification_auditor_renewal_deadline" ON "verification_auditor" ("renewal_deadline");
+
+CREATE TABLE IF NOT EXISTS "verification_attestation" (
+  "provider" varchar(255) NOT NULL,
+  "auditor" varchar(255) NOT NULL,
+  "tier" integer NOT NULL,
+  "evidence_hash" bytea NOT NULL,
+  "fee_denom" varchar(255) NOT NULL,
+  "fee_amount" numeric(30, 0) NOT NULL,
+  "fee_status" integer NOT NULL,
+  "created_at" timestamp with time zone NOT NULL,
+  "expires_at" timestamp with time zone NOT NULL,
+  "status" integer NOT NULL,
+  "voided_reason" integer NOT NULL,
+  "deposit_denom" varchar(255) NOT NULL,
+  "deposit_amount" numeric(30, 0) NOT NULL,
+  "deposit_status" integer NOT NULL,
+  "audit_escrow_id" numeric(20, 0) NOT NULL,
+  "fault_attribution" integer NOT NULL,
+  "observed_height" integer NOT NULL,
+  "observed_block_time" timestamp with time zone NOT NULL,
+  CONSTRAINT "verification_attestation_provider_auditor" PRIMARY KEY ("provider", "auditor")
+);
+
+CREATE INDEX IF NOT EXISTS "verification_attestation_provider_status_tier" ON "verification_attestation" ("provider", "status", "tier");
+CREATE INDEX IF NOT EXISTS "verification_attestation_expires_at_status" ON "verification_attestation" ("expires_at", "status");
+CREATE INDEX IF NOT EXISTS "verification_attestation_audit_escrow_id" ON "verification_attestation" ("audit_escrow_id");
+
+CREATE TABLE IF NOT EXISTS "verification_attestation_capability" (
+  "provider" varchar(255) NOT NULL,
+  "auditor" varchar(255) NOT NULL,
+  "capability" integer NOT NULL,
+  "observed_height" integer NOT NULL,
+  "observed_block_time" timestamp with time zone NOT NULL,
+  CONSTRAINT "verification_attestation_capability_identity" PRIMARY KEY ("provider", "auditor", "capability"),
+  CONSTRAINT "verification_attestation_capability_attestation_fkey"
+    FOREIGN KEY ("provider", "auditor") REFERENCES "verification_attestation" ("provider", "auditor") ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS "verification_attestation_capability_capability_provider"
+  ON "verification_attestation_capability" ("capability", "provider");
+
+CREATE TABLE IF NOT EXISTS "verification_audit_escrow" (
+  "id" numeric(20, 0) PRIMARY KEY NOT NULL,
+  "provider" varchar(255) NOT NULL,
+  "consumed_by_auditor" varchar(255) NOT NULL,
+  "requested_tier" integer NOT NULL,
+  "fee_denom" varchar(255) NOT NULL,
+  "fee_amount" numeric(30, 0) NOT NULL,
+  "fee_status" integer NOT NULL,
+  "provider_deposit_denom" varchar(255) NOT NULL,
+  "provider_deposit_amount" numeric(30, 0) NOT NULL,
+  "provider_deposit_status" integer NOT NULL,
+  "status" integer NOT NULL,
+  "opened_at" timestamp with time zone NOT NULL,
+  "consumed_at" timestamp with time zone,
+  "expires_at" timestamp with time zone NOT NULL,
+  "metadata_hash" bytea,
+  "settlement_reason" integer NOT NULL,
+  "fault_attribution" integer NOT NULL,
+  "observed_height" integer NOT NULL,
+  "observed_block_time" timestamp with time zone NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "verification_audit_escrow_provider_status" ON "verification_audit_escrow" ("provider", "status");
+CREATE INDEX IF NOT EXISTS "verification_audit_escrow_expires_at_status" ON "verification_audit_escrow" ("expires_at", "status");
+
+CREATE TABLE IF NOT EXISTS "verification_audit_escrow_capability" (
+  "audit_escrow_id" numeric(20, 0) NOT NULL,
+  "capability" integer NOT NULL,
+  "observed_height" integer NOT NULL,
+  "observed_block_time" timestamp with time zone NOT NULL,
+  CONSTRAINT "verification_audit_escrow_capability_identity" PRIMARY KEY ("audit_escrow_id", "capability"),
+  CONSTRAINT "verification_audit_escrow_capability_escrow_fkey"
+    FOREIGN KEY ("audit_escrow_id") REFERENCES "verification_audit_escrow" ("id") ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS "verification_audit_escrow_capability_capability" ON "verification_audit_escrow_capability" ("capability");
+
+CREATE TABLE IF NOT EXISTS "verification_discrepancy" (
+  "id" numeric(20, 0) PRIMARY KEY NOT NULL,
+  "provider" varchar(255) NOT NULL,
+  "auditor_a" varchar(255) NOT NULL,
+  "auditor_a_tier" integer NOT NULL,
+  "auditor_b" varchar(255) NOT NULL,
+  "auditor_b_tier" integer NOT NULL,
+  "detected_at" timestamp with time zone NOT NULL,
+  "resolution_status" integer NOT NULL,
+  "resolution_proposal_id" numeric(20, 0) NOT NULL,
+  "grace_record_id" numeric(20, 0) NOT NULL,
+  "resolution_reason" integer NOT NULL,
+  "fault_attribution" integer NOT NULL,
+  "resolution_evidence_hash" bytea,
+  "observed_height" integer NOT NULL,
+  "observed_block_time" timestamp with time zone NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "verification_discrepancy_provider_resolution_status" ON "verification_discrepancy" ("provider", "resolution_status");
+CREATE INDEX IF NOT EXISTS "verification_discrepancy_auditor_a" ON "verification_discrepancy" ("auditor_a");
+CREATE INDEX IF NOT EXISTS "verification_discrepancy_auditor_b" ON "verification_discrepancy" ("auditor_b");
+
+CREATE TABLE IF NOT EXISTS "verification_grace" (
+  "id" numeric(20, 0) PRIMARY KEY NOT NULL,
+  "provider" varchar(255) NOT NULL,
+  "preserved_tier" integer NOT NULL,
+  "started_at" timestamp with time zone NOT NULL,
+  "expires_at" timestamp with time zone NOT NULL,
+  "status" integer NOT NULL,
+  "observed_height" integer NOT NULL,
+  "observed_block_time" timestamp with time zone NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "verification_grace_provider_status" ON "verification_grace" ("provider", "status");
+CREATE INDEX IF NOT EXISTS "verification_grace_expires_at_status" ON "verification_grace" ("expires_at", "status");
+
+CREATE TABLE IF NOT EXISTS "verification_grace_discrepancy" (
+  "grace_id" numeric(20, 0) NOT NULL,
+  "discrepancy_id" numeric(20, 0) NOT NULL,
+  "observed_height" integer NOT NULL,
+  "observed_block_time" timestamp with time zone NOT NULL,
+  CONSTRAINT "verification_grace_discrepancy_identity" PRIMARY KEY ("grace_id", "discrepancy_id"),
+  CONSTRAINT "verification_grace_discrepancy_grace_fkey"
+    FOREIGN KEY ("grace_id") REFERENCES "verification_grace" ("id") ON DELETE CASCADE,
+  CONSTRAINT "verification_grace_discrepancy_discrepancy_fkey"
+    FOREIGN KEY ("discrepancy_id") REFERENCES "verification_discrepancy" ("id") ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS "verification_grace_discrepancy_discrepancy_id" ON "verification_grace_discrepancy" ("discrepancy_id");
+
+CREATE TABLE IF NOT EXISTS "verification_provider_bond" (
+  "provider" varchar(255) PRIMARY KEY NOT NULL,
+  "bonded_denom" varchar(255) NOT NULL,
+  "bonded_amount" numeric(30, 0) NOT NULL,
+  "required_for_current_tier_denom" varchar(255) NOT NULL,
+  "required_for_current_tier_amount" numeric(30, 0) NOT NULL,
+  "slashed" boolean NOT NULL,
+  "last_slash_time" timestamp with time zone,
+  "observed_height" integer NOT NULL,
+  "observed_block_time" timestamp with time zone NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS "verification_provider_bond_unbonding" (
+  "provider" varchar(255) NOT NULL,
+  "entry_index" integer NOT NULL,
+  "denom" varchar(255) NOT NULL,
+  "amount" numeric(30, 0) NOT NULL,
+  "completion_time" timestamp with time zone NOT NULL,
+  "observed_height" integer NOT NULL,
+  "observed_block_time" timestamp with time zone NOT NULL,
+  CONSTRAINT "verification_provider_bond_unbonding_identity" PRIMARY KEY ("provider", "entry_index"),
+  CONSTRAINT "verification_provider_bond_unbonding_bond_fkey"
+    FOREIGN KEY ("provider") REFERENCES "verification_provider_bond" ("provider") ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS "verification_provider_bond_unbonding_completion_time"
+  ON "verification_provider_bond_unbonding" ("completion_time");
+
+CREATE TABLE IF NOT EXISTS "verification_provider_observation" (
+  "provider" varchar(255) PRIMARY KEY NOT NULL,
+  "observed_height" integer NOT NULL,
+  "observed_block_time" timestamp with time zone NOT NULL,
+  "effective_tier" integer NOT NULL,
+  "max_placement_tier" integer NOT NULL,
+  "snapshot_state" varchar(255) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS "verification_provider_tier_stream" (
+  "id" smallint PRIMARY KEY NOT NULL,
+  "stream_id" uuid NOT NULL DEFAULT gen_random_uuid()
+);
+
+INSERT INTO "verification_provider_tier_stream" ("id")
+VALUES (1)
+ON CONFLICT ("id") DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS "verification_provider_tier_demotion" (
+  "id" bigserial PRIMARY KEY NOT NULL,
+  "provider" varchar(255) NOT NULL,
+  "previous_effective_tier" integer NOT NULL,
+  "previous_max_placement_tier" integer NOT NULL,
+  "previous_snapshot_state" varchar(255) NOT NULL,
+  "current_effective_tier" integer NOT NULL,
+  "current_max_placement_tier" integer NOT NULL,
+  "current_snapshot_state" varchar(255) NOT NULL,
+  "changes" varchar(255)[] NOT NULL,
+  "observed_height" integer NOT NULL,
+  "observed_block_time" timestamp with time zone NOT NULL,
+  "created_at" timestamp with time zone NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS "verification_provider_tier_demotion_provider_id"
+  ON "verification_provider_tier_demotion" ("provider", "id");
+CREATE INDEX IF NOT EXISTS "verification_provider_tier_demotion_observed_height"
+  ON "verification_provider_tier_demotion" ("observed_height");
+
+CREATE TABLE IF NOT EXISTS "verification_provider_snapshot" (
+  "provider" varchar(255) PRIMARY KEY NOT NULL,
+  "snapshot_hash" bytea NOT NULL,
+  "total_gpus" integer NOT NULL,
+  "total_vcpus" integer NOT NULL,
+  "total_memory_mb" numeric(20, 0) NOT NULL,
+  "total_storage_mb" numeric(20, 0) NOT NULL,
+  "active_leases" integer NOT NULL,
+  "software_version" varchar(255) NOT NULL,
+  "software_signature" bytea,
+  "software_identity_version" varchar(255),
+  "software_artifact_ref" text,
+  "software_digest_algorithm" varchar(255),
+  "software_digest" bytea,
+  "software_signature_type" varchar(255),
+  "software_identity_signature" bytea,
+  "software_signature_ref" text,
+  "software_public_key_ref" text,
+  "posted_at" timestamp with time zone NOT NULL,
+  "snapshot_timestamp" timestamp with time zone NOT NULL,
+  "compliance_deadline" timestamp with time zone NOT NULL,
+  "suspended" boolean NOT NULL,
+  "observed_height" integer NOT NULL,
+  "observed_block_time" timestamp with time zone NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "verification_provider_snapshot_compliance_deadline_suspended"
+  ON "verification_provider_snapshot" ("compliance_deadline", "suspended");
+CREATE INDEX IF NOT EXISTS "verification_provider_snapshot_snapshot_timestamp" ON "verification_provider_snapshot" ("snapshot_timestamp");
+
+CREATE TABLE IF NOT EXISTS "provider_maintenance" (
+  "provider" varchar(255) NOT NULL,
+  "id" numeric(20, 0) NOT NULL,
+  "maintenance_type" integer NOT NULL,
+  "starts_at" timestamp with time zone NOT NULL,
+  "expected_ends_at" timestamp with time zone NOT NULL,
+  "opened_at" timestamp with time zone NOT NULL,
+  "closed_at" timestamp with time zone,
+  "metadata_hash" bytea,
+  "status" integer NOT NULL,
+  "observed_height" integer NOT NULL,
+  "observed_block_time" timestamp with time zone NOT NULL,
+  CONSTRAINT "provider_maintenance_provider_id" PRIMARY KEY ("provider", "id")
+);
+
+CREATE INDEX IF NOT EXISTS "provider_maintenance_provider_status" ON "provider_maintenance" ("provider", "status");
+CREATE INDEX IF NOT EXISTS "provider_maintenance_starts_at_expected_ends_at" ON "provider_maintenance" ("starts_at", "expected_ends_at");
+
+CREATE TABLE IF NOT EXISTS "verification_params" (
+  "id" smallint PRIMARY KEY NOT NULL,
+  "params" jsonb NOT NULL,
+  "observed_height" integer NOT NULL,
+  "observed_block_time" timestamp with time zone NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS "verification_reconcile_target" (
+  "target_type" varchar(255) NOT NULL,
+  "target_key" varchar(255) NOT NULL,
+  "requested_height" integer NOT NULL,
+  "invalidated" boolean NOT NULL DEFAULT true,
+  "claimed_at" timestamp with time zone,
+  "attempt_count" integer NOT NULL DEFAULT 0,
+  "next_attempt_at" timestamp with time zone,
+  "last_error" text,
+  CONSTRAINT "verification_reconcile_target_identity" PRIMARY KEY ("target_type", "target_key")
+);
+
+CREATE INDEX IF NOT EXISTS "verification_reconcile_target_claimed_at_next_attempt_at"
+  ON "verification_reconcile_target" ("claimed_at" NULLS FIRST, "next_attempt_at" NULLS FIRST);
+CREATE INDEX IF NOT EXISTS "verification_reconcile_target_requested_height" ON "verification_reconcile_target" ("requested_height");
+
+CREATE TABLE IF NOT EXISTS "verification_block_event" (
+  "id" uuid PRIMARY KEY NOT NULL DEFAULT gen_random_uuid(),
+  "height" integer NOT NULL,
+  "index" integer NOT NULL,
+  "type" varchar(255) NOT NULL,
+  "data" jsonb NOT NULL,
+  "is_processed" boolean NOT NULL DEFAULT false,
+  CONSTRAINT "verification_block_event_height_fkey"
+    FOREIGN KEY ("height") REFERENCES "block" ("height") ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "verification_block_event_height_index" ON "verification_block_event" ("height", "index");
+CREATE INDEX IF NOT EXISTS "verification_block_event_height_is_processed" ON "verification_block_event" ("height", "is_processed");

--- a/apps/indexer/drizzle/meta/_journal.json
+++ b/apps/indexer/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1763000000000,
       "tag": "0009_drop_monitored_value",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1787570000000,
+      "tag": "0010_add_provider_verification",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/indexer/drizzle/relations.ts
+++ b/apps/indexer/drizzle/relations.ts
@@ -11,8 +11,23 @@ import {
   provider,
   providerAttribute,
   providerAttributeSignature,
+  providerMaintenance,
   providerSnapshot,
-  transaction
+  transaction,
+  verificationAttestation,
+  verificationAttestationCapability,
+  verificationAuditEscrow,
+  verificationAuditEscrowCapability,
+  verificationAuditor,
+  verificationBlockEvent,
+  verificationDiscrepancy,
+  verificationGrace,
+  verificationGraceDiscrepancy,
+  verificationProviderBond,
+  verificationProviderBondUnbonding,
+  verificationProviderObservation,
+  verificationProviderSnapshot,
+  verificationProviderTierDemotion
 } from "./schema";
 
 export const deploymentGroupRelations = relations(deploymentGroup, ({ one, many }) => ({
@@ -36,11 +51,20 @@ export const providerAttributeSignatureRelations = relations(providerAttributeSi
   })
 }));
 
-export const providerRelations = relations(provider, ({ many }) => ({
+export const providerRelations = relations(provider, ({ one, many }) => ({
   providerAttributeSignatures: many(providerAttributeSignature),
   leases: many(lease),
   providerAttributes: many(providerAttribute),
-  providerSnapshots: many(providerSnapshot)
+  providerSnapshots: many(providerSnapshot),
+  verificationAttestations: many(verificationAttestation),
+  verificationAuditEscrows: many(verificationAuditEscrow),
+  verificationDiscrepancies: many(verificationDiscrepancy),
+  verificationGraceRecords: many(verificationGrace),
+  verificationBond: one(verificationProviderBond),
+  verificationObservation: one(verificationProviderObservation),
+  verificationSnapshot: one(verificationProviderSnapshot),
+  verificationTierDemotions: many(verificationProviderTierDemotion),
+  maintenanceRecords: many(providerMaintenance)
 }));
 
 export const leaseRelations = relations(lease, ({ one }) => ({
@@ -93,7 +117,8 @@ export const messageRelations = relations(message, ({ one, many }) => ({
 
 export const blockRelations = relations(block, ({ many }) => ({
   messages: many(message),
-  transactions: many(transaction)
+  transactions: many(transaction),
+  verificationBlockEvents: many(verificationBlockEvent)
 }));
 
 export const transactionRelations = relations(transaction, ({ one, many }) => ({
@@ -113,5 +138,120 @@ export const addressReferenceRelations = relations(addressReference, ({ one }) =
   transaction: one(transaction, {
     fields: [addressReference.transactionId],
     references: [transaction.id]
+  })
+}));
+
+export const verificationAuditorRelations = relations(verificationAuditor, ({ many }) => ({
+  attestations: many(verificationAttestation)
+}));
+
+export const verificationAttestationRelations = relations(verificationAttestation, ({ one, many }) => ({
+  provider: one(provider, {
+    fields: [verificationAttestation.provider],
+    references: [provider.owner]
+  }),
+  auditor: one(verificationAuditor, {
+    fields: [verificationAttestation.auditor],
+    references: [verificationAuditor.address]
+  }),
+  capabilities: many(verificationAttestationCapability)
+}));
+
+export const verificationAttestationCapabilityRelations = relations(verificationAttestationCapability, ({ one }) => ({
+  attestation: one(verificationAttestation, {
+    fields: [verificationAttestationCapability.provider, verificationAttestationCapability.auditor],
+    references: [verificationAttestation.provider, verificationAttestation.auditor]
+  })
+}));
+
+export const verificationAuditEscrowRelations = relations(verificationAuditEscrow, ({ one, many }) => ({
+  provider: one(provider, {
+    fields: [verificationAuditEscrow.provider],
+    references: [provider.owner]
+  }),
+  capabilities: many(verificationAuditEscrowCapability)
+}));
+
+export const verificationAuditEscrowCapabilityRelations = relations(verificationAuditEscrowCapability, ({ one }) => ({
+  auditEscrow: one(verificationAuditEscrow, {
+    fields: [verificationAuditEscrowCapability.audit_escrow_id],
+    references: [verificationAuditEscrow.id]
+  })
+}));
+
+export const verificationDiscrepancyRelations = relations(verificationDiscrepancy, ({ one, many }) => ({
+  provider: one(provider, {
+    fields: [verificationDiscrepancy.provider],
+    references: [provider.owner]
+  }),
+  graceRecords: many(verificationGraceDiscrepancy)
+}));
+
+export const verificationGraceRelations = relations(verificationGrace, ({ one, many }) => ({
+  provider: one(provider, {
+    fields: [verificationGrace.provider],
+    references: [provider.owner]
+  }),
+  sourceDiscrepancies: many(verificationGraceDiscrepancy)
+}));
+
+export const verificationGraceDiscrepancyRelations = relations(verificationGraceDiscrepancy, ({ one }) => ({
+  grace: one(verificationGrace, {
+    fields: [verificationGraceDiscrepancy.grace_id],
+    references: [verificationGrace.id]
+  }),
+  discrepancy: one(verificationDiscrepancy, {
+    fields: [verificationGraceDiscrepancy.discrepancy_id],
+    references: [verificationDiscrepancy.id]
+  })
+}));
+
+export const verificationProviderBondRelations = relations(verificationProviderBond, ({ one, many }) => ({
+  provider: one(provider, {
+    fields: [verificationProviderBond.provider],
+    references: [provider.owner]
+  }),
+  unbondingEntries: many(verificationProviderBondUnbonding)
+}));
+
+export const verificationProviderBondUnbondingRelations = relations(verificationProviderBondUnbonding, ({ one }) => ({
+  providerBond: one(verificationProviderBond, {
+    fields: [verificationProviderBondUnbonding.provider],
+    references: [verificationProviderBond.provider]
+  })
+}));
+
+export const verificationProviderObservationRelations = relations(verificationProviderObservation, ({ one }) => ({
+  provider: one(provider, {
+    fields: [verificationProviderObservation.provider],
+    references: [provider.owner]
+  })
+}));
+
+export const verificationProviderTierDemotionRelations = relations(verificationProviderTierDemotion, ({ one }) => ({
+  provider: one(provider, {
+    fields: [verificationProviderTierDemotion.provider],
+    references: [provider.owner]
+  })
+}));
+
+export const verificationProviderSnapshotRelations = relations(verificationProviderSnapshot, ({ one }) => ({
+  provider: one(provider, {
+    fields: [verificationProviderSnapshot.provider],
+    references: [provider.owner]
+  })
+}));
+
+export const providerMaintenanceRelations = relations(providerMaintenance, ({ one }) => ({
+  provider: one(provider, {
+    fields: [providerMaintenance.provider],
+    references: [provider.owner]
+  })
+}));
+
+export const verificationBlockEventRelations = relations(verificationBlockEvent, ({ one }) => ({
+  block: one(block, {
+    fields: [verificationBlockEvent.height],
+    references: [block.height]
   })
 }));

--- a/apps/indexer/drizzle/schema.ts
+++ b/apps/indexer/drizzle/schema.ts
@@ -1,6 +1,7 @@
 import { sql } from "drizzle-orm";
 import {
   bigint,
+  bigserial,
   boolean,
   customType,
   doublePrecision,
@@ -10,6 +11,7 @@ import {
   jsonb,
   numeric,
   pgTable,
+  primaryKey,
   serial,
   smallint,
   text,
@@ -727,5 +729,443 @@ export const bmeStatusChange = pgTable(
       foreignColumns: [block.height],
       name: "bme_status_change_height_fkey"
     })
+  ]
+);
+
+export const verificationAuditor = pgTable(
+  "verification_auditor",
+  {
+    address: varchar({ length: 255 }).primaryKey().notNull(),
+    status: integer().notNull(),
+    max_attestation_tier: integer().notNull(),
+    bond_denom: varchar({ length: 255 }).notNull(),
+    bond_amount: numeric({ precision: 30, scale: 0 }).notNull(),
+    bond_status: integer().notNull(),
+    metadata_hash: bytea("metadata_hash"),
+    registered_at: timestamp({ withTimezone: true, mode: "string" }).notNull(),
+    renewal_deadline: timestamp({ withTimezone: true, mode: "string" }).notNull(),
+    discrepancy_count: numeric({ precision: 20, scale: 0 }).notNull(),
+    bond_unbonding_completion_time: timestamp({ withTimezone: true, mode: "string" }),
+    observed_height: integer().notNull(),
+    observed_block_time: timestamp({ withTimezone: true, mode: "string" }).notNull()
+  },
+  table => [
+    index("verification_auditor_status").using("btree", table.status.asc().nullsLast().op("int4_ops")),
+    index("verification_auditor_renewal_deadline").using("btree", table.renewal_deadline.asc().nullsLast().op("timestamptz_ops"))
+  ]
+);
+
+export const verificationAttestation = pgTable(
+  "verification_attestation",
+  {
+    provider: varchar({ length: 255 }).notNull(),
+    auditor: varchar({ length: 255 }).notNull(),
+    tier: integer().notNull(),
+    evidence_hash: bytea("evidence_hash").notNull(),
+    fee_denom: varchar({ length: 255 }).notNull(),
+    fee_amount: numeric({ precision: 30, scale: 0 }).notNull(),
+    fee_status: integer().notNull(),
+    created_at: timestamp({ withTimezone: true, mode: "string" }).notNull(),
+    expires_at: timestamp({ withTimezone: true, mode: "string" }).notNull(),
+    status: integer().notNull(),
+    voided_reason: integer().notNull(),
+    deposit_denom: varchar({ length: 255 }).notNull(),
+    deposit_amount: numeric({ precision: 30, scale: 0 }).notNull(),
+    deposit_status: integer().notNull(),
+    audit_escrow_id: numeric({ precision: 20, scale: 0 }).notNull(),
+    fault_attribution: integer().notNull(),
+    observed_height: integer().notNull(),
+    observed_block_time: timestamp({ withTimezone: true, mode: "string" }).notNull()
+  },
+  table => [
+    primaryKey({ columns: [table.provider, table.auditor], name: "verification_attestation_provider_auditor" }),
+    index("verification_attestation_provider_status_tier").using(
+      "btree",
+      table.provider.asc().nullsLast().op("text_ops"),
+      table.status.asc().nullsLast().op("int4_ops"),
+      table.tier.asc().nullsLast().op("int4_ops")
+    ),
+    index("verification_attestation_expires_at_status").using(
+      "btree",
+      table.expires_at.asc().nullsLast().op("timestamptz_ops"),
+      table.status.asc().nullsLast().op("int4_ops")
+    ),
+    index("verification_attestation_audit_escrow_id").using("btree", table.audit_escrow_id.asc().nullsLast().op("numeric_ops"))
+  ]
+);
+
+export const verificationAttestationCapability = pgTable(
+  "verification_attestation_capability",
+  {
+    provider: varchar({ length: 255 }).notNull(),
+    auditor: varchar({ length: 255 }).notNull(),
+    capability: integer().notNull(),
+    observed_height: integer().notNull(),
+    observed_block_time: timestamp({ withTimezone: true, mode: "string" }).notNull()
+  },
+  table => [
+    primaryKey({
+      columns: [table.provider, table.auditor, table.capability],
+      name: "verification_attestation_capability_identity"
+    }),
+    index("verification_attestation_capability_capability_provider").using(
+      "btree",
+      table.capability.asc().nullsLast().op("int4_ops"),
+      table.provider.asc().nullsLast().op("text_ops")
+    ),
+    foreignKey({
+      columns: [table.provider, table.auditor],
+      foreignColumns: [verificationAttestation.provider, verificationAttestation.auditor],
+      name: "verification_attestation_capability_attestation_fkey"
+    }).onDelete("cascade")
+  ]
+);
+
+export const verificationAuditEscrow = pgTable(
+  "verification_audit_escrow",
+  {
+    id: numeric({ precision: 20, scale: 0 }).primaryKey().notNull(),
+    provider: varchar({ length: 255 }).notNull(),
+    consumed_by_auditor: varchar({ length: 255 }).notNull(),
+    requested_tier: integer().notNull(),
+    fee_denom: varchar({ length: 255 }).notNull(),
+    fee_amount: numeric({ precision: 30, scale: 0 }).notNull(),
+    fee_status: integer().notNull(),
+    provider_deposit_denom: varchar({ length: 255 }).notNull(),
+    provider_deposit_amount: numeric({ precision: 30, scale: 0 }).notNull(),
+    provider_deposit_status: integer().notNull(),
+    status: integer().notNull(),
+    opened_at: timestamp({ withTimezone: true, mode: "string" }).notNull(),
+    consumed_at: timestamp({ withTimezone: true, mode: "string" }),
+    expires_at: timestamp({ withTimezone: true, mode: "string" }).notNull(),
+    metadata_hash: bytea("metadata_hash"),
+    settlement_reason: integer().notNull(),
+    fault_attribution: integer().notNull(),
+    observed_height: integer().notNull(),
+    observed_block_time: timestamp({ withTimezone: true, mode: "string" }).notNull()
+  },
+  table => [
+    index("verification_audit_escrow_provider_status").using(
+      "btree",
+      table.provider.asc().nullsLast().op("text_ops"),
+      table.status.asc().nullsLast().op("int4_ops")
+    ),
+    index("verification_audit_escrow_expires_at_status").using(
+      "btree",
+      table.expires_at.asc().nullsLast().op("timestamptz_ops"),
+      table.status.asc().nullsLast().op("int4_ops")
+    )
+  ]
+);
+
+export const verificationAuditEscrowCapability = pgTable(
+  "verification_audit_escrow_capability",
+  {
+    audit_escrow_id: numeric({ precision: 20, scale: 0 }).notNull(),
+    capability: integer().notNull(),
+    observed_height: integer().notNull(),
+    observed_block_time: timestamp({ withTimezone: true, mode: "string" }).notNull()
+  },
+  table => [
+    primaryKey({
+      columns: [table.audit_escrow_id, table.capability],
+      name: "verification_audit_escrow_capability_identity"
+    }),
+    index("verification_audit_escrow_capability_capability").using("btree", table.capability.asc().nullsLast().op("int4_ops")),
+    foreignKey({
+      columns: [table.audit_escrow_id],
+      foreignColumns: [verificationAuditEscrow.id],
+      name: "verification_audit_escrow_capability_escrow_fkey"
+    }).onDelete("cascade")
+  ]
+);
+
+export const verificationDiscrepancy = pgTable(
+  "verification_discrepancy",
+  {
+    id: numeric({ precision: 20, scale: 0 }).primaryKey().notNull(),
+    provider: varchar({ length: 255 }).notNull(),
+    auditor_a: varchar({ length: 255 }).notNull(),
+    auditor_a_tier: integer().notNull(),
+    auditor_b: varchar({ length: 255 }).notNull(),
+    auditor_b_tier: integer().notNull(),
+    detected_at: timestamp({ withTimezone: true, mode: "string" }).notNull(),
+    resolution_status: integer().notNull(),
+    resolution_proposal_id: numeric({ precision: 20, scale: 0 }).notNull(),
+    grace_record_id: numeric({ precision: 20, scale: 0 }).notNull(),
+    resolution_reason: integer().notNull(),
+    fault_attribution: integer().notNull(),
+    resolution_evidence_hash: bytea("resolution_evidence_hash"),
+    observed_height: integer().notNull(),
+    observed_block_time: timestamp({ withTimezone: true, mode: "string" }).notNull()
+  },
+  table => [
+    index("verification_discrepancy_provider_resolution_status").using(
+      "btree",
+      table.provider.asc().nullsLast().op("text_ops"),
+      table.resolution_status.asc().nullsLast().op("int4_ops")
+    ),
+    index("verification_discrepancy_auditor_a").using("btree", table.auditor_a.asc().nullsLast().op("text_ops")),
+    index("verification_discrepancy_auditor_b").using("btree", table.auditor_b.asc().nullsLast().op("text_ops"))
+  ]
+);
+
+export const verificationGrace = pgTable(
+  "verification_grace",
+  {
+    id: numeric({ precision: 20, scale: 0 }).primaryKey().notNull(),
+    provider: varchar({ length: 255 }).notNull(),
+    preserved_tier: integer().notNull(),
+    started_at: timestamp({ withTimezone: true, mode: "string" }).notNull(),
+    expires_at: timestamp({ withTimezone: true, mode: "string" }).notNull(),
+    status: integer().notNull(),
+    observed_height: integer().notNull(),
+    observed_block_time: timestamp({ withTimezone: true, mode: "string" }).notNull()
+  },
+  table => [
+    index("verification_grace_provider_status").using("btree", table.provider.asc().nullsLast().op("text_ops"), table.status.asc().nullsLast().op("int4_ops")),
+    index("verification_grace_expires_at_status").using(
+      "btree",
+      table.expires_at.asc().nullsLast().op("timestamptz_ops"),
+      table.status.asc().nullsLast().op("int4_ops")
+    )
+  ]
+);
+
+export const verificationGraceDiscrepancy = pgTable(
+  "verification_grace_discrepancy",
+  {
+    grace_id: numeric({ precision: 20, scale: 0 }).notNull(),
+    discrepancy_id: numeric({ precision: 20, scale: 0 }).notNull(),
+    observed_height: integer().notNull(),
+    observed_block_time: timestamp({ withTimezone: true, mode: "string" }).notNull()
+  },
+  table => [
+    primaryKey({
+      columns: [table.grace_id, table.discrepancy_id],
+      name: "verification_grace_discrepancy_identity"
+    }),
+    index("verification_grace_discrepancy_discrepancy_id").using("btree", table.discrepancy_id.asc().nullsLast().op("numeric_ops")),
+    foreignKey({
+      columns: [table.grace_id],
+      foreignColumns: [verificationGrace.id],
+      name: "verification_grace_discrepancy_grace_fkey"
+    }).onDelete("cascade"),
+    foreignKey({
+      columns: [table.discrepancy_id],
+      foreignColumns: [verificationDiscrepancy.id],
+      name: "verification_grace_discrepancy_discrepancy_fkey"
+    }).onDelete("cascade")
+  ]
+);
+
+export const verificationProviderBond = pgTable("verification_provider_bond", {
+  provider: varchar({ length: 255 }).primaryKey().notNull(),
+  bonded_denom: varchar({ length: 255 }).notNull(),
+  bonded_amount: numeric({ precision: 30, scale: 0 }).notNull(),
+  required_for_current_tier_denom: varchar({ length: 255 }).notNull(),
+  required_for_current_tier_amount: numeric({ precision: 30, scale: 0 }).notNull(),
+  slashed: boolean().notNull(),
+  last_slash_time: timestamp({ withTimezone: true, mode: "string" }),
+  observed_height: integer().notNull(),
+  observed_block_time: timestamp({ withTimezone: true, mode: "string" }).notNull()
+});
+
+export const verificationProviderBondUnbonding = pgTable(
+  "verification_provider_bond_unbonding",
+  {
+    provider: varchar({ length: 255 }).notNull(),
+    entry_index: integer().notNull(),
+    denom: varchar({ length: 255 }).notNull(),
+    amount: numeric({ precision: 30, scale: 0 }).notNull(),
+    completion_time: timestamp({ withTimezone: true, mode: "string" }).notNull(),
+    observed_height: integer().notNull(),
+    observed_block_time: timestamp({ withTimezone: true, mode: "string" }).notNull()
+  },
+  table => [
+    primaryKey({
+      columns: [table.provider, table.entry_index],
+      name: "verification_provider_bond_unbonding_identity"
+    }),
+    index("verification_provider_bond_unbonding_completion_time").using("btree", table.completion_time.asc().nullsLast().op("timestamptz_ops")),
+    foreignKey({
+      columns: [table.provider],
+      foreignColumns: [verificationProviderBond.provider],
+      name: "verification_provider_bond_unbonding_bond_fkey"
+    }).onDelete("cascade")
+  ]
+);
+
+export const verificationProviderObservation = pgTable("verification_provider_observation", {
+  provider: varchar({ length: 255 }).primaryKey().notNull(),
+  observed_height: integer().notNull(),
+  observed_block_time: timestamp({ withTimezone: true, mode: "string" }).notNull(),
+  effective_tier: integer().notNull(),
+  max_placement_tier: integer().notNull(),
+  snapshot_state: varchar({ length: 255 }).notNull()
+});
+
+export const verificationProviderTierStream = pgTable("verification_provider_tier_stream", {
+  id: smallint().primaryKey().notNull(),
+  stream_id: uuid()
+    .default(sql`gen_random_uuid()`)
+    .notNull()
+});
+
+export const verificationProviderTierDemotion = pgTable(
+  "verification_provider_tier_demotion",
+  {
+    id: bigserial({ mode: "bigint" }).primaryKey().notNull(),
+    provider: varchar({ length: 255 }).notNull(),
+    previous_effective_tier: integer().notNull(),
+    previous_max_placement_tier: integer().notNull(),
+    previous_snapshot_state: varchar({ length: 255 }).notNull(),
+    current_effective_tier: integer().notNull(),
+    current_max_placement_tier: integer().notNull(),
+    current_snapshot_state: varchar({ length: 255 }).notNull(),
+    changes: varchar({ length: 255 }).array().notNull(),
+    observed_height: integer().notNull(),
+    observed_block_time: timestamp({ withTimezone: true, mode: "string" }).notNull(),
+    created_at: timestamp({ withTimezone: true, mode: "string" }).defaultNow().notNull()
+  },
+  table => [
+    index("verification_provider_tier_demotion_provider_id").using(
+      "btree",
+      table.provider.asc().nullsLast().op("text_ops"),
+      table.id.asc().nullsLast().op("int8_ops")
+    ),
+    index("verification_provider_tier_demotion_observed_height").using("btree", table.observed_height.asc().nullsLast().op("int4_ops"))
+  ]
+);
+
+export const verificationProviderSnapshot = pgTable(
+  "verification_provider_snapshot",
+  {
+    provider: varchar({ length: 255 }).primaryKey().notNull(),
+    snapshot_hash: bytea("snapshot_hash").notNull(),
+    total_gpus: integer().notNull(),
+    total_vcpus: integer().notNull(),
+    total_memory_mb: numeric({ precision: 20, scale: 0 }).notNull(),
+    total_storage_mb: numeric({ precision: 20, scale: 0 }).notNull(),
+    active_leases: integer().notNull(),
+    software_version: varchar({ length: 255 }).notNull(),
+    software_signature: bytea("software_signature"),
+    software_identity_version: varchar({ length: 255 }),
+    software_artifact_ref: text(),
+    software_digest_algorithm: varchar({ length: 255 }),
+    software_digest: bytea("software_digest"),
+    software_signature_type: varchar({ length: 255 }),
+    software_identity_signature: bytea("software_identity_signature"),
+    software_signature_ref: text(),
+    software_public_key_ref: text(),
+    posted_at: timestamp({ withTimezone: true, mode: "string" }).notNull(),
+    snapshot_timestamp: timestamp({ withTimezone: true, mode: "string" }).notNull(),
+    compliance_deadline: timestamp({ withTimezone: true, mode: "string" }).notNull(),
+    suspended: boolean().notNull(),
+    observed_height: integer().notNull(),
+    observed_block_time: timestamp({ withTimezone: true, mode: "string" }).notNull()
+  },
+  table => [
+    index("verification_provider_snapshot_compliance_deadline_suspended").using(
+      "btree",
+      table.compliance_deadline.asc().nullsLast().op("timestamptz_ops"),
+      table.suspended.asc().nullsLast().op("bool_ops")
+    ),
+    index("verification_provider_snapshot_snapshot_timestamp").using("btree", table.snapshot_timestamp.asc().nullsLast().op("timestamptz_ops"))
+  ]
+);
+
+export const providerMaintenance = pgTable(
+  "provider_maintenance",
+  {
+    provider: varchar({ length: 255 }).notNull(),
+    id: numeric({ precision: 20, scale: 0 }).notNull(),
+    maintenance_type: integer().notNull(),
+    starts_at: timestamp({ withTimezone: true, mode: "string" }).notNull(),
+    expected_ends_at: timestamp({ withTimezone: true, mode: "string" }).notNull(),
+    opened_at: timestamp({ withTimezone: true, mode: "string" }).notNull(),
+    closed_at: timestamp({ withTimezone: true, mode: "string" }),
+    metadata_hash: bytea("metadata_hash"),
+    status: integer().notNull(),
+    observed_height: integer().notNull(),
+    observed_block_time: timestamp({ withTimezone: true, mode: "string" }).notNull()
+  },
+  table => [
+    primaryKey({ columns: [table.provider, table.id], name: "provider_maintenance_provider_id" }),
+    index("provider_maintenance_provider_status").using(
+      "btree",
+      table.provider.asc().nullsLast().op("text_ops"),
+      table.status.asc().nullsLast().op("int4_ops")
+    ),
+    index("provider_maintenance_starts_at_expected_ends_at").using(
+      "btree",
+      table.starts_at.asc().nullsLast().op("timestamptz_ops"),
+      table.expected_ends_at.asc().nullsLast().op("timestamptz_ops")
+    )
+  ]
+);
+
+export const verificationParams = pgTable("verification_params", {
+  id: smallint().primaryKey().notNull(),
+  params: jsonb().notNull(),
+  observed_height: integer().notNull(),
+  observed_block_time: timestamp({ withTimezone: true, mode: "string" }).notNull()
+});
+
+export const verificationReconcileTarget = pgTable(
+  "verification_reconcile_target",
+  {
+    target_type: varchar({ length: 255 }).notNull(),
+    target_key: varchar({ length: 255 }).notNull(),
+    requested_height: integer().notNull(),
+    invalidated: boolean().default(true).notNull(),
+    claimed_at: timestamp({ withTimezone: true, mode: "string" }),
+    attempt_count: integer().default(0).notNull(),
+    next_attempt_at: timestamp({ withTimezone: true, mode: "string" }),
+    last_error: text()
+  },
+  table => [
+    primaryKey({
+      columns: [table.target_type, table.target_key],
+      name: "verification_reconcile_target_identity"
+    }),
+    index("verification_reconcile_target_claimed_at_next_attempt_at").using(
+      "btree",
+      table.claimed_at.asc().nullsFirst().op("timestamptz_ops"),
+      table.next_attempt_at.asc().nullsFirst().op("timestamptz_ops")
+    ),
+    index("verification_reconcile_target_requested_height").using("btree", table.requested_height.asc().nullsLast().op("int4_ops"))
+  ]
+);
+
+export const verificationBlockEvent = pgTable(
+  "verification_block_event",
+  {
+    id: uuid()
+      .primaryKey()
+      .notNull()
+      .default(sql`gen_random_uuid()`),
+    height: integer().notNull(),
+    index: integer().notNull(),
+    type: varchar({ length: 255 }).notNull(),
+    data: jsonb().notNull(),
+    is_processed: boolean().default(false).notNull()
+  },
+  table => [
+    uniqueIndex("verification_block_event_height_index").using(
+      "btree",
+      table.height.asc().nullsLast().op("int4_ops"),
+      table.index.asc().nullsLast().op("int4_ops")
+    ),
+    index("verification_block_event_height_is_processed").using(
+      "btree",
+      table.height.asc().nullsLast().op("int4_ops"),
+      table.is_processed.asc().nullsLast().op("bool_ops")
+    ),
+    foreignKey({
+      columns: [table.height],
+      foreignColumns: [block.height],
+      name: "verification_block_event_height_fkey"
+    }).onDelete("cascade")
   ]
 );

--- a/apps/indexer/package.json
+++ b/apps/indexer/package.json
@@ -36,6 +36,7 @@
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/instrumentation": "*",
     "@akashnetwork/logging": "*",
+    "@akashnetwork/provider-verification": "*",
     "@cosmjs/crypto": "~0.38.0",
     "@cosmjs/encoding": "~0.38.0",
     "@cosmjs/proto-signing": "~0.38.0",

--- a/apps/indexer/package.json
+++ b/apps/indexer/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@akashnetwork/akash-api": "1.4.3",
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/database": "*",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/instrumentation": "*",

--- a/apps/indexer/src/chain/chainSync.ts
+++ b/apps/indexer/src/chain/chainSync.ts
@@ -1,6 +1,6 @@
 import { activeChain, BME_VAULT_ADDRESS, IBC_USDC_DENOMS } from "@akashnetwork/database/chainDefinitions";
 import { Block, Message } from "@akashnetwork/database/dbSchemas";
-import { BmeRawEvent } from "@akashnetwork/database/dbSchemas/akash";
+import { BmeRawEvent, VerificationBlockEvent } from "@akashnetwork/database/dbSchemas/akash";
 import { Day, Transaction, TransactionEvent, TransactionEventAttribute } from "@akashnetwork/database/dbSchemas/base";
 import { fromBase64 } from "@cosmjs/encoding";
 import { decodeTxRaw } from "@cosmjs/proto-signing";
@@ -11,6 +11,7 @@ import { Op } from "sequelize";
 
 import { sequelize } from "@src/db/dbConnection";
 import { BME_BLOCK_EVENT_TYPE_VALUES, BME_EVENT_TYPES } from "@src/indexers/bmeIndexer";
+import { PROVIDER_VERIFICATION_EVENT_TYPES } from "@src/indexers/providerVerification/providerVerificationEvent";
 import { ExecutionMode, executionMode, isProd, lastBlockToSync } from "@src/shared/constants";
 import type { BlockResultType } from "@src/shared/types";
 import { decodeIfBase64 } from "@src/shared/utils/base64";
@@ -192,6 +193,14 @@ async function insertBlocks(startHeight: number, endHeight: number) {
   let txsEventAttributesToAdd: any[] = [];
   let msgsToAdd: any[] = [];
   let bmeRawEventsToAdd: any[] = [];
+  let verificationBlockEventsToAdd: Array<{
+    id: string;
+    height: number;
+    index: number;
+    type: string;
+    data: Record<string, string | null>;
+    isProcessed: boolean;
+  }> = [];
 
   for (let i = startHeight; i <= endHeight; ++i) {
     const getCachedBlockTimer = benchmark.startTimer("getCachedBlockByHeight");
@@ -292,7 +301,22 @@ async function insertBlocks(startHeight: number, endHeight: number) {
       let bmeEventIndex = 0;
       let migrationBurnDetected = false;
       let migrationBurnedUakt = "0";
-      for (const event of endBlockEvents) {
+      for (const [eventIndex, event] of endBlockEvents.entries()) {
+        if (env.PROVIDER_VERIFICATION_ENABLED && PROVIDER_VERIFICATION_EVENT_TYPES.includes(event.type)) {
+          const data: Record<string, string | null> = {};
+          for (const attr of event.attributes) {
+            data[decodeIfBase64(attr.key)] = attr.value ? decodeIfBase64(attr.value) : null;
+          }
+          verificationBlockEventsToAdd.push({
+            id: randomUUID(),
+            height: i,
+            index: eventIndex,
+            type: event.type,
+            data,
+            isProcessed: false
+          });
+        }
+
         if ((BME_BLOCK_EVENT_TYPE_VALUES as readonly string[]).includes(event.type)) {
           const data: Record<string, string | null> = {};
           for (const attr of event.attributes) {
@@ -431,12 +455,18 @@ async function insertBlocks(startHeight: number, endHeight: number) {
               await BmeRawEvent.bulkCreate(bmeRawEventsToAdd, { transaction: insertDbTransaction });
             });
           }
+          if (verificationBlockEventsToAdd.length > 0) {
+            await benchmark.measureAsync("createVerificationBlockEvents", async () => {
+              await VerificationBlockEvent.bulkCreate(verificationBlockEventsToAdd, { transaction: insertDbTransaction });
+            });
+          }
           blocksToAdd = [];
           txsToAdd = [];
           txsEventsToAdd = [];
           txsEventAttributesToAdd = [];
           msgsToAdd = [];
           bmeRawEventsToAdd = [];
+          verificationBlockEventsToAdd = [];
           console.log(`Blocks added to db: ${i - startHeight + 1} / ${blockCount} (${(((i - startHeight + 1) * 100) / blockCount).toFixed(2)}%)`);
 
           if (lastInsertedBlock) {

--- a/apps/indexer/src/index.ts
+++ b/apps/indexer/src/index.ts
@@ -2,6 +2,7 @@ import "@akashnetwork/env-loader";
 
 import { activeChain, chainDefinitions } from "@akashnetwork/database/chainDefinitions";
 import { LoggerService } from "@akashnetwork/logging";
+import { createProviderVerificationQueryClient } from "@akashnetwork/provider-verification";
 import * as Sentry from "@sentry/node";
 import { Hono } from "hono";
 
@@ -14,6 +15,7 @@ import { initDatabase } from "./db/buildDatabase";
 import { sequelize } from "./db/dbConnection";
 import { fetchValidatorKeybaseInfos } from "./db/keybaseProvider";
 import { syncPriceHistory } from "./db/priceHistoryProvider";
+import { ProviderVerificationReconciler } from "./indexers/providerVerification/providerVerificationReconciler";
 import { startServer } from "./lib/start-server/start-server";
 import { updateProvidersLocation } from "./providers/ipLocationProvider";
 import { syncProvidersInfo } from "./providers/providerStatusProvider";
@@ -128,6 +130,13 @@ function startScheduler() {
     scheduler.registerTask("Provider IP Lookup", () => updateProvidersLocation(), "30 minutes", true);
     scheduler.registerTask("USD Spending Tracker", () => updateUsdSpending(), "1 minute", true);
     scheduler.registerTask("Update provider uptime", () => updateProviderUptime(), "10 minutes", true);
+
+    if (env.PROVIDER_VERIFICATION_ENABLED) {
+      const queryClient = createProviderVerificationQueryClient(env.PROVIDER_VERIFICATION_REST_API_URL ?? activeChain.apiUrl);
+      const reconciler = new ProviderVerificationReconciler(queryClient);
+      scheduler.registerTask("Refresh Provider Verification", () => reconciler.enqueueFullReconciliation(), "5 minutes", true);
+      scheduler.registerTask("Reconcile Provider Verification", () => reconciler.runBatch().then(() => undefined), "5 seconds", true);
+    }
   }
 
   if (!activeChain.startHeight) {

--- a/apps/indexer/src/indexers/index.ts
+++ b/apps/indexer/src/indexers/index.ts
@@ -1,5 +1,7 @@
 import { activeChain } from "@akashnetwork/database/chainDefinitions";
 
+import { env } from "@src/shared/utils/env";
+import { ProviderVerificationIndexer } from "./providerVerification/providerVerificationIndexer";
 import { AkashStatsIndexer } from "./akashStatsIndexer";
 import { BmeIndexer } from "./bmeIndexer";
 import type { Indexer } from "./indexer";
@@ -8,7 +10,9 @@ import { ValidatorIndexer } from "./validatorIndexer";
 
 const validatorIndexer = new ValidatorIndexer();
 const messageAddressesIndexer = new MessageAddressesIndexer();
-const customIndexers = [new AkashStatsIndexer(), new BmeIndexer()].filter(x => activeChain.customIndexers.includes(x.name));
+const customIndexers = [new AkashStatsIndexer(), new BmeIndexer(), ...(env.PROVIDER_VERIFICATION_ENABLED ? [new ProviderVerificationIndexer()] : [])].filter(
+  x => activeChain.customIndexers.includes(x.name)
+);
 
 export const indexers: Indexer[] = activeChain.startHeight
   ? [...customIndexers, messageAddressesIndexer]

--- a/apps/indexer/src/indexers/providerVerification/providerVerificationEvent.spec.ts
+++ b/apps/indexer/src/indexers/providerVerification/providerVerificationEvent.spec.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from "vitest";
+
+import { parseProviderVerificationEventImpact, PROVIDER_VERIFICATION_EVENT_TYPES, type ProviderVerificationEventImpact } from "./providerVerificationEvent";
+
+const EMPTY_IMPACT: ProviderVerificationEventImpact = {
+  providers: [],
+  auditors: [],
+  auditEscrowIds: [],
+  discrepancyIds: [],
+  graceIds: [],
+  maintenance: []
+};
+
+const EXPECTED_EVENT_TYPES = [
+  "akash.provider.v1beta4.EventProviderMaintenanceClosed",
+  "akash.provider.v1beta4.EventProviderMaintenanceOpened",
+  "akash.verification.v1.EventAttestationExpired",
+  "akash.verification.v1.EventAttestationReplaced",
+  "akash.verification.v1.EventAttestationRevoked",
+  "akash.verification.v1.EventAttestationSubmitted",
+  "akash.verification.v1.EventAttestationVoided",
+  "akash.verification.v1.EventAuditEscrowOpened",
+  "akash.verification.v1.EventAuditEscrowSettled",
+  "akash.verification.v1.EventAuditorBondPosted",
+  "akash.verification.v1.EventAuditorFrozen",
+  "akash.verification.v1.EventAuditorLapsed",
+  "akash.verification.v1.EventAuditorRegistered",
+  "akash.verification.v1.EventAuditorRemoved",
+  "akash.verification.v1.EventAuditorRenewed",
+  "akash.verification.v1.EventAuditorResigned",
+  "akash.verification.v1.EventDepositReturnedToAuditor",
+  "akash.verification.v1.EventDepositSlashed",
+  "akash.verification.v1.EventDiscrepancyDetected",
+  "akash.verification.v1.EventDiscrepancyResolved",
+  "akash.verification.v1.EventDiscrepancyTimedOut",
+  "akash.verification.v1.EventFeeEscrowed",
+  "akash.verification.v1.EventFeeReleasedToAuditor",
+  "akash.verification.v1.EventFeeReturnedToProvider",
+  "akash.verification.v1.EventProviderBondPosted",
+  "akash.verification.v1.EventProviderBondSlashed",
+  "akash.verification.v1.EventProviderBondWithdrawalCompleted",
+  "akash.verification.v1.EventProviderBondWithdrawalInitiated",
+  "akash.verification.v1.EventSnapshotHashPosted",
+  "akash.verification.v1.EventSnapshotResumed",
+  "akash.verification.v1.EventSnapshotSuspended",
+  "akash.verification.v1.EventVerificationGraceEnded",
+  "akash.verification.v1.EventVerificationGraceStarted"
+];
+
+describe("parseProviderVerificationEventImpact", () => {
+  it("covers every verification and provider maintenance event declared by the SDK", () => {
+    expect(PROVIDER_VERIFICATION_EVENT_TYPES).toEqual(EXPECTED_EVENT_TYPES);
+  });
+
+  it("parses an unordered persisted transaction event", () => {
+    expect(
+      parseProviderVerificationEventImpact({
+        type: "akash.verification.v1.EventAttestationSubmitted",
+        attributes: [
+          { key: "tier", value: "verification_tier_identified" },
+          { key: "audit_escrow_id", value: "41" },
+          { key: "auditor", value: "akash1auditor" },
+          { key: "provider", value: "akash1provider" }
+        ]
+      })
+    ).toEqual({
+      ...EMPTY_IMPACT,
+      providers: ["akash1provider"],
+      auditors: ["akash1auditor"],
+      auditEscrowIds: ["41"]
+    });
+  });
+
+  it("accepts a finalize-block event shape", () => {
+    const event = {
+      type: "akash.verification.v1.EventAttestationExpired",
+      attributes: [
+        { key: "auditor", value: "akash1auditor", index: true },
+        { key: "provider", value: "akash1provider", index: true },
+        { key: "tier", value: "verification_tier_identified", index: false }
+      ]
+    };
+
+    expect(parseProviderVerificationEventImpact(event)).toEqual({
+      ...EMPTY_IMPACT,
+      providers: ["akash1provider"],
+      auditors: ["akash1auditor"]
+    });
+  });
+
+  it("decodes JSON-quoted typed-event values", () => {
+    expect(
+      parseProviderVerificationEventImpact({
+        type: "akash.verification.v1.EventAuditorFrozen",
+        attributes: [
+          { key: "discrepancy_id", value: '"9007199254740993"' },
+          { key: "auditor", value: '"akash1auditor"' }
+        ]
+      })
+    ).toEqual({
+      ...EMPTY_IMPACT,
+      auditors: ["akash1auditor"],
+      discrepancyIds: ["9007199254740993"]
+    });
+  });
+
+  it("deduplicates repeated attributes and sorts each impact set", () => {
+    expect(
+      parseProviderVerificationEventImpact({
+        type: "akash.verification.v1.EventDiscrepancyDetected",
+        attributes: [
+          { key: "auditor_b", value: "akash1z" },
+          { key: "discrepancy_id", value: "9" },
+          { key: "auditor_a", value: "akash1a" },
+          { key: "provider", value: "akash1provider" },
+          { key: "auditor_b", value: '"akash1z"' },
+          { key: "discrepancy_id", value: '"9"' }
+        ]
+      })
+    ).toEqual({
+      ...EMPTY_IMPACT,
+      providers: ["akash1provider"],
+      auditors: ["akash1a", "akash1z"],
+      discrepancyIds: ["9"]
+    });
+  });
+
+  it("returns both escrow records affected by an attestation replacement", () => {
+    expect(
+      parseProviderVerificationEventImpact({
+        type: "akash.verification.v1.EventAttestationReplaced",
+        attributes: [
+          { key: "new_audit_escrow_id", value: "12" },
+          { key: "old_audit_escrow_id", value: "11" },
+          { key: "provider", value: "akash1provider" },
+          { key: "auditor", value: "akash1auditor" }
+        ]
+      })
+    ).toEqual({
+      ...EMPTY_IMPACT,
+      providers: ["akash1provider"],
+      auditors: ["akash1auditor"],
+      auditEscrowIds: ["11", "12"]
+    });
+  });
+
+  it("returns a maintenance record identity", () => {
+    expect(
+      parseProviderVerificationEventImpact({
+        type: "akash.provider.v1beta4.EventProviderMaintenanceOpened",
+        attributes: [
+          { key: "maintenance_id", value: '"7"' },
+          { key: "provider", value: '"akash1provider"' }
+        ]
+      })
+    ).toEqual({
+      ...EMPTY_IMPACT,
+      maintenance: [{ provider: "akash1provider", maintenanceId: "7" }]
+    });
+  });
+
+  it("returns only the grace identity when grace-ended omits the provider", () => {
+    expect(
+      parseProviderVerificationEventImpact({
+        type: "akash.verification.v1.EventVerificationGraceEnded",
+        attributes: [
+          { key: "status", value: "verification_grace_status_expired" },
+          { key: "grace_record_id", value: "25" }
+        ]
+      })
+    ).toEqual({ ...EMPTY_IMPACT, graceIds: ["25"] });
+  });
+
+  it("returns no impact for unknown events", () => {
+    expect(
+      parseProviderVerificationEventImpact({
+        type: "akash.verification.v1.EventAttestationRemoved",
+        attributes: [{ key: "provider", value: "akash1provider" }]
+      })
+    ).toEqual(EMPTY_IMPACT);
+  });
+});

--- a/apps/indexer/src/indexers/providerVerification/providerVerificationEvent.ts
+++ b/apps/indexer/src/indexers/providerVerification/providerVerificationEvent.ts
@@ -1,0 +1,160 @@
+export type ProviderVerificationEventAttribute = {
+  key: string;
+  value: string | null;
+};
+
+export type ProviderVerificationEvent = {
+  type: string;
+  attributes?: readonly ProviderVerificationEventAttribute[];
+};
+
+export type ProviderMaintenanceImpact = {
+  provider: string;
+  maintenanceId: string;
+};
+
+export type ProviderVerificationEventImpact = {
+  providers: string[];
+  auditors: string[];
+  auditEscrowIds: string[];
+  discrepancyIds: string[];
+  graceIds: string[];
+  maintenance: ProviderMaintenanceImpact[];
+};
+
+type ImpactField = Exclude<keyof ProviderVerificationEventImpact, "maintenance">;
+type EventImpactDefinition = Partial<Record<ImpactField, readonly string[]>> & { maintenance?: true };
+
+const VERIFICATION_EVENT_PREFIX = "akash.verification.v1.";
+const PROVIDER_EVENT_PREFIX = "akash.provider.v1beta4.";
+
+const EVENT_IMPACT_DEFINITIONS: Readonly<Record<string, EventImpactDefinition>> = {
+  [`${VERIFICATION_EVENT_PREFIX}EventAuditorRegistered`]: { auditors: ["auditor"] },
+  [`${VERIFICATION_EVENT_PREFIX}EventAuditorBondPosted`]: { auditors: ["auditor"] },
+  [`${VERIFICATION_EVENT_PREFIX}EventAuditorFrozen`]: { auditors: ["auditor"], discrepancyIds: ["discrepancy_id"] },
+  [`${VERIFICATION_EVENT_PREFIX}EventAuditorLapsed`]: { auditors: ["auditor"] },
+  [`${VERIFICATION_EVENT_PREFIX}EventAuditorResigned`]: { auditors: ["auditor"] },
+  [`${VERIFICATION_EVENT_PREFIX}EventAuditorRemoved`]: { auditors: ["auditor"] },
+  [`${VERIFICATION_EVENT_PREFIX}EventAuditorRenewed`]: { auditors: ["auditor"] },
+  [`${VERIFICATION_EVENT_PREFIX}EventAttestationSubmitted`]: {
+    providers: ["provider"],
+    auditors: ["auditor"],
+    auditEscrowIds: ["audit_escrow_id"]
+  },
+  [`${VERIFICATION_EVENT_PREFIX}EventAttestationExpired`]: { providers: ["provider"], auditors: ["auditor"] },
+  [`${VERIFICATION_EVENT_PREFIX}EventAttestationReplaced`]: {
+    providers: ["provider"],
+    auditors: ["auditor"],
+    auditEscrowIds: ["old_audit_escrow_id", "new_audit_escrow_id"]
+  },
+  [`${VERIFICATION_EVENT_PREFIX}EventAttestationRevoked`]: { providers: ["provider"], auditors: ["auditor"] },
+  [`${VERIFICATION_EVENT_PREFIX}EventAttestationVoided`]: { providers: ["provider"], auditors: ["auditor"] },
+  [`${VERIFICATION_EVENT_PREFIX}EventDiscrepancyDetected`]: {
+    providers: ["provider"],
+    auditors: ["auditor_a", "auditor_b"],
+    discrepancyIds: ["discrepancy_id"]
+  },
+  [`${VERIFICATION_EVENT_PREFIX}EventDiscrepancyResolved`]: {
+    auditors: ["vindicated_auditor"],
+    discrepancyIds: ["discrepancy_id"]
+  },
+  [`${VERIFICATION_EVENT_PREFIX}EventDiscrepancyTimedOut`]: {
+    auditors: ["auditor_a", "auditor_b"],
+    discrepancyIds: ["discrepancy_id"]
+  },
+  [`${VERIFICATION_EVENT_PREFIX}EventProviderBondPosted`]: { providers: ["provider"] },
+  [`${VERIFICATION_EVENT_PREFIX}EventProviderBondSlashed`]: { providers: ["provider"] },
+  [`${VERIFICATION_EVENT_PREFIX}EventProviderBondWithdrawalInitiated`]: { providers: ["provider"] },
+  [`${VERIFICATION_EVENT_PREFIX}EventProviderBondWithdrawalCompleted`]: { providers: ["provider"] },
+  [`${VERIFICATION_EVENT_PREFIX}EventSnapshotHashPosted`]: { providers: ["provider"] },
+  [`${VERIFICATION_EVENT_PREFIX}EventSnapshotSuspended`]: { providers: ["provider"] },
+  [`${VERIFICATION_EVENT_PREFIX}EventSnapshotResumed`]: { providers: ["provider"] },
+  [`${VERIFICATION_EVENT_PREFIX}EventFeeEscrowed`]: { providers: ["provider"], auditors: ["auditor"] },
+  [`${VERIFICATION_EVENT_PREFIX}EventFeeReleasedToAuditor`]: { auditors: ["auditor"] },
+  [`${VERIFICATION_EVENT_PREFIX}EventFeeReturnedToProvider`]: { providers: ["provider"] },
+  [`${VERIFICATION_EVENT_PREFIX}EventAuditEscrowOpened`]: { providers: ["provider"], auditEscrowIds: ["audit_escrow_id"] },
+  [`${VERIFICATION_EVENT_PREFIX}EventAuditEscrowSettled`]: { auditEscrowIds: ["audit_escrow_id"] },
+  [`${VERIFICATION_EVENT_PREFIX}EventDepositReturnedToAuditor`]: { auditors: ["auditor"] },
+  [`${VERIFICATION_EVENT_PREFIX}EventDepositSlashed`]: { auditors: ["auditor"] },
+  [`${VERIFICATION_EVENT_PREFIX}EventVerificationGraceStarted`]: { providers: ["provider"], graceIds: ["grace_record_id"] },
+  [`${VERIFICATION_EVENT_PREFIX}EventVerificationGraceEnded`]: { graceIds: ["grace_record_id"] },
+  [`${PROVIDER_EVENT_PREFIX}EventProviderMaintenanceOpened`]: { maintenance: true },
+  [`${PROVIDER_EVENT_PREFIX}EventProviderMaintenanceClosed`]: { maintenance: true }
+};
+
+export const PROVIDER_VERIFICATION_EVENT_TYPES = Object.freeze(Object.keys(EVENT_IMPACT_DEFINITIONS).sort());
+
+export function parseProviderVerificationEventImpact(event: ProviderVerificationEvent): ProviderVerificationEventImpact {
+  const definition = EVENT_IMPACT_DEFINITIONS[event.type];
+  const impact = createEmptyImpact();
+  if (!definition) return impact;
+
+  const attributes = collectAttributes(event.attributes ?? []);
+  for (const field of ["providers", "auditors", "auditEscrowIds", "discrepancyIds", "graceIds"] as const) {
+    impact[field] = collectValues(attributes, definition[field] ?? []);
+  }
+
+  if (definition.maintenance) {
+    const providers = collectValues(attributes, ["provider"]);
+    const maintenanceIds = collectValues(attributes, ["maintenance_id"]);
+    impact.maintenance = providers
+      .flatMap(provider => maintenanceIds.map(maintenanceId => ({ provider, maintenanceId })))
+      .sort((left, right) => left.provider.localeCompare(right.provider) || left.maintenanceId.localeCompare(right.maintenanceId));
+  }
+
+  return impact;
+}
+
+function createEmptyImpact(): ProviderVerificationEventImpact {
+  return {
+    providers: [],
+    auditors: [],
+    auditEscrowIds: [],
+    discrepancyIds: [],
+    graceIds: [],
+    maintenance: []
+  };
+}
+
+function collectAttributes(attributes: readonly ProviderVerificationEventAttribute[]): ReadonlyMap<string, ReadonlySet<string>> {
+  const valuesByKey = new Map<string, Set<string>>();
+
+  for (const attribute of attributes) {
+    const value = parseAttributeValue(attribute.value);
+    if (value === null) continue;
+
+    const values = valuesByKey.get(attribute.key) ?? new Set<string>();
+    values.add(value);
+    valuesByKey.set(attribute.key, values);
+  }
+
+  return valuesByKey;
+}
+
+function collectValues(attributes: ReadonlyMap<string, ReadonlySet<string>>, keys: readonly string[]): string[] {
+  const values = new Set<string>();
+  for (const key of keys) {
+    for (const value of attributes.get(key) ?? []) {
+      values.add(value);
+    }
+  }
+  return [...values].sort();
+}
+
+function parseAttributeValue(value: string | null): string | null {
+  if (value === null) return null;
+
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  if (/^-?\d+$/.test(trimmed)) return trimmed;
+
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    if (typeof parsed === "string") return parsed;
+    if (typeof parsed === "number" && Number.isFinite(parsed)) return String(parsed);
+    return null;
+  } catch {
+    return trimmed;
+  }
+}

--- a/apps/indexer/src/indexers/providerVerification/providerVerificationIndexer.spec.ts
+++ b/apps/indexer/src/indexers/providerVerification/providerVerificationIndexer.spec.ts
@@ -1,0 +1,75 @@
+import type { Message, Transaction, TransactionEvent } from "@akashnetwork/database/dbSchemas/base";
+import type { Transaction as DbTransaction } from "sequelize";
+import { describe, expect, it, vi } from "vitest";
+
+import { ProviderVerificationIndexer } from "./providerVerificationIndexer";
+import type { ProviderVerificationRepository } from "./providerVerificationRepository";
+
+describe(ProviderVerificationIndexer.name, () => {
+  it("enqueues transaction-event identities in the surrounding database transaction", async () => {
+    const repository = createRepository();
+    const indexer = new ProviderVerificationIndexer(repository);
+    const dbTransaction = {} as DbTransaction;
+    const transaction = { height: 123 } as Transaction;
+    const events = [
+      {
+        type: "akash.verification.v1.EventAttestationSubmitted",
+        attributes: [
+          { key: "provider", value: "akash1provider" },
+          { key: "auditor", value: "akash1auditor" },
+          { key: "audit_escrow_id", value: "8" }
+        ]
+      }
+    ] as TransactionEvent[];
+
+    await indexer.afterEveryTransaction({} as never, transaction, dbTransaction, events);
+
+    expect(repository.enqueueMany).toHaveBeenCalledWith(
+      [
+        { targetType: "audit_escrow", targetKey: "8" },
+        { targetType: "auditor", targetKey: "akash1auditor" },
+        { targetType: "provider", targetKey: "akash1provider" }
+      ],
+      123,
+      dbTransaction
+    );
+  });
+
+  it("uses the message fallback for provider removal because the SDK has no removal event", async () => {
+    const repository = createRepository();
+    const indexer = new ProviderVerificationIndexer(repository);
+    const dbTransaction = {} as DbTransaction;
+
+    await indexer.processMessage({ provider: "akash1provider", auditor: "akash1auditor" }, 124, dbTransaction, {
+      type: "/akash.verification.v1.MsgRemoveAttestation"
+    } as Message);
+
+    expect(repository.enqueue).toHaveBeenCalledWith({ targetType: "provider", targetKey: "akash1provider" }, 124, dbTransaction);
+  });
+
+  it("queues all provider aggregates with a parameter update transaction", async () => {
+    const repository = createRepository();
+    const indexer = new ProviderVerificationIndexer(repository);
+    const dbTransaction = {} as DbTransaction;
+
+    await indexer.processMessage({}, 125, dbTransaction, {
+      type: "/akash.verification.v1.MsgUpdateParams"
+    } as Message);
+
+    expect(repository.enqueue).toHaveBeenCalledWith({ targetType: "global", targetKey: "*" }, 125, dbTransaction);
+    expect(repository.enqueueAllProviders).toHaveBeenCalledWith(125, dbTransaction);
+  });
+});
+
+function createRepository() {
+  return {
+    enqueue: vi.fn(),
+    enqueueAllProviders: vi.fn(),
+    enqueueMany: vi.fn(),
+    getUnprocessedBlockEvents: vi.fn(),
+    markBlockEventsProcessed: vi.fn()
+  } satisfies Pick<
+    ProviderVerificationRepository,
+    "enqueue" | "enqueueAllProviders" | "enqueueMany" | "getUnprocessedBlockEvents" | "markBlockEventsProcessed"
+  >;
+}

--- a/apps/indexer/src/indexers/providerVerification/providerVerificationIndexer.ts
+++ b/apps/indexer/src/indexers/providerVerification/providerVerificationIndexer.ts
@@ -1,0 +1,134 @@
+import type * as verificationV1 from "@akashnetwork/chain-sdk/private-types/akash.v1";
+import type { AkashBlock as Block } from "@akashnetwork/database/dbSchemas/akash";
+import {
+  ProviderMaintenance,
+  VerificationAttestation,
+  VerificationAttestationCapability,
+  VerificationAuditEscrow,
+  VerificationAuditEscrowCapability,
+  VerificationAuditor,
+  VerificationBlockEvent,
+  VerificationDiscrepancy,
+  VerificationGrace,
+  VerificationGraceDiscrepancy,
+  VerificationParams,
+  VerificationProviderBond,
+  VerificationProviderBondUnbonding,
+  VerificationProviderObservation,
+  VerificationProviderSnapshot,
+  VerificationProviderTierDemotion,
+  VerificationProviderTierStream,
+  VerificationReconcileTarget
+} from "@akashnetwork/database/dbSchemas/akash";
+import type { Transaction, TransactionEvent } from "@akashnetwork/database/dbSchemas/base";
+import type { DecodedTxRaw } from "@cosmjs/proto-signing";
+import type { Transaction as DbTransaction } from "sequelize";
+
+import type { IGenesis } from "@src/chain/genesisTypes";
+import { Indexer } from "../indexer";
+import { parseProviderVerificationEventImpact, PROVIDER_VERIFICATION_EVENT_TYPES } from "./providerVerificationEvent";
+import { toProviderVerificationReconcileTargets } from "./providerVerificationReconcileTarget";
+import { ProviderVerificationRepository } from "./providerVerificationRepository";
+
+const providerVerificationEventTypes = new Set(PROVIDER_VERIFICATION_EVENT_TYPES);
+
+type VerificationEventRepository = Pick<
+  ProviderVerificationRepository,
+  "enqueue" | "enqueueAllProviders" | "enqueueMany" | "getUnprocessedBlockEvents" | "markBlockEventsProcessed"
+>;
+
+export class ProviderVerificationIndexer extends Indexer {
+  constructor(private readonly repository: VerificationEventRepository = new ProviderVerificationRepository()) {
+    super();
+    this.name = "ProviderVerificationIndexer";
+    this.runForEveryBlocks = true;
+    this.processFailedTxs = false;
+    this.msgHandlers = {
+      "/akash.verification.v1.MsgRemoveAttestation": this.handleRemoveAttestation,
+      "/akash.verification.v1.MsgUpdateParams": this.handleUpdateParams
+    };
+  }
+
+  async dropTables(): Promise<void> {
+    await VerificationProviderTierDemotion.drop({ cascade: true });
+    await VerificationProviderTierStream.drop({ cascade: true });
+    await VerificationGraceDiscrepancy.drop({ cascade: true });
+    await VerificationAttestationCapability.drop({ cascade: true });
+    await VerificationAuditEscrowCapability.drop({ cascade: true });
+    await VerificationProviderBondUnbonding.drop({ cascade: true });
+    await VerificationAttestation.drop({ cascade: true });
+    await VerificationAuditEscrow.drop({ cascade: true });
+    await VerificationProviderBond.drop({ cascade: true });
+    await VerificationProviderObservation.drop({ cascade: true });
+    await VerificationGrace.drop({ cascade: true });
+    await ProviderMaintenance.drop({ cascade: true });
+    await VerificationProviderSnapshot.drop({ cascade: true });
+    await VerificationDiscrepancy.drop({ cascade: true });
+    await VerificationAuditor.drop({ cascade: true });
+    await VerificationParams.drop({ cascade: true });
+    await VerificationReconcileTarget.drop({ cascade: true });
+    await VerificationBlockEvent.drop({ cascade: true });
+  }
+
+  async createTables(): Promise<void> {
+    await VerificationAuditor.sync({ force: false });
+    await VerificationAttestation.sync({ force: false });
+    await VerificationAttestationCapability.sync({ force: false });
+    await VerificationAuditEscrow.sync({ force: false });
+    await VerificationAuditEscrowCapability.sync({ force: false });
+    await VerificationDiscrepancy.sync({ force: false });
+    await VerificationGrace.sync({ force: false });
+    await VerificationGraceDiscrepancy.sync({ force: false });
+    await VerificationProviderBond.sync({ force: false });
+    await VerificationProviderObservation.sync({ force: false });
+    await VerificationProviderTierStream.sync({ force: false });
+    await VerificationProviderTierStream.findOrCreate({ where: { id: 1 } });
+    await VerificationProviderTierDemotion.sync({ force: false });
+    await VerificationProviderBondUnbonding.sync({ force: false });
+    await VerificationProviderSnapshot.sync({ force: false });
+    await ProviderMaintenance.sync({ force: false });
+    await VerificationParams.sync({ force: false });
+    await VerificationReconcileTarget.sync({ force: false });
+    await VerificationBlockEvent.sync({ force: false });
+  }
+
+  initCache(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  seed(_genesis: IGenesis): Promise<void> {
+    return Promise.resolve();
+  }
+
+  async afterEveryTransaction(
+    _rawTx: DecodedTxRaw,
+    currentTransaction: Transaction,
+    dbTransaction: DbTransaction,
+    txEvents: TransactionEvent[]
+  ): Promise<void> {
+    for (const event of txEvents) {
+      if (!providerVerificationEventTypes.has(event.type)) continue;
+      const impact = parseProviderVerificationEventImpact({ type: event.type, attributes: event.attributes });
+      await this.repository.enqueueMany(toProviderVerificationReconcileTargets(impact), currentTransaction.height, dbTransaction);
+    }
+  }
+
+  async afterEveryBlock(currentBlock: Block, _previousBlock: Block | null, dbTransaction: DbTransaction): Promise<void> {
+    const events = await this.repository.getUnprocessedBlockEvents(currentBlock.height, dbTransaction);
+    for (const event of events) {
+      const attributes = Object.entries(event.data).map(([key, value]) => ({ key, value }));
+      const impact = parseProviderVerificationEventImpact({ type: event.type, attributes });
+      await this.repository.enqueueMany(toProviderVerificationReconcileTargets(impact), currentBlock.height, dbTransaction);
+    }
+    if (events.length > 0) await this.repository.markBlockEventsProcessed(currentBlock.height, dbTransaction);
+  }
+
+  private async handleRemoveAttestation(message: verificationV1.MsgRemoveAttestation, height: number, transaction: DbTransaction): Promise<void> {
+    await this.repository.enqueue({ targetType: "provider", targetKey: message.provider }, height, transaction);
+  }
+
+  private async handleUpdateParams(_message: verificationV1.Verification_MsgUpdateParams, height: number, transaction: DbTransaction): Promise<void> {
+    await this.repository.enqueue({ targetType: "global", targetKey: "*" }, height, transaction);
+    await this.repository.enqueueAllProviders(height, transaction);
+  }
+}

--- a/apps/indexer/src/indexers/providerVerification/providerVerificationIndexerTables.spec.ts
+++ b/apps/indexer/src/indexers/providerVerification/providerVerificationIndexerTables.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { ProviderVerificationIndexer } from "./providerVerificationIndexer";
+
+const mocks = vi.hoisted(() => {
+  const model = () => ({ drop: vi.fn().mockResolvedValue(undefined), sync: vi.fn().mockResolvedValue(undefined) });
+  const models = {
+    ProviderMaintenance: model(),
+    VerificationAttestation: model(),
+    VerificationAttestationCapability: model(),
+    VerificationAuditEscrow: model(),
+    VerificationAuditEscrowCapability: model(),
+    VerificationAuditor: model(),
+    VerificationBlockEvent: model(),
+    VerificationDiscrepancy: model(),
+    VerificationGrace: model(),
+    VerificationGraceDiscrepancy: model(),
+    VerificationParams: model(),
+    VerificationProviderBond: model(),
+    VerificationProviderBondUnbonding: model(),
+    VerificationProviderObservation: model(),
+    VerificationProviderSnapshot: model(),
+    VerificationProviderTierDemotion: model(),
+    VerificationProviderTierStream: { ...model(), findOrCreate: vi.fn().mockResolvedValue([]) },
+    VerificationReconcileTarget: model()
+  };
+
+  return { models };
+});
+
+vi.mock("@akashnetwork/database/dbSchemas/akash", () => mocks.models);
+
+describe(`${ProviderVerificationIndexer.name}.createTables`, () => {
+  it("creates tier tables and seeds the singleton stream", async () => {
+    await new ProviderVerificationIndexer().createTables();
+
+    expect(mocks.models.VerificationProviderTierStream.sync).toHaveBeenCalledWith({ force: false });
+    expect(mocks.models.VerificationProviderTierStream.findOrCreate).toHaveBeenCalledWith({ where: { id: 1 } });
+    expect(mocks.models.VerificationProviderTierDemotion.sync).toHaveBeenCalledWith({ force: false });
+  });
+});

--- a/apps/indexer/src/indexers/providerVerification/providerVerificationReconcileTarget.spec.ts
+++ b/apps/indexer/src/indexers/providerVerification/providerVerificationReconcileTarget.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import type { ProviderVerificationEventImpact } from "./providerVerificationEvent";
+import { toProviderVerificationReconcileTargets } from "./providerVerificationReconcileTarget";
+
+describe(toProviderVerificationReconcileTargets.name, () => {
+  it("coalesces all directly queryable event identities", () => {
+    expect(
+      toProviderVerificationReconcileTargets(
+        impact({
+          providers: ["akash1provider"],
+          auditors: ["akash1auditor"],
+          auditEscrowIds: ["7", "7"],
+          discrepancyIds: ["9"],
+          maintenance: [{ provider: "akash1provider", maintenanceId: "4" }]
+        })
+      )
+    ).toEqual([
+      { targetType: "audit_escrow", targetKey: "7" },
+      { targetType: "auditor", targetKey: "akash1auditor" },
+      { targetType: "discrepancy", targetKey: "9" },
+      { targetType: "provider", targetKey: "akash1provider" }
+    ]);
+  });
+
+  it("requests a provider sweep for a grace identity that cannot be queried directly", () => {
+    expect(toProviderVerificationReconcileTargets(impact({ graceIds: ["12"] }))).toEqual([{ targetType: "all_providers", targetKey: "*" }]);
+  });
+
+  it("uses the provider carried by grace-started events instead of a sweep", () => {
+    expect(toProviderVerificationReconcileTargets(impact({ providers: ["akash1provider"], graceIds: ["12"] }))).toEqual([
+      { targetType: "provider", targetKey: "akash1provider" }
+    ]);
+  });
+});
+
+function impact(overrides: Partial<ProviderVerificationEventImpact>): ProviderVerificationEventImpact {
+  return {
+    providers: [],
+    auditors: [],
+    auditEscrowIds: [],
+    discrepancyIds: [],
+    graceIds: [],
+    maintenance: [],
+    ...overrides
+  };
+}

--- a/apps/indexer/src/indexers/providerVerification/providerVerificationReconcileTarget.ts
+++ b/apps/indexer/src/indexers/providerVerification/providerVerificationReconcileTarget.ts
@@ -1,0 +1,27 @@
+import type { ProviderVerificationEventImpact } from "./providerVerificationEvent";
+
+export type ProviderVerificationReconcileTargetType = "global" | "provider" | "auditor" | "audit_escrow" | "discrepancy" | "all_providers";
+
+export interface ProviderVerificationReconcileTarget {
+  targetType: ProviderVerificationReconcileTargetType;
+  targetKey: string;
+}
+
+export function toProviderVerificationReconcileTargets(impact: ProviderVerificationEventImpact): ProviderVerificationReconcileTarget[] {
+  const targets = new Map<string, ProviderVerificationReconcileTarget>();
+  const add = (targetType: ProviderVerificationReconcileTargetType, targetKey: string) => {
+    targets.set(`${targetType}:${targetKey}`, { targetType, targetKey });
+  };
+
+  for (const provider of impact.providers) add("provider", provider);
+  for (const auditor of impact.auditors) add("auditor", auditor);
+  for (const auditEscrowId of impact.auditEscrowIds) add("audit_escrow", auditEscrowId);
+  for (const discrepancyId of impact.discrepancyIds) add("discrepancy", discrepancyId);
+  for (const maintenance of impact.maintenance) add("provider", maintenance.provider);
+
+  // The chain exposes grace records by provider, not by grace ID. Grace-ended
+  // events omit the provider, so a bounded provider sweep is the only complete repair.
+  if (impact.graceIds.length > 0 && impact.providers.length === 0) add("all_providers", "*");
+
+  return [...targets.values()].sort((left, right) => left.targetType.localeCompare(right.targetType) || left.targetKey.localeCompare(right.targetKey));
+}

--- a/apps/indexer/src/indexers/providerVerification/providerVerificationReconciler.spec.ts
+++ b/apps/indexer/src/indexers/providerVerification/providerVerificationReconciler.spec.ts
@@ -1,0 +1,144 @@
+import type { ProviderVerificationQueryClient } from "@akashnetwork/provider-verification";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { ReconcileBlockSource, ReconcileRepository } from "./providerVerificationReconciler";
+import { ProviderVerificationReconciler } from "./providerVerificationReconciler";
+import type { ClaimedProviderVerificationTarget } from "./providerVerificationRepository";
+
+const block = { height: 200, datetime: new Date("2026-08-24T12:00:00.000Z") };
+
+describe(ProviderVerificationReconciler.name, () => {
+  const client = mock<ProviderVerificationQueryClient>();
+  const repository = mock<ReconcileRepository>();
+  const blockSource = mock<ReconcileBlockSource>();
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    blockSource.getLatestProcessedBlock.mockResolvedValue(block);
+    repository.hasDiscrepancies.mockResolvedValue(true);
+    repository.replaceGlobalState.mockResolvedValue(true);
+    repository.replaceProviderState.mockResolvedValue(true);
+  });
+
+  it("queues scheduled refreshes without invalidating the currently indexed view", async () => {
+    await new ProviderVerificationReconciler(client, repository, blockSource).enqueueFullReconciliation();
+
+    expect(repository.enqueue).toHaveBeenCalledWith({ targetType: "global", targetKey: "*" }, 200, undefined, false);
+    expect(repository.enqueueAllProviders).toHaveBeenCalledWith(200, undefined, false);
+  });
+
+  it("reconciles a provider at the latest locally processed height", async () => {
+    const target = providerTarget();
+    repository.claimNext.mockResolvedValueOnce(target).mockResolvedValueOnce(null);
+    client.getProviderState.mockResolvedValue(emptyProviderState("200"));
+
+    const processed = await new ProviderVerificationReconciler(client, repository, blockSource).runBatch();
+
+    expect(processed).toBe(1);
+    expect(client.getProviderState).toHaveBeenCalledWith("akash1provider", "200");
+    expect(repository.replaceProviderState).toHaveBeenCalledWith(expect.objectContaining({ provider: "akash1provider", observedHeight: 200 }));
+    expect(repository.complete).toHaveBeenCalledWith(target, 200);
+  });
+
+  it("refreshes global records before writing grace references that are not indexed yet", async () => {
+    const target = providerTarget();
+    repository.claimNext.mockResolvedValueOnce(target).mockResolvedValueOnce(null);
+    repository.hasDiscrepancies.mockResolvedValue(false);
+    client.getProviderState.mockResolvedValue({
+      ...emptyProviderState("200"),
+      grace: {
+        id: 4n,
+        provider: "akash1provider",
+        preservedTier: 2,
+        startedAt: block.datetime,
+        expiresAt: new Date("2026-08-25T12:00:00.000Z"),
+        sourceDiscrepancyIds: [7n],
+        status: 1
+      }
+    });
+    client.getGlobalState.mockResolvedValue({
+      observedHeight: "200",
+      params: { verificationModuleActive: true } as never,
+      auditors: [],
+      discrepancies: []
+    });
+
+    await new ProviderVerificationReconciler(client, repository, blockSource).runBatch();
+
+    expect(repository.replaceGlobalState).toHaveBeenCalledBefore(repository.replaceProviderState);
+  });
+
+  it("resolves escrow invalidations back to their provider aggregate", async () => {
+    const target = { ...providerTarget(), targetType: "audit_escrow" as const, targetKey: "17" };
+    repository.claimNext.mockResolvedValueOnce(target).mockResolvedValueOnce(null);
+    client.getAuditEscrow.mockResolvedValue({ provider: "akash1provider" } as Awaited<ReturnType<ProviderVerificationQueryClient["getAuditEscrow"]>>);
+    client.getProviderState.mockResolvedValue(emptyProviderState("200"));
+
+    await new ProviderVerificationReconciler(client, repository, blockSource).runBatch();
+
+    expect(client.getAuditEscrow).toHaveBeenCalledWith("17", "200");
+    expect(client.getProviderState).toHaveBeenCalledWith("akash1provider", "200");
+  });
+
+  it("resolves discrepancy invalidations back to their provider aggregate", async () => {
+    const target = { ...providerTarget(), targetType: "discrepancy" as const, targetKey: "19" };
+    repository.claimNext.mockResolvedValueOnce(target).mockResolvedValueOnce(null);
+    client.getDiscrepancy.mockResolvedValue({ provider: "akash1provider" } as Awaited<ReturnType<ProviderVerificationQueryClient["getDiscrepancy"]>>);
+    client.getGlobalState.mockResolvedValue({
+      observedHeight: "200",
+      params: { verificationModuleActive: true } as never,
+      auditors: [],
+      discrepancies: []
+    });
+    client.getProviderState.mockResolvedValue(emptyProviderState("200"));
+
+    await new ProviderVerificationReconciler(client, repository, blockSource).runBatch();
+
+    expect(client.getDiscrepancy).toHaveBeenCalledWith("19", "200");
+    expect(client.getGlobalState).toHaveBeenCalledWith("200");
+    expect(client.getProviderState).toHaveBeenCalledWith("akash1provider", "200");
+    expect(repository.replaceGlobalState).toHaveBeenCalledBefore(repository.replaceProviderState);
+  });
+
+  it("keeps a failed target for bounded retry", async () => {
+    const target = providerTarget();
+    const error = new Error("query unavailable");
+    repository.claimNext.mockResolvedValueOnce(target).mockResolvedValueOnce(null);
+    client.getProviderState.mockRejectedValue(error);
+
+    await new ProviderVerificationReconciler(client, repository, blockSource).runBatch();
+
+    expect(repository.fail).toHaveBeenCalledWith(target, error);
+    expect(repository.complete).not.toHaveBeenCalled();
+  });
+
+  it("retries a global target when the canonical params response is incomplete", async () => {
+    const target = { ...providerTarget(), targetType: "global" as const, targetKey: "*" };
+    repository.claimNext.mockResolvedValueOnce(target).mockResolvedValueOnce(null);
+    client.getGlobalState.mockResolvedValue({ observedHeight: "200", params: null, auditors: [], discrepancies: [] });
+
+    await new ProviderVerificationReconciler(client, repository, blockSource).runBatch();
+
+    expect(repository.replaceGlobalState).not.toHaveBeenCalled();
+    expect(repository.fail).toHaveBeenCalledWith(target, expect.objectContaining({ message: "Provider verification params are missing at height 200" }));
+  });
+});
+
+function providerTarget(): ClaimedProviderVerificationTarget {
+  return { targetType: "provider", targetKey: "akash1provider", requestedHeight: 100, attemptCount: 0 };
+}
+
+function emptyProviderState(observedHeight: string): Awaited<ReturnType<ProviderVerificationQueryClient["getProviderState"]>> {
+  return {
+    provider: "akash1provider",
+    attestations: [],
+    auditEscrows: [],
+    bond: null,
+    requiredBondForCurrentTier: null,
+    grace: null,
+    maintenances: [],
+    snapshot: null,
+    observedHeight
+  };
+}

--- a/apps/indexer/src/indexers/providerVerification/providerVerificationReconciler.ts
+++ b/apps/indexer/src/indexers/providerVerification/providerVerificationReconciler.ts
@@ -1,0 +1,125 @@
+import { Block } from "@akashnetwork/database/dbSchemas";
+import type { ProviderVerificationQueryClient } from "@akashnetwork/provider-verification";
+import type { Transaction as DbTransaction } from "sequelize";
+
+import type { ClaimedProviderVerificationTarget } from "./providerVerificationRepository";
+import { ProviderVerificationRepository } from "./providerVerificationRepository";
+import { mapProviderVerificationGlobalState, mapProviderVerificationProviderState } from "./providerVerificationStateMapper";
+
+type VerificationQueryClient = Pick<ProviderVerificationQueryClient, "getAuditEscrow" | "getDiscrepancy" | "getGlobalState" | "getProviderState">;
+
+interface ReconcileBlock {
+  height: number;
+  datetime: Date;
+}
+
+export interface ReconcileBlockSource {
+  getLatestProcessedBlock(): Promise<ReconcileBlock | null>;
+}
+
+export interface ReconcileRepository {
+  claimNext(): Promise<ClaimedProviderVerificationTarget | null>;
+  complete(target: ClaimedProviderVerificationTarget, processedHeight: number): Promise<void>;
+  enqueue(
+    target: { targetType: "global" | "provider" | "all_providers"; targetKey: string },
+    requestedHeight: number,
+    transaction?: DbTransaction,
+    invalidated?: boolean
+  ): Promise<void>;
+  enqueueAllProviders(requestedHeight: number, transaction?: DbTransaction, invalidated?: boolean): Promise<void>;
+  fail(target: ClaimedProviderVerificationTarget, error: unknown): Promise<void>;
+  findAuditEscrowProvider(id: string): Promise<string | null>;
+  hasDiscrepancies(ids: readonly string[]): Promise<boolean>;
+  replaceGlobalState(rows: ReturnType<typeof mapProviderVerificationGlobalState>): Promise<boolean>;
+  replaceProviderState(rows: ReturnType<typeof mapProviderVerificationProviderState>): Promise<boolean>;
+}
+
+const defaultBlockSource: ReconcileBlockSource = {
+  async getLatestProcessedBlock() {
+    const block = await Block.findOne({ where: { isProcessed: true }, order: [["height", "DESC"]], attributes: ["height", "datetime"] });
+    return block ? { height: block.height, datetime: block.datetime } : null;
+  }
+};
+
+export class ProviderVerificationReconciler {
+  constructor(
+    private readonly client: VerificationQueryClient,
+    private readonly repository: ReconcileRepository = new ProviderVerificationRepository(),
+    private readonly blockSource: ReconcileBlockSource = defaultBlockSource
+  ) {}
+
+  async enqueueFullReconciliation(): Promise<void> {
+    const block = await this.requireLatestProcessedBlock();
+    await this.repository.enqueue({ targetType: "global", targetKey: "*" }, block.height, undefined, false);
+    await this.repository.enqueueAllProviders(block.height, undefined, false);
+  }
+
+  async runBatch(limit = 25): Promise<number> {
+    let processed = 0;
+    while (processed < limit) {
+      const target = await this.repository.claimNext();
+      if (!target) break;
+
+      try {
+        const block = await this.requireLatestProcessedBlock(target.requestedHeight);
+        await this.reconcileTarget(target, block);
+        await this.repository.complete(target, block.height);
+      } catch (error) {
+        await this.repository.fail(target, error);
+      }
+      processed++;
+    }
+    return processed;
+  }
+
+  private async reconcileTarget(target: ClaimedProviderVerificationTarget, block: ReconcileBlock): Promise<void> {
+    const height = block.height.toString();
+    switch (target.targetType) {
+      case "global":
+      case "auditor":
+        await this.reconcileGlobal(height, block.datetime);
+        return;
+      case "discrepancy": {
+        const discrepancy = await this.client.getDiscrepancy(target.targetKey, height);
+        await this.reconcileGlobal(height, block.datetime);
+        if (discrepancy?.provider) await this.reconcileProvider(discrepancy.provider, height, block.datetime);
+        return;
+      }
+      case "provider":
+        await this.reconcileProvider(target.targetKey, height, block.datetime);
+        return;
+      case "audit_escrow": {
+        const escrow = await this.client.getAuditEscrow(target.targetKey, height);
+        const provider = escrow?.provider || (await this.repository.findAuditEscrowProvider(target.targetKey));
+        if (provider) await this.reconcileProvider(provider, height, block.datetime);
+        return;
+      }
+      case "all_providers":
+        await this.repository.enqueueAllProviders(block.height);
+        return;
+    }
+  }
+
+  private async reconcileGlobal(height: string, blockTime: Date): Promise<void> {
+    const state = await this.client.getGlobalState(height);
+    if (!state.params) throw new Error(`Provider verification params are missing at height ${height}`);
+    await this.repository.replaceGlobalState(mapProviderVerificationGlobalState(state, blockTime));
+  }
+
+  private async reconcileProvider(provider: string, height: string, blockTime: Date): Promise<void> {
+    const state = await this.client.getProviderState(provider, height);
+    const sourceDiscrepancyIds = state.grace?.sourceDiscrepancyIds.map(id => id.toString()) ?? [];
+    if (!(await this.repository.hasDiscrepancies(sourceDiscrepancyIds))) {
+      await this.reconcileGlobal(height, blockTime);
+    }
+    await this.repository.replaceProviderState(mapProviderVerificationProviderState(state, blockTime));
+  }
+
+  private async requireLatestProcessedBlock(minimumHeight = 0): Promise<ReconcileBlock> {
+    const block = await this.blockSource.getLatestProcessedBlock();
+    if (!block || block.height < minimumHeight) {
+      throw new Error(`Provider verification state is not ready at height ${minimumHeight}`);
+    }
+    return block;
+  }
+}

--- a/apps/indexer/src/indexers/providerVerification/providerVerificationRepository.spec.ts
+++ b/apps/indexer/src/indexers/providerVerification/providerVerificationRepository.spec.ts
@@ -1,0 +1,149 @@
+import { VerificationTier } from "@akashnetwork/chain-sdk/private-types/akash.v1";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ProviderVerificationRepository } from "./providerVerificationRepository";
+import type { ProviderVerificationProviderRows } from "./providerVerificationStateMapper";
+
+const mocks = vi.hoisted(() => {
+  const transaction = { id: "provider-replacement" };
+  const model = () => ({
+    bulkCreate: vi.fn().mockResolvedValue([]),
+    count: vi.fn().mockResolvedValue(0),
+    create: vi.fn().mockResolvedValue(undefined),
+    destroy: vi.fn().mockResolvedValue(0),
+    findAll: vi.fn().mockResolvedValue([]),
+    findByPk: vi.fn().mockResolvedValue(null),
+    update: vi.fn().mockResolvedValue([0]),
+    upsert: vi.fn().mockResolvedValue(undefined)
+  });
+  const connection = {
+    query: vi.fn().mockResolvedValue([]),
+    transaction: vi.fn(async (callback: (transaction: { id: string }) => Promise<boolean>) => callback(transaction))
+  };
+  const models = {
+    ProviderMaintenance: model(),
+    VerificationAttestation: model(),
+    VerificationAttestationCapability: model(),
+    VerificationAuditEscrow: model(),
+    VerificationAuditEscrowCapability: model(),
+    VerificationAuditor: model(),
+    VerificationBlockEvent: model(),
+    VerificationDiscrepancy: model(),
+    VerificationGrace: model(),
+    VerificationGraceDiscrepancy: model(),
+    VerificationParams: model(),
+    VerificationProviderBond: model(),
+    VerificationProviderBondUnbonding: model(),
+    VerificationProviderObservation: model(),
+    VerificationProviderSnapshot: model(),
+    VerificationProviderTierDemotion: model(),
+    VerificationReconcileTarget: { ...model(), sequelize: connection }
+  };
+
+  return { connection, models, transaction };
+});
+
+vi.mock("@akashnetwork/database/dbSchemas/akash", () => mocks.models);
+
+describe(`${ProviderVerificationRepository.name}.replaceProviderState`, () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.connection.query.mockResolvedValue([]);
+    mocks.models.VerificationAuditEscrow.findAll.mockResolvedValue([]);
+    mocks.models.VerificationGrace.findAll.mockResolvedValue([]);
+    mocks.models.VerificationProviderObservation.findByPk.mockResolvedValue(null);
+  });
+
+  it("establishes the first tier observation without emitting a demotion", async () => {
+    const rows = providerRows();
+
+    await expect(new ProviderVerificationRepository().replaceProviderState(rows)).resolves.toBe(true);
+
+    expect(mocks.models.VerificationProviderTierDemotion.create).not.toHaveBeenCalled();
+    expect(mocks.models.VerificationProviderObservation.upsert).toHaveBeenCalledWith(
+      {
+        provider: rows.provider,
+        observedHeight: rows.observedHeight,
+        observedBlockTime: rows.observedBlockTime,
+        effectiveTier: rows.tierState.effectiveTier,
+        maxPlacementTier: rows.tierState.maxPlacementTier,
+        snapshotState: rows.tierState.snapshotState
+      },
+      { transaction: mocks.transaction }
+    );
+  });
+
+  it("inserts one demotion in the provider replacement transaction", async () => {
+    mocks.models.VerificationProviderObservation.findByPk.mockResolvedValue({
+      observedHeight: 99,
+      effectiveTier: VerificationTier.verification_tier_established,
+      maxPlacementTier: VerificationTier.verification_tier_established,
+      snapshotState: "current"
+    });
+    const rows = providerRows({
+      tierState: {
+        effectiveTier: VerificationTier.verification_tier_verified,
+        maxPlacementTier: VerificationTier.verification_tier_identified,
+        snapshotState: "stale"
+      }
+    });
+
+    await expect(new ProviderVerificationRepository().replaceProviderState(rows)).resolves.toBe(true);
+
+    expect(mocks.models.VerificationProviderTierDemotion.create).toHaveBeenCalledTimes(1);
+    expect(mocks.models.VerificationProviderTierDemotion.create).toHaveBeenCalledWith(
+      {
+        provider: rows.provider,
+        previousEffectiveTier: VerificationTier.verification_tier_established,
+        previousMaxPlacementTier: VerificationTier.verification_tier_established,
+        previousSnapshotState: "current",
+        currentEffectiveTier: VerificationTier.verification_tier_verified,
+        currentMaxPlacementTier: VerificationTier.verification_tier_identified,
+        currentSnapshotState: "stale",
+        changes: ["tier_gate", "snapshot_eligibility"],
+        observedHeight: rows.observedHeight,
+        observedBlockTime: rows.observedBlockTime
+      },
+      { transaction: mocks.transaction }
+    );
+  });
+
+  it.each([100, 101])("rejects an observation at or below the existing height %s", async observedHeight => {
+    mocks.models.VerificationProviderObservation.findByPk.mockResolvedValue({
+      observedHeight,
+      effectiveTier: VerificationTier.verification_tier_established,
+      maxPlacementTier: VerificationTier.verification_tier_established,
+      snapshotState: "current"
+    });
+
+    await expect(new ProviderVerificationRepository().replaceProviderState(providerRows())).resolves.toBe(false);
+
+    expect(mocks.models.VerificationAttestation.destroy).not.toHaveBeenCalled();
+    expect(mocks.models.VerificationProviderTierDemotion.create).not.toHaveBeenCalled();
+    expect(mocks.models.VerificationProviderObservation.upsert).not.toHaveBeenCalled();
+  });
+});
+
+function providerRows(overrides: Partial<ProviderVerificationProviderRows> = {}): ProviderVerificationProviderRows {
+  return {
+    provider: "akash1provider",
+    observedHeight: 100,
+    observedBlockTime: new Date("2026-08-24T12:00:00.000Z"),
+    tierState: {
+      effectiveTier: VerificationTier.verification_tier_established,
+      maxPlacementTier: VerificationTier.verification_tier_established,
+      snapshotState: "current"
+    },
+    attestations: [],
+    attestationCapabilities: [],
+    auditEscrows: [],
+    auditEscrowCapabilities: [],
+    bond: null,
+    bondUnbondingEntries: [],
+    grace: null,
+    graceDiscrepancies: [],
+    maintenances: [],
+    snapshot: null,
+    ...overrides
+  };
+}

--- a/apps/indexer/src/indexers/providerVerification/providerVerificationRepository.ts
+++ b/apps/indexer/src/indexers/providerVerification/providerVerificationRepository.ts
@@ -1,0 +1,345 @@
+import {
+  ProviderMaintenance,
+  VerificationAttestation,
+  VerificationAttestationCapability,
+  VerificationAuditEscrow,
+  VerificationAuditEscrowCapability,
+  VerificationAuditor,
+  VerificationBlockEvent,
+  VerificationDiscrepancy,
+  VerificationGrace,
+  VerificationGraceDiscrepancy,
+  VerificationParams,
+  VerificationProviderBond,
+  VerificationProviderBondUnbonding,
+  VerificationProviderObservation,
+  VerificationProviderSnapshot,
+  VerificationProviderTierDemotion,
+  VerificationReconcileTarget
+} from "@akashnetwork/database/dbSchemas/akash";
+import {
+  detectProviderTierDemotion,
+  type ProviderTierDemotionChange,
+  type ProviderTierState,
+  type SnapshotComplianceState
+} from "@akashnetwork/provider-verification";
+import type { Transaction as DbTransaction } from "sequelize";
+import { Op, QueryTypes } from "sequelize";
+
+import type { ProviderVerificationReconcileTarget, ProviderVerificationReconcileTargetType } from "./providerVerificationReconcileTarget";
+import type { ProviderVerificationGlobalRows, ProviderVerificationProviderRows } from "./providerVerificationStateMapper";
+
+export interface ClaimedProviderVerificationTarget extends ProviderVerificationReconcileTarget {
+  requestedHeight: number;
+  attemptCount: number;
+}
+
+export class ProviderVerificationRepository {
+  async enqueue(target: ProviderVerificationReconcileTarget, requestedHeight: number, transaction?: DbTransaction, invalidated = true): Promise<void> {
+    await database().query(
+      `INSERT INTO verification_reconcile_target
+         (target_type, target_key, requested_height, invalidated, attempt_count)
+       VALUES (:targetType, :targetKey, :requestedHeight, :invalidated, 0)
+       ON CONFLICT (target_type, target_key) DO UPDATE
+       SET requested_height = GREATEST(verification_reconcile_target.requested_height, EXCLUDED.requested_height),
+           invalidated = verification_reconcile_target.invalidated OR EXCLUDED.invalidated`,
+      { replacements: { ...target, requestedHeight, invalidated }, transaction }
+    );
+  }
+
+  async enqueueMany(targets: readonly ProviderVerificationReconcileTarget[], requestedHeight: number, transaction?: DbTransaction): Promise<void> {
+    for (const target of targets) {
+      await this.enqueue(target, requestedHeight, transaction);
+    }
+  }
+
+  async enqueueAllProviders(requestedHeight: number, transaction?: DbTransaction, invalidated = true): Promise<void> {
+    await database().query(
+      `INSERT INTO verification_reconcile_target
+         (target_type, target_key, requested_height, invalidated, attempt_count)
+       SELECT 'provider', owner, :requestedHeight, :invalidated, 0
+       FROM provider
+       WHERE "deletedHeight" IS NULL
+       ON CONFLICT (target_type, target_key) DO UPDATE
+       SET requested_height = GREATEST(verification_reconcile_target.requested_height, EXCLUDED.requested_height),
+           invalidated = verification_reconcile_target.invalidated OR EXCLUDED.invalidated`,
+      { replacements: { requestedHeight, invalidated }, transaction }
+    );
+  }
+
+  async claimNext(): Promise<ClaimedProviderVerificationTarget | null> {
+    const [target] = await database().query<{
+      targetType: ProviderVerificationReconcileTargetType;
+      targetKey: string;
+      requestedHeight: number;
+      attemptCount: number;
+    }>(
+      `WITH candidate AS (
+         SELECT target_type, target_key
+         FROM verification_reconcile_target
+         WHERE (claimed_at IS NULL OR claimed_at < NOW() - INTERVAL '5 minutes')
+           AND (next_attempt_at IS NULL OR next_attempt_at <= NOW())
+         ORDER BY requested_height ASC, target_type ASC, target_key ASC
+         FOR UPDATE SKIP LOCKED
+         LIMIT 1
+       )
+       UPDATE verification_reconcile_target AS target
+       SET claimed_at = NOW()
+       FROM candidate
+       WHERE target.target_type = candidate.target_type
+         AND target.target_key = candidate.target_key
+       RETURNING target.target_type AS "targetType",
+                 target.target_key AS "targetKey",
+                 target.requested_height AS "requestedHeight",
+                 target.attempt_count AS "attemptCount"`,
+      { type: QueryTypes.SELECT }
+    );
+
+    return target ?? null;
+  }
+
+  async complete(target: ClaimedProviderVerificationTarget, processedHeight: number): Promise<void> {
+    const deleted = await VerificationReconcileTarget.destroy({
+      where: {
+        targetType: target.targetType,
+        targetKey: target.targetKey,
+        requestedHeight: { [Op.lte]: processedHeight }
+      }
+    });
+
+    if (deleted === 0) {
+      await VerificationReconcileTarget.update(
+        { claimedAt: null, attemptCount: 0, nextAttemptAt: null, lastError: null },
+        { where: { targetType: target.targetType, targetKey: target.targetKey } }
+      );
+    }
+  }
+
+  async fail(target: ClaimedProviderVerificationTarget, error: unknown): Promise<void> {
+    const attemptCount = target.attemptCount + 1;
+    const delaySeconds = Math.min(300, 2 ** Math.min(attemptCount, 8));
+    await VerificationReconcileTarget.update(
+      {
+        claimedAt: null,
+        attemptCount,
+        nextAttemptAt: new Date(Date.now() + delaySeconds * 1_000),
+        lastError: error instanceof Error ? error.message : String(error)
+      },
+      { where: { targetType: target.targetType, targetKey: target.targetKey } }
+    );
+  }
+
+  async replaceGlobalState(rows: ProviderVerificationGlobalRows): Promise<boolean> {
+    const observedHeight = globalObservedHeight(rows);
+
+    return database().transaction(async transaction => {
+      await acquireReconciliationLock("global", transaction);
+      const currentHeight = await queryMaxObservedHeight(["verification_params", "verification_auditor", "verification_discrepancy"], transaction);
+      if (currentHeight > observedHeight) return false;
+
+      if (rows.params) {
+        await VerificationParams.upsert({ ...rows.params }, { transaction });
+      } else {
+        await VerificationParams.destroy({ where: {}, transaction });
+      }
+
+      const auditorAddresses = rows.auditors.map(row => row.address);
+      await VerificationAuditor.destroy({ where: auditorAddresses.length > 0 ? { address: { [Op.notIn]: auditorAddresses } } : {}, transaction });
+      for (const row of rows.auditors) await VerificationAuditor.upsert({ ...row }, { transaction });
+
+      const discrepancyIds = rows.discrepancies.map(row => row.id);
+      await VerificationDiscrepancy.destroy({ where: discrepancyIds.length > 0 ? { id: { [Op.notIn]: discrepancyIds } } : {}, transaction });
+      for (const row of rows.discrepancies) await VerificationDiscrepancy.upsert({ ...row }, { transaction });
+      return true;
+    });
+  }
+
+  async replaceProviderState(rows: ProviderVerificationProviderRows): Promise<boolean> {
+    return database().transaction(async transaction => {
+      const providerWhere = { provider: rows.provider };
+      await acquireReconciliationLock(`provider:${rows.provider}`, transaction);
+      const currentObservation = await VerificationProviderObservation.findByPk(rows.provider, {
+        attributes: ["observedHeight", "effectiveTier", "maxPlacementTier", "snapshotState"],
+        transaction
+      });
+      if (currentObservation && currentObservation.observedHeight >= rows.observedHeight) return false;
+
+      const demotion = currentObservation ? createTierDemotion(currentObservation, rows) : null;
+
+      const escrows = await VerificationAuditEscrow.findAll({ attributes: ["id"], where: providerWhere, transaction });
+      const graces = await VerificationGrace.findAll({ attributes: ["id"], where: providerWhere, transaction });
+      const escrowIds = escrows.map(record => record.id);
+      const graceIds = graces.map(record => record.id);
+
+      await VerificationAttestationCapability.destroy({ where: providerWhere, transaction });
+      if (escrowIds.length > 0) {
+        await VerificationAuditEscrowCapability.destroy({ where: { auditEscrowId: { [Op.in]: escrowIds } }, transaction });
+      }
+      if (graceIds.length > 0) {
+        await VerificationGraceDiscrepancy.destroy({ where: { graceId: { [Op.in]: graceIds } }, transaction });
+      }
+      await VerificationProviderBondUnbonding.destroy({ where: providerWhere, transaction });
+
+      await VerificationAttestation.destroy({ where: providerWhere, transaction });
+      await VerificationAuditEscrow.destroy({ where: providerWhere, transaction });
+      await VerificationProviderBond.destroy({ where: providerWhere, transaction });
+      await VerificationGrace.destroy({ where: providerWhere, transaction });
+      await ProviderMaintenance.destroy({ where: providerWhere, transaction });
+      await VerificationProviderSnapshot.destroy({ where: providerWhere, transaction });
+
+      if (rows.attestations.length > 0)
+        await VerificationAttestation.bulkCreate(
+          rows.attestations.map(row => ({ ...row })),
+          { transaction }
+        );
+      if (rows.attestationCapabilities.length > 0) {
+        await VerificationAttestationCapability.bulkCreate(
+          rows.attestationCapabilities.map(row => ({ ...row })),
+          { transaction }
+        );
+      }
+      if (rows.auditEscrows.length > 0)
+        await VerificationAuditEscrow.bulkCreate(
+          rows.auditEscrows.map(row => ({ ...row })),
+          { transaction }
+        );
+      if (rows.auditEscrowCapabilities.length > 0) {
+        await VerificationAuditEscrowCapability.bulkCreate(
+          rows.auditEscrowCapabilities.map(row => ({ ...row })),
+          { transaction }
+        );
+      }
+      if (rows.bond) await VerificationProviderBond.create({ ...rows.bond }, { transaction });
+      if (rows.bondUnbondingEntries.length > 0) {
+        await VerificationProviderBondUnbonding.bulkCreate(
+          rows.bondUnbondingEntries.map(row => ({ ...row })),
+          { transaction }
+        );
+      }
+      if (rows.grace) await VerificationGrace.create({ ...rows.grace }, { transaction });
+      if (rows.graceDiscrepancies.length > 0) {
+        await VerificationGraceDiscrepancy.bulkCreate(
+          rows.graceDiscrepancies.map(row => ({ ...row })),
+          { transaction }
+        );
+      }
+      if (rows.maintenances.length > 0)
+        await ProviderMaintenance.bulkCreate(
+          rows.maintenances.map(row => ({ ...row })),
+          { transaction }
+        );
+      if (rows.snapshot) await VerificationProviderSnapshot.create({ ...rows.snapshot }, { transaction });
+      if (demotion) await VerificationProviderTierDemotion.create({ ...demotion }, { transaction });
+      await VerificationProviderObservation.upsert(
+        {
+          provider: rows.provider,
+          observedHeight: rows.observedHeight,
+          observedBlockTime: rows.observedBlockTime,
+          effectiveTier: rows.tierState.effectiveTier,
+          maxPlacementTier: rows.tierState.maxPlacementTier,
+          snapshotState: rows.tierState.snapshotState
+        },
+        { transaction }
+      );
+      return true;
+    });
+  }
+
+  async findAuditEscrowProvider(id: string): Promise<string | null> {
+    return (await VerificationAuditEscrow.findByPk(id, { attributes: ["provider"] }))?.provider ?? null;
+  }
+
+  async hasDiscrepancies(ids: readonly string[]): Promise<boolean> {
+    if (ids.length === 0) return true;
+    return (await VerificationDiscrepancy.count({ where: { id: { [Op.in]: ids } } })) === new Set(ids).size;
+  }
+
+  async getUnprocessedBlockEvents(height: number, transaction: DbTransaction): Promise<VerificationBlockEvent[]> {
+    return VerificationBlockEvent.findAll({ where: { height, isProcessed: false }, order: [["index", "ASC"]], transaction });
+  }
+
+  async markBlockEventsProcessed(height: number, transaction: DbTransaction): Promise<void> {
+    await VerificationBlockEvent.update({ isProcessed: true }, { where: { height, isProcessed: false }, transaction });
+  }
+}
+
+interface ProviderTierObservation {
+  effectiveTier: number;
+  maxPlacementTier: number;
+  snapshotState: string;
+}
+
+interface ProviderTierDemotionRow {
+  provider: string;
+  previousEffectiveTier: number;
+  previousMaxPlacementTier: number;
+  previousSnapshotState: string;
+  currentEffectiveTier: number;
+  currentMaxPlacementTier: number;
+  currentSnapshotState: string;
+  changes: ProviderTierDemotionChange[];
+  observedHeight: number;
+  observedBlockTime: Date;
+}
+
+function createTierDemotion(current: ProviderTierObservation, rows: ProviderVerificationProviderRows): ProviderTierDemotionRow | null {
+  const previous: ProviderTierState = {
+    effectiveTier: current.effectiveTier,
+    maxPlacementTier: current.maxPlacementTier,
+    snapshotState: parseSnapshotState(current.snapshotState)
+  };
+  const changes = detectProviderTierDemotion(previous, rows.tierState);
+  if (changes.length === 0) return null;
+
+  return {
+    provider: rows.provider,
+    previousEffectiveTier: previous.effectiveTier,
+    previousMaxPlacementTier: previous.maxPlacementTier,
+    previousSnapshotState: previous.snapshotState,
+    currentEffectiveTier: rows.tierState.effectiveTier,
+    currentMaxPlacementTier: rows.tierState.maxPlacementTier,
+    currentSnapshotState: rows.tierState.snapshotState,
+    changes,
+    observedHeight: rows.observedHeight,
+    observedBlockTime: rows.observedBlockTime
+  };
+}
+
+function parseSnapshotState(value: string): SnapshotComplianceState {
+  switch (value) {
+    case "unknown":
+    case "not_posted":
+    case "current":
+    case "stale":
+    case "suspended":
+      return value;
+    default:
+      throw new Error(`Invalid provider verification snapshot state: ${value}`);
+  }
+}
+
+async function queryMaxObservedHeight(tables: readonly string[], transaction: DbTransaction): Promise<number> {
+  const selects = tables.map(table => `SELECT observed_height FROM ${table}`).join(" UNION ALL ");
+  const [result] = await database().query<{ height: number | null }>(`SELECT MAX(observed_height) AS height FROM (${selects}) observations`, {
+    transaction,
+    type: QueryTypes.SELECT
+  });
+  return result?.height ?? 0;
+}
+
+function globalObservedHeight(rows: ProviderVerificationGlobalRows): number {
+  return rows.observedHeight;
+}
+
+async function acquireReconciliationLock(key: string, transaction: DbTransaction): Promise<void> {
+  await database().query("SELECT pg_advisory_xact_lock(hashtextextended(:key, 0))", {
+    replacements: { key: `provider-verification:${key}` },
+    transaction
+  });
+}
+
+function database() {
+  const connection = VerificationReconcileTarget.sequelize;
+  if (!connection) throw new Error("Provider verification models are not registered with a database connection");
+  return connection;
+}

--- a/apps/indexer/src/indexers/providerVerification/providerVerificationStateMapper.spec.ts
+++ b/apps/indexer/src/indexers/providerVerification/providerVerificationStateMapper.spec.ts
@@ -1,0 +1,133 @@
+import type { ProviderVerificationGlobalState, ProviderVerificationProviderState } from "@akashnetwork/provider-verification";
+import { describe, expect, it } from "vitest";
+
+import { mapProviderVerificationGlobalState, mapProviderVerificationProviderState } from "./providerVerificationStateMapper";
+
+const observedBlockTime = new Date("2026-08-24T12:00:00.000Z");
+
+describe("providerVerificationStateMapper", () => {
+  it("maps provider aggregates without losing bytes or bigint values", () => {
+    const state = {
+      provider: "akash1provider",
+      observedHeight: "1234",
+      attestations: [
+        {
+          provider: "akash1provider",
+          auditor: "akash1auditor",
+          tier: 2,
+          capabilities: [3, 4],
+          evidenceHash: Uint8Array.from([1, 2]),
+          fee: { denom: "uakt", amount: "10" },
+          feeStatus: 1,
+          createdAt: new Date("2026-08-01T00:00:00.000Z"),
+          expiresAt: new Date("2027-08-01T00:00:00.000Z"),
+          status: 1,
+          voidedReason: 0,
+          deposit: { denom: "uakt", amount: "20" },
+          depositStatus: 1,
+          auditEscrowId: 9007199254740993n,
+          faultAttribution: 0
+        }
+      ],
+      auditEscrows: [],
+      bond: {
+        provider: "akash1provider",
+        bondedAmount: { denom: "uakt", amount: "100" },
+        unbondingEntries: [],
+        slashed: false,
+        lastSlashTime: undefined
+      },
+      requiredBondForCurrentTier: { denom: "uakt", amount: "80" },
+      grace: null,
+      maintenances: [],
+      snapshot: {
+        provider: "akash1provider",
+        snapshotHash: Uint8Array.from([9, 8]),
+        resourceSummary: {
+          totalGpus: 1,
+          totalVcpus: 16,
+          totalMemoryMb: 32768n,
+          totalStorageMb: 1000000n,
+          activeLeases: 4,
+          softwareVersion: "v0.16.0",
+          softwareSignature: new Uint8Array(),
+          softwareIdentity: undefined
+        },
+        postedAt: new Date("2026-08-24T11:00:00.000Z"),
+        snapshotTimestamp: new Date("2026-08-24T10:59:00.000Z"),
+        complianceDeadline: new Date("2026-08-25T11:00:00.000Z"),
+        suspended: false
+      }
+    } as ProviderVerificationProviderState;
+
+    const rows = mapProviderVerificationProviderState(state, observedBlockTime);
+
+    expect(rows.attestations[0]).toMatchObject({ auditEscrowId: "9007199254740993", evidenceHash: Buffer.from([1, 2]), observedHeight: 1234 });
+    expect(rows.attestationCapabilities).toEqual([
+      expect.objectContaining({ capability: 3, provider: "akash1provider", auditor: "akash1auditor" }),
+      expect.objectContaining({ capability: 4, provider: "akash1provider", auditor: "akash1auditor" })
+    ]);
+    expect(rows.bond).toMatchObject({ bondedAmount: "100", requiredForCurrentTierAmount: "80" });
+    expect(rows.snapshot).toMatchObject({ snapshotHash: Buffer.from([9, 8]), totalMemoryMb: "32768", softwareSignature: null });
+    expect(rows.tierState).toEqual({ effectiveTier: 2, maxPlacementTier: 2, snapshotState: "current" });
+  });
+
+  it("serializes verification params and global bigint identities", () => {
+    const state = {
+      observedHeight: "99",
+      params: { verificationModuleActive: true },
+      auditors: [],
+      discrepancies: [
+        {
+          id: 9007199254740995n,
+          provider: "akash1provider",
+          auditorA: "akash1a",
+          auditorATier: 1,
+          auditorB: "akash1b",
+          auditorBTier: 3,
+          timestamp: observedBlockTime,
+          resolutionStatus: 1,
+          resolutionProposalId: 0n,
+          graceRecordId: 12n,
+          resolutionReason: 0,
+          faultAttribution: 0,
+          resolutionEvidenceHash: new Uint8Array()
+        }
+      ]
+    } as unknown as ProviderVerificationGlobalState;
+
+    const rows = mapProviderVerificationGlobalState(state, observedBlockTime);
+
+    expect(rows.params).toMatchObject({ id: 1, observedHeight: 99, params: { verification_module_active: true } });
+    expect(rows.discrepancies[0]).toMatchObject({ id: "9007199254740995", graceRecordId: "12", resolutionEvidenceHash: null });
+  });
+
+  it("persists an inactive verification module as false", () => {
+    const state = {
+      observedHeight: "100",
+      params: { verificationModuleActive: false },
+      auditors: [],
+      discrepancies: []
+    } as unknown as ProviderVerificationGlobalState;
+
+    const rows = mapProviderVerificationGlobalState(state, observedBlockTime);
+
+    expect(rows.params?.params).toMatchObject({ verification_module_active: false });
+  });
+
+  it("rejects incomplete chain records instead of inventing timestamps", () => {
+    const state = {
+      provider: "akash1provider",
+      observedHeight: "1",
+      attestations: [],
+      auditEscrows: [],
+      bond: null,
+      requiredBondForCurrentTier: null,
+      grace: null,
+      snapshot: null,
+      maintenances: [{ record: undefined, status: 1 }]
+    } as ProviderVerificationProviderState;
+
+    expect(() => mapProviderVerificationProviderState(state, observedBlockTime)).toThrow("maintenance.record is missing");
+  });
+});

--- a/apps/indexer/src/indexers/providerVerification/providerVerificationStateMapper.ts
+++ b/apps/indexer/src/indexers/providerVerification/providerVerificationStateMapper.ts
@@ -1,0 +1,403 @@
+import { Verification_Params } from "@akashnetwork/chain-sdk/private-types/akash.v1";
+import {
+  deriveProviderTierState,
+  type ProviderTierState,
+  type ProviderVerificationGlobalState,
+  type ProviderVerificationProviderState
+} from "@akashnetwork/provider-verification";
+
+interface Observation {
+  observedHeight: number;
+  observedBlockTime: Date;
+}
+
+export interface ProviderVerificationGlobalRows {
+  observedHeight: number;
+  params: (Observation & { id: number; params: Record<string, unknown> }) | null;
+  auditors: Array<
+    Observation & {
+      address: string;
+      status: number;
+      maxAttestationTier: number;
+      bondDenom: string;
+      bondAmount: string;
+      bondStatus: number;
+      metadataHash: Buffer | null;
+      registeredAt: Date;
+      renewalDeadline: Date;
+      discrepancyCount: string;
+      bondUnbondingCompletionTime: Date | null;
+    }
+  >;
+  discrepancies: Array<
+    Observation & {
+      id: string;
+      provider: string;
+      auditorA: string;
+      auditorATier: number;
+      auditorB: string;
+      auditorBTier: number;
+      detectedAt: Date;
+      resolutionStatus: number;
+      resolutionProposalId: string;
+      graceRecordId: string;
+      resolutionReason: number;
+      faultAttribution: number;
+      resolutionEvidenceHash: Buffer | null;
+    }
+  >;
+}
+
+export interface ProviderVerificationProviderRows {
+  provider: string;
+  observedHeight: number;
+  observedBlockTime: Date;
+  tierState: ProviderTierState;
+  attestations: Array<
+    Observation & {
+      provider: string;
+      auditor: string;
+      tier: number;
+      evidenceHash: Buffer;
+      feeDenom: string;
+      feeAmount: string;
+      feeStatus: number;
+      createdAt: Date;
+      expiresAt: Date;
+      status: number;
+      voidedReason: number;
+      depositDenom: string;
+      depositAmount: string;
+      depositStatus: number;
+      auditEscrowId: string;
+      faultAttribution: number;
+    }
+  >;
+  attestationCapabilities: Array<Observation & { provider: string; auditor: string; capability: number }>;
+  auditEscrows: Array<
+    Observation & {
+      id: string;
+      provider: string;
+      consumedByAuditor: string;
+      requestedTier: number;
+      feeDenom: string;
+      feeAmount: string;
+      feeStatus: number;
+      providerDepositDenom: string;
+      providerDepositAmount: string;
+      providerDepositStatus: number;
+      status: number;
+      openedAt: Date;
+      consumedAt: Date | null;
+      expiresAt: Date;
+      metadataHash: Buffer | null;
+      settlementReason: number;
+      faultAttribution: number;
+    }
+  >;
+  auditEscrowCapabilities: Array<Observation & { auditEscrowId: string; capability: number }>;
+  bond:
+    | (Observation & {
+        provider: string;
+        bondedDenom: string;
+        bondedAmount: string;
+        requiredForCurrentTierDenom: string;
+        requiredForCurrentTierAmount: string;
+        slashed: boolean;
+        lastSlashTime: Date | null;
+      })
+    | null;
+  bondUnbondingEntries: Array<Observation & { provider: string; entryIndex: number; denom: string; amount: string; completionTime: Date }>;
+  grace:
+    | (Observation & {
+        id: string;
+        provider: string;
+        preservedTier: number;
+        startedAt: Date;
+        expiresAt: Date;
+        status: number;
+      })
+    | null;
+  graceDiscrepancies: Array<Observation & { graceId: string; discrepancyId: string }>;
+  maintenances: Array<
+    Observation & {
+      provider: string;
+      id: string;
+      maintenanceType: number;
+      startsAt: Date;
+      expectedEndsAt: Date;
+      openedAt: Date;
+      closedAt: Date | null;
+      metadataHash: Buffer | null;
+      status: number;
+    }
+  >;
+  snapshot:
+    | (Observation & {
+        provider: string;
+        snapshotHash: Buffer;
+        totalGpus: number;
+        totalVcpus: number;
+        totalMemoryMb: string;
+        totalStorageMb: string;
+        activeLeases: number;
+        softwareVersion: string;
+        softwareSignature: Buffer | null;
+        softwareIdentityVersion: string | null;
+        softwareArtifactRef: string | null;
+        softwareDigestAlgorithm: string | null;
+        softwareDigest: Buffer | null;
+        softwareSignatureType: string | null;
+        softwareIdentitySignature: Buffer | null;
+        softwareSignatureRef: string | null;
+        softwarePublicKeyRef: string | null;
+        postedAt: Date;
+        snapshotTimestamp: Date;
+        complianceDeadline: Date;
+        suspended: boolean;
+      })
+    | null;
+}
+
+export function mapProviderVerificationGlobalState(state: ProviderVerificationGlobalState, observedBlockTime: Date): ProviderVerificationGlobalRows {
+  const observation = createObservation(state.observedHeight, observedBlockTime);
+
+  return {
+    observedHeight: observation.observedHeight,
+    params: state.params
+      ? {
+          id: 1,
+          params: serializeVerificationParams(state.params),
+          ...observation
+        }
+      : null,
+    auditors: state.auditors.map(auditor => ({
+      address: auditor.address,
+      status: auditor.status,
+      maxAttestationTier: auditor.maxAttestationTier,
+      bondDenom: auditor.bondAmount?.denom ?? "",
+      bondAmount: auditor.bondAmount?.amount ?? "0",
+      bondStatus: auditor.bondStatus,
+      metadataHash: optionalBuffer(auditor.metadataHash),
+      registeredAt: requiredDate(auditor.registeredAt, "auditor.registeredAt"),
+      renewalDeadline: requiredDate(auditor.renewalDeadline, "auditor.renewalDeadline"),
+      discrepancyCount: auditor.discrepancyCount.toString(),
+      bondUnbondingCompletionTime: auditor.bondUnbondingCompletionTime ?? null,
+      ...observation
+    })),
+    discrepancies: state.discrepancies.map(discrepancy => ({
+      id: discrepancy.id.toString(),
+      provider: discrepancy.provider,
+      auditorA: discrepancy.auditorA,
+      auditorATier: discrepancy.auditorATier,
+      auditorB: discrepancy.auditorB,
+      auditorBTier: discrepancy.auditorBTier,
+      detectedAt: requiredDate(discrepancy.timestamp, "discrepancy.timestamp"),
+      resolutionStatus: discrepancy.resolutionStatus,
+      resolutionProposalId: discrepancy.resolutionProposalId.toString(),
+      graceRecordId: discrepancy.graceRecordId.toString(),
+      resolutionReason: discrepancy.resolutionReason,
+      faultAttribution: discrepancy.faultAttribution,
+      resolutionEvidenceHash: optionalBuffer(discrepancy.resolutionEvidenceHash),
+      ...observation
+    }))
+  };
+}
+
+export function mapProviderVerificationProviderState(state: ProviderVerificationProviderState, observedBlockTime: Date): ProviderVerificationProviderRows {
+  const observation = createObservation(state.observedHeight, observedBlockTime);
+  const tierState = deriveProviderTierState({
+    attestations: state.attestations,
+    graces: state.grace ? [state.grace] : [],
+    snapshot: state.snapshot,
+    completeness: { attestations: true, graces: true, snapshot: true },
+    observedAt: observedBlockTime,
+    observedHeight: state.observedHeight
+  });
+  const attestations = state.attestations.map(attestation => ({
+    provider: attestation.provider,
+    auditor: attestation.auditor,
+    tier: attestation.tier,
+    evidenceHash: Buffer.from(attestation.evidenceHash),
+    feeDenom: attestation.fee?.denom ?? "",
+    feeAmount: attestation.fee?.amount ?? "0",
+    feeStatus: attestation.feeStatus,
+    createdAt: requiredDate(attestation.createdAt, "attestation.createdAt"),
+    expiresAt: requiredDate(attestation.expiresAt, "attestation.expiresAt"),
+    status: attestation.status,
+    voidedReason: attestation.voidedReason,
+    depositDenom: attestation.deposit?.denom ?? "",
+    depositAmount: attestation.deposit?.amount ?? "0",
+    depositStatus: attestation.depositStatus,
+    auditEscrowId: attestation.auditEscrowId.toString(),
+    faultAttribution: attestation.faultAttribution,
+    ...observation
+  }));
+  const auditEscrows = state.auditEscrows.map(escrow => ({
+    id: escrow.id.toString(),
+    provider: escrow.provider,
+    consumedByAuditor: escrow.consumedByAuditor,
+    requestedTier: escrow.requestedTier,
+    feeDenom: escrow.fee?.denom ?? "",
+    feeAmount: escrow.fee?.amount ?? "0",
+    feeStatus: escrow.feeStatus,
+    providerDepositDenom: escrow.providerDeposit?.denom ?? "",
+    providerDepositAmount: escrow.providerDeposit?.amount ?? "0",
+    providerDepositStatus: escrow.providerDepositStatus,
+    status: escrow.status,
+    openedAt: requiredDate(escrow.openedAt, "auditEscrow.openedAt"),
+    consumedAt: escrow.consumedAt ?? null,
+    expiresAt: requiredDate(escrow.expiresAt, "auditEscrow.expiresAt"),
+    metadataHash: optionalBuffer(escrow.metadataHash),
+    settlementReason: escrow.settlementReason,
+    faultAttribution: escrow.faultAttribution,
+    ...observation
+  }));
+  const grace = state.grace
+    ? {
+        id: state.grace.id.toString(),
+        provider: state.grace.provider,
+        preservedTier: state.grace.preservedTier,
+        startedAt: requiredDate(state.grace.startedAt, "grace.startedAt"),
+        expiresAt: requiredDate(state.grace.expiresAt, "grace.expiresAt"),
+        status: state.grace.status,
+        ...observation
+      }
+    : null;
+  const requiredBond = state.bond ? requiredCoin(state.requiredBondForCurrentTier, "requiredBondForCurrentTier") : null;
+  const bond = state.bond
+    ? {
+        provider: state.bond.provider,
+        bondedDenom: state.bond.bondedAmount?.denom ?? "",
+        bondedAmount: state.bond.bondedAmount?.amount ?? "0",
+        requiredForCurrentTierDenom: requiredBond!.denom,
+        requiredForCurrentTierAmount: requiredBond!.amount,
+        slashed: state.bond.slashed,
+        lastSlashTime: state.bond.lastSlashTime ?? null,
+        ...observation
+      }
+    : null;
+  const snapshot = mapSnapshot(state, observation);
+
+  return {
+    provider: state.provider,
+    observedHeight: observation.observedHeight,
+    observedBlockTime: observation.observedBlockTime,
+    tierState,
+    attestations,
+    attestationCapabilities: state.attestations.flatMap(attestation =>
+      attestation.capabilities.map(capability => ({
+        provider: attestation.provider,
+        auditor: attestation.auditor,
+        capability,
+        ...observation
+      }))
+    ),
+    auditEscrows,
+    auditEscrowCapabilities: state.auditEscrows.flatMap(escrow =>
+      escrow.requestedCapabilities.map(capability => ({ auditEscrowId: escrow.id.toString(), capability, ...observation }))
+    ),
+    bond,
+    bondUnbondingEntries:
+      state.bond?.unbondingEntries.map((entry, entryIndex) => ({
+        provider: state.bond!.provider,
+        entryIndex,
+        denom: entry.amount?.denom ?? "",
+        amount: entry.amount?.amount ?? "0",
+        completionTime: requiredDate(entry.completionTime, "bond.unbondingEntry.completionTime"),
+        ...observation
+      })) ?? [],
+    grace,
+    graceDiscrepancies:
+      state.grace?.sourceDiscrepancyIds.map(discrepancyId => ({
+        graceId: state.grace!.id.toString(),
+        discrepancyId: discrepancyId.toString(),
+        ...observation
+      })) ?? [],
+    maintenances: state.maintenances.map(maintenance => {
+      const record = maintenance.record;
+      if (!record) throw new Error("Invalid provider verification response: maintenance.record is missing");
+
+      return {
+        provider: record.provider,
+        id: record.id.toString(),
+        maintenanceType: record.maintenanceType,
+        startsAt: requiredDate(record.startsAt, "maintenance.startsAt"),
+        expectedEndsAt: requiredDate(record.expectedEndsAt, "maintenance.expectedEndsAt"),
+        openedAt: requiredDate(record.openedAt, "maintenance.openedAt"),
+        closedAt: record.closedAt ?? null,
+        metadataHash: optionalBuffer(record.metadataHash),
+        status: maintenance.status,
+        ...observation
+      };
+    }),
+    snapshot
+  };
+}
+
+function mapSnapshot(state: ProviderVerificationProviderState, observation: Observation): ProviderVerificationProviderRows["snapshot"] {
+  if (!state.snapshot) return null;
+  const summary = state.snapshot.resourceSummary;
+  if (!summary) throw new Error("Invalid provider verification response: snapshot.resourceSummary is missing");
+  const identity = summary.softwareIdentity;
+
+  return {
+    provider: state.snapshot.provider,
+    snapshotHash: Buffer.from(state.snapshot.snapshotHash),
+    totalGpus: summary.totalGpus,
+    totalVcpus: summary.totalVcpus,
+    totalMemoryMb: summary.totalMemoryMb.toString(),
+    totalStorageMb: summary.totalStorageMb.toString(),
+    activeLeases: summary.activeLeases,
+    softwareVersion: summary.softwareVersion,
+    softwareSignature: optionalBuffer(summary.softwareSignature),
+    softwareIdentityVersion: identity?.version || null,
+    softwareArtifactRef: identity?.artifactRef || null,
+    softwareDigestAlgorithm: identity?.digestAlgorithm || null,
+    softwareDigest: optionalBuffer(identity?.digest),
+    softwareSignatureType: identity?.signatureType || null,
+    softwareIdentitySignature: optionalBuffer(identity?.signature),
+    softwareSignatureRef: identity?.signatureRef || null,
+    softwarePublicKeyRef: identity?.publicKeyRef || null,
+    postedAt: requiredDate(state.snapshot.postedAt, "snapshot.postedAt"),
+    snapshotTimestamp: requiredDate(state.snapshot.snapshotTimestamp, "snapshot.snapshotTimestamp"),
+    complianceDeadline: requiredDate(state.snapshot.complianceDeadline, "snapshot.complianceDeadline"),
+    suspended: state.snapshot.suspended,
+    ...observation
+  };
+}
+
+function createObservation(height: string, observedBlockTime: Date): Observation {
+  const observedHeight = Number(height);
+  if (!Number.isSafeInteger(observedHeight) || observedHeight < 0) {
+    throw new Error(`Invalid provider verification observation height: ${height}`);
+  }
+  if (Number.isNaN(observedBlockTime.getTime())) {
+    throw new Error("Invalid provider verification observation block time");
+  }
+
+  return { observedHeight, observedBlockTime };
+}
+
+function serializeVerificationParams(params: Verification_Params): Record<string, unknown> {
+  return {
+    ...(Verification_Params.toJSON(params) as Record<string, unknown>),
+    verification_module_active: params.verificationModuleActive
+  };
+}
+
+function requiredDate(value: Date | undefined, field: string): Date {
+  if (!value || Number.isNaN(value.getTime())) {
+    throw new Error(`Invalid provider verification response: ${field} is missing`);
+  }
+  return value;
+}
+
+function optionalBuffer(value: Uint8Array | undefined): Buffer | null {
+  return value?.length ? Buffer.from(value) : null;
+}
+
+function requiredCoin(value: { denom: string; amount: string } | null, field: string): { denom: string; amount: string } {
+  if (!value) throw new Error(`Invalid provider verification response: ${field} is missing`);
+  return value;
+}

--- a/apps/indexer/src/shared/utils/env.ts
+++ b/apps/indexer/src/shared/utils/env.ts
@@ -14,6 +14,8 @@ export const env = {
   PASSAGE_DATABASE_CS: process.env.PASSAGE_DATABASE_CS,
   JUNO_DATABASE_CS: process.env.JUNO_DATABASE_CS,
   ACTIVE_CHAIN: process.env.ACTIVE_CHAIN,
+  PROVIDER_VERIFICATION_ENABLED: process.env.PROVIDER_VERIFICATION_ENABLED === "true",
+  PROVIDER_VERIFICATION_REST_API_URL: process.env.PROVIDER_VERIFICATION_REST_API_URL,
   KEEP_CACHE: process.env.KEEP_CACHE === "true",
   STANDBY: process.env.STANDBY === "true",
   DATA_FOLDER: process.env.DATA_FOLDER ?? "./data",

--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -36,7 +36,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",
     "@akashnetwork/instrumentation": "*",

--- a/apps/notifications/src/modules/chain/providers/registry.provider.ts
+++ b/apps/notifications/src/modules/chain/providers/registry.provider.ts
@@ -12,18 +12,16 @@ import type { Provider } from "@nestjs/common";
 export const RegistryProvider: Provider<Registry> = {
   provide: Registry,
   useFactory: () => {
-    const akashTypes: ReadonlyArray<[string, GeneratedType]> = [
-      ...Object.values(v1),
-      ...Object.values(v1beta4),
-      ...Object.values(v1beta5),
-      ...Object.values(cosmosv1),
-      ...Object.values(cosmosv1beta1),
-      ...Object.values(cosmosv1alpha1),
-      ...Object.values(cosmosv2alpha1)
-    ]
-      .filter(x => "$type" in x)
-      .map(x => ["/" + x.$type, x as unknown as GeneratedType]);
+    const modules: ReadonlyArray<Record<string, unknown>> = [v1, v1beta4, v1beta5, cosmosv1, cosmosv1beta1, cosmosv1alpha1, cosmosv2alpha1];
+    const akashTypes: ReadonlyArray<[string, GeneratedType]> = modules
+      .flatMap(module => Object.values(module))
+      .filter(hasType)
+      .map(type => ["/" + type.$type, type as unknown as GeneratedType]);
 
     return new Registry(akashTypes);
   }
 };
+
+function hasType(value: unknown): value is { $type: string } {
+  return typeof value === "object" && value !== null && "$type" in value && typeof value.$type === "string";
+}

--- a/apps/provider-inventory/package.json
+++ b/apps/provider-inventory/package.json
@@ -24,7 +24,7 @@
     "test:unit": "vitest run --project unit"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/instrumentation": "*",
     "@akashnetwork/logging": "*",

--- a/apps/provider-inventory/src/mappers/groupspec-mapper/groupspec-mapper.ts
+++ b/apps/provider-inventory/src/mappers/groupspec-mapper/groupspec-mapper.ts
@@ -45,4 +45,10 @@ export function getAttributeFingerprint(attributes: ResourceAttribute[] | undefi
     .join(",");
 }
 
-export type GroupSpecJSON = ToJSON<GroupSpec>;
+type GroupSpecRequirementsJSON = ToJSON<NonNullable<GroupSpec["requirements"]>>;
+
+export type GroupSpecJSON = Omit<ToJSON<GroupSpec>, "requirements"> & {
+  requirements: Omit<GroupSpecRequirementsJSON, "verification"> & {
+    verification?: GroupSpecRequirementsJSON["verification"];
+  };
+};

--- a/apps/provider-proxy/package.json
+++ b/apps/provider-proxy/package.json
@@ -20,7 +20,7 @@
     "test:unit": "vitest run --project unit"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/instrumentation": "*",
     "@akashnetwork/logging": "*",

--- a/apps/stats-web/package.json
+++ b/apps/stats-web/package.json
@@ -14,7 +14,7 @@
     "test:unit": "NODE_ENV=test vitest run"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/logging": "*",
     "@akashnetwork/network-store": "*",

--- a/apps/tx-signer/package.json
+++ b/apps/tx-signer/package.json
@@ -21,7 +21,7 @@
     "test:unit": "vitest run --project unit"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",
     "@akashnetwork/instrumentation": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5657,6 +5657,10 @@
       "resolved": "apps/provider-proxy",
       "link": true
     },
+    "node_modules/@akashnetwork/provider-verification": {
+      "resolved": "packages/provider-verification",
+      "link": true
+    },
     "node_modules/@akashnetwork/react-query-proxy": {
       "resolved": "packages/react-query-proxy",
       "link": true
@@ -45947,6 +45951,19 @@
       "devDependencies": {
         "@akashnetwork/dev-config": "*",
         "vitest": "^4.0.0"
+      }
+    },
+    "packages/provider-verification": {
+      "name": "@akashnetwork/provider-verification",
+      "version": "0.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43"
+      },
+      "devDependencies": {
+        "@akashnetwork/dev-config": "*",
+        "typescript": "~5.8.2",
+        "vitest": "^4.1.5"
       }
     },
     "packages/react-query-proxy": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2173,6 +2173,7 @@
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/instrumentation": "*",
         "@akashnetwork/logging": "*",
+        "@akashnetwork/provider-verification": "*",
         "@cosmjs/crypto": "~0.38.0",
         "@cosmjs/encoding": "~0.38.0",
         "@cosmjs/proto-signing": "~0.38.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21799,7 +21799,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-8yQrvS6sMpSwIovhPOwfyNf2Wz6v/B62LFSVYQ85+Rq3tLsBIG7rP5geMxaijTUxSkrO6RzN/IRuIAADYQsleA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -44976,7 +44975,8 @@
         "sequelize-typescript": "^2.1.5"
       },
       "devDependencies": {
-        "@akashnetwork/dev-config": "*"
+        "@akashnetwork/dev-config": "*",
+        "vitest": "^4.1.5"
       }
     },
     "packages/dev-config": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akash-api": "1.4.3",
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/console-api-types": "*",
         "@akashnetwork/database": "*",
         "@akashnetwork/env-loader": "*",
@@ -542,7 +542,7 @@
       "version": "3.31.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/console-api-types": "*",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
@@ -2168,7 +2168,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akash-api": "1.4.3",
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/database": "*",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/instrumentation": "*",
@@ -2558,7 +2558,7 @@
       "version": "2.16.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
         "@akashnetwork/instrumentation": "*",
@@ -3701,7 +3701,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/instrumentation": "*",
         "@akashnetwork/logging": "*",
@@ -4041,7 +4041,7 @@
       "version": "2.10.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/instrumentation": "*",
         "@akashnetwork/logging": "*",
@@ -4218,7 +4218,7 @@
       "name": "@akashnetwork/stats-web",
       "version": "1.14.1",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/logging": "*",
         "@akashnetwork/network-store": "*",
@@ -4982,7 +4982,7 @@
       "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
         "@akashnetwork/instrumentation": "*",
@@ -5473,9 +5473,9 @@
       }
     },
     "node_modules/@akashnetwork/chain-sdk": {
-      "version": "1.0.0-alpha.41",
-      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.41.tgz",
-      "integrity": "sha512-mr3fGDBSISxl0eZF83+IJLVulGSuJVu+MRj6fG61pi2rgfgnv9QEKpdU3w7wtFFt5saJaJNgsqAlyjGZQecZ1A==",
+      "version": "1.0.0-alpha.43",
+      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.43.tgz",
+      "integrity": "sha512-+XTgpLn3kibMEWBAOkfmOGo2VJcv+VtT5Uvq966Nk5YMyD9HCYUvdDLm1k167Di1S11t66SH06BhoY1M/m2IWg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.12.0",
@@ -45932,7 +45932,7 @@
       "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/net": "*",
         "jotai": "^2.9.2"
       },

--- a/packages/database/chainDefinitions.spec.ts
+++ b/packages/database/chainDefinitions.spec.ts
@@ -1,0 +1,35 @@
+import { netConfig } from "@akashnetwork/net";
+import { describe, expect, it } from "vitest";
+
+import { chainDefinitions, resolveAkashSandboxChainOverride } from "./chainDefinitions";
+
+describe("Akash sandbox chain definition", () => {
+  it("preserves the standard sandbox configuration by default", () => {
+    expect(chainDefinitions.akashSandbox).toMatchObject({
+      chainId: "sandbox-2",
+      rpcNodes: netConfig.getAllBaseRpcUrls("sandbox"),
+      apiUrl: netConfig.getBaseAPIUrl("sandbox"),
+      genesisFileUrl: `https://raw.githubusercontent.com/akash-network/net/main/${netConfig.mapped("sandbox")}/genesis.json`
+    });
+  });
+
+  it("parses a complete private sandbox configuration", () => {
+    expect(
+      resolveAkashSandboxChainOverride({
+        chainId: "aep-86",
+        rpcUrl: "https://rpc.aep86.example.com",
+        restApiUrl: "https://rest.aep86.example.com",
+        genesisUrl: "https://aep86.example.com/genesis.json"
+      })
+    ).toEqual({
+      chainId: "aep-86",
+      rpcUrl: "https://rpc.aep86.example.com",
+      restApiUrl: "https://rest.aep86.example.com",
+      genesisUrl: "https://aep86.example.com/genesis.json"
+    });
+  });
+
+  it("rejects a partial private sandbox configuration", () => {
+    expect(() => resolveAkashSandboxChainOverride({ chainId: "aep-86" })).toThrow("must be set together");
+  });
+});

--- a/packages/database/chainDefinitions.ts
+++ b/packages/database/chainDefinitions.ts
@@ -16,11 +16,29 @@ import {
   Provider,
   ProviderAttribute,
   ProviderAttributeSignature,
+  ProviderMaintenance,
   ProviderSnapshot,
   ProviderSnapshotNode,
   ProviderSnapshotNodeCPU,
   ProviderSnapshotNodeGPU,
-  ProviderSnapshotStorage
+  ProviderSnapshotStorage,
+  VerificationAttestation,
+  VerificationAttestationCapability,
+  VerificationAuditEscrow,
+  VerificationAuditEscrowCapability,
+  VerificationAuditor,
+  VerificationBlockEvent,
+  VerificationDiscrepancy,
+  VerificationGrace,
+  VerificationGraceDiscrepancy,
+  VerificationParams,
+  VerificationProviderBond,
+  VerificationProviderBondUnbonding,
+  VerificationProviderObservation,
+  VerificationProviderSnapshot,
+  VerificationProviderTierDemotion,
+  VerificationProviderTierStream,
+  VerificationReconcileTarget
 } from "./dbSchemas/akash";
 import type { Block, Message } from "./dbSchemas/base";
 dotenv.config({ path: ".env.local" });
@@ -36,8 +54,10 @@ export const IBC_USDC_DENOMS = [
 ];
 
 export interface ChainDef {
+  chainId: string;
   code: string;
   rpcNodes: string[];
+  apiUrl: string;
   cosmosDirectoryId: string;
   connectionString: string | undefined;
   genesisFileUrl: string;
@@ -54,17 +74,62 @@ export interface ChainDef {
   customModels?: ModelCtor<Model<any, any>>[];
 }
 
+interface AkashSandboxChainOverrideInput {
+  chainId?: string;
+  genesisUrl?: string;
+  restApiUrl?: string;
+  rpcUrl?: string;
+}
+
+export interface AkashSandboxChainOverride {
+  chainId: string;
+  genesisUrl: string;
+  restApiUrl: string;
+  rpcUrl: string;
+}
+
+const AKASH_SANDBOX_OVERRIDE_ENV_NAMES = [
+  "NEXT_PUBLIC_AKASH_SANDBOX_CHAIN_ID",
+  "NEXT_PUBLIC_AKASH_SANDBOX_RPC_URL",
+  "NEXT_PUBLIC_AKASH_SANDBOX_REST_API_URL",
+  "NEXT_PUBLIC_AKASH_SANDBOX_GENESIS_URL"
+] as const;
+
+export function resolveAkashSandboxChainOverride(input: AkashSandboxChainOverrideInput): AkashSandboxChainOverride | undefined {
+  const configuredValues = Object.values(input).filter(value => Boolean(value?.trim()));
+  if (configuredValues.length === 0) return undefined;
+  if (configuredValues.length !== AKASH_SANDBOX_OVERRIDE_ENV_NAMES.length) {
+    throw new Error(`${AKASH_SANDBOX_OVERRIDE_ENV_NAMES.join(", ")} must be set together`);
+  }
+
+  return {
+    chainId: requireValue(input.chainId, AKASH_SANDBOX_OVERRIDE_ENV_NAMES[0]),
+    rpcUrl: requireHttpUrl(input.rpcUrl, AKASH_SANDBOX_OVERRIDE_ENV_NAMES[1]),
+    restApiUrl: requireHttpUrl(input.restApiUrl, AKASH_SANDBOX_OVERRIDE_ENV_NAMES[2]),
+    genesisUrl: requireHttpUrl(input.genesisUrl, AKASH_SANDBOX_OVERRIDE_ENV_NAMES[3])
+  };
+}
+
+const akashSandboxOverride = resolveAkashSandboxChainOverride({
+  chainId: process.env.NEXT_PUBLIC_AKASH_SANDBOX_CHAIN_ID,
+  rpcUrl: process.env.NEXT_PUBLIC_AKASH_SANDBOX_RPC_URL,
+  restApiUrl: process.env.NEXT_PUBLIC_AKASH_SANDBOX_REST_API_URL,
+  genesisUrl: process.env.NEXT_PUBLIC_AKASH_SANDBOX_GENESIS_URL
+});
+
 export const chainDefinitions: { [key: string]: ChainDef } = {
   akash: {
+    chainId: "akashnet-2",
     code: "akash",
     rpcNodes: netConfig.getAllBaseRpcUrls("mainnet"),
+    apiUrl: netConfig.getBaseAPIUrl("mainnet"),
     cosmosDirectoryId: "akash",
     connectionString: process.env.AKASH_DATABASE_CS,
     genesisFileUrl: `https://raw.githubusercontent.com/akash-network/net/main/${netConfig.mapped("mainnet")}/genesis.json`,
     coinGeckoId: "akash-network",
     logoUrlSVG: "https://raw.githubusercontent.com/cosmos/chain-registry/master/akash/images/akt.svg",
     logoUrlPNG: "https://console.akash.network/images/chains/akash.png",
-    customIndexers: ["AkashStatsIndexer", "BmeIndexer"],
+    customIndexers: ["AkashStatsIndexer", "BmeIndexer", "ProviderVerificationIndexer"],
     bech32Prefix: "akash",
     denom: "akt",
     udenom: "uakt",
@@ -81,6 +146,7 @@ export const chainDefinitions: { [key: string]: ChainDef } = {
       Provider,
       ProviderAttribute,
       ProviderAttributeSignature,
+      ProviderMaintenance,
       ProviderSnapshot,
       ProviderSnapshotNode,
       ProviderSnapshotNodeCPU,
@@ -88,20 +154,39 @@ export const chainDefinitions: { [key: string]: ChainDef } = {
       ProviderSnapshotStorage,
       BmeLedgerRecord,
       BmeRawEvent,
-      BmeStatusChange
+      BmeStatusChange,
+      VerificationAttestation,
+      VerificationAttestationCapability,
+      VerificationAuditEscrow,
+      VerificationAuditEscrowCapability,
+      VerificationAuditor,
+      VerificationBlockEvent,
+      VerificationDiscrepancy,
+      VerificationGrace,
+      VerificationGraceDiscrepancy,
+      VerificationParams,
+      VerificationProviderBond,
+      VerificationProviderBondUnbonding,
+      VerificationProviderObservation,
+      VerificationProviderSnapshot,
+      VerificationProviderTierDemotion,
+      VerificationProviderTierStream,
+      VerificationReconcileTarget
     ]
   },
   get akashTestnet() {
     return {
+      chainId: "testnet-8",
       code: "akash-testnet",
       rpcNodes: netConfig.getAllBaseRpcUrls("testnet"),
+      apiUrl: netConfig.getBaseAPIUrl("testnet"),
       cosmosDirectoryId: "akash",
       connectionString: process.env.AKASH_TESTNET_DATABASE_CS,
       genesisFileUrl: `https://raw.githubusercontent.com/akash-network/net/main/${netConfig.mapped("testnet")}/genesis.json`,
       coinGeckoId: "akash-network",
       logoUrlSVG: "https://raw.githubusercontent.com/cosmos/chain-registry/master/akash/images/akt.svg",
       logoUrlPNG: "https://console.akash.network/images/chains/akash.png",
-      customIndexers: ["AkashStatsIndexer", "BmeIndexer"],
+      customIndexers: ["AkashStatsIndexer", "BmeIndexer", "ProviderVerificationIndexer"],
       bech32Prefix: "akash",
       denom: "act",
       udenom: "uact",
@@ -118,6 +203,7 @@ export const chainDefinitions: { [key: string]: ChainDef } = {
         Provider,
         ProviderAttribute,
         ProviderAttributeSignature,
+        ProviderMaintenance,
         ProviderSnapshot,
         ProviderSnapshotNode,
         ProviderSnapshotNodeCPU,
@@ -125,20 +211,39 @@ export const chainDefinitions: { [key: string]: ChainDef } = {
         ProviderSnapshotStorage,
         BmeLedgerRecord,
         BmeRawEvent,
-        BmeStatusChange
+        BmeStatusChange,
+        VerificationAttestation,
+        VerificationAttestationCapability,
+        VerificationAuditEscrow,
+        VerificationAuditEscrowCapability,
+        VerificationAuditor,
+        VerificationBlockEvent,
+        VerificationDiscrepancy,
+        VerificationGrace,
+        VerificationGraceDiscrepancy,
+        VerificationParams,
+        VerificationProviderBond,
+        VerificationProviderBondUnbonding,
+        VerificationProviderObservation,
+        VerificationProviderSnapshot,
+        VerificationProviderTierDemotion,
+        VerificationProviderTierStream,
+        VerificationReconcileTarget
       ]
     };
   },
   akashSandbox: {
+    chainId: akashSandboxOverride?.chainId ?? "sandbox-2",
     code: "akash-sandbox",
-    rpcNodes: netConfig.getAllBaseRpcUrls("sandbox"),
+    rpcNodes: akashSandboxOverride ? [akashSandboxOverride.rpcUrl] : netConfig.getAllBaseRpcUrls("sandbox"),
+    apiUrl: akashSandboxOverride?.restApiUrl ?? netConfig.getBaseAPIUrl("sandbox"),
     cosmosDirectoryId: "akash",
     connectionString: process.env.AKASH_SANDBOX_DATABASE_CS,
-    genesisFileUrl: `https://raw.githubusercontent.com/akash-network/net/main/${netConfig.mapped("sandbox")}/genesis.json`,
+    genesisFileUrl: akashSandboxOverride?.genesisUrl ?? `https://raw.githubusercontent.com/akash-network/net/main/${netConfig.mapped("sandbox")}/genesis.json`,
     coinGeckoId: "akash-network",
     logoUrlSVG: "https://raw.githubusercontent.com/cosmos/chain-registry/master/akash/images/akt.svg",
     logoUrlPNG: "https://console.akash.network/images/chains/akash.png",
-    customIndexers: ["AkashStatsIndexer", "BmeIndexer"],
+    customIndexers: ["AkashStatsIndexer", "BmeIndexer", "ProviderVerificationIndexer"],
     bech32Prefix: "akash",
     denom: "akt",
     udenom: "uakt",
@@ -155,6 +260,7 @@ export const chainDefinitions: { [key: string]: ChainDef } = {
       Provider,
       ProviderAttribute,
       ProviderAttributeSignature,
+      ProviderMaintenance,
       ProviderSnapshot,
       ProviderSnapshotNode,
       ProviderSnapshotNodeCPU,
@@ -162,9 +268,39 @@ export const chainDefinitions: { [key: string]: ChainDef } = {
       ProviderSnapshotStorage,
       BmeLedgerRecord,
       BmeRawEvent,
-      BmeStatusChange
+      BmeStatusChange,
+      VerificationAttestation,
+      VerificationAttestationCapability,
+      VerificationAuditEscrow,
+      VerificationAuditEscrowCapability,
+      VerificationAuditor,
+      VerificationBlockEvent,
+      VerificationDiscrepancy,
+      VerificationGrace,
+      VerificationGraceDiscrepancy,
+      VerificationParams,
+      VerificationProviderBond,
+      VerificationProviderBondUnbonding,
+      VerificationProviderObservation,
+      VerificationProviderSnapshot,
+      VerificationProviderTierDemotion,
+      VerificationProviderTierStream,
+      VerificationReconcileTarget
     ]
   }
 };
 
 export const activeChain = chainDefinitions[process.env.ACTIVE_CHAIN || "akash"];
+
+function requireValue(value: string | undefined, name: string): string {
+  const trimmedValue = value?.trim();
+  if (!trimmedValue) throw new Error(`${name} must not be empty`);
+  return trimmedValue;
+}
+
+function requireHttpUrl(value: string | undefined, name: string): string {
+  const url = requireValue(value, name);
+  const protocol = new URL(url).protocol;
+  if (protocol !== "http:" && protocol !== "https:") throw new Error(`${name} must use http or https`);
+  return url;
+}

--- a/packages/database/dbSchemas/akash/index.ts
+++ b/packages/database/dbSchemas/akash/index.ts
@@ -14,6 +14,24 @@ export { Bid } from "./bid";
 export { BmeLedgerRecord } from "./bmeLedgerRecord";
 export { BmeRawEvent } from "./bmeRawEvent";
 export { BmeStatusChange } from "./bmeStatusChange";
+export { ProviderMaintenance } from "./providerMaintenance";
+export { VerificationAttestation } from "./verificationAttestation";
+export { VerificationAttestationCapability } from "./verificationAttestationCapability";
+export { VerificationAuditEscrow } from "./verificationAuditEscrow";
+export { VerificationAuditEscrowCapability } from "./verificationAuditEscrowCapability";
+export { VerificationAuditor } from "./verificationAuditor";
+export { VerificationBlockEvent } from "./verificationBlockEvent";
+export { VerificationDiscrepancy } from "./verificationDiscrepancy";
+export { VerificationGrace } from "./verificationGrace";
+export { VerificationGraceDiscrepancy } from "./verificationGraceDiscrepancy";
+export { VerificationParams } from "./verificationParams";
+export { VerificationProviderBond } from "./verificationProviderBond";
+export { VerificationProviderBondUnbonding } from "./verificationProviderBondUnbonding";
+export { VerificationProviderObservation } from "./verificationProviderObservation";
+export { VerificationProviderSnapshot } from "./verificationProviderSnapshot";
+export { VerificationProviderTierDemotion } from "./verificationProviderTierDemotion";
+export { VerificationProviderTierStream } from "./verificationProviderTierStream";
+export { VerificationReconcileTarget } from "./verificationReconcileTarget";
 
 // Overrides
 export { AkashBlock } from "./akashBlock";

--- a/packages/database/dbSchemas/akash/provider.ts
+++ b/packages/database/dbSchemas/akash/provider.ts
@@ -1,11 +1,19 @@
 import { DataTypes } from "sequelize";
-import { BelongsTo, Column, Default, HasMany, Model, PrimaryKey, Table } from "sequelize-typescript";
+import { BelongsTo, Column, Default, HasMany, HasOne, Model, PrimaryKey, Table } from "sequelize-typescript";
 
 import { Required } from "../decorators/requiredDecorator";
 import { AkashBlock } from "./akashBlock";
 import { ProviderAttribute } from "./providerAttribute";
 import { ProviderAttributeSignature } from "./providerAttributeSignature";
+import { ProviderMaintenance } from "./providerMaintenance"; // eslint-disable-line import-x/no-cycle
 import { ProviderSnapshot } from "./providerSnapshot";
+import { VerificationAttestation } from "./verificationAttestation"; // eslint-disable-line import-x/no-cycle
+import { VerificationAuditEscrow } from "./verificationAuditEscrow"; // eslint-disable-line import-x/no-cycle
+import { VerificationDiscrepancy } from "./verificationDiscrepancy"; // eslint-disable-line import-x/no-cycle
+import { VerificationGrace } from "./verificationGrace"; // eslint-disable-line import-x/no-cycle
+import { VerificationProviderBond } from "./verificationProviderBond"; // eslint-disable-line import-x/no-cycle
+import { VerificationProviderObservation } from "./verificationProviderObservation"; // eslint-disable-line import-x/no-cycle
+import { VerificationProviderSnapshot } from "./verificationProviderSnapshot"; // eslint-disable-line import-x/no-cycle
 
 /**
  * Provider model for Akash
@@ -147,6 +155,14 @@ export class Provider extends Model {
    * The provider snapshots associated with the provider
    */
   @HasMany(() => ProviderSnapshot, "owner") providerSnapshots!: ProviderSnapshot[];
+  @HasMany(() => VerificationAttestation, { foreignKey: "provider", constraints: false }) verificationAttestations!: VerificationAttestation[];
+  @HasMany(() => VerificationAuditEscrow, { foreignKey: "provider", constraints: false }) verificationAuditEscrows!: VerificationAuditEscrow[];
+  @HasMany(() => VerificationDiscrepancy, { foreignKey: "provider", constraints: false }) verificationDiscrepancies!: VerificationDiscrepancy[];
+  @HasMany(() => VerificationGrace, { foreignKey: "provider", constraints: false }) verificationGraceRecords!: VerificationGrace[];
+  @HasMany(() => ProviderMaintenance, { foreignKey: "provider", constraints: false }) maintenanceRecords!: ProviderMaintenance[];
+  @HasOne(() => VerificationProviderBond, { foreignKey: "provider", constraints: false }) verificationBond?: VerificationProviderBond;
+  @HasOne(() => VerificationProviderObservation, { foreignKey: "provider", constraints: false }) verificationObservation?: VerificationProviderObservation;
+  @HasOne(() => VerificationProviderSnapshot, { foreignKey: "provider", constraints: false }) verificationSnapshot?: VerificationProviderSnapshot;
   /**
    * The block at which the provider was created
    */

--- a/packages/database/dbSchemas/akash/providerMaintenance.ts
+++ b/packages/database/dbSchemas/akash/providerMaintenance.ts
@@ -1,0 +1,26 @@
+import { DataTypes } from "sequelize";
+import { BelongsTo, Column, Model, PrimaryKey, Table } from "sequelize-typescript";
+
+import { Required } from "../decorators/requiredDecorator";
+import { Provider } from "./provider"; // eslint-disable-line import-x/no-cycle
+
+@Table({
+  tableName: "provider_maintenance",
+  underscored: true,
+  indexes: [{ fields: ["provider", "status"] }, { fields: ["starts_at", "expected_ends_at"] }]
+})
+export class ProviderMaintenance extends Model {
+  @Required @PrimaryKey @Column provider!: string;
+  @Required @PrimaryKey @Column(DataTypes.DECIMAL(20, 0)) id!: string;
+  @Required @Column maintenanceType!: number;
+  @Required @Column(DataTypes.DATE) startsAt!: Date;
+  @Required @Column(DataTypes.DATE) expectedEndsAt!: Date;
+  @Required @Column(DataTypes.DATE) openedAt!: Date;
+  @Column(DataTypes.DATE) closedAt?: Date;
+  @Column(DataTypes.BLOB) metadataHash?: Buffer;
+  @Required @Column status!: number;
+  @Required @Column observedHeight!: number;
+  @Required @Column(DataTypes.DATE) observedBlockTime!: Date;
+
+  @BelongsTo(() => Provider, { foreignKey: "provider", targetKey: "owner", constraints: false }) providerRecord!: Provider;
+}

--- a/packages/database/dbSchemas/akash/verificationAttestation.ts
+++ b/packages/database/dbSchemas/akash/verificationAttestation.ts
@@ -1,0 +1,35 @@
+import { DataTypes } from "sequelize";
+import { BelongsTo, Column, Model, PrimaryKey, Table } from "sequelize-typescript";
+
+import { Required } from "../decorators/requiredDecorator";
+import { Provider } from "./provider"; // eslint-disable-line import-x/no-cycle
+import { VerificationAuditor } from "./verificationAuditor"; // eslint-disable-line import-x/no-cycle
+
+@Table({
+  tableName: "verification_attestation",
+  underscored: true,
+  indexes: [{ fields: ["provider", "status", "tier"] }, { fields: ["expires_at", "status"] }, { fields: ["audit_escrow_id"] }]
+})
+export class VerificationAttestation extends Model {
+  @Required @PrimaryKey @Column provider!: string;
+  @Required @PrimaryKey @Column auditor!: string;
+  @Required @Column tier!: number;
+  @Required @Column(DataTypes.BLOB) evidenceHash!: Buffer;
+  @Required @Column feeDenom!: string;
+  @Required @Column(DataTypes.DECIMAL(30, 0)) feeAmount!: string;
+  @Required @Column feeStatus!: number;
+  @Required @Column(DataTypes.DATE) createdAt!: Date;
+  @Required @Column(DataTypes.DATE) expiresAt!: Date;
+  @Required @Column status!: number;
+  @Required @Column voidedReason!: number;
+  @Required @Column depositDenom!: string;
+  @Required @Column(DataTypes.DECIMAL(30, 0)) depositAmount!: string;
+  @Required @Column depositStatus!: number;
+  @Required @Column(DataTypes.DECIMAL(20, 0)) auditEscrowId!: string;
+  @Required @Column faultAttribution!: number;
+  @Required @Column observedHeight!: number;
+  @Required @Column(DataTypes.DATE) observedBlockTime!: Date;
+
+  @BelongsTo(() => Provider, { foreignKey: "provider", targetKey: "owner", constraints: false }) providerRecord!: Provider;
+  @BelongsTo(() => VerificationAuditor, { foreignKey: "auditor", targetKey: "address", constraints: false }) auditorRecord!: VerificationAuditor;
+}

--- a/packages/database/dbSchemas/akash/verificationAttestationCapability.ts
+++ b/packages/database/dbSchemas/akash/verificationAttestationCapability.ts
@@ -1,0 +1,17 @@
+import { DataTypes } from "sequelize";
+import { Column, Model, PrimaryKey, Table } from "sequelize-typescript";
+
+import { Required } from "../decorators/requiredDecorator";
+
+@Table({
+  tableName: "verification_attestation_capability",
+  underscored: true,
+  indexes: [{ fields: ["capability", "provider"] }]
+})
+export class VerificationAttestationCapability extends Model {
+  @Required @PrimaryKey @Column provider!: string;
+  @Required @PrimaryKey @Column auditor!: string;
+  @Required @PrimaryKey @Column capability!: number;
+  @Required @Column observedHeight!: number;
+  @Required @Column(DataTypes.DATE) observedBlockTime!: Date;
+}

--- a/packages/database/dbSchemas/akash/verificationAuditEscrow.ts
+++ b/packages/database/dbSchemas/akash/verificationAuditEscrow.ts
@@ -1,0 +1,36 @@
+import { DataTypes } from "sequelize";
+import { BelongsTo, Column, HasMany, Model, PrimaryKey, Table } from "sequelize-typescript";
+
+import { Required } from "../decorators/requiredDecorator";
+import { Provider } from "./provider"; // eslint-disable-line import-x/no-cycle
+import { VerificationAuditEscrowCapability } from "./verificationAuditEscrowCapability"; // eslint-disable-line import-x/no-cycle
+
+@Table({
+  tableName: "verification_audit_escrow",
+  underscored: true,
+  indexes: [{ fields: ["provider", "status"] }, { fields: ["expires_at", "status"] }]
+})
+export class VerificationAuditEscrow extends Model {
+  @Required @PrimaryKey @Column(DataTypes.DECIMAL(20, 0)) id!: string;
+  @Required @Column provider!: string;
+  @Required @Column consumedByAuditor!: string;
+  @Required @Column requestedTier!: number;
+  @Required @Column feeDenom!: string;
+  @Required @Column(DataTypes.DECIMAL(30, 0)) feeAmount!: string;
+  @Required @Column feeStatus!: number;
+  @Required @Column providerDepositDenom!: string;
+  @Required @Column(DataTypes.DECIMAL(30, 0)) providerDepositAmount!: string;
+  @Required @Column providerDepositStatus!: number;
+  @Required @Column status!: number;
+  @Required @Column(DataTypes.DATE) openedAt!: Date;
+  @Column(DataTypes.DATE) consumedAt?: Date;
+  @Required @Column(DataTypes.DATE) expiresAt!: Date;
+  @Column(DataTypes.BLOB) metadataHash?: Buffer;
+  @Required @Column settlementReason!: number;
+  @Required @Column faultAttribution!: number;
+  @Required @Column observedHeight!: number;
+  @Required @Column(DataTypes.DATE) observedBlockTime!: Date;
+
+  @BelongsTo(() => Provider, { foreignKey: "provider", targetKey: "owner", constraints: false }) providerRecord!: Provider;
+  @HasMany(() => VerificationAuditEscrowCapability, "auditEscrowId") capabilities!: VerificationAuditEscrowCapability[];
+}

--- a/packages/database/dbSchemas/akash/verificationAuditEscrowCapability.ts
+++ b/packages/database/dbSchemas/akash/verificationAuditEscrowCapability.ts
@@ -1,0 +1,19 @@
+import { DataTypes } from "sequelize";
+import { BelongsTo, Column, Model, PrimaryKey, Table } from "sequelize-typescript";
+
+import { Required } from "../decorators/requiredDecorator";
+import { VerificationAuditEscrow } from "./verificationAuditEscrow"; // eslint-disable-line import-x/no-cycle
+
+@Table({
+  tableName: "verification_audit_escrow_capability",
+  underscored: true,
+  indexes: [{ fields: ["capability"] }]
+})
+export class VerificationAuditEscrowCapability extends Model {
+  @Required @PrimaryKey @Column(DataTypes.DECIMAL(20, 0)) auditEscrowId!: string;
+  @Required @PrimaryKey @Column capability!: number;
+  @Required @Column observedHeight!: number;
+  @Required @Column(DataTypes.DATE) observedBlockTime!: Date;
+
+  @BelongsTo(() => VerificationAuditEscrow, "auditEscrowId") auditEscrow!: VerificationAuditEscrow;
+}

--- a/packages/database/dbSchemas/akash/verificationAuditor.ts
+++ b/packages/database/dbSchemas/akash/verificationAuditor.ts
@@ -1,0 +1,28 @@
+import { DataTypes } from "sequelize";
+import { Column, HasMany, Model, PrimaryKey, Table } from "sequelize-typescript";
+
+import { Required } from "../decorators/requiredDecorator";
+import { VerificationAttestation } from "./verificationAttestation"; // eslint-disable-line import-x/no-cycle
+
+@Table({
+  tableName: "verification_auditor",
+  underscored: true,
+  indexes: [{ fields: ["status"] }, { fields: ["renewal_deadline"] }]
+})
+export class VerificationAuditor extends Model {
+  @Required @PrimaryKey @Column address!: string;
+  @Required @Column status!: number;
+  @Required @Column maxAttestationTier!: number;
+  @Required @Column bondDenom!: string;
+  @Required @Column(DataTypes.DECIMAL(30, 0)) bondAmount!: string;
+  @Required @Column bondStatus!: number;
+  @Column(DataTypes.BLOB) metadataHash?: Buffer;
+  @Required @Column(DataTypes.DATE) registeredAt!: Date;
+  @Required @Column(DataTypes.DATE) renewalDeadline!: Date;
+  @Required @Column(DataTypes.DECIMAL(20, 0)) discrepancyCount!: string;
+  @Column(DataTypes.DATE) bondUnbondingCompletionTime?: Date;
+  @Required @Column observedHeight!: number;
+  @Required @Column(DataTypes.DATE) observedBlockTime!: Date;
+
+  @HasMany(() => VerificationAttestation, { foreignKey: "auditor", constraints: false }) attestations!: VerificationAttestation[];
+}

--- a/packages/database/dbSchemas/akash/verificationBlockEvent.ts
+++ b/packages/database/dbSchemas/akash/verificationBlockEvent.ts
@@ -1,0 +1,21 @@
+import { DataTypes, UUIDV4 } from "sequelize";
+import { BelongsTo, Column, Default, Model, PrimaryKey, Table } from "sequelize-typescript";
+
+import { Block } from "../base/block";
+import { Required } from "../decorators/requiredDecorator";
+
+/** Durable staging for verification invalidation signals from finalize_block_events. */
+@Table({
+  tableName: "verification_block_event",
+  underscored: true,
+  indexes: [{ unique: true, fields: ["height", "index"] }, { fields: ["height", "is_processed"] }]
+})
+export class VerificationBlockEvent extends Model {
+  @Required @PrimaryKey @Default(UUIDV4) @Column(DataTypes.UUID) id!: string;
+  @Required @Column height!: number;
+  @BelongsTo(() => Block, "height") block!: Block;
+  @Required @Column index!: number;
+  @Required @Column type!: string;
+  @Required @Column(DataTypes.JSONB) data!: Record<string, string | null>;
+  @Required @Default(false) @Column isProcessed!: boolean;
+}

--- a/packages/database/dbSchemas/akash/verificationDiscrepancy.ts
+++ b/packages/database/dbSchemas/akash/verificationDiscrepancy.ts
@@ -1,0 +1,30 @@
+import { DataTypes } from "sequelize";
+import { BelongsTo, Column, Model, PrimaryKey, Table } from "sequelize-typescript";
+
+import { Required } from "../decorators/requiredDecorator";
+import { Provider } from "./provider"; // eslint-disable-line import-x/no-cycle
+
+@Table({
+  tableName: "verification_discrepancy",
+  underscored: true,
+  indexes: [{ fields: ["provider", "resolution_status"] }, { fields: ["auditor_a"] }, { fields: ["auditor_b"] }]
+})
+export class VerificationDiscrepancy extends Model {
+  @Required @PrimaryKey @Column(DataTypes.DECIMAL(20, 0)) id!: string;
+  @Required @Column provider!: string;
+  @Required @Column auditorA!: string;
+  @Required @Column auditorATier!: number;
+  @Required @Column auditorB!: string;
+  @Required @Column auditorBTier!: number;
+  @Required @Column(DataTypes.DATE) detectedAt!: Date;
+  @Required @Column resolutionStatus!: number;
+  @Required @Column(DataTypes.DECIMAL(20, 0)) resolutionProposalId!: string;
+  @Required @Column(DataTypes.DECIMAL(20, 0)) graceRecordId!: string;
+  @Required @Column resolutionReason!: number;
+  @Required @Column faultAttribution!: number;
+  @Column(DataTypes.BLOB) resolutionEvidenceHash?: Buffer;
+  @Required @Column observedHeight!: number;
+  @Required @Column(DataTypes.DATE) observedBlockTime!: Date;
+
+  @BelongsTo(() => Provider, { foreignKey: "provider", targetKey: "owner", constraints: false }) providerRecord!: Provider;
+}

--- a/packages/database/dbSchemas/akash/verificationGrace.ts
+++ b/packages/database/dbSchemas/akash/verificationGrace.ts
@@ -1,0 +1,25 @@
+import { DataTypes } from "sequelize";
+import { BelongsTo, Column, HasMany, Model, PrimaryKey, Table } from "sequelize-typescript";
+
+import { Required } from "../decorators/requiredDecorator";
+import { Provider } from "./provider"; // eslint-disable-line import-x/no-cycle
+import { VerificationGraceDiscrepancy } from "./verificationGraceDiscrepancy"; // eslint-disable-line import-x/no-cycle
+
+@Table({
+  tableName: "verification_grace",
+  underscored: true,
+  indexes: [{ fields: ["provider", "status"] }, { fields: ["expires_at", "status"] }]
+})
+export class VerificationGrace extends Model {
+  @Required @PrimaryKey @Column(DataTypes.DECIMAL(20, 0)) id!: string;
+  @Required @Column provider!: string;
+  @Required @Column preservedTier!: number;
+  @Required @Column(DataTypes.DATE) startedAt!: Date;
+  @Required @Column(DataTypes.DATE) expiresAt!: Date;
+  @Required @Column status!: number;
+  @Required @Column observedHeight!: number;
+  @Required @Column(DataTypes.DATE) observedBlockTime!: Date;
+
+  @BelongsTo(() => Provider, { foreignKey: "provider", targetKey: "owner", constraints: false }) providerRecord!: Provider;
+  @HasMany(() => VerificationGraceDiscrepancy, "graceId") sourceDiscrepancies!: VerificationGraceDiscrepancy[];
+}

--- a/packages/database/dbSchemas/akash/verificationGraceDiscrepancy.ts
+++ b/packages/database/dbSchemas/akash/verificationGraceDiscrepancy.ts
@@ -1,0 +1,21 @@
+import { DataTypes } from "sequelize";
+import { BelongsTo, Column, Model, PrimaryKey, Table } from "sequelize-typescript";
+
+import { Required } from "../decorators/requiredDecorator";
+import { VerificationDiscrepancy } from "./verificationDiscrepancy"; // eslint-disable-line import-x/no-cycle
+import { VerificationGrace } from "./verificationGrace";
+
+@Table({
+  tableName: "verification_grace_discrepancy",
+  underscored: true,
+  indexes: [{ fields: ["discrepancy_id"] }]
+})
+export class VerificationGraceDiscrepancy extends Model {
+  @Required @PrimaryKey @Column(DataTypes.DECIMAL(20, 0)) graceId!: string;
+  @Required @PrimaryKey @Column(DataTypes.DECIMAL(20, 0)) discrepancyId!: string;
+  @Required @Column observedHeight!: number;
+  @Required @Column(DataTypes.DATE) observedBlockTime!: Date;
+
+  @BelongsTo(() => VerificationGrace, "graceId") grace!: VerificationGrace;
+  @BelongsTo(() => VerificationDiscrepancy, "discrepancyId") discrepancy!: VerificationDiscrepancy;
+}

--- a/packages/database/dbSchemas/akash/verificationParams.ts
+++ b/packages/database/dbSchemas/akash/verificationParams.ts
@@ -1,0 +1,15 @@
+import { DataTypes } from "sequelize";
+import { Column, Model, PrimaryKey, Table } from "sequelize-typescript";
+
+import { Required } from "../decorators/requiredDecorator";
+
+@Table({
+  tableName: "verification_params",
+  underscored: true
+})
+export class VerificationParams extends Model {
+  @Required @PrimaryKey @Column(DataTypes.SMALLINT) id!: number;
+  @Required @Column(DataTypes.JSONB) params!: Record<string, unknown>;
+  @Required @Column observedHeight!: number;
+  @Required @Column(DataTypes.DATE) observedBlockTime!: Date;
+}

--- a/packages/database/dbSchemas/akash/verificationProviderBond.ts
+++ b/packages/database/dbSchemas/akash/verificationProviderBond.ts
@@ -1,0 +1,25 @@
+import { DataTypes } from "sequelize";
+import { BelongsTo, Column, HasMany, Model, PrimaryKey, Table } from "sequelize-typescript";
+
+import { Required } from "../decorators/requiredDecorator";
+import { Provider } from "./provider"; // eslint-disable-line import-x/no-cycle
+import { VerificationProviderBondUnbonding } from "./verificationProviderBondUnbonding"; // eslint-disable-line import-x/no-cycle
+
+@Table({
+  tableName: "verification_provider_bond",
+  underscored: true
+})
+export class VerificationProviderBond extends Model {
+  @Required @PrimaryKey @Column provider!: string;
+  @Required @Column bondedDenom!: string;
+  @Required @Column(DataTypes.DECIMAL(30, 0)) bondedAmount!: string;
+  @Required @Column requiredForCurrentTierDenom!: string;
+  @Required @Column(DataTypes.DECIMAL(30, 0)) requiredForCurrentTierAmount!: string;
+  @Required @Column slashed!: boolean;
+  @Column(DataTypes.DATE) lastSlashTime?: Date;
+  @Required @Column observedHeight!: number;
+  @Required @Column(DataTypes.DATE) observedBlockTime!: Date;
+
+  @BelongsTo(() => Provider, { foreignKey: "provider", targetKey: "owner", constraints: false }) providerRecord!: Provider;
+  @HasMany(() => VerificationProviderBondUnbonding, "provider") unbondingEntries!: VerificationProviderBondUnbonding[];
+}

--- a/packages/database/dbSchemas/akash/verificationProviderBondUnbonding.ts
+++ b/packages/database/dbSchemas/akash/verificationProviderBondUnbonding.ts
@@ -1,0 +1,22 @@
+import { DataTypes } from "sequelize";
+import { BelongsTo, Column, Model, PrimaryKey, Table } from "sequelize-typescript";
+
+import { Required } from "../decorators/requiredDecorator";
+import { VerificationProviderBond } from "./verificationProviderBond"; // eslint-disable-line import-x/no-cycle
+
+@Table({
+  tableName: "verification_provider_bond_unbonding",
+  underscored: true,
+  indexes: [{ fields: ["completion_time"] }]
+})
+export class VerificationProviderBondUnbonding extends Model {
+  @Required @PrimaryKey @Column provider!: string;
+  @Required @PrimaryKey @Column entryIndex!: number;
+  @Required @Column denom!: string;
+  @Required @Column(DataTypes.DECIMAL(30, 0)) amount!: string;
+  @Required @Column(DataTypes.DATE) completionTime!: Date;
+  @Required @Column observedHeight!: number;
+  @Required @Column(DataTypes.DATE) observedBlockTime!: Date;
+
+  @BelongsTo(() => VerificationProviderBond, "provider") providerBond!: VerificationProviderBond;
+}

--- a/packages/database/dbSchemas/akash/verificationProviderObservation.ts
+++ b/packages/database/dbSchemas/akash/verificationProviderObservation.ts
@@ -1,0 +1,20 @@
+import { DataTypes } from "sequelize";
+import { BelongsTo, Column, Model, PrimaryKey, Table } from "sequelize-typescript";
+
+import { Required } from "../decorators/requiredDecorator";
+import { Provider } from "./provider"; // eslint-disable-line import-x/no-cycle
+
+@Table({
+  tableName: "verification_provider_observation",
+  underscored: true
+})
+export class VerificationProviderObservation extends Model {
+  @Required @PrimaryKey @Column provider!: string;
+  @Required @Column observedHeight!: number;
+  @Required @Column(DataTypes.DATE) observedBlockTime!: Date;
+  @Required @Column effectiveTier!: number;
+  @Required @Column maxPlacementTier!: number;
+  @Required @Column snapshotState!: string;
+
+  @BelongsTo(() => Provider, { foreignKey: "provider", targetKey: "owner", constraints: false }) providerRecord!: Provider;
+}

--- a/packages/database/dbSchemas/akash/verificationProviderSnapshot.ts
+++ b/packages/database/dbSchemas/akash/verificationProviderSnapshot.ts
@@ -1,0 +1,38 @@
+import { DataTypes } from "sequelize";
+import { BelongsTo, Column, Model, PrimaryKey, Table } from "sequelize-typescript";
+
+import { Required } from "../decorators/requiredDecorator";
+import { Provider } from "./provider"; // eslint-disable-line import-x/no-cycle
+
+@Table({
+  tableName: "verification_provider_snapshot",
+  underscored: true,
+  indexes: [{ fields: ["compliance_deadline", "suspended"] }, { fields: ["snapshot_timestamp"] }]
+})
+export class VerificationProviderSnapshot extends Model {
+  @Required @PrimaryKey @Column provider!: string;
+  @Required @Column(DataTypes.BLOB) snapshotHash!: Buffer;
+  @Required @Column totalGpus!: number;
+  @Required @Column totalVcpus!: number;
+  @Required @Column(DataTypes.DECIMAL(20, 0)) totalMemoryMb!: string;
+  @Required @Column(DataTypes.DECIMAL(20, 0)) totalStorageMb!: string;
+  @Required @Column activeLeases!: number;
+  @Required @Column softwareVersion!: string;
+  @Column(DataTypes.BLOB) softwareSignature?: Buffer;
+  @Column softwareIdentityVersion?: string;
+  @Column softwareArtifactRef?: string;
+  @Column softwareDigestAlgorithm?: string;
+  @Column(DataTypes.BLOB) softwareDigest?: Buffer;
+  @Column softwareSignatureType?: string;
+  @Column(DataTypes.BLOB) softwareIdentitySignature?: Buffer;
+  @Column softwareSignatureRef?: string;
+  @Column softwarePublicKeyRef?: string;
+  @Required @Column(DataTypes.DATE) postedAt!: Date;
+  @Required @Column(DataTypes.DATE) snapshotTimestamp!: Date;
+  @Required @Column(DataTypes.DATE) complianceDeadline!: Date;
+  @Required @Column suspended!: boolean;
+  @Required @Column observedHeight!: number;
+  @Required @Column(DataTypes.DATE) observedBlockTime!: Date;
+
+  @BelongsTo(() => Provider, { foreignKey: "provider", targetKey: "owner", constraints: false }) providerRecord!: Provider;
+}

--- a/packages/database/dbSchemas/akash/verificationProviderTierDemotion.ts
+++ b/packages/database/dbSchemas/akash/verificationProviderTierDemotion.ts
@@ -1,0 +1,27 @@
+import { DataTypes } from "sequelize";
+import { AutoIncrement, BelongsTo, Column, Default, Model, PrimaryKey, Table } from "sequelize-typescript";
+
+import { Required } from "../decorators/requiredDecorator";
+import { Provider } from "./provider";
+
+@Table({
+  tableName: "verification_provider_tier_demotion",
+  underscored: true,
+  indexes: [{ fields: ["provider", "id"] }, { fields: ["observed_height"] }]
+})
+export class VerificationProviderTierDemotion extends Model {
+  @Required @AutoIncrement @PrimaryKey @Column(DataTypes.BIGINT) id!: string;
+  @Required @Column provider!: string;
+  @Required @Column previousEffectiveTier!: number;
+  @Required @Column previousMaxPlacementTier!: number;
+  @Required @Column previousSnapshotState!: string;
+  @Required @Column currentEffectiveTier!: number;
+  @Required @Column currentMaxPlacementTier!: number;
+  @Required @Column currentSnapshotState!: string;
+  @Required @Column(DataTypes.ARRAY(DataTypes.STRING)) changes!: string[];
+  @Required @Column observedHeight!: number;
+  @Required @Column(DataTypes.DATE) observedBlockTime!: Date;
+  @Required @Default(DataTypes.NOW) @Column(DataTypes.DATE) createdAt!: Date;
+
+  @BelongsTo(() => Provider, { foreignKey: "provider", targetKey: "owner", constraints: false }) providerRecord!: Provider;
+}

--- a/packages/database/dbSchemas/akash/verificationProviderTierStream.ts
+++ b/packages/database/dbSchemas/akash/verificationProviderTierStream.ts
@@ -1,0 +1,13 @@
+import { DataTypes } from "sequelize";
+import { Column, Default, Model, PrimaryKey, Table } from "sequelize-typescript";
+
+import { Required } from "../decorators/requiredDecorator";
+
+@Table({
+  tableName: "verification_provider_tier_stream",
+  underscored: true
+})
+export class VerificationProviderTierStream extends Model {
+  @Required @PrimaryKey @Column(DataTypes.SMALLINT) id!: number;
+  @Required @Default(DataTypes.UUIDV4) @Column(DataTypes.UUID) streamId!: string;
+}

--- a/packages/database/dbSchemas/akash/verificationReconcileTarget.ts
+++ b/packages/database/dbSchemas/akash/verificationReconcileTarget.ts
@@ -1,0 +1,20 @@
+import { DataTypes } from "sequelize";
+import { Column, Default, Model, PrimaryKey, Table } from "sequelize-typescript";
+
+import { Required } from "../decorators/requiredDecorator";
+
+@Table({
+  tableName: "verification_reconcile_target",
+  underscored: true,
+  indexes: [{ fields: ["claimed_at", "next_attempt_at"] }, { fields: ["requested_height"] }]
+})
+export class VerificationReconcileTarget extends Model {
+  @Required @PrimaryKey @Column targetType!: string;
+  @Required @PrimaryKey @Column targetKey!: string;
+  @Required @Column requestedHeight!: number;
+  @Required @Default(true) @Column invalidated!: boolean;
+  @Column(DataTypes.DATE) claimedAt?: Date;
+  @Required @Default(0) @Column attemptCount!: number;
+  @Column(DataTypes.DATE) nextAttemptAt?: Date;
+  @Column(DataTypes.TEXT) lastError?: string;
+}

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -14,6 +14,8 @@
   "scripts": {
     "format": "prettier --write ./*.{ts,json} **/*.{ts,json}",
     "lint": "eslint .",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "validate:types": "tsc -p tsconfig.build.json --noEmit && echo"
   },
   "dependencies": {
@@ -23,6 +25,7 @@
     "sequelize-typescript": "^2.1.5"
   },
   "devDependencies": {
-    "@akashnetwork/dev-config": "*"
+    "@akashnetwork/dev-config": "*",
+    "vitest": "^4.1.5"
   }
 }

--- a/packages/network-store/package.json
+++ b/packages/network-store/package.json
@@ -18,7 +18,7 @@
     "validate:types": "tsc --noEmit && echo"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/net": "*",
     "jotai": "^2.9.2"
   },

--- a/packages/provider-verification/package.json
+++ b/packages/provider-verification/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@akashnetwork/provider-verification",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Shared AEP-86 provider verification policy evaluation",
+  "license": "Apache-2.0",
+  "author": "Akash Network",
+  "type": "module",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "default": "./src/index.ts"
+    }
+  },
+  "main": "src/index.ts",
+  "scripts": {
+    "format": "prettier --write ./*.{ts,json} **/*.{ts,json}",
+    "lint": "eslint .",
+    "test": "vitest run",
+    "validate:types": "tsc -p tsconfig.build.json --noEmit && echo"
+  },
+  "dependencies": {
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43"
+  },
+  "devDependencies": {
+    "@akashnetwork/dev-config": "*",
+    "typescript": "~5.8.2",
+    "vitest": "^4.1.5"
+  }
+}

--- a/packages/provider-verification/src/index.ts
+++ b/packages/provider-verification/src/index.ts
@@ -1,0 +1,12 @@
+export {
+  deriveProviderVerificationSummary,
+  evaluateProviderVerification,
+  type ProviderVerificationCompleteness,
+  type ProviderVerificationEvaluation,
+  type ProviderVerificationFacts,
+  type ProviderVerificationFailure,
+  type ProviderVerificationSummary,
+  type SnapshotComplianceState
+} from "./providerVerification.js";
+export * from "./providerVerificationQueryClient.js";
+export * from "./providerTierState.js";

--- a/packages/provider-verification/src/providerTierState.spec.ts
+++ b/packages/provider-verification/src/providerTierState.spec.ts
@@ -1,0 +1,149 @@
+import type { AttestationRecord, ProviderSnapshotRecord, ProviderVerificationGraceRecord } from "@akashnetwork/chain-sdk/private-types/akash.v1";
+import { AttestationStatus, VerificationGraceStatus, VerificationTier } from "@akashnetwork/chain-sdk/private-types/akash.v1";
+import { describe, expect, it } from "vitest";
+
+import { deriveProviderTierState, detectProviderTierDemotion } from "./providerTierState.js";
+import type { ProviderVerificationFacts } from "./providerVerification.js";
+
+const observedAt = new Date("2026-08-24T12:00:00.000Z");
+
+describe(deriveProviderTierState.name, () => {
+  it("uses active grace for the effective tier", () => {
+    expect(
+      deriveProviderTierState(
+        facts({
+          attestations: [attestation(VerificationTier.verification_tier_identified)],
+          graces: [grace(VerificationTier.verification_tier_established)],
+          snapshot: snapshot({ complianceDeadline: new Date("2026-08-25T12:00:00.000Z") })
+        })
+      )
+    ).toEqual({
+      effectiveTier: VerificationTier.verification_tier_established,
+      maxPlacementTier: VerificationTier.verification_tier_established,
+      snapshotState: "current"
+    });
+  });
+
+  it.each(["not_posted", "stale", "suspended"] as const)("clamps L2+ placement eligibility to L1 when the snapshot is %s", snapshotState => {
+    const snapshotByState = {
+      not_posted: null,
+      stale: snapshot({ complianceDeadline: observedAt }),
+      suspended: snapshot({ complianceDeadline: new Date("2026-08-25T12:00:00.000Z"), suspended: true })
+    };
+
+    expect(
+      deriveProviderTierState(facts({ attestations: [attestation(VerificationTier.verification_tier_trusted)], snapshot: snapshotByState[snapshotState] }))
+    ).toMatchObject({
+      effectiveTier: VerificationTier.verification_tier_trusted,
+      maxPlacementTier: VerificationTier.verification_tier_identified,
+      snapshotState
+    });
+  });
+
+  it("does not require a snapshot for L1", () => {
+    expect(deriveProviderTierState(facts({ attestations: [attestation(VerificationTier.verification_tier_identified)] }))).toMatchObject({
+      effectiveTier: VerificationTier.verification_tier_identified,
+      maxPlacementTier: VerificationTier.verification_tier_identified,
+      snapshotState: "not_posted"
+    });
+  });
+});
+
+describe(detectProviderTierDemotion.name, () => {
+  it("reports independent tier and snapshot eligibility decreases", () => {
+    const currentSnapshot = {
+      effectiveTier: VerificationTier.verification_tier_established,
+      maxPlacementTier: VerificationTier.verification_tier_established,
+      snapshotState: "current" as const
+    };
+
+    expect(
+      detectProviderTierDemotion(currentSnapshot, {
+        ...currentSnapshot,
+        maxPlacementTier: VerificationTier.verification_tier_identified,
+        snapshotState: "stale"
+      })
+    ).toEqual(["snapshot_eligibility"]);
+    expect(
+      detectProviderTierDemotion(currentSnapshot, {
+        effectiveTier: VerificationTier.verification_tier_verified,
+        maxPlacementTier: VerificationTier.verification_tier_verified,
+        snapshotState: "current"
+      })
+    ).toEqual(["tier_gate", "snapshot_eligibility"]);
+  });
+
+  it("does not emit on an upgrade or unchanged state", () => {
+    const previous = {
+      effectiveTier: VerificationTier.verification_tier_identified,
+      maxPlacementTier: VerificationTier.verification_tier_identified,
+      snapshotState: "not_posted" as const
+    };
+
+    expect(detectProviderTierDemotion(previous, previous)).toEqual([]);
+    expect(
+      detectProviderTierDemotion(previous, {
+        effectiveTier: VerificationTier.verification_tier_verified,
+        maxPlacementTier: VerificationTier.verification_tier_verified,
+        snapshotState: "current"
+      })
+    ).toEqual([]);
+  });
+});
+
+function facts(overrides: Partial<ProviderVerificationFacts> = {}): ProviderVerificationFacts {
+  return {
+    attestations: [],
+    graces: [],
+    snapshot: null,
+    completeness: { attestations: true, graces: true, snapshot: true },
+    observedAt,
+    observedHeight: "100",
+    ...overrides
+  };
+}
+
+function attestation(tier: VerificationTier): AttestationRecord {
+  return {
+    provider: "akash1provider",
+    auditor: "akash1auditor",
+    tier,
+    capabilities: [],
+    evidenceHash: new Uint8Array(),
+    fee: undefined,
+    feeStatus: 0,
+    createdAt: undefined,
+    expiresAt: undefined,
+    status: AttestationStatus.attestation_status_valid,
+    voidedReason: 0,
+    deposit: undefined,
+    depositStatus: 0,
+    auditEscrowId: 0n,
+    faultAttribution: 0
+  };
+}
+
+function grace(preservedTier: VerificationTier): ProviderVerificationGraceRecord {
+  return {
+    id: 1n,
+    provider: "akash1provider",
+    preservedTier,
+    sourceDiscrepancyIds: [],
+    startedAt: undefined,
+    expiresAt: undefined,
+    status: VerificationGraceStatus.verification_grace_status_active
+  };
+}
+
+function snapshot(overrides: Partial<ProviderSnapshotRecord> = {}): ProviderSnapshotRecord {
+  return {
+    provider: "akash1provider",
+    snapshotHash: new Uint8Array(),
+    resourceSummary: undefined,
+    postedAt: undefined,
+    snapshotTimestamp: undefined,
+    complianceDeadline: new Date("2026-08-25T12:00:00.000Z"),
+    suspended: false,
+    ...overrides
+  };
+}

--- a/packages/provider-verification/src/providerTierState.ts
+++ b/packages/provider-verification/src/providerTierState.ts
@@ -1,0 +1,32 @@
+import { VerificationTier } from "@akashnetwork/chain-sdk/private-types/akash.v1";
+
+import { deriveProviderVerificationSummary, type ProviderVerificationFacts, type SnapshotComplianceState } from "./providerVerification.js";
+
+export type ProviderTierDemotionChange = "tier_gate" | "snapshot_eligibility";
+
+export interface ProviderTierState {
+  effectiveTier: VerificationTier;
+  maxPlacementTier: VerificationTier;
+  snapshotState: SnapshotComplianceState;
+}
+
+export function deriveProviderTierState(facts: ProviderVerificationFacts): ProviderTierState {
+  const summary = deriveProviderVerificationSummary(facts);
+  const maxPlacementTier =
+    summary.tierGateTier < VerificationTier.verification_tier_verified || summary.snapshotState === "current"
+      ? summary.tierGateTier
+      : VerificationTier.verification_tier_identified;
+
+  return {
+    effectiveTier: summary.tierGateTier,
+    maxPlacementTier,
+    snapshotState: summary.snapshotState
+  };
+}
+
+export function detectProviderTierDemotion(previous: ProviderTierState, current: ProviderTierState): ProviderTierDemotionChange[] {
+  const changes: ProviderTierDemotionChange[] = [];
+  if (current.effectiveTier < previous.effectiveTier) changes.push("tier_gate");
+  if (current.maxPlacementTier < previous.maxPlacementTier) changes.push("snapshot_eligibility");
+  return changes;
+}

--- a/packages/provider-verification/src/providerVerification.spec.ts
+++ b/packages/provider-verification/src/providerVerification.spec.ts
@@ -1,0 +1,267 @@
+import type { AttestationRecord, ProviderVerificationGraceRecord, VerificationRequirement } from "@akashnetwork/chain-sdk/private-types/akash.v1";
+import {
+  AttestationStatus,
+  AuditorSelectionMode,
+  CapabilityFlag,
+  VerificationGraceStatus,
+  VerificationTier
+} from "@akashnetwork/chain-sdk/private-types/akash.v1";
+import { describe, expect, it } from "vitest";
+
+import { deriveProviderVerificationSummary, evaluateProviderVerification, type ProviderVerificationFacts } from "./providerVerification.js";
+
+const observedAt = new Date("2026-08-24T12:00:00.000Z");
+
+describe("deriveProviderVerificationSummary", () => {
+  it("matches the market keeper by using stored-valid attestations regardless of auditor lifecycle or expires_at", () => {
+    const facts = createFacts({
+      attestations: [
+        createAttestation({ auditor: "auditor-b", tier: VerificationTier.verification_tier_verified, capabilities: [CapabilityFlag.capability_bare_metal] }),
+        createAttestation({
+          auditor: "auditor-a",
+          tier: VerificationTier.verification_tier_established,
+          capabilities: [CapabilityFlag.capability_persistent_storage]
+        }),
+        createAttestation({
+          auditor: "auditor-c",
+          status: AttestationStatus.attestation_status_expired,
+          tier: VerificationTier.verification_tier_trusted,
+          capabilities: [CapabilityFlag.capability_confidential_computing]
+        })
+      ]
+    });
+
+    expect(deriveProviderVerificationSummary(facts)).toMatchObject({
+      bestStatusValidTier: VerificationTier.verification_tier_established,
+      tierGateTier: VerificationTier.verification_tier_established,
+      capabilities: [CapabilityFlag.capability_persistent_storage, CapabilityFlag.capability_bare_metal],
+      validAttestationCount: 2,
+      validAuditors: ["auditor-a", "auditor-b"]
+    });
+  });
+
+  it("uses active grace only for the tier gate", () => {
+    const facts = createFacts({
+      attestations: [createAttestation({ tier: VerificationTier.verification_tier_identified, capabilities: [CapabilityFlag.capability_persistent_storage] })],
+      graces: [createGrace(VerificationTier.verification_tier_established)]
+    });
+
+    expect(deriveProviderVerificationSummary(facts)).toMatchObject({
+      bestStatusValidTier: VerificationTier.verification_tier_identified,
+      tierGateTier: VerificationTier.verification_tier_established,
+      capabilities: [CapabilityFlag.capability_persistent_storage]
+    });
+  });
+});
+
+describe("evaluateProviderVerification", () => {
+  it("does not enforce a vacuous requirement", () => {
+    const result = evaluateProviderVerification({
+      moduleActive: null,
+      requirement: createRequirement({ minTier: VerificationTier.verification_tier_unspecified }),
+      facts: createFacts()
+    });
+
+    expect(result.outcome).toBe("pass");
+  });
+
+  it("does not enforce verification while the chain module is inactive", () => {
+    const result = evaluateProviderVerification({
+      moduleActive: false,
+      requirement: createRequirement({ minTier: VerificationTier.verification_tier_trusted }),
+      facts: createFacts({ completeness: { attestations: false, graces: false, snapshot: false } })
+    });
+
+    expect(result.outcome).toBe("pass");
+  });
+
+  it("returns unknown instead of excluding a provider when required facts are incomplete", () => {
+    const result = evaluateProviderVerification({
+      moduleActive: true,
+      requirement: createRequirement({ minTier: VerificationTier.verification_tier_verified }),
+      facts: createFacts({ completeness: { attestations: true, graces: false, snapshot: false } })
+    });
+
+    expect(result).toMatchObject({ outcome: "unknown", incompleteFacts: ["graces", "snapshot"] });
+  });
+
+  it("checks snapshot before tier and retains the full failure set", () => {
+    const result = evaluateProviderVerification({
+      moduleActive: true,
+      requirement: createRequirement({
+        minTier: VerificationTier.verification_tier_verified,
+        requiredCapabilities: [CapabilityFlag.capability_persistent_storage],
+        minAuditorCount: 2
+      }),
+      facts: createFacts()
+    });
+
+    expect(result.outcome).toBe("fail");
+    if (result.outcome !== "fail") throw new Error("expected failure");
+    expect(result.firstFailure.code).toBe("snapshot_not_posted");
+    expect(result.failures.map(failure => failure.code)).toEqual([
+      "snapshot_not_posted",
+      "insufficient_tier",
+      "missing_capability",
+      "insufficient_auditor_count"
+    ]);
+  });
+
+  it("matches capability union and tier-qualified auditor semantics", () => {
+    const result = evaluateProviderVerification({
+      moduleActive: true,
+      requirement: createRequirement({
+        minTier: VerificationTier.verification_tier_verified,
+        requiredCapabilities: [CapabilityFlag.capability_persistent_storage, CapabilityFlag.capability_bare_metal],
+        requiredAuditors: ["auditor-l2", "auditor-l1"],
+        auditorMode: AuditorSelectionMode.auditor_selection_mode_any,
+        minAuditorCount: 1
+      }),
+      facts: createFacts({
+        attestations: [
+          createAttestation({ auditor: "auditor-l2", tier: VerificationTier.verification_tier_verified, capabilities: [CapabilityFlag.capability_bare_metal] }),
+          createAttestation({
+            auditor: "auditor-l1",
+            tier: VerificationTier.verification_tier_identified,
+            capabilities: [CapabilityFlag.capability_persistent_storage]
+          })
+        ],
+        snapshot: { complianceDeadline: new Date("2026-08-25T12:00:00.000Z"), suspended: false }
+      })
+    });
+
+    expect(result).toMatchObject({ outcome: "pass", qualifiedAuditors: ["auditor-l2"] });
+  });
+
+  it("treats unspecified auditor mode as any and reports all missing auditors for all mode", () => {
+    const facts = createFacts({ attestations: [createAttestation({ auditor: "auditor-a" })] });
+    const anyResult = evaluateProviderVerification({
+      moduleActive: true,
+      requirement: createRequirement({ requiredAuditors: ["auditor-a", "auditor-b"] }),
+      facts
+    });
+    const allResult = evaluateProviderVerification({
+      moduleActive: true,
+      requirement: createRequirement({ requiredAuditors: ["auditor-a", "auditor-b"], auditorMode: AuditorSelectionMode.auditor_selection_mode_all }),
+      facts
+    });
+
+    expect(anyResult.outcome).toBe("pass");
+    expect(allResult).toMatchObject({
+      outcome: "fail",
+      firstFailure: { code: "required_auditor_not_found", missing: ["auditor-b"] }
+    });
+  });
+
+  it("does not add a provider-bond check that the market BidFilter does not perform", () => {
+    const result = evaluateProviderVerification({
+      moduleActive: true,
+      requirement: createRequirement({ minTier: VerificationTier.verification_tier_verified }),
+      facts: createFacts({
+        attestations: [createAttestation({ tier: VerificationTier.verification_tier_verified })],
+        snapshot: { complianceDeadline: new Date("2026-08-25T12:00:00.000Z"), suspended: false }
+      })
+    });
+
+    expect(result.outcome).toBe("pass");
+  });
+
+  it("uses the snapshot compliance deadline even before suspension is persisted", () => {
+    const result = evaluateProviderVerification({
+      moduleActive: true,
+      requirement: createRequirement({ minTier: VerificationTier.verification_tier_verified }),
+      facts: createFacts({
+        attestations: [createAttestation({ tier: VerificationTier.verification_tier_verified })],
+        snapshot: { complianceDeadline: observedAt, suspended: false }
+      })
+    });
+
+    expect(result).toMatchObject({ outcome: "fail", firstFailure: { code: "snapshot_stale" } });
+  });
+
+  it("does not let an active grace bypass L2 snapshot suspension", () => {
+    const result = evaluateProviderVerification({
+      moduleActive: true,
+      requirement: createRequirement({ minTier: VerificationTier.verification_tier_verified }),
+      facts: createFacts({
+        graces: [createGrace(VerificationTier.verification_tier_verified)],
+        snapshot: { complianceDeadline: new Date("2026-08-25T12:00:00.000Z"), suspended: true }
+      })
+    });
+
+    expect(result).toMatchObject({
+      outcome: "fail",
+      firstFailure: { code: "snapshot_suspended" },
+      failures: [{ code: "snapshot_suspended" }]
+    });
+  });
+
+  it("keeps eligibility when a partial bond slash leaves the attestation valid", () => {
+    const result = evaluateProviderVerification({
+      moduleActive: true,
+      requirement: createRequirement({ minTier: VerificationTier.verification_tier_verified }),
+      facts: createFacts({
+        attestations: [createAttestation({ tier: VerificationTier.verification_tier_verified })],
+        snapshot: { complianceDeadline: new Date("2026-08-25T12:00:00.000Z"), suspended: false }
+      })
+    });
+
+    expect(result.outcome).toBe("pass");
+  });
+});
+
+function createFacts(overrides: Partial<ProviderVerificationFacts> = {}): ProviderVerificationFacts {
+  return {
+    attestations: [],
+    graces: [],
+    snapshot: null,
+    completeness: { attestations: true, graces: true, snapshot: true },
+    observedAt,
+    observedHeight: "100",
+    ...overrides
+  };
+}
+
+function createAttestation(overrides: Partial<AttestationRecord> = {}): AttestationRecord {
+  return {
+    provider: "provider",
+    auditor: "auditor",
+    tier: VerificationTier.verification_tier_identified,
+    capabilities: [],
+    evidenceHash: new Uint8Array(),
+    fee: undefined,
+    feeStatus: 0,
+    createdAt: new Date("2025-01-01T00:00:00.000Z"),
+    expiresAt: new Date("2025-01-02T00:00:00.000Z"),
+    status: AttestationStatus.attestation_status_valid,
+    voidedReason: 0,
+    deposit: undefined,
+    depositStatus: 0,
+    auditEscrowId: 1n,
+    faultAttribution: 0,
+    ...overrides
+  };
+}
+
+function createGrace(preservedTier: VerificationTier): ProviderVerificationGraceRecord {
+  return {
+    id: 1n,
+    provider: "provider",
+    preservedTier,
+    sourceDiscrepancyIds: [1n],
+    startedAt: observedAt,
+    expiresAt: new Date("2026-08-25T12:00:00.000Z"),
+    status: VerificationGraceStatus.verification_grace_status_active
+  };
+}
+
+function createRequirement(overrides: Partial<VerificationRequirement> = {}): VerificationRequirement {
+  return {
+    minTier: VerificationTier.verification_tier_identified,
+    requiredCapabilities: [],
+    requiredAuditors: [],
+    auditorMode: AuditorSelectionMode.auditor_selection_mode_unspecified,
+    minAuditorCount: 0,
+    ...overrides
+  };
+}

--- a/packages/provider-verification/src/providerVerification.ts
+++ b/packages/provider-verification/src/providerVerification.ts
@@ -1,0 +1,191 @@
+import type {
+  AttestationRecord,
+  ProviderSnapshotRecord,
+  ProviderVerificationGraceRecord,
+  VerificationRequirement
+} from "@akashnetwork/chain-sdk/private-types/akash.v1";
+import {
+  AttestationStatus,
+  AuditorSelectionMode,
+  CapabilityFlag,
+  VerificationGraceStatus,
+  VerificationTier
+} from "@akashnetwork/chain-sdk/private-types/akash.v1";
+
+type AttestationFact = Pick<AttestationRecord, "auditor" | "capabilities" | "status" | "tier">;
+type GraceFact = Pick<ProviderVerificationGraceRecord, "preservedTier" | "status">;
+type SnapshotFact = Pick<ProviderSnapshotRecord, "complianceDeadline" | "suspended">;
+
+export interface ProviderVerificationCompleteness {
+  attestations: boolean;
+  graces: boolean;
+  snapshot: boolean;
+}
+
+export interface ProviderVerificationFacts {
+  attestations: readonly AttestationFact[];
+  graces: readonly GraceFact[];
+  snapshot: SnapshotFact | null;
+  completeness: ProviderVerificationCompleteness;
+  observedAt: Date;
+  observedHeight: string;
+}
+
+export type SnapshotComplianceState = "unknown" | "not_posted" | "current" | "stale" | "suspended";
+
+export interface ProviderVerificationSummary {
+  bestStatusValidTier: VerificationTier;
+  tierGateTier: VerificationTier;
+  capabilities: CapabilityFlag[];
+  validAttestationCount: number;
+  validAuditors: string[];
+  snapshotState: SnapshotComplianceState;
+  observedHeight: string;
+}
+
+export type ProviderVerificationFailure =
+  | { code: "snapshot_not_posted" }
+  | { code: "snapshot_suspended" }
+  | { code: "snapshot_stale" }
+  | { code: "insufficient_tier"; actual: VerificationTier; required: VerificationTier }
+  | { code: "missing_capability"; capability: CapabilityFlag }
+  | { code: "insufficient_auditor_count"; actual: number; required: number }
+  | { code: "required_auditor_not_found"; mode: AuditorSelectionMode; missing: string[] };
+
+interface EvaluationBase {
+  summary: ProviderVerificationSummary;
+  qualifiedAuditors: string[];
+}
+
+export type ProviderVerificationEvaluation =
+  | (EvaluationBase & { outcome: "pass"; firstFailure: null; failures: [] })
+  | (EvaluationBase & {
+      outcome: "fail";
+      firstFailure: ProviderVerificationFailure;
+      failures: ProviderVerificationFailure[];
+    })
+  | (EvaluationBase & { outcome: "unknown"; firstFailure: null; failures: []; incompleteFacts: Array<keyof ProviderVerificationCompleteness | "params"> });
+
+interface EvaluateProviderVerificationInput {
+  moduleActive: boolean | null;
+  requirement: VerificationRequirement | null;
+  facts: ProviderVerificationFacts;
+}
+
+export function deriveProviderVerificationSummary(facts: ProviderVerificationFacts): ProviderVerificationSummary {
+  const validAttestations = facts.attestations.filter(attestation => attestation.status === AttestationStatus.attestation_status_valid);
+  const bestStatusValidTier = validAttestations.reduce(
+    (best, attestation) => betterTier(best, attestation.tier),
+    VerificationTier.verification_tier_unspecified
+  );
+  const tierGateTier = facts.graces
+    .filter(grace => grace.status === VerificationGraceStatus.verification_grace_status_active)
+    .reduce((best, grace) => betterTier(best, grace.preservedTier), bestStatusValidTier);
+  const capabilities = uniqueSorted(
+    validAttestations.flatMap(attestation => attestation.capabilities).filter(capability => capability !== CapabilityFlag.capability_unspecified)
+  );
+  const validAuditors = uniqueSorted(validAttestations.map(attestation => attestation.auditor).filter(Boolean));
+
+  return {
+    bestStatusValidTier,
+    tierGateTier,
+    capabilities,
+    validAttestationCount: validAttestations.length,
+    validAuditors,
+    snapshotState: deriveSnapshotState(facts),
+    observedHeight: facts.observedHeight
+  };
+}
+
+export function evaluateProviderVerification({ moduleActive, requirement, facts }: EvaluateProviderVerificationInput): ProviderVerificationEvaluation {
+  const summary = deriveProviderVerificationSummary(facts);
+  const noRequirement = !requirement || requirement.minTier === VerificationTier.verification_tier_unspecified;
+
+  if (noRequirement || moduleActive === false) {
+    return pass(summary, []);
+  }
+
+  const incompleteFacts: Array<keyof ProviderVerificationCompleteness | "params"> = [];
+  if (moduleActive === null) incompleteFacts.push("params");
+  if (!facts.completeness.attestations) incompleteFacts.push("attestations");
+  if (!facts.completeness.graces) incompleteFacts.push("graces");
+  if (requiresSnapshot(requirement.minTier) && !facts.completeness.snapshot) incompleteFacts.push("snapshot");
+
+  const qualifiedAuditors = qualifiedAuditorsForTier(facts.attestations, requirement.minTier);
+  if (incompleteFacts.length > 0) {
+    return { outcome: "unknown", firstFailure: null, failures: [], incompleteFacts, qualifiedAuditors, summary };
+  }
+
+  const failures: ProviderVerificationFailure[] = [];
+  if (requiresSnapshot(requirement.minTier)) {
+    if (summary.snapshotState === "not_posted") failures.push({ code: "snapshot_not_posted" });
+    if (summary.snapshotState === "suspended") failures.push({ code: "snapshot_suspended" });
+    if (summary.snapshotState === "stale") failures.push({ code: "snapshot_stale" });
+  }
+
+  if (summary.tierGateTier < requirement.minTier) {
+    failures.push({ code: "insufficient_tier", actual: summary.tierGateTier, required: requirement.minTier });
+  }
+
+  for (const capability of requirement.requiredCapabilities) {
+    if (capability !== CapabilityFlag.capability_unspecified && !summary.capabilities.includes(capability)) {
+      failures.push({ code: "missing_capability", capability });
+    }
+  }
+
+  if (qualifiedAuditors.length < requirement.minAuditorCount) {
+    failures.push({ code: "insufficient_auditor_count", actual: qualifiedAuditors.length, required: requirement.minAuditorCount });
+  }
+
+  const requiredAuditorFailure = evaluateRequiredAuditors(requirement, qualifiedAuditors);
+  if (requiredAuditorFailure) failures.push(requiredAuditorFailure);
+
+  return failures.length === 0 ? pass(summary, qualifiedAuditors) : { outcome: "fail", firstFailure: failures[0], failures, qualifiedAuditors, summary };
+}
+
+function deriveSnapshotState(facts: ProviderVerificationFacts): SnapshotComplianceState {
+  if (!facts.completeness.snapshot) return "unknown";
+  if (!facts.snapshot) return "not_posted";
+  if (facts.snapshot.suspended) return "suspended";
+  if (!facts.snapshot.complianceDeadline || facts.snapshot.complianceDeadline <= facts.observedAt) return "stale";
+  return "current";
+}
+
+function requiresSnapshot(tier: VerificationTier): boolean {
+  return tier >= VerificationTier.verification_tier_verified;
+}
+
+function betterTier(left: VerificationTier, right: VerificationTier): VerificationTier {
+  return right > left ? right : left;
+}
+
+function qualifiedAuditorsForTier(attestations: readonly AttestationFact[], minTier: VerificationTier): string[] {
+  return uniqueSorted(
+    attestations
+      .filter(attestation => attestation.status === AttestationStatus.attestation_status_valid && attestation.tier >= minTier)
+      .map(attestation => attestation.auditor)
+      .filter(Boolean)
+  );
+}
+
+function evaluateRequiredAuditors(
+  requirement: VerificationRequirement,
+  qualifiedAuditors: readonly string[]
+): Extract<ProviderVerificationFailure, { code: "required_auditor_not_found" }> | null {
+  if (requirement.requiredAuditors.length === 0) return null;
+
+  const available = new Set(qualifiedAuditors);
+  const missing = requirement.requiredAuditors.filter(auditor => !available.has(auditor));
+  const allRequired = requirement.auditorMode === AuditorSelectionMode.auditor_selection_mode_all;
+  const satisfied = allRequired ? missing.length === 0 : requirement.requiredAuditors.some(auditor => available.has(auditor));
+
+  return satisfied ? null : { code: "required_auditor_not_found", mode: requirement.auditorMode, missing };
+}
+
+function uniqueSorted<T extends number | string>(values: readonly T[]): T[] {
+  return [...new Set(values)].sort((left, right) => (left < right ? -1 : left > right ? 1 : 0));
+}
+
+function pass(summary: ProviderVerificationSummary, qualifiedAuditors: string[]): ProviderVerificationEvaluation {
+  return { outcome: "pass", firstFailure: null, failures: [], qualifiedAuditors, summary };
+}

--- a/packages/provider-verification/src/providerVerificationQueryClient.spec.ts
+++ b/packages/provider-verification/src/providerVerificationQueryClient.spec.ts
@@ -1,0 +1,176 @@
+import { SDKError, SDKErrorCode } from "@akashnetwork/chain-sdk/web";
+import { describe, expect, it, vi } from "vitest";
+
+import { type ProviderQueries, ProviderVerificationQueryClient, type VerificationQueries } from "./providerVerificationQueryClient.js";
+
+const height = "1234";
+const options = { headers: { "x-cosmos-block-height": height } };
+
+describe(ProviderVerificationQueryClient.name, () => {
+  it("pins and paginates global queries at one height", async () => {
+    const getAuditors = vi
+      .fn()
+      .mockResolvedValueOnce({ auditors: [{ address: "akash1auditor1" }], pagination: { nextKey: Uint8Array.from([1]), total: 0n } })
+      .mockResolvedValueOnce({ auditors: [{ address: "akash1auditor2" }], pagination: { nextKey: new Uint8Array(), total: 0n } });
+    const getDiscrepancies = vi.fn().mockResolvedValue({ discrepancies: [], pagination: { nextKey: new Uint8Array(), total: 0n } });
+    const getParams = vi.fn().mockResolvedValue({ params: { verificationModuleActive: true } });
+    const client = createClient({ getAuditors, getDiscrepancies, getParams });
+
+    const result = await client.getGlobalState(height);
+
+    expect(result).toMatchObject({
+      auditors: [{ address: "akash1auditor1" }, { address: "akash1auditor2" }],
+      discrepancies: [],
+      observedHeight: height,
+      params: { verificationModuleActive: true }
+    });
+    expect(getParams).toHaveBeenCalledWith({}, options);
+    expect(getAuditors).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ pagination: expect.objectContaining({ key: new Uint8Array(), limit: 100n }) }),
+      options
+    );
+    expect(getAuditors).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ pagination: expect.objectContaining({ key: Uint8Array.from([1]), limit: 100n }) }),
+      options
+    );
+    expect(getDiscrepancies).toHaveBeenCalledWith(expect.any(Object), options);
+  });
+
+  it("returns one height-consistent provider state and maps missing optional records to null", async () => {
+    const getProviderAttestations = vi
+      .fn()
+      .mockResolvedValue({ attestations: [{ auditor: "akash1auditor" }], pagination: { nextKey: new Uint8Array(), total: 0n } });
+    const getProviderAuditEscrows = vi.fn().mockResolvedValue({ escrows: [], pagination: { nextKey: new Uint8Array(), total: 0n } });
+    const getProviderBond = vi.fn().mockResolvedValue({
+      bond: { provider: "akash1provider" },
+      requiredForCurrentTier: { amount: "500", denom: "uakt" }
+    });
+    const getProviderVerificationGrace = vi.fn().mockResolvedValue({ grace: undefined });
+    const getProviderSnapshot = vi.fn().mockResolvedValue({ snapshot: { provider: "akash1provider" } });
+    const getProviderMaintenances = vi.fn().mockResolvedValue({ maintenance: [], pagination: { nextKey: new Uint8Array(), total: 0n } });
+    const client = createClient(
+      {
+        getProviderAttestations,
+        getProviderAuditEscrows,
+        getProviderBond,
+        getProviderVerificationGrace,
+        getProviderSnapshot
+      },
+      { getProviderMaintenances }
+    );
+
+    const result = await client.getProviderState("akash1provider", height);
+
+    expect(result).toMatchObject({
+      provider: "akash1provider",
+      attestations: [{ auditor: "akash1auditor" }],
+      auditEscrows: [],
+      bond: { provider: "akash1provider" },
+      requiredBondForCurrentTier: { amount: "500", denom: "uakt" },
+      grace: null,
+      snapshot: { provider: "akash1provider" },
+      maintenances: [],
+      observedHeight: height
+    });
+    for (const query of [
+      getProviderAttestations,
+      getProviderAuditEscrows,
+      getProviderBond,
+      getProviderVerificationGrace,
+      getProviderSnapshot,
+      getProviderMaintenances
+    ]) {
+      expect(query.mock.calls[0].at(-1)).toEqual(options);
+    }
+  });
+
+  it("does not hide transport failures", async () => {
+    const client = createClient({ getProviderBond: vi.fn().mockRejectedValue(new SDKError("unavailable", SDKErrorCode.Unavailable)) });
+
+    await expect(client.getProviderState("akash1provider", height)).rejects.toMatchObject({ code: SDKErrorCode.Unavailable });
+  });
+
+  it("queries only placement facts for provider screening", async () => {
+    const getProviderAttestations = vi
+      .fn()
+      .mockResolvedValue({ attestations: [{ auditor: "akash1auditor" }], pagination: { nextKey: new Uint8Array(), total: 0n } });
+    const getProviderVerificationGrace = vi.fn().mockResolvedValue({ grace: undefined });
+    const getProviderSnapshot = vi.fn().mockResolvedValue({ snapshot: { provider: "akash1provider" } });
+    const getProviderAuditEscrows = vi.fn().mockRejectedValue(new SDKError("unavailable", SDKErrorCode.Unavailable));
+    const getProviderBond = vi.fn();
+    const getProviderMaintenances = vi.fn();
+    const client = createClient(
+      { getProviderAttestations, getProviderVerificationGrace, getProviderSnapshot, getProviderAuditEscrows, getProviderBond },
+      { getProviderMaintenances }
+    );
+
+    await expect(client.getProviderScreeningState("akash1provider", height)).resolves.toMatchObject({
+      provider: "akash1provider",
+      attestations: [{ auditor: "akash1auditor" }],
+      grace: null,
+      snapshot: { provider: "akash1provider" },
+      observedHeight: height
+    });
+    expect(getProviderAuditEscrows).not.toHaveBeenCalled();
+    expect(getProviderBond).not.toHaveBeenCalled();
+    expect(getProviderMaintenances).not.toHaveBeenCalled();
+  });
+
+  it("maps a missing provider bond response to absent bond facts", async () => {
+    const client = createClient({ getProviderBond: vi.fn().mockRejectedValue(new SDKError("missing", SDKErrorCode.NotFound)) });
+
+    const result = await client.getProviderState("akash1provider", height);
+
+    expect(result.bond).toBeNull();
+    expect(result.requiredBondForCurrentTier).toBeNull();
+  });
+
+  it("pins singular reconciliation queries and preserves uint64 identities", async () => {
+    const getAuditEscrow = vi.fn().mockResolvedValue({ escrow: { id: 9007199254740993n } });
+    const getDiscrepancy = vi.fn().mockResolvedValue({ discrepancy: { id: 9007199254740995n } });
+    const getAuditor = vi.fn().mockResolvedValue({ auditor: { address: "akash1auditor" } });
+    const client = createClient({ getAuditEscrow, getAuditor, getDiscrepancy });
+
+    await expect(client.getAuditEscrow("9007199254740993", height)).resolves.toMatchObject({ id: 9007199254740993n });
+    await expect(client.getDiscrepancy("9007199254740995", height)).resolves.toMatchObject({ id: 9007199254740995n });
+    await expect(client.getAuditor("akash1auditor", height)).resolves.toMatchObject({ address: "akash1auditor" });
+
+    expect(getAuditEscrow).toHaveBeenCalledWith({ id: 9007199254740993n }, options);
+    expect(getDiscrepancy).toHaveBeenCalledWith({ id: 9007199254740995n }, options);
+    expect(getAuditor).toHaveBeenCalledWith({ auditor: "akash1auditor" }, options);
+  });
+
+  it("rejects malformed uint64 identifiers before calling the SDK", async () => {
+    const getAuditEscrow = vi.fn();
+    const client = createClient({ getAuditEscrow });
+
+    await expect(client.getAuditEscrow("-1", height)).rejects.toThrow("Invalid uint64 identifier");
+    expect(getAuditEscrow).not.toHaveBeenCalled();
+  });
+});
+
+function createClient(verification: Partial<VerificationQueries> = {}, provider: Partial<ProviderQueries> = {}) {
+  const emptyPage = { pagination: { nextKey: new Uint8Array(), total: 0n } };
+  const verificationQueries = {
+    getAuditors: vi.fn().mockResolvedValue({ auditors: [], ...emptyPage }),
+    getAuditor: vi.fn().mockResolvedValue({ auditor: undefined }),
+    getAuditEscrow: vi.fn().mockResolvedValue({ escrow: undefined }),
+    getDiscrepancy: vi.fn().mockResolvedValue({ discrepancy: undefined }),
+    getDiscrepancies: vi.fn().mockResolvedValue({ discrepancies: [], ...emptyPage }),
+    getParams: vi.fn().mockResolvedValue({ params: undefined }),
+    getProviderAttestations: vi.fn().mockResolvedValue({ attestations: [], ...emptyPage }),
+    getProviderAuditEscrows: vi.fn().mockResolvedValue({ escrows: [], ...emptyPage }),
+    getProviderBond: vi.fn().mockResolvedValue({ bond: undefined, requiredForCurrentTier: undefined }),
+    getProviderSnapshot: vi.fn().mockResolvedValue({ snapshot: undefined }),
+    getProviderVerificationGrace: vi.fn().mockResolvedValue({ grace: undefined }),
+    ...verification
+  } as VerificationQueries;
+  const providerQueries = {
+    getProviderMaintenances: vi.fn().mockResolvedValue({ maintenance: [], ...emptyPage }),
+    ...provider
+  } as ProviderQueries;
+
+  return new ProviderVerificationQueryClient(verificationQueries, providerQueries);
+}

--- a/packages/provider-verification/src/providerVerificationQueryClient.ts
+++ b/packages/provider-verification/src/providerVerificationQueryClient.ts
@@ -1,0 +1,230 @@
+import type {
+  AttestationRecord,
+  AuditEscrowRecord,
+  AuditorRecord,
+  DiscrepancyEvent,
+  ProviderBondRecord,
+  ProviderSnapshotRecord,
+  ProviderVerificationGraceRecord,
+  Verification_Params
+} from "@akashnetwork/chain-sdk/private-types/akash.v1";
+import { AttestationStatus, AuditEscrowStatus, AuditorStatus, DiscrepancyStatus } from "@akashnetwork/chain-sdk/private-types/akash.v1";
+import type { ProviderMaintenanceWithStatus } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
+import { ProviderMaintenanceStatus } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
+import type { Coin } from "@akashnetwork/chain-sdk/private-types/cosmos.v1beta1";
+import { createChainNodeWebSDK, SDKError, SDKErrorCode } from "@akashnetwork/chain-sdk/web";
+
+type ChainNodeWebSDK = ReturnType<typeof createChainNodeWebSDK>;
+export type VerificationQueries = Pick<
+  ChainNodeWebSDK["akash"]["verification"]["v1"],
+  | "getAuditors"
+  | "getAuditor"
+  | "getAuditEscrow"
+  | "getDiscrepancy"
+  | "getDiscrepancies"
+  | "getParams"
+  | "getProviderAttestations"
+  | "getProviderAuditEscrows"
+  | "getProviderBond"
+  | "getProviderSnapshot"
+  | "getProviderVerificationGrace"
+>;
+export type ProviderQueries = Pick<ChainNodeWebSDK["akash"]["provider"]["v1beta4"], "getProviderMaintenances">;
+
+interface Pagination {
+  nextKey: Uint8Array;
+}
+
+export interface ProviderVerificationGlobalState {
+  params: Verification_Params | null;
+  auditors: AuditorRecord[];
+  discrepancies: DiscrepancyEvent[];
+  observedHeight: string;
+}
+
+export interface ProviderVerificationScreeningState {
+  provider: string;
+  attestations: AttestationRecord[];
+  grace: ProviderVerificationGraceRecord | null;
+  snapshot: ProviderSnapshotRecord | null;
+  observedHeight: string;
+}
+
+export interface ProviderVerificationProviderState extends ProviderVerificationScreeningState {
+  auditEscrows: AuditEscrowRecord[];
+  bond: ProviderBondRecord | null;
+  requiredBondForCurrentTier: Coin | null;
+  maintenances: ProviderMaintenanceWithStatus[];
+}
+
+export class ProviderVerificationQueryClient {
+  constructor(
+    private readonly verification: VerificationQueries,
+    private readonly provider: ProviderQueries
+  ) {}
+
+  async getAuditor(auditor: string, height: string): Promise<AuditorRecord | null> {
+    return optionalRecord(
+      () => this.verification.getAuditor({ auditor }, queryOptions(height)),
+      response => response.auditor
+    );
+  }
+
+  async getAuditEscrow(id: string, height: string): Promise<AuditEscrowRecord | null> {
+    return optionalRecord(
+      () => this.verification.getAuditEscrow({ id: parseUint64(id) }, queryOptions(height)),
+      response => response.escrow
+    );
+  }
+
+  async getDiscrepancy(id: string, height: string): Promise<DiscrepancyEvent | null> {
+    return optionalRecord(
+      () => this.verification.getDiscrepancy({ id: parseUint64(id) }, queryOptions(height)),
+      response => response.discrepancy
+    );
+  }
+
+  async getGlobalState(height: string): Promise<ProviderVerificationGlobalState> {
+    const options = queryOptions(height);
+    const [paramsResponse, auditors, discrepancies] = await Promise.all([
+      this.verification.getParams({}, options),
+      collectPages(async pagination => {
+        const response = await this.verification.getAuditors({ pagination, statusFilter: AuditorStatus.auditor_status_unspecified }, options);
+
+        return { items: response.auditors, pagination: response.pagination };
+      }),
+      collectPages(async pagination => {
+        const response = await this.verification.getDiscrepancies({ pagination, statusFilter: DiscrepancyStatus.discrepancy_status_unspecified }, options);
+
+        return { items: response.discrepancies, pagination: response.pagination };
+      })
+    ]);
+
+    return {
+      params: paramsResponse.params ?? null,
+      auditors,
+      discrepancies,
+      observedHeight: height
+    };
+  }
+
+  async getProviderState(provider: string, height: string): Promise<ProviderVerificationProviderState> {
+    const options = queryOptions(height);
+    const [screening, auditEscrows, bondResponse, maintenances] = await Promise.all([
+      this.getProviderScreeningState(provider, height),
+      collectPages(async pagination => {
+        const response = await this.verification.getProviderAuditEscrows(
+          { pagination, provider, statusFilter: AuditEscrowStatus.audit_escrow_status_unspecified },
+          options
+        );
+
+        return { items: response.escrows, pagination: response.pagination };
+      }),
+      optionalResponse(() => this.verification.getProviderBond({ provider }, options)),
+      collectPages(async pagination => {
+        const response = await this.provider.getProviderMaintenances(
+          { pagination, provider, statusFilter: ProviderMaintenanceStatus.provider_maintenance_status_unspecified },
+          options
+        );
+
+        return { items: response.maintenance, pagination: response.pagination };
+      })
+    ]);
+
+    return {
+      ...screening,
+      auditEscrows,
+      bond: bondResponse?.bond ?? null,
+      requiredBondForCurrentTier: bondResponse?.requiredForCurrentTier ?? null,
+      maintenances
+    };
+  }
+
+  async getProviderScreeningState(provider: string, height: string): Promise<ProviderVerificationScreeningState> {
+    const options = queryOptions(height);
+    const [attestations, grace, snapshot] = await Promise.all([
+      collectPages(async pagination => {
+        const response = await this.verification.getProviderAttestations(
+          { pagination, provider, statusFilter: AttestationStatus.attestation_status_unspecified },
+          options
+        );
+
+        return { items: response.attestations, pagination: response.pagination };
+      }),
+      optionalRecord(
+        () => this.verification.getProviderVerificationGrace({ provider }, options),
+        response => response.grace
+      ),
+      optionalRecord(
+        () => this.verification.getProviderSnapshot({ provider }, options),
+        response => response.snapshot
+      )
+    ]);
+
+    return {
+      provider,
+      attestations,
+      grace,
+      snapshot,
+      observedHeight: height
+    };
+  }
+}
+
+export function createProviderVerificationQueryClient(baseUrl: string): ProviderVerificationQueryClient {
+  const sdk = createChainNodeWebSDK({ query: { baseUrl } });
+  return new ProviderVerificationQueryClient(sdk.akash.verification.v1, sdk.akash.provider.v1beta4);
+}
+
+function queryOptions(height: string) {
+  return { headers: { "x-cosmos-block-height": height } };
+}
+
+async function collectPages<T>(
+  fetchPage: (pagination: ReturnType<typeof pageRequest>) => Promise<{ items: T[]; pagination: Pagination | undefined }>
+): Promise<T[]> {
+  const items: T[] = [];
+  let nextKey: Uint8Array<ArrayBufferLike> = new Uint8Array();
+
+  do {
+    const response = await fetchPage(pageRequest(nextKey));
+    items.push(...response.items);
+    nextKey = response.pagination?.nextKey ?? new Uint8Array();
+  } while (nextKey.length > 0);
+
+  return items;
+}
+
+function pageRequest(key: Uint8Array<ArrayBufferLike>) {
+  return {
+    key,
+    offset: 0n,
+    limit: 100n,
+    countTotal: false,
+    reverse: false
+  };
+}
+
+function parseUint64(value: string): bigint {
+  if (!/^\d+$/.test(value)) throw new Error(`Invalid uint64 identifier: ${value}`);
+  const parsed = BigInt(value);
+  if (parsed > 18_446_744_073_709_551_615n) throw new Error(`Invalid uint64 identifier: ${value}`);
+  return parsed;
+}
+
+async function optionalRecord<TResponse, TRecord>(
+  query: () => Promise<TResponse>,
+  select: (response: TResponse) => TRecord | undefined
+): Promise<TRecord | null> {
+  const response = await optionalResponse(query);
+  return response ? (select(response) ?? null) : null;
+}
+
+async function optionalResponse<TResponse>(query: () => Promise<TResponse>): Promise<TResponse | null> {
+  try {
+    return await query();
+  } catch (error) {
+    if (error instanceof SDKError && error.code === SDKErrorCode.NotFound) return null;
+    throw error;
+  }
+}

--- a/packages/provider-verification/tsconfig.build.json
+++ b/packages/provider-verification/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@akashnetwork/dev-config/tsconfig.base-node.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "noImplicitAny": true,
+    "strict": true,
+    "target": "ES2022"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/provider-verification/tsconfig.json
+++ b/packages/provider-verification/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/provider-verification/vitest.config.ts
+++ b/packages/provider-verification/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    name: "provider-verification",
+    include: ["**/*.spec.ts"],
+    environment: "node"
+  }
+});


### PR DESCRIPTION
## Why

Console needs durable, query-reconciled AEP-86 state before API and UI consumers can expose provider verification reliably. This is the indexer application slice of CON-800.

## What

- Match verification and provider-maintenance typed events
- Persist end-block events and enqueue affected chain objects idempotently
- Reconcile attestations, auditors, bonds, snapshots, escrows, discrepancies, grace records, maintenance windows, and params from chain queries
- Derive and persist provider tier observations and demotion transitions
- Gate ingestion and reconciliation behind `PROVIDER_VERIFICATION_ENABLED`

## Dependencies

- #3713 publishes the AEP-86 chain-sdk types used here
- #3715 provides the shared verification policy evaluator
- #3716 provides the persistence schema and migration

The dependency commits are included temporarily so this branch can build and will disappear from the diff as the foundation PRs merge.