### PR TITLE
refactor(deployment): send the unreachable-provider warning for real

### DIFF
--- a/.helm/console-api-prod-mainnet-values.yaml
+++ b/.helm/console-api-prod-mainnet-values.yaml
@@ -47,9 +47,6 @@ jobs:
       - ./dist/console.js
       - notify-expiring-deployments
       - --dry-run
-  # Ships in dry-run for a bake period: --dry-run only logs UNREACHABLE_PROVIDER_DEPLOYMENT_WOULD_NOTIFY.
-  # The first live run catches up on every outage already past the threshold, so check the volume in
-  # those logs before dropping the flag.
   # Offset from the two runtime-limit sweeps so no two of them hit deployment_settings on the same minute.
   - name: notify-unreachable-deployments
     schedule: "11,41 * * * *" # every 30 minutes
@@ -59,7 +56,6 @@ jobs:
       - ./dist/instrumentation.js
       - ./dist/console.js
       - notify-unreachable-deployments
-      - --dry-run
   # Ships in dry-run and stays that way until the warning email above has been live for longer than the
   # gap between the two thresholds (14 - 3 = 11 days), so no owner's first word about an outage is the
   # closure notice. Check that every UNREACHABLE_PROVIDER_DEPLOYMENT_WOULD_CLOSE was warned first.


### PR DESCRIPTION
## Why

The notify sweep has run in dry-run on prod since 2026-08-28 (#3697, live in v3.144.1). The bake numbers are stable and small enough to let land.

| | |
|---|---|
| providers dark 3+ days | 1972 |
| deployments with a lease on one | 756 |
| `NOT_A_MANAGED_WALLET` (nobody to email) | 746 |
| **`WOULD_NOTIFY`** | **10** |
| `failed` | 0 |

The count has not moved across two days of sweeps, and no sweep has reported a failure. Ten first-run emails is a volume worth letting through, which is what the bake comment asked to check before dropping the flag.

Sweeps run in 8 seconds over ~750 deployments.

## What

Removes `--dry-run` from the `notify-unreachable-deployments` cron on prod-mainnet, and the bake comment that no longer applies.

**The close sweep stays in dry-run.** It may only follow once this warning has been live longer than the gap between the two thresholds (14 − 3 = 11 days), so that no owner's first word about an outage is the closure notice. Earliest date for that follow-up is 11 days after this merges.

Expect ~10 emails on the first live run, then near zero: the run writes `providerUnreachableNotifiedFor`, which suppresses repeats for the same outage.

Watch after merge:
- `UNREACHABLE_PROVIDER_DEPLOYMENT_NOTIFIED` — should be ~10 on the first sweep, ~0 after
- `UNREACHABLE_PROVIDER_DEPLOYMENT_NOTIFY_FAILED` and `..._CLAIM_RELEASE_FAILED` — should be absent
- `notified` in `UNREACHABLE_PROVIDER_DEPLOYMENTS_SWEEP_END`

Ref CON-909

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Deployment reachability notifications now execute live instead of simulation mode.
  - Removed outdated dry-run rollout comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->