### PR TITLE
feat(stats): render provider verification records

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@akashnetwork/akash-api": "1.4.3",
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/console-api-types": "*",
     "@akashnetwork/database": "*",
     "@akashnetwork/env-loader": "*",

--- a/apps/deploy-web/package.json
+++ b/apps/deploy-web/package.json
@@ -26,7 +26,7 @@
     "type-check": "tsc"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/console-api-types": "*",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",

--- a/apps/indexer/package.json
+++ b/apps/indexer/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@akashnetwork/akash-api": "1.4.3",
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/database": "*",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/instrumentation": "*",

--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -36,7 +36,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",
     "@akashnetwork/instrumentation": "*",

--- a/apps/notifications/src/modules/chain/providers/registry.provider.ts
+++ b/apps/notifications/src/modules/chain/providers/registry.provider.ts
@@ -12,18 +12,16 @@ import type { Provider } from "@nestjs/common";
 export const RegistryProvider: Provider<Registry> = {
   provide: Registry,
   useFactory: () => {
-    const akashTypes: ReadonlyArray<[string, GeneratedType]> = [
-      ...Object.values(v1),
-      ...Object.values(v1beta4),
-      ...Object.values(v1beta5),
-      ...Object.values(cosmosv1),
-      ...Object.values(cosmosv1beta1),
-      ...Object.values(cosmosv1alpha1),
-      ...Object.values(cosmosv2alpha1)
-    ]
-      .filter(x => "$type" in x)
-      .map(x => ["/" + x.$type, x as unknown as GeneratedType]);
+    const modules: ReadonlyArray<Record<string, unknown>> = [v1, v1beta4, v1beta5, cosmosv1, cosmosv1beta1, cosmosv1alpha1, cosmosv2alpha1];
+    const akashTypes: ReadonlyArray<[string, GeneratedType]> = modules
+      .flatMap(module => Object.values(module))
+      .filter(hasType)
+      .map(type => ["/" + type.$type, type as unknown as GeneratedType]);
 
     return new Registry(akashTypes);
   }
 };
+
+function hasType(value: unknown): value is { $type: string } {
+  return typeof value === "object" && value !== null && "$type" in value && typeof value.$type === "string";
+}

--- a/apps/provider-inventory/package.json
+++ b/apps/provider-inventory/package.json
@@ -24,7 +24,7 @@
     "test:unit": "vitest run --project unit"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/instrumentation": "*",
     "@akashnetwork/logging": "*",

--- a/apps/provider-inventory/src/mappers/groupspec-mapper/groupspec-mapper.ts
+++ b/apps/provider-inventory/src/mappers/groupspec-mapper/groupspec-mapper.ts
@@ -45,4 +45,10 @@ export function getAttributeFingerprint(attributes: ResourceAttribute[] | undefi
     .join(",");
 }
 
-export type GroupSpecJSON = ToJSON<GroupSpec>;
+type GroupSpecRequirementsJSON = ToJSON<NonNullable<GroupSpec["requirements"]>>;
+
+export type GroupSpecJSON = Omit<ToJSON<GroupSpec>, "requirements"> & {
+  requirements: Omit<GroupSpecRequirementsJSON, "verification"> & {
+    verification?: GroupSpecRequirementsJSON["verification"];
+  };
+};

--- a/apps/provider-proxy/package.json
+++ b/apps/provider-proxy/package.json
@@ -20,7 +20,7 @@
     "test:unit": "vitest run --project unit"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/instrumentation": "*",
     "@akashnetwork/logging": "*",

--- a/apps/stats-web/package.json
+++ b/apps/stats-web/package.json
@@ -14,7 +14,7 @@
     "test:unit": "NODE_ENV=test vitest run"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/logging": "*",
     "@akashnetwork/network-store": "*",

--- a/apps/stats-web/src/components/transactions/TxMessageRow.tsx
+++ b/apps/stats-web/src/components/transactions/TxMessageRow.tsx
@@ -2,6 +2,8 @@
 import { useMemo } from "react";
 
 import { DynamicReactJson } from "../DynamicJsonView";
+import { Aep86RecordView } from "./akash/aep86/Aep86RecordView";
+import { isAep86MessageType } from "./akash/aep86/aep86Types";
 import * as akashMessages from "./akash";
 import * as cosmosMessages from "./generic";
 
@@ -53,6 +55,10 @@ type TxMessageProps = {
   message: TransactionMessage;
 };
 const TxMessage: React.FunctionComponent<TxMessageProps> = ({ message }) => {
+  if (isAep86MessageType(message.type)) {
+    return <Aep86RecordView data={message.data} />;
+  }
+
   const [namespace, ...typeDetails] = message.type.split(".");
   const version = typeDetails[typeDetails.length - 2];
   const name = typeDetails[typeDetails.length - 1];

--- a/apps/stats-web/src/components/transactions/akash/aep86/Aep86RecordView.tsx
+++ b/apps/stats-web/src/components/transactions/akash/aep86/Aep86RecordView.tsx
@@ -1,0 +1,23 @@
+"use client";
+import type { ReactNode } from "react";
+
+import type { Aep86DisplayField } from "./aep86Formatting";
+import { toAep86DisplayFields } from "./aep86Formatting";
+
+import { AddressLink } from "@/components/AddressLink";
+import { DynamicReactJson } from "@/components/DynamicJsonView";
+import { LabelValue } from "@/components/LabelValue";
+
+function renderValue(field: Aep86DisplayField): ReactNode {
+  if (field.kind === "address") return <AddressLink address={field.value as string} />;
+  if (field.kind === "json") return <DynamicReactJson src={field.value as object} />;
+
+  return <span className={field.key.toLowerCase().includes("hash") ? "font-mono" : undefined}>{field.value as string}</span>;
+}
+
+export function Aep86RecordView({ data }: { data: unknown }) {
+  const fields = toAep86DisplayFields(data);
+  if (!fields.length) return <span className="text-muted-foreground">No fields</span>;
+
+  return fields.map(field => <LabelValue key={field.key} label={field.label} value={renderValue(field)} />);
+}

--- a/apps/stats-web/src/components/transactions/akash/aep86/aep86Formatting.ts
+++ b/apps/stats-web/src/components/transactions/akash/aep86/aep86Formatting.ts
@@ -1,0 +1,110 @@
+type Coin = {
+  amount: string;
+  denom: string;
+};
+
+export type Aep86DisplayField = {
+  key: string;
+  kind: "address" | "json" | "text";
+  label: string;
+  value: object | string;
+};
+
+const tierLabels: Record<string, string> = {
+  verification_tier_unspecified: "L0",
+  verification_tier_identified: "L1",
+  verification_tier_verified: "L2",
+  verification_tier_established: "L3",
+  verification_tier_trusted: "L4"
+};
+
+const enumPrefixes = [
+  "attestation_revocation_reason_",
+  "audit_escrow_settlement_reason_",
+  "discrepancy_resolution_reason_",
+  "governance_attestation_reason_",
+  "provider_bond_slash_reason_",
+  "provider_maintenance_status_",
+  "provider_maintenance_type_",
+  "verification_grace_status_",
+  "fault_attribution_",
+  "capability_"
+];
+
+const addressFields = new Set(["auditor", "auditorA", "auditorB", "authority", "initiator", "provider", "vindicatedAuditor"]);
+
+function snakeToCamelCase(value: string): string {
+  return value.replace(/_([a-z])/g, (_, letter: string) => letter.toUpperCase());
+}
+
+function titleCase(value: string): string {
+  return value
+    .split("_")
+    .filter(Boolean)
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+function isCoin(value: unknown): value is Coin {
+  return isJsonObject(value) && "amount" in value && typeof value.amount === "string" && "denom" in value && typeof value.denom === "string";
+}
+
+function isJsonObject(value: unknown): value is object {
+  return !!value && typeof value === "object";
+}
+
+export function getAep86FieldLabel(key: string): string {
+  return snakeToCamelCase(key)
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/^./, value => value.toUpperCase())
+    .replace(/\bId\b/g, "ID")
+    .replace(/\bUri\b/g, "URI");
+}
+
+export function formatAep86Scalar(value: unknown): string {
+  if (value === null || value === undefined || value === "") return "Not provided";
+  if (typeof value === "boolean") return value ? "Yes" : "No";
+  if (value instanceof Date) return value.toISOString();
+
+  const stringValue = String(value);
+  if (tierLabels[stringValue]) return tierLabels[stringValue];
+
+  const prefix = enumPrefixes.find(candidate => stringValue.startsWith(candidate));
+  return prefix ? titleCase(stringValue.slice(prefix.length)) : stringValue;
+}
+
+function formatArray(value: unknown[]): Aep86DisplayField["value"] {
+  if (value.every(item => !isJsonObject(item))) {
+    return value.length ? value.map(formatAep86Scalar).join(", ") : "None";
+  }
+
+  return value;
+}
+
+export function toAep86DisplayFields(data: unknown): Aep86DisplayField[] {
+  if (!data || typeof data !== "object" || Array.isArray(data)) return [];
+
+  return Object.entries(data).map(([key, value]) => {
+    const normalizedKey = snakeToCamelCase(key);
+    const label = getAep86FieldLabel(key);
+
+    if (addressFields.has(normalizedKey) && typeof value === "string") {
+      return { key, kind: "address", label, value };
+    }
+
+    if (isCoin(value)) {
+      return { key, kind: "text", label, value: `${value.amount} ${value.denom}` };
+    }
+
+    if (Array.isArray(value)) {
+      const formattedValue = formatArray(value);
+      return { key, kind: typeof formattedValue === "string" ? "text" : "json", label, value: formattedValue };
+    }
+
+    if (isJsonObject(value)) {
+      return { key, kind: "json", label, value };
+    }
+
+    return { key, kind: "text", label, value: formatAep86Scalar(value) };
+  });
+}

--- a/apps/stats-web/src/components/transactions/akash/aep86/aep86Types.spec.ts
+++ b/apps/stats-web/src/components/transactions/akash/aep86/aep86Types.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import { formatAep86Scalar, getAep86FieldLabel, toAep86DisplayFields } from "./aep86Formatting";
+import { AEP86_EVENT_TYPE_URLS, AEP86_MESSAGE_TYPE_URLS, isAep86EventType, isAep86MessageType } from "./aep86Types";
+
+describe("AEP-86 type dispatch", () => {
+  it("recognizes every verification and maintenance message by full type URL", () => {
+    expect(AEP86_MESSAGE_TYPE_URLS).toHaveLength(22);
+    expect(AEP86_MESSAGE_TYPE_URLS.every(isAep86MessageType)).toBe(true);
+  });
+
+  it("recognizes every verification and maintenance event with or without a leading slash", () => {
+    expect(AEP86_EVENT_TYPE_URLS).toHaveLength(33);
+    expect(AEP86_EVENT_TYPE_URLS.every(isAep86EventType)).toBe(true);
+    expect(isAep86EventType("akash.verification.v1.EventAttestationSubmitted")).toBe(true);
+  });
+
+  it("does not confuse update-params messages from different modules", () => {
+    expect(isAep86MessageType("/akash.verification.v1.MsgUpdateParams")).toBe(true);
+    expect(isAep86MessageType("/akash.provider.v1beta4.MsgUpdateParams")).toBe(false);
+    expect(isAep86MessageType("MsgUpdateParams")).toBe(false);
+  });
+});
+
+describe("AEP-86 record formatting", () => {
+  it("formats tiers, capabilities, booleans, and field labels", () => {
+    expect(formatAep86Scalar("verification_tier_established")).toBe("L3");
+    expect(formatAep86Scalar("capability_persistent_storage")).toBe("Persistent Storage");
+    expect(formatAep86Scalar(true)).toBe("Yes");
+    expect(getAep86FieldLabel("audit_escrow_id")).toBe("Audit Escrow ID");
+  });
+
+  it("builds a readable attestation view without losing hashes or coin denominations", () => {
+    expect(
+      toAep86DisplayFields({
+        provider: "akash1provider",
+        tier: "verification_tier_identified",
+        capabilities: ["capability_persistent_storage"],
+        evidenceHash: "evidence-base64",
+        fee: { amount: "10000000", denom: "uakt" },
+        slashAuditorA: false
+      })
+    ).toEqual([
+      { key: "provider", kind: "address", label: "Provider", value: "akash1provider" },
+      { key: "tier", kind: "text", label: "Tier", value: "L1" },
+      { key: "capabilities", kind: "text", label: "Capabilities", value: "Persistent Storage" },
+      { key: "evidenceHash", kind: "text", label: "Evidence Hash", value: "evidence-base64" },
+      { key: "fee", kind: "text", label: "Fee", value: "10000000 uakt" },
+      { key: "slashAuditorA", kind: "text", label: "Slash Auditor A", value: "No" }
+    ]);
+  });
+
+  it("formats provider maintenance event fields", () => {
+    expect(
+      toAep86DisplayFields({
+        maintenanceId: "7",
+        provider: "akash1provider",
+        maintenanceType: "provider_maintenance_type_security",
+        startsAt: "2026-08-24T10:00:00Z"
+      })
+    ).toEqual([
+      { key: "maintenanceId", kind: "text", label: "Maintenance ID", value: "7" },
+      { key: "provider", kind: "address", label: "Provider", value: "akash1provider" },
+      { key: "maintenanceType", kind: "text", label: "Maintenance Type", value: "Security" },
+      { key: "startsAt", kind: "text", label: "Starts At", value: "2026-08-24T10:00:00Z" }
+    ]);
+  });
+});

--- a/apps/stats-web/src/components/transactions/akash/aep86/aep86Types.ts
+++ b/apps/stats-web/src/components/transactions/akash/aep86/aep86Types.ts
@@ -1,0 +1,78 @@
+const VERIFICATION_TYPE_PREFIX = "/akash.verification.v1.";
+const PROVIDER_TYPE_PREFIX = "/akash.provider.v1beta4.";
+
+export const AEP86_MESSAGE_TYPE_URLS = [
+  `${VERIFICATION_TYPE_PREFIX}MsgPostAuditorBond`,
+  `${VERIFICATION_TYPE_PREFIX}MsgSubmitAttestation`,
+  `${VERIFICATION_TYPE_PREFIX}MsgOpenAuditEscrow`,
+  `${VERIFICATION_TYPE_PREFIX}MsgCancelAuditEscrow`,
+  `${VERIFICATION_TYPE_PREFIX}MsgSettleAuditEscrow`,
+  `${VERIFICATION_TYPE_PREFIX}MsgRevokeAttestation`,
+  `${VERIFICATION_TYPE_PREFIX}MsgRemoveAttestation`,
+  `${VERIFICATION_TYPE_PREFIX}MsgResignAuditor`,
+  `${VERIFICATION_TYPE_PREFIX}MsgPostProviderBond`,
+  `${VERIFICATION_TYPE_PREFIX}MsgWithdrawProviderBond`,
+  `${VERIFICATION_TYPE_PREFIX}MsgPostSnapshotHash`,
+  `${VERIFICATION_TYPE_PREFIX}MsgRegisterAuditor`,
+  `${VERIFICATION_TYPE_PREFIX}MsgRenewAuditor`,
+  `${VERIFICATION_TYPE_PREFIX}MsgRemoveAuditor`,
+  `${VERIFICATION_TYPE_PREFIX}MsgRevokeProviderAttestation`,
+  `${VERIFICATION_TYPE_PREFIX}MsgRevokeAllProviderAttestations`,
+  `${VERIFICATION_TYPE_PREFIX}MsgRevokeAuditorAttestations`,
+  `${VERIFICATION_TYPE_PREFIX}MsgResolveDiscrepancy`,
+  `${VERIFICATION_TYPE_PREFIX}MsgSlashProviderBond`,
+  `${VERIFICATION_TYPE_PREFIX}MsgUpdateParams`,
+  `${PROVIDER_TYPE_PREFIX}MsgOpenProviderMaintenance`,
+  `${PROVIDER_TYPE_PREFIX}MsgCloseProviderMaintenance`
+] as const;
+
+export const AEP86_EVENT_TYPE_URLS = [
+  `${VERIFICATION_TYPE_PREFIX}EventAuditorRegistered`,
+  `${VERIFICATION_TYPE_PREFIX}EventAuditorBondPosted`,
+  `${VERIFICATION_TYPE_PREFIX}EventAuditorFrozen`,
+  `${VERIFICATION_TYPE_PREFIX}EventAuditorLapsed`,
+  `${VERIFICATION_TYPE_PREFIX}EventAuditorResigned`,
+  `${VERIFICATION_TYPE_PREFIX}EventAuditorRemoved`,
+  `${VERIFICATION_TYPE_PREFIX}EventAuditorRenewed`,
+  `${VERIFICATION_TYPE_PREFIX}EventAttestationSubmitted`,
+  `${VERIFICATION_TYPE_PREFIX}EventAttestationExpired`,
+  `${VERIFICATION_TYPE_PREFIX}EventAttestationReplaced`,
+  `${VERIFICATION_TYPE_PREFIX}EventAttestationRevoked`,
+  `${VERIFICATION_TYPE_PREFIX}EventAttestationVoided`,
+  `${VERIFICATION_TYPE_PREFIX}EventDiscrepancyDetected`,
+  `${VERIFICATION_TYPE_PREFIX}EventDiscrepancyResolved`,
+  `${VERIFICATION_TYPE_PREFIX}EventDiscrepancyTimedOut`,
+  `${VERIFICATION_TYPE_PREFIX}EventProviderBondPosted`,
+  `${VERIFICATION_TYPE_PREFIX}EventProviderBondSlashed`,
+  `${VERIFICATION_TYPE_PREFIX}EventProviderBondWithdrawalInitiated`,
+  `${VERIFICATION_TYPE_PREFIX}EventProviderBondWithdrawalCompleted`,
+  `${VERIFICATION_TYPE_PREFIX}EventSnapshotHashPosted`,
+  `${VERIFICATION_TYPE_PREFIX}EventSnapshotSuspended`,
+  `${VERIFICATION_TYPE_PREFIX}EventSnapshotResumed`,
+  `${VERIFICATION_TYPE_PREFIX}EventFeeEscrowed`,
+  `${VERIFICATION_TYPE_PREFIX}EventFeeReleasedToAuditor`,
+  `${VERIFICATION_TYPE_PREFIX}EventFeeReturnedToProvider`,
+  `${VERIFICATION_TYPE_PREFIX}EventAuditEscrowOpened`,
+  `${VERIFICATION_TYPE_PREFIX}EventAuditEscrowSettled`,
+  `${VERIFICATION_TYPE_PREFIX}EventDepositReturnedToAuditor`,
+  `${VERIFICATION_TYPE_PREFIX}EventDepositSlashed`,
+  `${VERIFICATION_TYPE_PREFIX}EventVerificationGraceStarted`,
+  `${VERIFICATION_TYPE_PREFIX}EventVerificationGraceEnded`,
+  `${PROVIDER_TYPE_PREFIX}EventProviderMaintenanceOpened`,
+  `${PROVIDER_TYPE_PREFIX}EventProviderMaintenanceClosed`
+] as const;
+
+const messageTypeUrls = new Set<string>(AEP86_MESSAGE_TYPE_URLS);
+const eventTypeUrls = new Set<string>(AEP86_EVENT_TYPE_URLS);
+
+function normalizeTypeUrl(typeUrl: string): string {
+  return typeUrl.startsWith("/") ? typeUrl : `/${typeUrl}`;
+}
+
+export function isAep86MessageType(typeUrl: string): boolean {
+  return messageTypeUrls.has(normalizeTypeUrl(typeUrl));
+}
+
+export function isAep86EventType(typeUrl: string): boolean {
+  return eventTypeUrls.has(normalizeTypeUrl(typeUrl));
+}

--- a/apps/stats-web/src/hooks/useFriendlyMessageType.spec.ts
+++ b/apps/stats-web/src/hooks/useFriendlyMessageType.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { useFriendlyMessageType } from "./useFriendlyMessageType";
+
+describe("useFriendlyMessageType", () => {
+  it("formats full message type URLs", () => {
+    expect(useFriendlyMessageType("/akash.verification.v1.MsgSubmitAttestation")).toBe("Submit Attestation");
+  });
+
+  it("formats typed events without leaving the Event prefix behind", () => {
+    expect(useFriendlyMessageType("akash.provider.v1beta4.EventProviderMaintenanceOpened")).toBe("Provider Maintenance Opened");
+  });
+
+  it("preserves existing unprefixed names", () => {
+    expect(useFriendlyMessageType("akash.market.v1.LeaseClosed")).toBe("Lease Closed");
+  });
+});

--- a/apps/stats-web/src/hooks/useFriendlyMessageType.ts
+++ b/apps/stats-web/src/hooks/useFriendlyMessageType.ts
@@ -2,11 +2,6 @@ export const useFriendlyMessageType = (type: string) => {
   if (!type) return "";
 
   const splittedType = type.split(".");
-  const msgType = splittedType[splittedType.length - 1];
-  const friendlyMessageType = msgType
-    .substring(3) // Remove "Msg"
-    .split(/(?=[A-Z])/)
-    .join(" ");
-
-  return friendlyMessageType;
+  const messageType = splittedType[splittedType.length - 1].replace(/^(Msg|Event)/, "");
+  return messageType.split(/(?=[A-Z])/).join(" ");
 };

--- a/apps/tx-signer/package.json
+++ b/apps/tx-signer/package.json
@@ -21,7 +21,7 @@
     "test:unit": "vitest run --project unit"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",
     "@akashnetwork/instrumentation": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akash-api": "1.4.3",
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/console-api-types": "*",
         "@akashnetwork/database": "*",
         "@akashnetwork/env-loader": "*",
@@ -542,7 +542,7 @@
       "version": "3.31.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/console-api-types": "*",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
@@ -2168,7 +2168,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akash-api": "1.4.3",
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/database": "*",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/instrumentation": "*",
@@ -2558,7 +2558,7 @@
       "version": "2.16.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
         "@akashnetwork/instrumentation": "*",
@@ -3701,7 +3701,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/instrumentation": "*",
         "@akashnetwork/logging": "*",
@@ -4041,7 +4041,7 @@
       "version": "2.10.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/instrumentation": "*",
         "@akashnetwork/logging": "*",
@@ -4218,7 +4218,7 @@
       "name": "@akashnetwork/stats-web",
       "version": "1.14.1",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/logging": "*",
         "@akashnetwork/network-store": "*",
@@ -4982,7 +4982,7 @@
       "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
         "@akashnetwork/instrumentation": "*",
@@ -5473,9 +5473,9 @@
       }
     },
     "node_modules/@akashnetwork/chain-sdk": {
-      "version": "1.0.0-alpha.41",
-      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.41.tgz",
-      "integrity": "sha512-mr3fGDBSISxl0eZF83+IJLVulGSuJVu+MRj6fG61pi2rgfgnv9QEKpdU3w7wtFFt5saJaJNgsqAlyjGZQecZ1A==",
+      "version": "1.0.0-alpha.43",
+      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.43.tgz",
+      "integrity": "sha512-+XTgpLn3kibMEWBAOkfmOGo2VJcv+VtT5Uvq966Nk5YMyD9HCYUvdDLm1k167Di1S11t66SH06BhoY1M/m2IWg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.12.0",
@@ -45932,7 +45932,7 @@
       "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
         "@akashnetwork/net": "*",
         "jotai": "^2.9.2"
       },

--- a/packages/network-store/package.json
+++ b/packages/network-store/package.json
@@ -18,7 +18,7 @@
     "validate:types": "tsc --noEmit && echo"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.43",
     "@akashnetwork/net": "*",
     "jotai": "^2.9.2"
   },


### PR DESCRIPTION
## Why

Part of CON-800.

AEP-86 transactions and typed events should be readable in Stats without asking
reviewers or operators to decode raw protobuf JSON.

## What

- recognize all 22 verification and maintenance transaction messages
- recognize all 33 verification and maintenance typed events
- render addresses, tiers, capabilities, coins, hashes, and nested records
- format both message and event names consistently
- preserve the existing generic JSON fallback for unrelated transaction types

## Dependencies

- #3713 supplies the AEP-86 TypeScript SDK contract and type URLs

The registry was checked against the current verification and provider proto
surfaces; response messages and unrelated provider CRUD are intentionally absent.