### PR TITLE
fix(billing): confirm credits read low before sending the email

### DIFF
--- a/apps/api/drizzle/0047_credits_low_confirm_window.sql
+++ b/apps/api/drizzle/0047_credits_low_confirm_window.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "user_wallets" ADD COLUMN "credits_low_since" timestamp with time zone;

--- a/apps/api/drizzle/meta/0047_snapshot.json
+++ b/apps/api/drizzle/meta/0047_snapshot.json
@@ -1,0 +1,1552 @@
+{
+  "id": "83bc3b6a-7ec1-4562-bd38-80b5a21778d6",
+  "prevId": "11d70361-d6f4-4db1-a725-f4078913c145",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.user_wallets": {
+      "name": "user_wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_allowance": {
+          "name": "deployment_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "fee_allowance": {
+          "name": "fee_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "trial": {
+          "name": "trial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits_low_notified_at": {
+          "name": "credits_low_notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits_sufficient_since": {
+          "name": "credits_sufficient_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits_low_since": {
+          "name": "credits_low_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_wallets_user_id_userSetting_id_fk": {
+          "name": "user_wallets_user_id_userSetting_id_fk",
+          "tableFrom": "user_wallets",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_wallets_user_id_unique": {
+          "name": "user_wallets_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "user_wallets_address_unique": {
+          "name": "user_wallets_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_methods": {
+      "name": "payment_methods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_method_id": {
+          "name": "payment_method_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_validated": {
+          "name": "is_validated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payment_methods_fingerprint_payment_method_id_unique": {
+          "name": "payment_methods_fingerprint_payment_method_id_unique",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_default_unique": {
+          "name": "payment_methods_user_id_is_default_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"payment_methods\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_fingerprint_idx": {
+          "name": "payment_methods_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_idx": {
+          "name": "payment_methods_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_validated_idx": {
+          "name": "payment_methods_user_id_is_validated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_validated",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_fingerprint_payment_method_id_idx": {
+          "name": "payment_methods_user_id_fingerprint_payment_method_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_methods_user_id_userSetting_id_fk": {
+          "name": "payment_methods_user_id_userSetting_id_fk",
+          "tableFrom": "payment_methods",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_transactions": {
+      "name": "stripe_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "stripe_transaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "stripe_transaction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created'"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_refunded": {
+          "name": "amount_refunded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bonus_amount": {
+          "name": "bonus_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_charge_id": {
+          "name": "stripe_charge_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_coupon_id": {
+          "name": "stripe_coupon_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_promotion_code_id": {
+          "name": "stripe_promotion_code_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_idempotency_key": {
+          "name": "stripe_idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method_type": {
+          "name": "payment_method_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_brand": {
+          "name": "card_brand",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_last4": {
+          "name": "card_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_url": {
+          "name": "receipt_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_transactions_stripe_invoice_id_unique": {
+          "name": "stripe_transactions_stripe_invoice_id_unique",
+          "columns": [
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stripe_transactions\".\"stripe_invoice_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_idempotency_key_unique": {
+          "name": "stripe_transactions_stripe_idempotency_key_unique",
+          "columns": [
+            {
+              "expression": "stripe_idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stripe_transactions\".\"stripe_idempotency_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_user_id_idx": {
+          "name": "stripe_transactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_payment_intent_id_idx": {
+          "name": "stripe_transactions_stripe_payment_intent_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_payment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_charge_id_idx": {
+          "name": "stripe_transactions_stripe_charge_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_coupon_id_idx": {
+          "name": "stripe_transactions_stripe_coupon_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_coupon_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_promotion_code_id_idx": {
+          "name": "stripe_transactions_stripe_promotion_code_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_promotion_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_status_idx": {
+          "name": "stripe_transactions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_created_at_idx": {
+          "name": "stripe_transactions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_user_id_created_at_idx": {
+          "name": "stripe_transactions_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_transactions_user_id_userSetting_id_fk": {
+          "name": "stripe_transactions_user_id_userSetting_id_fk",
+          "tableFrom": "stripe_transactions",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_settings": {
+      "name": "wallet_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_reload_enabled": {
+          "name": "auto_reload_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_reload_mode": {
+          "name": "auto_reload_mode",
+          "type": "auto_reload_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'prediction'"
+        },
+        "auto_reload_threshold": {
+          "name": "auto_reload_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2000
+        },
+        "auto_reload_amount": {
+          "name": "auto_reload_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10000
+        },
+        "last_auto_charge_at": {
+          "name": "last_auto_charge_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_settings_user_id_idx": {
+          "name": "wallet_settings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_settings_wallet_id_user_wallets_id_fk": {
+          "name": "wallet_settings_wallet_id_user_wallets_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "user_wallets",
+          "columnsFrom": [
+            "wallet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wallet_settings_user_id_userSetting_id_fk": {
+          "name": "wallet_settings_user_id_userSetting_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallet_settings_wallet_id_unique": {
+          "name": "wallet_settings_wallet_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wallet_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.userSetting": {
+      "name": "userSetting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscribedToNewsletter": {
+          "name": "subscribedToNewsletter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "youtubeUsername": {
+          "name": "youtubeUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitterUsername": {
+          "name": "twitterUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "githubUsername": {
+          "name": "githubUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_ip": {
+          "name": "last_ip",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_user_agent": {
+          "name": "last_user_agent",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fingerprint": {
+          "name": "last_fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboardingSkippedAt": {
+          "name": "onboardingSkippedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "userSetting_userId_unique": {
+          "name": "userSetting_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        },
+        "userSetting_username_unique": {
+          "name": "userSetting_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.template": {
+      "name": "template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "copiedFromId": {
+          "name": "copiedFromId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cpu": {
+          "name": "cpu",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ram": {
+          "name": "ram",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage": {
+          "name": "storage",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sdl": {
+          "name": "sdl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "template_userId_idx": {
+          "name": "template_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.templateFavorite": {
+      "name": "templateFavorite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "templateId": {
+          "name": "templateId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addedDate": {
+          "name": "addedDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "templateFavorite_userId_templateId_unique": {
+          "name": "templateFavorite_userId_templateId_unique",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "templateId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "templateFavorite_templateId_template_id_fk": {
+          "name": "templateFavorite_templateId_template_id_fk",
+          "tableFrom": "templateFavorite",
+          "tableTo": "template",
+          "columnsFrom": [
+            "templateId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_settings": {
+      "name": "deployment_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dseq": {
+          "name": "dseq",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_top_up_enabled": {
+          "name": "auto_top_up_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closed": {
+          "name": "closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_funded_at": {
+          "name": "last_funded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_limit_hours": {
+          "name": "runtime_limit_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sdl": {
+          "name": "sdl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manifest_version": {
+          "name": "manifest_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_ends_at": {
+          "name": "runtime_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_ending_notified_for": {
+          "name": "runtime_ending_notified_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_unreachable_notified_for": {
+          "name": "provider_unreachable_notified_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "id_auto_top_up_enabled_closed_idx": {
+          "name": "id_auto_top_up_enabled_closed_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auto_top_up_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "closed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_settings_user_id_userSetting_id_fk": {
+          "name": "deployment_settings_user_id_userSetting_id_fk",
+          "tableFrom": "deployment_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dseq_user_id_idx": {
+          "name": "dseq_user_id_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "dseq",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_key": {
+          "name": "hashed_key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_format": {
+          "name": "key_format",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_user_id_userSetting_id_fk": {
+          "name": "api_keys_user_id_userSetting_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_hashed_key_unique": {
+          "name": "api_keys_hashed_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hashed_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_verification_codes": {
+      "name": "email_verification_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_verification_codes_user_id_idx": {
+          "name": "email_verification_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_verification_codes_user_id_userSetting_id_fk": {
+          "name": "email_verification_codes_user_id_userSetting_id_fk",
+          "tableFrom": "email_verification_codes",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.data_keys": {
+      "name": "data_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wrapped_key": {
+          "name": "wrapped_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wrapped_by_kid": {
+          "name": "wrapped_by_kid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "data_keys_wrapped_by_kid_idx": {
+          "name": "data_keys_wrapped_by_kid_idx",
+          "columns": [
+            {
+              "expression": "wrapped_by_kid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "data_keys_user_id_userSetting_id_fk": {
+          "name": "data_keys_user_id_userSetting_id_fk",
+          "tableFrom": "data_keys",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "data_keys_user_id_unique": {
+          "name": "data_keys_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.stripe_transaction_status": {
+      "name": "stripe_transaction_status",
+      "schema": "public",
+      "values": [
+        "created",
+        "pending",
+        "requires_action",
+        "succeeded",
+        "failed",
+        "refunded",
+        "canceled"
+      ]
+    },
+    "public.stripe_transaction_type": {
+      "name": "stripe_transaction_type",
+      "schema": "public",
+      "values": [
+        "payment_intent",
+        "coupon_claim",
+        "manual_credit"
+      ]
+    },
+    "public.auto_reload_mode": {
+      "name": "auto_reload_mode",
+      "schema": "public",
+      "values": [
+        "prediction",
+        "threshold"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -330,6 +330,13 @@
       "when": 1788075327869,
       "tag": "0046_credits_low_recovery_latch",
       "breakpoints": true
+    },
+    {
+      "idx": 47,
+      "version": "7",
+      "when": 1788162567618,
+      "tag": "0047_credits_low_confirm_window",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/billing/config/env.config.ts
+++ b/apps/api/src/billing/config/env.config.ts
@@ -45,6 +45,8 @@ export const envSchema = z.object({
   AUTO_RELOAD_CHARGE_COOLDOWN_IN_MIN: z.number({ coerce: true }).min(0).default(60),
   /** How long credits must keep reading sufficient before the low-credit email unlatches, so a single misread cannot unlatch it. */
   CREDITS_LOW_RECOVERY_CONFIRM_WINDOW_MIN: z.number({ coerce: true }).min(0).default(30),
+  /** How long credits must keep reading low before the email goes out, so a single misread cannot send one. */
+  CREDITS_LOW_CONFIRM_WINDOW_MIN: z.number({ coerce: true }).min(0).default(30),
   MANAGED_WALLET_TRIAL_BLOCKED_GPU_MODELS: z
     .string()
     .default("nvidia/b300,nvidia/b200,nvidia/h200,nvidia/h100,nvidia/pro6000se,nvidia/pro6000we,nvidia/a100,nvidia/rtx5090,nvidia/rtx4090,nvidia/rtx3090")

--- a/apps/api/src/billing/model-schemas/user-wallet/user-wallet.schema.ts
+++ b/apps/api/src/billing/model-schemas/user-wallet/user-wallet.schema.ts
@@ -1,5 +1,6 @@
 import { boolean, numeric, pgTable, serial, timestamp, uuid, varchar } from "drizzle-orm/pg-core";
 
+// eslint-disable-next-line import-x/no-cycle
 import { Users } from "@src/user/model-schemas/user/user.schema";
 
 export const UserWallets = pgTable("user_wallets", {

--- a/apps/api/src/billing/model-schemas/user-wallet/user-wallet.schema.ts
+++ b/apps/api/src/billing/model-schemas/user-wallet/user-wallet.schema.ts
@@ -1,6 +1,5 @@
 import { boolean, numeric, pgTable, serial, timestamp, uuid, varchar } from "drizzle-orm/pg-core";
 
-// eslint-disable-next-line import-x/no-cycle
 import { Users } from "@src/user/model-schemas/user/user.schema";
 
 export const UserWallets = pgTable("user_wallets", {
@@ -16,6 +15,7 @@ export const UserWallets = pgTable("user_wallets", {
   activatedAt: timestamp("activated_at", { withTimezone: true }),
   creditsLowNotifiedAt: timestamp("credits_low_notified_at", { withTimezone: true }),
   creditsSufficientSince: timestamp("credits_sufficient_since", { withTimezone: true }),
+  creditsLowSince: timestamp("credits_low_since", { withTimezone: true }),
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at").defaultNow().notNull()
 });

--- a/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.integration.ts
+++ b/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.integration.ts
@@ -46,7 +46,8 @@ describe(UserWalletRepository.name, () => {
     it("clears the notified stamp once credits have read sufficient for the whole window", async () => {
       const { userWalletRepository, wallet } = await setup({
         creditsLowNotifiedAt: subMinutes(new Date(), 90),
-        creditsSufficientSince: subMinutes(new Date(), 31)
+        creditsSufficientSince: subMinutes(new Date(), 31),
+        creditsLowSince: subMinutes(new Date(), 120)
       });
 
       const isCleared = await userWalletRepository.clearCreditsLowNotifiedIfRecoveryConfirmed(wallet.id, 30);
@@ -55,6 +56,7 @@ describe(UserWalletRepository.name, () => {
       expect(isCleared).toBe(true);
       expect(updated?.creditsLowNotifiedAt).toBeNull();
       expect(updated?.creditsSufficientSince).toBeNull();
+      expect(updated?.creditsLowSince).toBeNull();
     });
 
     it("keeps the notified stamp while the window has not elapsed", async () => {
@@ -99,6 +101,41 @@ describe(UserWalletRepository.name, () => {
     });
   });
 
+  describe("isCreditsLowConfirmed", () => {
+    it("confirms once credits have read low for the whole window", async () => {
+      const { userWalletRepository, wallet } = await setup({ creditsLowSince: subMinutes(new Date(), 31) });
+
+      expect(await userWalletRepository.isCreditsLowConfirmed(wallet.id, 30)).toBe(true);
+    });
+
+    it("withholds confirmation while the window has not elapsed", async () => {
+      const { userWalletRepository, wallet } = await setup({ creditsLowSince: subMinutes(new Date(), 5) });
+
+      expect(await userWalletRepository.isCreditsLowConfirmed(wallet.id, 30)).toBe(false);
+    });
+
+    it("withholds confirmation when no low reading has been recorded", async () => {
+      const { userWalletRepository, wallet } = await setup();
+
+      expect(await userWalletRepository.isCreditsLowConfirmed(wallet.id, 30)).toBe(false);
+    });
+
+    it("withholds confirmation when the wallet was already notified", async () => {
+      const { userWalletRepository, wallet } = await setup({
+        creditsLowNotifiedAt: subMinutes(new Date(), 90),
+        creditsLowSince: subMinutes(new Date(), 91)
+      });
+
+      expect(await userWalletRepository.isCreditsLowConfirmed(wallet.id, 30)).toBe(false);
+    });
+
+    it("confirms immediately when the window is disabled", async () => {
+      const { userWalletRepository, wallet } = await setup({ creditsLowSince: new Date() });
+
+      expect(await userWalletRepository.isCreditsLowConfirmed(wallet.id, 0)).toBe(true);
+    });
+  });
+
   describe("findByAddresses", () => {
     it("returns every wallet matching the given addresses", async () => {
       const first = await setup();
@@ -125,7 +162,7 @@ describe(UserWalletRepository.name, () => {
     });
   });
 
-  async function setup(input: { creditsLowNotifiedAt?: Date; creditsSufficientSince?: Date } = {}) {
+  async function setup(input: { creditsLowNotifiedAt?: Date; creditsSufficientSince?: Date; creditsLowSince?: Date } = {}) {
     const userRepository = container.resolve(UserRepository);
     const userWalletRepository = container.resolve(UserWalletRepository);
 
@@ -133,7 +170,11 @@ describe(UserWalletRepository.name, () => {
     const created = await userWalletRepository.create({ userId: user.id, address: createAkashAddress() });
     const wallet = await userWalletRepository.updateById(
       created.id,
-      { creditsLowNotifiedAt: input.creditsLowNotifiedAt ?? null, creditsSufficientSince: input.creditsSufficientSince ?? null },
+      {
+        creditsLowNotifiedAt: input.creditsLowNotifiedAt ?? null,
+        creditsSufficientSince: input.creditsSufficientSince ?? null,
+        creditsLowSince: input.creditsLowSince ?? null
+      },
       { returning: true }
     );
 

--- a/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.ts
+++ b/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.ts
@@ -119,7 +119,7 @@ export class UserWalletRepository extends BaseRepository<ApiPgTables["UserWallet
     return !!cleared;
   }
 
-  /** Re-reads the window in SQL so a concurrent check that read the credits sufficient still wins by clearing `creditsLowSince`. */
+  /** Re-reads the window in SQL so a concurrent check that already cleared `creditsLowSince` still wins. */
   async isCreditsLowConfirmed(id: UserWalletOutput["id"], confirmWindowMinutes: number): Promise<boolean> {
     const [confirmed] = await this.cursor
       .select({ id: this.table.id })

--- a/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.ts
+++ b/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.ts
@@ -103,7 +103,7 @@ export class UserWalletRepository extends BaseRepository<ApiPgTables["UserWallet
   async clearCreditsLowNotifiedIfRecoveryConfirmed(id: UserWalletOutput["id"], confirmWindowMinutes: number): Promise<boolean> {
     const [cleared] = await this.cursor
       .update(this.table)
-      .set({ creditsLowNotifiedAt: null, creditsSufficientSince: null })
+      .set({ creditsLowNotifiedAt: null, creditsSufficientSince: null, creditsLowSince: null })
       .where(
         this.whereAccessibleBy(
           and(
@@ -117,6 +117,25 @@ export class UserWalletRepository extends BaseRepository<ApiPgTables["UserWallet
       .returning({ id: this.table.id });
 
     return !!cleared;
+  }
+
+  /** Re-reads the window in SQL so a concurrent check that read the credits sufficient still wins by clearing `creditsLowSince`. */
+  async isCreditsLowConfirmed(id: UserWalletOutput["id"], confirmWindowMinutes: number): Promise<boolean> {
+    const [confirmed] = await this.cursor
+      .select({ id: this.table.id })
+      .from(this.table)
+      .where(
+        this.whereAccessibleBy(
+          and(
+            eq(this.table.id, id),
+            isNull(this.table.creditsLowNotifiedAt),
+            isNotNull(this.table.creditsLowSince),
+            lte(this.table.creditsLowSince, sql`now() - ${confirmWindowMinutes}::double precision * interval '1 minute'`)
+          )
+        )
+      );
+
+    return !!confirmed;
   }
 
   async findDrainingWallets(thresholds: { fee: number; trialExpirationDays: number }) {

--- a/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.spec.ts
+++ b/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.spec.ts
@@ -95,7 +95,8 @@ describe(WalletCreditsLowCheckHandler.name, () => {
 
   it("does not send when weekly cost is 0", async () => {
     const { handler, notificationService, userWalletRepository, logger, job } = setup({
-      weeklyCostUsd: 0
+      weeklyCostUsd: 0,
+      creditsLowSince: null
     });
 
     await handler.handle(job);
@@ -109,7 +110,8 @@ describe(WalletCreditsLowCheckHandler.name, () => {
   it("does not send when balance is at or above weekly cost", async () => {
     const { handler, notificationService, userWalletRepository, logger, job } = setup({
       balanceUsd: 35,
-      weeklyCostUsd: 35
+      weeklyCostUsd: 35,
+      creditsLowSince: null
     });
 
     await handler.handle(job);
@@ -131,6 +133,60 @@ describe(WalletCreditsLowCheckHandler.name, () => {
     expect(userWalletRepository.updateById).not.toHaveBeenCalled();
     expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "CREDITS_LOW_CHECK_SKIPPED", reason: "already_notified" }));
     expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("starts the low window instead of sending when credits first read low", async () => {
+    const { handler, notificationService, userWalletRepository, wallet, logger, job } = setup({ creditsLowSince: null });
+
+    await handler.handle(job);
+
+    expect(notificationService.createNotification).not.toHaveBeenCalled();
+    expect(userWalletRepository.updateById).toHaveBeenCalledWith(wallet.id, { creditsLowSince: expect.any(Date) });
+    expect(userWalletRepository.isCreditsLowConfirmed).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "CREDITS_LOW_CHECK_SKIPPED", reason: "low_unconfirmed" }));
+  });
+
+  it("does not send while credits have not read low for the whole confirmation window", async () => {
+    const { handler, notificationService, userWalletRepository, wallet, logger, job } = setup({ isLowConfirmed: false });
+
+    await handler.handle(job);
+
+    expect(notificationService.createNotification).not.toHaveBeenCalled();
+    expect(userWalletRepository.isCreditsLowConfirmed).toHaveBeenCalledWith(wallet.id, 30);
+    expect(userWalletRepository.updateById).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "CREDITS_LOW_CHECK_SKIPPED", reason: "low_unconfirmed" }));
+  });
+
+  it("sends once credits have read low for the whole confirmation window", async () => {
+    const { handler, notificationService, userWalletRepository, wallet, job } = setup({ confirmWindowMinutes: 45 });
+
+    await handler.handle(job);
+
+    expect(userWalletRepository.isCreditsLowConfirmed).toHaveBeenCalledWith(wallet.id, 45);
+    expect(notificationService.createNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it("restarts the low window when credits read sufficient before the email goes out", async () => {
+    const { handler, notificationService, userWalletRepository, wallet, logger, job } = setup({
+      balanceUsd: 40,
+      weeklyCostUsd: 35
+    });
+
+    await handler.handle(job);
+
+    expect(notificationService.createNotification).not.toHaveBeenCalled();
+    expect(userWalletRepository.updateById).toHaveBeenCalledWith(wallet.id, { creditsLowSince: null });
+    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "CREDITS_LOW_CHECK_SKIPPED", reason: "sufficient_balance" }));
+  });
+
+  it("keeps the low window running when the wallet is already notified", async () => {
+    const { handler, userWalletRepository, job } = setup({
+      creditsLowNotifiedAt: new Date("2026-01-01T00:00:00.000Z")
+    });
+
+    await handler.handle(job);
+
+    expect(userWalletRepository.isCreditsLowConfirmed).not.toHaveBeenCalled();
   });
 
   it("starts the recovery window instead of clearing creditsLowNotifiedAt when the balance first reads recovered", async () => {
@@ -169,7 +225,11 @@ describe(WalletCreditsLowCheckHandler.name, () => {
 
     await handler.handle(job);
 
-    expect(userWalletRepository.updateById).toHaveBeenCalledWith(wallet.id, { creditsLowNotifiedAt: null, creditsSufficientSince: null });
+    expect(userWalletRepository.updateById).toHaveBeenCalledWith(wallet.id, {
+      creditsLowNotifiedAt: null,
+      creditsSufficientSince: null,
+      creditsLowSince: null
+    });
     expect(userWalletRepository.clearCreditsLowNotifiedIfRecoveryConfirmed).not.toHaveBeenCalled();
     expect(logger.info).toHaveBeenCalledWith({ event: "CREDITS_LOW_NOTIFIED_CLEARED", userId: user.id, reason: "zero_cost" });
   });
@@ -266,7 +326,11 @@ describe(WalletCreditsLowCheckHandler.name, () => {
     await handler.handle(job);
 
     expect(notificationService.createNotification).toHaveBeenCalled();
-    expect(userWalletRepository.updateById).toHaveBeenCalledWith(wallet.id, { creditsLowNotifiedAt: expect.any(Date), creditsSufficientSince: null });
+    expect(userWalletRepository.updateById).toHaveBeenCalledWith(wallet.id, {
+      creditsLowNotifiedAt: expect.any(Date),
+      creditsSufficientSince: null,
+      creditsLowSince: null
+    });
     expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "CREDITS_LOW_EMAIL_SENT" }));
   });
 
@@ -280,7 +344,8 @@ describe(WalletCreditsLowCheckHandler.name, () => {
     expect(notificationService.createNotification).toHaveBeenCalled();
     expect(userWalletRepository.updateById).toHaveBeenCalledWith(expect.any(Number), {
       creditsLowNotifiedAt: expect.any(Date),
-      creditsSufficientSince: null
+      creditsSufficientSince: null,
+      creditsLowSince: null
     });
   });
 
@@ -296,6 +361,8 @@ describe(WalletCreditsLowCheckHandler.name, () => {
     isTrialing?: boolean;
     creditsLowNotifiedAt?: Date | null;
     creditsSufficientSince?: Date | null;
+    creditsLowSince?: Date | null;
+    isLowConfirmed?: boolean;
     user?: ReturnType<typeof createUser>;
     balanceUsd?: number;
     weeklyCostUsd?: number;
@@ -309,7 +376,8 @@ describe(WalletCreditsLowCheckHandler.name, () => {
       userId: user.id,
       isTrialing: input?.isTrialing ?? false,
       creditsLowNotifiedAt: input?.creditsLowNotifiedAt ?? null,
-      creditsSufficientSince: input?.creditsSufficientSince ?? null
+      creditsSufficientSince: input?.creditsSufficientSince ?? null,
+      creditsLowSince: input?.creditsLowSince === undefined ? new Date("2026-01-01T00:00:00.000Z") : input.creditsLowSince
     });
     const walletSetting = generateWalletSetting({
       userId: user.id,
@@ -336,7 +404,8 @@ describe(WalletCreditsLowCheckHandler.name, () => {
     });
     const billingConfig = mockConfigService<BillingConfigService>({
       CONSOLE_WEB_PAYMENT_LINK: paymentLink,
-      CREDITS_LOW_RECOVERY_CONFIRM_WINDOW_MIN: input?.confirmWindowMinutes ?? 30
+      CREDITS_LOW_RECOVERY_CONFIRM_WINDOW_MIN: input?.confirmWindowMinutes ?? 30,
+      CREDITS_LOW_CONFIRM_WINDOW_MIN: input?.confirmWindowMinutes ?? 30
     });
     const logger = mock<ReturnType<CreateLogger>>();
     const createLogger = vi.fn<CreateLogger>(() => logger);
@@ -353,6 +422,7 @@ describe(WalletCreditsLowCheckHandler.name, () => {
     });
     userWalletRepository.updateById.mockResolvedValue(undefined);
     userWalletRepository.clearCreditsLowNotifiedIfRecoveryConfirmed.mockResolvedValue(false);
+    userWalletRepository.isCreditsLowConfirmed.mockResolvedValue(input?.isLowConfirmed ?? true);
 
     const handler = new WalletCreditsLowCheckHandler(
       walletSettingRepository,

--- a/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.ts
+++ b/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.ts
@@ -10,7 +10,7 @@ import { NotificationService } from "@src/notifications/services/notification/no
 import { creditsRunningLowNotification } from "@src/notifications/services/notification-templates/credits-running-low-notification";
 import { type UserOutput, UserRepository } from "@src/user/repositories";
 
-type SkipReason = "auto_reload_enabled" | "no_wallet" | "trialing" | "no_email" | "zero_cost" | "sufficient_balance" | "already_notified";
+type SkipReason = "auto_reload_enabled" | "no_wallet" | "trialing" | "no_email" | "zero_cost" | "sufficient_balance" | "already_notified" | "low_unconfirmed";
 
 type NotLowReason = Extract<SkipReason, "zero_cost" | "sufficient_balance">;
 
@@ -67,6 +67,11 @@ export class WalletCreditsLowCheckHandler implements JobHandler<WalletCreditsLow
       return;
     }
 
+    if (!(await this.#isLowStreakConfirmed(wallet))) {
+      this.#skip("low_unconfirmed", payload.userId);
+      return;
+    }
+
     const paymentLink = this.billingConfig.get("CONSOLE_WEB_PAYMENT_LINK");
     const daysRemaining = cumulativeDailyCostsUsd.filter(costUsd => costUsd <= balanceUsd).length;
 
@@ -98,10 +103,20 @@ export class WalletCreditsLowCheckHandler implements JobHandler<WalletCreditsLow
    */
   async #stampNotified(wallet: UserWalletOutput, userId: UserOutput["id"]): Promise<void> {
     try {
-      await this.userWalletRepository.updateById(wallet.id, { creditsLowNotifiedAt: new Date(), creditsSufficientSince: null });
+      await this.userWalletRepository.updateById(wallet.id, { creditsLowNotifiedAt: new Date(), creditsSufficientSince: null, creditsLowSince: null });
     } catch (error) {
       this.logger.error({ event: "CREDITS_LOW_NOTIFIED_STAMP_FAILED", userId, error });
     }
+  }
+
+  /** Mirrors the recovery latch on the sending side: a lone low reading only opens the window, so one misread cannot send an email by itself. */
+  async #isLowStreakConfirmed(wallet: UserWalletOutput): Promise<boolean> {
+    if (!wallet.creditsLowSince) {
+      await this.userWalletRepository.updateById(wallet.id, { creditsLowSince: new Date() });
+      return false;
+    }
+
+    return await this.userWalletRepository.isCreditsLowConfirmed(wallet.id, this.billingConfig.get("CREDITS_LOW_CONFIRM_WINDOW_MIN"));
   }
 
   async #getValidWalletResources(userId: UserOutput["id"]) {
@@ -139,12 +154,13 @@ export class WalletCreditsLowCheckHandler implements JobHandler<WalletCreditsLow
     { canUnlatchImmediately }: { canUnlatchImmediately: boolean }
   ): Promise<void> {
     if (!wallet.creditsLowNotifiedAt) {
+      await this.#endLowStreak(wallet);
       this.#skip(reason, userId);
       return;
     }
 
     if (canUnlatchImmediately) {
-      await this.userWalletRepository.updateById(wallet.id, { creditsLowNotifiedAt: null, creditsSufficientSince: null });
+      await this.userWalletRepository.updateById(wallet.id, { creditsLowNotifiedAt: null, creditsSufficientSince: null, creditsLowSince: null });
       this.logger.info({ event: "CREDITS_LOW_NOTIFIED_CLEARED", userId, reason });
       this.#skip(reason, userId);
       return;
@@ -174,6 +190,14 @@ export class WalletCreditsLowCheckHandler implements JobHandler<WalletCreditsLow
     }
 
     await this.userWalletRepository.updateById(wallet.id, { creditsSufficientSince: null });
+  }
+
+  async #endLowStreak(wallet: UserWalletOutput): Promise<void> {
+    if (!wallet.creditsLowSince) {
+      return;
+    }
+
+    await this.userWalletRepository.updateById(wallet.id, { creditsLowSince: null });
   }
 
   #skip(reason: SkipReason, userId: UserOutput["id"]): void {

--- a/apps/api/src/billing/services/wallet-settings/wallet-settings.service.spec.ts
+++ b/apps/api/src/billing/services/wallet-settings/wallet-settings.service.spec.ts
@@ -40,7 +40,11 @@ describe(WalletSettingService.name, () => {
         { withCleanup: true }
       );
       expect(walletReloadJobService.cancelCreditsLowCheckByUserId).toHaveBeenCalledWith(user.id);
-      expect(userWalletRepository.updateById).toHaveBeenCalledWith(enabledSetting.walletId, { creditsLowNotifiedAt: null, creditsSufficientSince: null });
+      expect(userWalletRepository.updateById).toHaveBeenCalledWith(enabledSetting.walletId, {
+        creditsLowNotifiedAt: null,
+        creditsSufficientSince: null,
+        creditsLowSince: null
+      });
     });
 
     it("enqueues a credits-low check when Auto Recharge is disabled", async () => {

--- a/apps/api/src/billing/services/wallet-settings/wallet-settings.service.ts
+++ b/apps/api/src/billing/services/wallet-settings/wallet-settings.service.ts
@@ -144,7 +144,7 @@ export class WalletSettingService {
       if (!prev?.autoReloadEnabled) {
         await this.walletReloadJobService.scheduleForWalletSetting(next, { withCleanup: true });
         await this.walletReloadJobService.cancelCreditsLowCheckByUserId(next.userId);
-        await this.userWalletRepository.updateById(next.walletId, { creditsLowNotifiedAt: null, creditsSufficientSince: null });
+        await this.userWalletRepository.updateById(next.walletId, { creditsLowNotifiedAt: null, creditsSufficientSince: null, creditsLowSince: null });
         return;
       }
 

--- a/apps/api/src/deployment/services/stale-managed-deployments-cleaner/stale-managed-deployments-cleaner.service.spec.ts
+++ b/apps/api/src/deployment/services/stale-managed-deployments-cleaner/stale-managed-deployments-cleaner.service.spec.ts
@@ -44,6 +44,14 @@ describe(StaleManagedDeploymentsCleanerService.name, () => {
       expect(deploymentRepository.findStaleDeployments).toHaveBeenCalledWith({ owner: wallet.address, createdHeight: 1_000_000 });
     });
 
+    it("reads the chain height itself when called for a single wallet", async () => {
+      const { service, blockRepository, wallet } = setup();
+
+      await service.cleanUpForWallet(wallet, 0);
+
+      expect(blockRepository.getLatestProcessedHeight).toHaveBeenCalledTimes(1);
+    });
+
     it("does not broadcast when there are no stale deployments", async () => {
       const { service, managedSignerService, wallet } = setup({ staleDeployments: [] });
 
@@ -99,6 +107,25 @@ describe(StaleManagedDeploymentsCleanerService.name, () => {
       expect(logger.error).toHaveBeenCalledWith(UNSETTLEABLE_LOG);
     });
 
+    it("reads the chain height once for the whole sweep", async () => {
+      const { service, blockRepository, deploymentRepository } = setup({ pages: 4, walletsPerPage: 3 });
+
+      await service.cleanup({ concurrency: 3 });
+
+      expect(blockRepository.getLatestProcessedHeight).toHaveBeenCalledTimes(1);
+      expect(deploymentRepository.findStaleDeployments).toHaveBeenCalledTimes(12);
+    });
+
+    it("screens every wallet against the same cutoff", async () => {
+      const { service, deploymentRepository } = setup({ currentHeight: 1_000_000, pages: 3, walletsPerPage: 2 });
+
+      await service.cleanup({ concurrency: 2 });
+
+      const cutoffs = new Set(deploymentRepository.findStaleDeployments.mock.calls.map(([{ createdHeight }]) => createdHeight));
+      expect(cutoffs.size).toBe(1);
+      expect([...cutoffs][0]).toBeLessThan(1_000_000);
+    });
+
     it("rethrows unrelated errors into the wallet error handler without retrying", async () => {
       const unexpectedError = new Error("some unexpected failure");
       const { service, managedSignerService, managedUserWalletService, logger, errorLogger } = setup({
@@ -130,12 +157,26 @@ describe(StaleManagedDeploymentsCleanerService.name, () => {
     expect(createErrorLogger).toHaveBeenCalledWith({ context: ErrorService.name });
   });
 
-  function setup(input?: { currentHeight?: number; staleDeployments?: { dseq: number }[]; executeDerivedTx?: ManagedSignerService["executeDerivedTx"] }) {
+  function setup(input?: {
+    currentHeight?: number;
+    staleDeployments?: { dseq: number }[];
+    executeDerivedTx?: ManagedSignerService["executeDerivedTx"];
+    pages?: number;
+    walletsPerPage?: number;
+  }) {
     const wallet = createUserWallet({ id: 123, address: "akash1test" });
+
+    const walletPages = Array.from({ length: input?.pages ?? 1 }, (_, page) =>
+      Array.from({ length: input?.walletsPerPage ?? 1 }, (_, index) =>
+        page === 0 && index === 0 ? wallet : createUserWallet({ id: 1000 + page * 10 + index, address: `akash1owner${page}${index}` })
+      )
+    );
 
     const userWalletRepository = mock<UserWalletRepository>({
       paginate: vi.fn(async (_options, cb) => {
-        await cb([wallet]);
+        for (const page of walletPages) {
+          await cb(page);
+        }
       }) as UserWalletRepository["paginate"]
     });
     const deploymentRepository = mock<DeploymentRepository>();

--- a/apps/api/src/deployment/services/stale-managed-deployments-cleaner/stale-managed-deployments-cleaner.service.ts
+++ b/apps/api/src/deployment/services/stale-managed-deployments-cleaner/stale-managed-deployments-cleaner.service.ts
@@ -36,6 +36,8 @@ export class StaleManagedDeploymentsCleanerService {
   }
 
   async cleanup(options: CleanUpStaleDeploymentsParams) {
+    const staleBeforeHeight = await this.#resolveStaleBeforeHeight(this.MAX_LIVE_BLOCKS);
+
     await this.userWalletRepository.paginate({ limit: options.concurrency || 10 }, async wallets => {
       const cleanUpAllWallets = wallets.map(async wallet => {
         await this.errorService.execWithErrorHandler(
@@ -44,7 +46,7 @@ export class StaleManagedDeploymentsCleanerService {
             event: "DEPLOYMENT_CLEAN_UP_ERROR",
             context: StaleManagedDeploymentsCleanerService.name
           },
-          () => this.cleanUpForWallet(wallet)
+          () => this.#closeLeaselessDeployments(wallet, staleBeforeHeight)
         );
       });
 
@@ -53,10 +55,18 @@ export class StaleManagedDeploymentsCleanerService {
   }
 
   async cleanUpForWallet(wallet: UserWalletOutput, maxLiveBlocks: number = this.MAX_LIVE_BLOCKS) {
-    const currentHeight = await this.blockRepository.getLatestProcessedHeight();
+    await this.#closeLeaselessDeployments(wallet, await this.#resolveStaleBeforeHeight(maxLiveBlocks));
+  }
+
+  /** Read once per sweep instead of per wallet: the tip is the same for every one of them, and the sweep walks the whole managed-wallet table. */
+  async #resolveStaleBeforeHeight(maxLiveBlocks: number): Promise<number> {
+    return (await this.blockRepository.getLatestProcessedHeight()) - maxLiveBlocks;
+  }
+
+  async #closeLeaselessDeployments(wallet: UserWalletOutput, staleBeforeHeight: number) {
     const deployments = await this.deploymentRepository.findStaleDeployments({
       owner: wallet.address!,
-      createdHeight: currentHeight - maxLiveBlocks
+      createdHeight: staleBeforeHeight
     });
 
     const messages = deployments.map(deployment => this.rpcMessageService.getCloseDeploymentMsg(wallet.address!, deployment.dseq));

--- a/apps/api/test/seeders/user-wallet.seeder.ts
+++ b/apps/api/test/seeders/user-wallet.seeder.ts
@@ -14,7 +14,8 @@ export function createUserWallet({
   updatedAt = faker.date.past(),
   activatedAt = createdAt,
   creditsLowNotifiedAt = null,
-  creditsSufficientSince = null
+  creditsSufficientSince = null,
+  creditsLowSince = null
 }: Partial<UserWalletOutput> = {}): UserWalletOutput {
   return {
     id,
@@ -28,7 +29,8 @@ export function createUserWallet({
     updatedAt,
     activatedAt,
     creditsLowNotifiedAt,
-    creditsSufficientSince
+    creditsSufficientSince,
+    creditsLowSince
   };
 }
 

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -5,12 +5,7 @@ import path from "node:path";
 const gitRoot = process.cwd();
 
 /**
- * Nearest ancestor (including the file's own directory) that owns an
- * eslint.config.mjs, defaulting to the repo root. lint-staged runs from the git
- * root, but flat config resolves a single config from cwd — so each staged file is
- * linted against its owning config to keep app-local rules and parser options
- * (e.g. decorator metadata for DI) authoritative, exactly as `npm run lint` does
- * inside that workspace.
+ * Nearest ancestor (including the file's own directory) that owns an eslint.config.mjs, defaulting to the repo root.
  */
 function findOwningEslintConfig(absoluteFile) {
   let dir = path.dirname(absoluteFile);
@@ -25,13 +20,23 @@ function findOwningEslintConfig(absoluteFile) {
 
 const toArg = file => JSON.stringify(path.relative(gitRoot, file));
 
+const eslintBin = path.join(gitRoot, "node_modules", ".bin", "eslint");
+
+/**
+ * Runs eslint from the owning config's directory because the shared import resolver reads `./tsconfig.json` relative to
+ * cwd, so linting from the git root stops resolving `@src` aliases and silently drops every rule that follows them.
+ */
 function eslintCommandsByOwningConfig(files) {
   const filesByConfig = new Map();
   for (const file of files) {
     const config = findOwningEslintConfig(file);
     filesByConfig.set(config, [...(filesByConfig.get(config) ?? []), file]);
   }
-  return [...filesByConfig].map(([config, group]) => `eslint --fix --quiet --config ${toArg(config)} ${group.map(toArg).join(" ")}`);
+  return [...filesByConfig].map(([config, group]) => {
+    const configDir = path.dirname(config);
+    const args = group.map(file => JSON.stringify(path.relative(configDir, file))).join(" ");
+    return `sh -c 'bin="$1"; cd "$2" || exit 1; shift 2; exec "$bin" --fix --quiet "$@"' sh ${JSON.stringify(eslintBin)} ${JSON.stringify(configDir)} ${args}`;
+  });
 }
 
 export default {


### PR DESCRIPTION
## Why

Ref CON-917. #3728 cut low-credit email volume by 82% in production, but it only made the latch harder to *clear*. The send side still fires on a single coverage reading, so one misread still sends a real email.

Measured over matched 18h40m windows either side of the #3728 deploy (2026-08-30 12:41Z):

|  | before #3728 | after #3728 |
| -- | -- | -- |
| Emails | 44 | 8 |
| Distinct users | 8 | 5 |
| Emails per user | 5.5 | 1.6 |
| Emails per 100 checks | 3.11 | 0.95 |

One wallet accounts for 4 of the 8 remaining emails, on a clean ~4h cycle:

```
00:05:25  EMAIL_SENT                  bal=29.07  cost=41.42
00:05:49  SKIPPED sufficient_balance            <- 24s later, opposite verdict
01:04:05  NOTIFIED_CLEARED                      <- ~58 min of confirmed recovery
04:05:31  EMAIL_SENT                  bal=29.07  cost=41.42
04:05:41  SKIPPED sufficient_balance            <- 10s later
05:03:48  NOTIFIED_CLEARED
```

That wallet logged 15 `sufficient_balance` skips and **zero** `already_notified`, which is the signature: the latch is never still set when the next low verdict arrives, so a longer recovery window cannot help. The asymmetry is the defect. Unlatching demands 30 minutes of confirmed recovery; sending demands one sample.

This still misses the CON-896 acceptance criterion "A user still gets exactly one low-credit email per low period."

## What

Mirrors the existing recovery latch on the sending side.

- New `user_wallets.credits_low_since` column (migration `0047`) and `CREDITS_LOW_CONFIRM_WINDOW_MIN`, default 30 min to match `CREDITS_LOW_RECOVERY_CONFIRM_WINDOW_MIN`.
- The first low reading stamps `creditsLowSince` and skips with a new `low_unconfirmed` reason. The email goes out only once credits have kept reading low for the whole window.
- Any not-low reading ends the low streak, so an isolated blip cannot accumulate toward a send.
- `UserWalletRepository.isCreditsLowConfirmed` re-reads the window in SQL, so a concurrent check that saw the credits sufficient still wins by clearing `creditsLowSince`. Same reasoning as `clearCreditsLowNotifiedIfRecoveryConfirmed`.
- Every path that resets the latch (`#stampNotified`, the immediate unlatch, the confirmed-recovery clear, and enabling Auto Recharge) now also clears `creditsLowSince`.

Send-then-stamp ordering is unchanged, so a stamp failure after a successful send still cannot resend the email.

**Trade-off:** a genuinely low wallet now waits for a second confirming check, so its first email arrives up to one sweep (~1h) later than today. That is the intended cost of not emailing on a single sample, and it applies uniformly rather than exempting `daysRemaining: 0` wallets, whose coverage readings are the wildest of all (one read `bal=5 / cost=1280.45`).

The underlying coverage instability is not fixed here, only made unable to send mail on its own. `credits_low_since` and the `low_unconfirmed` skip reason make the suppression measurable in production.

**Migration:** one nullable column added to `user_wallets`, no backfill, no lock concern.

## Tests

- 5 new unit tests on the handler (window start, window not elapsed, send after the window, streak restart on recovery, no window check while notified), plus existing expectations updated for the new reset field. 24 pass.
- 5 new integration tests on `isCreditsLowConfirmed` covering elapsed, not elapsed, no reading, already notified, and a disabled window.
- Full `apps/api` unit suite: 2142 pass. `npx tsc --noEmit`: no new errors vs `main`. `npm run lint -- --quiet`: clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a configurable confirmation window before low-credit notifications are sent, defaulting to 30 minutes.
  - Wallets now track how long balances have remained below the credit threshold.

- **Bug Fixes**
  - Low-credit status resets correctly after balance recovery, notification resets, or enabling Auto Recharge.
  - Stale deployment cleanup now uses a consistent blockchain height throughout each cleanup sweep.

- **Tests**
  - Expanded coverage for confirmation timing, recovery, notification suppression, wallet resets, and deployment cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->