### PR TITLE
fix(billing): stop a transient coverage reading from resending the low-credit email

### DIFF
--- a/apps/api/drizzle/0046_credits_low_recovery_latch.sql
+++ b/apps/api/drizzle/0046_credits_low_recovery_latch.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "user_wallets" ADD COLUMN "credits_sufficient_since" timestamp with time zone;

--- a/apps/api/drizzle/meta/0046_snapshot.json
+++ b/apps/api/drizzle/meta/0046_snapshot.json
@@ -1,0 +1,1546 @@
+{
+  "id": "11d70361-d6f4-4db1-a725-f4078913c145",
+  "prevId": "9b8b2670-3ddf-4478-99f6-d25378df7b47",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.user_wallets": {
+      "name": "user_wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_allowance": {
+          "name": "deployment_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "fee_allowance": {
+          "name": "fee_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "trial": {
+          "name": "trial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits_low_notified_at": {
+          "name": "credits_low_notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits_sufficient_since": {
+          "name": "credits_sufficient_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_wallets_user_id_userSetting_id_fk": {
+          "name": "user_wallets_user_id_userSetting_id_fk",
+          "tableFrom": "user_wallets",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_wallets_user_id_unique": {
+          "name": "user_wallets_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "user_wallets_address_unique": {
+          "name": "user_wallets_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_methods": {
+      "name": "payment_methods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_method_id": {
+          "name": "payment_method_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_validated": {
+          "name": "is_validated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payment_methods_fingerprint_payment_method_id_unique": {
+          "name": "payment_methods_fingerprint_payment_method_id_unique",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_default_unique": {
+          "name": "payment_methods_user_id_is_default_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"payment_methods\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_fingerprint_idx": {
+          "name": "payment_methods_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_idx": {
+          "name": "payment_methods_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_validated_idx": {
+          "name": "payment_methods_user_id_is_validated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_validated",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_fingerprint_payment_method_id_idx": {
+          "name": "payment_methods_user_id_fingerprint_payment_method_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_methods_user_id_userSetting_id_fk": {
+          "name": "payment_methods_user_id_userSetting_id_fk",
+          "tableFrom": "payment_methods",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_transactions": {
+      "name": "stripe_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "stripe_transaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "stripe_transaction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created'"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_refunded": {
+          "name": "amount_refunded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bonus_amount": {
+          "name": "bonus_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_charge_id": {
+          "name": "stripe_charge_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_coupon_id": {
+          "name": "stripe_coupon_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_promotion_code_id": {
+          "name": "stripe_promotion_code_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_idempotency_key": {
+          "name": "stripe_idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method_type": {
+          "name": "payment_method_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_brand": {
+          "name": "card_brand",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_last4": {
+          "name": "card_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_url": {
+          "name": "receipt_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_transactions_stripe_invoice_id_unique": {
+          "name": "stripe_transactions_stripe_invoice_id_unique",
+          "columns": [
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stripe_transactions\".\"stripe_invoice_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_idempotency_key_unique": {
+          "name": "stripe_transactions_stripe_idempotency_key_unique",
+          "columns": [
+            {
+              "expression": "stripe_idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stripe_transactions\".\"stripe_idempotency_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_user_id_idx": {
+          "name": "stripe_transactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_payment_intent_id_idx": {
+          "name": "stripe_transactions_stripe_payment_intent_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_payment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_charge_id_idx": {
+          "name": "stripe_transactions_stripe_charge_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_coupon_id_idx": {
+          "name": "stripe_transactions_stripe_coupon_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_coupon_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_promotion_code_id_idx": {
+          "name": "stripe_transactions_stripe_promotion_code_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_promotion_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_status_idx": {
+          "name": "stripe_transactions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_created_at_idx": {
+          "name": "stripe_transactions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_user_id_created_at_idx": {
+          "name": "stripe_transactions_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_transactions_user_id_userSetting_id_fk": {
+          "name": "stripe_transactions_user_id_userSetting_id_fk",
+          "tableFrom": "stripe_transactions",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_settings": {
+      "name": "wallet_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_reload_enabled": {
+          "name": "auto_reload_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_reload_mode": {
+          "name": "auto_reload_mode",
+          "type": "auto_reload_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'prediction'"
+        },
+        "auto_reload_threshold": {
+          "name": "auto_reload_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2000
+        },
+        "auto_reload_amount": {
+          "name": "auto_reload_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10000
+        },
+        "last_auto_charge_at": {
+          "name": "last_auto_charge_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_settings_user_id_idx": {
+          "name": "wallet_settings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_settings_wallet_id_user_wallets_id_fk": {
+          "name": "wallet_settings_wallet_id_user_wallets_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "user_wallets",
+          "columnsFrom": [
+            "wallet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wallet_settings_user_id_userSetting_id_fk": {
+          "name": "wallet_settings_user_id_userSetting_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallet_settings_wallet_id_unique": {
+          "name": "wallet_settings_wallet_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wallet_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.userSetting": {
+      "name": "userSetting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscribedToNewsletter": {
+          "name": "subscribedToNewsletter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "youtubeUsername": {
+          "name": "youtubeUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitterUsername": {
+          "name": "twitterUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "githubUsername": {
+          "name": "githubUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_ip": {
+          "name": "last_ip",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_user_agent": {
+          "name": "last_user_agent",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fingerprint": {
+          "name": "last_fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboardingSkippedAt": {
+          "name": "onboardingSkippedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "userSetting_userId_unique": {
+          "name": "userSetting_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        },
+        "userSetting_username_unique": {
+          "name": "userSetting_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.template": {
+      "name": "template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "copiedFromId": {
+          "name": "copiedFromId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cpu": {
+          "name": "cpu",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ram": {
+          "name": "ram",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage": {
+          "name": "storage",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sdl": {
+          "name": "sdl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "template_userId_idx": {
+          "name": "template_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.templateFavorite": {
+      "name": "templateFavorite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "templateId": {
+          "name": "templateId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addedDate": {
+          "name": "addedDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "templateFavorite_userId_templateId_unique": {
+          "name": "templateFavorite_userId_templateId_unique",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "templateId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "templateFavorite_templateId_template_id_fk": {
+          "name": "templateFavorite_templateId_template_id_fk",
+          "tableFrom": "templateFavorite",
+          "tableTo": "template",
+          "columnsFrom": [
+            "templateId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_settings": {
+      "name": "deployment_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dseq": {
+          "name": "dseq",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_top_up_enabled": {
+          "name": "auto_top_up_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closed": {
+          "name": "closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_funded_at": {
+          "name": "last_funded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_limit_hours": {
+          "name": "runtime_limit_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sdl": {
+          "name": "sdl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manifest_version": {
+          "name": "manifest_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_ends_at": {
+          "name": "runtime_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_ending_notified_for": {
+          "name": "runtime_ending_notified_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_unreachable_notified_for": {
+          "name": "provider_unreachable_notified_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "id_auto_top_up_enabled_closed_idx": {
+          "name": "id_auto_top_up_enabled_closed_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auto_top_up_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "closed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_settings_user_id_userSetting_id_fk": {
+          "name": "deployment_settings_user_id_userSetting_id_fk",
+          "tableFrom": "deployment_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dseq_user_id_idx": {
+          "name": "dseq_user_id_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "dseq",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_key": {
+          "name": "hashed_key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_format": {
+          "name": "key_format",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_user_id_userSetting_id_fk": {
+          "name": "api_keys_user_id_userSetting_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_hashed_key_unique": {
+          "name": "api_keys_hashed_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hashed_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_verification_codes": {
+      "name": "email_verification_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_verification_codes_user_id_idx": {
+          "name": "email_verification_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_verification_codes_user_id_userSetting_id_fk": {
+          "name": "email_verification_codes_user_id_userSetting_id_fk",
+          "tableFrom": "email_verification_codes",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.data_keys": {
+      "name": "data_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wrapped_key": {
+          "name": "wrapped_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wrapped_by_kid": {
+          "name": "wrapped_by_kid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "data_keys_wrapped_by_kid_idx": {
+          "name": "data_keys_wrapped_by_kid_idx",
+          "columns": [
+            {
+              "expression": "wrapped_by_kid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "data_keys_user_id_userSetting_id_fk": {
+          "name": "data_keys_user_id_userSetting_id_fk",
+          "tableFrom": "data_keys",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "data_keys_user_id_unique": {
+          "name": "data_keys_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.stripe_transaction_status": {
+      "name": "stripe_transaction_status",
+      "schema": "public",
+      "values": [
+        "created",
+        "pending",
+        "requires_action",
+        "succeeded",
+        "failed",
+        "refunded",
+        "canceled"
+      ]
+    },
+    "public.stripe_transaction_type": {
+      "name": "stripe_transaction_type",
+      "schema": "public",
+      "values": [
+        "payment_intent",
+        "coupon_claim",
+        "manual_credit"
+      ]
+    },
+    "public.auto_reload_mode": {
+      "name": "auto_reload_mode",
+      "schema": "public",
+      "values": [
+        "prediction",
+        "threshold"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -323,6 +323,13 @@
       "when": 1787764821094,
       "tag": "0045_mark_provider_unreachable_notice",
       "breakpoints": true
+    },
+    {
+      "idx": 46,
+      "version": "7",
+      "when": 1788075327869,
+      "tag": "0046_credits_low_recovery_latch",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/billing/config/env.config.ts
+++ b/apps/api/src/billing/config/env.config.ts
@@ -43,6 +43,8 @@ export const envSchema = z.object({
    * has no disable semantics).
    */
   AUTO_RELOAD_CHARGE_COOLDOWN_IN_MIN: z.number({ coerce: true }).min(0).default(60),
+  /** How long credits must keep reading sufficient before the low-credit email unlatches, so a single misread cannot unlatch it. */
+  CREDITS_LOW_RECOVERY_CONFIRM_WINDOW_MIN: z.number({ coerce: true }).min(0).default(30),
   MANAGED_WALLET_TRIAL_BLOCKED_GPU_MODELS: z
     .string()
     .default("nvidia/b300,nvidia/b200,nvidia/h200,nvidia/h100,nvidia/pro6000se,nvidia/pro6000we,nvidia/a100,nvidia/rtx5090,nvidia/rtx4090,nvidia/rtx3090")

--- a/apps/api/src/billing/model-schemas/user-wallet/user-wallet.schema.ts
+++ b/apps/api/src/billing/model-schemas/user-wallet/user-wallet.schema.ts
@@ -15,6 +15,7 @@ export const UserWallets = pgTable("user_wallets", {
   isTrialing: boolean("trial").default(true),
   activatedAt: timestamp("activated_at", { withTimezone: true }),
   creditsLowNotifiedAt: timestamp("credits_low_notified_at", { withTimezone: true }),
+  creditsSufficientSince: timestamp("credits_sufficient_since", { withTimezone: true }),
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at").defaultNow().notNull()
 });

--- a/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.integration.ts
+++ b/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.integration.ts
@@ -1,4 +1,5 @@
 import { faker } from "@faker-js/faker";
+import subMinutes from "date-fns/subMinutes";
 import { container } from "tsyringe";
 import { describe, expect, it } from "vitest";
 
@@ -41,12 +42,74 @@ describe(UserWalletRepository.name, () => {
     });
   });
 
-  async function setup() {
+  describe("clearCreditsLowNotifiedIfRecoveryConfirmed", () => {
+    it("clears the notified stamp once credits have read sufficient for the whole window", async () => {
+      const { userWalletRepository, wallet } = await setup({
+        creditsLowNotifiedAt: subMinutes(new Date(), 90),
+        creditsSufficientSince: subMinutes(new Date(), 31)
+      });
+
+      const isCleared = await userWalletRepository.clearCreditsLowNotifiedIfRecoveryConfirmed(wallet.id, 30);
+
+      const updated = await userWalletRepository.findById(wallet.id);
+      expect(isCleared).toBe(true);
+      expect(updated?.creditsLowNotifiedAt).toBeNull();
+      expect(updated?.creditsSufficientSince).toBeNull();
+    });
+
+    it("keeps the notified stamp while the window has not elapsed", async () => {
+      const creditsLowNotifiedAt = subMinutes(new Date(), 90);
+      const { userWalletRepository, wallet } = await setup({
+        creditsLowNotifiedAt,
+        creditsSufficientSince: subMinutes(new Date(), 5)
+      });
+
+      const isCleared = await userWalletRepository.clearCreditsLowNotifiedIfRecoveryConfirmed(wallet.id, 30);
+
+      const updated = await userWalletRepository.findById(wallet.id);
+      expect(isCleared).toBe(false);
+      expect(updated?.creditsLowNotifiedAt).toEqual(creditsLowNotifiedAt);
+    });
+
+    it("keeps the notified stamp when no recovery has been recorded", async () => {
+      const { userWalletRepository, wallet } = await setup({ creditsLowNotifiedAt: subMinutes(new Date(), 90) });
+
+      const isCleared = await userWalletRepository.clearCreditsLowNotifiedIfRecoveryConfirmed(wallet.id, 30);
+
+      expect(isCleared).toBe(false);
+    });
+
+    it("reports no clear when the wallet was never notified", async () => {
+      const { userWalletRepository, wallet } = await setup({ creditsSufficientSince: subMinutes(new Date(), 90) });
+
+      const isCleared = await userWalletRepository.clearCreditsLowNotifiedIfRecoveryConfirmed(wallet.id, 30);
+
+      expect(isCleared).toBe(false);
+    });
+
+    it("clears exactly once across concurrent attempts", async () => {
+      const { userWalletRepository, wallet } = await setup({
+        creditsLowNotifiedAt: subMinutes(new Date(), 90),
+        creditsSufficientSince: subMinutes(new Date(), 31)
+      });
+
+      const results = await Promise.all(Array.from({ length: 5 }, () => userWalletRepository.clearCreditsLowNotifiedIfRecoveryConfirmed(wallet.id, 30)));
+
+      expect(results.filter(Boolean)).toHaveLength(1);
+    });
+  });
+
+  async function setup(input: { creditsLowNotifiedAt?: Date; creditsSufficientSince?: Date } = {}) {
     const userRepository = container.resolve(UserRepository);
     const userWalletRepository = container.resolve(UserWalletRepository);
 
     const user = await userRepository.create({ userId: faker.string.uuid() });
-    const wallet = await userWalletRepository.create({ userId: user.id, address: createAkashAddress() });
+    const created = await userWalletRepository.create({ userId: user.id, address: createAkashAddress() });
+    const wallet = await userWalletRepository.updateById(
+      created.id,
+      { creditsLowNotifiedAt: input.creditsLowNotifiedAt ?? null, creditsSufficientSince: input.creditsSufficientSince ?? null },
+      { returning: true }
+    );
 
     return { userRepository, userWalletRepository, user, wallet };
   }

--- a/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.ts
+++ b/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.ts
@@ -1,6 +1,6 @@
 import { Trace } from "@akashnetwork/instrumentation";
 import subDays from "date-fns/subDays";
-import { and, count, eq, gt, inArray, isNotNull, isNull, lte, or } from "drizzle-orm";
+import { and, count, eq, gt, inArray, isNotNull, isNull, lte, or, sql } from "drizzle-orm";
 import { singleton } from "tsyringe";
 
 import { type ApiPgDatabase, type ApiPgTables, InjectPg, InjectPgTable } from "@src/core/providers";
@@ -97,6 +97,29 @@ export class UserWalletRepository extends BaseRepository<ApiPgTables["UserWallet
       .returning();
 
     return claimed ? this.toOutput(claimed) : undefined;
+  }
+
+  /**
+   * Unlatches the low-credit email only when credits have read sufficient for the whole window, re-checking
+   * that in SQL so a concurrent check that saw them low still wins by clearing `creditsSufficientSince`.
+   */
+  async clearCreditsLowNotifiedIfRecoveryConfirmed(id: UserWalletOutput["id"], confirmWindowMinutes: number): Promise<boolean> {
+    const [cleared] = await this.cursor
+      .update(this.table)
+      .set({ creditsLowNotifiedAt: null, creditsSufficientSince: null })
+      .where(
+        this.whereAccessibleBy(
+          and(
+            eq(this.table.id, id),
+            isNotNull(this.table.creditsLowNotifiedAt),
+            isNotNull(this.table.creditsSufficientSince),
+            lte(this.table.creditsSufficientSince, sql`now() - ${confirmWindowMinutes} * interval '1 minute'`)
+          )
+        )
+      )
+      .returning({ id: this.table.id });
+
+    return !!cleared;
   }
 
   async findDrainingWallets(thresholds: { fee: number; trialExpirationDays: number }) {

--- a/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.ts
+++ b/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.ts
@@ -99,10 +99,7 @@ export class UserWalletRepository extends BaseRepository<ApiPgTables["UserWallet
     return claimed ? this.toOutput(claimed) : undefined;
   }
 
-  /**
-   * Unlatches the low-credit email only when credits have read sufficient for the whole window, re-checking
-   * that in SQL so a concurrent check that saw them low still wins by clearing `creditsSufficientSince`.
-   */
+  /** Re-checks the window in SQL so a concurrent check that read the credits low still wins by clearing `creditsSufficientSince`. */
   async clearCreditsLowNotifiedIfRecoveryConfirmed(id: UserWalletOutput["id"], confirmWindowMinutes: number): Promise<boolean> {
     const [cleared] = await this.cursor
       .update(this.table)
@@ -113,7 +110,7 @@ export class UserWalletRepository extends BaseRepository<ApiPgTables["UserWallet
             eq(this.table.id, id),
             isNotNull(this.table.creditsLowNotifiedAt),
             isNotNull(this.table.creditsSufficientSince),
-            lte(this.table.creditsSufficientSince, sql`now() - ${confirmWindowMinutes} * interval '1 minute'`)
+            lte(this.table.creditsSufficientSince, sql`now() - ${confirmWindowMinutes}::double precision * interval '1 minute'`)
           )
         )
       )

--- a/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.spec.ts
+++ b/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.spec.ts
@@ -133,7 +133,7 @@ describe(WalletCreditsLowCheckHandler.name, () => {
     expect(logger.warn).not.toHaveBeenCalled();
   });
 
-  it("clears creditsLowNotifiedAt when balance recovers", async () => {
+  it("starts the recovery window instead of clearing creditsLowNotifiedAt when the balance first reads recovered", async () => {
     const { handler, notificationService, userWalletRepository, wallet, job } = setup({
       creditsLowNotifiedAt: new Date("2026-01-01T00:00:00.000Z"),
       balanceUsd: 40,
@@ -143,19 +143,97 @@ describe(WalletCreditsLowCheckHandler.name, () => {
     await handler.handle(job);
 
     expect(notificationService.createNotification).not.toHaveBeenCalled();
-    expect(userWalletRepository.updateById).toHaveBeenCalledWith(wallet.id, { creditsLowNotifiedAt: null });
+    expect(userWalletRepository.updateById).toHaveBeenCalledWith(wallet.id, { creditsSufficientSince: expect.any(Date) });
+    expect(userWalletRepository.clearCreditsLowNotifiedIfRecoveryConfirmed).not.toHaveBeenCalled();
   });
 
-  it("clears creditsLowNotifiedAt when weekly cost is 0", async () => {
-    const { handler, notificationService, userWalletRepository, wallet, job } = setup({
+  it("starts the recovery window instead of clearing creditsLowNotifiedAt when weekly cost reads 0 with deployments still on auto top-up", async () => {
+    const { handler, userWalletRepository, wallet, job } = setup({
       creditsLowNotifiedAt: new Date("2026-01-01T00:00:00.000Z"),
       weeklyCostUsd: 0
     });
 
     await handler.handle(job);
 
+    expect(userWalletRepository.updateById).toHaveBeenCalledWith(wallet.id, { creditsSufficientSince: expect.any(Date) });
+    expect(userWalletRepository.clearCreditsLowNotifiedIfRecoveryConfirmed).not.toHaveBeenCalled();
+  });
+
+  it("clears creditsLowNotifiedAt right away when no deployment is on auto top-up anymore", async () => {
+    const { handler, userWalletRepository, wallet, user, logger, job } = setup({
+      creditsLowNotifiedAt: new Date("2026-01-01T00:00:00.000Z"),
+      creditsSufficientSince: new Date("2026-01-01T00:10:00.000Z"),
+      weeklyCostUsd: 0,
+      hasAutoTopUpSettings: false
+    });
+
+    await handler.handle(job);
+
+    expect(userWalletRepository.updateById).toHaveBeenCalledWith(wallet.id, { creditsLowNotifiedAt: null, creditsSufficientSince: null });
+    expect(userWalletRepository.clearCreditsLowNotifiedIfRecoveryConfirmed).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith({ event: "CREDITS_LOW_NOTIFIED_CLEARED", userId: user.id, reason: "zero_cost" });
+  });
+
+  it("clears creditsLowNotifiedAt once credits have read sufficient for the whole confirmation window", async () => {
+    const creditsSufficientSince = new Date("2026-01-01T00:10:00.000Z");
+    const { handler, userWalletRepository, wallet, user, logger, job } = setup({
+      creditsLowNotifiedAt: new Date("2026-01-01T00:00:00.000Z"),
+      creditsSufficientSince,
+      balanceUsd: 40,
+      weeklyCostUsd: 35,
+      confirmWindowMinutes: 30
+    });
+    userWalletRepository.clearCreditsLowNotifiedIfRecoveryConfirmed.mockResolvedValue(true);
+
+    await handler.handle(job);
+
+    expect(userWalletRepository.clearCreditsLowNotifiedIfRecoveryConfirmed).toHaveBeenCalledWith(wallet.id, 30);
+    expect(logger.info).toHaveBeenCalledWith({
+      event: "CREDITS_LOW_NOTIFIED_CLEARED",
+      userId: user.id,
+      reason: "sufficient_balance",
+      creditsSufficientSince
+    });
+  });
+
+  it("keeps creditsLowNotifiedAt when the recovery window has not elapsed yet", async () => {
+    const { handler, userWalletRepository, wallet, logger, job } = setup({
+      creditsLowNotifiedAt: new Date("2026-01-01T00:00:00.000Z"),
+      creditsSufficientSince: new Date("2026-01-01T00:10:00.000Z"),
+      balanceUsd: 40,
+      weeklyCostUsd: 35
+    });
+    userWalletRepository.clearCreditsLowNotifiedIfRecoveryConfirmed.mockResolvedValue(false);
+
+    await handler.handle(job);
+
+    expect(userWalletRepository.clearCreditsLowNotifiedIfRecoveryConfirmed).toHaveBeenCalledWith(wallet.id, expect.any(Number));
+    expect(userWalletRepository.updateById).not.toHaveBeenCalled();
+    expect(logger.info).not.toHaveBeenCalledWith(expect.objectContaining({ event: "CREDITS_LOW_NOTIFIED_CLEARED" }));
+  });
+
+  it("restarts the recovery window when credits read low again while notified", async () => {
+    const { handler, notificationService, userWalletRepository, wallet, logger, job } = setup({
+      creditsLowNotifiedAt: new Date("2026-01-01T00:00:00.000Z"),
+      creditsSufficientSince: new Date("2026-01-01T00:10:00.000Z")
+    });
+
+    await handler.handle(job);
+
     expect(notificationService.createNotification).not.toHaveBeenCalled();
-    expect(userWalletRepository.updateById).toHaveBeenCalledWith(wallet.id, { creditsLowNotifiedAt: null });
+    expect(userWalletRepository.updateById).toHaveBeenCalledWith(wallet.id, { creditsSufficientSince: null });
+    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "CREDITS_LOW_CHECK_SKIPPED", reason: "already_notified" }));
+  });
+
+  it("fails the job when the recovery window cannot be recorded", async () => {
+    const { handler, userWalletRepository, job } = setup({
+      creditsLowNotifiedAt: new Date("2026-01-01T00:00:00.000Z"),
+      balanceUsd: 40,
+      weeklyCostUsd: 35
+    });
+    userWalletRepository.updateById.mockRejectedValue(new Error("connection reset"));
+
+    await expect(handler.handle(job)).rejects.toThrow("connection reset");
   });
 
   it("does not send when the user has no email", async () => {
@@ -188,7 +266,7 @@ describe(WalletCreditsLowCheckHandler.name, () => {
     await handler.handle(job);
 
     expect(notificationService.createNotification).toHaveBeenCalled();
-    expect(userWalletRepository.updateById).toHaveBeenCalledWith(wallet.id, { creditsLowNotifiedAt: expect.any(Date) });
+    expect(userWalletRepository.updateById).toHaveBeenCalledWith(wallet.id, { creditsLowNotifiedAt: expect.any(Date), creditsSufficientSince: null });
     expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "CREDITS_LOW_EMAIL_SENT" }));
   });
 
@@ -200,7 +278,10 @@ describe(WalletCreditsLowCheckHandler.name, () => {
     await handler.handle(job);
 
     expect(notificationService.createNotification).toHaveBeenCalled();
-    expect(userWalletRepository.updateById).toHaveBeenCalledWith(expect.any(Number), { creditsLowNotifiedAt: expect.any(Date) });
+    expect(userWalletRepository.updateById).toHaveBeenCalledWith(expect.any(Number), {
+      creditsLowNotifiedAt: expect.any(Date),
+      creditsSufficientSince: null
+    });
   });
 
   it("creates the logger with the service context", () => {
@@ -214,17 +295,21 @@ describe(WalletCreditsLowCheckHandler.name, () => {
     walletSettingNotFound?: boolean;
     isTrialing?: boolean;
     creditsLowNotifiedAt?: Date | null;
+    creditsSufficientSince?: Date | null;
     user?: ReturnType<typeof createUser>;
     balanceUsd?: number;
     weeklyCostUsd?: number;
     cumulativeDailyCostsUsd?: number[];
+    hasAutoTopUpSettings?: boolean;
+    confirmWindowMinutes?: number;
     paymentLink?: string;
   }) {
     const user = input?.user ?? createUser({ email: "user@example.com" });
     const wallet = createUserWallet({
       userId: user.id,
       isTrialing: input?.isTrialing ?? false,
-      creditsLowNotifiedAt: input?.creditsLowNotifiedAt ?? null
+      creditsLowNotifiedAt: input?.creditsLowNotifiedAt ?? null,
+      creditsSufficientSince: input?.creditsSufficientSince ?? null
     });
     const walletSetting = generateWalletSetting({
       userId: user.id,
@@ -250,7 +335,8 @@ describe(WalletCreditsLowCheckHandler.name, () => {
       createNotification: vi.fn().mockResolvedValue(undefined)
     });
     const billingConfig = mockConfigService<BillingConfigService>({
-      CONSOLE_WEB_PAYMENT_LINK: paymentLink
+      CONSOLE_WEB_PAYMENT_LINK: paymentLink,
+      CREDITS_LOW_RECOVERY_CONFIRM_WINDOW_MIN: input?.confirmWindowMinutes ?? 30
     });
     const logger = mock<ReturnType<CreateLogger>>();
     const createLogger = vi.fn<CreateLogger>(() => logger);
@@ -260,8 +346,13 @@ describe(WalletCreditsLowCheckHandler.name, () => {
     userWalletRepository.findOneByUserId.mockResolvedValue(wallet);
     userRepository.findById.mockResolvedValue(user);
     balancesService.getDeploymentBalanceInFiat.mockResolvedValue(balanceUsd);
-    drainingDeploymentService.calculateWeeklyCoverageForAddress.mockResolvedValue({ weeklyCostUsd, cumulativeDailyCostsUsd });
+    drainingDeploymentService.calculateWeeklyCoverageForAddress.mockResolvedValue({
+      weeklyCostUsd,
+      cumulativeDailyCostsUsd,
+      hasAutoTopUpSettings: input?.hasAutoTopUpSettings ?? true
+    });
     userWalletRepository.updateById.mockResolvedValue(undefined);
+    userWalletRepository.clearCreditsLowNotifiedIfRecoveryConfirmed.mockResolvedValue(false);
 
     const handler = new WalletCreditsLowCheckHandler(
       walletSettingRepository,

--- a/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.ts
+++ b/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.ts
@@ -12,6 +12,8 @@ import { type UserOutput, UserRepository } from "@src/user/repositories";
 
 type SkipReason = "auto_reload_enabled" | "no_wallet" | "trialing" | "no_email" | "zero_cost" | "sufficient_balance" | "already_notified";
 
+type NotLowReason = Extract<SkipReason, "zero_cost" | "sufficient_balance">;
+
 const UNEXPECTED_SKIP_REASONS: ReadonlySet<SkipReason> = new Set(["no_wallet", "no_email"]);
 
 @singleton()
@@ -45,21 +47,22 @@ export class WalletCreditsLowCheckHandler implements JobHandler<WalletCreditsLow
 
     const { wallet, user } = resources;
     const balanceUsd = await this.balancesService.getDeploymentBalanceInFiat(wallet.address);
-    const { weeklyCostUsd, cumulativeDailyCostsUsd } = await this.drainingDeploymentService.calculateWeeklyCoverageForAddress(wallet.address);
+    const { weeklyCostUsd, cumulativeDailyCostsUsd, hasAutoTopUpSettings } = await this.drainingDeploymentService.calculateWeeklyCoverageForAddress(
+      wallet.address
+    );
 
     if (weeklyCostUsd === 0) {
-      await this.#clearNotifiedIfSet(wallet);
-      this.#skip("zero_cost", payload.userId);
+      await this.#handleCreditsNotLow(wallet, payload.userId, "zero_cost", { canUnlatchImmediately: !hasAutoTopUpSettings });
       return;
     }
 
     if (balanceUsd >= weeklyCostUsd) {
-      await this.#clearNotifiedIfSet(wallet);
-      this.#skip("sufficient_balance", payload.userId);
+      await this.#handleCreditsNotLow(wallet, payload.userId, "sufficient_balance", { canUnlatchImmediately: false });
       return;
     }
 
     if (wallet.creditsLowNotifiedAt) {
+      await this.#endRecoveryStreak(wallet);
       this.#skip("already_notified", payload.userId);
       return;
     }
@@ -95,7 +98,7 @@ export class WalletCreditsLowCheckHandler implements JobHandler<WalletCreditsLow
    */
   async #stampNotified(wallet: UserWalletOutput, userId: UserOutput["id"]): Promise<void> {
     try {
-      await this.userWalletRepository.updateById(wallet.id, { creditsLowNotifiedAt: new Date() });
+      await this.userWalletRepository.updateById(wallet.id, { creditsLowNotifiedAt: new Date(), creditsSufficientSince: null });
     } catch (error) {
       this.logger.error({ event: "CREDITS_LOW_NOTIFIED_STAMP_FAILED", userId, error });
     }
@@ -128,12 +131,49 @@ export class WalletCreditsLowCheckHandler implements JobHandler<WalletCreditsLow
     return { wallet, user };
   }
 
-  async #clearNotifiedIfSet(wallet: UserWalletOutput): Promise<void> {
+  /** Nothing re-checks a wallet with no auto-top-up deployment left, so that verdict unlatches at once while a chain-derived one must hold for the window. */
+  async #handleCreditsNotLow(
+    wallet: UserWalletOutput,
+    userId: UserOutput["id"],
+    reason: NotLowReason,
+    { canUnlatchImmediately }: { canUnlatchImmediately: boolean }
+  ): Promise<void> {
     if (!wallet.creditsLowNotifiedAt) {
+      this.#skip(reason, userId);
       return;
     }
 
-    await this.userWalletRepository.updateById(wallet.id, { creditsLowNotifiedAt: null });
+    if (canUnlatchImmediately) {
+      await this.userWalletRepository.updateById(wallet.id, { creditsLowNotifiedAt: null, creditsSufficientSince: null });
+      this.logger.info({ event: "CREDITS_LOW_NOTIFIED_CLEARED", userId, reason });
+      this.#skip(reason, userId);
+      return;
+    }
+
+    if (!wallet.creditsSufficientSince) {
+      await this.userWalletRepository.updateById(wallet.id, { creditsSufficientSince: new Date() });
+      this.#skip(reason, userId);
+      return;
+    }
+
+    const isCleared = await this.userWalletRepository.clearCreditsLowNotifiedIfRecoveryConfirmed(
+      wallet.id,
+      this.billingConfig.get("CREDITS_LOW_RECOVERY_CONFIRM_WINDOW_MIN")
+    );
+
+    if (isCleared) {
+      this.logger.info({ event: "CREDITS_LOW_NOTIFIED_CLEARED", userId, reason, creditsSufficientSince: wallet.creditsSufficientSince });
+    }
+
+    this.#skip(reason, userId);
+  }
+
+  async #endRecoveryStreak(wallet: UserWalletOutput): Promise<void> {
+    if (!wallet.creditsSufficientSince) {
+      return;
+    }
+
+    await this.userWalletRepository.updateById(wallet.id, { creditsSufficientSince: null });
   }
 
   #skip(reason: SkipReason, userId: UserOutput["id"]): void {

--- a/apps/api/src/billing/services/wallet-settings/wallet-settings.service.spec.ts
+++ b/apps/api/src/billing/services/wallet-settings/wallet-settings.service.spec.ts
@@ -40,7 +40,7 @@ describe(WalletSettingService.name, () => {
         { withCleanup: true }
       );
       expect(walletReloadJobService.cancelCreditsLowCheckByUserId).toHaveBeenCalledWith(user.id);
-      expect(userWalletRepository.updateById).toHaveBeenCalledWith(enabledSetting.walletId, { creditsLowNotifiedAt: null });
+      expect(userWalletRepository.updateById).toHaveBeenCalledWith(enabledSetting.walletId, { creditsLowNotifiedAt: null, creditsSufficientSince: null });
     });
 
     it("enqueues a credits-low check when Auto Recharge is disabled", async () => {

--- a/apps/api/src/billing/services/wallet-settings/wallet-settings.service.ts
+++ b/apps/api/src/billing/services/wallet-settings/wallet-settings.service.ts
@@ -144,7 +144,7 @@ export class WalletSettingService {
       if (!prev?.autoReloadEnabled) {
         await this.walletReloadJobService.scheduleForWalletSetting(next, { withCleanup: true });
         await this.walletReloadJobService.cancelCreditsLowCheckByUserId(next.userId);
-        await this.userWalletRepository.updateById(next.walletId, { creditsLowNotifiedAt: null });
+        await this.userWalletRepository.updateById(next.walletId, { creditsLowNotifiedAt: null, creditsSufficientSince: null });
         return;
       }
 

--- a/apps/api/src/deployment/repositories/lease/lease.repository.integration.ts
+++ b/apps/api/src/deployment/repositories/lease/lease.repository.integration.ts
@@ -106,6 +106,51 @@ describe(LeaseRepository.name, () => {
     });
   });
 
+  describe("findActiveLeaseRates", () => {
+    it("sums the price of every open lease a deployment holds", async () => {
+      const { repository } = setup();
+      const [firstProvider, secondProvider] = await Promise.all([seedProvider(), seedProvider()]);
+      const deployment = await seedDeployment();
+      await seedLease(deployment, { providerAddress: firstProvider, gseq: 1, price: 30 });
+      await seedLease(deployment, { providerAddress: secondProvider, gseq: 2, price: 20 });
+
+      const found = await repository.findActiveLeaseRates(deployment.owner, [deployment.dseq]);
+
+      expect(found).toEqual([{ dseq: deployment.dseq, blockRate: 50 }]);
+    });
+
+    it("leaves out closed leases", async () => {
+      const { repository } = setup();
+      const [openProvider, closedProvider] = await Promise.all([seedProvider(), seedProvider()]);
+      const deployment = await seedDeployment();
+      await seedLease(deployment, { providerAddress: openProvider, gseq: 1, price: 30 });
+      await seedLease(deployment, { providerAddress: closedProvider, gseq: 2, price: 20, closedHeight: 10_000 });
+
+      const found = await repository.findActiveLeaseRates(deployment.owner, [deployment.dseq]);
+
+      expect(found).toEqual([{ dseq: deployment.dseq, blockRate: 30 }]);
+    });
+
+    it("omits a deployment whose leases are all closed", async () => {
+      const { repository } = setup();
+      const provider = await seedProvider();
+      const deployment = await seedDeployment();
+      await seedLease(deployment, { providerAddress: provider, price: 30, closedHeight: 10_000 });
+
+      const found = await repository.findActiveLeaseRates(deployment.owner, [deployment.dseq]);
+
+      expect(found).toEqual([]);
+    });
+
+    it("returns nothing when no deployment is given", async () => {
+      const { repository } = setup();
+
+      const found = await repository.findActiveLeaseRates(createAkashAddress(), []);
+
+      expect(found).toEqual([]);
+    });
+  });
+
   function setup() {
     return { repository: container.resolve(LeaseRepository) };
   }
@@ -123,7 +168,7 @@ async function seedDeployment() {
 
 async function seedLease(
   deployment: { id: string; owner: string; dseq: string },
-  overrides: { providerAddress: string; gseq?: number; closedHeight?: number }
+  overrides: { providerAddress: string; gseq?: number; closedHeight?: number; price?: number }
 ) {
   const gseq = overrides.gseq ?? 1;
   const group = await createDeploymentGroup({ deploymentId: deployment.id, owner: deployment.owner, dseq: deployment.dseq, gseq });
@@ -136,6 +181,7 @@ async function seedLease(
     gseq,
     oseq: 1,
     providerAddress: overrides.providerAddress,
-    closedHeight: overrides.closedHeight
+    closedHeight: overrides.closedHeight,
+    price: overrides.price
   });
 }

--- a/apps/api/src/deployment/repositories/lease/lease.repository.ts
+++ b/apps/api/src/deployment/repositories/lease/lease.repository.ts
@@ -134,13 +134,7 @@ export class LeaseRepository implements DrainingDeploymentLeaseSource {
     return [];
   }
 
-  /**
-   * Per-block spending rate of each given deployment's open leases, whatever its escrow holds.
-   *
-   * @param owner - Owner address
-   * @param dseqs - Array of deployment sequence numbers to filter by
-   * @returns Rate per deployment, omitting deployments with no open lease
-   */
+  /** Counts every lease the indexer has not seen close, including ones a provider is reclaiming, which the RPC source leaves out. */
   async findActiveLeaseRates(owner: string, dseqs: string[]): Promise<ActiveLeaseRate[]> {
     if (!dseqs.length) return [];
 

--- a/apps/api/src/deployment/repositories/lease/lease.repository.ts
+++ b/apps/api/src/deployment/repositories/lease/lease.repository.ts
@@ -3,7 +3,7 @@ import { col, fn, Op, QueryTypes, Sequelize, WhereOptions } from "sequelize";
 import { inject, singleton } from "tsyringe";
 
 import { CHAIN_DB } from "@src/chain";
-import { DrainingDeploymentLeaseSource } from "@src/deployment/types/draining-deployment";
+import { ActiveLeaseRate, DrainingDeploymentLeaseSource } from "@src/deployment/types/draining-deployment";
 
 export interface DrainingDeploymentOutput {
   dseq: number;
@@ -132,6 +132,33 @@ export class LeaseRepository implements DrainingDeploymentLeaseSource {
     }
 
     return [];
+  }
+
+  /**
+   * Per-block spending rate of each given deployment's open leases, whatever its escrow holds.
+   *
+   * @param owner - Owner address
+   * @param dseqs - Array of deployment sequence numbers to filter by
+   * @returns Rate per deployment, omitting deployments with no open lease
+   */
+  async findActiveLeaseRates(owner: string, dseqs: string[]): Promise<ActiveLeaseRate[]> {
+    if (!dseqs.length) return [];
+
+    const leases = await Lease.findAll({
+      where: {
+        owner,
+        dseq: { [Op.in]: dseqs },
+        closedHeight: { [Op.is]: null }
+      },
+      attributes: ["dseq", [fn("sum", col("price")), "blockRate"]],
+      group: ["dseq"],
+      raw: true
+    });
+
+    return (leases as unknown as Array<{ dseq: string; blockRate: string | number }>).map(lease => ({
+      dseq: String(lease.dseq),
+      blockRate: Number(lease.blockRate)
+    }));
   }
 
   /**

--- a/apps/api/src/deployment/services/draining-deployment-rpc/draining-deployment-rpc.service.spec.ts
+++ b/apps/api/src/deployment/services/draining-deployment-rpc/draining-deployment-rpc.service.spec.ts
@@ -231,6 +231,78 @@ describe(DrainingDeploymentRpcService.name, () => {
     });
   });
 
+  describe("findActiveLeaseRates", () => {
+    it("sums the rate of every live lease of a deployment, asking the chain for active ones only", async () => {
+      const { service, leaseHttpService, owner, dseqs } = setup({
+        inputs: [
+          {
+            leases: [
+              { blockRate: 50, gseq: 1 },
+              { blockRate: 25, gseq: 2 }
+            ]
+          }
+        ]
+      });
+
+      const result = await service.findActiveLeaseRates(owner, dseqs);
+
+      expect(leaseHttpService.list).toHaveBeenCalledWith(expect.objectContaining({ owner, state: "active" }));
+      expect(result).toEqual([{ dseq: dseqs[0], blockRate: 75 }]);
+    });
+
+    it("omits deployments the caller did not ask about", async () => {
+      const { service, owner, dseqs } = setup({
+        inputs: [{ leases: [{ blockRate: 50 }] }, { leases: [{ blockRate: 30 }] }]
+      });
+
+      const result = await service.findActiveLeaseRates(owner, [dseqs[0]]);
+
+      expect(result).toEqual([{ dseq: dseqs[0], blockRate: 50 }]);
+    });
+
+    it("collects leases across every page", async () => {
+      const { service, leaseHttpService, owner, dseqs, leaseList } = setup({
+        inputs: [
+          {
+            leases: [
+              { blockRate: 50, gseq: 1 },
+              { blockRate: 25, gseq: 2 }
+            ]
+          }
+        ]
+      });
+      leaseHttpService.list
+        .mockResolvedValueOnce({ leases: [leaseList[0]], pagination: { next_key: "page-2", total: "2" } })
+        .mockResolvedValueOnce({ leases: [leaseList[1]], pagination: { next_key: null, total: "2" } });
+
+      const result = await service.findActiveLeaseRates(owner, dseqs);
+
+      expect(leaseHttpService.list).toHaveBeenCalledTimes(2);
+      expect(leaseHttpService.list).toHaveBeenLastCalledWith(expect.objectContaining({ pagination: { limit: 1000, key: "page-2" } }));
+      expect(result).toEqual([{ dseq: dseqs[0], blockRate: 75 }]);
+    });
+
+    it("omits a lease with a non-positive rate", async () => {
+      const { service, loggerService, owner, dseqs } = setup({
+        inputs: [{ leases: [{ blockRate: 0 }] }]
+      });
+
+      const result = await service.findActiveLeaseRates(owner, dseqs);
+
+      expect(result).toEqual([]);
+      expect(loggerService.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "ACTIVE_LEASE_RATE_INVALID", dseq: dseqs[0], owner }));
+    });
+
+    it("queries nothing when no deployment is given", async () => {
+      const { service, leaseHttpService, owner } = setup();
+
+      const result = await service.findActiveLeaseRates(owner, []);
+
+      expect(result).toEqual([]);
+      expect(leaseHttpService.list).not.toHaveBeenCalled();
+    });
+  });
+
   function setup({
     inputs = []
   }: {
@@ -326,6 +398,7 @@ describe(DrainingDeploymentRpcService.name, () => {
       createLogger,
       owner,
       dseqs,
+      leaseList,
       closureHeight
     };
   }

--- a/apps/api/src/deployment/services/draining-deployment-rpc/draining-deployment-rpc.service.ts
+++ b/apps/api/src/deployment/services/draining-deployment-rpc/draining-deployment-rpc.service.ts
@@ -47,14 +47,7 @@ export class DrainingDeploymentRpcService implements DrainingDeploymentLeaseSour
     return outputs.filter(output => output.isClosed || output.predictedClosedHeight <= closureHeight);
   }
 
-  /**
-   * Per-block spending rate of each given deployment's live leases, whatever its escrow holds.
-   * Excludes leases a provider is reclaiming, which bill for their remaining grace window only.
-   *
-   * @param owner - The owner address to query leases for
-   * @param dseqs - Array of deployment sequence numbers to filter by
-   * @returns Rate per deployment, omitting deployments with no live lease
-   */
+  /** Leaves out leases a provider is reclaiming, which bill for their remaining grace window rather than the week ahead. */
   async findActiveLeaseRates(owner: string, dseqs: string[]): Promise<ActiveLeaseRate[]> {
     if (!dseqs.length) {
       return [];

--- a/apps/api/src/deployment/services/draining-deployment-rpc/draining-deployment-rpc.service.ts
+++ b/apps/api/src/deployment/services/draining-deployment-rpc/draining-deployment-rpc.service.ts
@@ -1,9 +1,9 @@
-import { DeploymentHttpService, LeaseHttpService, type RpcLease } from "@akashnetwork/http-sdk";
+import { DeploymentHttpService, LeaseHttpService, type LeaseState, type RpcLease } from "@akashnetwork/http-sdk";
 import { inject, singleton } from "tsyringe";
 
 import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
 import { DrainingDeploymentOutput } from "@src/deployment/repositories/lease/lease.repository";
-import { DrainingDeploymentLeaseSource, RpcDeploymentInfo } from "@src/deployment/types/draining-deployment";
+import { ActiveLeaseRate, DrainingDeploymentLeaseSource, RpcDeploymentInfo } from "@src/deployment/types/draining-deployment";
 
 /** The chain rejects a deposit into any escrow account that is not open, so every other state means closed to us. */
 const OPEN_ESCROW_ACCOUNT_STATE = "open";
@@ -48,20 +48,53 @@ export class DrainingDeploymentRpcService implements DrainingDeploymentLeaseSour
   }
 
   /**
+   * Per-block spending rate of each given deployment's live leases, whatever its escrow holds.
+   * Excludes leases a provider is reclaiming, which bill for their remaining grace window only.
+   *
+   * @param owner - The owner address to query leases for
+   * @param dseqs - Array of deployment sequence numbers to filter by
+   * @returns Rate per deployment, omitting deployments with no live lease
+   */
+  async findActiveLeaseRates(owner: string, dseqs: string[]): Promise<ActiveLeaseRate[]> {
+    if (!dseqs.length) {
+      return [];
+    }
+
+    const leases = await this.#fetchLeases(owner, new Set(dseqs), "active");
+    const ratesByDseq = new Map<string, number>();
+
+    for (const lease of leases) {
+      const dseq = String(Number(lease.lease.id.dseq));
+      const rateAmount = Number(lease.escrow_payment.state.rate.amount);
+
+      if (!Number.isFinite(rateAmount) || rateAmount <= 0) {
+        this.loggerService.warn({ event: "ACTIVE_LEASE_RATE_INVALID", dseq, owner });
+        continue;
+      }
+
+      ratesByDseq.set(dseq, (ratesByDseq.get(dseq) ?? 0) + rateAmount);
+    }
+
+    return Array.from(ratesByDseq, ([dseq, blockRate]) => ({ dseq, blockRate }));
+  }
+
+  /**
    * Fetches lease data from RPC for the given owner and dseqs.
    * Handles pagination automatically.
    *
    * @param owner - The owner address to query leases for
    * @param dseqSet - Set of deployment sequence numbers to filter by
+   * @param state - Optional lease state to filter on server-side
    * @returns Array of RPC lease data
    */
-  async #fetchLeases(owner: string, dseqSet: Set<string>): Promise<RpcLease[]> {
+  async #fetchLeases(owner: string, dseqSet: Set<string>, state?: LeaseState): Promise<RpcLease[]> {
     const allItems: RpcLease[] = [];
     let nextKey: string | null = null;
 
     do {
       const response = await this.leaseHttpService.list({
         owner,
+        state,
         pagination: { limit: 1000, key: nextKey || undefined }
       });
 

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
@@ -1086,6 +1086,31 @@ describe(DrainingDeploymentService.name, () => {
       expect(result.weeklyCostUsd).toBeGreaterThan(0);
     });
 
+    it("bills a deployment whose lease rate comes back with leading zeros", async () => {
+      const blockRate = 50;
+      const { service, address, rpcService, deploymentSettings, balancesService } = await setupWeeklyBurnForAddress({
+        deployments: [{ blockRate }]
+      });
+      rpcService.findActiveLeaseRates.mockResolvedValue([{ dseq: `000${deploymentSettings[0].dseq}`, blockRate }]);
+
+      const result = await service.calculateWeeklyCoverageForAddress(address);
+
+      expect(balancesService.toFiatAmount).toHaveBeenCalledWith(Math.floor(blockRate * averageBlockCountInAnHour * 24 * 7));
+      expect(result.weeklyCostUsd).toBeGreaterThan(0);
+    });
+
+    it("ignores a lease rate that matches no auto top-up deployment", async () => {
+      const { service, address, rpcService, loggerService } = await setupWeeklyBurnForAddress({
+        deployments: [{ blockRate: 50 }]
+      });
+      rpcService.findActiveLeaseRates.mockResolvedValue([{ dseq: "999999", blockRate: 50 }]);
+
+      const result = await service.calculateWeeklyCoverageForAddress(address);
+
+      expect(result).toEqual({ weeklyCostUsd: 0, cumulativeDailyCostsUsd: [], hasAutoTopUpSettings: true });
+      expect(loggerService.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "ACTIVE_LEASE_RATE_WITHOUT_SETTING", dseq: "999999", address }));
+    });
+
     it("falls back to the database when the lease rate query fails", async () => {
       const blockRate = 50;
       const rpcError = new Error("RPC error");

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
@@ -942,8 +942,7 @@ describe(DrainingDeploymentService.name, () => {
 
       baseSetup.deploymentSettingRepository.findAutoTopUpDeploymentsByOwner.mockResolvedValue(deploymentSettings);
 
-      baseSetup.rpcService.findActiveLeaseRates.mockRejectedValue(new Error("RPC error"));
-      baseSetup.leaseRepository.findActiveLeaseRates.mockResolvedValue(leaseRates);
+      baseSetup.rpcService.findActiveLeaseRates.mockResolvedValue(leaseRates);
 
       baseSetup.balancesService.toFiatAmount.mockImplementation(async (uaktAmount: number) => {
         if (uaktAmount === 0) {

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
@@ -851,16 +851,8 @@ describe(DrainingDeploymentService.name, () => {
 
   describe("calculateWeeklyDeploymentCost", () => {
     it("calculates weekly cost for all active deployments", async () => {
-      const blockRate1 = 50;
-      const blockRate2 = 75;
-      const baseSetup = setup();
-      const deployments = [
-        { predictedClosedHeight: baseSetup.currentHeight + 100, blockRate: blockRate1 },
-        { predictedClosedHeight: baseSetup.currentHeight + 200, blockRate: blockRate2 }
-      ];
-
       const { service, userId, ability } = await setupCalculateWeeklyCost({
-        deployments,
+        deployments: [{ blockRate: 50 }, { blockRate: 75 }],
         expectedFiatAmount: 12.5
       });
 
@@ -869,29 +861,10 @@ describe(DrainingDeploymentService.name, () => {
       expect(result).toBe(12.5);
     });
 
-    it("includes deployments closing after 7 days", async () => {
-      const blockRate = 50;
-      const baseSetup = setup();
-      const blocksInAWeek = Math.floor(averageBlockCountInAnHour * 24 * 7);
-      const deploymentClosingAfterWeek = {
-        predictedClosedHeight: baseSetup.currentHeight + blocksInAWeek + 1000,
-        blockRate
-      };
-
-      const { service, userId, ability } = await setupCalculateWeeklyCost({
-        deployments: [deploymentClosingAfterWeek],
-        expectedFiatAmount: 5.0
-      });
-
-      const result = await service.calculateWeeklyDeploymentCost(userId, ability);
-
-      expect(result).toBe(5.0);
-    });
-
     it("returns 0 when user wallet not found", async () => {
       const { service, userId, ability } = await setupCalculateWeeklyCost({
         userWallet: undefined,
-        deployments: [{ predictedClosedHeight: 1000100, blockRate: 50 }]
+        deployments: [{ blockRate: 50 }]
       });
 
       const result = await service.calculateWeeklyDeploymentCost(userId, ability);
@@ -902,7 +875,7 @@ describe(DrainingDeploymentService.name, () => {
     it("returns 0 when user wallet has no address", async () => {
       const { service, userId, ability } = await setupCalculateWeeklyCost({
         userWallet: createUserWallet({ address: null }),
-        deployments: [{ predictedClosedHeight: 1000100, blockRate: 50 }]
+        deployments: [{ blockRate: 50 }]
       });
 
       const result = await service.calculateWeeklyDeploymentCost(userId, ability);
@@ -920,37 +893,9 @@ describe(DrainingDeploymentService.name, () => {
       expect(result).toBe(0);
     });
 
-    it("excludes deployments with null predictedClosedHeight", async () => {
-      const { service, userId, ability } = await setupCalculateWeeklyCost({
-        deployments: [{ predictedClosedHeight: null as unknown as number, blockRate: 50 }]
-      });
-
-      const result = await service.calculateWeeklyDeploymentCost(userId, ability);
-
-      expect(result).toBe(0);
-    });
-
-    it("excludes deployments closing at or before currentHeight", async () => {
-      const baseSetup = setup();
-      const { service, userId, ability } = await setupCalculateWeeklyCost({
-        deployments: [
-          { predictedClosedHeight: baseSetup.currentHeight - 100, blockRate: 50 },
-          { predictedClosedHeight: baseSetup.currentHeight, blockRate: 75 }
-        ]
-      });
-
-      const result = await service.calculateWeeklyDeploymentCost(userId, ability);
-
-      expect(result).toBe(0);
-    });
-
     it("excludes deployments with blockRate <= 0", async () => {
-      const baseSetup = setup();
       const { service, userId, ability } = await setupCalculateWeeklyCost({
-        deployments: [
-          { predictedClosedHeight: baseSetup.currentHeight + 100, blockRate: 0 },
-          { predictedClosedHeight: baseSetup.currentHeight + 200, blockRate: -10 }
-        ]
+        deployments: [{ blockRate: 0 }, { blockRate: -10 }]
       });
 
       const result = await service.calculateWeeklyDeploymentCost(userId, ability);
@@ -961,9 +906,8 @@ describe(DrainingDeploymentService.name, () => {
     it("caps a runtime-limited deployment at its remaining hours like the credits-low threshold", async () => {
       const blockRate = 50;
       const runtimeLimitHours = 12;
-      const baseSetup = setup();
       const { service, userId, ability, balancesService } = await setupCalculateWeeklyCost({
-        deployments: [{ predictedClosedHeight: baseSetup.currentHeight + 1_000_000, blockRate, runtimeLimitHours }],
+        deployments: [{ blockRate, runtimeLimitHours }],
         expectedFiatAmount: 3.6
       });
 
@@ -975,7 +919,7 @@ describe(DrainingDeploymentService.name, () => {
 
     async function setupCalculateWeeklyCost(input: {
       userWallet?: ReturnType<typeof createUserWallet> | undefined;
-      deployments: Array<{ predictedClosedHeight: number | null; blockRate: number; runtimeLimitHours?: number }>;
+      deployments: Array<{ blockRate: number; runtimeLimitHours?: number }>;
       expectedFiatAmount?: number;
     }) {
       const userId = faker.string.uuid();
@@ -991,22 +935,15 @@ describe(DrainingDeploymentService.name, () => {
       const deploymentSettings = input.deployments.map(deployment =>
         createAutoTopUpDeployment({ address, runtimeLimitHours: deployment.runtimeLimitHours ?? null })
       );
-
-      const drainingDeployments = deploymentSettings.map((setting, idx) => {
-        const deployment = input.deployments[idx];
-        const predictedClosedHeight = deployment?.predictedClosedHeight;
-        return createDrainingDeployment({
-          dseq: Number(setting.dseq),
-          owner: address,
-          blockRate: deployment?.blockRate ?? 0,
-          predictedClosedHeight: predictedClosedHeight === null ? baseSetup.currentHeight - 1 : predictedClosedHeight ?? baseSetup.currentHeight + 100
-        });
-      });
+      const leaseRates = deploymentSettings.map((setting, idx) => ({
+        dseq: setting.dseq,
+        blockRate: input.deployments[idx]?.blockRate ?? 0
+      }));
 
       baseSetup.deploymentSettingRepository.findAutoTopUpDeploymentsByOwner.mockResolvedValue(deploymentSettings);
 
-      baseSetup.rpcService.findManyByDseqAndOwner.mockRejectedValue(new Error("RPC error"));
-      baseSetup.leaseRepository.findManyByDseqAndOwner.mockImplementation((_closureHeight, _owner, _dseqs) => Promise.resolve(drainingDeployments));
+      baseSetup.rpcService.findActiveLeaseRates.mockRejectedValue(new Error("RPC error"));
+      baseSetup.leaseRepository.findActiveLeaseRates.mockResolvedValue(leaseRates);
 
       baseSetup.balancesService.toFiatAmount.mockImplementation(async (uaktAmount: number) => {
         if (uaktAmount === 0) {
@@ -1090,7 +1027,7 @@ describe(DrainingDeploymentService.name, () => {
 
         const result = await service.calculateWeeklyCoverageForAddress(address);
 
-        expect(result).toEqual({ weeklyCostUsd: 0, cumulativeDailyCostsUsd: [] });
+        expect(result).toEqual({ weeklyCostUsd: 0, cumulativeDailyCostsUsd: [], hasAutoTopUpSettings: true });
         expect(balancesService.toFiatAmount).not.toHaveBeenCalled();
       } finally {
         vi.useRealTimers();
@@ -1136,36 +1073,67 @@ describe(DrainingDeploymentService.name, () => {
       );
     });
 
-    it("returns 0 when user wallet is not found", async () => {
+    it("bills a deployment whose escrow has already run dry, since it keeps running and keeps billing", async () => {
+      const blockRate = 50;
+      const { service, address, balancesService, rpcService } = await setupWeeklyBurnForAddress({
+        deployments: [{ blockRate }]
+      });
+
+      const result = await service.calculateWeeklyCoverageForAddress(address);
+
+      expect(rpcService.findManyByDseqAndOwner).not.toHaveBeenCalled();
+      expect(balancesService.toFiatAmount).toHaveBeenCalledWith(Math.floor(blockRate * averageBlockCountInAnHour * 24 * 7));
+      expect(result.weeklyCostUsd).toBeGreaterThan(0);
+    });
+
+    it("falls back to the database when the lease rate query fails", async () => {
+      const blockRate = 50;
+      const rpcError = new Error("RPC error");
+      const { service, address, leaseRepository, loggerService, deploymentSettings } = await setupWeeklyBurnForAddress({
+        deployments: [{ blockRate }],
+        rpcError
+      });
+
+      const result = await service.calculateWeeklyCoverageForAddress(address);
+
+      expect(leaseRepository.findActiveLeaseRates).toHaveBeenCalledWith(
+        address,
+        deploymentSettings.map(setting => setting.dseq)
+      );
+      expect(loggerService.error).toHaveBeenCalledWith(expect.objectContaining({ event: "ACTIVE_LEASE_RATE_RPC_QUERY_FAILED_FALLBACK_TO_DB" }));
+      expect(result.weeklyCostUsd).toBe(usdFromCredits(Math.floor(blockRate * averageBlockCountInAnHour * 24 * 7)));
+    });
+
+    it("reports no auto top-up settings when user wallet is not found", async () => {
       const { service, address } = await setupWeeklyBurnForAddress({
         userWallet: undefined,
-        deployments: [{ predictedClosedHeight: 1000100, blockRate: 50 }]
+        deployments: [{ blockRate: 50 }]
       });
 
       const result = await service.calculateWeeklyCoverageForAddress(address);
 
-      expect(result).toEqual({ weeklyCostUsd: 0, cumulativeDailyCostsUsd: [] });
+      expect(result).toEqual({ weeklyCostUsd: 0, cumulativeDailyCostsUsd: [], hasAutoTopUpSettings: false });
     });
 
-    it("returns 0 when user wallet has no address", async () => {
+    it("reports no auto top-up settings when user wallet has no address", async () => {
       const { service, address } = await setupWeeklyBurnForAddress({
         userWallet: createUserWallet({ address: null }),
-        deployments: [{ predictedClosedHeight: 1000100, blockRate: 50 }]
+        deployments: [{ blockRate: 50 }]
       });
 
       const result = await service.calculateWeeklyCoverageForAddress(address);
 
-      expect(result).toEqual({ weeklyCostUsd: 0, cumulativeDailyCostsUsd: [] });
+      expect(result).toEqual({ weeklyCostUsd: 0, cumulativeDailyCostsUsd: [], hasAutoTopUpSettings: false });
     });
 
-    it("returns 0 when no deployments are found", async () => {
+    it("reports no auto top-up settings when no deployments are found", async () => {
       const { service, address } = await setupWeeklyBurnForAddress({
         deployments: []
       });
 
       const result = await service.calculateWeeklyCoverageForAddress(address);
 
-      expect(result).toEqual({ weeklyCostUsd: 0, cumulativeDailyCostsUsd: [] });
+      expect(result).toEqual({ weeklyCostUsd: 0, cumulativeDailyCostsUsd: [], hasAutoTopUpSettings: false });
     });
 
     it("returns 0 when block rate is zero", async () => {
@@ -1175,7 +1143,7 @@ describe(DrainingDeploymentService.name, () => {
 
       const result = await service.calculateWeeklyCoverageForAddress(address);
 
-      expect(result).toEqual({ weeklyCostUsd: 0, cumulativeDailyCostsUsd: [] });
+      expect(result).toEqual({ weeklyCostUsd: 0, cumulativeDailyCostsUsd: [], hasAutoTopUpSettings: true });
       expect(balancesService.toFiatAmount).not.toHaveBeenCalled();
     });
 
@@ -1186,11 +1154,11 @@ describe(DrainingDeploymentService.name, () => {
     async function setupWeeklyBurnForAddress(input: {
       userWallet?: ReturnType<typeof createUserWallet> | undefined;
       deployments: Array<{
-        predictedClosedHeight?: number | null;
         blockRate: number;
         runtimeLimitHours?: number | null;
         runtimeEndsAt?: Date | null;
       }>;
+      rpcError?: Error;
     }) {
       const address = createAkashAddress();
       const userWallet = "userWallet" in input ? input.userWallet : createUserWallet({ address });
@@ -1206,24 +1174,26 @@ describe(DrainingDeploymentService.name, () => {
           runtimeEndsAt: deployment.runtimeEndsAt ?? null
         })
       );
-
-      const drainingDeployments = deploymentSettings.map((setting, idx) => {
-        const deployment = input.deployments[idx];
-        return createDrainingDeployment({
-          dseq: Number(setting.dseq),
-          owner: address,
-          blockRate: deployment?.blockRate ?? 0,
-          predictedClosedHeight: deployment?.predictedClosedHeight ?? baseSetup.currentHeight + 100
-        });
-      });
+      const leaseRates = deploymentSettings.map((setting, idx) => ({
+        dseq: setting.dseq,
+        blockRate: input.deployments[idx]?.blockRate ?? 0
+      }));
 
       baseSetup.deploymentSettingRepository.findAutoTopUpDeploymentsByOwner.mockResolvedValue(deploymentSettings);
-      baseSetup.rpcService.findManyByDseqAndOwner.mockResolvedValue(drainingDeployments);
+
+      if (input.rpcError) {
+        baseSetup.rpcService.findActiveLeaseRates.mockRejectedValue(input.rpcError);
+        baseSetup.leaseRepository.findActiveLeaseRates.mockResolvedValue(leaseRates);
+      } else {
+        baseSetup.rpcService.findActiveLeaseRates.mockResolvedValue(leaseRates);
+      }
+
       baseSetup.balancesService.toFiatAmount.mockImplementation(async (uaktAmount: number) => usdFromCredits(uaktAmount));
 
       return {
         ...baseSetup,
-        address
+        address,
+        deploymentSettings
       };
     }
   });

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
@@ -10,7 +10,7 @@ import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
 import type { DryRunOptions } from "@src/core/types/console";
 import { AutoTopUpDeployment, DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import { DrainingDeploymentOutput, LeaseRepository } from "@src/deployment/repositories/lease/lease.repository";
-import { DrainingDeployment } from "@src/deployment/types/draining-deployment";
+import { ActiveLeaseRate, DrainingDeployment } from "@src/deployment/types/draining-deployment";
 import { averageBlockCountInAnHour } from "@src/utils/constants";
 import { DeploymentCloseJobService } from "../deployment-close-job/deployment-close-job.service";
 import { DeploymentConfigService } from "../deployment-config/deployment-config.service";
@@ -22,10 +22,11 @@ export type { DrainingDeployment } from "@src/deployment/types/draining-deployme
 export type WeeklyCoverage = {
   weeklyCostUsd: number;
   cumulativeDailyCostsUsd: number[];
+  /** Distinguishes a zero cost the database is certain of from one a chain read could have gotten wrong. */
+  hasAutoTopUpSettings: boolean;
 };
 
-export type WeeklyBurnSource = Pick<DrainingDeployment, "predictedClosedHeight" | "blockRate"> &
-  Partial<Pick<AutoTopUpDeployment, "runtimeLimitHours" | "runtimeEndsAt">>;
+export type WeeklyBurnSource = Pick<DrainingDeployment, "blockRate"> & Partial<Pick<AutoTopUpDeployment, "runtimeLimitHours" | "runtimeEndsAt">>;
 
 export type AutoTopUpOwnerDeployments = {
   address: string;
@@ -421,20 +422,23 @@ export class DrainingDeploymentService {
    * balance can be translated into covered days without assuming the capped weekly total
    * is a uniform seven-day burn rate.
    * Not CASL-scoped — the credits-low job calls this with the wallet address.
+   * Bills a deployment whose escrow has run dry too, since it keeps running on auto top-up.
    */
   async calculateWeeklyCoverageForAddress(address: string): Promise<WeeklyCoverage> {
-    const noCoverage: WeeklyCoverage = { weeklyCostUsd: 0, cumulativeDailyCostsUsd: [] };
-
     const deploymentSettings = await this.#findAutoTopUpDeploymentSettings(address);
     if (deploymentSettings.length === 0) {
-      return noCoverage;
+      return { weeklyCostUsd: 0, cumulativeDailyCostsUsd: [], hasAutoTopUpSettings: false };
     }
 
+    const noCoverage: WeeklyCoverage = { weeklyCostUsd: 0, cumulativeDailyCostsUsd: [], hasAutoTopUpSettings: true };
     const currentHeight = await this.blockHttpService.getCurrentHeight();
-    const leases = await this.#findDrainingDeployments(deploymentSettings, address, Number.MAX_SAFE_INTEGER);
+    const leaseRates = await this.#findActiveLeaseRates(
+      address,
+      deploymentSettings.map(deployment => deployment.dseq)
+    );
     const settingsByDseq = keyBy(deploymentSettings, s => String(s.dseq));
     const burns = this.#buildWeeklyBurns(
-      leases.map(lease => ({ ...settingsByDseq[String(lease.dseq)], predictedClosedHeight: lease.predictedClosedHeight, blockRate: lease.blockRate })),
+      leaseRates.map(leaseRate => ({ ...settingsByDseq[leaseRate.dseq], blockRate: leaseRate.blockRate })),
       currentHeight
     );
 
@@ -446,7 +450,7 @@ export class DrainingDeploymentService {
     const weeklyCostUsd = await this.balancesService.toFiatAmount(weeklyCredits);
     const cumulativeDailyCostsUsd = Array.from({ length: 7 }, (_, day) => (this.#creditsForHours(burns, (day + 1) * 24) / weeklyCredits) * weeklyCostUsd);
 
-    return { weeklyCostUsd, cumulativeDailyCostsUsd };
+    return { weeklyCostUsd, cumulativeDailyCostsUsd, hasAutoTopUpSettings: true };
   }
 
   /** Comparing this against a credit balance stands in for the handler's USD test: `toFiatAmount` is monotonic, off by at most its cent rounding. */
@@ -456,7 +460,7 @@ export class DrainingDeploymentService {
 
   #buildWeeklyBurns(deployments: WeeklyBurnSource[], currentHeight: number): Array<{ hourlyCredits: number; coverageHours: number }> {
     return deployments.flatMap(deployment => {
-      if (!deployment.predictedClosedHeight || deployment.predictedClosedHeight <= currentHeight || deployment.blockRate <= 0) {
+      if (!Number.isFinite(deployment.blockRate) || deployment.blockRate <= 0) {
         return [];
       }
 
@@ -561,6 +565,31 @@ export class DrainingDeploymentService {
         error
       });
       return await this.leaseRepository.findManyByDseqAndOwner(closureHeight, owner, dseqs);
+    }
+  }
+
+  /**
+   * Live lease rates for the given deployments, falling back to the indexer database if RPC fails.
+   *
+   * @param owner - The owner address to query leases for
+   * @param dseqs - Array of deployment sequence numbers to filter by
+   * @returns Rate per deployment, omitting deployments with no live lease
+   */
+  async #findActiveLeaseRates(owner: string, dseqs: string[]): Promise<ActiveLeaseRate[]> {
+    if (!dseqs.length) {
+      return [];
+    }
+
+    try {
+      return await this.rpcService.findActiveLeaseRates(owner, dseqs);
+    } catch (error) {
+      this.loggerService.error({
+        event: "ACTIVE_LEASE_RATE_RPC_QUERY_FAILED_FALLBACK_TO_DB",
+        message: `RPC query failed for owner ${owner}, falling back to database`,
+        owner,
+        error
+      });
+      return await this.leaseRepository.findActiveLeaseRates(owner, dseqs);
     }
   }
 }

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
@@ -436,11 +436,7 @@ export class DrainingDeploymentService {
       address,
       deploymentSettings.map(deployment => deployment.dseq)
     );
-    const settingsByDseq = keyBy(deploymentSettings, s => String(s.dseq));
-    const burns = this.#buildWeeklyBurns(
-      leaseRates.map(leaseRate => ({ ...settingsByDseq[leaseRate.dseq], blockRate: leaseRate.blockRate })),
-      currentHeight
-    );
+    const burns = this.#buildWeeklyBurns(this.#applySettingsToLeaseRates(deploymentSettings, leaseRates, address), currentHeight);
 
     const weeklyCredits = this.#creditsForHours(burns, WEEK_HOURS);
     if (weeklyCredits === 0) {
@@ -451,6 +447,22 @@ export class DrainingDeploymentService {
     const cumulativeDailyCostsUsd = Array.from({ length: 7 }, (_, day) => (this.#creditsForHours(burns, (day + 1) * 24) / weeklyCredits) * weeklyCostUsd);
 
     return { weeklyCostUsd, cumulativeDailyCostsUsd, hasAutoTopUpSettings: true };
+  }
+
+  /** Joins on the numeric value of a dseq, since the two lease-rate sources differ on whether they keep its leading zeros. */
+  #applySettingsToLeaseRates(deploymentSettings: AutoTopUpDeployment[], leaseRates: ActiveLeaseRate[], address: string): WeeklyBurnSource[] {
+    const settingsByDseq = keyBy(deploymentSettings, setting => String(Number(setting.dseq)));
+
+    return leaseRates.flatMap(leaseRate => {
+      const setting = settingsByDseq[String(Number(leaseRate.dseq))];
+
+      if (!setting) {
+        this.loggerService.warn({ event: "ACTIVE_LEASE_RATE_WITHOUT_SETTING", dseq: leaseRate.dseq, address });
+        return [];
+      }
+
+      return [{ ...setting, blockRate: leaseRate.blockRate }];
+    });
   }
 
   /** Comparing this against a credit balance stands in for the handler's USD test: `toFiatAmount` is monotonic, off by at most its cent rounding. */
@@ -568,13 +580,7 @@ export class DrainingDeploymentService {
     }
   }
 
-  /**
-   * Live lease rates for the given deployments, falling back to the indexer database if RPC fails.
-   *
-   * @param owner - The owner address to query leases for
-   * @param dseqs - Array of deployment sequence numbers to filter by
-   * @returns Rate per deployment, omitting deployments with no live lease
-   */
+  /** The indexer fallback counts reclaiming leases the chain source leaves out, which can only overstate the week ahead. */
   async #findActiveLeaseRates(owner: string, dseqs: string[]): Promise<ActiveLeaseRate[]> {
     try {
       return await this.rpcService.findActiveLeaseRates(owner, dseqs);

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
@@ -576,10 +576,6 @@ export class DrainingDeploymentService {
    * @returns Rate per deployment, omitting deployments with no live lease
    */
   async #findActiveLeaseRates(owner: string, dseqs: string[]): Promise<ActiveLeaseRate[]> {
-    if (!dseqs.length) {
-      return [];
-    }
-
     try {
       return await this.rpcService.findActiveLeaseRates(owner, dseqs);
     } catch (error) {

--- a/apps/api/src/deployment/types/draining-deployment.ts
+++ b/apps/api/src/deployment/types/draining-deployment.ts
@@ -6,6 +6,11 @@ export type DrainingDeployment = AutoTopUpDeployment & {
   blockRate: number;
 };
 
+export type ActiveLeaseRate = {
+  dseq: string;
+  blockRate: number;
+};
+
 export type RpcDeploymentInfo = {
   dseq: string;
   escrowBalance: number;
@@ -15,4 +20,5 @@ export type RpcDeploymentInfo = {
 
 export interface DrainingDeploymentLeaseSource {
   findManyByDseqAndOwner(closureHeight: number, owner: string, dseqs: string[]): Promise<DrainingDeploymentOutput[]>;
+  findActiveLeaseRates(owner: string, dseqs: string[]): Promise<ActiveLeaseRate[]>;
 }

--- a/apps/api/test/seeders/user-wallet.seeder.ts
+++ b/apps/api/test/seeders/user-wallet.seeder.ts
@@ -13,7 +13,8 @@ export function createUserWallet({
   createdAt = faker.date.past(),
   updatedAt = faker.date.past(),
   activatedAt = createdAt,
-  creditsLowNotifiedAt = null
+  creditsLowNotifiedAt = null,
+  creditsSufficientSince = null
 }: Partial<UserWalletOutput> = {}): UserWalletOutput {
   return {
     id,
@@ -26,7 +27,8 @@ export function createUserWallet({
     createdAt,
     updatedAt,
     activatedAt,
-    creditsLowNotifiedAt
+    creditsLowNotifiedAt,
+    creditsSufficientSince
   };
 }
 


### PR DESCRIPTION
## Why

Fixes CON-917

Since CON-896 (#3683) went out on 2026-08-27, users whose credits are low get the same email over and over: 12 emails to 3 users in the 4.5 hours after the release, against 40 emails to 20 users over the whole preceding week. One user got seven in 95 minutes.

`creditsLowNotifiedAt` is what stops a second email, and any single check that read not-low cleared it. One bad reading therefore cost one extra email, sent by the next check about 90 seconds later.

Production logs show what those bad readings were. The worst-hit user sat at a $0.59 balance against a $3.42 weekly cost for the whole window, and each of their emails was preceded by a `sufficient_balance` skip (traces `13bd26c4ed6f` at 14:40:57Z and `f09bcf2cdc75` at 15:01:14Z). Neither of those jobs logged an RPC failure, a database fallback, or a lease/deployment mismatch, so the partial-lease-view theory in the issue does not hold for this incident. The under-read comes from the coverage calculation itself: it prices a deployment only while its escrow still covers a future block, so a deployment whose escrow has run dry counts as costing nothing. That is the normal state of an auto-top-up deployment on a low-credit wallet between top-ups. This user's own deploy-and-close activity both flipped the reading and triggered the checks that read it.

CON-896 did not introduce the race, it widened it. Checks used to run once an hour and now run on every close, fund and lease start.

## What

Two changes. The latch alone would still let a quiet stretch of misreads clear it, and the coverage fix alone would still let a single misread through during an RPC outage.

Clearing the latch now needs a reading that holds. A new `user_wallets.credits_sufficient_since` column records when credits first read sufficient; clearing waits for that to survive `CREDITS_LOW_RECOVERY_CONFIRM_WINDOW_MIN` (default 30), and any low reading in between wipes it. The window is re-checked in SQL rather than in the handler, so a concurrent check that saw the wallet low still wins. The hourly sweep keeps enqueueing checks for a notified wallet whose readings look recovered, so a real recovery clears within a sweep or two.

One verdict still clears immediately: having no auto-top-up deployment left. That comes from our own database rather than a chain read, and the sweep never yields such an owner, so a pending window there would never get a confirming check and the latch would stick forever.

Coverage now prices every open deployment from its live lease rate and drops the escrow gate. A drained deployment is still running and auto top-up is still paying for it, so a week of it is a real cost. Two things fall out of the new source: closed leases stop inflating a deployment's rate (every lease ever created for the dseq used to be summed in), and the check makes one paginated chain query instead of two. This also corrects the `daysRemaining` figure in the email, which came from the same under-read.

`/v1/weekly-cost` shares this calculation, so the weekly cost shown in the product now includes escrow-drained deployments too. That is the intended trade: it is the more honest number, and one shared calculation is what CON-896 set out to build.

Leases in the `reclaiming` state are left out, which slightly under-counts a deployment inside its AEP-82 grace window. Including them would mean paging through every historical closed lease, and an under-read can no longer clear the latch anyway.

Migration `0046_credits_low_recovery_latch.sql` adds one nullable timestamp column to `user_wallets`, with no backfill and no table rewrite.

Verified with `npm test`, `npm run lint -- --quiet` and `npx tsc --noEmit` in `apps/api`: 2031 unit and 323 functional tests pass, and type errors are unchanged from `main`. The affected integration files pass (91 tests), including a concurrency test showing the guarded clear fires exactly once across five racing calls; the rest of the integration suite needs the Docker Postgres that CI provides. The incident sequence is covered as unit tests: low sends one email, a `sufficient_balance` blip leaves the latch alone, and the next low reading skips as `already_notified`.

After deploy, watch `console-api-mainnet-bg-jobs` in Loki. `CREDITS_LOW_EMAIL_SENT` per user should fall back to roughly one per low period, and the new `CREDITS_LOW_NOTIFIED_CLEARED` event should only appear on real recoveries. A blip still shows up as a `sufficient_balance` skip; what proves the fix is that no email and no clear follows it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added recovery confirmation for clearing low-credit alerts, with a configurable confirmation window.
  - Wallet settings now reset recovery tracking when automatic recharge is enabled.
  - Improved weekly deployment cost calculations using active lease rates, including database fallback handling.
  - Added coverage for deployments with depleted escrow and clearer auto-recharge status reporting.

- **Bug Fixes**
  - Prevented low-credit alerts from clearing before balances remain sufficient for the required period.
  - Improved handling of invalid lease rates, closed deployments, and dry-run operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
