### PR TITLE
fix(billing): show the held balance as escrow instead of reserved

### DIFF
--- a/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/AccountBalanceOverview.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/AccountBalanceOverview.spec.tsx
@@ -29,7 +29,7 @@ describe(AccountBalanceOverview.name, () => {
     expect(screen.queryByText(/lasts until/)).not.toBeInTheDocument();
   });
 
-  it("shows the reserved and available balances with their descriptors", () => {
+  it("shows the escrow and available balances with their descriptors", () => {
     setup({
       reserved: 1338,
       available: 1873.2,
@@ -39,13 +39,13 @@ describe(AccountBalanceOverview.name, () => {
       ]
     });
 
-    expect(screen.getByLabelText("Reserved balance")).toHaveTextContent("1338");
+    expect(screen.getByLabelText("Escrow balance")).toHaveTextContent("1338");
     expect(screen.getByLabelText("Available balance")).toHaveTextContent("1873.2");
     expect(screen.getByText("Held to keep your 2 deployments running")).toBeInTheDocument();
     expect(screen.getByText("Free to spend on something new")).toBeInTheDocument();
   });
 
-  it("uses singular wording when a single deployment holds reserved funds", () => {
+  it("uses singular wording when a single deployment holds escrow funds", () => {
     setup({ reserved: 100, deployments: [{ dseq: "1", name: "app-a", reservedUsd: 100, perHourUsd: 1 }] });
 
     expect(screen.getByText("Held to keep your 1 deployment running")).toBeInTheDocument();
@@ -56,7 +56,7 @@ describe(AccountBalanceOverview.name, () => {
 
     expect(screen.queryByText("llama-chat")).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: /What is reserved/ }));
+    fireEvent.click(screen.getByRole("button", { name: /What's in escrow/ }));
 
     expect(screen.getByText("llama-chat")).toBeInTheDocument();
     expect(screen.getByText(/\/hr/)).toBeInTheDocument();
@@ -65,14 +65,14 @@ describe(AccountBalanceOverview.name, () => {
   it("toggles the breakdown label between closed and open", () => {
     setup({ deployments: [{ dseq: "1", name: "llama-chat", reservedUsd: 508.8, perHourUsd: 4.24 }] });
 
-    expect(screen.getByRole("button", { name: /What is reserved \(1\)/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /What's in escrow \(1\)/ })).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: /What is reserved/ }));
+    fireEvent.click(screen.getByRole("button", { name: /What's in escrow/ }));
 
     expect(screen.getByRole("button", { name: /Hide breakdown/ })).toBeInTheDocument();
   });
 
-  it("counts only deployments that still hold reserved funds so the labels match the badges", () => {
+  it("counts only deployments that still hold escrow funds so the labels match the badges", () => {
     setup({
       deployments: [
         { dseq: "1", name: "llama-chat", reservedUsd: 508.8, perHourUsd: 4.24 },
@@ -80,14 +80,14 @@ describe(AccountBalanceOverview.name, () => {
       ]
     });
 
-    expect(screen.getByRole("button", { name: /What is reserved \(1\)/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /What's in escrow \(1\)/ })).toBeInTheDocument();
     expect(screen.getByText("Held to keep your 1 deployment running")).toBeInTheDocument();
   });
 
-  it("hides the breakdown toggle when no deployment holds reserved funds", () => {
+  it("hides the breakdown toggle when no deployment holds escrow funds", () => {
     setup({ deployments: [{ dseq: "1", name: "drained-app", reservedUsd: 0, perHourUsd: 0 }] });
 
-    expect(screen.queryByRole("button", { name: /What is reserved/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /What's in escrow/ })).not.toBeInTheDocument();
   });
 
   it("clears hover dimming when the hovered deployment disappears mid-hover", () => {
@@ -97,7 +97,7 @@ describe(AccountBalanceOverview.name, () => {
     ];
     const { rerenderWith } = setup({ deployments, available: 100 });
 
-    fireEvent.click(screen.getByRole("button", { name: /What is reserved/ }));
+    fireEvent.click(screen.getByRole("button", { name: /What's in escrow/ }));
     fireEvent.mouseEnter(screen.getByRole("link", { name: /llama-chat/ }).closest("li")!);
 
     expect(screen.getByRole("link", { name: /side-api/ }).closest("li")).toHaveStyle({ opacity: "0.4" });
@@ -110,7 +110,7 @@ describe(AccountBalanceOverview.name, () => {
   it("links each deployment badge to its detail page", () => {
     setup({ deployments: [{ dseq: "42", name: "llama-chat", reservedUsd: 508.8, perHourUsd: 4.24 }] });
 
-    fireEvent.click(screen.getByRole("button", { name: /What is reserved/ }));
+    fireEvent.click(screen.getByRole("button", { name: /What's in escrow/ }));
 
     expect(screen.getByRole("link", { name: /llama-chat/ })).toHaveAttribute("href", UrlService.deploymentDetails("42"));
   });

--- a/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/AccountBalanceOverview.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/AccountBalanceOverview.spec.tsx
@@ -31,11 +31,11 @@ describe(AccountBalanceOverview.name, () => {
 
   it("shows the escrow and available balances with their descriptors", () => {
     setup({
-      reserved: 1338,
+      escrow: 1338,
       available: 1873.2,
       deployments: [
-        { dseq: "1", name: "app-a", reservedUsd: 1000, perHourUsd: 1 },
-        { dseq: "2", name: "app-b", reservedUsd: 338, perHourUsd: 1 }
+        { dseq: "1", name: "app-a", escrowUsd: 1000, perHourUsd: 1 },
+        { dseq: "2", name: "app-b", escrowUsd: 338, perHourUsd: 1 }
       ]
     });
 
@@ -46,13 +46,13 @@ describe(AccountBalanceOverview.name, () => {
   });
 
   it("uses singular wording when a single deployment holds escrow funds", () => {
-    setup({ reserved: 100, deployments: [{ dseq: "1", name: "app-a", reservedUsd: 100, perHourUsd: 1 }] });
+    setup({ escrow: 100, deployments: [{ dseq: "1", name: "app-a", escrowUsd: 100, perHourUsd: 1 }] });
 
     expect(screen.getByText("Held to keep your 1 deployment running")).toBeInTheDocument();
   });
 
   it("reveals the deployment breakdown only after the collapsible is opened", () => {
-    setup({ deployments: [{ dseq: "1", name: "llama-chat", reservedUsd: 508.8, perHourUsd: 4.24 }], available: 1873.2 });
+    setup({ deployments: [{ dseq: "1", name: "llama-chat", escrowUsd: 508.8, perHourUsd: 4.24 }], available: 1873.2 });
 
     expect(screen.queryByText("llama-chat")).not.toBeInTheDocument();
 
@@ -63,7 +63,7 @@ describe(AccountBalanceOverview.name, () => {
   });
 
   it("toggles the breakdown label between closed and open", () => {
-    setup({ deployments: [{ dseq: "1", name: "llama-chat", reservedUsd: 508.8, perHourUsd: 4.24 }] });
+    setup({ deployments: [{ dseq: "1", name: "llama-chat", escrowUsd: 508.8, perHourUsd: 4.24 }] });
 
     expect(screen.getByRole("button", { name: /What's in escrow \(1\)/ })).toBeInTheDocument();
 
@@ -75,8 +75,8 @@ describe(AccountBalanceOverview.name, () => {
   it("counts only deployments that still hold escrow funds so the labels match the badges", () => {
     setup({
       deployments: [
-        { dseq: "1", name: "llama-chat", reservedUsd: 508.8, perHourUsd: 4.24 },
-        { dseq: "2", name: "drained-app", reservedUsd: 0, perHourUsd: 0 }
+        { dseq: "1", name: "llama-chat", escrowUsd: 508.8, perHourUsd: 4.24 },
+        { dseq: "2", name: "drained-app", escrowUsd: 0, perHourUsd: 0 }
       ]
     });
 
@@ -85,15 +85,15 @@ describe(AccountBalanceOverview.name, () => {
   });
 
   it("hides the breakdown toggle when no deployment holds escrow funds", () => {
-    setup({ deployments: [{ dseq: "1", name: "drained-app", reservedUsd: 0, perHourUsd: 0 }] });
+    setup({ deployments: [{ dseq: "1", name: "drained-app", escrowUsd: 0, perHourUsd: 0 }] });
 
     expect(screen.queryByRole("button", { name: /What's in escrow/ })).not.toBeInTheDocument();
   });
 
   it("clears hover dimming when the hovered deployment disappears mid-hover", () => {
     const deployments = [
-      { dseq: "1", name: "llama-chat", reservedUsd: 100, perHourUsd: 1 },
-      { dseq: "2", name: "side-api", reservedUsd: 50, perHourUsd: 1 }
+      { dseq: "1", name: "llama-chat", escrowUsd: 100, perHourUsd: 1 },
+      { dseq: "2", name: "side-api", escrowUsd: 50, perHourUsd: 1 }
     ];
     const { rerenderWith } = setup({ deployments, available: 100 });
 
@@ -108,7 +108,7 @@ describe(AccountBalanceOverview.name, () => {
   });
 
   it("links each deployment badge to its detail page", () => {
-    setup({ deployments: [{ dseq: "42", name: "llama-chat", reservedUsd: 508.8, perHourUsd: 4.24 }] });
+    setup({ deployments: [{ dseq: "42", name: "llama-chat", escrowUsd: 508.8, perHourUsd: 4.24 }] });
 
     fireEvent.click(screen.getByRole("button", { name: /What's in escrow/ }));
 
@@ -167,7 +167,7 @@ describe(AccountBalanceOverview.name, () => {
     const renderView = (partial: Partial<AccountBalanceOverviewData>) => {
       const data: AccountBalanceOverviewData = {
         totalUsd: 0,
-        reserved: 0,
+        escrow: 0,
         available: 0,
         deployments: [],
         perHour: 0,

--- a/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/AccountBalanceOverview.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/AccountBalanceOverview.tsx
@@ -104,14 +104,14 @@ export const AccountBalanceOverview: React.FunctionComponent<{ dependencies?: ty
           <div className="space-y-1">
             <div className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
               <span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: "hsl(var(--primary))" }} aria-hidden />
-              <span>Reserved</span>
-              <d.CustomNoDivTooltip title="Each running deployment is funded by its own escrow. The reserved amount is what those escrows currently hold to keep your deployments online, so it can't be used to start new ones. Whatever a deployment doesn't use returns to your available balance when it closes.">
+              <span>Escrow</span>
+              <d.CustomNoDivTooltip title="Each running deployment has its own escrow account. This is what those accounts hold to keep your deployments online, so it can't be used to start new ones. Whatever a deployment doesn't use returns to your available balance when it closes.">
                 <span className="inline-flex cursor-pointer text-muted-foreground">
                   <d.InfoCircle className="h-3.5 w-3.5" />
                 </span>
               </d.CustomNoDivTooltip>
             </div>
-            <div className="text-2xl font-bold leading-none" aria-label="Reserved balance">
+            <div className="text-2xl font-bold leading-none" aria-label="Escrow balance">
               {usd(overview.reserved)}
             </div>
             <p className="text-sm text-muted-foreground">
@@ -147,7 +147,7 @@ export const AccountBalanceOverview: React.FunctionComponent<{ dependencies?: ty
               aria-expanded={isBreakdownOpen}
             >
               {isBreakdownOpen ? <d.NavArrowDown className="h-4 w-4" /> : <d.NavArrowRight className="h-4 w-4" />}
-              {isBreakdownOpen ? "Hide breakdown" : `What is reserved (${reservedSegments.length})`}
+              {isBreakdownOpen ? "Hide breakdown" : `What's in escrow (${reservedSegments.length})`}
             </button>
             {isBreakdownOpen && (
               <div className="mt-3 space-y-3">
@@ -173,7 +173,7 @@ export const AccountBalanceOverview: React.FunctionComponent<{ dependencies?: ty
                     </li>
                   ))}
                 </ul>
-                <p className="text-xs text-muted-foreground">{`Each running deployment keeps around ${RESERVE_WINDOW_HOURS} hours of its cost in reserve.`}</p>
+                <p className="text-xs text-muted-foreground">{`Each running deployment keeps around ${RESERVE_WINDOW_HOURS} hours of its cost in escrow.`}</p>
               </div>
             )}
           </div>

--- a/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/AccountBalanceOverview.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/AccountBalanceOverview.tsx
@@ -31,7 +31,7 @@ export const DEPENDENCIES = {
  * automatic funding tops a deployment up to this target rather than adding to what it already holds.
  * Mirrors the backend `AUTO_TOP_UP_TARGET_RUNWAY_IN_H`. Update if that target changes.
  */
-const RESERVE_WINDOW_HOURS = 48;
+const ESCROW_WINDOW_HOURS = 48;
 
 export const AccountBalanceOverview: React.FunctionComponent<{ dependencies?: typeof DEPENDENCIES }> = ({ dependencies: d = DEPENDENCIES }) => {
   const overview = d.useAccountBalanceOverview();
@@ -70,7 +70,7 @@ export const AccountBalanceOverview: React.FunctionComponent<{ dependencies?: ty
     );
   }
 
-  const reservedSegments = segments.filter(segment => segment.key !== "available");
+  const escrowSegments = segments.filter(segment => segment.key !== "available");
   const activeHoveredKey = hoveredKey && segments.some(segment => segment.key === hoveredKey) ? hoveredKey : null;
   const hasRunway = overview.runwayDays !== null && overview.lastsUntil !== null;
 
@@ -112,10 +112,10 @@ export const AccountBalanceOverview: React.FunctionComponent<{ dependencies?: ty
               </d.CustomNoDivTooltip>
             </div>
             <div className="text-2xl font-bold leading-none" aria-label="Escrow balance">
-              {usd(overview.reserved)}
+              {usd(overview.escrow)}
             </div>
             <p className="text-sm text-muted-foreground">
-              {`Held to keep your ${reservedSegments.length} deployment${reservedSegments.length === 1 ? "" : "s"} running`}
+              {`Held to keep your ${escrowSegments.length} deployment${escrowSegments.length === 1 ? "" : "s"} running`}
             </p>
           </div>
           <div className="space-y-1">
@@ -138,7 +138,7 @@ export const AccountBalanceOverview: React.FunctionComponent<{ dependencies?: ty
           </div>
         </div>
 
-        {reservedSegments.length > 0 && (
+        {escrowSegments.length > 0 && (
           <div className="border-t pt-4">
             <button
               type="button"
@@ -147,12 +147,12 @@ export const AccountBalanceOverview: React.FunctionComponent<{ dependencies?: ty
               aria-expanded={isBreakdownOpen}
             >
               {isBreakdownOpen ? <d.NavArrowDown className="h-4 w-4" /> : <d.NavArrowRight className="h-4 w-4" />}
-              {isBreakdownOpen ? "Hide breakdown" : `What's in escrow (${reservedSegments.length})`}
+              {isBreakdownOpen ? "Hide breakdown" : `What's in escrow (${escrowSegments.length})`}
             </button>
             {isBreakdownOpen && (
               <div className="mt-3 space-y-3">
                 <ul className="flex flex-wrap gap-2">
-                  {reservedSegments.map(segment => (
+                  {escrowSegments.map(segment => (
                     <li
                       key={segment.key}
                       className="transition-opacity duration-150"
@@ -173,7 +173,7 @@ export const AccountBalanceOverview: React.FunctionComponent<{ dependencies?: ty
                     </li>
                   ))}
                 </ul>
-                <p className="text-xs text-muted-foreground">{`Each running deployment keeps around ${RESERVE_WINDOW_HOURS} hours of its cost in escrow.`}</p>
+                <p className="text-xs text-muted-foreground">{`Each running deployment keeps around ${ESCROW_WINDOW_HOURS} hours of its cost in escrow.`}</p>
               </div>
             )}
           </div>

--- a/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/BalanceBreakdownBar.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/BalanceBreakdownBar.spec.tsx
@@ -2,12 +2,12 @@ import { IntlProvider } from "react-intl";
 import { describe, expect, it } from "vitest";
 
 import { BalanceBreakdownBar, buildBalanceSegments } from "./BalanceBreakdownBar";
-import type { ReservedDeployment } from "./useAccountBalanceOverview";
+import type { EscrowedDeployment } from "./useAccountBalanceOverview";
 
 import { render, screen } from "@testing-library/react";
 
 describe(buildBalanceSegments.name, () => {
-  it("orders reserved deployments before the available segment", () => {
+  it("orders escrowed deployments before the available segment", () => {
     const segments = buildBalanceSegments(deployments([100, 50]), 200);
 
     expect(segments.map(s => s.key)).toEqual(["dseq-0", "dseq-1", "available"]);
@@ -39,15 +39,15 @@ describe(buildBalanceSegments.name, () => {
     expect(withDrained.map(s => s.color)).toEqual(withoutDrained.map(s => s.color));
   });
 
-  it("carries each deployment's hourly rate onto its reserved segment but not the available one", () => {
+  it("carries each deployment's hourly rate onto its escrow segment but not the available one", () => {
     const segments = buildBalanceSegments(deployments([120]), 200);
 
     expect(segments[0].perHourUsd).toBe(1);
     expect(segments[1].perHourUsd).toBeUndefined();
   });
 
-  function deployments(amounts: number[]): ReservedDeployment[] {
-    return amounts.map((reservedUsd, index) => ({ dseq: `dseq-${index}`, name: `deployment-${index}`, reservedUsd, perHourUsd: reservedUsd / 120 }));
+  function deployments(amounts: number[]): EscrowedDeployment[] {
+    return amounts.map((escrowUsd, index) => ({ dseq: `dseq-${index}`, name: `deployment-${index}`, escrowUsd, perHourUsd: escrowUsd / 120 }));
   }
 });
 

--- a/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/BalanceBreakdownBar.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/BalanceBreakdownBar.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { useIntl } from "react-intl";
 import { Flash } from "iconoir-react";
 
-import type { ReservedDeployment } from "./useAccountBalanceOverview";
+import type { EscrowedDeployment } from "./useAccountBalanceOverview";
 
 export type BalanceSegment = {
   key: string;
@@ -18,8 +18,8 @@ export type BalanceSegment = {
   badgeColor?: string;
 };
 
-/** Stepped opacity for the reserved ramp: largest deployment is the most opaque, tapering to 0.35. */
-function reservedAlpha(index: number, count: number): number {
+/** Stepped opacity for the escrow ramp: largest deployment is the most opaque, tapering to 0.35. */
+function escrowAlpha(index: number, count: number): number {
   if (count <= 1) return 0.9;
   return Number((0.9 - (index / (count - 1)) * 0.55).toFixed(3));
 }
@@ -38,7 +38,7 @@ const THRESHOLD_LINE_DASHES = "repeating-linear-gradient(to bottom, hsl(var(--fo
 
 /**
  * Where the auto-top-up marker sits inside the Available segment: the dashed line lands `threshold`
- * dollars past the reserved/available boundary, which is where the bar's right edge will be once the
+ * dollars past the escrow/available boundary, which is where the bar's right edge will be once the
  * balance has drained far enough to trigger a top-up. Expressed as a percentage of the segment so it
  * stays glued to that boundary regardless of the 2px gaps between segments. Null once available is at or
  * below the threshold, where the line would fall on the segment's own right edge and read as noise.
@@ -50,16 +50,16 @@ function buildThresholdMarker(threshold: number, available: number) {
 
 /**
  * Builds the ordered segments for the balance bar and its legend so both share identical colors.
- * Reserved deployments use a single-hue ramp (sorted largest-first); Available is the success green.
+ * Escrowed deployments use a single-hue ramp (sorted largest-first); Available is the success green.
  */
-export function buildBalanceSegments(deployments: ReservedDeployment[], available: number): BalanceSegment[] {
-  const fundedDeployments = deployments.filter(deployment => deployment.reservedUsd > 0);
-  const reservedSegments = fundedDeployments.map((deployment, index) => {
-    const alpha = reservedAlpha(index, fundedDeployments.length);
+export function buildBalanceSegments(deployments: EscrowedDeployment[], available: number): BalanceSegment[] {
+  const fundedDeployments = deployments.filter(deployment => deployment.escrowUsd > 0);
+  const escrowSegments = fundedDeployments.map((deployment, index) => {
+    const alpha = escrowAlpha(index, fundedDeployments.length);
     return {
       key: deployment.dseq,
       label: deployment.name,
-      amountUsd: deployment.reservedUsd,
+      amountUsd: deployment.escrowUsd,
       perHourUsd: deployment.perHourUsd,
       color: `hsl(var(--primary) / ${alpha})`,
       badgeBackground: badgeBackground("var(--primary)", alpha),
@@ -76,7 +76,7 @@ export function buildBalanceSegments(deployments: ReservedDeployment[], availabl
     badgeColor: "hsl(var(--success))"
   };
 
-  return [...reservedSegments, availableSegment].filter(segment => segment.amountUsd > 0);
+  return [...escrowSegments, availableSegment].filter(segment => segment.amountUsd > 0);
 }
 
 /**

--- a/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/useAccountBalanceOverview.spec.ts
+++ b/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/useAccountBalanceOverview.spec.ts
@@ -13,21 +13,21 @@ import { renderHook } from "@testing-library/react";
 type WalletSettings = NonNullable<ReturnType<typeof DEPENDENCIES.useWalletSettingsQuery>["data"]>;
 
 describe(useAccountBalanceOverview.name, () => {
-  it("splits total into available and reserved", () => {
-    const { result } = setup({ totalUsd: 500, reservedUsd: 150 });
+  it("splits total into available and escrow", () => {
+    const { result } = setup({ totalUsd: 500, escrowUsd: 150 });
 
     expect(result.current.totalUsd).toBe(500);
-    expect(result.current.reserved).toBe(150);
+    expect(result.current.escrow).toBe(150);
     expect(result.current.available).toBe(350);
   });
 
   it("never returns negative available", () => {
-    const { result } = setup({ totalUsd: 100, reservedUsd: 150 });
+    const { result } = setup({ totalUsd: 100, escrowUsd: 150 });
 
     expect(result.current.available).toBe(0);
   });
 
-  it("builds a per-deployment reserved breakdown sorted largest-first", () => {
+  it("builds a per-deployment escrow breakdown sorted largest-first", () => {
     const { result } = setup({
       deployments: [
         { dseq: "1", fundsUsd: 50 },
@@ -37,12 +37,12 @@ describe(useAccountBalanceOverview.name, () => {
     });
 
     expect(result.current.deployments).toEqual([
-      { dseq: "2", name: "llama-chat", reservedUsd: 100, perHourUsd: 0 },
-      { dseq: "1", name: "Deployment 1", reservedUsd: 50, perHourUsd: 0 }
+      { dseq: "2", name: "llama-chat", escrowUsd: 100, perHourUsd: 0 },
+      { dseq: "1", name: "Deployment 1", escrowUsd: 50, perHourUsd: 0 }
     ]);
   });
 
-  it("keeps reserved in sync with the per-deployment breakdown since both come from the same balances", () => {
+  it("keeps escrow in sync with the per-deployment breakdown since both come from the same balances", () => {
     const { result } = setup({
       totalUsd: 500,
       deployments: [
@@ -51,8 +51,8 @@ describe(useAccountBalanceOverview.name, () => {
       ]
     });
 
-    expect(result.current.reserved).toBe(150);
-    expect(result.current.reserved).toBe(result.current.deployments.reduce((sum, deployment) => sum + deployment.reservedUsd, 0));
+    expect(result.current.escrow).toBe(150);
+    expect(result.current.escrow).toBe(result.current.deployments.reduce((sum, deployment) => sum + deployment.escrowUsd, 0));
     expect(result.current.available).toBe(350);
   });
 
@@ -153,22 +153,22 @@ describe(useAccountBalanceOverview.name, () => {
   });
 
   it("still resolves balances when the AKT market price is unavailable", () => {
-    const { result } = setup({ totalUsd: 500, reservedUsd: 150, priceUnavailable: true });
+    const { result } = setup({ totalUsd: 500, escrowUsd: 150, priceUnavailable: true });
 
     expect(result.current.isLoading).toBe(false);
     expect(result.current.totalUsd).toBe(500);
     expect(result.current.available).toBe(350);
   });
 
-  it("nets what the provider earned since the escrow settled off the reserved amount", () => {
+  it("nets what the provider earned since settlement off the escrow amount", () => {
     const { result } = setup({
       deployments: [{ dseq: "1", fundsUsd: 100, settledAt: 1000 }],
       leases: [{ dseq: "1", amount: "1000000" }],
       latestBlockHeight: 1050
     });
 
-    expect(result.current.deployments[0].reservedUsd).toBeCloseTo(50, 6);
-    expect(result.current.reserved).toBeCloseTo(50, 6);
+    expect(result.current.deployments[0].escrowUsd).toBeCloseTo(50, 6);
+    expect(result.current.escrow).toBeCloseTo(50, 6);
   });
 
   it("reports the settled amount for a deployment that settled at the current height", () => {
@@ -178,7 +178,7 @@ describe(useAccountBalanceOverview.name, () => {
       latestBlockHeight: 1050
     });
 
-    expect(result.current.deployments[0].reservedUsd).toBe(100);
+    expect(result.current.deployments[0].escrowUsd).toBe(100);
   });
 
   it("reports the settled amount for a deployment with no live lease", () => {
@@ -188,7 +188,7 @@ describe(useAccountBalanceOverview.name, () => {
       latestBlockHeight: 1050
     });
 
-    expect(result.current.deployments[0].reservedUsd).toBe(100);
+    expect(result.current.deployments[0].escrowUsd).toBe(100);
   });
 
   it("reports the settled amount while the latest block height is unknown", () => {
@@ -197,10 +197,10 @@ describe(useAccountBalanceOverview.name, () => {
       leases: [{ dseq: "1", amount: "1000000" }]
     });
 
-    expect(result.current.deployments[0].reservedUsd).toBe(100);
+    expect(result.current.deployments[0].escrowUsd).toBe(100);
   });
 
-  it("leaves available untouched by the accrual, since total and reserved both drop by it", () => {
+  it("leaves available untouched by the accrual, since total and escrow both drop by it", () => {
     const settled = setup({
       totalUsd: 500,
       deployments: [{ dseq: "1", fundsUsd: 100, settledAt: 1050 }],
@@ -232,7 +232,7 @@ describe(useAccountBalanceOverview.name, () => {
 
   function setup(input: {
     totalUsd?: number;
-    reservedUsd?: number;
+    escrowUsd?: number;
     deployments?: Array<{ dseq: string; fundsUsd: number; settledAt?: number }>;
     latestBlockHeight?: number;
     names?: Record<string, string>;
@@ -246,17 +246,17 @@ describe(useAccountBalanceOverview.name, () => {
     balancesIdle?: boolean;
     priceUnavailable?: boolean;
   }) {
-    const reservedDeployments = input.deployments ?? (input.reservedUsd ? [{ dseq: "reserved", fundsUsd: input.reservedUsd }] : []);
-    const activeDeployments = reservedDeployments.map(deployment => ({
+    const escrowedDeployments = input.deployments ?? (input.escrowUsd ? [{ dseq: "escrow", fundsUsd: input.escrowUsd }] : []);
+    const activeDeployments = escrowedDeployments.map(deployment => ({
       dseq: deployment.dseq,
       escrowAccount: { state: { settled_at: String(deployment.settledAt ?? ""), funds: [{ denom: UAKT_DENOM, amount: String(deployment.fundsUsd) }] } }
     }));
-    const reservedTotal = reservedDeployments.reduce((sum, deployment) => sum + deployment.fundsUsd, 0);
+    const escrowTotal = escrowedDeployments.reduce((sum, deployment) => sum + deployment.fundsUsd, 0);
 
     const balances = Object.assign(mock<Balances>(), {
       balanceUAKT: 0,
       balanceUUSDC: 0,
-      balanceUACT: (input.totalUsd ?? 0) - reservedTotal,
+      balanceUACT: (input.totalUsd ?? 0) - escrowTotal,
       deploymentEscrowUAKT: 0,
       deploymentEscrowUUSDC: 0,
       deploymentEscrowUACT: 0,

--- a/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/useAccountBalanceOverview.ts
+++ b/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/useAccountBalanceOverview.ts
@@ -26,18 +26,18 @@ export const DEPENDENCIES = {
   useLocalNotes
 };
 
-export type ReservedDeployment = {
+export type EscrowedDeployment = {
   dseq: string;
   name: string;
-  reservedUsd: number;
+  escrowUsd: number;
   perHourUsd: number;
 };
 
 export type AccountBalanceOverview = {
   totalUsd: number;
-  reserved: number;
+  escrow: number;
   available: number;
-  deployments: ReservedDeployment[];
+  deployments: EscrowedDeployment[];
   perHour: number;
   /** null when nothing is being spent (runway is effectively infinite). */
   lastsUntil: Date | null;
@@ -82,7 +82,7 @@ export function useAccountBalanceOverview({ dependencies: d = DEPENDENCIES }: { 
     return { perBlockUsd, perHour: perBlockToHourly(perBlockUsd) };
   }, [liveEscrow]);
 
-  const deployments = useMemo<ReservedDeployment[]>(() => {
+  const deployments = useMemo<EscrowedDeployment[]>(() => {
     if (!balances) return [];
     return balances.activeDeployments
       .map(deployment => {
@@ -91,7 +91,7 @@ export function useAccountBalanceOverview({ dependencies: d = DEPENDENCIES }: { 
         return {
           dseq: deployment.dseq,
           name: getDeploymentName(deployment.dseq) ?? `Deployment ${deployment.dseq}`,
-          reservedUsd: getLiveEscrowBalance({
+          escrowUsd: getLiveEscrowBalance({
             settledBalance: deployment.escrowAccount.state.funds.reduce((sum, fund) => sum + udenomToUsd(fund.amount, fund.denom), 0),
             pricePerBlock,
             settledAt: Number(deployment.escrowAccount.state.settled_at),
@@ -100,12 +100,12 @@ export function useAccountBalanceOverview({ dependencies: d = DEPENDENCIES }: { 
           perHourUsd: perBlockToHourly(pricePerBlock)
         };
       })
-      .sort((a, b) => b.reservedUsd - a.reservedUsd);
+      .sort((a, b) => b.escrowUsd - a.escrowUsd);
   }, [balances, getDeploymentName, udenomToUsd, liveEscrow]);
 
   const totalUsd = walletBalance?.totalUsd ?? 0;
-  const reserved = deployments.reduce((sum, deployment) => sum + deployment.reservedUsd, 0);
-  const available = Math.max(0, totalUsd - reserved);
+  const escrow = deployments.reduce((sum, deployment) => sum + deployment.escrowUsd, 0);
+  const available = Math.max(0, totalUsd - escrow);
   const hasSpend = spend.perBlockUsd > 0;
   const lastsUntil = hasSpend ? getTimeLeft(spend.perBlockUsd, totalUsd) : null;
   const autoReloadEnabled = walletSettings?.autoReloadEnabled ?? false;
@@ -114,7 +114,7 @@ export function useAccountBalanceOverview({ dependencies: d = DEPENDENCIES }: { 
 
   return {
     totalUsd,
-    reserved,
+    escrow,
     available,
     deployments,
     perHour: spend.perHour,

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/FundingImpactReviewSection.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/FundingImpactReviewSection.spec.tsx
@@ -31,11 +31,11 @@ describe("FundingImpactReviewSection", () => {
     expect(screen.getByRole("link", { name: "Check Billing" })).toHaveAttribute("href", UrlService.billing());
   });
 
-  it("summarizes the reserve and the available after it, without a runtime figure while funding is open-ended", () => {
+  it("summarizes the escrow and the available after it, without a runtime figure while funding is open-ended", () => {
     setup({ impact: visible() });
 
     const trigger = screen.getByRole("button");
-    expect(trigger).toHaveTextContent("Reserved ~$144");
+    expect(trigger).toHaveTextContent("Escrow ~$144");
     expect(trigger).toHaveTextContent("available after $56");
     expect(trigger).not.toHaveTextContent("of runtime");
   });
@@ -45,7 +45,7 @@ describe("FundingImpactReviewSection", () => {
     expect(screen.getByRole("button")).toHaveTextContent("12 hours of runtime");
   });
 
-  it("shows a dash for available after when the balance cannot cover the reserve", () => {
+  it("shows a dash for available after when the balance cannot cover the escrow", () => {
     setup({ impact: visible({ state: "not-enough-available", availableAfterUsd: null }) });
     expect(screen.getByRole("button")).toHaveTextContent("available after —");
   });
@@ -55,12 +55,12 @@ describe("FundingImpactReviewSection", () => {
 
     await userEvent.click(screen.getByRole("button"));
 
-    expect(screen.getByText(/Reserved ~ \$144 \(estimate\)/)).toBeInTheDocument();
+    expect(screen.getByText(/Escrow ~ \$144 \(estimate\)/)).toBeInTheDocument();
     expect(screen.getByText("$200")).toBeInTheDocument();
     expect(screen.getByText("available now")).toBeInTheDocument();
-    expect(screen.getByTestId("balance-bar")).toHaveTextContent("reserve:144,available:56");
+    expect(screen.getByTestId("balance-bar")).toHaveTextContent("escrow:144,available:56");
     expect(screen.getByTestId("balance-bar")).toHaveAttribute("data-threshold", "20");
-    expect(screen.getByText(/The reserve is held, not charged/)).toBeInTheDocument();
+    expect(screen.getByText(/The escrow is held, not charged/)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Full balance breakdown in Billing/ })).toHaveAttribute("href", UrlService.billing());
   });
 
@@ -84,7 +84,7 @@ describe("FundingImpactReviewSection", () => {
     setup({ impact: visible({ state: "crosses-threshold", availableAfterUsd: 19, thresholdUsd: 20 }) });
 
     expect(screen.getByText("Buys credits")).toBeInTheDocument();
-    await userEvent.click(screen.getByRole("button", { name: /Reserved/ }));
+    await userEvent.click(screen.getByRole("button", { name: /Escrow/ }));
 
     const callout = screen.getByRole("alert");
     expect(callout).toHaveTextContent("Confirming drops available to $19, below your Auto Top-Up threshold of $20");
@@ -95,7 +95,7 @@ describe("FundingImpactReviewSection", () => {
     setup({ impact: visible({ state: "no-payment-method", cardLabel: null }) });
 
     expect(screen.getByText("No payment method")).toBeInTheDocument();
-    await userEvent.click(screen.getByRole("button", { name: /Reserved/ }));
+    await userEvent.click(screen.getByRole("button", { name: /Escrow/ }));
 
     expect(screen.getByText(/nothing is charged automatically/)).toBeInTheDocument();
     expect(screen.queryByText(/charged \$/)).not.toBeInTheDocument();
@@ -106,7 +106,7 @@ describe("FundingImpactReviewSection", () => {
     setup({ impact: visible({ state: "trial", trialDurationHours: 12 }) });
 
     expect(screen.getByText("Trial")).toBeInTheDocument();
-    await userEvent.click(screen.getByRole("button", { name: /Reserved/ }));
+    await userEvent.click(screen.getByRole("button", { name: /Escrow/ }));
 
     expect(screen.getByText(/closed automatically after 12 hours/)).toBeInTheDocument();
     expect(screen.queryByText(/payment method/)).not.toBeInTheDocument();
@@ -114,13 +114,13 @@ describe("FundingImpactReviewSection", () => {
     expect(screen.getByRole("link", { name: "Add Credits" })).toHaveAttribute("href", UrlService.billing({ openPayment: true }));
   });
 
-  it("offers credits and drops the bar when the balance cannot cover the reserve", async () => {
+  it("offers credits and drops the bar when the balance cannot cover the escrow", async () => {
     setup({ impact: visible({ state: "not-enough-available", availableAfterUsd: null, availableNowUsd: 100 }) });
 
     expect(screen.getByText("Not enough available")).toBeInTheDocument();
-    await userEvent.click(screen.getByRole("button", { name: /Reserved/ }));
+    await userEvent.click(screen.getByRole("button", { name: /Escrow/ }));
 
-    expect(screen.getByRole("alert")).toHaveTextContent("Your available balance of $100 can't cover the estimated reserve of ~$144");
+    expect(screen.getByRole("alert")).toHaveTextContent("Your available balance of $100 can't cover the estimated escrow of ~$144");
     expect(screen.queryByTestId("balance-bar")).not.toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Add Credits" })).toHaveAttribute("href", UrlService.billing({ openPayment: true }));
   });

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/FundingImpactReviewSection.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/FundingImpactReviewSection.spec.tsx
@@ -129,7 +129,7 @@ describe("FundingImpactReviewSection", () => {
     return {
       kind: "visible",
       state: "funded",
-      reserveUsd: 144,
+      escrowUsd: 144,
       availableNowUsd: 200,
       availableAfterUsd: 56,
       thresholdUsd: null,

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/FundingImpactReviewSection.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/FundingImpactReviewSection.tsx
@@ -43,7 +43,7 @@ const BADGE_TONES: Record<Badge["tone"], string> = {
 };
 
 /**
- * What confirming does to the account's money: the estimated reserve, the available balance it comes out
+ * What confirming does to the account's money: the estimated escrow, the available balance it comes out
  * of, and whether it triggers an automatic credit purchase. Purely informative — it never blocks the
  * deploy, and it renders nothing at all when the estimate can't be made.
  */
@@ -70,7 +70,7 @@ export const FundingImpactReviewSection: FC<Props> = ({ rows, runtimeLimitHours,
         <d.Link href={UrlService.billing()} className="underline">
           Check Billing
         </d.Link>{" "}
-        for what gets reserved.
+        for what goes into escrow.
       </p>
     );
   }
@@ -86,7 +86,7 @@ export const FundingImpactReviewSection: FC<Props> = ({ rows, runtimeLimitHours,
     <Collapsible open={isExpanded} onOpenChange={setIsExpanded} className="rounded-lg border p-4">
       <CollapsibleTrigger className="group flex w-full items-center justify-between gap-4 text-left">
         <span className="text-sm">
-          Reserved <span className="font-medium">~{usd(impact.reserveUsd)}</span>
+          Escrow <span className="font-medium">~{usd(impact.reserveUsd)}</span>
           <span className="text-muted-foreground"> · available after </span>
           {impact.availableAfterUsd === null ? (
             <span className="text-destructive">—</span>
@@ -105,7 +105,7 @@ export const FundingImpactReviewSection: FC<Props> = ({ rows, runtimeLimitHours,
         <div className="flex items-center justify-between gap-4 text-xs">
           <span className="flex items-center gap-2">
             <span className="h-2 w-2 rounded-full bg-muted-foreground/40" />
-            <span className="text-muted-foreground">Reserved ~ {usd(impact.reserveUsd)} (estimate)</span>
+            <span className="text-muted-foreground">Escrow ~ {usd(impact.reserveUsd)} (estimate)</span>
           </span>
           <span className="flex items-center gap-2">
             <span className="h-2 w-2 rounded-full bg-success" />
@@ -118,7 +118,7 @@ export const FundingImpactReviewSection: FC<Props> = ({ rows, runtimeLimitHours,
         {impact.availableAfterUsd !== null && (
           <d.BalanceBreakdownBar
             segments={[
-              { key: "reserve", label: "Reserved", amountUsd: impact.reserveUsd, color: "hsl(var(--muted-foreground) / 0.4)" },
+              { key: "escrow", label: "Escrow", amountUsd: impact.reserveUsd, color: "hsl(var(--muted-foreground) / 0.4)" },
               { key: "available", label: "Available", amountUsd: impact.availableAfterUsd, color: "hsl(var(--success))" }
             ]}
             threshold={impact.thresholdUsd}
@@ -129,7 +129,7 @@ export const FundingImpactReviewSection: FC<Props> = ({ rows, runtimeLimitHours,
         {renderStateDetails(impact, usd, addCreditsButton)}
 
         <p className="text-sm text-muted-foreground">
-          The reserve is held, not charged. You pay for the time your deployment actually runs, and anything it doesn&apos;t use returns to available when the
+          The escrow is held, not charged. You pay for the time your deployment actually runs, and anything it doesn&apos;t use returns to available when the
           deployment closes.
         </p>
 
@@ -181,7 +181,7 @@ function renderStateDetails(impact: VisibleImpact, usd: (value: number) => React
       return (
         <Callout tone="warning">
           <span className="flex-1">
-            Your available balance of <span className="font-medium">{usd(impact.availableNowUsd)}</span> can&apos;t cover the estimated reserve of{" "}
+            Your available balance of <span className="font-medium">{usd(impact.availableNowUsd)}</span> can&apos;t cover the estimated escrow of{" "}
             <span className="font-medium">~{usd(impact.reserveUsd)}</span>.
           </span>
           {addCreditsButton}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/FundingImpactReviewSection.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/FundingImpactReviewSection.tsx
@@ -86,7 +86,7 @@ export const FundingImpactReviewSection: FC<Props> = ({ rows, runtimeLimitHours,
     <Collapsible open={isExpanded} onOpenChange={setIsExpanded} className="rounded-lg border p-4">
       <CollapsibleTrigger className="group flex w-full items-center justify-between gap-4 text-left">
         <span className="text-sm">
-          Escrow <span className="font-medium">~{usd(impact.reserveUsd)}</span>
+          Escrow <span className="font-medium">~{usd(impact.escrowUsd)}</span>
           <span className="text-muted-foreground"> · available after </span>
           {impact.availableAfterUsd === null ? (
             <span className="text-destructive">—</span>
@@ -105,7 +105,7 @@ export const FundingImpactReviewSection: FC<Props> = ({ rows, runtimeLimitHours,
         <div className="flex items-center justify-between gap-4 text-xs">
           <span className="flex items-center gap-2">
             <span className="h-2 w-2 rounded-full bg-muted-foreground/40" />
-            <span className="text-muted-foreground">Escrow ~ {usd(impact.reserveUsd)} (estimate)</span>
+            <span className="text-muted-foreground">Escrow ~ {usd(impact.escrowUsd)} (estimate)</span>
           </span>
           <span className="flex items-center gap-2">
             <span className="h-2 w-2 rounded-full bg-success" />
@@ -118,7 +118,7 @@ export const FundingImpactReviewSection: FC<Props> = ({ rows, runtimeLimitHours,
         {impact.availableAfterUsd !== null && (
           <d.BalanceBreakdownBar
             segments={[
-              { key: "escrow", label: "Escrow", amountUsd: impact.reserveUsd, color: "hsl(var(--muted-foreground) / 0.4)" },
+              { key: "escrow", label: "Escrow", amountUsd: impact.escrowUsd, color: "hsl(var(--muted-foreground) / 0.4)" },
               { key: "available", label: "Available", amountUsd: impact.availableAfterUsd, color: "hsl(var(--success))" }
             ]}
             threshold={impact.thresholdUsd}
@@ -182,7 +182,7 @@ function renderStateDetails(impact: VisibleImpact, usd: (value: number) => React
         <Callout tone="warning">
           <span className="flex-1">
             Your available balance of <span className="font-medium">{usd(impact.availableNowUsd)}</span> can&apos;t cover the estimated escrow of{" "}
-            <span className="font-medium">~{usd(impact.reserveUsd)}</span>.
+            <span className="font-medium">~{usd(impact.escrowUsd)}</span>.
           </span>
           {addCreditsButton}
         </Callout>

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/useFundingImpact.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/useFundingImpact.spec.tsx
@@ -49,45 +49,45 @@ describe(useFundingImpact.name, () => {
     expect(result.current).toEqual({ kind: "unavailable" });
   });
 
-  it("reserves the target runway's worth of the priced rows, drawing only what the bootstrap deposit left", () => {
+  it("escrows the target runway's worth of the priced rows, drawing only what the bootstrap deposit left", () => {
     const { result } = setup({ overview: { available: 200 } });
 
     expect(result.current).toMatchObject({
       kind: "visible",
       state: "funded",
-      reserveUsd: 144,
+      escrowUsd: 144,
       availableNowUsd: 200,
       availableAfterUsd: 56.5
     });
   });
 
-  it("floors the reserve at the bootstrap deposit for a deployment cheaper than the target runway", () => {
+  it("floors the escrow at the bootstrap deposit for a deployment cheaper than the target runway", () => {
     const { result } = setup({ rows: [pricedRow("0.00001")] });
 
-    expect(result.current).toMatchObject({ state: "funded", reserveUsd: 0.5, availableAfterUsd: 200 });
+    expect(result.current).toMatchObject({ state: "funded", escrowUsd: 0.5, availableAfterUsd: 200 });
   });
 
-  it("sums every priced row into the reserve", () => {
+  it("sums every priced row into the escrow", () => {
     const { result } = setup({ rows: [pricedRow("0.005"), pricedRow("0.005"), mock<ReviewRow>({ price: undefined })] });
-    expect(result.current).toMatchObject({ reserveUsd: 288 });
+    expect(result.current).toMatchObject({ escrowUsd: 288 });
   });
 
-  it("bounds the reserve by a runtime limit shorter than the target runway", () => {
+  it("bounds the escrow by a runtime limit shorter than the target runway", () => {
     const { result } = setup({ runtimeLimitHours: 12 });
-    expect(result.current).toMatchObject({ reserveUsd: 36 });
+    expect(result.current).toMatchObject({ escrowUsd: 36 });
   });
 
   it("keeps the target runway when the runtime limit exceeds it", () => {
     const { result } = setup({ runtimeLimitHours: 96 });
-    expect(result.current).toMatchObject({ reserveUsd: 144 });
+    expect(result.current).toMatchObject({ escrowUsd: 144 });
   });
 
-  it("crosses the threshold when available after reserving lands exactly on it", () => {
+  it("crosses the threshold when available after escrowing lands exactly on it", () => {
     const { result } = setup({ overview: { available: 200, autoReloadThreshold: 56.5 } });
     expect(result.current).toMatchObject({ state: "crosses-threshold", thresholdUsd: 56.5 });
   });
 
-  it("stays funded when available after reserving is above the threshold", () => {
+  it("stays funded when available after escrowing is above the threshold", () => {
     const { result } = setup({ overview: { available: 200, autoReloadThreshold: 56 } });
     expect(result.current).toMatchObject({ state: "funded" });
   });
@@ -97,9 +97,9 @@ describe(useFundingImpact.name, () => {
     expect(result.current).toMatchObject({ state: "funded", thresholdUsd: null });
   });
 
-  it("reports not enough available when the reserve exceeds the balance", () => {
+  it("reports not enough available when the escrow exceeds the balance", () => {
     const { result } = setup({ overview: { available: 100 } });
-    expect(result.current).toMatchObject({ state: "not-enough-available", reserveUsd: 144, availableNowUsd: 100, availableAfterUsd: null });
+    expect(result.current).toMatchObject({ state: "not-enough-available", escrowUsd: 144, availableNowUsd: 100, availableAfterUsd: null });
   });
 
   it("ranks not enough available above the missing payment method", () => {

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/useFundingImpact.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/useFundingImpact.ts
@@ -31,9 +31,9 @@ export type FundingImpact =
   | {
       kind: "visible";
       state: FundingImpactState;
-      reserveUsd: number;
+      escrowUsd: number;
       availableNowUsd: number;
-      /** Null when the remaining reserve exceeds what is available, where an "available after" figure would be a lie. */
+      /** Null when the remaining escrow exceeds what is available, where an "available after" figure would be a lie. */
       availableAfterUsd: number | null;
       thresholdUsd: number | null;
       chargeUsd: number;
@@ -49,9 +49,9 @@ type Input = {
 
 /**
  * Estimates what confirming the reviewed deployment does to the account's money: automatic funding
- * reserves the target runway's worth of the reviewed bid prices (bounded by the runtime limit), floored
+ * escrows the target runway's worth of the reviewed bid prices (bounded by the runtime limit), floored
  * at the bootstrap deposit the deployment already holds from creation. Since that bootstrap already left
- * the available balance, only the difference up to the reserve is drawn at confirm time.
+ * the available balance, only the difference up to the escrow is drawn at confirm time.
  */
 export function useFundingImpact({ rows, runtimeLimitHours, dependencies: d = DEPENDENCIES }: Input): FundingImpact {
   const isEscrowAbstracted = d.useIsEscrowAbstracted();
@@ -73,9 +73,9 @@ export function useFundingImpact({ rows, runtimeLimitHours, dependencies: d = DE
   const perBlockUdenom = pricedRows.reduce((sum, row) => sum + Number(row.price.amount), 0);
   const hourlyCostUsd = udenomToUsd(perBlockUdenom * API_BLOCKS_PER_HOUR, pricedRows[0].price.denom);
   const fundedHours = runtimeLimitHours === undefined ? targetRunwayHours : Math.min(targetRunwayHours, runtimeLimitHours);
-  const reserveUsd = Math.max(defaultDepositUsd, hourlyCostUsd * fundedHours);
-  /** The bootstrap deposit was drawn at creation and already counts as reserved, so confirming only draws the rest. */
-  const remainingDrawUsd = reserveUsd - defaultDepositUsd;
+  const escrowUsd = Math.max(defaultDepositUsd, hourlyCostUsd * fundedHours);
+  /** The bootstrap deposit was drawn at creation and already sits in escrow, so confirming only draws the rest. */
+  const remainingDrawUsd = escrowUsd - defaultDepositUsd;
 
   const availableNowUsd = overview.available;
   const availableAfterUsd = availableNowUsd >= remainingDrawUsd ? availableNowUsd - remainingDrawUsd : null;
@@ -86,7 +86,7 @@ export function useFundingImpact({ rows, runtimeLimitHours, dependencies: d = DE
   return {
     kind: "visible",
     state: resolveState({ availableAfterUsd, thresholdUsd, hasPaymentMethod, isTrialing }),
-    reserveUsd,
+    escrowUsd,
     availableNowUsd,
     availableAfterUsd,
     thresholdUsd,
@@ -97,7 +97,7 @@ export function useFundingImpact({ rows, runtimeLimitHours, dependencies: d = DE
 }
 
 /**
- * First match wins: a balance that cannot cover the reserve outranks everything, then a charge that is
+ * First match wins: a balance that cannot cover the escrow outranks everything, then a charge that is
  * really coming (auto top-up ignores the trial flag, so a trialing card gets charged like any other), then
  * the trial, so a trialing account is never told its card is missing, then the genuinely missing card.
  */

--- a/apps/deploy-web/src/components/home/AccountStatsCards/AccountStatsCards.spec.tsx
+++ b/apps/deploy-web/src/components/home/AccountStatsCards/AccountStatsCards.spec.tsx
@@ -9,17 +9,17 @@ import { buildWalletBalance } from "@tests/seeders/walletBalance";
 import { MockComponents } from "@tests/unit/mocks";
 
 describe(AccountStatsCards.name, () => {
-  it("renders total USD balance", () => {
+  it("renders the total account balance", () => {
     setup({ walletBalance: buildWalletBalance({ totalUsd: 150.5 }) });
 
-    expect(screen.getByText("Available Balance")).toBeInTheDocument();
+    expect(screen.getByText("Account balance")).toBeInTheDocument();
     expect(screen.getByText("$150.50")).toBeInTheDocument();
   });
 
-  it("renders deployment escrow USD", () => {
+  it("renders what the running deployments hold in escrow", () => {
     setup({ walletBalance: buildWalletBalance({ totalDeploymentEscrowUSD: 42.0 }) });
 
-    expect(screen.getByText("$42.00 used in deployments")).toBeInTheDocument();
+    expect(screen.getByText("$42.00 in escrow")).toBeInTheDocument();
   });
 
   it("does not render AKT or USDC or ACT cards", () => {
@@ -46,7 +46,7 @@ describe(AccountStatsCards.name, () => {
   it("renders zero balance when wallet balance is null", () => {
     setup({ walletBalance: null });
 
-    expect(screen.getByText("Available Balance")).toBeInTheDocument();
+    expect(screen.getByText("Account balance")).toBeInTheDocument();
     expect(screen.getAllByText("$0.00")).not.toHaveLength(0);
   });
 

--- a/apps/deploy-web/src/components/home/AccountStatsCards/AccountStatsCards.tsx
+++ b/apps/deploy-web/src/components/home/AccountStatsCards/AccountStatsCards.tsx
@@ -26,13 +26,13 @@ type Props = {
 
 export const AccountStatsCards: React.FC<Props> = ({ walletBalance, activeDeploymentsCount, costPerMonth, costPerHour, dependencies: d = DEPENDENCIES }) => {
   const totalUsdBalance = walletBalance?.totalUsd || 0;
-  const usdInDeployments = walletBalance?.totalDeploymentEscrowUSD || 0;
+  const escrowUsd = walletBalance?.totalDeploymentEscrowUSD || 0;
 
   return (
     <div className="grid gap-6 lg:grid-cols-3">
       <d.Card>
         <d.CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
-          <h3 className="text-sm font-medium leading-none text-muted-foreground">Available Balance</h3>
+          <h3 className="text-sm font-medium leading-none text-muted-foreground">Account balance</h3>
           <d.Wallet className="h-4 w-4 text-muted-foreground" />
         </d.CardHeader>
         <d.CardContent>
@@ -41,7 +41,7 @@ export const AccountStatsCards: React.FC<Props> = ({ walletBalance, activeDeploy
               <d.FormattedNumber value={totalUsdBalance} style="currency" currency="USD" />
             </p>
             <p className="text-sm text-muted-foreground">
-              <d.FormattedNumber value={usdInDeployments} style="currency" currency="USD" /> used in deployments
+              <d.FormattedNumber value={escrowUsd} style="currency" currency="USD" /> in escrow
             </p>
           </div>
         </d.CardContent>

--- a/apps/deploy-web/tests/ui/managed-wallet-alerts.spec.ts
+++ b/apps/deploy-web/tests/ui/managed-wallet-alerts.spec.ts
@@ -40,7 +40,7 @@ test.describe("Managed wallet alerts", () => {
     });
 
     await test.step("does not show the escrow balance alert", async () => {
-      await expect(page.getByLabel("Escrow Balance")).toHaveCount(0);
+      await expect(page.getByLabel("Escrow Balance", { exact: true })).toHaveCount(0);
     });
 
     await test.step("verify deployment close alert is enabled by default", async () => {


### PR DESCRIPTION
## Why

Billing and the review step called the escrowed part of the balance "Reserved" — a word coined for Console that matches nothing else in the ecosystem. Execs want Console to use the same nomenclature as the chain, the CLI and the docs, so the UI says "Escrow".

Ref CON-739, Ref CON-915 — both carry an acceptance criterion saying the wording *avoids* "escrow". Those ACs now contradict the exec call and need editing, otherwise the next person re-litigates this.

## What

Vocabulary only. Per-deployment escrow controls and figures stay hidden behind `useIsEscrowAbstracted`, no deposit prompt returns, and no funding behaviour changes.

Three surfaces:

- **Billing balance card** — "Reserved" becomes "Escrow", "What is reserved (N)" becomes "What's in escrow (N)", and the footnote says the cost is kept in escrow. The tooltip needed rewriting rather than a swap: it already talked about escrows, so substituting the label left it saying that the escrow amount is what those escrows hold. The whole Available column is untouched.
- **Review and deploy** — the funding-impact section's trigger, legend, bar segment and "the reserve is held, not charged" explainer all say escrow.
- **Home card** — this one was mislabelled: the heading said "Available Balance" while the figure under it was the total, and its second line called the escrow figure "used in deployments", a third name for the same number. It now reads "Account balance" and "$X in escrow", matching billing.

Internals follow the copy. The data layer already spoke of escrow (the figure comes from `getLiveEscrowBalance`); only the display layer had invented "reserved", so `ReservedDeployment` → `EscrowedDeployment`, `reservedUsd`/`reserveUsd` → `escrowUsd`, and the overview's `reserved` field → `escrow`. The `"available"` segment key stays — both consumers filter on it.

One test hardening worth flagging: the alerts e2e asserts no "Escrow Balance" label exists on the deployment page. `getByLabel` matches case-insensitive substrings, so an `aria-label="Escrow balance"` elsewhere could satisfy it. It doesn't collide today (the balance card only renders on `/billing`), but the assertion is now pinned to an exact match.

Verified with the full deploy-web unit suite (3709 passing), `lint --quiet` clean, and `tsc --noEmit` at its pre-existing 92-error baseline with none in the touched files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Updates**
  - Updated billing and deployment funding screens to use “escrow” terminology consistently.
  - Renamed balance labels to “Account balance,” “Escrow Balance,” and “What’s in escrow.”
  - Revised explanatory text, tooltips, deployment counts, and insufficient-balance messages.
  - Updated account cards to display funds “in escrow.”

- **Tests**
  - Updated coverage and assertions for escrow balances, funding calculations, breakdowns, and alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->