### PR TITLE
feat(deploy-web): add provider verification workflows

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@akashnetwork/akash-api": "1.4.3",
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/console-api-types": "*",
     "@akashnetwork/database": "*",
     "@akashnetwork/env-loader": "*",

--- a/apps/deploy-web/package.json
+++ b/apps/deploy-web/package.json
@@ -26,7 +26,7 @@
     "type-check": "tsc"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/console-api-types": "*",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentHeader/ConfigureDeploymentHeader.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentHeader/ConfigureDeploymentHeader.spec.tsx
@@ -20,12 +20,62 @@ const GENERATED_SDL = 'version: "2.0" # generated';
 describe(ConfigureDeploymentHeader.name, () => {
   it("requests quotes with the SDL generated from the submitted form values, not a stale snapshot", async () => {
     const requestQuotes = vi.fn();
-    const { enqueueSnackbar } = setup({ phase: "configuring", requestQuotes });
+    const { enqueueSnackbar, checkVerificationProviderAvailability } = setup({ phase: "configuring", requestQuotes });
 
     fireEvent.click(screen.getByRole("button", { name: /request quotes/i }));
 
     await waitFor(() => expect(requestQuotes).toHaveBeenCalledWith(GENERATED_SDL));
     expect(enqueueSnackbar).not.toHaveBeenCalled();
+    expect(checkVerificationProviderAvailability).not.toHaveBeenCalled();
+  });
+
+  it("checks verified placements before requesting quotes", async () => {
+    const requestQuotes = vi.fn();
+    const { checkVerificationProviderAvailability } = setup({
+      phase: "configuring",
+      requestQuotes,
+      placements: [verifiedPlacement("west")]
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: /request quotes/i }));
+
+    await waitFor(() => expect(requestQuotes).toHaveBeenCalledWith(GENERATED_SDL));
+    expect(checkVerificationProviderAvailability).toHaveBeenCalledWith({ sdl: GENERATED_SDL, placements: [verifiedPlacement("west")] });
+  });
+
+  it("blocks quote requests when a verified placement has no matching provider", async () => {
+    const requestQuotes = vi.fn();
+    const { enqueueSnackbar } = setup({
+      phase: "configuring",
+      requestQuotes,
+      placements: [verifiedPlacement("west")],
+      unavailablePlacements: ["west"]
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: /request quotes/i }));
+
+    await waitFor(() => expect(enqueueSnackbar).toHaveBeenCalledTimes(1));
+    expect(requestQuotes).not.toHaveBeenCalled();
+    render(enqueueSnackbar.mock.calls[0][0] as ReactNode);
+    expect(screen.getByText("No matching providers")).toBeInTheDocument();
+    expect(screen.getByText(/west: No providers currently meet/i)).toBeInTheDocument();
+  });
+
+  it("blocks quote requests when verified provider availability cannot be checked", async () => {
+    const requestQuotes = vi.fn();
+    const { enqueueSnackbar } = setup({
+      phase: "configuring",
+      requestQuotes,
+      placements: [verifiedPlacement("west")],
+      availabilityError: new Error("screening unavailable")
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: /request quotes/i }));
+
+    await waitFor(() => expect(enqueueSnackbar).toHaveBeenCalledTimes(1));
+    expect(requestQuotes).not.toHaveBeenCalled();
+    render(enqueueSnackbar.mock.calls[0][0] as ReactNode);
+    expect(screen.getByText("Provider availability couldn't be checked")).toBeInTheDocument();
   });
 
   it("blocks a trial deployment whose GPU resolves to a blocked selection and surfaces the trial message", async () => {
@@ -236,7 +286,7 @@ describe(ConfigureDeploymentHeader.name, () => {
     phase: DeploymentFlow["phase"];
     requestQuotes?: (sdl: string) => void;
     validationErrors?: string[];
-    placements?: { id: string }[];
+    placements?: TestPlacement[];
     selections?: Record<string, string>;
     onDeploy?: () => void;
     allPlacementsHaveBids?: boolean;
@@ -249,6 +299,8 @@ describe(ConfigureDeploymentHeader.name, () => {
     cancelAndEdit?: () => void;
     isRestricted?: boolean;
     services?: Array<{ profile: { hasGpu?: boolean; gpuModels?: Array<{ vendor: string; name?: string }> } }>;
+    unavailablePlacements?: string[];
+    availabilityError?: Error;
   }) {
     const flow = mock<DeploymentFlow>({
       phase: input.phase,
@@ -263,6 +315,10 @@ describe(ConfigureDeploymentHeader.name, () => {
     flow.selections = input.selections ?? {};
     const enqueueSnackbar = vi.fn();
     const useDeploymentCost = vi.fn(() => input.cost ?? null);
+    const checkVerificationProviderAvailability = vi.fn(async () => {
+      if (input.availabilityError) throw input.availabilityError;
+      return input.unavailablePlacements ?? [];
+    });
     const dependencies: typeof DEPENDENCIES = {
       useDeploymentResourceSummary: (() => "1 vCPU") as never,
       useDeploymentHasGpu: () => input.hasGpu ?? true,
@@ -274,7 +330,8 @@ describe(ConfigureDeploymentHeader.name, () => {
       PriceValue: ({ value }) => <span data-testid="price">{String(value)}</span>,
       useQuoteExpiry: () => input.expiry ?? null,
       CustomTooltip: ({ children }) => <>{children}</>,
-      useTrialGate: () => ({ isRestricted: input.isRestricted ?? false, isWalletReady: true })
+      useTrialGate: () => ({ isRestricted: input.isRestricted ?? false, isWalletReady: true }),
+      useVerificationProviderPreflight: () => checkVerificationProviderAvailability
     };
     render(
       <Wrapper placements={input.placements} services={input.services}>
@@ -287,7 +344,7 @@ describe(ConfigureDeploymentHeader.name, () => {
         />
       </Wrapper>
     );
-    return { enqueueSnackbar, useDeploymentCost };
+    return { enqueueSnackbar, useDeploymentCost, checkVerificationProviderAvailability };
   }
 
   function Wrapper({
@@ -296,10 +353,20 @@ describe(ConfigureDeploymentHeader.name, () => {
     services
   }: {
     children: ReactNode;
-    placements?: { id: string }[];
+    placements?: TestPlacement[];
     services?: Array<{ profile: { hasGpu?: boolean; gpuModels?: Array<{ vendor: string; name?: string }> } }>;
   }) {
     const form = useForm({ defaultValues: { placements: placements ?? [], services: services ?? [] } });
     return <FormProvider {...form}>{children}</FormProvider>;
   }
 });
+
+type TestPlacement = {
+  id: string;
+  name?: string;
+  verification?: { minTier: number; capabilities: []; auditors: [] };
+};
+
+function verifiedPlacement(name: string): TestPlacement {
+  return { id: name, name, verification: { minTier: 1, capabilities: [], auditors: [] } };
+}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentHeader/ConfigureDeploymentHeader.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentHeader/ConfigureDeploymentHeader.tsx
@@ -1,4 +1,5 @@
 import type { FC, ReactNode } from "react";
+import { useState } from "react";
 import { useFormContext, useWatch } from "react-hook-form";
 import { Button, CustomTooltip, Snackbar } from "@akashnetwork/ui/components";
 import { cn } from "@akashnetwork/ui/utils";
@@ -18,6 +19,7 @@ import { useDeploymentCost } from "../useDeploymentCost/useDeploymentCost";
 import type { DeploymentFlow } from "../useDeploymentFlow/useDeploymentFlow";
 import type { QuoteExpiry } from "../useQuoteExpiry/useQuoteExpiry";
 import { useQuoteExpiry } from "../useQuoteExpiry/useQuoteExpiry";
+import { useVerificationProviderPreflight } from "./verificationProviderPreflight";
 
 export const DEPENDENCIES = {
   useDeploymentResourceSummary,
@@ -32,7 +34,8 @@ export const DEPENDENCIES = {
   PriceValue,
   useQuoteExpiry,
   CustomTooltip,
-  useTrialGate
+  useTrialGate,
+  useVerificationProviderPreflight
 };
 
 type Props = { flow: DeploymentFlow; sdl: string; onDeploy: () => void; allPlacementsHaveBids: boolean; dependencies?: typeof DEPENDENCIES };
@@ -43,6 +46,8 @@ export const ConfigureDeploymentHeader: FC<Props> = ({ flow, sdl, onDeploy, allP
   const { control, handleSubmit, getValues } = useFormContext<SdlBuilderFormValuesType>();
   const { enqueueSnackbar } = d.useSnackbar();
   const { isRestricted } = d.useTrialGate();
+  const checkVerificationProviderAvailability = d.useVerificationProviderPreflight();
+  const [isCheckingProviders, setIsCheckingProviders] = useState(false);
   const placements = useWatch({ control, name: "placements" });
   const cost = d.useDeploymentCost({ dseq: flow.dseq, sdl, placements, selections: flow.selections });
   const expiry = d.useQuoteExpiry({ dseq: flow.dseq, enabled: flow.phase === "quoting" });
@@ -71,7 +76,7 @@ export const ConfigureDeploymentHeader: FC<Props> = ({ flow, sdl, onDeploy, allP
    * Either failure surfaces the errors to the user; otherwise the same freshly generated SDL is what gets
    * submitted, so validation and creation can never disagree about which spec they acted on.
    */
-  const onRequestQuotes = handleSubmit(values => {
+  const onRequestQuotes = handleSubmit(async values => {
     const sdl = d.generateSdl(values);
     const errors = [...d.validateGeneratedSdl(sdl)];
     // Load-bearing trial guard: enabling the GPU card leaves the model at the empty default without ever
@@ -97,6 +102,38 @@ export const ConfigureDeploymentHeader: FC<Props> = ({ flow, sdl, onDeploy, allP
       );
       return;
     }
+
+    if (values.placements.some(placement => placement.verification !== undefined)) {
+      setIsCheckingProviders(true);
+      try {
+        const unavailablePlacements = await checkVerificationProviderAvailability({ sdl, placements: values.placements });
+        if (unavailablePlacements.length > 0) {
+          enqueueSnackbar(
+            <d.Snackbar
+              title="No matching providers"
+              subTitle={
+                <ul className="list-disc pl-4">
+                  {unavailablePlacements.map(placement => (
+                    <li key={placement}>{placement}: No providers currently meet its resources and verification requirements.</li>
+                  ))}
+                </ul>
+              }
+              iconVariant="error"
+            />,
+            { variant: "error" }
+          );
+          return;
+        }
+      } catch {
+        enqueueSnackbar(<d.Snackbar title="Provider availability couldn't be checked" subTitle="Try again before requesting quotes." iconVariant="error" />, {
+          variant: "error"
+        });
+        return;
+      } finally {
+        setIsCheckingProviders(false);
+      }
+    }
+
     flow.actions.requestQuotes(sdl);
   });
 
@@ -125,8 +162,9 @@ export const ConfigureDeploymentHeader: FC<Props> = ({ flow, sdl, onDeploy, allP
           </div>
         </div>
         {isEditable ? (
-          <Button type="button" onClick={onRequestQuotes} className="h-9 shrink-0 px-3 md:h-10 md:px-8">
-            Request quotes
+          <Button type="button" onClick={onRequestQuotes} disabled={isCheckingProviders} className="h-9 shrink-0 gap-2 px-3 md:h-10 md:px-8">
+            {isCheckingProviders && <LoaderCircle className="h-4 w-4 animate-spin text-current" aria-hidden="true" />}
+            {isCheckingProviders ? "Checking providers…" : "Request quotes"}
           </Button>
         ) : quotesExpired && !hasOpenBids ? (
           <Button type="button" onClick={flow.actions.cancelAndEdit} className="h-9 shrink-0 px-3 md:h-10 md:px-8">

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentHeader/verificationProviderPreflight.spec.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentHeader/verificationProviderPreflight.spec.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { ScreeningRequestBody } from "@src/queries/useScreenedProviders";
+import type { PlacementType } from "@src/types";
+import { findUnavailableVerificationPlacements } from "./verificationProviderPreflight";
+
+const REQUEST: ScreeningRequestBody = {
+  requirements: { signedBy: { allOf: [], anyOf: [] }, attributes: [] },
+  resources: []
+};
+
+describe(findUnavailableVerificationPlacements.name, () => {
+  it("checks every placement with a verification requirement", async () => {
+    const screenProviders = vi.fn(async request => ({ providers: request.requirements.attributes[0]?.value === "available" ? [{}] : [] }));
+    const buildRequest = vi.fn((_: string, placementName: string) => ({
+      ...REQUEST,
+      requirements: {
+        ...REQUEST.requirements,
+        attributes: [{ key: "placement", value: placementName === "west" ? "available" : "unavailable" }]
+      }
+    }));
+
+    const unavailable = await findUnavailableVerificationPlacements(
+      {
+        sdl: "generated sdl",
+        placements: [placement("west", true), placement("east", true), placement("unrestricted", false)],
+        timeZone: "UTC"
+      },
+      { buildRequest, screenProviders }
+    );
+
+    expect(unavailable).toEqual(["east"]);
+    expect(buildRequest).toHaveBeenCalledTimes(2);
+    expect(screenProviders).toHaveBeenCalledTimes(2);
+    expect(screenProviders).toHaveBeenCalledWith(expect.objectContaining({ timezone: "UTC" }));
+  });
+
+  it("does not call screening when no placement requires verification", async () => {
+    const buildRequest = vi.fn(() => REQUEST);
+    const screenProviders = vi.fn(async () => ({ providers: [] }));
+
+    const unavailable = await findUnavailableVerificationPlacements(
+      { sdl: "generated sdl", placements: [placement("unrestricted", false)], timeZone: "UTC" },
+      { buildRequest, screenProviders }
+    );
+
+    expect(unavailable).toEqual([]);
+    expect(buildRequest).not.toHaveBeenCalled();
+    expect(screenProviders).not.toHaveBeenCalled();
+  });
+
+  it("fails when a verified placement cannot be converted into a screening request", async () => {
+    await expect(
+      findUnavailableVerificationPlacements(
+        { sdl: "invalid", placements: [placement("west", true)], timeZone: "UTC" },
+        { buildRequest: () => null, screenProviders: async () => ({ providers: [] }) }
+      )
+    ).rejects.toThrow("Unable to screen placement west");
+  });
+});
+
+function placement(name: string, verified: boolean): Pick<PlacementType, "name" | "verification"> {
+  return {
+    name,
+    verification: verified ? { minTier: 1, capabilities: [], auditors: [] } : undefined
+  };
+}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentHeader/verificationProviderPreflight.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentHeader/verificationProviderPreflight.ts
@@ -1,0 +1,40 @@
+import { buildPlacementScreeningRequest, type ScreeningRequest, type ScreeningRequestBody } from "@src/queries/useScreenedProviders";
+import { createApiSdk } from "@src/services/api-sdk/createApiSdk";
+import { PROXY_API_BASE_URL } from "@src/services/auth/auth/interceptors";
+import type { PlacementType } from "@src/types";
+
+type VerificationPlacement = Pick<PlacementType, "name" | "verification">;
+
+type Dependencies = {
+  buildRequest: (sdl: string, placementName: string) => ScreeningRequestBody | null;
+  screenProviders: (request: ScreeningRequest) => Promise<{ providers: readonly unknown[] }>;
+};
+
+const api = createApiSdk({ baseUrl: PROXY_API_BASE_URL });
+
+const DEFAULT_DEPENDENCIES: Dependencies = {
+  buildRequest: buildPlacementScreeningRequest,
+  screenProviders: request => api.v1.screenProviders(request)
+};
+
+export async function findUnavailableVerificationPlacements(
+  input: { sdl: string; placements: VerificationPlacement[]; timeZone?: string },
+  dependencies: Dependencies = DEFAULT_DEPENDENCIES
+): Promise<string[]> {
+  const timeZone = input.timeZone ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const checks = input.placements
+    .filter(placement => placement.verification !== undefined)
+    .map(async placement => {
+      const request = dependencies.buildRequest(input.sdl, placement.name);
+      if (!request) throw new Error(`Unable to screen placement ${placement.name}`);
+
+      const result = await dependencies.screenProviders({ ...request, timezone: timeZone });
+      return result.providers.length === 0 ? placement.name : null;
+    });
+
+  return (await Promise.all(checks)).filter((name): name is string => name !== null);
+}
+
+export function useVerificationProviderPreflight() {
+  return findUnavailableVerificationPlacements;
+}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/PlacementCard/PlacementCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/PlacementCard/PlacementCard.spec.tsx
@@ -113,6 +113,25 @@ describe("PlacementCard", () => {
     expect(RegionSelect.mock.calls[0][0]).toEqual(expect.objectContaining({ disabled: true }));
   });
 
+  it("shows the provider verification editor behind its feature flag", () => {
+    const PlacementVerificationEditor = vi.fn<typeof DEPENDENCIES.PlacementVerificationEditor>(() => null);
+    setup({
+      serviceTitles: ["web"],
+      verificationEnabled: true,
+      dependencies: { PlacementVerificationEditor }
+    });
+
+    expect(PlacementVerificationEditor).toHaveBeenCalledOnce();
+    expect(PlacementVerificationEditor.mock.calls[0][0]).toEqual(expect.objectContaining({ placementName: "placement-1", placementIndex: 0, locked: false }));
+  });
+
+  it("hides the provider verification editor while its feature flag is disabled", () => {
+    const PlacementVerificationEditor = vi.fn<typeof DEPENDENCIES.PlacementVerificationEditor>(() => null);
+    setup({ serviceTitles: ["web"], verificationEnabled: false, dependencies: { PlacementVerificationEditor } });
+
+    expect(PlacementVerificationEditor).not.toHaveBeenCalled();
+  });
+
   it("shows the DONE badge when the placement has a selection", () => {
     setup({ serviceTitles: ["web"], selectionState: "done" });
     expect(screen.getByText("DONE")).toBeInTheDocument();
@@ -124,6 +143,7 @@ describe("PlacementCard", () => {
     status?: ConfigStatus;
     error?: string;
     locked?: boolean;
+    verificationEnabled?: boolean;
     selectionState?: PlacementSelectionState;
     dependencies?: Partial<typeof DEPENDENCIES>;
   }) {
@@ -158,6 +178,7 @@ describe("PlacementCard", () => {
           onRemoveService={onRemoveService}
           onRemove={onRemove}
           dependencies={MockComponents(DEPENDENCIES, {
+            useFlag: () => input.verificationEnabled ?? false,
             usePlacementStatus: () => input.status ?? "incomplete",
             useFieldError: () => ({ error: input.error }),
             ...input.dependencies
@@ -166,6 +187,6 @@ describe("PlacementCard", () => {
       </Wrapper>
     );
 
-    return { onAddService, onRemove, onSelectService, onRemoveService, services, container };
+    return { onAddService, onRemove, onSelectService, onRemoveService, placement, services, container };
   }
 });

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/PlacementCard/PlacementCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/PlacementCard/PlacementCard.tsx
@@ -5,6 +5,7 @@ import { cn } from "@akashnetwork/ui/utils";
 import { Plus, Trash } from "iconoir-react";
 
 import { RegionSelect } from "@src/components/sdl/RegionSelect/RegionSelect";
+import { useFlag } from "@src/hooks/useFlag";
 import type { PlacementType } from "@src/types";
 import { ConfigStatusIcon } from "../ConfigStatusIcon/ConfigStatusIcon";
 import type { PlacementSelectionState } from "../PlacementSelectionBadge/PlacementSelectionBadge";
@@ -12,8 +13,9 @@ import { PlacementSelectionBadge } from "../PlacementSelectionBadge/PlacementSel
 import { ServiceRow } from "../ServiceRow/ServiceRow";
 import type { IndexedService } from "../usePlacementManager/usePlacementManager";
 import { usePlacementStatus } from "../usePlacementStatus/usePlacementStatus";
+import { PlacementVerificationEditor } from "./PlacementVerificationEditor";
 
-export const DEPENDENCIES = { InlineEditInput, RegionSelect, ServiceRow, usePlacementStatus, useFieldError };
+export const DEPENDENCIES = { InlineEditInput, PlacementVerificationEditor, RegionSelect, ServiceRow, useFlag, usePlacementStatus, useFieldError };
 
 type Props = {
   placement: PlacementType;
@@ -50,6 +52,7 @@ export const PlacementCard: FC<Props> = ({
   const status = d.usePlacementStatus(placement.id as string);
   const { error } = d.useFieldError(`placements.${placementIndex}.name`);
   const errorId = useId();
+  const isProviderVerificationEnabled = d.useFlag("provider_verification");
   const isSelected = services.some(({ service }) => service.id === selectedServiceId);
   const firstServiceId = services[0]?.service.id as string | undefined;
 
@@ -97,6 +100,7 @@ export const PlacementCard: FC<Props> = ({
       <fieldset disabled={locked} className="m-0 min-w-0 border-0 p-0 disabled:pointer-events-none">
         <d.RegionSelect placementIndex={placementIndex} disabled={locked} />
       </fieldset>
+      {isProviderVerificationEnabled && <d.PlacementVerificationEditor placementName={placement.name} placementIndex={placementIndex} locked={locked} />}
       <ul aria-label={`${placement.name} services`} className="mt-2 space-y-2">
         {services.map(({ service, index }) => (
           <d.ServiceRow

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/PlacementCard/PlacementVerificationEditor.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/PlacementCard/PlacementVerificationEditor.spec.tsx
@@ -1,0 +1,188 @@
+import type { PropsWithChildren } from "react";
+import { act } from "react";
+import type { UseFormReturn } from "react-hook-form";
+import { FormProvider, useForm } from "react-hook-form";
+import { TooltipProvider } from "@akashnetwork/ui/components";
+import { describe, expect, it, vi } from "vitest";
+
+import type { PlacementVerificationType, SdlBuilderFormValuesType } from "@src/types";
+import { defaultServiceWithPlacement } from "@src/utils/sdl/data";
+import { getPlacementVerificationSummary, PlacementVerificationEditor } from "./PlacementVerificationEditor";
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+describe(PlacementVerificationEditor.name, () => {
+  it("summarizes the placement requirement", () => {
+    expect(
+      getPlacementVerificationSummary({
+        minTier: 3,
+        minAuditorCount: 2,
+        capabilities: ["persistent_storage"],
+        auditors: [{ id: "auditor-1", value: "akash1auditor" }],
+        auditorMode: "all"
+      })
+    ).toBe("L3 minimum · 2 auditors · 1 capability · 1 named auditor");
+  });
+
+  it("shows the unrestricted state before a requirement is configured", () => {
+    setup();
+
+    expect(screen.getByRole("button", { name: "Edit provider verification: Not required" })).toBeInTheDocument();
+  });
+
+  it("edits the placement verification requirement", async () => {
+    const user = userEvent.setup();
+    const { form } = setup();
+
+    await user.click(screen.getByRole("button", { name: "Edit provider verification: Not required" }));
+    await user.click(screen.getByRole("switch", { name: "Require provider verification" }));
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(form().getValues("placements.0.verification")).toEqual({ minTier: 1, capabilities: [], auditors: [] });
+    expect(screen.getByRole("button", { name: "Edit provider verification: L1 minimum" })).toBeInTheDocument();
+  });
+
+  it("edits only the selected placement", async () => {
+    const user = userEvent.setup();
+    const firstPlacementVerification: PlacementVerificationType = { minTier: 4, capabilities: [], auditors: [] };
+    const { form } = setup({ placementIndex: 1, firstPlacementVerification });
+
+    await user.click(screen.getByRole("button", { name: "Edit provider verification: Not required" }));
+    await user.click(screen.getByRole("switch", { name: "Require provider verification" }));
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(form().getValues("placements.0.verification")).toEqual(firstPlacementVerification);
+    expect(form().getValues("placements.1.verification")).toEqual({ minTier: 1, capabilities: [], auditors: [] });
+  });
+
+  it("restores nested verification fields when editing is cancelled", async () => {
+    const user = userEvent.setup();
+    const verification: PlacementVerificationType = {
+      minTier: 2,
+      minAuditorCount: 1,
+      capabilities: ["persistent_storage"],
+      auditors: [{ id: "kept", value: "akash1kept" }],
+      auditorMode: "all"
+    };
+    const { form } = setup({ verification });
+
+    await user.click(screen.getByRole("button", { name: /Edit provider verification/ }));
+    await user.clear(screen.getByRole("spinbutton", { name: "Minimum auditors" }));
+    await user.type(screen.getByRole("spinbutton", { name: "Minimum auditors" }), "3");
+    await user.click(screen.getByRole("button", { name: "Add auditor" }));
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(form().getValues("placements.0.verification")).toEqual(verification);
+  });
+
+  it("restores verification fields when the dialog is dismissed", async () => {
+    const user = userEvent.setup();
+    const verification: PlacementVerificationType = { minTier: 2, capabilities: [], auditors: [] };
+    const { form } = setup({ verification });
+
+    await user.click(screen.getByRole("button", { name: /Edit provider verification/ }));
+    await user.click(screen.getByRole("switch", { name: "Require provider verification" }));
+    await user.keyboard("{Escape}");
+
+    expect(form().getValues("placements.0.verification")).toEqual(verification);
+  });
+
+  it("prunes blank named auditors only when the editor is saved", async () => {
+    const user = userEvent.setup();
+    const { form } = setup({
+      verification: {
+        minTier: 2,
+        capabilities: [],
+        auditors: [
+          { id: "blank", value: "" },
+          { id: "kept", value: "akash1kept" }
+        ],
+        auditorMode: "any"
+      }
+    });
+
+    await user.click(screen.getByRole("button", { name: /Edit provider verification/ }));
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(form().getValues("placements.0.verification.auditors")).toEqual([{ id: "kept", value: "akash1kept" }]);
+  });
+
+  it("opens read-only while the deployment form is locked", async () => {
+    const user = userEvent.setup();
+    setup({ locked: true });
+
+    const button = screen.getByRole("button", { name: "Edit provider verification: Not required" });
+    expect(button).toBeEnabled();
+    await user.click(button);
+    expect(screen.getByRole("switch", { name: "Require provider verification" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+  });
+
+  it("marks the closed editor when submitted verification fields are invalid", async () => {
+    const { form } = setup({ verification: { minTier: 2, capabilities: [], auditors: [] } });
+
+    await act(async () => {
+      await form().handleSubmit(() => undefined)();
+      form().setError("placements.0.verification.minTier", { type: "manual", message: "Invalid tier" });
+    });
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /Edit provider verification/ })).toHaveAttribute("aria-invalid", "true"));
+  });
+
+  it("does not select the placement when the editor is opened", async () => {
+    const user = userEvent.setup();
+    const onPlacementClick = vi.fn();
+    setup({ onPlacementClick });
+
+    await user.click(screen.getByRole("button", { name: "Edit provider verification: Not required" }));
+
+    expect(onPlacementClick).not.toHaveBeenCalled();
+  });
+});
+
+function setup({
+  verification,
+  locked = false,
+  onPlacementClick,
+  placementIndex = 0,
+  firstPlacementVerification
+}: {
+  verification?: PlacementVerificationType;
+  locked?: boolean;
+  onPlacementClick?: () => void;
+  placementIndex?: number;
+  firstPlacementVerification?: PlacementVerificationType;
+} = {}) {
+  const values = defaultServiceWithPlacement();
+  if (placementIndex === 1) {
+    values.placements.push({ ...structuredClone(values.placements[0]), id: "placement-2", name: "edge" });
+    values.placements[0].verification = firstPlacementVerification;
+  }
+  values.placements[placementIndex].verification = verification;
+  let form: UseFormReturn<SdlBuilderFormValuesType> | undefined;
+
+  const Wrapper = ({ children }: PropsWithChildren) => {
+    const methods = useForm<SdlBuilderFormValuesType>({ defaultValues: values });
+    form = methods;
+
+    return (
+      <TooltipProvider>
+        <FormProvider {...methods}>
+          <div onClick={onPlacementClick}>{children}</div>
+        </FormProvider>
+      </TooltipProvider>
+    );
+  };
+
+  render(<PlacementVerificationEditor placementName={values.placements[placementIndex].name} placementIndex={placementIndex} locked={locked} />, {
+    wrapper: Wrapper
+  });
+
+  return {
+    form: () => {
+      if (!form) throw new Error("Form did not initialize");
+      return form;
+    }
+  };
+}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/PlacementCard/PlacementVerificationEditor.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/PlacementCard/PlacementVerificationEditor.tsx
@@ -1,0 +1,139 @@
+"use client";
+import type { MouseEvent } from "react";
+import { useCallback, useState } from "react";
+import { useFormContext, useWatch } from "react-hook-form";
+import {
+  Button,
+  DialogV2,
+  DialogV2Body,
+  DialogV2Content,
+  DialogV2Description,
+  DialogV2Footer,
+  DialogV2Header,
+  DialogV2Title
+} from "@akashnetwork/ui/components";
+import { SaveIcon, ShieldCheck } from "lucide-react";
+
+import { PlacementVerificationFormControl } from "@src/components/sdl/PlacementVerificationFormControl";
+import type { PlacementVerificationType, SdlBuilderFormValuesType } from "@src/types";
+
+type Props = {
+  placementIndex: number;
+  placementName: string;
+  locked: boolean;
+};
+
+export const PlacementVerificationEditor: React.FC<Props> = ({ placementIndex, placementName, locked }) => {
+  const { control, formState, getValues, reset, trigger } = useFormContext<SdlBuilderFormValuesType>();
+  const verification = useWatch({ control, name: `placements.${placementIndex}.verification` });
+  const [isOpen, setIsOpen] = useState(false);
+  const [snapshot, setSnapshot] = useState<SdlBuilderFormValuesType | null>(null);
+  const hasErrors = formState.isSubmitted && !!formState.errors.placements?.[placementIndex]?.verification;
+  const summary = getPlacementVerificationSummary(verification);
+
+  const openEditor = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation();
+      setSnapshot(structuredClone(getValues()));
+      setIsOpen(true);
+    },
+    [getValues]
+  );
+
+  const revalidate = useCallback(() => {
+    if (formState.isSubmitted) void trigger(`placements.${placementIndex}.verification`);
+  }, [formState.isSubmitted, placementIndex, trigger]);
+
+  const cancel = useCallback(() => {
+    if (snapshot) reset(snapshot, { keepErrors: true, keepIsSubmitted: true });
+    revalidate();
+    setIsOpen(false);
+  }, [reset, revalidate, snapshot]);
+
+  const save = useCallback(() => {
+    const values = structuredClone(getValues());
+    const requirement = values.placements[placementIndex].verification;
+
+    if (requirement?.auditors) {
+      requirement.auditors = requirement.auditors.filter(auditor => auditor.value.trim());
+      if (requirement.auditors.length === 0) requirement.auditorMode = undefined;
+    }
+
+    reset(values, { keepDirty: true, keepErrors: true, keepIsSubmitted: true });
+    revalidate();
+    setIsOpen(false);
+  }, [getValues, placementIndex, reset, revalidate]);
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="ghost"
+        onClick={openEditor}
+        aria-label={`Edit provider verification: ${summary}`}
+        aria-invalid={hasErrors}
+        className={`mt-2 flex h-auto w-full items-center justify-start gap-2 px-2 py-2 text-left ${hasErrors ? "border border-destructive" : ""}`}
+      >
+        <ShieldCheck className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+        <span className="min-w-0 flex-1">
+          <span className="block text-xs font-medium">Provider verification</span>
+          <span className="block truncate text-xs font-normal text-muted-foreground">{summary}</span>
+        </span>
+      </Button>
+
+      <DialogV2
+        open={isOpen}
+        onOpenChange={open => {
+          if (!open) cancel();
+        }}
+      >
+        <DialogV2Content
+          className="max-w-2xl"
+          aria-describedby={`placement-${placementIndex}-verification-description`}
+          onClick={event => event.stopPropagation()}
+        >
+          <DialogV2Header>
+            <DialogV2Title>Provider verification · {placementName}</DialogV2Title>
+            <DialogV2Description id={`placement-${placementIndex}-verification-description`} className="sr-only">
+              Provider verification requirements for {placementName}
+            </DialogV2Description>
+          </DialogV2Header>
+          <DialogV2Body>
+            <fieldset disabled={locked} className="contents">
+              <PlacementVerificationFormControl control={control} placementIndex={placementIndex} showTopDivider={false} />
+            </fieldset>
+          </DialogV2Body>
+          <DialogV2Footer>
+            <Button type="button" variant="ghost" onClick={cancel}>
+              Cancel
+            </Button>
+            <Button type="button" onClick={save} disabled={locked}>
+              Save
+              <SaveIcon className="ml-2 size-4" />
+            </Button>
+          </DialogV2Footer>
+        </DialogV2Content>
+      </DialogV2>
+    </>
+  );
+};
+
+export function getPlacementVerificationSummary(verification: PlacementVerificationType | undefined): string {
+  if (!verification) return "Not required";
+
+  const parts = [`L${verification.minTier} minimum`];
+
+  if (verification.minAuditorCount) {
+    parts.push(`${verification.minAuditorCount} ${verification.minAuditorCount === 1 ? "auditor" : "auditors"}`);
+  }
+
+  if (verification.capabilities?.length) {
+    parts.push(`${verification.capabilities.length} ${verification.capabilities.length === 1 ? "capability" : "capabilities"}`);
+  }
+
+  if (verification.auditors?.length) {
+    parts.push(`${verification.auditors.length} named ${verification.auditors.length === 1 ? "auditor" : "auditors"}`);
+  }
+
+  return parts.join(" · ");
+}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.spec.tsx
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
 
 import type { PlacementOffer } from "@src/queries/usePlacementOffers";
+import type { ProviderVerificationExclusion } from "@src/queries/useScreenedProviders";
 import type { DeploymentFlowPhase } from "../useDeploymentFlow/useDeploymentFlow";
 import { ProviderSearchInput } from "./ProviderSearchInput/ProviderSearchInput";
 import type { DEPENDENCIES } from "./MarketplacePane";
@@ -14,7 +16,14 @@ describe(MarketplacePane.name, () => {
   it("reads offers for the current phase, dseq, sdl, placement and region", () => {
     const { usePlacementOffers } = setup({ sdl: "version: 2.0", placementName: "dcloud", region: "na-us-west", phase: "quoting", dseq: "100" });
 
-    expect(usePlacementOffers).toHaveBeenCalledWith({ sdl: "version: 2.0", placementName: "dcloud", region: "na-us-west", phase: "quoting", dseq: "100" });
+    expect(usePlacementOffers).toHaveBeenCalledWith({
+      sdl: "version: 2.0",
+      placementName: "dcloud",
+      region: "na-us-west",
+      phase: "quoting",
+      dseq: "100",
+      verificationEnabled: false
+    });
   });
 
   it("shows the placement name in the header", () => {
@@ -28,6 +37,13 @@ describe(MarketplacePane.name, () => {
     const { MarketplaceProvidersTable } = setup({ offers, isLoading: false });
 
     expect(MarketplaceProvidersTable).toHaveBeenCalledWith(expect.objectContaining({ providers: offers, isLoading: false }), expect.anything());
+  });
+
+  it("passes verification exclusions to the table only when the feature is enabled", () => {
+    const exclusions = [mock<ProviderVerificationExclusion>({ owner: "akash1excluded" })];
+    const { MarketplaceProvidersTable } = setup({ providerVerificationEnabled: true, exclusions });
+
+    expect(MarketplaceProvidersTable).toHaveBeenCalledWith(expect.objectContaining({ exclusions, verificationEnabled: true }), expect.anything());
   });
 
   it("passes the spec's GPU count to the table", () => {
@@ -131,6 +147,8 @@ describe(MarketplacePane.name, () => {
       isSearchActive?: boolean;
       gpuCount?: number;
       isOnboarded?: boolean;
+      providerVerificationEnabled?: boolean;
+      exclusions?: ReturnType<typeof DEPENDENCIES.usePlacementOffers>["exclusions"];
       selectedPlacementId?: string;
       selectedBidId?: string;
       onSelectProvider?: (placementId: string, bidId: string) => void;
@@ -138,6 +156,7 @@ describe(MarketplacePane.name, () => {
   ) {
     const usePlacementOffers = vi.fn(() => ({
       offers: input.offers ?? [],
+      exclusions: input.exclusions ?? [],
       isLoading: input.isLoading ?? false,
       isError: input.isError ?? false,
       isInvalid: input.isInvalid ?? false
@@ -161,7 +180,8 @@ describe(MarketplacePane.name, () => {
       MarketplaceProvidersTable: MarketplaceProvidersTable as never,
       ProviderSearchInput,
       useDeploymentGpuCount,
-      useIsOnboarded: () => input.isOnboarded ?? true
+      useIsOnboarded: () => input.isOnboarded ?? true,
+      useFlag: () => input.providerVerificationEnabled ?? false
     };
     const user = userEvent.setup();
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.tsx
@@ -1,14 +1,25 @@
 import type { FC } from "react";
+import { useMemo } from "react";
 
+import { useFlag } from "@src/hooks/useFlag";
 import { useIsOnboarded } from "@src/hooks/useIsOnboarded";
 import { usePlacementOffers } from "@src/queries/usePlacementOffers";
+import { hasPlacementVerificationRequirement } from "@src/queries/useScreenedProviders";
 import { useDeploymentGpuCount } from "../DeploymentResourceSummary/useDeploymentResourceSummary";
 import type { DeploymentFlowPhase } from "../useDeploymentFlow/useDeploymentFlow";
 import { MarketplaceProvidersTable } from "./MarketplaceProvidersTable/MarketplaceProvidersTable";
 import { useProviderSearch } from "./MarketplaceProvidersTable/useProviderSearch/useProviderSearch";
 import { ProviderSearchInput } from "./ProviderSearchInput/ProviderSearchInput";
 
-export const DEPENDENCIES = { usePlacementOffers, useProviderSearch, MarketplaceProvidersTable, ProviderSearchInput, useDeploymentGpuCount, useIsOnboarded };
+export const DEPENDENCIES = {
+  usePlacementOffers,
+  useProviderSearch,
+  MarketplaceProvidersTable,
+  ProviderSearchInput,
+  useDeploymentGpuCount,
+  useIsOnboarded,
+  useFlag
+};
 
 interface Props {
   sdl: string;
@@ -33,9 +44,18 @@ export const MarketplacePane: FC<Props> = ({
   onSelectProvider,
   dependencies: d = DEPENDENCIES
 }) => {
-  const { offers, isLoading, isError, isInvalid } = d.usePlacementOffers({ phase, dseq: dseq ?? undefined, sdl, placementName, region });
+  const isProviderVerificationEnabled = d.useFlag("provider_verification");
+  const { offers, exclusions, isLoading, isError, isInvalid } = d.usePlacementOffers({
+    phase,
+    dseq: dseq ?? undefined,
+    sdl,
+    placementName,
+    region,
+    verificationEnabled: isProviderVerificationEnabled
+  });
   const { query, setQuery, clear, filteredProviders, isSearchActive } = d.useProviderSearch(offers);
   const hasFailedWithoutData = isError && offers.length === 0;
+  const verificationRequired = useMemo(() => hasPlacementVerificationRequirement(sdl, placementName), [placementName, sdl]);
   const gpuCount = d.useDeploymentGpuCount(selectedPlacementId);
   /** Provider names link out only once the user is onboarded: the route gate bounces a not-yet-onboarded user back into the funnel, so the link would dead-end. */
   const showProviderLink = d.useIsOnboarded();
@@ -66,6 +86,9 @@ export const MarketplacePane: FC<Props> = ({
         ) : (
           <d.MarketplaceProvidersTable
             providers={filteredProviders}
+            exclusions={exclusions}
+            verificationEnabled={isProviderVerificationEnabled}
+            verificationRequired={verificationRequired}
             isLoading={isLoading}
             isSearchActive={isSearchActive}
             onClearSearch={clear}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProviderCell.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProviderCell.tsx
@@ -1,4 +1,6 @@
 import type { FC } from "react";
+import { CapabilityFlag, VerificationTier } from "@akashnetwork/chain-sdk/private-types/akash.v1";
+import { Badge } from "@akashnetwork/ui/components";
 import Link from "next/link";
 
 import { ShortenedValue } from "@src/components/shared/ShortenedValue";
@@ -21,6 +23,7 @@ interface Props {
   offer: PlacementOffer;
   /** Whether the name links to the provider's detail page. */
   showProviderLink: boolean;
+  verificationEnabled?: boolean;
 }
 
 /**
@@ -28,7 +31,7 @@ interface Props {
  * in-progress deployment isn't lost) when `showProviderLink` allows it. When the name is a moniker (organization), the
  * actual host is shown beneath it — the self-declared name alone doesn't tell you which provider you're really getting.
  */
-export const MarketplaceProviderCell: FC<Props> = ({ offer, showProviderLink }) => {
+export const MarketplaceProviderCell: FC<Props> = ({ offer, showProviderLink, verificationEnabled = false }) => {
   const displayName = providerDisplayName(offer);
   const host = getProviderHost(offer.hostUri);
   const subtitle = host && host !== displayName ? host : null;
@@ -50,6 +53,68 @@ export const MarketplaceProviderCell: FC<Props> = ({ offer, showProviderLink }) 
         <span className="min-w-0 truncate font-medium">{name}</span>
       )}
       {subtitle && <span className="min-w-0 truncate text-xs font-normal text-muted-foreground">{subtitle}</span>}
+      {verificationEnabled && offer.verification && <VerificationFacts verification={offer.verification} />}
     </div>
   );
 };
+
+function VerificationFacts({ verification }: { verification: NonNullable<PlacementOffer["verification"]> }) {
+  if (verification.outcome === "not_evaluated") {
+    return (
+      <div className="mt-1">
+        <Badge variant="outline" className="px-1.5 py-0 text-xs font-normal">
+          Verification not evaluated
+        </Badge>
+      </div>
+    );
+  }
+
+  const { summary } = verification;
+  const auditorCount = summary.validAuditors.length;
+  const capabilities = summary.capabilities.map(formatCapability).filter(Boolean);
+
+  return (
+    <div className="mt-1 space-y-0.5 text-xs font-normal text-muted-foreground">
+      <div className="flex flex-wrap items-center gap-1">
+        <Badge variant="secondary" className="px-1.5 py-0 text-xs font-normal">
+          Auditor-attested {formatTier(summary.tierGateTier)}
+        </Badge>
+        <span>
+          {auditorCount} {auditorCount === 1 ? "auditor" : "auditors"}
+        </span>
+      </div>
+      {capabilities.length > 0 && <p>{capabilities.join(", ")}</p>}
+      <p>Provider-signed inventory: {summary.snapshotState.replace("_", " ")}</p>
+    </div>
+  );
+}
+
+function formatTier(tier: number): string {
+  switch (tier) {
+    case VerificationTier.verification_tier_identified:
+      return "L1";
+    case VerificationTier.verification_tier_verified:
+      return "L2";
+    case VerificationTier.verification_tier_established:
+      return "L3";
+    case VerificationTier.verification_tier_trusted:
+      return "L4";
+    default:
+      return "L0";
+  }
+}
+
+function formatCapability(capability: number): string {
+  switch (capability) {
+    case CapabilityFlag.capability_tee_hardware_attestation:
+      return "TEE hardware";
+    case CapabilityFlag.capability_confidential_computing:
+      return "Confidential computing";
+    case CapabilityFlag.capability_persistent_storage:
+      return "Persistent storage";
+    case CapabilityFlag.capability_bare_metal:
+      return "Bare metal";
+    default:
+      return "";
+  }
+}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.spec.tsx
@@ -1,10 +1,12 @@
 import { IntlProvider } from "react-intl";
+import { CapabilityFlag, VerificationTier } from "@akashnetwork/chain-sdk/private-types/akash.v1";
 import { TooltipProvider } from "@akashnetwork/ui/components";
 import { format, subDays } from "date-fns";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { PlacementOffer } from "@src/queries/usePlacementOffers";
+import type { ProviderVerificationExclusion } from "@src/queries/useScreenedProviders";
 import { MarketplaceProvidersTable } from "./MarketplaceProvidersTable";
 
 import { render, screen, within } from "@testing-library/react";
@@ -31,6 +33,29 @@ describe(MarketplaceProvidersTable.name, () => {
     setup({ providers: [buildOffer({ hostUri: "https://a.example:8443", location: null })] });
 
     expect(screen.getAllByText("—").length).toBeGreaterThan(0);
+  });
+
+  it("shows auditor-attested facts for an eligible provider when verification is enabled", () => {
+    setup({ providers: [verifiedOffer()], verificationEnabled: true });
+
+    expect(screen.getByText("Auditor-attested L2")).toBeInTheDocument();
+    expect(screen.getByText("2 auditors")).toBeInTheDocument();
+    expect(screen.getByText("Persistent storage")).toBeInTheDocument();
+    expect(screen.getByText("Provider-signed inventory: current")).toBeInTheDocument();
+  });
+
+  it("does not expose verification facts while the feature flag is off", () => {
+    setup({ providers: [verifiedOffer()], verificationEnabled: false });
+
+    expect(screen.queryByText("Auditor-attested L2")).not.toBeInTheDocument();
+  });
+
+  it("shows the first exclusion reason and provides the full failure set", async () => {
+    setup({ providers: [verifiedOffer()], verificationEnabled: true, exclusions: [verificationExclusion()] });
+
+    expect(screen.getAllByText(/Auditor-attested tier is L1; L2 is required/)).not.toHaveLength(0);
+    await userEvent.click(screen.getByText("View all 2 reasons"));
+    expect(screen.getByText("Missing auditor-attested capability: Persistent storage")).toBeInTheDocument();
   });
 
   it("sorts rows by provider host when the Provider header is toggled ascending", async () => {
@@ -122,6 +147,22 @@ describe(MarketplaceProvidersTable.name, () => {
 
     expect(screen.getByText("No providers found.")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /clear search/i })).not.toBeInTheDocument();
+  });
+
+  it("shows an actionable empty state when no provider meets the verification policy", () => {
+    setup({ providers: [], verificationEnabled: true, verificationRequired: true });
+
+    expect(screen.getByText("No providers currently meet this verification policy.")).toBeInTheDocument();
+    expect(screen.getByText(/lower tier/i)).toBeInTheDocument();
+    expect(screen.queryByText("No providers found.")).not.toBeInTheDocument();
+  });
+
+  it("keeps the actionable verification empty state above provider exclusions", () => {
+    setup({ providers: [], verificationEnabled: true, verificationRequired: true, exclusions: [verificationExclusion()] });
+
+    expect(screen.getByText("No providers currently meet this verification policy.")).toBeInTheDocument();
+    expect(screen.getByText(/review the exclusions below/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Auditor-attested tier is L1; L2 is required/)).not.toHaveLength(0);
   });
 
   it("omits the clear action in the search empty state when no clear handler is provided", () => {
@@ -329,6 +370,57 @@ describe(MarketplaceProvidersTable.name, () => {
     });
   }
 
+  function verifiedOffer(): PlacementOffer {
+    return mock<PlacementOffer>({
+      offerState: "searching",
+      owner: "akash1verified",
+      organization: "Verified Provider",
+      hostUri: "https://verified.example:8443",
+      location: "us-west",
+      incidents: [],
+      verification: {
+        outcome: "pass",
+        summary: {
+          bestStatusValidTier: VerificationTier.verification_tier_verified,
+          tierGateTier: VerificationTier.verification_tier_verified,
+          capabilities: [CapabilityFlag.capability_persistent_storage],
+          validAttestationCount: 2,
+          validAuditors: ["akash1auditor1", "akash1auditor2"],
+          snapshotState: "current",
+          observedHeight: "123"
+        }
+      }
+    });
+  }
+
+  function verificationExclusion(): ProviderVerificationExclusion {
+    return {
+      owner: "akash1excluded",
+      firstFailure: {
+        code: "insufficient_tier",
+        actual: VerificationTier.verification_tier_identified,
+        required: VerificationTier.verification_tier_verified
+      },
+      failures: [
+        {
+          code: "insufficient_tier",
+          actual: VerificationTier.verification_tier_identified,
+          required: VerificationTier.verification_tier_verified
+        },
+        { code: "missing_capability", capability: CapabilityFlag.capability_persistent_storage }
+      ],
+      summary: {
+        bestStatusValidTier: VerificationTier.verification_tier_identified,
+        tierGateTier: VerificationTier.verification_tier_identified,
+        capabilities: [],
+        validAttestationCount: 1,
+        validAuditors: ["akash1auditor"],
+        snapshotState: "not_posted",
+        observedHeight: "123"
+      }
+    };
+  }
+
   function setup(input: {
     providers: PlacementOffer[];
     isLoading?: boolean;
@@ -338,6 +430,9 @@ describe(MarketplaceProvidersTable.name, () => {
     isSelectable?: boolean;
     gpuCount?: number;
     showProviderLink?: boolean;
+    verificationEnabled?: boolean;
+    verificationRequired?: boolean;
+    exclusions?: ProviderVerificationExclusion[];
   }) {
     const onSelect = vi.fn();
     const user = userEvent.setup();
@@ -347,6 +442,9 @@ describe(MarketplaceProvidersTable.name, () => {
           <TooltipProvider>
             <MarketplaceProvidersTable
               providers={input.providers}
+              exclusions={input.exclusions}
+              verificationEnabled={input.verificationEnabled}
+              verificationRequired={input.verificationRequired}
               isLoading={input.isLoading}
               isSearchActive={input.isSearchActive}
               onClearSearch={input.onClearSearch}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.tsx
@@ -1,5 +1,6 @@
 import type { FC } from "react";
 import { useMemo, useState } from "react";
+import { AuditorSelectionMode, CapabilityFlag, VerificationTier } from "@akashnetwork/chain-sdk/private-types/akash.v1";
 import { Badge, Button, Skeleton, Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@akashnetwork/ui/components";
 import { cn } from "@akashnetwork/ui/utils";
 import type { Column, Row, SortingState } from "@tanstack/react-table";
@@ -8,6 +9,7 @@ import { ArrowDown, ArrowUp, ChevronsUpDown } from "lucide-react";
 
 import { CostRate } from "@src/components/shared/CostRate";
 import type { PlacementOffer } from "@src/queries/usePlacementOffers";
+import type { ProviderVerificationExclusion, ProviderVerificationFailure } from "@src/queries/useScreenedProviders";
 import { providerDisplayName } from "@src/utils/providerUtils";
 import type { ProviderUptime } from "./ProviderUptimeCell/deriveProviderUptime";
 import { useProvidersUptime } from "./ProviderUptimeCell/deriveProviderUptime";
@@ -36,6 +38,9 @@ const COLUMN_WIDTH_CLASS: Record<string, string | undefined> = {
 
 interface Props {
   providers: PlacementOffer[];
+  exclusions?: ProviderVerificationExclusion[];
+  verificationEnabled?: boolean;
+  verificationRequired?: boolean;
   isLoading?: boolean;
   isSearchActive?: boolean;
   onClearSearch?: () => void;
@@ -51,6 +56,9 @@ interface Props {
 
 export const MarketplaceProvidersTable: FC<Props> = ({
   providers,
+  exclusions = [],
+  verificationEnabled = false,
+  verificationRequired = false,
   isLoading,
   isSearchActive,
   onClearSearch,
@@ -68,8 +76,18 @@ export const MarketplaceProvidersTable: FC<Props> = ({
   /** Cost only makes sense once bids arrive: a submitted bid is priced and a closed/expired one keeps its last price, but a screened-only candidate has none. */
   const showCost = providers.some(provider => !!provider.price);
   const columns = useMemo(
-    () => buildColumns(uptimeByOwner, { selectedBidId, onSelect, isSelectable, showCost, showStatus: isMerged, gpuCount, showProviderLink }),
-    [uptimeByOwner, selectedBidId, onSelect, isSelectable, showCost, isMerged, gpuCount, showProviderLink]
+    () =>
+      buildColumns(uptimeByOwner, {
+        selectedBidId,
+        onSelect,
+        isSelectable,
+        showCost,
+        showStatus: isMerged,
+        gpuCount,
+        showProviderLink,
+        verificationEnabled
+      }),
+    [uptimeByOwner, selectedBidId, onSelect, isSelectable, showCost, isMerged, gpuCount, showProviderLink, verificationEnabled]
   );
 
   const table = useReactTable({
@@ -98,6 +116,25 @@ export const MarketplaceProvidersTable: FC<Props> = ({
         </div>
       );
     }
+    if (verificationRequired && exclusions.length > 0) {
+      return (
+        <div className="space-y-3">
+          <div role="status" className="space-y-1 p-4">
+            <p className="text-sm font-medium">No providers currently meet this verification policy.</p>
+            <p className="text-sm text-muted-foreground">Review the exclusions below or relax the placement requirements.</p>
+          </div>
+          <VerificationExclusions exclusions={exclusions} />
+        </div>
+      );
+    }
+    if (verificationRequired) {
+      return (
+        <div role="status" className="space-y-1 p-4">
+          <p className="text-sm font-medium">No providers currently meet this verification policy.</p>
+          <p className="text-sm text-muted-foreground">Try a lower tier, fewer required capabilities, or different resource requirements.</p>
+        </div>
+      );
+    }
     return <p className="p-4 text-sm text-muted-foreground">No providers found.</p>;
   }
 
@@ -112,35 +149,38 @@ export const MarketplaceProvidersTable: FC<Props> = ({
   const columnCount = table.getVisibleFlatColumns().length;
 
   return (
-    <div className="overflow-hidden rounded-lg border border-zinc-300 bg-card shadow-sm dark:border-zinc-700">
-      <Table className="table-fixed">
-        <TableHeader>
-          {table.getHeaderGroups().map(headerGroup => (
-            <TableRow key={headerGroup.id} className="bg-muted/40 hover:bg-muted/40">
-              {headerGroup.headers.map(header => (
-                <TableHead key={header.id} className={cn("h-10 pl-4 pr-2", COLUMN_WIDTH_CLASS[header.column.id])}>
-                  {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
-                </TableHead>
-              ))}
-            </TableRow>
-          ))}
-        </TableHeader>
-        <TableBody>
-          {biddableRows.map(row => (
-            <OfferRow key={row.id} row={row} />
-          ))}
-          {noBidRows.length > 0 && biddableRows.length > 0 && (
-            <TableRow key="didnt-bid-divider" className="hover:bg-transparent">
-              <TableCell colSpan={columnCount} className="h-8 bg-muted/30 py-1 pl-4 font-mono text-xs uppercase tracking-wide text-muted-foreground">
-                didn&apos;t bid
-              </TableCell>
-            </TableRow>
-          )}
-          {noBidRows.map(row => (
-            <OfferRow key={row.id} row={row} />
-          ))}
-        </TableBody>
-      </Table>
+    <div className="space-y-3">
+      <div className="overflow-hidden rounded-lg border border-zinc-300 bg-card shadow-sm dark:border-zinc-700">
+        <Table className="table-fixed">
+          <TableHeader>
+            {table.getHeaderGroups().map(headerGroup => (
+              <TableRow key={headerGroup.id} className="bg-muted/40 hover:bg-muted/40">
+                {headerGroup.headers.map(header => (
+                  <TableHead key={header.id} className={cn("h-10 pl-4 pr-2", COLUMN_WIDTH_CLASS[header.column.id])}>
+                    {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
+                  </TableHead>
+                ))}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {biddableRows.map(row => (
+              <OfferRow key={row.id} row={row} />
+            ))}
+            {noBidRows.length > 0 && biddableRows.length > 0 && (
+              <TableRow key="didnt-bid-divider" className="hover:bg-transparent">
+                <TableCell colSpan={columnCount} className="h-8 bg-muted/30 py-1 pl-4 font-mono text-xs uppercase tracking-wide text-muted-foreground">
+                  didn&apos;t bid
+                </TableCell>
+              </TableRow>
+            )}
+            {noBidRows.map(row => (
+              <OfferRow key={row.id} row={row} />
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+      {verificationEnabled && exclusions.length > 0 && <VerificationExclusions exclusions={exclusions} />}
     </div>
   );
 };
@@ -241,13 +281,16 @@ function buildColumns(
     showStatus: boolean;
     gpuCount: number;
     showProviderLink: boolean;
+    verificationEnabled: boolean;
   }
 ) {
   return [
     columnHelper.accessor(providerDisplayName, {
       id: "hostUri",
       header: ({ column }) => <SortableHeader column={column} title="Provider" />,
-      cell: info => <MarketplaceProviderCell offer={info.row.original} showProviderLink={selection.showProviderLink} />
+      cell: info => (
+        <MarketplaceProviderCell offer={info.row.original} showProviderLink={selection.showProviderLink} verificationEnabled={selection.verificationEnabled} />
+      )
     }),
     columnHelper.accessor("location", {
       header: ({ column }) => <SortableHeader column={column} title="Region" />,
@@ -299,4 +342,85 @@ function buildColumns(
         ]
       : [])
   ];
+}
+
+function VerificationExclusions({ exclusions }: { exclusions: ProviderVerificationExclusion[] }) {
+  return (
+    <section aria-label="Providers excluded by verification policy" className="border-t border-zinc-300 pt-3 dark:border-zinc-700">
+      <h3 className="font-mono text-xs font-medium uppercase text-muted-foreground">Excluded by verification policy ({exclusions.length})</h3>
+      <div className="mt-2 divide-y divide-zinc-200 border-y border-zinc-200 dark:divide-zinc-800 dark:border-zinc-800">
+        {exclusions.map(exclusion => (
+          <div key={exclusion.owner} className="py-2 text-sm">
+            <p>
+              <span className="font-medium">{exclusion.owner}</span>
+              <span className="text-muted-foreground">: {formatVerificationFailure(exclusion.firstFailure)}</span>
+            </p>
+            {exclusion.failures.length > 1 && (
+              <details className="mt-1 text-xs text-muted-foreground">
+                <summary className="cursor-pointer">View all {exclusion.failures.length} reasons</summary>
+                <ul className="mt-1 space-y-1 pl-4">
+                  {exclusion.failures.map((failure, index) => (
+                    <li key={`${failure.code}-${index}`}>{formatVerificationFailure(failure)}</li>
+                  ))}
+                </ul>
+              </details>
+            )}
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function formatVerificationFailure(failure: ProviderVerificationFailure): string {
+  switch (failure.code) {
+    case "snapshot_not_posted":
+      return "No provider-signed inventory snapshot is posted";
+    case "snapshot_suspended":
+      return "Provider-signed inventory snapshot is suspended";
+    case "snapshot_stale":
+      return "Provider-signed inventory snapshot is stale";
+    case "insufficient_tier":
+      return `Auditor-attested tier is ${formatTier(failure.actual)}; ${formatTier(failure.required)} is required`;
+    case "missing_capability":
+      return `Missing auditor-attested capability: ${formatCapability(failure.capability)}`;
+    case "insufficient_auditor_count":
+      return `${failure.actual} qualifying auditors; ${failure.required} required`;
+    case "required_auditor_not_found":
+      return `${formatAuditorMode(failure.mode)} named-auditor policy is not satisfied`;
+  }
+}
+
+function formatTier(tier: number): string {
+  switch (tier) {
+    case VerificationTier.verification_tier_identified:
+      return "L1";
+    case VerificationTier.verification_tier_verified:
+      return "L2";
+    case VerificationTier.verification_tier_established:
+      return "L3";
+    case VerificationTier.verification_tier_trusted:
+      return "L4";
+    default:
+      return "L0";
+  }
+}
+
+function formatCapability(capability: number): string {
+  switch (capability) {
+    case CapabilityFlag.capability_tee_hardware_attestation:
+      return "TEE hardware attestation";
+    case CapabilityFlag.capability_confidential_computing:
+      return "Confidential computing";
+    case CapabilityFlag.capability_persistent_storage:
+      return "Persistent storage";
+    case CapabilityFlag.capability_bare_metal:
+      return "Bare metal";
+    default:
+      return "Unknown capability";
+  }
+}
+
+function formatAuditorMode(mode: number): string {
+  return mode === AuditorSelectionMode.auditor_selection_mode_all ? "All" : "Any";
 }

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.spec.tsx
@@ -4,10 +4,11 @@ import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { ForwardedPort, LeaseServiceStatus, LeaseStatusDto } from "@src/queries/useLeaseQuery";
-import type { DeploymentGroup, LeaseDto } from "@src/types/deployment";
-import type { ApiProviderList } from "@src/types/provider";
+import type { DeploymentGroup, LeaseDto, RpcVerificationRequirement } from "@src/types/deployment";
+import type { ApiProviderDetail, ApiProviderList, ProviderVerificationView } from "@src/types/provider";
 import { DEPENDENCIES, PlacementCard } from "./PlacementCard";
 import type { ManifestServiceDetail } from "./placementModel";
+import type { PlacementVerificationPanelProps } from "./PlacementVerificationPanel";
 
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -166,30 +167,73 @@ describe(PlacementCard.name, () => {
     expect(screen.queryByText("Reclaiming")).not.toBeInTheDocument();
   });
 
+  it("passes the on-chain policy and API provider facts to the verification panel when enabled", () => {
+    const PlacementVerificationPanel = vi.fn((_props: PlacementVerificationPanelProps) => <div>verification-panel</div>);
+    const verification = mock<ProviderVerificationView>({ provider: "akash1p" });
+
+    setup({
+      lease: buildLease({ verification: buildVerificationRequirement(), signedBy: { all_of: ["akash1legacy"], any_of: [] } }),
+      providerDetail: buildProviderDetail(verification),
+      dependencies: { useFlag: () => true, PlacementVerificationPanel }
+    });
+
+    expect(screen.getByText("verification-panel")).toBeInTheDocument();
+    expect(PlacementVerificationPanel.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        placementName: "dcloud",
+        policy: {
+          legacySignedBy: { allOf: ["akash1legacy"], anyOf: [] },
+          verification: expect.objectContaining({ minTier: "L2" })
+        },
+        verification
+      })
+    );
+  });
+
+  it("does not mount the verification panel while the feature flag is disabled", () => {
+    const PlacementVerificationPanel = vi.fn((_props: PlacementVerificationPanelProps) => <div>verification-panel</div>);
+    const useProviderDetail = vi.fn(() => mock<ReturnType<typeof DEPENDENCIES.useProviderDetail>>({ data: null }));
+
+    setup({
+      lease: buildLease({ verification: buildVerificationRequirement() }),
+      dependencies: { useFlag: () => false, useProviderDetail, PlacementVerificationPanel }
+    });
+
+    expect(PlacementVerificationPanel).not.toHaveBeenCalled();
+    expect(useProviderDetail).toHaveBeenCalledWith("akash1p", { enabled: false });
+  });
+
   function buildLease(input?: {
     groupName?: string;
     state?: string;
     groupState?: string;
     gpuAmount?: number;
     gpuAttributes?: { key: string; value: string }[];
+    signedBy?: { all_of: string[]; any_of: string[] };
+    verification?: RpcVerificationRequirement;
   }) {
-    return mock<LeaseDto>({
+    const lease = mock<LeaseDto>({
       id: "1",
       provider: "akash1p",
       state: input?.state ?? "active",
       cpuAmount: 6,
       gpuAmount: input?.gpuAmount ?? 0,
       memoryAmount: 1_000_000,
-      storageAmount: 2_000_000,
-      group: mock<DeploymentGroup>({
-        state: input?.groupState ?? "active",
-        group_spec: {
-          name: input?.groupName ?? "dcloud",
-          requirements: { attributes: [] as { key: string; value: string }[] },
-          resources: input?.gpuAttributes ? [{ resource: { gpu: { attributes: input.gpuAttributes } } }] : ([] as DeploymentGroup["group_spec"]["resources"])
-        }
-      } as Partial<DeploymentGroup>)
+      storageAmount: 2_000_000
     });
+    lease.group = {
+      state: input?.groupState ?? "active",
+      group_spec: {
+        name: input?.groupName ?? "dcloud",
+        requirements: {
+          signed_by: input?.signedBy ?? { all_of: [], any_of: [] },
+          verification: input?.verification,
+          attributes: []
+        },
+        resources: input?.gpuAttributes ? [{ resource: { gpu: { attributes: input.gpuAttributes } } }] : []
+      }
+    } as unknown as DeploymentGroup;
+    return lease;
   }
 
   function buildStatus(serviceNames: string[], forwardedPorts: Record<string, ForwardedPort[]> = {}) {
@@ -201,12 +245,29 @@ describe(PlacementCard.name, () => {
   }
 
   function buildProvider(input?: { region?: string }) {
-    return mock<ApiProviderList>({
+    const provider = mock<ApiProviderList>({
       owner: "akash1p",
       organization: "Meridian Cloud",
       locationRegion: "",
-      attributes: input?.region ? [{ key: "region", value: input.region, auditedBy: [] }] : []
+      attributes: input?.region ? [{ key: "region", value: input.region, auditedBy: [] }] : [],
+      verification: null
     });
+    provider.verification = null;
+    return provider;
+  }
+
+  function buildProviderDetail(verification: ProviderVerificationView): ApiProviderDetail {
+    return mock<ApiProviderDetail>({ owner: "akash1p", verification });
+  }
+
+  function buildVerificationRequirement(): RpcVerificationRequirement {
+    return {
+      min_tier: "verification_tier_verified",
+      required_capabilities: ["capability_persistent_storage"],
+      required_auditors: ["akash1auditor"],
+      auditor_mode: "auditor_selection_mode_any",
+      min_auditor_count: 1
+    };
   }
 
   it.each([502, 503])("warns that the provider is not responding when lease status fails with %s", status => {
@@ -233,6 +294,7 @@ describe(PlacementCard.name, () => {
   function setup(input?: {
     lease?: LeaseDto;
     provider?: ApiProviderList;
+    providerDetail?: ApiProviderDetail | null;
     leaseStatus?: LeaseStatusDto | null;
     leaseStatusError?: unknown;
     isLeaseStatusPending?: boolean;
@@ -248,6 +310,8 @@ describe(PlacementCard.name, () => {
         isPending: !leaseStatus && !input?.leaseStatusError,
         isLoading: input?.isLeaseStatusPending ?? false
       });
+    const useProviderDetail: typeof DEPENDENCIES.useProviderDetail = () =>
+      mock<ReturnType<typeof DEPENDENCIES.useProviderDetail>>({ data: input?.providerDetail ?? null });
     const useTeeResourceCarveouts: typeof DEPENDENCIES.useTeeResourceCarveouts = () => [];
 
     return render(
@@ -260,7 +324,7 @@ describe(PlacementCard.name, () => {
           placementServices={input?.placementServices}
           dseq="123"
           onClosed={vi.fn()}
-          dependencies={MockComponents(DEPENDENCIES, { useLeaseStatus, useTeeResourceCarveouts, ...input?.dependencies })}
+          dependencies={MockComponents(DEPENDENCIES, { useLeaseStatus, useProviderDetail, useTeeResourceCarveouts, ...input?.dependencies })}
         />
       </TooltipProvider>
     );

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementCard.tsx
@@ -4,8 +4,10 @@ import { useState } from "react";
 import { MapPin, NavArrowRight, Server } from "iconoir-react";
 import Link from "next/link";
 
+import { useFlag } from "@src/hooks/useFlag";
 import { useTeeResourceCarveouts } from "@src/hooks/useTeeResourceCarveouts";
 import { useLeaseStatus } from "@src/queries/useLeaseQuery";
+import { useProviderDetail } from "@src/queries/useProvidersQuery";
 import { isProviderUnavailableError } from "@src/services/query-error-policy/query-error-policy";
 import type { LeaseDto } from "@src/types/deployment";
 import type { ApiProviderList } from "@src/types/provider";
@@ -25,14 +27,19 @@ import { formatGpuLabel, getPlacementGpuModels, getPlacementName, getProviderReg
 import { PlacementServiceRow } from "./PlacementServiceRow";
 import type { PlacementStat } from "./PlacementStats";
 import { PlacementStats } from "./PlacementStats";
+import { getPlacementSecurityPolicy } from "./placementVerificationModel";
+import { PlacementVerificationPanel } from "./PlacementVerificationPanel";
 
 export const DEPENDENCIES = {
+  useFlag,
   useLeaseStatus,
+  useProviderDetail,
   useTeeResourceCarveouts,
   ReclamationCard,
   ConfidentialComputeResources,
   DownloadAttestationEvidence,
-  PlacementServiceRow
+  PlacementServiceRow,
+  PlacementVerificationPanel
 };
 
 export interface PlacementCardProps {
@@ -66,6 +73,10 @@ export const PlacementCard: FC<PlacementCardProps> = ({
   const isLeaseStatusPending = isLeaseActive && !!provider && isLoading;
   const isProviderUnreachable = isLeaseActive && isProviderUnavailableError(leaseStatusError);
   const carveouts = d.useTeeResourceCarveouts(lease);
+  const isProviderVerificationEnabled = d.useFlag("provider_verification");
+  const { data: providerDetail } = d.useProviderDetail(provider?.owner ?? "", {
+    enabled: isProviderVerificationEnabled && !!provider?.owner
+  });
   const [expanded, setExpanded] = useState<ReadonlySet<string>>(() => new Set());
 
   const isReclaimed = isProviderReclaimed(lease);
@@ -76,6 +87,7 @@ export const PlacementCard: FC<PlacementCardProps> = ({
   const services = placementServices ?? manifestServices;
   const serviceNames = leaseStatus ? Object.keys(leaseStatus.services) : Object.keys(services);
   const providerName = provider ? providerDisplayName(provider) : undefined;
+  const securityPolicy = getPlacementSecurityPolicy(lease.group);
   const allExpanded = serviceNames.length > 0 && serviceNames.every(serviceName => expanded.has(serviceName));
 
   function toggleAll() {
@@ -128,6 +140,10 @@ export const PlacementCard: FC<PlacementCardProps> = ({
           <PlacementStats stats={buildPlacementStats(lease, serviceNames.length, gpuModels)} />
         </div>
       </div>
+
+      {isProviderVerificationEnabled && (
+        <d.PlacementVerificationPanel placementName={name} policy={securityPolicy} verification={providerDetail?.verification} />
+      )}
 
       {(isReclaimed || carveouts.length > 0 || (isLeaseActive && !!provider && !!teeType)) && (
         <div className="space-y-4 px-6 pt-6">

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementVerificationPanel.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementVerificationPanel.spec.tsx
@@ -1,0 +1,214 @@
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { ProviderVerificationView } from "@src/types/provider";
+import type { PlacementSecurityPolicy, PlacementVerificationPolicy } from "./placementVerificationModel";
+import { PlacementVerificationPanel } from "./PlacementVerificationPanel";
+
+import { fireEvent, render, screen } from "@testing-library/react";
+
+describe(PlacementVerificationPanel.name, () => {
+  it("shows a legacy-only policy separately from AEP-86", () => {
+    setup({ policy: buildPolicy({ legacy: true }) });
+
+    expect(screen.getByText("Legacy auditor policy")).toBeInTheDocument();
+    expect(screen.queryByText("Legacy signedBy")).not.toBeInTheDocument();
+    openDetails();
+
+    expect(screen.getByText("Legacy signedBy")).toBeInTheDocument();
+    expect(screen.getByText("akash1legacy")).toBeInTheDocument();
+    expect(screen.queryByText("AEP-86 policy")).not.toBeInTheDocument();
+  });
+
+  it("shows a verification-only policy next to current provider facts", () => {
+    setup({
+      policy: buildPolicy({ verification: buildRequirement() }),
+      verification: buildVerification()
+    });
+
+    expect(screen.getByText("Requires L2 · 1 auditor · Persistent storage")).toBeInTheDocument();
+    expect(screen.getByText("L2 - Verified")).toBeInTheDocument();
+    expect(screen.queryByText("AEP-86 policy")).not.toBeInTheDocument();
+    openDetails();
+
+    expect(screen.queryByText("Legacy signedBy")).not.toBeInTheDocument();
+    expect(screen.getByText("AEP-86 policy")).toBeInTheDocument();
+    expect(screen.getAllByText("L2 - Verified")).toHaveLength(3);
+    expect(screen.getByText("Any named auditor")).toBeInTheDocument();
+    expect(screen.getByText("akash1auditor")).toBeInTheDocument();
+    expect(screen.getByText("Current")).toBeInTheDocument();
+  });
+
+  it("shows legacy signedBy and AEP-86 requirements together", () => {
+    setup({
+      policy: buildPolicy({ legacy: true, verification: buildRequirement({ auditorMode: "all" }) }),
+      verification: buildVerification()
+    });
+
+    openDetails();
+
+    expect(screen.getByText("Legacy signedBy")).toBeInTheDocument();
+    expect(screen.getByText("AEP-86 policy")).toBeInTheDocument();
+    expect(screen.getByText("All named auditors")).toBeInTheDocument();
+  });
+
+  it("shows current provider facts when the placement carries neither policy", () => {
+    setup({ policy: buildPolicy({}), verification: buildVerification() });
+
+    expect(screen.getByText("No verification requirement")).toBeInTheDocument();
+    openDetails();
+
+    expect(screen.getByText("Auditor-attested tier")).toBeInTheDocument();
+  });
+
+  it("renders nothing when neither a placement policy nor provider facts are available", () => {
+    const { container } = setup({ policy: buildPolicy({}), verification: null });
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("warns about a tier demotion without implying the lease closes", () => {
+    setup({
+      policy: buildPolicy({ verification: buildRequirement({ minTier: "L3" }) }),
+      verification: buildVerification({ effectiveTier: "L1" })
+    });
+
+    expect(screen.getByText("Provider tier is below policy")).toBeInTheDocument();
+    openDetails();
+
+    expect(screen.getByText("The current L1 tier is below this placement's L3 policy. The lease remains open.")).toBeInTheDocument();
+  });
+
+  it("shows discrepancy grace without treating it as a lease close", () => {
+    setup({
+      policy: buildPolicy({ verification: buildRequirement({ minTier: "L2" }) }),
+      verification: buildVerification({ effectiveTier: "L2", reviewState: "grace" })
+    });
+
+    expect(screen.getByText("Verification grace active")).toBeInTheDocument();
+    openDetails();
+
+    expect(screen.getByText(/grace preserves the policy tier temporarily; the lease remains open/i)).toBeInTheDocument();
+  });
+
+  it("shows an active maintenance window", () => {
+    setup({
+      policy: buildPolicy({ verification: buildRequirement() }),
+      verification: buildVerification({ maintenanceState: "active", maintenanceStatus: "active" })
+    });
+
+    expect(screen.getByText("Provider maintenance active")).toBeInTheDocument();
+    openDetails();
+
+    expect(screen.getByText(/expected to end/i)).toBeInTheDocument();
+  });
+
+  it("shows a scheduled maintenance window", () => {
+    setup({
+      policy: buildPolicy({ verification: buildRequirement() }),
+      verification: buildVerification({ maintenanceState: "scheduled", maintenanceStatus: "scheduled" })
+    });
+
+    expect(screen.getByText("L2 - Verified")).toBeInTheDocument();
+    openDetails();
+
+    expect(screen.getByText("Provider maintenance scheduled")).toBeInTheDocument();
+    expect(screen.getByText(/scheduled to start/i)).toBeInTheDocument();
+  });
+
+  it("labels incomplete state as not fully evaluated", () => {
+    setup({
+      policy: buildPolicy({ verification: buildRequirement() }),
+      verification: buildVerification({ complete: false, effectiveTier: null })
+    });
+
+    expect(screen.getByText("Not fully evaluated")).toBeInTheDocument();
+    openDetails();
+
+    expect(screen.getByText("Verification status incomplete")).toBeInTheDocument();
+    expect(screen.getAllByText("Not evaluated").length).toBeGreaterThan(0);
+  });
+
+  function setup(input: { policy: PlacementSecurityPolicy; verification?: ProviderVerificationView | null }) {
+    return render(<PlacementVerificationPanel placementName="dcloud" policy={input.policy} verification={input.verification} />);
+  }
+
+  function openDetails() {
+    fireEvent.click(screen.getByRole("button", { name: "View details" }));
+    expect(screen.getByRole("dialog", { name: "Provider verification · dcloud" })).toBeInTheDocument();
+  }
+});
+
+function buildPolicy(input: { legacy?: boolean; verification?: PlacementVerificationPolicy }): PlacementSecurityPolicy {
+  return {
+    legacySignedBy: input.legacy ? { allOf: ["akash1legacy"], anyOf: [] } : null,
+    verification: input.verification ?? null
+  };
+}
+
+function buildRequirement(overrides: Partial<PlacementVerificationPolicy> = {}): PlacementVerificationPolicy {
+  return {
+    minTier: "L2",
+    requiredCapabilities: ["persistent_storage"],
+    requiredAuditors: ["akash1auditor"],
+    auditorMode: "any",
+    minAuditorCount: 1,
+    ...overrides
+  };
+}
+
+function buildVerification(
+  input: {
+    effectiveTier?: ProviderVerificationView["summary"]["effectiveTier"];
+    reviewState?: ProviderVerificationView["summary"]["reviewState"];
+    maintenanceState?: ProviderVerificationView["summary"]["maintenanceState"];
+    maintenanceStatus?: "active" | "scheduled";
+    complete?: boolean;
+  } = {}
+): ProviderVerificationView {
+  const complete = input.complete ?? true;
+  const maintenanceStatus = input.maintenanceStatus;
+
+  return mock<ProviderVerificationView>({
+    provider: "akash1provider",
+    moduleActive: true,
+    summary: {
+      bestAttestedTier: "L2",
+      effectiveTier: input.effectiveTier === undefined ? "L2" : input.effectiveTier,
+      capabilities: ["persistent_storage"],
+      validAttestationCount: 1,
+      validAuditorCount: 1,
+      validAuditors: ["akash1auditor"],
+      snapshotState: "current",
+      maintenanceState: input.maintenanceState ?? "none",
+      reviewState: input.reviewState ?? "none"
+    },
+    maintenance: maintenanceStatus
+      ? [
+          {
+            status: maintenanceStatus,
+            record: {
+              id: "1",
+              provider: "akash1provider",
+              maintenanceType: "planned",
+              startsAt: "2026-08-26T12:00:00.000Z",
+              expectedEndsAt: "2026-08-26T14:00:00.000Z",
+              openedAt: "2026-08-25T12:00:00.000Z",
+              closedAt: null,
+              metadataHash: null
+            }
+          }
+        ]
+      : [],
+    completeness: {
+      params: complete,
+      attestations: complete,
+      graces: complete,
+      snapshot: complete,
+      bond: complete,
+      auditEscrows: complete,
+      maintenance: complete,
+      discrepancies: complete
+    }
+  });
+}

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementVerificationPanel.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/PlacementVerificationPanel.tsx
@@ -1,0 +1,298 @@
+import { type FC, type ReactNode, useId, useState } from "react";
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+  Button,
+  DialogV2,
+  DialogV2Body,
+  DialogV2Content,
+  DialogV2Description,
+  DialogV2Footer,
+  DialogV2Header,
+  DialogV2Title
+} from "@akashnetwork/ui/components";
+import { InfoCircle, NavArrowRight, WarningTriangle } from "iconoir-react";
+import { ShieldCheck } from "lucide-react";
+
+import type { ProviderVerificationCapability, ProviderVerificationTier, ProviderVerificationView } from "@src/types/provider";
+import { StatusBadge, type StatusTone } from "../DeploymentStatusBadge";
+import type { PlacementSecurityPolicy, PlacementVerificationPolicy } from "./placementVerificationModel";
+import { isTierBelow } from "./placementVerificationModel";
+
+export interface PlacementVerificationPanelProps {
+  placementName: string;
+  policy: PlacementSecurityPolicy;
+  verification?: ProviderVerificationView | null;
+}
+
+const TIER_LABELS: Record<ProviderVerificationTier, string> = {
+  L0: "L0 - Unverified",
+  L1: "L1 - Identified",
+  L2: "L2 - Verified",
+  L3: "L3 - Established",
+  L4: "L4 - Trusted",
+  unknown: "Not evaluated"
+};
+
+const CAPABILITY_LABELS: Record<ProviderVerificationCapability, string> = {
+  unspecified: "Unspecified",
+  tee_hardware_attestation: "TEE hardware attestation",
+  confidential_computing: "Confidential computing",
+  persistent_storage: "Persistent storage",
+  bare_metal: "Bare metal",
+  unknown: "Unknown"
+};
+
+const SNAPSHOT_LABELS: Record<ProviderVerificationView["summary"]["snapshotState"], string> = {
+  unknown: "Not evaluated",
+  not_posted: "Not posted",
+  current: "Current",
+  stale: "Stale",
+  suspended: "Suspended"
+};
+
+export const PlacementVerificationPanel: FC<PlacementVerificationPanelProps> = ({ placementName, policy, verification }) => {
+  const headingId = useId();
+  const descriptionId = useId();
+  const [isOpen, setIsOpen] = useState(false);
+  if (!policy.legacySignedBy && !policy.verification && !verification) return null;
+
+  const notices = buildNotices(policy.verification, verification);
+  const currentTier = verification?.summary.effectiveTier ?? null;
+  const capabilities = verification?.summary.capabilities;
+  const status = getCompactStatus(notices, currentTier);
+
+  return (
+    <section aria-labelledby={headingId} className="border-b px-6 py-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex min-w-0 items-start gap-3">
+          <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+          <div className="min-w-0">
+            <h4 id={headingId} className="text-sm font-medium">
+              Provider verification
+            </h4>
+            <p className="mt-0.5 text-xs text-muted-foreground">{formatPolicySummary(policy)}</p>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2 sm:shrink-0 sm:flex-nowrap">
+          <StatusBadge label={status.label} tone={status.tone} />
+          <Button type="button" variant="outline" size="sm" onClick={() => setIsOpen(true)}>
+            View details
+            <NavArrowRight className="ml-1 h-4 w-4" aria-hidden="true" />
+          </Button>
+        </div>
+      </div>
+
+      <DialogV2 open={isOpen} onOpenChange={setIsOpen}>
+        <DialogV2Content className="max-w-3xl" aria-describedby={descriptionId}>
+          <DialogV2Header>
+            <DialogV2Title>Provider verification · {placementName}</DialogV2Title>
+            <DialogV2Description id={descriptionId} className="sr-only">
+              Placement requirements and current provider verification facts for {placementName}
+            </DialogV2Description>
+          </DialogV2Header>
+          <DialogV2Body className="space-y-5">
+            <div className="grid gap-5 md:grid-cols-2 md:gap-8">
+              <div className="space-y-4">
+                <p className="text-xs font-medium uppercase text-muted-foreground">Placement policy</p>
+                {policy.legacySignedBy && <LegacyPolicy policy={policy.legacySignedBy} />}
+                {policy.verification && <VerificationPolicy policy={policy.verification} />}
+                {!policy.legacySignedBy && !policy.verification && <p className="text-sm font-medium">No verification requirement</p>}
+              </div>
+
+              <div className="space-y-3">
+                <p className="text-xs font-medium uppercase text-muted-foreground">Current provider facts</p>
+                <Fact label="Auditor-attested tier">
+                  <StatusBadge label={currentTier ? TIER_LABELS[currentTier] : "Not evaluated"} tone={getTierTone(currentTier)} />
+                </Fact>
+                <Fact label="Valid auditors" value={verification?.summary.validAuditorCount?.toString() ?? "Not evaluated"} />
+                <Fact label="Attested capabilities" value={formatCapabilities(capabilities)} />
+                <Fact label="Provider-signed inventory" value={verification ? SNAPSHOT_LABELS[verification.summary.snapshotState] : "Not evaluated"} />
+              </div>
+            </div>
+
+            {notices.length > 0 && (
+              <div className="space-y-2">
+                {notices.map(notice => (
+                  <Alert key={notice.key} variant={notice.tone === "warning" ? "warning" : "default"} className="p-4">
+                    {notice.tone === "warning" ? <WarningTriangle className="h-4 w-4" /> : <InfoCircle className="h-4 w-4" />}
+                    <AlertTitle className="text-sm">{notice.title}</AlertTitle>
+                    <AlertDescription className="text-xs text-muted-foreground">{notice.description}</AlertDescription>
+                  </Alert>
+                ))}
+              </div>
+            )}
+          </DialogV2Body>
+          <DialogV2Footer>
+            <Button type="button" onClick={() => setIsOpen(false)}>
+              Close
+            </Button>
+          </DialogV2Footer>
+        </DialogV2Content>
+      </DialogV2>
+    </section>
+  );
+};
+
+function formatPolicySummary(policy: PlacementSecurityPolicy): string {
+  const parts: string[] = [];
+
+  if (policy.legacySignedBy) parts.push("Legacy auditor policy");
+  if (policy.verification) {
+    parts.push(`Requires ${policy.verification.minTier}`);
+    parts.push(`${policy.verification.minAuditorCount} ${policy.verification.minAuditorCount === 1 ? "auditor" : "auditors"}`);
+    if (policy.verification.requiredCapabilities.length > 0) {
+      parts.push(formatCapabilities(policy.verification.requiredCapabilities));
+    }
+  }
+
+  return parts.length > 0 ? parts.join(" · ") : "No verification requirement";
+}
+
+function getCompactStatus(notices: VerificationNotice[], currentTier: ProviderVerificationTier | null): { label: string; tone: StatusTone } {
+  const warning = notices.find(notice => notice.tone === "warning");
+  if (warning) return { label: warning.title, tone: "warning" };
+  if (notices.some(notice => notice.key === "inactive")) return { label: "Verification inactive", tone: "pending" };
+  if (notices.some(notice => notice.key === "incomplete")) return { label: "Not fully evaluated", tone: "loading" };
+  if (!currentTier || currentTier === "unknown") return { label: "Not evaluated", tone: "loading" };
+
+  return { label: TIER_LABELS[currentTier], tone: getTierTone(currentTier) };
+}
+
+function getTierTone(tier: ProviderVerificationTier | null): StatusTone {
+  if (!tier || tier === "unknown") return "loading";
+  return tier === "L0" ? "pending" : "running";
+}
+
+const LegacyPolicy: FC<{ policy: NonNullable<PlacementSecurityPolicy["legacySignedBy"]> }> = ({ policy }) => (
+  <div className="space-y-2">
+    <p className="text-sm font-medium">Legacy signedBy</p>
+    {policy.allOf.length > 0 && <AddressPolicy label="All required" addresses={policy.allOf} />}
+    {policy.anyOf.length > 0 && <AddressPolicy label="Any required" addresses={policy.anyOf} />}
+  </div>
+);
+
+const VerificationPolicy: FC<{ policy: PlacementVerificationPolicy }> = ({ policy }) => (
+  <div className="space-y-2">
+    <p className="text-sm font-medium">AEP-86 policy</p>
+    <Fact label="Minimum tier" value={TIER_LABELS[policy.minTier]} />
+    <Fact label="Required capabilities" value={formatCapabilities(policy.requiredCapabilities)} />
+    <Fact label="Minimum auditors" value={String(policy.minAuditorCount)} />
+    {policy.requiredAuditors.length > 0 && (
+      <AddressPolicy
+        label={policy.auditorMode === "all" ? "All named auditors" : policy.auditorMode === "any" ? "Any named auditor" : "Named auditors"}
+        addresses={policy.requiredAuditors}
+      />
+    )}
+  </div>
+);
+
+const Fact: FC<{ label: string; value?: string; children?: ReactNode }> = ({ label, value, children }) => (
+  <div className="flex min-w-0 items-start justify-between gap-4 text-sm">
+    <span className="text-muted-foreground">{label}</span>
+    {children ?? <span className="min-w-0 text-right font-medium">{value}</span>}
+  </div>
+);
+
+const AddressPolicy: FC<{ label: string; addresses: string[] }> = ({ label, addresses }) => (
+  <div className="text-sm">
+    <p className="text-muted-foreground">{label}</p>
+    <ul className="mt-1 space-y-1">
+      {addresses.map(address => (
+        <li key={address} className="break-all font-mono text-xs">
+          {address}
+        </li>
+      ))}
+    </ul>
+  </div>
+);
+
+function formatCapabilities(capabilities: ProviderVerificationCapability[] | null | undefined): string {
+  if (capabilities === null || capabilities === undefined) return "Not evaluated";
+  if (capabilities.length === 0) return "None";
+  return capabilities.map(capability => CAPABILITY_LABELS[capability]).join(", ");
+}
+
+interface VerificationNotice {
+  key: string;
+  title: string;
+  description: string;
+  tone: "default" | "warning";
+}
+
+function buildNotices(policy: PlacementVerificationPolicy | null, verification: ProviderVerificationView | null | undefined): VerificationNotice[] {
+  const notices: VerificationNotice[] = [];
+  const currentTier = verification?.summary.effectiveTier ?? null;
+
+  if (policy && verification?.moduleActive === false) {
+    notices.push({
+      key: "inactive",
+      title: "Provider verification is not active",
+      description: "This placement policy is recorded, but verification is not active on this network.",
+      tone: "default"
+    });
+  }
+
+  if ((policy || verification) && (!verification || !Object.values(verification.completeness).every(Boolean))) {
+    notices.push({
+      key: "incomplete",
+      title: "Verification status incomplete",
+      description: "Current verification facts are still syncing and are not fully evaluated.",
+      tone: "default"
+    });
+  }
+
+  if (policy && isTierBelow(currentTier, policy.minTier)) {
+    notices.push({
+      key: "demotion",
+      title: "Provider tier is below policy",
+      description: `The current ${currentTier} tier is below this placement's ${policy.minTier} policy. The lease remains open.`,
+      tone: "warning"
+    });
+  }
+
+  if (verification?.summary.reviewState === "grace") {
+    notices.push({
+      key: "grace",
+      title: "Verification grace active",
+      description: "The provider's attested tier is under review. Grace preserves the policy tier temporarily; the lease remains open.",
+      tone: "warning"
+    });
+  } else if (verification?.summary.reviewState === "under_review") {
+    notices.push({
+      key: "review",
+      title: "Verification under review",
+      description: "A provider verification discrepancy is being reviewed. The lease remains open.",
+      tone: "warning"
+    });
+  }
+
+  if (verification?.summary.maintenanceState === "active") {
+    notices.push({
+      key: "maintenance-active",
+      title: "Provider maintenance active",
+      description: formatMaintenanceDescription(verification, "active"),
+      tone: "warning"
+    });
+  } else if (verification?.summary.maintenanceState === "scheduled") {
+    notices.push({
+      key: "maintenance-scheduled",
+      title: "Provider maintenance scheduled",
+      description: formatMaintenanceDescription(verification, "scheduled"),
+      tone: "default"
+    });
+  }
+
+  return notices;
+}
+
+function formatMaintenanceDescription(verification: ProviderVerificationView, status: "active" | "scheduled"): string {
+  const maintenance = verification.maintenance.find(item => item.status === status)?.record;
+  const timestamp = status === "active" ? maintenance?.expectedEndsAt : maintenance?.startsAt;
+  if (!timestamp) return status === "active" ? "The provider reports an active maintenance window." : "The provider reports an upcoming maintenance window.";
+
+  const label = new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" }).format(new Date(timestamp));
+  return status === "active" ? `Expected to end ${label}.` : `Scheduled to start ${label}.`;
+}

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/placementVerificationModel.spec.ts
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/placementVerificationModel.spec.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import type { DeploymentGroup } from "@src/types/deployment";
+import { getPlacementSecurityPolicy, isTierBelow } from "./placementVerificationModel";
+
+describe("placementVerificationModel", () => {
+  it("normalizes the on-chain placement requirement without merging legacy signedBy", () => {
+    const result = getPlacementSecurityPolicy({
+      group_spec: {
+        requirements: {
+          signed_by: { all_of: ["akash1legacy"], any_of: [] },
+          attributes: [],
+          verification: {
+            min_tier: "verification_tier_established",
+            required_capabilities: ["capability_confidential_computing", "capability_bare_metal"],
+            required_auditors: ["akash1auditor"],
+            auditor_mode: "auditor_selection_mode_all",
+            min_auditor_count: 2
+          }
+        }
+      }
+    } as unknown as DeploymentGroup);
+
+    expect(result).toEqual({
+      legacySignedBy: { allOf: ["akash1legacy"], anyOf: [] },
+      verification: {
+        minTier: "L3",
+        requiredCapabilities: ["confidential_computing", "bare_metal"],
+        requiredAuditors: ["akash1auditor"],
+        auditorMode: "all",
+        minAuditorCount: 2
+      }
+    });
+  });
+
+  it("collapses empty legacy signedBy while retaining the verification policy", () => {
+    const result = getPlacementSecurityPolicy({
+      group_spec: {
+        requirements: {
+          signed_by: { all_of: [], any_of: [] },
+          attributes: [],
+          verification: {
+            min_tier: "verification_tier_identified",
+            required_capabilities: [],
+            required_auditors: [],
+            auditor_mode: "auditor_selection_mode_unspecified",
+            min_auditor_count: 0
+          }
+        }
+      }
+    } as unknown as DeploymentGroup);
+
+    expect(result.legacySignedBy).toBeNull();
+    expect(result.verification).toEqual({ minTier: "L1", requiredCapabilities: [], requiredAuditors: [], auditorMode: "unknown", minAuditorCount: 0 });
+  });
+
+  it("detects only comparable tier demotions", () => {
+    expect(isTierBelow("L1", "L2")).toBe(true);
+    expect(isTierBelow("L3", "L2")).toBe(false);
+    expect(isTierBelow(null, "L2")).toBe(false);
+    expect(isTierBelow("unknown", "L2")).toBe(false);
+  });
+
+  it("maps the proto default tier to L0", () => {
+    const result = getPlacementSecurityPolicy({
+      group_spec: {
+        requirements: {
+          signed_by: { all_of: [], any_of: [] },
+          attributes: [],
+          verification: {
+            min_tier: "verification_tier_unspecified",
+            required_capabilities: [],
+            required_auditors: [],
+            auditor_mode: "auditor_selection_mode_unspecified",
+            min_auditor_count: 0
+          }
+        }
+      }
+    } as unknown as DeploymentGroup);
+
+    expect(result.verification?.minTier).toBe("L0");
+  });
+});

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/placementVerificationModel.ts
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentPlacements/placementVerificationModel.ts
@@ -1,0 +1,62 @@
+import type { DeploymentGroup, RpcVerificationCapability, RpcVerificationTier } from "@src/types/deployment";
+import type { ProviderVerificationCapability, ProviderVerificationTier } from "@src/types/provider";
+
+export interface PlacementVerificationPolicy {
+  minTier: ProviderVerificationTier;
+  requiredCapabilities: ProviderVerificationCapability[];
+  requiredAuditors: string[];
+  auditorMode: "any" | "all" | "unknown";
+  minAuditorCount: number;
+}
+
+export interface PlacementSecurityPolicy {
+  legacySignedBy: {
+    allOf: string[];
+    anyOf: string[];
+  } | null;
+  verification: PlacementVerificationPolicy | null;
+}
+
+const TIERS: Record<RpcVerificationTier, ProviderVerificationTier> = {
+  verification_tier_unspecified: "L0",
+  verification_tier_identified: "L1",
+  verification_tier_verified: "L2",
+  verification_tier_established: "L3",
+  verification_tier_trusted: "L4"
+};
+
+const CAPABILITIES: Record<RpcVerificationCapability, ProviderVerificationCapability> = {
+  capability_unspecified: "unspecified",
+  capability_tee_hardware_attestation: "tee_hardware_attestation",
+  capability_confidential_computing: "confidential_computing",
+  capability_persistent_storage: "persistent_storage",
+  capability_bare_metal: "bare_metal"
+};
+
+export function getPlacementSecurityPolicy(group: DeploymentGroup | undefined): PlacementSecurityPolicy {
+  const requirements = group?.group_spec?.requirements;
+  const signedBy = requirements?.signed_by;
+  const allOf = signedBy?.all_of ?? [];
+  const anyOf = signedBy?.any_of ?? [];
+  const verification = requirements?.verification;
+
+  return {
+    legacySignedBy: allOf.length > 0 || anyOf.length > 0 ? { allOf, anyOf } : null,
+    verification: verification
+      ? {
+          minTier: TIERS[verification.min_tier] ?? "unknown",
+          requiredCapabilities: verification.required_capabilities.map(capability => CAPABILITIES[capability] ?? "unknown"),
+          requiredAuditors: verification.required_auditors,
+          auditorMode:
+            verification.auditor_mode === "auditor_selection_mode_all" ? "all" : verification.auditor_mode === "auditor_selection_mode_any" ? "any" : "unknown",
+          minAuditorCount: verification.min_auditor_count
+        }
+      : null
+  };
+}
+
+export function isTierBelow(current: ProviderVerificationTier | null, required: ProviderVerificationTier): boolean {
+  const rank = { L0: 0, L1: 1, L2: 2, L3: 3, L4: 4 } as const;
+  if (current === null || current === "unknown" || required === "unknown") return false;
+  return rank[current] < rank[required];
+}

--- a/apps/deploy-web/src/components/providers/ProviderDetail.tsx
+++ b/apps/deploy-web/src/components/providers/ProviderDetail.tsx
@@ -11,6 +11,7 @@ import dynamic from "next/dynamic";
 
 import { LabelValue } from "@src/components/shared/LabelValue";
 import { useWallet } from "@src/context/WalletProvider";
+import { useFlag } from "@src/hooks/useFlag";
 import { useAllLeases } from "@src/queries/useLeaseQuery";
 import { useProviderAttributesSchema, useProviderDetail, useProviderStatus } from "@src/queries/useProvidersQuery";
 import type { ApiProviderDetail, ClientProviderDetailWithStatus } from "@src/types/provider";
@@ -22,6 +23,7 @@ import { Title } from "../shared/Title";
 import { ActiveLeasesGraph } from "./ActiveLeasesGraph";
 import ProviderDetailLayout, { ProviderDetailTabs } from "./ProviderDetailLayout";
 import { ProviderSpecs } from "./ProviderSpecs";
+import { ProviderVerificationDetails } from "./ProviderVerificationDetails";
 
 const NetworkCapacity = dynamic(() => import("./NetworkCapacity/NetworkCapacity"), {
   ssr: false
@@ -33,6 +35,7 @@ type Props = {
 };
 
 export const ProviderDetail: React.FunctionComponent<Props> = ({ owner, _provider }) => {
+  const isProviderVerificationEnabled = useFlag("provider_verification");
   const [provider, setProvider] = useState<ClientProviderDetailWithStatus>(_provider as ClientProviderDetailWithStatus);
   const { address } = useWallet();
   const {
@@ -174,6 +177,15 @@ export const ProviderDetail: React.FunctionComponent<Props> = ({ owner, _provide
           </>
         )}
 
+        {provider && isProviderVerificationEnabled && (
+          <div className="mt-6">
+            <Title subTitle className="mb-4 font-normal">
+              Provider verification
+            </Title>
+            <ProviderVerificationDetails providerDeclaredTier={provider.tier} verification={provider.verification} />
+          </div>
+        )}
+
         {provider && providerAttributesSchema && (
           <>
             <div className="mb-6 mt-6">
@@ -197,7 +209,7 @@ export const ProviderDetail: React.FunctionComponent<Props> = ({ owner, _provide
                     <LabelValue label="Region" value={provider.locationRegion} />
                     <LabelValue label="City" value={provider.city} />
                     <LabelValue label="Location Type" value={provider.locationType} />
-                    <LabelValue label="Tier" value={provider.tier} />
+                    <LabelValue label="Tier (self-declared)" value={provider.tier} />
                   </div>
                 </CardContent>
               </Card>

--- a/apps/deploy-web/src/components/providers/ProviderList.tsx
+++ b/apps/deploy-web/src/components/providers/ProviderList.tsx
@@ -21,6 +21,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 
 import { useLocalNotes } from "@src/components/LocalNoteManager";
 import { useWallet } from "@src/context/WalletProvider";
+import { useFlag } from "@src/hooks/useFlag";
 import { useAllLeases } from "@src/queries/useLeaseQuery";
 import { useNetworkCapacity, useProviderList } from "@src/queries/useProvidersQuery";
 import networkStore from "@src/store/networkStore";
@@ -30,6 +31,7 @@ import { domainName, UrlService } from "@src/utils/urlUtils";
 import Layout from "../layout/Layout";
 import { CustomNextSeo } from "../shared/CustomNextSeo";
 import { Title } from "../shared/Title";
+import { hasAuditOrAttestation } from "./providerListFilters";
 import { ProviderMap } from "./ProviderMap";
 import { ProviderTable } from "./ProviderTable";
 
@@ -49,6 +51,7 @@ const sortOptions: { id: SortId; title: string }[] = [
 
 export const ProviderList: React.FunctionComponent = () => {
   const { address } = useWallet();
+  const isProviderVerificationEnabled = useFlag("provider_verification");
   const [pageIndex, setPageIndex] = useState(0);
   const [isFilteringActive, setIsFilteringActive] = useState(true);
   const [isFilteringFavorites, setIsFilteringFavorites] = useState(false);
@@ -109,7 +112,7 @@ export const ProviderList: React.FunctionComponent = () => {
       }
 
       if (isFilteringAudited) {
-        filteredProviders = filteredProviders.filter(x => x.isAudited);
+        filteredProviders = filteredProviders.filter(x => hasAuditOrAttestation(x, isProviderVerificationEnabled));
       }
 
       filteredProviders = filteredProviders.sort((a, b) => {
@@ -132,7 +135,7 @@ export const ProviderList: React.FunctionComponent = () => {
 
       setFilteredProviders(filteredProviders);
     }
-  }, [providers, isFilteringActive, isFilteringFavorites, isFilteringAudited, favoriteProviders, search, sort, leases]);
+  }, [providers, isFilteringActive, isFilteringFavorites, isFilteringAudited, favoriteProviders, search, sort, leases, isProviderVerificationEnabled]);
 
   const refresh = () => {
     getProviders();
@@ -228,7 +231,11 @@ export const ProviderList: React.FunctionComponent = () => {
                   <CheckboxWithLabel checked={isFilteringActive} onCheckedChange={onIsFilteringActiveClick} label="Active" />
                 </div>
                 <div>
-                  <CheckboxWithLabel checked={isFilteringAudited} onCheckedChange={onIsFilteringAuditedClick} label="Audited" />
+                  <CheckboxWithLabel
+                    checked={isFilteringAudited}
+                    onCheckedChange={onIsFilteringAuditedClick}
+                    label={isProviderVerificationEnabled ? "Audited or attested" : "Audited"}
+                  />
                 </div>
                 <div>
                   <CheckboxWithLabel checked={isFilteringFavorites} onCheckedChange={onIsFilteringFavoritesClick} label="Favorites" />

--- a/apps/deploy-web/src/components/providers/ProviderSummary.tsx
+++ b/apps/deploy-web/src/components/providers/ProviderSummary.tsx
@@ -8,6 +8,7 @@ import { Uptime } from "@src/components/providers/Uptime";
 import { FavoriteButton } from "@src/components/shared/FavoriteButton";
 import { LabelValue } from "@src/components/shared/LabelValue";
 import { StatusPill } from "@src/components/shared/StatusPill";
+import { useFlag } from "@src/hooks/useFlag";
 import type { ApiProviderList, ClientProviderDetailWithStatus } from "@src/types/provider";
 import { ProviderMap } from "./ProviderMap";
 
@@ -17,6 +18,7 @@ type Props = {
 
 export const ProviderSummary: React.FunctionComponent<Props> = ({ provider }) => {
   const { favoriteProviders, updateFavoriteProviders } = useLocalNotes();
+  const isProviderVerificationEnabled = useFlag("provider_verification");
   const isFavorite = favoriteProviders.some(x => provider.owner === x);
 
   const onStarClick: MouseEventHandler = event => {
@@ -50,7 +52,7 @@ export const ProviderSummary: React.FunctionComponent<Props> = ({ provider }) =>
 
             <LabelValue label="Favorite" value={<FavoriteButton isFavorite={isFavorite} onClick={onStarClick} />} />
             <LabelValue
-              label="Audited"
+              label={isProviderVerificationEnabled ? "Legacy audit" : "Audited"}
               value={
                 provider.isAudited ? (
                   <div className="inline-flex items-center space-x-2">

--- a/apps/deploy-web/src/components/providers/ProviderTable.tsx
+++ b/apps/deploy-web/src/components/providers/ProviderTable.tsx
@@ -2,6 +2,7 @@
 import { Table, TableBody, TableHead, TableHeader, TableRow } from "@akashnetwork/ui/components";
 import { cn } from "@akashnetwork/ui/utils";
 
+import { useFlag } from "@src/hooks/useFlag";
 import type { ClientProviderList } from "@src/types/provider";
 import { ProviderListRow } from "./ProviderTableRow";
 
@@ -11,6 +12,7 @@ type Props = {
 };
 
 export const ProviderTable: React.FunctionComponent<Props> = ({ providers, sortOption }) => {
+  const isProviderVerificationEnabled = useFlag("provider_verification");
   const isSortingLeases =
     sortOption === "active-leases-desc" || sortOption === "active-leases-asc" || sortOption === "my-leases-desc" || sortOption === "my-active-leases-desc";
 
@@ -19,6 +21,7 @@ export const ProviderTable: React.FunctionComponent<Props> = ({ providers, sortO
       <TableHeader>
         <TableRow>
           <TableHead className="w-[10%]">Name</TableHead>
+          {isProviderVerificationEnabled && <TableHead className="min-w-[16rem]">Verification</TableHead>}
           <TableHead className="w-[10%] text-center">Location</TableHead>
           <TableHead className="w-[5%] text-center">Uptime (7d)</TableHead>
           <TableHead className={cn("w-[5%] text-center", { ["font-bold text-primary"]: isSortingLeases })}>Active Leases</TableHead>
@@ -26,14 +29,14 @@ export const ProviderTable: React.FunctionComponent<Props> = ({ providers, sortO
           <TableHead className={cn("w-[15%]", { ["font-bold text-primary"]: sortOption === "gpu-available-desc" })}>GPU</TableHead>
           <TableHead className="w-[15%]">Memory</TableHead>
           <TableHead className="w-[15%]">Disk</TableHead>
-          <TableHead className="w-[5%] text-center">Audited</TableHead>
+          <TableHead className="w-[5%] text-center">{isProviderVerificationEnabled ? "Legacy audit" : "Audited"}</TableHead>
           <TableHead className="w-[5%] text-center">Favorite</TableHead>
         </TableRow>
       </TableHeader>
 
       <TableBody>
         {providers.map(provider => {
-          return <ProviderListRow key={provider.owner} provider={provider} />;
+          return <ProviderListRow key={provider.owner} provider={provider} showVerification={isProviderVerificationEnabled} />;
         })}
       </TableBody>
     </Table>

--- a/apps/deploy-web/src/components/providers/ProviderTableRow.tsx
+++ b/apps/deploy-web/src/components/providers/ProviderTableRow.tsx
@@ -17,13 +17,15 @@ import { UrlService } from "@src/utils/urlUtils";
 import { FavoriteButton } from "../shared/FavoriteButton";
 import { AuditorButton } from "./AuditorButton";
 import { CapacityIcon } from "./CapacityIcon";
+import { ProviderVerificationListCell } from "./ProviderVerificationListCell";
 import { Uptime } from "./Uptime";
 
 type Props = {
   provider: ClientProviderList;
+  showVerification: boolean;
 };
 
-export const ProviderListRow: React.FunctionComponent<Props> = ({ provider }) => {
+export const ProviderListRow: React.FunctionComponent<Props> = ({ provider, showVerification }) => {
   const router = useRouter();
   const { favoriteProviders, updateFavoriteProviders } = useLocalNotes();
   const isFavorite = favoriteProviders.some(x => provider.owner === x);
@@ -84,6 +86,11 @@ export const ProviderListRow: React.FunctionComponent<Props> = ({ provider }) =>
           ) : (
             <span className="text-xs">{provider.hostUri}</span>
           )}
+        </TableCell>
+      )}
+      {showVerification && (
+        <TableCell>
+          <ProviderVerificationListCell verification={provider.verification} />
         </TableCell>
       )}
       <TableCell className="text-center">

--- a/apps/deploy-web/src/components/providers/ProviderVerificationDetails.tsx
+++ b/apps/deploy-web/src/components/providers/ProviderVerificationDetails.tsx
@@ -1,0 +1,546 @@
+"use client";
+import { Alert, Badge, Card, CardContent, Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@akashnetwork/ui/components";
+import { Database, Scale, ShieldCheck, Users, WalletCards } from "lucide-react";
+
+import type { ProviderVerificationCapability, ProviderVerificationCoin, ProviderVerificationTier, ProviderVerificationView } from "@src/types/provider";
+
+const CAPABILITY_LABELS: Record<ProviderVerificationCapability, string> = {
+  unspecified: "Unspecified",
+  tee_hardware_attestation: "TEE hardware attestation",
+  confidential_computing: "Confidential computing",
+  persistent_storage: "Persistent storage",
+  bare_metal: "Bare metal",
+  unknown: "Unknown"
+};
+
+type Props = {
+  providerDeclaredTier: string | null;
+  verification: ProviderVerificationView | null;
+};
+
+export const ProviderVerificationDetails: React.FunctionComponent<Props> = ({ providerDeclaredTier, verification }) => {
+  if (!verification) {
+    return (
+      <Card data-testid="provider-verification-details">
+        <CardContent className="p-5">
+          <p className="text-sm font-medium">Provider verification has not been evaluated.</p>
+          <p className="mt-1 text-xs text-muted-foreground">No indexed AEP-86 state is available for this provider.</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const openDiscrepancies = verification.discrepancies.filter(discrepancy => ["pending", "timed_out"].includes(discrepancy.resolutionStatus));
+  const activeMaintenance = verification.maintenance.filter(item => ["scheduled", "active"].includes(item.status));
+
+  return (
+    <Card className="overflow-hidden" data-testid="provider-verification-details">
+      <CardContent className="p-0">
+        {verification.moduleActive === false && (
+          <Alert className="rounded-none border-x-0 border-t-0" variant="warning">
+            The verification module is inactive. These records are visible, but verification placement requirements are not enforced.
+          </Alert>
+        )}
+
+        {(verification.summary.reviewState === "under_review" || verification.summary.reviewState === "grace") && (
+          <Alert className="rounded-none border-x-0 border-t-0" variant="warning">
+            {verification.summary.reviewState === "under_review"
+              ? "Conflicting auditor attestations are under governance review."
+              : `Verification grace is active${verification.grace ? ` at ${verification.grace.preservedTier}` : ""}.`}
+          </Alert>
+        )}
+
+        {activeMaintenance.length > 0 && (
+          <Alert className="rounded-none border-x-0 border-t-0" variant="warning">
+            This provider has {activeMaintenance.some(item => item.status === "active") ? "active" : "scheduled"} maintenance.
+          </Alert>
+        )}
+
+        <section className="grid grid-cols-2 border-b sm:grid-cols-3 xl:grid-cols-5" aria-label="Provider verification summary">
+          <SummaryItem icon={ShieldCheck} label="Effective tier" value={verification.summary.effectiveTier ?? "Not evaluated"} />
+          <SummaryItem icon={Users} label="Valid auditors" value={formatOptionalInteger(verification.summary.validAuditorCount)} />
+          <SummaryItem icon={Database} label="Provider-signed inventory" value={stateLabel(verification.summary.snapshotState)} />
+          <SummaryItem icon={Scale} label="Review" value={reviewLabel(verification.summary.reviewState)} />
+          <SummaryItem icon={ShieldCheck} label="Self-declared tier" value={providerDeclaredTier || "Not declared"} />
+        </section>
+
+        <section className="border-b p-5" aria-labelledby="provider-verification-capabilities">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+              <h3 id="provider-verification-capabilities" className="text-sm font-semibold">
+                Auditor-attested capabilities
+              </h3>
+              <p className="mt-1 text-xs text-muted-foreground">Current capabilities from valid attestation records.</p>
+            </div>
+            <ObservedState verification={verification} />
+          </div>
+          <div className="mt-4 flex flex-wrap gap-2">
+            {verification.summary.capabilities === null ? (
+              <EmptyState>Not evaluated</EmptyState>
+            ) : verification.summary.capabilities.length === 0 ? (
+              <EmptyState>No capabilities attested</EmptyState>
+            ) : (
+              verification.summary.capabilities.map(capability => (
+                <Badge key={capability} variant="secondary" className="rounded font-normal">
+                  {CAPABILITY_LABELS[capability]}
+                </Badge>
+              ))
+            )}
+          </div>
+        </section>
+
+        <section className="grid border-b lg:grid-cols-2 lg:divide-x" aria-label="Snapshot and provider bond">
+          <SnapshotSection verification={verification} />
+          <BondSection verification={verification} />
+        </section>
+
+        <DataSection title="Attestation records" description="Raw AEP-86 records; only valid attestations contribute to the provider summary.">
+          <div className="overflow-x-auto">
+            <Table className="min-w-[1320px]">
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Auditor</TableHead>
+                  <TableHead>Tier and capabilities</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Fee</TableHead>
+                  <TableHead>Auditor deposit</TableHead>
+                  <TableHead>Created and expires</TableHead>
+                  <TableHead>Escrow</TableHead>
+                  <TableHead>Evidence hash</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {!verification.completeness.attestations ? (
+                  <EmptyTableRow columns={8}>Not evaluated</EmptyTableRow>
+                ) : verification.attestations.length === 0 ? (
+                  <EmptyTableRow columns={8}>No current attestations</EmptyTableRow>
+                ) : (
+                  verification.attestations.map(attestation => (
+                    <TableRow key={`${attestation.auditor}-${attestation.auditEscrowId}-${attestation.createdAt ?? "unknown"}`}>
+                      <TableCell className="max-w-[220px] break-all font-mono text-xs">{attestation.auditor}</TableCell>
+                      <TableCell className="max-w-[220px]">
+                        <TierBadge tier={attestation.tier} />
+                        <div className="mt-1 text-xs text-muted-foreground">
+                          {attestation.capabilities.length > 0 ? attestation.capabilities.map(value => CAPABILITY_LABELS[value]).join(", ") : "No capabilities"}
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <StateBadge value={attestation.status} positive="valid" />
+                        <div className="mt-1 text-xs text-muted-foreground">Reason: {humanize(attestation.voidedReason)}</div>
+                        <div className="text-xs text-muted-foreground">Fault: {humanize(attestation.faultAttribution)}</div>
+                      </TableCell>
+                      <TableCell>
+                        <div>{formatCoin(attestation.fee)}</div>
+                        <div className="text-xs text-muted-foreground">{humanize(attestation.feeStatus)}</div>
+                      </TableCell>
+                      <TableCell>
+                        <div>{formatCoin(attestation.deposit)}</div>
+                        <div className="text-xs text-muted-foreground">{humanize(attestation.depositStatus)}</div>
+                      </TableCell>
+                      <TableCell>
+                        <div>{formatTimestamp(attestation.createdAt)}</div>
+                        <div className="mt-1 text-xs text-muted-foreground">Expires {formatTimestamp(attestation.expiresAt)}</div>
+                      </TableCell>
+                      <TableCell className="font-mono">#{attestation.auditEscrowId}</TableCell>
+                      <TableCell className="max-w-[220px] break-all font-mono text-xs">{attestation.evidenceHash || "Not recorded"}</TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        </DataSection>
+
+        <DataSection title="Audit escrow lifecycle" description="Current fee and deposit settlement state for this provider's audit requests.">
+          <div className="overflow-x-auto">
+            <Table className="min-w-[1240px]">
+              <TableHeader>
+                <TableRow>
+                  <TableHead>ID</TableHead>
+                  <TableHead>Requested tier</TableHead>
+                  <TableHead>Auditor</TableHead>
+                  <TableHead>Fee</TableHead>
+                  <TableHead>Provider deposit</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Timing</TableHead>
+                  <TableHead>Settlement</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {!verification.completeness.auditEscrows ? (
+                  <EmptyTableRow columns={8}>Not evaluated</EmptyTableRow>
+                ) : verification.auditEscrows.length === 0 ? (
+                  <EmptyTableRow columns={8}>No audit escrows</EmptyTableRow>
+                ) : (
+                  verification.auditEscrows.map(escrow => (
+                    <TableRow key={escrow.id}>
+                      <TableCell className="font-mono">#{escrow.id}</TableCell>
+                      <TableCell>
+                        <TierBadge tier={escrow.requestedTier} />
+                      </TableCell>
+                      <TableCell className="max-w-[220px] break-all font-mono text-xs">{escrow.consumedByAuditor || "Awaiting auditor"}</TableCell>
+                      <TableCell>
+                        <div>{formatCoin(escrow.fee)}</div>
+                        <div className="text-xs text-muted-foreground">{humanize(escrow.feeStatus)}</div>
+                      </TableCell>
+                      <TableCell>
+                        <div>{formatCoin(escrow.providerDeposit)}</div>
+                        <div className="text-xs text-muted-foreground">{humanize(escrow.providerDepositStatus)}</div>
+                      </TableCell>
+                      <TableCell>
+                        <StateBadge value={escrow.status} positive="settled" />
+                      </TableCell>
+                      <TableCell>
+                        <div>Opened {formatTimestamp(escrow.openedAt)}</div>
+                        <div className="text-xs text-muted-foreground">Consumed {formatTimestamp(escrow.consumedAt)}</div>
+                        <div className="text-xs text-muted-foreground">Expires {formatTimestamp(escrow.expiresAt)}</div>
+                      </TableCell>
+                      <TableCell>
+                        <div>{humanize(escrow.settlementReason)}</div>
+                        <div className="text-xs text-muted-foreground">Fault: {humanize(escrow.faultAttribution)}</div>
+                      </TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        </DataSection>
+
+        <DataSection title="Maintenance windows" description="Provider maintenance notices recorded on chain.">
+          <div className="overflow-x-auto">
+            <Table className="min-w-[760px]">
+              <TableHeader>
+                <TableRow>
+                  <TableHead>ID</TableHead>
+                  <TableHead>Type</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Starts</TableHead>
+                  <TableHead>Expected end</TableHead>
+                  <TableHead>Closed</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {!verification.completeness.maintenance ? (
+                  <EmptyTableRow columns={6}>Not evaluated</EmptyTableRow>
+                ) : verification.maintenance.length === 0 ? (
+                  <EmptyTableRow columns={6}>No maintenance windows</EmptyTableRow>
+                ) : (
+                  verification.maintenance.map((maintenance, index) => (
+                    <TableRow key={maintenance.record?.id ?? `maintenance-${index}`}>
+                      <TableCell className="font-mono">{maintenance.record ? `#${maintenance.record.id}` : "Not recorded"}</TableCell>
+                      <TableCell>{maintenance.record ? humanize(maintenance.record.maintenanceType) : "Not evaluated"}</TableCell>
+                      <TableCell>
+                        <StateBadge value={maintenance.status} positive="closed" />
+                      </TableCell>
+                      <TableCell>{formatTimestamp(maintenance.record?.startsAt ?? null)}</TableCell>
+                      <TableCell>{formatTimestamp(maintenance.record?.expectedEndsAt ?? null)}</TableCell>
+                      <TableCell>{formatTimestamp(maintenance.record?.closedAt ?? null)}</TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        </DataSection>
+
+        <DataSection
+          title="Open discrepancies and grace"
+          description="Conflicting auditor attestations awaiting resolution and any temporary tier preservation."
+        >
+          {verification.grace ? (
+            <div className="grid gap-3 border-b px-5 py-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
+              <Metric label="Grace ID" value={`#${verification.grace.id}`} />
+              <Metric label="Preserved tier" value={verification.grace.preservedTier} />
+              <Metric label="Status" value={humanize(verification.grace.status)} />
+              <Metric label="Started" value={formatTimestamp(verification.grace.startedAt)} />
+              <Metric label="Expires" value={formatTimestamp(verification.grace.expiresAt)} />
+              <Metric
+                label="Source discrepancies"
+                value={verification.grace.sourceDiscrepancyIds.length > 0 ? verification.grace.sourceDiscrepancyIds.map(id => `#${id}`).join(", ") : "None"}
+              />
+            </div>
+          ) : !verification.completeness.graces ? (
+            <div className="border-b px-5 py-4">
+              <EmptyState>Grace not evaluated</EmptyState>
+            </div>
+          ) : null}
+
+          <div className="overflow-x-auto">
+            <Table className="min-w-[1180px]">
+              <TableHeader>
+                <TableRow>
+                  <TableHead>ID</TableHead>
+                  <TableHead>Auditor A</TableHead>
+                  <TableHead>Auditor B</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Proposal</TableHead>
+                  <TableHead>Resolution</TableHead>
+                  <TableHead>Observed</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {!verification.completeness.discrepancies ? (
+                  <EmptyTableRow columns={7}>Not evaluated</EmptyTableRow>
+                ) : openDiscrepancies.length === 0 ? (
+                  <EmptyTableRow columns={7}>No open discrepancies</EmptyTableRow>
+                ) : (
+                  openDiscrepancies.map(discrepancy => (
+                    <TableRow key={discrepancy.id}>
+                      <TableCell className="font-mono">#{discrepancy.id}</TableCell>
+                      <TableCell className="max-w-[230px]">
+                        <div className="break-all font-mono text-xs">{discrepancy.auditorA}</div>
+                        <TierBadge tier={discrepancy.auditorATier} />
+                      </TableCell>
+                      <TableCell className="max-w-[230px]">
+                        <div className="break-all font-mono text-xs">{discrepancy.auditorB}</div>
+                        <TierBadge tier={discrepancy.auditorBTier} />
+                      </TableCell>
+                      <TableCell>
+                        <StateBadge value={discrepancy.resolutionStatus} />
+                      </TableCell>
+                      <TableCell className="font-mono">
+                        {discrepancy.resolutionProposalId === "0" ? "Not submitted" : `#${discrepancy.resolutionProposalId}`}
+                      </TableCell>
+                      <TableCell>
+                        <div>{humanize(discrepancy.resolutionReason)}</div>
+                        <div className="text-xs text-muted-foreground">Fault: {humanize(discrepancy.faultAttribution)}</div>
+                        {discrepancy.resolutionEvidenceHash && (
+                          <div className="mt-1 max-w-[220px] break-all font-mono text-xs text-muted-foreground">{discrepancy.resolutionEvidenceHash}</div>
+                        )}
+                      </TableCell>
+                      <TableCell>{formatTimestamp(discrepancy.timestamp)}</TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        </DataSection>
+      </CardContent>
+    </Card>
+  );
+};
+
+function SnapshotSection({ verification }: { verification: ProviderVerificationView }) {
+  const snapshot = verification.snapshot;
+
+  return (
+    <div className="min-w-0 p-5">
+      <div className="mb-4 flex items-center gap-2">
+        <Database className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+        <h3 className="text-sm font-semibold">Latest provider-signed inventory</h3>
+      </div>
+      {!verification.completeness.snapshot ? (
+        <EmptyState>Not evaluated</EmptyState>
+      ) : !snapshot ? (
+        <EmptyState>Not posted</EmptyState>
+      ) : (
+        <div className="space-y-4">
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4 lg:grid-cols-2 xl:grid-cols-4">
+            <Metric label="State" value={snapshot.suspended ? "Suspended" : stateLabel(verification.summary.snapshotState)} />
+            <Metric label="Posted" value={formatTimestamp(snapshot.postedAt)} />
+            <Metric label="Captured" value={formatTimestamp(snapshot.snapshotTimestamp)} />
+            <Metric label="Compliance deadline" value={formatTimestamp(snapshot.complianceDeadline)} />
+          </div>
+          {snapshot.resourceSummary && (
+            <div className="grid grid-cols-2 gap-3 border-t pt-4 sm:grid-cols-4 lg:grid-cols-2 xl:grid-cols-4">
+              <Metric label="vCPU" value={snapshot.resourceSummary.totalVcpus.toLocaleString()} />
+              <Metric label="GPU" value={snapshot.resourceSummary.totalGpus.toLocaleString()} />
+              <Metric label="Memory" value={`${formatInteger(snapshot.resourceSummary.totalMemoryMb)} MB`} />
+              <Metric label="Storage" value={`${formatInteger(snapshot.resourceSummary.totalStorageMb)} MB`} />
+              <Metric label="Active leases" value={snapshot.resourceSummary.activeLeases.toLocaleString()} />
+              <Metric label="Software" value={snapshot.resourceSummary.softwareVersion || "Not recorded"} />
+            </div>
+          )}
+          <HashValue label="Snapshot hash" value={snapshot.snapshotHash} />
+          {snapshot.resourceSummary?.softwareSignature && <HashValue label="Software signature" value={snapshot.resourceSummary.softwareSignature} />}
+          {snapshot.resourceSummary?.softwareIdentity && (
+            <div className="grid grid-cols-1 gap-3 border-t pt-4 sm:grid-cols-2">
+              <Metric label="Software artifact" value={snapshot.resourceSummary.softwareIdentity.artifactRef || "Not recorded"} />
+              <Metric
+                label="Software digest"
+                value={
+                  snapshot.resourceSummary.softwareIdentity.digest
+                    ? `${snapshot.resourceSummary.softwareIdentity.digestAlgorithm}: ${snapshot.resourceSummary.softwareIdentity.digest}`
+                    : "Not recorded"
+                }
+              />
+              <Metric label="Signature type" value={snapshot.resourceSummary.softwareIdentity.signatureType || "Not recorded"} />
+              <Metric label="Public key reference" value={snapshot.resourceSummary.softwareIdentity.publicKeyRef || "Not recorded"} />
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function BondSection({ verification }: { verification: ProviderVerificationView }) {
+  const bond = verification.bond;
+
+  return (
+    <div className="min-w-0 border-t p-5 lg:border-t-0">
+      <div className="mb-4 flex items-center gap-2">
+        <WalletCards className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+        <h3 className="text-sm font-semibold">Provider bond</h3>
+      </div>
+      {!verification.completeness.bond ? (
+        <EmptyState>Not evaluated</EmptyState>
+      ) : !bond ? (
+        <EmptyState>No provider bond posted</EmptyState>
+      ) : (
+        <div className="space-y-4">
+          <div className="grid grid-cols-2 gap-3">
+            <Metric label="Bonded amount" value={formatCoin(bond.bondedAmount)} />
+            <Metric label="Required for current tier" value={formatCoin(bond.requiredForCurrentTier)} />
+            <Metric label="Slashed" value={bond.slashed ? "Yes" : "No"} />
+            <Metric label="Last slash" value={formatTimestamp(bond.lastSlashTime)} />
+            <Metric label="Unbonding entries" value={bond.unbondingEntries.length.toString()} />
+          </div>
+          {bond.unbondingEntries.length > 0 && (
+            <div className="space-y-2 border-t pt-4">
+              {bond.unbondingEntries.map((entry, index) => (
+                <div key={`${entry.completionTime}-${index}`} className="flex flex-wrap items-center justify-between gap-2 text-xs">
+                  <span>{formatCoin(entry.amount)}</span>
+                  <span className="text-muted-foreground">Completes {formatTimestamp(entry.completionTime)}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DataSection({ title, description, children }: { title: string; description: string; children: React.ReactNode }) {
+  return (
+    <section className="border-b last:border-b-0">
+      <div className="px-5 py-4">
+        <h3 className="text-sm font-semibold">{title}</h3>
+        <p className="mt-1 text-xs text-muted-foreground">{description}</p>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function SummaryItem({ icon: Icon, label, value }: { icon: typeof ShieldCheck; label: string; value: string }) {
+  return (
+    <div className="min-w-0 border-b border-r p-4 last:border-r-0 xl:border-b-0">
+      <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+        <Icon className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+        <span className="break-words leading-tight">{label}</span>
+      </div>
+      <p className="mt-1 break-words text-sm font-semibold">{value}</p>
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="min-w-0">
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="mt-1 break-words text-sm font-medium">{value}</p>
+    </div>
+  );
+}
+
+function HashValue({ label, value }: { label: string; value: string | null }) {
+  return (
+    <div className="min-w-0 border-t pt-4">
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="mt-1 break-all font-mono text-xs">{value || "Not recorded"}</p>
+    </div>
+  );
+}
+
+function EmptyState({ children }: { children: React.ReactNode }) {
+  return <p className="text-sm text-muted-foreground">{children}</p>;
+}
+
+function EmptyTableRow({ columns, children }: { columns: number; children: React.ReactNode }) {
+  return (
+    <TableRow>
+      <TableCell colSpan={columns} className="py-6 text-center text-sm text-muted-foreground">
+        {children}
+      </TableCell>
+    </TableRow>
+  );
+}
+
+function ObservedState({ verification }: { verification: ProviderVerificationView }) {
+  return (
+    <span className="text-xs text-muted-foreground">
+      Indexed at height {verification.observedHeight} · {formatTimestamp(verification.observedAt)}
+    </span>
+  );
+}
+
+function TierBadge({ tier }: { tier: ProviderVerificationTier }) {
+  return (
+    <Badge variant={tier === "unknown" ? "outline" : "secondary"} className="rounded">
+      {tier === "unknown" ? "Not evaluated" : tier}
+    </Badge>
+  );
+}
+
+function StateBadge({ value, positive }: { value: string; positive?: string }) {
+  const isPositive = value === positive;
+  const isNegative = ["expired", "voided", "revoked", "removed", "cancelled", "slashed", "timed_out"].includes(value);
+
+  return (
+    <Badge variant={isPositive ? "success" : isNegative ? "destructive" : "outline"} className="whitespace-nowrap rounded font-normal">
+      {humanize(value)}
+    </Badge>
+  );
+}
+
+function formatOptionalInteger(value: number | null): string {
+  return value === null ? "Not evaluated" : String(value);
+}
+
+function formatCoin(value: ProviderVerificationCoin | null): string {
+  return value ? `${formatInteger(value.amount)} ${value.denom}` : "Not recorded";
+}
+
+function formatInteger(value: string): string {
+  try {
+    return new Intl.NumberFormat("en-US").format(BigInt(value));
+  } catch {
+    return value;
+  }
+}
+
+function formatTimestamp(value: string | null): string {
+  if (!value) return "Not recorded";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "Not recorded";
+  return new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZone: "UTC",
+    timeZoneName: "short"
+  }).format(date);
+}
+
+function reviewLabel(value: ProviderVerificationView["summary"]["reviewState"]): string {
+  if (value === "under_review") return "Under review";
+  if (value === "grace") return "Grace active";
+  return stateLabel(value);
+}
+
+function stateLabel(value: string): string {
+  if (value === "unknown") return "Not evaluated";
+  if (value === "not_posted") return "Not posted";
+  return humanize(value);
+}
+
+function humanize(value: string): string {
+  const text = value.replaceAll("_", " ");
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}

--- a/apps/deploy-web/src/components/providers/ProviderVerificationListCell.spec.tsx
+++ b/apps/deploy-web/src/components/providers/ProviderVerificationListCell.spec.tsx
@@ -1,0 +1,217 @@
+import { describe, expect, it } from "vitest";
+
+import type { ProviderVerificationView } from "@src/types/provider";
+import { ProviderVerificationDetails } from "./ProviderVerificationDetails";
+import { ProviderVerificationListCell } from "./ProviderVerificationListCell";
+
+import { render, screen } from "@testing-library/react";
+
+describe(ProviderVerificationListCell.name, () => {
+  it("shows the complete compact verification state", () => {
+    render(<ProviderVerificationListCell verification={buildVerification()} />);
+
+    expect(screen.getByText("L3")).toBeInTheDocument();
+    expect(screen.getByText("2 auditors")).toBeInTheDocument();
+    expect(screen.getByText("Persistent storage")).toBeInTheDocument();
+    expect(screen.getByText("Bare metal")).toBeInTheDocument();
+    expect(screen.getByLabelText("Provider-signed inventory: Current")).toBeInTheDocument();
+    expect(screen.getByLabelText("Maintenance: Active")).toBeInTheDocument();
+    expect(screen.getByLabelText("Discrepancy review: Grace active")).toBeInTheDocument();
+  });
+
+  it("does not infer a pass from missing indexed state", () => {
+    render(<ProviderVerificationListCell verification={null} />);
+
+    expect(screen.getByText("Not evaluated")).toBeInTheDocument();
+  });
+});
+
+describe(ProviderVerificationDetails.name, () => {
+  it("renders the normalized provider verification lifecycle with provenance", () => {
+    render(<ProviderVerificationDetails providerDeclaredTier="community" verification={buildVerification()} />);
+
+    expect(screen.getByText("Auditor-attested capabilities")).toBeInTheDocument();
+    expect(screen.getByText("Latest provider-signed inventory")).toBeInTheDocument();
+    expect(screen.getByText("Attestation records")).toBeInTheDocument();
+    expect(screen.getByText("Audit escrow lifecycle")).toBeInTheDocument();
+    expect(screen.getByText("Maintenance windows")).toBeInTheDocument();
+    expect(screen.getByText("Open discrepancies and grace")).toBeInTheDocument();
+    expect(screen.getByText("community")).toBeInTheDocument();
+    expect(screen.getAllByText("L3").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("akash1auditoralpha").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("100,000,000 uakt").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("#23").length).toBeGreaterThan(0);
+  });
+
+  it("labels incomplete checks as not evaluated", () => {
+    const verification = buildVerification();
+    verification.summary.effectiveTier = null;
+    verification.summary.capabilities = null;
+    verification.summary.validAuditorCount = null;
+    verification.summary.snapshotState = "unknown";
+    verification.snapshot = null;
+    verification.bond = null;
+    verification.attestations = [];
+    verification.auditEscrows = [];
+    verification.maintenance = [];
+    verification.discrepancies = [];
+    verification.grace = null;
+    verification.completeness = {
+      params: true,
+      attestations: false,
+      graces: false,
+      snapshot: false,
+      bond: false,
+      auditEscrows: false,
+      maintenance: false,
+      discrepancies: false
+    };
+
+    render(<ProviderVerificationDetails providerDeclaredTier={null} verification={verification} />);
+
+    expect(screen.getAllByText("Not evaluated").length).toBeGreaterThanOrEqual(6);
+    expect(screen.queryByText("Passed")).not.toBeInTheDocument();
+  });
+});
+
+function buildVerification(): ProviderVerificationView {
+  return {
+    provider: "akash1provider",
+    providerDeclaredTier: "community",
+    moduleActive: true,
+    provenance: {
+      providerTier: "provider self-declared",
+      inventory: "provider-signed inventory",
+      attestations: "auditor-attested"
+    },
+    summary: {
+      bestAttestedTier: "L3",
+      effectiveTier: "L3",
+      capabilities: ["persistent_storage", "bare_metal"],
+      validAttestationCount: 2,
+      validAuditorCount: 2,
+      validAuditors: ["akash1auditoralpha", "akash1auditorbeta"],
+      snapshotState: "current",
+      maintenanceState: "active",
+      reviewState: "grace"
+    },
+    attestations: [
+      {
+        provider: "akash1provider",
+        auditor: "akash1auditoralpha",
+        tier: "L3",
+        capabilities: ["persistent_storage"],
+        evidenceHash: "ZXZpZGVuY2U=",
+        fee: { denom: "uakt", amount: "10000000" },
+        feeStatus: "escrowed",
+        createdAt: "2026-08-23T12:00:00.000Z",
+        expiresAt: "2027-08-23T12:00:00.000Z",
+        status: "valid",
+        voidedReason: "unspecified",
+        deposit: { denom: "uakt", amount: "100000000" },
+        depositStatus: "escrowed",
+        auditEscrowId: "23",
+        faultAttribution: "unspecified"
+      }
+    ],
+    bond: {
+      provider: "akash1provider",
+      bondedAmount: { denom: "uakt", amount: "1000000000" },
+      requiredForCurrentTier: { denom: "uakt", amount: "1000000000" },
+      unbondingEntries: [],
+      slashed: false,
+      lastSlashTime: null
+    },
+    snapshot: {
+      provider: "akash1provider",
+      snapshotHash: "c25hcHNob3Q=",
+      resourceSummary: {
+        totalGpus: 1,
+        totalVcpus: 16,
+        totalMemoryMb: "65536",
+        totalStorageMb: "1048576",
+        activeLeases: 4,
+        softwareVersion: "v0.16.0-a4",
+        softwareSignature: "c2lnbmF0dXJl",
+        softwareIdentity: null
+      },
+      postedAt: "2026-08-24T10:00:00.000Z",
+      snapshotTimestamp: "2026-08-24T09:59:00.000Z",
+      complianceDeadline: "2026-08-24T11:00:00.000Z",
+      suspended: false
+    },
+    grace: {
+      id: "31",
+      provider: "akash1provider",
+      preservedTier: "L3",
+      sourceDiscrepancyIds: ["8"],
+      startedAt: "2026-08-24T08:00:00.000Z",
+      expiresAt: "2026-08-25T08:00:00.000Z",
+      status: "active"
+    },
+    auditEscrows: [
+      {
+        id: "23",
+        provider: "akash1provider",
+        consumedByAuditor: "akash1auditoralpha",
+        requestedTier: "L3",
+        requestedCapabilities: ["persistent_storage"],
+        fee: { denom: "uakt", amount: "10000000" },
+        feeStatus: "escrowed",
+        providerDeposit: { denom: "uakt", amount: "100000000" },
+        providerDepositStatus: "escrowed",
+        status: "consumed",
+        openedAt: "2026-08-23T10:00:00.000Z",
+        consumedAt: "2026-08-23T12:00:00.000Z",
+        expiresAt: "2026-08-25T10:00:00.000Z",
+        metadataHash: null,
+        settlementReason: "unspecified",
+        faultAttribution: "unspecified"
+      }
+    ],
+    maintenance: [
+      {
+        record: {
+          id: "4",
+          provider: "akash1provider",
+          maintenanceType: "planned",
+          startsAt: "2026-08-24T10:00:00.000Z",
+          expectedEndsAt: "2026-08-24T12:00:00.000Z",
+          openedAt: "2026-08-23T10:00:00.000Z",
+          closedAt: null,
+          metadataHash: null
+        },
+        status: "active"
+      }
+    ],
+    discrepancies: [
+      {
+        id: "8",
+        provider: "akash1provider",
+        auditorA: "akash1auditoralpha",
+        auditorATier: "L3",
+        auditorB: "akash1auditorbeta",
+        auditorBTier: "L1",
+        timestamp: "2026-08-24T08:00:00.000Z",
+        resolutionStatus: "pending",
+        resolutionProposalId: "0",
+        graceRecordId: "31",
+        resolutionReason: "unspecified",
+        faultAttribution: "unspecified",
+        resolutionEvidenceHash: null
+      }
+    ],
+    observedAt: "2026-08-24T10:05:00.000Z",
+    observedHeight: "1020781",
+    completeness: {
+      params: true,
+      attestations: true,
+      graces: true,
+      snapshot: true,
+      bond: true,
+      auditEscrows: true,
+      maintenance: true,
+      discrepancies: true
+    }
+  };
+}

--- a/apps/deploy-web/src/components/providers/ProviderVerificationListCell.tsx
+++ b/apps/deploy-web/src/components/providers/ProviderVerificationListCell.tsx
@@ -1,0 +1,107 @@
+"use client";
+import { Badge } from "@akashnetwork/ui/components";
+import { Database, Scale, Users, Wrench } from "lucide-react";
+
+import type { ProviderVerificationCapability, ProviderVerificationListView } from "@src/types/provider";
+
+const CAPABILITY_LABELS: Record<ProviderVerificationCapability, string> = {
+  unspecified: "Unspecified",
+  tee_hardware_attestation: "TEE hardware",
+  confidential_computing: "Confidential compute",
+  persistent_storage: "Persistent storage",
+  bare_metal: "Bare metal",
+  unknown: "Unknown"
+};
+
+type Props = {
+  verification: ProviderVerificationListView | null;
+};
+
+export const ProviderVerificationListCell: React.FunctionComponent<Props> = ({ verification }) => {
+  if (!verification) {
+    return <span className="text-xs text-muted-foreground">Not evaluated</span>;
+  }
+
+  const { summary } = verification;
+  const tier = summary.effectiveTier;
+  const capabilities = summary.capabilities;
+
+  return (
+    <div className="min-w-[15rem] space-y-1.5 py-1 text-left" data-testid="provider-verification-list-cell">
+      <div className="flex min-w-0 flex-wrap items-center gap-1.5">
+        <Badge variant={tier && tier !== "unknown" ? "secondary" : "outline"} className="h-5 rounded px-1.5 text-xs">
+          {tier ?? "Not evaluated"}
+        </Badge>
+        <span className="inline-flex items-center gap-1 whitespace-nowrap text-xs text-muted-foreground">
+          <Users className="h-3.5 w-3.5" aria-hidden="true" />
+          {formatAuditorCount(summary.validAuditorCount)}
+        </span>
+      </div>
+
+      <div className="flex min-h-5 min-w-0 flex-wrap gap-1">
+        {capabilities === null ? (
+          <span className="text-xs text-muted-foreground">Capabilities not evaluated</span>
+        ) : capabilities.length === 0 ? (
+          <span className="text-xs text-muted-foreground">No attested capabilities</span>
+        ) : (
+          <>
+            {capabilities.slice(0, 2).map(capability => (
+              <Badge
+                key={capability}
+                variant="outline"
+                className="h-5 max-w-[9rem] truncate rounded px-1.5 text-xs font-normal"
+                title={CAPABILITY_LABELS[capability]}
+              >
+                {CAPABILITY_LABELS[capability]}
+              </Badge>
+            ))}
+            {capabilities.length > 2 && (
+              <Badge
+                variant="outline"
+                className="h-5 rounded px-1.5 text-xs font-normal"
+                title={capabilities
+                  .slice(2)
+                  .map(value => CAPABILITY_LABELS[value])
+                  .join(", ")}
+              >
+                +{capabilities.length - 2}
+              </Badge>
+            )}
+          </>
+        )}
+      </div>
+
+      <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-[11px] text-muted-foreground">
+        <CompactState icon={Database} label="Provider-signed inventory" value={stateLabel(summary.snapshotState)} />
+        <CompactState icon={Wrench} label="Maintenance" value={stateLabel(summary.maintenanceState)} />
+        <CompactState icon={Scale} label="Discrepancy review" value={reviewLabel(summary.reviewState)} />
+      </div>
+    </div>
+  );
+};
+
+function CompactState({ icon: Icon, label, value }: { icon: typeof Database; label: string; value: string }) {
+  return (
+    <span className="inline-flex min-w-0 items-center gap-1 whitespace-nowrap" title={`${label}: ${value}`} aria-label={`${label}: ${value}`}>
+      <Icon className="h-3 w-3 shrink-0" aria-hidden="true" />
+      <span>{value}</span>
+    </span>
+  );
+}
+
+function formatAuditorCount(value: number | null): string {
+  if (value === null) return "Not evaluated";
+  return `${value} auditor${value === 1 ? "" : "s"}`;
+}
+
+function reviewLabel(value: ProviderVerificationListView["summary"]["reviewState"]): string {
+  if (value === "under_review") return "Under review";
+  if (value === "grace") return "Grace active";
+  return stateLabel(value);
+}
+
+function stateLabel(value: string): string {
+  if (value === "unknown") return "Not evaluated";
+  if (value === "not_posted") return "Not posted";
+  return value.charAt(0).toUpperCase() + value.slice(1).replaceAll("_", " ");
+}

--- a/apps/deploy-web/src/components/providers/providerListFilters.spec.ts
+++ b/apps/deploy-web/src/components/providers/providerListFilters.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import type { ClientProviderList } from "@src/types/provider";
+import { hasAuditOrAttestation } from "./providerListFilters";
+
+describe(hasAuditOrAttestation.name, () => {
+  it.each([
+    { legacyAudited: true, verificationEnabled: false, validAuditorCount: null, expected: true },
+    { legacyAudited: false, verificationEnabled: true, validAuditorCount: 1, expected: true },
+    { legacyAudited: false, verificationEnabled: true, validAuditorCount: 0, expected: false },
+    { legacyAudited: false, verificationEnabled: true, validAuditorCount: null, expected: false },
+    { legacyAudited: false, verificationEnabled: false, validAuditorCount: 1, expected: false }
+  ])(
+    "returns $expected for legacy=$legacyAudited enabled=$verificationEnabled auditors=$validAuditorCount",
+    ({ legacyAudited, verificationEnabled, validAuditorCount, expected }) => {
+      const provider = {
+        isAudited: legacyAudited,
+        verification:
+          validAuditorCount === null
+            ? null
+            : {
+                summary: { validAuditorCount }
+              }
+      } as ClientProviderList;
+
+      expect(hasAuditOrAttestation(provider, verificationEnabled)).toBe(expected);
+    }
+  );
+});

--- a/apps/deploy-web/src/components/providers/providerListFilters.ts
+++ b/apps/deploy-web/src/components/providers/providerListFilters.ts
@@ -1,0 +1,7 @@
+import type { ClientProviderList } from "@src/types/provider";
+
+type AuditedProvider = Pick<ClientProviderList, "isAudited" | "verification">;
+
+export function hasAuditOrAttestation(provider: AuditedProvider, isProviderVerificationEnabled: boolean): boolean {
+  return provider.isAudited || (isProviderVerificationEnabled && (provider.verification?.summary.validAuditorCount ?? 0) > 0);
+}

--- a/apps/deploy-web/src/components/sdl/PlacementFormModal.tsx
+++ b/apps/deploy-web/src/components/sdl/PlacementFormModal.tsx
@@ -9,6 +9,7 @@ import { InfoCircle } from "iconoir-react";
 
 import { UAKT_DENOM } from "@src/config/denom.config";
 import { useSupportedDenoms } from "@src/hooks/useDenom";
+import { useFlag } from "@src/hooks/useFlag";
 import type { PlacementType, SdlBuilderFormValuesType, ServiceType } from "@src/types";
 import { udenomToDenom } from "@src/utils/mathHelpers";
 import { getAvgCostPerMonth, toReadableDenom, uaktToAKT } from "@src/utils/priceUtils";
@@ -17,6 +18,8 @@ import { USDLabel } from "../shared/UsdLabel";
 import type { AttributesRefType } from "./AttributesFormControl";
 import { AttributesFormControl } from "./AttributesFormControl";
 import { FormPaper } from "./FormPaper";
+import type { PlacementVerificationRefType } from "./PlacementVerificationFormControl";
+import { PlacementVerificationFormControl } from "./PlacementVerificationFormControl";
 import type { SignedByRefType } from "./SignedByFormControl";
 import { SignedByFormControl } from "./SignedByFormControl";
 
@@ -32,6 +35,8 @@ type Props = {
 export const PlacementFormModal: React.FunctionComponent<Props> = ({ control, services, serviceIndex, onClose, placement: _placement }) => {
   const signedByRef = useRef<SignedByRefType>(null);
   const attritubesRef = useRef<AttributesRefType>(null);
+  const verificationRef = useRef<PlacementVerificationRefType>(null);
+  const isProviderVerificationEnabled = useFlag("provider_verification");
   const supportedSdlDenoms = useSupportedDenoms();
   const currentService = services[serviceIndex];
   const placementIndex = usePlacementIndexForService(control, serviceIndex);
@@ -41,6 +46,7 @@ export const PlacementFormModal: React.FunctionComponent<Props> = ({ control, se
     const attributesToRemove: number[] = [];
     const signedByAnyToRemove: number[] = [];
     const signedByAllToRemove: number[] = [];
+    const verificationAuditorsToRemove: number[] = [];
 
     _placement.attributes?.forEach((e, i) => {
       if (!e.key.trim() || !e.value?.trim()) {
@@ -60,9 +66,16 @@ export const PlacementFormModal: React.FunctionComponent<Props> = ({ control, se
       }
     });
 
+    _placement.verification?.auditors?.forEach((auditor, index) => {
+      if (!auditor.value.trim()) {
+        verificationAuditorsToRemove.push(index);
+      }
+    });
+
     attritubesRef.current?._removeAttribute(attributesToRemove);
     signedByRef.current?._removeSignedByAnyOf(signedByAnyToRemove);
     signedByRef.current?._removeSignedByAllOf(signedByAllToRemove);
+    verificationRef.current?.removeAuditors(verificationAuditorsToRemove);
 
     onClose();
   };
@@ -176,6 +189,8 @@ export const PlacementFormModal: React.FunctionComponent<Props> = ({ control, se
               <AttributesFormControl control={control} placementIndex={placementIndex} attributes={_placement.attributes || []} ref={attritubesRef} />
             </div>
           </div>
+
+          {isProviderVerificationEnabled && <PlacementVerificationFormControl ref={verificationRef} control={control} placementIndex={placementIndex} />}
         </div>
       </FormPaper>
     </Popup>

--- a/apps/deploy-web/src/components/sdl/PlacementVerificationFormControl.spec.tsx
+++ b/apps/deploy-web/src/components/sdl/PlacementVerificationFormControl.spec.tsx
@@ -1,0 +1,197 @@
+import type { RefObject } from "react";
+import { createRef } from "react";
+import type { UseFormReturn } from "react-hook-form";
+import { FormProvider, useForm } from "react-hook-form";
+import { TooltipProvider } from "@akashnetwork/ui/components";
+import { describe, expect, it } from "vitest";
+
+import type { PlacementVerificationType, SdlBuilderFormValuesType } from "@src/types";
+import { defaultServiceWithPlacement } from "@src/utils/sdl/data";
+import type { PlacementVerificationRefType } from "./PlacementVerificationFormControl";
+import { PlacementVerificationFormControl } from "./PlacementVerificationFormControl";
+
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+describe(PlacementVerificationFormControl.name, () => {
+  it("adds and removes the optional verification requirement", async () => {
+    const user = userEvent.setup();
+    const { form } = setup();
+    const toggle = screen.getByRole("switch", { name: "Require provider verification" });
+
+    expect(toggle).not.toBeChecked();
+    expect(screen.queryByRole("combobox", { name: "Minimum verification tier" })).not.toBeInTheDocument();
+    expect(screen.getByText("Any provider may bid")).toBeInTheDocument();
+    expect(screen.getByText("L1 - Identified")).toBeInTheDocument();
+    expect(screen.getByText("L4 - Trusted")).toBeInTheDocument();
+
+    await user.click(toggle);
+
+    expect(form().getValues("placements.0.verification")).toEqual({
+      minTier: 1,
+      capabilities: [],
+      auditors: []
+    });
+    expect(screen.getByRole("combobox", { name: "Minimum verification tier" })).toHaveTextContent("L1 - Identified");
+    expect(screen.getByText("Operator identity verified")).toBeInTheDocument();
+
+    await user.click(toggle);
+
+    expect(form().getValues("placements.0.verification")).toBeUndefined();
+    expect(screen.queryByRole("combobox", { name: "Minimum verification tier" })).not.toBeInTheDocument();
+    expect(screen.getByText("Any provider may bid")).toBeInTheDocument();
+  });
+
+  it("updates the tier and its concise meaning", async () => {
+    const user = userEvent.setup();
+    const { form } = setup({ verification: buildVerification() });
+
+    await user.click(screen.getByRole("combobox", { name: "Minimum verification tier" }));
+    await user.click(screen.getByRole("option", { name: "L3 - Established" }));
+
+    expect(form().getValues("placements.0.verification.minTier")).toBe(3);
+    expect(screen.getByText("Sustained reliability checked")).toBeInTheDocument();
+  });
+
+  it("writes canonical capabilities without duplicates", async () => {
+    const user = userEvent.setup();
+    const { form } = setup({ verification: buildVerification() });
+    const persistentStorage = screen.getByRole("checkbox", { name: "Persistent storage" });
+    const bareMetal = screen.getByRole("checkbox", { name: "Bare metal" });
+
+    await user.click(persistentStorage);
+    await user.click(bareMetal);
+
+    expect(form().getValues("placements.0.verification.capabilities")).toEqual(["persistent_storage", "bare_metal"]);
+
+    await user.click(persistentStorage);
+
+    expect(form().getValues("placements.0.verification.capabilities")).toEqual(["bare_metal"]);
+  });
+
+  it("updates the minimum auditor count", async () => {
+    const user = userEvent.setup();
+    const { form } = setup({ verification: buildVerification() });
+    const input = screen.getByRole("spinbutton", { name: "Minimum auditors" });
+
+    await user.clear(input);
+    await user.type(input, "2");
+
+    expect(form().getValues("placements.0.verification.minAuditorCount")).toBe(2);
+  });
+
+  it("manages named auditors and their any/all policy", async () => {
+    const user = userEvent.setup();
+    const { form } = setup({ verification: buildVerification() });
+
+    await user.click(screen.getByRole("button", { name: "Add auditor" }));
+    await user.type(screen.getByRole("textbox", { name: "Auditor 1" }), "akash1auditor");
+    await user.click(screen.getByRole("combobox", { name: "Named auditor policy" }));
+    await user.click(screen.getByRole("option", { name: "All listed auditors" }));
+
+    expect(form().getValues("placements.0.verification.auditors.0.value")).toBe("akash1auditor");
+    expect(form().getValues("placements.0.verification.auditorMode")).toBe("all");
+
+    await user.click(screen.getByRole("button", { name: "Remove auditor 1" }));
+
+    expect(form().getValues("placements.0.verification.auditors")).toEqual([]);
+    expect(form().getValues("placements.0.verification.auditorMode")).toBeUndefined();
+    expect(screen.queryByRole("combobox", { name: "Named auditor policy" })).not.toBeInTheDocument();
+  });
+
+  it("renders imported requirements without changing them on mount", () => {
+    const verification = buildVerification({
+      minTier: 4,
+      capabilities: ["tee_hardware_attestation", "confidential_computing"],
+      auditors: [{ id: "auditor-1", value: "akash1trusted" }],
+      auditorMode: "all",
+      minAuditorCount: 2
+    });
+    const { form } = setup({ verification });
+
+    expect(screen.getByRole("switch", { name: "Require provider verification" })).toBeChecked();
+    expect(screen.getByRole("combobox", { name: "Minimum verification tier" })).toHaveTextContent("L4 - Trusted");
+    expect(screen.getByRole("checkbox", { name: "TEE hardware attestation" })).toBeChecked();
+    expect(screen.getByRole("textbox", { name: "Auditor 1" })).toHaveValue("akash1trusted");
+    expect(form().getValues("placements.0.verification")).toEqual(verification);
+  });
+
+  it("leaves legacy signedBy untouched when verification is disabled", async () => {
+    const user = userEvent.setup();
+    const { form } = setup({ verification: buildVerification(), signedBy: "akash1legacy" });
+
+    await user.click(screen.getByRole("switch", { name: "Require provider verification" }));
+
+    expect(form().getValues("placements.0.verification")).toBeUndefined();
+    expect(form().getValues("placements.0.signedBy")).toEqual({
+      anyOf: [{ id: "legacy", value: "akash1legacy" }],
+      allOf: []
+    });
+  });
+
+  it("exposes the same blank-row pruning operation as the placement editor's other arrays", () => {
+    const ref = createRef<PlacementVerificationRefType>();
+    const { form } = setup({
+      verification: buildVerification({
+        auditors: [
+          { id: "blank", value: "" },
+          { id: "kept", value: "akash1kept" }
+        ]
+      }),
+      verificationRef: ref
+    });
+
+    act(() => ref.current?.removeAuditors([0]));
+
+    expect(form().getValues("placements.0.verification.auditors")).toEqual([{ id: "kept", value: "akash1kept" }]);
+  });
+});
+
+function buildVerification(overrides: Partial<PlacementVerificationType> = {}): PlacementVerificationType {
+  return {
+    minTier: 1,
+    capabilities: [],
+    auditors: [],
+    auditorMode: "any",
+    minAuditorCount: 0,
+    ...overrides
+  };
+}
+
+function setup({
+  verification,
+  signedBy,
+  verificationRef
+}: {
+  verification?: PlacementVerificationType;
+  signedBy?: string;
+  verificationRef?: RefObject<PlacementVerificationRefType>;
+} = {}) {
+  const values = defaultServiceWithPlacement();
+  values.placements[0].verification = verification;
+  if (signedBy) {
+    values.placements[0].signedBy = { anyOf: [{ id: "legacy", value: signedBy }], allOf: [] };
+  }
+
+  let form: UseFormReturn<SdlBuilderFormValuesType> | undefined;
+  const Wrapper = () => {
+    const methods = useForm<SdlBuilderFormValuesType>({ defaultValues: values });
+    form = methods;
+    return (
+      <TooltipProvider>
+        <FormProvider {...methods}>
+          <PlacementVerificationFormControl ref={verificationRef} control={methods.control} placementIndex={0} />
+        </FormProvider>
+      </TooltipProvider>
+    );
+  };
+
+  render(<Wrapper />);
+
+  return {
+    form: () => {
+      if (!form) throw new Error("Form did not initialize");
+      return form;
+    }
+  };
+}

--- a/apps/deploy-web/src/components/sdl/PlacementVerificationFormControl.tsx
+++ b/apps/deploy-web/src/components/sdl/PlacementVerificationFormControl.tsx
@@ -1,0 +1,269 @@
+"use client";
+import { forwardRef, useCallback, useImperativeHandle } from "react";
+import type { Control } from "react-hook-form";
+import { useFieldArray, useFormContext, useWatch } from "react-hook-form";
+import {
+  Button,
+  CheckboxWithLabel,
+  CustomTooltip,
+  FormField,
+  FormInput,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Switch
+} from "@akashnetwork/ui/components";
+import { Bin, InfoCircle, Plus } from "iconoir-react";
+import { nanoid } from "nanoid";
+
+import type { PlacementVerificationType, SdlBuilderFormValuesType } from "@src/types";
+
+type Props = {
+  placementIndex: number;
+  control: Control<SdlBuilderFormValuesType>;
+  showTopDivider?: boolean;
+};
+
+export type PlacementVerificationRefType = {
+  removeAuditors: (index: number | number[]) => void;
+};
+
+type Capability = NonNullable<PlacementVerificationType["capabilities"]>[number];
+
+const defaultVerification = (): PlacementVerificationType => ({
+  minTier: 1,
+  capabilities: [],
+  auditors: []
+});
+
+const TIER_OPTIONS = [
+  { value: 1, label: "L1 - Identified", description: "Operator identity verified" },
+  { value: 2, label: "L2 - Verified", description: "Resources and location checked" },
+  { value: 3, label: "L3 - Established", description: "Sustained reliability checked" },
+  { value: 4, label: "L4 - Trusted", description: "Physical audit and SLA" }
+] as const;
+
+const CAPABILITY_OPTIONS = [
+  { value: "tee_hardware_attestation", label: "TEE hardware attestation" },
+  { value: "confidential_computing", label: "Confidential computing" },
+  { value: "persistent_storage", label: "Persistent storage" },
+  { value: "bare_metal", label: "Bare metal" }
+] satisfies ReadonlyArray<{ value: Capability; label: string }>;
+
+export const PlacementVerificationFormControl = forwardRef<PlacementVerificationRefType, Props>(({ control, placementIndex, showTopDivider = true }, ref) => {
+  const { setValue } = useFormContext<SdlBuilderFormValuesType>();
+  const verification = useWatch({ control, name: `placements.${placementIndex}.verification` });
+  const {
+    fields: auditors,
+    append: appendAuditor,
+    remove: removeAuditor
+  } = useFieldArray({
+    control,
+    name: `placements.${placementIndex}.verification.auditors`,
+    keyName: "fieldId"
+  });
+  const selectedTier = TIER_OPTIONS.find(option => option.value === verification?.minTier) ?? TIER_OPTIONS[0];
+
+  const removeAuditors = useCallback(
+    (index: number | number[]) => {
+      const indexes = new Set(Array.isArray(index) ? index : [index]);
+      const removesEveryAuditor = auditors.length > 0 && auditors.every((_, auditorIndex) => indexes.has(auditorIndex));
+
+      removeAuditor(index);
+      if (removesEveryAuditor) {
+        setValue(`placements.${placementIndex}.verification.auditorMode`, undefined, { shouldDirty: true });
+      }
+    },
+    [auditors, placementIndex, removeAuditor, setValue]
+  );
+
+  useImperativeHandle(ref, () => ({ removeAuditors }), [removeAuditors]);
+
+  return (
+    <section aria-labelledby={`placement-${placementIndex}-verification-title`} className={showTopDivider ? "mt-6 border-t pt-4" : undefined}>
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <div className="flex items-center">
+            <strong id={`placement-${placementIndex}-verification-title`} className="text-sm">
+              Require verified providers
+            </strong>
+            <CustomTooltip title="Require auditor-attested provider verification for this placement.">
+              <InfoCircle className="ml-2 text-sm text-muted-foreground" />
+            </CustomTooltip>
+          </div>
+          <p className="mt-1 text-xs text-muted-foreground">{verification ? "Only providers meeting every requirement may bid" : "Any provider may bid"}</p>
+        </div>
+
+        <FormField
+          control={control}
+          name={`placements.${placementIndex}.verification`}
+          render={({ field }) => (
+            <Switch
+              aria-label="Require provider verification"
+              checked={field.value !== undefined}
+              onCheckedChange={checked => field.onChange(checked ? defaultVerification() : undefined)}
+            />
+          )}
+        />
+      </div>
+
+      {verification ? (
+        <div className="mt-4 space-y-5">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <FormField
+              control={control}
+              name={`placements.${placementIndex}.verification.minTier`}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel htmlFor={`placement-${placementIndex}-verification-tier`}>Minimum tier</FormLabel>
+                  <Select value={String(field.value)} onValueChange={value => field.onChange(Number(value))}>
+                    <SelectTrigger id={`placement-${placementIndex}-verification-tier`} className="mt-1" aria-label="Minimum verification tier">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {TIER_OPTIONS.map(option => (
+                        <SelectItem key={option.value} value={String(option.value)}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <p className="text-xs text-muted-foreground">{selectedTier.description}</p>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={control}
+              name={`placements.${placementIndex}.verification.minAuditorCount`}
+              render={({ field }) => (
+                <FormInput
+                  type="number"
+                  label="Minimum auditors"
+                  value={field.value ?? ""}
+                  min={0}
+                  max={4_294_967_295}
+                  step={1}
+                  onChange={event => field.onChange(event.target.value === "" ? undefined : event.target.valueAsNumber)}
+                />
+              )}
+            />
+          </div>
+
+          <FormField
+            control={control}
+            name={`placements.${placementIndex}.verification.capabilities`}
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Required capabilities</FormLabel>
+                <div className="grid gap-3 pt-1 sm:grid-cols-2">
+                  {CAPABILITY_OPTIONS.map(option => (
+                    <CheckboxWithLabel
+                      key={option.value}
+                      label={option.label}
+                      checked={field.value?.includes(option.value) ?? false}
+                      onCheckedChange={checked => {
+                        const current = field.value ?? [];
+                        field.onChange(checked === true ? [...current, option.value] : current.filter(value => value !== option.value));
+                      }}
+                    />
+                  ))}
+                </div>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <div className="border-t pt-4">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <FormLabel>Named auditors</FormLabel>
+                <p className="mt-1 text-xs text-muted-foreground">Optional auditor address requirements</p>
+              </div>
+              <Button type="button" variant="default" size="sm" onClick={() => appendAuditor({ id: nanoid(), value: "" })}>
+                <Plus className="mr-1 h-4 w-4" />
+                Add auditor
+              </Button>
+            </div>
+
+            {auditors.length > 0 ? (
+              <div className="mt-4 space-y-3">
+                {auditors.map((auditor, auditorIndex) => (
+                  <div key={auditor.fieldId} className="flex items-end gap-2">
+                    <div className="flex-1">
+                      <FormField
+                        control={control}
+                        name={`placements.${placementIndex}.verification.auditors.${auditorIndex}.value`}
+                        render={({ field }) => (
+                          <FormInput
+                            type="text"
+                            label={`Auditor ${auditorIndex + 1}`}
+                            placeholder="akash1..."
+                            className="w-full"
+                            value={field.value}
+                            onChange={event => field.onChange(event.target.value)}
+                          />
+                        )}
+                      />
+                    </div>
+                    <Button
+                      type="button"
+                      onClick={() => removeAuditors(auditorIndex)}
+                      size="icon"
+                      variant="ghost"
+                      aria-label={`Remove auditor ${auditorIndex + 1}`}
+                    >
+                      <Bin />
+                    </Button>
+                  </div>
+                ))}
+
+                <FormField
+                  control={control}
+                  name={`placements.${placementIndex}.verification.auditorMode`}
+                  render={({ field }) => (
+                    <FormItem className="max-w-sm">
+                      <FormLabel htmlFor={`placement-${placementIndex}-auditor-mode`}>Named auditor policy</FormLabel>
+                      <Select value={field.value ?? "any"} onValueChange={value => field.onChange(value === "all" ? "all" : "any")}>
+                        <SelectTrigger id={`placement-${placementIndex}-auditor-mode`} className="mt-1" aria-label="Named auditor policy">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="any">Any listed auditor</SelectItem>
+                          <SelectItem value="all">All listed auditors</SelectItem>
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+            ) : (
+              <p className="mt-3 text-xs text-muted-foreground">None</p>
+            )}
+          </div>
+        </div>
+      ) : (
+        <div className="mt-5">
+          <p className="mb-2 font-mono text-xs uppercase text-muted-foreground">Verification tiers</p>
+          <div className="overflow-hidden rounded-md border">
+            {TIER_OPTIONS.map(option => (
+              <div key={option.value} className="grid grid-cols-[7.5rem_1fr] items-center gap-3 border-b px-3 py-2.5 last:border-b-0">
+                <span className="text-sm font-medium">{option.label}</span>
+                <span className="text-xs text-muted-foreground">{option.description}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+});
+
+PlacementVerificationFormControl.displayName = "PlacementVerificationFormControl";

--- a/apps/deploy-web/src/queries/usePlacementOffers.spec.ts
+++ b/apps/deploy-web/src/queries/usePlacementOffers.spec.ts
@@ -1,7 +1,8 @@
+import { VerificationTier } from "@akashnetwork/chain-sdk/private-types/akash.v1";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
-import type { ScreenedProvider } from "@src/queries/useScreenedProviders";
+import type { ProviderVerificationExclusion, ScreenedProvider } from "@src/queries/useScreenedProviders";
 import type { ApiProviderList } from "@src/types/provider";
 import type { DEPENDENCIES } from "./usePlacementOffers";
 import { usePlacementOffers } from "./usePlacementOffers";
@@ -156,6 +157,107 @@ describe(usePlacementOffers.name, () => {
     ]);
   });
 
+  it("keeps an accepted chain bid when verification preflight did not include the provider", () => {
+    const eligible = verifiedProvider({ owner: "akash1eligible", tier: VerificationTier.verification_tier_verified });
+    const { result } = setup({
+      phase: "quoting",
+      dseq: "100",
+      verificationEnabled: true,
+      screened: [eligible],
+      bids: [
+        { bid: { state: "open", price: { amount: "1900", denom: "uakt" }, id: { provider: "akash1eligible", dseq: "100", gseq: 1, oseq: 1 } } },
+        { bid: { state: "open", price: { amount: "100", denom: "uakt" }, id: { provider: "akash1excluded", dseq: "100", gseq: 1, oseq: 1 } } }
+      ]
+    });
+
+    expect(result.current.offers.map(offer => offer.owner)).toEqual(["akash1eligible", "akash1excluded"]);
+  });
+
+  it("suppresses a stale preflight exclusion after the provider has an accepted chain bid", () => {
+    const exclusion = mock<ProviderVerificationExclusion>({ owner: "akash1bidder" });
+    const { result } = setup({
+      phase: "quoting",
+      dseq: "100",
+      verificationEnabled: true,
+      screened: [],
+      screenedExclusions: [exclusion],
+      bids: [{ bid: { state: "open", price: { amount: "100", denom: "uakt" }, id: { provider: "akash1bidder", dseq: "100", gseq: 1, oseq: 1 } } }]
+    });
+
+    expect(result.current.offers.map(offer => offer.owner)).toEqual(["akash1bidder"]);
+    expect(result.current.exclusions).toEqual([]);
+  });
+
+  it("keeps incomplete verification facts eligible and marks them not evaluated", () => {
+    const provider = verifiedProvider({ owner: "akash1unknown", tier: VerificationTier.verification_tier_unspecified });
+    provider.verification = {
+      outcome: "not_evaluated",
+      incompleteFacts: ["snapshot"],
+      summary: provider.verification!.summary
+    };
+    const { result } = setup({ phase: "configuring", verificationEnabled: true, screened: [provider] });
+
+    expect(result.current.offers).toEqual([
+      expect.objectContaining({ owner: "akash1unknown", verification: expect.objectContaining({ outcome: "not_evaluated" }) })
+    ]);
+  });
+
+  it("ranks verification-eligible providers by tier before price", () => {
+    const { result } = setup({
+      phase: "quoting",
+      dseq: "100",
+      verificationEnabled: true,
+      screened: [
+        verifiedProvider({ owner: "akash1l2", tier: VerificationTier.verification_tier_verified }),
+        verifiedProvider({ owner: "akash1l3", tier: VerificationTier.verification_tier_established })
+      ],
+      bids: [
+        { bid: { state: "open", price: { amount: "100", denom: "uakt" }, id: { provider: "akash1l2", dseq: "100", gseq: 1, oseq: 1 } } },
+        { bid: { state: "open", price: { amount: "5000", denom: "uakt" }, id: { provider: "akash1l3", dseq: "100", gseq: 1, oseq: 1 } } }
+      ]
+    });
+
+    expect(result.current.offers.map(offer => offer.owner)).toEqual(["akash1l3", "akash1l2"]);
+  });
+
+  it("uses auditor count, uptime, price, then name to break verification ranking ties", () => {
+    const recentDay = new Intl.DateTimeFormat("en-CA", {
+      timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit"
+    }).format(Date.now());
+    const base = { tier: VerificationTier.verification_tier_verified, auditors: ["akash1a"] };
+    const screened = [
+      verifiedProvider({ owner: "akash1pricey", organization: "Zulu", ...base }),
+      verifiedProvider({ owner: "akash1cheap", organization: "Beta", ...base }),
+      verifiedProvider({ owner: "akash1aardvark", organization: "Aardvark", ...base }),
+      verifiedProvider({
+        owner: "akash1down",
+        organization: "Alpha",
+        ...base,
+        incidents: [{ date: recentDay, hasOpenIncident: false, incidentCount: 1, downtimeSeconds: 3600 }]
+      }),
+      verifiedProvider({ owner: "akash1auditors", organization: "Omega", tier: base.tier, auditors: ["akash1a", "akash1b"] })
+    ];
+    const bids = screened.map(provider => ({
+      bid: {
+        state: "open",
+        price: { amount: provider.owner === "akash1pricey" ? "500" : "100", denom: "uakt" },
+        id: { provider: provider.owner, dseq: "100", gseq: 1, oseq: 1 }
+      }
+    }));
+    const { result } = setup({ phase: "quoting", dseq: "100", verificationEnabled: true, screened, bids });
+
+    expect(result.current.offers.map(offer => offer.owner)).toEqual(["akash1auditors", "akash1aardvark", "akash1cheap", "akash1pricey", "akash1down"]);
+  });
+
+  it("preserves server order when the placement has no verification result", () => {
+    const { result } = setup({ phase: "configuring", verificationEnabled: true, screened: [polaris(), mock<ScreenedProvider>({ owner: "akash1first" })] });
+
+    expect(result.current.offers.map(offer => offer.owner)).toEqual(["akash1aaa", "akash1first"]);
+  });
+
   it("reuses screened metadata for a bidder instead of the provider list", () => {
     const { result } = setup({
       phase: "quoting",
@@ -238,18 +340,53 @@ describe(usePlacementOffers.name, () => {
     return mock<ScreenedProvider>({ owner: "akash1aaa", organization: "Polaris", location: "us-east" });
   }
 
+  function verifiedProvider(input: {
+    owner: string;
+    tier: VerificationTier;
+    auditors?: string[];
+    organization?: string;
+    incidents?: ScreenedProvider["incidents"];
+  }): ScreenedProvider {
+    return mock<ScreenedProvider>({
+      owner: input.owner,
+      organization: input.organization ?? input.owner,
+      location: "us-east",
+      incidents: input.incidents ?? [],
+      verification: {
+        outcome: "pass",
+        summary: {
+          bestStatusValidTier: input.tier,
+          tierGateTier: input.tier,
+          capabilities: [],
+          validAttestationCount: input.auditors?.length ?? 1,
+          validAuditors: input.auditors ?? ["akash1auditor"],
+          snapshotState: "current",
+          observedHeight: "123"
+        }
+      }
+    });
+  }
+
   function setup(input: {
     phase: "configuring" | "quoting";
     dseq?: string;
     screened: ScreenedProvider[];
     screenedInvalid?: boolean;
+    screenedExclusions?: ProviderVerificationExclusion[];
+    verificationEnabled?: boolean;
     placementGseq?: number;
     providerList?: Array<Partial<ApiProviderList> & { owner: string }>;
     bidsLoading?: boolean;
     bidsError?: boolean;
     bids?: Array<{ bid: { state: string; price: { amount: string; denom: string }; id: { provider: string; dseq: string; gseq: number; oseq: number } } }>;
   }) {
-    const useScreenedProviders = vi.fn(() => ({ providers: input.screened, isLoading: false, isError: false, isInvalid: input.screenedInvalid ?? false }));
+    const useScreenedProviders = vi.fn(() => ({
+      providers: input.screened,
+      exclusions: input.screenedExclusions ?? [],
+      isLoading: false,
+      isError: false,
+      isInvalid: input.screenedInvalid ?? false
+    }));
     const useProviderList = vi.fn(() => ({ data: input.providerList ?? [], isLoading: false, isError: false }));
     const dependencies: typeof DEPENDENCIES = {
       useScreenedProviders: useScreenedProviders as never,
@@ -258,7 +395,17 @@ describe(usePlacementOffers.name, () => {
       getPlacementGseq: (() => input.placementGseq) as never
     };
     const view = renderHook(() =>
-      usePlacementOffers({ phase: input.phase, dseq: input.dseq, sdl: "sdl", placementName: "placement-1", region: "us-east" }, dependencies)
+      usePlacementOffers(
+        {
+          phase: input.phase,
+          dseq: input.dseq,
+          sdl: "sdl",
+          placementName: "placement-1",
+          region: "us-east",
+          verificationEnabled: input.verificationEnabled
+        },
+        dependencies
+      )
     );
     return { ...view, useScreenedProviders, useProviderList };
   }

--- a/apps/deploy-web/src/queries/usePlacementOffers.ts
+++ b/apps/deploy-web/src/queries/usePlacementOffers.ts
@@ -1,11 +1,13 @@
 import { useMemo } from "react";
 
+import { deriveProviderUptime } from "@src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/ProviderUptimeCell/deriveProviderUptime";
 import { BID_POLL_INTERVAL, useListBids } from "@src/queries/useListBids";
 import { useProviderList } from "@src/queries/useProvidersQuery";
-import type { ScreenedProvider } from "@src/queries/useScreenedProviders";
+import type { ProviderVerificationExclusion, ScreenedProvider } from "@src/queries/useScreenedProviders";
 import { useScreenedProviders } from "@src/queries/useScreenedProviders";
 import type { ApiProviderList } from "@src/types/provider";
 import { formatBidId } from "@src/utils/bids/bidId";
+import { providerDisplayName } from "@src/utils/providerUtils";
 import { getPlacementGseq } from "@src/utils/sdl/placementGseq";
 
 export type OfferState = "searching" | "submitted" | "closed" | "unavailable";
@@ -26,10 +28,12 @@ interface UsePlacementOffersInput {
   sdl: string;
   placementName: string;
   region?: string;
+  verificationEnabled?: boolean;
 }
 
 interface UsePlacementOffersResult {
   offers: PlacementOffer[];
+  exclusions: ProviderVerificationExclusion[];
   isLoading: boolean;
   isError: boolean;
   /** True while still configuring a spec that can't be screened — the marketplace shows a message instead of a list. */
@@ -58,7 +62,7 @@ export const DEPENDENCIES = { useScreenedProviders, useListBids, useProviderList
  * sequence (`gseq`).
  */
 export function usePlacementOffers(
-  { phase, dseq, sdl, placementName, region }: UsePlacementOffersInput,
+  { phase, dseq, sdl, placementName, region, verificationEnabled = false }: UsePlacementOffersInput,
   dependencies: typeof DEPENDENCIES = DEPENDENCIES
 ): UsePlacementOffersResult {
   const isLocked = phase === "creating" || phase === "quoting" || phase === "closing" || phase === "deploying";
@@ -69,29 +73,34 @@ export function usePlacementOffers(
   const gseq = useMemo(() => dependencies.getPlacementGseq(sdl, placementName), [dependencies, sdl, placementName]);
   const providersByOwner = useMemo(() => new Map((providerListQuery.data ?? []).map(provider => [provider.owner, provider])), [providerListQuery.data]);
   const screenedByOwner = useMemo(() => new Map(screened.providers.map(provider => [provider.owner, provider])), [screened.providers]);
+  const exclusions = screened.exclusions ?? [];
+  const hasVerificationScreening = verificationEnabled && (exclusions.length > 0 || screened.providers.some(hasVerificationResult));
+  const placementBids = useMemo(() => (bidsQuery.data?.data ?? []).filter(entry => gseq === undefined || entry.bid.id.gseq === gseq), [bidsQuery.data, gseq]);
+  const biddingOwners = useMemo(() => new Set(placementBids.map(entry => entry.bid.id.provider)), [placementBids]);
 
   const offers = useMemo(
     function buildOffers(): PlacementOffer[] {
-      if (isScreening) return screened.providers.map(toSearchingOffer);
+      if (isScreening) return rankOffers(screened.providers.map(toSearchingOffer), hasVerificationScreening);
 
-      const placementBids = (bidsQuery.data?.data ?? []).filter(entry => gseq === undefined || entry.bid.id.gseq === gseq);
-      if (placementBids.length === 0) return screened.providers.map(toSearchingOffer);
+      if (placementBids.length === 0) return rankOffers(screened.providers.map(toSearchingOffer), hasVerificationScreening);
 
       const bidByOwner = pickBestBidPerOwner(placementBids);
-      return mergedOwners(screened.providers, bidByOwner).map(function toMergedOffer(owner): PlacementOffer {
+      const merged = mergedOwners(screened.providers, bidByOwner).map(function toMergedOffer(owner): PlacementOffer {
         const meta = screenedByOwner.get(owner) ?? providerListToOffer(owner, providersByOwner.get(owner));
         const entry = bidByOwner.get(owner);
         if (entry?.bid.state === "open") return { ...meta, offerState: "submitted", bidId: formatBidId(entry.bid.id), price: entry.bid.price };
         if (entry) return { ...meta, offerState: "closed", bidId: undefined, price: entry.bid.price };
         return { ...meta, offerState: "unavailable", bidId: undefined, price: undefined };
       });
+      return rankOffers(merged, hasVerificationScreening);
     },
-    [isScreening, screened.providers, screenedByOwner, bidsQuery.data, gseq, providersByOwner]
+    [isScreening, screened.providers, screenedByOwner, placementBids, providersByOwner, hasVerificationScreening]
   );
 
   const isQuoting = phase === "quoting";
   return {
     offers,
+    exclusions: verificationEnabled ? exclusions.filter(exclusion => !biddingOwners.has(exclusion.owner)) : [],
     isLoading: screened.isLoading || (isQuoting && offers.length === 0 && bidsQuery.isLoading),
     isError: screened.isError || (isQuoting && bidsQuery.isError),
     isInvalid: !isLocked && screened.isInvalid
@@ -130,6 +139,47 @@ function mergedOwners(screened: ScreenedProvider[], bidByOwner: Map<string, BidE
     }
   }
   return owners;
+}
+
+function rankOffers(offers: PlacementOffer[], enabled: boolean): PlacementOffer[] {
+  if (!enabled) return offers;
+
+  const now = Date.now();
+  const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const uptimeByOwner = new Map(offers.map(offer => [offer.owner, deriveProviderUptime(offer.incidents ?? [], now, timeZone).percent]));
+
+  return [...offers].sort((left, right) => {
+    const leftSummary = left.verification?.summary;
+    const rightSummary = right.verification?.summary;
+    const byTier = (rightSummary?.tierGateTier ?? -1) - (leftSummary?.tierGateTier ?? -1);
+    if (byTier !== 0) return byTier;
+
+    const byAuditors = (rightSummary?.validAuditors.length ?? -1) - (leftSummary?.validAuditors.length ?? -1);
+    if (byAuditors !== 0) return byAuditors;
+
+    const byUptime = (uptimeByOwner.get(right.owner) ?? 0) - (uptimeByOwner.get(left.owner) ?? 0);
+    if (byUptime !== 0) return byUptime;
+
+    const byPrice = comparePrice(left.price, right.price);
+    if (byPrice !== 0) return byPrice;
+
+    return providerDisplayName(left).localeCompare(providerDisplayName(right));
+  });
+}
+
+function hasVerificationResult(provider: ScreenedProvider): boolean {
+  return provider.verification?.outcome === "pass" || provider.verification?.outcome === "not_evaluated";
+}
+
+function comparePrice(left: PlacementOffer["price"], right: PlacementOffer["price"]): number {
+  if (!left && !right) return 0;
+  if (!left) return 1;
+  if (!right) return -1;
+  if (left.denom !== right.denom) return left.denom.localeCompare(right.denom);
+
+  const leftAmount = BigInt(left.amount);
+  const rightAmount = BigInt(right.amount);
+  return leftAmount < rightAmount ? -1 : leftAmount > rightAmount ? 1 : 0;
 }
 
 /**

--- a/apps/deploy-web/src/queries/useScreenedProviders.spec.tsx
+++ b/apps/deploy-web/src/queries/useScreenedProviders.spec.tsx
@@ -1,3 +1,4 @@
+import { AuditorSelectionMode, CapabilityFlag, VerificationTier } from "@akashnetwork/chain-sdk/private-types/akash.v1";
 import { createProxy } from "@akashnetwork/react-query-proxy";
 import { keepPreviousData, type UseQueryResult } from "@tanstack/react-query";
 import { describe, expect, it, vi } from "vitest";
@@ -44,13 +45,29 @@ deployment:
       count: 1
 `;
 
+const VERIFICATION_SDL = HELLO_WORLD_SDL.replace(
+  "      pricing:",
+  `      signedBy:
+        anyOf:
+          - akash1legacy
+      verification:
+        min_tier: 2
+        capabilities:
+          - persistent_storage
+        auditors:
+          - akash1auditor
+        auditor_mode: all
+        min_auditor_count: 1
+      pricing:`
+);
+
 describe("useScreenedProviders", () => {
-  it("screens the given placement's group spec, audited-only", () => {
+  it("screens the given placement without adding an auditor policy", () => {
     const { useQuery } = setup({ placementName: "dcloud" });
 
     expect(useQuery).toHaveBeenCalledWith(
       expect.objectContaining({
-        requirements: { signedBy: { allOf: [AUDITOR] }, attributes: [] },
+        requirements: { signedBy: { allOf: [], anyOf: [] }, attributes: [] },
         resources: expect.arrayContaining([expect.objectContaining({ count: 1 })])
       }),
       expect.anything()
@@ -76,6 +93,28 @@ describe("useScreenedProviders", () => {
     const { result } = setup({ placementName: "dcloud", providers });
 
     expect(result.current.providers).toEqual(providers);
+  });
+
+  it("returns structured verification exclusions from the query result", () => {
+    const exclusion = {
+      owner: "akash1excluded",
+      firstFailure: { code: "snapshot_stale" as const },
+      failures: [{ code: "snapshot_stale" as const }],
+      summary: {
+        bestStatusValidTier: VerificationTier.verification_tier_verified,
+        tierGateTier: VerificationTier.verification_tier_verified,
+        capabilities: [],
+        validAttestationCount: 1,
+        validAuditors: ["akash1auditor"],
+        snapshotState: "stale" as const,
+        observedHeight: "123"
+      }
+    };
+    const { result } = setup({ placementName: "dcloud", exclusions: [exclusion] });
+
+    expect(result.current.exclusions).toHaveLength(1);
+    expect(result.current.exclusions[0].owner).toBe("akash1excluded");
+    expect(result.current.exclusions[0].firstFailure.code).toBe("snapshot_stale");
   });
 
   it("requests the previous data as a placeholder so the list refines in place instead of blanking", () => {
@@ -120,10 +159,17 @@ describe("useScreenedProviders", () => {
     }
   });
 
-  function setup(input: { placementName: string; sdl?: string; region?: string; providers?: ScreenedProvider[]; enabled?: boolean }) {
+  function setup(input: {
+    placementName: string;
+    sdl?: string;
+    region?: string;
+    providers?: ScreenedProvider[];
+    exclusions?: ScreenedProvidersResponse["exclusions"];
+    enabled?: boolean;
+  }) {
     const useQuery = vi.fn().mockReturnValue(
       mock<UseQueryResult<ScreenedProvidersResponse>>({
-        data: { providers: input.providers ?? [] },
+        data: { providers: input.providers ?? [], exclusions: input.exclusions },
         isLoading: false,
         isError: false
       })
@@ -179,11 +225,27 @@ deployment:
 `;
 
 describe("buildPlacementScreeningRequest", () => {
-  it("builds an audited request from the matching placement group spec", () => {
+  it("builds a request from the matching placement without adding signedBy", () => {
     const request = buildPlacementScreeningRequest(HELLO_WORLD_SDL, "dcloud");
 
-    expect(request).toMatchObject({ requirements: { signedBy: { allOf: [AUDITOR] } } });
+    expect(request).toMatchObject({ requirements: { signedBy: { allOf: [], anyOf: [] } } });
     expect(request?.resources[0].resource.cpu.units.val).toBeTruthy();
+  });
+
+  it("preserves signedBy and verification as independent placement policies", () => {
+    const request = buildPlacementScreeningRequest(VERIFICATION_SDL, "dcloud");
+
+    expect(request?.requirements).toEqual({
+      signedBy: { allOf: [], anyOf: ["akash1legacy"] },
+      attributes: [],
+      verification: {
+        minTier: VerificationTier.verification_tier_verified,
+        requiredCapabilities: [CapabilityFlag.capability_persistent_storage],
+        requiredAuditors: ["akash1auditor"],
+        auditorMode: AuditorSelectionMode.auditor_selection_mode_all,
+        minAuditorCount: 1
+      }
+    });
   });
 
   it("substitutes a placeholder image so an image-less spec still screens its own resources", () => {

--- a/apps/deploy-web/src/queries/useScreenedProviders.ts
+++ b/apps/deploy-web/src/queries/useScreenedProviders.ts
@@ -1,4 +1,6 @@
 import { useMemo } from "react";
+import type { VerificationRequirement } from "@akashnetwork/chain-sdk/private-types/akash.v1";
+import { AuditorSelectionMode, CapabilityFlag, VerificationTier } from "@akashnetwork/chain-sdk/private-types/akash.v1";
 import { GroupSpec } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
 import { generateManifest, type SDLInput, yaml } from "@akashnetwork/chain-sdk/web";
 import type { paths } from "@akashnetwork/console-api-types";
@@ -8,14 +10,52 @@ import { useServices } from "@src/context/ServicesProvider";
 import { usePacedValue } from "@src/hooks/usePacedValue/usePacedValue";
 import { AUDITOR } from "@src/utils/deploymentData/v1beta3";
 
-type ScreeningRequest = NonNullable<paths["/v1/bid-screening"]["post"]["requestBody"]>["content"]["application/json"];
+export type ScreeningRequest = NonNullable<paths["/v1/bid-screening"]["post"]["requestBody"]>["content"]["application/json"];
+type VerificationRequirementRequest = NonNullable<NonNullable<ScreeningRequest["requirements"]>["verification"]>;
 
 /** The screening request minus `timezone`, which the hook attaches from the client's resolved locale. */
-type ScreeningRequestBody = Omit<ScreeningRequest, "timezone">;
+export type ScreeningRequestBody = Omit<ScreeningRequest, "timezone" | "requirements"> & {
+  requirements: ScreeningRequest["requirements"] & { verification?: VerificationRequirementRequest };
+};
 
-export type ScreenedProvidersResponse = paths["/v1/bid-screening"]["post"]["responses"][200]["content"]["application/json"];
+type GeneratedScreenedProvidersResponse = paths["/v1/bid-screening"]["post"]["responses"][200]["content"]["application/json"];
+type GeneratedScreenedProvider = GeneratedScreenedProvidersResponse["providers"][number];
 
-export type ScreenedProvider = ScreenedProvidersResponse["providers"][number];
+export interface ProviderVerificationSummary {
+  bestStatusValidTier: number;
+  tierGateTier: number;
+  capabilities: number[];
+  validAttestationCount: number;
+  validAuditors: string[];
+  snapshotState: "unknown" | "not_posted" | "current" | "stale" | "suspended";
+  observedHeight: string;
+}
+
+export type ProviderVerificationFailure =
+  | { code: "snapshot_not_posted" }
+  | { code: "snapshot_suspended" }
+  | { code: "snapshot_stale" }
+  | { code: "insufficient_tier"; actual: number; required: number }
+  | { code: "missing_capability"; capability: number }
+  | { code: "insufficient_auditor_count"; actual: number; required: number }
+  | { code: "required_auditor_not_found"; mode: number; missing: string[] };
+
+export interface ProviderVerificationExclusion {
+  owner: string;
+  firstFailure: ProviderVerificationFailure;
+  failures: ProviderVerificationFailure[];
+  summary: ProviderVerificationSummary;
+}
+
+export type ScreenedProvider = GeneratedScreenedProvider & {
+  verification?:
+    { outcome: "pass"; summary: ProviderVerificationSummary } | { outcome: "not_evaluated"; incompleteFacts: string[]; summary: ProviderVerificationSummary };
+};
+
+export type ScreenedProvidersResponse = Omit<GeneratedScreenedProvidersResponse, "providers"> & {
+  providers: ScreenedProvider[];
+  exclusions?: ProviderVerificationExclusion[];
+};
 
 interface UseScreenedProvidersInput {
   sdl: string;
@@ -36,6 +76,7 @@ interface UseScreenedProvidersInput {
 
 interface UseScreenedProvidersResult {
   providers: ScreenedProvider[];
+  exclusions: ProviderVerificationExclusion[];
   isLoading: boolean;
   isError: boolean;
   /**
@@ -66,7 +107,8 @@ const SKIPPED_SCREENING_REQUEST: ScreeningRequest = { ...buildCatalogScreeningRe
  * the current SDL to group specs and queries the one matching `placementName`. When the SDL can't be turned
  * into a screening request (invalid or incomplete spec) it does NOT fall back to the full catalog — no
  * provider would bid on an unusable spec — instead it reports `isInvalid` so the marketplace shows a message.
- * A selected region travels in the SDL, so a valid spec already screens by region. Audited-only via signedBy.
+ * A selected region travels in the SDL, so a valid spec already screens by region. The placement's legacy
+ * signedBy and AEP-86 verification policies are forwarded independently.
  */
 export function useScreenedProviders({ sdl, placementName, enabled = true }: UseScreenedProvidersInput): UseScreenedProvidersResult {
   const { api } = useServices();
@@ -83,7 +125,8 @@ export function useScreenedProviders({ sdl, placementName, enabled = true }: Use
   });
 
   return {
-    providers: isInvalid ? [] : query.data?.providers ?? [],
+    providers: isInvalid ? [] : (query.data?.providers ?? []),
+    exclusions: isInvalid ? [] : ((query.data as ScreenedProvidersResponse | undefined)?.exclusions ?? []),
     isLoading: !isInvalid && query.isLoading,
     isError: !isInvalid && query.isError,
     isInvalid
@@ -92,10 +135,9 @@ export function useScreenedProviders({ sdl, placementName, enabled = true }: Use
 
 /**
  * Converts the current SDL into a screening request for a single placement's group spec. Returns null
- * when the SDL is incomplete/invalid (e.g. mid-edit) or the placement isn't in it yet, so the caller can
- * fall back to the full catalog. `signedBy` forces audited-only screening; `attributes` are passed through
- * from the placement and carry the `location-region` filter (and any other declared attribute). The proto
- * JSON encodes resource values as decimal integer strings, which the screening endpoint accepts.
+ * when the SDL is incomplete/invalid (e.g. mid-edit) or the placement isn't in it yet. `signedBy`,
+ * verification, and attributes are copied from the generated group spec without combining their semantics.
+ * The proto JSON encodes resource values as decimal integer strings, which the screening endpoint accepts.
  */
 export function buildPlacementScreeningRequest(rawSdl: string, placementName: string): ScreeningRequestBody | null {
   if (!rawSdl) return null;
@@ -112,21 +154,87 @@ export function buildPlacementScreeningRequest(rawSdl: string, placementName: st
     const group = manifest.groupSpecs.find(candidate => candidate.name === placementName);
     if (!group) return null;
 
-    const groupJson = GroupSpec.toJSON(group) as {
-      resources: ScreeningRequest["resources"];
-      requirements?: { attributes?: Array<{ key: string; value: string }> };
-    };
+    const groupJson = GroupSpec.toJSON(group) as { resources: ScreeningRequest["resources"] };
+    const requirements = group.requirements;
+    const verification = requirements?.verification ? toVerificationRequirementRequest(requirements.verification) : null;
+    if (requirements?.verification && !verification) return null;
 
     return {
       requirements: {
-        signedBy: { allOf: [AUDITOR] },
-        attributes: groupJson.requirements?.attributes ?? []
+        signedBy: {
+          allOf: requirements?.signedBy?.allOf ?? [],
+          anyOf: requirements?.signedBy?.anyOf ?? []
+        },
+        attributes: requirements?.attributes ?? [],
+        ...(verification ? { verification } : {})
       },
       resources: groupJson.resources,
       reclamationWindow: manifest.reclamation?.minWindow?.seconds ? Number(manifest.reclamation?.minWindow?.seconds) : undefined
     };
   } catch {
     return null;
+  }
+}
+
+export function hasPlacementVerificationRequirement(rawSdl: string, placementName: string): boolean {
+  return buildPlacementScreeningRequest(rawSdl, placementName)?.requirements.verification !== undefined;
+}
+
+function toVerificationRequirementRequest(requirement: VerificationRequirement): VerificationRequirementRequest | null {
+  const minTier = toVerificationTierRequest(requirement.minTier);
+  const auditorMode = toAuditorSelectionModeRequest(requirement.auditorMode);
+  if (minTier === null || auditorMode === null) return null;
+
+  const requiredCapabilities: NonNullable<VerificationRequirementRequest["requiredCapabilities"]> = [];
+  for (const capability of requirement.requiredCapabilities) {
+    const mappedCapability = toCapabilityFlagRequest(capability);
+    if (mappedCapability === null) return null;
+    requiredCapabilities.push(mappedCapability);
+  }
+
+  return {
+    minTier,
+    requiredCapabilities,
+    requiredAuditors: requirement.requiredAuditors,
+    auditorMode,
+    minAuditorCount: requirement.minAuditorCount
+  };
+}
+
+function toVerificationTierRequest(tier: VerificationTier): VerificationRequirementRequest["minTier"] | null {
+  switch (tier) {
+    case VerificationTier.verification_tier_unspecified:
+    case VerificationTier.verification_tier_identified:
+    case VerificationTier.verification_tier_verified:
+    case VerificationTier.verification_tier_established:
+    case VerificationTier.verification_tier_trusted:
+      return tier;
+    case VerificationTier.UNRECOGNIZED:
+      return null;
+  }
+}
+
+function toCapabilityFlagRequest(capability: CapabilityFlag): NonNullable<VerificationRequirementRequest["requiredCapabilities"]>[number] | null {
+  switch (capability) {
+    case CapabilityFlag.capability_tee_hardware_attestation:
+    case CapabilityFlag.capability_confidential_computing:
+    case CapabilityFlag.capability_persistent_storage:
+    case CapabilityFlag.capability_bare_metal:
+      return capability;
+    case CapabilityFlag.capability_unspecified:
+    case CapabilityFlag.UNRECOGNIZED:
+      return null;
+  }
+}
+
+function toAuditorSelectionModeRequest(mode: AuditorSelectionMode): VerificationRequirementRequest["auditorMode"] | null {
+  switch (mode) {
+    case AuditorSelectionMode.auditor_selection_mode_unspecified:
+    case AuditorSelectionMode.auditor_selection_mode_any:
+    case AuditorSelectionMode.auditor_selection_mode_all:
+      return mode;
+    case AuditorSelectionMode.UNRECOGNIZED:
+      return null;
   }
 }
 

--- a/apps/deploy-web/src/types/deployment.ts
+++ b/apps/deploy-web/src/types/deployment.ts
@@ -66,6 +66,28 @@ export interface RpcDeployment {
 
 export type DeploymentGroup = DeploymentGroup_v2 | DeploymentGroup_v3;
 
+export type RpcVerificationTier =
+  | "verification_tier_identified"
+  | "verification_tier_verified"
+  | "verification_tier_established"
+  | "verification_tier_trusted"
+  | "verification_tier_unspecified";
+
+export type RpcVerificationCapability =
+  | "capability_unspecified"
+  | "capability_tee_hardware_attestation"
+  | "capability_confidential_computing"
+  | "capability_persistent_storage"
+  | "capability_bare_metal";
+
+export interface RpcVerificationRequirement {
+  min_tier: RpcVerificationTier;
+  required_capabilities: RpcVerificationCapability[];
+  required_auditors: string[];
+  auditor_mode: "auditor_selection_mode_unspecified" | "auditor_selection_mode_any" | "auditor_selection_mode_all";
+  min_auditor_count: number;
+}
+
 export type DeploymentResource_V2 = DeploymentResource;
 export type DeploymentResource_V3 = DeploymentResource;
 
@@ -83,6 +105,7 @@ interface DeploymentGroup_v2 {
         all_of: string[];
         any_of: string[];
       };
+      verification?: RpcVerificationRequirement;
       attributes: Array<{
         key: string;
         value: string;
@@ -157,6 +180,7 @@ interface DeploymentGroup_v3 {
         all_of: string[];
         any_of: string[];
       };
+      verification?: RpcVerificationRequirement;
       attributes: Array<{
         key: string;
         value: string;

--- a/apps/deploy-web/src/types/feature-flags.ts
+++ b/apps/deploy-web/src/types/feature-flags.ts
@@ -9,4 +9,5 @@ export type FeatureFlag =
   | "ui_build_and_deploy"
   | "ui_agent_mode_deploy"
   | "hackathons"
-  | "deployment_runtime_limit";
+  | "deployment_runtime_limit"
+  | "provider_verification";

--- a/apps/deploy-web/src/types/provider.ts
+++ b/apps/deploy-web/src/types/provider.ts
@@ -164,6 +164,184 @@ export interface ProviderStatusDto {
   };
 }
 
+export type ProviderVerificationTier = "L0" | "L1" | "L2" | "L3" | "L4" | "unknown";
+
+export type ProviderVerificationCapability =
+  "unspecified" | "tee_hardware_attestation" | "confidential_computing" | "persistent_storage" | "bare_metal" | "unknown";
+
+export interface ProviderVerificationCoin {
+  denom: string;
+  amount: string;
+}
+
+export interface ProviderVerificationListView {
+  provider: string;
+  moduleActive: boolean | null;
+  summary: {
+    effectiveTier: ProviderVerificationTier | null;
+    validAuditorCount: number | null;
+    capabilities: ProviderVerificationCapability[] | null;
+    snapshotState: "unknown" | "not_posted" | "current" | "stale" | "suspended";
+    maintenanceState: "unknown" | "none" | "scheduled" | "active";
+    reviewState: "unknown" | "none" | "under_review" | "grace";
+  };
+  observedAt: string;
+  observedHeight: string;
+}
+
+export interface ProviderVerificationView {
+  provider: string;
+  providerDeclaredTier: string | null;
+  moduleActive: boolean | null;
+  provenance: {
+    providerTier: "provider self-declared";
+    inventory: "provider-signed inventory";
+    attestations: "auditor-attested";
+  };
+  summary: {
+    bestAttestedTier: ProviderVerificationTier | null;
+    effectiveTier: ProviderVerificationTier | null;
+    capabilities: ProviderVerificationCapability[] | null;
+    validAttestationCount: number | null;
+    validAuditorCount: number | null;
+    validAuditors: string[] | null;
+    snapshotState: "unknown" | "not_posted" | "current" | "stale" | "suspended";
+    maintenanceState: "unknown" | "none" | "scheduled" | "active";
+    reviewState: "unknown" | "none" | "under_review" | "grace";
+  };
+  attestations: Array<{
+    provider: string;
+    auditor: string;
+    tier: ProviderVerificationTier;
+    capabilities: ProviderVerificationCapability[];
+    evidenceHash: string | null;
+    fee: ProviderVerificationCoin | null;
+    feeStatus: "unspecified" | "escrowed" | "released_to_auditor" | "returned_to_provider" | "unknown";
+    createdAt: string | null;
+    expiresAt: string | null;
+    status: "unspecified" | "valid" | "voided" | "expired" | "revoked" | "removed" | "unknown";
+    voidedReason: "unspecified" | "discrepancy" | "governance" | "bond_withdrawn" | "bond_slashed" | "unknown";
+    deposit: ProviderVerificationCoin | null;
+    depositStatus: "unspecified" | "escrowed" | "pending_discrepancy" | "returned_to_auditor" | "slashed" | "unknown";
+    auditEscrowId: string;
+    faultAttribution: "unspecified" | "provider_fault" | "auditor_fault" | "shared_fault" | "no_fault" | "inconclusive" | "unknown";
+  }>;
+  bond: {
+    provider: string;
+    bondedAmount: ProviderVerificationCoin | null;
+    requiredForCurrentTier: ProviderVerificationCoin;
+    unbondingEntries: Array<{
+      amount: ProviderVerificationCoin | null;
+      completionTime: string | null;
+    }>;
+    slashed: boolean;
+    lastSlashTime: string | null;
+  } | null;
+  snapshot: {
+    provider: string;
+    snapshotHash: string | null;
+    resourceSummary: {
+      totalGpus: number;
+      totalVcpus: number;
+      totalMemoryMb: string;
+      totalStorageMb: string;
+      activeLeases: number;
+      softwareVersion: string;
+      softwareSignature: string | null;
+      softwareIdentity: {
+        version: string;
+        artifactRef: string;
+        digestAlgorithm: string;
+        digest: string | null;
+        signatureType: string;
+        signature: string | null;
+        signatureRef: string;
+        publicKeyRef: string;
+      } | null;
+    } | null;
+    postedAt: string | null;
+    snapshotTimestamp: string | null;
+    complianceDeadline: string | null;
+    suspended: boolean;
+  } | null;
+  grace: {
+    id: string;
+    provider: string;
+    preservedTier: ProviderVerificationTier;
+    sourceDiscrepancyIds: string[];
+    startedAt: string | null;
+    expiresAt: string | null;
+    status: "unspecified" | "active" | "expired" | "terminated" | "unknown";
+  } | null;
+  auditEscrows: Array<{
+    id: string;
+    provider: string;
+    consumedByAuditor: string | null;
+    requestedTier: ProviderVerificationTier;
+    requestedCapabilities: ProviderVerificationCapability[];
+    fee: ProviderVerificationCoin | null;
+    feeStatus: "unspecified" | "escrowed" | "released_to_auditor" | "returned_to_provider" | "unknown";
+    providerDeposit: ProviderVerificationCoin | null;
+    providerDepositStatus: "unspecified" | "escrowed" | "returned_to_provider" | "slashed" | "unknown";
+    status: "unspecified" | "open" | "consumed" | "cancelled" | "expired" | "settled" | "unknown";
+    openedAt: string | null;
+    consumedAt: string | null;
+    expiresAt: string | null;
+    metadataHash: string | null;
+    settlementReason: "unspecified" | "cancelled_unconsumed" | "expired_unconsumed" | "provider_fault" | "no_fault" | "unknown";
+    faultAttribution: "unspecified" | "provider_fault" | "auditor_fault" | "shared_fault" | "no_fault" | "inconclusive" | "unknown";
+  }>;
+  maintenance: Array<{
+    record: {
+      id: string;
+      provider: string;
+      maintenanceType: "unspecified" | "planned" | "emergency" | "security" | "network" | "capacity" | "unknown";
+      startsAt: string | null;
+      expectedEndsAt: string | null;
+      openedAt: string | null;
+      closedAt: string | null;
+      metadataHash: string | null;
+    } | null;
+    status: "unspecified" | "scheduled" | "active" | "elapsed" | "closed" | "unknown";
+  }>;
+  discrepancies: Array<{
+    id: string;
+    provider: string;
+    auditorA: string;
+    auditorATier: ProviderVerificationTier;
+    auditorB: string;
+    auditorBTier: ProviderVerificationTier;
+    timestamp: string | null;
+    resolutionStatus: "unspecified" | "pending" | "resolved" | "timed_out" | "unknown";
+    resolutionProposalId: string;
+    graceRecordId: string;
+    resolutionReason:
+      | "unspecified"
+      | "auditor_a_correct"
+      | "auditor_b_correct"
+      | "both_auditors_wrong"
+      | "provider_fault"
+      | "shared_fault"
+      | "evidence_inconclusive"
+      | "governance_timeout_review"
+      | "unknown";
+    faultAttribution: "unspecified" | "provider_fault" | "auditor_fault" | "shared_fault" | "no_fault" | "inconclusive" | "unknown";
+    resolutionEvidenceHash: string | null;
+  }>;
+  observedAt: string;
+  observedHeight: string;
+  completeness: {
+    params: boolean;
+    attestations: boolean;
+    graces: boolean;
+    snapshot: boolean;
+    bond: boolean;
+    auditEscrows: boolean;
+    maintenance: boolean;
+    discrepancies: boolean;
+  };
+}
+
 export interface ApiProviderList {
   owner: string;
   name: string | null;
@@ -232,6 +410,7 @@ export interface ApiProviderList {
   workloadSupportChia: boolean;
   workloadSupportChiaCapabilities: string[];
   featEndpointIp: boolean;
+  verification: ProviderVerificationListView | null;
 }
 
 export interface ClientProviderList extends ApiProviderList {
@@ -239,7 +418,8 @@ export interface ClientProviderList extends ApiProviderList {
   userActiveLeases?: number;
 }
 
-export interface ApiProviderDetail extends ApiProviderList {
+export interface ApiProviderDetail extends Omit<ApiProviderList, "verification"> {
+  verification: ProviderVerificationView | null;
   uptime: Array<{
     id: string;
     isOnline: boolean;

--- a/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.spec.ts
+++ b/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.spec.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from "vitest";
 
-import { CredentialsSchema, EndpointSchema, EnvironmentVariableSchema, SdlBuilderFormValuesSchema, ServiceSchema, ServiceStorageSchema } from "./sdlBuilder";
+import {
+  CredentialsSchema,
+  EndpointSchema,
+  EnvironmentVariableSchema,
+  PlacementSchema,
+  SdlBuilderFormValuesSchema,
+  ServiceSchema,
+  ServiceStorageSchema
+} from "./sdlBuilder";
 
 describe("ServiceStorageSchema", () => {
   it("surfaces a friendly required message instead of the raw type error when size is cleared", () => {
@@ -54,6 +62,67 @@ describe("EnvironmentVariableSchema", () => {
     const result = EnvironmentVariableSchema.safeParse({ id: "user-1", key: "FOO", value: "bar" });
 
     expect(result.success).toBe(true);
+  });
+});
+
+describe("PlacementSchema", () => {
+  it("accepts verification requirements independently of legacy signedBy", () => {
+    const result = PlacementSchema.safeParse({
+      id: "p-1",
+      name: "dcloud",
+      signedBy: { anyOf: [{ value: "akash1legacy" }], allOf: [] },
+      verification: {
+        minTier: 3,
+        capabilities: ["persistent_storage", "bare_metal"],
+        auditors: [{ value: "akash1auditor" }],
+        auditorMode: "all",
+        minAuditorCount: 2
+      }
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it.each([0, 5, 1.5])("rejects verification tier %s at the form schema boundary", minTier => {
+    const result = PlacementSchema.safeParse({ id: "p-1", name: "dcloud", verification: { minTier } });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues).toContainEqual(expect.objectContaining({ path: ["verification", "minTier"] }));
+  });
+
+  it("rejects unknown verification capabilities at the form schema boundary", () => {
+    const result = PlacementSchema.safeParse({
+      id: "p-1",
+      name: "dcloud",
+      verification: { minTier: 1, capabilities: ["unknown_capability"] }
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues).toContainEqual(expect.objectContaining({ path: ["verification", "capabilities", 0] }));
+  });
+
+  it.each([4_294_967_296, -1, 1.5])("rejects verification auditor count %s outside protobuf uint32", minAuditorCount => {
+    const result = PlacementSchema.safeParse({ id: "p-1", name: "dcloud", verification: { minTier: 1, minAuditorCount } });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues).toContainEqual(expect.objectContaining({ path: ["verification", "minAuditorCount"] }));
+  });
+
+  it("accepts the maximum protobuf uint32 auditor count", () => {
+    const result = PlacementSchema.safeParse({ id: "p-1", name: "dcloud", verification: { minTier: 1, minAuditorCount: 4_294_967_295 } });
+
+    expect(result.success).toBe(true);
+  });
+
+  it.each([" auditor", "auditor ", "cosmos1auditor"])('rejects verification auditor address "%s" like the Go SDL parser', value => {
+    const result = PlacementSchema.safeParse({ id: "p-1", name: "dcloud", verification: { minTier: 1, auditors: [{ value }] } });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues).toContainEqual(expect.objectContaining({ path: ["verification", "auditors", 0, "value"] }));
   });
 });
 

--- a/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.ts
+++ b/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.ts
@@ -125,6 +125,25 @@ export const SignedBySchema = z.object({
   value: z.string().min(1, { message: "Value is required." })
 });
 
+export const VerificationCapabilitySchema = z.enum(["tee_hardware_attestation", "confidential_computing", "persistent_storage", "bare_metal"]);
+
+const VerificationAuditorSchema = z.object({
+  id: z.string().optional(),
+  value: z
+    .string()
+    .min(1, { message: "Auditor address is required." })
+    .refine(value => value === value.trim(), { message: "Auditor address cannot contain surrounding whitespace." })
+    .refine(value => value.startsWith("akash1"), { message: "Auditor address must start with akash1." })
+});
+
+export const PlacementVerificationSchema = z.object({
+  minTier: z.number().int().min(1).max(4),
+  capabilities: z.array(VerificationCapabilitySchema).optional(),
+  auditors: z.array(VerificationAuditorSchema).optional(),
+  auditorMode: z.enum(["any", "all"]).optional(),
+  minAuditorCount: z.number().int().min(0).max(4_294_967_295).optional()
+});
+
 export const CUSTOM_HOST_ID = "__CUSTOM__";
 export const CredentialsSchema = z
   .object({
@@ -269,7 +288,8 @@ export const PlacementSchema = z.object({
       allOf: z.array(SignedBySchema),
       anyOf: z.array(SignedBySchema)
     })
-    .optional()
+    .optional(),
+  verification: PlacementVerificationSchema.optional()
 });
 
 export const EndpointSchema = z.object({
@@ -610,6 +630,7 @@ export type EnvironmentVariableType = z.infer<typeof EnvironmentVariableSchema>;
 export type AcceptType = z.infer<typeof AcceptSchema>;
 export type PlacementAttributeType = z.infer<typeof PlacementAttributeSchema>;
 export type SignedByType = z.infer<typeof SignedBySchema>;
+export type PlacementVerificationType = z.infer<typeof PlacementVerificationSchema>;
 export type ExposeType = z.infer<typeof ExposeSchema>;
 export type PlacementType = z.infer<typeof PlacementSchema>;
 export type EndpointType = z.infer<typeof EndpointSchema>;

--- a/apps/deploy-web/src/utils/sdl/sdlGenerator.spec.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlGenerator.spec.ts
@@ -94,6 +94,51 @@ describe("sdlGenerator", () => {
       expect(parsedAny.profiles.placement["dcloud"].attributes?.["location-region"]).toBeUndefined();
     });
 
+    it("emits verification requirements alongside legacy signedBy", () => {
+      const formValues = buildFormValues(buildLogCollectorService({ title: "web", image: "nginx:latest" }));
+      formValues.placements[0].signedBy = { anyOf: [{ value: "akash1legacy" }], allOf: [] };
+      formValues.placements[0].verification = {
+        minTier: 3,
+        capabilities: ["persistent_storage", "bare_metal"],
+        auditors: [{ value: "akash1auditor1" }, { value: "akash1auditor2" }],
+        auditorMode: "all",
+        minAuditorCount: 2
+      };
+
+      const parsed = yaml.load(generateSdl(formValues)) as {
+        profiles: { placement: Record<string, { signedBy?: unknown; verification?: unknown }> };
+      };
+
+      expect(parsed.profiles.placement.dcloud).toMatchObject({
+        signedBy: { anyOf: ["akash1legacy"] },
+        verification: {
+          min_tier: 3,
+          capabilities: ["persistent_storage", "bare_metal"],
+          auditors: ["akash1auditor1", "akash1auditor2"],
+          auditor_mode: "all",
+          min_auditor_count: 2
+        }
+      });
+    });
+
+    it("omits verification when the placement has no requirement", () => {
+      const parsed = yaml.load(generateSdl(buildFormValues(buildLogCollectorService({ title: "web", image: "nginx:latest" })))) as {
+        profiles: { placement: Record<string, { verification?: unknown }> };
+      };
+
+      expect(parsed.profiles.placement.dcloud.verification).toBeUndefined();
+    });
+
+    it("omits empty optional verification collections", () => {
+      const formValues = buildFormValues(buildLogCollectorService({ title: "web", image: "nginx:latest" }));
+      formValues.placements[0].verification = { minTier: 1, capabilities: [], auditors: [] };
+      const parsed = yaml.load(generateSdl(formValues)) as {
+        profiles: { placement: Record<string, { verification: Record<string, unknown> }> };
+      };
+
+      expect(parsed.profiles.placement.dcloud.verification).toEqual({ min_tier: 1 });
+    });
+
     it("throws when a service references a placementId that does not exist", () => {
       const formValues = {
         placements: [{ id: "p-1", name: "dcloud" }],

--- a/apps/deploy-web/src/utils/sdl/sdlGenerator.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlGenerator.ts
@@ -29,6 +29,34 @@ const buildGpuAttributes = (interconnect: { group?: string } | undefined): Recor
   return attributes;
 };
 
+type PlacementVerification = NonNullable<PlacementType["verification"]>;
+type SdlVerificationRequirement = {
+  min_tier: PlacementVerification["minTier"];
+  capabilities?: PlacementVerification["capabilities"];
+  auditors?: string[];
+  auditor_mode?: PlacementVerification["auditorMode"];
+  min_auditor_count?: PlacementVerification["minAuditorCount"];
+};
+
+const buildVerificationRequirement = (verification: PlacementVerification): SdlVerificationRequirement => {
+  const requirement: SdlVerificationRequirement = { min_tier: verification.minTier };
+
+  if (verification.capabilities?.length) {
+    requirement.capabilities = verification.capabilities;
+  }
+  if (verification.auditors?.length) {
+    requirement.auditors = verification.auditors.map(auditor => auditor.value);
+  }
+  if (verification.auditorMode) {
+    requirement.auditor_mode = verification.auditorMode;
+  }
+  if (verification.minAuditorCount !== undefined) {
+    requirement.min_auditor_count = verification.minAuditorCount;
+  }
+
+  return requirement;
+};
+
 export const generateSdl = (formValues: SdlBuilderFormValuesType) => {
   const sdl: Record<string, any> = { version: "2.0", services: {}, profiles: { compute: {}, placement: {} }, deployment: {} };
 
@@ -52,6 +80,10 @@ export const generateSdl = (formValues: SdlBuilderFormValuesType) => {
     if ((placement.signedBy?.allOf?.length || 0) > 0) {
       sdl.profiles.placement[placement.name].signedBy = sdl.profiles.placement[placement.name].signedBy || {};
       sdl.profiles.placement[placement.name].signedBy.allOf = placement.signedBy?.allOf.map(x => x.value);
+    }
+
+    if (placement.verification) {
+      sdl.profiles.placement[placement.name].verification = buildVerificationRequirement(placement.verification);
     }
 
     if ((placement.attributes?.length || 0) > 0) {

--- a/apps/deploy-web/src/utils/sdl/sdlImport.spec.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlImport.spec.ts
@@ -561,3 +561,131 @@ describe("importSimpleSdl reclamation", () => {
     expect(parsed.reclamation).toEqual({ min_window: minWindow });
   });
 });
+
+describe("importSimpleSdl verification", () => {
+  it("imports and regenerates the complete verification requirement independently of signedBy", () => {
+    const yml = placementRequirementSdl([
+      "      signedBy:",
+      "        anyOf:",
+      "          - akash1legacy",
+      "      verification:",
+      "        min_tier: 3",
+      "        capabilities:",
+      "          - persistent_storage",
+      "          - bare_metal",
+      "        auditors:",
+      "          - akash1auditor1",
+      "          - akash1auditor2",
+      "        auditor_mode: all",
+      "        min_auditor_count: 2"
+    ]);
+
+    const imported = importSimpleSdl(yml);
+    expect(SdlBuilderFormValuesSchema.safeParse(imported).success).toBe(true);
+    expect(imported.placements[0]).toMatchObject({
+      signedBy: { anyOf: [{ value: "akash1legacy" }], allOf: [] },
+      verification: {
+        minTier: 3,
+        capabilities: ["persistent_storage", "bare_metal"],
+        auditors: [{ value: "akash1auditor1" }, { value: "akash1auditor2" }],
+        auditorMode: "all",
+        minAuditorCount: 2
+      }
+    });
+
+    const parsed = yaml.load(generateSdl(imported)) as {
+      profiles: { placement: Record<string, { signedBy?: unknown; verification?: unknown }> };
+    };
+    expect(parsed.profiles.placement.dcloud).toMatchObject({
+      signedBy: { anyOf: ["akash1legacy"] },
+      verification: {
+        min_tier: 3,
+        capabilities: ["persistent_storage", "bare_metal"],
+        auditors: ["akash1auditor1", "akash1auditor2"],
+        auditor_mode: "all",
+        min_auditor_count: 2
+      }
+    });
+  });
+
+  it("leaves verification absent when the SDL has no requirement", () => {
+    const imported = importSimpleSdl(placementRequirementSdl([]));
+
+    expect(imported.placements[0].verification).toBeUndefined();
+    const parsed = yaml.load(generateSdl(imported)) as {
+      profiles: { placement: Record<string, { verification?: unknown }> };
+    };
+    expect(parsed.profiles.placement.dcloud.verification).toBeUndefined();
+  });
+
+  it("leaves invalid verification values to the form schema validation boundary", () => {
+    const imported = importSimpleSdl(
+      placementRequirementSdl(["      verification:", "        min_tier: 5", "        capabilities:", "          - unknown_capability"])
+    );
+
+    const result = SdlBuilderFormValuesSchema.safeParse(imported);
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: ["placements", 0, "verification", "minTier"] }),
+        expect.objectContaining({ path: ["placements", 0, "verification", "capabilities", 0] })
+      ])
+    );
+  });
+
+  it.each(["any", "all"])("collapses a vacuous tier-zero verification block with auditor mode %s", auditorMode => {
+    const imported = importSimpleSdl(
+      placementRequirementSdl([
+        "      verification:",
+        "        min_tier: 0",
+        "        capabilities: []",
+        "        auditors: []",
+        `        auditor_mode: ${auditorMode}`,
+        "        min_auditor_count: 0"
+      ])
+    );
+
+    expect(imported.placements[0].verification).toBeUndefined();
+    const parsed = yaml.load(generateSdl(imported)) as {
+      profiles: { placement: Record<string, { verification?: unknown }> };
+    };
+    expect(parsed.profiles.placement.dcloud.verification).toBeUndefined();
+  });
+});
+
+const placementRequirementSdl = (placementLines: string[]) =>
+  [
+    "version: '2.0'",
+    "services:",
+    "  web:",
+    "    image: nginx:latest",
+    "    expose:",
+    "      - port: 80",
+    "        as: 80",
+    "        to:",
+    "          - global: true",
+    "profiles:",
+    "  compute:",
+    "    web:",
+    "      resources:",
+    "        cpu:",
+    "          units: 0.5",
+    "        memory:",
+    "          size: 512Mi",
+    "        storage:",
+    "          - size: 512Mi",
+    "  placement:",
+    "    dcloud:",
+    ...placementLines,
+    "      pricing:",
+    "        web:",
+    "          denom: uakt",
+    "          amount: 1000",
+    "deployment:",
+    "  web:",
+    "    dcloud:",
+    "      profile: web",
+    "      count: 1"
+  ].join("\n");

--- a/apps/deploy-web/src/utils/sdl/sdlImport.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlImport.ts
@@ -7,6 +7,15 @@ import { CustomValidationError } from "../deploymentData";
 import { capitalizeFirstLetter } from "../stringUtils";
 import { defaultHttpOptions } from "./data";
 
+type PlacementVerification = NonNullable<PlacementType["verification"]>;
+type SdlVerificationRequirement = {
+  min_tier: number;
+  capabilities?: PlacementVerification["capabilities"];
+  auditors?: string[];
+  auditor_mode?: PlacementVerification["auditorMode"];
+  min_auditor_count?: number;
+};
+
 /** YAML parses unquoted scalars like `0` or `false` into native types, so tokens are stringified instead of filtered as falsy. */
 export const parseSvcCommand = (command?: string | (string | number | boolean)[]): string => {
   if (!command) {
@@ -271,6 +280,23 @@ function hydratePlacement(id: string, name: string, profile: any): PlacementType
     signedBy: {
       anyOf: profile.signedBy?.anyOf ? profile.signedBy.anyOf.map((x: string) => ({ id: nanoid(), value: x })) : [],
       allOf: profile.signedBy?.allOf ? profile.signedBy.allOf.map((x: string) => ({ id: nanoid(), value: x })) : []
-    }
+    },
+    verification: hydrateVerification(profile.verification as SdlVerificationRequirement | undefined)
   };
+}
+
+function hydrateVerification(verification: SdlVerificationRequirement | undefined): PlacementType["verification"] {
+  if (!verification || isVacuousVerification(verification)) return undefined;
+
+  return {
+    minTier: verification.min_tier,
+    capabilities: verification.capabilities,
+    auditors: verification.auditors?.map(value => ({ id: nanoid(), value })),
+    auditorMode: verification.auditor_mode,
+    minAuditorCount: verification.min_auditor_count
+  };
+}
+
+function isVacuousVerification(verification: SdlVerificationRequirement): boolean {
+  return verification.min_tier === 0 && !verification.capabilities?.length && !verification.auditors?.length && (verification.min_auditor_count ?? 0) === 0;
 }

--- a/apps/indexer/package.json
+++ b/apps/indexer/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@akashnetwork/akash-api": "1.4.3",
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/database": "*",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/instrumentation": "*",

--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -36,7 +36,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",
     "@akashnetwork/instrumentation": "*",

--- a/apps/notifications/src/modules/chain/providers/registry.provider.ts
+++ b/apps/notifications/src/modules/chain/providers/registry.provider.ts
@@ -12,18 +12,16 @@ import type { Provider } from "@nestjs/common";
 export const RegistryProvider: Provider<Registry> = {
   provide: Registry,
   useFactory: () => {
-    const akashTypes: ReadonlyArray<[string, GeneratedType]> = [
-      ...Object.values(v1),
-      ...Object.values(v1beta4),
-      ...Object.values(v1beta5),
-      ...Object.values(cosmosv1),
-      ...Object.values(cosmosv1beta1),
-      ...Object.values(cosmosv1alpha1),
-      ...Object.values(cosmosv2alpha1)
-    ]
-      .filter(x => "$type" in x)
-      .map(x => ["/" + x.$type, x as unknown as GeneratedType]);
+    const modules: ReadonlyArray<Record<string, unknown>> = [v1, v1beta4, v1beta5, cosmosv1, cosmosv1beta1, cosmosv1alpha1, cosmosv2alpha1];
+    const akashTypes: ReadonlyArray<[string, GeneratedType]> = modules
+      .flatMap(module => Object.values(module))
+      .filter(hasType)
+      .map(type => ["/" + type.$type, type as unknown as GeneratedType]);
 
     return new Registry(akashTypes);
   }
 };
+
+function hasType(value: unknown): value is { $type: string } {
+  return typeof value === "object" && value !== null && "$type" in value && typeof value.$type === "string";
+}

--- a/apps/provider-inventory/package.json
+++ b/apps/provider-inventory/package.json
@@ -24,7 +24,7 @@
     "test:unit": "vitest run --project unit"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/instrumentation": "*",
     "@akashnetwork/logging": "*",

--- a/apps/provider-inventory/src/mappers/groupspec-mapper/groupspec-mapper.ts
+++ b/apps/provider-inventory/src/mappers/groupspec-mapper/groupspec-mapper.ts
@@ -45,4 +45,10 @@ export function getAttributeFingerprint(attributes: ResourceAttribute[] | undefi
     .join(",");
 }
 
-export type GroupSpecJSON = ToJSON<GroupSpec>;
+type GroupSpecRequirementsJSON = ToJSON<NonNullable<GroupSpec["requirements"]>>;
+
+export type GroupSpecJSON = Omit<ToJSON<GroupSpec>, "requirements"> & {
+  requirements: Omit<GroupSpecRequirementsJSON, "verification"> & {
+    verification?: GroupSpecRequirementsJSON["verification"];
+  };
+};

--- a/apps/provider-proxy/package.json
+++ b/apps/provider-proxy/package.json
@@ -20,7 +20,7 @@
     "test:unit": "vitest run --project unit"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/instrumentation": "*",
     "@akashnetwork/logging": "*",

--- a/apps/stats-web/package.json
+++ b/apps/stats-web/package.json
@@ -14,7 +14,7 @@
     "test:unit": "NODE_ENV=test vitest run"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/logging": "*",
     "@akashnetwork/network-store": "*",

--- a/apps/tx-signer/package.json
+++ b/apps/tx-signer/package.json
@@ -21,7 +21,7 @@
     "test:unit": "vitest run --project unit"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",
     "@akashnetwork/instrumentation": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akash-api": "1.4.3",
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/console-api-types": "*",
         "@akashnetwork/database": "*",
         "@akashnetwork/env-loader": "*",
@@ -542,7 +542,7 @@
       "version": "3.31.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/console-api-types": "*",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
@@ -2168,7 +2168,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akash-api": "1.4.3",
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/database": "*",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/instrumentation": "*",
@@ -2558,7 +2558,7 @@
       "version": "2.16.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
         "@akashnetwork/instrumentation": "*",
@@ -3701,7 +3701,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/instrumentation": "*",
         "@akashnetwork/logging": "*",
@@ -4041,7 +4041,7 @@
       "version": "2.10.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/instrumentation": "*",
         "@akashnetwork/logging": "*",
@@ -4218,7 +4218,7 @@
       "name": "@akashnetwork/stats-web",
       "version": "1.14.1",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/logging": "*",
         "@akashnetwork/network-store": "*",
@@ -4982,7 +4982,7 @@
       "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
         "@akashnetwork/instrumentation": "*",
@@ -5473,9 +5473,9 @@
       }
     },
     "node_modules/@akashnetwork/chain-sdk": {
-      "version": "1.0.0-alpha.41",
-      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.41.tgz",
-      "integrity": "sha512-mr3fGDBSISxl0eZF83+IJLVulGSuJVu+MRj6fG61pi2rgfgnv9QEKpdU3w7wtFFt5saJaJNgsqAlyjGZQecZ1A==",
+      "version": "1.0.0-alpha.43",
+      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.43.tgz",
+      "integrity": "sha512-+XTgpLn3kibMEWBAOkfmOGo2VJcv+VtT5Uvq966Nk5YMyD9HCYUvdDLm1k167Di1S11t66SH06BhoY1M/m2IWg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.12.0",
@@ -45932,7 +45932,7 @@
       "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/net": "*",
         "jotai": "^2.9.2"
       },

--- a/packages/console-api-types/src/schema.d.ts
+++ b/packages/console-api-types/src/schema.d.ts
@@ -3333,6 +3333,30 @@ export interface paths {
               workloadSupportChia: boolean;
               workloadSupportChiaCapabilities: string[] | null;
               featEndpointIp: boolean;
+              verification: {
+                provider: string;
+                moduleActive: boolean | null;
+                summary: {
+                  /**
+                   * @description Tier used by the chain tier gate, including active discrepancy grace
+                   * @enum {string|null}
+                   */
+                  effectiveTier: "L0" | "L1" | "L2" | "L3" | "L4" | "unknown" | null;
+                  validAuditorCount: number | null;
+                  capabilities:
+                    | ("unspecified" | "tee_hardware_attestation" | "confidential_computing" | "persistent_storage" | "bare_metal" | "unknown")[]
+                    | null;
+                  /** @enum {string} */
+                  snapshotState: "unknown" | "not_posted" | "current" | "stale" | "suspended";
+                  /** @enum {string} */
+                  maintenanceState: "unknown" | "none" | "scheduled" | "active";
+                  /** @enum {string} */
+                  reviewState: "unknown" | "none" | "under_review" | "grace";
+                };
+                /** Format: date-time */
+                observedAt: string;
+                observedHeight: string;
+              } | null;
             }[];
           };
         };
@@ -3461,6 +3485,247 @@ export interface paths {
               workloadSupportChia: boolean;
               workloadSupportChiaCapabilities: string[];
               featEndpointIp: boolean;
+              verification: {
+                provider: string;
+                /** @description Legacy, self-declared provider tier attribute; not an AEP-86 attestation */
+                providerDeclaredTier: string | null;
+                moduleActive: boolean | null;
+                provenance: {
+                  /** @enum {string} */
+                  providerTier: "provider self-declared";
+                  /** @enum {string} */
+                  inventory: "provider-signed inventory";
+                  /** @enum {string} */
+                  attestations: "auditor-attested";
+                };
+                summary: {
+                  /** @enum {string|null} */
+                  bestAttestedTier: "L0" | "L1" | "L2" | "L3" | "L4" | "unknown" | null;
+                  /**
+                   * @description Tier used by the chain tier gate, including active discrepancy grace
+                   * @enum {string|null}
+                   */
+                  effectiveTier: "L0" | "L1" | "L2" | "L3" | "L4" | "unknown" | null;
+                  capabilities:
+                    | ("unspecified" | "tee_hardware_attestation" | "confidential_computing" | "persistent_storage" | "bare_metal" | "unknown")[]
+                    | null;
+                  validAttestationCount: number | null;
+                  validAuditorCount: number | null;
+                  validAuditors: string[] | null;
+                  /** @enum {string} */
+                  snapshotState: "unknown" | "not_posted" | "current" | "stale" | "suspended";
+                  /** @enum {string} */
+                  maintenanceState: "unknown" | "none" | "scheduled" | "active";
+                  /** @enum {string} */
+                  reviewState: "unknown" | "none" | "under_review" | "grace";
+                };
+                attestations: {
+                  provider: string;
+                  auditor: string;
+                  /** @enum {string} */
+                  tier: "L0" | "L1" | "L2" | "L3" | "L4" | "unknown";
+                  capabilities: ("unspecified" | "tee_hardware_attestation" | "confidential_computing" | "persistent_storage" | "bare_metal" | "unknown")[];
+                  /** @description Base64-encoded bytes, or null when the chain field is empty */
+                  evidenceHash: string | null;
+                  fee: {
+                    denom: string;
+                    amount: string;
+                  } | null;
+                  /** @enum {string} */
+                  feeStatus: "unspecified" | "escrowed" | "released_to_auditor" | "returned_to_provider" | "unknown";
+                  /** Format: date-time */
+                  createdAt: string | null;
+                  /** Format: date-time */
+                  expiresAt: string | null;
+                  /** @enum {string} */
+                  status: "unspecified" | "valid" | "voided" | "expired" | "revoked" | "removed" | "unknown";
+                  /** @enum {string} */
+                  voidedReason: "unspecified" | "discrepancy" | "governance" | "bond_withdrawn" | "bond_slashed" | "unknown";
+                  deposit: {
+                    denom: string;
+                    amount: string;
+                  } | null;
+                  /** @enum {string} */
+                  depositStatus: "unspecified" | "escrowed" | "pending_discrepancy" | "returned_to_auditor" | "slashed" | "unknown";
+                  auditEscrowId: string;
+                  /** @enum {string} */
+                  faultAttribution: "unspecified" | "provider_fault" | "auditor_fault" | "shared_fault" | "no_fault" | "inconclusive" | "unknown";
+                }[];
+                bond: {
+                  provider: string;
+                  bondedAmount: {
+                    denom: string;
+                    amount: string;
+                  } | null;
+                  requiredForCurrentTier: {
+                    denom: string;
+                    amount: string;
+                  };
+                  unbondingEntries: {
+                    amount: {
+                      denom: string;
+                      amount: string;
+                    } | null;
+                    /** Format: date-time */
+                    completionTime: string | null;
+                  }[];
+                  slashed: boolean;
+                  /** Format: date-time */
+                  lastSlashTime: string | null;
+                } | null;
+                snapshot: {
+                  provider: string;
+                  /** @description Base64-encoded bytes, or null when the chain field is empty */
+                  snapshotHash: string | null;
+                  resourceSummary: {
+                    totalGpus: number;
+                    totalVcpus: number;
+                    totalMemoryMb: string;
+                    totalStorageMb: string;
+                    activeLeases: number;
+                    softwareVersion: string;
+                    /** @description Base64-encoded bytes, or null when the chain field is empty */
+                    softwareSignature: string | null;
+                    softwareIdentity: {
+                      version: string;
+                      artifactRef: string;
+                      digestAlgorithm: string;
+                      /** @description Base64-encoded bytes, or null when the chain field is empty */
+                      digest: string | null;
+                      signatureType: string;
+                      /** @description Base64-encoded bytes, or null when the chain field is empty */
+                      signature: string | null;
+                      signatureRef: string;
+                      publicKeyRef: string;
+                    } | null;
+                  } | null;
+                  /** Format: date-time */
+                  postedAt: string | null;
+                  /** Format: date-time */
+                  snapshotTimestamp: string | null;
+                  /** Format: date-time */
+                  complianceDeadline: string | null;
+                  suspended: boolean;
+                } | null;
+                grace: {
+                  id: string;
+                  provider: string;
+                  /** @enum {string} */
+                  preservedTier: "L0" | "L1" | "L2" | "L3" | "L4" | "unknown";
+                  sourceDiscrepancyIds: string[];
+                  /** Format: date-time */
+                  startedAt: string | null;
+                  /** Format: date-time */
+                  expiresAt: string | null;
+                  /** @enum {string} */
+                  status: "unspecified" | "active" | "expired" | "terminated" | "unknown";
+                } | null;
+                auditEscrows: {
+                  id: string;
+                  provider: string;
+                  consumedByAuditor: string | null;
+                  /** @enum {string} */
+                  requestedTier: "L0" | "L1" | "L2" | "L3" | "L4" | "unknown";
+                  requestedCapabilities: (
+                    | "unspecified"
+                    | "tee_hardware_attestation"
+                    | "confidential_computing"
+                    | "persistent_storage"
+                    | "bare_metal"
+                    | "unknown"
+                  )[];
+                  fee: {
+                    denom: string;
+                    amount: string;
+                  } | null;
+                  /** @enum {string} */
+                  feeStatus: "unspecified" | "escrowed" | "released_to_auditor" | "returned_to_provider" | "unknown";
+                  providerDeposit: {
+                    denom: string;
+                    amount: string;
+                  } | null;
+                  /** @enum {string} */
+                  providerDepositStatus: "unspecified" | "escrowed" | "returned_to_provider" | "slashed" | "unknown";
+                  /** @enum {string} */
+                  status: "unspecified" | "open" | "consumed" | "cancelled" | "expired" | "settled" | "unknown";
+                  /** Format: date-time */
+                  openedAt: string | null;
+                  /** Format: date-time */
+                  consumedAt: string | null;
+                  /** Format: date-time */
+                  expiresAt: string | null;
+                  /** @description Base64-encoded bytes, or null when the chain field is empty */
+                  metadataHash: string | null;
+                  /** @enum {string} */
+                  settlementReason: "unspecified" | "cancelled_unconsumed" | "expired_unconsumed" | "provider_fault" | "no_fault" | "unknown";
+                  /** @enum {string} */
+                  faultAttribution: "unspecified" | "provider_fault" | "auditor_fault" | "shared_fault" | "no_fault" | "inconclusive" | "unknown";
+                }[];
+                maintenance: {
+                  record: {
+                    id: string;
+                    provider: string;
+                    /** @enum {string} */
+                    maintenanceType: "unspecified" | "planned" | "emergency" | "security" | "network" | "capacity" | "unknown";
+                    /** Format: date-time */
+                    startsAt: string | null;
+                    /** Format: date-time */
+                    expectedEndsAt: string | null;
+                    /** Format: date-time */
+                    openedAt: string | null;
+                    /** Format: date-time */
+                    closedAt: string | null;
+                    /** @description Base64-encoded bytes, or null when the chain field is empty */
+                    metadataHash: string | null;
+                  } | null;
+                  /** @enum {string} */
+                  status: "unspecified" | "scheduled" | "active" | "elapsed" | "closed" | "unknown";
+                }[];
+                discrepancies: {
+                  id: string;
+                  provider: string;
+                  auditorA: string;
+                  /** @enum {string} */
+                  auditorATier: "L0" | "L1" | "L2" | "L3" | "L4" | "unknown";
+                  auditorB: string;
+                  /** @enum {string} */
+                  auditorBTier: "L0" | "L1" | "L2" | "L3" | "L4" | "unknown";
+                  /** Format: date-time */
+                  timestamp: string | null;
+                  /** @enum {string} */
+                  resolutionStatus: "unspecified" | "pending" | "resolved" | "timed_out" | "unknown";
+                  resolutionProposalId: string;
+                  graceRecordId: string;
+                  /** @enum {string} */
+                  resolutionReason:
+                    | "unspecified"
+                    | "auditor_a_correct"
+                    | "auditor_b_correct"
+                    | "both_auditors_wrong"
+                    | "provider_fault"
+                    | "shared_fault"
+                    | "evidence_inconclusive"
+                    | "governance_timeout_review"
+                    | "unknown";
+                  /** @enum {string} */
+                  faultAttribution: "unspecified" | "provider_fault" | "auditor_fault" | "shared_fault" | "no_fault" | "inconclusive" | "unknown";
+                  /** @description Base64-encoded bytes, or null when the chain field is empty */
+                  resolutionEvidenceHash: string | null;
+                }[];
+                /** Format: date-time */
+                observedAt: string;
+                observedHeight: string;
+                completeness: {
+                  params: boolean;
+                  attestations: boolean;
+                  graces: boolean;
+                  snapshot: boolean;
+                  bond: boolean;
+                  auditEscrows: boolean;
+                  maintenance: boolean;
+                  discrepancies: boolean;
+                };
+              } | null;
               uptime: {
                 id: string;
                 isOnline: boolean;
@@ -8627,6 +8892,17 @@ export interface operations {
                */
               value: string;
             }[];
+            verification?: {
+              minTier: 0 | 1 | 2 | 3 | 4;
+              /** @default [] */
+              requiredCapabilities?: (1 | 2 | 3 | 4)[];
+              /** @default [] */
+              requiredAuditors?: string[];
+              /** @default 0 */
+              auditorMode?: 0 | 1 | 2;
+              /** @default 0 */
+              minAuditorCount?: number;
+            };
           };
           /** @description Resource units with replica counts */
           resources: {
@@ -8771,6 +9047,40 @@ export interface operations {
                * @example Akash
                */
               organization: string | null;
+              verification?:
+                | {
+                    /** @enum {string} */
+                    outcome: "pass";
+                    summary: {
+                      /** @enum {integer} */
+                      bestStatusValidTier: 0 | 1 | 2 | 3 | 4 | -1;
+                      /** @enum {integer} */
+                      tierGateTier: 0 | 1 | 2 | 3 | 4 | -1;
+                      capabilities: (0 | 1 | 2 | 3 | 4 | -1)[];
+                      validAttestationCount: number;
+                      validAuditors: string[];
+                      /** @enum {string} */
+                      snapshotState: "unknown" | "not_posted" | "current" | "stale" | "suspended";
+                      observedHeight: string;
+                    };
+                  }
+                | {
+                    /** @enum {string} */
+                    outcome: "not_evaluated";
+                    incompleteFacts: ("params" | "attestations" | "graces" | "snapshot" | "module_inactive")[];
+                    summary: {
+                      /** @enum {integer} */
+                      bestStatusValidTier: 0 | 1 | 2 | 3 | 4 | -1;
+                      /** @enum {integer} */
+                      tierGateTier: 0 | 1 | 2 | 3 | 4 | -1;
+                      capabilities: (0 | 1 | 2 | 3 | 4 | -1)[];
+                      validAttestationCount: number;
+                      validAuditors: string[];
+                      /** @enum {string} */
+                      snapshotState: "unknown" | "not_posted" | "current" | "stale" | "suspended";
+                      observedHeight: string;
+                    };
+                  };
               /** @description Per-day downtime over a rolling 7-day window */
               incidents: {
                 /**
@@ -8785,6 +9095,102 @@ export interface operations {
                 /** @description Downtime clipped to that day, in seconds (max 86400) */
                 downtimeSeconds: number;
               }[];
+            }[];
+            exclusions?: {
+              owner: string;
+              firstFailure:
+                | {
+                    /** @enum {string} */
+                    code: "snapshot_not_posted";
+                  }
+                | {
+                    /** @enum {string} */
+                    code: "snapshot_suspended";
+                  }
+                | {
+                    /** @enum {string} */
+                    code: "snapshot_stale";
+                  }
+                | {
+                    /** @enum {string} */
+                    code: "insufficient_tier";
+                    /** @enum {integer} */
+                    actual: 0 | 1 | 2 | 3 | 4 | -1;
+                    /** @enum {integer} */
+                    required: 0 | 1 | 2 | 3 | 4 | -1;
+                  }
+                | {
+                    /** @enum {string} */
+                    code: "missing_capability";
+                    /** @enum {integer} */
+                    capability: 0 | 1 | 2 | 3 | 4 | -1;
+                  }
+                | {
+                    /** @enum {string} */
+                    code: "insufficient_auditor_count";
+                    actual: number;
+                    required: number;
+                  }
+                | {
+                    /** @enum {string} */
+                    code: "required_auditor_not_found";
+                    /** @enum {integer} */
+                    mode: 0 | 1 | 2 | -1;
+                    missing: string[];
+                  };
+              failures: (
+                | {
+                    /** @enum {string} */
+                    code: "snapshot_not_posted";
+                  }
+                | {
+                    /** @enum {string} */
+                    code: "snapshot_suspended";
+                  }
+                | {
+                    /** @enum {string} */
+                    code: "snapshot_stale";
+                  }
+                | {
+                    /** @enum {string} */
+                    code: "insufficient_tier";
+                    /** @enum {integer} */
+                    actual: 0 | 1 | 2 | 3 | 4 | -1;
+                    /** @enum {integer} */
+                    required: 0 | 1 | 2 | 3 | 4 | -1;
+                  }
+                | {
+                    /** @enum {string} */
+                    code: "missing_capability";
+                    /** @enum {integer} */
+                    capability: 0 | 1 | 2 | 3 | 4 | -1;
+                  }
+                | {
+                    /** @enum {string} */
+                    code: "insufficient_auditor_count";
+                    actual: number;
+                    required: number;
+                  }
+                | {
+                    /** @enum {string} */
+                    code: "required_auditor_not_found";
+                    /** @enum {integer} */
+                    mode: 0 | 1 | 2 | -1;
+                    missing: string[];
+                  }
+              )[];
+              summary: {
+                /** @enum {integer} */
+                bestStatusValidTier: 0 | 1 | 2 | 3 | 4 | -1;
+                /** @enum {integer} */
+                tierGateTier: 0 | 1 | 2 | 3 | 4 | -1;
+                capabilities: (0 | 1 | 2 | 3 | 4 | -1)[];
+                validAttestationCount: number;
+                validAuditors: string[];
+                /** @enum {string} */
+                snapshotState: "unknown" | "not_posted" | "current" | "stale" | "suspended";
+                observedHeight: string;
+              };
             }[];
           };
         };

--- a/packages/network-store/package.json
+++ b/packages/network-store/package.json
@@ -18,7 +18,7 @@
     "validate:types": "tsc --noEmit && echo"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/net": "*",
     "jotai": "^2.9.2"
   },


### PR DESCRIPTION
## Why

Part of CON-800.

Console users need to define AEP-86 placement requirements, understand why a
provider is excluded, and inspect provider verification facts without querying
the chain directly. This keeps the complete user workflow in one application
PR even though the resulting change is necessarily XL.

## Feature surface

![AEP-86 provider verification feature surface](https://raw.githubusercontent.com/chalabi2/console/aep-86-pr-assets/aep-86-console-feature-surface.png)

## What

- add flag-gated verification controls to SDL authoring and preserve import and
  generation round trips
- preflight placement requirements and explain when no provider can satisfy them
- hard-filter marketplace results and display verification-based exclusions
- show effective tier, auditors, capabilities, snapshots, maintenance, escrows,
  and discrepancies on provider views
- show the placement policy beside current provider facts on active deployments
- preserve legacy `signedBy` requirements when both policies are present

## Dependencies

- #3713 publishes the AEP-86 TypeScript SDK contract used by this UI
- #3718 supplies server-side bid screening and exclusion reasons
- #3719 supplies normalized provider list and detail verification views

The implementation remains behind the `provider_verification` feature flag.