### PR TITLE
refactor(notifications): name the provider host without the scheme and port

### DIFF
--- a/apps/api/src/deployment/services/unreachable-provider-deployments-notifier/unreachable-provider-deployments-notifier.service.spec.ts
+++ b/apps/api/src/deployment/services/unreachable-provider-deployments-notifier/unreachable-provider-deployments-notifier.service.spec.ts
@@ -48,7 +48,7 @@ describe(UnreachableProviderDeploymentsNotifierService.name, () => {
       })
     );
     const [{ payload }] = notificationService.createNotification.mock.calls[0];
-    expect(payload.description).toContain("https://dark:8443");
+    expect(payload.description).toContain("<strong>dark</strong>");
     expect(payload.description).toContain(`${DEPLOY_WEB_BASE_URL}/deployments/${DSEQ}`);
   });
 

--- a/apps/api/src/notifications/lib/provider-host-name/provider-host-name.spec.ts
+++ b/apps/api/src/notifications/lib/provider-host-name/provider-host-name.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { toProviderHostName } from "./provider-host-name";
+
+describe(toProviderHostName.name, () => {
+  it("strips the scheme and the port from a host uri", () => {
+    expect(toProviderHostName("https://provider.akt.sies.com.gt:8443")).toBe("provider.akt.sies.com.gt");
+  });
+
+  it("keeps a host uri that carries no scheme", () => {
+    expect(toProviderHostName("provider.akt.sies.com.gt:8443")).toBe("provider.akt.sies.com.gt:8443");
+  });
+
+  it("keeps a host uri that is not a url at all", () => {
+    expect(toProviderHostName('<script>alert("xss")</script>')).toBe('<script>alert("xss")</script>');
+  });
+});

--- a/apps/api/src/notifications/lib/provider-host-name/provider-host-name.ts
+++ b/apps/api/src/notifications/lib/provider-host-name/provider-host-name.ts
@@ -1,0 +1,8 @@
+/** A provider's host URI is whatever it declared on chain, so anything that is not a parseable URL is shown as it came. */
+export function toProviderHostName(hostUri: string): string {
+  try {
+    return new URL(hostUri).hostname || hostUri;
+  } catch {
+    return hostUri;
+  }
+}

--- a/apps/api/src/notifications/services/notification-templates/provider-unreachable-closed.spec.ts
+++ b/apps/api/src/notifications/services/notification-templates/provider-unreachable-closed.spec.ts
@@ -21,7 +21,7 @@ describe(providerUnreachableClosedNotification.name, () => {
     expect(result.notificationId).toBe("providerUnreachableClosed.654321.akash1owner");
     expect(result.payload.summary).toBe("Your Akash deployment was closed: provider unreachable");
     expect(result.payload.description).toContain("<strong>654321</strong>");
-    expect(result.payload.description).toContain("<strong>https://provider.akash.cmolls.de:8443</strong>");
+    expect(result.payload.description).toContain("<strong>provider.akash.cmolls.de</strong>");
     expect(result.payload.description).toContain("14 days ago");
     expect(result.payload.description).toContain("returned");
     expect(result.payload.description).toContain(`<a href="${REDEPLOY_URL}">Deploy it again</a>`);

--- a/apps/api/src/notifications/services/notification-templates/provider-unreachable-closed.ts
+++ b/apps/api/src/notifications/services/notification-templates/provider-unreachable-closed.ts
@@ -1,5 +1,6 @@
 import escapeHtml from "lodash/escape";
 
+import { toProviderHostName } from "@src/notifications/lib/provider-host-name/provider-host-name";
 import type { UserOutput } from "@src/user/repositories";
 import type { CreateNotificationInput } from "../notification/notification.service";
 
@@ -17,7 +18,7 @@ export function providerUnreachableClosedNotification(
       summary: "Your Akash deployment was closed: provider unreachable",
       description:
         `Deployment <strong>${vars.dseq}</strong> has been closed. Its provider, ` +
-        `<strong>${escapeHtml(vars.hostUri)}</strong>, stopped responding ${vars.downForDays} days ago and never came back, ` +
+        `<strong>${escapeHtml(toProviderHostName(vars.hostUri))}</strong>, stopped responding ${vars.downForDays} days ago and never came back, ` +
         `so the deployment was costing you money without running anything. What was left of its funds has been returned ` +
         `to your account. <a href="${vars.redeployUrl}">Deploy it again</a> whenever you are ready.`
     },

--- a/apps/api/src/notifications/services/notification-templates/provider-unreachable-notification.spec.ts
+++ b/apps/api/src/notifications/services/notification-templates/provider-unreachable-notification.spec.ts
@@ -25,7 +25,7 @@ describe(providerUnreachableNotification.name, () => {
     expect(result.notificationId).toBe(`providerUnreachable.${downSince.toISOString()}.654321.akash1owner`);
     expect(result.payload.summary).toBe("Your Akash deployment's provider is unreachable");
     expect(result.payload.description).toContain("<strong>654321</strong>");
-    expect(result.payload.description).toContain("<strong>https://provider.akash.cmolls.de:8443</strong>");
+    expect(result.payload.description).toContain("<strong>provider.akash.cmolls.de</strong>");
     expect(result.payload.description).toContain("5 days");
     expect(result.payload.description).toContain(`<a href="${DEPLOYMENT_URL}">Close the deployment</a>`);
     expect(result.payload.description).toContain("we will close the deployment for you");

--- a/apps/api/src/notifications/services/notification-templates/provider-unreachable-notification.ts
+++ b/apps/api/src/notifications/services/notification-templates/provider-unreachable-notification.ts
@@ -1,6 +1,7 @@
 import { formatDistanceToNow } from "date-fns";
 import escapeHtml from "lodash/escape";
 
+import { toProviderHostName } from "@src/notifications/lib/provider-host-name/provider-host-name";
 import type { UserOutput } from "@src/user/repositories";
 import type { CreateNotificationInput } from "../notification/notification.service";
 
@@ -19,7 +20,7 @@ export function providerUnreachableNotification(
     payload: {
       summary: "Your Akash deployment's provider is unreachable",
       description:
-        `The provider hosting deployment <strong>${vars.dseq}</strong>, <strong>${escapeHtml(vars.hostUri)}</strong>, ` +
+        `The provider hosting deployment <strong>${vars.dseq}</strong>, <strong>${escapeHtml(toProviderHostName(vars.hostUri))}</strong>, ` +
         `has not responded for ${formatDistanceToNow(downSince)} and your workload is most likely down. ` +
         `You are still paying for it. <a href="${vars.deploymentUrl}">Close the deployment</a> to get the remaining ` +
         `funds back, then redeploy somewhere else. If every provider hosting this deployment is still unreachable ` +


### PR DESCRIPTION
## Why

Ref CON-900.

The warning email names the provider by the full host URI it declared on chain, like `https://provider.akt.sies.com.gt:8443`. The scheme and the port tell the owner nothing, and mail clients autolink the whole string, so the email ends up handing out a clickable link to a host that by definition is not answering. The closure email prints the same thing.

## What

Both templates now print the host name on its own: `provider.akt.sies.com.gt`.

`toProviderHostName` parses the URI and returns its hostname. Anything that does not parse as a URL, whether it has no scheme or is whatever a provider felt like putting on chain, is printed as it came, so the existing escaping still covers hostile input.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Provider-unreachable notifications now display a cleaner provider hostname without the URL scheme or port.
  * Provider names are highlighted consistently in deployment descriptions.

* **Tests**
  * Added coverage for hostname formatting, including URLs with schemes, ports, and non-URL values.
  * Updated notification checks to reflect the clearer provider information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->