### PR TITLE
fix(dx): give background job retries a base delay so backoff is not zero

### DIFF
--- a/apps/api/src/core/services/job-queue/job-queue.service.integration.ts
+++ b/apps/api/src/core/services/job-queue/job-queue.service.integration.ts
@@ -1,0 +1,194 @@
+import { secondsToMilliseconds } from "date-fns";
+import { sql } from "drizzle-orm";
+import { PgBoss, type Queue as PgBossQueue } from "pg-boss";
+import { container } from "tsyringe";
+import { afterAll, describe, expect, it, vi } from "vitest";
+
+import type { ApiPgDatabase } from "@src/core";
+import { type EnqueueOptions, type Job, JOB_NAME, type JobHandler, JobQueueService, PG_BOSS_TOKEN, POSTGRES_DB } from "@src/core";
+import { CoreConfigService } from "@src/core/services/core-config/core-config.service";
+
+const RETRY_DELAY_IN_SECONDS = 30;
+const RETRY_DELAY_MAX_IN_SECONDS = 5 * 60;
+const RETRY_LIMIT = 5;
+
+let jobQueueReady: Promise<{ jobQueue: JobQueueService; pgBoss: PgBoss }> | undefined;
+
+/** pg-boss owns its own schema and creates it on start, so the boss this suite shares is bootstrapped once per file. */
+function bootstrapJobQueue() {
+  jobQueueReady ??= (async () => {
+    const coreConfig = container.resolve(CoreConfigService);
+    const pgBoss = new PgBoss({
+      connectionString: coreConfig.get("POSTGRES_DB_URI"),
+      schema: coreConfig.get("POSTGRES_BACKGROUND_JOBS_SCHEMA"),
+      schedule: false
+    });
+    container.registerInstance(PG_BOSS_TOKEN, pgBoss);
+
+    const jobQueue = container.resolve(JobQueueService);
+    await jobQueue.setup();
+
+    return { jobQueue, pgBoss };
+  })();
+
+  return jobQueueReady;
+}
+
+type QueueRow = {
+  name: string;
+  policy: string;
+  retry_limit: number;
+  retry_backoff: boolean;
+  retry_delay: number;
+  retry_delay_max: number | null;
+  created_on: string;
+  updated_on: string;
+};
+
+type JobRow = {
+  state: string;
+  retry_limit: number;
+  retry_backoff: boolean;
+  retry_delay: number;
+  retry_delay_max: number | null;
+  start_after: string;
+};
+
+describe(JobQueueService.name, () => {
+  afterAll(async () => {
+    if (jobQueueReady) await (await jobQueueReady).jobQueue.dispose();
+  });
+
+  it("converges a queue that pg-boss created without a base delay", async () => {
+    const { jobQueue, handler, createLegacyQueue, findQueue } = await setup({ queueName: "converging", policy: "singleton" });
+    await createLegacyQueue();
+    const before = await findQueue();
+    expect(before.retry_delay).toBe(0);
+
+    await jobQueue.registerHandlers([handler]);
+
+    const after = await findQueue();
+    expect(after).toMatchObject({
+      retry_limit: RETRY_LIMIT,
+      retry_backoff: true,
+      retry_delay: RETRY_DELAY_IN_SECONDS,
+      retry_delay_max: RETRY_DELAY_MAX_IN_SECONDS,
+      policy: "singleton"
+    });
+    expect(after.created_on).toEqual(before.created_on);
+  });
+
+  it("gives a queue it creates for the first time the same base delay", async () => {
+    const { jobQueue, handler, findQueue } = await setup({ queueName: "never-seen" });
+
+    await jobQueue.registerHandlers([handler]);
+
+    expect(await findQueue()).toMatchObject({ retry_delay: RETRY_DELAY_IN_SECONDS, retry_backoff: true });
+  });
+
+  it("stops writing to the queue once its settings match", async () => {
+    const { jobQueue, handler, createLegacyQueue, findQueue } = await setup({ queueName: "settling" });
+    await createLegacyQueue();
+    await jobQueue.registerHandlers([handler]);
+    const converged = await findQueue();
+    expect(converged.retry_delay).toBe(RETRY_DELAY_IN_SECONDS);
+
+    await jobQueue.registerHandlers([handler]);
+
+    expect((await findQueue()).updated_on).toEqual(converged.updated_on);
+  });
+
+  it("stamps the converged base delay onto jobs enqueued afterwards", async () => {
+    const { jobQueue, handler, createLegacyQueue, enqueue, findJob } = await setup({ queueName: "inheriting" });
+    await createLegacyQueue();
+    await jobQueue.registerHandlers([handler]);
+
+    await enqueue();
+
+    expect(await findJob()).toMatchObject({
+      retry_limit: RETRY_LIMIT,
+      retry_backoff: true,
+      retry_delay: RETRY_DELAY_IN_SECONDS,
+      retry_delay_max: RETRY_DELAY_MAX_IN_SECONDS
+    });
+  });
+
+  it("pushes a failed job's next attempt into the future instead of running it at once", async () => {
+    const { jobQueue, handler, enqueue, findJob } = await setup({ queueName: "backing-off", handle: vi.fn().mockRejectedValue(new Error("boom")) });
+    await jobQueue.registerHandlers([handler]);
+    await enqueue();
+
+    await jobQueue.startWorkers({ concurrency: 1, pollingIntervalSeconds: 0.5 });
+
+    const retrying = await waitForJobState(findJob, "retry");
+    const gap = new Date(retrying.start_after).getTime() - Date.now();
+    expect(gap).toBeGreaterThan(secondsToMilliseconds(RETRY_DELAY_IN_SECONDS) * 0.8);
+    expect(gap).toBeLessThanOrEqual(secondsToMilliseconds(RETRY_DELAY_IN_SECONDS * 2));
+  });
+
+  it("cancels a job that is waiting on a retry", async () => {
+    const singletonKey = "owner-1";
+    const { jobQueue, handler, enqueue, findJob } = await setup({ queueName: "cancel-retrying", handle: vi.fn().mockRejectedValue(new Error("boom")) });
+    await jobQueue.registerHandlers([handler]);
+    await enqueue({ singletonKey });
+    await jobQueue.startWorkers({ concurrency: 1, pollingIntervalSeconds: 0.5 });
+    await waitForJobState(findJob, "retry");
+
+    await jobQueue.cancelCreatedBy({ name: "cancel-retrying", singletonKey });
+
+    expect((await findJob()).state).toBe("cancelled");
+  });
+
+  function waitForJobState(findJob: () => Promise<JobRow>, state: string) {
+    return vi.waitFor(
+      async () => {
+        const job = await findJob();
+        expect(job.state).toBe(state);
+        return job;
+      },
+      { timeout: 20_000, interval: 250 }
+    );
+  }
+
+  function backgroundJobsSchema() {
+    return sql.identifier(container.resolve(CoreConfigService).get("POSTGRES_BACKGROUND_JOBS_SCHEMA"));
+  }
+
+  async function setup(input: { queueName: string; policy?: PgBossQueue["policy"]; handle?: JobHandler<Job>["handle"] }) {
+    const { jobQueue, pgBoss } = await bootstrapJobQueue();
+    const { queueName, policy } = input;
+    const db = container.resolve<ApiPgDatabase>(POSTGRES_DB);
+
+    class ScopedJob implements Job {
+      static readonly [JOB_NAME] = queueName;
+      readonly name = queueName;
+      readonly version = 1;
+
+      constructor(public readonly data: Record<string, unknown> = {}) {}
+    }
+
+    return {
+      jobQueue,
+      handler: { accepts: ScopedJob, policy, handle: input.handle ?? vi.fn().mockResolvedValue(undefined) } satisfies JobHandler<Job>,
+      enqueue: (options?: EnqueueOptions) => jobQueue.enqueue(new ScopedJob(), options),
+      createLegacyQueue: () =>
+        pgBoss.createQueue(queueName, { retryLimit: RETRY_LIMIT, retryBackoff: true, retryDelayMax: RETRY_DELAY_MAX_IN_SECONDS, policy }),
+      findQueue: async () => {
+        const rows = await db.execute<QueueRow>(
+          sql`select name, policy, retry_limit, retry_backoff, retry_delay, retry_delay_max, created_on::text, updated_on::text
+              from ${backgroundJobsSchema()}.queue where name = ${queueName}`
+        );
+
+        return (rows as unknown as QueueRow[])[0];
+      },
+      findJob: async () => {
+        const rows = await db.execute<JobRow>(
+          sql`select state, retry_limit, retry_backoff, retry_delay, retry_delay_max, start_after::text
+              from ${backgroundJobsSchema()}.job where name = ${queueName}`
+        );
+
+        return (rows as unknown as JobRow[])[0];
+      }
+    };
+  }
+});

--- a/apps/api/src/core/services/job-queue/job-queue.service.spec.ts
+++ b/apps/api/src/core/services/job-queue/job-queue.service.spec.ts
@@ -1,5 +1,5 @@
 import { faker } from "@faker-js/faker";
-import type { Job as PgBossJob, PgBoss, WorkHandler } from "pg-boss";
+import type { Job as PgBossJob, PgBoss, QueueResult, WorkHandler } from "pg-boss";
 import type { Sql } from "postgres";
 import { describe, expect, it, vi } from "vitest";
 import { mock, mockDeep } from "vitest-mock-extended";
@@ -21,6 +21,7 @@ describe(JobQueueService.name, () => {
 
       expect(pgBoss.createQueue).toHaveBeenCalledWith("test", {
         retryBackoff: true,
+        retryDelay: 30,
         retryDelayMax: 5 * 60,
         retryLimit: 5,
         policy: undefined
@@ -28,24 +29,8 @@ describe(JobQueueService.name, () => {
     });
 
     it("handles multiple handlers", async () => {
-      const handleFn1 = vi.fn().mockResolvedValue(undefined);
-      const handleFn2 = vi.fn().mockResolvedValue(undefined);
-
-      class AnotherTestJob implements Job {
-        static readonly [JOB_NAME] = "another";
-        readonly name = AnotherTestJob[JOB_NAME];
-        readonly version = 1;
-
-        constructor(public readonly data: { type: string }) {}
-      }
-
-      class AnotherHandler implements JobHandler<AnotherTestJob> {
-        readonly accepts = AnotherTestJob;
-        readonly handle: JobHandler<AnotherTestJob>["handle"] = handleFn2;
-      }
-
-      const handler1 = new TestHandler(handleFn1);
-      const handler2 = new AnotherHandler();
+      const handler1 = new TestHandler(vi.fn().mockResolvedValue(undefined));
+      const handler2 = new AnotherTestHandler(vi.fn().mockResolvedValue(undefined));
       const { service, pgBoss } = setup();
 
       await service.registerHandlers([handler1, handler2]);
@@ -53,12 +38,14 @@ describe(JobQueueService.name, () => {
       expect(pgBoss.createQueue).toHaveBeenCalledTimes(2);
       expect(pgBoss.createQueue).toHaveBeenCalledWith("test", {
         retryBackoff: true,
+        retryDelay: 30,
         retryDelayMax: 5 * 60,
         retryLimit: 5,
         policy: undefined
       });
       expect(pgBoss.createQueue).toHaveBeenCalledWith("another", {
         retryBackoff: true,
+        retryDelay: 30,
         retryDelayMax: 5 * 60,
         retryLimit: 5,
         policy: undefined
@@ -73,6 +60,78 @@ describe(JobQueueService.name, () => {
       const { service } = setup();
 
       await expect(service.registerHandlers([handler1, handler2])).rejects.toThrow("JobQueue does not support multiple handlers for the same queue: test");
+    });
+
+    it("creates the queue with its handler's policy", async () => {
+      const { service, pgBoss } = setup();
+
+      await service.registerHandlers([new SingletonTestHandler(vi.fn())]);
+
+      expect(pgBoss.createQueue).toHaveBeenCalledWith("test", expect.objectContaining({ policy: "singleton" }));
+    });
+
+    it("converges an existing queue onto the current retry settings", async () => {
+      const { service, pgBoss, logger } = setup({ queues: [liveQueue({ retryDelay: 0 })] });
+
+      await service.registerHandlers([new TestHandler(vi.fn())]);
+
+      expect(pgBoss.updateQueue).toHaveBeenCalledWith("test", {
+        retryBackoff: true,
+        retryDelay: 30,
+        retryDelayMax: 5 * 60,
+        retryLimit: 5
+      });
+      expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "JOB_QUEUE_RETRY_OPTIONS_CONVERGED", queue: "test" }));
+    });
+
+    it("never asks pg-boss to change a policy it refuses to change", async () => {
+      const { service, pgBoss } = setup({ queues: [liveQueue({ retryDelay: 0 })] });
+
+      await service.registerHandlers([new SingletonTestHandler(vi.fn())]);
+
+      const [, options] = vi.mocked(pgBoss.updateQueue).mock.calls[0];
+      expect(Object.keys(options as object)).not.toContain("policy");
+    });
+
+    it("leaves a queue that already carries the current retry settings alone", async () => {
+      const { service, pgBoss } = setup({ queues: [liveQueue()] });
+
+      await service.registerHandlers([new TestHandler(vi.fn())]);
+
+      expect(pgBoss.updateQueue).not.toHaveBeenCalled();
+    });
+
+    it("reads the live queue settings once for all handlers", async () => {
+      const { service, pgBoss } = setup();
+
+      await service.registerHandlers([new TestHandler(vi.fn()), new AnotherTestHandler(vi.fn())]);
+
+      expect(pgBoss.getQueues).toHaveBeenCalledTimes(1);
+      expect(pgBoss.getQueues).toHaveBeenCalledWith(["test", "another"]);
+    });
+
+    it("warns when a handler declares a policy the live queue does not carry", async () => {
+      const { service, logger } = setup({ queues: [liveQueue({ policy: "standard" })] });
+
+      await service.registerHandlers([new SingletonTestHandler(vi.fn())]);
+
+      expect(logger.warn).toHaveBeenCalledWith({
+        event: "JOB_QUEUE_POLICY_UNCHANGEABLE",
+        queue: "test",
+        declared: "singleton",
+        live: "standard"
+      });
+    });
+
+    it("starts workers even when it cannot converge the queue settings", async () => {
+      const error = new Error("update failed");
+      const { service, pgBoss, logger } = setup({ queues: [liveQueue({ retryDelay: 0 })] });
+      vi.mocked(pgBoss.updateQueue).mockRejectedValue(error);
+
+      await service.registerHandlers([new TestHandler(vi.fn())]);
+
+      expect(logger.error).toHaveBeenCalledWith({ event: "JOB_QUEUE_RETRY_OPTIONS_CONVERGE_FAILED", error });
+      await expect(service.startWorkers()).resolves.toBeUndefined();
     });
   });
 
@@ -217,6 +276,17 @@ describe(JobQueueService.name, () => {
       expect(executeSql).toHaveBeenCalledWith(expect.stringContaining("state = 'cancelled'"), ["test-job", "singleton-1"]);
     });
 
+    it("cancels a job waiting on a retry, not only one that has never run", async () => {
+      const { service, pgBoss, txService } = setup();
+      txService.getConnection.mockReturnValue(undefined);
+      const executeSql = vi.fn().mockResolvedValue({ rows: [] });
+      vi.spyOn(pgBoss, "getDb").mockReturnValue({ executeSql });
+
+      await service.cancelCreatedBy({ name: "test-job", singletonKey: "singleton-1" });
+
+      expect(executeSql).toHaveBeenCalledWith(expect.stringContaining("state IN ('created', 'retry')"), ["test-job", "singleton-1"]);
+    });
+
     it("cancels created jobs on the ambient transaction connection when one is active", async () => {
       const { service, pgBoss, txService } = setup();
       const unsafe = vi.fn().mockResolvedValue([{ id: "job-1" }]);
@@ -299,6 +369,7 @@ describe(JobQueueService.name, () => {
 
       expect(pgBoss.createQueue).toHaveBeenCalledWith("test", {
         retryBackoff: true,
+        retryDelay: 30,
         retryDelayMax: 5 * 60,
         retryLimit: 5,
         policy: undefined
@@ -425,7 +496,7 @@ describe(JobQueueService.name, () => {
     expect(createLogger).toHaveBeenCalledWith({ context: JobQueueService.name });
   });
 
-  function setup(input?: { pgBoss?: PgBoss; postgresDbUri?: string }) {
+  function setup(input?: { pgBoss?: PgBoss; postgresDbUri?: string; queues?: QueueResult[] }) {
     const mocks = {
       logger: mock<ReturnType<CreateLogger>>(),
       coreConfig: mock<CoreConfigService>({
@@ -435,6 +506,8 @@ describe(JobQueueService.name, () => {
         input?.pgBoss ??
         mockDeep<PgBoss>({
           createQueue: vi.fn().mockResolvedValue(undefined),
+          updateQueue: vi.fn().mockResolvedValue(undefined),
+          getQueues: vi.fn().mockResolvedValue(input?.queues ?? []),
           send: vi.fn().mockResolvedValue("job-id"),
           work: vi.fn().mockResolvedValue(undefined),
           start: vi.fn().mockResolvedValue(undefined),
@@ -479,5 +552,36 @@ describe(JobQueueService.name, () => {
   class TestHandler implements JobHandler<TestJob> {
     readonly accepts = TestJob;
     constructor(public readonly handle: JobHandler<TestJob>["handle"]) {}
+  }
+
+  class SingletonTestHandler implements JobHandler<TestJob> {
+    readonly accepts = TestJob;
+    readonly policy = "singleton" as const;
+    constructor(public readonly handle: JobHandler<TestJob>["handle"]) {}
+  }
+
+  class AnotherTestJob implements Job {
+    static readonly [JOB_NAME] = "another";
+    readonly name = AnotherTestJob[JOB_NAME];
+    readonly version = 1;
+
+    constructor(public readonly data: { type: string }) {}
+  }
+
+  class AnotherTestHandler implements JobHandler<AnotherTestJob> {
+    readonly accepts = AnotherTestJob;
+    constructor(public readonly handle: JobHandler<AnotherTestJob>["handle"]) {}
+  }
+
+  function liveQueue(overrides?: Partial<QueueResult>) {
+    return mock<QueueResult>({
+      name: TestJob[JOB_NAME],
+      policy: "standard",
+      retryLimit: 5,
+      retryBackoff: true,
+      retryDelay: 30,
+      retryDelayMax: 5 * 60,
+      ...overrides
+    });
   }
 });

--- a/apps/api/src/core/services/job-queue/job-queue.service.spec.ts
+++ b/apps/api/src/core/services/job-queue/job-queue.service.spec.ts
@@ -130,7 +130,32 @@ describe(JobQueueService.name, () => {
 
       await service.registerHandlers([new TestHandler(vi.fn())]);
 
-      expect(logger.error).toHaveBeenCalledWith({ event: "JOB_QUEUE_RETRY_OPTIONS_CONVERGE_FAILED", error });
+      expect(logger.error).toHaveBeenCalledWith({ event: "JOB_QUEUE_RETRY_OPTIONS_CONVERGE_FAILED", queue: "test", error });
+      await expect(service.startWorkers()).resolves.toBeUndefined();
+    });
+
+    it("converges the remaining queues when one of them refuses to update", async () => {
+      const error = new Error("update failed");
+      const { service, pgBoss } = setup({
+        queues: [liveQueue({ retryDelay: 0 }), liveQueue({ name: "another", retryDelay: 0 })]
+      });
+      vi.mocked(pgBoss.updateQueue).mockRejectedValueOnce(error).mockResolvedValue(undefined);
+
+      await service.registerHandlers([new TestHandler(vi.fn()), new AnotherTestHandler(vi.fn())]);
+
+      expect(pgBoss.updateQueue).toHaveBeenCalledTimes(2);
+      expect(pgBoss.updateQueue).toHaveBeenLastCalledWith("another", expect.objectContaining({ retryDelay: 30 }));
+    });
+
+    it("starts workers even when it cannot read the live queue settings", async () => {
+      const error = new Error("read failed");
+      const { service, pgBoss, logger } = setup();
+      vi.mocked(pgBoss.getQueues).mockRejectedValue(error);
+
+      await service.registerHandlers([new TestHandler(vi.fn())]);
+
+      expect(logger.error).toHaveBeenCalledWith({ event: "JOB_QUEUE_READ_FAILED", error });
+      expect(pgBoss.updateQueue).not.toHaveBeenCalled();
       await expect(service.startWorkers()).resolves.toBeUndefined();
     });
   });

--- a/apps/api/src/core/services/job-queue/job-queue.service.ts
+++ b/apps/api/src/core/services/job-queue/job-queue.service.ts
@@ -11,6 +11,24 @@ import { TxService } from "../tx/tx.service";
 
 export const PG_BOSS_TOKEN: InjectionToken<PgBoss> = Symbol("pgBoss");
 
+type QueueRetryOptions = Pick<PgBossQueue, "retryLimit" | "retryBackoff" | "retryDelay" | "retryDelayMax">;
+
+/** pg-boss multiplies its backoff by `retryDelay` and defaults it to 0, which would collapse every retry gap to zero. */
+const QUEUE_RETRY_OPTIONS: QueueRetryOptions = {
+  retryLimit: 5,
+  retryBackoff: true,
+  retryDelay: 30,
+  retryDelayMax: 5 * 60
+};
+
+const DEFAULT_QUEUE_POLICY: PgBossQueue["policy"] = "standard";
+
+const RETRY_OPTION_KEYS = Object.keys(QUEUE_RETRY_OPTIONS) as (keyof QueueRetryOptions)[];
+
+function retryOptionsOf(queue: QueueRetryOptions) {
+  return RETRY_OPTION_KEYS.map(key => [key, queue[key]] as const);
+}
+
 @singleton()
 export class JobQueueService implements Disposable {
   private readonly pgBoss: PgBoss;
@@ -45,15 +63,49 @@ export class JobQueueService implements Disposable {
         throw new Error(`JobQueue does not support multiple handlers for the same queue: ${queueName}`);
       }
       seenJobs.add(queueName);
-      await this.pgBoss.createQueue(queueName, {
-        retryLimit: 5,
-        retryBackoff: true,
-        retryDelayMax: 5 * 60,
-        policy: handler.policy
-      });
+      await this.pgBoss.createQueue(queueName, { ...QUEUE_RETRY_OPTIONS, policy: handler.policy });
     });
     await Promise.all(promises);
+    await this.#convergeRetryOptions(handlers);
     this.handlers = handlers.slice(0);
+  }
+
+  /**
+   * `createQueue` never touches a queue that already exists, so settings corrected in code reach production only from here.
+   * A failure leaves the queues as they were, which is why it is logged rather than raised: it must not keep workers down.
+   */
+  async #convergeRetryOptions(handlers: JobHandler<Job>[]): Promise<void> {
+    try {
+      const queueNames = handlers.map(handler => handler.accepts[JOB_NAME]);
+      const liveQueues = new Map((await this.pgBoss.getQueues(queueNames)).map(queue => [queue.name, queue]));
+
+      for (const handler of handlers) {
+        const queue = liveQueues.get(handler.accepts[JOB_NAME]);
+        if (!queue) continue;
+
+        const declaredPolicy = handler.policy ?? DEFAULT_QUEUE_POLICY;
+        if (queue.policy !== declaredPolicy) {
+          this.logger.warn({
+            event: "JOB_QUEUE_POLICY_UNCHANGEABLE",
+            queue: queue.name,
+            declared: declaredPolicy,
+            live: queue.policy
+          });
+        }
+
+        if (retryOptionsOf(queue).every(([key, value]) => value === QUEUE_RETRY_OPTIONS[key])) continue;
+
+        await this.pgBoss.updateQueue(queue.name, QUEUE_RETRY_OPTIONS);
+        this.logger.info({
+          event: "JOB_QUEUE_RETRY_OPTIONS_CONVERGED",
+          queue: queue.name,
+          from: Object.fromEntries(retryOptionsOf(queue)),
+          to: QUEUE_RETRY_OPTIONS
+        });
+      }
+    } catch (error) {
+      this.logger.error({ event: "JOB_QUEUE_RETRY_OPTIONS_CONVERGE_FAILED", error });
+    }
   }
 
   /**
@@ -165,7 +217,7 @@ export class JobQueueService implements Disposable {
           SET completed_on = now(),
             state = 'cancelled'
           WHERE name = $1
-            AND state = 'created'
+            AND state IN ('created', 'retry')
             AND singleton_key = $2
           RETURNING id
         )

--- a/apps/api/src/core/services/job-queue/job-queue.service.ts
+++ b/apps/api/src/core/services/job-queue/job-queue.service.ts
@@ -1,6 +1,13 @@
 import { createMongoAbility, MongoAbility } from "@casl/ability";
 import { context, propagation, SpanStatusCode, trace } from "@opentelemetry/api";
-import { Job as PgBossJob, PgBoss, Queue as PgBossQueue, SendOptions as PgBossSendOptions, WorkOptions as PgBossWorkOptions } from "pg-boss";
+import {
+  Job as PgBossJob,
+  PgBoss,
+  Queue as PgBossQueue,
+  type QueueResult as PgBossQueueResult,
+  SendOptions as PgBossSendOptions,
+  WorkOptions as PgBossWorkOptions
+} from "pg-boss";
 import type { Sql } from "postgres";
 import { Disposable, inject, InjectionToken, singleton } from "tsyringe";
 
@@ -70,31 +77,27 @@ export class JobQueueService implements Disposable {
     this.handlers = handlers.slice(0);
   }
 
-  /**
-   * `createQueue` never touches a queue that already exists, so settings corrected in code reach production only from here.
-   * A failure leaves the queues as they were, which is why it is logged rather than raised: it must not keep workers down.
-   */
+  /** `createQueue` never touches a queue that already exists, so settings corrected in code reach production only from here. */
   async #convergeRetryOptions(handlers: JobHandler<Job>[]): Promise<void> {
-    try {
-      const queueNames = handlers.map(handler => handler.accepts[JOB_NAME]);
-      const liveQueues = new Map((await this.pgBoss.getQueues(queueNames)).map(queue => [queue.name, queue]));
+    const liveQueues = await this.#readLiveQueues(handlers);
 
-      for (const handler of handlers) {
-        const queue = liveQueues.get(handler.accepts[JOB_NAME]);
-        if (!queue) continue;
+    for (const handler of handlers) {
+      const queue = liveQueues.get(handler.accepts[JOB_NAME]);
+      if (!queue) continue;
 
-        const declaredPolicy = handler.policy ?? DEFAULT_QUEUE_POLICY;
-        if (queue.policy !== declaredPolicy) {
-          this.logger.warn({
-            event: "JOB_QUEUE_POLICY_UNCHANGEABLE",
-            queue: queue.name,
-            declared: declaredPolicy,
-            live: queue.policy
-          });
-        }
+      const declaredPolicy = handler.policy ?? DEFAULT_QUEUE_POLICY;
+      if (queue.policy !== declaredPolicy) {
+        this.logger.warn({
+          event: "JOB_QUEUE_POLICY_UNCHANGEABLE",
+          queue: queue.name,
+          declared: declaredPolicy,
+          live: queue.policy
+        });
+      }
 
-        if (retryOptionsOf(queue).every(([key, value]) => value === QUEUE_RETRY_OPTIONS[key])) continue;
+      if (retryOptionsOf(queue).every(([key, value]) => value === QUEUE_RETRY_OPTIONS[key])) continue;
 
+      try {
         await this.pgBoss.updateQueue(queue.name, QUEUE_RETRY_OPTIONS);
         this.logger.info({
           event: "JOB_QUEUE_RETRY_OPTIONS_CONVERGED",
@@ -102,9 +105,20 @@ export class JobQueueService implements Disposable {
           from: Object.fromEntries(retryOptionsOf(queue)),
           to: QUEUE_RETRY_OPTIONS
         });
+      } catch (error) {
+        this.logger.error({ event: "JOB_QUEUE_RETRY_OPTIONS_CONVERGE_FAILED", queue: queue.name, error });
       }
+    }
+  }
+
+  /** Converging is drift correction, so a read that fails leaves every queue as it was rather than keeping the workers down. */
+  async #readLiveQueues(handlers: JobHandler<Job>[]): Promise<Map<string, PgBossQueueResult>> {
+    try {
+      const queues = await this.pgBoss.getQueues(handlers.map(handler => handler.accepts[JOB_NAME]));
+      return new Map(queues.map(queue => [queue.name, queue]));
     } catch (error) {
-      this.logger.error({ event: "JOB_QUEUE_RETRY_OPTIONS_CONVERGE_FAILED", error });
+      this.logger.error({ event: "JOB_QUEUE_READ_FAILED", error });
+      return new Map();
     }
   }
 

--- a/apps/api/src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler.ts
+++ b/apps/api/src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler.ts
@@ -47,7 +47,7 @@ export class DeleteUnbackedDeploymentSettingHandler implements JobHandler<Delete
 
   /**
    * Running is not evidence that the deployment is missing — the broadcast may have landed and the process died
-   * before cancelling, and `cancelCreatedBy` only cancels a job still in state `created`, so a compensation a
+   * before cancelling, and `cancelCreatedBy` only cancels a job still waiting, so a compensation a
    * worker has already picked up cannot be called off at all. What keeps a live deployment's row safe in that
    * window is not the cancellation but the two things below, and anything short of a chain answer escapes,
    * because the queue retrying costs a row's extra lifetime while a wrong delete costs the only stored copy of


### PR DESCRIPTION
## Why

Fixes CON-916

Every background queue is created with `retryBackoff: true` and no `retryDelay`. pg-boss defaults that base to 0, and its backoff is a plain multiplier on it:

```sql
now() + LEAST(retry_delay_max,
  retry_delay * (2 ^ LEAST(16, retry_count + 1) / 2 + 2 ^ LEAST(16, retry_count + 1) / 2 * random())
) * interval '1s'
```

Zero times any exponent is zero, so a failed job's next attempt is scheduled for `now()` and all six attempts burn inside one polling interval. A blip that outlasts a few milliseconds takes the job with it, even though the condition would have cleared seconds later. (pg-boss's own JSDoc says `retryBackoff` coerces the base to 1 when it is unset. It does not. In 12.11.2 no code path touches the value.)

The other half of the ticket: `createQueue` is `INSERT ... ON CONFLICT DO NOTHING` inside a plpgsql function that returns early when nothing was inserted. Fixing the options in code would never have reached the queues that already exist in production.

## What

All three changes are in `JobQueueService`.

The queue options moved to a module constant and gained `retryDelay: 30`. Attempts now land at roughly 30s, 1m, 2m, 4m, 5m before the job is marked failed. I left `retryLimit` at 5 so that whatever we see in prod after this deploys is attributable to one variable.

`registerHandlers` now does a single `getQueues()` read after the creates and calls `updateQueue` only for queues whose retry columns drifted, logging `JOB_QUEUE_RETRY_OPTIONS_CONVERGED` with the before and after. Steady state is one SELECT and no writes, which matters because `registerHandlers` runs on every CLI invocation too, not only on pod boot. A failure there is logged rather than raised. Convergence is drift correction, and a thrown initializer leaves the pod up but never listening, which is a bad trade against slightly wrong backoff. It also warns when a handler's declared policy does not match the live queue: policy is create-only and `updateQueue` refuses it outright, so a policy added to an existing handler is a silent no-op in production forever, and the warning is the only way we would ever notice.

`cancelCreatedBy` widened from `state = 'created'` to `state IN ('created', 'retry')`. This is a regression the first change would otherwise introduce rather than a pre-existing bug: jobs used to pass through `retry` in microseconds, and they now sit there for up to five minutes. That is long enough for `WalletReloadJobService` to cancel a check, miss it, re-enqueue, and leave two live checks for one user. The `singleton` policy does not cover this, since its unique index is `WHERE state = 'active'` and so it serializes execution instead of preventing duplicate scheduling.

### Not in this PR

Jobs that are already queued keep `retry_delay = 0`, because pg-boss snapshots retry settings onto the job row at send time. Most queues drain within a day, but `NotificationJob` holds trial-expiry rows scheduled as far out as `trialEndsAt + 7d`. Repairing those is one UPDATE filtered on `state IN ('created','retry') AND retry_delay = 0`, run after this deploys so nothing new lands with 0. That `retry_delay = 0` filter is also what keeps it off the CON-913 compensations, which already carry their own pacing.

### Testing

The new `job-queue.service.integration.ts` runs against real pg-boss. It manufactures a legacy queue through pg-boss's own `create_queue` rather than raw SQL, asserts `retry_delay = 0` up front, and then checks that convergence updated the row instead of recreating it (`created_on` unchanged), that a job enqueued afterwards inherits the base delay, that a genuinely failing job lands in `retry` 30 to 60 seconds out, and that a retrying job can be cancelled.

The api unit suite passes at 1995. `tsc` reports 41 errors on this branch and 41 on the baseline, none of them in the touched files. The 4 integration failures in `user.repository` and `api-key.repository` reproduce on a clean `main` with these changes stashed.

One thing for reviewers: `deployment-writer.service.integration.ts` asserts `retry_delay: 30` under the title "stores a retry horizon on the compensation itself, rather than inheriting the queue's". Now that the queue default is 30 as well, that one field no longer proves the title. `retry_limit: 47` and `retry_delay_max: 1800` still do, so I left the test alone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved background job retry handling with consistent retry delays and queue settings.
  * Existing queues now automatically reconcile configuration differences without preventing worker startup.
  * Cancelling jobs now also stops jobs currently waiting for retry.
  * Added safeguards for delayed retries after job failures.

* **Tests**
  * Expanded coverage for queue configuration, retries, reconciliation, cancellation, and startup failure scenarios.
  * Added integration testing with PostgreSQL-backed queues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->