### PR TITLE
fix(deployment): keep the coverage log inside the runtime line limit

### DIFF
--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
@@ -20,13 +20,13 @@ import type { DeploymentTopUpInstrumentation } from "../top-up-managed-deploymen
 import { DrainingDeploymentService } from "./draining-deployment.service";
 
 import { mockConfigService } from "@test/mocks/config-service.mock";
-
-/** The container runtime splits stdout at 16 KiB, which mangles a longer line into unparseable JSON. */
-const MAX_LOGGABLE_LINE_BYTES = 16384;
 import { createAkashAddress } from "@test/seeders";
 import { createAutoTopUpDeployment, createManyAutoTopUpDeployments } from "@test/seeders/auto-top-up-deployment.seeder";
 import { createDrainingDeployment } from "@test/seeders/draining-deployment.seeder";
 import { createUserWallet } from "@test/seeders/user-wallet.seeder";
+
+/** The container runtime splits stdout at 16 KiB, which mangles a longer line into unparseable JSON. */
+const MAX_LOGGABLE_LINE_BYTES = 16384;
 
 describe(DrainingDeploymentService.name, () => {
   describe("findDrainingDeploymentsByOwner", () => {

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
@@ -20,6 +20,9 @@ import type { DeploymentTopUpInstrumentation } from "../top-up-managed-deploymen
 import { DrainingDeploymentService } from "./draining-deployment.service";
 
 import { mockConfigService } from "@test/mocks/config-service.mock";
+
+/** The container runtime splits stdout at 16 KiB, which mangles a longer line into unparseable JSON. */
+const MAX_LOGGABLE_LINE_BYTES = 16384;
 import { createAkashAddress } from "@test/seeders";
 import { createAutoTopUpDeployment, createManyAutoTopUpDeployments } from "@test/seeders/auto-top-up-deployment.seeder";
 import { createDrainingDeployment } from "@test/seeders/draining-deployment.seeder";
@@ -1148,7 +1151,7 @@ describe(DrainingDeploymentService.name, () => {
 
     it("logs the coverage inputs behind a non-zero weekly cost", async () => {
       const blockRate = 50;
-      const { service, address, deploymentSettings, loggerService, currentHeight } = await setupWeeklyBurnForAddress({
+      const { service, address, loggerService, currentHeight } = await setupWeeklyBurnForAddress({
         deployments: [{ blockRate }]
       });
 
@@ -1158,8 +1161,9 @@ describe(DrainingDeploymentService.name, () => {
         event: "WEEKLY_COVERAGE_CALCULATED",
         address,
         currentHeight,
-        settingDseqs: deploymentSettings.map(setting => setting.dseq),
-        leaseRates: [{ dseq: deploymentSettings[0].dseq, blockRate }],
+        settingCount: 1,
+        leaseRateCount: 1,
+        leaseRateTotal: blockRate,
         weeklyCredits: Math.floor(blockRate * averageBlockCountInAnHour * 24 * 7)
       });
     });
@@ -1175,8 +1179,9 @@ describe(DrainingDeploymentService.name, () => {
       expect(loggerService.info).toHaveBeenCalledWith(
         expect.objectContaining({
           event: "WEEKLY_COVERAGE_CALCULATED",
-          settingDseqs: deploymentSettings.map(setting => setting.dseq),
-          leaseRates: [],
+          settingCount: deploymentSettings.length,
+          leaseRateCount: 0,
+          leaseRateTotal: 0,
           weeklyCredits: 0
         })
       );
@@ -1200,6 +1205,22 @@ describe(DrainingDeploymentService.name, () => {
       expect(result.weeklyCostUsd).toBe(usdFromCredits(Math.floor(blockRate * averageBlockCountInAnHour * 24 * 7)));
     });
 
+    it("keeps the coverage log small enough to survive the log pipeline for a wallet with many deployments", async () => {
+      const { service, address, loggerService } = await setupWeeklyBurnForAddress({
+        deployments: Array.from({ length: 2000 }, () => ({ blockRate: 50 }))
+      });
+
+      await service.calculateWeeklyCoverageForAddress(address);
+
+      const coverageLogs = loggerService.info.mock.calls
+        .map(([logged]) => logged as { event?: string })
+        .filter(logged => logged.event === "WEEKLY_COVERAGE_CALCULATED");
+
+      expect(coverageLogs).toHaveLength(1);
+      expect(coverageLogs[0]).toMatchObject({ settingCount: 2000, leaseRateCount: 2000 });
+      expect(JSON.stringify(coverageLogs[0]).length).toBeLessThan(MAX_LOGGABLE_LINE_BYTES);
+    });
+
     it("logs the coverage inputs behind an absent auto top-up setting", async () => {
       const { service, address, loggerService } = await setupWeeklyBurnForAddress({
         userWallet: undefined,
@@ -1211,8 +1232,9 @@ describe(DrainingDeploymentService.name, () => {
       expect(loggerService.info).toHaveBeenCalledWith({
         event: "WEEKLY_COVERAGE_CALCULATED",
         address,
-        settingDseqs: [],
-        leaseRates: [],
+        settingCount: 0,
+        leaseRateCount: 0,
+        leaseRateTotal: 0,
         weeklyCredits: 0
       });
     });

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
@@ -440,7 +440,7 @@ export class DrainingDeploymentService {
   async calculateWeeklyCoverageForAddress(address: string): Promise<WeeklyCoverage> {
     const deploymentSettings = await this.#findAutoTopUpDeploymentSettings(address);
     if (deploymentSettings.length === 0) {
-      this.loggerService.info({ event: "WEEKLY_COVERAGE_CALCULATED", address, settingDseqs: [], leaseRates: [], weeklyCredits: 0 });
+      this.loggerService.info({ event: "WEEKLY_COVERAGE_CALCULATED", address, settingCount: 0, leaseRateCount: 0, leaseRateTotal: 0, weeklyCredits: 0 });
       return { weeklyCostUsd: 0, cumulativeDailyCostsUsd: [], hasAutoTopUpSettings: false };
     }
 
@@ -458,8 +458,9 @@ export class DrainingDeploymentService {
       event: "WEEKLY_COVERAGE_CALCULATED",
       address,
       currentHeight,
-      settingDseqs: deploymentSettings.map(deployment => deployment.dseq),
-      leaseRates,
+      settingCount: deploymentSettings.length,
+      leaseRateCount: leaseRates.length,
+      leaseRateTotal: leaseRates.reduce((total, leaseRate) => total + leaseRate.blockRate, 0),
       weeklyCredits
     });
 


### PR DESCRIPTION
## Why

Ref CON-917. Fixes a defect in #3746, which shipped ~2h ago.

`WEEKLY_COVERAGE_CALCULATED` logged `settingDseqs` and the full `leaseRates` array. Both are unbounded, and a wallet with a few hundred open deployment settings pushes the line past the 16 KiB the container runtime writes before it splits. The split arrives as a partial chunk of truncated JSON, which nothing downstream can parse.

Straight from production, the wallet behind the worst historical flapping (`2c359842`, 57 emails in the 7d before the fix):

```
logtag:  "P"          <- partial, the runtime split it
log len: 16384        <- exactly the chunk limit
log:     "{\"level\":\"info\",...,\"settingDseqs\":[\"1788059749322\",\"178802478  <- cut mid-dseq
```

So the log is lost for precisely the wallets it was added to explain. Every other wallet in the same window logged fine, which is what made it look like a missing log rather than a mangled one: the check ran, produced `weeklyCostUsd: 368.22`, and left no parseable trace.

The size scales with how many deployments a wallet holds, so this gets worse on exactly the accounts under investigation.

## What

Log `settingCount`, `leaseRateCount` and `leaseRateTotal` (the summed block rate) instead of the two arrays. That still answers the question the log exists for, which is which of the two inputs moved between two checks, and the line is now a fixed size regardless of deployment count.

Dropped from the payload:

- `settingDseqs` — the count plus `ACTIVE_LEASE_RATE_WITHOUT_SETTING`, which already logs individual join misses, covers what the list was for.
- `leaseRates` — `leaseRateTotal` is the value `weeklyCredits` actually derives from, so it is the more direct signal anyway.

The regression test builds a 2000-deployment wallet and asserts the serialized entry stays under the 16 KiB limit. It fails on the previous logging (`expected { …(6) } to match object { settingCount: 2000, … }`) and passes on this one.

Logging only, no behaviour change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Weekly coverage logs now use compact aggregate counts and total lease rates instead of detailed deployment and lease lists.
  * Improved log readability and efficiency for wallets with large numbers of deployments.
* **Tests**
  * Added coverage for large deployment sets and updated expectations for zero-cost and missing-setting scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->