### PR TITLE
fix(template): retry github rate limits and self-heal an empty template cache

### DIFF
--- a/apps/api/src/template/services/github-archive/github-archive.service.spec.ts
+++ b/apps/api/src/template/services/github-archive/github-archive.service.spec.ts
@@ -225,6 +225,30 @@ describe(GitHubArchiveService.name, () => {
       expect(fetchSpy).toHaveBeenCalledTimes(2);
     });
 
+    it("aborts when the response body goes silent part way through the download", async () => {
+      const { service, fetchSpy, tarGzChunks } = setup();
+      const [firstChunk] = tarGzChunks({ "root/readme.md": "# Hello" });
+      fetchSpy.mockImplementation((_url, init) => {
+        const signal = (init as RequestInit).signal!;
+        return Promise.resolve(
+          new Response(
+            new ReadableStream({
+              start(controller) {
+                signal.addEventListener("abort", () => controller.error(signal.reason), { once: true });
+                controller.enqueue(firstChunk);
+              }
+            })
+          )
+        );
+      });
+
+      const stalled = expect(service.getArchive("owner", "repo", "ref")).rejects.toThrow("received no data for 30000ms");
+      await vi.advanceTimersByTimeAsync(3 * 30_000 + BEYOND_ALL_RETRY_BACKOFFS_MS);
+
+      await stalled;
+      expect(fetchSpy).toHaveBeenCalledTimes(3);
+    });
+
     it("aborts a download that stops producing data", async () => {
       const { service, fetchSpy } = setup();
       fetchSpy.mockImplementation(

--- a/apps/api/src/template/services/github-archive/github-archive.service.spec.ts
+++ b/apps/api/src/template/services/github-archive/github-archive.service.spec.ts
@@ -197,6 +197,34 @@ describe(GitHubArchiveService.name, () => {
       expect(cancelSource).toHaveBeenCalled();
     });
 
+    it("retries when github rate limits the download", async () => {
+      const { service, fetchSpy, archiveResponse } = setup();
+      fetchSpy
+        .mockResolvedValueOnce(new Response(null, { status: 429, statusText: "Too Many Requests" }))
+        .mockResolvedValueOnce(archiveResponse({ "root/readme.md": "# Hello" }));
+
+      const archive = service.getArchive("owner", "repo", "ref");
+      await vi.advanceTimersByTimeAsync(BEYOND_ALL_RETRY_BACKOFFS_MS);
+      const reader = await archive;
+
+      expect(await reader.readFile("readme.md")).toBe("# Hello");
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("retries when github fails the download with a server error", async () => {
+      const { service, fetchSpy, archiveResponse } = setup();
+      fetchSpy
+        .mockResolvedValueOnce(new Response(null, { status: 502, statusText: "Bad Gateway" }))
+        .mockResolvedValueOnce(archiveResponse({ "root/readme.md": "# Hello" }));
+
+      const archive = service.getArchive("owner", "repo", "ref");
+      await vi.advanceTimersByTimeAsync(BEYOND_ALL_RETRY_BACKOFFS_MS);
+      const reader = await archive;
+
+      expect(await reader.readFile("readme.md")).toBe("# Hello");
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
     it("aborts a download that stops producing data", async () => {
       const { service, fetchSpy } = setup();
       fetchSpy.mockImplementation(

--- a/apps/api/src/template/services/github-archive/github-archive.service.ts
+++ b/apps/api/src/template/services/github-archive/github-archive.service.ts
@@ -14,6 +14,9 @@ const MAX_DOWNLOAD_RETRIES = 2;
 const RETRY_INITIAL_DELAY_MS = 1_000;
 const RETRY_MAX_DELAY_MS = 10_000;
 
+/** Only a missing or deleted archive will never appear; 403 and 429 are GitHub rate limits that clear on their own. */
+const PERMANENTLY_UNAVAILABLE_STATUSES = new Set([404, 410]);
+
 class ArchiveNotAvailableError extends Error {}
 
 export interface DirectoryEntry {
@@ -123,7 +126,7 @@ export class GitHubArchiveService {
 
       if (!response.ok) {
         const message = `Failed to download archive from ${url}: ${response.status} ${response.statusText}`;
-        throw response.status >= 400 && response.status < 500 ? new ArchiveNotAvailableError(message) : new Error(message);
+        throw PERMANENTLY_UNAVAILABLE_STATUSES.has(response.status) ? new ArchiveNotAvailableError(message) : new Error(message);
       }
 
       if (!response.body) {

--- a/apps/api/src/template/services/template-gallery/template-gallery.service.spec.ts
+++ b/apps/api/src/template/services/template-gallery/template-gallery.service.spec.ts
@@ -95,6 +95,21 @@ describe(TemplateGalleryService.name, () => {
       );
     });
 
+    it("refetches and overwrites a cache file poisoned with an empty gallery", async () => {
+      const { service, templateFetcher, fsMock } = setup();
+      const freshTemplates = [createCategory({ title: "AI", templates: [{ id: "fresh-1", name: "Fresh 1" }] })];
+
+      fsMock.access.mockResolvedValue(undefined);
+      fsMock.readFile.mockResolvedValue(JSON.stringify([]));
+      templateFetcher.fetchAwesomeAkashTemplates.mockResolvedValue(freshTemplates);
+
+      const result = await service.getTemplateGallery();
+
+      expect(templateFetcher.fetchAwesomeAkashTemplates).toHaveBeenCalled();
+      expect(result.map(category => category.title)).toContain("AI");
+      expect(fsMock.writeFile).toHaveBeenCalledWith(expect.stringContaining("akash-network-awesome-akash"), expect.stringContaining("fresh-1"));
+    });
+
     it("refuses to publish a repository that yielded no categories", async () => {
       const { service, templateFetcher, fsMock } = setup();
 

--- a/apps/api/src/template/services/template-gallery/template-gallery.service.ts
+++ b/apps/api/src/template/services/template-gallery/template-gallery.service.ts
@@ -301,32 +301,43 @@ export class TemplateGalleryService {
     );
 
     if (cacheFileExists) {
-      this.#logger.debug({
-        event: "GET_TEMPLATES_FROM_REPO_CACHE",
-        message: "Returning cached templates from filesystem",
+      const fileContent = await this.#fs.readFile(cacheFilePath, "utf8");
+      const cachedCategories: Category[] = JSON.parse(fileContent);
+
+      if (cachedCategories.length > 0) {
+        this.#logger.debug({
+          event: "GET_TEMPLATES_FROM_REPO_CACHE",
+          message: "Returning cached templates from filesystem",
+          path: cacheFilePath,
+          repository
+        });
+        return cachedCategories;
+      }
+
+      this.#logger.warn({
+        event: "EMPTY_TEMPLATES_CACHE_DISCARDED",
+        message: "Cached templates are empty, refetching from github",
         path: cacheFilePath,
         repository
       });
-      const fileContent = await this.#fs.readFile(cacheFilePath, "utf8");
-      return JSON.parse(fileContent);
-    } else {
-      this.#logger.debug({
-        event: "GET_TEMPLATES",
-        message: "Generating templates from github repository",
-        repository,
-        commitSha: latestCommitSha
-      });
-      const categories = await fetchTemplates(latestCommitSha);
-
-      if (categories.length === 0) {
-        throw new Error(`Refusing to cache an empty template gallery for ${repoOwner}/${repoName}@${latestCommitSha}`);
-      }
-
-      await this.#fs.mkdir(path.dirname(cacheFilePath), { recursive: true });
-      await this.#fs.writeFile(cacheFilePath, JSON.stringify(categories, null, 2));
-
-      return categories;
     }
+
+    this.#logger.debug({
+      event: "GET_TEMPLATES",
+      message: "Generating templates from github repository",
+      repository,
+      commitSha: latestCommitSha
+    });
+    const categories = await fetchTemplates(latestCommitSha);
+
+    if (categories.length === 0) {
+      throw new Error(`Refusing to cache an empty template gallery for ${repoOwner}/${repoName}@${latestCommitSha}`);
+    }
+
+    await this.#fs.mkdir(path.dirname(cacheFilePath), { recursive: true });
+    await this.#fs.writeFile(cacheFilePath, JSON.stringify(categories, null, 2));
+
+    return categories;
   }
 }
 


### PR DESCRIPTION
## Why

Ref CON-924

Follow-up to #3744, which merged before three review-driven commits landed on the branch. Two of them fix defects that are now live on `main`, the third closes a test gap.

The important one is a regression #3744 introduced. `ArchiveNotAvailableError` classified the **entire** 4xx range as permanently unavailable, and the retry policy excludes that class:

```ts
throw response.status >= 400 && response.status < 500 ? new ArchiveNotAvailableError(message) : new Error(message);
```

So a GitHub secondary rate limit (429, or a 403 rate-limit) fails the download on the first attempt with no retry — plausible precisely because we pull two ~70 MB archives concurrently, which is the CON-924 scenario. And because #3744's empty-gallery guard *did* land, that transient rate limit now fails the whole publish workflow rather than degrading. `main` currently pairs the strictest failure behaviour with the weakest retry behaviour.

## What

**`github-archive.service.ts`** — only `404` and `410` mean "this archive will never appear". `429`, `403` and 5xx now fall through to the cockatiel retry policy.

**`template-gallery.service.ts`** — #3744's empty-categories guard only covered the *write* path. The read branch still returned whatever was on disk for that commit sha without inspecting it, so the exact CON-924 artefact — a `[]` file written before the guard existed — kept being served until upstream HEAD moved. An empty cached gallery is now treated as a cache miss, so it refetches and overwrites, and a poisoned cache self-heals.

**`github-archive.service.spec.ts`** — the existing stall test left `fetch()` itself pending, so it never reached `response.body` or `reader.read()`, which is the path the 30s stall timer actually guards during a large download. Added a test driving a body that delivers one chunk and then goes silent, modelling how undici errors the body on abort.

### Verification

Each fix has a test confirmed to fail without it, so they pin behaviour rather than shape:

- 429 and 502 retry; 404 still makes exactly one attempt
- a cache file containing `[]` triggers a refetch and is overwritten
- the mid-body stall test fails when the stall timeout is disabled

95 tests pass across `src/template`. `eslint --quiet` clean; `tsc --noEmit` clean for `src/template` apart from a pre-existing `tar.Header` typing error that also fails on `main`. Ran `npm run build:akash-templates` against the real repos on this branch: **30 categories, 395 templates**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved archive downloads by retrying temporary HTTP failures, including rate limits and server errors.
  * Added timeout and abort handling when archive responses stall.
  * Fixed empty template gallery caches so fresh template data is fetched and saved automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->