### PR TITLE
feat(billing): show trial status and limits on the billing page

### DIFF
--- a/apps/api/src/billing/controllers/wallet/wallet.controller.spec.ts
+++ b/apps/api/src/billing/controllers/wallet/wallet.controller.spec.ts
@@ -29,6 +29,7 @@ describe("WalletController", () => {
           address: faker.string.alphanumeric(44),
           creditAmount: 100,
           isTrialing: true,
+          trialEndsAt: faker.date.future(),
           createdAt: new Date()
         },
         {
@@ -37,6 +38,7 @@ describe("WalletController", () => {
           address: faker.string.alphanumeric(44),
           creditAmount: 200,
           isTrialing: false,
+          trialEndsAt: null,
           createdAt: new Date()
         }
       ];

--- a/apps/api/src/billing/http-schemas/wallet.schema.ts
+++ b/apps/api/src/billing/http-schemas/wallet.schema.ts
@@ -15,6 +15,7 @@ const WalletOutputSchema = z.object({
   address: z.string().openapi({}),
   denom: z.string().openapi({}),
   isTrialing: z.boolean(),
+  trialEndsAt: z.date().nullable().openapi({ description: "When the free trial expires, or null when the wallet is no longer trialing." }),
   topUpMinAmountUsd: z.number().openapi({ description: "Minimum USD amount accepted by the next paid top-up for this wallet." }),
   createdAt: z.date().openapi({})
 });

--- a/apps/api/src/billing/lib/trial-window/trial-window.ts
+++ b/apps/api/src/billing/lib/trial-window/trial-window.ts
@@ -1,0 +1,14 @@
+import addDays from "date-fns/addDays";
+
+import type { UserWalletOutput } from "@src/billing/repositories/user-wallet/user-wallet.repository";
+
+type TrialWindowWallet = Pick<UserWalletOutput, "activatedAt" | "createdAt">;
+
+/** A wallet created before the trial activation job ran starts its trial only once activated. */
+export function getTrialStartedAt(wallet: TrialWindowWallet): Date {
+  return wallet.activatedAt ?? wallet.createdAt;
+}
+
+export function getTrialEndsAt(wallet: TrialWindowWallet, trialDurationDays: number): Date {
+  return addDays(getTrialStartedAt(wallet), trialDurationDays);
+}

--- a/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.ts
+++ b/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.ts
@@ -34,6 +34,7 @@ export interface UserWalletPublicOutput {
   address: WalletInitialized["address"];
   creditAmount: UserWalletOutput["creditAmount"];
   isTrialing: boolean;
+  trialEndsAt: Date | null;
   createdAt: UserWalletOutput["createdAt"];
 }
 
@@ -197,13 +198,14 @@ export class UserWalletRepository extends BaseRepository<ApiPgTables["UserWallet
     return dbInput;
   }
 
-  toPublic(output: WalletInitialized): UserWalletPublicOutput {
+  toPublic(output: WalletInitialized, options: { trialEndsAt: Date | null } = { trialEndsAt: null }): UserWalletPublicOutput {
     return {
       id: output.id,
       userId: output.userId,
       address: output.address,
       creditAmount: output.creditAmount,
       isTrialing: !!output.isTrialing,
+      trialEndsAt: options.trialEndsAt,
       createdAt: output.createdAt
     };
   }

--- a/apps/api/src/billing/services/managed-user-wallet/managed-user-wallet.service.ts
+++ b/apps/api/src/billing/services/managed-user-wallet/managed-user-wallet.service.ts
@@ -3,13 +3,13 @@ import { Trace, withSpan } from "@akashnetwork/instrumentation";
 import { EncodeObject } from "@cosmjs/proto-signing";
 import { ConstantBackoff, handleWhenResult, type IPolicy, retry } from "cockatiel";
 import add from "date-fns/add";
-import addDays from "date-fns/addDays";
 import isAfter from "date-fns/isAfter";
 import subDays from "date-fns/subDays";
 import assert from "http-assert";
 import { BadGateway } from "http-errors";
 import { inject, singleton } from "tsyringe";
 
+import { getTrialEndsAt, getTrialStartedAt } from "@src/billing/lib/trial-window/trial-window";
 import { type BillingConfig, InjectBillingConfig } from "@src/billing/providers";
 import type { UserWalletOutput } from "@src/billing/repositories";
 import { TxManagerService } from "@src/billing/services/tx-manager/tx-manager.service";
@@ -112,10 +112,9 @@ export class ManagedUserWalletService {
   async refillWalletFees(signer: ManagedSignerService, wallet: Pick<UserWalletOutput, "address" | "isTrialing" | "createdAt" | "activatedAt">) {
     assert(wallet.address, 402, "Wallet is not initialized");
 
-    const trialStartedAt = wallet.activatedAt ?? wallet.createdAt;
     const trialWindowStart = subDays(new Date(), this.config.TRIAL_ALLOWANCE_EXPIRATION_DAYS);
-    const isInTrialWindow = wallet.isTrialing && isAfter(trialStartedAt, trialWindowStart);
-    const expiration = isInTrialWindow ? addDays(trialStartedAt, this.config.TRIAL_ALLOWANCE_EXPIRATION_DAYS) : undefined;
+    const isInTrialWindow = wallet.isTrialing && isAfter(getTrialStartedAt(wallet), trialWindowStart);
+    const expiration = isInTrialWindow ? getTrialEndsAt(wallet, this.config.TRIAL_ALLOWANCE_EXPIRATION_DAYS) : undefined;
     const fees = this.config.FEE_ALLOWANCE_REFILL_AMOUNT;
 
     await this.authorizeSpending(signer, {

--- a/apps/api/src/billing/services/trial-validation/trial-validation.service.spec.ts
+++ b/apps/api/src/billing/services/trial-validation/trial-validation.service.spec.ts
@@ -303,6 +303,41 @@ describe(TrialValidationService.name, () => {
     });
   });
 
+  describe("getTrialEndsAt", () => {
+    it("returns null when the wallet is no longer trialing", () => {
+      const { service } = setupTrialWindow({ trialDurationDays: 30 });
+      const wallet = createUserWallet({ isTrialing: false, activatedAt: new Date("2026-08-01T00:00:00.000Z") });
+
+      expect(service.getTrialEndsAt(wallet)).toBeNull();
+    });
+
+    it("counts the trial from activation when the wallet is activated", () => {
+      const { service } = setupTrialWindow({ trialDurationDays: 30 });
+      const wallet = createUserWallet({
+        isTrialing: true,
+        createdAt: new Date("2026-08-01T00:00:00.000Z"),
+        activatedAt: new Date("2026-08-10T00:00:00.000Z")
+      });
+
+      expect(service.getTrialEndsAt(wallet)).toEqual(new Date("2026-09-09T00:00:00.000Z"));
+    });
+
+    it("falls back to wallet creation when activation has not been stamped", () => {
+      const { service } = setupTrialWindow({ trialDurationDays: 30 });
+      const wallet = createUserWallet({ isTrialing: true, createdAt: new Date("2026-08-01T00:00:00.000Z"), activatedAt: null });
+
+      expect(service.getTrialEndsAt(wallet)).toEqual(new Date("2026-08-31T00:00:00.000Z"));
+    });
+  });
+
+  function setupTrialWindow(input: { trialDurationDays: number }) {
+    const config = mockConfigService<BillingConfigService>({
+      TRIAL_ALLOWANCE_EXPIRATION_DAYS: input.trialDurationDays
+    });
+    const service = new TrialValidationService(config, mock<ProviderRepository>(), mock<BidHttpService>(), mock<BlockedGpuService>());
+    return { service };
+  }
+
   function setupTopUp(input: { trialMin: number }) {
     const providerRepository = mock<ProviderRepository>();
     const bidHttpService = mock<BidHttpService>();

--- a/apps/api/src/billing/services/trial-validation/trial-validation.service.ts
+++ b/apps/api/src/billing/services/trial-validation/trial-validation.service.ts
@@ -7,6 +7,7 @@ import assert from "http-assert";
 import { singleton } from "tsyringe";
 
 import { STANDARD_TOP_UP_MIN_AMOUNT_USD } from "@src/billing/config";
+import { getTrialEndsAt } from "@src/billing/lib/trial-window/trial-window";
 import type { UserWalletOutput } from "@src/billing/repositories";
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import { AUDITOR, TRIAL_ATTRIBUTE, TRIAL_REGISTERED_ATTRIBUTE } from "@src/deployment/config/provider.config";
@@ -72,6 +73,12 @@ export class TrialValidationService {
 
   getTopUpMinAmountUsd(userWallet: Pick<UserWalletOutput, "isTrialing">): number {
     return userWallet.isTrialing ? this.config.get("MANAGED_WALLET_TRIAL_MIN_TOP_UP_AMOUNT") : STANDARD_TOP_UP_MIN_AMOUNT_USD;
+  }
+
+  getTrialEndsAt(userWallet: Pick<UserWalletOutput, "isTrialing" | "activatedAt" | "createdAt">): Date | null {
+    if (!userWallet.isTrialing) return null;
+
+    return getTrialEndsAt(userWallet, this.config.get("TRIAL_ALLOWANCE_EXPIRATION_DAYS"));
   }
 
   validateTopUpAmount(userWallet: Pick<UserWalletOutput, "isTrialing" | "activatedAt"> | undefined, amountUsd: number) {

--- a/apps/api/src/billing/services/wallet-initializer/wallet-initializer.service.spec.ts
+++ b/apps/api/src/billing/services/wallet-initializer/wallet-initializer.service.spec.ts
@@ -18,6 +18,7 @@ import { TrialActivationInstrumentationService } from "../activate-trial/trial-a
 import { ManagedSignerService } from "../managed-signer/managed-signer.service";
 import { ManagedUserWalletService } from "../managed-user-wallet/managed-user-wallet.service";
 import { StripeService } from "../stripe/stripe.service";
+import { TrialValidationService } from "../trial-validation/trial-validation.service";
 import { WalletInitializerService } from "./wallet-initializer.service";
 
 import { createChainWallet } from "@test/seeders/chain-wallet.seeder";
@@ -222,9 +223,10 @@ describe(WalletInitializerService.name, () => {
         accessibleBy() {
           return this as unknown as UserWalletRepository;
         },
-        toPublic: value => ({
+        toPublic: (value, options) => ({
           ...value,
-          isTrialing: !!value.isTrialing
+          isTrialing: !!value.isTrialing,
+          trialEndsAt: options?.trialEndsAt ?? null
         })
       }) as unknown as UserWalletRepository
     );
@@ -264,6 +266,7 @@ describe(WalletInitializerService.name, () => {
       })
     );
     di.registerInstance(TrialActivationInstrumentationService, mock<TrialActivationInstrumentationService>());
+    di.registerInstance(TrialValidationService, mock<TrialValidationService>());
 
     container.clearInstances();
 

--- a/apps/api/src/billing/services/wallet-initializer/wallet-initializer.service.ts
+++ b/apps/api/src/billing/services/wallet-initializer/wallet-initializer.service.ts
@@ -6,6 +6,7 @@ import { isWalletInitialized, type UserWalletPublicOutput, UserWalletRepository,
 import { TrialActivationInstrumentationService } from "@src/billing/services/activate-trial/trial-activation-instrumentation.service";
 import { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
 import { StripeService } from "@src/billing/services/stripe/stripe.service";
+import { TrialValidationService } from "@src/billing/services/trial-validation/trial-validation.service";
 import { DomainEventsService } from "@src/core/services/domain-events/domain-events.service";
 import { FeatureFlags } from "@src/core/services/feature-flags/feature-flags";
 import { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
@@ -22,7 +23,8 @@ export class WalletInitializerService {
     private readonly featureFlagsService: FeatureFlagsService,
     private readonly stripeService: StripeService,
     private readonly userRepository: UserRepository,
-    private readonly trialActivationInstrumentation: TrialActivationInstrumentationService
+    private readonly trialActivationInstrumentation: TrialActivationInstrumentationService,
+    private readonly trialValidationService: TrialValidationService
   ) {}
 
   async #assertNoDuplicateFingerprint(user: UserOutput): Promise<void> {
@@ -52,7 +54,7 @@ export class WalletInitializerService {
     await this.#assertNoDuplicateFingerprint(user);
 
     const userWallet = await this.ensureWallet(userId);
-    if (userWallet.activatedAt) return this.userWalletRepository.toPublic(userWallet);
+    if (userWallet.activatedAt) return this.#toPublic(userWallet);
 
     const chainWallet = await this.walletManager.createAndAuthorizeTrialSpending(this.managedSignerService, { addressIndex: userWallet.id });
     const activatedWallet = await this.userWalletRepository.updateById(
@@ -68,7 +70,11 @@ export class WalletInitializerService {
     await this.domainEvents.publish(new TrialStarted({ userId }));
     this.trialActivationInstrumentation.recordActivated(userId, Date.now() - new Date(activatedWallet.createdAt).getTime());
 
-    return this.userWalletRepository.toPublic({ ...activatedWallet, address: userWallet.address });
+    return this.#toPublic({ ...activatedWallet, address: userWallet.address });
+  }
+
+  #toPublic(wallet: WalletInitialized): UserWalletPublicOutput {
+    return this.userWalletRepository.toPublic(wallet, { trialEndsAt: this.trialValidationService.getTrialEndsAt(wallet) });
   }
 
   /**

--- a/apps/api/src/billing/services/wallet-reader/wallet-reader.service.spec.ts
+++ b/apps/api/src/billing/services/wallet-reader/wallet-reader.service.spec.ts
@@ -3,6 +3,7 @@ import { mock } from "vitest-mock-extended";
 
 import type { AuthService } from "@src/auth/services/auth.service";
 import type { UserWalletOutput, UserWalletRepository } from "@src/billing/repositories";
+import type { TrialValidationService } from "@src/billing/services/trial-validation/trial-validation.service";
 import { WalletReaderService } from "./wallet-reader.service";
 
 import { createUserWallet } from "@test/seeders/user-wallet.seeder";
@@ -31,6 +32,18 @@ describe(WalletReaderService.name, () => {
       expect(result).toEqual([]);
     });
 
+    it("exposes the trial expiry computed for the wallet", async () => {
+      const userId = "test-user-id";
+      const trialEndsAt = new Date("2026-09-30T00:00:00.000Z");
+      const wallet = createUserWallet({ userId, activatedAt: new Date(), isTrialing: true });
+      const { service, trialValidationService } = setup({ wallets: [wallet], trialEndsAt });
+
+      const result = await service.getWallets({ userId });
+
+      expect(result[0].trialEndsAt).toEqual(trialEndsAt);
+      expect(trialValidationService.getTrialEndsAt).toHaveBeenCalledWith(wallet);
+    });
+
     it("returns an empty list when the user only has a non-activated wallet", async () => {
       const userId = "test-user-id";
       const nonActivatedWallet = createUserWallet({ userId, activatedAt: null });
@@ -42,25 +55,29 @@ describe(WalletReaderService.name, () => {
     });
   });
 
-  function setup(input: { wallets: UserWalletOutput[] }) {
+  function setup(input: { wallets: UserWalletOutput[]; trialEndsAt?: Date | null }) {
     const userWalletRepository = mock<UserWalletRepository>({
       find: vi.fn().mockResolvedValue(input.wallets),
       accessibleBy() {
         return this as unknown as UserWalletRepository;
       },
-      toPublic: value => ({
+      toPublic: (value, options) => ({
         id: value.id,
         userId: value.userId,
         address: value.address,
         creditAmount: value.creditAmount,
         isTrialing: !!value.isTrialing,
+        trialEndsAt: options?.trialEndsAt ?? null,
         createdAt: value.createdAt
       })
     }) as unknown as UserWalletRepository;
     const authService = mock<AuthService>({ ability: {} });
+    const trialValidationService = mock<TrialValidationService>({
+      getTrialEndsAt: vi.fn().mockReturnValue(input.trialEndsAt ?? null)
+    });
 
-    const service = new WalletReaderService(userWalletRepository, authService as AuthService);
+    const service = new WalletReaderService(userWalletRepository, authService as AuthService, trialValidationService);
 
-    return { service, userWalletRepository, authService };
+    return { service, userWalletRepository, authService, trialValidationService };
   }
 });

--- a/apps/api/src/billing/services/wallet-reader/wallet-reader.service.ts
+++ b/apps/api/src/billing/services/wallet-reader/wallet-reader.service.ts
@@ -10,6 +10,7 @@ import {
   UserWalletRepository,
   type WalletInitialized
 } from "@src/billing/repositories";
+import { TrialValidationService } from "@src/billing/services/trial-validation/trial-validation.service";
 
 export interface GetWalletOptions {
   userId: string;
@@ -19,7 +20,8 @@ export interface GetWalletOptions {
 export class WalletReaderService {
   constructor(
     private readonly userWalletRepository: UserWalletRepository,
-    private readonly authService: AuthService
+    private readonly authService: AuthService,
+    private readonly trialValidationService: TrialValidationService
   ) {}
 
   async getWallets(query: GetWalletOptions): Promise<UserWalletPublicOutput[]> {
@@ -27,7 +29,7 @@ export class WalletReaderService {
 
     return wallets
       .filter((wallet): wallet is WalletInitialized => wallet.activatedAt !== null && isWalletInitialized(wallet))
-      .map(wallet => this.userWalletRepository.toPublic(wallet));
+      .map(wallet => this.userWalletRepository.toPublic(wallet, { trialEndsAt: this.trialValidationService.getTrialEndsAt(wallet) }));
   }
 
   async getWalletByUserId(userId: string): Promise<WalletInitialized>;

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -15548,6 +15548,11 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                             "description": "Minimum USD amount accepted by the next paid top-up for this wallet.",
                             "type": "number",
                           },
+                          "trialEndsAt": {
+                            "description": "When the free trial expires, or null when the wallet is no longer trialing.",
+                            "nullable": true,
+                            "type": "string",
+                          },
                           "userId": {
                             "type": "string",
                           },
@@ -15559,6 +15564,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                           "address",
                           "denom",
                           "isTrialing",
+                          "trialEndsAt",
                           "topUpMinAmountUsd",
                           "createdAt",
                         ],

--- a/apps/api/test/functional/get-wallet-list.spec.ts
+++ b/apps/api/test/functional/get-wallet-list.spec.ts
@@ -1,0 +1,67 @@
+import { faker } from "@faker-js/faker";
+import addDays from "date-fns/addDays";
+import { container } from "tsyringe";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { UserAuthTokenService } from "@src/auth/services/user-auth-token/user-auth-token.service";
+import { UserWalletRepository } from "@src/billing/repositories";
+import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
+import { app } from "@src/rest-app";
+import { UserRepository } from "@src/user/repositories/user/user.repository";
+
+import { createAkashAddress } from "@test/seeders/akash-address.seeder";
+
+describe("Get Wallet List", () => {
+  const userRepository = container.resolve(UserRepository);
+  const userAuthTokenService = container.resolve(UserAuthTokenService);
+  const userWalletRepository = container.resolve(UserWalletRepository);
+  const billingConfig = container.resolve(BillingConfigService);
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("GET /v1/wallets", () => {
+    it("returns the trial expiry counted from activation for a trialing wallet", async () => {
+      const activatedAt = new Date("2026-08-01T00:00:00.000Z");
+      const { user, token } = await setup({ isTrialing: true, activatedAt });
+
+      const response = await app.request(`/v1/wallets?userId=${user.id}`, {
+        headers: { authorization: `Bearer ${token}` }
+      });
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.data[0].isTrialing).toBe(true);
+      expect(body.data[0].trialEndsAt).toBe(addDays(activatedAt, billingConfig.get("TRIAL_ALLOWANCE_EXPIRATION_DAYS")).toISOString());
+    });
+
+    it("returns no trial expiry once the wallet has stopped trialing", async () => {
+      const { user, token } = await setup({ isTrialing: false, activatedAt: new Date("2026-08-01T00:00:00.000Z") });
+
+      const response = await app.request(`/v1/wallets?userId=${user.id}`, {
+        headers: { authorization: `Bearer ${token}` }
+      });
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.data[0].isTrialing).toBe(false);
+      expect(body.data[0].trialEndsAt).toBeNull();
+    });
+  });
+
+  async function setup(input: { isTrialing: boolean; activatedAt: Date }) {
+    const user = await userRepository.create({ userId: faker.string.uuid() });
+    const token = faker.string.alphanumeric(40);
+    const { wallet } = await userWalletRepository.getOrCreate({ userId: user.id });
+    await userWalletRepository.updateById(wallet.id, {
+      address: createAkashAddress(),
+      isTrialing: input.isTrialing,
+      activatedAt: input.activatedAt
+    });
+
+    vi.spyOn(userAuthTokenService, "getValidUserId").mockResolvedValue(user.userId);
+
+    return { user, token };
+  }
+});

--- a/apps/deploy-web/src/components/billing-usage/BillingPage.tsx
+++ b/apps/deploy-web/src/components/billing-usage/BillingPage.tsx
@@ -9,6 +9,7 @@ import { BillingContainer } from "@src/components/billing-usage/BillingContainer
 import { BillingView } from "@src/components/billing-usage/BillingView/BillingView";
 import { PaymentMethodsContainer } from "@src/components/billing-usage/PaymentMethodsContainer/PaymentMethodsContainer";
 import { PaymentMethodsView } from "@src/components/billing-usage/PaymentMethodsView/PaymentMethodsView";
+import { TrialStatusPanel } from "@src/components/billing-usage/TrialStatusPanel/TrialStatusPanel";
 import { useBillingBackgroundLoading } from "@src/components/billing-usage/useBillingBackgroundLoading";
 import Layout from "@src/components/layout/Layout";
 import { SettingsLayout } from "@src/components/layout/SettingsLayout/SettingsLayout";
@@ -26,6 +27,7 @@ export const BillingPage: FC = () => {
         description="Manage your balance, payment methods, and payment history."
         headerActions={isAutoCreditReloadEnabled ? <AddToBalanceButton /> : undefined}
       >
+        <TrialStatusPanel />
         {isAutoCreditReloadEnabled ? (
           <BillingActionsProvider>
             <AccountBalanceOverview />

--- a/apps/deploy-web/src/components/billing-usage/TrialStatusPanel/TrialStatusPanel.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/TrialStatusPanel/TrialStatusPanel.spec.tsx
@@ -16,26 +16,44 @@ describe("TrialStatusPanel", () => {
     expect(screen.queryByText("Free trial")).not.toBeInTheDocument();
   });
 
-  it("shows the days remaining in the trial", () => {
+  it("shows the days remaining out of the full trial length", () => {
     setup({ trial: { daysLeft: 18, totalDays: 30 } });
 
-    expect(screen.getByText("18 days left")).toBeInTheDocument();
-    expect(screen.getByText("of your 30 day trial")).toBeInTheDocument();
+    expect(screen.getByText("18 days left out of 30 days before the trial ends")).toBeInTheDocument();
+  });
+
+  it("keeps the countdown singular on the last day", () => {
+    setup({ trial: { daysLeft: 1, totalDays: 30 } });
+
+    expect(screen.getByText("1 day left out of 30 days before the trial ends")).toBeInTheDocument();
+  });
+
+  it("drains the progress bar as the trial runs down", () => {
+    setup({ trial: { daysRemainingPercent: 60 } });
+
+    expect(screen.getByRole("progressbar", { name: "Trial days remaining" })).toHaveAttribute("aria-valuenow", "60");
   });
 
   it("lists the trial limitations with the configured deployment duration", () => {
     setup({ trial: { deploymentDurationHours: 24 } });
 
     expect(screen.getByText("Deployments close automatically after 24 hours")).toBeInTheDocument();
-    expect(screen.getByText("High-end GPUs stay locked, so trials run on CPU")).toBeInTheDocument();
-    expect(screen.getByText("Only providers approved for trials can host your workloads")).toBeInTheDocument();
+    expect(screen.getByText("High-end GPUs are locked, though lower-end GPUs stay available")).toBeInTheDocument();
+    expect(screen.getByText("GPU interconnect and GPU-backed confidential compute are unavailable")).toBeInTheDocument();
   });
 
   it("announces the trial has ended once no days remain", () => {
-    setup({ trial: { daysLeft: 0, isExpired: true } });
+    setup({ trial: { daysLeft: 0, isExpired: true, daysRemainingPercent: 0 } });
 
     expect(screen.getByText("Your free trial has ended")).toBeInTheDocument();
     expect(screen.queryByText(/days left/)).not.toBeInTheDocument();
+  });
+
+  it("holds the countdown and the bar back until the expiry is known", () => {
+    setup({ trial: { daysLeft: null } });
+
+    expect(screen.queryByText(/before the trial ends/)).not.toBeInTheDocument();
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
   });
 
   it("opens the add credits sheet from the purchase button", async () => {
@@ -53,7 +71,7 @@ describe("TrialStatusPanel", () => {
         isTrialing: true,
         totalDays: 30,
         daysLeft: 18,
-        daysElapsedPercent: 40,
+        daysRemainingPercent: 60,
         isExpired: false,
         deploymentDurationHours: 24,
         ...input.trial

--- a/apps/deploy-web/src/components/billing-usage/TrialStatusPanel/TrialStatusPanel.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/TrialStatusPanel/TrialStatusPanel.spec.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import { DEPENDENCIES, TrialStatusPanel } from "./TrialStatusPanel";
+import type { TrialStatus } from "./useTrialStatus";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MockComponents } from "@tests/unit/mocks";
+
+describe("TrialStatusPanel", () => {
+  it("renders nothing when the wallet is no longer trialing", () => {
+    setup({ trial: { isTrialing: false } });
+
+    expect(screen.queryByText("Free trial")).not.toBeInTheDocument();
+  });
+
+  it("shows the days remaining in the trial", () => {
+    setup({ trial: { daysLeft: 18, totalDays: 30 } });
+
+    expect(screen.getByText("18 days left")).toBeInTheDocument();
+    expect(screen.getByText("of your 30 day trial")).toBeInTheDocument();
+  });
+
+  it("lists the trial limitations with the configured deployment duration", () => {
+    setup({ trial: { deploymentDurationHours: 24 } });
+
+    expect(screen.getByText("Deployments close automatically after 24 hours")).toBeInTheDocument();
+    expect(screen.getByText("High-end GPUs stay locked, so trials run on CPU")).toBeInTheDocument();
+    expect(screen.getByText("Only providers approved for trials can host your workloads")).toBeInTheDocument();
+  });
+
+  it("announces the trial has ended once no days remain", () => {
+    setup({ trial: { daysLeft: 0, isExpired: true } });
+
+    expect(screen.getByText("Your free trial has ended")).toBeInTheDocument();
+    expect(screen.queryByText(/days left/)).not.toBeInTheDocument();
+  });
+
+  it("opens the add credits sheet from the purchase button", async () => {
+    const AddCreditsSheet = vi.fn(() => <></>);
+    setup({ dependencies: { AddCreditsSheet } });
+
+    await userEvent.click(screen.getByRole("button", { name: "Purchase credits" }));
+
+    expect(AddCreditsSheet).toHaveBeenLastCalledWith(expect.objectContaining({ open: true, initialTab: "purchase" }), expect.anything());
+  });
+
+  function setup(input: { trial?: Partial<TrialStatus>; dependencies?: Partial<typeof DEPENDENCIES> } = {}) {
+    const useTrialStatus = () =>
+      mock<TrialStatus>({
+        isTrialing: true,
+        totalDays: 30,
+        daysLeft: 18,
+        daysElapsedPercent: 40,
+        isExpired: false,
+        deploymentDurationHours: 24,
+        ...input.trial
+      });
+
+    return render(
+      <TrialStatusPanel
+        dependencies={{
+          ...MockComponents(DEPENDENCIES, input.dependencies),
+          Card: DEPENDENCIES.Card,
+          CardContent: DEPENDENCIES.CardContent,
+          CardHeader: DEPENDENCIES.CardHeader,
+          Button: DEPENDENCIES.Button,
+          Progress: DEPENDENCIES.Progress,
+          useTrialStatus,
+          ...input.dependencies
+        }}
+      />
+    );
+  }
+});

--- a/apps/deploy-web/src/components/billing-usage/TrialStatusPanel/TrialStatusPanel.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/TrialStatusPanel/TrialStatusPanel.spec.tsx
@@ -84,6 +84,7 @@ describe("TrialStatusPanel", () => {
           Card: DEPENDENCIES.Card,
           CardContent: DEPENDENCIES.CardContent,
           CardHeader: DEPENDENCIES.CardHeader,
+          Badge: DEPENDENCIES.Badge,
           Button: DEPENDENCIES.Button,
           Progress: DEPENDENCIES.Progress,
           useTrialStatus,

--- a/apps/deploy-web/src/components/billing-usage/TrialStatusPanel/TrialStatusPanel.tsx
+++ b/apps/deploy-web/src/components/billing-usage/TrialStatusPanel/TrialStatusPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 import React, { useState } from "react";
-import { Button, Card, CardContent, CardHeader, Progress } from "@akashnetwork/ui/components";
-import { Clock, Cpu, ShieldCheck } from "iconoir-react";
+import { Button, Card, CardContent, CardHeader, Progress, Skeleton } from "@akashnetwork/ui/components";
+import { Clock, Cpu, Lock } from "iconoir-react";
 
 import { AddCreditsSheet } from "@src/components/auth/AddCreditsSheet/AddCreditsSheet";
 import { BONUS_PERCENT, MAX_BONUS } from "@src/components/billing-usage/FirstPurchaseBonusAlert/FirstPurchaseBonusAlert";
@@ -15,9 +15,10 @@ export const DEPENDENCIES = {
   CardContent,
   CardHeader,
   Progress,
+  Skeleton,
   Clock,
   Cpu,
-  ShieldCheck
+  Lock
 };
 
 const UNLOCK_SHEET_DESCRIPTION = "Purchase credits to unlock GPUs, unlimited runtime, and the full Console.";
@@ -30,8 +31,8 @@ export const TrialStatusPanel: React.FunctionComponent<{ dependencies?: typeof D
 
   const limitations = [
     { icon: <d.Clock className="h-4 w-4 text-muted-foreground" />, text: `Deployments close automatically after ${trial.deploymentDurationHours} hours` },
-    { icon: <d.Cpu className="h-4 w-4 text-muted-foreground" />, text: "High-end GPUs stay locked, so trials run on CPU" },
-    { icon: <d.ShieldCheck className="h-4 w-4 text-muted-foreground" />, text: "Only providers approved for trials can host your workloads" }
+    { icon: <d.Cpu className="h-4 w-4 text-muted-foreground" />, text: "High-end GPUs are locked, though lower-end GPUs stay available" },
+    { icon: <d.Lock className="h-4 w-4 text-muted-foreground" />, text: "GPU interconnect and GPU-backed confidential compute are unavailable" }
   ];
 
   return (
@@ -42,15 +43,21 @@ export const TrialStatusPanel: React.FunctionComponent<{ dependencies?: typeof D
           <span className="rounded-full bg-primary/10 px-2.5 py-1 text-xs font-medium text-primary">Trial</span>
         </d.CardHeader>
         <d.CardContent className="space-y-4">
-          <div className="space-y-2">
-            <div className="flex flex-wrap items-baseline justify-between gap-2">
-              <span className="text-2xl font-bold leading-none" aria-label="Trial days remaining">
-                {trial.isExpired ? "Your free trial has ended" : trial.daysLeft === null ? "Trial in progress" : `${trial.daysLeft} days left`}
-              </span>
-              {!trial.isExpired && trial.daysLeft !== null && <span className="text-sm text-muted-foreground">{`of your ${trial.totalDays} day trial`}</span>}
+          {trial.daysLeft === null ? (
+            <div className="space-y-2">
+              <d.Skeleton className="h-2 w-full" />
+              <d.Skeleton className="h-4 w-64" />
             </div>
-            <d.Progress value={trial.isExpired ? 100 : trial.daysElapsedPercent} className="h-2" aria-label="Trial progress" />
-          </div>
+          ) : (
+            <div className="space-y-2">
+              <d.Progress value={trial.daysRemainingPercent} className="h-2" aria-label="Trial days remaining" />
+              <p className="text-sm text-muted-foreground">
+                {trial.isExpired
+                  ? "Your free trial has ended"
+                  : `${trial.daysLeft} ${trial.daysLeft === 1 ? "day" : "days"} left out of ${trial.totalDays} days before the trial ends`}
+              </p>
+            </div>
+          )}
 
           <div className="space-y-2 border-t pt-4">
             <p className="text-sm font-medium">What the trial limits</p>

--- a/apps/deploy-web/src/components/billing-usage/TrialStatusPanel/TrialStatusPanel.tsx
+++ b/apps/deploy-web/src/components/billing-usage/TrialStatusPanel/TrialStatusPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useState } from "react";
-import { Button, Card, CardContent, CardHeader, Progress, Skeleton } from "@akashnetwork/ui/components";
+import { Badge, Button, Card, CardContent, CardHeader, Progress, Skeleton } from "@akashnetwork/ui/components";
 import { Clock, Cpu, Lock } from "iconoir-react";
 
 import { AddCreditsSheet } from "@src/components/auth/AddCreditsSheet/AddCreditsSheet";
@@ -10,6 +10,7 @@ import { useTrialStatus } from "./useTrialStatus";
 export const DEPENDENCIES = {
   useTrialStatus,
   AddCreditsSheet,
+  Badge,
   Button,
   Card,
   CardContent,
@@ -40,7 +41,7 @@ export const TrialStatusPanel: React.FunctionComponent<{ dependencies?: typeof D
       <d.Card>
         <d.CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
           <h3 className="text-lg font-bold leading-none">Free trial</h3>
-          <span className="rounded-full bg-primary/10 px-2.5 py-1 text-xs font-medium text-primary">Trial</span>
+          <d.Badge variant="info">Trial</d.Badge>
         </d.CardHeader>
         <d.CardContent className="space-y-4">
           {trial.daysLeft === null ? (

--- a/apps/deploy-web/src/components/billing-usage/TrialStatusPanel/TrialStatusPanel.tsx
+++ b/apps/deploy-web/src/components/billing-usage/TrialStatusPanel/TrialStatusPanel.tsx
@@ -1,0 +1,96 @@
+"use client";
+import React, { useState } from "react";
+import { Button, Card, CardContent, CardHeader, Progress } from "@akashnetwork/ui/components";
+import { Clock, Cpu, ShieldCheck } from "iconoir-react";
+
+import { AddCreditsSheet } from "@src/components/auth/AddCreditsSheet/AddCreditsSheet";
+import { BONUS_PERCENT, MAX_BONUS } from "@src/components/billing-usage/FirstPurchaseBonusAlert/FirstPurchaseBonusAlert";
+import { useTrialStatus } from "./useTrialStatus";
+
+export const DEPENDENCIES = {
+  useTrialStatus,
+  AddCreditsSheet,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  Progress,
+  Clock,
+  Cpu,
+  ShieldCheck
+};
+
+const UNLOCK_SHEET_DESCRIPTION = "Purchase credits to unlock GPUs, unlimited runtime, and the full Console.";
+
+export const TrialStatusPanel: React.FunctionComponent<{ dependencies?: typeof DEPENDENCIES }> = ({ dependencies: d = DEPENDENCIES }) => {
+  const trial = d.useTrialStatus();
+  const [isAddCreditsOpen, setIsAddCreditsOpen] = useState(false);
+
+  if (!trial.isTrialing) return null;
+
+  const limitations = [
+    { icon: <d.Clock className="h-4 w-4 text-muted-foreground" />, text: `Deployments close automatically after ${trial.deploymentDurationHours} hours` },
+    { icon: <d.Cpu className="h-4 w-4 text-muted-foreground" />, text: "High-end GPUs stay locked, so trials run on CPU" },
+    { icon: <d.ShieldCheck className="h-4 w-4 text-muted-foreground" />, text: "Only providers approved for trials can host your workloads" }
+  ];
+
+  return (
+    <>
+      <d.Card>
+        <d.CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
+          <h3 className="text-lg font-bold leading-none">Free trial</h3>
+          <span className="rounded-full bg-primary/10 px-2.5 py-1 text-xs font-medium text-primary">Trial</span>
+        </d.CardHeader>
+        <d.CardContent className="space-y-4">
+          <div className="space-y-2">
+            <div className="flex flex-wrap items-baseline justify-between gap-2">
+              <span className="text-2xl font-bold leading-none" aria-label="Trial days remaining">
+                {trial.isExpired ? "Your free trial has ended" : trial.daysLeft === null ? "Trial in progress" : `${trial.daysLeft} days left`}
+              </span>
+              {!trial.isExpired && trial.daysLeft !== null && <span className="text-sm text-muted-foreground">{`of your ${trial.totalDays} day trial`}</span>}
+            </div>
+            <d.Progress value={trial.isExpired ? 100 : trial.daysElapsedPercent} className="h-2" aria-label="Trial progress" />
+          </div>
+
+          <div className="space-y-2 border-t pt-4">
+            <p className="text-sm font-medium">What the trial limits</p>
+            <ul className="space-y-1.5">
+              {limitations.map(limitation => (
+                <li key={limitation.text} className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <span className="shrink-0" aria-hidden>
+                    {limitation.icon}
+                  </span>
+                  {limitation.text}
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div className="flex flex-wrap items-center justify-between gap-3 border-t pt-4">
+            <p className="text-sm text-muted-foreground">
+              {`Purchase credits to lift every limit above. Your first purchase earns ${BONUS_PERCENT}% in bonus credits, up to $${MAX_BONUS} free.`}
+            </p>
+            <d.Button onClick={openAddCredits}>Purchase credits</d.Button>
+          </div>
+        </d.CardContent>
+      </d.Card>
+
+      <d.AddCreditsSheet
+        open={isAddCreditsOpen}
+        onOpenChange={setIsAddCreditsOpen}
+        initialTab="purchase"
+        description={UNLOCK_SHEET_DESCRIPTION}
+        context="billing_trial_panel"
+        onDone={closeAddCredits}
+      />
+    </>
+  );
+
+  function openAddCredits() {
+    setIsAddCreditsOpen(true);
+  }
+
+  function closeAddCredits() {
+    setIsAddCreditsOpen(false);
+  }
+};

--- a/apps/deploy-web/src/components/billing-usage/TrialStatusPanel/useTrialStatus.spec.ts
+++ b/apps/deploy-web/src/components/billing-usage/TrialStatusPanel/useTrialStatus.spec.ts
@@ -24,10 +24,16 @@ describe(useTrialStatus.name, () => {
     expect(result.current.isExpired).toBe(true);
   });
 
-  it("reports the share of the trial already spent", () => {
+  it("drains the bar in step with the days left", () => {
     const { result } = setup({ trialEndsAt: addDays(new Date(), 15), totalDays: 30 });
 
-    expect(result.current.daysElapsedPercent).toBe(50);
+    expect(result.current.daysRemainingPercent).toBe(50);
+  });
+
+  it("keeps the bar full while the expiry is still unknown", () => {
+    const { result } = setup({ trialEndsAt: null });
+
+    expect(result.current.daysRemainingPercent).toBe(100);
   });
 
   it("leaves the countdown unknown when the wallet reports no expiry", () => {

--- a/apps/deploy-web/src/components/billing-usage/TrialStatusPanel/useTrialStatus.spec.ts
+++ b/apps/deploy-web/src/components/billing-usage/TrialStatusPanel/useTrialStatus.spec.ts
@@ -1,7 +1,9 @@
 import type { ApiManagedWalletOutput } from "@akashnetwork/http-sdk";
 import addDays from "date-fns/addDays";
+import addHours from "date-fns/addHours";
 import subDays from "date-fns/subDays";
-import { describe, expect, it } from "vitest";
+import subHours from "date-fns/subHours";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { DEPENDENCIES } from "./useTrialStatus";
@@ -10,11 +12,33 @@ import { useTrialStatus } from "./useTrialStatus";
 import { renderHook } from "@testing-library/react";
 
 describe(useTrialStatus.name, () => {
-  it("reports the calendar days left until the trial expires", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("reports the days left until the trial expires", () => {
     const { result } = setup({ trialEndsAt: addDays(new Date(), 12) });
 
     expect(result.current.daysLeft).toBe(12);
     expect(result.current.isExpired).toBe(false);
+  });
+
+  it("keeps a trial expiring later the same day running", () => {
+    const now = pinClockTo(new Date(2026, 5, 5, 9, 0, 0));
+
+    const { result } = setup({ trialEndsAt: addHours(now, 6) });
+
+    expect(result.current.daysLeft).toBe(1);
+    expect(result.current.isExpired).toBe(false);
+  });
+
+  it("marks the trial expired once its timestamp has passed", () => {
+    const now = pinClockTo(new Date(2026, 5, 5, 9, 0, 0));
+
+    const { result } = setup({ trialEndsAt: subHours(now, 1) });
+
+    expect(result.current.daysLeft).toBe(0);
+    expect(result.current.isExpired).toBe(true);
   });
 
   it("clamps an elapsed trial to zero days left", () => {
@@ -42,6 +66,12 @@ describe(useTrialStatus.name, () => {
     expect(result.current.daysLeft).toBeNull();
     expect(result.current.isExpired).toBe(false);
   });
+
+  function pinClockTo(now: Date) {
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    return now;
+  }
 
   function setup(input: { trialEndsAt: Date | null; totalDays?: number; isTrialing?: boolean }) {
     const useWallet: typeof DEPENDENCIES.useWallet = () => mock<ReturnType<typeof DEPENDENCIES.useWallet>>({ isTrialing: input.isTrialing ?? true });

--- a/apps/deploy-web/src/components/billing-usage/TrialStatusPanel/useTrialStatus.spec.ts
+++ b/apps/deploy-web/src/components/billing-usage/TrialStatusPanel/useTrialStatus.spec.ts
@@ -1,0 +1,58 @@
+import type { ApiManagedWalletOutput } from "@akashnetwork/http-sdk";
+import addDays from "date-fns/addDays";
+import subDays from "date-fns/subDays";
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { DEPENDENCIES } from "./useTrialStatus";
+import { useTrialStatus } from "./useTrialStatus";
+
+import { renderHook } from "@testing-library/react";
+
+describe(useTrialStatus.name, () => {
+  it("reports the calendar days left until the trial expires", () => {
+    const { result } = setup({ trialEndsAt: addDays(new Date(), 12) });
+
+    expect(result.current.daysLeft).toBe(12);
+    expect(result.current.isExpired).toBe(false);
+  });
+
+  it("clamps an elapsed trial to zero days left", () => {
+    const { result } = setup({ trialEndsAt: subDays(new Date(), 3) });
+
+    expect(result.current.daysLeft).toBe(0);
+    expect(result.current.isExpired).toBe(true);
+  });
+
+  it("reports the share of the trial already spent", () => {
+    const { result } = setup({ trialEndsAt: addDays(new Date(), 15), totalDays: 30 });
+
+    expect(result.current.daysElapsedPercent).toBe(50);
+  });
+
+  it("leaves the countdown unknown when the wallet reports no expiry", () => {
+    const { result } = setup({ trialEndsAt: null });
+
+    expect(result.current.daysLeft).toBeNull();
+    expect(result.current.isExpired).toBe(false);
+  });
+
+  function setup(input: { trialEndsAt: Date | null; totalDays?: number; isTrialing?: boolean }) {
+    const useWallet: typeof DEPENDENCIES.useWallet = () => mock<ReturnType<typeof DEPENDENCIES.useWallet>>({ isTrialing: input.isTrialing ?? true });
+
+    const useManagedWallet: typeof DEPENDENCIES.useManagedWallet = () =>
+      mock<ReturnType<typeof DEPENDENCIES.useManagedWallet>>({
+        wallet: mock<ApiManagedWalletOutput>({ trialEndsAt: input.trialEndsAt ? input.trialEndsAt.toISOString() : null })
+      });
+
+    const useServices: typeof DEPENDENCIES.useServices = () =>
+      mock<ReturnType<typeof DEPENDENCIES.useServices>>({
+        publicConfig: mock<ReturnType<typeof DEPENDENCIES.useServices>["publicConfig"]>({
+          NEXT_PUBLIC_TRIAL_DURATION_DAYS: input.totalDays ?? 30,
+          NEXT_PUBLIC_TRIAL_DEPLOYMENTS_DURATION_HOURS: 24
+        })
+      });
+
+    return renderHook(() => useTrialStatus({ dependencies: { useWallet, useManagedWallet, useServices } }));
+  }
+});

--- a/apps/deploy-web/src/components/billing-usage/TrialStatusPanel/useTrialStatus.ts
+++ b/apps/deploy-web/src/components/billing-usage/TrialStatusPanel/useTrialStatus.ts
@@ -1,5 +1,5 @@
 "use client";
-import differenceInCalendarDays from "date-fns/differenceInCalendarDays";
+import differenceInMilliseconds from "date-fns/differenceInMilliseconds";
 
 import { useServices } from "@src/context/ServicesProvider";
 import { useWallet } from "@src/context/WalletProvider";
@@ -10,6 +10,8 @@ export const DEPENDENCIES = {
   useManagedWallet,
   useServices
 };
+
+const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
 
 export type TrialStatus = {
   isTrialing: boolean;
@@ -29,14 +31,15 @@ export function useTrialStatus({ dependencies: d = DEPENDENCIES }: { dependencie
 
   const totalDays = publicConfig.NEXT_PUBLIC_TRIAL_DURATION_DAYS;
   const trialEndsAt = wallet?.trialEndsAt ? new Date(wallet.trialEndsAt) : null;
-  const daysLeft = trialEndsAt ? Math.min(Math.max(differenceInCalendarDays(trialEndsAt, new Date()), 0), totalDays) : null;
+  const millisecondsLeft = trialEndsAt ? differenceInMilliseconds(trialEndsAt, new Date()) : null;
+  const daysLeft = millisecondsLeft === null ? null : Math.min(Math.max(Math.ceil(millisecondsLeft / MILLISECONDS_PER_DAY), 0), totalDays);
 
   return {
     isTrialing,
     totalDays,
     daysLeft,
     daysRemainingPercent: daysLeft === null ? 100 : (daysLeft / totalDays) * 100,
-    isExpired: daysLeft === 0,
+    isExpired: millisecondsLeft !== null && millisecondsLeft <= 0,
     deploymentDurationHours: publicConfig.NEXT_PUBLIC_TRIAL_DEPLOYMENTS_DURATION_HOURS
   };
 }

--- a/apps/deploy-web/src/components/billing-usage/TrialStatusPanel/useTrialStatus.ts
+++ b/apps/deploy-web/src/components/billing-usage/TrialStatusPanel/useTrialStatus.ts
@@ -1,0 +1,41 @@
+"use client";
+import differenceInCalendarDays from "date-fns/differenceInCalendarDays";
+
+import { useServices } from "@src/context/ServicesProvider";
+import { useWallet } from "@src/context/WalletProvider";
+import { useManagedWallet } from "@src/hooks/useManagedWallet";
+
+export const DEPENDENCIES = {
+  useWallet,
+  useManagedWallet,
+  useServices
+};
+
+export type TrialStatus = {
+  isTrialing: boolean;
+  totalDays: number;
+  /** null until the API reports an expiry, which keeps the panel from guessing a countdown it doesn't know. */
+  daysLeft: number | null;
+  daysElapsedPercent: number;
+  isExpired: boolean;
+  deploymentDurationHours: number;
+};
+
+export function useTrialStatus({ dependencies: d = DEPENDENCIES }: { dependencies?: typeof DEPENDENCIES } = {}): TrialStatus {
+  const { isTrialing } = d.useWallet();
+  const { wallet } = d.useManagedWallet();
+  const { publicConfig } = d.useServices();
+
+  const totalDays = publicConfig.NEXT_PUBLIC_TRIAL_DURATION_DAYS;
+  const trialEndsAt = wallet?.trialEndsAt ? new Date(wallet.trialEndsAt) : null;
+  const daysLeft = trialEndsAt ? Math.min(Math.max(differenceInCalendarDays(trialEndsAt, new Date()), 0), totalDays) : null;
+
+  return {
+    isTrialing,
+    totalDays,
+    daysLeft,
+    daysElapsedPercent: daysLeft === null ? 0 : ((totalDays - daysLeft) / totalDays) * 100,
+    isExpired: daysLeft === 0,
+    deploymentDurationHours: publicConfig.NEXT_PUBLIC_TRIAL_DEPLOYMENTS_DURATION_HOURS
+  };
+}

--- a/apps/deploy-web/src/components/billing-usage/TrialStatusPanel/useTrialStatus.ts
+++ b/apps/deploy-web/src/components/billing-usage/TrialStatusPanel/useTrialStatus.ts
@@ -16,7 +16,8 @@ export type TrialStatus = {
   totalDays: number;
   /** null until the API reports an expiry, which keeps the panel from guessing a countdown it doesn't know. */
   daysLeft: number | null;
-  daysElapsedPercent: number;
+  /** Drains as the trial runs down: full on day one, empty once it expires. */
+  daysRemainingPercent: number;
   isExpired: boolean;
   deploymentDurationHours: number;
 };
@@ -34,7 +35,7 @@ export function useTrialStatus({ dependencies: d = DEPENDENCIES }: { dependencie
     isTrialing,
     totalDays,
     daysLeft,
-    daysElapsedPercent: daysLeft === null ? 0 : ((totalDays - daysLeft) / totalDays) * 100,
+    daysRemainingPercent: daysLeft === null ? 100 : (daysLeft / totalDays) * 100,
     isExpired: daysLeft === 0,
     deploymentDurationHours: publicConfig.NEXT_PUBLIC_TRIAL_DEPLOYMENTS_DURATION_HOURS
   };

--- a/packages/http-sdk/src/managed-wallet-http/managed-wallet-http.service.ts
+++ b/packages/http-sdk/src/managed-wallet-http/managed-wallet-http.service.ts
@@ -9,6 +9,7 @@ export interface ApiWalletOutput {
   denom: string;
   creditAmount: number;
   isTrialing: boolean;
+  trialEndsAt: string | null;
   topUpMinAmountUsd: number;
   createdAt: Date;
 }


### PR DESCRIPTION
## Why

Someone on the free trial gets no indication on the Billing page that they are on a trial. The page shows their balance, auto top-up, and payment methods, with nothing explaining why their deployments keep closing after a day or why the high-end GPUs are unavailable. The one trial cue on the page is the "Get $100" banner at the top, which sells credits without saying what the trial restricts or how long it lasts.

## What

Adds a "Free trial" panel at the top of the Billing page, rendered only while the wallet is still trialing. It shows:

- a progress bar that starts full and drains one day at a time, captioned with the days left out of the trial length
- the limits that apply, matching what the configure screen actually gates: the deployment lifetime (from public config, so it tracks the API), blocked high-end GPU models, GPU interconnect, and GPU-backed confidential compute
- a "Purchase credits" button that opens the same add-credits sheet the funding banner uses, with the first-purchase bonus mentioned

The panel returns null once the wallet stops trialing. Past day 30 while still trialing, it switches to "Your free trial has ended" and keeps the same CTA. While the expiry is still loading, the bar and caption render as skeletons rather than a full bar that would read as an untouched trial.

### API change

Nothing computed a trial expiry anywhere. `GET /v1/wallets` returned only `createdAt`, and `NEXT_PUBLIC_TRIAL_DURATION_DAYS` was declared in deploy-web but never read. Deriving the countdown from `createdAt` in the browser overstates the time left whenever trial activation lags registration, so the endpoint now returns `trialEndsAt`, computed server-side from `activatedAt ?? createdAt` plus `TRIAL_ALLOWANCE_EXPIRATION_DAYS`.

That formula already lived inside `ManagedUserWalletService.refillWalletFees`. It moves into `billing/lib/trial-window` so the fee grant expiry and the new field stay on one definition. The new field is additive and nullable, so it does not break existing clients.

### Testing

Unit specs cover the panel, the hook's day math, and `getTrialEndsAt`. `GET /v1/wallets` had no functional test, so this adds one covering both the trialing and non-trialing responses against a real database.

I have not loaded the page in a browser against a live trial account, so the visual result is unconfirmed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added trial expiration details to wallet information.
  * Added a billing panel showing trial status, remaining time, limitations, and expiration.
  * Added trial-specific credit purchase guidance and first-purchase bonus messaging.
  * Trial expiration is calculated consistently for activated and newly created wallets.

* **Bug Fixes**
  * Wallets no longer display trial expiration dates when they are not trialing.

* **Tests**
  * Added coverage for trial calculations, wallet responses, status display, countdowns, and expiration states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->