### PR TITLE
refactor(deployment): look up the sweep's wallets in one query

### DIFF
--- a/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.integration.ts
+++ b/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.integration.ts
@@ -99,6 +99,32 @@ describe(UserWalletRepository.name, () => {
     });
   });
 
+  describe("findByAddresses", () => {
+    it("returns every wallet matching the given addresses", async () => {
+      const first = await setup();
+      const second = await setup();
+
+      const wallets = await first.userWalletRepository.findByAddresses([first.wallet.address as string, second.wallet.address as string]);
+
+      expect(wallets.map(wallet => wallet.address).sort()).toEqual([first.wallet.address, second.wallet.address].sort());
+    });
+
+    it("skips addresses that have no wallet", async () => {
+      const { userWalletRepository, wallet } = await setup();
+
+      const wallets = await userWalletRepository.findByAddresses([wallet.address as string, createAkashAddress()]);
+
+      expect(wallets).toHaveLength(1);
+      expect(wallets[0].address).toBe(wallet.address);
+    });
+
+    it("returns nothing when given no addresses", async () => {
+      const { userWalletRepository } = await setup();
+
+      expect(await userWalletRepository.findByAddresses([])).toEqual([]);
+    });
+  });
+
   async function setup(input: { creditsLowNotifiedAt?: Date; creditsSufficientSince?: Date } = {}) {
     const userRepository = container.resolve(UserRepository);
     const userWalletRepository = container.resolve(UserWalletRepository);

--- a/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.ts
+++ b/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.ts
@@ -152,6 +152,12 @@ export class UserWalletRepository extends BaseRepository<ApiPgTables["UserWallet
     return this.toOutput(userWallet);
   }
 
+  async findByAddresses(addresses: string[]) {
+    if (addresses.length === 0) return [];
+
+    return this.toOutputList(await this.cursor.query.UserWallets.findMany({ where: this.whereAccessibleBy(inArray(this.table.address, addresses)) }));
+  }
+
   async findFirst() {
     return this.findOneBy();
   }

--- a/apps/api/src/deployment/services/unreachable-provider-deployments-closer/unreachable-provider-deployments-closer.service.spec.ts
+++ b/apps/api/src/deployment/services/unreachable-provider-deployments-closer/unreachable-provider-deployments-closer.service.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
-import type { UserWalletRepository } from "@src/billing/repositories";
+import type { UserWalletOutput, UserWalletRepository } from "@src/billing/repositories";
 import type { CreateLogger, JobQueueService } from "@src/core";
 import type { DeploymentSettingRepository, DeploymentSettingsOutput } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import type { ActiveLeaseOnProvider, LeaseRepository } from "@src/deployment/repositories/lease/lease.repository";
@@ -116,16 +116,36 @@ describe(UnreachableProviderDeploymentsCloserService.name, () => {
     });
 
     it("keeps screening the other deployments after one lookup fails", async () => {
-      const { service, userWalletRepository, jobQueueService } = setup({
+      const { service, deploymentSettingRepository, jobQueueService } = setup({
         outages: [anOutage({})],
         leases: [aLease({}), aLease({ owner: "akash1other", dseq: "999" })]
       });
-      userWalletRepository.findOneByAddress.mockRejectedValueOnce(new Error("connection reset"));
+      deploymentSettingRepository.findOneBy.mockRejectedValueOnce(new Error("connection reset"));
 
       const result = await service.closeUnreachableProviderDeployments({ dryRun: false });
 
       expect(jobQueueService.enqueue).toHaveBeenCalledTimes(1);
       expect(result.err).toBe(true);
+    });
+
+    it("looks up every owner's wallet in a single query", async () => {
+      const { service, userWalletRepository } = setup({
+        outages: [anOutage({})],
+        leases: [aLease({}), aLease({ owner: "akash1other", dseq: "999" })]
+      });
+
+      await service.closeUnreachableProviderDeployments({ dryRun: false });
+
+      expect(userWalletRepository.findByAddresses).toHaveBeenCalledTimes(1);
+      expect(userWalletRepository.findByAddresses).toHaveBeenCalledWith([OWNER, "akash1other"]);
+    });
+
+    it("asks for an owner once when several of its deployments are dark", async () => {
+      const { service, userWalletRepository } = setup({ outages: [anOutage({})], leases: [aLease({}), aLease({ dseq: "999" })] });
+
+      await service.closeUnreachableProviderDeployments({ dryRun: false });
+
+      expect(userWalletRepository.findByAddresses).toHaveBeenCalledWith([OWNER]);
     });
 
     it("schedules nothing when the outage record cannot be trusted", async () => {
@@ -199,8 +219,8 @@ describe(UnreachableProviderDeploymentsCloserService.name, () => {
     leaseRepository.findActiveLeasesOfDeployment.mockResolvedValue(input.deploymentLeases ?? []);
 
     const userWalletRepository = mock<UserWalletRepository>();
-    userWalletRepository.findOneByAddress.mockImplementation(async address =>
-      input.wallet === null ? undefined : mock<Awaited<ReturnType<UserWalletRepository["findOneByAddress"]>>>({ id: 7, userId: "user-1", address })
+    userWalletRepository.findByAddresses.mockImplementation(async addresses =>
+      input.wallet === null ? [] : addresses.map(address => mock<UserWalletOutput>({ id: 7, userId: "user-1", address }))
     );
 
     const deploymentSettingRepository = mock<DeploymentSettingRepository>();

--- a/apps/api/src/deployment/services/unreachable-provider-deployments-closer/unreachable-provider-deployments-closer.service.ts
+++ b/apps/api/src/deployment/services/unreachable-provider-deployments-closer/unreachable-provider-deployments-closer.service.ts
@@ -1,7 +1,7 @@
 import { Err, Ok, Result } from "ts-results";
 import { inject, singleton } from "tsyringe";
 
-import { UserWalletRepository } from "@src/billing/repositories";
+import { isWalletInitialized, UserWalletRepository, type WalletInitialized } from "@src/billing/repositories";
 import { type CreateLogger, JOB_NAME, JobQueueService, LOGGER_FACTORY } from "@src/core";
 import type { DryRunOptions } from "@src/core/types/console";
 import { CloseUnreachableProviderDeploymentCommand } from "@src/deployment/commands/close-unreachable-provider-deployment.command";
@@ -48,10 +48,11 @@ export class UnreachableProviderDeploymentsCloserService {
     let scheduledCount = 0;
     let alreadyScheduledCount = 0;
     const pendingKeys = dryRun ? new Set<string>() : await this.jobQueueService.findPendingSingletonKeys(CloseUnreachableProviderDeploymentCommand[JOB_NAME]);
+    const walletsByOwner = await this.#findManagedWalletsByOwner(deployments);
 
     for (const deployment of deployments) {
       try {
-        if (!(await this.#isCloseable(deployment))) continue;
+        if (!(await this.#isCloseable(deployment, walletsByOwner.get(deployment.owner)))) continue;
 
         if (dryRun) {
           this.logger.info({
@@ -116,11 +117,17 @@ export class UnreachableProviderDeploymentsCloserService {
     return resolveFullyDarkDeployment(leases, new Map(outages.map(outage => [outage.provider, outage])));
   }
 
-  /** Screens out what the handler would skip anyway, so a dry run's count is the count that would really be closed. */
-  async #isCloseable(deployment: DarkDeployment): Promise<boolean> {
-    const wallet = await this.userWalletRepository.findOneByAddress(deployment.owner);
+  /** One lookup for the whole sweep, because most dark deployments are self-custody and a per-deployment query spends the run discovering that. */
+  async #findManagedWalletsByOwner(deployments: DarkDeployment[]): Promise<Map<string, WalletInitialized>> {
+    const owners = [...new Set(deployments.map(deployment => deployment.owner))];
+    const wallets = await this.userWalletRepository.findByAddresses(owners);
 
-    if (!wallet?.address) {
+    return new Map(wallets.filter(isWalletInitialized).map(wallet => [wallet.address, wallet]));
+  }
+
+  /** Screens out what the handler would skip anyway, so a dry run's count is the count that would really be closed. */
+  async #isCloseable(deployment: DarkDeployment, wallet: WalletInitialized | undefined): Promise<boolean> {
+    if (!wallet) {
       this.logger.debug({
         event: "UNREACHABLE_PROVIDER_DEPLOYMENT_CLOSE_SKIPPED",
         reason: "NOT_A_MANAGED_WALLET",

--- a/apps/api/src/deployment/services/unreachable-provider-deployments-notifier/unreachable-provider-deployments-notifier.service.spec.ts
+++ b/apps/api/src/deployment/services/unreachable-provider-deployments-notifier/unreachable-provider-deployments-notifier.service.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
-import type { UserWalletRepository } from "@src/billing/repositories";
+import type { UserWalletOutput, UserWalletRepository } from "@src/billing/repositories";
 import type { CreateLogger } from "@src/core";
 import type { DeploymentSettingRepository, DeploymentSettingsOutput } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import type { ActiveLeaseOnProvider, LeaseRepository } from "@src/deployment/repositories/lease/lease.repository";
@@ -220,8 +220,8 @@ describe(UnreachableProviderDeploymentsNotifierService.name, () => {
     leaseRepository.findActiveLeasesOfDeploymentsOnProviders.mockResolvedValue(input.leases ?? []);
 
     const userWalletRepository = mock<UserWalletRepository>();
-    userWalletRepository.findOneByAddress.mockResolvedValue(
-      input.wallet === null ? undefined : mock<Awaited<ReturnType<UserWalletRepository["findOneByAddress"]>>>({ userId: "user-1" })
+    userWalletRepository.findByAddresses.mockImplementation(async addresses =>
+      input.wallet === null ? [] : addresses.map(address => mock<UserWalletOutput>({ userId: "user-1", address }))
     );
 
     const deploymentSettingRepository = mock<DeploymentSettingRepository>();

--- a/apps/api/src/deployment/services/unreachable-provider-deployments-notifier/unreachable-provider-deployments-notifier.service.ts
+++ b/apps/api/src/deployment/services/unreachable-provider-deployments-notifier/unreachable-provider-deployments-notifier.service.ts
@@ -1,7 +1,7 @@
 import { Err, Ok, Result } from "ts-results";
 import { inject, singleton } from "tsyringe";
 
-import { UserWalletRepository } from "@src/billing/repositories";
+import { isWalletInitialized, UserWalletRepository, type WalletInitialized } from "@src/billing/repositories";
 import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
 import type { DryRunOptions } from "@src/core/types/console";
 import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
@@ -46,10 +46,11 @@ export class UnreachableProviderDeploymentsNotifierService {
 
     const errors: unknown[] = [];
     let notifiedCount = 0;
+    const walletsByOwner = await this.#findManagedWalletsByOwner(deployments);
 
     for (const deployment of deployments) {
       try {
-        if (await this.#notifyOwner(deployment, dryRun)) {
+        if (await this.#notifyOwner(deployment, walletsByOwner.get(deployment.owner), dryRun)) {
           notifiedCount++;
         }
       } catch (error) {
@@ -106,9 +107,15 @@ export class UnreachableProviderDeploymentsNotifierService {
     return `${lease.owner}/${lease.dseq}`;
   }
 
-  async #notifyOwner(deployment: DarkDeployment, dryRun: boolean): Promise<boolean> {
-    const wallet = await this.userWalletRepository.findOneByAddress(deployment.owner);
+  /** One lookup for the whole sweep, because most dark deployments are self-custody and a per-deployment query spends the run discovering that. */
+  async #findManagedWalletsByOwner(deployments: DarkDeployment[]): Promise<Map<string, WalletInitialized>> {
+    const owners = [...new Set(deployments.map(deployment => deployment.owner))];
+    const wallets = await this.userWalletRepository.findByAddresses(owners);
 
+    return new Map(wallets.filter(isWalletInitialized).map(wallet => [wallet.address, wallet]));
+  }
+
+  async #notifyOwner(deployment: DarkDeployment, wallet: WalletInitialized | undefined, dryRun: boolean): Promise<boolean> {
     if (!wallet) {
       this.logger.debug({
         event: "UNREACHABLE_PROVIDER_DEPLOYMENT_SKIPPED",


### PR DESCRIPTION
## Why

Both unreachable-provider sweeps screened each dark deployment with its own `findOneByAddress`, sequentially. Measured on prod:

| | per sweep | per day |
|---|---|---|
| close (hourly) | 751 | ~18,000 |
| notify (every 30 min) | 756 | ~36,000 |

Confirmed in Loki: 1502 `user_wallet` queries across two close sweeps, exactly matching the `found=751` each reported.

746 of the 751 exist only to discover the owner is self-custody and has no wallet. At ~10.6 ms per round-trip that is the whole 8-second sweep runtime, and it scales with the dark-provider backlog rather than with the ~10 deployments a sweep can actually act on.

The chain side was never the cause. `findActiveLeasesOfDeploymentsOnProviders` is a single statement with the dark providers as an IN list.

## What

Adds `UserWalletRepository.findByAddresses`, mirroring the existing `findByUserId` (`inArray` + `whereAccessibleBy` + `toOutputList`). Both sweeps now fetch every owner's wallet before the loop and read from a map, so only the ~10 survivors still cost a query.

**Roughly 750 queries per sweep becomes 2.**

No behavior change. Same skip reasons, same log events, same counts. Two details worth noting for review:

- Owners are deduped, so a user with several dark deployments is asked for once.
- The per-deployment `try/catch` still guards the settings lookup and the enqueue. The wallet lookup moving out of it means a failed bulk query now fails the sweep instead of one deployment, which is the right outcome for a single query that all screening depends on. The test that covered per-deployment resilience now exercises it via the settings lookup.

## Testing

- 2118 unit tests pass; added coverage for the batched call and the dedupe
- Integration tests pass against a real database, including 3 new `findByAddresses` cases (matching, missing address, empty input)
- Lint clean, no new type errors against the `main` baseline (41 on both)

Sequenced deliberately after #3731 so the notify bake measures the current code rather than a query shape changing underneath it.

Ref CON-909