### PR TITLE
fix(observability): raise the api heap limit and enable on-demand heap snapshots

### DIFF
--- a/.helm/console-api-prod-mainnet-values.yaml
+++ b/.helm/console-api-prod-mainnet-values.yaml
@@ -73,6 +73,9 @@ jobs:
       - ./dist/console.js
       - mint-act
 
+# --max-old-space-size lifts V8's ~2GB default so the 4Gi container is actually usable; the snapshot flags let us `kill -USR2` a pod to dump its heap to /tmp while diagnosing the Sep 1 leak.
+extraNodeOptions: "--max-old-space-size=3584 --allow-fs-write=/tmp/ --heapsnapshot-signal=SIGUSR2 --diagnostic-dir=/tmp"
+
 replicas: 3
 
 resources:


### PR DESCRIPTION
## Why

`console-api-mainnet` prod pods have been dying roughly hourly since ~14:48 UTC today with `FATAL ERROR: Ineffective mark-compacts near heap limit` (the "Console service restart" alert). The container has 4Gi but V8 self-caps around 2GB because no `--max-old-space-size` is set, so pods die with ~1.7Gi unused. The leak itself is still under investigation; the snapshot flags let us capture the retainer graph from a live pod (`kill -USR2 <node pid>` writes the heap to /tmp) instead of only observing the crash.

## What

- add `extraNodeOptions` to the prod-mainnet values with `--max-old-space-size=3584 --allow-fs-write=/tmp/ --heapsnapshot-signal=SIGUSR2 --diagnostic-dir=/tmp`

Requires akash-network/helm-charts#591 (console-api chart 0.11.1), which threads `extraNodeOptions` into the shared `NODE_OPTIONS` env; until that chart is released this value is inert, so merge order cannot break a deploy. Verified via `helm template` that the rendered flags append to the existing folded scalar, and locally (Node 24.14.1, same major as prod) that all four flags behave under `--permission`: the heap cap applies, SIGUSR2 writes the snapshot, and the process keeps serving.