### PR TITLE
refactor(deployment): run the expiry-warning and dark-provider-close crons for real

### DIFF
--- a/.helm/console-api-prod-mainnet-values.yaml
+++ b/.helm/console-api-prod-mainnet-values.yaml
@@ -35,8 +35,6 @@ jobs:
       - ./dist/instrumentation.js
       - ./dist/console.js
       - gpu-pricing-bot
-  # Ships in dry-run for a bake period: --dry-run only logs EXPIRING_DEPLOYMENT_WOULD_NOTIFY.
-  # Drop the flag to start emailing for real once those logs look right.
   # Offset off the hour so it does not hit deployment_settings on the same minute as top-up-deployments.
   - name: notify-expiring-deployments
     schedule: "7,22,37,52 * * * *" # every 15 minutes
@@ -46,7 +44,6 @@ jobs:
       - ./dist/instrumentation.js
       - ./dist/console.js
       - notify-expiring-deployments
-      - --dry-run
   # Offset from the two runtime-limit sweeps so no two of them hit deployment_settings on the same minute.
   - name: notify-unreachable-deployments
     schedule: "11,41 * * * *" # every 30 minutes
@@ -56,9 +53,6 @@ jobs:
       - ./dist/instrumentation.js
       - ./dist/console.js
       - notify-unreachable-deployments
-  # Ships in dry-run and stays that way until the warning email above has been live for longer than the
-  # gap between the two thresholds (14 - 3 = 11 days), so no owner's first word about an outage is the
-  # closure notice. Check that every UNREACHABLE_PROVIDER_DEPLOYMENT_WOULD_CLOSE was warned first.
   # Offset from the sweeps above so no two of them hit deployment_settings on the same minute.
   - name: close-unreachable-deployments
     schedule: "26 * * * *" # hourly
@@ -68,7 +62,6 @@ jobs:
       - ./dist/instrumentation.js
       - ./dist/console.js
       - close-unreachable-deployments
-      - --dry-run
   - name: mint-act
     schedule: "*/10 * * * *" # every 10 minutes
     concurrencyPolicy: Forbid


### PR DESCRIPTION
## Why

The last two prod crons still in dry-run are ready to go live:

- `notify-expiring-deployments` has swept every 15 minutes since Aug 25 and logged `found: 0, failed: 0` on every run. Runtime limits are new and flag-gated, so no candidate can show up during a bake period no matter how long we wait; the flag is only delaying the feature at this point.
- `close-unreachable-deployments` has been flagging the same 6 deployments, all on providers dark for 1 to 3 months. Their owners got the warning email on Aug 30 when #3731 went live. This merges ahead of the 11-day lead the values file asked for, on purpose: every day these deployments stay open, more escrow accrues toward providers that are not coming back, and that accrual settles to the provider at close. Owners are still warned before anything closes; what shrinks is the lead time, and only for this backlog, whose workloads have been gone for months. New outages get the full 3-day warn / 14-day close stagger.

Related to CON-885, CON-900, CON-901

## What

Removes the two `--dry-run` flags and their bake-period comments from the prod-mainnet values. On its first live run `notify-expiring-deployments` sends nothing, since there are no candidates yet. `close-unreachable-deployments` closes the 6 backlog deployments on its first run after the deploy and returns their remaining escrow to the owners.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated deployment notification and closure jobs to run without dry-run mode.
  * Existing schedules and commands remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->