### PR TITLE
fix(deployment): meter the runtime limit instead of packing it into one string

### DIFF
--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.spec.tsx
@@ -71,31 +71,50 @@ describe("DeploymentDetailHeader", () => {
     expect(screen.getByText("Off")).toBeInTheDocument();
   });
 
-  it("shows the runtime limit tile when the deployment has one", () => {
+  it("shows the limit alone, with no meter, before the countdown is anchored to a lease", () => {
     setup({ runtimeLimitHours: 12 });
 
     expect(screen.getByText("RUNTIME LIMIT")).toBeInTheDocument();
     expect(screen.getByText("12h")).toBeInTheDocument();
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
   });
 
-  it("keeps the remaining-time label ticking as time passes, without any query refetch", async () => {
+  it("keeps the remaining time and the limit it is measured against apart, rather than in one string", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-08-21T12:00:00.000Z"));
 
     try {
       setup({ runtimeLimitHours: 12, runtimeEndsAt: "2026-08-21T14:00:00.000Z" });
 
-      expect(screen.getByText("12h · 2h left")).toBeInTheDocument();
+      expect(screen.getByText("2h left")).toBeInTheDocument();
+      expect(screen.getByText("12h")).toBeInTheDocument();
+      expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuetext", "2h of 12h left");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps the remaining time and its meter draining as time passes, without any query refetch", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-21T12:00:00.000Z"));
+
+    try {
+      setup({ runtimeLimitHours: 12, runtimeEndsAt: "2026-08-21T14:00:00.000Z" });
+
+      expect(screen.getByText("2h left")).toBeInTheDocument();
+      expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "17");
 
       await act(async () => {
         await vi.advanceTimersByTimeAsync(61 * 60 * 1000);
       });
-      expect(screen.getByText("12h · 59m left")).toBeInTheDocument();
+      expect(screen.getByText("59m left")).toBeInTheDocument();
+      expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "8");
 
       await act(async () => {
         await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
       });
-      expect(screen.getByText("12h · limit reached")).toBeInTheDocument();
+      expect(screen.getByText("Limit reached")).toBeInTheDocument();
+      expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "0");
     } finally {
       vi.useRealTimers();
     }

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.tsx
@@ -23,7 +23,7 @@ import type { DeploymentDto, LeaseDto } from "@src/types/deployment";
 import type { ApiProviderList } from "@src/types/provider";
 import { isLeaseLive } from "@src/utils/leaseUtils";
 import { roundDecimal, udenomToDenom } from "@src/utils/mathHelpers";
-import { formatRuntimeLimit } from "@src/utils/runtimeLimitUtils";
+import { getRuntimeLimitCountdown } from "@src/utils/runtimeLimitUtils";
 import { formatByteSize } from "@src/utils/unitUtils";
 import {
   countPlacementServices,
@@ -34,6 +34,7 @@ import {
 } from "./DeploymentPlacements/placementModel";
 import { DeploymentVisitControl } from "./DeploymentVisitControl/DeploymentVisitControl";
 import { DeploymentStatusBadge } from "./DeploymentStatusBadge";
+import { RuntimeLimitMeter } from "./RuntimeLimitMeter";
 
 export const DEPENDENCIES = {
   useLocalNotes,
@@ -82,6 +83,7 @@ export const DeploymentDetailHeader: FC<DeploymentDetailHeaderProps> = ({ deploy
 
   const runtimeEndsAt = settings?.runtimeEndsAt ?? null;
   const now = useTickingNow(!!runtimeEndsAt);
+  const runtimeLimitCountdown = settings?.runtimeLimitHours ? getRuntimeLimitCountdown(settings.runtimeLimitHours, runtimeEndsAt, now) : null;
 
   const storedDeployment = getDeploymentData(deployment.dseq);
   const storedManifest = storedDeployment?.manifest;
@@ -138,7 +140,7 @@ export const DeploymentDetailHeader: FC<DeploymentDetailHeaderProps> = ({ deploy
                 <d.PriceValue denom={denom} value={udenomToDenom(balanceUdenom, 6)} />
               </SummaryItem>
             )}
-            {settings?.runtimeLimitHours ? (
+            {runtimeLimitCountdown ? (
               <SummaryItem
                 label={
                   <span className="inline-flex items-center gap-1">
@@ -149,7 +151,15 @@ export const DeploymentDetailHeader: FC<DeploymentDetailHeaderProps> = ({ deploy
                   </span>
                 }
               >
-                {formatRuntimeLimit(settings.runtimeLimitHours, runtimeEndsAt, now)}
+                <div className="min-w-24 space-y-1.5">
+                  <div className="flex items-baseline justify-between gap-2">
+                    <span>{runtimeLimitCountdown.remainingLabel}</span>
+                    {runtimeLimitCountdown.status !== "unanchored" && (
+                      <span className="text-xs font-normal text-muted-foreground">{runtimeLimitCountdown.limitLabel}</span>
+                    )}
+                  </div>
+                  <RuntimeLimitMeter countdown={runtimeLimitCountdown} />
+                </div>
               </SummaryItem>
             ) : (
               !isEscrowAbstracted && (

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentBillingSection.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentBillingSection.spec.tsx
@@ -52,10 +52,20 @@ describe("DeploymentBillingSection", () => {
       expect(screen.queryByRole("switch", { name: "Auto Top-Up" })).not.toBeInTheDocument();
     });
 
-    it("shows the limit and its countdown under the balance", () => {
+    it("shows the limit alone, with no meter, before the countdown is anchored to a lease", () => {
       setup({ state: "active", runtimeLimitHours: 12, runtimeEndsAt: null });
 
-      expect(screen.getByText("Runtime limit: 12h")).toBeInTheDocument();
+      expect(screen.getByText("12h")).toBeInTheDocument();
+      expect(screen.getByText("runtime limit")).toBeInTheDocument();
+      expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+    });
+
+    it("meters the remaining time against the limit once the countdown is anchored", () => {
+      setup({ state: "active", runtimeLimitHours: 1, runtimeEndsAt: "2026-08-21T12:36:00.000Z" });
+
+      expect(screen.getByText("36m left")).toBeInTheDocument();
+      expect(screen.getByText("of 1h limit")).toBeInTheDocument();
+      expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "60");
     });
 
     it("sends the new total when hours are added", async () => {
@@ -143,7 +153,7 @@ describe("DeploymentBillingSection", () => {
     it("keeps the runtime-limit controls on a limited deployment while hiding the balance", () => {
       setup({ state: "active", runtimeLimitHours: 12, isEscrowAbstracted: true });
 
-      expect(screen.getByText("Runtime limit: 12h")).toBeInTheDocument();
+      expect(screen.getByText("12h")).toBeInTheDocument();
       expect(screen.getByRole("button", { name: "Add hours" })).toBeInTheDocument();
       expect(screen.getByRole("button", { name: "Switch to always on" })).toBeInTheDocument();
       expect(screen.queryByText("Current balance")).not.toBeInTheDocument();

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentBillingSection.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentBillingSection.tsx
@@ -3,6 +3,7 @@ import type { FC } from "react";
 import { useCallback, useState } from "react";
 import { Button, CustomTooltip, Snackbar, Spinner, Switch } from "@akashnetwork/ui/components";
 import { usePopup } from "@akashnetwork/ui/context";
+import { cn } from "@akashnetwork/ui/utils";
 import formatDuration from "date-fns/formatDuration";
 import intervalToDuration from "date-fns/intervalToDuration";
 import { InfoCircle } from "iconoir-react";
@@ -21,8 +22,9 @@ import type { AppError } from "@src/types";
 import type { DeploymentDto, LeaseDto } from "@src/types/deployment";
 import { extractErrorMessage } from "@src/utils/errorUtils";
 import { udenomToDenom } from "@src/utils/mathHelpers";
-import { formatRuntimeLimit } from "@src/utils/runtimeLimitUtils";
+import { getRuntimeLimitCountdown } from "@src/utils/runtimeLimitUtils";
 import { DeploymentDepositModal } from "../../DeploymentDepositModal/DeploymentDepositModal";
+import { RuntimeLimitMeter } from "../RuntimeLimitMeter";
 import { AddRuntimeHoursModal } from "./AddRuntimeHoursModal";
 
 export const DEPENDENCIES = {
@@ -73,6 +75,7 @@ export const DeploymentBillingSection: FC<DeploymentBillingSectionProps> = ({ de
 
   const isRuntimeLimited = !!runtimeLimitHours;
   const now = d.useTickingNow(!!runtimeEndsAt);
+  const runtimeLimitCountdown = runtimeLimitHours ? getRuntimeLimitCountdown(runtimeLimitHours, runtimeEndsAt, now) : null;
 
   const openDepositModal = useCallback(() => {
     setIsDepositing(true);
@@ -142,7 +145,7 @@ export const DeploymentBillingSection: FC<DeploymentBillingSectionProps> = ({ de
   return (
     <div className="rounded-xl border bg-card p-6">
       <div className="flex flex-wrap items-center justify-between gap-4">
-        <div className="space-y-1">
+        <div className="min-w-0 flex-1 space-y-1 sm:max-w-sm">
           {!isEscrowAbstracted && (
             <>
               <div className="text-xs uppercase tracking-wide text-muted-foreground">Current balance</div>
@@ -151,7 +154,15 @@ export const DeploymentBillingSection: FC<DeploymentBillingSectionProps> = ({ de
               </div>
             </>
           )}
-          {isRuntimeLimited && <div className="text-sm text-muted-foreground">Runtime limit: {formatRuntimeLimit(runtimeLimitHours, runtimeEndsAt, now)}</div>}
+          {runtimeLimitCountdown && (
+            <div className="space-y-1.5 pt-1">
+              <div className={cn("flex items-baseline gap-2", runtimeLimitCountdown.status !== "unanchored" && "justify-between")}>
+                <span className="text-sm font-semibold">{runtimeLimitCountdown.remainingLabel}</span>
+                <span className="text-xs text-muted-foreground">{runtimeLimitCountdown.captionLabel}</span>
+              </div>
+              <RuntimeLimitMeter countdown={runtimeLimitCountdown} />
+            </div>
+          )}
         </div>
         {isActive && (isRuntimeLimited || !isEscrowAbstracted) && (
           <Button variant="outline" size="md" onClick={isRuntimeLimited ? openAddHoursModal : openDepositModal}>

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/RuntimeLimitMeter.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/RuntimeLimitMeter.spec.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { getRuntimeLimitCountdown } from "@src/utils/runtimeLimitUtils";
+import { RuntimeLimitMeter } from "./RuntimeLimitMeter";
+
+import { render, screen } from "@testing-library/react";
+
+const NOW = Date.parse("2026-08-21T12:00:00.000Z");
+
+describe("RuntimeLimitMeter", () => {
+  it("renders nothing until the countdown is anchored to a lease", () => {
+    setup({ runtimeLimitHours: 12, runtimeEndsAt: null });
+
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+  });
+
+  it("fills to the share of the limit that is left", () => {
+    setup({ runtimeLimitHours: 12, runtimeEndsAt: "2026-08-21T15:00:00.000Z" });
+
+    expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "25");
+  });
+
+  it("announces both the remaining time and the limit it is measured against", () => {
+    setup({ runtimeLimitHours: 1, runtimeEndsAt: "2026-08-21T12:36:00.000Z" });
+
+    expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuetext", "36m of 1h left");
+  });
+
+  it("empties once the limit is reached", () => {
+    setup({ runtimeLimitHours: 1, runtimeEndsAt: "2026-08-21T11:00:00.000Z" });
+
+    expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "0");
+  });
+
+  function setup(input: { runtimeLimitHours: number; runtimeEndsAt: string | null }) {
+    const countdown = getRuntimeLimitCountdown(input.runtimeLimitHours, input.runtimeEndsAt, NOW);
+    render(<RuntimeLimitMeter countdown={countdown} />);
+    return { countdown };
+  }
+});

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/RuntimeLimitMeter.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/RuntimeLimitMeter.tsx
@@ -1,0 +1,31 @@
+"use client";
+import type { FC } from "react";
+import { Progress } from "@akashnetwork/ui/components";
+import { cn } from "@akashnetwork/ui/utils";
+
+import type { RuntimeLimitCountdown } from "@src/utils/runtimeLimitUtils";
+
+export interface RuntimeLimitMeterProps {
+  countdown: RuntimeLimitCountdown;
+  className?: string;
+}
+
+/**
+ * The remaining share of a runtime limit as a slim bar: the track is the limit the user bought and the fill is
+ * what is left of it, so the two quantities read as container and portion instead of as two durations.
+ *
+ * Renders nothing until the countdown is anchored — a deployment whose lease has not started has no elapsed
+ * time to show, and a full bar would claim otherwise. That decision lives here so no caller repeats it.
+ */
+export const RuntimeLimitMeter: FC<RuntimeLimitMeterProps> = ({ countdown, className }) => {
+  if (countdown.status === "unanchored") return null;
+
+  return (
+    <Progress
+      value={countdown.percentRemaining}
+      getValueLabel={() => countdown.accessibleLabel}
+      aria-label={`Runtime remaining: ${countdown.accessibleLabel}`}
+      className={cn("h-1", className)}
+    />
+  );
+};

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/RuntimeLimitMeter.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/RuntimeLimitMeter.tsx
@@ -10,13 +10,7 @@ export interface RuntimeLimitMeterProps {
   className?: string;
 }
 
-/**
- * The remaining share of a runtime limit as a slim bar: the track is the limit the user bought and the fill is
- * what is left of it, so the two quantities read as container and portion instead of as two durations.
- *
- * Renders nothing until the countdown is anchored — a deployment whose lease has not started has no elapsed
- * time to show, and a full bar would claim otherwise. That decision lives here so no caller repeats it.
- */
+/** Renders nothing while the countdown is unanchored, where a full bar would claim elapsed time the lease has not started spending. */
 export const RuntimeLimitMeter: FC<RuntimeLimitMeterProps> = ({ countdown, className }) => {
   if (countdown.status === "unanchored") return null;
 

--- a/apps/deploy-web/src/utils/runtimeLimitUtils.spec.ts
+++ b/apps/deploy-web/src/utils/runtimeLimitUtils.spec.ts
@@ -1,64 +1,62 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
-import { formatRuntimeLimit } from "./runtimeLimitUtils";
+import { getRuntimeLimitCountdown } from "./runtimeLimitUtils";
 
-describe(formatRuntimeLimit.name, () => {
+const NOW = Date.parse("2026-08-21T12:00:00.000Z");
+
+describe(getRuntimeLimitCountdown.name, () => {
   it("shows only the limit before the countdown is anchored", () => {
-    expect(formatRuntimeLimit(12, null)).toBe("12h");
+    const countdown = getRuntimeLimitCountdown(12, null, NOW);
+
+    expect(countdown.status).toBe("unanchored");
+    expect(countdown.remainingLabel).toBe("12h");
+    expect(countdown.captionLabel).toBe("runtime limit");
   });
 
-  it("shows whole hours remaining when the deadline lands on the hour", () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-08-21T12:00:00.000Z"));
+  it("measures the remaining share against the granted limit", () => {
+    const countdown = getRuntimeLimitCountdown(12, "2026-08-21T18:00:00.000Z", NOW);
 
-    try {
-      expect(formatRuntimeLimit(12, "2026-08-21T17:00:00.000Z")).toBe("12h · 5h left");
-    } finally {
-      vi.useRealTimers();
-    }
+    expect(countdown.status).toBe("running");
+    expect(countdown.remainingLabel).toBe("6h left");
+    expect(countdown.captionLabel).toBe("of 12h limit");
+    expect(countdown.accessibleLabel).toBe("6h of 12h left");
+    expect(countdown.percentRemaining).toBe(50);
   });
 
   it("adds the minutes when the remaining time is not a whole number of hours", () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-08-21T12:00:00.000Z"));
-
-    try {
-      expect(formatRuntimeLimit(12, "2026-08-21T14:10:00.000Z")).toBe("12h · 2h 10m left");
-    } finally {
-      vi.useRealTimers();
-    }
+    expect(getRuntimeLimitCountdown(12, "2026-08-21T14:10:00.000Z", NOW).remainingLabel).toBe("2h 10m left");
   });
 
   it("counts in minutes alone once under an hour remains", () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-08-21T12:00:00.000Z"));
-
-    try {
-      expect(formatRuntimeLimit(12, "2026-08-21T12:45:00.000Z")).toBe("12h · 45m left");
-    } finally {
-      vi.useRealTimers();
-    }
+    expect(getRuntimeLimitCountdown(1, "2026-08-21T12:36:00.000Z", NOW).remainingLabel).toBe("36m left");
   });
 
-  it("still reads a full minute through the final seconds", () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-08-21T12:00:00.000Z"));
+  it("keeps the meter visible through the final seconds, alongside a full-minute reading", () => {
+    const countdown = getRuntimeLimitCountdown(12, "2026-08-21T12:00:01.000Z", NOW);
 
-    try {
-      expect(formatRuntimeLimit(12, "2026-08-21T12:00:01.000Z")).toBe("12h · 1m left");
-    } finally {
-      vi.useRealTimers();
-    }
+    expect(countdown.remainingLabel).toBe("1m left");
+    expect(countdown.percentRemaining).toBe(1);
   });
 
   it("marks the limit as reached once the deadline passes", () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-08-21T12:00:00.000Z"));
+    const countdown = getRuntimeLimitCountdown(12, "2026-08-21T11:00:00.000Z", NOW);
 
-    try {
-      expect(formatRuntimeLimit(12, "2026-08-21T11:00:00.000Z")).toBe("12h · limit reached");
-    } finally {
-      vi.useRealTimers();
-    }
+    expect(countdown.status).toBe("reached");
+    expect(countdown.remainingLabel).toBe("Limit reached");
+    expect(countdown.captionLabel).toBe("12h limit");
+    expect(countdown.accessibleLabel).toBe("12h limit reached");
+    expect(countdown.percentRemaining).toBe(0);
+  });
+
+  it("caps the meter when the deadline sits further out than the limit allows", () => {
+    expect(getRuntimeLimitCountdown(1, "2026-08-21T20:00:00.000Z", NOW).percentRemaining).toBe(100);
+  });
+
+  it("keeps the meter finite when the limit itself is zero", () => {
+    expect(getRuntimeLimitCountdown(0, "2026-08-21T13:00:00.000Z", NOW).percentRemaining).toBe(100);
+  });
+
+  it("treats an unparseable deadline as unanchored rather than reached", () => {
+    expect(getRuntimeLimitCountdown(12, "not-a-date", NOW).status).toBe("unanchored");
   });
 });

--- a/apps/deploy-web/src/utils/runtimeLimitUtils.ts
+++ b/apps/deploy-web/src/utils/runtimeLimitUtils.ts
@@ -10,17 +10,13 @@ export const MAX_RUNTIME_LIMIT_HOURS = 8760;
 export type RuntimeLimitStatus = "unanchored" | "running" | "reached";
 
 export type RuntimeLimitCountdown = {
-  /** `unanchored` until the lease starts and the deadline exists; `reached` once it has passed. */
   status: RuntimeLimitStatus;
-  /** The granted total, e.g. "12h". */
   limitLabel: string;
-  /** How much of the limit is left, e.g. "2h 10m left"; the total alone while unanchored. */
   remainingLabel: string;
-  /** What the remaining time is measured against, phrased to sit under it, e.g. "of 12h limit". */
+  /** Names what the remaining time is measured against, e.g. "of 12h limit". */
   captionLabel: string;
-  /** Both quantities spelled out for screen readers, e.g. "2h 10m of 12h left". */
+  /** Spells out both quantities for screen readers, e.g. "2h 10m of 12h left". */
   accessibleLabel: string;
-  /** Share of the limit still unspent, 0-100, for the meter. */
   percentRemaining: number;
 };
 
@@ -28,24 +24,7 @@ const MILLISECONDS_PER_MINUTE = 60 * 1000;
 const MINUTES_PER_HOUR = 60;
 const MILLISECONDS_PER_HOUR = MINUTES_PER_HOUR * MILLISECONDS_PER_MINUTE;
 
-/**
- * What the deployment detail page shows for a runtime limit: the remaining time, the granted total, and the
- * share of the total still unspent. The two quantities are kept apart on purpose — rendered as one string
- * ("1h · 36m left") a total and a remainder read as a single duration.
- *
- * The share is derived rather than measured: no start timestamp is stored, so the denominator is the granted
- * limit itself and the implied start is `runtimeEndsAt - runtimeLimitHours`. Adding hours moves both
- * endpoints together, so the meter refills by exactly what was bought. The labels stay exact regardless.
- *
- * The wall clock is read through the `now` parameter rather than `Date.now()` directly. That keeps the output
- * deterministic in tests and lets callers stay fresh on pages that never refetch by passing a ticking clock
- * (`useTickingNow`) — without one, the countdown would freeze at first render.
- *
- * @param runtimeLimitHours The limit the user requested, shown as-is (e.g. "12h").
- * @param runtimeEndsAt When the deployment is closed automatically, ISO-encoded; null while the countdown is
- * unanchored, in which case only the limit itself can be shown.
- * @param now The instant to measure remaining time against; defaults to the real present.
- */
+/** The remaining share is measured against the granted limit itself, since no lease-start timestamp is stored. */
 export function getRuntimeLimitCountdown(runtimeLimitHours: number, runtimeEndsAt: string | null, now: number = Date.now()): RuntimeLimitCountdown {
   const limitLabel = `${runtimeLimitHours}h`;
   const deadline = runtimeEndsAt ? new Date(runtimeEndsAt).getTime() : NaN;
@@ -101,11 +80,7 @@ function formatTimeRemaining(milliseconds: number): string {
   return `${hours}h ${minutes}m`;
 }
 
-/**
- * Floored at one percent so a bar whose label still claims "1m left" never reads as empty, and capped at a
- * hundred so a deadline further out than the limit — a limit shortened after the fact, or clock skew — cannot
- * overflow the track.
- */
+/** Clamped to 1-100 so a limit still counting down never reads as empty and a deadline beyond the limit never overflows the track. */
 function toPercentRemaining(millisecondsRemaining: number, runtimeLimitHours: number): number {
   const limitMilliseconds = runtimeLimitHours * MILLISECONDS_PER_HOUR;
   if (limitMilliseconds <= 0) return 100;

--- a/apps/deploy-web/src/utils/runtimeLimitUtils.ts
+++ b/apps/deploy-web/src/utils/runtimeLimitUtils.ts
@@ -7,34 +7,84 @@ export const MAX_RUNTIME_LIMIT_INCREMENT_HOURS = 48;
 /** Ceiling on a runtime limit's total, reachable only by repeated extensions. Mirrors the API's cap. */
 export const MAX_RUNTIME_LIMIT_HOURS = 8760;
 
-/**
- * The runtime-limit tile's value: the requested hours, plus how long remains once the countdown is
- * anchored (it anchors when the lease starts, so a not-yet-leased deployment shows only the hours).
- *
- * The wall clock is read through the `now` parameter rather than `Date.now()` directly. That keeps the
- * output deterministic under fake timers in tests and lets callers stay fresh on pages that never refetch
- * by passing a ticking clock (`useTickingNow`) — without one, the "2h 10m left" / "limit reached" verdict
- * would freeze at first render.
- *
- * @param runtimeLimitHours The limit the user requested, shown as-is (e.g. "12h").
- * @param runtimeEndsAt When the deployment is closed automatically, ISO-encoded; null while the countdown
- * is unanchored, in which case only the limit itself is shown.
- * @param now The instant to measure remaining time against; defaults to the real present.
- */
-export function formatRuntimeLimit(runtimeLimitHours: number, runtimeEndsAt: string | null, now: number = Date.now()): string {
-  const limit = `${runtimeLimitHours}h`;
-  if (!runtimeEndsAt) {
-    return limit;
-  }
-  const millisecondsRemaining = new Date(runtimeEndsAt).getTime() - now;
-  if (millisecondsRemaining <= 0) {
-    return `${limit} · limit reached`;
-  }
-  return `${limit} · ${formatTimeRemaining(millisecondsRemaining)} left`;
-}
+export type RuntimeLimitStatus = "unanchored" | "running" | "reached";
+
+export type RuntimeLimitCountdown = {
+  /** `unanchored` until the lease starts and the deadline exists; `reached` once it has passed. */
+  status: RuntimeLimitStatus;
+  /** The granted total, e.g. "12h". */
+  limitLabel: string;
+  /** How much of the limit is left, e.g. "2h 10m left"; the total alone while unanchored. */
+  remainingLabel: string;
+  /** What the remaining time is measured against, phrased to sit under it, e.g. "of 12h limit". */
+  captionLabel: string;
+  /** Both quantities spelled out for screen readers, e.g. "2h 10m of 12h left". */
+  accessibleLabel: string;
+  /** Share of the limit still unspent, 0-100, for the meter. */
+  percentRemaining: number;
+};
 
 const MILLISECONDS_PER_MINUTE = 60 * 1000;
 const MINUTES_PER_HOUR = 60;
+const MILLISECONDS_PER_HOUR = MINUTES_PER_HOUR * MILLISECONDS_PER_MINUTE;
+
+/**
+ * What the deployment detail page shows for a runtime limit: the remaining time, the granted total, and the
+ * share of the total still unspent. The two quantities are kept apart on purpose — rendered as one string
+ * ("1h · 36m left") a total and a remainder read as a single duration.
+ *
+ * The share is derived rather than measured: no start timestamp is stored, so the denominator is the granted
+ * limit itself and the implied start is `runtimeEndsAt - runtimeLimitHours`. Adding hours moves both
+ * endpoints together, so the meter refills by exactly what was bought. The labels stay exact regardless.
+ *
+ * The wall clock is read through the `now` parameter rather than `Date.now()` directly. That keeps the output
+ * deterministic in tests and lets callers stay fresh on pages that never refetch by passing a ticking clock
+ * (`useTickingNow`) — without one, the countdown would freeze at first render.
+ *
+ * @param runtimeLimitHours The limit the user requested, shown as-is (e.g. "12h").
+ * @param runtimeEndsAt When the deployment is closed automatically, ISO-encoded; null while the countdown is
+ * unanchored, in which case only the limit itself can be shown.
+ * @param now The instant to measure remaining time against; defaults to the real present.
+ */
+export function getRuntimeLimitCountdown(runtimeLimitHours: number, runtimeEndsAt: string | null, now: number = Date.now()): RuntimeLimitCountdown {
+  const limitLabel = `${runtimeLimitHours}h`;
+  const deadline = runtimeEndsAt ? new Date(runtimeEndsAt).getTime() : NaN;
+
+  if (!Number.isFinite(deadline)) {
+    return {
+      status: "unanchored",
+      limitLabel,
+      remainingLabel: limitLabel,
+      captionLabel: "runtime limit",
+      accessibleLabel: `${limitLabel} limit, not started`,
+      percentRemaining: 100
+    };
+  }
+
+  const millisecondsRemaining = deadline - now;
+
+  if (millisecondsRemaining <= 0) {
+    return {
+      status: "reached",
+      limitLabel,
+      remainingLabel: "Limit reached",
+      captionLabel: `${limitLabel} limit`,
+      accessibleLabel: `${limitLabel} limit reached`,
+      percentRemaining: 0
+    };
+  }
+
+  const remainingLabel = formatTimeRemaining(millisecondsRemaining);
+
+  return {
+    status: "running",
+    limitLabel,
+    remainingLabel: `${remainingLabel} left`,
+    captionLabel: `of ${limitLabel} limit`,
+    accessibleLabel: `${remainingLabel} of ${limitLabel} left`,
+    percentRemaining: toPercentRemaining(millisecondsRemaining, runtimeLimitHours)
+  };
+}
 
 /**
  * The remaining time as the coarsest honest reading: minutes alone below an hour, hours alone on the hour,
@@ -49,4 +99,15 @@ function formatTimeRemaining(milliseconds: number): string {
   if (hours === 0) return `${minutes}m`;
   if (minutes === 0) return `${hours}h`;
   return `${hours}h ${minutes}m`;
+}
+
+/**
+ * Floored at one percent so a bar whose label still claims "1m left" never reads as empty, and capped at a
+ * hundred so a deadline further out than the limit — a limit shortened after the fact, or clock skew — cannot
+ * overflow the track.
+ */
+function toPercentRemaining(millisecondsRemaining: number, runtimeLimitHours: number): number {
+  const limitMilliseconds = runtimeLimitHours * MILLISECONDS_PER_HOUR;
+  if (limitMilliseconds <= 0) return 100;
+  return Math.min(100, Math.max(1, Math.round((millisecondsRemaining / limitMilliseconds) * 100)));
 }

--- a/packages/ui/components/progress.tsx
+++ b/packages/ui/components/progress.tsx
@@ -7,7 +7,7 @@ import { cn } from "../utils";
 
 const Progress = React.forwardRef<React.ElementRef<typeof ProgressPrimitive.Root>, React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>>(
   ({ className, value, ...props }, ref) => (
-    <ProgressPrimitive.Root ref={ref} className={cn("bg-secondary relative h-4 w-full overflow-hidden rounded-full", className)} {...props}>
+    <ProgressPrimitive.Root ref={ref} value={value} className={cn("bg-secondary relative h-4 w-full overflow-hidden rounded-full", className)} {...props}>
       <ProgressPrimitive.Indicator className="bg-primary h-full w-full flex-1 transition-all" style={{ transform: `translateX(-${100 - (value || 0)}%)` }} />
     </ProgressPrimitive.Root>
   )


### PR DESCRIPTION
## Why

A runtime-limited deployment showed `1h · 36m left` on the detail page. Read quickly, that says one hour and thirty-six minutes. What it means is a one-hour limit with 36 minutes of it left, and the dot gave the reader nothing to tell the two numbers apart. Reported by me from the beta UI, no Linear issue.

While wiring up the bar I found the shared `Progress` component destructured `value` for the indicator transform and never forwarded it to the Radix root, so every progress bar in the app has been rendering as an indeterminate progressbar: right fill, no `aria-valuenow`, nothing for a screen reader to read. That is fixed in its own commit.

## What

The remaining time becomes the value, the limit sits next to it as a quiet secondary, and a slim bar drains underneath. The track is the limit you bought, the fill is what is left of it.

Header tile:

```
RUNTIME LIMIT ⓘ
36m left               1h
▓▓▓▓▓▓▓▓▓▓▓▓▓░░░░░░░░░░
```

Settings ▸ Billing:

```
36m left                    of 1h limit   [ Add hours ]
▓▓▓▓▓▓▓▓▓▓▓▓▓░░░░░░░░░░░░░░░░░░░░
```

- `formatRuntimeLimit` is replaced by `getRuntimeLimitCountdown()`, which returns the remaining label, the limit, the caption, the screen-reader label and the remaining percentage. Both call sites read from that one model.
- The percentage is derived, since no start timestamp is stored: the denominator is the granted limit and the implied start is `runtimeEndsAt - runtimeLimitHours`. It is floored at 1% so a bar whose label says "1m left" is never empty, and capped at 100% so clock skew cannot overflow the track.
- New `RuntimeLimitMeter` wraps the shared `Progress` at `h-1` and renders nothing until the lease anchors the countdown.
- Before the lease starts the row reads `12h  runtime limit`. The old copy carried that context in its "Runtime limit:" prefix, which the new layout drops.
- No warning colour when little time is left. That was a deliberate call: one neutral fill at every level.

Verified: deploy-web unit suite green (367 files, 3620 tests), `packages/ui` green, `eslint --quiet` clean, `tsc --noEmit` at the existing 92-error baseline with nothing in the touched files. I also rendered both blocks against the app's compiled Tailwind and screenshotted five states in light and dark (running with hours and minutes, running under an hour, final minute, limit reached, not yet leased); that caught a bar clipped to 96px when the text was wider, and an orphaned caption in the unanchored row.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a runtime-limit progress meter for deployments with anchored countdowns.
  * Displayed remaining runtime and total runtime limit as separate values.
  * Added accessible progress and countdown labels.
  * Added “Limit reached” status when runtime expires.

* **Bug Fixes**
  * Improved runtime-limit display before countdown anchoring and for zero or invalid limits.
  * Ensured progress accurately decreases as time passes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->