### PR TITLE
fix(deployment): point funding API text and docs link at automatic funding

### DIFF
--- a/apps/api/src/deployment/http-schemas/deployment.schema.ts
+++ b/apps/api/src/deployment/http-schemas/deployment.schema.ts
@@ -109,8 +109,7 @@ export const CreateDeploymentRequestSchema = z.object({
     sdl: z.string(),
     deposit: z.number().optional().openapi({
       deprecated: true,
-      description:
-        "Deposit in dollars. Ignored when managed deposits are enabled for your account, in which case the platform sets it automatically; otherwise it is required."
+      description: "Deprecated and ignored. The platform funds every deployment automatically from your account credits."
     }),
     runtimeLimitHours: z
       .number()
@@ -145,7 +144,7 @@ export const CloseDeploymentResponseSchema = z.object({
 export const DepositDeploymentRequestSchema = z.object({
   data: z.object({
     dseq: DseqSchema.describe("Deployment sequence number"),
-    deposit: z.number().describe("Amount to deposit in dollars (e.g. 5.5)")
+    deposit: z.number().describe("Amount to deposit in dollars (e.g. 5.5). Accepted for backwards compatibility; automatic funding makes it unnecessary.")
   })
 });
 

--- a/apps/api/src/deployment/routes/deployments/deployments.router.ts
+++ b/apps/api/src/deployment/routes/deployments/deployments.router.ts
@@ -124,7 +124,7 @@ deploymentsRouter.openapi(deleteRoute, async function routeCloseDeployment(c) {
 const depositRoute = createRoute({
   method: "post",
   path: "/v1/deposit-deployment",
-  summary: "Deposit into a deployment",
+  summary: "Deposit into a deployment (deprecated)",
   description: "Deprecated. Managed deployments are funded automatically; this endpoint will be removed in a future release.",
   operationId: "depositDeployment",
   deprecated: true,

--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -68,6 +68,16 @@
                           "isTrialing": {
                             "type": "boolean"
                           },
+                          "trialEndsAt": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "When the free trial expires, or null when the wallet is no longer trialing."
+                          },
+                          "trialDurationDays": {
+                            "type": "number",
+                            "nullable": true,
+                            "description": "Total length of the free trial in days, or null when the wallet is no longer trialing."
+                          },
                           "topUpMinAmountUsd": {
                             "type": "number",
                             "description": "Minimum USD amount accepted by the next paid top-up for this wallet."
@@ -83,6 +93,8 @@
                           "address",
                           "denom",
                           "isTrialing",
+                          "trialEndsAt",
+                          "trialDurationDays",
                           "topUpMinAmountUsd",
                           "createdAt"
                         ]
@@ -4788,7 +4800,7 @@
                       },
                       "deposit": {
                         "type": "number",
-                        "description": "Deposit in dollars. Ignored when managed deposits are enabled for your account, in which case the platform sets it automatically; otherwise it is required.",
+                        "description": "Deprecated and ignored. The platform funds every deployment automatically from your account credits.",
                         "deprecated": true
                       },
                       "runtimeLimitHours": {
@@ -5196,7 +5208,7 @@
     },
     "/v1/deposit-deployment": {
       "post": {
-        "summary": "Deposit into a deployment",
+        "summary": "Deposit into a deployment (deprecated)",
         "description": "Deprecated. Managed deployments are funded automatically; this endpoint will be removed in a future release.",
         "operationId": "depositDeployment",
         "deprecated": true,
@@ -5227,7 +5239,7 @@
                       },
                       "deposit": {
                         "type": "number",
-                        "description": "Amount to deposit in dollars (e.g. 5.5)"
+                        "description": "Amount to deposit in dollars (e.g. 5.5). Accepted for backwards compatibility; automatic funding makes it unnecessary."
                       }
                     },
                     "required": [

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -6953,7 +6953,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                     "properties": {
                       "deposit": {
                         "deprecated": true,
-                        "description": "Deposit in dollars. Ignored when managed deposits are enabled for your account, in which case the platform sets it automatically; otherwise it is required.",
+                        "description": "Deprecated and ignored. The platform funds every deployment automatically from your account credits.",
                         "type": "number",
                       },
                       "runtimeLimitHours": {
@@ -7967,7 +7967,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                   "data": {
                     "properties": {
                       "deposit": {
-                        "description": "Amount to deposit in dollars (e.g. 5.5)",
+                        "description": "Amount to deposit in dollars (e.g. 5.5). Accepted for backwards compatibility; automatic funding makes it unnecessary.",
                         "type": "number",
                       },
                       "dseq": {
@@ -8373,7 +8373,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
             "ApiKeyAuth": [],
           },
         ],
-        "summary": "Deposit into a deployment",
+        "summary": "Deposit into a deployment (deprecated)",
         "tags": [
           "Deployments",
         ],

--- a/apps/deploy-web/src/components/new-deployment/ManifestEdit/ManifestEdit.spec.tsx
+++ b/apps/deploy-web/src/components/new-deployment/ManifestEdit/ManifestEdit.spec.tsx
@@ -143,6 +143,33 @@ describe(ManifestEdit.name, () => {
     });
   });
 
+  it("opens the funding docs from the deposit modal", async () => {
+    const windowOpen = vi.spyOn(window, "open").mockImplementation(() => null);
+    const SDLEditor = vi.fn(ComponentMock);
+
+    setup({
+      editedManifest: "some-manifest",
+      DeploymentDepositModal: vi.fn((props: Record<string, any>) => <>{props.subtitle}</>),
+      LinkTo: vi.fn((props: Record<string, any>) => <button onClick={props.onClick}>{props.children}</button>),
+      SDLEditor,
+      hasComponents: ["yml-editor"],
+      selectedSdlEditMode: "yaml"
+    });
+
+    act(() => {
+      triggerSdlValidation(SDLEditor, true);
+    });
+
+    await vi.waitFor(() => {
+      expect(screen.getByRole("button", { name: /Create Deployment/i })).not.toBeDisabled();
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: /Create Deployment/i }));
+    await userEvent.click(await screen.findByRole("button", { name: /Learn more/i }));
+
+    expect(windowOpen).toHaveBeenCalledWith("https://akash.network/docs/getting-started/how-funding-works/", "_blank");
+  });
+
   it("replaces non-wallet denom in SDL for managed wallet", async () => {
     const setEditedManifest = vi.fn();
     const sdlWithUsdcDenom = [
@@ -228,6 +255,7 @@ describe(ManifestEdit.name, () => {
     SDLEditor?: Mock;
     SdlBuilder?: Mock | ForwardRefExoticComponent<any>;
     DeploymentDepositModal?: Mock;
+    LinkTo?: Mock;
     analyticsService?: AppDIContainer["analyticsService"];
     selectedSdlEditMode?: "yaml" | "builder";
     setEditedManifest?: Mock;
@@ -253,7 +281,7 @@ describe(ManifestEdit.name, () => {
       DeploymentMinimumEscrowAlertText: ComponentMock,
       TrialDeploymentBadge: ComponentMock,
       CustomNextSeo: ComponentMock,
-      LinkTo: ComponentMock,
+      LinkTo: input?.LinkTo ?? ComponentMock,
       ViewPanel: ComponentMock,
       useBlockchainStatus: () => mock<ReturnType<typeof DEPENDENCIES.useBlockchainStatus>>({ isBlockchainDown: input?.isBlockchainDown ?? false }),
       useWallet: (() => ({

--- a/apps/deploy-web/src/components/new-deployment/ManifestEdit/ManifestEdit.tsx
+++ b/apps/deploy-web/src/components/new-deployment/ManifestEdit/ManifestEdit.tsx
@@ -419,7 +419,7 @@ export const ManifestEdit: React.FunctionComponent<Props> = ({
             <span>
               <d.DeploymentMinimumEscrowAlertText />
               <d.LinkTo
-                onClick={ev => handleDocClick(ev, "https://akash.network/docs/getting-started/intro-to-akash/payments/#escrow-accounts")}
+                onClick={ev => handleDocClick(ev, "https://akash.network/docs/getting-started/how-funding-works/")}
                 className="text-gray-500 no-underline hover:underline disabled:text-gray-300"
               >
                 Learn more.

--- a/packages/console-api-types/src/schema.d.ts
+++ b/packages/console-api-types/src/schema.d.ts
@@ -38,6 +38,10 @@ export interface paths {
                 address: string;
                 denom: string;
                 isTrialing: boolean;
+                /** @description When the free trial expires, or null when the wallet is no longer trialing. */
+                trialEndsAt: string | null;
+                /** @description Total length of the free trial in days, or null when the wallet is no longer trialing. */
+                trialDurationDays: number | null;
                 /** @description Minimum USD amount accepted by the next paid top-up for this wallet. */
                 topUpMinAmountUsd: number;
                 createdAt: string;
@@ -2118,7 +2122,7 @@ export interface paths {
     get?: never;
     put?: never;
     /**
-     * Deposit into a deployment
+     * Deposit into a deployment (deprecated)
      * @deprecated
      * @description Deprecated. Managed deployments are funded automatically; this endpoint will be removed in a future release.
      */
@@ -8302,7 +8306,7 @@ export interface operations {
             sdl: string;
             /**
              * @deprecated
-             * @description Deposit in dollars. Ignored when managed deposits are enabled for your account, in which case the platform sets it automatically; otherwise it is required.
+             * @description Deprecated and ignored. The platform funds every deployment automatically from your account credits.
              */
             deposit?: number;
             /** @description Optional runtime limit in hours (1 to 48), counted from lease start. Automatic funding keeps the deployment running until the limit, then the deployment is closed automatically and unused funds are returned. Extend a limit with PATCH /v2/deployment-settings/{dseq}. Omit for always-on funding. */
@@ -8346,7 +8350,7 @@ export interface operations {
           data: {
             /** @description Deployment sequence number */
             dseq: string;
-            /** @description Amount to deposit in dollars (e.g. 5.5) */
+            /** @description Amount to deposit in dollars (e.g. 5.5). Accepted for backwards compatibility; automatic funding makes it unnecessary. */
             deposit: number;
           };
         };


### PR DESCRIPTION
## Why

Part of CON-890.

Two things in this repo still describe the pre-CON-733 funding model:

1. The deposit dialog's "Learn more" link points at `akash.network/docs/getting-started/intro-to-akash/payments/#escrow-accounts`. That page does not exist and no redirect covers it, so anyone clicking it gets a 404. The modal is still reachable through the git-provider, redeploy, and CI-template paths.
2. The published API reference text reads as though a caller picks a deposit — "Deposit into a deployment", "Amount to deposit in dollars". The create field's description says it is required whenever managed deposits are off, a branch that is unreachable now `auto_reload_fixed_threshold` is fully rolled out.

## What

- Repoints the "Learn more" link at the new How Funding Works page (akash-network/website#1337, merge that first).
- `DepositDeploymentRequestSchema.deposit` and the route summary now read as deprecated. The route already carried `deprecated: true` and a deprecation description from #3597; this is the wording that surrounds it.
- The create `deposit` description drops the unreachable "otherwise it is required" branch and says plainly that it is ignored.
- Regenerates `apps/api/swagger/openapi.json` and `packages/console-api-types/src/schema.d.ts`.

Note: the regen also picks up `trialEndsAt` / `trialDurationDays` on the wallet response. Those come from #3742, which landed without regenerating the spec — no CI job checks freshness. Reverting them would mean hand-editing generated output, so they ride along here.

Not fixed here: the `ManifestEdit` deposit modal is the only deposit surface not gated on `useIsEscrowAbstracted()`, so those creation paths still prompt for an amount the API discards. That is a gap in CON-737 and wants its own issue rather than scope creep in a docs change.

## Verification

- `apps/api`: `npm run test:unit` green (176 files, 2193 tests), `npm run lint -- --quiet` clean
- `npx tsc --noEmit -p apps/api`: 43 lines of output on this branch and 43 on `main` — identical pre-existing baseline, no new errors
- `apps/deploy-web`: `npm run test:unit -- src/components/new-deployment/ManifestEdit` green (16 tests)
- Regenerated spec confirms `POST /v1/deployments` requires only `sdl`, and the deposit route reports `deprecated: true`
- No `intro-to-akash` links remain anywhere in `apps/*/src` or `packages/*/src`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that deployment deposits are deprecated, ignored, and no longer needed because funding is handled automatically.
  * Marked the deployment deposit endpoint as deprecated in its public documentation.
  * Updated funding help links to point to the current documentation.

* **API Changes**
  * Added trial-related wallet fields to the documented API contract.
  * Noted that some deployment funding fields are retained only for backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->