### PR TITLE
fix(deployment): bound the memory a deployment lookup retains

### DIFF
--- a/apps/api/src/caching/helpers.spec.ts
+++ b/apps/api/src/caching/helpers.spec.ts
@@ -265,6 +265,62 @@ describe("Memoize Function", () => {
       expect(cacheKeys).toHaveLength(1);
       expect(cacheKeys).toContain("TestClass#testMethod#test");
     });
+
+    describe("when maxEntries is set", () => {
+      it("keeps entries out of the shared cache", async () => {
+        setup();
+
+        class TestClass {
+          @Memoize({ maxEntries: 2 })
+          async testMethod(_arg: string) {
+            return "test";
+          }
+        }
+
+        await new TestClass().testMethod("a");
+
+        expect(cacheEngine.getKeys()).toHaveLength(0);
+      });
+
+      it("serves a cached entry without recomputing", async () => {
+        setup();
+        const compute = vi.fn().mockResolvedValue("test");
+
+        class TestClass {
+          @Memoize({ maxEntries: 2 })
+          async testMethod(arg: string) {
+            return compute(arg);
+          }
+        }
+
+        const instance = new TestClass();
+        await instance.testMethod("a");
+        await instance.testMethod("a");
+
+        expect(compute).toHaveBeenCalledTimes(1);
+      });
+
+      it("recomputes an entry evicted once maxEntries is exceeded", async () => {
+        setup();
+        const compute = vi.fn().mockResolvedValue("test");
+
+        class TestClass {
+          @Memoize({ maxEntries: 2 })
+          async testMethod(arg: string) {
+            return compute(arg);
+          }
+        }
+
+        const instance = new TestClass();
+        await instance.testMethod("a");
+        await instance.testMethod("b");
+        await instance.testMethod("c");
+        await instance.testMethod("a");
+
+        expect(compute).toHaveBeenCalledTimes(4);
+        expect(compute).toHaveBeenNthCalledWith(4, "a");
+      });
+    });
   });
 
   describe(memoizeAsync.name, () => {

--- a/apps/api/src/caching/helpers.ts
+++ b/apps/api/src/caching/helpers.ts
@@ -17,12 +17,15 @@ interface CachedObject<T> {
 interface MemoizeOptions {
   ttlInSeconds?: number;
   key?: string;
+  /** Set on methods whose arguments form an unbounded key space, to cap them in a private cache instead of letting them evict the shared one. */
+  maxEntries?: number;
 }
 
 export const Memoize = (options?: MemoizeOptions) => (target: object, propertyName: string, descriptor: PropertyDescriptor) => {
   const originalMethod = descriptor.value;
 
   const cacheKey = options?.key || `${target.constructor.name}#${propertyName}`;
+  const store = options?.maxEntries ? new MemoryCacheEngine({ maxEntries: options.maxEntries }) : cacheEngine;
 
   descriptor.value = async function memoizedFunction(...args: unknown[]) {
     const argsKey =
@@ -33,12 +36,12 @@ export const Memoize = (options?: MemoizeOptions) => (target: object, propertyNa
             .join("#")}`
         : cacheKey;
 
-    return cacheResponse(options?.ttlInSeconds || 60 * 2, argsKey, originalMethod.bind(this, ...args));
+    return cacheResponse(options?.ttlInSeconds || 60 * 2, argsKey, originalMethod.bind(this, ...args), store);
   };
 };
 
-export async function cacheResponse<T>(seconds: number, key: string, refreshRequest: () => Promise<T>): Promise<T> {
-  const cachedObject = cacheEngine.getFromCache<CachedObject<T>>(key);
+export async function cacheResponse<T>(seconds: number, key: string, refreshRequest: () => Promise<T>, store: MemoryCacheEngine = cacheEngine): Promise<T> {
+  const cachedObject = store.getFromCache<CachedObject<T>>(key);
   logger.debug(`Request for key: ${key}`);
 
   const hasCachedData = cachedObject !== undefined;
@@ -64,7 +67,7 @@ export async function cacheResponse<T>(seconds: number, key: string, refreshRequ
           logger.debug(`Background refresh completed for key: ${key}`);
           // Only store in cache if we have valid data
           if (data !== undefined) {
-            cacheEngine.storeInCache(key, { date: new Date(), data: data });
+            store.storeInCache(key, { date: new Date(), data: data });
           }
           return data;
         })
@@ -96,7 +99,7 @@ export async function cacheResponse<T>(seconds: number, key: string, refreshRequ
         logger.debug(`New request completed for key: ${key}`);
         // Only store in cache if we have valid data
         if (data !== undefined) {
-          cacheEngine.storeInCache(key, { date: new Date(), data: data });
+          store.storeInCache(key, { date: new Date(), data: data });
         }
         return data;
       })

--- a/apps/api/src/caching/memoryCacheEngine.spec.ts
+++ b/apps/api/src/caching/memoryCacheEngine.spec.ts
@@ -168,6 +168,56 @@ describe(MemoryCacheEngine.name, () => {
     });
   });
 
+  describe("when constructed with maxEntries", () => {
+    it("does not share entries with the shared cache", () => {
+      const { engine } = setup();
+      const privateEngine = new MemoryCacheEngine({ maxEntries: 2 });
+
+      engine.storeInCache("shared", 1);
+      privateEngine.storeInCache("private", 2);
+
+      expect(privateEngine.getFromCache("shared")).toBeUndefined();
+      expect(engine.getFromCache("private")).toBeUndefined();
+    });
+
+    it("evicts the least recently used entry once maxEntries is exceeded", () => {
+      const privateEngine = new MemoryCacheEngine({ maxEntries: 2 });
+
+      privateEngine.storeInCache("a", 1);
+      privateEngine.storeInCache("b", 2);
+      privateEngine.storeInCache("c", 3);
+
+      expect(privateEngine.getFromCache("a")).toBeUndefined();
+      expect(privateEngine.getKeys()).toHaveLength(2);
+      expect(privateEngine.getKeys()).toContain("b");
+      expect(privateEngine.getKeys()).toContain("c");
+    });
+
+    it("is not emptied by clearAllKeyInCache on the shared engine", () => {
+      const { engine } = setup();
+      const privateEngine = new MemoryCacheEngine({ maxEntries: 2 });
+      privateEngine.storeInCache("private", 1);
+
+      engine.clearAllKeyInCache();
+
+      expect(privateEngine.getFromCache("private")).toBe(1);
+    });
+  });
+
+  describe("clearAllCaches", () => {
+    it("empties private caches alongside the shared one", () => {
+      const { engine } = setup();
+      const privateEngine = new MemoryCacheEngine({ maxEntries: 2 });
+      engine.storeInCache("shared", 1);
+      privateEngine.storeInCache("private", 2);
+
+      MemoryCacheEngine.clearAllCaches();
+
+      expect(engine.getFromCache("shared")).toBeUndefined();
+      expect(privateEngine.getFromCache("private")).toBeUndefined();
+    });
+  });
+
   function setup() {
     const engine = new MemoryCacheEngine();
     engine.clearAllKeyInCache();

--- a/apps/api/src/caching/memoryCacheEngine.ts
+++ b/apps/api/src/caching/memoryCacheEngine.ts
@@ -1,22 +1,42 @@
 import { LRUCache } from "lru-cache";
 
 export type CacheValue = NonNullable<unknown>;
-const cache = new LRUCache<string, CacheValue>({ max: 500 });
+const SHARED_MAX_ENTRIES = 500;
+const sharedCache = new LRUCache<string, CacheValue>({ max: SHARED_MAX_ENTRIES });
+const allCaches = new Set<LRUCache<string, CacheValue>>([sharedCache]);
 
 export default class MemoryCacheEngine {
+  readonly #cache: LRUCache<string, CacheValue>;
+
+  /** Passing `maxEntries` gives the engine a private cache, so a high-cardinality key space cannot evict every other memoized response out of the shared one. */
+  constructor(options?: { maxEntries: number }) {
+    if (options) {
+      this.#cache = new LRUCache<string, CacheValue>({ max: options.maxEntries });
+      allCaches.add(this.#cache);
+    } else {
+      this.#cache = sharedCache;
+    }
+  }
+
+  static clearAllCaches() {
+    for (const cache of allCaches) {
+      cache.clear();
+    }
+  }
+
   getFromCache<T extends CacheValue>(key: string): T | undefined {
-    return cache.get(key) as T | undefined;
+    return this.#cache.get(key) as T | undefined;
   }
 
   storeInCache<T extends CacheValue>(key: string, data: T, durationInSeconds?: number) {
-    cache.set(key, data, durationInSeconds ? { ttl: durationInSeconds * 1000 } : undefined);
+    this.#cache.set(key, data, durationInSeconds ? { ttl: durationInSeconds * 1000 } : undefined);
   }
 
   /**
    * Used to delete all keys in a memcache
    */
   clearAllKeyInCache() {
-    cache.clear();
+    this.#cache.clear();
   }
 
   /**
@@ -24,7 +44,7 @@ export default class MemoryCacheEngine {
    * @param {*} key
    */
   clearKeyInCache(key: string) {
-    cache.delete(key);
+    this.#cache.delete(key);
   }
 
   /**
@@ -40,9 +60,9 @@ export default class MemoryCacheEngine {
    * @param {*} prefix
    */
   clearByPrefix(prefix: string) {
-    for (const key of cache.keys()) {
+    for (const key of this.#cache.keys()) {
       if (key.startsWith(prefix)) {
-        cache.delete(key);
+        this.#cache.delete(key);
       }
     }
   }
@@ -51,6 +71,6 @@ export default class MemoryCacheEngine {
    * Used to get all keys in the cache
    */
   getKeys(): string[] {
-    return [...cache.keys()];
+    return [...this.#cache.keys()];
   }
 }

--- a/apps/api/src/deployment/repositories/message/message.repository.ts
+++ b/apps/api/src/deployment/repositories/message/message.repository.ts
@@ -30,10 +30,12 @@ export class MessageRepository {
       include: [
         {
           model: Transaction,
+          attributes: ["hash"],
           required: true
         },
         {
           model: Block,
+          attributes: ["datetime"],
           required: true
         }
       ]

--- a/apps/api/src/deployment/services/deployment-reader/deployment-reader.service.ts
+++ b/apps/api/src/deployment/services/deployment-reader/deployment-reader.service.ts
@@ -247,7 +247,7 @@ export class DeploymentReaderService {
     };
   }
 
-  @Memoize({ ttlInSeconds: 30 })
+  @Memoize({ ttlInSeconds: 30, maxEntries: 500 })
   public async getDeploymentByOwnerAndDseq(owner: string, dseq: string) {
     // Quick existence check - avoids expensive blockchain HTTP call for non-existent deployments
     const count = await Deployment.count({ where: { owner, dseq } });


### PR DESCRIPTION
## Why

`apps/api` mainnet pods are being OOM-killed every 30–60 minutes. Three crash logs across three pods all die at the same ~1.9 GB V8 ceiling with `Ineffective mark-compacts near heap limit`, and a full reduce-mark-compact recovers only ~50 MB — so the heap is genuinely live, not churn. GC mutator utilisation degrades to 0.25 (75% of wall time in GC) before the process dies, which is what produces the multi-second latencies and `CONNECT_TIMEOUT`s that show up alongside.

Memory settles when a pod goes idle, so this is not an accumulating leak — it is retention proportional to in-flight concurrency. The traffic driving it is a high volume of `GET /v1/deployment/:owner/:dseq` from scripted clients (`Go-http-client`, `Python/aiohttp`) walking distinct deployments.

This PR removes the two largest per-request costs on that path. It does not add a concurrency cap, which is the remaining structural fix.

## What

**Stop loading columns the endpoint never reads.** `getDeploymentRelatedMessages` joined the full `Transaction` and `Block` rows onto every related message in order to read three fields (`txHash`, `date`, `type`). `transaction` carries a user-supplied TEXT `memo` plus a `log` column, so a deployment with hundreds of bid messages pulled tens of MB per request. The query now selects only what the mapping uses — verified against the SQL the integration test emits:

```
before: message.*, transaction.{id,hash,index,height,msgCount,multisigThreshold,
                                gasUsed,gasWanted,fee,memo,isProcessed,
                                hasProcessingError,log}, block.*
after:  message.*, transaction.{id,hash}, block.{height,datetime}
```

**Stop one unbounded key space from evicting the whole shared cache.** `getDeploymentByOwnerAndDseq` memoizes on `owner#dseq` — one key per deployment — into the process-wide 500-entry LRU shared by *every* `@Memoize`d method in the API. A walk over distinct deployments flushes every other cached response out of it. A new `maxEntries` option gives a method its own bounded cache instead:

```ts
@Memoize({ ttlInSeconds: 30, maxEntries: 500 })
public async getDeploymentByOwnerAndDseq(owner: string, dseq: string) {
```

`MemoryCacheEngine` gains an optional private cache and a `clearAllCaches()` static so tests can reset private caches too. Default construction is unchanged and still uses the shared cache, so no other memoized method is affected.

No API or response shape changes. No migration.

## Verification

- `npm run test:unit` — 2200 passed (the 2 `wallet-settings` failures on a first run were a missing local Postgres; green once `test:ci-setup` was up)
- `npm run test:integration src/deployment/repositories/message` — 7 passed, and the logged SQL confirms the narrowed column list
- `npm run lint -- --quiet` — clean
- `npx tsc --noEmit` — 45 errors, all pre-existing on `main`; none in the touched files

## Follow-ups (not in this PR)

- Cap concurrency on this route — memory is proportional to it, and this PR lowers the constant without bounding it
- Bound the message row count for a single pathological deployment
- Set an explicit `--max-old-space-size`; V8 self-caps at ~1.9 GB in a 6 GB container
- Disable `level: debug` Postgres SQL logging on mainnet (~40 KB string per query on the hot path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable limits for in-memory caching, including isolated per-operation caches.
  - Added least-recently-used eviction when caches reach their configured capacity.
  - Global cache clearing now also clears private caches.

- **Performance Improvements**
  - Deployment lookups now use a bounded cache while retaining fast repeated access.
  - Deployment message queries retrieve only the data needed for display, improving efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->