### PR TITLE
fix(deployment): refresh the runtime limit once the lease anchors its deadline

### DIFF
--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.tsx
@@ -73,7 +73,7 @@ export const DeploymentDetailHeader: FC<DeploymentDetailHeaderProps> = ({ deploy
   const { isTrialing } = d.useWallet();
   const isEscrowAbstracted = d.useIsEscrowAbstracted();
   const { balanceUdenom, denom } = d.useDeploymentEscrowBalance({ deployment, leases });
-  const { data: settings } = d.useDeploymentSettingQuery({ dseq: deployment.dseq });
+  const { data: settings } = d.useDeploymentSettingQuery({ dseq: deployment.dseq, pollUntilRuntimeAnchored: true });
   const teeTypes = d.useDeclaredTeeTypes(deployment);
   const interconnect = d.useDeclaredGpuInterconnect(deployment);
 

--- a/apps/deploy-web/src/components/shared/TrialDeploymentBadge.spec.tsx
+++ b/apps/deploy-web/src/components/shared/TrialDeploymentBadge.spec.tsx
@@ -124,6 +124,18 @@ describe("TrialDeploymentBadge", () => {
     expect(badge?.closest("div")).toBeInTheDocument();
   });
 
+  it("carries the info tone while the trial runs, so it reads apart from the status and capability badges beside it", () => {
+    setup({ blockHeight: 10000720 });
+
+    expect(screen.getByTestId("badge")).toHaveAttribute("data-variant", "info");
+  });
+
+  it("switches to the destructive tone once the trial expires", () => {
+    setup({ blockHeight: 10002880 });
+
+    expect(screen.getByTestId("badge")).toHaveAttribute("data-variant", "destructive");
+  });
+
   function setup(input: { blockHeight: number; trialDurationHours?: number; averageBlockTime?: number; className?: string; createdHeight?: number }) {
     const mockUseTrialTimeRemaining = mockFn<
       () => {
@@ -154,7 +166,7 @@ describe("TrialDeploymentBadge", () => {
       className: input.className,
       dependencies: {
         ...TRIAL_BADGE_DEPENDENCIES,
-        Badge: ComponentMock,
+        Badge: BadgeMock,
         CustomTooltip: ComponentMock,
         TrialDeploymentTooltip: ComponentMock,
         useTrialTimeRemaining: mockUseTrialTimeRemaining
@@ -164,3 +176,11 @@ describe("TrialDeploymentBadge", () => {
     render(<TrialDeploymentBadge {...props} />);
   }
 });
+
+function BadgeMock({ variant, children }: React.ComponentProps<typeof TRIAL_BADGE_DEPENDENCIES.Badge>) {
+  return (
+    <div data-testid="badge" data-variant={variant}>
+      {children}
+    </div>
+  );
+}

--- a/apps/deploy-web/src/components/shared/TrialDeploymentBadge.tsx
+++ b/apps/deploy-web/src/components/shared/TrialDeploymentBadge.tsx
@@ -40,7 +40,7 @@ export function TrialDeploymentBadge({ createdHeight, trialDurationHours, averag
       }
     >
       <div className="inline-flex items-center gap-1">
-        <d.Badge variant={isExpired ? "destructive" : "default"} className={cn("inline-flex cursor-help items-center gap-1", className)}>
+        <d.Badge variant={isExpired ? "destructive" : "info"} className={cn("inline-flex cursor-help items-center gap-1", className)}>
           <span>Trial</span>
           <Info className="h-3 w-3" />
         </d.Badge>

--- a/apps/deploy-web/src/hooks/useAutoTopUp/useAutoTopUp.ts
+++ b/apps/deploy-web/src/hooks/useAutoTopUp/useAutoTopUp.ts
@@ -58,7 +58,7 @@ export function useAutoTopUp({ deployment, leases, onDeposited, dependencies: d 
   const { confirm } = d.usePopup();
   const formatCurrency = d.useCurrencyFormatter();
   const { udenomToUsd } = d.usePricing();
-  const deploymentSetting = d.useDeploymentSettingQuery({ dseq: deployment.dseq });
+  const deploymentSetting = d.useDeploymentSettingQuery({ dseq: deployment.dseq, pollUntilRuntimeAnchored: true });
   const { realTimeLeft, deploymentCost } = d.useDeploymentMetrics({ deployment, leases });
 
   const escrowDenom = getEscrowDenom(deployment);

--- a/apps/deploy-web/src/hooks/useTickingNow.spec.ts
+++ b/apps/deploy-web/src/hooks/useTickingNow.spec.ts
@@ -39,6 +39,26 @@ describe(useTickingNow.name, () => {
     }
   });
 
+  it("reads the clock again when enabling, so a deadline that lands mid-session is not measured against the mount-time clock", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-21T12:00:00.000Z"));
+
+    try {
+      const { result, rerender } = renderHook(({ enabled }) => useTickingNow(enabled), { initialProps: { enabled: false } });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+      });
+      await act(async () => {
+        rerender({ enabled: true });
+      });
+
+      expect(result.current).toBe(new Date("2026-08-21T12:05:00.000Z").getTime());
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("stops ticking once disabled", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-08-21T12:00:00.000Z"));

--- a/apps/deploy-web/src/hooks/useTickingNow.ts
+++ b/apps/deploy-web/src/hooks/useTickingNow.ts
@@ -21,8 +21,8 @@ export const DEFAULT_TICK_INTERVAL_MS = 60_000;
  *
  * Behavior:
  * - While disabled there is no interval and no re-renders; the returned time holds at the last value (the
- *   mount-time clock, or the final tick before disabling) — safe, because disabled means nothing on screen
- *   depends on the clock.
+ *   mount-time clock, or the final tick before disabling). Enabling reads the clock again before the first
+ *   tick, so a deadline that lands mid-session is measured against the real current time.
  * - The effect re-subscribes whenever `enabled` or `intervalMs` changes and always clears its interval on
  *   unmount, so switching deadlines or navigating away never leaks a timer.
  * - Ticks land on interval boundaries relative to subscription, not wall-clock minutes; exact alignment does
@@ -44,6 +44,8 @@ export function useTickingNow(enabled: boolean, intervalMs = DEFAULT_TICK_INTERV
   useEffect(
     function tickWhileEnabled() {
       if (!enabled) return;
+
+      setNow(Date.now());
       const interval = setInterval(function advanceNow() {
         setNow(Date.now());
       }, intervalMs);

--- a/apps/deploy-web/src/queries/deploymentSettingsQuery.spec.ts
+++ b/apps/deploy-web/src/queries/deploymentSettingsQuery.spec.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import { getRuntimeAnchorPollInterval, RUNTIME_ANCHOR_POLL_MS, useDeploymentSettingQuery } from "./deploymentSettingsQuery";
+import { QueryKeys } from "./queryKeys";
 
 import { act } from "@testing-library/react";
 import { setupQuery } from "@tests/unit/query-client";
@@ -126,6 +127,29 @@ describe("useDeploymentSettingQuery", () => {
         expect(result.current.data?.autoTopUpEnabled).toBe(true);
       });
       expect(deploymentSettingService.updateByDseq).toHaveBeenCalledWith(dseq, { autoTopUpEnabled: true });
+    });
+  });
+
+  it("drops an in-flight settings fetch before writing an update, so a slow poll cannot restore the pre-update snapshot", async () => {
+    const dseq = faker.string.numeric(6);
+    const deploymentSettingService = mock<DeploymentSettingHttpService>({
+      findByDseq: vi.fn().mockResolvedValue(buildDeploymentSetting({ dseq, runtimeLimitHours: 2, runtimeEndsAt: null })),
+      updateByDseq: vi.fn().mockResolvedValue(buildDeploymentSetting({ dseq, runtimeLimitHours: null }))
+    });
+    const queryClient = new QueryClient();
+    const cancelQueries = vi.spyOn(queryClient, "cancelQueries");
+
+    const { result } = setup({
+      dseq,
+      services: { deploymentSetting: () => deploymentSettingService, queryClient: () => queryClient }
+    });
+
+    await act(async () => {
+      result.current.update({ runtimeLimitHours: null });
+    });
+
+    await vi.waitFor(() => {
+      expect(cancelQueries).toHaveBeenCalledWith({ queryKey: QueryKeys.getDeploymentSettingKey(dseq) });
     });
   });
 

--- a/apps/deploy-web/src/queries/deploymentSettingsQuery.spec.ts
+++ b/apps/deploy-web/src/queries/deploymentSettingsQuery.spec.ts
@@ -80,7 +80,11 @@ describe("useDeploymentSettingQuery", () => {
           .mockResolvedValueOnce(buildDeploymentSetting({ dseq, runtimeLimitHours: 2, runtimeEndsAt: null }))
           .mockResolvedValue(anchored);
 
-        const { result } = setup({ dseq, services: { deploymentSetting: () => mock<DeploymentSettingHttpService>({ findByDseq }) } });
+        const { result } = setup({
+          dseq,
+          pollUntilRuntimeAnchored: true,
+          services: { deploymentSetting: () => mock<DeploymentSettingHttpService>({ findByDseq }) }
+        });
 
         await act(async () => {
           await vi.advanceTimersByTimeAsync(0);
@@ -91,6 +95,25 @@ describe("useDeploymentSettingQuery", () => {
           await vi.advanceTimersByTimeAsync(RUNTIME_ANCHOR_POLL_MS * 2);
         });
         expect(result.current.data?.runtimeEndsAt).toBe(anchored.runtimeEndsAt);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("stays idle for a caller that renders no deadline, so a configure page holding a stored limit does not fetch in the background", async () => {
+      vi.useFakeTimers();
+
+      try {
+        const dseq = faker.string.numeric(6);
+        const findByDseq = vi.fn().mockResolvedValue(buildDeploymentSetting({ dseq, runtimeLimitHours: 2, runtimeEndsAt: null }));
+
+        setup({ dseq, services: { deploymentSetting: () => mock<DeploymentSettingHttpService>({ findByDseq }) } });
+
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(RUNTIME_ANCHOR_POLL_MS * 4);
+        });
+
+        expect(findByDseq).toHaveBeenCalledTimes(1);
       } finally {
         vi.useRealTimers();
       }
@@ -153,8 +176,8 @@ describe("useDeploymentSettingQuery", () => {
     });
   });
 
-  function setup(input: { dseq: string; services?: Record<string, () => unknown> }) {
-    return setupQuery(() => useDeploymentSettingQuery({ dseq: input.dseq }), {
+  function setup(input: { dseq: string; pollUntilRuntimeAnchored?: boolean; services?: Record<string, () => unknown> }) {
+    return setupQuery(() => useDeploymentSettingQuery({ dseq: input.dseq, pollUntilRuntimeAnchored: input.pollUntilRuntimeAnchored }), {
       services: {
         deploymentSetting: () => mock<DeploymentSettingHttpService>(),
         ...input.services

--- a/apps/deploy-web/src/queries/deploymentSettingsQuery.spec.ts
+++ b/apps/deploy-web/src/queries/deploymentSettingsQuery.spec.ts
@@ -4,7 +4,7 @@ import { QueryClient } from "@tanstack/react-query";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
-import { useDeploymentSettingQuery } from "./deploymentSettingsQuery";
+import { getRuntimeAnchorPollInterval, RUNTIME_ANCHOR_POLL_MS, useDeploymentSettingQuery } from "./deploymentSettingsQuery";
 
 import { act } from "@testing-library/react";
 import { setupQuery } from "@tests/unit/query-client";
@@ -36,6 +36,63 @@ describe("useDeploymentSettingQuery", () => {
 
       expect(result.current.data).toBeUndefined();
       expect(deploymentSettingService.findByDseq).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("polling until the runtime limit is anchored", () => {
+    it("polls while a runtime limit has no deadline yet, since the lease anchors it server-side after this page loads", () => {
+      const setting = buildDeploymentSetting({ dseq: "1", runtimeLimitHours: 2, runtimeEndsAt: null });
+
+      expect(getRuntimeAnchorPollInterval(setting, false)).toBe(RUNTIME_ANCHOR_POLL_MS);
+    });
+
+    it("stops polling once the deadline lands", () => {
+      const setting = buildDeploymentSetting({ dseq: "1", runtimeLimitHours: 2, runtimeEndsAt: faker.date.future().toISOString() });
+
+      expect(getRuntimeAnchorPollInterval(setting, false)).toBe(false);
+    });
+
+    it("never polls a deployment that has no runtime limit to anchor", () => {
+      const setting = buildDeploymentSetting({ dseq: "1" });
+
+      expect(getRuntimeAnchorPollInterval(setting, false)).toBe(false);
+    });
+
+    it("stops polling after a failed fetch, so a persistent error does not retry forever", () => {
+      const setting = buildDeploymentSetting({ dseq: "1", runtimeLimitHours: 2, runtimeEndsAt: null });
+
+      expect(getRuntimeAnchorPollInterval(setting, true)).toBe(false);
+    });
+
+    it("waits for the first response before deciding", () => {
+      expect(getRuntimeAnchorPollInterval(undefined, false)).toBe(false);
+    });
+
+    it("picks up the deadline the lease anchors after the page loaded, without a reload", async () => {
+      vi.useFakeTimers();
+
+      try {
+        const dseq = faker.string.numeric(6);
+        const anchored = buildDeploymentSetting({ dseq, runtimeLimitHours: 2, runtimeEndsAt: faker.date.future().toISOString() });
+        const findByDseq = vi
+          .fn()
+          .mockResolvedValueOnce(buildDeploymentSetting({ dseq, runtimeLimitHours: 2, runtimeEndsAt: null }))
+          .mockResolvedValue(anchored);
+
+        const { result } = setup({ dseq, services: { deploymentSetting: () => mock<DeploymentSettingHttpService>({ findByDseq }) } });
+
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(0);
+        });
+        expect(result.current.data?.runtimeEndsAt).toBeNull();
+
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(RUNTIME_ANCHOR_POLL_MS * 2);
+        });
+        expect(result.current.data?.runtimeEndsAt).toBe(anchored.runtimeEndsAt);
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 
@@ -82,7 +139,7 @@ describe("useDeploymentSettingQuery", () => {
   }
 });
 
-function buildDeploymentSetting(overrides: { dseq: string; autoTopUpEnabled?: boolean }) {
+function buildDeploymentSetting(overrides: { dseq: string; autoTopUpEnabled?: boolean; runtimeLimitHours?: number | null; runtimeEndsAt?: string | null }) {
   return {
     id: faker.number.int(),
     userId: faker.string.uuid(),
@@ -90,6 +147,8 @@ function buildDeploymentSetting(overrides: { dseq: string; autoTopUpEnabled?: bo
     autoTopUpEnabled: overrides.autoTopUpEnabled ?? false,
     estimatedTopUpAmount: faker.number.float({ min: 0, max: 100 }),
     topUpFrequencyMs: faker.number.int({ min: 1000, max: 100000 }),
+    runtimeLimitHours: overrides.runtimeLimitHours ?? null,
+    runtimeEndsAt: overrides.runtimeEndsAt ?? null,
     createdAt: faker.date.recent().toISOString(),
     updatedAt: faker.date.recent().toISOString()
   };

--- a/apps/deploy-web/src/queries/deploymentSettingsQuery.ts
+++ b/apps/deploy-web/src/queries/deploymentSettingsQuery.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import type { UpdateDeploymentSettingInput } from "@akashnetwork/http-sdk";
+import type { DeploymentSettingOutput, UpdateDeploymentSettingInput } from "@akashnetwork/http-sdk";
 import { isHttpError } from "@akashnetwork/http-sdk";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { millisecondsInMinute } from "date-fns/constants";
@@ -25,6 +25,20 @@ export function useUpdateDeploymentSettingMutation(params: { dseq: string }) {
   });
 }
 
+/** Cadence for re-polling a runtime limit whose deadline the lease has not anchored yet. */
+export const RUNTIME_ANCHOR_POLL_MS = 5_000;
+
+/**
+ * A runtime limit's deadline is anchored server-side at lease start, so a detail page opened before the
+ * lease starts caches a null deadline and, under this query's stale window, would hold the pre-countdown
+ * reading until a manual page reload. Poll until the deadline lands; a failed fetch stops it so a
+ * persistent error does not retry forever.
+ */
+export function getRuntimeAnchorPollInterval(setting: DeploymentSettingOutput | undefined, hasErrored: boolean): number | false {
+  if (hasErrored) return false;
+  return !!setting?.runtimeLimitHours && !setting.runtimeEndsAt ? RUNTIME_ANCHOR_POLL_MS : false;
+}
+
 export function useDeploymentSettingQuery(params: { dseq: string }) {
   const queryKey = useMemo(() => QueryKeys.getDeploymentSettingKey(params.dseq), [params.dseq]);
   const { deploymentSetting } = useServices();
@@ -34,6 +48,7 @@ export function useDeploymentSettingQuery(params: { dseq: string }) {
     queryFn: () => deploymentSetting.findByDseq(params.dseq),
     enabled: !!params.dseq,
     staleTime: 5 * millisecondsInMinute,
+    refetchInterval: query => getRuntimeAnchorPollInterval(query.state.data, query.state.status === "error"),
     retry: (failureCount, error) => {
       if (isHttpError(error) && error.response?.status === 404) {
         return false;

--- a/apps/deploy-web/src/queries/deploymentSettingsQuery.ts
+++ b/apps/deploy-web/src/queries/deploymentSettingsQuery.ts
@@ -10,7 +10,8 @@ import { QueryKeys } from "./queryKeys";
 /**
  * Patches a deployment's settings and writes the response straight back into the settings query, so a
  * caller that has no query of its own (the review modal, which patches a deployment it is about to
- * deploy) still leaves the detail page's cache correct.
+ * deploy) still leaves the detail page's cache correct. An in-flight fetch is cancelled first, since one
+ * resolving after the write would put its pre-update snapshot back.
  */
 export function useUpdateDeploymentSettingMutation(params: { dseq: string }) {
   const queryKey = useMemo(() => QueryKeys.getDeploymentSettingKey(params.dseq), [params.dseq]);
@@ -19,6 +20,7 @@ export function useUpdateDeploymentSettingMutation(params: { dseq: string }) {
 
   return useMutation({
     mutationFn: (input: UpdateDeploymentSettingInput) => deploymentSetting.updateByDseq(params.dseq, input),
+    onMutate: () => queryClient.cancelQueries({ queryKey }),
     onSuccess: data => {
       queryClient.setQueryData(queryKey, data);
     }

--- a/apps/deploy-web/src/queries/deploymentSettingsQuery.ts
+++ b/apps/deploy-web/src/queries/deploymentSettingsQuery.ts
@@ -30,18 +30,13 @@ export function useUpdateDeploymentSettingMutation(params: { dseq: string }) {
 /** Cadence for re-polling a runtime limit whose deadline the lease has not anchored yet. */
 export const RUNTIME_ANCHOR_POLL_MS = 5_000;
 
-/**
- * A runtime limit's deadline is anchored server-side at lease start, so a detail page opened before the
- * lease starts caches a null deadline and, under this query's stale window, would hold the pre-countdown
- * reading until a manual page reload. Poll until the deadline lands; a failed fetch stops it so a
- * persistent error does not retry forever.
- */
+/** A runtime limit's deadline is anchored server-side at lease start, so a page opened before then holds a null deadline until something refetches. */
 export function getRuntimeAnchorPollInterval(setting: DeploymentSettingOutput | undefined, hasErrored: boolean): number | false {
   if (hasErrored) return false;
   return !!setting?.runtimeLimitHours && !setting.runtimeEndsAt ? RUNTIME_ANCHOR_POLL_MS : false;
 }
 
-export function useDeploymentSettingQuery(params: { dseq: string }) {
+export function useDeploymentSettingQuery(params: { dseq: string; pollUntilRuntimeAnchored?: boolean }) {
   const queryKey = useMemo(() => QueryKeys.getDeploymentSettingKey(params.dseq), [params.dseq]);
   const { deploymentSetting } = useServices();
 
@@ -50,7 +45,7 @@ export function useDeploymentSettingQuery(params: { dseq: string }) {
     queryFn: () => deploymentSetting.findByDseq(params.dseq),
     enabled: !!params.dseq,
     staleTime: 5 * millisecondsInMinute,
-    refetchInterval: query => getRuntimeAnchorPollInterval(query.state.data, query.state.status === "error"),
+    refetchInterval: query => (params.pollUntilRuntimeAnchored ? getRuntimeAnchorPollInterval(query.state.data, query.state.status === "error") : false),
     retry: (failureCount, error) => {
       if (isHttpError(error) && error.response?.status === 404) {
         return false;


### PR DESCRIPTION
## Why

Landing on a deployment's detail page showed the runtime limit stuck on the bare limit, with no countdown and no meter, until a manual page reload.

`runtimeEndsAt` is null until the server anchors it at lease start, and `useDeploymentSettingQuery` caches for five minutes with no polling. The page is normally opened straight after deploying, before the lease exists, so the query caches the null deadline and then holds it. Neither a remount nor a window focus refetches, because both are gated by that stale window, which leaves a hard refresh as the only way to make the countdown appear.

`useTickingNow` is not involved. It re-subscribes correctly and re-renders every minute, and a stalled local clock would fix itself within a minute rather than needing a reload.

Part of CON-883

## What

The query polls every 5s while a runtime limit is waiting on its deadline, and stops the moment one lands. `useManagedWalletQuery` already waits out server-side wallet provisioning this way, so this follows it. A failed fetch stops the polling too, so a persistent error does not retry forever, and a deployment with no runtime limit never polls at all.

The decision is a small exported function rather than an inline closure so it can be tested directly. Alongside its unit tests there is one that drives the real query through fake timers and asserts it picks up a deadline appearing after the first fetch, which is the behavior the bug was actually about.

Worth flagging: a runtime-limited deployment whose lease never starts would poll for as long as the page stays open. `DeploymentDetail` redirects such a deployment back to Configure in practice, and `useManagedWalletQuery` has the same unbounded shape, so I left it rather than adding a stop condition the query has no state for.


The poll is opt-in per caller. It ran for every mounted settings query at first, and `ConfigureDeploymentForm` keeps `ReviewAndDeployModal` mounted with its dialog closed, so a configure page holding a stored limit for its dseq fetched settings every 5s for as long as it stayed open. Nothing there renders the deadline: the modal reads `runtimeLimitHours` only. `DeploymentDetailHeader` and `useAutoTopUp` are the two that read `runtimeEndsAt`, and they are the two that ask for the poll.

Making the deadline land live also exposed `useTickingNow`. It seeded its clock at mount and its effect returned early while disabled, so the false-to-true transition never refreshed it and the first render of the anchored countdown overstated the time left by however long the page had waited for the lease. Its docblock called that safe because a disabled ticker meant nothing on screen depended on the clock, which is exactly the premise polling removes. It now reads the clock again before starting the interval, which covers the meter in `DeploymentBillingSection` too.

## Also in here

The trial badge now uses the `info` tone instead of `default`. `default` is `--primary`, which is near-black in light mode and near-white in dark, so next to the two grey `secondary` badges it read as one more neutral chip. Green, amber and red are already taken by the status badge's running, pending and closed tones, and red also marks an expired trial, which leaves blue as the one colour that collides with nothing. The badge renders in the detail header, the deployment list row, and manifest edit, and all three change.

