### PR TITLE
refactor(deployment): read the auto top-up sweep's owners in one query

### DIFF
--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
@@ -536,6 +536,71 @@ describe(DeploymentSettingRepository.name, () => {
     });
   });
 
+  describe("findAutoTopUpDeploymentsByOwnerIteratively", () => {
+    it("gathers every deployment of an owner into a single yield", async () => {
+      const { createSetting, wallet, findAutoTopUpOwners } = await setup();
+      await createSetting();
+
+      const owners = await findAutoTopUpOwners([wallet.address]);
+
+      expect(owners).toHaveLength(1);
+      expect(owners[0].deploymentSettings).toHaveLength(2);
+    });
+
+    it("reports the wallet each owner funds from", async () => {
+      const { wallet, findAutoTopUpOwners } = await setup();
+
+      const owners = await findAutoTopUpOwners([wallet.address]);
+
+      expect(owners[0]).toMatchObject({ address: wallet.address, walletId: wallet.walletId });
+    });
+
+    it("keeps two owners apart", async () => {
+      const { createSetting, trialUser, wallet, trialWallet, findAutoTopUpOwners } = await setup();
+      await createSetting(trialUser.id);
+
+      const owners = await findAutoTopUpOwners([wallet.address, trialWallet.address]);
+
+      expect(owners.map(owner => owner.address).sort()).toEqual([wallet.address, trialWallet.address].sort());
+      expect(owners.map(owner => owner.deploymentSettings.length)).toEqual([1, 1]);
+    });
+
+    it("passes over a deployment whose owner turned auto top-up off", async () => {
+      const { deploymentSettingRepository, user, wallet, findAutoTopUpOwners } = await setup();
+      await deploymentSettingRepository.create({ userId: user.id, dseq: newDseq(), autoTopUpEnabled: false });
+
+      const owners = await findAutoTopUpOwners([wallet.address]);
+
+      expect(owners[0].deploymentSettings).toHaveLength(1);
+    });
+
+    it("passes over a deployment already marked closed", async () => {
+      const { deploymentSettingRepository, createSetting, wallet, findAutoTopUpOwners } = await setup();
+      const closedId = await createSetting();
+      await deploymentSettingRepository.markAsClosed([closedId]);
+
+      const owners = await findAutoTopUpOwners([wallet.address]);
+
+      expect(owners[0].deploymentSettings.map(deployment => deployment.id)).not.toContain(closedId);
+    });
+
+    it("drops an owner whose only deployment is closed", async () => {
+      const { deploymentSettingRepository, settingId, wallet, findAutoTopUpOwners } = await setup();
+      await deploymentSettingRepository.markAsClosed([settingId]);
+
+      expect(await findAutoTopUpOwners([wallet.address])).toEqual([]);
+    });
+
+    it("yields the same deployments the per-owner lookup returns", async () => {
+      const { deploymentSettingRepository, createSetting, wallet, findAutoTopUpOwners } = await setup();
+      await createSetting();
+
+      const owners = await findAutoTopUpOwners([wallet.address]);
+
+      expect(owners[0].deploymentSettings).toEqual(await deploymentSettingRepository.findAutoTopUpDeploymentsByOwner(wallet.address));
+    });
+  });
+
   function newDseq() {
     return faker.number.int({ min: 100000, max: 999999 }).toString();
   }
@@ -551,23 +616,41 @@ describe(DeploymentSettingRepository.name, () => {
     const trialUser = await userRepository.create({ userId: faker.string.uuid() });
 
     async function createWallet(userId: string, isTrialing: boolean) {
-      await db.insert(userWalletsTable).values({ userId, address: createAkashAddress(), deploymentAllowance: "10000000", feeAllowance: "5000000", isTrialing });
+      const address = createAkashAddress();
+      const [wallet] = await db
+        .insert(userWalletsTable)
+        .values({ userId, address, deploymentAllowance: "10000000", feeAllowance: "5000000", isTrialing })
+        .returning({ id: userWalletsTable.id });
+
+      return { address, walletId: wallet.id };
     }
 
-    await createWallet(user.id, false);
-    await createWallet(trialUser.id, true);
+    const wallet = await createWallet(user.id, false);
+    const trialWallet = await createWallet(trialUser.id, true);
 
     function abilityFor(owner: UserOutput) {
       return abilityService.getAbilityFor("REGULAR_USER", owner);
     }
 
-    async function createSetting() {
+    async function createSetting(userId: string = user.id) {
       const setting = await deploymentSettingRepository.create({
-        userId: user.id,
+        userId,
         dseq: faker.number.int({ min: 100000, max: 999999 }).toString(),
         autoTopUpEnabled: true
       });
       return setting.id;
+    }
+
+    async function findAutoTopUpOwners(addresses: string[]) {
+      const owners = [];
+
+      for await (const owner of deploymentSettingRepository.findAutoTopUpDeploymentsByOwnerIteratively()) {
+        if (addresses.includes(owner.address)) {
+          owners.push(owner);
+        }
+      }
+
+      return owners;
     }
 
     async function createLimitedSetting(runtimeLimitHours: number, overrides: { autoTopUpEnabled?: boolean } = {}) {
@@ -621,11 +704,14 @@ describe(DeploymentSettingRepository.name, () => {
       deploymentSettingRepository,
       user,
       trialUser,
+      wallet,
+      trialWallet,
       settingId,
       abilityFor,
       createSetting,
       createLimitedSetting,
       createAnchoredSetting,
+      findAutoTopUpOwners,
       backdateLastFundedAt,
       readClosed
     };

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -86,41 +86,33 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
     return super.create({ ...input, autoTopUpEnabled: input.autoTopUpEnabled ?? AUTO_TOP_UP_ENABLED_BY_DEFAULT });
   }
 
+  /** Reads every owner in one query, because the per-owner lookup this used to repeat selects from the same tables under the same filters. */
   async *findAutoTopUpDeploymentsByOwnerIteratively(): AsyncGenerator<{
     address: string;
     walletId: number;
     deploymentSettings: AutoTopUpDeployment[];
   }> {
-    const baseClauses = [eq(this.table.autoTopUpEnabled, true), eq(this.table.closed, false)];
+    const deploymentsByOwner = new Map<string, AutoTopUpDeployment[]>();
 
-    const distinctOwnersQuery = this.pg
-      .selectDistinctOn([UserWallets.address], {
-        walletId: UserWallets.id,
-        address: UserWallets.address
-      })
-      .from(this.table)
-      .leftJoin(Users, eq(this.table.userId, Users.id))
-      .leftJoin(UserWallets, eq(Users.id, UserWallets.userId));
+    for (const deployment of await this.#findAutoTopUpDeployments()) {
+      deploymentsByOwner.set(deployment.address, [...(deploymentsByOwner.get(deployment.address) ?? []), deployment]);
+    }
 
-    const distinctClauses = [...baseClauses, isNotNull(UserWallets.address)];
-
-    const distinctOwners = await distinctOwnersQuery.where(and(...distinctClauses));
-
-    for (const { address, walletId } of distinctOwners) {
-      if (!address || !walletId) {
-        continue;
-      }
-
-      const deployments = await this.findAutoTopUpDeploymentsByOwner(address);
-
-      if (deployments.length > 0) {
-        yield { address, walletId, deploymentSettings: deployments as AutoTopUpDeployment[] };
-      }
+    for (const [address, deploymentSettings] of deploymentsByOwner) {
+      yield { address, walletId: deploymentSettings[0].walletId, deploymentSettings };
     }
   }
 
-  async findAutoTopUpDeploymentsByOwner(address: string): Promise<AutoTopUpDeployment[]> {
-    const clauses = [eq(this.table.autoTopUpEnabled, true), eq(this.table.closed, false), eq(UserWallets.address, address)];
+  findAutoTopUpDeploymentsByOwner(address: string): Promise<AutoTopUpDeployment[]> {
+    return this.#findAutoTopUpDeployments(address);
+  }
+
+  async #findAutoTopUpDeployments(address?: string): Promise<AutoTopUpDeployment[]> {
+    const clauses = [eq(this.table.autoTopUpEnabled, true), eq(this.table.closed, false), isNotNull(UserWallets.address)];
+
+    if (address) {
+      clauses.push(eq(UserWallets.address, address));
+    }
 
     const deployments = await this.pg
       .select({

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -110,7 +110,7 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
   async #findAutoTopUpDeployments(address?: string): Promise<AutoTopUpDeployment[]> {
     const clauses = [eq(this.table.autoTopUpEnabled, true), eq(this.table.closed, false), isNotNull(UserWallets.address)];
 
-    if (address) {
+    if (address !== undefined) {
       clauses.push(eq(UserWallets.address, address));
     }
 


### PR DESCRIPTION
## Why

Follow-up to #3732, same N+1 shape in a different sweep.

Measured in prod-mainnet over 24h by counting Postgres query lines per cron pod. The hourly `top-up-deployments` job makes ~1,482 queries per run, and **1,457 of them are a single repeated statement** (98%), about 34,000 a day.

`findAutoTopUpDeploymentsByOwnerIteratively` picks its owners with a `SELECT DISTINCT ON (address)` and then re-queries each one through `findAutoTopUpDeploymentsByOwner`. The two statements select from the same tables under the same filters, so the second pass only re-reads rows the first pass already touched.

The outer query is `LEFT JOIN user_wallets ... WHERE address IS NOT NULL` and the inner is `INNER JOIN user_wallets`, which select the same rows, so a single unfiltered run of the inner query returns everything the loop was assembling.

## What

Both paths now go through one private query that takes an optional address. The sweep runs it once and groups by owner in memory; `findAutoTopUpDeploymentsByOwner` passes an address and keeps its current behaviour for the event-driven funding path in `findDrainingDeploymentsForOwner`.

`~1,482 queries per run -> ~25`, roughly 34,000 fewer a day.

The generator interface is unchanged, so `DrainingDeploymentService` still streams owner by owner and its per-owner RPC calls interleave exactly as before.

### Worth a look during review

- **Per-owner ordering is preserved, owner ordering is not.** Each owner's `deploymentSettings` keeps `ORDER BY deployment_settings.id DESC`, so `deploymentSettings[0]` is the same row as before, which matters because the consumer reads `userId` / `autoReloadEnabled` / `isTrialing` / `creditsLowNotifiedAt` off it. The order owners are *yielded* in changes from address-sorted to first-appearance in the `id DESC` scan. Nothing downstream depends on it, but it is a real difference.
- **`isNotNull(address)` moved into the shared query.** It replaces the old in-loop `if (!address || !walletId) continue` guard. It is implied by `address = $n` on the single-owner path, so that path is unaffected.
- **The whole result set is now held at once** rather than a page per owner. It is ~1,500 rows of 13 small columns.

## Testing

- 7 new integration tests in `deployment-setting.repository.integration.ts` covering the grouping: one yield per owner, the wallet reported, two owners kept apart, auto-top-up-off and closed rows excluded, an owner dropped when its only deployment closes, and one asserting the batched result equals what `findAutoTopUpDeploymentsByOwner` returns for the same address.
- 54 integration tests pass in that file, 2118 unit tests pass across apps/api.
- Lint clean. `tsc --noEmit` reports 41 errors on this branch and 41 on the `main` baseline, so none are new.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retrieval of auto-top-up deployments across wallet owners.
  * Excluded disabled or closed deployments and owners without eligible deployments.
  * Ensured iterative results remain consistent with owner-specific lookups.
  * Improved filtering so deployment results remain accurate for all wallet addresses.

* **Tests**
  * Added integration coverage for owner grouping, wallet metadata, filtering, and result parity.
  * Added validation for wallet identifiers and collection of iterative results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->