### PR TITLE
fix(deployment): record deployments created through the transaction endpoint

### DIFF
--- a/apps/api/src/app/providers/jobs.provider.ts
+++ b/apps/api/src/app/providers/jobs.provider.ts
@@ -7,6 +7,7 @@ import type { AppInitializer } from "@src/core/providers/app-initializer";
 import { APP_INITIALIZER, ON_APP_START } from "@src/core/providers/app-initializer";
 import { JobQueueService } from "@src/core/services/job-queue/job-queue.service";
 import { DeleteUnbackedDeploymentSettingHandler } from "@src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler";
+import { RecordDeploymentSettingHandler } from "@src/deployment/services/record-deployment-setting/record-deployment-setting.handler";
 import { NotificationHandler } from "@src/notifications/services/notification-handler/notification.handler";
 import { AutoRechargeSucceededHandler } from "../services/auto-recharge-succeeded/auto-recharge-succeeded.handler";
 import { CloseExpiredDeploymentHandler } from "../services/close-expired-deployment/close-expired-deployment.handler";
@@ -38,7 +39,8 @@ export async function startJobQueues(): Promise<void> {
     container.resolve(FirstPurchaseBonusGrantedHandler),
     container.resolve(AutoRechargeSucceededHandler),
     container.resolve(ActivateTrialHandler),
-    container.resolve(DeleteUnbackedDeploymentSettingHandler)
+    container.resolve(DeleteUnbackedDeploymentSettingHandler),
+    container.resolve(RecordDeploymentSettingHandler)
   ]);
 }
 

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
@@ -24,6 +24,7 @@ import type { WalletReloadJobService } from "@src/billing/services/wallet-reload
 import type { CreateLogger } from "@src/core";
 import type { DomainEventsService } from "@src/core/services/domain-events/domain-events.service";
 import type { FeatureFlagValue } from "@src/core/services/feature-flags/feature-flags";
+import { RecordDeploymentSetting } from "@src/deployment/services/record-deployment-setting/record-deployment-setting.handler";
 import type { UserOutput, UserRepository } from "@src/user/repositories";
 import { createAkashAddress } from "../../../../test/seeders";
 import type { TxManagerService } from "../tx-manager/tx-manager.service";
@@ -383,6 +384,71 @@ describe(ManagedSignerService.name, () => {
       expect(options).toEqual({ singletonKey: `FundDeploymentCommand.123.${wallet.id}` });
     });
 
+    it("records a deployment created by broadcasting its message, so the funding sweep can see it", async () => {
+      const wallet = createUserWallet({ userId: "user-123", feeAllowance: 100, deploymentAllowance: 100, isTrialing: false });
+      const user = createUser({ userId: "user-123" });
+      const deploymentMessage: EncodeObject = {
+        typeUrl: MsgCreateDeployment.$type,
+        value: MsgCreateDeployment.fromPartial({ id: { owner: "akash1test", dseq: 123 } })
+      };
+
+      const { service, domainEvents } = setup({
+        findOneByUserId: vi.fn().mockResolvedValue(wallet),
+        findById: vi.fn().mockResolvedValue(user),
+        signAndBroadcastWithDerivedWallet: vi.fn().mockResolvedValue({ code: 0, hash: "tx-hash", rawLog: "success" }),
+        refreshUserWalletLimits: vi.fn().mockResolvedValue(undefined),
+        publish: vi.fn().mockResolvedValue(undefined)
+      });
+
+      await service.executeDerivedDecodedTxByUserId("user-123", [deploymentMessage]);
+
+      const [event, options] = vi.mocked(domainEvents.publish).mock.calls.find(([published]) => published instanceof RecordDeploymentSetting)!;
+      expect(event.data).toEqual({ userId: wallet.userId, dseq: "123" });
+      expect(options).toEqual({ singletonKey: `recordDeploymentSetting.${wallet.userId}.123` });
+    });
+
+    it("records a deployment a trialing wallet created, so converting to paid needs no repair", async () => {
+      const wallet = createUserWallet({ userId: "user-123", feeAllowance: 100, deploymentAllowance: 100, isTrialing: true });
+      const user = createUser({ userId: "user-123" });
+      const deploymentMessage: EncodeObject = {
+        typeUrl: MsgCreateDeployment.$type,
+        value: MsgCreateDeployment.fromPartial({ id: { owner: "akash1test", dseq: 123 } })
+      };
+
+      const { service, domainEvents } = setup({
+        findOneByUserId: vi.fn().mockResolvedValue(wallet),
+        findById: vi.fn().mockResolvedValue(user),
+        signAndBroadcastWithDerivedWallet: vi.fn().mockResolvedValue({ code: 0, hash: "tx-hash", rawLog: "success" }),
+        refreshUserWalletLimits: vi.fn().mockResolvedValue(undefined),
+        publish: vi.fn().mockResolvedValue(undefined)
+      });
+
+      await service.executeDerivedDecodedTxByUserId("user-123", [deploymentMessage]);
+
+      expect(domainEvents.publish).toHaveBeenCalledWith(expect.any(RecordDeploymentSetting), expect.anything());
+    });
+
+    it("records nothing for a transaction that creates no deployment", async () => {
+      const wallet = createUserWallet({ userId: "user-123", feeAllowance: 100, deploymentAllowance: 100, isTrialing: false });
+      const user = createUser({ userId: "user-123" });
+      const closeMessage: EncodeObject = {
+        typeUrl: MsgCloseDeployment.$type,
+        value: MsgCloseDeployment.fromPartial({ id: { owner: "akash1test", dseq: 123 } })
+      };
+
+      const { service, domainEvents } = setup({
+        findOneByUserId: vi.fn().mockResolvedValue(wallet),
+        findById: vi.fn().mockResolvedValue(user),
+        signAndBroadcastWithDerivedWallet: vi.fn().mockResolvedValue({ code: 0, hash: "tx-hash", rawLog: "success" }),
+        refreshUserWalletLimits: vi.fn().mockResolvedValue(undefined),
+        publish: vi.fn().mockResolvedValue(undefined)
+      });
+
+      await service.executeDerivedDecodedTxByUserId("user-123", [closeMessage]);
+
+      expect(domainEvents.publish).not.toHaveBeenCalledWith(expect.any(RecordDeploymentSetting), expect.anything());
+    });
+
     it("does not publish FundDeploymentCommand when a trialing wallet creates a lease", async () => {
       const wallet = createUserWallet({
         userId: "user-123",
@@ -448,7 +514,7 @@ describe(ManagedSignerService.name, () => {
 
       await service.executeDerivedDecodedTxByUserId("user-123", [deploymentMessage]);
 
-      expect(domainEvents.publish).not.toHaveBeenCalled();
+      expect(domainEvents.publish).not.toHaveBeenCalledWith(expect.any(FundDeploymentCommand), expect.anything());
     });
 
     it("throws and skips side-effects when the broadcast tx lands on-chain with a non-zero code", async () => {

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
@@ -428,6 +428,33 @@ describe(ManagedSignerService.name, () => {
       expect(domainEvents.publish).toHaveBeenCalledWith(expect.any(RecordDeploymentSetting), expect.anything());
     });
 
+    it("records the deployment after the lease side effects, so failing to record cannot suppress funding", async () => {
+      const wallet = createUserWallet({ userId: "user-123", feeAllowance: 100, deploymentAllowance: 100, isTrialing: false });
+      const user = createUser({ userId: "user-123" });
+      const messages: EncodeObject[] = [
+        { typeUrl: MsgCreateDeployment.$type, value: MsgCreateDeployment.fromPartial({ id: { owner: "akash1test", dseq: 123 } }) },
+        {
+          typeUrl: MsgCreateLease.$type,
+          value: MsgCreateLease.fromPartial({ bidId: { dseq: 123, owner: "akash1test", gseq: 1, oseq: 1, provider: "akash1test" } })
+        }
+      ];
+
+      const { service, domainEvents } = setup({
+        findOneByUserId: vi.fn().mockResolvedValue(wallet),
+        findById: vi.fn().mockResolvedValue(user),
+        signAndBroadcastWithDerivedWallet: vi.fn().mockResolvedValue({ code: 0, hash: "tx-hash", rawLog: "success" }),
+        refreshUserWalletLimits: vi.fn().mockResolvedValue(undefined),
+        publish: vi.fn().mockImplementation(async (event: unknown) => {
+          if (event instanceof RecordDeploymentSetting) throw new Error("queue unavailable");
+        })
+      });
+
+      await expect(service.executeDerivedDecodedTxByUserId("user-123", messages)).rejects.toThrow("queue unavailable");
+
+      expect(domainEvents.publish).toHaveBeenCalledWith(expect.any(FundDeploymentCommand), expect.anything());
+      expect(domainEvents.publish).toHaveBeenCalledWith(expect.any(EnableDeploymentAlertCommand));
+    });
+
     it("records nothing for a transaction that creates no deployment", async () => {
       const wallet = createUserWallet({ userId: "user-123", feeAllowance: 100, deploymentAllowance: 100, isTrialing: false });
       const user = createUser({ userId: "user-123" });

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
@@ -23,6 +23,7 @@ import { TxManagerService } from "@src/billing/services/tx-manager/tx-manager.se
 import { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
 import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
 import { DomainEventsService } from "@src/core/services/domain-events/domain-events.service";
+import { RecordDeploymentSetting, recordDeploymentSettingKeyFor } from "@src/deployment/services/record-deployment-setting/record-deployment-setting.handler";
 import { UserRepository } from "@src/user/repositories";
 import { COSMOS_TX_CODE_OK } from "@src/utils/constants";
 import { BalancesService } from "../balances/balances.service";
@@ -143,6 +144,8 @@ export class ManagedSignerService {
       throw error;
     }
 
+    await this.#recordCreatedDeployments(userWallet, messages);
+
     if (hasCreateTrialLeaseMessage) {
       await this.domainEvents.publish(
         new TrialDeploymentLeaseCreated({
@@ -190,6 +193,22 @@ export class ManagedSignerService {
     }
 
     return result as Pick<IndexedTx, "code" | "hash" | "rawLog"> & { transactionHash: string };
+  }
+
+  /**
+   * A deployment created here is created by broadcasting its message rather than through the deployment API,
+   * which is what would otherwise record it, so the record is written from the landed transaction instead.
+   */
+  async #recordCreatedDeployments(userWallet: UserWalletOutput, messages: EncodeObject[]) {
+    const createdDseqs = messages
+      .filter((message): message is { typeUrl: string; value: MsgCreateDeployment } => message.typeUrl.endsWith(".MsgCreateDeployment"))
+      .map(message => message.value.id?.dseq)
+      .filter(dseq => dseq !== undefined);
+
+    for (const dseq of createdDseqs) {
+      const key = { userId: userWallet.userId, dseq: dseq.toString() };
+      await this.domainEvents.publish(new RecordDeploymentSetting(key), { singletonKey: recordDeploymentSettingKeyFor(key) });
+    }
   }
 
   async #ensureAutoReloadSchedule(userId: UserWalletOutput["userId"], messages: EncodeObject[]) {

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
@@ -144,8 +144,6 @@ export class ManagedSignerService {
       throw error;
     }
 
-    await this.#recordCreatedDeployments(userWallet, messages);
-
     if (hasCreateTrialLeaseMessage) {
       await this.domainEvents.publish(
         new TrialDeploymentLeaseCreated({
@@ -178,6 +176,8 @@ export class ManagedSignerService {
         );
       }
     }
+
+    await this.#recordCreatedDeployments(userWallet, messages);
 
     await this.balancesService.refreshUserWalletLimits(userWallet);
     await this.#ensureAutoReloadSchedule(userWallet.userId, messages);

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
@@ -195,10 +195,7 @@ export class ManagedSignerService {
     return result as Pick<IndexedTx, "code" | "hash" | "rawLog"> & { transactionHash: string };
   }
 
-  /**
-   * A deployment created here is created by broadcasting its message rather than through the deployment API,
-   * which is what would otherwise record it, so the record is written from the landed transaction instead.
-   */
+  /** A create broadcast here never passes through the deployment API that would record it, so the record is written from the landed transaction. */
   async #recordCreatedDeployments(userWallet: UserWalletOutput, messages: EncodeObject[]) {
     const createdDseqs = messages
       .filter((message): message is { typeUrl: string; value: MsgCreateDeployment } => message.typeUrl.endsWith(".MsgCreateDeployment"))

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
@@ -601,6 +601,40 @@ describe(DeploymentSettingRepository.name, () => {
     });
   });
 
+  describe("createDefaultIfMissing", () => {
+    it("records a deployment nothing had recorded yet, with funding on", async () => {
+      const { deploymentSettingRepository, user } = await setup();
+      const dseq = newDseq();
+
+      const created = await deploymentSettingRepository.createDefaultIfMissing({ userId: user.id, dseq });
+
+      expect(created).toBe(true);
+      expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq })).toEqual(expect.objectContaining({ autoTopUpEnabled: true }));
+    });
+
+    it("leaves the choices of a row another path already wrote", async () => {
+      const { deploymentSettingRepository, user } = await setup();
+      const dseq = newDseq();
+      await deploymentSettingRepository.create({ userId: user.id, dseq, autoTopUpEnabled: false, runtimeLimitHours: 12 });
+
+      const created = await deploymentSettingRepository.createDefaultIfMissing({ userId: user.id, dseq });
+
+      expect(created).toBe(false);
+      expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq })).toEqual(
+        expect.objectContaining({ autoTopUpEnabled: false, runtimeLimitHours: 12 })
+      );
+    });
+
+    it("writes one row across concurrent attempts for the same deployment", async () => {
+      const { deploymentSettingRepository, user } = await setup();
+      const dseq = newDseq();
+
+      const results = await Promise.all(Array.from({ length: 5 }, () => deploymentSettingRepository.createDefaultIfMissing({ userId: user.id, dseq })));
+
+      expect(results.filter(Boolean)).toHaveLength(1);
+    });
+  });
+
   function newDseq() {
     return faker.number.int({ min: 100000, max: 999999 }).toString();
   }

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -295,6 +295,21 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
   }
 
   /**
+   * Records the identity of a deployment created by broadcasting its message directly, where nothing but
+   * that identity is known: no SDL, no manifest version, no runtime limit. Conflicts are ignored rather
+   * than merged, so a row any other path already wrote keeps every choice its writer made.
+   */
+  async createDefaultIfMissing({ userId, dseq }: { userId: string; dseq: string }): Promise<boolean> {
+    const rows = await this.cursor
+      .insert(this.table)
+      .values({ userId, dseq, autoTopUpEnabled: AUTO_TOP_UP_ENABLED_BY_DEFAULT })
+      .onConflictDoNothing({ target: [this.table.dseq, this.table.userId] })
+      .returning({ id: this.table.id });
+
+    return rows.length > 0;
+  }
+
+  /**
    * Raises a deployment's runtime limit and shifts an anchored deadline by the same delta in one
    * guarded UPDATE. The WHERE clause re-checks every rule the service validated, plus the caller's
    * ability predicate, so two extensions racing each other cannot compound past one increment and a

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -294,11 +294,7 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
     return row.id;
   }
 
-  /**
-   * Records the identity of a deployment created by broadcasting its message directly, where nothing but
-   * that identity is known: no SDL, no manifest version, no runtime limit. Conflicts are ignored rather
-   * than merged, so a row any other path already wrote keeps every choice its writer made.
-   */
+  /** Conflicts are ignored rather than merged, so a row another path already wrote keeps every choice its writer made. */
   async createDefaultIfMissing({ userId, dseq }: { userId: string; dseq: string }): Promise<boolean> {
     const rows = await this.cursor
       .insert(this.table)

--- a/apps/api/src/deployment/services/record-deployment-setting/record-deployment-setting.handler.spec.ts
+++ b/apps/api/src/deployment/services/record-deployment-setting/record-deployment-setting.handler.spec.ts
@@ -1,0 +1,71 @@
+import { faker } from "@faker-js/faker";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { CreateLogger } from "@src/core";
+import type { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import { RecordDeploymentSettingHandler, recordDeploymentSettingKeyFor } from "./record-deployment-setting.handler";
+
+const DSEQ = "1748400000000";
+
+describe(RecordDeploymentSettingHandler.name, () => {
+  it("records the deployment it is given", async () => {
+    const { handler, payload, deploymentSettingRepository } = setup({});
+
+    await handler.handle(payload);
+
+    expect(deploymentSettingRepository.createDefaultIfMissing).toHaveBeenCalledWith(expect.objectContaining({ userId: payload.userId, dseq: DSEQ }));
+  });
+
+  it("reports the deployment it recorded", async () => {
+    const { handler, payload, logger } = setup({ wasMissing: true });
+
+    await handler.handle(payload);
+
+    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "DEPLOYMENT_SETTING_RECORDED", userId: payload.userId, dseq: DSEQ }));
+  });
+
+  it("reports a deployment another path had already recorded", async () => {
+    const { handler, payload, logger } = setup({ wasMissing: false });
+
+    await handler.handle(payload);
+
+    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "DEPLOYMENT_SETTING_ALREADY_RECORDED", userId: payload.userId, dseq: DSEQ }));
+  });
+
+  it("lets a failed write surface, so the queue retries rather than losing the record", async () => {
+    const { handler, payload } = setup({ writeRejectsWith: new Error("connection terminated") });
+
+    await expect(handler.handle(payload)).rejects.toThrow("connection terminated");
+  });
+
+  it("keys a record by the owning user and the dseq", () => {
+    expect(recordDeploymentSettingKeyFor({ userId: "user-1", dseq: DSEQ })).toBe(`recordDeploymentSetting.user-1.${DSEQ}`);
+  });
+
+  it("creates the logger with the handler context", () => {
+    const { createLogger } = setup({});
+
+    expect(createLogger).toHaveBeenCalledWith({ context: RecordDeploymentSettingHandler.name });
+  });
+
+  function setup(input: { wasMissing?: boolean; writeRejectsWith?: unknown }) {
+    const deploymentSettingRepository = mock<DeploymentSettingRepository>();
+    deploymentSettingRepository.createDefaultIfMissing.mockImplementation(async () => {
+      if (input.writeRejectsWith) throw input.writeRejectsWith;
+      return input.wasMissing ?? true;
+    });
+
+    const logger = mock<ReturnType<CreateLogger>>();
+    const createLogger = vi.fn<CreateLogger>(() => logger);
+    const handler = new RecordDeploymentSettingHandler(deploymentSettingRepository, createLogger);
+
+    return {
+      handler,
+      payload: { userId: faker.string.uuid(), dseq: DSEQ, version: 1 as const },
+      deploymentSettingRepository,
+      logger,
+      createLogger
+    };
+  }
+});

--- a/apps/api/src/deployment/services/record-deployment-setting/record-deployment-setting.handler.ts
+++ b/apps/api/src/deployment/services/record-deployment-setting/record-deployment-setting.handler.ts
@@ -30,6 +30,9 @@ export function recordDeploymentSettingKeyFor({ userId, dseq }: { userId: string
 export class RecordDeploymentSettingHandler implements JobHandler<RecordDeploymentSetting> {
   public readonly accepts = RecordDeploymentSetting;
 
+  /** Gives the command's per-deployment singletonKey its meaning: without it the key is inert and a retried broadcast queues a second job. */
+  public readonly policy = "singleton";
+
   private readonly logger: ReturnType<CreateLogger>;
 
   constructor(

--- a/apps/api/src/deployment/services/record-deployment-setting/record-deployment-setting.handler.ts
+++ b/apps/api/src/deployment/services/record-deployment-setting/record-deployment-setting.handler.ts
@@ -1,0 +1,51 @@
+import { inject, singleton } from "tsyringe";
+
+import { type CreateLogger, type Job, JOB_NAME, type JobHandler, type JobPayload, LOGGER_FACTORY } from "@src/core";
+import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+
+/**
+ * Records a deployment created by broadcasting `MsgCreateDeployment` through the transaction endpoint, which
+ * bypasses the deployment API and so writes no settings row of its own; without one the funding sweep, which
+ * works from those rows, never sees the deployment.
+ */
+export class RecordDeploymentSetting implements Job {
+  static readonly [JOB_NAME] = "RecordDeploymentSetting";
+  readonly name = RecordDeploymentSetting[JOB_NAME];
+  readonly version = 1;
+
+  constructor(
+    public readonly data: {
+      userId: string;
+      dseq: string;
+    }
+  ) {}
+}
+
+/** Keyed by the row's natural key so a retried broadcast of the same deployment enqueues one job, not two. */
+export function recordDeploymentSettingKeyFor({ userId, dseq }: { userId: string; dseq: string }): string {
+  return `recordDeploymentSetting.${userId}.${dseq}`;
+}
+
+@singleton()
+export class RecordDeploymentSettingHandler implements JobHandler<RecordDeploymentSetting> {
+  public readonly accepts = RecordDeploymentSetting;
+
+  private readonly logger: ReturnType<CreateLogger>;
+
+  constructor(
+    private readonly deploymentSettingRepository: DeploymentSettingRepository,
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
+  ) {
+    this.logger = createLogger({ context: RecordDeploymentSettingHandler.name });
+  }
+
+  /**
+   * The repository is used unscoped because job execution runs under an empty ability, and it needs no chain
+   * check before writing: the job is only ever enqueued after the create transaction has already landed.
+   */
+  async handle(payload: JobPayload<RecordDeploymentSetting>): Promise<void> {
+    const created = await this.deploymentSettingRepository.createDefaultIfMissing(payload);
+
+    this.logger.info({ event: created ? "DEPLOYMENT_SETTING_RECORDED" : "DEPLOYMENT_SETTING_ALREADY_RECORDED", userId: payload.userId, dseq: payload.dseq });
+  }
+}

--- a/apps/api/src/deployment/services/record-deployment-setting/record-deployment-setting.handler.ts
+++ b/apps/api/src/deployment/services/record-deployment-setting/record-deployment-setting.handler.ts
@@ -3,11 +3,7 @@ import { inject, singleton } from "tsyringe";
 import { type CreateLogger, type Job, JOB_NAME, type JobHandler, type JobPayload, LOGGER_FACTORY } from "@src/core";
 import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 
-/**
- * Records a deployment created by broadcasting `MsgCreateDeployment` through the transaction endpoint, which
- * bypasses the deployment API and so writes no settings row of its own; without one the funding sweep, which
- * works from those rows, never sees the deployment.
- */
+/** Records a deployment created through the transaction endpoint, which bypasses the deployment API and so leaves the funding sweep with no row to find. */
 export class RecordDeploymentSetting implements Job {
   static readonly [JOB_NAME] = "RecordDeploymentSetting";
   readonly name = RecordDeploymentSetting[JOB_NAME];
@@ -42,10 +38,7 @@ export class RecordDeploymentSettingHandler implements JobHandler<RecordDeployme
     this.logger = createLogger({ context: RecordDeploymentSettingHandler.name });
   }
 
-  /**
-   * The repository is used unscoped because job execution runs under an empty ability, and it needs no chain
-   * check before writing: the job is only ever enqueued after the create transaction has already landed.
-   */
+  /** Unscoped because job execution runs under an empty ability, which a scoped read would throw on before any SQL ran. */
   async handle(payload: JobPayload<RecordDeploymentSetting>): Promise<void> {
     const created = await this.deploymentSettingRepository.createDefaultIfMissing(payload);
 


### PR DESCRIPTION
## Why

Part of CON-895.

A deployment created by broadcasting `MsgCreateDeployment` through the tx endpoint never gets a `deployment_settings` row. `POST /v1/deployments` writes one as it creates, but the tx endpoint bypasses that path entirely. The funding sweep reads those rows, so a deployment created this way stops being funded once its initial deposit drains, and only recovers if someone opens its detail page and the lazy read creates the row.

This is not a fringe SDK case. deploy-web's legacy builder broadcasts its own create message, so git and remote deploys still land here. Trial wallets are worse off: they are excluded from the lease-start funding publish as well, so a trial deployment created this way gets no row and no initial funding, and it keeps both gaps after the wallet converts to paid, since nothing in the conversion touches existing deployments.

Retiring the legacy builder is tracked in CON-920, which is blocked behind CON-672. Until that lands, every create on this path adds to the population the backfill is meant to clean up.

## What

The signer publishes a `RecordDeploymentSetting` job for each `MsgCreateDeployment` in a transaction that landed. The handler writes the row through a new `createDefaultIfMissing`, which uses `onConflictDoNothing` so a row written by any other path keeps the choices its writer made.

No compensation job, unlike the write in `DeploymentWriterService`. That one records the row before broadcasting and has to undo it if the broadcast never reaches the chain. This one runs after the create has already succeeded, so there is nothing to unwind.

Trial wallets are included. The row records what the deployment is, not a decision to fund it, and every funding path checks the trial flag for itself. That is what makes a later conversion to paid need no repair.

One side effect worth knowing: `POST /v1/deployments` signs through this service too, so an API create now enqueues a job that finds its row already present and logs `DEPLOYMENT_SETTING_ALREADY_RECORDED`.

Tests: unit coverage for the handler and the signer wiring, plus a repository integration test where five concurrent calls for the same deployment produce one row.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployment settings are now automatically created when a deployment is successfully recorded.
  * New settings enable automatic top-ups by default.
  * Repeated recording attempts no longer create duplicate deployment settings.
* **Bug Fixes**
  * Improved reliability when recording deployment settings after successful transactions.
  * Deployment-setting updates are now processed safely during concurrent activity.
* **Tests**
  * Added coverage for successful, repeated, failed, trial, and paid deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->