### PR TITLE
refactor(deployment): read the chain tip once per stale-deployment sweep

### DIFF
--- a/apps/api/src/deployment/services/stale-managed-deployments-cleaner/stale-managed-deployments-cleaner.service.spec.ts
+++ b/apps/api/src/deployment/services/stale-managed-deployments-cleaner/stale-managed-deployments-cleaner.service.spec.ts
@@ -44,6 +44,14 @@ describe(StaleManagedDeploymentsCleanerService.name, () => {
       expect(deploymentRepository.findStaleDeployments).toHaveBeenCalledWith({ owner: wallet.address, createdHeight: 1_000_000 });
     });
 
+    it("reads the chain height itself when called for a single wallet", async () => {
+      const { service, blockRepository, wallet } = setup();
+
+      await service.cleanUpForWallet(wallet, 0);
+
+      expect(blockRepository.getLatestProcessedHeight).toHaveBeenCalledTimes(1);
+    });
+
     it("does not broadcast when there are no stale deployments", async () => {
       const { service, managedSignerService, wallet } = setup({ staleDeployments: [] });
 
@@ -99,6 +107,25 @@ describe(StaleManagedDeploymentsCleanerService.name, () => {
       expect(logger.error).toHaveBeenCalledWith(UNSETTLEABLE_LOG);
     });
 
+    it("reads the chain height once for the whole sweep", async () => {
+      const { service, blockRepository, deploymentRepository } = setup({ pages: 4, walletsPerPage: 3 });
+
+      await service.cleanup({ concurrency: 3 });
+
+      expect(blockRepository.getLatestProcessedHeight).toHaveBeenCalledTimes(1);
+      expect(deploymentRepository.findStaleDeployments).toHaveBeenCalledTimes(12);
+    });
+
+    it("screens every wallet against the same cutoff", async () => {
+      const { service, deploymentRepository } = setup({ currentHeight: 1_000_000, pages: 3, walletsPerPage: 2 });
+
+      await service.cleanup({ concurrency: 2 });
+
+      const cutoffs = new Set(deploymentRepository.findStaleDeployments.mock.calls.map(([{ createdHeight }]) => createdHeight));
+      expect(cutoffs.size).toBe(1);
+      expect([...cutoffs][0]).toBeLessThan(1_000_000);
+    });
+
     it("rethrows unrelated errors into the wallet error handler without retrying", async () => {
       const unexpectedError = new Error("some unexpected failure");
       const { service, managedSignerService, managedUserWalletService, logger, errorLogger } = setup({
@@ -130,12 +157,26 @@ describe(StaleManagedDeploymentsCleanerService.name, () => {
     expect(createErrorLogger).toHaveBeenCalledWith({ context: ErrorService.name });
   });
 
-  function setup(input?: { currentHeight?: number; staleDeployments?: { dseq: number }[]; executeDerivedTx?: ManagedSignerService["executeDerivedTx"] }) {
+  function setup(input?: {
+    currentHeight?: number;
+    staleDeployments?: { dseq: number }[];
+    executeDerivedTx?: ManagedSignerService["executeDerivedTx"];
+    pages?: number;
+    walletsPerPage?: number;
+  }) {
     const wallet = createUserWallet({ id: 123, address: "akash1test" });
+
+    const walletPages = Array.from({ length: input?.pages ?? 1 }, (_, page) =>
+      Array.from({ length: input?.walletsPerPage ?? 1 }, (_, index) =>
+        page === 0 && index === 0 ? wallet : createUserWallet({ id: 1000 + page * 10 + index, address: `akash1owner${page}${index}` })
+      )
+    );
 
     const userWalletRepository = mock<UserWalletRepository>({
       paginate: vi.fn(async (_options, cb) => {
-        await cb([wallet]);
+        for (const page of walletPages) {
+          await cb(page);
+        }
       }) as UserWalletRepository["paginate"]
     });
     const deploymentRepository = mock<DeploymentRepository>();

--- a/apps/api/src/deployment/services/stale-managed-deployments-cleaner/stale-managed-deployments-cleaner.service.ts
+++ b/apps/api/src/deployment/services/stale-managed-deployments-cleaner/stale-managed-deployments-cleaner.service.ts
@@ -36,6 +36,8 @@ export class StaleManagedDeploymentsCleanerService {
   }
 
   async cleanup(options: CleanUpStaleDeploymentsParams) {
+    const staleBeforeHeight = await this.#resolveStaleBeforeHeight(this.MAX_LIVE_BLOCKS);
+
     await this.userWalletRepository.paginate({ limit: options.concurrency || 10 }, async wallets => {
       const cleanUpAllWallets = wallets.map(async wallet => {
         await this.errorService.execWithErrorHandler(
@@ -44,7 +46,7 @@ export class StaleManagedDeploymentsCleanerService {
             event: "DEPLOYMENT_CLEAN_UP_ERROR",
             context: StaleManagedDeploymentsCleanerService.name
           },
-          () => this.cleanUpForWallet(wallet)
+          () => this.#closeLeaselessDeployments(wallet, staleBeforeHeight)
         );
       });
 
@@ -53,10 +55,18 @@ export class StaleManagedDeploymentsCleanerService {
   }
 
   async cleanUpForWallet(wallet: UserWalletOutput, maxLiveBlocks: number = this.MAX_LIVE_BLOCKS) {
-    const currentHeight = await this.blockRepository.getLatestProcessedHeight();
+    await this.#closeLeaselessDeployments(wallet, await this.#resolveStaleBeforeHeight(maxLiveBlocks));
+  }
+
+  /** Read once per sweep instead of per wallet: the tip is the same for every one of them, and the sweep walks the whole managed-wallet table. */
+  async #resolveStaleBeforeHeight(maxLiveBlocks: number): Promise<number> {
+    return (await this.blockRepository.getLatestProcessedHeight()) - maxLiveBlocks;
+  }
+
+  async #closeLeaselessDeployments(wallet: UserWalletOutput, staleBeforeHeight: number) {
     const deployments = await this.deploymentRepository.findStaleDeployments({
       owner: wallet.address!,
-      createdHeight: currentHeight - maxLiveBlocks
+      createdHeight: staleBeforeHeight
     });
 
     const messages = deployments.map(deployment => this.rpcMessageService.getCloseDeploymentMsg(wallet.address!, deployment.dseq));


### PR DESCRIPTION
## Why

`cleanup-stale-deployments` is the heaviest cron in apps/api: **66,098 Postgres queries a day** measured in prod-mainnet, on a job that runs twice.

It paginates the whole `user_wallets` table 10 rows at a time and calls `cleanUpForWallet` on every wallet, which read the block height itself. That was **15,734 identical `SELECT max("height") FROM block WHERE "isProcessed" = true`** per run, confirmed by counting them in Loki. Half the job was re-reading one number that cannot change per wallet.

For scale on the other half: only **22** `DEPLOYMENT_CLEAN_UP` events fire in 24h, so ~31,000 per-wallet queries find real work about 11 times a run.

## What

`cleanup()` resolves the cutoff once and passes it down to a private `#closeLeaselessDeployments`. `cleanUpForWallet` keeps resolving its own height, because `DeploymentWriterService` calls it for a single wallet in the deployment-create path with `maxLiveBlocks: 0`.

**15,734 height queries per run -> 1.** The job drops from ~33,000 queries to ~17,000, so ~32,000 fewer a day.

### The one behavioural change

The cutoff is now taken at the start of the run rather than per wallet. The run takes 2m36s in prod, so a wallet processed at the end is screened against a height up to that much older.

This only ever makes the sweep **more conservative**: `createdHeight < tip - MAX_LIVE_BLOCKS` with an older tip matches strictly fewer deployments, so nothing gets closed earlier than before. The worst case is a deployment that crosses the 10-minute staleness line during the run and waits for the next one. Given the cron runs every 12 hours, anything created just after a run already waits that long, so a sub-3-minute shift in the cutoff is small next to the existing cadence.

## What this does not fix

The remaining ~15,700 `findStaleDeployments` calls, one per wallet, are still there. Inverting the sweep to "find stale deployments, then look up their owners" cannot be a single query: `deployment` and `lease` are sequelize models on the chain DB while `user_wallets` is drizzle on the user DB, so there is no join available. The options are to read all network-wide stale deployments and intersect in memory, or to chunk `owner IN (...)` and take 15,700 down to ~16. Choosing needs the network-wide stale-deployment count, which I could not get. Left for a follow-up.

## Testing

- 3 new unit tests: the sweep reads the height once across 4 pages of 3 wallets, every wallet is screened against the same cutoff, and `cleanUpForWallet` still reads its own height for the single-wallet path. The spec's `paginate` mock now yields configurable pages so multi-page behaviour is actually exercised.
- 13 tests pass in that spec, 2137 across apps/api.
- Lint clean. `tsc --noEmit` reports 41 errors here and 41 on the `main` baseline, so none are new.
