### PR TITLE
fix(deployment): drop already-closed deployments from the cleanup batch

### DIFF
--- a/apps/api/src/billing/services/chain-error/chain-error.service.spec.ts
+++ b/apps/api/src/billing/services/chain-error/chain-error.service.spec.ts
@@ -328,6 +328,55 @@ describe(ChainErrorService.name, () => {
     });
   });
 
+  describe("getClosedDeploymentMessageIndex", () => {
+    it("returns the parsed index when it falls within the batch", () => {
+      const { service } = setup();
+      const err = new Error("Query failed with (6): rpc error: code = Unknown desc = failed to execute message; message index: 1: Deployment closed");
+
+      expect(service.getClosedDeploymentMessageIndex(err, 3)).toBe(1);
+    });
+
+    it("reads the index off the original error once toAppError has replaced the message", async () => {
+      const { service } = setup();
+      const rawError = new Error("Query failed with (6): rpc error: code = Unknown desc = failed to execute message; message index: 2: Deployment closed");
+      const appError = await service.toAppError(rawError, []);
+
+      expect(service.getClosedDeploymentMessageIndex(appError, 3)).toBe(2);
+    });
+
+    it("returns undefined when the index falls outside the batch", () => {
+      const { service } = setup();
+      const err = new Error("failed to execute message; message index: 7: deployment closed");
+
+      expect(service.getClosedDeploymentMessageIndex(err, 2)).toBeUndefined();
+    });
+
+    it("resolves a single-message batch to index zero when the message carries no index", () => {
+      const { service } = setup();
+
+      expect(service.getClosedDeploymentMessageIndex(new Error("Deployment closed"), 1)).toBe(0);
+    });
+
+    it("returns undefined for a multi-message batch when the message carries no index", () => {
+      const { service } = setup();
+
+      expect(service.getClosedDeploymentMessageIndex(new Error("Deployment closed"), 2)).toBeUndefined();
+    });
+
+    it("returns undefined for an error that is not a closed-deployment error", () => {
+      const { service } = setup();
+      const err = new Error("failed to execute message; message index: 0: insufficient funds");
+
+      expect(service.getClosedDeploymentMessageIndex(err, 1)).toBeUndefined();
+    });
+
+    it("returns undefined for a non-error value", () => {
+      const { service } = setup();
+
+      expect(service.getClosedDeploymentMessageIndex("Deployment closed", 1)).toBeUndefined();
+    });
+  });
+
   describe("isUnsettleableDeploymentError", () => {
     it("returns true for the escrow settlement underflow panic", () => {
       const { service } = setup();

--- a/apps/api/src/billing/services/chain-error/chain-error.service.ts
+++ b/apps/api/src/billing/services/chain-error/chain-error.service.ts
@@ -126,6 +126,21 @@ export class ChainErrorService {
     return /account closed|deployment closed/i.test(error.message);
   }
 
+  /** An index outside the batch is not resolved to a neighbour: closing the wrong deployment is worse than alerting. */
+  public getClosedDeploymentMessageIndex(error: unknown, batchSize: number): number | undefined {
+    if (!(error instanceof Error) || !this.isDeploymentClosedError(error)) {
+      return undefined;
+    }
+
+    const messageIndex = this.getFailedMessageIndex(error);
+
+    if (messageIndex !== undefined) {
+      return messageIndex >= 0 && messageIndex < batchSize ? messageIndex : undefined;
+    }
+
+    return batchSize === 1 ? 0 : undefined;
+  }
+
   /**
    * `toAppError` replaces the raw chain message with a mapped one, so on that path the index survives only
    * on `originalError`, which is read first because it is the rawest message available.

--- a/apps/api/src/deployment/services/stale-managed-deployments-cleaner/stale-managed-deployments-cleaner.service.spec.ts
+++ b/apps/api/src/deployment/services/stale-managed-deployments-cleaner/stale-managed-deployments-cleaner.service.spec.ts
@@ -1,4 +1,5 @@
 import type { BalanceHttpService } from "@akashnetwork/http-sdk";
+import type { IndexedTx } from "@cosmjs/stargate";
 import createError from "http-errors";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
@@ -71,6 +72,116 @@ describe(StaleManagedDeploymentsCleanerService.name, () => {
     });
   });
 
+  describe("when a deployment is already closed on chain", () => {
+    it("drops the closed deployment and closes the rest in a second broadcast", async () => {
+      const executeDerivedTx = vi.fn().mockRejectedValueOnce(buildDeploymentClosedAppError(1)).mockResolvedValueOnce(buildOkTx());
+      const { service, logger, wallet } = setup({ staleDeployments: [{ dseq: 1 }, { dseq: 2 }, { dseq: 3 }], executeDerivedTx });
+
+      await service.cleanUpForWallet(wallet, 0);
+
+      expect(executeDerivedTx).toHaveBeenCalledTimes(2);
+      expect(executeDerivedTx).toHaveBeenLastCalledWith(wallet.id, [
+        expect.objectContaining({ value: expect.objectContaining({ dseq: 1 }) }),
+        expect.objectContaining({ value: expect.objectContaining({ dseq: 3 }) })
+      ]);
+      expect(logger.info).toHaveBeenCalledWith({ event: "DEPLOYMENT_CLEAN_UP_ALREADY_CLOSED", owner: wallet.address, dseq: 2 });
+      expect(logger.info).toHaveBeenCalledWith({ event: "DEPLOYMENT_CLEAN_UP_SUCCESS", owner: wallet.address, alreadyClosedCount: 1 });
+    });
+
+    it("resolves quietly when the wallet's only orphan is already closed and the error carries no index", async () => {
+      const executeDerivedTx = vi.fn().mockRejectedValueOnce(buildDeploymentClosedAppError());
+      const { service, logger, errorLogger, wallet } = setup({ staleDeployments: [{ dseq: 7 }], executeDerivedTx });
+
+      await service.cleanUpForWallet(wallet, 0);
+
+      expect(executeDerivedTx).toHaveBeenCalledTimes(1);
+      expect(logger.info).toHaveBeenCalledWith({ event: "DEPLOYMENT_CLEAN_UP_ALREADY_CLOSED", owner: wallet.address, dseq: 7 });
+      expect(logger.info).toHaveBeenCalledWith({ event: "DEPLOYMENT_CLEAN_UP_SUCCESS", owner: wallet.address, alreadyClosedCount: 1 });
+      expect(logger.error).not.toHaveBeenCalled();
+      expect(errorLogger.error).not.toHaveBeenCalled();
+    });
+
+    it("reports success without an error when the whole batch is already closed", async () => {
+      const executeDerivedTx = vi.fn().mockRejectedValue(buildDeploymentClosedAppError(0));
+      const { service, logger, errorLogger, wallet } = setup({ staleDeployments: [{ dseq: 1 }, { dseq: 2 }], executeDerivedTx });
+
+      await service.cleanUpForWallet(wallet, 0);
+
+      expect(executeDerivedTx).toHaveBeenCalledTimes(2);
+      expect(logger.info).toHaveBeenCalledWith({ event: "DEPLOYMENT_CLEAN_UP_SUCCESS", owner: wallet.address, alreadyClosedCount: 2 });
+      expect(logger.error).not.toHaveBeenCalled();
+      expect(errorLogger.error).not.toHaveBeenCalled();
+    });
+
+    it("rethrows into the wallet error handler when the reported index falls outside the batch", async () => {
+      const error = buildDeploymentClosedAppError(7);
+      const { service, managedSignerService, logger, errorLogger } = setup({
+        staleDeployments: [{ dseq: 1 }, { dseq: 2 }],
+        executeDerivedTx: vi.fn().mockRejectedValue(error)
+      });
+
+      await expect(service.cleanup({ concurrency: 1 })).resolves.toBeUndefined();
+
+      expect(managedSignerService.executeDerivedTx).toHaveBeenCalledTimes(1);
+      expect(logger.info).not.toHaveBeenCalledWith(expect.objectContaining({ event: "DEPLOYMENT_CLEAN_UP_ALREADY_CLOSED" }));
+      expect(errorLogger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "DEPLOYMENT_CLEAN_UP_ERROR", error }));
+    });
+
+    it("stops after the drop limit without reporting an error when too many deployments turn out closed", async () => {
+      const executeDerivedTx = vi.fn().mockRejectedValue(buildDeploymentClosedAppError(0));
+      const { service, logger, errorLogger, wallet } = setup({
+        staleDeployments: [{ dseq: 1 }, { dseq: 2 }, { dseq: 3 }, { dseq: 4 }, { dseq: 5 }],
+        executeDerivedTx
+      });
+
+      await service.cleanUpForWallet(wallet, 0);
+
+      expect(executeDerivedTx).toHaveBeenCalledTimes(3);
+      expect(logger.warn).toHaveBeenCalledWith({ event: "DEPLOYMENT_CLEAN_UP_DROP_LIMIT", owner: wallet.address, remainingCount: 2 });
+      expect(logger.info).not.toHaveBeenCalledWith(expect.objectContaining({ event: "DEPLOYMENT_CLEAN_UP_SUCCESS" }));
+      expect(logger.error).not.toHaveBeenCalled();
+      expect(errorLogger.error).not.toHaveBeenCalled();
+    });
+
+    it("treats a landed tx that reverted on a closed deployment as a failure and drops it", async () => {
+      const revertedTx = mock<IndexedTx>({ code: 8, hash: "tx-hash", rawLog: "failed to execute message; message index: 0: Deployment closed" });
+      const executeDerivedTx = vi.fn().mockResolvedValueOnce(revertedTx).mockResolvedValueOnce(buildOkTx());
+      const { service, logger, wallet } = setup({ staleDeployments: [{ dseq: 1 }, { dseq: 2 }], executeDerivedTx });
+
+      await service.cleanUpForWallet(wallet, 0);
+
+      expect(executeDerivedTx).toHaveBeenCalledTimes(2);
+      expect(logger.info).toHaveBeenCalledWith({ event: "DEPLOYMENT_CLEAN_UP_ALREADY_CLOSED", owner: wallet.address, dseq: 1 });
+      expect(logger.info).toHaveBeenCalledWith({ event: "DEPLOYMENT_CLEAN_UP_SUCCESS", owner: wallet.address, alreadyClosedCount: 1 });
+    });
+
+    it("composes the fee refill with the closed-deployment drop", async () => {
+      const executeDerivedTx = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("not allowed to pay fees"))
+        .mockRejectedValueOnce(buildDeploymentClosedAppError(0))
+        .mockResolvedValueOnce(buildOkTx());
+      const { service, managedUserWalletService, logger, wallet } = setup({ staleDeployments: [{ dseq: 1 }, { dseq: 2 }], executeDerivedTx });
+
+      await service.cleanUpForWallet(wallet, 0);
+
+      expect(managedUserWalletService.authorizeSpending).toHaveBeenCalledTimes(1);
+      expect(executeDerivedTx).toHaveBeenCalledTimes(3);
+      expect(logger.info).toHaveBeenCalledWith({ event: "DEPLOYMENT_CLEAN_UP_SUCCESS", owner: wallet.address, alreadyClosedCount: 1 });
+    });
+
+    it("logs the unsettleable event when the re-broadcast after a drop hits the escrow underflow", async () => {
+      const executeDerivedTx = vi.fn().mockRejectedValueOnce(buildDeploymentClosedAppError(0)).mockRejectedValueOnce(buildUnsettleableAppError());
+      const { service, logger, wallet } = setup({ staleDeployments: [{ dseq: 1 }, { dseq: 2 }], executeDerivedTx });
+
+      await service.cleanUpForWallet(wallet, 0);
+
+      expect(executeDerivedTx).toHaveBeenCalledTimes(2);
+      expect(logger.info).toHaveBeenCalledWith({ event: "DEPLOYMENT_CLEAN_UP_ALREADY_CLOSED", owner: wallet.address, dseq: 1 });
+      expect(logger.error).toHaveBeenCalledWith(UNSETTLEABLE_LOG);
+    });
+  });
+
   describe("cleanup", () => {
     it("logs the unsettleable event and swallows the error without refilling fees or retrying", async () => {
       const { service, managedSignerService, managedUserWalletService, logger, errorLogger } = setup({
@@ -86,7 +197,7 @@ describe(StaleManagedDeploymentsCleanerService.name, () => {
     });
 
     it("refills fees and retries when the wallet is not allowed to pay fees", async () => {
-      const executeDerivedTx = vi.fn().mockRejectedValueOnce(new Error("not allowed to pay fees")).mockResolvedValueOnce(undefined);
+      const executeDerivedTx = vi.fn().mockRejectedValueOnce(new Error("not allowed to pay fees")).mockResolvedValueOnce(buildOkTx());
       const { service, managedUserWalletService, logger } = setup({ executeDerivedTx });
 
       await service.cleanup({ concurrency: 1 });
@@ -145,6 +256,19 @@ describe(StaleManagedDeploymentsCleanerService.name, () => {
     return createError(400, "Deployment escrow cannot be settled yet", { originalError: new Error(UNSETTLEABLE_PANIC) });
   }
 
+  function buildDeploymentClosedAppError(index?: number) {
+    const rawMessage =
+      index === undefined
+        ? "Query failed with (6): rpc error: code = Unknown desc = Deployment closed"
+        : `Query failed with (6): rpc error: code = Unknown desc = failed to execute message; message index: ${index}: Deployment closed`;
+
+    return createError(400, "Deployment closed", { originalError: new Error(rawMessage) });
+  }
+
+  function buildOkTx() {
+    return mock<IndexedTx>({ code: 0, hash: "tx-hash", rawLog: "success" });
+  }
+
   it("creates the logger with the service context", () => {
     const { createLogger } = setup();
 
@@ -183,7 +307,7 @@ describe(StaleManagedDeploymentsCleanerService.name, () => {
     const blockRepository = mock<BlockRepository>();
     const rpcMessageService = mock<RpcMessageService>();
     const managedSignerService = mock<ManagedSignerService>({
-      executeDerivedTx: input?.executeDerivedTx ?? vi.fn().mockResolvedValue(undefined)
+      executeDerivedTx: input?.executeDerivedTx ?? vi.fn().mockResolvedValue(buildOkTx())
     });
     const managedUserWalletService = mock<ManagedUserWalletService>();
     const config = mock<BillingConfig>({ FEE_ALLOWANCE_REFILL_AMOUNT: 1000 });
@@ -196,6 +320,7 @@ describe(StaleManagedDeploymentsCleanerService.name, () => {
 
     blockRepository.getLatestProcessedHeight.mockResolvedValue(input?.currentHeight ?? 1_000_000);
     deploymentRepository.findStaleDeployments.mockResolvedValue(input?.staleDeployments ?? [{ dseq: 456 }]);
+    rpcMessageService.getCloseDeploymentMsg.mockImplementation((_address, dseq) => ({ typeUrl: "/close", value: { dseq } }) as never);
 
     const service = new StaleManagedDeploymentsCleanerService(
       userWalletRepository,

--- a/apps/api/src/deployment/services/stale-managed-deployments-cleaner/stale-managed-deployments-cleaner.service.spec.ts
+++ b/apps/api/src/deployment/services/stale-managed-deployments-cleaner/stale-managed-deployments-cleaner.service.spec.ts
@@ -136,11 +136,34 @@ describe(StaleManagedDeploymentsCleanerService.name, () => {
 
       await service.cleanUpForWallet(wallet, 0);
 
-      expect(executeDerivedTx).toHaveBeenCalledTimes(3);
+      expect(executeDerivedTx).toHaveBeenCalledTimes(4);
       expect(logger.warn).toHaveBeenCalledWith({ event: "DEPLOYMENT_CLEAN_UP_DROP_LIMIT", owner: wallet.address, remainingCount: 2 });
       expect(logger.info).not.toHaveBeenCalledWith(expect.objectContaining({ event: "DEPLOYMENT_CLEAN_UP_SUCCESS" }));
       expect(logger.error).not.toHaveBeenCalled();
       expect(errorLogger.error).not.toHaveBeenCalled();
+    });
+
+    it("still closes the survivors when the drop limit is reached on the last closed deployment", async () => {
+      const executeDerivedTx = vi
+        .fn()
+        .mockRejectedValueOnce(buildDeploymentClosedAppError(0))
+        .mockRejectedValueOnce(buildDeploymentClosedAppError(0))
+        .mockRejectedValueOnce(buildDeploymentClosedAppError(0))
+        .mockResolvedValueOnce(buildOkTx());
+      const { service, logger, wallet } = setup({
+        staleDeployments: [{ dseq: 1 }, { dseq: 2 }, { dseq: 3 }, { dseq: 4 }, { dseq: 5 }],
+        executeDerivedTx
+      });
+
+      await service.cleanUpForWallet(wallet, 0);
+
+      expect(executeDerivedTx).toHaveBeenCalledTimes(4);
+      expect(executeDerivedTx).toHaveBeenLastCalledWith(wallet.id, [
+        expect.objectContaining({ value: expect.objectContaining({ dseq: 4 }) }),
+        expect.objectContaining({ value: expect.objectContaining({ dseq: 5 }) })
+      ]);
+      expect(logger.warn).not.toHaveBeenCalledWith(expect.objectContaining({ event: "DEPLOYMENT_CLEAN_UP_DROP_LIMIT" }));
+      expect(logger.info).toHaveBeenCalledWith({ event: "DEPLOYMENT_CLEAN_UP_SUCCESS", owner: wallet.address, alreadyClosedCount: 3 });
     });
 
     it("treats a landed tx that reverted on a closed deployment as a failure and drops it", async () => {

--- a/apps/api/src/deployment/services/stale-managed-deployments-cleaner/stale-managed-deployments-cleaner.service.ts
+++ b/apps/api/src/deployment/services/stale-managed-deployments-cleaner/stale-managed-deployments-cleaner.service.ts
@@ -12,7 +12,10 @@ import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
 import { ErrorService } from "@src/core/services/error/error.service";
 import { DeploymentRepository } from "@src/deployment/repositories/deployment/deployment.repository";
 import { CleanUpStaleDeploymentsParams } from "@src/deployment/types/state-deployments";
-import { averageBlockTime } from "@src/utils/constants";
+import { averageBlockTime, COSMOS_TX_CODE_OK } from "@src/utils/constants";
+
+/** Bounds how long one wallet's backlog of already-closed deployments can hold a cleanup pass. */
+const MAX_CLOSED_DEPLOYMENT_DROPS = 3;
 
 @singleton()
 export class StaleManagedDeploymentsCleanerService {
@@ -63,43 +66,67 @@ export class StaleManagedDeploymentsCleanerService {
     return (await this.blockRepository.getLatestProcessedHeight()) - maxLiveBlocks;
   }
 
+  /**
+   * Re-broadcasting without an already-closed deployment is safe only because both classified shapes prove the tx
+   * was rejected whole: a fee estimation never broadcasts, and a non-zero tx code means every message reverted.
+   */
   async #closeLeaselessDeployments(wallet: UserWalletOutput, staleBeforeHeight: number) {
-    const deployments = await this.deploymentRepository.findStaleDeployments({
+    let remaining = await this.deploymentRepository.findStaleDeployments({
       owner: wallet.address!,
       createdHeight: staleBeforeHeight
     });
 
-    const messages = deployments.map(deployment => this.rpcMessageService.getCloseDeploymentMsg(wallet.address!, deployment.dseq));
-
-    if (!messages.length) {
+    if (!remaining.length) {
       return;
     }
 
     this.logger.info({ event: "DEPLOYMENT_CLEAN_UP", owner: wallet.address });
 
-    try {
-      await this.closeDeployments(wallet, messages);
-      this.logger.info({ event: "DEPLOYMENT_CLEAN_UP_SUCCESS", owner: wallet.address });
-    } catch (error) {
-      if (error instanceof Error && this.chainErrorService.isUnsettleableDeploymentError(error)) {
-        this.logger.error({
-          event: "DEPLOYMENT_CLEAN_UP_UNSETTLEABLE",
-          reason: "Deployment escrow cannot be settled yet; chain rejects close until it settles",
-          owner: wallet.address
-        });
-        return;
+    let closedDeploymentsDropped = 0;
+
+    while (remaining.length) {
+      const messages = remaining.map(deployment => this.rpcMessageService.getCloseDeploymentMsg(wallet.address!, deployment.dseq));
+      const failure = await this.closeDeployments(wallet, messages);
+
+      if (!failure) {
+        break;
       }
 
-      throw error;
+      const closedIndex = this.chainErrorService.getClosedDeploymentMessageIndex(failure, remaining.length);
+
+      if (closedIndex === undefined) {
+        if (failure instanceof Error && this.chainErrorService.isUnsettleableDeploymentError(failure)) {
+          this.logger.error({
+            event: "DEPLOYMENT_CLEAN_UP_UNSETTLEABLE",
+            reason: "Deployment escrow cannot be settled yet; chain rejects close until it settles",
+            owner: wallet.address
+          });
+          return;
+        }
+
+        throw failure;
+      }
+
+      this.logger.info({ event: "DEPLOYMENT_CLEAN_UP_ALREADY_CLOSED", owner: wallet.address, dseq: remaining[closedIndex].dseq });
+      remaining = remaining.filter((_, index) => index !== closedIndex);
+
+      if (++closedDeploymentsDropped >= MAX_CLOSED_DEPLOYMENT_DROPS && remaining.length) {
+        this.logger.warn({ event: "DEPLOYMENT_CLEAN_UP_DROP_LIMIT", owner: wallet.address, remainingCount: remaining.length });
+        return;
+      }
     }
+
+    this.logger.info({ event: "DEPLOYMENT_CLEAN_UP_SUCCESS", owner: wallet.address, alreadyClosedCount: closedDeploymentsDropped });
   }
 
-  private async closeDeployments(wallet: UserWalletOutput, messages: EncodeObject[]) {
+  /** Returns the failure rather than throwing so the caller classifies a rejected estimate and a reverted tx alike. */
+  private async closeDeployments(wallet: UserWalletOutput, messages: EncodeObject[]): Promise<unknown> {
     try {
-      await this.managedSignerService.executeDerivedTx(wallet.id, messages);
-    } catch (error: any) {
-      if (!error.message.includes("not allowed to pay fees")) {
-        throw error;
+      await this.#broadcastClose(wallet.id, messages);
+      return undefined;
+    } catch (error) {
+      if (!(error instanceof Error) || !error.message.includes("not allowed to pay fees")) {
+        return error;
       }
 
       await this.managedUserWalletService.authorizeSpending(this.managedSignerService, {
@@ -109,7 +136,20 @@ export class StaleManagedDeploymentsCleanerService {
         }
       });
 
-      await this.managedSignerService.executeDerivedTx(wallet.id, messages);
+      try {
+        await this.#broadcastClose(wallet.id, messages);
+        return undefined;
+      } catch (retryError) {
+        return retryError;
+      }
+    }
+  }
+
+  async #broadcastClose(walletId: number, messages: EncodeObject[]): Promise<void> {
+    const tx = await this.managedSignerService.executeDerivedTx(walletId, messages);
+
+    if (tx.code !== COSMOS_TX_CODE_OK) {
+      throw new Error(`Close tx ${tx.hash} failed on-chain with code ${tx.code}: ${tx.rawLog}`);
     }
   }
 }

--- a/apps/api/src/deployment/services/stale-managed-deployments-cleaner/stale-managed-deployments-cleaner.service.ts
+++ b/apps/api/src/deployment/services/stale-managed-deployments-cleaner/stale-managed-deployments-cleaner.service.ts
@@ -14,7 +14,7 @@ import { DeploymentRepository } from "@src/deployment/repositories/deployment/de
 import { CleanUpStaleDeploymentsParams } from "@src/deployment/types/state-deployments";
 import { averageBlockTime, COSMOS_TX_CODE_OK } from "@src/utils/constants";
 
-/** Bounds how long one wallet's backlog of already-closed deployments can hold a cleanup pass. */
+/** Bounds how many already-closed deployments one pass drops; the batch left after the last drop is still broadcast once. */
 const MAX_CLOSED_DEPLOYMENT_DROPS = 3;
 
 @singleton()
@@ -66,10 +66,7 @@ export class StaleManagedDeploymentsCleanerService {
     return (await this.blockRepository.getLatestProcessedHeight()) - maxLiveBlocks;
   }
 
-  /**
-   * Re-broadcasting without an already-closed deployment is safe only because both classified shapes prove the tx
-   * was rejected whole: a fee estimation never broadcasts, and a non-zero tx code means every message reverted.
-   */
+  /** Dropping a message and re-broadcasting is safe because both classified failures reject the tx whole: an estimate never lands, a non-zero code reverts. */
   async #closeLeaselessDeployments(wallet: UserWalletOutput, staleBeforeHeight: number) {
     let remaining = await this.deploymentRepository.findStaleDeployments({
       owner: wallet.address!,
@@ -107,13 +104,14 @@ export class StaleManagedDeploymentsCleanerService {
         throw failure;
       }
 
-      this.logger.info({ event: "DEPLOYMENT_CLEAN_UP_ALREADY_CLOSED", owner: wallet.address, dseq: remaining[closedIndex].dseq });
-      remaining = remaining.filter((_, index) => index !== closedIndex);
-
-      if (++closedDeploymentsDropped >= MAX_CLOSED_DEPLOYMENT_DROPS && remaining.length) {
+      if (closedDeploymentsDropped >= MAX_CLOSED_DEPLOYMENT_DROPS) {
         this.logger.warn({ event: "DEPLOYMENT_CLEAN_UP_DROP_LIMIT", owner: wallet.address, remainingCount: remaining.length });
         return;
       }
+
+      this.logger.info({ event: "DEPLOYMENT_CLEAN_UP_ALREADY_CLOSED", owner: wallet.address, dseq: remaining[closedIndex].dseq });
+      remaining = remaining.filter((_, index) => index !== closedIndex);
+      closedDeploymentsDropped++;
     }
 
     this.logger.info({ event: "DEPLOYMENT_CLEAN_UP_SUCCESS", owner: wallet.address, alreadyClosedCount: closedDeploymentsDropped });

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
@@ -778,8 +778,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
       const error = new Error(`insufficient funds: 10uakt is smaller than 20uakt`);
 
       chainErrorService.isMasterWalletInsufficientFundsError.mockResolvedValue(false);
-      chainErrorService.isDeploymentClosedError.mockReturnValue(false);
-      chainErrorService.getFailedMessageIndex.mockReturnValue(undefined);
+      chainErrorService.getClosedDeploymentMessageIndex.mockReturnValue(undefined);
       const mockTx = mock<IndexedTx>({
         code: 0,
         hash: "tx-hash",
@@ -1507,8 +1506,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
         setupDrainingOwner({ deploymentCount: 3 });
       const error = createDeploymentClosedError(1);
 
-      chainErrorService.isDeploymentClosedError.mockReturnValue(true);
-      chainErrorService.getFailedMessageIndex.mockReturnValue(1);
+      chainErrorService.getClosedDeploymentMessageIndex.mockReturnValue(1);
       managedSignerService.executeDerivedTx.mockRejectedValueOnce(error);
 
       await expect(service.topUpDeployments({ dryRun: false })).resolves.toEqual(expect.objectContaining({ ok: true }));
@@ -1535,8 +1533,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
         deploymentCount: 4
       });
 
-      chainErrorService.isDeploymentClosedError.mockReturnValue(true);
-      chainErrorService.getFailedMessageIndex.mockReturnValueOnce(0).mockReturnValueOnce(1);
+      chainErrorService.getClosedDeploymentMessageIndex.mockReturnValueOnce(0).mockReturnValueOnce(1);
       managedSignerService.executeDerivedTx.mockRejectedValueOnce(createDeploymentClosedError(0)).mockRejectedValueOnce(createDeploymentClosedError(1));
 
       await service.topUpDeployments({ dryRun: false });
@@ -1552,8 +1549,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
         deploymentCount: 2
       });
 
-      chainErrorService.isDeploymentClosedError.mockReturnValue(true);
-      chainErrorService.getFailedMessageIndex.mockReturnValue(0);
+      chainErrorService.getClosedDeploymentMessageIndex.mockReturnValue(0);
       managedSignerService.executeDerivedTx.mockRejectedValue(createDeploymentClosedError(0));
 
       await expect(service.topUpDeployments({ dryRun: false })).resolves.toEqual(expect.objectContaining({ ok: true }));
@@ -1570,8 +1566,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
         deploymentCount: 2
       });
 
-      chainErrorService.isDeploymentClosedError.mockReturnValue(true);
-      chainErrorService.getFailedMessageIndex.mockReturnValue(0);
+      chainErrorService.getClosedDeploymentMessageIndex.mockReturnValue(0);
       managedSignerService.executeDerivedTx.mockResolvedValueOnce(
         mock<IndexedTx>({ code: 8, hash: "tx-hash", rawLog: "failed to execute message; message index: 0: Deployment closed" })
       );
@@ -1589,8 +1584,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
       });
       const error = createDeploymentClosedError(7);
 
-      chainErrorService.isDeploymentClosedError.mockReturnValue(true);
-      chainErrorService.getFailedMessageIndex.mockReturnValue(7);
+      chainErrorService.getClosedDeploymentMessageIndex.mockReturnValue(undefined);
       managedSignerService.executeDerivedTx.mockRejectedValue(error);
 
       await service.topUpDeployments({ dryRun: false });
@@ -1607,8 +1601,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
       });
       const markError = new Error("connection terminated");
 
-      chainErrorService.isDeploymentClosedError.mockReturnValue(true);
-      chainErrorService.getFailedMessageIndex.mockReturnValue(0);
+      chainErrorService.getClosedDeploymentMessageIndex.mockReturnValue(0);
       managedSignerService.executeDerivedTx.mockRejectedValueOnce(createDeploymentClosedError(0));
       deploymentSettingRepository.markAsClosed.mockRejectedValue(markError);
 
@@ -1629,8 +1622,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
         deploymentCount: 6
       });
 
-      chainErrorService.isDeploymentClosedError.mockReturnValue(true);
-      chainErrorService.getFailedMessageIndex.mockReturnValue(0);
+      chainErrorService.getClosedDeploymentMessageIndex.mockReturnValue(0);
       managedSignerService.executeDerivedTx.mockRejectedValue(createDeploymentClosedError(0));
 
       await expect(service.topUpDeployments({ dryRun: false })).resolves.toEqual(expect.objectContaining({ ok: true }));
@@ -1695,8 +1687,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
       drainingDeploymentService.findDrainingDeploymentsForOwner.mockResolvedValue(deployments);
       drainingDeploymentService.calculateAmountToTargetRunway.mockReturnValue(1000000);
       cachedBalanceService.getFresh.mockResolvedValue(createMockCachedBalance(() => 1000000));
-      chainErrorService.isDeploymentClosedError.mockReturnValue(true);
-      chainErrorService.getFailedMessageIndex.mockReturnValue(0);
+      chainErrorService.getClosedDeploymentMessageIndex.mockReturnValue(0);
       managedSignerService.executeDerivedTx.mockRejectedValueOnce(createDeploymentClosedError(0));
 
       await service.topUpDrainingDeploymentsForOwner({ walletId, address: owner });

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
@@ -506,7 +506,7 @@ export class TopUpManagedDeploymentsService {
         return true;
       }
 
-      const closedIndex = this.#findClosedDeploymentIndex(failure, remaining);
+      const closedIndex = this.chainErrorService.getClosedDeploymentMessageIndex(failure, remaining.length);
 
       if (closedIndex === undefined) {
         await this.#recordOwnerFundingFailure({ owner, items: remaining, error: failure, instrumentation });
@@ -561,21 +561,6 @@ export class TopUpManagedDeploymentsService {
     } catch (error: unknown) {
       return error;
     }
-  }
-
-  /** An index outside the batch is not resolved to a neighbour: closing the wrong deployment is worse than alerting. */
-  #findClosedDeploymentIndex(error: unknown, items: CollectedMessage[]): number | undefined {
-    if (!(error instanceof Error) || !this.chainErrorService.isDeploymentClosedError(error)) {
-      return undefined;
-    }
-
-    const messageIndex = this.chainErrorService.getFailedMessageIndex(error);
-
-    if (messageIndex !== undefined) {
-      return messageIndex >= 0 && messageIndex < items.length ? messageIndex : undefined;
-    }
-
-    return items.length === 1 ? 0 : undefined;
   }
 
   /** A failed write is reported rather than thrown, which would strand the survivors the retry exists to fund. */


### PR DESCRIPTION
## Why

Fixes CON-918

When the platform closes a trial wallet's orphaned (open, lease-less) deployments, all of them go into a single chain transaction. If any one of them was already closed on chain (the user cancelled it, the chain closed it for exhausted funds, or an overlapping cleanup run got there first), the chain rejected the whole transaction with `Deployment closed` and none of the wallet's orphans were closed. The trial user stayed stranded with escrow held and a 402 on retry, the periodic cleanup job hit the same wall, and every occurrence logged at error level. CON-90 fixed the same failure shape on the auto top-up side; this brings the cleanup flow in line.

## What

- `ChainErrorService.getClosedDeploymentMessageIndex(error, batchSize)` is the culprit-index resolution from the top-up fix (closed-error check, `message index: N` parse, bounds check, single-message fallback), now shared. `TopUpManagedDeploymentsService` delegates to it instead of keeping a private copy.
- `StaleManagedDeploymentsCleanerService` now runs a bounded drop-and-rebroadcast loop: when the chain rejects the batch because a deployment is closed, it drops the reported message and re-broadcasts the survivors, up to 3 drops per wallet per pass. An already-closed deployment logs at info (`DEPLOYMENT_CLEAN_UP_ALREADY_CLOSED`, with the dseq); hitting the drop cap logs at warn (`DEPLOYMENT_CLEAN_UP_DROP_LIMIT`). No DB write is needed: `deployment.closedHeight` is indexer-owned and catches up on its own, at which point the row leaves the stale query.
- The cleaner now checks the landed tx's code. A broadcast that reverted on chain used to log `DEPLOYMENT_CLEAN_UP_SUCCESS`; it is now classified as a failure. This check is also what makes the re-broadcast safe: a rejected estimate never broadcasts, and a non-zero code means every message reverted, so both failure shapes prove the transaction failed whole.
- `DEPLOYMENT_CLEAN_UP_SUCCESS` gains an additive `alreadyClosedCount` field, in case anyone parses that log line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup and retry handling for deployments that have already closed.
  * Correctly identifies affected deployments in single-message and batched operations.
  * Limits cleanup drops per pass and stops safely when escrow cannot be settled.
  * Retries fee authorization failures and reports unsuccessful transactions accurately.
  * Preserves handling for unknown, invalid, or out-of-range error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->