### PR TITLE
fix(billing): open Add Credits in place instead of dead-ending on /billing

### DIFF
--- a/apps/deploy-web/src/components/billing-usage/AddCreditsHost/AddCreditsHost.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AddCreditsHost/AddCreditsHost.spec.tsx
@@ -1,0 +1,98 @@
+import { createStore, Provider as JotaiProvider } from "jotai";
+import { describe, expect, it } from "vitest";
+
+import type { AddCreditsRequest } from "@src/store/addCreditsStore";
+import { addCreditsRequestAtom } from "@src/store/addCreditsStore";
+import type { DEPENDENCIES } from "./AddCreditsHost";
+import { AddCreditsHost } from "./AddCreditsHost";
+
+import { act, render, screen } from "@testing-library/react";
+
+describe("AddCreditsHost", () => {
+  it("keeps the sheet closed until something requests credits", () => {
+    setup();
+
+    expect(screen.getByTestId("add-credits-sheet")).toHaveAttribute("data-open", "false");
+  });
+
+  it("opens the sheet on the requested tab, with the requested description and context", () => {
+    const { open } = setup();
+
+    open({ initialTab: "coupon", description: "Redeem your hackathon coupon.", context: "hackathon" });
+
+    const sheet = screen.getByTestId("add-credits-sheet");
+    expect(sheet).toHaveAttribute("data-open", "true");
+    expect(sheet).toHaveAttribute("data-tab", "coupon");
+    expect(sheet).toHaveAttribute("data-context", "hackathon");
+    expect(sheet).toHaveTextContent("Redeem your hackathon coupon.");
+  });
+
+  it("falls back to the purchase tab and neutral copy for a request that names neither", () => {
+    const { open } = setup();
+
+    open({});
+
+    const sheet = screen.getByTestId("add-credits-sheet");
+    expect(sheet).toHaveAttribute("data-tab", "purchase");
+    expect(sheet).toHaveTextContent("Buy credits or redeem a coupon to top up your balance.");
+  });
+
+  it("clears the request when the sheet is dismissed, so the same call site can reopen it", () => {
+    const { open, store } = setup();
+    open({ context: "review_funding_impact" });
+
+    act(() => screen.getByRole("button", { name: "close" }).click());
+
+    expect(store.get(addCreditsRequestAtom)).toBeNull();
+    expect(screen.getByTestId("add-credits-sheet")).toHaveAttribute("data-open", "false");
+  });
+
+  it("closes the sheet and celebrates the credited total once a purchase completes", () => {
+    const { open, store } = setup();
+    open({ context: "review_funding_impact" });
+
+    act(() => screen.getByRole("button", { name: "done" }).click());
+
+    expect(store.get(addCreditsRequestAtom)).toBeNull();
+    expect(screen.getByTestId("payment-success")).toHaveTextContent("100+10");
+  });
+
+  it("closes the sheet without celebrating when a coupon is redeemed instead", () => {
+    const { open, store } = setup();
+    open({ initialTab: "coupon" });
+
+    act(() => screen.getByRole("button", { name: "redeemed" }).click());
+
+    expect(store.get(addCreditsRequestAtom)).toBeNull();
+    expect(screen.queryByTestId("payment-success")).not.toBeInTheDocument();
+  });
+
+  function setup() {
+    const store = createStore();
+    const AddCreditsSheet: typeof DEPENDENCIES.AddCreditsSheet = ({ open, onOpenChange, onDone, onRedeemed, initialTab, description, context }) => (
+      <div data-testid="add-credits-sheet" data-open={open} data-tab={initialTab} data-context={context}>
+        {description}
+        <button onClick={() => onOpenChange(false)}>close</button>
+        <button onClick={() => onDone(100, undefined, 10)}>done</button>
+        <button onClick={() => onRedeemed?.()}>redeemed</button>
+      </div>
+    );
+    const PaymentSuccessAnimation: typeof DEPENDENCIES.PaymentSuccessAnimation = ({ show, amount, bonusAmount }) => (
+      <>
+        {show && (
+          <div data-testid="payment-success">
+            {amount}+{bonusAmount}
+          </div>
+        )}
+      </>
+    );
+
+    render(
+      <JotaiProvider store={store}>
+        <AddCreditsHost dependencies={{ AddCreditsSheet, PaymentSuccessAnimation }} />
+      </JotaiProvider>
+    );
+
+    return { store, open: (request: AddCreditsRequest) => act(() => store.set(addCreditsRequestAtom, request)) };
+  }
+});

--- a/apps/deploy-web/src/components/billing-usage/AddCreditsHost/AddCreditsHost.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AddCreditsHost/AddCreditsHost.tsx
@@ -1,0 +1,49 @@
+"use client";
+import { useState } from "react";
+import { useAtom } from "jotai";
+
+import { AddCreditsSheet } from "@src/components/auth/AddCreditsSheet/AddCreditsSheet";
+import { PaymentSuccessAnimation } from "@src/components/billing-usage/PaymentSuccessAnimation/PaymentSuccessAnimation";
+import { addCreditsRequestAtom } from "@src/store/addCreditsStore";
+
+export const DEPENDENCIES = { AddCreditsSheet, PaymentSuccessAnimation };
+
+const DEFAULT_DESCRIPTION = "Buy credits or redeem a coupon to top up your balance.";
+
+type CompletedPurchase = { amount: string; bonusAmount: string };
+
+/**
+ * Hosts the single Add Credits sheet that any call site opens through `useAddCredits`. Mounted above the
+ * onboarding gate so an open sheet survives a redirect, and cheap while closed because the sheet only mounts
+ * its Stripe form once open.
+ */
+export function AddCreditsHost({ dependencies: d = DEPENDENCIES }: { dependencies?: typeof DEPENDENCIES }) {
+  const [request, setRequest] = useAtom(addCreditsRequestAtom);
+  const [completedPurchase, setCompletedPurchase] = useState<CompletedPurchase | null>(null);
+
+  const closeSheet = () => setRequest(null);
+
+  return (
+    <>
+      <d.PaymentSuccessAnimation
+        show={!!completedPurchase}
+        amount={completedPurchase?.amount ?? ""}
+        bonusAmount={completedPurchase?.bonusAmount ?? ""}
+        onComplete={() => setCompletedPurchase(null)}
+      />
+
+      <d.AddCreditsSheet
+        open={!!request}
+        onOpenChange={isOpen => (!isOpen ? closeSheet() : undefined)}
+        initialTab={request?.initialTab ?? "purchase"}
+        description={request?.description ?? DEFAULT_DESCRIPTION}
+        context={request?.context}
+        onDone={(amount, _organization, bonusAmount) => {
+          setCompletedPurchase({ amount: String(amount), bonusAmount: String(bonusAmount ?? 0) });
+          closeSheet();
+        }}
+        onRedeemed={closeSheet}
+      />
+    </>
+  );
+}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/FundingImpactReviewSection.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/FundingImpactReviewSection.spec.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import { UrlService } from "@src/utils/urlUtils";
@@ -99,7 +99,7 @@ describe("FundingImpactReviewSection", () => {
 
     expect(screen.getByText(/nothing is charged automatically/)).toBeInTheDocument();
     expect(screen.queryByText(/charged \$/)).not.toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Add Credits" })).toHaveAttribute("href", UrlService.billing({ openPayment: true }));
+    expect(screen.getByRole("button", { name: "Add Credits" })).toBeInTheDocument();
   });
 
   it("names the trial and its duration without claiming anything about a card", async () => {
@@ -111,7 +111,7 @@ describe("FundingImpactReviewSection", () => {
     expect(screen.getByText(/closed automatically after 12 hours/)).toBeInTheDocument();
     expect(screen.queryByText(/payment method/)).not.toBeInTheDocument();
     expect(screen.queryByText(/charged \$/)).not.toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Add Credits" })).toHaveAttribute("href", UrlService.billing({ openPayment: true }));
+    expect(screen.getByRole("button", { name: "Add Credits" })).toBeInTheDocument();
   });
 
   it("offers credits and drops the bar when the balance cannot cover the escrow", async () => {
@@ -122,7 +122,20 @@ describe("FundingImpactReviewSection", () => {
 
     expect(screen.getByRole("alert")).toHaveTextContent("Your available balance of $100 can't cover the estimated escrow of ~$144");
     expect(screen.queryByTestId("balance-bar")).not.toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Add Credits" })).toHaveAttribute("href", UrlService.billing({ openPayment: true }));
+    expect(screen.getByRole("button", { name: "Add Credits" })).toBeInTheDocument();
+  });
+
+  it("opens the add credits sheet in place instead of navigating to billing", async () => {
+    const { openAddCredits } = setup({ impact: visible({ state: "trial" }) });
+
+    await userEvent.click(screen.getByRole("button", { name: /Escrow/ }));
+    await userEvent.click(screen.getByRole("button", { name: "Add Credits" }));
+
+    expect(openAddCredits).toHaveBeenCalledWith({
+      initialTab: "purchase",
+      description: "Add credits to keep this deployment funded and running.",
+      context: "review_funding_impact"
+    });
   });
 
   function visible(overrides?: Partial<Extract<FundingImpact, { kind: "visible" }>>): FundingImpact {
@@ -141,7 +154,9 @@ describe("FundingImpactReviewSection", () => {
   }
 
   function setup(input: { impact: FundingImpact; runtimeLimitHours?: number }) {
+    const openAddCredits = vi.fn();
     const useFundingImpact: typeof DEPENDENCIES.useFundingImpact = () => input.impact;
+    const useAddCredits: typeof DEPENDENCIES.useAddCredits = () => openAddCredits;
     const BalanceBreakdownBar: typeof DEPENDENCIES.BalanceBreakdownBar = ({ segments, threshold }) => (
       <div data-testid="balance-bar" data-threshold={threshold ?? undefined}>
         {segments.map(segment => `${segment.key}:${segment.amountUsd}`).join(",")}
@@ -153,12 +168,15 @@ describe("FundingImpactReviewSection", () => {
     )) as typeof DEPENDENCIES.Link;
     const Skeleton: typeof DEPENDENCIES.Skeleton = () => <div data-testid="skeleton" />;
 
-    return render(
-      <FundingImpactReviewSection
-        rows={[mock<ReviewRow>({ price: { amount: "0.005", denom: "uakt" } })]}
-        runtimeLimitHours={input.runtimeLimitHours}
-        dependencies={{ useFundingImpact, BalanceBreakdownBar, UsdValue, Link, Skeleton }}
-      />
-    );
+    return {
+      openAddCredits,
+      ...render(
+        <FundingImpactReviewSection
+          rows={[mock<ReviewRow>({ price: { amount: "0.005", denom: "uakt" } })]}
+          runtimeLimitHours={input.runtimeLimitHours}
+          dependencies={{ useFundingImpact, useAddCredits, BalanceBreakdownBar, UsdValue, Link, Skeleton }}
+        />
+      )
+    };
   }
 });

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/FundingImpactReviewSection.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/FundingImpactReviewSection.tsx
@@ -7,6 +7,7 @@ import Link from "next/link";
 
 import { BalanceBreakdownBar } from "@src/components/billing-usage/AccountBalanceOverview/BalanceBreakdownBar";
 import { UsdValue } from "@src/components/billing-usage/UsdValue/UsdValue";
+import { useAddCredits } from "@src/hooks/useAddCredits";
 import { UrlService } from "@src/utils/urlUtils";
 import type { FundingImpact } from "./useFundingImpact";
 import { useFundingImpact } from "./useFundingImpact";
@@ -14,11 +15,14 @@ import type { ReviewRow } from "./useReviewRows";
 
 export const DEPENDENCIES = {
   useFundingImpact,
+  useAddCredits,
   BalanceBreakdownBar,
   UsdValue,
   Link,
   Skeleton
 };
+
+const ADD_CREDITS_DESCRIPTION = "Add credits to keep this deployment funded and running.";
 
 type Props = {
   rows: ReviewRow[];
@@ -49,6 +53,7 @@ const BADGE_TONES: Record<Badge["tone"], string> = {
  */
 export const FundingImpactReviewSection: FC<Props> = ({ rows, runtimeLimitHours, dependencies: d = DEPENDENCIES }) => {
   const impact = d.useFundingImpact({ rows, runtimeLimitHours });
+  const openAddCredits = d.useAddCredits();
   const [isExpanded, setIsExpanded] = useState(false);
   const usd = (value: number) => <d.UsdValue value={value} />;
 
@@ -77,8 +82,8 @@ export const FundingImpactReviewSection: FC<Props> = ({ rows, runtimeLimitHours,
 
   const badge = STATE_BADGES[impact.state];
   const addCreditsButton = (
-    <Button size="sm" asChild>
-      <d.Link href={UrlService.billing({ openPayment: true })}>Add Credits</d.Link>
+    <Button size="sm" onClick={() => openAddCredits({ initialTab: "purchase", description: ADD_CREDITS_DESCRIPTION, context: "review_funding_impact" })}>
+      Add Credits
     </Button>
   );
 

--- a/apps/deploy-web/src/components/onboarding/RequireOnboarding/RequireOnboarding.spec.tsx
+++ b/apps/deploy-web/src/components/onboarding/RequireOnboarding/RequireOnboarding.spec.tsx
@@ -41,6 +41,12 @@ describe(RequireOnboarding.name, () => {
     expect(screen.getByText("child")).toBeInTheDocument();
   });
 
+  it("lets a not-onboarded user reach billing, where the trial converts", () => {
+    const { replace } = setup({ address: "akash1", hasWallet: true, leases: 0, path: "/billing" });
+    expect(screen.getByText("child")).toBeInTheDocument();
+    expect(replace).not.toHaveBeenCalled();
+  });
+
   it("lets a not-onboarded user render the onboarding picker", () => {
     setup({ address: "akash1", hasWallet: true, leases: 0, path: "/onboarding" });
     expect(screen.getByText("child")).toBeInTheDocument();

--- a/apps/deploy-web/src/components/onboarding/RequireOnboarding/RequireOnboarding.tsx
+++ b/apps/deploy-web/src/components/onboarding/RequireOnboarding/RequireOnboarding.tsx
@@ -14,8 +14,8 @@ const ONBOARDING_ROUTE = "/onboarding";
 
 type GateDecision = "loading" | "render" | "toOnboarding" | "toReturn";
 
-/** A not-yet-onboarded user may stay on these routes (they deploy their first app here). */
-const ONBOARDING_ALLOWED_PREFIXES = ["/new-deployment/configure"];
+/** A not-yet-onboarded user may stay on these routes (they deploy their first app, and fund it, here). */
+const ONBOARDING_ALLOWED_PREFIXES = ["/new-deployment/configure", "/billing"];
 
 export const DEPENDENCIES = {
   useUser,
@@ -96,10 +96,12 @@ function LeaseBasedGate({
  * Resolves the lease-based gate's action, in priority order. Public pages always render (RequireAuth owns auth,
  * and the WalletProvider boot gate guarantees the wallet lookup has settled before this gate mounts).
  * Allow-list pages (configure, a deployment detail) render *immediately*, ahead of the identity wait and
- * the leases query, because they own their own loading UX (e.g. the auto-deploy progress overlay). The
- * `/onboarding` picker likewise renders once identity is known without waiting for leases: its trial wallet
- * provisions in the background, and the leases query flips to loading the moment that wallet's address appears,
- * which would otherwise flash the full-screen loader and remount the page (including an open Add Credits sheet).
+ * the leases query, because they own their own loading UX (e.g. the auto-deploy progress overlay). Billing is
+ * allow-listed for a different reason: it is where a trial converts, so bouncing a user who came to pay would
+ * turn every link into it into a dead end. The `/onboarding` picker likewise renders once identity is known
+ * without waiting for leases: its trial wallet provisions in the background, and the leases query flips to
+ * loading the moment that wallet's address appears, which would otherwise flash the full-screen loader and
+ * remount the page (including an open Add Credits sheet).
  * An already-onboarded user who lands on `/onboarding` is still sent back where they came from, but only once
  * leases resolve (they render the picker until then). Everywhere else first waits until user identity is
  * known, then for leases to settle: an onboarded user renders, a not-onboarded user is sent to `/onboarding`. A

--- a/apps/deploy-web/src/components/shared/TrialDeploymentTooltip.spec.tsx
+++ b/apps/deploy-web/src/components/shared/TrialDeploymentTooltip.spec.tsx
@@ -120,7 +120,7 @@ describe("TrialDeploymentTooltip", () => {
       trialDuration: input.trialDuration ?? 24,
       dependencies: input.dependencies ?? {
         ...TRIAL_TOOLTIP_DEPENDENCIES,
-        AddFundsLink: ComponentMock
+        AddFundsButton: ComponentMock
       }
     };
 

--- a/apps/deploy-web/src/components/shared/TrialDeploymentTooltip.tsx
+++ b/apps/deploy-web/src/components/shared/TrialDeploymentTooltip.tsx
@@ -1,11 +1,8 @@
 "use client";
 import * as React from "react";
-import { buttonVariants } from "@akashnetwork/ui/components";
-import { cn } from "@akashnetwork/ui/utils";
 import { HandCard } from "iconoir-react";
 
-import { AddFundsLink } from "@src/components/user/AddFundsLink";
-import { useServices } from "@src/context/ServicesProvider";
+import { AddFundsButton } from "@src/components/user/AddFundsButton";
 
 export type TrialDeploymentTooltipProps = {
   createdHeight?: number;
@@ -16,8 +13,10 @@ export type TrialDeploymentTooltipProps = {
 };
 
 export const DEPENDENCIES = {
-  AddFundsLink
+  AddFundsButton
 };
+
+const ADD_CREDITS_DESCRIPTION = "Add credits to activate your account, so trial deployments stop closing on their own.";
 
 export function TrialDeploymentTooltip({
   createdHeight,
@@ -63,18 +62,15 @@ export function TrialDeploymentTooltip({
   );
 }
 
-const AddFunds = ({ dependencies: d = DEPENDENCIES }: { dependencies: typeof DEPENDENCIES }) => {
-  const { urlService } = useServices();
-  return (
-    <div className="flex flex-col gap-2">
-      <p className="text-xs">Add funds to activate your account.</p>
-      <d.AddFundsLink
-        className={cn("w-full space-x-2 hover:no-underline", buttonVariants({ variant: "default" }))}
-        href={urlService.billing({ openPayment: true })}
-      >
-        <HandCard className="text-xs" />
-        <span className="whitespace-nowrap">Add Funds</span>
-      </d.AddFundsLink>
-    </div>
-  );
-};
+const AddFunds = ({ dependencies: d = DEPENDENCIES }: { dependencies: typeof DEPENDENCIES }) => (
+  <div className="flex flex-col gap-2">
+    <p className="text-xs">Add funds to activate your account.</p>
+    <d.AddFundsButton
+      className="w-full space-x-2"
+      request={{ initialTab: "purchase", description: ADD_CREDITS_DESCRIPTION, context: "trial_deployment_badge" }}
+    >
+      <HandCard className="text-xs" />
+      <span className="whitespace-nowrap">Add Funds</span>
+    </d.AddFundsButton>
+  </div>
+);

--- a/apps/deploy-web/src/components/user/AddFundsButton.spec.tsx
+++ b/apps/deploy-web/src/components/user/AddFundsButton.spec.tsx
@@ -1,0 +1,53 @@
+import type { MouseEventHandler } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { AnalyticsService } from "@src/services/analytics/analytics.service";
+import type { AddCreditsRequest } from "@src/store/addCreditsStore";
+import { AddFundsButton, DEPENDENCIES } from "./AddFundsButton";
+
+import { fireEvent, render, screen } from "@testing-library/react";
+
+describe("AddFundsButton", () => {
+  it("opens the add credits sheet with the request it was given", () => {
+    const request = { initialTab: "purchase", context: "trial_deployment_badge" } as const;
+    const { openAddCredits } = setup({ request });
+
+    fireEvent.click(screen.getByRole("button", { name: "Add Funds" }));
+
+    expect(openAddCredits).toHaveBeenCalledWith(request);
+  });
+
+  it("tracks the click before opening", () => {
+    const { analyticsService } = setup();
+
+    fireEvent.click(screen.getByRole("button", { name: "Add Funds" }));
+
+    expect(analyticsService.track).toHaveBeenCalledWith("add_funds_btn_clk");
+  });
+
+  it("does not open the sheet when the login and verification gate swallows the click", () => {
+    const { openAddCredits } = setup({ isGateOpen: false });
+
+    fireEvent.click(screen.getByRole("button", { name: "Add Funds" }));
+
+    expect(openAddCredits).not.toHaveBeenCalled();
+  });
+
+  function setup(input?: { request?: AddCreditsRequest; isGateOpen?: boolean }) {
+    const analyticsService = mock<AnalyticsService>();
+    const openAddCredits = vi.fn();
+    const useServices: typeof DEPENDENCIES.useServices = () => mock<ReturnType<typeof DEPENDENCIES.useServices>>({ analyticsService });
+    const useAddCredits: typeof DEPENDENCIES.useAddCredits = () => openAddCredits;
+    const useAddFundsVerifiedLoginRequiredEventHandler: typeof DEPENDENCIES.useAddFundsVerifiedLoginRequiredEventHandler =
+      () => (callback: MouseEventHandler) => (input?.isGateOpen ?? true ? callback : () => undefined);
+
+    render(
+      <AddFundsButton request={input?.request} dependencies={{ ...DEPENDENCIES, useServices, useAddCredits, useAddFundsVerifiedLoginRequiredEventHandler }}>
+        Add Funds
+      </AddFundsButton>
+    );
+
+    return { analyticsService, openAddCredits };
+  }
+});

--- a/apps/deploy-web/src/components/user/AddFundsButton.tsx
+++ b/apps/deploy-web/src/components/user/AddFundsButton.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import type { ButtonProps } from "@akashnetwork/ui/components";
+import { Button } from "@akashnetwork/ui/components";
+
+import { useServices } from "@src/context/ServicesProvider";
+import { useAddCredits } from "@src/hooks/useAddCredits";
+import { useAddFundsVerifiedLoginRequiredEventHandler } from "@src/hooks/useAddFundsVerifiedLoginRequiredEventHandler";
+import type { AddCreditsRequest } from "@src/store/addCreditsStore";
+
+export const DEPENDENCIES = { useServices, useAddCredits, useAddFundsVerifiedLoginRequiredEventHandler, Button };
+
+type Props = Omit<ButtonProps, "onClick"> & {
+  request?: AddCreditsRequest;
+  dependencies?: typeof DEPENDENCIES;
+};
+
+/**
+ * The `AddFundsLink` counterpart for call sites that sell credits in place: same click tracking and
+ * login/email-verification gating, but it opens the Add Credits sheet instead of navigating to `/billing`.
+ */
+export const AddFundsButton: React.FC<Props> = ({ request, dependencies: d = DEPENDENCIES, ...props }) => {
+  const { analyticsService } = d.useServices();
+  const openAddCredits = d.useAddCredits();
+  const whenLoggedInAndVerified = d.useAddFundsVerifiedLoginRequiredEventHandler();
+
+  return (
+    <d.Button
+      {...props}
+      onClick={event => {
+        analyticsService.track("add_funds_btn_clk");
+        whenLoggedInAndVerified(() => openAddCredits(request))(event);
+      }}
+    />
+  );
+};

--- a/apps/deploy-web/src/context/WalletProvider/useSignAndBroadcast.spec.tsx
+++ b/apps/deploy-web/src/context/WalletProvider/useSignAndBroadcast.spec.tsx
@@ -10,11 +10,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { TestContainerProvider } from "@tests/unit/TestContainerProvider";
 
 describe("AddCreditsSnackbarContent", () => {
-  // notistack renders snackbars in a portal mounted outside PopupProvider. Rendering this content
-  // without a PopupProvider reproduces that portal context: if it reached usePopup() (via AddFundsButton),
-  // it would throw "usePopup must be used within a PopupProvider" and crash the page instead of showing
-  // the trial-GPU warning. Opening the sheet through a jotai atom keeps the snackbar self-contained.
-  it("renders the Add Funds button without a PopupProvider in the tree", () => {
+  it("renders the Add Funds button without a PopupProvider, matching notistack's portal where usePopup would throw", () => {
     setup();
 
     expect(screen.getByRole("button", { name: "Add Funds" })).toBeInTheDocument();

--- a/apps/deploy-web/src/context/WalletProvider/useSignAndBroadcast.spec.tsx
+++ b/apps/deploy-web/src/context/WalletProvider/useSignAndBroadcast.spec.tsx
@@ -1,8 +1,9 @@
+import { createStore, Provider as JotaiProvider } from "jotai";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { AnalyticsService } from "@src/services/analytics/analytics.service";
-import { UrlService } from "@src/utils/urlUtils";
+import { addCreditsRequestAtom } from "@src/store/addCreditsStore";
 import { AddCreditsSnackbarContent } from "./useSignAndBroadcast";
 
 import { fireEvent, render, screen } from "@testing-library/react";
@@ -10,16 +11,13 @@ import { TestContainerProvider } from "@tests/unit/TestContainerProvider";
 
 describe("AddCreditsSnackbarContent", () => {
   // notistack renders snackbars in a portal mounted outside PopupProvider. Rendering this content
-  // without a PopupProvider reproduces that portal context: if it reached usePopup() (via AddFundsLink),
+  // without a PopupProvider reproduces that portal context: if it reached usePopup() (via AddFundsButton),
   // it would throw "usePopup must be used within a PopupProvider" and crash the page instead of showing
-  // the trial-GPU warning. A plain next/link Link keeps the snackbar self-contained.
-  it("renders the Add Funds link without a PopupProvider in the tree", () => {
+  // the trial-GPU warning. Opening the sheet through a jotai atom keeps the snackbar self-contained.
+  it("renders the Add Funds button without a PopupProvider in the tree", () => {
     setup();
 
-    const link = screen.getByRole("link", { name: "Add Funds" });
-
-    expect(link).toBeInTheDocument();
-    expect(link).toHaveAttribute("href", UrlService.billing({ openPayment: true }));
+    expect(screen.getByRole("button", { name: "Add Funds" })).toBeInTheDocument();
   });
 
   it("renders the message when provided", () => {
@@ -28,11 +26,23 @@ describe("AddCreditsSnackbarContent", () => {
     expect(screen.getByText("Add funds to unlock GPU access")).toBeInTheDocument();
   });
 
-  it("tracks analytics and calls onAction when the link is clicked", () => {
+  it("requests the add credits sheet rather than a link to billing", () => {
+    const { store } = setup();
+
+    fireEvent.click(screen.getByRole("button", { name: "Add Funds" }));
+
+    expect(store.get(addCreditsRequestAtom)).toEqual({
+      initialTab: "purchase",
+      description: "Add credits to your balance to continue.",
+      context: "insufficient_funds_snackbar"
+    });
+  });
+
+  it("tracks analytics and calls onAction when the button is clicked", () => {
     const onAction = vi.fn();
     const { analyticsService } = setup({ onAction });
 
-    fireEvent.click(screen.getByRole("link", { name: "Add Funds" }));
+    fireEvent.click(screen.getByRole("button", { name: "Add Funds" }));
 
     expect(analyticsService.track).toHaveBeenCalledWith("add_funds_btn_clk");
     expect(onAction).toHaveBeenCalledTimes(1);
@@ -40,11 +50,14 @@ describe("AddCreditsSnackbarContent", () => {
 
   function setup(input?: { message?: string; onAction?: () => void }) {
     const analyticsService = mock<AnalyticsService>();
+    const store = createStore();
     render(
-      <TestContainerProvider services={{ analyticsService: () => analyticsService }}>
-        <AddCreditsSnackbarContent message={input?.message} onAction={input?.onAction} />
-      </TestContainerProvider>
+      <JotaiProvider store={store}>
+        <TestContainerProvider services={{ analyticsService: () => analyticsService }}>
+          <AddCreditsSnackbarContent message={input?.message} onAction={input?.onAction} />
+        </TestContainerProvider>
+      </JotaiProvider>
     );
-    return { analyticsService, ...input };
+    return { analyticsService, store, ...input };
   }
 });

--- a/apps/deploy-web/src/context/WalletProvider/useSignAndBroadcast.tsx
+++ b/apps/deploy-web/src/context/WalletProvider/useSignAndBroadcast.tsx
@@ -58,9 +58,7 @@ export function useSignAndBroadcast({ refetchBalances }: UseSignAndBroadcastInpu
 
 const ADD_CREDITS_DESCRIPTION = "Add credits to your balance to continue.";
 
-// Rendered inside the notistack snackbar portal, which mounts outside PopupProvider. Open the sheet through
-// the jotai-backed useAddCredits (not AddFundsButton, which calls usePopup() via the email-verification hook
-// and would throw here); jotai's store provider sits above notistack, so the atom is reachable.
+/** Renders in notistack's portal outside PopupProvider, so it opens the sheet through the jotai atom instead of AddFundsButton, whose email-verification hook calls usePopup() and would throw here. */
 export const AddCreditsSnackbarContent: React.FC<{ message?: string; onAction?: () => void }> = ({ message, onAction }) => {
   const { analyticsService } = useServices();
   const openAddCredits = useAddCredits();

--- a/apps/deploy-web/src/context/WalletProvider/useSignAndBroadcast.tsx
+++ b/apps/deploy-web/src/context/WalletProvider/useSignAndBroadcast.tsx
@@ -1,15 +1,13 @@
 "use client";
 import React, { useState } from "react";
-import { buttonVariants, Snackbar } from "@akashnetwork/ui/components";
-import { cn } from "@akashnetwork/ui/utils";
+import { Button, Snackbar } from "@akashnetwork/ui/components";
 import type { EncodeObject } from "@cosmjs/proto-signing";
-import Link from "next/link";
 import { useSnackbar } from "notistack";
 
 import type { LoadingState } from "@src/components/layout/TransactionModal";
+import { useAddCredits } from "@src/hooks/useAddCredits";
 import { useNotificator } from "@src/hooks/useNotificator";
 import { useUser } from "@src/hooks/useUser";
-import { UrlService } from "@src/utils/urlUtils";
 import { useServices } from "../ServicesProvider";
 import { signAndBroadcast } from "./signAndBroadcast";
 
@@ -58,24 +56,27 @@ export function useSignAndBroadcast({ refetchBalances }: UseSignAndBroadcastInpu
   return { signAndBroadcastTx, loadingState };
 }
 
-// Rendered inside the notistack snackbar portal, which mounts outside PopupProvider. Use a plain
-// next/link Link (not AddFundsLink, which calls usePopup() via the email-verification hook and would
-// throw here); the billing page itself handles login/verification gating.
+const ADD_CREDITS_DESCRIPTION = "Add credits to your balance to continue.";
+
+// Rendered inside the notistack snackbar portal, which mounts outside PopupProvider. Open the sheet through
+// the jotai-backed useAddCredits (not AddFundsButton, which calls usePopup() via the email-verification hook
+// and would throw here); jotai's store provider sits above notistack, so the atom is reachable.
 export const AddCreditsSnackbarContent: React.FC<{ message?: string; onAction?: () => void }> = ({ message, onAction }) => {
   const { analyticsService } = useServices();
+  const openAddCredits = useAddCredits();
   return (
     <>
       {message && <div>{message}</div>}
-      <Link
-        href={UrlService.billing({ openPayment: true })}
-        className={cn("mt-2 inline-flex h-7 items-center px-3 text-xs", buttonVariants({ variant: "default" }))}
+      <Button
+        className="mt-2 h-7 px-3 text-xs"
         onClick={() => {
           analyticsService.track("add_funds_btn_clk");
+          openAddCredits({ initialTab: "purchase", description: ADD_CREDITS_DESCRIPTION, context: "insufficient_funds_snackbar" });
           onAction?.();
         }}
       >
         Add Funds
-      </Link>
+      </Button>
     </>
   );
 };

--- a/apps/deploy-web/src/hooks/useAddCredits.spec.tsx
+++ b/apps/deploy-web/src/hooks/useAddCredits.spec.tsx
@@ -1,0 +1,33 @@
+import type { ReactNode } from "react";
+import { createStore, Provider as JotaiProvider } from "jotai";
+import { describe, expect, it } from "vitest";
+
+import { addCreditsRequestAtom } from "@src/store/addCreditsStore";
+import { useAddCredits } from "./useAddCredits";
+
+import { act, renderHook } from "@testing-library/react";
+
+describe(useAddCredits.name, () => {
+  it("publishes the request so the app-wide host opens the sheet", () => {
+    const { result, store } = setup();
+
+    act(() => result.current({ initialTab: "coupon", context: "hackathon" }));
+
+    expect(store.get(addCreditsRequestAtom)).toEqual({ initialTab: "coupon", context: "hackathon" });
+  });
+
+  it("publishes an empty request when the call site has no preference", () => {
+    const { result, store } = setup();
+
+    act(() => result.current());
+
+    expect(store.get(addCreditsRequestAtom)).toEqual({});
+  });
+
+  function setup() {
+    const store = createStore();
+    const wrapper = ({ children }: { children: ReactNode }) => <JotaiProvider store={store}>{children}</JotaiProvider>;
+
+    return { ...renderHook(() => useAddCredits(), { wrapper }), store };
+  }
+});

--- a/apps/deploy-web/src/hooks/useAddCredits.ts
+++ b/apps/deploy-web/src/hooks/useAddCredits.ts
@@ -1,0 +1,12 @@
+import { useCallback } from "react";
+import { useSetAtom } from "jotai";
+
+import type { AddCreditsRequest } from "@src/store/addCreditsStore";
+import { addCreditsRequestAtom } from "@src/store/addCreditsStore";
+
+/** Opens the app-wide Add Credits sheet where the user already is, so selling credits never costs a navigation. */
+export function useAddCredits() {
+  const requestAddCredits = useSetAtom(addCreditsRequestAtom);
+
+  return useCallback((request: AddCreditsRequest = {}) => requestAddCredits(request), [requestAddCredits]);
+}

--- a/apps/deploy-web/src/pages/_app.tsx
+++ b/apps/deploy-web/src/pages/_app.tsx
@@ -20,6 +20,7 @@ import NProgress from "nprogress";
 import { AccountCreatedTracker } from "@src/components/analytics/AccountCreatedTracker/AccountCreatedTracker";
 import { AppBootstrap } from "@src/components/AppBootstrap/AppBootstrap";
 import { RequireAuth } from "@src/components/auth/RequireAuth/RequireAuth";
+import { AddCreditsHost } from "@src/components/billing-usage/AddCreditsHost/AddCreditsHost";
 import { AppThemeProvider } from "@src/components/layout/AppThemeProvider";
 import { CustomIntlProvider } from "@src/components/layout/CustomIntlProvider";
 import { PageHead } from "@src/components/layout/PageHead";
@@ -62,6 +63,7 @@ const App: React.FunctionComponent<Props> = props => {
             <FlagProvider>
               <WalletProvider>
                 <PaymentPollingProvider>
+                  <AddCreditsHost />
                   <NavigationGuardProvider>
                     <RequireOnboarding isPublic={isPublic}>
                       <WaitForFeatureFlags>

--- a/apps/deploy-web/src/store/addCreditsStore.ts
+++ b/apps/deploy-web/src/store/addCreditsStore.ts
@@ -1,0 +1,17 @@
+import type { ReactNode } from "react";
+import { atom } from "jotai";
+
+import type { AddCreditsTab } from "@src/components/billing-usage/AddCreditsTabs/AddCreditsTabs";
+
+export type AddCreditsRequest = {
+  initialTab?: AddCreditsTab;
+  description?: ReactNode;
+  /** Where the sheet was opened from; sent with its lifecycle events for funnel segmentation. */
+  context?: string;
+};
+
+/**
+ * The pending request to open the app-wide Add Credits sheet. An atom rather than a context because the
+ * insufficient-funds snackbar renders in notistack's portal, above every provider that could host the sheet.
+ */
+export const addCreditsRequestAtom = atom<AddCreditsRequest | null>(null);

--- a/apps/deploy-web/tests/ui/onboarding-gate.spec.ts
+++ b/apps/deploy-web/tests/ui/onboarding-gate.spec.ts
@@ -42,6 +42,12 @@ test.describe("Onboarding gate — not-onboarded user", () => {
       await visit(page, "/onboarding");
       await expect(page.getByRole("heading", { name: /deploy your first app/i })).toBeVisible({ timeout: 30_000 });
     });
+
+    await test.step("allowed on billing, where the trial converts", async () => {
+      await visit(page, "/billing");
+      await expect(page.getByRole("heading", { name: "Billing" })).toBeVisible({ timeout: 30_000 });
+      await expect(page).not.toHaveURL(/\/onboarding/);
+    });
   });
 });
 


### PR DESCRIPTION
## Why

During the trial, before the user's first deployment, every "Add Credits" / "Add Funds" button was a dead end.

Onboarding is derived, not stored: `isOnboarded = hasWallet && address && hasLeases(address)`, or `user.onboardingSkippedAt` is set. A trial user who hasn't deployed yet fails that, and `RequireOnboarding` confined them to the configure screen, a deployment detail page, and `/onboarding`. Since all those buttons navigate to `/billing?openPayment=true`, and `/billing` wasn't on the allow list, the gate did `router.replace("/onboarding")`. The user got dumped back on the template picker with no credit sheet.

In the review modal it was worse than a dead link: the deployment already exists on chain with open bids at that point, so leaving the screen threw away the selections they were about to confirm.

Three buttons were actually reachable in that window:

| Where | Component |
|---|---|
| Review and deploy, funding section | `FundingImpactReviewSection` |
| Trial badge tooltip on a deployment detail page | `TrialDeploymentTooltip` |
| Insufficient-funds (402) snackbar | `AddCreditsSnackbarContent` |

No Linear issue for this yet.

## What

The three buttons now open the Add Credits sheet where the user already is, instead of navigating.

The sheet is hosted once in `_app.tsx` (`AddCreditsHost`, inside `PaymentPollingProvider` and above the gate, so an open sheet survives a redirect) and opened through a jotai atom via `useAddCredits`. An atom rather than a context because `AddCreditsSnackbarContent` renders inside notistack's portal, which sits above every provider that could hold the sheet. That's the same reason the snackbar already avoided `AddFundsLink`, whose email-verification hook reaches `usePopup()` and throws there. `JotaiProvider` is above notistack, so the atom reaches all three call sites.

`AddFundsButton` is a new sibling of `AddFundsLink` for the tooltip: same `add_funds_btn_clk` tracking and login/email-verification gate, opens instead of navigating.

`/billing` also joins the gate's allow list. It's where a trial converts, so bouncing someone who came to pay turned every link into it into a dead end, including the review section's two informational ones ("Check Billing", "Full balance breakdown in Billing"). Those stay as links and now work.

Each entry point passes its own sheet copy, since the sheet's default description is GPU-template specific and wrong for all three.

### Not in scope

`AddToBalanceButton` keeps its own local sheet, so the `?openPayment=true` URL path that `AccountHeader`, `GetStartedStepper`, `CreateLease` and `DeploymentDepositModal` rely on is untouched. Those four only render on routes a not-onboarded user is bounced from already, so they aren't broken today.

Worth a follow-up though: that query param is inert whenever the `auto_credit_reload` flag is off, because `BillingPage` only renders the button that reads it behind the flag. Separate latent bug, left alone here.

## Verification

`npm run test:unit` 376 files / 3723 tests pass, `npm run lint -- --quiet` clean, `npx tsc --noEmit` at the unchanged 92-error spec baseline with zero errors in touched files.

Ran the real components locally to check the one thing jsdom can't: the sheet is a Radix Sheet at `z-[751]` opening over a `DialogV2` at the same `z-[751]`, so stacking comes down to portal mount order.

Measured on that flow: URL unchanged (no navigation, no bounce), both layers mounted with the review state intact behind, `document.elementFromPoint` inside the sheet at its centre, Escape closing only the sheet (the review modal keeps its own Escape prevented), the review modal interactive again afterwards with no Radix `pointer-events` leak, and reopening from the same button working. No page errors.

Also confirmed `/billing` renders for a not-onboarded trial user, with a negative control: putting `/billing` back behind the gate reproduced the bounce, so the allow-list entry is what fixes it rather than a fail-open on a mocked-away query.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a streamlined Add Credits flow from deployment reviews, trial prompts, and wallet notifications.
  - Added contextual purchase details and success feedback after purchases.
  - Billing is now accessible during onboarding for trial conversion.

- **Bug Fixes**
  - Prevented unauthorized or unverified users from opening the Add Credits flow.

- **Tests**
  - Expanded coverage for purchase flows, onboarding access, gating, analytics, and dismissal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->