### PR TITLE
fix(observability): move heap-snapshot flags into the server argv

### DIFF
--- a/.helm/console-api-prod-mainnet-values.yaml
+++ b/.helm/console-api-prod-mainnet-values.yaml
@@ -73,8 +73,8 @@ jobs:
       - ./dist/console.js
       - mint-act
 
-# --max-old-space-size lifts V8's ~2GB default so the 4Gi container is actually usable; the snapshot flags let us `kill -USR2` a pod to dump its heap to /tmp while diagnosing the Sep 1 leak.
-extraNodeOptions: "--max-old-space-size=3584 --allow-fs-write=/tmp/ --heapsnapshot-signal=SIGUSR2 --diagnostic-dir=/tmp"
+# Lifts V8's ~2GB default so the 4Gi container is actually usable. Only plain V8 flags belong here: this lands in NODE_OPTIONS for every node process in the pods (npm, cron commands), and permission-model flags crash any process lacking --permission in its argv.
+extraNodeOptions: "--max-old-space-size=3584"
 
 replicas: 3
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -19,7 +19,7 @@
     "format": "prettier --write ./*.{js,json} **/*.{ts,js,json}",
     "lint": "eslint .",
     "migration:gen": "drizzle-kit generate",
-    "prod": "node --permission --allow-fs-read=./dist/ --allow-fs-read=./env/ --allow-fs-read=./node_modules/ --allow-fs-read=../../node_modules/ --allow-fs-read=../../packages/env-loader/ --allow-fs-read=./drizzle/ --enable-source-maps --require ./dist/instrumentation.js ./dist/server.js",
+    "prod": "node --permission --allow-fs-read=./dist/ --allow-fs-read=./env/ --allow-fs-read=./node_modules/ --allow-fs-read=../../node_modules/ --allow-fs-read=../../packages/env-loader/ --allow-fs-read=./drizzle/ --allow-fs-write=/tmp/ --heapsnapshot-signal=SIGUSR2 --diagnostic-dir=/tmp --enable-source-maps --require ./dist/instrumentation.js ./dist/server.js",
     "sdk:gen:swagger": "rm -rf ./swagger && npm run build:app && SERVER_ORIGIN=https://console-api-sandbox.akash.network NOTIFICATIONS_SWAGGER_PATH=../notifications/swagger/swagger.json POSTGRES_DB_URI=postgres://localhost/unused AMPLITUDE_API_KEY=unused FEATURE_FLAGS_ENABLE_ALL=true INTERFACE=swagger-gen node dist/server.js",
     "start": "tsup --watch",
     "start:dev": "tsup src/server.ts --watch",


### PR DESCRIPTION
## Why

The prod-mainnet deploy of #3752's NODE_OPTIONS failed and auto-rolled back: `--allow-fs-write` is only valid alongside `--permission`, and NODE_OPTIONS is inherited by every node process in the pods — the `npm run prod` wrapper and the cron `node ./dist/console.js <job>` commands run without `--permission`, so they all crashed at boot with `ERR_MISSING_OPTION` (server pods stuck at 1/3 updated, every CronJob failing).

## What

- `apps/api/package.json`: the `prod` script now carries `--allow-fs-write=/tmp/ --heapsnapshot-signal=SIGUSR2 --diagnostic-dir=/tmp` directly in the node argv, next to the existing `--permission`. Verified on Node 24.14.1 that this combination boots and that an external `kill -USR2` writes a heap snapshot to the diagnostic dir.
- `.helm/console-api-prod-mainnet-values.yaml`: `extraNodeOptions` keeps only `--max-old-space-size=3584`, which is a plain V8 flag and safe for npm and the cron commands (verified npm boots with it).

The snapshot flags are inert unless SIGUSR2 is sent, so carrying them in every environment's server argv is harmless.