### PR TITLE
fix(deployment): shorten unreachable-provider cron names to fit k8s limit

### DIFF
--- a/.helm/console-api-prod-mainnet-values.yaml
+++ b/.helm/console-api-prod-mainnet-values.yaml
@@ -51,27 +51,27 @@ jobs:
   # The first live run catches up on every outage already past the threshold, so check the volume in
   # those logs before dropping the flag.
   # Offset from the two runtime-limit sweeps so no two of them hit deployment_settings on the same minute.
-  - name: notify-unreachable-provider-deployments
+  - name: notify-unreachable-deployments
     schedule: "11,41 * * * *" # every 30 minutes
     command:
       - node
       - --require
       - ./dist/instrumentation.js
       - ./dist/console.js
-      - notify-unreachable-provider-deployments
+      - notify-unreachable-deployments
       - --dry-run
   # Ships in dry-run and stays that way until the warning email above has been live for longer than the
   # gap between the two thresholds (14 - 3 = 11 days), so no owner's first word about an outage is the
   # closure notice. Check that every UNREACHABLE_PROVIDER_DEPLOYMENT_WOULD_CLOSE was warned first.
   # Offset from the sweeps above so no two of them hit deployment_settings on the same minute.
-  - name: close-unreachable-provider-deployments
+  - name: close-unreachable-deployments
     schedule: "26 * * * *" # hourly
     command:
       - node
       - --require
       - ./dist/instrumentation.js
       - ./dist/console.js
-      - close-unreachable-provider-deployments
+      - close-unreachable-deployments
       - --dry-run
   - name: mint-act
     schedule: "*/10 * * * *" # every 10 minutes

--- a/.helm/console-api-staging-sandbox-values.yaml
+++ b/.helm/console-api-staging-sandbox-values.yaml
@@ -35,23 +35,23 @@ jobs:
       - ./dist/console.js
       - notify-expiring-deployments
   # Offset from the two runtime-limit sweeps so no two of them hit deployment_settings on the same minute.
-  - name: notify-unreachable-provider-deployments
+  - name: notify-unreachable-deployments
     schedule: "11,41 * * * *" # every 30 minutes
     command:
       - node
       - --require
       - ./dist/instrumentation.js
       - ./dist/console.js
-      - notify-unreachable-provider-deployments
+      - notify-unreachable-deployments
   # Offset from the sweeps above so no two of them hit deployment_settings on the same minute.
-  - name: close-unreachable-provider-deployments
+  - name: close-unreachable-deployments
     schedule: "26 * * * *" # hourly
     command:
       - node
       - --require
       - ./dist/instrumentation.js
       - ./dist/console.js
-      - close-unreachable-provider-deployments
+      - close-unreachable-deployments
 
 replicas: 2
 

--- a/apps/api/src/app/console.ts
+++ b/apps/api/src/app/console.ts
@@ -71,7 +71,7 @@ program
   });
 
 program
-  .command("notify-unreachable-provider-deployments")
+  .command("notify-unreachable-deployments")
   .description("Warn users whose deployments run on a provider that has been unreachable for days")
   .option("-d, --dry-run", "Log which users would be warned without sending any email", false)
   .action(async (options, command) => {
@@ -81,7 +81,7 @@ program
   });
 
 program
-  .command("close-unreachable-provider-deployments")
+  .command("close-unreachable-deployments")
   .description("Close deployments whose every provider has been unreachable for weeks")
   .option("-d, --dry-run", "Log which deployments would be closed without broadcasting", false)
   .action(async (options, command) => {


### PR DESCRIPTION
## Why

The `console-api@v3.144.0` deploy failed and rolled back on the beta sandbox stage:

```
Error: UPGRADE FAILED: release console-api-sandbox failed, and has been rolled back
due to rollback-on-failure being set: failed to create resource: CronJob.batch
"console-api-sandbox-notify-unreachable-provider-deployments" is invalid:
metadata.name: Invalid value: must be no more than 52 characters
```

Kubernetes caps CronJob names at 52 characters, because the controller appends a timestamp suffix to build Job names and those must fit the 63-character DNS label limit. The `console-api-<chain>` release prefix takes 20 of the 52, leaving 32 for the job name. The two crons added in #3697 and #3699 wanted 39 and 38.

`Deploy to prod` was skipped once sandbox failed, so prod-mainnet never applied, but it carries the same names and would have failed the same way.

## What

Renames both jobs to fit, along with the CLI commands they invoke so the k8s resource name still reads back to the command it runs, as every other job in these files does.

| Job | Was | Now | Full name |
|---|---|---|---|
| notify | `notify-unreachable-provider-deployments` (39) | `notify-unreachable-deployments` (30) | 50 chars |
| close | `close-unreachable-provider-deployments` (38) | `close-unreachable-deployments` (29) | 49 chars |

Every other CronJob in the console-api values files was already inside the limit; the longest, `notify-expiring-deployments`, lands at 47.

The pg-boss queue name (`CloseUnreachableProviderDeploymentCommand`) is a separate identifier and is untouched, so any job already enqueued still resolves to its handler. Schedules, dry-run flags, and the bake plan are unchanged.

No test asserts the CLI command names. Verified: 2082 unit tests pass, lint clean, no new type errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Renamed commands for notifying and closing unreachable deployments to use shorter, more generic names.
  * Updated scheduled deployment jobs to use the renamed commands.
  * Scheduling, dry-run options, and execution behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->