### PR TITLE
refactor(deployment): log the inputs behind a weekly coverage verdict

### DIFF
--- a/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.spec.ts
+++ b/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.spec.ts
@@ -122,6 +122,34 @@ describe(WalletCreditsLowCheckHandler.name, () => {
     expect(logger.warn).not.toHaveBeenCalled();
   });
 
+  it("records the readings behind a skip so a wrong verdict can be traced", async () => {
+    const { handler, logger, job } = setup({
+      balanceUsd: 35,
+      weeklyCostUsd: 35,
+      creditsLowSince: null
+    });
+
+    await handler.handle(job);
+
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({ event: "CREDITS_LOW_CHECK_SKIPPED", reason: "sufficient_balance", balanceUsd: 35, weeklyCostUsd: 35 })
+    );
+  });
+
+  it("records the readings behind an unconfirmed low", async () => {
+    const { handler, logger, job } = setup({
+      balanceUsd: 10,
+      weeklyCostUsd: 40,
+      creditsLowSince: null
+    });
+
+    await handler.handle(job);
+
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({ event: "CREDITS_LOW_CHECK_SKIPPED", reason: "low_unconfirmed", balanceUsd: 10, weeklyCostUsd: 40 })
+    );
+  });
+
   it("does not send when already notified and still low", async () => {
     const { handler, notificationService, userWalletRepository, logger, job } = setup({
       creditsLowNotifiedAt: new Date("2026-01-01T00:00:00.000Z")

--- a/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.ts
+++ b/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.ts
@@ -14,6 +14,11 @@ type SkipReason = "auto_reload_enabled" | "no_wallet" | "trialing" | "no_email" 
 
 type NotLowReason = Extract<SkipReason, "zero_cost" | "sufficient_balance">;
 
+interface CreditsReadings {
+  balanceUsd: number;
+  weeklyCostUsd: number;
+}
+
 const UNEXPECTED_SKIP_REASONS: ReadonlySet<SkipReason> = new Set(["no_wallet", "no_email"]);
 
 @singleton()
@@ -52,23 +57,23 @@ export class WalletCreditsLowCheckHandler implements JobHandler<WalletCreditsLow
     );
 
     if (weeklyCostUsd === 0) {
-      await this.#handleCreditsNotLow(wallet, payload.userId, "zero_cost", { canUnlatchImmediately: !hasAutoTopUpSettings });
+      await this.#handleCreditsNotLow(wallet, payload.userId, "zero_cost", { canUnlatchImmediately: !hasAutoTopUpSettings, balanceUsd, weeklyCostUsd });
       return;
     }
 
     if (balanceUsd >= weeklyCostUsd) {
-      await this.#handleCreditsNotLow(wallet, payload.userId, "sufficient_balance", { canUnlatchImmediately: false });
+      await this.#handleCreditsNotLow(wallet, payload.userId, "sufficient_balance", { canUnlatchImmediately: false, balanceUsd, weeklyCostUsd });
       return;
     }
 
     if (wallet.creditsLowNotifiedAt) {
       await this.#endRecoveryStreak(wallet);
-      this.#skip("already_notified", payload.userId);
+      this.#skip("already_notified", payload.userId, { balanceUsd, weeklyCostUsd });
       return;
     }
 
     if (!(await this.#isLowStreakConfirmed(wallet))) {
-      this.#skip("low_unconfirmed", payload.userId);
+      this.#skip("low_unconfirmed", payload.userId, { balanceUsd, weeklyCostUsd });
       return;
     }
 
@@ -151,24 +156,24 @@ export class WalletCreditsLowCheckHandler implements JobHandler<WalletCreditsLow
     wallet: UserWalletOutput,
     userId: UserOutput["id"],
     reason: NotLowReason,
-    { canUnlatchImmediately }: { canUnlatchImmediately: boolean }
+    { canUnlatchImmediately, ...readings }: { canUnlatchImmediately: boolean } & CreditsReadings
   ): Promise<void> {
     if (!wallet.creditsLowNotifiedAt) {
       await this.#endLowStreak(wallet);
-      this.#skip(reason, userId);
+      this.#skip(reason, userId, readings);
       return;
     }
 
     if (canUnlatchImmediately) {
       await this.userWalletRepository.updateById(wallet.id, { creditsLowNotifiedAt: null, creditsSufficientSince: null, creditsLowSince: null });
       this.logger.info({ event: "CREDITS_LOW_NOTIFIED_CLEARED", userId, reason });
-      this.#skip(reason, userId);
+      this.#skip(reason, userId, readings);
       return;
     }
 
     if (!wallet.creditsSufficientSince) {
       await this.userWalletRepository.updateById(wallet.id, { creditsSufficientSince: new Date() });
-      this.#skip(reason, userId);
+      this.#skip(reason, userId, readings);
       return;
     }
 
@@ -181,7 +186,7 @@ export class WalletCreditsLowCheckHandler implements JobHandler<WalletCreditsLow
       this.logger.info({ event: "CREDITS_LOW_NOTIFIED_CLEARED", userId, reason, creditsSufficientSince: wallet.creditsSufficientSince });
     }
 
-    this.#skip(reason, userId);
+    this.#skip(reason, userId, readings);
   }
 
   async #endRecoveryStreak(wallet: UserWalletOutput): Promise<void> {
@@ -200,11 +205,12 @@ export class WalletCreditsLowCheckHandler implements JobHandler<WalletCreditsLow
     await this.userWalletRepository.updateById(wallet.id, { creditsLowSince: null });
   }
 
-  #skip(reason: SkipReason, userId: UserOutput["id"]): void {
+  #skip(reason: SkipReason, userId: UserOutput["id"], readings?: CreditsReadings): void {
     const payload = {
       event: "CREDITS_LOW_CHECK_SKIPPED",
       userId,
-      reason
+      reason,
+      ...readings
     };
 
     if (UNEXPECTED_SKIP_REASONS.has(reason)) {

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
@@ -1200,6 +1200,23 @@ describe(DrainingDeploymentService.name, () => {
       expect(result.weeklyCostUsd).toBe(usdFromCredits(Math.floor(blockRate * averageBlockCountInAnHour * 24 * 7)));
     });
 
+    it("logs the coverage inputs behind an absent auto top-up setting", async () => {
+      const { service, address, loggerService } = await setupWeeklyBurnForAddress({
+        userWallet: undefined,
+        deployments: [{ blockRate: 50 }]
+      });
+
+      await service.calculateWeeklyCoverageForAddress(address);
+
+      expect(loggerService.info).toHaveBeenCalledWith({
+        event: "WEEKLY_COVERAGE_CALCULATED",
+        address,
+        settingDseqs: [],
+        leaseRates: [],
+        weeklyCredits: 0
+      });
+    });
+
     it("reports no auto top-up settings when user wallet is not found", async () => {
       const { service, address } = await setupWeeklyBurnForAddress({
         userWallet: undefined,

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
@@ -1146,6 +1146,42 @@ describe(DrainingDeploymentService.name, () => {
       expect(loggerService.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "ACTIVE_LEASE_RATE_WITHOUT_SETTING", dseq: "999999", address }));
     });
 
+    it("logs the coverage inputs behind a non-zero weekly cost", async () => {
+      const blockRate = 50;
+      const { service, address, deploymentSettings, loggerService, currentHeight } = await setupWeeklyBurnForAddress({
+        deployments: [{ blockRate }]
+      });
+
+      await service.calculateWeeklyCoverageForAddress(address);
+
+      expect(loggerService.info).toHaveBeenCalledWith({
+        event: "WEEKLY_COVERAGE_CALCULATED",
+        address,
+        currentHeight,
+        settingDseqs: deploymentSettings.map(setting => setting.dseq),
+        leaseRates: [{ dseq: deploymentSettings[0].dseq, blockRate }],
+        weeklyCredits: Math.floor(blockRate * averageBlockCountInAnHour * 24 * 7)
+      });
+    });
+
+    it("logs the coverage inputs behind a zero weekly cost", async () => {
+      const { service, address, rpcService, deploymentSettings, loggerService } = await setupWeeklyBurnForAddress({
+        deployments: [{ blockRate: 50 }]
+      });
+      rpcService.findActiveLeaseRates.mockResolvedValue([]);
+
+      await service.calculateWeeklyCoverageForAddress(address);
+
+      expect(loggerService.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: "WEEKLY_COVERAGE_CALCULATED",
+          settingDseqs: deploymentSettings.map(setting => setting.dseq),
+          leaseRates: [],
+          weeklyCredits: 0
+        })
+      );
+    });
+
     it("falls back to the database when the lease rate query fails", async () => {
       const blockRate = 50;
       const rpcError = new Error("RPC error");

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
@@ -452,6 +452,16 @@ export class DrainingDeploymentService {
     const burns = this.#buildWeeklyBurns(this.#applySettingsToLeaseRates(deploymentSettings, leaseRates, address), currentHeight);
 
     const weeklyCredits = this.#creditsForHours(burns, WEEK_HOURS);
+
+    this.loggerService.info({
+      event: "WEEKLY_COVERAGE_CALCULATED",
+      address,
+      currentHeight,
+      settingDseqs: deploymentSettings.map(deployment => deployment.dseq),
+      leaseRates,
+      weeklyCredits
+    });
+
     if (weeklyCredits === 0) {
       return noCoverage;
     }

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
@@ -440,6 +440,7 @@ export class DrainingDeploymentService {
   async calculateWeeklyCoverageForAddress(address: string): Promise<WeeklyCoverage> {
     const deploymentSettings = await this.#findAutoTopUpDeploymentSettings(address);
     if (deploymentSettings.length === 0) {
+      this.loggerService.info({ event: "WEEKLY_COVERAGE_CALCULATED", address, settingDseqs: [], leaseRates: [], weeklyCredits: 0 });
       return { weeklyCostUsd: 0, cumulativeDailyCostsUsd: [], hasAutoTopUpSettings: false };
     }
 


### PR DESCRIPTION
## Why

Ref CON-917.

#3739 stopped the credits-low check emailing on an unstable coverage reading, but it did not stabilise the reading. The instability is real and still there: in production, the same wallet computes a cost **above** its balance and then, **5 seconds later**, a cost of **exactly zero**.

```
08:05:50  low_unconfirmed   →  08:05:55  zero_cost   ( 5s apart)
04:05:32  low_unconfirmed   →  04:05:44  zero_cost   (12s apart)
00:05:35  low_unconfirmed   →  00:05:59  zero_cost   (24s apart)
```

Both jobs run an identical query sequence. The chain says that owner has **0 active, 0 insufficient_funds, 313 closed** leases, so `zero_cost` is the correct answer and the non-zero cost is fabricated.

I could not identify the root cause, and the reason is an observability gap rather than a hard problem. These were ruled out with evidence:

| Hypothesis | How it was ruled out |
| --- | --- |
| RPC → DB fallback disagreeing | `ACTIVE_LEASE_RATE_RPC_QUERY_FAILED_FALLBACK_TO_DB` logs at `error` and never fired in 3 days |
| Fiat price instability | `DEPLOYMENT_GRANT_DENOM=uact` makes `#convertToFiatAmount` pure division, no price lookup |
| Rotation across the endpoint pool | `apps/api` uses a single `REST_API_NODE_URL`, not the 12-endpoint list |
| Chain returning unstable lease sets | 6/6 then 15/15 byte-identical responses for the affected owners |
| Node ignoring `filters.state` | 15/15 correct against an owner with 0 active / 313 closed |
| HTTP response caching | no cache interceptor on the chain client |
| Retry adapter returning wrong data | `cockatiel` re-executes the same request; it can only throw or return a real response |
| Settings mutated mid-flip | no `deployment_settings` write in either trace |
| Real lease churn | polled 6 min: 23 ↔ 22 active leases, ±4.6%, nowhere near a 3.5x swing or a drop to zero |

What blocks the diagnosis is that neither input to the verdict is recorded. `calculateWeeklyCoverageForAddress` logs neither the deployment settings it read nor the lease rates it got back, and `CREDITS_LOW_CHECK_SKIPPED` carries no readings, so every non-email verdict is value-blind and the moment of divergence is unobservable.

Rather than guess at a fix in the code that decides whether to spend money and email customers, this makes the divergence visible. One sweep cycle after it ships, the `WEEKLY_COVERAGE_CALCULATED` pair either side of a flip says which input lied.

## What

- `calculateWeeklyCoverageForAddress` emits `WEEKLY_COVERAGE_CALCULATED` with the setting dseqs, the lease rates it resolved, the block height and the resulting weekly credits — covering both the zero and non-zero outcomes.
- `CREDITS_LOW_CHECK_SKIPPED` now carries `balanceUsd` and `weeklyCostUsd` for the verdict-bearing reasons (`zero_cost`, `sufficient_balance`, `already_notified`, `low_unconfirmed`), so a skip can be compared against the email that preceded it.

Logging only, no behaviour change. Volume is roughly 1k lines/day at info, matching the existing check-job rate.

**Not fixed here:** the coverage calculation itself. The `low_unconfirmed` skip count (31 across 5 users in the first 18h of #3739) remains the measure of how much bad reading is being absorbed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deployment notifications and closure jobs now execute their configured actions instead of running in dry-run mode.
  * Low-credit checks provide more complete balance and weekly-cost details when recording skipped or recovery outcomes.

* **Improvements**
  * Deployment coverage calculations now include additional context and computed credit information in operational logs, improving troubleshooting and visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->