### PR TITLE
feat(deployment): show what a new deployment reserves before confirming

### DIFF
--- a/apps/api/env/.env
+++ b/apps/api/env/.env
@@ -1,6 +1,6 @@
 CORS_WEBSITE_URLS=https://stats.akash.network,https://console.akash.network,https://akash.network,https://akash.hooman.digital,http://localhost:3000,http://localhost:3001,https://akashconsole.vercel.app,https://console-beta.akash.network,https://provider-console-beta.akash.network,https://provider-console.akash.network
 WEBSITE_URL=https://console-beta.akash.network
-TRIAL_DEPLOYMENT_ALLOWANCE_AMOUNT=10000000
+TRIAL_DEPLOYMENT_ALLOWANCE_AMOUNT=1000000
 DEPLOYMENT_ALLOWANCE_REFILL_AMOUNT=10000000
 DEPLOYMENT_ALLOWANCE_REFILL_THRESHOLD=1000000
 TRIAL_FEES_ALLOWANCE_AMOUNT=1000000

--- a/apps/api/src/deployment/controllers/deployment-funding-config/deployment-funding-config.controller.ts
+++ b/apps/api/src/deployment/controllers/deployment-funding-config/deployment-funding-config.controller.ts
@@ -1,0 +1,23 @@
+import { singleton } from "tsyringe";
+
+import type { DeploymentFundingConfigResponse } from "@src/deployment/http-schemas/deployment-funding-config.schema";
+import { DeploymentConfigService } from "@src/deployment/services/deployment-config/deployment-config.service";
+
+@singleton()
+export class DeploymentFundingConfigController {
+  readonly #config: DeploymentConfigService;
+
+  constructor(config: DeploymentConfigService) {
+    this.#config = config;
+  }
+
+  getConfig(): DeploymentFundingConfigResponse {
+    return {
+      data: {
+        targetRunwayHours: this.#config.get("AUTO_TOP_UP_TARGET_RUNWAY_IN_H"),
+        balanceHeadroomUsd: this.#config.get("AUTO_TOP_UP_BALANCE_HEADROOM_IN_USD"),
+        defaultDepositUsd: this.#config.get("DEPLOYMENT_DEFAULT_DEPOSIT")
+      }
+    };
+  }
+}

--- a/apps/api/src/deployment/http-schemas/deployment-funding-config.schema.ts
+++ b/apps/api/src/deployment/http-schemas/deployment-funding-config.schema.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+export const DeploymentFundingConfigResponseSchema = z.object({
+  data: z.object({
+    targetRunwayHours: z.number().openapi({
+      description: "Hours of runtime automatic funding reserves for a deployment once its lease starts"
+    }),
+    balanceHeadroomUsd: z.number().openapi({
+      description: "USD amount automatic funding leaves untouched in the available balance so new deployments can still be created"
+    }),
+    defaultDepositUsd: z.number().openapi({
+      description: "USD amount every deployment is bootstrapped with at creation, before funding tops it up toward the target runway"
+    })
+  })
+});
+
+export type DeploymentFundingConfigResponse = z.infer<typeof DeploymentFundingConfigResponseSchema>;

--- a/apps/api/src/deployment/routes/deployment-funding-config/deployment-funding-config.router.ts
+++ b/apps/api/src/deployment/routes/deployment-funding-config/deployment-funding-config.router.ts
@@ -1,0 +1,35 @@
+import { container } from "tsyringe";
+
+import { createRoute } from "@src/core/lib/create-route/create-route";
+import { OpenApiHonoHandler } from "@src/core/services/open-api-hono-handler/open-api-hono-handler";
+import { SECURITY_NONE } from "@src/core/services/openapi-docs/openapi-security";
+import { DeploymentFundingConfigController } from "@src/deployment/controllers/deployment-funding-config/deployment-funding-config.controller";
+import { DeploymentFundingConfigResponseSchema } from "@src/deployment/http-schemas/deployment-funding-config.schema";
+
+const route = createRoute({
+  method: "get",
+  path: "/v1/deployment-funding-config",
+  summary: "Get deployment funding config",
+  // eslint-disable-next-line akash/operation-id-format
+  operationId: "getDeploymentFundingConfig",
+  tags: ["Deployments"],
+  security: SECURITY_NONE,
+  cache: { maxAge: 300, staleWhileRevalidate: 600 },
+  request: {},
+  responses: {
+    200: {
+      description: "Returns the platform constants automatic deployment funding runs on",
+      content: {
+        "application/json": {
+          schema: DeploymentFundingConfigResponseSchema
+        }
+      }
+    }
+  }
+});
+
+export const deploymentFundingConfigRouter = new OpenApiHonoHandler();
+
+deploymentFundingConfigRouter.openapi(route, async function routeGetDeploymentFundingConfig(c) {
+  return c.json(container.resolve(DeploymentFundingConfigController).getConfig(), 200);
+});

--- a/apps/api/src/routers/open-api-handlers.ts
+++ b/apps/api/src/routers/open-api-handlers.ts
@@ -30,6 +30,7 @@ import {
   marketDataRouter,
   networkCapacityRouter
 } from "@src/dashboard";
+import { deploymentFundingConfigRouter } from "@src/deployment/routes/deployment-funding-config/deployment-funding-config.router";
 import { deploymentSettingRouter } from "@src/deployment/routes/deployment-setting/deployment-setting.router";
 import { deploymentsRouter } from "@src/deployment/routes/deployments/deployments.router";
 import { getSDLSecretsContextRouter } from "@src/deployment/routes/get-sdl-secrets-context/get-sdl-secrets-context.router";
@@ -74,6 +75,7 @@ export const openApiHonoHandlers: OpenApiHonoHandler[] = [
   signupRouter,
   verifyEmailCodeRouter,
   verifyEmailRouter,
+  deploymentFundingConfigRouter,
   deploymentSettingRouter,
   deploymentsRouter,
   getSDLSecretsContextRouter,

--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -2911,6 +2911,55 @@
         }
       }
     },
+    "/v1/deployment-funding-config": {
+      "get": {
+        "summary": "Get deployment funding config",
+        "operationId": "getDeploymentFundingConfig",
+        "tags": [
+          "Deployments"
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Returns the platform constants automatic deployment funding runs on",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "targetRunwayHours": {
+                          "type": "number",
+                          "description": "Hours of runtime automatic funding reserves for a deployment once its lease starts"
+                        },
+                        "balanceHeadroomUsd": {
+                          "type": "number",
+                          "description": "USD amount automatic funding leaves untouched in the available balance so new deployments can still be created"
+                        },
+                        "defaultDepositUsd": {
+                          "type": "number",
+                          "description": "USD amount every deployment is bootstrapped with at creation, before funding tops it up toward the target runway"
+                        }
+                      },
+                      "required": [
+                        "targetRunwayHours",
+                        "balanceHeadroomUsd",
+                        "defaultDepositUsd"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/deployment-settings/{userId}/{dseq}": {
       "get": {
         "summary": "Get deployment settings by user ID and dseq",
@@ -3083,7 +3132,7 @@
                     "properties": {
                       "autoTopUpEnabled": {
                         "type": "boolean",
-                        "description": "Whether auto top-up is enabled for this deployment"
+                        "description": "Whether auto top-up is enabled for this deployment. An explicit false is rejected once always-on funding is rolled out"
                       },
                       "runtimeLimitHours": {
                         "type": "integer",
@@ -3265,8 +3314,7 @@
                       },
                       "autoTopUpEnabled": {
                         "type": "boolean",
-                        "default": false,
-                        "description": "Whether auto top-up is enabled for this deployment"
+                        "description": "Whether auto top-up is enabled for this deployment. Defaults to enabled when omitted; an explicit false is rejected once always-on funding is rolled out"
                       }
                     },
                     "required": [
@@ -3531,7 +3579,7 @@
                     "properties": {
                       "autoTopUpEnabled": {
                         "type": "boolean",
-                        "description": "Whether auto top-up is enabled for this deployment"
+                        "description": "Whether auto top-up is enabled for this deployment. An explicit false is rejected once always-on funding is rolled out"
                       },
                       "runtimeLimitHours": {
                         "type": "integer",
@@ -3709,8 +3757,7 @@
                       },
                       "autoTopUpEnabled": {
                         "type": "boolean",
-                        "default": false,
-                        "description": "Whether auto top-up is enabled for this deployment"
+                        "description": "Whether auto top-up is enabled for this deployment. Defaults to enabled when omitted; an explicit false is rejected once always-on funding is rolled out"
                       },
                       "userId": {
                         "type": "string",
@@ -7645,6 +7692,108 @@
                   },
                   "required": [
                     "data"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/sdl-secrets-context": {
+      "get": {
+        "summary": "Get SDL secrets encryption context",
+        "tags": [
+          "SDL Secrets"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns SDL secrets context",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "sub": {
+                      "type": "string",
+                      "description": "The subject of the SDL secrets context"
+                    },
+                    "kid": {
+                      "type": "string",
+                      "description": "The key ID of the SDL secrets context"
+                    },
+                    "jwk": {
+                      "type": "object",
+                      "properties": {
+                        "kty": {
+                          "type": "string"
+                        },
+                        "n": {
+                          "type": "string"
+                        },
+                        "e": {
+                          "type": "string"
+                        },
+                        "use": {
+                          "type": "string"
+                        },
+                        "alg": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kty",
+                        "n",
+                        "e",
+                        "use",
+                        "alg"
+                      ],
+                      "description": "The JSON Web Key used to encrypt the SDL secrets"
+                    },
+                    "requiredClaims": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "enum": [
+                          "kid",
+                          "sub",
+                          "exp"
+                        ]
+                      },
+                      "description": "The required claims for the SDL secrets context"
+                    }
+                  },
+                  "required": [
+                    "sub",
+                    "kid",
+                    "jwk",
+                    "requiredClaims"
+                  ]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "SDL secrets encryption is unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
                   ]
                 }
               }

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -5444,6 +5444,55 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
         ],
       },
     },
+    "/v1/deployment-funding-config": {
+      "get": {
+        "operationId": "getDeploymentFundingConfig",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {
+                        "balanceHeadroomUsd": {
+                          "description": "USD amount automatic funding leaves untouched in the available balance so new deployments can still be created",
+                          "type": "number",
+                        },
+                        "defaultDepositUsd": {
+                          "description": "USD amount every deployment is bootstrapped with at creation, before funding tops it up toward the target runway",
+                          "type": "number",
+                        },
+                        "targetRunwayHours": {
+                          "description": "Hours of runtime automatic funding reserves for a deployment once its lease starts",
+                          "type": "number",
+                        },
+                      },
+                      "required": [
+                        "targetRunwayHours",
+                        "balanceHeadroomUsd",
+                        "defaultDepositUsd",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Returns the platform constants automatic deployment funding runs on",
+          },
+        },
+        "security": [],
+        "summary": "Get deployment funding config",
+        "tags": [
+          "Deployments",
+        ],
+      },
+    },
     "/v1/deployment-settings": {
       "post": {
         "requestBody": {

--- a/apps/api/test/functional/deployment-funding-config.spec.ts
+++ b/apps/api/test/functional/deployment-funding-config.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { app } from "@src/rest-app";
+
+describe("GET /v1/deployment-funding-config", () => {
+  it("returns the funding constants without requiring auth", async () => {
+    const response = await app.request("/v1/deployment-funding-config");
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      data: {
+        targetRunwayHours: 48,
+        balanceHeadroomUsd: 5,
+        defaultDepositUsd: 0.5
+      }
+    });
+  });
+
+  it("marks the response as cacheable", async () => {
+    const response = await app.request("/v1/deployment-funding-config");
+
+    expect(response.headers.get("cache-control")).toContain("max-age=300");
+  });
+});

--- a/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/BalanceBreakdownBar.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/BalanceBreakdownBar.spec.tsx
@@ -108,6 +108,20 @@ describe(BalanceBreakdownBar.name, () => {
     expect(screen.getByRole("img").children).toHaveLength(2);
   });
 
+  it("keeps the threshold line but drops the caption when the host hides it", () => {
+    setup({
+      segments: [
+        { key: "d1", label: "llama", amountUsd: 1000, color: "hsl(var(--primary))" },
+        { key: "available", label: "Available", amountUsd: 1000, color: "hsl(var(--success))" }
+      ],
+      threshold: 250,
+      hideThresholdCaption: true
+    });
+
+    expect(screen.getByTestId("balance-threshold-line")).toBeInTheDocument();
+    expect(screen.queryByTestId("balance-threshold-caption")).not.toBeInTheDocument();
+  });
+
   it("drops the marker when available is at or below the threshold", () => {
     setup({
       segments: [
@@ -121,10 +135,10 @@ describe(BalanceBreakdownBar.name, () => {
     expect(screen.queryByTestId("balance-threshold-caption")).not.toBeInTheDocument();
   });
 
-  function setup(input: { segments: Parameters<typeof BalanceBreakdownBar>[0]["segments"]; threshold?: number | null }) {
+  function setup(input: { segments: Parameters<typeof BalanceBreakdownBar>[0]["segments"]; threshold?: number | null; hideThresholdCaption?: boolean }) {
     return render(
       <IntlProvider locale="en-US">
-        <BalanceBreakdownBar segments={input.segments} threshold={input.threshold} />
+        <BalanceBreakdownBar segments={input.segments} threshold={input.threshold} hideThresholdCaption={input.hideThresholdCaption} />
       </IntlProvider>
     );
   }

--- a/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/BalanceBreakdownBar.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/BalanceBreakdownBar.tsx
@@ -90,7 +90,9 @@ export const BalanceBreakdownBar: React.FunctionComponent<{
   hoveredKey?: string | null;
   onHover?: (key: string | null) => void;
   threshold?: number | null;
-}> = ({ segments, hoveredKey = null, onHover, threshold = null }) => {
+  /** Hides the "Tops up at $X" caption for hosts that explain the threshold in their own copy. */
+  hideThresholdCaption?: boolean;
+}> = ({ segments, hoveredKey = null, onHover, threshold = null, hideThresholdCaption = false }) => {
   const intl = useIntl();
   const formatUsd = (value: number) => intl.formatNumber(value, { style: "currency", currency: "USD" });
   const label = segments.map(segment => `${segment.label} ${formatUsd(segment.amountUsd)}`).join(", ");
@@ -98,7 +100,7 @@ export const BalanceBreakdownBar: React.FunctionComponent<{
   const marker = threshold !== null && threshold > 0 && available > 0 ? buildThresholdMarker(threshold, available) : null;
 
   return (
-    <div className={marker === null ? undefined : "pb-6"}>
+    <div className={marker === null || hideThresholdCaption ? undefined : "pb-6"}>
       <div className="flex h-3 w-full gap-[2px]" role="img" aria-label={`Balance breakdown: ${label}`}>
         {segments.map(segment => (
           <div
@@ -122,16 +124,18 @@ export const BalanceBreakdownBar: React.FunctionComponent<{
                   data-testid="balance-threshold-line"
                   aria-hidden
                 />
-                <div
-                  className="pointer-events-none absolute top-full mt-2 flex -translate-x-1/2 items-center gap-1 whitespace-nowrap text-xs text-muted-foreground"
-                  style={{ left: `${marker.positionPct}%` }}
-                  data-testid="balance-threshold-caption"
-                >
-                  <Flash className="h-3 w-3 shrink-0" />
-                  <span>
-                    Tops up at <span className="font-medium text-foreground">{formatUsd(marker.amountUsd)}</span>
-                  </span>
-                </div>
+                {!hideThresholdCaption && (
+                  <div
+                    className="pointer-events-none absolute top-full mt-2 flex -translate-x-1/2 items-center gap-1 whitespace-nowrap text-xs text-muted-foreground"
+                    style={{ left: `${marker.positionPct}%` }}
+                    data-testid="balance-threshold-caption"
+                  >
+                    <Flash className="h-3 w-3 shrink-0" />
+                    <span>
+                      Tops up at <span className="font-medium text-foreground">{formatUsd(marker.amountUsd)}</span>
+                    </span>
+                  </div>
+                )}
               </>
             )}
           </div>

--- a/apps/deploy-web/src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup.tsx
@@ -37,7 +37,7 @@ const AUTO_RELOAD_THRESHOLD_MIN_USD = 10;
 const AUTO_RELOAD_MAX_USD = 10_000;
 
 /** Mirrors the API's AUTO_RELOAD_AMOUNT_MIN_USD — the floor applied to every recurring auto-top-up charge, independent of the trial-aware one-time top-up minimum. */
-const AUTO_RELOAD_AMOUNT_MIN_USD = 25;
+export const AUTO_RELOAD_AMOUNT_MIN_USD = 25;
 
 /**
  * Mirrors the API's AUTO_RELOAD_CHARGE_COOLDOWN_IN_MIN, which defaults to 60. Threshold mode takes an hourly per-wallet

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/FundingImpactReviewSection.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/FundingImpactReviewSection.spec.tsx
@@ -34,8 +34,13 @@ describe("FundingImpactReviewSection", () => {
   });
 
   it("summarizes a sub-runway runtime limit in hours", () => {
-    setup({ impact: visible({ fundedHours: 12 }) });
+    setup({ impact: visible({ runtimeCoveredHours: 12 }) });
     expect(screen.getByRole("button")).toHaveTextContent("≈12 hours of runtime");
+  });
+
+  it("drops the runtime part of the summary when no runtime can be quoted", () => {
+    setup({ impact: visible({ runtimeCoveredHours: null }) });
+    expect(screen.getByRole("button")).not.toHaveTextContent("of runtime");
   });
 
   it("shows a dash for available after when the balance cannot cover the reserve", () => {
@@ -113,7 +118,7 @@ describe("FundingImpactReviewSection", () => {
       reserveUsd: 144,
       availableNowUsd: 200,
       availableAfterUsd: 56,
-      fundedHours: 48,
+      runtimeCoveredHours: 48,
       thresholdUsd: null,
       chargeUsd: 100,
       cardLabel: "Visa **** 4242",

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/FundingImpactReviewSection.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/FundingImpactReviewSection.spec.tsx
@@ -1,0 +1,144 @@
+import type { ReactNode } from "react";
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import { UrlService } from "@src/utils/urlUtils";
+import type { DEPENDENCIES } from "./FundingImpactReviewSection";
+import { FundingImpactReviewSection } from "./FundingImpactReviewSection";
+import type { FundingImpact } from "./useFundingImpact";
+import type { ReviewRow } from "./useReviewRows";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+describe("FundingImpactReviewSection", () => {
+  it("renders nothing while hidden", () => {
+    const { container } = setup({ impact: { kind: "hidden" } });
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("points at Billing without blocking when the balance is unavailable", () => {
+    setup({ impact: { kind: "unavailable" } });
+
+    expect(screen.getByText(/Balance details are unavailable right now/)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Check Billing" })).toHaveAttribute("href", UrlService.billing());
+  });
+
+  it("summarizes the reserve, the available after it, and the runtime it covers", () => {
+    setup({ impact: visible() });
+
+    const trigger = screen.getByRole("button");
+    expect(trigger).toHaveTextContent("Reserved ~$144");
+    expect(trigger).toHaveTextContent("available after $56");
+    expect(trigger).toHaveTextContent("≈2 days of runtime");
+  });
+
+  it("summarizes a sub-runway runtime limit in hours", () => {
+    setup({ impact: visible({ fundedHours: 12 }) });
+    expect(screen.getByRole("button")).toHaveTextContent("≈12 hours of runtime");
+  });
+
+  it("shows a dash for available after when the balance cannot cover the reserve", () => {
+    setup({ impact: visible({ state: "not-enough-available", availableAfterUsd: null }) });
+    expect(screen.getByRole("button")).toHaveTextContent("available after —");
+  });
+
+  it("expands into the legend, the balance bar, the explainer, and the Billing link", async () => {
+    setup({ impact: visible({ thresholdUsd: 20 }) });
+
+    await userEvent.click(screen.getByRole("button"));
+
+    expect(screen.getByText(/Reserved ~ \$144 \(estimate\)/)).toBeInTheDocument();
+    expect(screen.getByText("$200")).toBeInTheDocument();
+    expect(screen.getByText("available now")).toBeInTheDocument();
+    expect(screen.getByTestId("balance-bar")).toHaveTextContent("reserve:144,available:56");
+    expect(screen.getByTestId("balance-bar")).toHaveAttribute("data-threshold", "20");
+    expect(screen.getByText(/The reserve is held, not charged/)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Full balance breakdown in Billing/ })).toHaveAttribute("href", UrlService.billing());
+  });
+
+  it("says available stays above the threshold when funded", async () => {
+    setup({ impact: visible({ thresholdUsd: 20 }) });
+
+    await userEvent.click(screen.getByRole("button"));
+
+    expect(screen.getByText(/available stays above it, so no credits are purchased/)).toBeInTheDocument();
+  });
+
+  it("omits the threshold sentence when no threshold rule applies", async () => {
+    setup({ impact: visible({ thresholdUsd: null }) });
+
+    await userEvent.click(screen.getByRole("button"));
+
+    expect(screen.queryByText(/available stays above it/)).not.toBeInTheDocument();
+  });
+
+  it("warns which card buys credits when confirming crosses the threshold", async () => {
+    setup({ impact: visible({ state: "crosses-threshold", availableAfterUsd: 19, thresholdUsd: 20 }) });
+
+    expect(screen.getByText("Buys credits")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: /Reserved/ }));
+
+    const callout = screen.getByRole("alert");
+    expect(callout).toHaveTextContent("Confirming drops available to $19, below your Auto Top-Up threshold of $20");
+    expect(callout).toHaveTextContent("Visa **** 4242 is charged $100 for credits");
+  });
+
+  it("prompts for credits without claiming a charge when no payment method is on file", async () => {
+    setup({ impact: visible({ state: "no-payment-method", cardLabel: null }) });
+
+    expect(screen.getByText("No payment method")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: /Reserved/ }));
+
+    expect(screen.getByText(/nothing is charged automatically/)).toBeInTheDocument();
+    expect(screen.queryByText(/charged \$/)).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Add Credits" })).toHaveAttribute("href", UrlService.billing({ openPayment: true }));
+  });
+
+  it("offers credits and drops the bar when the balance cannot cover the reserve", async () => {
+    setup({ impact: visible({ state: "not-enough-available", availableAfterUsd: null, availableNowUsd: 100 }) });
+
+    expect(screen.getByText("Not enough available")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: /Reserved/ }));
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Your available balance of $100 can't cover the estimated reserve of ~$144");
+    expect(screen.queryByTestId("balance-bar")).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Add Credits" })).toHaveAttribute("href", UrlService.billing({ openPayment: true }));
+  });
+
+  function visible(overrides?: Partial<Extract<FundingImpact, { kind: "visible" }>>): FundingImpact {
+    return {
+      kind: "visible",
+      state: "funded",
+      reserveUsd: 144,
+      availableNowUsd: 200,
+      availableAfterUsd: 56,
+      fundedHours: 48,
+      thresholdUsd: null,
+      chargeUsd: 100,
+      cardLabel: "Visa **** 4242",
+      ...overrides
+    };
+  }
+
+  function setup(input: { impact: FundingImpact }) {
+    const useFundingImpact: typeof DEPENDENCIES.useFundingImpact = () => input.impact;
+    const BalanceBreakdownBar: typeof DEPENDENCIES.BalanceBreakdownBar = ({ segments, threshold }) => (
+      <div data-testid="balance-bar" data-threshold={threshold ?? undefined}>
+        {segments.map(segment => `${segment.key}:${segment.amountUsd}`).join(",")}
+      </div>
+    );
+    const UsdValue: typeof DEPENDENCIES.UsdValue = ({ value }) => <>${value}</>;
+    const Link: typeof DEPENDENCIES.Link = (({ href, children }: { href: string; children: ReactNode }) => (
+      <a href={href}>{children}</a>
+    )) as typeof DEPENDENCIES.Link;
+
+    return render(
+      <FundingImpactReviewSection
+        rows={[mock<ReviewRow>({ price: { amount: "0.005", denom: "uakt" } })]}
+        runtimeLimitHours={undefined}
+        dependencies={{ useFundingImpact, BalanceBreakdownBar, UsdValue, Link }}
+      />
+    );
+  }
+});

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/FundingImpactReviewSection.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/FundingImpactReviewSection.spec.tsx
@@ -17,6 +17,13 @@ describe("FundingImpactReviewSection", () => {
     expect(container).toBeEmptyDOMElement();
   });
 
+  it("renders a skeleton of the summary row while loading", () => {
+    setup({ impact: { kind: "loading" } });
+
+    expect(screen.getAllByTestId("skeleton").length).toBeGreaterThan(0);
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
   it("points at Billing without blocking when the balance is unavailable", () => {
     setup({ impact: { kind: "unavailable" } });
 
@@ -137,12 +144,13 @@ describe("FundingImpactReviewSection", () => {
     const Link: typeof DEPENDENCIES.Link = (({ href, children }: { href: string; children: ReactNode }) => (
       <a href={href}>{children}</a>
     )) as typeof DEPENDENCIES.Link;
+    const Skeleton: typeof DEPENDENCIES.Skeleton = () => <div data-testid="skeleton" />;
 
     return render(
       <FundingImpactReviewSection
         rows={[mock<ReviewRow>({ price: { amount: "0.005", denom: "uakt" } })]}
         runtimeLimitHours={undefined}
-        dependencies={{ useFundingImpact, BalanceBreakdownBar, UsdValue, Link }}
+        dependencies={{ useFundingImpact, BalanceBreakdownBar, UsdValue, Link, Skeleton }}
       />
     );
   }

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/FundingImpactReviewSection.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/FundingImpactReviewSection.spec.tsx
@@ -31,23 +31,18 @@ describe("FundingImpactReviewSection", () => {
     expect(screen.getByRole("link", { name: "Check Billing" })).toHaveAttribute("href", UrlService.billing());
   });
 
-  it("summarizes the reserve, the available after it, and the runtime it covers", () => {
+  it("summarizes the reserve and the available after it, without a runtime figure while funding is open-ended", () => {
     setup({ impact: visible() });
 
     const trigger = screen.getByRole("button");
     expect(trigger).toHaveTextContent("Reserved ~$144");
     expect(trigger).toHaveTextContent("available after $56");
-    expect(trigger).toHaveTextContent("≈2 days of runtime");
+    expect(trigger).not.toHaveTextContent("of runtime");
   });
 
-  it("summarizes a sub-runway runtime limit in hours", () => {
-    setup({ impact: visible({ runtimeCoveredHours: 12 }) });
-    expect(screen.getByRole("button")).toHaveTextContent("≈12 hours of runtime");
-  });
-
-  it("drops the runtime part of the summary when no runtime can be quoted", () => {
-    setup({ impact: visible({ runtimeCoveredHours: null }) });
-    expect(screen.getByRole("button")).not.toHaveTextContent("of runtime");
+  it("summarizes the runtime limit when one is set", () => {
+    setup({ impact: visible(), runtimeLimitHours: 12 });
+    expect(screen.getByRole("button")).toHaveTextContent("12 hours of runtime");
   });
 
   it("shows a dash for available after when the balance cannot cover the reserve", () => {
@@ -125,7 +120,6 @@ describe("FundingImpactReviewSection", () => {
       reserveUsd: 144,
       availableNowUsd: 200,
       availableAfterUsd: 56,
-      runtimeCoveredHours: 48,
       thresholdUsd: null,
       chargeUsd: 100,
       cardLabel: "Visa **** 4242",
@@ -133,7 +127,7 @@ describe("FundingImpactReviewSection", () => {
     };
   }
 
-  function setup(input: { impact: FundingImpact }) {
+  function setup(input: { impact: FundingImpact; runtimeLimitHours?: number }) {
     const useFundingImpact: typeof DEPENDENCIES.useFundingImpact = () => input.impact;
     const BalanceBreakdownBar: typeof DEPENDENCIES.BalanceBreakdownBar = ({ segments, threshold }) => (
       <div data-testid="balance-bar" data-threshold={threshold ?? undefined}>
@@ -149,7 +143,7 @@ describe("FundingImpactReviewSection", () => {
     return render(
       <FundingImpactReviewSection
         rows={[mock<ReviewRow>({ price: { amount: "0.005", denom: "uakt" } })]}
-        runtimeLimitHours={undefined}
+        runtimeLimitHours={input.runtimeLimitHours}
         dependencies={{ useFundingImpact, BalanceBreakdownBar, UsdValue, Link, Skeleton }}
       />
     );

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/FundingImpactReviewSection.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/FundingImpactReviewSection.spec.tsx
@@ -102,6 +102,18 @@ describe("FundingImpactReviewSection", () => {
     expect(screen.getByRole("link", { name: "Add Credits" })).toHaveAttribute("href", UrlService.billing({ openPayment: true }));
   });
 
+  it("names the trial and its duration without claiming anything about a card", async () => {
+    setup({ impact: visible({ state: "trial", trialDurationHours: 12 }) });
+
+    expect(screen.getByText("Trial")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: /Reserved/ }));
+
+    expect(screen.getByText(/closed automatically after 12 hours/)).toBeInTheDocument();
+    expect(screen.queryByText(/payment method/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/charged \$/)).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Add Credits" })).toHaveAttribute("href", UrlService.billing({ openPayment: true }));
+  });
+
   it("offers credits and drops the bar when the balance cannot cover the reserve", async () => {
     setup({ impact: visible({ state: "not-enough-available", availableAfterUsd: null, availableNowUsd: 100 }) });
 
@@ -123,6 +135,7 @@ describe("FundingImpactReviewSection", () => {
       thresholdUsd: null,
       chargeUsd: 100,
       cardLabel: "Visa **** 4242",
+      trialDurationHours: 24,
       ...overrides
     };
   }

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/FundingImpactReviewSection.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/FundingImpactReviewSection.tsx
@@ -75,7 +75,7 @@ export const FundingImpactReviewSection: FC<Props> = ({ rows, runtimeLimitHours,
           ) : (
             <span className="font-medium text-success">{usd(impact.availableAfterUsd)}</span>
           )}
-          <span className="text-muted-foreground"> · ≈{formatRuntime(impact.fundedHours)} of runtime</span>
+          {impact.runtimeCoveredHours !== null && <span className="text-muted-foreground"> · ≈{formatRuntime(impact.runtimeCoveredHours)} of runtime</span>}
         </span>
         <span className="flex shrink-0 items-center gap-3">
           {badge && (

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/FundingImpactReviewSection.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/FundingImpactReviewSection.tsx
@@ -1,0 +1,181 @@
+"use client";
+import type { FC, ReactNode } from "react";
+import { useState } from "react";
+import { Button, Collapsible, CollapsibleContent, CollapsibleTrigger } from "@akashnetwork/ui/components";
+import { Flash, NavArrowDown } from "iconoir-react";
+import Link from "next/link";
+
+import { BalanceBreakdownBar } from "@src/components/billing-usage/AccountBalanceOverview/BalanceBreakdownBar";
+import { UsdValue } from "@src/components/billing-usage/UsdValue/UsdValue";
+import { UrlService } from "@src/utils/urlUtils";
+import type { FundingImpact } from "./useFundingImpact";
+import { useFundingImpact } from "./useFundingImpact";
+import type { ReviewRow } from "./useReviewRows";
+
+export const DEPENDENCIES = {
+  useFundingImpact,
+  BalanceBreakdownBar,
+  UsdValue,
+  Link
+};
+
+type Props = {
+  rows: ReviewRow[];
+  runtimeLimitHours: number | undefined;
+  dependencies?: typeof DEPENDENCIES;
+};
+
+type VisibleImpact = Extract<FundingImpact, { kind: "visible" }>;
+
+const STATE_BADGES: Partial<Record<VisibleImpact["state"], string>> = {
+  "crosses-threshold": "Buys credits",
+  "no-payment-method": "No payment method",
+  "not-enough-available": "Not enough available"
+};
+
+/**
+ * What confirming does to the account's money: the estimated reserve, the available balance it comes out
+ * of, and whether it triggers an automatic credit purchase. Purely informative — it never blocks the
+ * deploy, and it renders nothing at all when the estimate can't be made.
+ */
+export const FundingImpactReviewSection: FC<Props> = ({ rows, runtimeLimitHours, dependencies: d = DEPENDENCIES }) => {
+  const impact = d.useFundingImpact({ rows, runtimeLimitHours });
+  const [isExpanded, setIsExpanded] = useState(false);
+  const usd = (value: number) => <d.UsdValue value={value} />;
+
+  if (impact.kind === "hidden") return null;
+
+  if (impact.kind === "unavailable") {
+    return (
+      <p className="text-xs text-muted-foreground">
+        Balance details are unavailable right now.{" "}
+        <d.Link href={UrlService.billing()} className="underline">
+          Check Billing
+        </d.Link>{" "}
+        for what gets reserved.
+      </p>
+    );
+  }
+
+  const badge = STATE_BADGES[impact.state];
+  const addCreditsButton = (
+    <Button size="sm" asChild>
+      <d.Link href={UrlService.billing({ openPayment: true })}>Add Credits</d.Link>
+    </Button>
+  );
+
+  return (
+    <Collapsible open={isExpanded} onOpenChange={setIsExpanded} className="rounded-lg border p-4">
+      <CollapsibleTrigger className="group flex w-full items-center justify-between gap-4 text-left">
+        <span className="text-sm">
+          Reserved <span className="font-medium">~{usd(impact.reserveUsd)}</span>
+          <span className="text-muted-foreground"> · available after </span>
+          {impact.availableAfterUsd === null ? (
+            <span className="text-destructive">—</span>
+          ) : (
+            <span className="font-medium text-success">{usd(impact.availableAfterUsd)}</span>
+          )}
+          <span className="text-muted-foreground"> · ≈{formatRuntime(impact.fundedHours)} of runtime</span>
+        </span>
+        <span className="flex shrink-0 items-center gap-3">
+          {badge && (
+            <span className="rounded border border-destructive/60 px-2 py-0.5 font-mono text-xs uppercase tracking-wide text-destructive">{badge}</span>
+          )}
+          <NavArrowDown className="h-4 w-4 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
+        </span>
+      </CollapsibleTrigger>
+
+      <CollapsibleContent className="space-y-3 pt-4">
+        <div className="flex items-center justify-between gap-4 text-xs">
+          <span className="flex items-center gap-2">
+            <span className="h-2 w-2 rounded-full bg-muted-foreground/40" />
+            <span className="text-muted-foreground">Reserved ~ {usd(impact.reserveUsd)} (estimate)</span>
+          </span>
+          <span className="flex items-center gap-2">
+            <span className="h-2 w-2 rounded-full bg-success" />
+            <span>
+              <span className="font-medium">{usd(impact.availableNowUsd)}</span> <span className="text-muted-foreground">available now</span>
+            </span>
+          </span>
+        </div>
+
+        {impact.availableAfterUsd !== null && (
+          <d.BalanceBreakdownBar
+            segments={[
+              { key: "reserve", label: "Reserved", amountUsd: impact.reserveUsd, color: "hsl(var(--muted-foreground) / 0.4)" },
+              { key: "available", label: "Available", amountUsd: impact.availableAfterUsd, color: "hsl(var(--success))" }
+            ]}
+            threshold={impact.thresholdUsd}
+            hideThresholdCaption
+          />
+        )}
+
+        {renderStateDetails(impact, usd, addCreditsButton)}
+
+        <p className="text-sm text-muted-foreground">
+          The reserve is held, not charged. You pay for the time your deployment actually runs, and anything it doesn&apos;t use returns to available when the
+          deployment closes.
+        </p>
+
+        <d.Link href={UrlService.billing()} className="inline-block text-sm text-success hover:underline">
+          Full balance breakdown in Billing →
+        </d.Link>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+};
+
+function renderStateDetails(impact: VisibleImpact, usd: (value: number) => ReactNode, addCreditsButton: ReactNode): ReactNode {
+  switch (impact.state) {
+    case "funded":
+      return impact.thresholdUsd === null ? null : (
+        <p className="text-sm text-muted-foreground">
+          Auto Top-Up threshold <span className="font-medium text-foreground">{usd(impact.thresholdUsd)}</span> · available stays above it, so no credits are
+          purchased.
+        </p>
+      );
+    case "crosses-threshold":
+      return (
+        <Callout tone="warning">
+          <Flash className="h-4 w-4 shrink-0" />
+          <span>
+            Confirming drops available to <span className="font-medium">{impact.availableAfterUsd === null ? "—" : usd(impact.availableAfterUsd)}</span>, below
+            your Auto Top-Up threshold of <span className="font-medium">{impact.thresholdUsd === null ? "—" : usd(impact.thresholdUsd)}</span>.{" "}
+            {impact.cardLabel ?? "Your default card"} is charged <span className="font-medium">{usd(impact.chargeUsd)}</span> for credits.
+          </span>
+        </Callout>
+      );
+    case "no-payment-method":
+      return (
+        <Callout tone="neutral">
+          <span className="flex-1">No payment method on file, so nothing is charged automatically. Add credits to keep deployments funded.</span>
+          {addCreditsButton}
+        </Callout>
+      );
+    case "not-enough-available":
+      return (
+        <Callout tone="warning">
+          <span className="flex-1">
+            Your available balance of <span className="font-medium">{usd(impact.availableNowUsd)}</span> can&apos;t cover the estimated reserve of{" "}
+            <span className="font-medium">~{usd(impact.reserveUsd)}</span>.
+          </span>
+          {addCreditsButton}
+        </Callout>
+      );
+  }
+}
+
+const Callout: FC<{ tone: "warning" | "neutral"; children: ReactNode }> = ({ tone, children }) => (
+  <div
+    className={`flex items-center gap-3 rounded-lg border p-3 text-sm ${tone === "warning" ? "border-destructive/50 bg-destructive/5" : "bg-muted/40"}`}
+    role={tone === "warning" ? "alert" : undefined}
+  >
+    {children}
+  </div>
+);
+
+function formatRuntime(hours: number): string {
+  if (hours < 48) return `${Math.round(hours)} ${Math.round(hours) === 1 ? "hour" : "hours"}`;
+  const days = Math.round(hours / 24);
+  return `${days} ${days === 1 ? "day" : "days"}`;
+}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/FundingImpactReviewSection.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/FundingImpactReviewSection.tsx
@@ -133,7 +133,7 @@ export const FundingImpactReviewSection: FC<Props> = ({ rows, runtimeLimitHours,
           deployment closes.
         </p>
 
-        <d.Link href={UrlService.billing()} className="inline-block text-sm text-success hover:underline">
+        <d.Link href={UrlService.billing()} className="inline-block text-sm text-primary hover:underline">
           Full balance breakdown in Billing →
         </d.Link>
       </CollapsibleContent>

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/FundingImpactReviewSection.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/FundingImpactReviewSection.tsx
@@ -1,7 +1,7 @@
 "use client";
 import type { FC, ReactNode } from "react";
 import { useState } from "react";
-import { Button, Collapsible, CollapsibleContent, CollapsibleTrigger } from "@akashnetwork/ui/components";
+import { Button, Collapsible, CollapsibleContent, CollapsibleTrigger, Skeleton } from "@akashnetwork/ui/components";
 import { Flash, NavArrowDown } from "iconoir-react";
 import Link from "next/link";
 
@@ -16,7 +16,8 @@ export const DEPENDENCIES = {
   useFundingImpact,
   BalanceBreakdownBar,
   UsdValue,
-  Link
+  Link,
+  Skeleton
 };
 
 type Props = {
@@ -44,6 +45,15 @@ export const FundingImpactReviewSection: FC<Props> = ({ rows, runtimeLimitHours,
   const usd = (value: number) => <d.UsdValue value={value} />;
 
   if (impact.kind === "hidden") return null;
+
+  if (impact.kind === "loading") {
+    return (
+      <div className="flex items-center justify-between gap-4 rounded-lg border p-4">
+        <d.Skeleton className="h-4 w-72 max-w-full" />
+        <d.Skeleton className="h-4 w-4 shrink-0" />
+      </div>
+    );
+  }
 
   if (impact.kind === "unavailable") {
     return (

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/FundingImpactReviewSection.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/FundingImpactReviewSection.tsx
@@ -85,7 +85,7 @@ export const FundingImpactReviewSection: FC<Props> = ({ rows, runtimeLimitHours,
           ) : (
             <span className="font-medium text-success">{usd(impact.availableAfterUsd)}</span>
           )}
-          {impact.runtimeCoveredHours !== null && <span className="text-muted-foreground"> · ≈{formatRuntime(impact.runtimeCoveredHours)} of runtime</span>}
+          {runtimeLimitHours !== undefined && <span className="text-muted-foreground"> · {formatRuntime(runtimeLimitHours)} of runtime</span>}
         </span>
         <span className="flex shrink-0 items-center gap-3">
           {badge && (

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/FundingImpactReviewSection.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/FundingImpactReviewSection.tsx
@@ -28,10 +28,18 @@ type Props = {
 
 type VisibleImpact = Extract<FundingImpact, { kind: "visible" }>;
 
-const STATE_BADGES: Partial<Record<VisibleImpact["state"], string>> = {
-  "crosses-threshold": "Buys credits",
-  "no-payment-method": "No payment method",
-  "not-enough-available": "Not enough available"
+type Badge = { label: string; tone: "warning" | "neutral" };
+
+const STATE_BADGES: Partial<Record<VisibleImpact["state"], Badge>> = {
+  "crosses-threshold": { label: "Buys credits", tone: "warning" },
+  trial: { label: "Trial", tone: "neutral" },
+  "no-payment-method": { label: "No payment method", tone: "warning" },
+  "not-enough-available": { label: "Not enough available", tone: "warning" }
+};
+
+const BADGE_TONES: Record<Badge["tone"], string> = {
+  warning: "border-destructive/60 text-destructive",
+  neutral: "border-muted-foreground/40 text-muted-foreground"
 };
 
 /**
@@ -88,9 +96,7 @@ export const FundingImpactReviewSection: FC<Props> = ({ rows, runtimeLimitHours,
           {runtimeLimitHours !== undefined && <span className="text-muted-foreground"> · {formatRuntime(runtimeLimitHours)} of runtime</span>}
         </span>
         <span className="flex shrink-0 items-center gap-3">
-          {badge && (
-            <span className="rounded border border-destructive/60 px-2 py-0.5 font-mono text-xs uppercase tracking-wide text-destructive">{badge}</span>
-          )}
+          {badge && <span className={`rounded border px-2 py-0.5 font-mono text-xs uppercase tracking-wide ${BADGE_TONES[badge.tone]}`}>{badge.label}</span>}
           <NavArrowDown className="h-4 w-4 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
         </span>
       </CollapsibleTrigger>
@@ -153,6 +159,15 @@ function renderStateDetails(impact: VisibleImpact, usd: (value: number) => React
             your Auto Top-Up threshold of <span className="font-medium">{impact.thresholdUsd === null ? "—" : usd(impact.thresholdUsd)}</span>.{" "}
             {impact.cardLabel ?? "Your default card"} is charged <span className="font-medium">{usd(impact.chargeUsd)}</span> for credits.
           </span>
+        </Callout>
+      );
+    case "trial":
+      return (
+        <Callout tone="neutral">
+          <span className="flex-1">
+            Trial deployments are closed automatically after {impact.trialDurationHours} hours. Add funds to activate your account and keep deployments running.
+          </span>
+          {addCreditsButton}
         </Callout>
       );
     case "no-payment-method":

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/ReviewAndDeployModal.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/ReviewAndDeployModal.spec.tsx
@@ -55,6 +55,16 @@ describe(ReviewAndDeployModal.name, () => {
     expect(screen.getByRole("button", { name: /confirm and deploy/i })).toBeDisabled();
   });
 
+  it("shows the funding impact for the reviewed rows and the effective runtime limit", () => {
+    setup({ runtimeLimitHours: 12 });
+    expect(screen.getByTestId("funding-impact-section")).toHaveTextContent("1 rows · limit 12");
+  });
+
+  it("shows the funding impact without a limit when runtime limits are not offered", () => {
+    setup({ runtimeLimitHours: 12, isRuntimeLimitEnabled: false });
+    expect(screen.getByTestId("funding-impact-section")).toHaveTextContent("1 rows · no limit");
+  });
+
   describe("runtime limit", () => {
     it("offers the runtime limit section by default", () => {
       setup({});
@@ -262,6 +272,11 @@ describe(ReviewAndDeployModal.name, () => {
         {isLimited ? "Turn off runtime limit" : "Turn on runtime limit"}
       </button>
     );
+    const FundingImpactReviewSection: typeof DEPENDENCIES.FundingImpactReviewSection = ({ rows: fundingRows, runtimeLimitHours }) => (
+      <div data-testid="funding-impact-section">
+        {fundingRows.length} rows · {runtimeLimitHours === undefined ? "no limit" : `limit ${runtimeLimitHours}`}
+      </div>
+    );
     const useFlag: typeof DEPENDENCIES.useFlag = () => input.isRuntimeLimitEnabled ?? true;
     const useTrialGate: typeof DEPENDENCIES.useTrialGate = () => ({ isRestricted: input.isRestricted ?? false, isWalletReady: true });
 
@@ -307,6 +322,7 @@ describe(ReviewAndDeployModal.name, () => {
           useReviewRows,
           PricePerTimeUnit,
           useDeploymentHasGpu,
+          FundingImpactReviewSection,
           RuntimeLimitReviewSection,
           useFlag,
           useTrialGate,

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/ReviewAndDeployModal.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/ReviewAndDeployModal.spec.tsx
@@ -76,8 +76,13 @@ describe(ReviewAndDeployModal.name, () => {
       expect(screen.queryByTestId("runtime-limit-section")).not.toBeInTheDocument();
     });
 
-    it("hides the runtime limit section for a trial user", () => {
-      setup({ isRestricted: true });
+    it("offers the runtime limit section to a trial user", () => {
+      setup({ isTrialing: true });
+      expect(screen.getByTestId("runtime-limit-section")).toBeInTheDocument();
+    });
+
+    it("hides the runtime limit section until the wallet is provisioned", () => {
+      setup({ isWalletReady: false });
       expect(screen.queryByTestId("runtime-limit-section")).not.toBeInTheDocument();
     });
 
@@ -121,9 +126,9 @@ describe(ReviewAndDeployModal.name, () => {
       expect(onConfirm).toHaveBeenCalled();
     });
 
-    it("does not patch a leftover limit for a trial user", async () => {
+    it("does not patch a leftover limit before the wallet is provisioned", async () => {
       const onConfirm = vi.fn();
-      const { mutateAsync } = setup({ onConfirm, runtimeLimitHours: 12, isRestricted: true });
+      const { mutateAsync } = setup({ onConfirm, runtimeLimitHours: 12, isWalletReady: false });
 
       await userEvent.click(screen.getByRole("button", { name: /confirm and deploy/i }));
 
@@ -246,7 +251,8 @@ describe(ReviewAndDeployModal.name, () => {
     isStoredSettingLoading?: boolean;
     storedSettingError?: Error;
     isRuntimeLimitEnabled?: boolean;
-    isRestricted?: boolean;
+    isTrialing?: boolean;
+    isWalletReady?: boolean;
     isPatchPending?: boolean;
     patchError?: Error;
     secondPatchError?: Error;
@@ -278,7 +284,10 @@ describe(ReviewAndDeployModal.name, () => {
       </div>
     );
     const useFlag: typeof DEPENDENCIES.useFlag = () => input.isRuntimeLimitEnabled ?? true;
-    const useTrialGate: typeof DEPENDENCIES.useTrialGate = () => ({ isRestricted: input.isRestricted ?? false, isWalletReady: true });
+    const useTrialGate: typeof DEPENDENCIES.useTrialGate = () => ({
+      isRestricted: input.isTrialing ?? false,
+      isWalletReady: input.isWalletReady ?? true
+    });
 
     let patchCalls = 0;
     const mutateAsync = vi.fn().mockImplementation(() => {

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/ReviewAndDeployModal.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/ReviewAndDeployModal.tsx
@@ -77,13 +77,13 @@ export const ReviewAndDeployModal: FC<Props> = ({
   const { enqueueSnackbar } = d.useSnackbar();
   const updateSetting = d.useUpdateDeploymentSettingMutation({ dseq: dseq ?? "" });
   /**
-   * Runtime limits sit behind a flag, and mean nothing for trial users whose deployments are never
-   * auto-funded. Gating the submitted value too, not just the control, keeps a draft saved while the flag
-   * was on from silently applying a limit after it is turned off.
+   * Runtime limits sit behind a flag and need a provisioned wallet to store a setting against. Gating the
+   * submitted value too, not just the control, keeps a draft saved while the flag was on from silently
+   * applying a limit after it is turned off.
    */
   const isRuntimeLimitEnabled = d.useFlag("deployment_runtime_limit");
-  const { isRestricted } = d.useTrialGate();
-  const isRuntimeLimitOffered = isRuntimeLimitEnabled && !isRestricted;
+  const { isWalletReady } = d.useTrialGate();
+  const isRuntimeLimitOffered = isRuntimeLimitEnabled && isWalletReady;
   const effectiveRuntimeLimitHours = isRuntimeLimitOffered && runtimeLimitHours ? runtimeLimitHours : undefined;
   /**
    * Read only while a limit is on offer. With the feature off nothing here may touch the stored setting,

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/ReviewAndDeployModal.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/ReviewAndDeployModal.tsx
@@ -24,6 +24,7 @@ import { extractErrorMessage } from "@src/utils/errorUtils";
 import { PRICE_DISPLAY_PRECISION, udenomToDenom } from "@src/utils/mathHelpers";
 import { useTrialGate } from "../ConfigurationPane/HardwareSection/useTrialGate/useTrialGate";
 import { useDeploymentHasGpu } from "../DeploymentResourceSummary/useDeploymentResourceSummary";
+import { FundingImpactReviewSection } from "./FundingImpactReviewSection";
 import { RuntimeLimitReviewSection } from "./RuntimeLimitReviewSection";
 import type { ReviewRow } from "./useReviewRows";
 import { useReviewRows } from "./useReviewRows";
@@ -32,6 +33,7 @@ export const DEPENDENCIES = {
   useReviewRows,
   PricePerTimeUnit,
   useDeploymentHasGpu,
+  FundingImpactReviewSection,
   RuntimeLimitReviewSection,
   useFlag,
   useTrialGate,
@@ -208,6 +210,8 @@ export const ReviewAndDeployModal: FC<Props> = ({
             </div>
             <TotalPrice rows={rows} showAsHourly={showAsHourly} PricePerTimeUnit={d.PricePerTimeUnit} />
           </div>
+
+          <d.FundingImpactReviewSection rows={rows} runtimeLimitHours={effectiveRuntimeLimitHours} />
 
           {isRuntimeLimitOffered && (
             <d.RuntimeLimitReviewSection

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/useFundingImpact.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/useFundingImpact.spec.tsx
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { AccountBalanceOverview } from "@src/components/billing-usage/AccountBalanceOverview/useAccountBalanceOverview";
-import type { DEPENDENCIES } from "./useFundingImpact";
+import type { DEPENDENCIES, FundingImpact } from "./useFundingImpact";
 import { useFundingImpact } from "./useFundingImpact";
 import type { ReviewRow } from "./useReviewRows";
 
@@ -44,7 +44,7 @@ describe(useFundingImpact.name, () => {
     expect(result.current).toEqual({ kind: "unavailable" });
   });
 
-  it("reserves the target runway's worth of the priced rows", () => {
+  it("reserves the target runway's worth of the priced rows, drawing only what the bootstrap deposit left", () => {
     const { result } = setup({ overview: { available: 200 } });
 
     expect(result.current).toMatchObject({
@@ -52,9 +52,17 @@ describe(useFundingImpact.name, () => {
       state: "funded",
       reserveUsd: 144,
       availableNowUsd: 200,
-      availableAfterUsd: 56,
-      fundedHours: 48
+      availableAfterUsd: 56.5,
+      runtimeCoveredHours: 48
     });
+  });
+
+  it("floors the reserve at the bootstrap deposit for a deployment cheaper than the target runway", () => {
+    const { result } = setup({ rows: [pricedRow("0.00001")] });
+
+    expect(result.current).toMatchObject({ state: "funded", reserveUsd: 0.5, availableAfterUsd: 200 });
+    const impact = result.current as Extract<FundingImpact, { kind: "visible" }>;
+    expect(impact.runtimeCoveredHours).toBeCloseTo(83.3, 1);
   });
 
   it("sums every priced row into the reserve", () => {
@@ -64,21 +72,26 @@ describe(useFundingImpact.name, () => {
 
   it("bounds the reserve by a runtime limit shorter than the target runway", () => {
     const { result } = setup({ runtimeLimitHours: 12 });
-    expect(result.current).toMatchObject({ reserveUsd: 36, fundedHours: 12 });
+    expect(result.current).toMatchObject({ reserveUsd: 36, runtimeCoveredHours: 12 });
   });
 
   it("keeps the target runway when the runtime limit exceeds it", () => {
     const { result } = setup({ runtimeLimitHours: 96 });
-    expect(result.current).toMatchObject({ reserveUsd: 144, fundedHours: 48 });
+    expect(result.current).toMatchObject({ reserveUsd: 144, runtimeCoveredHours: 48 });
+  });
+
+  it("caps the covered runtime at the runtime limit when the bootstrap deposit outlasts it", () => {
+    const { result } = setup({ rows: [pricedRow("0.00001")], runtimeLimitHours: 12 });
+    expect(result.current).toMatchObject({ reserveUsd: 0.5, runtimeCoveredHours: 12 });
   });
 
   it("crosses the threshold when available after reserving lands exactly on it", () => {
-    const { result } = setup({ overview: { available: 200, autoReloadThreshold: 56 } });
-    expect(result.current).toMatchObject({ state: "crosses-threshold", thresholdUsd: 56 });
+    const { result } = setup({ overview: { available: 200, autoReloadThreshold: 56.5 } });
+    expect(result.current).toMatchObject({ state: "crosses-threshold", thresholdUsd: 56.5 });
   });
 
   it("stays funded when available after reserving is above the threshold", () => {
-    const { result } = setup({ overview: { available: 200, autoReloadThreshold: 55 } });
+    const { result } = setup({ overview: { available: 200, autoReloadThreshold: 56 } });
     expect(result.current).toMatchObject({ state: "funded" });
   });
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/useFundingImpact.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/useFundingImpact.spec.tsx
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { AccountBalanceOverview } from "@src/components/billing-usage/AccountBalanceOverview/useAccountBalanceOverview";
+import type { DEPENDENCIES } from "./useFundingImpact";
+import { useFundingImpact } from "./useFundingImpact";
+import type { ReviewRow } from "./useReviewRows";
+
+import { renderHook } from "@testing-library/react";
+
+describe(useFundingImpact.name, () => {
+  it("hides when escrow is not abstracted", () => {
+    const { result } = setup({ isEscrowAbstracted: false });
+    expect(result.current).toEqual({ kind: "hidden" });
+  });
+
+  it("hides when no row is priced", () => {
+    const { result } = setup({ rows: [mock<ReviewRow>({ price: undefined })] });
+    expect(result.current).toEqual({ kind: "hidden" });
+  });
+
+  it("hides while the balance overview is loading", () => {
+    const { result } = setup({ overview: { isLoading: true } });
+    expect(result.current).toEqual({ kind: "hidden" });
+  });
+
+  it("hides while the funding config has not loaded", () => {
+    const { result } = setup({ fundingConfig: undefined });
+    expect(result.current).toEqual({ kind: "hidden" });
+  });
+
+  it("hides while the default payment method is loading", () => {
+    const { result } = setup({ isPaymentMethodLoading: true });
+    expect(result.current).toEqual({ kind: "hidden" });
+  });
+
+  it("reports the balance as unavailable when the overview errors", () => {
+    const { result } = setup({ overview: { isError: true } });
+    expect(result.current).toEqual({ kind: "unavailable" });
+  });
+
+  it("reports the balance as unavailable when the funding config errors", () => {
+    const { result } = setup({ isFundingConfigError: true });
+    expect(result.current).toEqual({ kind: "unavailable" });
+  });
+
+  it("reserves the target runway's worth of the priced rows", () => {
+    const { result } = setup({ overview: { available: 200 } });
+
+    expect(result.current).toMatchObject({
+      kind: "visible",
+      state: "funded",
+      reserveUsd: 144,
+      availableNowUsd: 200,
+      availableAfterUsd: 56,
+      fundedHours: 48
+    });
+  });
+
+  it("sums every priced row into the reserve", () => {
+    const { result } = setup({ rows: [pricedRow("0.005"), pricedRow("0.005"), mock<ReviewRow>({ price: undefined })] });
+    expect(result.current).toMatchObject({ reserveUsd: 288 });
+  });
+
+  it("bounds the reserve by a runtime limit shorter than the target runway", () => {
+    const { result } = setup({ runtimeLimitHours: 12 });
+    expect(result.current).toMatchObject({ reserveUsd: 36, fundedHours: 12 });
+  });
+
+  it("keeps the target runway when the runtime limit exceeds it", () => {
+    const { result } = setup({ runtimeLimitHours: 96 });
+    expect(result.current).toMatchObject({ reserveUsd: 144, fundedHours: 48 });
+  });
+
+  it("crosses the threshold when available after reserving lands exactly on it", () => {
+    const { result } = setup({ overview: { available: 200, autoReloadThreshold: 56 } });
+    expect(result.current).toMatchObject({ state: "crosses-threshold", thresholdUsd: 56 });
+  });
+
+  it("stays funded when available after reserving is above the threshold", () => {
+    const { result } = setup({ overview: { available: 200, autoReloadThreshold: 55 } });
+    expect(result.current).toMatchObject({ state: "funded" });
+  });
+
+  it("stays funded without a threshold when no threshold rule applies", () => {
+    const { result } = setup({ overview: { available: 200, autoReloadThreshold: null } });
+    expect(result.current).toMatchObject({ state: "funded", thresholdUsd: null });
+  });
+
+  it("reports not enough available when the reserve exceeds the balance", () => {
+    const { result } = setup({ overview: { available: 100 } });
+    expect(result.current).toMatchObject({ state: "not-enough-available", reserveUsd: 144, availableNowUsd: 100, availableAfterUsd: null });
+  });
+
+  it("ranks not enough available above the missing payment method for a broke trial user", () => {
+    const { result } = setup({ overview: { available: 100 }, isTrialing: true, paymentMethod: null });
+    expect(result.current).toMatchObject({ state: "not-enough-available" });
+  });
+
+  it("reports the missing payment method for a funded trial user even with a card on file", () => {
+    const { result } = setup({ isTrialing: true });
+    expect(result.current).toMatchObject({ state: "no-payment-method" });
+  });
+
+  it("never claims a charge without a payment method, even when the threshold would be crossed", () => {
+    const { result } = setup({ overview: { available: 200, autoReloadThreshold: 56 }, paymentMethod: null });
+    expect(result.current).toMatchObject({ state: "no-payment-method" });
+  });
+
+  it("quotes the configured auto top-up amount as the charge", () => {
+    const { result } = setup({ walletSettings: { autoReloadAmount: 250 } });
+    expect(result.current).toMatchObject({ chargeUsd: 250 });
+  });
+
+  it("floors the charge at the minimum auto top-up amount", () => {
+    const { result } = setup({ walletSettings: { autoReloadAmount: 10 } });
+    expect(result.current).toMatchObject({ chargeUsd: 25 });
+  });
+
+  it("falls back to the default auto top-up amount without wallet settings", () => {
+    const { result } = setup({ walletSettings: null });
+    expect(result.current).toMatchObject({ chargeUsd: 100 });
+  });
+
+  it("labels the default card by brand and last digits", () => {
+    const { result } = setup({ paymentMethod: { card: { brand: "visa", last4: "4242" } } });
+    expect(result.current).toMatchObject({ cardLabel: "Visa **** 4242" });
+  });
+
+  it("leaves the card label empty when the payment method has no card", () => {
+    const { result } = setup({ paymentMethod: { card: null } });
+    expect(result.current).toMatchObject({ cardLabel: null });
+  });
+
+  function setup(input: {
+    rows?: ReviewRow[];
+    runtimeLimitHours?: number;
+    isEscrowAbstracted?: boolean;
+    overview?: Partial<AccountBalanceOverview>;
+    fundingConfig?: { targetRunwayHours: number; balanceHeadroomUsd: number; defaultDepositUsd: number };
+    isFundingConfigError?: boolean;
+    walletSettings?: { autoReloadAmount?: number } | null;
+    paymentMethod?: { card?: { brand: string | null; last4: string | null } | null } | null;
+    isPaymentMethodLoading?: boolean;
+    isTrialing?: boolean;
+  }) {
+    type Dependencies = typeof DEPENDENCIES;
+    const overview = Object.assign(mock<AccountBalanceOverview>(), {
+      available: 200,
+      autoReloadThreshold: null,
+      isLoading: false,
+      isError: false,
+      ...input.overview
+    });
+    const fundingConfig = Object.assign(mock<ReturnType<Dependencies["useDeploymentFundingConfigQuery"]>>(), {
+      data: "fundingConfig" in input ? input.fundingConfig : { targetRunwayHours: 48, balanceHeadroomUsd: 5, defaultDepositUsd: 0.5 },
+      isError: input.isFundingConfigError ?? false
+    });
+    const walletSettings = Object.assign(mock<ReturnType<Dependencies["useWalletSettingsQuery"]>>(), {
+      data: input.walletSettings === undefined ? { autoReloadAmount: 100 } : input.walletSettings
+    });
+    const paymentMethod = Object.assign(mock<ReturnType<Dependencies["useDefaultPaymentMethodQuery"]>>(), {
+      data: input.paymentMethod === undefined ? { card: { brand: "visa", last4: "4242" } } : input.paymentMethod,
+      isLoading: input.isPaymentMethodLoading ?? false
+    });
+
+    const dependencies = {
+      useIsEscrowAbstracted: () => input.isEscrowAbstracted ?? true,
+      useAccountBalanceOverview: () => overview,
+      usePricing: () => Object.assign(mock<ReturnType<Dependencies["usePricing"]>>(), { udenomToUsd: (amount: number) => amount }),
+      useWalletSettingsQuery: () => walletSettings,
+      useDefaultPaymentMethodQuery: () => paymentMethod,
+      useWallet: () => Object.assign(mock<ReturnType<Dependencies["useWallet"]>>(), { isTrialing: input.isTrialing ?? false }),
+      useDeploymentFundingConfigQuery: () => fundingConfig
+    } as unknown as Dependencies;
+
+    return renderHook(() =>
+      useFundingImpact({
+        rows: input.rows ?? [pricedRow("0.005")],
+        runtimeLimitHours: input.runtimeLimitHours,
+        dependencies
+      })
+    );
+  }
+
+  function pricedRow(perBlockAmount: string): ReviewRow {
+    return mock<ReviewRow>({ price: { amount: perBlockAmount, denom: "uakt" } });
+  }
+});

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/useFundingImpact.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/useFundingImpact.spec.tsx
@@ -44,6 +44,11 @@ describe(useFundingImpact.name, () => {
     expect(result.current).toEqual({ kind: "unavailable" });
   });
 
+  it("reports the balance as unavailable when the default payment method errors", () => {
+    const { result } = setup({ isPaymentMethodError: true });
+    expect(result.current).toEqual({ kind: "unavailable" });
+  });
+
   it("reserves the target runway's worth of the priced rows, drawing only what the bootstrap deposit left", () => {
     const { result } = setup({ overview: { available: 200 } });
 
@@ -97,14 +102,9 @@ describe(useFundingImpact.name, () => {
     expect(result.current).toMatchObject({ state: "not-enough-available", reserveUsd: 144, availableNowUsd: 100, availableAfterUsd: null });
   });
 
-  it("ranks not enough available above the missing payment method for a broke trial user", () => {
-    const { result } = setup({ overview: { available: 100 }, isTrialing: true, paymentMethod: null });
+  it("ranks not enough available above the missing payment method", () => {
+    const { result } = setup({ overview: { available: 100 }, paymentMethod: null });
     expect(result.current).toMatchObject({ state: "not-enough-available" });
-  });
-
-  it("reports the missing payment method for a funded trial user even with a card on file", () => {
-    const { result } = setup({ isTrialing: true });
-    expect(result.current).toMatchObject({ state: "no-payment-method" });
   });
 
   it("never claims a charge without a payment method, even when the threshold would be crossed", () => {
@@ -147,7 +147,7 @@ describe(useFundingImpact.name, () => {
     walletSettings?: { autoReloadAmount?: number } | null;
     paymentMethod?: { card?: { brand: string | null; last4: string | null } | null } | null;
     isPaymentMethodLoading?: boolean;
-    isTrialing?: boolean;
+    isPaymentMethodError?: boolean;
   }) {
     type Dependencies = typeof DEPENDENCIES;
     const overview = Object.assign(mock<AccountBalanceOverview>(), {
@@ -166,7 +166,8 @@ describe(useFundingImpact.name, () => {
     });
     const paymentMethod = Object.assign(mock<ReturnType<Dependencies["useDefaultPaymentMethodQuery"]>>(), {
       data: input.paymentMethod === undefined ? { card: { brand: "visa", last4: "4242" } } : input.paymentMethod,
-      isLoading: input.isPaymentMethodLoading ?? false
+      isLoading: input.isPaymentMethodLoading ?? false,
+      isError: input.isPaymentMethodError ?? false
     });
 
     const dependencies = {
@@ -175,7 +176,6 @@ describe(useFundingImpact.name, () => {
       usePricing: () => Object.assign(mock<ReturnType<Dependencies["usePricing"]>>(), { udenomToUsd: (amount: number) => amount }),
       useWalletSettingsQuery: () => walletSettings,
       useDefaultPaymentMethodQuery: () => paymentMethod,
-      useWallet: () => Object.assign(mock<ReturnType<Dependencies["useWallet"]>>(), { isTrialing: input.isTrialing ?? false }),
       useDeploymentFundingConfigQuery: () => fundingConfig
     } as unknown as Dependencies;
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/useFundingImpact.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/useFundingImpact.spec.tsx
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { AccountBalanceOverview } from "@src/components/billing-usage/AccountBalanceOverview/useAccountBalanceOverview";
-import type { DEPENDENCIES, FundingImpact } from "./useFundingImpact";
+import type { DEPENDENCIES } from "./useFundingImpact";
 import { useFundingImpact } from "./useFundingImpact";
 import type { ReviewRow } from "./useReviewRows";
 
@@ -52,8 +52,7 @@ describe(useFundingImpact.name, () => {
       state: "funded",
       reserveUsd: 144,
       availableNowUsd: 200,
-      availableAfterUsd: 56.5,
-      runtimeCoveredHours: 48
+      availableAfterUsd: 56.5
     });
   });
 
@@ -61,8 +60,6 @@ describe(useFundingImpact.name, () => {
     const { result } = setup({ rows: [pricedRow("0.00001")] });
 
     expect(result.current).toMatchObject({ state: "funded", reserveUsd: 0.5, availableAfterUsd: 200 });
-    const impact = result.current as Extract<FundingImpact, { kind: "visible" }>;
-    expect(impact.runtimeCoveredHours).toBeCloseTo(83.3, 1);
   });
 
   it("sums every priced row into the reserve", () => {
@@ -72,17 +69,12 @@ describe(useFundingImpact.name, () => {
 
   it("bounds the reserve by a runtime limit shorter than the target runway", () => {
     const { result } = setup({ runtimeLimitHours: 12 });
-    expect(result.current).toMatchObject({ reserveUsd: 36, runtimeCoveredHours: 12 });
+    expect(result.current).toMatchObject({ reserveUsd: 36 });
   });
 
   it("keeps the target runway when the runtime limit exceeds it", () => {
     const { result } = setup({ runtimeLimitHours: 96 });
-    expect(result.current).toMatchObject({ reserveUsd: 144, runtimeCoveredHours: 48 });
-  });
-
-  it("caps the covered runtime at the runtime limit when the bootstrap deposit outlasts it", () => {
-    const { result } = setup({ rows: [pricedRow("0.00001")], runtimeLimitHours: 12 });
-    expect(result.current).toMatchObject({ reserveUsd: 0.5, runtimeCoveredHours: 12 });
+    expect(result.current).toMatchObject({ reserveUsd: 144 });
   });
 
   it("crosses the threshold when available after reserving lands exactly on it", () => {

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/useFundingImpact.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/useFundingImpact.spec.tsx
@@ -19,19 +19,19 @@ describe(useFundingImpact.name, () => {
     expect(result.current).toEqual({ kind: "hidden" });
   });
 
-  it("hides while the balance overview is loading", () => {
+  it("reports loading while the balance overview is loading", () => {
     const { result } = setup({ overview: { isLoading: true } });
-    expect(result.current).toEqual({ kind: "hidden" });
+    expect(result.current).toEqual({ kind: "loading" });
   });
 
-  it("hides while the funding config has not loaded", () => {
+  it("reports loading while the funding config has not loaded", () => {
     const { result } = setup({ fundingConfig: undefined });
-    expect(result.current).toEqual({ kind: "hidden" });
+    expect(result.current).toEqual({ kind: "loading" });
   });
 
-  it("hides while the default payment method is loading", () => {
+  it("reports loading while the default payment method is loading", () => {
     const { result } = setup({ isPaymentMethodLoading: true });
-    expect(result.current).toEqual({ kind: "hidden" });
+    expect(result.current).toEqual({ kind: "loading" });
   });
 
   it("reports the balance as unavailable when the overview errors", () => {

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/useFundingImpact.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/useFundingImpact.spec.tsx
@@ -107,6 +107,31 @@ describe(useFundingImpact.name, () => {
     expect(result.current).toMatchObject({ state: "not-enough-available" });
   });
 
+  it("reports the trial rather than a missing payment method for a trialing account", () => {
+    const { result } = setup({ isTrialing: true, paymentMethod: null });
+    expect(result.current).toMatchObject({ state: "trial" });
+  });
+
+  it("keeps the charge warning for a trialing account whose card would be charged", () => {
+    const { result } = setup({ isTrialing: true, overview: { available: 200, autoReloadThreshold: 56.5 } });
+    expect(result.current).toMatchObject({ state: "crosses-threshold" });
+  });
+
+  it("ranks not enough available above the trial", () => {
+    const { result } = setup({ isTrialing: true, overview: { available: 100 } });
+    expect(result.current).toMatchObject({ state: "not-enough-available" });
+  });
+
+  it("reports the trial for a trialing account with a card below the threshold rule", () => {
+    const { result } = setup({ isTrialing: true, overview: { available: 200, autoReloadThreshold: null } });
+    expect(result.current).toMatchObject({ state: "trial" });
+  });
+
+  it("quotes the configured trial deployment duration", () => {
+    const { result } = setup({ trialDurationHours: 12 });
+    expect(result.current).toMatchObject({ trialDurationHours: 12 });
+  });
+
   it("never claims a charge without a payment method, even when the threshold would be crossed", () => {
     const { result } = setup({ overview: { available: 200, autoReloadThreshold: 56 }, paymentMethod: null });
     expect(result.current).toMatchObject({ state: "no-payment-method" });
@@ -148,6 +173,8 @@ describe(useFundingImpact.name, () => {
     paymentMethod?: { card?: { brand: string | null; last4: string | null } | null } | null;
     isPaymentMethodLoading?: boolean;
     isPaymentMethodError?: boolean;
+    isTrialing?: boolean;
+    trialDurationHours?: number;
   }) {
     type Dependencies = typeof DEPENDENCIES;
     const overview = Object.assign(mock<AccountBalanceOverview>(), {
@@ -176,6 +203,11 @@ describe(useFundingImpact.name, () => {
       usePricing: () => Object.assign(mock<ReturnType<Dependencies["usePricing"]>>(), { udenomToUsd: (amount: number) => amount }),
       useWalletSettingsQuery: () => walletSettings,
       useDefaultPaymentMethodQuery: () => paymentMethod,
+      useWallet: () => Object.assign(mock<ReturnType<Dependencies["useWallet"]>>(), { isTrialing: input.isTrialing ?? false }),
+      useServices: () =>
+        Object.assign(mock<ReturnType<Dependencies["useServices"]>>(), {
+          publicConfig: { NEXT_PUBLIC_TRIAL_DEPLOYMENTS_DURATION_HOURS: input.trialDurationHours ?? 24 }
+        }),
       useDeploymentFundingConfigQuery: () => fundingConfig
     } as unknown as Dependencies;
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/useFundingImpact.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/useFundingImpact.ts
@@ -1,6 +1,8 @@
 "use client";
 import { useAccountBalanceOverview } from "@src/components/billing-usage/AccountBalanceOverview/useAccountBalanceOverview";
 import { AUTO_RELOAD_AMOUNT_MIN_USD, DEFAULT_AUTO_RELOAD_AMOUNT } from "@src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup";
+import { useServices } from "@src/context/ServicesProvider";
+import { useWallet } from "@src/context/WalletProvider";
 import { useIsEscrowAbstracted } from "@src/hooks/useIsEscrowAbstracted";
 import { usePricing } from "@src/hooks/usePricing/usePricing";
 import { useDeploymentFundingConfigQuery, useWalletSettingsQuery } from "@src/queries";
@@ -15,10 +17,12 @@ export const DEPENDENCIES = {
   usePricing,
   useWalletSettingsQuery,
   useDefaultPaymentMethodQuery,
+  useWallet,
+  useServices,
   useDeploymentFundingConfigQuery
 };
 
-export type FundingImpactState = "funded" | "crosses-threshold" | "no-payment-method" | "not-enough-available";
+export type FundingImpactState = "funded" | "crosses-threshold" | "trial" | "no-payment-method" | "not-enough-available";
 
 export type FundingImpact =
   | { kind: "hidden" }
@@ -34,6 +38,7 @@ export type FundingImpact =
       thresholdUsd: number | null;
       chargeUsd: number;
       cardLabel: string | null;
+      trialDurationHours: number;
     };
 
 type Input = {
@@ -54,6 +59,8 @@ export function useFundingImpact({ rows, runtimeLimitHours, dependencies: d = DE
   const { udenomToUsd } = d.usePricing();
   const { data: walletSettings } = d.useWalletSettingsQuery();
   const defaultPaymentMethod = d.useDefaultPaymentMethodQuery();
+  const { isTrialing } = d.useWallet();
+  const { publicConfig } = d.useServices();
   const fundingConfig = d.useDeploymentFundingConfigQuery();
 
   const pricedRows = rows.filter((row): row is ReviewRow & { price: { amount: string; denom: string } } => !!row.price);
@@ -78,24 +85,31 @@ export function useFundingImpact({ rows, runtimeLimitHours, dependencies: d = DE
 
   return {
     kind: "visible",
-    state: resolveState({ availableAfterUsd, thresholdUsd, hasPaymentMethod }),
+    state: resolveState({ availableAfterUsd, thresholdUsd, hasPaymentMethod, isTrialing }),
     reserveUsd,
     availableNowUsd,
     availableAfterUsd,
     thresholdUsd,
     chargeUsd: Math.max(walletSettings?.autoReloadAmount ?? DEFAULT_AUTO_RELOAD_AMOUNT, AUTO_RELOAD_AMOUNT_MIN_USD),
-    cardLabel: card ? `${capitalizeFirstLetter(card.brand || "card")} **** ${card.last4 || ""}`.trim() : null
+    cardLabel: card ? `${capitalizeFirstLetter(card.brand || "card")} **** ${card.last4 || ""}`.trim() : null,
+    trialDurationHours: publicConfig.NEXT_PUBLIC_TRIAL_DEPLOYMENTS_DURATION_HOURS
   };
 }
 
 /**
- * First match wins: a balance that cannot cover the reserve outranks everything, then the missing payment
- * method (no charge can happen, so no crossing warning may claim one), then the threshold crossing, then
- * plain funded.
+ * First match wins: a balance that cannot cover the reserve outranks everything, then a charge that is
+ * really coming (auto top-up ignores the trial flag, so a trialing card gets charged like any other), then
+ * the trial, so a trialing account is never told its card is missing, then the genuinely missing card.
  */
-function resolveState(input: { availableAfterUsd: number | null; thresholdUsd: number | null; hasPaymentMethod: boolean }): FundingImpactState {
+function resolveState(input: {
+  availableAfterUsd: number | null;
+  thresholdUsd: number | null;
+  hasPaymentMethod: boolean;
+  isTrialing: boolean;
+}): FundingImpactState {
   if (input.availableAfterUsd === null) return "not-enough-available";
+  if (input.hasPaymentMethod && input.thresholdUsd !== null && input.availableAfterUsd <= input.thresholdUsd) return "crosses-threshold";
+  if (input.isTrialing) return "trial";
   if (!input.hasPaymentMethod) return "no-payment-method";
-  if (input.thresholdUsd !== null && input.availableAfterUsd <= input.thresholdUsd) return "crosses-threshold";
   return "funded";
 }

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/useFundingImpact.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/useFundingImpact.ts
@@ -33,8 +33,6 @@ export type FundingImpact =
       availableNowUsd: number;
       /** Null when the remaining reserve exceeds what is available, where an "available after" figure would be a lie. */
       availableAfterUsd: number | null;
-      /** How much runtime the reserve pays for, bounded by the runtime limit; null when the bids are free. */
-      runtimeCoveredHours: number | null;
       thresholdUsd: number | null;
       chargeUsd: number;
       cardLabel: string | null;
@@ -74,7 +72,6 @@ export function useFundingImpact({ rows, runtimeLimitHours, dependencies: d = DE
   const reserveUsd = Math.max(defaultDepositUsd, hourlyCostUsd * fundedHours);
   /** The bootstrap deposit was drawn at creation and already counts as reserved, so confirming only draws the rest. */
   const remainingDrawUsd = reserveUsd - defaultDepositUsd;
-  const runtimeCoveredHours = hourlyCostUsd > 0 ? Math.min(reserveUsd / hourlyCostUsd, runtimeLimitHours ?? Infinity) : null;
 
   const availableNowUsd = overview.available;
   const availableAfterUsd = availableNowUsd >= remainingDrawUsd ? availableNowUsd - remainingDrawUsd : null;
@@ -88,7 +85,6 @@ export function useFundingImpact({ rows, runtimeLimitHours, dependencies: d = DE
     reserveUsd,
     availableNowUsd,
     availableAfterUsd,
-    runtimeCoveredHours,
     thresholdUsd,
     chargeUsd: Math.max(walletSettings?.autoReloadAmount ?? DEFAULT_AUTO_RELOAD_AMOUNT, AUTO_RELOAD_AMOUNT_MIN_USD),
     cardLabel: card ? `${capitalizeFirstLetter(card.brand || "card")} **** ${card.last4 || ""}`.trim() : null

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/useFundingImpact.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/useFundingImpact.ts
@@ -24,6 +24,7 @@ export type FundingImpactState = "funded" | "crosses-threshold" | "no-payment-me
 
 export type FundingImpact =
   | { kind: "hidden" }
+  | { kind: "loading" }
   | { kind: "unavailable" }
   | {
       kind: "visible";
@@ -64,7 +65,7 @@ export function useFundingImpact({ rows, runtimeLimitHours, dependencies: d = DE
 
   if (!isEscrowAbstracted || pricedRows.length === 0) return { kind: "hidden" };
   if (overview.isError || fundingConfig.isError) return { kind: "unavailable" };
-  if (overview.isLoading || !fundingConfig.data || defaultPaymentMethod.isLoading) return { kind: "hidden" };
+  if (overview.isLoading || !fundingConfig.data || defaultPaymentMethod.isLoading) return { kind: "loading" };
 
   const { targetRunwayHours, defaultDepositUsd } = fundingConfig.data;
   const perBlockUdenom = pricedRows.reduce((sum, row) => sum + Number(row.price.amount), 0);

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/useFundingImpact.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/useFundingImpact.ts
@@ -30,10 +30,10 @@ export type FundingImpact =
       state: FundingImpactState;
       reserveUsd: number;
       availableNowUsd: number;
-      /** Null when the reserve exceeds what is available, where an "available after" figure would be a lie. */
+      /** Null when the remaining reserve exceeds what is available, where an "available after" figure would be a lie. */
       availableAfterUsd: number | null;
-      /** How much runtime the reserve pays for: the funding target, bounded by the runtime limit. */
-      fundedHours: number;
+      /** How much runtime the reserve pays for, bounded by the runtime limit; null when the bids are free. */
+      runtimeCoveredHours: number | null;
       thresholdUsd: number | null;
       chargeUsd: number;
       cardLabel: string | null;
@@ -47,8 +47,9 @@ type Input = {
 
 /**
  * Estimates what confirming the reviewed deployment does to the account's money: automatic funding
- * reserves the target runway's worth of the reviewed bid prices (bounded by the runtime limit), so the
- * reserve, the available balance left after it, and the auto-top-up consequences are all knowable here.
+ * reserves the target runway's worth of the reviewed bid prices (bounded by the runtime limit), floored
+ * at the bootstrap deposit the deployment already holds from creation. Since that bootstrap already left
+ * the available balance, only the difference up to the reserve is drawn at confirm time.
  */
 export function useFundingImpact({ rows, runtimeLimitHours, dependencies: d = DEPENDENCIES }: Input): FundingImpact {
   const isEscrowAbstracted = d.useIsEscrowAbstracted();
@@ -65,14 +66,17 @@ export function useFundingImpact({ rows, runtimeLimitHours, dependencies: d = DE
   if (overview.isError || fundingConfig.isError) return { kind: "unavailable" };
   if (overview.isLoading || !fundingConfig.data || defaultPaymentMethod.isLoading) return { kind: "hidden" };
 
+  const { targetRunwayHours, defaultDepositUsd } = fundingConfig.data;
   const perBlockUdenom = pricedRows.reduce((sum, row) => sum + Number(row.price.amount), 0);
   const hourlyCostUsd = udenomToUsd(perBlockUdenom * API_BLOCKS_PER_HOUR, pricedRows[0].price.denom);
-  const fundedHours =
-    runtimeLimitHours === undefined ? fundingConfig.data.targetRunwayHours : Math.min(fundingConfig.data.targetRunwayHours, runtimeLimitHours);
-  const reserveUsd = hourlyCostUsd * fundedHours;
+  const fundedHours = runtimeLimitHours === undefined ? targetRunwayHours : Math.min(targetRunwayHours, runtimeLimitHours);
+  const reserveUsd = Math.max(defaultDepositUsd, hourlyCostUsd * fundedHours);
+  /** The bootstrap deposit was drawn at creation and already counts as reserved, so confirming only draws the rest. */
+  const remainingDrawUsd = reserveUsd - defaultDepositUsd;
+  const runtimeCoveredHours = hourlyCostUsd > 0 ? Math.min(reserveUsd / hourlyCostUsd, runtimeLimitHours ?? Infinity) : null;
 
   const availableNowUsd = overview.available;
-  const availableAfterUsd = availableNowUsd >= reserveUsd ? availableNowUsd - reserveUsd : null;
+  const availableAfterUsd = availableNowUsd >= remainingDrawUsd ? availableNowUsd - remainingDrawUsd : null;
   const thresholdUsd = overview.autoReloadThreshold;
   const hasPaymentMethod = !isTrialing && !!defaultPaymentMethod.data;
   const card = defaultPaymentMethod.data?.card;
@@ -83,7 +87,7 @@ export function useFundingImpact({ rows, runtimeLimitHours, dependencies: d = DE
     reserveUsd,
     availableNowUsd,
     availableAfterUsd,
-    fundedHours,
+    runtimeCoveredHours,
     thresholdUsd,
     chargeUsd: Math.max(walletSettings?.autoReloadAmount ?? DEFAULT_AUTO_RELOAD_AMOUNT, AUTO_RELOAD_AMOUNT_MIN_USD),
     cardLabel: card ? `${capitalizeFirstLetter(card.brand || "card")} **** ${card.last4 || ""}`.trim() : null

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/useFundingImpact.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/useFundingImpact.ts
@@ -1,0 +1,103 @@
+"use client";
+import { useAccountBalanceOverview } from "@src/components/billing-usage/AccountBalanceOverview/useAccountBalanceOverview";
+import { AUTO_RELOAD_AMOUNT_MIN_USD, DEFAULT_AUTO_RELOAD_AMOUNT } from "@src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup";
+import { useWallet } from "@src/context/WalletProvider";
+import { useIsEscrowAbstracted } from "@src/hooks/useIsEscrowAbstracted";
+import { usePricing } from "@src/hooks/usePricing/usePricing";
+import { useDeploymentFundingConfigQuery, useWalletSettingsQuery } from "@src/queries";
+import { useDefaultPaymentMethodQuery } from "@src/queries/usePaymentQueries";
+import { API_BLOCKS_PER_HOUR } from "@src/utils/deploymentUtils";
+import { capitalizeFirstLetter } from "@src/utils/stringUtils";
+import type { ReviewRow } from "./useReviewRows";
+
+export const DEPENDENCIES = {
+  useIsEscrowAbstracted,
+  useAccountBalanceOverview,
+  usePricing,
+  useWalletSettingsQuery,
+  useDefaultPaymentMethodQuery,
+  useWallet,
+  useDeploymentFundingConfigQuery
+};
+
+export type FundingImpactState = "funded" | "crosses-threshold" | "no-payment-method" | "not-enough-available";
+
+export type FundingImpact =
+  | { kind: "hidden" }
+  | { kind: "unavailable" }
+  | {
+      kind: "visible";
+      state: FundingImpactState;
+      reserveUsd: number;
+      availableNowUsd: number;
+      /** Null when the reserve exceeds what is available, where an "available after" figure would be a lie. */
+      availableAfterUsd: number | null;
+      /** How much runtime the reserve pays for: the funding target, bounded by the runtime limit. */
+      fundedHours: number;
+      thresholdUsd: number | null;
+      chargeUsd: number;
+      cardLabel: string | null;
+    };
+
+type Input = {
+  rows: ReviewRow[];
+  runtimeLimitHours: number | undefined;
+  dependencies?: typeof DEPENDENCIES;
+};
+
+/**
+ * Estimates what confirming the reviewed deployment does to the account's money: automatic funding
+ * reserves the target runway's worth of the reviewed bid prices (bounded by the runtime limit), so the
+ * reserve, the available balance left after it, and the auto-top-up consequences are all knowable here.
+ */
+export function useFundingImpact({ rows, runtimeLimitHours, dependencies: d = DEPENDENCIES }: Input): FundingImpact {
+  const isEscrowAbstracted = d.useIsEscrowAbstracted();
+  const overview = d.useAccountBalanceOverview();
+  const { udenomToUsd } = d.usePricing();
+  const { data: walletSettings } = d.useWalletSettingsQuery();
+  const defaultPaymentMethod = d.useDefaultPaymentMethodQuery();
+  const { isTrialing } = d.useWallet();
+  const fundingConfig = d.useDeploymentFundingConfigQuery();
+
+  const pricedRows = rows.filter((row): row is ReviewRow & { price: { amount: string; denom: string } } => !!row.price);
+
+  if (!isEscrowAbstracted || pricedRows.length === 0) return { kind: "hidden" };
+  if (overview.isError || fundingConfig.isError) return { kind: "unavailable" };
+  if (overview.isLoading || !fundingConfig.data || defaultPaymentMethod.isLoading) return { kind: "hidden" };
+
+  const perBlockUdenom = pricedRows.reduce((sum, row) => sum + Number(row.price.amount), 0);
+  const hourlyCostUsd = udenomToUsd(perBlockUdenom * API_BLOCKS_PER_HOUR, pricedRows[0].price.denom);
+  const fundedHours =
+    runtimeLimitHours === undefined ? fundingConfig.data.targetRunwayHours : Math.min(fundingConfig.data.targetRunwayHours, runtimeLimitHours);
+  const reserveUsd = hourlyCostUsd * fundedHours;
+
+  const availableNowUsd = overview.available;
+  const availableAfterUsd = availableNowUsd >= reserveUsd ? availableNowUsd - reserveUsd : null;
+  const thresholdUsd = overview.autoReloadThreshold;
+  const hasPaymentMethod = !isTrialing && !!defaultPaymentMethod.data;
+  const card = defaultPaymentMethod.data?.card;
+
+  return {
+    kind: "visible",
+    state: resolveState({ availableAfterUsd, thresholdUsd, hasPaymentMethod }),
+    reserveUsd,
+    availableNowUsd,
+    availableAfterUsd,
+    fundedHours,
+    thresholdUsd,
+    chargeUsd: Math.max(walletSettings?.autoReloadAmount ?? DEFAULT_AUTO_RELOAD_AMOUNT, AUTO_RELOAD_AMOUNT_MIN_USD),
+    cardLabel: card ? `${capitalizeFirstLetter(card.brand || "card")} **** ${card.last4 || ""}`.trim() : null
+  };
+}
+
+/**
+ * First match wins: a balance that cannot cover the reserve outranks everything (its copy claims no
+ * automatic charge, so it also holds for trial users), then the missing payment method (no charge can
+ * happen, so no crossing warning may claim one), then the threshold crossing, then plain funded.
+ */
+function resolveState(input: { availableAfterUsd: number | null; thresholdUsd: number | null; hasPaymentMethod: boolean }): FundingImpactState {
+  if (input.availableAfterUsd === null) return "not-enough-available";
+  if (!input.hasPaymentMethod) return "no-payment-method";
+  if (input.thresholdUsd !== null && input.availableAfterUsd <= input.thresholdUsd) return "crosses-threshold";
+  return "funded";
+}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/useFundingImpact.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/useFundingImpact.ts
@@ -1,7 +1,6 @@
 "use client";
 import { useAccountBalanceOverview } from "@src/components/billing-usage/AccountBalanceOverview/useAccountBalanceOverview";
 import { AUTO_RELOAD_AMOUNT_MIN_USD, DEFAULT_AUTO_RELOAD_AMOUNT } from "@src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup";
-import { useWallet } from "@src/context/WalletProvider";
 import { useIsEscrowAbstracted } from "@src/hooks/useIsEscrowAbstracted";
 import { usePricing } from "@src/hooks/usePricing/usePricing";
 import { useDeploymentFundingConfigQuery, useWalletSettingsQuery } from "@src/queries";
@@ -16,7 +15,6 @@ export const DEPENDENCIES = {
   usePricing,
   useWalletSettingsQuery,
   useDefaultPaymentMethodQuery,
-  useWallet,
   useDeploymentFundingConfigQuery
 };
 
@@ -56,13 +54,12 @@ export function useFundingImpact({ rows, runtimeLimitHours, dependencies: d = DE
   const { udenomToUsd } = d.usePricing();
   const { data: walletSettings } = d.useWalletSettingsQuery();
   const defaultPaymentMethod = d.useDefaultPaymentMethodQuery();
-  const { isTrialing } = d.useWallet();
   const fundingConfig = d.useDeploymentFundingConfigQuery();
 
   const pricedRows = rows.filter((row): row is ReviewRow & { price: { amount: string; denom: string } } => !!row.price);
 
   if (!isEscrowAbstracted || pricedRows.length === 0) return { kind: "hidden" };
-  if (overview.isError || fundingConfig.isError) return { kind: "unavailable" };
+  if (overview.isError || fundingConfig.isError || defaultPaymentMethod.isError) return { kind: "unavailable" };
   if (overview.isLoading || !fundingConfig.data || defaultPaymentMethod.isLoading) return { kind: "loading" };
 
   const { targetRunwayHours, defaultDepositUsd } = fundingConfig.data;
@@ -76,7 +73,7 @@ export function useFundingImpact({ rows, runtimeLimitHours, dependencies: d = DE
   const availableNowUsd = overview.available;
   const availableAfterUsd = availableNowUsd >= remainingDrawUsd ? availableNowUsd - remainingDrawUsd : null;
   const thresholdUsd = overview.autoReloadThreshold;
-  const hasPaymentMethod = !isTrialing && !!defaultPaymentMethod.data;
+  const hasPaymentMethod = !!defaultPaymentMethod.data;
   const card = defaultPaymentMethod.data?.card;
 
   return {
@@ -92,9 +89,9 @@ export function useFundingImpact({ rows, runtimeLimitHours, dependencies: d = DE
 }
 
 /**
- * First match wins: a balance that cannot cover the reserve outranks everything (its copy claims no
- * automatic charge, so it also holds for trial users), then the missing payment method (no charge can
- * happen, so no crossing warning may claim one), then the threshold crossing, then plain funded.
+ * First match wins: a balance that cannot cover the reserve outranks everything, then the missing payment
+ * method (no charge can happen, so no crossing warning may claim one), then the threshold crossing, then
+ * plain funded.
  */
 function resolveState(input: { availableAfterUsd: number | null; thresholdUsd: number | null; hasPaymentMethod: boolean }): FundingImpactState {
   if (input.availableAfterUsd === null) return "not-enough-available";

--- a/apps/deploy-web/src/queries/index.ts
+++ b/apps/deploy-web/src/queries/index.ts
@@ -5,6 +5,7 @@ export * from "./useManagedWalletQuery";
 export * from "./useApiKeysQuery";
 export * from "./usePaymentQueries";
 export * from "./useUsageQuery";
+export * from "./useDeploymentFundingConfigQuery";
 export * from "./useWalletSettingsQueries";
 export * from "./useDeploymentQueries";
 export * from "./useDeploymentQueries";

--- a/apps/deploy-web/src/queries/useDeploymentFundingConfigQuery.spec.tsx
+++ b/apps/deploy-web/src/queries/useDeploymentFundingConfigQuery.spec.tsx
@@ -1,0 +1,26 @@
+import { createProxy } from "@akashnetwork/react-query-proxy";
+import { describe, expect, it, vi } from "vitest";
+
+import { useDeploymentFundingConfigQuery } from "./useDeploymentFundingConfigQuery";
+
+import { type RenderAppHookOptions, setupQuery } from "@tests/unit/query-client";
+
+type ApiService = ReturnType<NonNullable<NonNullable<RenderAppHookOptions["services"]>["api"]>>;
+
+describe(useDeploymentFundingConfigQuery.name, () => {
+  it("returns the funding config data", async () => {
+    const config = { targetRunwayHours: 48, balanceHeadroomUsd: 5, defaultDepositUsd: 0.5 };
+    const getDeploymentFundingConfig = vi.fn().mockResolvedValue({ data: config });
+    const api = createProxy({ v1: { getDeploymentFundingConfig } }) as unknown as ApiService;
+
+    const { result } = setupQuery(() => useDeploymentFundingConfigQuery(), {
+      services: { api: () => api }
+    });
+
+    await vi.waitFor(() => {
+      expect(getDeploymentFundingConfig).toHaveBeenCalled();
+      expect(result.current.isSuccess).toBe(true);
+      expect(result.current.data).toEqual(config);
+    });
+  });
+});

--- a/apps/deploy-web/src/queries/useDeploymentFundingConfigQuery.ts
+++ b/apps/deploy-web/src/queries/useDeploymentFundingConfigQuery.ts
@@ -1,0 +1,13 @@
+import type { paths } from "@akashnetwork/console-api-types";
+
+import { useServices } from "@src/context/ServicesProvider";
+
+export type DeploymentFundingConfig = paths["/v1/deployment-funding-config"]["get"]["responses"][200]["content"]["application/json"]["data"];
+
+export const useDeploymentFundingConfigQuery = () => {
+  const { api } = useServices();
+  return api.v1.getDeploymentFundingConfig.useQuery(undefined, {
+    select: response => response.data,
+    staleTime: Infinity
+  });
+};

--- a/packages/console-api-types/src/operations.gen.ts
+++ b/packages/console-api-types/src/operations.gen.ts
@@ -96,6 +96,14 @@ export const operations = {
       queryParams: ["timezone", "startDate", "endDate"],
       hasBody: false
     },
+    getDeploymentFundingConfig: {
+      path: "/v1/deployment-funding-config",
+      method: "get",
+      operationId: "getDeploymentFundingConfig",
+      pathParams: [],
+      queryParams: [],
+      hasBody: false
+    },
     getDeployment: { path: "/v1/deployments/{dseq}", method: "get", operationId: "getDeployment", pathParams: ["dseq"], queryParams: [], hasBody: false },
     closeDeployment: {
       path: "/v1/deployments/{dseq}",

--- a/packages/console-api-types/src/schema.d.ts
+++ b/packages/console-api-types/src/schema.d.ts
@@ -1436,6 +1436,34 @@ export interface paths {
           };
           content?: never;
         };
+        /** @description The email or password was rejected */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+        /** @description Account could not be created */
+        422: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+        /** @description Too many attempts */
+        429: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+        /** @description Account creation is temporarily unavailable */
+        502: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
       };
     };
     delete?: never;
@@ -1563,6 +1591,23 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/v1/deployment-funding-config": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get deployment funding config */
+    get: operations["getDeploymentFundingConfig"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/v1/deployment-settings/{userId}/{dseq}": {
     parameters: {
       query?: never;
@@ -1646,8 +1691,10 @@ export interface paths {
         content: {
           "application/json": {
             data: {
-              /** @description Whether auto top-up is enabled for this deployment */
-              autoTopUpEnabled: boolean;
+              /** @description Whether auto top-up is enabled for this deployment. An explicit false is rejected once always-on funding is rolled out */
+              autoTopUpEnabled?: boolean;
+              /** @description Runtime limit in hours, counted from lease start. On a deployment with no limit yet it may be at most 48. Extending an existing limit must raise it by at most 48 hours per request; send the new total rather than the increment. Lowering a limit is not supported. Send null to remove the limit and return the deployment to always-on funding. */
+              runtimeLimitHours?: number | null;
             };
           };
         };
@@ -1683,8 +1730,30 @@ export interface paths {
             };
           };
         };
+        /** @description Invalid runtime limit change */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": {
+              message: string;
+            };
+          };
+        };
         /** @description Deployment settings not found */
         404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": {
+              message: string;
+            };
+          };
+        };
+        /** @description Runtime limit changed concurrently */
+        409: {
           headers: {
             [name: string]: unknown;
           };
@@ -1723,10 +1792,7 @@ export interface paths {
               userId: string;
               /** @description Deployment sequence number */
               dseq: string;
-              /**
-               * @description Whether auto top-up is enabled for this deployment
-               * @default false
-               */
+              /** @description Whether auto top-up is enabled for this deployment. Defaults to enabled when omitted; an explicit false is rejected once always-on funding is rolled out */
               autoTopUpEnabled?: boolean;
             };
           };
@@ -1856,8 +1922,10 @@ export interface paths {
         content: {
           "application/json": {
             data: {
-              /** @description Whether auto top-up is enabled for this deployment */
-              autoTopUpEnabled: boolean;
+              /** @description Whether auto top-up is enabled for this deployment. An explicit false is rejected once always-on funding is rolled out */
+              autoTopUpEnabled?: boolean;
+              /** @description Runtime limit in hours, counted from lease start. On a deployment with no limit yet it may be at most 48. Extending an existing limit must raise it by at most 48 hours per request; send the new total rather than the increment. Lowering a limit is not supported. Send null to remove the limit and return the deployment to always-on funding. */
+              runtimeLimitHours?: number | null;
             };
           };
         };
@@ -1893,8 +1961,30 @@ export interface paths {
             };
           };
         };
+        /** @description Invalid runtime limit change */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": {
+              message: string;
+            };
+          };
+        };
         /** @description Deployment settings not found */
         404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": {
+              message: string;
+            };
+          };
+        };
+        /** @description Runtime limit changed concurrently */
+        409: {
           headers: {
             [name: string]: unknown;
           };
@@ -1931,10 +2021,7 @@ export interface paths {
             data: {
               /** @description Deployment sequence number */
               dseq: string;
-              /**
-               * @description Whether auto top-up is enabled for this deployment
-               * @default false
-               */
+              /** @description Whether auto top-up is enabled for this deployment. Defaults to enabled when omitted; an explicit false is rejected once always-on funding is rolled out */
               autoTopUpEnabled?: boolean;
               /**
                * Format: uuid
@@ -2668,6 +2755,68 @@ export interface paths {
                 /** @description Total weekly cost in USD for all deployments with auto top-up enabled */
                 weeklyCost: number;
               };
+            };
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/sdl-secrets-context": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get SDL secrets encryption context */
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Returns SDL secrets context */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": {
+              /** @description The subject of the SDL secrets context */
+              sub: string;
+              /** @description The key ID of the SDL secrets context */
+              kid: string;
+              /** @description The JSON Web Key used to encrypt the SDL secrets */
+              jwk: {
+                kty: string;
+                n: string;
+                e: string;
+                use: string;
+                alg: string;
+              };
+              /** @description The required claims for the SDL secrets context */
+              requiredClaims: ("kid" | "sub" | "exp")[];
+            };
+          };
+        };
+        /** @description SDL secrets encryption is unavailable */
+        503: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": {
+              message: string;
             };
           };
         };
@@ -7755,6 +7904,35 @@ export interface operations {
       };
     };
   };
+  getDeploymentFundingConfig: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Returns the platform constants automatic deployment funding runs on */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            data: {
+              /** @description Hours of runtime automatic funding reserves for a deployment once its lease starts */
+              targetRunwayHours: number;
+              /** @description USD amount automatic funding leaves untouched in the available balance so new deployments can still be created */
+              balanceHeadroomUsd: number;
+              /** @description USD amount every deployment is bootstrapped with at creation, before funding tops it up toward the target runway */
+              defaultDepositUsd: number;
+            };
+          };
+        };
+      };
+    };
+  };
   getDeployment: {
     parameters: {
       query?: never;
@@ -8127,7 +8305,7 @@ export interface operations {
              * @description Deposit in dollars. Ignored when managed deposits are enabled for your account, in which case the platform sets it automatically; otherwise it is required.
              */
             deposit?: number;
-            /** @description Optional runtime limit in hours, counted from lease start. Automatic funding keeps the deployment running until the limit, then stops so the deployment drains and closes. Omit for always-on funding. */
+            /** @description Optional runtime limit in hours (1 to 48), counted from lease start. Automatic funding keeps the deployment running until the limit, then the deployment is closed automatically and unused funds are returned. Extend a limit with PATCH /v2/deployment-settings/{dseq}. Omit for always-on funding. */
             runtimeLimitHours?: number;
           };
         };


### PR DESCRIPTION
## Why

Closes CON-915

Deployment creation no longer asks for a deposit, so the review step showed a price and nothing about what confirming does to the account's money. The reserve that funding takes out of the available balance, and the credit purchase that fires when available drops under the Auto Top-Up threshold, were only visible after the fact in Billing.

## What

**API**: adds a public `GET /v1/deployment-funding-config` returning the constants automatic funding runs on (`targetRunwayHours`, `balanceHeadroomUsd`, `defaultDepositUsd` from the deployment env config). The review widget needs the target runway to estimate the reserve and nothing exposed it before: `estimatedTopUpAmount` on deployment settings needs a lease, which doesn't exist at review time. No auth, cacheable, same shape as the blockchain-status route.

**deploy-web**: the Review and deploy modal gets a collapsible funding section between the total cost and the runtime limit, reusing Billing's `BalanceBreakdownBar`, `UsdValue`, and Available / Reserved / Auto Top-Up labels.

- Summary line: the reserve estimate (selected bid prices x 600 blocks/h x min(target runway, runtime limit)), the available balance after it, and the runtime the reserve covers.
- Expanded: a reserved/available legend, the balance bar with the threshold marker, a state-specific line, the held-not-charged explainer, and a link to Billing.
- States, first match wins: available can't cover the reserve (warning plus Add Credits, Confirm stays enabled); crossing the threshold (warns which card gets charged and for how much); free trial (muted Trial badge, the trial's auto-close duration, Add Credits, no charge claims); no default payment method (Add Credits prompt, no charge claims); funded. Balance failed to load shows one quiet line and never blocks deploying, and legacy deposit accounts see nothing (gated on `useIsEscrowAbstracted`).
- The trial ranks below the threshold crossing on purpose: the auto top-up check never reads the trial flag, so a trialing account with a saved card really is charged, and it should see that warning rather than the trial notice.

The endpoint also returns `balanceHeadroomUsd` and `defaultDepositUsd`, but the widget only consumes `targetRunwayHours` for now: the design shows the desired reserve even when the balance can't cover it, so a headroom-capped figure would never render.

`BalanceBreakdownBar` gets an optional `hideThresholdCaption` prop since the widget explains the threshold in its own copy. Billing is unchanged.

The runtime limit is now offered to trial accounts as well. Its gate excluded them on the grounds that "trial users whose deployments are never auto-funded", and that premise doesn't hold: `autoTopUpEnabled` defaults to true for every deployment and neither auto-top-up sweep query filters on `isTrialing`. The gate is now wallet readiness alone. A trial deployment is still closed after `TRIAL_DEPLOYMENT_CLEANUP_HOURS` regardless, so a longer limit is moot while a shorter one takes effect, and the advance runtime-ending email stays non-trial only (`findExpiringRuntimeDeployments` filters on the flag).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added funding impact details to the deployment review screen, including estimated reserve, remaining balance, runtime coverage, and payment guidance.
  * Added deployment funding configuration access through a new API endpoint.
  * Added support for runtime limits and related deployment funding states.
  * Improved balance breakdowns by allowing threshold captions to be hidden while retaining markers.

* **Documentation**
  * Updated API documentation with funding configuration, runtime-limit validation, and deployment funding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


