### PR TITLE
fix(deployment): stop the runtime countdown claiming time left on a closed deployment

### DIFF
--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.spec.tsx
@@ -120,6 +120,52 @@ describe("DeploymentDetailHeader", () => {
     }
   });
 
+  it("reads as ended, with no meter, once the deployment is closed with time still on its limit", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-21T12:00:00.000Z"));
+
+    try {
+      setup({ state: "closed", runtimeLimitHours: 12, runtimeEndsAt: "2026-08-21T14:00:00.000Z" });
+
+      expect(screen.getByText("Runtime ended")).toBeInTheDocument();
+      expect(screen.getByText("12h")).toBeInTheDocument();
+      expect(screen.queryByText("2h left")).not.toBeInTheDocument();
+      expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("reads as ended once every lease is closed, before the deployment itself is", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-21T12:00:00.000Z"));
+
+    try {
+      setup({
+        runtimeLimitHours: 12,
+        runtimeEndsAt: "2026-08-21T14:00:00.000Z",
+        leases: [mock<LeaseDto>({ id: "1", provider: "akash1provider", state: "closed", reason: undefined })]
+      });
+
+      expect(screen.getByText("Runtime ended")).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps counting down while the lease list is still loading, so an active deployment never flashes as ended", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-21T12:00:00.000Z"));
+
+    try {
+      setup({ runtimeLimitHours: 12, runtimeEndsAt: "2026-08-21T14:00:00.000Z", leases: null });
+
+      expect(screen.getByText("2h left")).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("hides the runtime limit tile when the deployment has none", () => {
     setup({});
 
@@ -278,7 +324,8 @@ describe("DeploymentDetailHeader", () => {
     name?: string | null;
     isTrialing?: boolean;
     storedManifest?: string | null;
-    leases?: LeaseDto[];
+    state?: string;
+    leases?: LeaseDto[] | null;
     providers?: ApiProviderList[];
     gpuAmount?: number;
     groups?: DeploymentGroup[];
@@ -318,7 +365,7 @@ describe("DeploymentDetailHeader", () => {
 
     const deployment = mock<DeploymentDto>({
       dseq: "1786440078202",
-      state: "active",
+      state: input.state ?? "active",
       cpuAmount: 2,
       gpuAmount: input.gpuAmount ?? 0,
       memoryAmount: 536870912,
@@ -330,7 +377,7 @@ describe("DeploymentDetailHeader", () => {
     render(
       <DeploymentDetailHeader
         deployment={deployment}
-        leases={input.leases ?? [mock<LeaseDto>({ id: "1", provider: "akash1provider", state: "active" })]}
+        leases={input.leases !== undefined ? input.leases : [mock<LeaseDto>({ id: "1", provider: "akash1provider", state: "active" })]}
         providers={input.providers ?? [mock<ApiProviderList>({ owner: "akash1provider" })]}
         dependencies={MockComponents(DEPENDENCIES, {
           useLocalNotes,

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.tsx
@@ -16,6 +16,7 @@ import { useWallet } from "@src/context/WalletProvider";
 import { useDeclaredGpuInterconnect } from "@src/hooks/useDeclaredGpuInterconnect";
 import { useDeclaredTeeTypes } from "@src/hooks/useDeclaredTeeTypes";
 import { useDeploymentEscrowBalance } from "@src/hooks/useDeploymentEscrowBalance/useDeploymentEscrowBalance";
+import { useHasDeploymentStopped } from "@src/hooks/useHasDeploymentStopped";
 import { useIsEscrowAbstracted } from "@src/hooks/useIsEscrowAbstracted";
 import { useTickingNow } from "@src/hooks/useTickingNow";
 import { useDeploymentSettingQuery } from "@src/queries/deploymentSettingsQuery";
@@ -81,9 +82,12 @@ export const DeploymentDetailHeader: FC<DeploymentDetailHeaderProps> = ({ deploy
   const costPerBlockUDenom = liveLeases.reduce((sum, lease) => sum + parseFloat(lease.price.amount), 0);
   const liveGpuCount = liveLeases.reduce((sum, lease) => sum + (lease.gpuAmount ?? 0), 0);
 
+  const hasStopped = useHasDeploymentStopped({ deployment, leases });
   const runtimeEndsAt = settings?.runtimeEndsAt ?? null;
-  const now = useTickingNow(!!runtimeEndsAt);
-  const runtimeLimitCountdown = settings?.runtimeLimitHours ? getRuntimeLimitCountdown(settings.runtimeLimitHours, runtimeEndsAt, now) : null;
+  const now = useTickingNow(!!runtimeEndsAt && !hasStopped);
+  const runtimeLimitCountdown = settings?.runtimeLimitHours
+    ? getRuntimeLimitCountdown({ runtimeLimitHours: settings.runtimeLimitHours, runtimeEndsAt, hasStopped, now })
+    : null;
 
   const storedDeployment = getDeploymentData(deployment.dseq);
   const storedManifest = storedDeployment?.manifest;

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentBillingSection.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentBillingSection.spec.tsx
@@ -150,6 +150,21 @@ describe("DeploymentBillingSection", () => {
       expect(screen.queryByRole("switch", { name: "Auto Top-Up" })).not.toBeInTheDocument();
     });
 
+    it("reads as ended, with no meter, once the deployment is closed with time still on its limit", () => {
+      setup({ state: "closed", runtimeLimitHours: 12, runtimeEndsAt: "2026-08-21T18:00:00.000Z" });
+
+      expect(screen.getByText("Runtime ended")).toBeInTheDocument();
+      expect(screen.getByText("of 12h limit")).toBeInTheDocument();
+      expect(screen.queryByText("6h left")).not.toBeInTheDocument();
+      expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+    });
+
+    it("keeps counting down while the lease list is still loading, so an active deployment never flashes as ended", () => {
+      setup({ state: "active", runtimeLimitHours: 12, runtimeEndsAt: "2026-08-21T18:00:00.000Z", leases: null });
+
+      expect(screen.getByText("6h left")).toBeInTheDocument();
+    });
+
     it("keeps the runtime-limit controls on a limited deployment while hiding the balance", () => {
       setup({ state: "active", runtimeLimitHours: 12, isEscrowAbstracted: true });
 

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentBillingSection.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentSettings/DeploymentBillingSection.tsx
@@ -14,6 +14,7 @@ import { useServices } from "@src/context/ServicesProvider";
 import { useWallet } from "@src/context/WalletProvider";
 import { useAutoTopUp } from "@src/hooks/useAutoTopUp/useAutoTopUp";
 import { useDeploymentEscrowBalance } from "@src/hooks/useDeploymentEscrowBalance/useDeploymentEscrowBalance";
+import { useHasDeploymentStopped } from "@src/hooks/useHasDeploymentStopped";
 import { useIsEscrowAbstracted } from "@src/hooks/useIsEscrowAbstracted";
 import { usePricing } from "@src/hooks/usePricing/usePricing";
 import { useTickingNow } from "@src/hooks/useTickingNow";
@@ -74,8 +75,9 @@ export const DeploymentBillingSection: FC<DeploymentBillingSectionProps> = ({ de
   const updateSetting = d.useUpdateDeploymentSettingMutation({ dseq: deployment.dseq });
 
   const isRuntimeLimited = !!runtimeLimitHours;
-  const now = d.useTickingNow(!!runtimeEndsAt);
-  const runtimeLimitCountdown = runtimeLimitHours ? getRuntimeLimitCountdown(runtimeLimitHours, runtimeEndsAt, now) : null;
+  const hasStopped = useHasDeploymentStopped({ deployment, leases });
+  const now = d.useTickingNow(!!runtimeEndsAt && !hasStopped);
+  const runtimeLimitCountdown = runtimeLimitHours ? getRuntimeLimitCountdown({ runtimeLimitHours, runtimeEndsAt, hasStopped, now }) : null;
 
   const openDepositModal = useCallback(() => {
     setIsDepositing(true);

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/RuntimeLimitMeter.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/RuntimeLimitMeter.spec.tsx
@@ -32,8 +32,14 @@ describe("RuntimeLimitMeter", () => {
     expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "0");
   });
 
-  function setup(input: { runtimeLimitHours: number; runtimeEndsAt: string | null }) {
-    const countdown = getRuntimeLimitCountdown(input.runtimeLimitHours, input.runtimeEndsAt, NOW);
+  it("renders nothing once the deployment has stopped, where a partial bar would still read as draining", () => {
+    setup({ runtimeLimitHours: 12, runtimeEndsAt: "2026-08-21T15:00:00.000Z", hasStopped: true });
+
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+  });
+
+  function setup(input: { runtimeLimitHours: number; runtimeEndsAt: string | null; hasStopped?: boolean }) {
+    const countdown = getRuntimeLimitCountdown({ ...input, now: NOW });
     render(<RuntimeLimitMeter countdown={countdown} />);
     return { countdown };
   }

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/RuntimeLimitMeter.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/RuntimeLimitMeter.tsx
@@ -10,9 +10,9 @@ export interface RuntimeLimitMeterProps {
   className?: string;
 }
 
-/** Renders nothing while the countdown is unanchored, where a full bar would claim elapsed time the lease has not started spending. */
+/** Renders nothing unless time is actually draining: a bar on a lease that never started, or has stopped, claims runtime that is not being spent. */
 export const RuntimeLimitMeter: FC<RuntimeLimitMeterProps> = ({ countdown, className }) => {
-  if (countdown.status === "unanchored") return null;
+  if (countdown.status === "unanchored" || countdown.status === "ended") return null;
 
   return (
     <Progress

--- a/apps/deploy-web/src/hooks/useHasDeploymentStopped.spec.ts
+++ b/apps/deploy-web/src/hooks/useHasDeploymentStopped.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { DeploymentDto, LeaseDto } from "@src/types/deployment";
+import { useHasDeploymentStopped } from "./useHasDeploymentStopped";
+
+import { renderHook } from "@testing-library/react";
+
+describe(useHasDeploymentStopped.name, () => {
+  it("reports a closed deployment as stopped", () => {
+    const { result } = setup({ state: "closed", leaseStates: ["active"] });
+
+    expect(result.current).toBe(true);
+  });
+
+  it("reports an open deployment whose leases have all closed as stopped", () => {
+    const { result } = setup({ state: "active", leaseStates: ["closed"] });
+
+    expect(result.current).toBe(true);
+  });
+
+  it("reports an open deployment with a live lease as running", () => {
+    const { result } = setup({ state: "active", leaseStates: ["active"] });
+
+    expect(result.current).toBe(false);
+  });
+
+  it("reports an open deployment with no leases at all as stopped", () => {
+    const { result } = setup({ state: "active", leaseStates: [] });
+
+    expect(result.current).toBe(true);
+  });
+
+  it("withholds judgement while the lease query is still in flight", () => {
+    expect(setup({ state: "active", leaseStates: null }).result.current).toBe(false);
+    expect(setup({ state: "active", leaseStates: undefined }).result.current).toBe(false);
+  });
+
+  function setup(input: { state: string; leaseStates: string[] | null | undefined }) {
+    const deployment = mock<DeploymentDto>({ state: input.state });
+    const leases = input.leaseStates?.map(state => mock<LeaseDto>({ state }));
+
+    return renderHook(() => useHasDeploymentStopped({ deployment, leases: input.leaseStates === null ? null : leases }));
+  }
+});

--- a/apps/deploy-web/src/hooks/useHasDeploymentStopped.ts
+++ b/apps/deploy-web/src/hooks/useHasDeploymentStopped.ts
@@ -1,0 +1,16 @@
+import type { DeploymentDto, LeaseDto } from "@src/types/deployment";
+import { isLeaseLive } from "@src/utils/leaseUtils";
+
+/**
+ * Whether the deployment has stopped running. Only true once the leases are known: an in-flight lease
+ * query is not evidence it stopped, and treating it as such would flash stopped-state UI on every load.
+ */
+export function useHasDeploymentStopped({
+  deployment,
+  leases
+}: {
+  deployment: Pick<DeploymentDto, "state">;
+  leases: Pick<LeaseDto, "state">[] | null | undefined;
+}): boolean {
+  return deployment.state === "closed" || (!!leases && !leases.some(isLeaseLive));
+}

--- a/apps/deploy-web/src/utils/runtimeLimitUtils.spec.ts
+++ b/apps/deploy-web/src/utils/runtimeLimitUtils.spec.ts
@@ -6,7 +6,7 @@ const NOW = Date.parse("2026-08-21T12:00:00.000Z");
 
 describe(getRuntimeLimitCountdown.name, () => {
   it("shows only the limit before the countdown is anchored", () => {
-    const countdown = getRuntimeLimitCountdown(12, null, NOW);
+    const countdown = getRuntimeLimitCountdown({ runtimeLimitHours: 12, runtimeEndsAt: null, now: NOW });
 
     expect(countdown.status).toBe("unanchored");
     expect(countdown.remainingLabel).toBe("12h");
@@ -14,7 +14,7 @@ describe(getRuntimeLimitCountdown.name, () => {
   });
 
   it("measures the remaining share against the granted limit", () => {
-    const countdown = getRuntimeLimitCountdown(12, "2026-08-21T18:00:00.000Z", NOW);
+    const countdown = getRuntimeLimitCountdown({ runtimeLimitHours: 12, runtimeEndsAt: "2026-08-21T18:00:00.000Z", now: NOW });
 
     expect(countdown.status).toBe("running");
     expect(countdown.remainingLabel).toBe("6h left");
@@ -24,22 +24,22 @@ describe(getRuntimeLimitCountdown.name, () => {
   });
 
   it("adds the minutes when the remaining time is not a whole number of hours", () => {
-    expect(getRuntimeLimitCountdown(12, "2026-08-21T14:10:00.000Z", NOW).remainingLabel).toBe("2h 10m left");
+    expect(getRuntimeLimitCountdown({ runtimeLimitHours: 12, runtimeEndsAt: "2026-08-21T14:10:00.000Z", now: NOW }).remainingLabel).toBe("2h 10m left");
   });
 
   it("counts in minutes alone once under an hour remains", () => {
-    expect(getRuntimeLimitCountdown(1, "2026-08-21T12:36:00.000Z", NOW).remainingLabel).toBe("36m left");
+    expect(getRuntimeLimitCountdown({ runtimeLimitHours: 1, runtimeEndsAt: "2026-08-21T12:36:00.000Z", now: NOW }).remainingLabel).toBe("36m left");
   });
 
   it("keeps the meter visible through the final seconds, alongside a full-minute reading", () => {
-    const countdown = getRuntimeLimitCountdown(12, "2026-08-21T12:00:01.000Z", NOW);
+    const countdown = getRuntimeLimitCountdown({ runtimeLimitHours: 12, runtimeEndsAt: "2026-08-21T12:00:01.000Z", now: NOW });
 
     expect(countdown.remainingLabel).toBe("1m left");
     expect(countdown.percentRemaining).toBe(1);
   });
 
   it("marks the limit as reached once the deadline passes", () => {
-    const countdown = getRuntimeLimitCountdown(12, "2026-08-21T11:00:00.000Z", NOW);
+    const countdown = getRuntimeLimitCountdown({ runtimeLimitHours: 12, runtimeEndsAt: "2026-08-21T11:00:00.000Z", now: NOW });
 
     expect(countdown.status).toBe("reached");
     expect(countdown.remainingLabel).toBe("Limit reached");
@@ -49,14 +49,35 @@ describe(getRuntimeLimitCountdown.name, () => {
   });
 
   it("caps the meter when the deadline sits further out than the limit allows", () => {
-    expect(getRuntimeLimitCountdown(1, "2026-08-21T20:00:00.000Z", NOW).percentRemaining).toBe(100);
+    expect(getRuntimeLimitCountdown({ runtimeLimitHours: 1, runtimeEndsAt: "2026-08-21T20:00:00.000Z", now: NOW }).percentRemaining).toBe(100);
   });
 
   it("keeps the meter finite when the limit itself is zero", () => {
-    expect(getRuntimeLimitCountdown(0, "2026-08-21T13:00:00.000Z", NOW).percentRemaining).toBe(100);
+    expect(getRuntimeLimitCountdown({ runtimeLimitHours: 0, runtimeEndsAt: "2026-08-21T13:00:00.000Z", now: NOW }).percentRemaining).toBe(100);
+  });
+
+  it("freezes on a stopped deployment rather than claiming the time left over", () => {
+    const countdown = getRuntimeLimitCountdown({ runtimeLimitHours: 12, runtimeEndsAt: "2026-08-21T18:00:00.000Z", hasStopped: true, now: NOW });
+
+    expect(countdown.status).toBe("ended");
+    expect(countdown.remainingLabel).toBe("Runtime ended");
+    expect(countdown.captionLabel).toBe("of 12h limit");
+    expect(countdown.accessibleLabel).toBe("Runtime ended, 12h limit");
+    expect(countdown.percentRemaining).toBe(0);
+  });
+
+  it("keeps reading as ended once a stopped deployment's deadline passes, so the label never changes after the close", () => {
+    const countdown = getRuntimeLimitCountdown({ runtimeLimitHours: 12, runtimeEndsAt: "2026-08-21T11:00:00.000Z", hasStopped: true, now: NOW });
+
+    expect(countdown.status).toBe("ended");
+    expect(countdown.remainingLabel).toBe("Runtime ended");
+  });
+
+  it("stays unanchored on a stopped deployment whose countdown never started", () => {
+    expect(getRuntimeLimitCountdown({ runtimeLimitHours: 12, runtimeEndsAt: null, hasStopped: true, now: NOW }).status).toBe("unanchored");
   });
 
   it("treats an unparseable deadline as unanchored rather than reached", () => {
-    expect(getRuntimeLimitCountdown(12, "not-a-date", NOW).status).toBe("unanchored");
+    expect(getRuntimeLimitCountdown({ runtimeLimitHours: 12, runtimeEndsAt: "not-a-date", now: NOW }).status).toBe("unanchored");
   });
 });

--- a/apps/deploy-web/src/utils/runtimeLimitUtils.ts
+++ b/apps/deploy-web/src/utils/runtimeLimitUtils.ts
@@ -7,7 +7,7 @@ export const MAX_RUNTIME_LIMIT_INCREMENT_HOURS = 48;
 /** Ceiling on a runtime limit's total, reachable only by repeated extensions. Mirrors the API's cap. */
 export const MAX_RUNTIME_LIMIT_HOURS = 8760;
 
-export type RuntimeLimitStatus = "unanchored" | "running" | "reached";
+export type RuntimeLimitStatus = "unanchored" | "running" | "reached" | "ended";
 
 export type RuntimeLimitCountdown = {
   status: RuntimeLimitStatus;
@@ -24,8 +24,21 @@ const MILLISECONDS_PER_MINUTE = 60 * 1000;
 const MINUTES_PER_HOUR = 60;
 const MILLISECONDS_PER_HOUR = MINUTES_PER_HOUR * MILLISECONDS_PER_MINUTE;
 
+export type RuntimeLimitCountdownInput = {
+  runtimeLimitHours: number;
+  runtimeEndsAt: string | null;
+  /** Whether the deployment has stopped running, which freezes the countdown wherever the server left it. */
+  hasStopped?: boolean;
+  now?: number;
+};
+
 /** The remaining share is measured against the granted limit itself, since no lease-start timestamp is stored. */
-export function getRuntimeLimitCountdown(runtimeLimitHours: number, runtimeEndsAt: string | null, now: number = Date.now()): RuntimeLimitCountdown {
+export function getRuntimeLimitCountdown({
+  runtimeLimitHours,
+  runtimeEndsAt,
+  hasStopped = false,
+  now = Date.now()
+}: RuntimeLimitCountdownInput): RuntimeLimitCountdown {
   const limitLabel = `${runtimeLimitHours}h`;
   const deadline = runtimeEndsAt ? new Date(runtimeEndsAt).getTime() : NaN;
 
@@ -37,6 +50,17 @@ export function getRuntimeLimitCountdown(runtimeLimitHours: number, runtimeEndsA
       captionLabel: "runtime limit",
       accessibleLabel: `${limitLabel} limit, not started`,
       percentRemaining: 100
+    };
+  }
+
+  if (hasStopped) {
+    return {
+      status: "ended",
+      limitLabel,
+      remainingLabel: "Runtime ended",
+      captionLabel: `of ${limitLabel} limit`,
+      accessibleLabel: `Runtime ended, ${limitLabel} limit`,
+      percentRemaining: 0
     };
   }
 


### PR DESCRIPTION
## Why

A runtime-limited deployment keeps its `runtimeEndsAt` after it closes: the server writes the timestamp at lease start, and `markAsClosed` leaves it in place. Neither the header tile nor the Billing card consulted deployment or lease state, so a deployment closed by hand kept reading "1h 56m left" over a draining progress bar, sitting directly under its own "Closed by you" badge. It was advertising runtime that no longer existed.

Part of CON-883

## What

Once we know the deployment has stopped, both surfaces read "Runtime ended" against the limit it was granted, and the meter disappears.

| Surface | Before | After |
| --- | --- | --- |
| Header `RUNTIME LIMIT` tile | `1h 56m left` · `2h` + draining bar | `Runtime ended` · `2h`, no bar |
| Settings → Billing card | `1h 56m left` · `of 2h limit` + bar | `Runtime ended` · `of 2h limit`, no bar |

`getRuntimeLimitCountdown` gains an `ended` status, and its three positional args become one object so the new `hasStopped` flag reads at the call sites. The new branch is checked ahead of `reached`, which matters for the timeout path: a deployment closed by its own limit would otherwise flip from "Runtime ended" to "Limit reached" as the clock crossed the deadline. Both close paths, manual and timeout, now read the same.

"Stopped" is `hasDeploymentStopped(state, leases)`, a new helper next to `isLeaseLive` in `leaseUtils`: the deployment's state is closed, or every lease is. That second half covers the window where the lease died but the on-chain deployment has not been closed yet. It deliberately treats an in-flight lease query as unknown rather than stopped, since otherwise an active deployment would flash "Runtime ended" on every page load. There is a spec for that on both components.

Neither render block needed a JSX change, since both already branched on `status`. The "Add hours" and "Switch to always on" controls stay gated on `isActive` as before. Ticking is now switched off while the label is frozen, which drops a pointless 60s re-render loop.

One test-only oddity worth knowing about: giving a fixture a closed lease trips `DeploymentStatusBadge` into `classifyLeaseCloseReason`, which calls `.trim()` on `lease.reason`, and `mock<LeaseDto>()` auto-fills that field with a function. It is pinned to `undefined` in the one fixture that needs it. Production always passes a string or nothing, so this is a mock artifact rather than a bug.

Verified with the full deploy-web unit suite (3629 tests across 367 files), `lint --quiet`, and a cold `tsc --noEmit` whose output is byte-identical to a cold run on `main`: 92 pre-existing spec errors, none of them in the touched files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Stopped deployments now correctly display an ended runtime status, even when time remains.
  - Runtime countdowns no longer continue ticking after a deployment has stopped.
  - Progress meters are hidden when runtime is ended or not actively being consumed.
  - Active deployments continue showing countdown information while lease data is loading.
- **Tests**
  - Expanded coverage for stopped, active, closed, and lease-loading deployment states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->