### PR TITLE
feat(observability): count the deployments each auto top-up pass scans

### DIFF
--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -53,6 +53,7 @@ export type AutoTopUpDeployment = {
   walletCreditsLowNotifiedAt: Date | null;
   runtimeLimitHours: number | null;
   runtimeEndsAt: Date | null;
+  lastFundedAt: Date | null;
 };
 
 /**
@@ -134,7 +135,8 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
         walletActivatedAt: UserWallets.activatedAt,
         walletCreditsLowNotifiedAt: UserWallets.creditsLowNotifiedAt,
         runtimeLimitHours: this.table.runtimeLimitHours,
-        runtimeEndsAt: this.table.runtimeEndsAt
+        runtimeEndsAt: this.table.runtimeEndsAt,
+        lastFundedAt: this.table.lastFundedAt
       })
       .from(this.table)
       .leftJoin(Users, eq(this.table.userId, Users.id))

--- a/apps/api/src/deployment/services/top-up-managed-deployments/deployment-top-up-instrumentation.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/deployment-top-up-instrumentation.ts
@@ -3,6 +3,8 @@ import type { DrainingDeployment } from "@src/deployment/types/draining-deployme
 
 export type FundingMessageItem = { deployment: DrainingDeployment; input: DepositDeploymentMsgOptions };
 
+export type OwnerInsufficientBalanceItem = { deployment: DrainingDeployment; desiredAmount: number };
+
 /**
  * Telemetry sink shared by the two deployment top-up paths: the hourly cron and the event-driven
  * immediate funding that runs when credits land. The cron's summarizer-backed instrumentation and the
@@ -23,6 +25,7 @@ export interface DeploymentTopUpInstrumentation {
     runwayMinutes: number;
   }): void;
   recordMessagePreparationError(details: { deployment: DrainingDeployment; error: unknown }): void;
+  recordOwnerInsufficientBalance(details: { owner: string; spendable: number; deployments: OwnerInsufficientBalanceItem[] }): void;
   recordSkipped(details: { owner: string; deploymentCount: number }): void;
   recordDeposit(details: { owner: string; items: FundingMessageItem[] }): void;
   recordChainTxError(details: { owner: string; items: FundingMessageItem[]; error: unknown }): void;

--- a/apps/api/src/deployment/services/top-up-managed-deployments/fund-draining-deployments-instrumentation.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/fund-draining-deployments-instrumentation.service.spec.ts
@@ -280,7 +280,15 @@ describe(FundDrainingDeploymentsInstrumentationService.name, () => {
   });
 
   describe("recordDeploymentPreparation", () => {
-    it("records no instrument and does not throw on the stateless path", () => {
+    it("counts the scanned deployment", () => {
+      const { service, scanned } = setup();
+
+      service.recordDeploymentPreparation("akash1owner", 200);
+
+      expect(scanned.add).toHaveBeenCalledExactlyOnceWith(1);
+    });
+
+    it("leaves the job-completion instruments untouched", () => {
       const { service, jobCompletions } = setup();
 
       expect(() => service.recordDeploymentPreparation("akash1owner", 1000500)).not.toThrow();
@@ -365,6 +373,7 @@ describe(FundDrainingDeploymentsInstrumentationService.name, () => {
       service,
       jobCompletions: counters["fund_draining_deployments_job_completions_total"],
       deposits: counters["fund_draining_deployments_deposits_total"],
+      scanned: counters["fund_draining_deployments_scanned_total"],
       skips: counters["fund_draining_deployments_skips_total"],
       messagePreparationErrors: counters["fund_draining_deployments_message_preparation_errors_total"],
       insufficientBalanceWithAutoReload: counters["fund_draining_deployments_insufficient_balance_with_auto_reload_total"],

--- a/apps/api/src/deployment/services/top-up-managed-deployments/fund-draining-deployments-instrumentation.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/fund-draining-deployments-instrumentation.service.spec.ts
@@ -127,6 +127,45 @@ describe(FundDrainingDeploymentsInstrumentationService.name, () => {
     });
   });
 
+  describe("recordOwnerInsufficientBalance", () => {
+    it("counts every deployment as insufficient balance and warns once for the owner", () => {
+      const { service, messagePreparationErrors, insufficientBalanceWithAutoReload } = setup();
+      const first = mock<DrainingDeployment>({ dseq: "123", address: "akash1owner", isWalletAutoTopUpEnabled: true });
+      const second = mock<DrainingDeployment>({ dseq: "456", address: "akash1owner", isWalletAutoTopUpEnabled: true });
+
+      service.recordOwnerInsufficientBalance({
+        owner: "akash1owner",
+        spendable: 0,
+        deployments: [
+          { deployment: first, desiredAmount: 1_000_000 },
+          { deployment: second, desiredAmount: 2_000_000 }
+        ]
+      });
+
+      expect(messagePreparationErrors.add).toHaveBeenCalledExactlyOnceWith(2, { error_type: "insufficient_balance" });
+      expect(insufficientBalanceWithAutoReload.add).toHaveBeenCalledExactlyOnceWith(2);
+      expect(mockLogger.warn).toHaveBeenCalledExactlyOnceWith({
+        event: "FUND_DRAINING_OWNER_INSUFFICIENT_BALANCE",
+        owner: "akash1owner",
+        spendable: 0,
+        deploymentCount: 2,
+        deployments: [
+          { dseq: "123", desiredAmount: 1_000_000 },
+          { dseq: "456", desiredAmount: 2_000_000 }
+        ]
+      });
+    });
+
+    it("leaves the auto-reload counter untouched when the wallet has auto top-up disabled", () => {
+      const { service, insufficientBalanceWithAutoReload } = setup();
+      const deployment = mock<DrainingDeployment>({ dseq: "123", address: "akash1owner", isWalletAutoTopUpEnabled: false });
+
+      service.recordOwnerInsufficientBalance({ owner: "akash1owner", spendable: 0, deployments: [{ deployment, desiredAmount: 1_000_000 }] });
+
+      expect(insufficientBalanceWithAutoReload.add).not.toHaveBeenCalled();
+    });
+  });
+
   describe("recordChainTxError", () => {
     it("increments chain tx errors and logs the error", () => {
       const { service, chainTxErrors } = setup();

--- a/apps/api/src/deployment/services/top-up-managed-deployments/fund-draining-deployments-instrumentation.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/fund-draining-deployments-instrumentation.service.ts
@@ -4,7 +4,7 @@ import { singleton } from "tsyringe";
 
 import { MetricsService } from "@src/core";
 import type { DrainingDeployment } from "@src/deployment/types/draining-deployment";
-import type { DeploymentTopUpInstrumentation, FundingMessageItem } from "./deployment-top-up-instrumentation";
+import type { DeploymentTopUpInstrumentation, FundingMessageItem, OwnerInsufficientBalanceItem } from "./deployment-top-up-instrumentation";
 
 export type FundDrainingFailureReason = "master_wallet_insufficient_funds" | "deposit_tx_failed" | "unknown";
 
@@ -179,6 +179,24 @@ export class FundDrainingDeploymentsInstrumentationService implements Deployment
       dseq: deployment.dseq,
       address: deployment.address,
       error
+    });
+  }
+
+  recordOwnerInsufficientBalance({ owner, spendable, deployments }: { owner: string; spendable: number; deployments: OwnerInsufficientBalanceItem[] }): void {
+    this.messagePreparationErrors.add(deployments.length, { error_type: "insufficient_balance" });
+
+    const withAutoReloadCount = deployments.filter(({ deployment }) => deployment.isWalletAutoTopUpEnabled).length;
+
+    if (withAutoReloadCount > 0) {
+      this.insufficientBalanceWithAutoReload.add(withAutoReloadCount);
+    }
+
+    this.emitLog("warn", {
+      event: "FUND_DRAINING_OWNER_INSUFFICIENT_BALANCE",
+      owner,
+      spendable,
+      deploymentCount: deployments.length,
+      deployments: deployments.map(({ deployment, desiredAmount }) => ({ dseq: deployment.dseq, desiredAmount }))
     });
   }
 

--- a/apps/api/src/deployment/services/top-up-managed-deployments/fund-draining-deployments-instrumentation.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/fund-draining-deployments-instrumentation.service.ts
@@ -35,6 +35,7 @@ export class FundDrainingDeploymentsInstrumentationService implements Deployment
   private readonly jobCompletions: Counter;
   private readonly jobDuration: Histogram;
   private readonly deposits: Counter;
+  private readonly deploymentsScanned: Counter;
   private readonly depositAmount: Histogram;
   private readonly skips: Counter;
   private readonly messagePreparationErrors: Counter;
@@ -61,6 +62,10 @@ export class FundDrainingDeploymentsInstrumentationService implements Deployment
 
     this.deposits = this.metricsService.createCounter(this.meter, "fund_draining_deployments_deposits_total", {
       description: "Total number of successful immediate draining-deployment deposit transactions"
+    });
+
+    this.deploymentsScanned = this.metricsService.createCounter(this.meter, "fund_draining_deployments_scanned_total", {
+      description: "Total number of draining deployments the immediate funding path evaluated for funding"
     });
 
     this.depositAmount = this.metricsService.createHistogram(this.meter, "fund_draining_deployments_deposit_amount", {
@@ -281,10 +286,12 @@ export class FundDrainingDeploymentsInstrumentationService implements Deployment
   }
 
   /**
-   * The cron records blocks-until-predicted-close against a run-scoped start height. The stateless
-   * event-driven path has no per-run start height, so there is nothing meaningful to record here.
+   * The cron also records blocks-until-predicted-close against a run-scoped start height; the stateless
+   * event-driven path has no per-run start height, so only the scanned count is meaningful here.
    */
-  recordDeploymentPreparation(_ownerAddress: string, _predictedClosedHeight: number): void {}
+  recordDeploymentPreparation(_ownerAddress: string, _predictedClosedHeight: number): void {
+    this.deploymentsScanned.add(1);
+  }
 
   private serializeDeposits(items: FundingMessageItem[]): { dseq: number | string; amount: number; denom: string }[] {
     return items.map(({ input }) => ({ dseq: input.dseq, amount: input.amount, denom: input.denom }));

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.spec.ts
@@ -185,6 +185,61 @@ describe(TopUpManagedDeploymentsInstrumentationService.name, () => {
     });
   });
 
+  describe("recordOwnerInsufficientBalance", () => {
+    it("counts every deployment as insufficient balance and warns once for the owner", () => {
+      const { service, logger, summarizer, countersByName } = setup();
+      service.start(100, { dryRun: false });
+      const first = createDrainingDeployment({ isWalletAutoTopUpEnabled: true });
+      const second = createDrainingDeployment({ isWalletAutoTopUpEnabled: true, address: first.address });
+
+      service.recordOwnerInsufficientBalance({
+        owner: first.address,
+        spendable: 0,
+        deployments: [
+          { deployment: first, desiredAmount: 1_000_000 },
+          { deployment: second, desiredAmount: 2_000_000 }
+        ]
+      });
+
+      expect(summarizer.get("insufficientBalanceCount")).toBe(2);
+      expect(countersByName["auto_top_up_message_preparation_errors_total"].add).toHaveBeenCalledExactlyOnceWith(2, { error_type: "insufficient_balance" });
+      expect(countersByName["auto_top_up_insufficient_balance_with_auto_reload_total"].add).toHaveBeenCalledExactlyOnceWith(2);
+      expect(logger.warn).toHaveBeenCalledExactlyOnceWith({
+        event: "TOP_UP_OWNER_INSUFFICIENT_BALANCE",
+        owner: first.address,
+        spendable: 0,
+        deploymentCount: 2,
+        deployments: [
+          { dseq: first.dseq, desiredAmount: 1_000_000 },
+          { dseq: second.dseq, desiredAmount: 2_000_000 }
+        ],
+        dryRun: false
+      });
+    });
+
+    it("leaves the auto-reload counter untouched when the wallet has auto top-up disabled", () => {
+      const { service, countersByName } = setup();
+      service.start(100, { dryRun: false });
+      const deployment = createDrainingDeployment({ isWalletAutoTopUpEnabled: false });
+
+      service.recordOwnerInsufficientBalance({ owner: deployment.address, spendable: 0, deployments: [{ deployment, desiredAmount: 1_000_000 }] });
+
+      expect(countersByName["auto_top_up_insufficient_balance_with_auto_reload_total"].add).not.toHaveBeenCalled();
+    });
+
+    it("keeps the summary count in dry run without emitting metrics", () => {
+      const { service, summarizer, logger, countersByName } = setup();
+      service.start(100, { dryRun: true });
+      const deployment = createDrainingDeployment();
+
+      service.recordOwnerInsufficientBalance({ owner: deployment.address, spendable: 0, deployments: [{ deployment, desiredAmount: 1_000_000 }] });
+
+      expect(summarizer.get("insufficientBalanceCount")).toBe(1);
+      expect(countersByName["auto_top_up_message_preparation_errors_total"].add).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ dryRun: true }));
+    });
+  });
+
   describe("recordHeadroomConceded", () => {
     it("counts the concession, warns with the amounts either side of it, and carries the dry-run flag", () => {
       const { service, logger, summarizer, countersByName } = setup();

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.spec.ts
@@ -290,6 +290,24 @@ describe(TopUpManagedDeploymentsInstrumentationService.name, () => {
       expect(summarizer.get("deploymentCount")).toBe(1);
     });
 
+    it("counts the scanned deployment so the summary's deployment count has a metric counterpart", () => {
+      const { service, countersByName } = setup();
+      service.start(100, { dryRun: false });
+
+      service.recordDeploymentPreparation("owner1", 200);
+
+      expect(countersByName["auto_top_up_deployments_scanned_total"].add).toHaveBeenCalledExactlyOnceWith(1);
+    });
+
+    it("does not emit the scanned counter in dry run mode", () => {
+      const { service, countersByName } = setup();
+      service.start(100, { dryRun: true });
+
+      service.recordDeploymentPreparation("owner1", 200);
+
+      expect(countersByName["auto_top_up_deployments_scanned_total"].add).not.toHaveBeenCalled();
+    });
+
     it("skips predicted close blocks when start height is not set", () => {
       const { service, summarizer } = setup();
 

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.ts
@@ -17,6 +17,7 @@ export class TopUpManagedDeploymentsInstrumentationService implements Deployment
   private readonly chainTxErrors: Counter;
   private readonly messagePreparationErrors: Counter;
   private readonly deploymentsMarkedClosed: Counter;
+  private readonly deploymentsScanned: Counter;
   private readonly depositAmount: Histogram;
   private readonly predictedCloseBlocks: Histogram;
   private readonly insufficientBalanceWithAutoReload: Counter;
@@ -59,6 +60,10 @@ export class TopUpManagedDeploymentsInstrumentationService implements Deployment
 
     this.deploymentsMarkedClosed = this.metricsService.createCounter(this.meter, "auto_top_up_deployments_marked_closed_total", {
       description: "Total number of deployments marked as closed by the auto top-up job"
+    });
+
+    this.deploymentsScanned = this.metricsService.createCounter(this.meter, "auto_top_up_deployments_scanned_total", {
+      description: "Total number of draining deployments the auto top-up job evaluated for funding"
     });
 
     this.depositAmount = this.metricsService.createHistogram(this.meter, "auto_top_up_deposit_amount", {
@@ -313,6 +318,10 @@ export class TopUpManagedDeploymentsInstrumentationService implements Deployment
     this.topUpSummarizer.inc("deploymentCount");
     this.topUpSummarizer.trackWallet(ownerAddress);
     this.topUpSummarizer.ensurePredictedClosedHeight(predictedClosedHeight);
+
+    this.execWhenEnabled(() => {
+      this.deploymentsScanned.add(1);
+    });
 
     const startHeight = this.topUpSummarizer.get("startBlockHeight");
 

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.ts
@@ -6,7 +6,7 @@ import { type CreateLogger, LOGGER_FACTORY, MetricsService } from "@src/core";
 import type { DryRunOptions } from "@src/core/types/console";
 import { TopUpSummarizer } from "@src/deployment/lib/top-up-summarizer/top-up-summarizer";
 import { DrainingDeployment } from "@src/deployment/types/draining-deployment";
-import type { DeploymentTopUpInstrumentation } from "./deployment-top-up-instrumentation";
+import type { DeploymentTopUpInstrumentation, OwnerInsufficientBalanceItem } from "./deployment-top-up-instrumentation";
 
 @scoped(Lifecycle.ResolutionScoped)
 export class TopUpManagedDeploymentsInstrumentationService implements DeploymentTopUpInstrumentation {
@@ -217,6 +217,29 @@ export class TopUpManagedDeploymentsInstrumentationService implements Deployment
         this.messagePreparationErrors.add(1, { error_type: "unknown" });
       });
     }
+  }
+
+  recordOwnerInsufficientBalance({ owner, spendable, deployments }: { owner: string; spendable: number; deployments: OwnerInsufficientBalanceItem[] }): void {
+    this.topUpSummarizer.inc("insufficientBalanceCount", deployments.length);
+
+    this.logger.warn({
+      event: "TOP_UP_OWNER_INSUFFICIENT_BALANCE",
+      owner,
+      spendable,
+      deploymentCount: deployments.length,
+      deployments: deployments.map(({ deployment, desiredAmount }) => ({ dseq: deployment.dseq, desiredAmount })),
+      dryRun: this.options?.dryRun
+    });
+
+    this.execWhenEnabled(() => {
+      this.messagePreparationErrors.add(deployments.length, { error_type: "insufficient_balance" });
+
+      const withAutoReloadCount = deployments.filter(({ deployment }) => deployment.isWalletAutoTopUpEnabled).length;
+
+      if (withAutoReloadCount > 0) {
+        this.insufficientBalanceWithAutoReload.add(withAutoReloadCount);
+      }
+    });
   }
 
   recordDepositBelowUsefulRunway(details: { dseq: string; address: string; desiredAmount: number; affordableAmount: number; runwayMinutes: number }): void {

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.integration.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.integration.ts
@@ -404,12 +404,19 @@ describe(TopUpManagedDeploymentsService.name, () => {
     });
 
     // Owner has a draining deployment but their wallet's deployment allowance is zero.
-    // The CachedBalance.reserveSufficientAmount call throws "Insufficient balance",
-    // which the job catches and counts but does not propagate.
-    // No transactions should be submitted, and the job should still return Ok.
-    it("handles insufficient user balance by skipping the deployment", async () => {
-      const { topUpService, executeDerivedTx, createUserWithWallet, createDeploymentSetting, mockLeasesForOwner, mockDeploymentsForOwner, stubGetFreshLimits } =
-        await setup();
+    // The whole owner is skipped in one round: no deposit tx, no funding claim stamped
+    // on the settings row, and the job still returns Ok.
+    it("handles insufficient user balance by skipping the owner without claiming", async () => {
+      const {
+        topUpService,
+        executeDerivedTx,
+        createUserWithWallet,
+        createDeploymentSetting,
+        findSetting,
+        mockLeasesForOwner,
+        mockDeploymentsForOwner,
+        stubGetFreshLimits
+      } = await setup();
       const { user, address } = await createUserWithWallet();
       const drainingDseq = "700001";
 
@@ -423,6 +430,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
 
       expect(result.ok).toBe(true);
       expect(executeDerivedTx).not.toHaveBeenCalled();
+      expect((await findSetting(address, drainingDseq))?.lastFundedAt).toBeNull();
     });
 
     it("caps the deposit at what sits above the headroom floor so a new deployment can still be created", async () => {

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
@@ -16,7 +16,7 @@ import { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/
 import type { BlockHttpService } from "@src/chain/services/block-http/block-http.service";
 import type { JobQueueService } from "@src/core";
 import type { CreateLogger } from "@src/core/providers/logging.provider";
-import type { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import type { AutoTopUpDeployment, DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import type { DeploymentConfigService } from "@src/deployment/services/deployment-config/deployment-config.service";
 import type {
   AutoTopUpOwnerDeployments,
@@ -49,8 +49,8 @@ describe(TopUpManagedDeploymentsService.name, () => {
   }
 
   /** Mirrors `CachedBalance` with no floor held: one allowance answers every preview and the reservation. */
-  function createMockCachedBalance(affordableAmount: (desiredAmount: number) => number) {
-    const balance = mock<CachedBalance>();
+  function createMockCachedBalance(affordableAmount: (desiredAmount: number) => number, spendable: number = Number.MAX_SAFE_INTEGER) {
+    const balance = mock<CachedBalance>({ spendable });
     balance.previewSufficientAmount.mockImplementation(affordableAmount);
     balance.previewSufficientAmountWithoutHeadroom.mockImplementation(affordableAmount);
     balance.reserveSufficientAmount.mockImplementation(desiredAmount => {
@@ -93,6 +93,26 @@ describe(TopUpManagedDeploymentsService.name, () => {
     } as DrainingDeployment;
 
     return createOwnerYield([activeDeployment], { drainingDeployments: [], ...overrides });
+  }
+
+  function createZeroBalanceOwnerDeployments(count: number, overrides: Partial<AutoTopUpDeployment>): DrainingDeployment[] {
+    const address = createAkashAddress();
+    const walletId = faker.number.int();
+
+    return Array.from({ length: count }, (_, index) => {
+      const setting = createAutoTopUpDeployment({ address, walletId, dseq: String(5001 + index), ...overrides });
+
+      return {
+        ...setting,
+        ...createDrainingDeployment({
+          dseq: Number(setting.dseq),
+          owner: address,
+          predictedClosedHeight: CURRENT_BLOCK_HEIGHT + 1500,
+          denom: DEPLOYMENT_GRANT_DENOM
+        }),
+        dseq: setting.dseq
+      } as DrainingDeployment;
+    });
   }
 
   function mockOwnerYields(drainingDeploymentService: ReturnType<typeof mock<DrainingDeploymentService>>, ...owners: AutoTopUpOwnerDeployments[]) {
@@ -245,6 +265,74 @@ describe(TopUpManagedDeploymentsService.name, () => {
         expect(height).toBe(CURRENT_BLOCK_HEIGHT);
       });
       expect(blockHttpService.getCurrentHeight).toHaveBeenCalledTimes(2);
+    });
+
+    it("skips a zero-balance owner in one round instead of claiming and releasing per deployment", async () => {
+      const { service, drainingDeploymentService, cachedBalanceService, deploymentSettingRepository, managedSignerService, instrumentation } = setup();
+      const desiredAmount = 1_000_000;
+      const deployments = createZeroBalanceOwnerDeployments(3, { isWalletAutoTopUpEnabled: true });
+
+      mockOwnerYields(drainingDeploymentService, createOwnerYield(deployments));
+      drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(desiredAmount);
+      cachedBalanceService.get.mockResolvedValue(mock<CachedBalance>({ spendable: 0 }));
+
+      await service.topUpDeployments({ dryRun: false });
+
+      expect(deploymentSettingRepository.claimForFunding).not.toHaveBeenCalled();
+      expect(deploymentSettingRepository.releaseFundingClaim).not.toHaveBeenCalled();
+      expect(managedSignerService.executeDerivedTx).not.toHaveBeenCalled();
+      deployments.forEach(deployment => {
+        expect(instrumentation.recordDeploymentPreparation).toHaveBeenCalledWith(deployment.address, deployment.predictedClosedHeight);
+      });
+      expect(instrumentation.recordOwnerInsufficientBalance).toHaveBeenCalledExactlyOnceWith({
+        owner: deployments[0].address,
+        spendable: 0,
+        deployments: deployments.map(deployment => ({ deployment, desiredAmount }))
+      });
+      expect(instrumentation.recordMessagePreparationError).not.toHaveBeenCalled();
+      expect(instrumentation.recordSkipped).toHaveBeenCalledWith({ owner: deployments[0].address, deploymentCount: deployments.length });
+      expect(instrumentation.finish).toHaveBeenCalledWith("success", CURRENT_BLOCK_HEIGHT);
+    });
+
+    it("leaves a zero-balance owner's deployments inside the funding cooldown out of the reported counts", async () => {
+      const { service, drainingDeploymentService, cachedBalanceService, instrumentation } = setup();
+      const desiredAmount = 1_000_000;
+      const [claimable, insideCooldown] = createZeroBalanceOwnerDeployments(2, {});
+      insideCooldown.lastFundedAt = new Date(Date.now() - (DEDUP_COOLDOWN_IN_MIN / 2) * 60 * 1000);
+
+      mockOwnerYields(drainingDeploymentService, createOwnerYield([claimable, insideCooldown]));
+      drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(desiredAmount);
+      cachedBalanceService.get.mockResolvedValue(mock<CachedBalance>({ spendable: 0 }));
+
+      await service.topUpDeployments({ dryRun: false });
+
+      expect(instrumentation.recordDeploymentPreparation).toHaveBeenCalledExactlyOnceWith(claimable.address, claimable.predictedClosedHeight);
+      expect(instrumentation.recordOwnerInsufficientBalance).toHaveBeenCalledExactlyOnceWith({
+        owner: claimable.address,
+        spendable: 0,
+        deployments: [{ deployment: claimable, desiredAmount }]
+      });
+      expect(instrumentation.recordSkipped).toHaveBeenCalledWith({ owner: claimable.address, deploymentCount: 2 });
+    });
+
+    it("reports a non-positive desired amount instead of insufficient balance for a zero-balance owner", async () => {
+      const { service, drainingDeploymentService, cachedBalanceService, instrumentation } = setup();
+      const deployments = createZeroBalanceOwnerDeployments(1, {});
+
+      mockOwnerYields(drainingDeploymentService, createOwnerYield(deployments));
+      drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(0);
+      cachedBalanceService.get.mockResolvedValue(mock<CachedBalance>({ spendable: 0 }));
+
+      await service.topUpDeployments({ dryRun: false });
+
+      expect(instrumentation.recordInvalidDepositAmount).toHaveBeenCalledExactlyOnceWith({
+        desiredAmount: 0,
+        dseq: deployments[0].dseq,
+        address: deployments[0].address,
+        blockRate: deployments[0].blockRate
+      });
+      expect(instrumentation.recordOwnerInsufficientBalance).not.toHaveBeenCalled();
+      expect(instrumentation.recordSkipped).toHaveBeenCalledWith({ owner: deployments[0].address, deploymentCount: 1 });
     });
 
     it("should handle errors and continue processing", async () => {
@@ -591,7 +679,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
     });
 
     it("should log errors when message preparation fails", async () => {
-      const { service, drainingDeploymentService, instrumentation } = setup();
+      const { service, drainingDeploymentService, cachedBalanceService, instrumentation } = setup();
       const deployment = createAutoTopUpDeployment();
       const error = new Error("Failed to calculate amount");
 
@@ -615,6 +703,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
       drainingDeploymentService.calculateAmountToTargetRunway.mockImplementation(() => {
         throw error;
       });
+      cachedBalanceService.get.mockResolvedValue(createMockCachedBalance(() => 1_000_000));
 
       await service.topUpDeployments({ dryRun: false });
 
@@ -1008,22 +1097,28 @@ describe(TopUpManagedDeploymentsService.name, () => {
       expect(fundDrainingInstrumentation.recordMessagePreparationError).not.toHaveBeenCalled();
     });
 
-    it("reports an exhausted allowance as insufficient balance when yielding the headroom releases nothing", async () => {
-      const { service, drainingDeploymentService, cachedBalanceService, managedSignerService, fundDrainingInstrumentation } = setup();
+    it("reports an exhausted allowance as insufficient balance once per owner", async () => {
+      const { service, drainingDeploymentService, cachedBalanceService, managedSignerService, deploymentSettingRepository, fundDrainingInstrumentation } =
+        setup();
       const owner = createAkashAddress();
       const walletId = faker.number.int({ min: 1000000, max: 9999999 });
       const deployment = createDrainingFor(owner, walletId);
+      const desiredAmount = 3_000_000;
 
       drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue([deployment]);
-      drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(3_000_000);
+      drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(desiredAmount);
       cachedBalanceService.getFresh.mockResolvedValue(new CachedBalance(0, { headroom: HEADROOM, minDeposit: MIN_DEPOSIT }));
 
       await service.topUpDrainingDeploymentsForOwner({ walletId, address: owner });
 
       expect(fundDrainingInstrumentation.recordHeadroomConceded).not.toHaveBeenCalled();
-      expect(fundDrainingInstrumentation.recordMessagePreparationError).toHaveBeenCalledWith(
-        expect.objectContaining({ error: expect.objectContaining({ message: expect.stringContaining("Insufficient balance") }) })
-      );
+      expect(fundDrainingInstrumentation.recordOwnerInsufficientBalance).toHaveBeenCalledExactlyOnceWith({
+        owner,
+        spendable: 0,
+        deployments: [{ deployment, desiredAmount }]
+      });
+      expect(fundDrainingInstrumentation.recordMessagePreparationError).not.toHaveBeenCalled();
+      expect(deploymentSettingRepository.claimForFunding).not.toHaveBeenCalled();
       expect(managedSignerService.executeDerivedTx).not.toHaveBeenCalled();
     });
 

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
@@ -1,4 +1,5 @@
 import { MsgAccountDeposit } from "@akashnetwork/chain-sdk/private-types/akash.v1";
+import { millisecondsInMinute } from "date-fns/constants";
 import { Err, Ok, Result } from "ts-results";
 import { singleton } from "tsyringe";
 
@@ -17,7 +18,7 @@ import { DrainingDeploymentService } from "@src/deployment/services/draining-dep
 import { COSMOS_TX_CODE_OK } from "@src/utils/constants";
 import { CachedBalance, CachedBalanceService } from "../cached-balance/cached-balance.service";
 import { DeploymentConfigService } from "../deployment-config/deployment-config.service";
-import type { DeploymentTopUpInstrumentation } from "./deployment-top-up-instrumentation";
+import type { DeploymentTopUpInstrumentation, OwnerInsufficientBalanceItem } from "./deployment-top-up-instrumentation";
 import { FundDrainingDeploymentsInstrumentationService } from "./fund-draining-deployments-instrumentation.service";
 import { TopUpManagedDeploymentsInstrumentationService } from "./top-up-managed-deployments-instrumentation.service";
 
@@ -132,6 +133,11 @@ export class TopUpManagedDeploymentsService {
     instrumentation: DeploymentTopUpInstrumentation,
     currentHeight: number
   ): Promise<void> {
+    if (balance.spendable <= 0) {
+      this.#skipOwnerWithoutSpendableBalance({ address, deployments }, balance, instrumentation, currentHeight);
+      return;
+    }
+
     if (options.dryRun) {
       const messageInputs = await this.collectMessages(deployments, balance, instrumentation, currentHeight);
 
@@ -221,6 +227,47 @@ export class TopUpManagedDeploymentsService {
     const balance = await this.balancesService.retrieveDeploymentLimit({ address: owner.address });
 
     return needsCreditsLowTransition({ balance, weeklyCost: weeklyCredits, isNotified });
+  }
+
+  /** Mirrors the preparation loop's telemetry without claiming rows, so the cooldown filter here must keep matching the claim query's. */
+  #skipOwnerWithoutSpendableBalance(
+    { address, deployments }: { address: string; deployments: DrainingDeployment[] },
+    balance: CachedBalance,
+    instrumentation: DeploymentTopUpInstrumentation,
+    currentHeight: number
+  ): void {
+    const insufficient: OwnerInsufficientBalanceItem[] = [];
+
+    for (const deployment of this.#filterClaimable(deployments)) {
+      instrumentation.recordDeploymentPreparation(deployment.address, deployment.predictedClosedHeight);
+
+      const desiredAmount = this.drainingDeploymentService.calculateAmountToTargetRunway(deployment, currentHeight);
+
+      if (desiredAmount <= 0) {
+        instrumentation.recordInvalidDepositAmount({
+          desiredAmount,
+          dseq: deployment.dseq,
+          address: deployment.address,
+          blockRate: deployment.blockRate
+        });
+        continue;
+      }
+
+      insufficient.push({ deployment, desiredAmount });
+    }
+
+    if (insufficient.length) {
+      instrumentation.recordOwnerInsufficientBalance({ owner: address, spendable: balance.spendable, deployments: insufficient });
+    }
+
+    instrumentation.recordSkipped({ owner: address, deploymentCount: deployments.length });
+  }
+
+  #filterClaimable(deployments: DrainingDeployment[]): DrainingDeployment[] {
+    const cooldownMs = this.deploymentConfig.get("AUTO_TOP_UP_DEDUP_COOLDOWN_IN_MIN") * millisecondsInMinute;
+    const claimableBefore = new Date(Date.now() - cooldownMs);
+
+    return deployments.filter(deployment => !deployment.lastFundedAt || deployment.lastFundedAt < claimableBefore);
   }
 
   /**

--- a/apps/api/test/seeders/auto-top-up-deployment.seeder.ts
+++ b/apps/api/test/seeders/auto-top-up-deployment.seeder.ts
@@ -17,6 +17,7 @@ export function createAutoTopUpDeployment(overrides: Partial<AutoTopUpDeployment
     walletCreditsLowNotifiedAt: null,
     runtimeLimitHours: null,
     runtimeEndsAt: null,
+    lastFundedAt: null,
     ...overrides
   };
 }


### PR DESCRIPTION
## Why

Part of CON-910

The incident behind CON-910 (2026-08-26: only 4 of 74 scanned deployments funded, no alert) needs an alert on the share of scanned deployments that actually get funded. The run summary carries `deploymentCount`, but no metric does, so that share cannot be derived from Prometheus. The dashboard and alert changes themselves live in Grafana; this PR adds the missing series.

## What

Both funding paths now count every deployment they evaluate:

- `auto_top_up_deployments_scanned_total` on the hourly cron's meter, emitted from `recordDeploymentPreparation` next to the summary's `deploymentCount` increment (dry runs excluded, like every other counter there).
- `fund_draining_deployments_scanned_total` on the credits-landed path's meter, whose `recordDeploymentPreparation` was a no-op until now.

The initial funded-share alert will be defined on counters that already have history so it can be backtested against 2026-08-26; once this series has history the expression can move to deposits over scanned.

Stacked on #3720 (CON-912) so the scanned counts land after the zero-balance skip keeps them stable; will retarget as the chain merges.
