### PR TITLE
fix(template): stream github archives instead of aborting large downloads at 60s

### DIFF
--- a/apps/api/src/template/services/github-archive/github-archive.service.spec.ts
+++ b/apps/api/src/template/services/github-archive/github-archive.service.spec.ts
@@ -1,12 +1,17 @@
 import { gzipSync } from "node:zlib";
 import tar from "tar";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { CreateLogger } from "@src/core";
 import { GitHubArchiveService } from "./github-archive.service";
 
 describe(GitHubArchiveService.name, () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
   describe("getArchive with fileFilter", () => {
     it("only stores content for files matching the filter", async () => {
       const { service, installArchive } = setup();
@@ -82,22 +87,101 @@ describe(GitHubArchiveService.name, () => {
     });
   });
 
+  describe("download resilience", () => {
+    it("retries when a download fails and succeeds on a later attempt", async () => {
+      const { service, fetchSpy, archiveResponse } = setup();
+      fetchSpy.mockRejectedValueOnce(new Error("socket hang up")).mockResolvedValueOnce(archiveResponse({ "root/readme.md": "# Hello" }));
+
+      const reader = await service.getArchive("owner", "repo", "ref");
+
+      expect(await reader.readFile("readme.md")).toBe("# Hello");
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("gives up after exhausting all attempts and reports the last error", async () => {
+      const { service, fetchSpy } = setup();
+      fetchSpy.mockRejectedValue(new Error("socket hang up"));
+
+      await expect(service.getArchive("owner", "repo", "ref")).rejects.toThrow("socket hang up");
+      expect(fetchSpy).toHaveBeenCalledTimes(3);
+    });
+
+    it("does not retry when github reports the archive is unavailable", async () => {
+      const { service, fetchSpy } = setup();
+      fetchSpy.mockResolvedValue(new Response(null, { status: 404, statusText: "Not Found" }));
+
+      await expect(service.getArchive("owner", "repo", "ref")).rejects.toThrow("404 Not Found");
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("aborts a download that stops producing data", async () => {
+      const { service, fetchSpy } = setup();
+      fetchSpy.mockImplementation(
+        (_url, init) =>
+          new Promise((_resolve, reject) => {
+            const signal = (init as RequestInit).signal!;
+            signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+          })
+      );
+
+      const stalled = expect(service.getArchive("owner", "repo", "ref")).rejects.toThrow("received no data for 30000ms");
+      await vi.advanceTimersByTimeAsync(3 * 30_000);
+
+      await stalled;
+      expect(fetchSpy).toHaveBeenCalledTimes(3);
+    });
+
+    it("keeps downloading while data keeps arriving past the stall timeout", async () => {
+      const { service, fetchSpy, tarGzChunks } = setup();
+      const chunks = tarGzChunks({ "root/readme.md": "# Hello" });
+      fetchSpy.mockImplementation(() =>
+        Promise.resolve(
+          new Response(
+            new ReadableStream({
+              async pull(controller) {
+                const chunk = chunks.shift();
+                if (!chunk) return controller.close();
+                await vi.advanceTimersByTimeAsync(20_000);
+                controller.enqueue(chunk);
+              }
+            })
+          )
+        )
+      );
+
+      const reader = await service.getArchive("owner", "repo", "ref");
+
+      expect(await reader.readFile("readme.md")).toBe("# Hello");
+    });
+  });
+
   function setup() {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
     const logger = mock<ReturnType<CreateLogger>>();
     const service = new GitHubArchiveService(logger);
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
 
-    async function installArchive(files: Record<string, string>) {
-      const tarGzBuffer = createTarGzBuffer(files);
-
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(new Uint8Array(tarGzBuffer), {
-          status: 200,
-          headers: { "Content-Type": "application/gzip" }
-        })
-      );
+    function archiveResponse(files: Record<string, string>) {
+      return new Response(new Uint8Array(createTarGzBuffer(files)), {
+        status: 200,
+        headers: { "Content-Type": "application/gzip" }
+      });
     }
 
-    return { service, logger, installArchive };
+    function tarGzChunks(files: Record<string, string>, chunkSize = 64) {
+      const buffer = createTarGzBuffer(files);
+      const chunks: Uint8Array[] = [];
+      for (let offset = 0; offset < buffer.length; offset += chunkSize) {
+        chunks.push(new Uint8Array(buffer.subarray(offset, offset + chunkSize)));
+      }
+      return chunks;
+    }
+
+    async function installArchive(files: Record<string, string>) {
+      fetchSpy.mockResolvedValue(archiveResponse(files));
+    }
+
+    return { service, logger, installArchive, fetchSpy, archiveResponse, tarGzChunks };
   }
 
   function createTarGzBuffer(files: Record<string, string>): Buffer {

--- a/apps/api/src/template/services/github-archive/github-archive.service.spec.ts
+++ b/apps/api/src/template/services/github-archive/github-archive.service.spec.ts
@@ -174,6 +174,29 @@ describe(GitHubArchiveService.name, () => {
       expect(fetchSpy).toHaveBeenCalledTimes(2);
     });
 
+    it("cancels the response body when extraction fails so the connection is released", async () => {
+      const { service, fetchSpy } = setup();
+      const cancelSource = vi.fn();
+      fetchSpy.mockImplementation(() =>
+        Promise.resolve(
+          new Response(
+            new ReadableStream({
+              pull(controller) {
+                controller.enqueue(new Uint8Array(1024));
+              },
+              cancel: cancelSource
+            })
+          )
+        )
+      );
+
+      const failed = expect(service.getArchive("owner", "repo", "ref")).rejects.toThrow();
+      await vi.advanceTimersByTimeAsync(BEYOND_ALL_RETRY_BACKOFFS_MS);
+      await failed;
+
+      expect(cancelSource).toHaveBeenCalled();
+    });
+
     it("aborts a download that stops producing data", async () => {
       const { service, fetchSpy } = setup();
       fetchSpy.mockImplementation(

--- a/apps/api/src/template/services/github-archive/github-archive.service.spec.ts
+++ b/apps/api/src/template/services/github-archive/github-archive.service.spec.ts
@@ -6,6 +6,8 @@ import { mock } from "vitest-mock-extended";
 import type { CreateLogger } from "@src/core";
 import { GitHubArchiveService } from "./github-archive.service";
 
+const BEYOND_ALL_RETRY_BACKOFFS_MS = 60_000;
+
 describe(GitHubArchiveService.name, () => {
   afterEach(() => {
     vi.useRealTimers();
@@ -92,7 +94,9 @@ describe(GitHubArchiveService.name, () => {
       const { service, fetchSpy, archiveResponse } = setup();
       fetchSpy.mockRejectedValueOnce(new Error("socket hang up")).mockResolvedValueOnce(archiveResponse({ "root/readme.md": "# Hello" }));
 
-      const reader = await service.getArchive("owner", "repo", "ref");
+      const archive = service.getArchive("owner", "repo", "ref");
+      await vi.advanceTimersByTimeAsync(BEYOND_ALL_RETRY_BACKOFFS_MS);
+      const reader = await archive;
 
       expect(await reader.readFile("readme.md")).toBe("# Hello");
       expect(fetchSpy).toHaveBeenCalledTimes(2);
@@ -102,7 +106,10 @@ describe(GitHubArchiveService.name, () => {
       const { service, fetchSpy } = setup();
       fetchSpy.mockRejectedValue(new Error("socket hang up"));
 
-      await expect(service.getArchive("owner", "repo", "ref")).rejects.toThrow("socket hang up");
+      const failed = expect(service.getArchive("owner", "repo", "ref")).rejects.toThrow("socket hang up");
+      await vi.advanceTimersByTimeAsync(BEYOND_ALL_RETRY_BACKOFFS_MS);
+
+      await failed;
       expect(fetchSpy).toHaveBeenCalledTimes(3);
     });
 
@@ -112,6 +119,59 @@ describe(GitHubArchiveService.name, () => {
 
       await expect(service.getArchive("owner", "repo", "ref")).rejects.toThrow("404 Not Found");
       expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("retries when the response body fails part way through the download", async () => {
+      const { service, fetchSpy, archiveResponse, tarGzChunks } = setup();
+      const truncated = tarGzChunks({ "root/readme.md": "# Hello" }).slice(0, 2);
+      fetchSpy
+        .mockResolvedValueOnce(
+          new Response(
+            new ReadableStream({
+              pull(controller) {
+                const chunk = truncated.shift();
+                if (chunk) return controller.enqueue(chunk);
+                controller.error(new TypeError("terminated"));
+              }
+            })
+          )
+        )
+        .mockResolvedValueOnce(archiveResponse({ "root/readme.md": "# Hello" }));
+
+      const archive = service.getArchive("owner", "repo", "ref");
+      await vi.advanceTimersByTimeAsync(BEYOND_ALL_RETRY_BACKOFFS_MS);
+      const reader = await archive;
+
+      expect(await reader.readFile("readme.md")).toBe("# Hello");
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("retries when fetch itself fails at the transport level", async () => {
+      const { service, fetchSpy, archiveResponse } = setup();
+      const transportFailure = new TypeError("fetch failed");
+      transportFailure.cause = new Error("HeadersTimeoutError");
+      fetchSpy.mockRejectedValueOnce(transportFailure).mockResolvedValueOnce(archiveResponse({ "root/readme.md": "# Hello" }));
+
+      const archive = service.getArchive("owner", "repo", "ref");
+      await vi.advanceTimersByTimeAsync(BEYOND_ALL_RETRY_BACKOFFS_MS);
+      const reader = await archive;
+
+      expect(await reader.readFile("readme.md")).toBe("# Hello");
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("retries a TimeoutError raised by an aborted fetch", async () => {
+      const { service, fetchSpy, archiveResponse } = setup();
+      fetchSpy
+        .mockRejectedValueOnce(new DOMException("The operation was aborted due to timeout", "TimeoutError"))
+        .mockResolvedValueOnce(archiveResponse({ "root/readme.md": "# Hello" }));
+
+      const archive = service.getArchive("owner", "repo", "ref");
+      await vi.advanceTimersByTimeAsync(BEYOND_ALL_RETRY_BACKOFFS_MS);
+      const reader = await archive;
+
+      expect(await reader.readFile("readme.md")).toBe("# Hello");
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
     });
 
     it("aborts a download that stops producing data", async () => {
@@ -125,7 +185,7 @@ describe(GitHubArchiveService.name, () => {
       );
 
       const stalled = expect(service.getArchive("owner", "repo", "ref")).rejects.toThrow("received no data for 30000ms");
-      await vi.advanceTimersByTimeAsync(3 * 30_000);
+      await vi.advanceTimersByTimeAsync(3 * 30_000 + BEYOND_ALL_RETRY_BACKOFFS_MS);
 
       await stalled;
       expect(fetchSpy).toHaveBeenCalledTimes(3);

--- a/apps/api/src/template/services/github-archive/github-archive.service.ts
+++ b/apps/api/src/template/services/github-archive/github-archive.service.ts
@@ -6,6 +6,13 @@ import tar from "tar";
 
 import type { CreateLogger } from "@src/core";
 
+/** The template repo archives are ~70 MB each, so the download budget has to bound stalls rather than total transfer time. */
+const DOWNLOAD_STALL_TIMEOUT_MS = 30_000;
+
+const MAX_DOWNLOAD_ATTEMPTS = 3;
+
+class ArchiveNotAvailableError extends Error {}
+
 export interface DirectoryEntry {
   name: string;
   path: string;
@@ -20,6 +27,19 @@ export interface ArchiveReader {
 interface ParsedArchive {
   files: Map<string, string>;
   directories: Map<string, DirectoryEntry[]>;
+}
+
+async function* streamWhileMakingProgress(body: ReadableStream<Uint8Array>, onProgress: () => void) {
+  const reader = body.getReader();
+
+  try {
+    for (let chunk = await reader.read(); !chunk.done; chunk = await reader.read()) {
+      onProgress();
+      yield chunk.value;
+    }
+  } finally {
+    reader.releaseLock();
+  }
 }
 
 export class GitHubArchiveService {
@@ -54,19 +74,60 @@ export class GitHubArchiveService {
 
   async #downloadAndParse(owner: string, repo: string, ref: string, fileFilter?: (relativePath: string) => boolean): Promise<ArchiveReader> {
     const url = `https://github.com/${owner}/${repo}/archive/${ref}.tar.gz`;
-    const response = await fetch(url, { signal: AbortSignal.timeout(60_000) });
+    let lastError: unknown;
 
-    if (!response.ok) {
-      throw new Error(`Failed to download archive from ${url}: ${response.status} ${response.statusText}`);
+    for (let attempt = 1; attempt <= MAX_DOWNLOAD_ATTEMPTS; attempt++) {
+      try {
+        return this.#createArchiveReader(await this.#downloadAndExtract(url, fileFilter));
+      } catch (error) {
+        if (error instanceof ArchiveNotAvailableError) throw error;
+
+        lastError = error;
+        this.#logger.warn({
+          event: "ARCHIVE_DOWNLOAD_ATTEMPT_FAILED",
+          url,
+          attempt,
+          maxAttempts: MAX_DOWNLOAD_ATTEMPTS,
+          error
+        });
+      }
     }
 
-    const buffer = Buffer.from(await response.arrayBuffer());
-    const parsed = await this.#extractArchive(buffer, fileFilter);
-
-    return this.#createArchiveReader(parsed);
+    throw lastError;
   }
 
-  async #extractArchive(buffer: Buffer, fileFilter?: (relativePath: string) => boolean): Promise<ParsedArchive> {
+  async #downloadAndExtract(url: string, fileFilter?: (relativePath: string) => boolean): Promise<ParsedArchive> {
+    const abortWhenStalled = new AbortController();
+    let stallTimer: NodeJS.Timeout | undefined;
+
+    const restartStallTimer = () => {
+      clearTimeout(stallTimer);
+      stallTimer = setTimeout(
+        () => abortWhenStalled.abort(new Error(`Archive download from ${url} received no data for ${DOWNLOAD_STALL_TIMEOUT_MS}ms`)),
+        DOWNLOAD_STALL_TIMEOUT_MS
+      );
+    };
+
+    try {
+      restartStallTimer();
+      const response = await fetch(url, { signal: abortWhenStalled.signal });
+
+      if (!response.ok) {
+        const message = `Failed to download archive from ${url}: ${response.status} ${response.statusText}`;
+        throw response.status >= 400 && response.status < 500 ? new ArchiveNotAvailableError(message) : new Error(message);
+      }
+
+      if (!response.body) {
+        throw new Error(`Archive download from ${url} returned no body`);
+      }
+
+      return await this.#extractArchive(Readable.from(streamWhileMakingProgress(response.body, restartStallTimer)), fileFilter);
+    } finally {
+      clearTimeout(stallTimer);
+    }
+  }
+
+  async #extractArchive(source: Readable, fileFilter?: (relativePath: string) => boolean): Promise<ParsedArchive> {
     const files = new Map<string, string>();
     const dirChildren = new Map<string, Map<string, DirectoryEntry>>();
     let rootPrefix = "";
@@ -120,7 +181,7 @@ export class GitHubArchiveService {
       }
     });
 
-    await pipeline(Readable.from(buffer), createGunzip(), parser);
+    await pipeline(source, createGunzip(), parser);
 
     const directories = new Map<string, DirectoryEntry[]>();
     for (const [dirPath, childMap] of dirChildren) {

--- a/apps/api/src/template/services/github-archive/github-archive.service.ts
+++ b/apps/api/src/template/services/github-archive/github-archive.service.ts
@@ -1,3 +1,4 @@
+import { ExponentialBackoff, handleWhen, retry, type RetryPolicy } from "cockatiel";
 import { LRUCache } from "lru-cache";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
@@ -9,7 +10,9 @@ import type { CreateLogger } from "@src/core";
 /** The template repo archives are ~70 MB each, so the download budget has to bound stalls rather than total transfer time. */
 const DOWNLOAD_STALL_TIMEOUT_MS = 30_000;
 
-const MAX_DOWNLOAD_ATTEMPTS = 3;
+const MAX_DOWNLOAD_RETRIES = 2;
+const RETRY_INITIAL_DELAY_MS = 1_000;
+const RETRY_MAX_DELAY_MS = 10_000;
 
 class ArchiveNotAvailableError extends Error {}
 
@@ -45,9 +48,17 @@ async function* streamWhileMakingProgress(body: ReadableStream<Uint8Array>, onPr
 export class GitHubArchiveService {
   readonly #cache = new LRUCache<string, Promise<ArchiveReader>>({ max: 10 });
   readonly #logger: ReturnType<CreateLogger>;
+  readonly #downloadPolicy: RetryPolicy;
 
   constructor(logger: ReturnType<CreateLogger>) {
     this.#logger = logger;
+    this.#downloadPolicy = retry(
+      handleWhen(error => !(error instanceof ArchiveNotAvailableError)),
+      {
+        maxAttempts: MAX_DOWNLOAD_RETRIES,
+        backoff: new ExponentialBackoff({ initialDelay: RETRY_INITIAL_DELAY_MS, maxDelay: RETRY_MAX_DELAY_MS })
+      }
+    );
   }
 
   async getArchive(owner: string, repo: string, ref: string, fileFilter?: (relativePath: string) => boolean): Promise<ArchiveReader> {
@@ -74,26 +85,23 @@ export class GitHubArchiveService {
 
   async #downloadAndParse(owner: string, repo: string, ref: string, fileFilter?: (relativePath: string) => boolean): Promise<ArchiveReader> {
     const url = `https://github.com/${owner}/${repo}/archive/${ref}.tar.gz`;
-    let lastError: unknown;
 
-    for (let attempt = 1; attempt <= MAX_DOWNLOAD_ATTEMPTS; attempt++) {
+    const parsedArchive = await this.#downloadPolicy.execute(async ({ attempt }) => {
       try {
-        return this.#createArchiveReader(await this.#downloadAndExtract(url, fileFilter));
+        return await this.#downloadAndExtract(url, fileFilter);
       } catch (error) {
-        if (error instanceof ArchiveNotAvailableError) throw error;
-
-        lastError = error;
         this.#logger.warn({
           event: "ARCHIVE_DOWNLOAD_ATTEMPT_FAILED",
           url,
-          attempt,
-          maxAttempts: MAX_DOWNLOAD_ATTEMPTS,
+          attempt: attempt + 1,
+          maxAttempts: MAX_DOWNLOAD_RETRIES + 1,
           error
         });
+        throw error;
       }
-    }
+    });
 
-    throw lastError;
+    return this.#createArchiveReader(parsedArchive);
   }
 
   async #downloadAndExtract(url: string, fileFilter?: (relativePath: string) => boolean): Promise<ParsedArchive> {

--- a/apps/api/src/template/services/github-archive/github-archive.service.ts
+++ b/apps/api/src/template/services/github-archive/github-archive.service.ts
@@ -41,6 +41,7 @@ async function* streamWhileMakingProgress(body: ReadableStream<Uint8Array>, onPr
       yield chunk.value;
     }
   } finally {
+    await reader.cancel().catch(() => undefined);
     reader.releaseLock();
   }
 }

--- a/apps/api/src/template/services/template-gallery/template-gallery.service.spec.ts
+++ b/apps/api/src/template/services/template-gallery/template-gallery.service.spec.ts
@@ -95,6 +95,15 @@ describe(TemplateGalleryService.name, () => {
       );
     });
 
+    it("refuses to publish a repository that yielded no categories", async () => {
+      const { service, templateFetcher, fsMock } = setup();
+
+      templateFetcher.fetchAwesomeAkashTemplates.mockResolvedValue([]);
+
+      await expect(service.getTemplateGallery()).rejects.toThrow("Refusing to cache an empty template gallery for akash-network/awesome-akash@abc123");
+      expect(fsMock.writeFile).not.toHaveBeenCalledWith(expect.stringContaining("akash-network-awesome-akash"), expect.anything());
+    });
+
     it("throws error when github request for latest commit sha fails and no cached files exist", async () => {
       const { service, templateFetcher, fsMock } = setup();
       const error = new Error("Network error");
@@ -156,7 +165,6 @@ describe(TemplateGalleryService.name, () => {
       const { service, templateFetcher, fsMock } = setup();
       const categoriesSchema = z.array(z.object({ title: z.string() }));
 
-      templateFetcher.fetchAwesomeAkashTemplates.mockResolvedValue([]);
       fsMock.mkdir.mockResolvedValue(undefined);
       fsMock.writeFile.mockResolvedValue(undefined);
 
@@ -353,8 +361,10 @@ describe(TemplateGalleryService.name, () => {
 
     const templateFetcher = mock<TemplateFetcherService>({
       fetchLatestCommitSha: vi.fn(() => Promise.resolve("abc123")),
-      fetchAwesomeAkashTemplates: vi.fn(() => Promise.resolve([])),
-      fetchOmnibusTemplates: vi.fn(() => Promise.resolve([])),
+      fetchAwesomeAkashTemplates: vi.fn(() =>
+        Promise.resolve([createCategory({ title: "AI", templates: [{ id: "awesome-akash-1", name: "Awesome Akash 1" }] })])
+      ),
+      fetchOmnibusTemplates: vi.fn(() => Promise.resolve([createCategory({ title: "Blockchain", templates: [{ id: "omnibus-1", name: "Omnibus 1" }] })])),
       clearArchiveCache: vi.fn()
     });
 

--- a/apps/api/src/template/services/template-gallery/template-gallery.service.ts
+++ b/apps/api/src/template/services/template-gallery/template-gallery.service.ts
@@ -317,6 +317,11 @@ export class TemplateGalleryService {
         commitSha: latestCommitSha
       });
       const categories = await fetchTemplates(latestCommitSha);
+
+      if (categories.length === 0) {
+        throw new Error(`Refusing to cache an empty template gallery for ${repoOwner}/${repoName}@${latestCommitSha}`);
+      }
+
       await this.#fs.mkdir(path.dirname(cacheFilePath), { recursive: true });
       await this.#fs.writeFile(cacheFilePath, JSON.stringify(categories, null, 2));
 


### PR DESCRIPTION
## Why

Closes CON-924

The `Publish Akash Templates` workflow silently published a gutted template gallery. In [attempt 1 of run 33407172476](https://github.com/akash-network/console/actions/runs/33407172476/job/99537495643) the `awesome-akash` archive download was aborted 60.006s after it started:

```
15:14:14.069  GET_TEMPLATES  repository: awesome-akash
15:15:14.075  FETCH_TEMPLATES_FROM_README_FAILED
              error: "TimeoutError: The operation was aborted due to timeout (code: 23)
                  at new DOMException (node:internal/per_context/domexception:76:18)
                  at Timeout._onTimeout (node:internal/abort_controller:154:9)"
15:15:14.113  TEMPLATE_GALLERY_CACHE_BUILD_STATS
              categoryCount: 1, categoryNames: ["Blockchain"], totalTemplates: 62
```

That stack is a byte-for-byte match for `AbortSignal.timeout()` firing — `node:internal/abort_controller:154` is its timer callback and `code: 23` is `DOMException.TIMEOUT_ERR`. It is our own `AbortSignal.timeout(60_000)` in `GitHubArchiveService`, not an undici-internal timeout: those surface through global `fetch` as `TypeError: fetch failed` with a `.cause`, never as a bare `TimeoutError`.

Two defects combined:

1. **The 60s budget covered the whole transfer, not just stalls.** The signal passed to `fetch` also governs `response.arrayBuffer()`. The `awesome-akash` tarball is 67 MB and `cosmos/chain-registry` is another 66 MB downloaded concurrently, so the runner needed a sustained >= 1.1 MB/s or a perfectly healthy download was killed mid-flight. Buffering the whole archive before extracting made it worse: one archive's CPU-heavy extraction blocked the event loop while the other's clock kept running.

2. **The failure was swallowed and the broken result was published.** `fetchTemplatesFromReadme` catches everything and returns `[]`, so the step exited 0 and wrangler deployed 62 templates instead of 395. `getTemplatesFromRepo` also persisted that `[]` into the commit-SHA-keyed cache file, which in the long-running API would pin the empty result for that SHA.

## What

**`github-archive.service.ts`** — the response body now streams into gunzip/tar instead of being buffered via `arrayBuffer()`, and the 60s whole-operation deadline became a 30s **stall** timer that resets on every chunk. A large-but-progressing download now succeeds; only a genuinely dead connection aborts, and the abort reason names the URL and the stall window instead of the opaque `TimeoutError`. Streaming also drops peak memory by ~134 MB and lets extraction overlap the download, so the two archives no longer starve each other.

Downloads are also retried through a `cockatiel` retry policy (exponential backoff with jitter, 3 attempts total), matching how the rest of the repo handles transient transport failures. `handleWhen` excludes 4xx responses, since a missing archive won't appear on a retry.

**`template-gallery.service.ts`** — a repository that yielded zero categories is now an error instead of something cached and published.

> [!IMPORTANT]
> This is a behavioural change worth a look: `awesome-akash` failing will now **fail the workflow** rather than deploy a partial gallery, leaving the previous Cloudflare Pages deployment in place. Per-template-source resilience is untouched, so a single broken template still only skips itself.

`fetchTemplatesFromReadme` still returns `[]` on failure (an existing test asserts it). The new gallery-level guard means that no longer reaches production, but happy to move the propagation into the fetcher instead if reviewers prefer.

### Verification

Retry coverage is pinned for every shape this can fail in, since the point of the change is that a repeat of CON-924 recovers on its own:

- a mid-stream body error after partial data (`controller.error(new TypeError("terminated"))`)
- a transport-level `TypeError: fetch failed` with a `.cause`
- a bare `TimeoutError` `DOMException`, i.e. the exact error from the incident
- retries exhausted, surfacing the last error
- a 404, asserted to make exactly one attempt
- a stalled download aborting, plus one proving a download slower than the stall timeout still completes

90 tests pass across `src/template`. `eslint --quiet` clean; `tsc --noEmit` clean for `src/template` apart from a pre-existing `tar.Header` typing error that also fails on `main`. Ran `npm run build:akash-templates` against the real repos: **30 categories, 395 templates in ~9.5s**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub archive downloads with automatic retries for transient failures.
  * Added protection against stalled, timed-out, truncated, or interrupted downloads.
  * Reduced memory usage by processing archives as they download.
  * Prevented empty template galleries from being published or cached.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->