### PR TITLE
feat(provider-inventory): screen bids by verification

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@akashnetwork/akash-api": "1.4.3",
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/console-api-types": "*",
     "@akashnetwork/database": "*",
     "@akashnetwork/env-loader": "*",

--- a/apps/deploy-web/package.json
+++ b/apps/deploy-web/package.json
@@ -26,7 +26,7 @@
     "type-check": "tsc"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/console-api-types": "*",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",

--- a/apps/indexer/package.json
+++ b/apps/indexer/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@akashnetwork/akash-api": "1.4.3",
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/database": "*",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/instrumentation": "*",

--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -36,7 +36,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",
     "@akashnetwork/instrumentation": "*",

--- a/apps/notifications/src/modules/chain/providers/registry.provider.ts
+++ b/apps/notifications/src/modules/chain/providers/registry.provider.ts
@@ -12,18 +12,16 @@ import type { Provider } from "@nestjs/common";
 export const RegistryProvider: Provider<Registry> = {
   provide: Registry,
   useFactory: () => {
-    const akashTypes: ReadonlyArray<[string, GeneratedType]> = [
-      ...Object.values(v1),
-      ...Object.values(v1beta4),
-      ...Object.values(v1beta5),
-      ...Object.values(cosmosv1),
-      ...Object.values(cosmosv1beta1),
-      ...Object.values(cosmosv1alpha1),
-      ...Object.values(cosmosv2alpha1)
-    ]
-      .filter(x => "$type" in x)
-      .map(x => ["/" + x.$type, x as unknown as GeneratedType]);
+    const modules: ReadonlyArray<Record<string, unknown>> = [v1, v1beta4, v1beta5, cosmosv1, cosmosv1beta1, cosmosv1alpha1, cosmosv2alpha1];
+    const akashTypes: ReadonlyArray<[string, GeneratedType]> = modules
+      .flatMap(module => Object.values(module))
+      .filter(hasType)
+      .map(type => ["/" + type.$type, type as unknown as GeneratedType]);
 
     return new Registry(akashTypes);
   }
 };
+
+function hasType(value: unknown): value is { $type: string } {
+  return typeof value === "object" && value !== null && "$type" in value && typeof value.$type === "string";
+}

--- a/apps/provider-inventory/drizzle/0005_add_provider_verification.sql
+++ b/apps/provider-inventory/drizzle/0005_add_provider_verification.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "provider_inventory" ADD COLUMN "verification" jsonb;

--- a/apps/provider-inventory/drizzle/meta/0005_snapshot.json
+++ b/apps/provider-inventory/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,275 @@
+{
+  "id": "50ff95c1-cb89-47bd-8bf7-095331fac248",
+  "prevId": "d65bf4ae-2ed9-4979-a847-fd2673014509",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.provider_incidents": {
+      "name": "provider_incidents",
+      "schema": "",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uniq_provider_incidents_open_per_provider": {
+          "name": "uniq_provider_incidents_open_per_provider",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "ended_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_incidents_provider": {
+          "name": "idx_incidents_provider",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_inventory": {
+      "name": "provider_inventory",
+      "schema": "",
+      "columns": {
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "host_uri": {
+          "name": "host_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_online": {
+          "name": "is_online",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_online_since": {
+          "name": "is_online_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inventory": {
+          "name": "inventory",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "total_available_cpu": {
+          "name": "total_available_cpu",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "total_available_memory": {
+          "name": "total_available_memory",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "total_available_gpu": {
+          "name": "total_available_gpu",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "total_available_eph": {
+          "name": "total_available_eph",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "total_available_persistent": {
+          "name": "total_available_persistent",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "total_available_leased_ip": {
+          "name": "total_available_leased_ip",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "max_node_free_cpu": {
+          "name": "max_node_free_cpu",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "max_node_free_memory": {
+          "name": "max_node_free_memory",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "max_node_free_gpu": {
+          "name": "max_node_free_gpu",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "reclamation_window": {
+          "name": "reclamation_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gpu_models": {
+          "name": "gpu_models",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "storage_classes": {
+          "name": "storage_classes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "self_attributes": {
+          "name": "self_attributes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "signed_attributes": {
+          "name": "signed_attributes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "audited_by": {
+          "name": "audited_by",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "verification": {
+          "name": "verification",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_provider_inventory_online": {
+          "name": "idx_provider_inventory_online",
+          "columns": [
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "is_online AND is_online_since IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/provider-inventory/drizzle/meta/_journal.json
+++ b/apps/provider-inventory/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1781690088926,
       "tag": "0004_add_reclamation_window",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1787631983025,
+      "tag": "0005_add_provider_verification",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/provider-inventory/package.json
+++ b/apps/provider-inventory/package.json
@@ -28,6 +28,7 @@
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/instrumentation": "*",
     "@akashnetwork/logging": "*",
+    "@akashnetwork/provider-verification": "*",
     "@hono/node-server": "^1.19.0",
     "@hono/otel": "~0.4.0",
     "@hono/zod-openapi": "^0.18.4",

--- a/apps/provider-inventory/package.json
+++ b/apps/provider-inventory/package.json
@@ -24,7 +24,7 @@
     "test:unit": "vitest run --project unit"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/instrumentation": "*",
     "@akashnetwork/logging": "*",

--- a/apps/provider-inventory/src/config/env.config.ts
+++ b/apps/provider-inventory/src/config/env.config.ts
@@ -18,6 +18,7 @@ export const envSchema = z.object({
     .nonnegative()
     .int()
     .default(10 * ONE_MINUTE),
+  VERIFICATION_QUERY_CONCURRENCY: z.number({ coerce: true }).int().positive().default(20),
   MAX_CONCURRENT_STREAM_CONNECTIONS: z.number({ coerce: true }).positive().default(100),
   STREAM_RECONNECT_INITIAL_DELAY_MS: z.number({ coerce: true }).nonnegative().default(60_000),
   STREAM_RECONNECT_MAX_DELAY_MS: z

--- a/apps/provider-inventory/src/controllers/bid-screening/bid-screening.controller.ts
+++ b/apps/provider-inventory/src/controllers/bid-screening/bid-screening.controller.ts
@@ -13,7 +13,6 @@ export class BidScreeningController {
   }
 
   async screenProviders(request: BidScreeningRequest, options?: Abortable): Promise<BidScreeningResponse> {
-    const results = await this.#bidScreeningService.findMatchingProviders(request as unknown as BidScreeningInput, options);
-    return { providers: results };
+    return await this.#bidScreeningService.screenProviders(request as unknown as BidScreeningInput, options);
   }
 }

--- a/apps/provider-inventory/src/http-schemas/bid-screening.schema.spec.ts
+++ b/apps/provider-inventory/src/http-schemas/bid-screening.schema.spec.ts
@@ -1,0 +1,52 @@
+import { AuditorSelectionMode, CapabilityFlag, VerificationTier } from "@akashnetwork/chain-sdk/private-types/akash.v1";
+import { describe, expect, it } from "vitest";
+
+import { VerificationRequirementSchema } from "./bid-screening.schema";
+
+describe("VerificationRequirementSchema", () => {
+  it("accepts the generated GroupSpec verification shape", () => {
+    const result = VerificationRequirementSchema.parse({
+      minTier: VerificationTier.verification_tier_verified,
+      requiredCapabilities: [CapabilityFlag.capability_persistent_storage],
+      requiredAuditors: ["akash1auditor"],
+      auditorMode: AuditorSelectionMode.auditor_selection_mode_all,
+      minAuditorCount: 2
+    });
+
+    expect(result).toEqual({
+      minTier: VerificationTier.verification_tier_verified,
+      requiredCapabilities: [CapabilityFlag.capability_persistent_storage],
+      requiredAuditors: ["akash1auditor"],
+      auditorMode: AuditorSelectionMode.auditor_selection_mode_all,
+      minAuditorCount: 2
+    });
+  });
+
+  it("defaults generated repeated and scalar fields", () => {
+    expect(VerificationRequirementSchema.parse({ minTier: VerificationTier.verification_tier_identified })).toEqual({
+      minTier: VerificationTier.verification_tier_identified,
+      requiredCapabilities: [],
+      requiredAuditors: [],
+      auditorMode: AuditorSelectionMode.auditor_selection_mode_unspecified,
+      minAuditorCount: 0
+    });
+  });
+
+  it("rejects capabilities that are not defined by AEP-86", () => {
+    const result = VerificationRequirementSchema.safeParse({
+      minTier: VerificationTier.verification_tier_identified,
+      requiredCapabilities: [999]
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects filters on a tier-zero requirement", () => {
+    const result = VerificationRequirementSchema.safeParse({
+      minTier: VerificationTier.verification_tier_unspecified,
+      requiredAuditors: ["akash1auditor"]
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/provider-inventory/src/http-schemas/bid-screening.schema.ts
+++ b/apps/provider-inventory/src/http-schemas/bid-screening.schema.ts
@@ -1,3 +1,4 @@
+import { AuditorSelectionMode, CapabilityFlag, VerificationTier } from "@akashnetwork/chain-sdk/private-types/akash.v1";
 import { z } from "@hono/zod-openapi";
 
 const UIntStringSchema = z.string().regex(/^\d+$/, "Must be an unsigned integer string");
@@ -91,9 +92,64 @@ const SignedBySchema = z.object({
   anyOf: z.array(z.string()).default([])
 });
 
+const VerificationTierSchema = z.union([
+  z.literal(VerificationTier.verification_tier_unspecified),
+  z.literal(VerificationTier.verification_tier_identified),
+  z.literal(VerificationTier.verification_tier_verified),
+  z.literal(VerificationTier.verification_tier_established),
+  z.literal(VerificationTier.verification_tier_trusted)
+]);
+
+const CapabilityFlagSchema = z.union([
+  z.literal(CapabilityFlag.capability_tee_hardware_attestation),
+  z.literal(CapabilityFlag.capability_confidential_computing),
+  z.literal(CapabilityFlag.capability_persistent_storage),
+  z.literal(CapabilityFlag.capability_bare_metal)
+]);
+
+const AnyVerificationTierSchema = z.nativeEnum(VerificationTier);
+const AnyCapabilityFlagSchema = z.nativeEnum(CapabilityFlag);
+const AnyAuditorSelectionModeSchema = z.nativeEnum(AuditorSelectionMode);
+
+const AuditorSelectionModeSchema = z.union([
+  z.literal(AuditorSelectionMode.auditor_selection_mode_unspecified),
+  z.literal(AuditorSelectionMode.auditor_selection_mode_any),
+  z.literal(AuditorSelectionMode.auditor_selection_mode_all)
+]);
+
+const ProviderVerificationSummarySchema = z.object({
+  bestStatusValidTier: AnyVerificationTierSchema,
+  tierGateTier: AnyVerificationTierSchema,
+  capabilities: z.array(AnyCapabilityFlagSchema),
+  validAttestationCount: z.number().int().nonnegative(),
+  validAuditors: z.array(z.string()),
+  snapshotState: z.enum(["unknown", "not_posted", "current", "stale", "suspended"]),
+  observedHeight: z.string()
+});
+
+export const VerificationRequirementSchema = z
+  .object({
+    minTier: VerificationTierSchema,
+    requiredCapabilities: z.array(CapabilityFlagSchema).default([]),
+    requiredAuditors: z.array(z.string().min(1)).default([]),
+    auditorMode: AuditorSelectionModeSchema.default(AuditorSelectionMode.auditor_selection_mode_unspecified),
+    minAuditorCount: z.number().int().min(0).max(4_294_967_295).default(0)
+  })
+  .superRefine((requirement, ctx) => {
+    if (requirement.minTier !== VerificationTier.verification_tier_unspecified) return;
+    if (requirement.requiredCapabilities.length === 0 && requirement.requiredAuditors.length === 0 && requirement.minAuditorCount === 0) return;
+
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Tier 0 cannot be combined with capabilities, auditors, or a minimum auditor count"
+    });
+  });
+export type VerificationRequirementInput = z.infer<typeof VerificationRequirementSchema>;
+
 const RequirementsSchema = z.object({
   signedBy: SignedBySchema.default({}),
-  attributes: z.array(AttributeSchema).default([])
+  attributes: z.array(AttributeSchema).default([]),
+  verification: VerificationRequirementSchema.optional()
 });
 
 /**
@@ -140,6 +196,19 @@ const ProviderResultSchema = z.object({
     description: "Provider organization from the organization attribute (signed preferred, else self-declared); null if unset",
     example: "Akash"
   }),
+  verification: z
+    .discriminatedUnion("outcome", [
+      z.object({
+        outcome: z.literal("pass"),
+        summary: ProviderVerificationSummarySchema
+      }),
+      z.object({
+        outcome: z.literal("not_evaluated"),
+        incompleteFacts: z.array(z.enum(["params", "attestations", "graces", "snapshot", "module_inactive"])),
+        summary: ProviderVerificationSummarySchema
+      })
+    ])
+    .optional(),
   incidents: z
     .array(
       z.object({
@@ -152,8 +221,26 @@ const ProviderResultSchema = z.object({
     .openapi({ description: "Per-day downtime over a rolling 7-day window" })
 });
 
+const VerificationFailureSchema = z.discriminatedUnion("code", [
+  z.object({ code: z.literal("snapshot_not_posted") }),
+  z.object({ code: z.literal("snapshot_suspended") }),
+  z.object({ code: z.literal("snapshot_stale") }),
+  z.object({ code: z.literal("insufficient_tier"), actual: AnyVerificationTierSchema, required: AnyVerificationTierSchema }),
+  z.object({ code: z.literal("missing_capability"), capability: AnyCapabilityFlagSchema }),
+  z.object({ code: z.literal("insufficient_auditor_count"), actual: z.number().int().nonnegative(), required: z.number().int().nonnegative() }),
+  z.object({ code: z.literal("required_auditor_not_found"), mode: AnyAuditorSelectionModeSchema, missing: z.array(z.string()) })
+]);
+
+const VerificationExclusionSchema = z.object({
+  owner: z.string(),
+  firstFailure: VerificationFailureSchema,
+  failures: z.array(VerificationFailureSchema).min(1),
+  summary: ProviderVerificationSummarySchema
+});
+
 export const BidScreeningResponseSchema = z.object({
-  providers: z.array(ProviderResultSchema)
+  providers: z.array(ProviderResultSchema),
+  exclusions: z.array(VerificationExclusionSchema).optional()
 });
 export type BidScreeningResponse = z.infer<typeof BidScreeningResponseSchema>;
 

--- a/apps/provider-inventory/src/mappers/groupspec-mapper/groupspec-mapper.ts
+++ b/apps/provider-inventory/src/mappers/groupspec-mapper/groupspec-mapper.ts
@@ -45,4 +45,10 @@ export function getAttributeFingerprint(attributes: ResourceAttribute[] | undefi
     .join(",");
 }
 
-export type GroupSpecJSON = ToJSON<GroupSpec>;
+type GroupSpecRequirementsJSON = ToJSON<NonNullable<GroupSpec["requirements"]>>;
+
+export type GroupSpecJSON = Omit<ToJSON<GroupSpec>, "requirements"> & {
+  requirements: Omit<GroupSpecRequirementsJSON, "verification"> & {
+    verification?: GroupSpecRequirementsJSON["verification"];
+  };
+};

--- a/apps/provider-inventory/src/mappers/groupspec-mapper/groupspec-mapper.ts
+++ b/apps/provider-inventory/src/mappers/groupspec-mapper/groupspec-mapper.ts
@@ -22,13 +22,11 @@ export function mapGroupSpecToResourceUnits(request: Omit<GroupSpecJSON, "name">
         memory: {
           quantity: resource.memory.quantity.val
         },
-        storage: resource.storage.map(
-          (s): RequestedStorage => ({
-            name: s.name,
-            quantity: s.quantity.val,
-            attributes: parseStorageAttributes(s.attributes ?? [])
-          })
-        ),
+        storage: resource.storage.map((s): RequestedStorage => ({
+          name: s.name,
+          quantity: s.quantity.val,
+          attributes: parseStorageAttributes(s.attributes ?? [])
+        })),
         // GroupSpecJSON kind is of type string, not enum. It's enum for gRPC response/request. So, can safely cast here.
         endpoints: (resource.endpoints ?? []) as unknown as RequestedResourceUnit["resources"]["endpoints"]
       },

--- a/apps/provider-inventory/src/mappers/provider-verification-mapper/provider-verification-mapper.spec.ts
+++ b/apps/provider-inventory/src/mappers/provider-verification-mapper/provider-verification-mapper.spec.ts
@@ -1,0 +1,100 @@
+import { AttestationStatus, CapabilityFlag, VerificationGraceStatus, VerificationTier } from "@akashnetwork/chain-sdk/private-types/akash.v1";
+import type { ProviderVerificationScreeningState } from "@akashnetwork/provider-verification";
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import { mapProviderVerification, mapStoredProviderVerificationFacts } from "./provider-verification-mapper";
+
+describe(mapProviderVerification.name, () => {
+  it("stores only the normalized facts required for screening", () => {
+    const stored = mapProviderVerification({
+      moduleActive: true,
+      observedAt: new Date("2026-08-24T12:00:00.000Z"),
+      observedHeight: "123",
+      state: mock<ProviderVerificationScreeningState>({
+        provider: "akash1provider",
+        attestations: [
+          mock({
+            auditor: "akash1z",
+            capabilities: [CapabilityFlag.capability_persistent_storage, CapabilityFlag.capability_bare_metal],
+            status: AttestationStatus.attestation_status_valid,
+            tier: VerificationTier.verification_tier_verified
+          }),
+          mock({
+            auditor: "akash1a",
+            capabilities: [],
+            status: AttestationStatus.attestation_status_expired,
+            tier: VerificationTier.verification_tier_identified
+          })
+        ],
+        grace: mock({
+          preservedTier: VerificationTier.verification_tier_established,
+          status: VerificationGraceStatus.verification_grace_status_active
+        }),
+        snapshot: mock({ complianceDeadline: new Date("2026-08-25T12:00:00.000Z"), suspended: false })
+      })
+    });
+
+    expect(stored).toEqual({
+      moduleActive: true,
+      facts: {
+        attestations: [
+          {
+            auditor: "akash1a",
+            capabilities: [],
+            status: AttestationStatus.attestation_status_expired,
+            tier: VerificationTier.verification_tier_identified
+          },
+          {
+            auditor: "akash1z",
+            capabilities: [CapabilityFlag.capability_persistent_storage, CapabilityFlag.capability_bare_metal],
+            status: AttestationStatus.attestation_status_valid,
+            tier: VerificationTier.verification_tier_verified
+          }
+        ],
+        completeness: { attestations: true, graces: true, snapshot: true },
+        graces: [
+          {
+            preservedTier: VerificationTier.verification_tier_established,
+            status: VerificationGraceStatus.verification_grace_status_active
+          }
+        ],
+        observedAt: "2026-08-24T12:00:00.000Z",
+        observedHeight: "123",
+        snapshot: { complianceDeadline: "2026-08-25T12:00:00.000Z", suspended: false }
+      }
+    });
+  });
+
+  it("represents unavailable provider queries as incomplete facts", () => {
+    const stored = mapProviderVerification({
+      moduleActive: null,
+      observedAt: new Date("2026-08-24T12:00:00.000Z"),
+      observedHeight: "123",
+      state: null
+    });
+
+    expect(stored.facts.completeness).toEqual({ attestations: false, graces: false, snapshot: false });
+    expect(stored.facts.attestations).toEqual([]);
+    expect(stored.facts.graces).toEqual([]);
+    expect(stored.facts.snapshot).toBeNull();
+  });
+
+  it("hydrates persisted timestamps for the shared evaluator", () => {
+    const stored = mapProviderVerification({
+      moduleActive: true,
+      observedAt: new Date("2026-08-24T12:00:00.000Z"),
+      observedHeight: "123",
+      state: mock<ProviderVerificationScreeningState>({
+        attestations: [],
+        grace: null,
+        snapshot: mock({ complianceDeadline: new Date("2026-08-25T12:00:00.000Z"), suspended: false })
+      })
+    });
+
+    const facts = mapStoredProviderVerificationFacts(stored);
+
+    expect(facts.observedAt).toEqual(new Date("2026-08-24T12:00:00.000Z"));
+    expect(facts.snapshot?.complianceDeadline).toEqual(new Date("2026-08-25T12:00:00.000Z"));
+  });
+});

--- a/apps/provider-inventory/src/mappers/provider-verification-mapper/provider-verification-mapper.ts
+++ b/apps/provider-inventory/src/mappers/provider-verification-mapper/provider-verification-mapper.ts
@@ -1,0 +1,69 @@
+import type { ProviderVerificationScreeningState } from "@akashnetwork/provider-verification";
+import type { ProviderVerificationFacts } from "@akashnetwork/provider-verification";
+
+import type { StoredProviderVerification } from "@src/types/provider-verification";
+
+interface MapProviderVerificationInput {
+  moduleActive: boolean | null;
+  observedAt: Date;
+  observedHeight: string;
+  state: ProviderVerificationScreeningState | null;
+}
+
+export function mapProviderVerification(input: MapProviderVerificationInput): StoredProviderVerification {
+  const { moduleActive, observedAt, observedHeight, state } = input;
+
+  if (!state) {
+    return {
+      moduleActive,
+      facts: {
+        attestations: [],
+        completeness: { attestations: false, graces: false, snapshot: false },
+        graces: [],
+        observedAt: observedAt.toISOString(),
+        observedHeight,
+        snapshot: null
+      }
+    };
+  }
+
+  return {
+    moduleActive,
+    facts: {
+      attestations: state.attestations
+        .map(attestation => ({
+          auditor: attestation.auditor,
+          capabilities: [...attestation.capabilities].sort((left, right) => left - right),
+          status: attestation.status,
+          tier: attestation.tier
+        }))
+        .sort((left, right) => left.auditor.localeCompare(right.auditor)),
+      completeness: { attestations: true, graces: true, snapshot: true },
+      graces: state.grace ? [{ preservedTier: state.grace.preservedTier, status: state.grace.status }] : [],
+      observedAt: observedAt.toISOString(),
+      observedHeight,
+      snapshot: state.snapshot
+        ? {
+            complianceDeadline: state.snapshot.complianceDeadline?.toISOString() ?? null,
+            suspended: state.snapshot.suspended
+          }
+        : null
+    }
+  };
+}
+
+export function mapStoredProviderVerificationFacts(verification: StoredProviderVerification): ProviderVerificationFacts {
+  return {
+    attestations: verification.facts.attestations,
+    completeness: verification.facts.completeness,
+    graces: verification.facts.graces,
+    observedAt: new Date(verification.facts.observedAt),
+    observedHeight: verification.facts.observedHeight,
+    snapshot: verification.facts.snapshot
+      ? {
+          complianceDeadline: verification.facts.snapshot.complianceDeadline ? new Date(verification.facts.snapshot.complianceDeadline) : undefined,
+          suspended: verification.facts.snapshot.suspended
+        }
+      : null
+  };
+}

--- a/apps/provider-inventory/src/model-schemas/provider-inventory/provider-inventory.schema.ts
+++ b/apps/provider-inventory/src/model-schemas/provider-inventory/provider-inventory.schema.ts
@@ -2,6 +2,7 @@ import { sql } from "drizzle-orm";
 import { bigint, boolean, index, integer, pgTable, text, timestamp } from "drizzle-orm/pg-core";
 
 import { jsonbBigint } from "@src/lib/jsonb-bigint/jsonb-bigint.column";
+import type { StoredProviderVerification } from "@src/types/provider-verification";
 
 export const providerInventory = pgTable(
   "provider_inventory",
@@ -48,6 +49,7 @@ export const providerInventory = pgTable(
     selfAttributes: jsonbBigint("self_attributes").notNull().default([]),
     signedAttributes: jsonbBigint("signed_attributes").notNull().default([]),
     auditedBy: text("audited_by").array().notNull().default([]),
+    verification: jsonbBigint("verification").$type<StoredProviderVerification>(),
 
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow()

--- a/apps/provider-inventory/src/providers/index.ts
+++ b/apps/provider-inventory/src/providers/index.ts
@@ -3,3 +3,4 @@ export * from "./app-config.provider";
 export * from "./postgres.provider";
 export * from "./drizzle.provider";
 export * from "./logger-factory.provider";
+export * from "./provider-verification-query-client.provider";

--- a/apps/provider-inventory/src/providers/provider-verification-query-client.provider.ts
+++ b/apps/provider-inventory/src/providers/provider-verification-query-client.provider.ts
@@ -1,0 +1,14 @@
+import { ProviderVerificationQueryClient } from "@akashnetwork/provider-verification";
+import type { InjectionToken } from "tsyringe";
+import { container, instancePerContainerCachingFactory } from "tsyringe";
+
+import { CHAIN_SDK } from "./chain-sdk.provider";
+
+export const PROVIDER_VERIFICATION_QUERY_CLIENT = Symbol("PROVIDER_VERIFICATION_QUERY_CLIENT") as InjectionToken<ProviderVerificationQueryClient>;
+
+container.register(PROVIDER_VERIFICATION_QUERY_CLIENT, {
+  useFactory: instancePerContainerCachingFactory(c => {
+    const sdk = c.resolve(CHAIN_SDK);
+    return new ProviderVerificationQueryClient(sdk.akash.verification.v1, sdk.akash.provider.v1beta4);
+  })
+});

--- a/apps/provider-inventory/src/repositories/bid-screening/bid-screening.repository.integration.ts
+++ b/apps/provider-inventory/src/repositories/bid-screening/bid-screening.repository.integration.ts
@@ -10,6 +10,7 @@ import { parseStorageAttributes } from "@src/mappers/storage-attribute-parser/st
 import { providerInventory } from "@src/model-schemas/provider-inventory/provider-inventory.schema";
 import { DRIZZLE_DB } from "@src/providers/drizzle.provider";
 import type { RequestedResourceUnit, ResourceAttribute } from "@src/types/inventory";
+import type { StoredProviderVerification } from "@src/types/provider-verification";
 import type { PlacementRequirements } from "./bid-screening.aggregator";
 import { AUDITOR, BidScreeningRepository } from "./bid-screening.repository";
 
@@ -582,6 +583,21 @@ describe(BidScreeningRepository.name, () => {
       expect(second.updatedAt).not.toBe(first.updatedAt);
     });
 
+    it("re-fetches a fresh candidate when only the verification observation changes", async () => {
+      await seed({ owner: "akash1verification", verification: verificationAt("100") });
+      const [first] = await repository.findCandidates([unit({})], requirements());
+
+      await db
+        .update(providerInventory)
+        .set({ verification: verificationAt("101") })
+        .where(eq(providerInventory.owner, "akash1verification"));
+
+      const [second] = await repository.findCandidates([unit({})], requirements());
+
+      expect(second).not.toBe(first);
+      expect(second.verification?.facts.observedHeight).toBe("101");
+    });
+
     it("reuses cached providers while fetching only the uncached ones in a mixed batch", async () => {
       await seed({ owner: "akash1cacheWarm" });
       const [warm] = await repository.findCandidates([unit({})], requirements());
@@ -620,6 +636,7 @@ describe(BidScreeningRepository.name, () => {
     reclamationWindow?: number | null;
     inventory?: unknown;
     createdAt?: Date;
+    verification?: StoredProviderVerification | null;
   }
 
   async function seed(input: SeedInput): Promise<void> {
@@ -644,7 +661,8 @@ describe(BidScreeningRepository.name, () => {
       storageClasses: input.storageClasses ?? [],
       reclamationWindow: input.reclamationWindow ?? null,
       inventory: input.inventory ?? { nodes: [], storage: {} },
-      createdAt: input.createdAt
+      createdAt: input.createdAt,
+      verification: input.verification ?? null
     });
   }
 });
@@ -696,6 +714,20 @@ function requirements(input?: Partial<PlacementRequirements>): PlacementRequirem
 
 function owners(rows: { owner: string }[]): string[] {
   return rows.map(r => r.owner).sort();
+}
+
+function verificationAt(observedHeight: string): StoredProviderVerification {
+  return {
+    moduleActive: true,
+    facts: {
+      attestations: [],
+      completeness: { attestations: true, graces: true, snapshot: true },
+      graces: [],
+      observedAt: "2026-08-24T12:00:00.000Z",
+      observedHeight,
+      snapshot: null
+    }
+  };
 }
 
 interface RawStorageVolume {

--- a/apps/provider-inventory/src/repositories/bid-screening/bid-screening.repository.ts
+++ b/apps/provider-inventory/src/repositories/bid-screening/bid-screening.repository.ts
@@ -4,6 +4,7 @@ import { inject, singleton } from "tsyringe";
 import { providerInventory } from "@src/model-schemas/provider-inventory/provider-inventory.schema";
 import { type Database, PG_CLIENT } from "@src/providers/postgres.provider";
 import type { ClusterState, RequestedResourceUnit } from "@src/types/inventory";
+import type { StoredProviderVerification } from "@src/types/provider-verification";
 import { aggregateCriteria, type BidScreeningCriteria, type PlacementRequirements } from "./bid-screening.aggregator";
 // TODO(Issue 5): move auditor allowlist into configuration and accept it as a request input.
 export const AUDITOR = "akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63";
@@ -17,6 +18,8 @@ export interface BidScreeningCandidate {
   updatedAt: string;
   location: string | null;
   organization: string | null;
+  verification: StoredProviderVerification | null;
+  verificationObservedHeight: string | null;
 }
 
 const TABLE = getTableName(providerInventory);
@@ -38,10 +41,11 @@ export class BidScreeningRepository {
     const criteria = aggregateCriteria(resourceUnits, requirements);
     const where = this.#buildWhere(criteria);
 
-    const rows = await sql<Array<{ owner: string; updatedAt: string }>>`
+    const rows = await sql<Array<{ owner: string; updatedAt: string; verificationObservedHeight: string | null }>>`
       SELECT
         ${sql(providerInventory.owner.name)} AS owner,
-        to_char(${sql(providerInventory.updatedAt.name)} AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS "updatedAt"
+        to_char(${sql(providerInventory.updatedAt.name)} AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS "updatedAt",
+        ${sql(providerInventory.verification.name)} #>> '{facts,observedHeight}' AS "verificationObservedHeight"
       FROM ${sql(TABLE)}
       WHERE ${where}
     `;
@@ -52,7 +56,7 @@ export class BidScreeningRepository {
     for (let i = 0; i < rows.length; i++) {
       const row = rows[i];
       const cache = this.#providersInventory.get(row.owner);
-      if (!cache || cache.updatedAt !== row.updatedAt) {
+      if (!cache || cache.updatedAt !== row.updatedAt || cache.verificationObservedHeight !== row.verificationObservedHeight) {
         ownersToFetch.push(row.owner);
         missingFinalCandidatesIndexes.set(row.owner, i);
       } else {
@@ -68,6 +72,8 @@ export class BidScreeningRepository {
           to_char(${sql(providerInventory.createdAt.name)} AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS "createdAt",
           ${sql(providerInventory.hostUri.name)} AS "hostUri",
           ${sql(providerInventory.inventory.name)} AS cluster,
+          ${sql(providerInventory.verification.name)} AS verification,
+          ${sql(providerInventory.verification.name)} #>> '{facts,observedHeight}' AS "verificationObservedHeight",
           ${sql(providerInventory.auditedBy.name)} @> ARRAY[${AUDITOR}]::text[] AS "isAudited",
           COALESCE(
             (SELECT sa->>'value' FROM jsonb_array_elements(${sql(providerInventory.signedAttributes.name)}) AS sa WHERE sa->>'key' = 'location-region' LIMIT 1),

--- a/apps/provider-inventory/src/repositories/provider-inventory/provider-inventory.repository.integration.ts
+++ b/apps/provider-inventory/src/repositories/provider-inventory/provider-inventory.repository.integration.ts
@@ -7,8 +7,9 @@ import { describe, expect, it } from "vitest";
 
 import { providerInventory } from "@src/model-schemas/provider-inventory/provider-inventory.schema";
 import { DRIZZLE_DB } from "@src/providers/drizzle.provider";
-import type { ChainProvider } from "@src/types/chain-provider";
+import type { ChainProvider, DiscoveredChainProvider } from "@src/types/chain-provider";
 import type { ClusterState } from "@src/types/inventory";
+import type { StoredProviderVerification } from "@src/types/provider-verification";
 import { ProviderInventoryRepository } from "./provider-inventory.repository";
 
 describe(ProviderInventoryRepository.name, () => {
@@ -225,6 +226,28 @@ describe(ProviderInventoryRepository.name, () => {
     });
   });
 
+  describe("bulkUpdateVerification", () => {
+    it("persists the latest verification observation without advancing the liveness clock", async () => {
+      const { repository, db } = setup();
+      const updatedAt = new Date("2026-01-01T00:00:00.000Z");
+      await seed(db, { owner: "akash1a", updatedAt });
+
+      await repository.bulkUpdateVerification([createDiscoveredProvider({ owner: "akash1a", verification: verificationAt("123") })]);
+
+      const [row] = await db.select().from(providerInventory).where(eq(providerInventory.owner, "akash1a"));
+      expect(row.verification).toEqual(verificationAt("123"));
+      expect(row.updatedAt).toEqual(updatedAt);
+    });
+
+    it("does not insert inventory rows for providers that were not upserted", async () => {
+      const { repository, db } = setup();
+
+      await repository.bulkUpdateVerification([createDiscoveredProvider({ owner: "akash1missing" })]);
+
+      expect(await db.select().from(providerInventory)).toEqual([]);
+    });
+  });
+
   describe("updateInventory", () => {
     it("updates the existing row and never inserts a row for an owner with no attributes row", async () => {
       const { repository, db } = setup();
@@ -423,6 +446,7 @@ interface SeedInput {
   selfAttributes?: { key: string; value: string }[];
   signedAttributes?: { key: string; value: string; auditor: string }[];
   auditedBy?: string[];
+  verification?: StoredProviderVerification | null;
   updatedAt?: Date;
 }
 
@@ -435,6 +459,7 @@ async function seed(db: PostgresJsDatabase, input: SeedInput): Promise<void> {
     selfAttributes: input.selfAttributes ?? [],
     signedAttributes: input.signedAttributes ?? [],
     auditedBy: input.auditedBy ?? [],
+    verification: input.verification ?? null,
     ...(input.updatedAt && { updatedAt: input.updatedAt })
   });
 }
@@ -447,6 +472,27 @@ function createProvider(overrides?: Partial<ChainProvider>): ChainProvider {
     signedAttributes: [],
     auditedBy: [],
     ...overrides
+  };
+}
+
+function createDiscoveredProvider(overrides?: Partial<DiscoveredChainProvider>): DiscoveredChainProvider {
+  return {
+    ...createProvider(overrides),
+    verification: overrides?.verification ?? verificationAt("123")
+  };
+}
+
+function verificationAt(observedHeight: string): StoredProviderVerification {
+  return {
+    moduleActive: true,
+    facts: {
+      attestations: [],
+      completeness: { attestations: true, graces: true, snapshot: true },
+      graces: [],
+      observedAt: "2026-08-24T12:00:00.000Z",
+      observedHeight,
+      snapshot: null
+    }
   };
 }
 

--- a/apps/provider-inventory/src/repositories/provider-inventory/provider-inventory.repository.ts
+++ b/apps/provider-inventory/src/repositories/provider-inventory/provider-inventory.repository.ts
@@ -5,7 +5,7 @@ import { inject, singleton } from "tsyringe";
 import { paginate } from "@src/lib/generators/paginate/paginate";
 import { providerInventory } from "@src/model-schemas/provider-inventory/provider-inventory.schema";
 import { type Database, PG_CLIENT } from "@src/providers/postgres.provider";
-import type { ChainProvider } from "@src/types/chain-provider";
+import type { ChainProvider, DiscoveredChainProvider } from "@src/types/chain-provider";
 import { ClusterState } from "@src/types/inventory";
 import { DbDriver } from "../db-driver/db-driver";
 import { mapToStoredClusterState } from "./stored-cluster-state-mapper/stored-cluster-state-mapper";
@@ -147,5 +147,27 @@ export class ProviderInventoryRepository {
     `;
 
     return rows.map(row => ({ owner: row.owner }));
+  }
+
+  async bulkUpdateVerification(providers: DiscoveredChainProvider[]): Promise<void> {
+    if (providers.length === 0) return;
+
+    const sql = this.#sql;
+    const c = providerInventory;
+    const payload = providers.map(provider => ({
+      [c.owner.name]: provider.owner,
+      [c.verification.name]: provider.verification
+    }));
+
+    await sql`
+      UPDATE ${sql(TABLE)} AS inventory
+      SET ${sql(c.verification.name)} = observations.${sql(c.verification.name)}
+      FROM jsonb_to_recordset(${sql.json(payload as Parameters<typeof sql.json>[0])}::jsonb) AS observations(
+        ${sql(c.owner.name)} text,
+        ${sql(c.verification.name)} jsonb
+      )
+      WHERE inventory.${sql(c.owner.name)} = observations.${sql(c.owner.name)}
+        AND inventory.${sql(c.verification.name)} IS DISTINCT FROM observations.${sql(c.verification.name)}
+    `;
   }
 }

--- a/apps/provider-inventory/src/services/bid-screening/bid-screening.service.spec.ts
+++ b/apps/provider-inventory/src/services/bid-screening/bid-screening.service.spec.ts
@@ -1,9 +1,12 @@
+import type { VerificationRequirement } from "@akashnetwork/chain-sdk/private-types/akash.v1";
+import { AttestationStatus, AuditorSelectionMode, CapabilityFlag, VerificationTier } from "@akashnetwork/chain-sdk/private-types/akash.v1";
 import type { LoggerService } from "@akashnetwork/logging";
 import { describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { BidScreeningCandidate, BidScreeningRepository } from "@src/repositories/bid-screening/bid-screening.repository";
 import type { DailyDowntimeRow, ProviderIncidentRepository } from "@src/repositories/provider-incident/provider-incident.repository";
+import type { StoredProviderVerification } from "@src/types/provider-verification";
 import type { ClusterInventoryMatcherService } from "../cluster-inventory-matcher/cluster-inventory-matcher.service";
 import type { BidScreeningInput } from "./bid-screening.service";
 import { BidScreeningService } from "./bid-screening.service";
@@ -228,6 +231,127 @@ describe(BidScreeningService.name, () => {
       expect(incidentRepository.findDailyDowntimeByProviders).toHaveBeenCalledWith(["akash1abc"], request.timezone);
       expect(results[0].incidents).toEqual([{ date: "2026-06-01", hasOpenIncident: true, incidentCount: 1, downtimeSeconds: 3600 }]);
     });
+
+    it("keeps the existing response shape when no verification requirement is present", async () => {
+      const { service, repository, matcher } = setup();
+      repository.findCandidates.mockResolvedValue([makeCandidate("akash1abc")]);
+      matcher.match.mockReturnValue({ matched: true });
+
+      const result = await service.screenProviders(makeRequest());
+
+      expect(result).toEqual({
+        providers: [
+          expect.objectContaining({
+            owner: "akash1abc"
+          })
+        ]
+      });
+      expect(result.providers[0]).not.toHaveProperty("verification");
+    });
+
+    it("includes providers that pass verification after capacity matching", async () => {
+      const { service, repository, matcher } = setup();
+      repository.findCandidates.mockResolvedValue([makeCandidate("akash1abc", { verification: storedVerification() })]);
+      matcher.match.mockReturnValue({ matched: true });
+
+      const result = await service.screenProviders(
+        makeRequest({
+          verification: verificationRequirement({ requiredCapabilities: [CapabilityFlag.capability_persistent_storage] })
+        })
+      );
+
+      expect(result.exclusions).toEqual([]);
+      expect(result.providers[0].verification).toMatchObject({
+        outcome: "pass",
+        summary: { tierGateTier: VerificationTier.verification_tier_identified }
+      });
+    });
+
+    it("requires both legacy signedBy and verification when both are present", async () => {
+      const { service, repository, matcher } = setup();
+      repository.findCandidates.mockResolvedValue([makeCandidate("akash1abc", { verification: storedVerification() })]);
+      matcher.match.mockReturnValue({ matched: true });
+      const request = makeRequest({
+        signedBy: { allOf: ["akash1legacyauditor"], anyOf: [] },
+        verification: verificationRequirement({ minTier: VerificationTier.verification_tier_verified })
+      });
+
+      const result = await service.screenProviders(request);
+
+      expect(repository.findCandidates).toHaveBeenCalledWith(expect.any(Array), request.requirements);
+      expect(result.providers).toEqual([]);
+      expect(result.exclusions?.[0].firstFailure).toEqual({ code: "snapshot_not_posted" });
+    });
+
+    it("excludes verification failures with the first and complete failure set", async () => {
+      const { service, repository, matcher } = setup();
+      repository.findCandidates.mockResolvedValue([makeCandidate("akash1abc", { verification: storedVerification() })]);
+      matcher.match.mockReturnValue({ matched: true });
+
+      const result = await service.screenProviders(
+        makeRequest({
+          verification: verificationRequirement({
+            minTier: VerificationTier.verification_tier_verified,
+            requiredCapabilities: [CapabilityFlag.capability_bare_metal],
+            minAuditorCount: 2
+          })
+        })
+      );
+
+      expect(result.providers).toEqual([]);
+      expect(result.exclusions).toEqual([
+        expect.objectContaining({
+          owner: "akash1abc",
+          firstFailure: { code: "snapshot_not_posted" },
+          failures: [
+            { code: "snapshot_not_posted" },
+            {
+              code: "insufficient_tier",
+              actual: VerificationTier.verification_tier_identified,
+              required: VerificationTier.verification_tier_verified
+            },
+            { code: "missing_capability", capability: CapabilityFlag.capability_bare_metal },
+            { code: "insufficient_auditor_count", actual: 0, required: 2 }
+          ]
+        })
+      ]);
+    });
+
+    it("fails open and marks unavailable verification facts as not evaluated", async () => {
+      const { service, repository, matcher } = setup();
+      repository.findCandidates.mockResolvedValue([makeCandidate("akash1abc")]);
+      matcher.match.mockReturnValue({ matched: true });
+
+      const result = await service.screenProviders(makeRequest({ verification: verificationRequirement() }));
+
+      expect(result.exclusions).toEqual([]);
+      expect(result.providers[0].verification).toEqual({
+        outcome: "not_evaluated",
+        incompleteFacts: ["params", "attestations", "graces"],
+        summary: expect.any(Object)
+      });
+    });
+
+    it("marks disabled-module screening as not evaluated without excluding the provider", async () => {
+      const { service, repository, matcher } = setup();
+      repository.findCandidates.mockResolvedValue([makeCandidate("akash1abc", { verification: storedVerification({ moduleActive: false, complete: false }) })]);
+      matcher.match.mockReturnValue({ matched: true });
+
+      const result = await service.screenProviders(makeRequest({ verification: verificationRequirement() }));
+
+      expect(result.exclusions).toEqual([]);
+      expect(result.providers[0].verification).toMatchObject({ outcome: "not_evaluated", incompleteFacts: ["module_inactive"] });
+    });
+
+    it("does not report capacity failures as verification exclusions", async () => {
+      const { service, repository, matcher } = setup();
+      repository.findCandidates.mockResolvedValue([makeCandidate("akash1abc", { verification: storedVerification() })]);
+      matcher.match.mockReturnValue({ matched: false, error: "INSUFFICIENT_CAPACITY" });
+
+      const result = await service.screenProviders(makeRequest({ verification: verificationRequirement() }));
+
+      expect(result).toEqual({ providers: [], exclusions: [] });
+    });
   });
 
   function setup() {
@@ -247,7 +371,13 @@ function makeDowntimeRow(provider: string, overrides?: Partial<DailyDowntimeRow>
 
 function makeCandidate(
   owner: string,
-  overrides?: { isAudited?: boolean; createdAt?: string; location?: string | null; organization?: string | null }
+  overrides?: {
+    isAudited?: boolean;
+    createdAt?: string;
+    location?: string | null;
+    organization?: string | null;
+    verification?: StoredProviderVerification | null;
+  }
 ): BidScreeningCandidate {
   return {
     owner,
@@ -255,6 +385,8 @@ function makeCandidate(
     isAudited: overrides?.isAudited ?? false,
     createdAt: overrides?.createdAt ?? "2026-01-01T00:00:00.000Z",
     updatedAt: "2026-01-01T00:00:00.000Z",
+    verification: overrides?.verification ?? null,
+    verificationObservedHeight: overrides?.verification?.facts.observedHeight ?? null,
     location: overrides?.location ?? null,
     organization: overrides?.organization ?? null,
     cluster: {
@@ -278,13 +410,15 @@ function makeRequest(
   overrides?: Partial<{
     attributes: { key: string; value: string }[];
     signedBy: { allOf: string[]; anyOf: string[] };
+    verification: VerificationRequirement;
   }>
 ): BidScreeningInput {
   return {
     timezone: "America/Chicago",
     requirements: {
       signedBy: overrides?.signedBy ?? { allOf: [], anyOf: [] },
-      attributes: overrides?.attributes ?? []
+      attributes: overrides?.attributes ?? [],
+      verification: overrides?.verification
     },
     resources: [
       {
@@ -300,5 +434,40 @@ function makeRequest(
         price: { denom: "uakt", amount: "1000" }
       }
     ]
+  };
+}
+
+function verificationRequirement(overrides: Partial<VerificationRequirement> = {}): VerificationRequirement {
+  return {
+    minTier: VerificationTier.verification_tier_identified,
+    requiredCapabilities: [],
+    requiredAuditors: [],
+    auditorMode: AuditorSelectionMode.auditor_selection_mode_unspecified,
+    minAuditorCount: 0,
+    ...overrides
+  };
+}
+
+function storedVerification(input: { complete?: boolean; moduleActive?: boolean | null } = {}): StoredProviderVerification {
+  const complete = input.complete ?? true;
+  return {
+    moduleActive: input.moduleActive ?? true,
+    facts: {
+      attestations: complete
+        ? [
+            {
+              auditor: "akash1auditor",
+              capabilities: [CapabilityFlag.capability_persistent_storage],
+              status: AttestationStatus.attestation_status_valid,
+              tier: VerificationTier.verification_tier_identified
+            }
+          ]
+        : [],
+      completeness: { attestations: complete, graces: complete, snapshot: complete },
+      graces: [],
+      observedAt: "2026-08-24T12:00:00.000Z",
+      observedHeight: "123",
+      snapshot: null
+    }
   };
 }

--- a/apps/provider-inventory/src/services/bid-screening/bid-screening.service.ts
+++ b/apps/provider-inventory/src/services/bid-screening/bid-screening.service.ts
@@ -1,14 +1,17 @@
+import { type VerificationRequirement, VerificationTier } from "@akashnetwork/chain-sdk/private-types/akash.v1";
 import { withSpan } from "@akashnetwork/instrumentation";
+import { evaluateProviderVerification, type ProviderVerificationFacts } from "@akashnetwork/provider-verification";
 import type { Abortable } from "node:events";
 import { inject, singleton } from "tsyringe";
 
+import { mapStoredProviderVerificationFacts } from "@src/mappers/provider-verification-mapper/provider-verification-mapper";
 import { bidScreeningBinPackerMatched, bidScreeningPrefilterCandidates } from "@src/metrics/metrics";
 import { LOGGER_FACTORY, type LoggerFactory, LoggerService } from "@src/providers/logger-factory.provider";
 import { type BidScreeningCandidate, BidScreeningRepository } from "@src/repositories/bid-screening/bid-screening.repository";
 import { DailyDowntimeRow, ProviderIncidentRepository } from "@src/repositories/provider-incident/provider-incident.repository";
 import type { GroupSpecJSON } from "../../mappers/groupspec-mapper/groupspec-mapper";
 import { mapGroupSpecToResourceUnits } from "../../mappers/groupspec-mapper/groupspec-mapper";
-import type { BidScreeningResult, RequestedResourceUnit } from "../../types/inventory";
+import type { BidScreeningExclusion, BidScreeningResult, BidScreeningSelection, RequestedResourceUnit } from "../../types/inventory";
 import { ClusterInventoryMatcherService } from "../cluster-inventory-matcher/cluster-inventory-matcher.service";
 
 const EMPTY_OBJECT = Object.freeze(Object.create(null));
@@ -33,6 +36,10 @@ export class BidScreeningService {
   }
 
   async findMatchingProviders(request: BidScreeningInput, options?: Abortable): Promise<BidScreeningResult[]> {
+    return (await this.screenProviders(request, options)).providers;
+  }
+
+  async screenProviders(request: BidScreeningInput, options?: Abortable): Promise<BidScreeningSelection> {
     const resourceUnits = await withSpan("mapRequestToResourceUnits", async () => mapGroupSpecToResourceUnits(request));
 
     this.#logger.info({ event: "BID_SCREENING_START", resourceGroupCount: resourceUnits.length });
@@ -49,20 +56,26 @@ export class BidScreeningService {
       if (options?.signal?.aborted) return [];
       const items = this.#filterProviders(candidates, resourceUnits);
       bidScreeningBinPackerMatched.record(items.length);
-      this.#logger.info({
-        event: "BID_SCREENING_COMPLETE",
-        candidatesCount: candidates.length,
-        matchedCount: items.length
-      });
       return items;
+    });
+
+    const verificationRequirement = effectiveVerificationRequirement(request.requirements.verification);
+    const screening = this.#screenByVerification(matched, verificationRequirement);
+    this.#logger.info({
+      event: "BID_SCREENING_COMPLETE",
+      candidatesCount: candidates.length,
+      capacityMatchedCount: matched.length,
+      excludedByVerificationCount: screening.exclusions.length,
+      matchedCount: screening.providers.length,
+      verificationNotEvaluatedCount: screening.providers.filter(provider => provider.verification?.outcome === "not_evaluated").length
     });
 
     const incidentsByOwner: Partial<Record<string, Omit<DailyDowntimeRow, "provider">[]>> = await withSpan(
       "fetchIncidentsForMatched",
       async ({ activeSpan }) => {
-        if (!matched.length || options?.signal?.aborted) return EMPTY_OBJECT;
+        if (!screening.providers.length || options?.signal?.aborted) return EMPTY_OBJECT;
         const rows = await this.#incidentRepository.findDailyDowntimeByProviders(
-          matched.map(candidate => candidate.owner),
+          screening.providers.map(({ candidate }) => candidate.owner),
           request.timezone
         );
         activeSpan.setAttribute("amountOfIncidents", rows.length);
@@ -81,7 +94,8 @@ export class BidScreeningService {
       }
     );
 
-    return matched.map(candidate => this.#toResult(candidate, incidentsByOwner));
+    const providers = screening.providers.map(({ candidate, verification }) => this.#toResult(candidate, incidentsByOwner, verification));
+    return verificationRequirement ? { providers, exclusions: screening.exclusions } : { providers };
   }
 
   #filterProviders(candidates: BidScreeningCandidate[], resourceUnits: RequestedResourceUnit[]): BidScreeningCandidate[] {
@@ -100,7 +114,47 @@ export class BidScreeningService {
     return matched;
   }
 
-  #toResult(candidate: BidScreeningCandidate, incidentsByOwner: Partial<Record<string, Omit<DailyDowntimeRow, "provider">[]>>): BidScreeningResult {
+  #screenByVerification(candidates: BidScreeningCandidate[], requirement: VerificationRequirement | null): VerificationScreeningResult {
+    if (!requirement) return { providers: candidates.map(candidate => ({ candidate })), exclusions: [] };
+
+    const providers: VerificationScreeningResult["providers"] = [];
+    const exclusions: BidScreeningExclusion[] = [];
+
+    for (const candidate of candidates) {
+      const stored = candidate.verification;
+      const facts = stored ? mapStoredProviderVerificationFacts(stored) : unknownVerificationFacts();
+      const evaluation = evaluateProviderVerification({ facts, moduleActive: stored?.moduleActive ?? null, requirement });
+
+      if (evaluation.outcome === "fail") {
+        exclusions.push({
+          owner: candidate.owner,
+          firstFailure: evaluation.firstFailure,
+          failures: evaluation.failures,
+          summary: evaluation.summary
+        });
+      } else if (evaluation.outcome === "unknown") {
+        providers.push({
+          candidate,
+          verification: { outcome: "not_evaluated", incompleteFacts: evaluation.incompleteFacts, summary: evaluation.summary }
+        });
+      } else if (stored?.moduleActive === false) {
+        providers.push({
+          candidate,
+          verification: { outcome: "not_evaluated", incompleteFacts: ["module_inactive"], summary: evaluation.summary }
+        });
+      } else {
+        providers.push({ candidate, verification: { outcome: "pass", summary: evaluation.summary } });
+      }
+    }
+
+    return { exclusions, providers };
+  }
+
+  #toResult(
+    candidate: BidScreeningCandidate,
+    incidentsByOwner: Partial<Record<string, Omit<DailyDowntimeRow, "provider">[]>>,
+    verification?: BidScreeningResult["verification"]
+  ): BidScreeningResult {
     return {
       owner: candidate.owner,
       hostUri: candidate.hostUri,
@@ -108,7 +162,8 @@ export class BidScreeningService {
       createdAt: candidate.createdAt,
       location: candidate.location,
       organization: candidate.organization,
-      incidents: incidentsByOwner[candidate.owner] ?? []
+      incidents: incidentsByOwner[candidate.owner] ?? [],
+      ...(verification ? { verification } : {})
     };
   }
 }
@@ -116,4 +171,26 @@ export class BidScreeningService {
 export interface BidScreeningInput extends Omit<GroupSpecJSON, "name"> {
   timezone: string;
   reclamationWindow?: number;
+}
+
+interface VerificationScreeningResult {
+  providers: Array<{ candidate: BidScreeningCandidate; verification?: BidScreeningResult["verification"] }>;
+  exclusions: BidScreeningExclusion[];
+}
+
+function effectiveVerificationRequirement(requirement: VerificationRequirement | undefined): VerificationRequirement | null {
+  return !requirement || requirement.minTier === VerificationTier.verification_tier_unspecified ? null : requirement;
+}
+
+function unknownVerificationFacts(): ProviderVerificationFacts {
+  const facts: ProviderVerificationFacts = {
+    attestations: [],
+    completeness: { attestations: false, graces: false, snapshot: false },
+    graces: [],
+    observedAt: new Date(0),
+    observedHeight: "",
+    snapshot: null
+  };
+
+  return facts;
 }

--- a/apps/provider-inventory/src/services/chain-provider-poller/chain-provider-poller.service.spec.ts
+++ b/apps/provider-inventory/src/services/chain-provider-poller/chain-provider-poller.service.spec.ts
@@ -1,13 +1,17 @@
+import { AttestationStatus, CapabilityFlag, VerificationTier } from "@akashnetwork/chain-sdk/private-types/akash.v1";
 import type { ChainNodeWebSDK } from "@akashnetwork/chain-sdk/web";
+import type { ProviderVerificationQueryClient, ProviderVerificationScreeningState } from "@akashnetwork/provider-verification";
 import { describe, expect, it } from "vitest";
 import { mock, mockDeep } from "vitest-mock-extended";
 
+import type { EnvConfig } from "@src/providers/app-config.provider";
 import type { LoggerFactory } from "@src/providers/logger-factory.provider";
-import type { ChainProvider } from "@src/types/chain-provider";
+import type { DiscoveredChainProvider } from "@src/types/chain-provider";
 import { ChainProviderPollerService } from "./chain-provider-poller.service";
 
 type ProvidersResponse = Awaited<ReturnType<ChainNodeWebSDK["akash"]["provider"]["v1beta4"]["getProviders"]>>;
 type AuditResponse = Awaited<ReturnType<ChainNodeWebSDK["akash"]["audit"]["v1"]["getAllProvidersAttributes"]>>;
+type ParamsResponse = Awaited<ReturnType<ChainNodeWebSDK["akash"]["verification"]["v1"]["getParams"]>>;
 type ChainSDKProvider = ProvidersResponse["providers"][number];
 type AuditRecord = AuditResponse["providers"][number];
 
@@ -16,7 +20,7 @@ describe(ChainProviderPollerService.name, () => {
     const { service, getProviders } = setup();
     getProviders.mockResolvedValueOnce(providersResponse([chainProvider({ owner: "akash1aaa" })], new Uint8Array(0)));
 
-    const batches: ChainProvider[][] = [];
+    const batches: DiscoveredChainProvider[][] = [];
     for await (const batch of service.poll()) {
       batches.push(batch);
     }
@@ -34,7 +38,7 @@ describe(ChainProviderPollerService.name, () => {
       })
     );
 
-    const batches: ChainProvider[][] = [];
+    const batches: DiscoveredChainProvider[][] = [];
     for await (const batch of service.poll()) {
       batches.push(batch);
     }
@@ -50,7 +54,7 @@ describe(ChainProviderPollerService.name, () => {
       .mockResolvedValueOnce(providersResponse([chainProvider({ owner: "akash1aaa" })], pageOneKey))
       .mockResolvedValueOnce(providersResponse([chainProvider({ owner: "akash1bbb" })], new Uint8Array(0)));
 
-    const batches: ChainProvider[][] = [];
+    const batches: DiscoveredChainProvider[][] = [];
     for await (const batch of service.poll()) {
       batches.push(batch);
     }
@@ -108,17 +112,128 @@ describe(ChainProviderPollerService.name, () => {
     ]);
   });
 
-  function setup() {
+  it("pins discovery and verification queries to one latest block", async () => {
+    const { service, getAllProvidersAttributes, getParams, getProviders, verificationClient } = setup({ moduleActive: true });
+    getProviders.mockResolvedValueOnce(providersResponse([chainProvider({ owner: "akash1aaa" })], new Uint8Array(0)));
+    verificationClient.getProviderScreeningState.mockResolvedValue(providerVerificationState("akash1aaa"));
+
+    const [batch] = await Array.fromAsync(service.poll());
+
+    expect(getParams).toHaveBeenCalledTimes(1);
+    expect(getParams).toHaveBeenCalledWith({}, expect.objectContaining({ headers: { "x-cosmos-block-height": "123" } }));
+    expect(getAllProvidersAttributes).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ headers: { "x-cosmos-block-height": "123" } }));
+    expect(getProviders).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ headers: { "x-cosmos-block-height": "123" } }));
+    expect(verificationClient.getProviderScreeningState).toHaveBeenCalledWith("akash1aaa", "123");
+    expect(batch[0].verification).toMatchObject({
+      moduleActive: true,
+      facts: {
+        completeness: { attestations: true, graces: true, snapshot: true },
+        observedAt: "2026-08-24T12:00:00.000Z",
+        observedHeight: "123"
+      }
+    });
+  });
+
+  it("skips provider verification fanout when the module is inactive", async () => {
+    const { service, getProviders, verificationClient } = setup({ moduleActive: false });
+    getProviders.mockResolvedValueOnce(providersResponse([chainProvider({ owner: "akash1aaa" })], new Uint8Array(0)));
+
+    const [batch] = await Array.fromAsync(service.poll());
+
+    expect(verificationClient.getProviderScreeningState).not.toHaveBeenCalled();
+    expect(batch[0].verification).toMatchObject({
+      moduleActive: false,
+      facts: { completeness: { attestations: false, graces: false, snapshot: false }, observedHeight: "123" }
+    });
+  });
+
+  it("marks verification unknown without breaking provider discovery when params are unavailable", async () => {
+    const { service, getParams, getProviders, verificationClient } = setup();
+    getParams.mockRejectedValueOnce(new Error("verification route unavailable"));
+    getProviders.mockResolvedValueOnce(providersResponse([chainProvider({ owner: "akash1aaa" })], new Uint8Array(0)));
+
+    const [batch] = await Array.fromAsync(service.poll());
+
+    expect(batch).toHaveLength(1);
+    expect(batch[0].verification.moduleActive).toBeNull();
+    expect(batch[0].verification.facts.completeness).toEqual({ attestations: false, graces: false, snapshot: false });
+    expect(verificationClient.getProviderScreeningState).not.toHaveBeenCalled();
+  });
+
+  it("marks one provider unknown when its pinned verification queries fail", async () => {
+    const { service, getProviders, verificationClient } = setup({ moduleActive: true });
+    getProviders.mockResolvedValueOnce(providersResponse([chainProvider({ owner: "akash1aaa" })], new Uint8Array(0)));
+    verificationClient.getProviderScreeningState.mockRejectedValueOnce(new Error("query failed"));
+
+    const [batch] = await Array.fromAsync(service.poll());
+
+    expect(batch[0].verification).toMatchObject({
+      moduleActive: true,
+      facts: { completeness: { attestations: false, graces: false, snapshot: false }, observedHeight: "123" }
+    });
+  });
+
+  it("bounds concurrent provider verification queries", async () => {
+    const { service, getProviders, verificationClient } = setup({ moduleActive: true, verificationQueryConcurrency: 2 });
+    const providers = Array.from({ length: 6 }, (_, index) => chainProvider({ owner: `akash1provider${index}` }));
+    getProviders.mockResolvedValueOnce(providersResponse(providers, new Uint8Array(0)));
+    let active = 0;
+    let maxActive = 0;
+    verificationClient.getProviderScreeningState.mockImplementation(async provider => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await new Promise(resolve => setTimeout(resolve, 5));
+      active--;
+      return providerVerificationState(provider);
+    });
+
+    await Array.fromAsync(service.poll());
+
+    expect(verificationClient.getProviderScreeningState).toHaveBeenCalledTimes(6);
+    expect(maxActive).toBe(2);
+  });
+
+  function setup(input: { moduleActive?: boolean; verificationQueryConcurrency?: number } = {}) {
     const chainSDK = mockDeep<ChainNodeWebSDK>();
     const getAllProvidersAttributes = chainSDK.akash.audit.v1.getAllProvidersAttributes;
+    const getLatestBlock = chainSDK.cosmos.base.tendermint.v1beta1.getLatestBlock;
+    const getParams = chainSDK.akash.verification.v1.getParams;
     const getProviders = chainSDK.akash.provider.v1beta4.getProviders;
+    const verificationClient = mock<ProviderVerificationQueryClient>();
 
     getAllProvidersAttributes.mockResolvedValue(auditResponse([], new Uint8Array(0)));
+    getLatestBlock.mockResolvedValue({
+      blockId: undefined,
+      block: undefined,
+      sdkBlock: {
+        data: undefined,
+        evidence: undefined,
+        lastCommit: undefined,
+        header: {
+          appHash: new Uint8Array(),
+          chainId: "testnet",
+          consensusHash: new Uint8Array(),
+          dataHash: new Uint8Array(),
+          evidenceHash: new Uint8Array(),
+          height: 123n,
+          lastBlockId: undefined,
+          lastCommitHash: new Uint8Array(),
+          lastResultsHash: new Uint8Array(),
+          nextValidatorsHash: new Uint8Array(),
+          proposerAddress: "akashvaloper1proposer",
+          time: new Date("2026-08-24T12:00:00.000Z"),
+          validatorsHash: new Uint8Array(),
+          version: undefined
+        }
+      }
+    });
+    getParams.mockResolvedValue({ params: mock<NonNullable<ParamsResponse["params"]>>({ verificationModuleActive: input.moduleActive ?? false }) });
 
     const loggerFactory: LoggerFactory = () => mock<ReturnType<LoggerFactory>>();
-    const service = new ChainProviderPollerService(chainSDK, loggerFactory);
+    const config = { VERIFICATION_QUERY_CONCURRENCY: input.verificationQueryConcurrency ?? 20 } as EnvConfig;
+    const service = new ChainProviderPollerService(chainSDK, verificationClient, config, loggerFactory);
 
-    return { service, chainSDK, getAllProvidersAttributes, getProviders };
+    return { service, chainSDK, getAllProvidersAttributes, getParams, getProviders, verificationClient };
   }
 });
 
@@ -137,4 +252,21 @@ function providersResponse(providers: ChainSDKProvider[], nextKey: Uint8Array): 
 
 function auditResponse(providers: AuditRecord[], nextKey: Uint8Array): AuditResponse {
   return { providers, pagination: { nextKey } } as unknown as AuditResponse;
+}
+
+function providerVerificationState(provider: string): ProviderVerificationScreeningState {
+  return mock<ProviderVerificationScreeningState>({
+    provider,
+    attestations: [
+      mock({
+        auditor: "akash1auditor",
+        capabilities: [CapabilityFlag.capability_persistent_storage],
+        status: AttestationStatus.attestation_status_valid,
+        tier: VerificationTier.verification_tier_verified
+      })
+    ],
+    grace: null,
+    snapshot: null,
+    observedHeight: "123"
+  });
 }

--- a/apps/provider-inventory/src/services/chain-provider-poller/chain-provider-poller.service.ts
+++ b/apps/provider-inventory/src/services/chain-provider-poller/chain-provider-poller.service.ts
@@ -1,34 +1,58 @@
 import type { ChainNodeWebSDK } from "@akashnetwork/chain-sdk/web";
 import type { LoggerService } from "@akashnetwork/logging";
+import { ProviderVerificationQueryClient } from "@akashnetwork/provider-verification";
+import { Sema } from "async-sema";
 import { inject, singleton } from "tsyringe";
 
 import { paginate } from "@src/lib/generators/paginate/paginate";
+import { mapProviderVerification } from "@src/mappers/provider-verification-mapper/provider-verification-mapper";
+import type { EnvConfig } from "@src/providers/app-config.provider";
+import { APP_CONFIG } from "@src/providers/app-config.provider";
 import { CHAIN_SDK } from "@src/providers/chain-sdk.provider";
 import type { LoggerFactory } from "@src/providers/logger-factory.provider";
 import { LOGGER_FACTORY } from "@src/providers/logger-factory.provider";
-import type { ChainProvider } from "@src/types/chain-provider";
+import { PROVIDER_VERIFICATION_QUERY_CLIENT } from "@src/providers/provider-verification-query-client.provider";
+import type { ChainProvider, DiscoveredChainProvider } from "@src/types/chain-provider";
+
+interface VerificationObservation {
+  moduleActive: boolean | null;
+  observedAt: Date;
+  observedHeight: string;
+}
 
 @singleton()
 export class ChainProviderPollerService {
   readonly #logger: LoggerService;
   readonly #chainSDK: ChainNodeWebSDK;
+  readonly #verificationClient: ProviderVerificationQueryClient;
+  readonly #verificationQueryConcurrency: number;
 
-  constructor(@inject(CHAIN_SDK) chainSDK: ChainNodeWebSDK, @inject(LOGGER_FACTORY) loggerFactory: LoggerFactory) {
+  constructor(
+    @inject(CHAIN_SDK) chainSDK: ChainNodeWebSDK,
+    @inject(PROVIDER_VERIFICATION_QUERY_CLIENT) verificationClient: ProviderVerificationQueryClient,
+    @inject(APP_CONFIG) config: EnvConfig,
+    @inject(LOGGER_FACTORY) loggerFactory: LoggerFactory
+  ) {
     this.#chainSDK = chainSDK;
+    this.#verificationClient = verificationClient;
+    this.#verificationQueryConcurrency = config.VERIFICATION_QUERY_CONCURRENCY;
     this.#logger = loggerFactory({ context: "ChainProviderPoller" });
   }
 
-  async *poll(input: { signal?: AbortSignal; batchSize?: number } = {}): AsyncGenerator<ChainProvider[]> {
+  async *poll(input: { signal?: AbortSignal; batchSize?: number } = {}): AsyncGenerator<DiscoveredChainProvider[]> {
     const MAX_PROVIDERS_PER_BATCH = input.batchSize ?? 500;
     this.#logger.info({ event: "CHAIN_POLL_START" });
+
+    const verificationObservation = await this.#getVerificationObservation(input.signal);
+    const queryOptions = {
+      headers: { "x-cosmos-block-height": verificationObservation.observedHeight },
+      signal: input.signal
+    };
 
     const signedByOwner = new Map<string, { attributes: Array<{ key: string; value: string; auditor: string }>; auditors: Set<string> }>();
     const auditPages = paginate(
       async key => {
-        const response = await this.#chainSDK.akash.audit.v1.getAllProvidersAttributes(
-          { pagination: { limit: MAX_PROVIDERS_PER_BATCH, key } },
-          { signal: input.signal }
-        );
+        const response = await this.#chainSDK.akash.audit.v1.getAllProvidersAttributes({ pagination: { limit: MAX_PROVIDERS_PER_BATCH, key } }, queryOptions);
         return { items: response.providers, nextKey: response.pagination?.nextKey };
       },
       { signal: input.signal }
@@ -51,10 +75,7 @@ export class ChainProviderPollerService {
     const providerPages = paginate(
       async key => {
         this.#logger.info({ event: "CHAIN_PROVIDERS_POLL_BATCH", nextKey: key ? Buffer.from(key).toString("base64") : null });
-        const response = await this.#chainSDK.akash.provider.v1beta4.getProviders(
-          { pagination: { limit: MAX_PROVIDERS_PER_BATCH, key } },
-          { signal: input.signal }
-        );
+        const response = await this.#chainSDK.akash.provider.v1beta4.getProviders({ pagination: { limit: MAX_PROVIDERS_PER_BATCH, key } }, queryOptions);
         return { items: response.providers, nextKey: response.pagination?.nextKey };
       },
       { signal: input.signal }
@@ -79,11 +100,57 @@ export class ChainProviderPollerService {
       }
 
       if (validProviders.length > 0) {
-        yield validProviders;
+        yield await this.#attachVerification(validProviders, verificationObservation, input.signal);
       }
     }
 
     this.#logger.info({ event: "CHAIN_PROVIDERS_POLL_COMPLETE", providerCount });
+  }
+
+  async #getVerificationObservation(signal?: AbortSignal): Promise<VerificationObservation> {
+    const blockResponse = await this.#chainSDK.cosmos.base.tendermint.v1beta1.getLatestBlock({}, { signal });
+    const header = blockResponse.sdkBlock?.header ?? blockResponse.block?.header;
+    if (!header?.time) throw new Error("Latest block response did not include a height and time");
+
+    const observedHeight = header.height.toString();
+    const observedAt = header.time;
+
+    try {
+      const response = await this.#chainSDK.akash.verification.v1.getParams({}, { headers: { "x-cosmos-block-height": observedHeight }, signal });
+      return { moduleActive: response.params?.verificationModuleActive ?? null, observedAt, observedHeight };
+    } catch (error) {
+      this.#logger.warn({ event: "VERIFICATION_PARAMS_UNAVAILABLE", error, observedHeight });
+      return { moduleActive: null, observedAt, observedHeight };
+    }
+  }
+
+  async #attachVerification(providers: ChainProvider[], observation: VerificationObservation, signal?: AbortSignal): Promise<DiscoveredChainProvider[]> {
+    if (observation.moduleActive !== true) {
+      return providers.map(provider => ({
+        ...provider,
+        verification: mapProviderVerification({ ...observation, state: null })
+      }));
+    }
+
+    const semaphore = new Sema(this.#verificationQueryConcurrency);
+    return await Promise.all(
+      providers.map(async provider => {
+        await semaphore.acquire();
+        try {
+          if (signal?.aborted) {
+            return { ...provider, verification: mapProviderVerification({ ...observation, state: null }) };
+          }
+
+          const state = await this.#verificationClient.getProviderScreeningState(provider.owner, observation.observedHeight);
+          return { ...provider, verification: mapProviderVerification({ ...observation, state }) };
+        } catch (error) {
+          this.#logger.warn({ event: "VERIFICATION_PROVIDER_STATE_UNAVAILABLE", error, owner: provider.owner, observedHeight: observation.observedHeight });
+          return { ...provider, verification: mapProviderVerification({ ...observation, state: null }) };
+        } finally {
+          semaphore.release();
+        }
+      })
+    );
   }
 }
 

--- a/apps/provider-inventory/src/services/discovery-scheduler/discovery-scheduler.service.spec.ts
+++ b/apps/provider-inventory/src/services/discovery-scheduler/discovery-scheduler.service.spec.ts
@@ -7,7 +7,7 @@ import type { ProviderIncidentRepository } from "@src/repositories/provider-inci
 import type { ProviderInventory, ProviderInventoryRepository } from "@src/repositories/provider-inventory/provider-inventory.repository";
 import type { ChainProviderPollerService } from "@src/services/chain-provider-poller/chain-provider-poller.service";
 import type { StreamLifecycleManagerService } from "@src/services/stream-lifecycle-manager/stream-lifecycle-manager.service";
-import type { ChainProvider } from "@src/types/chain-provider";
+import type { DiscoveredChainProvider } from "@src/types/chain-provider";
 import type { TimerService } from "../timer/timer.service";
 import { DiscoverySchedulerService } from "./discovery-scheduler.service";
 
@@ -78,6 +78,7 @@ describe(DiscoverySchedulerService.name, () => {
 
     expect(lifecycle.getRegistry).toHaveBeenCalled();
     expect(writer.bulkUpsertProviders).toHaveBeenCalledWith([fresh]);
+    expect(writer.bulkUpdateVerification).toHaveBeenCalledWith([fresh]);
     expect(lifecycle.start).toHaveBeenCalledWith({ ...fresh, offlineSince: null }, expect.any(AbortSignal));
   });
 
@@ -192,6 +193,17 @@ describe(DiscoverySchedulerService.name, () => {
 
     expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "UPSERT_PROVIDERS_ERROR", owners: [provider.owner] }));
     expect(lifecycle.start).not.toHaveBeenCalled();
+  });
+
+  it("logs verification persistence errors without breaking provider discovery", async () => {
+    const provider = createProvider();
+    const { writer, lifecycle, logger } = setup({ providers: [provider] });
+    writer.bulkUpdateVerification.mockRejectedValueOnce(new Error("DB update failed"));
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "UPSERT_PROVIDER_VERIFICATION_ERROR", owners: [provider.owner] }));
+    expect(lifecycle.start).toHaveBeenCalledWith({ ...provider, offlineSince: null }, expect.any(AbortSignal));
   });
 
   it("prunes incidents older than the configured retention window on the first tick", async () => {
@@ -332,7 +344,7 @@ describe(DiscoverySchedulerService.name, () => {
   });
 
   function setup(input?: {
-    providers?: ChainProvider[];
+    providers?: DiscoveredChainProvider[];
     pollError?: Error;
     pollDelay?: (config: EnvConfig) => number;
     onlineOwners?: Pick<ProviderInventory, "owner" | "hostUri">[];
@@ -348,6 +360,7 @@ describe(DiscoverySchedulerService.name, () => {
     lifecycle.stopAndDelete.mockResolvedValue();
     lifecycle.waitForPendingConnections.mockResolvedValue();
     writer.bulkUpsertProviders.mockResolvedValue([]);
+    writer.bulkUpdateVerification.mockResolvedValue();
     incidentRepository.getOfflineSince.mockResolvedValue(input?.offlineSince ?? new Map());
     incidentRepository.deleteEndedBefore.mockResolvedValue(0);
 
@@ -419,13 +432,24 @@ function asyncIterableThatThrows<T>(error: Error): AsyncGenerator<T> {
   } as AsyncGenerator<T>;
 }
 
-function createProvider(overrides?: Partial<ChainProvider>): ChainProvider {
+function createProvider(overrides?: Partial<DiscoveredChainProvider>): DiscoveredChainProvider {
   return {
     owner: "akash1abc",
     hostUri: "https://provider.example.com:8443",
     selfAttributes: [],
     signedAttributes: [],
     auditedBy: [],
+    verification: {
+      moduleActive: null,
+      facts: {
+        attestations: [],
+        completeness: { attestations: false, graces: false, snapshot: false },
+        graces: [],
+        observedAt: "2026-08-24T12:00:00.000Z",
+        observedHeight: "123",
+        snapshot: null
+      }
+    },
     ...overrides
   };
 }

--- a/apps/provider-inventory/src/services/discovery-scheduler/discovery-scheduler.service.ts
+++ b/apps/provider-inventory/src/services/discovery-scheduler/discovery-scheduler.service.ts
@@ -11,7 +11,7 @@ import { ProviderIncidentRepository } from "@src/repositories/provider-incident/
 import { ProviderInventoryRepository } from "@src/repositories/provider-inventory/provider-inventory.repository";
 import { ChainProviderPollerService } from "@src/services/chain-provider-poller/chain-provider-poller.service";
 import { StreamLifecycleManagerService } from "@src/services/stream-lifecycle-manager/stream-lifecycle-manager.service";
-import type { ChainProvider } from "@src/types/chain-provider";
+import type { DiscoveredChainProvider } from "@src/types/chain-provider";
 import { TimerService } from "../timer/timer.service";
 
 @singleton()
@@ -215,15 +215,23 @@ export class DiscoverySchedulerService {
     }
   }
 
-  async #upsertProviders(providers: ChainProvider[]) {
+  async #upsertProviders(providers: DiscoveredChainProvider[]) {
     const owners = providers.map(p => p.owner);
+    let updatedProviders: Awaited<ReturnType<ProviderInventoryRepository["bulkUpsertProviders"]>>;
     try {
-      const updatedProviders = await this.#repository.bulkUpsertProviders(providers);
+      updatedProviders = await this.#repository.bulkUpsertProviders(providers);
       this.#logger.debug({ event: "UPSERT_PROVIDERS_UPSERTED", owners });
-      return new Set(updatedProviders?.map(p => p.owner) ?? []);
     } catch (error) {
       this.#logger.error({ event: "UPSERT_PROVIDERS_ERROR", owners, error });
       return null;
     }
+
+    try {
+      await this.#repository.bulkUpdateVerification(providers);
+    } catch (error) {
+      this.#logger.error({ event: "UPSERT_PROVIDER_VERIFICATION_ERROR", owners, error });
+    }
+
+    return new Set(updatedProviders.map(p => p.owner));
   }
 }

--- a/apps/provider-inventory/src/types/chain-provider.ts
+++ b/apps/provider-inventory/src/types/chain-provider.ts
@@ -20,3 +20,8 @@ export interface ChainProvider {
 export interface ChainProviderWithOfflineSince extends ChainProvider {
   offlineSince: Date | null;
 }
+
+export interface DiscoveredChainProvider extends ChainProvider {
+  verification: StoredProviderVerification;
+}
+import type { StoredProviderVerification } from "./provider-verification";

--- a/apps/provider-inventory/src/types/inventory.ts
+++ b/apps/provider-inventory/src/types/inventory.ts
@@ -1,3 +1,5 @@
+import type { ProviderVerificationFailure, ProviderVerificationSummary } from "@akashnetwork/provider-verification";
+
 import type { DailyDowntimeRow } from "@src/repositories/provider-incident/provider-incident.repository";
 import type { ParsedGPUAttributes } from "../mappers/gpu-attribute-parser/gpu-attribute-parser";
 import type { ParsedStorageAttributes } from "../mappers/storage-attribute-parser/storage-attribute-parser";
@@ -75,6 +77,25 @@ export interface BidScreeningResult {
   location: string | null;
   organization: string | null;
   incidents: Omit<DailyDowntimeRow, "provider">[];
+  verification?:
+    | { outcome: "pass"; summary: ProviderVerificationSummary }
+    | {
+        outcome: "not_evaluated";
+        incompleteFacts: Array<"params" | "attestations" | "graces" | "snapshot" | "module_inactive">;
+        summary: ProviderVerificationSummary;
+      };
+}
+
+export interface BidScreeningExclusion {
+  owner: string;
+  firstFailure: ProviderVerificationFailure;
+  failures: ProviderVerificationFailure[];
+  summary: ProviderVerificationSummary;
+}
+
+export interface BidScreeningSelection {
+  providers: BidScreeningResult[];
+  exclusions?: BidScreeningExclusion[];
 }
 
 export type ToJSON<T> = T extends Uint8Array ? bigint : T extends object ? { -readonly [K in keyof T]: ToJSON<Exclude<T[K], undefined>> } : T;

--- a/apps/provider-inventory/src/types/provider-verification.ts
+++ b/apps/provider-inventory/src/types/provider-verification.ts
@@ -1,0 +1,33 @@
+import type { AttestationStatus, CapabilityFlag, VerificationGraceStatus, VerificationTier } from "@akashnetwork/chain-sdk/private-types/akash.v1";
+import type { ProviderVerificationCompleteness } from "@akashnetwork/provider-verification";
+
+export interface StoredVerificationAttestation {
+  auditor: string;
+  capabilities: CapabilityFlag[];
+  status: AttestationStatus;
+  tier: VerificationTier;
+}
+
+export interface StoredVerificationGrace {
+  preservedTier: VerificationTier;
+  status: VerificationGraceStatus;
+}
+
+export interface StoredVerificationSnapshot {
+  complianceDeadline: string | null;
+  suspended: boolean;
+}
+
+export interface StoredProviderVerificationFacts {
+  attestations: StoredVerificationAttestation[];
+  completeness: ProviderVerificationCompleteness;
+  graces: StoredVerificationGrace[];
+  observedAt: string;
+  observedHeight: string;
+  snapshot: StoredVerificationSnapshot | null;
+}
+
+export interface StoredProviderVerification {
+  facts: StoredProviderVerificationFacts;
+  moduleActive: boolean | null;
+}

--- a/apps/provider-inventory/test/functional/discovery-pipeline.spec.ts
+++ b/apps/provider-inventory/test/functional/discovery-pipeline.spec.ts
@@ -112,6 +112,34 @@ describe("DiscoveryScheduler pipeline", () => {
     let providers: ChainProvider[] = input.providers ?? [];
 
     const chainSDK = mockDeep<ChainNodeWebSDK>();
+    chainSDK.cosmos.base.tendermint.v1beta1.getLatestBlock.mockResolvedValue({
+      blockId: undefined,
+      block: undefined,
+      sdkBlock: {
+        data: undefined,
+        evidence: undefined,
+        lastCommit: undefined,
+        header: {
+          appHash: new Uint8Array(),
+          chainId: "testnet",
+          consensusHash: new Uint8Array(),
+          dataHash: new Uint8Array(),
+          evidenceHash: new Uint8Array(),
+          height: 123n,
+          lastBlockId: undefined,
+          lastCommitHash: new Uint8Array(),
+          lastResultsHash: new Uint8Array(),
+          nextValidatorsHash: new Uint8Array(),
+          proposerAddress: "akashvaloper1proposer",
+          time: new Date("2026-08-24T12:00:00.000Z"),
+          validatorsHash: new Uint8Array(),
+          version: undefined
+        }
+      }
+    });
+    chainSDK.akash.verification.v1.getParams.mockResolvedValue({
+      params: mock<NonNullable<Awaited<ReturnType<ChainNodeWebSDK["akash"]["verification"]["v1"]["getParams"]>>["params"]>>({ verificationModuleActive: false })
+    });
     chainSDK.akash.provider.v1beta4.getProviders.mockImplementation(() => {
       if (pollError) return Promise.reject(pollError);
       return Promise.resolve({
@@ -168,6 +196,7 @@ describe("DiscoveryScheduler pipeline", () => {
 
 function createProvider(overrides: Partial<ChainProvider> & Pick<ChainProvider, "owner" | "hostUri">): ChainProvider {
   return {
+    auditedBy: [],
     selfAttributes: [],
     signedAttributes: [],
     ...overrides

--- a/apps/provider-proxy/package.json
+++ b/apps/provider-proxy/package.json
@@ -20,7 +20,7 @@
     "test:unit": "vitest run --project unit"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/instrumentation": "*",
     "@akashnetwork/logging": "*",

--- a/apps/stats-web/package.json
+++ b/apps/stats-web/package.json
@@ -14,7 +14,7 @@
     "test:unit": "NODE_ENV=test vitest run"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/logging": "*",
     "@akashnetwork/network-store": "*",

--- a/apps/tx-signer/package.json
+++ b/apps/tx-signer/package.json
@@ -21,7 +21,7 @@
     "test:unit": "vitest run --project unit"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",
     "@akashnetwork/instrumentation": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5657,6 +5657,10 @@
       "resolved": "apps/provider-proxy",
       "link": true
     },
+    "node_modules/@akashnetwork/provider-verification": {
+      "resolved": "packages/provider-verification",
+      "link": true
+    },
     "node_modules/@akashnetwork/react-query-proxy": {
       "resolved": "packages/react-query-proxy",
       "link": true
@@ -45947,6 +45951,19 @@
       "devDependencies": {
         "@akashnetwork/dev-config": "*",
         "vitest": "^4.0.0"
+      }
+    },
+    "packages/provider-verification": {
+      "name": "@akashnetwork/provider-verification",
+      "version": "0.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43"
+      },
+      "devDependencies": {
+        "@akashnetwork/dev-config": "*",
+        "typescript": "~5.8.2",
+        "vitest": "^4.1.5"
       }
     },
     "packages/react-query-proxy": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akash-api": "1.4.3",
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/console-api-types": "*",
         "@akashnetwork/database": "*",
         "@akashnetwork/env-loader": "*",
@@ -542,7 +542,7 @@
       "version": "3.31.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/console-api-types": "*",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
@@ -2168,7 +2168,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akash-api": "1.4.3",
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/database": "*",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/instrumentation": "*",
@@ -2558,7 +2558,7 @@
       "version": "2.16.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
         "@akashnetwork/instrumentation": "*",
@@ -3701,7 +3701,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/instrumentation": "*",
         "@akashnetwork/logging": "*",
@@ -4041,7 +4041,7 @@
       "version": "2.10.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/instrumentation": "*",
         "@akashnetwork/logging": "*",
@@ -4218,7 +4218,7 @@
       "name": "@akashnetwork/stats-web",
       "version": "1.14.1",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/logging": "*",
         "@akashnetwork/network-store": "*",
@@ -4982,7 +4982,7 @@
       "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
         "@akashnetwork/instrumentation": "*",
@@ -5473,9 +5473,9 @@
       }
     },
     "node_modules/@akashnetwork/chain-sdk": {
-      "version": "1.0.0-alpha.41",
-      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.41.tgz",
-      "integrity": "sha512-mr3fGDBSISxl0eZF83+IJLVulGSuJVu+MRj6fG61pi2rgfgnv9QEKpdU3w7wtFFt5saJaJNgsqAlyjGZQecZ1A==",
+      "version": "1.0.0-alpha.43",
+      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.43.tgz",
+      "integrity": "sha512-+XTgpLn3kibMEWBAOkfmOGo2VJcv+VtT5Uvq966Nk5YMyD9HCYUvdDLm1k167Di1S11t66SH06BhoY1M/m2IWg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.12.0",
@@ -45932,7 +45932,7 @@
       "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/net": "*",
         "jotai": "^2.9.2"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -3705,6 +3705,7 @@
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/instrumentation": "*",
         "@akashnetwork/logging": "*",
+        "@akashnetwork/provider-verification": "*",
         "@hono/node-server": "^1.19.0",
         "@hono/otel": "~0.4.0",
         "@hono/zod-openapi": "^0.18.4",
@@ -21803,7 +21804,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-8yQrvS6sMpSwIovhPOwfyNf2Wz6v/B62LFSVYQ85+Rq3tLsBIG7rP5geMxaijTUxSkrO6RzN/IRuIAADYQsleA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/react": "*"
       }

--- a/packages/network-store/package.json
+++ b/packages/network-store/package.json
@@ -18,7 +18,7 @@
     "validate:types": "tsc --noEmit && echo"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/net": "*",
     "jotai": "^2.9.2"
   },

--- a/packages/provider-verification/package.json
+++ b/packages/provider-verification/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@akashnetwork/provider-verification",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Shared AEP-86 provider verification policy evaluation",
+  "license": "Apache-2.0",
+  "author": "Akash Network",
+  "type": "module",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "default": "./src/index.ts"
+    }
+  },
+  "main": "src/index.ts",
+  "scripts": {
+    "format": "prettier --write ./*.{ts,json} **/*.{ts,json}",
+    "lint": "eslint .",
+    "test": "vitest run",
+    "validate:types": "tsc -p tsconfig.build.json --noEmit && echo"
+  },
+  "dependencies": {
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43"
+  },
+  "devDependencies": {
+    "@akashnetwork/dev-config": "*",
+    "typescript": "~5.8.2",
+    "vitest": "^4.1.5"
+  }
+}

--- a/packages/provider-verification/src/index.ts
+++ b/packages/provider-verification/src/index.ts
@@ -1,0 +1,12 @@
+export {
+  deriveProviderVerificationSummary,
+  evaluateProviderVerification,
+  type ProviderVerificationCompleteness,
+  type ProviderVerificationEvaluation,
+  type ProviderVerificationFacts,
+  type ProviderVerificationFailure,
+  type ProviderVerificationSummary,
+  type SnapshotComplianceState
+} from "./providerVerification.js";
+export * from "./providerVerificationQueryClient.js";
+export * from "./providerTierState.js";

--- a/packages/provider-verification/src/providerTierState.spec.ts
+++ b/packages/provider-verification/src/providerTierState.spec.ts
@@ -1,0 +1,149 @@
+import type { AttestationRecord, ProviderSnapshotRecord, ProviderVerificationGraceRecord } from "@akashnetwork/chain-sdk/private-types/akash.v1";
+import { AttestationStatus, VerificationGraceStatus, VerificationTier } from "@akashnetwork/chain-sdk/private-types/akash.v1";
+import { describe, expect, it } from "vitest";
+
+import { deriveProviderTierState, detectProviderTierDemotion } from "./providerTierState.js";
+import type { ProviderVerificationFacts } from "./providerVerification.js";
+
+const observedAt = new Date("2026-08-24T12:00:00.000Z");
+
+describe(deriveProviderTierState.name, () => {
+  it("uses active grace for the effective tier", () => {
+    expect(
+      deriveProviderTierState(
+        facts({
+          attestations: [attestation(VerificationTier.verification_tier_identified)],
+          graces: [grace(VerificationTier.verification_tier_established)],
+          snapshot: snapshot({ complianceDeadline: new Date("2026-08-25T12:00:00.000Z") })
+        })
+      )
+    ).toEqual({
+      effectiveTier: VerificationTier.verification_tier_established,
+      maxPlacementTier: VerificationTier.verification_tier_established,
+      snapshotState: "current"
+    });
+  });
+
+  it.each(["not_posted", "stale", "suspended"] as const)("clamps L2+ placement eligibility to L1 when the snapshot is %s", snapshotState => {
+    const snapshotByState = {
+      not_posted: null,
+      stale: snapshot({ complianceDeadline: observedAt }),
+      suspended: snapshot({ complianceDeadline: new Date("2026-08-25T12:00:00.000Z"), suspended: true })
+    };
+
+    expect(
+      deriveProviderTierState(facts({ attestations: [attestation(VerificationTier.verification_tier_trusted)], snapshot: snapshotByState[snapshotState] }))
+    ).toMatchObject({
+      effectiveTier: VerificationTier.verification_tier_trusted,
+      maxPlacementTier: VerificationTier.verification_tier_identified,
+      snapshotState
+    });
+  });
+
+  it("does not require a snapshot for L1", () => {
+    expect(deriveProviderTierState(facts({ attestations: [attestation(VerificationTier.verification_tier_identified)] }))).toMatchObject({
+      effectiveTier: VerificationTier.verification_tier_identified,
+      maxPlacementTier: VerificationTier.verification_tier_identified,
+      snapshotState: "not_posted"
+    });
+  });
+});
+
+describe(detectProviderTierDemotion.name, () => {
+  it("reports independent tier and snapshot eligibility decreases", () => {
+    const currentSnapshot = {
+      effectiveTier: VerificationTier.verification_tier_established,
+      maxPlacementTier: VerificationTier.verification_tier_established,
+      snapshotState: "current" as const
+    };
+
+    expect(
+      detectProviderTierDemotion(currentSnapshot, {
+        ...currentSnapshot,
+        maxPlacementTier: VerificationTier.verification_tier_identified,
+        snapshotState: "stale"
+      })
+    ).toEqual(["snapshot_eligibility"]);
+    expect(
+      detectProviderTierDemotion(currentSnapshot, {
+        effectiveTier: VerificationTier.verification_tier_verified,
+        maxPlacementTier: VerificationTier.verification_tier_verified,
+        snapshotState: "current"
+      })
+    ).toEqual(["tier_gate", "snapshot_eligibility"]);
+  });
+
+  it("does not emit on an upgrade or unchanged state", () => {
+    const previous = {
+      effectiveTier: VerificationTier.verification_tier_identified,
+      maxPlacementTier: VerificationTier.verification_tier_identified,
+      snapshotState: "not_posted" as const
+    };
+
+    expect(detectProviderTierDemotion(previous, previous)).toEqual([]);
+    expect(
+      detectProviderTierDemotion(previous, {
+        effectiveTier: VerificationTier.verification_tier_verified,
+        maxPlacementTier: VerificationTier.verification_tier_verified,
+        snapshotState: "current"
+      })
+    ).toEqual([]);
+  });
+});
+
+function facts(overrides: Partial<ProviderVerificationFacts> = {}): ProviderVerificationFacts {
+  return {
+    attestations: [],
+    graces: [],
+    snapshot: null,
+    completeness: { attestations: true, graces: true, snapshot: true },
+    observedAt,
+    observedHeight: "100",
+    ...overrides
+  };
+}
+
+function attestation(tier: VerificationTier): AttestationRecord {
+  return {
+    provider: "akash1provider",
+    auditor: "akash1auditor",
+    tier,
+    capabilities: [],
+    evidenceHash: new Uint8Array(),
+    fee: undefined,
+    feeStatus: 0,
+    createdAt: undefined,
+    expiresAt: undefined,
+    status: AttestationStatus.attestation_status_valid,
+    voidedReason: 0,
+    deposit: undefined,
+    depositStatus: 0,
+    auditEscrowId: 0n,
+    faultAttribution: 0
+  };
+}
+
+function grace(preservedTier: VerificationTier): ProviderVerificationGraceRecord {
+  return {
+    id: 1n,
+    provider: "akash1provider",
+    preservedTier,
+    sourceDiscrepancyIds: [],
+    startedAt: undefined,
+    expiresAt: undefined,
+    status: VerificationGraceStatus.verification_grace_status_active
+  };
+}
+
+function snapshot(overrides: Partial<ProviderSnapshotRecord> = {}): ProviderSnapshotRecord {
+  return {
+    provider: "akash1provider",
+    snapshotHash: new Uint8Array(),
+    resourceSummary: undefined,
+    postedAt: undefined,
+    snapshotTimestamp: undefined,
+    complianceDeadline: new Date("2026-08-25T12:00:00.000Z"),
+    suspended: false,
+    ...overrides
+  };
+}

--- a/packages/provider-verification/src/providerTierState.ts
+++ b/packages/provider-verification/src/providerTierState.ts
@@ -1,0 +1,32 @@
+import { VerificationTier } from "@akashnetwork/chain-sdk/private-types/akash.v1";
+
+import { deriveProviderVerificationSummary, type ProviderVerificationFacts, type SnapshotComplianceState } from "./providerVerification.js";
+
+export type ProviderTierDemotionChange = "tier_gate" | "snapshot_eligibility";
+
+export interface ProviderTierState {
+  effectiveTier: VerificationTier;
+  maxPlacementTier: VerificationTier;
+  snapshotState: SnapshotComplianceState;
+}
+
+export function deriveProviderTierState(facts: ProviderVerificationFacts): ProviderTierState {
+  const summary = deriveProviderVerificationSummary(facts);
+  const maxPlacementTier =
+    summary.tierGateTier < VerificationTier.verification_tier_verified || summary.snapshotState === "current"
+      ? summary.tierGateTier
+      : VerificationTier.verification_tier_identified;
+
+  return {
+    effectiveTier: summary.tierGateTier,
+    maxPlacementTier,
+    snapshotState: summary.snapshotState
+  };
+}
+
+export function detectProviderTierDemotion(previous: ProviderTierState, current: ProviderTierState): ProviderTierDemotionChange[] {
+  const changes: ProviderTierDemotionChange[] = [];
+  if (current.effectiveTier < previous.effectiveTier) changes.push("tier_gate");
+  if (current.maxPlacementTier < previous.maxPlacementTier) changes.push("snapshot_eligibility");
+  return changes;
+}

--- a/packages/provider-verification/src/providerVerification.spec.ts
+++ b/packages/provider-verification/src/providerVerification.spec.ts
@@ -1,0 +1,267 @@
+import type { AttestationRecord, ProviderVerificationGraceRecord, VerificationRequirement } from "@akashnetwork/chain-sdk/private-types/akash.v1";
+import {
+  AttestationStatus,
+  AuditorSelectionMode,
+  CapabilityFlag,
+  VerificationGraceStatus,
+  VerificationTier
+} from "@akashnetwork/chain-sdk/private-types/akash.v1";
+import { describe, expect, it } from "vitest";
+
+import { deriveProviderVerificationSummary, evaluateProviderVerification, type ProviderVerificationFacts } from "./providerVerification.js";
+
+const observedAt = new Date("2026-08-24T12:00:00.000Z");
+
+describe("deriveProviderVerificationSummary", () => {
+  it("matches the market keeper by using stored-valid attestations regardless of auditor lifecycle or expires_at", () => {
+    const facts = createFacts({
+      attestations: [
+        createAttestation({ auditor: "auditor-b", tier: VerificationTier.verification_tier_verified, capabilities: [CapabilityFlag.capability_bare_metal] }),
+        createAttestation({
+          auditor: "auditor-a",
+          tier: VerificationTier.verification_tier_established,
+          capabilities: [CapabilityFlag.capability_persistent_storage]
+        }),
+        createAttestation({
+          auditor: "auditor-c",
+          status: AttestationStatus.attestation_status_expired,
+          tier: VerificationTier.verification_tier_trusted,
+          capabilities: [CapabilityFlag.capability_confidential_computing]
+        })
+      ]
+    });
+
+    expect(deriveProviderVerificationSummary(facts)).toMatchObject({
+      bestStatusValidTier: VerificationTier.verification_tier_established,
+      tierGateTier: VerificationTier.verification_tier_established,
+      capabilities: [CapabilityFlag.capability_persistent_storage, CapabilityFlag.capability_bare_metal],
+      validAttestationCount: 2,
+      validAuditors: ["auditor-a", "auditor-b"]
+    });
+  });
+
+  it("uses active grace only for the tier gate", () => {
+    const facts = createFacts({
+      attestations: [createAttestation({ tier: VerificationTier.verification_tier_identified, capabilities: [CapabilityFlag.capability_persistent_storage] })],
+      graces: [createGrace(VerificationTier.verification_tier_established)]
+    });
+
+    expect(deriveProviderVerificationSummary(facts)).toMatchObject({
+      bestStatusValidTier: VerificationTier.verification_tier_identified,
+      tierGateTier: VerificationTier.verification_tier_established,
+      capabilities: [CapabilityFlag.capability_persistent_storage]
+    });
+  });
+});
+
+describe("evaluateProviderVerification", () => {
+  it("does not enforce a vacuous requirement", () => {
+    const result = evaluateProviderVerification({
+      moduleActive: null,
+      requirement: createRequirement({ minTier: VerificationTier.verification_tier_unspecified }),
+      facts: createFacts()
+    });
+
+    expect(result.outcome).toBe("pass");
+  });
+
+  it("does not enforce verification while the chain module is inactive", () => {
+    const result = evaluateProviderVerification({
+      moduleActive: false,
+      requirement: createRequirement({ minTier: VerificationTier.verification_tier_trusted }),
+      facts: createFacts({ completeness: { attestations: false, graces: false, snapshot: false } })
+    });
+
+    expect(result.outcome).toBe("pass");
+  });
+
+  it("returns unknown instead of excluding a provider when required facts are incomplete", () => {
+    const result = evaluateProviderVerification({
+      moduleActive: true,
+      requirement: createRequirement({ minTier: VerificationTier.verification_tier_verified }),
+      facts: createFacts({ completeness: { attestations: true, graces: false, snapshot: false } })
+    });
+
+    expect(result).toMatchObject({ outcome: "unknown", incompleteFacts: ["graces", "snapshot"] });
+  });
+
+  it("checks snapshot before tier and retains the full failure set", () => {
+    const result = evaluateProviderVerification({
+      moduleActive: true,
+      requirement: createRequirement({
+        minTier: VerificationTier.verification_tier_verified,
+        requiredCapabilities: [CapabilityFlag.capability_persistent_storage],
+        minAuditorCount: 2
+      }),
+      facts: createFacts()
+    });
+
+    expect(result.outcome).toBe("fail");
+    if (result.outcome !== "fail") throw new Error("expected failure");
+    expect(result.firstFailure.code).toBe("snapshot_not_posted");
+    expect(result.failures.map(failure => failure.code)).toEqual([
+      "snapshot_not_posted",
+      "insufficient_tier",
+      "missing_capability",
+      "insufficient_auditor_count"
+    ]);
+  });
+
+  it("matches capability union and tier-qualified auditor semantics", () => {
+    const result = evaluateProviderVerification({
+      moduleActive: true,
+      requirement: createRequirement({
+        minTier: VerificationTier.verification_tier_verified,
+        requiredCapabilities: [CapabilityFlag.capability_persistent_storage, CapabilityFlag.capability_bare_metal],
+        requiredAuditors: ["auditor-l2", "auditor-l1"],
+        auditorMode: AuditorSelectionMode.auditor_selection_mode_any,
+        minAuditorCount: 1
+      }),
+      facts: createFacts({
+        attestations: [
+          createAttestation({ auditor: "auditor-l2", tier: VerificationTier.verification_tier_verified, capabilities: [CapabilityFlag.capability_bare_metal] }),
+          createAttestation({
+            auditor: "auditor-l1",
+            tier: VerificationTier.verification_tier_identified,
+            capabilities: [CapabilityFlag.capability_persistent_storage]
+          })
+        ],
+        snapshot: { complianceDeadline: new Date("2026-08-25T12:00:00.000Z"), suspended: false }
+      })
+    });
+
+    expect(result).toMatchObject({ outcome: "pass", qualifiedAuditors: ["auditor-l2"] });
+  });
+
+  it("treats unspecified auditor mode as any and reports all missing auditors for all mode", () => {
+    const facts = createFacts({ attestations: [createAttestation({ auditor: "auditor-a" })] });
+    const anyResult = evaluateProviderVerification({
+      moduleActive: true,
+      requirement: createRequirement({ requiredAuditors: ["auditor-a", "auditor-b"] }),
+      facts
+    });
+    const allResult = evaluateProviderVerification({
+      moduleActive: true,
+      requirement: createRequirement({ requiredAuditors: ["auditor-a", "auditor-b"], auditorMode: AuditorSelectionMode.auditor_selection_mode_all }),
+      facts
+    });
+
+    expect(anyResult.outcome).toBe("pass");
+    expect(allResult).toMatchObject({
+      outcome: "fail",
+      firstFailure: { code: "required_auditor_not_found", missing: ["auditor-b"] }
+    });
+  });
+
+  it("does not add a provider-bond check that the market BidFilter does not perform", () => {
+    const result = evaluateProviderVerification({
+      moduleActive: true,
+      requirement: createRequirement({ minTier: VerificationTier.verification_tier_verified }),
+      facts: createFacts({
+        attestations: [createAttestation({ tier: VerificationTier.verification_tier_verified })],
+        snapshot: { complianceDeadline: new Date("2026-08-25T12:00:00.000Z"), suspended: false }
+      })
+    });
+
+    expect(result.outcome).toBe("pass");
+  });
+
+  it("uses the snapshot compliance deadline even before suspension is persisted", () => {
+    const result = evaluateProviderVerification({
+      moduleActive: true,
+      requirement: createRequirement({ minTier: VerificationTier.verification_tier_verified }),
+      facts: createFacts({
+        attestations: [createAttestation({ tier: VerificationTier.verification_tier_verified })],
+        snapshot: { complianceDeadline: observedAt, suspended: false }
+      })
+    });
+
+    expect(result).toMatchObject({ outcome: "fail", firstFailure: { code: "snapshot_stale" } });
+  });
+
+  it("does not let an active grace bypass L2 snapshot suspension", () => {
+    const result = evaluateProviderVerification({
+      moduleActive: true,
+      requirement: createRequirement({ minTier: VerificationTier.verification_tier_verified }),
+      facts: createFacts({
+        graces: [createGrace(VerificationTier.verification_tier_verified)],
+        snapshot: { complianceDeadline: new Date("2026-08-25T12:00:00.000Z"), suspended: true }
+      })
+    });
+
+    expect(result).toMatchObject({
+      outcome: "fail",
+      firstFailure: { code: "snapshot_suspended" },
+      failures: [{ code: "snapshot_suspended" }]
+    });
+  });
+
+  it("keeps eligibility when a partial bond slash leaves the attestation valid", () => {
+    const result = evaluateProviderVerification({
+      moduleActive: true,
+      requirement: createRequirement({ minTier: VerificationTier.verification_tier_verified }),
+      facts: createFacts({
+        attestations: [createAttestation({ tier: VerificationTier.verification_tier_verified })],
+        snapshot: { complianceDeadline: new Date("2026-08-25T12:00:00.000Z"), suspended: false }
+      })
+    });
+
+    expect(result.outcome).toBe("pass");
+  });
+});
+
+function createFacts(overrides: Partial<ProviderVerificationFacts> = {}): ProviderVerificationFacts {
+  return {
+    attestations: [],
+    graces: [],
+    snapshot: null,
+    completeness: { attestations: true, graces: true, snapshot: true },
+    observedAt,
+    observedHeight: "100",
+    ...overrides
+  };
+}
+
+function createAttestation(overrides: Partial<AttestationRecord> = {}): AttestationRecord {
+  return {
+    provider: "provider",
+    auditor: "auditor",
+    tier: VerificationTier.verification_tier_identified,
+    capabilities: [],
+    evidenceHash: new Uint8Array(),
+    fee: undefined,
+    feeStatus: 0,
+    createdAt: new Date("2025-01-01T00:00:00.000Z"),
+    expiresAt: new Date("2025-01-02T00:00:00.000Z"),
+    status: AttestationStatus.attestation_status_valid,
+    voidedReason: 0,
+    deposit: undefined,
+    depositStatus: 0,
+    auditEscrowId: 1n,
+    faultAttribution: 0,
+    ...overrides
+  };
+}
+
+function createGrace(preservedTier: VerificationTier): ProviderVerificationGraceRecord {
+  return {
+    id: 1n,
+    provider: "provider",
+    preservedTier,
+    sourceDiscrepancyIds: [1n],
+    startedAt: observedAt,
+    expiresAt: new Date("2026-08-25T12:00:00.000Z"),
+    status: VerificationGraceStatus.verification_grace_status_active
+  };
+}
+
+function createRequirement(overrides: Partial<VerificationRequirement> = {}): VerificationRequirement {
+  return {
+    minTier: VerificationTier.verification_tier_identified,
+    requiredCapabilities: [],
+    requiredAuditors: [],
+    auditorMode: AuditorSelectionMode.auditor_selection_mode_unspecified,
+    minAuditorCount: 0,
+    ...overrides
+  };
+}

--- a/packages/provider-verification/src/providerVerification.ts
+++ b/packages/provider-verification/src/providerVerification.ts
@@ -1,0 +1,191 @@
+import type {
+  AttestationRecord,
+  ProviderSnapshotRecord,
+  ProviderVerificationGraceRecord,
+  VerificationRequirement
+} from "@akashnetwork/chain-sdk/private-types/akash.v1";
+import {
+  AttestationStatus,
+  AuditorSelectionMode,
+  CapabilityFlag,
+  VerificationGraceStatus,
+  VerificationTier
+} from "@akashnetwork/chain-sdk/private-types/akash.v1";
+
+type AttestationFact = Pick<AttestationRecord, "auditor" | "capabilities" | "status" | "tier">;
+type GraceFact = Pick<ProviderVerificationGraceRecord, "preservedTier" | "status">;
+type SnapshotFact = Pick<ProviderSnapshotRecord, "complianceDeadline" | "suspended">;
+
+export interface ProviderVerificationCompleteness {
+  attestations: boolean;
+  graces: boolean;
+  snapshot: boolean;
+}
+
+export interface ProviderVerificationFacts {
+  attestations: readonly AttestationFact[];
+  graces: readonly GraceFact[];
+  snapshot: SnapshotFact | null;
+  completeness: ProviderVerificationCompleteness;
+  observedAt: Date;
+  observedHeight: string;
+}
+
+export type SnapshotComplianceState = "unknown" | "not_posted" | "current" | "stale" | "suspended";
+
+export interface ProviderVerificationSummary {
+  bestStatusValidTier: VerificationTier;
+  tierGateTier: VerificationTier;
+  capabilities: CapabilityFlag[];
+  validAttestationCount: number;
+  validAuditors: string[];
+  snapshotState: SnapshotComplianceState;
+  observedHeight: string;
+}
+
+export type ProviderVerificationFailure =
+  | { code: "snapshot_not_posted" }
+  | { code: "snapshot_suspended" }
+  | { code: "snapshot_stale" }
+  | { code: "insufficient_tier"; actual: VerificationTier; required: VerificationTier }
+  | { code: "missing_capability"; capability: CapabilityFlag }
+  | { code: "insufficient_auditor_count"; actual: number; required: number }
+  | { code: "required_auditor_not_found"; mode: AuditorSelectionMode; missing: string[] };
+
+interface EvaluationBase {
+  summary: ProviderVerificationSummary;
+  qualifiedAuditors: string[];
+}
+
+export type ProviderVerificationEvaluation =
+  | (EvaluationBase & { outcome: "pass"; firstFailure: null; failures: [] })
+  | (EvaluationBase & {
+      outcome: "fail";
+      firstFailure: ProviderVerificationFailure;
+      failures: ProviderVerificationFailure[];
+    })
+  | (EvaluationBase & { outcome: "unknown"; firstFailure: null; failures: []; incompleteFacts: Array<keyof ProviderVerificationCompleteness | "params"> });
+
+interface EvaluateProviderVerificationInput {
+  moduleActive: boolean | null;
+  requirement: VerificationRequirement | null;
+  facts: ProviderVerificationFacts;
+}
+
+export function deriveProviderVerificationSummary(facts: ProviderVerificationFacts): ProviderVerificationSummary {
+  const validAttestations = facts.attestations.filter(attestation => attestation.status === AttestationStatus.attestation_status_valid);
+  const bestStatusValidTier = validAttestations.reduce(
+    (best, attestation) => betterTier(best, attestation.tier),
+    VerificationTier.verification_tier_unspecified
+  );
+  const tierGateTier = facts.graces
+    .filter(grace => grace.status === VerificationGraceStatus.verification_grace_status_active)
+    .reduce((best, grace) => betterTier(best, grace.preservedTier), bestStatusValidTier);
+  const capabilities = uniqueSorted(
+    validAttestations.flatMap(attestation => attestation.capabilities).filter(capability => capability !== CapabilityFlag.capability_unspecified)
+  );
+  const validAuditors = uniqueSorted(validAttestations.map(attestation => attestation.auditor).filter(Boolean));
+
+  return {
+    bestStatusValidTier,
+    tierGateTier,
+    capabilities,
+    validAttestationCount: validAttestations.length,
+    validAuditors,
+    snapshotState: deriveSnapshotState(facts),
+    observedHeight: facts.observedHeight
+  };
+}
+
+export function evaluateProviderVerification({ moduleActive, requirement, facts }: EvaluateProviderVerificationInput): ProviderVerificationEvaluation {
+  const summary = deriveProviderVerificationSummary(facts);
+  const noRequirement = !requirement || requirement.minTier === VerificationTier.verification_tier_unspecified;
+
+  if (noRequirement || moduleActive === false) {
+    return pass(summary, []);
+  }
+
+  const incompleteFacts: Array<keyof ProviderVerificationCompleteness | "params"> = [];
+  if (moduleActive === null) incompleteFacts.push("params");
+  if (!facts.completeness.attestations) incompleteFacts.push("attestations");
+  if (!facts.completeness.graces) incompleteFacts.push("graces");
+  if (requiresSnapshot(requirement.minTier) && !facts.completeness.snapshot) incompleteFacts.push("snapshot");
+
+  const qualifiedAuditors = qualifiedAuditorsForTier(facts.attestations, requirement.minTier);
+  if (incompleteFacts.length > 0) {
+    return { outcome: "unknown", firstFailure: null, failures: [], incompleteFacts, qualifiedAuditors, summary };
+  }
+
+  const failures: ProviderVerificationFailure[] = [];
+  if (requiresSnapshot(requirement.minTier)) {
+    if (summary.snapshotState === "not_posted") failures.push({ code: "snapshot_not_posted" });
+    if (summary.snapshotState === "suspended") failures.push({ code: "snapshot_suspended" });
+    if (summary.snapshotState === "stale") failures.push({ code: "snapshot_stale" });
+  }
+
+  if (summary.tierGateTier < requirement.minTier) {
+    failures.push({ code: "insufficient_tier", actual: summary.tierGateTier, required: requirement.minTier });
+  }
+
+  for (const capability of requirement.requiredCapabilities) {
+    if (capability !== CapabilityFlag.capability_unspecified && !summary.capabilities.includes(capability)) {
+      failures.push({ code: "missing_capability", capability });
+    }
+  }
+
+  if (qualifiedAuditors.length < requirement.minAuditorCount) {
+    failures.push({ code: "insufficient_auditor_count", actual: qualifiedAuditors.length, required: requirement.minAuditorCount });
+  }
+
+  const requiredAuditorFailure = evaluateRequiredAuditors(requirement, qualifiedAuditors);
+  if (requiredAuditorFailure) failures.push(requiredAuditorFailure);
+
+  return failures.length === 0 ? pass(summary, qualifiedAuditors) : { outcome: "fail", firstFailure: failures[0], failures, qualifiedAuditors, summary };
+}
+
+function deriveSnapshotState(facts: ProviderVerificationFacts): SnapshotComplianceState {
+  if (!facts.completeness.snapshot) return "unknown";
+  if (!facts.snapshot) return "not_posted";
+  if (facts.snapshot.suspended) return "suspended";
+  if (!facts.snapshot.complianceDeadline || facts.snapshot.complianceDeadline <= facts.observedAt) return "stale";
+  return "current";
+}
+
+function requiresSnapshot(tier: VerificationTier): boolean {
+  return tier >= VerificationTier.verification_tier_verified;
+}
+
+function betterTier(left: VerificationTier, right: VerificationTier): VerificationTier {
+  return right > left ? right : left;
+}
+
+function qualifiedAuditorsForTier(attestations: readonly AttestationFact[], minTier: VerificationTier): string[] {
+  return uniqueSorted(
+    attestations
+      .filter(attestation => attestation.status === AttestationStatus.attestation_status_valid && attestation.tier >= minTier)
+      .map(attestation => attestation.auditor)
+      .filter(Boolean)
+  );
+}
+
+function evaluateRequiredAuditors(
+  requirement: VerificationRequirement,
+  qualifiedAuditors: readonly string[]
+): Extract<ProviderVerificationFailure, { code: "required_auditor_not_found" }> | null {
+  if (requirement.requiredAuditors.length === 0) return null;
+
+  const available = new Set(qualifiedAuditors);
+  const missing = requirement.requiredAuditors.filter(auditor => !available.has(auditor));
+  const allRequired = requirement.auditorMode === AuditorSelectionMode.auditor_selection_mode_all;
+  const satisfied = allRequired ? missing.length === 0 : requirement.requiredAuditors.some(auditor => available.has(auditor));
+
+  return satisfied ? null : { code: "required_auditor_not_found", mode: requirement.auditorMode, missing };
+}
+
+function uniqueSorted<T extends number | string>(values: readonly T[]): T[] {
+  return [...new Set(values)].sort((left, right) => (left < right ? -1 : left > right ? 1 : 0));
+}
+
+function pass(summary: ProviderVerificationSummary, qualifiedAuditors: string[]): ProviderVerificationEvaluation {
+  return { outcome: "pass", firstFailure: null, failures: [], qualifiedAuditors, summary };
+}

--- a/packages/provider-verification/src/providerVerificationQueryClient.spec.ts
+++ b/packages/provider-verification/src/providerVerificationQueryClient.spec.ts
@@ -1,0 +1,176 @@
+import { SDKError, SDKErrorCode } from "@akashnetwork/chain-sdk/web";
+import { describe, expect, it, vi } from "vitest";
+
+import { type ProviderQueries, ProviderVerificationQueryClient, type VerificationQueries } from "./providerVerificationQueryClient.js";
+
+const height = "1234";
+const options = { headers: { "x-cosmos-block-height": height } };
+
+describe(ProviderVerificationQueryClient.name, () => {
+  it("pins and paginates global queries at one height", async () => {
+    const getAuditors = vi
+      .fn()
+      .mockResolvedValueOnce({ auditors: [{ address: "akash1auditor1" }], pagination: { nextKey: Uint8Array.from([1]), total: 0n } })
+      .mockResolvedValueOnce({ auditors: [{ address: "akash1auditor2" }], pagination: { nextKey: new Uint8Array(), total: 0n } });
+    const getDiscrepancies = vi.fn().mockResolvedValue({ discrepancies: [], pagination: { nextKey: new Uint8Array(), total: 0n } });
+    const getParams = vi.fn().mockResolvedValue({ params: { verificationModuleActive: true } });
+    const client = createClient({ getAuditors, getDiscrepancies, getParams });
+
+    const result = await client.getGlobalState(height);
+
+    expect(result).toMatchObject({
+      auditors: [{ address: "akash1auditor1" }, { address: "akash1auditor2" }],
+      discrepancies: [],
+      observedHeight: height,
+      params: { verificationModuleActive: true }
+    });
+    expect(getParams).toHaveBeenCalledWith({}, options);
+    expect(getAuditors).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ pagination: expect.objectContaining({ key: new Uint8Array(), limit: 100n }) }),
+      options
+    );
+    expect(getAuditors).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ pagination: expect.objectContaining({ key: Uint8Array.from([1]), limit: 100n }) }),
+      options
+    );
+    expect(getDiscrepancies).toHaveBeenCalledWith(expect.any(Object), options);
+  });
+
+  it("returns one height-consistent provider state and maps missing optional records to null", async () => {
+    const getProviderAttestations = vi
+      .fn()
+      .mockResolvedValue({ attestations: [{ auditor: "akash1auditor" }], pagination: { nextKey: new Uint8Array(), total: 0n } });
+    const getProviderAuditEscrows = vi.fn().mockResolvedValue({ escrows: [], pagination: { nextKey: new Uint8Array(), total: 0n } });
+    const getProviderBond = vi.fn().mockResolvedValue({
+      bond: { provider: "akash1provider" },
+      requiredForCurrentTier: { amount: "500", denom: "uakt" }
+    });
+    const getProviderVerificationGrace = vi.fn().mockResolvedValue({ grace: undefined });
+    const getProviderSnapshot = vi.fn().mockResolvedValue({ snapshot: { provider: "akash1provider" } });
+    const getProviderMaintenances = vi.fn().mockResolvedValue({ maintenance: [], pagination: { nextKey: new Uint8Array(), total: 0n } });
+    const client = createClient(
+      {
+        getProviderAttestations,
+        getProviderAuditEscrows,
+        getProviderBond,
+        getProviderVerificationGrace,
+        getProviderSnapshot
+      },
+      { getProviderMaintenances }
+    );
+
+    const result = await client.getProviderState("akash1provider", height);
+
+    expect(result).toMatchObject({
+      provider: "akash1provider",
+      attestations: [{ auditor: "akash1auditor" }],
+      auditEscrows: [],
+      bond: { provider: "akash1provider" },
+      requiredBondForCurrentTier: { amount: "500", denom: "uakt" },
+      grace: null,
+      snapshot: { provider: "akash1provider" },
+      maintenances: [],
+      observedHeight: height
+    });
+    for (const query of [
+      getProviderAttestations,
+      getProviderAuditEscrows,
+      getProviderBond,
+      getProviderVerificationGrace,
+      getProviderSnapshot,
+      getProviderMaintenances
+    ]) {
+      expect(query.mock.calls[0].at(-1)).toEqual(options);
+    }
+  });
+
+  it("does not hide transport failures", async () => {
+    const client = createClient({ getProviderBond: vi.fn().mockRejectedValue(new SDKError("unavailable", SDKErrorCode.Unavailable)) });
+
+    await expect(client.getProviderState("akash1provider", height)).rejects.toMatchObject({ code: SDKErrorCode.Unavailable });
+  });
+
+  it("queries only placement facts for provider screening", async () => {
+    const getProviderAttestations = vi
+      .fn()
+      .mockResolvedValue({ attestations: [{ auditor: "akash1auditor" }], pagination: { nextKey: new Uint8Array(), total: 0n } });
+    const getProviderVerificationGrace = vi.fn().mockResolvedValue({ grace: undefined });
+    const getProviderSnapshot = vi.fn().mockResolvedValue({ snapshot: { provider: "akash1provider" } });
+    const getProviderAuditEscrows = vi.fn().mockRejectedValue(new SDKError("unavailable", SDKErrorCode.Unavailable));
+    const getProviderBond = vi.fn();
+    const getProviderMaintenances = vi.fn();
+    const client = createClient(
+      { getProviderAttestations, getProviderVerificationGrace, getProviderSnapshot, getProviderAuditEscrows, getProviderBond },
+      { getProviderMaintenances }
+    );
+
+    await expect(client.getProviderScreeningState("akash1provider", height)).resolves.toMatchObject({
+      provider: "akash1provider",
+      attestations: [{ auditor: "akash1auditor" }],
+      grace: null,
+      snapshot: { provider: "akash1provider" },
+      observedHeight: height
+    });
+    expect(getProviderAuditEscrows).not.toHaveBeenCalled();
+    expect(getProviderBond).not.toHaveBeenCalled();
+    expect(getProviderMaintenances).not.toHaveBeenCalled();
+  });
+
+  it("maps a missing provider bond response to absent bond facts", async () => {
+    const client = createClient({ getProviderBond: vi.fn().mockRejectedValue(new SDKError("missing", SDKErrorCode.NotFound)) });
+
+    const result = await client.getProviderState("akash1provider", height);
+
+    expect(result.bond).toBeNull();
+    expect(result.requiredBondForCurrentTier).toBeNull();
+  });
+
+  it("pins singular reconciliation queries and preserves uint64 identities", async () => {
+    const getAuditEscrow = vi.fn().mockResolvedValue({ escrow: { id: 9007199254740993n } });
+    const getDiscrepancy = vi.fn().mockResolvedValue({ discrepancy: { id: 9007199254740995n } });
+    const getAuditor = vi.fn().mockResolvedValue({ auditor: { address: "akash1auditor" } });
+    const client = createClient({ getAuditEscrow, getAuditor, getDiscrepancy });
+
+    await expect(client.getAuditEscrow("9007199254740993", height)).resolves.toMatchObject({ id: 9007199254740993n });
+    await expect(client.getDiscrepancy("9007199254740995", height)).resolves.toMatchObject({ id: 9007199254740995n });
+    await expect(client.getAuditor("akash1auditor", height)).resolves.toMatchObject({ address: "akash1auditor" });
+
+    expect(getAuditEscrow).toHaveBeenCalledWith({ id: 9007199254740993n }, options);
+    expect(getDiscrepancy).toHaveBeenCalledWith({ id: 9007199254740995n }, options);
+    expect(getAuditor).toHaveBeenCalledWith({ auditor: "akash1auditor" }, options);
+  });
+
+  it("rejects malformed uint64 identifiers before calling the SDK", async () => {
+    const getAuditEscrow = vi.fn();
+    const client = createClient({ getAuditEscrow });
+
+    await expect(client.getAuditEscrow("-1", height)).rejects.toThrow("Invalid uint64 identifier");
+    expect(getAuditEscrow).not.toHaveBeenCalled();
+  });
+});
+
+function createClient(verification: Partial<VerificationQueries> = {}, provider: Partial<ProviderQueries> = {}) {
+  const emptyPage = { pagination: { nextKey: new Uint8Array(), total: 0n } };
+  const verificationQueries = {
+    getAuditors: vi.fn().mockResolvedValue({ auditors: [], ...emptyPage }),
+    getAuditor: vi.fn().mockResolvedValue({ auditor: undefined }),
+    getAuditEscrow: vi.fn().mockResolvedValue({ escrow: undefined }),
+    getDiscrepancy: vi.fn().mockResolvedValue({ discrepancy: undefined }),
+    getDiscrepancies: vi.fn().mockResolvedValue({ discrepancies: [], ...emptyPage }),
+    getParams: vi.fn().mockResolvedValue({ params: undefined }),
+    getProviderAttestations: vi.fn().mockResolvedValue({ attestations: [], ...emptyPage }),
+    getProviderAuditEscrows: vi.fn().mockResolvedValue({ escrows: [], ...emptyPage }),
+    getProviderBond: vi.fn().mockResolvedValue({ bond: undefined, requiredForCurrentTier: undefined }),
+    getProviderSnapshot: vi.fn().mockResolvedValue({ snapshot: undefined }),
+    getProviderVerificationGrace: vi.fn().mockResolvedValue({ grace: undefined }),
+    ...verification
+  } as VerificationQueries;
+  const providerQueries = {
+    getProviderMaintenances: vi.fn().mockResolvedValue({ maintenance: [], ...emptyPage }),
+    ...provider
+  } as ProviderQueries;
+
+  return new ProviderVerificationQueryClient(verificationQueries, providerQueries);
+}

--- a/packages/provider-verification/src/providerVerificationQueryClient.ts
+++ b/packages/provider-verification/src/providerVerificationQueryClient.ts
@@ -1,0 +1,230 @@
+import type {
+  AttestationRecord,
+  AuditEscrowRecord,
+  AuditorRecord,
+  DiscrepancyEvent,
+  ProviderBondRecord,
+  ProviderSnapshotRecord,
+  ProviderVerificationGraceRecord,
+  Verification_Params
+} from "@akashnetwork/chain-sdk/private-types/akash.v1";
+import { AttestationStatus, AuditEscrowStatus, AuditorStatus, DiscrepancyStatus } from "@akashnetwork/chain-sdk/private-types/akash.v1";
+import type { ProviderMaintenanceWithStatus } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
+import { ProviderMaintenanceStatus } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
+import type { Coin } from "@akashnetwork/chain-sdk/private-types/cosmos.v1beta1";
+import { createChainNodeWebSDK, SDKError, SDKErrorCode } from "@akashnetwork/chain-sdk/web";
+
+type ChainNodeWebSDK = ReturnType<typeof createChainNodeWebSDK>;
+export type VerificationQueries = Pick<
+  ChainNodeWebSDK["akash"]["verification"]["v1"],
+  | "getAuditors"
+  | "getAuditor"
+  | "getAuditEscrow"
+  | "getDiscrepancy"
+  | "getDiscrepancies"
+  | "getParams"
+  | "getProviderAttestations"
+  | "getProviderAuditEscrows"
+  | "getProviderBond"
+  | "getProviderSnapshot"
+  | "getProviderVerificationGrace"
+>;
+export type ProviderQueries = Pick<ChainNodeWebSDK["akash"]["provider"]["v1beta4"], "getProviderMaintenances">;
+
+interface Pagination {
+  nextKey: Uint8Array;
+}
+
+export interface ProviderVerificationGlobalState {
+  params: Verification_Params | null;
+  auditors: AuditorRecord[];
+  discrepancies: DiscrepancyEvent[];
+  observedHeight: string;
+}
+
+export interface ProviderVerificationScreeningState {
+  provider: string;
+  attestations: AttestationRecord[];
+  grace: ProviderVerificationGraceRecord | null;
+  snapshot: ProviderSnapshotRecord | null;
+  observedHeight: string;
+}
+
+export interface ProviderVerificationProviderState extends ProviderVerificationScreeningState {
+  auditEscrows: AuditEscrowRecord[];
+  bond: ProviderBondRecord | null;
+  requiredBondForCurrentTier: Coin | null;
+  maintenances: ProviderMaintenanceWithStatus[];
+}
+
+export class ProviderVerificationQueryClient {
+  constructor(
+    private readonly verification: VerificationQueries,
+    private readonly provider: ProviderQueries
+  ) {}
+
+  async getAuditor(auditor: string, height: string): Promise<AuditorRecord | null> {
+    return optionalRecord(
+      () => this.verification.getAuditor({ auditor }, queryOptions(height)),
+      response => response.auditor
+    );
+  }
+
+  async getAuditEscrow(id: string, height: string): Promise<AuditEscrowRecord | null> {
+    return optionalRecord(
+      () => this.verification.getAuditEscrow({ id: parseUint64(id) }, queryOptions(height)),
+      response => response.escrow
+    );
+  }
+
+  async getDiscrepancy(id: string, height: string): Promise<DiscrepancyEvent | null> {
+    return optionalRecord(
+      () => this.verification.getDiscrepancy({ id: parseUint64(id) }, queryOptions(height)),
+      response => response.discrepancy
+    );
+  }
+
+  async getGlobalState(height: string): Promise<ProviderVerificationGlobalState> {
+    const options = queryOptions(height);
+    const [paramsResponse, auditors, discrepancies] = await Promise.all([
+      this.verification.getParams({}, options),
+      collectPages(async pagination => {
+        const response = await this.verification.getAuditors({ pagination, statusFilter: AuditorStatus.auditor_status_unspecified }, options);
+
+        return { items: response.auditors, pagination: response.pagination };
+      }),
+      collectPages(async pagination => {
+        const response = await this.verification.getDiscrepancies({ pagination, statusFilter: DiscrepancyStatus.discrepancy_status_unspecified }, options);
+
+        return { items: response.discrepancies, pagination: response.pagination };
+      })
+    ]);
+
+    return {
+      params: paramsResponse.params ?? null,
+      auditors,
+      discrepancies,
+      observedHeight: height
+    };
+  }
+
+  async getProviderState(provider: string, height: string): Promise<ProviderVerificationProviderState> {
+    const options = queryOptions(height);
+    const [screening, auditEscrows, bondResponse, maintenances] = await Promise.all([
+      this.getProviderScreeningState(provider, height),
+      collectPages(async pagination => {
+        const response = await this.verification.getProviderAuditEscrows(
+          { pagination, provider, statusFilter: AuditEscrowStatus.audit_escrow_status_unspecified },
+          options
+        );
+
+        return { items: response.escrows, pagination: response.pagination };
+      }),
+      optionalResponse(() => this.verification.getProviderBond({ provider }, options)),
+      collectPages(async pagination => {
+        const response = await this.provider.getProviderMaintenances(
+          { pagination, provider, statusFilter: ProviderMaintenanceStatus.provider_maintenance_status_unspecified },
+          options
+        );
+
+        return { items: response.maintenance, pagination: response.pagination };
+      })
+    ]);
+
+    return {
+      ...screening,
+      auditEscrows,
+      bond: bondResponse?.bond ?? null,
+      requiredBondForCurrentTier: bondResponse?.requiredForCurrentTier ?? null,
+      maintenances
+    };
+  }
+
+  async getProviderScreeningState(provider: string, height: string): Promise<ProviderVerificationScreeningState> {
+    const options = queryOptions(height);
+    const [attestations, grace, snapshot] = await Promise.all([
+      collectPages(async pagination => {
+        const response = await this.verification.getProviderAttestations(
+          { pagination, provider, statusFilter: AttestationStatus.attestation_status_unspecified },
+          options
+        );
+
+        return { items: response.attestations, pagination: response.pagination };
+      }),
+      optionalRecord(
+        () => this.verification.getProviderVerificationGrace({ provider }, options),
+        response => response.grace
+      ),
+      optionalRecord(
+        () => this.verification.getProviderSnapshot({ provider }, options),
+        response => response.snapshot
+      )
+    ]);
+
+    return {
+      provider,
+      attestations,
+      grace,
+      snapshot,
+      observedHeight: height
+    };
+  }
+}
+
+export function createProviderVerificationQueryClient(baseUrl: string): ProviderVerificationQueryClient {
+  const sdk = createChainNodeWebSDK({ query: { baseUrl } });
+  return new ProviderVerificationQueryClient(sdk.akash.verification.v1, sdk.akash.provider.v1beta4);
+}
+
+function queryOptions(height: string) {
+  return { headers: { "x-cosmos-block-height": height } };
+}
+
+async function collectPages<T>(
+  fetchPage: (pagination: ReturnType<typeof pageRequest>) => Promise<{ items: T[]; pagination: Pagination | undefined }>
+): Promise<T[]> {
+  const items: T[] = [];
+  let nextKey: Uint8Array<ArrayBufferLike> = new Uint8Array();
+
+  do {
+    const response = await fetchPage(pageRequest(nextKey));
+    items.push(...response.items);
+    nextKey = response.pagination?.nextKey ?? new Uint8Array();
+  } while (nextKey.length > 0);
+
+  return items;
+}
+
+function pageRequest(key: Uint8Array<ArrayBufferLike>) {
+  return {
+    key,
+    offset: 0n,
+    limit: 100n,
+    countTotal: false,
+    reverse: false
+  };
+}
+
+function parseUint64(value: string): bigint {
+  if (!/^\d+$/.test(value)) throw new Error(`Invalid uint64 identifier: ${value}`);
+  const parsed = BigInt(value);
+  if (parsed > 18_446_744_073_709_551_615n) throw new Error(`Invalid uint64 identifier: ${value}`);
+  return parsed;
+}
+
+async function optionalRecord<TResponse, TRecord>(
+  query: () => Promise<TResponse>,
+  select: (response: TResponse) => TRecord | undefined
+): Promise<TRecord | null> {
+  const response = await optionalResponse(query);
+  return response ? (select(response) ?? null) : null;
+}
+
+async function optionalResponse<TResponse>(query: () => Promise<TResponse>): Promise<TResponse | null> {
+  try {
+    return await query();
+  } catch (error) {
+    if (error instanceof SDKError && error.code === SDKErrorCode.NotFound) return null;
+    throw error;
+  }
+}

--- a/packages/provider-verification/tsconfig.build.json
+++ b/packages/provider-verification/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@akashnetwork/dev-config/tsconfig.base-node.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "noImplicitAny": true,
+    "strict": true,
+    "target": "ES2022"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/provider-verification/tsconfig.json
+++ b/packages/provider-verification/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/provider-verification/vitest.config.ts
+++ b/packages/provider-verification/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    name: "provider-verification",
+    include: ["**/*.spec.ts"],
+    environment: "node"
+  }
+});


### PR DESCRIPTION
## Why

Marketplace preflight must enforce AEP-86 placement requirements before Console presents providers as eligible. This is the provider-inventory application slice of CON-800.

## What

- Preserve SDL verification requirements in bid-screening requests
- Poll and persist normalized verification facts with provider inventory
- Hard-filter providers that fail tier, capability, auditor-count, or named-auditor policy
- Keep incomplete chain facts visible as `not_evaluated` instead of treating them as passed
- Return both the first actionable failure and the complete exclusion set
- Add the provider-inventory verification column and generated migration

## Dependencies

- #3713 publishes the AEP-86 chain-sdk types used here
- #3715 provides the shared verification policy evaluator

The dependency commits are included temporarily so this branch can build and will disappear from the diff as the foundation PRs merge.