### PR TITLE
fix(billing): rate-limit prediction-mode auto top-up charges

### DIFF
--- a/apps/api/src/billing/repositories/wallet-settings/wallet-settings.repository.integration.ts
+++ b/apps/api/src/billing/repositories/wallet-settings/wallet-settings.repository.integration.ts
@@ -14,11 +14,6 @@ import { createAkashAddress } from "@test/seeders/akash-address.seeder";
 const COOLDOWN_MINUTES = 60;
 const NO_COOLDOWN = 0;
 
-/** Narrows an attempt the assertions have already established was won. */
-function claimOf(attempt: ChargeClaimAttempt) {
-  return (attempt as Extract<ChargeClaimAttempt, { won: true }>).claim;
-}
-
 /** Narrows an attempt the assertions have already established was rate limited. */
 function reopenSecondsOf(attempt: ChargeClaimAttempt) {
   return (attempt as Extract<ChargeClaimAttempt, { won: false }>).secondsUntilWindowReopen;
@@ -40,7 +35,7 @@ describe(WalletSettingRepository.name, () => {
       const first = await walletSettingRepository.claimForCharge(settingId, COOLDOWN_MINUTES);
       const second = await walletSettingRepository.claimForCharge(settingId, COOLDOWN_MINUTES);
 
-      expect(first).toEqual({ won: true, claim: { id: settingId, claimedAt: expect.any(String) } });
+      expect(first).toEqual({ won: true });
       expect(second).toEqual({ won: false, secondsUntilWindowReopen: expect.any(Number) });
     });
 
@@ -74,7 +69,7 @@ describe(WalletSettingRepository.name, () => {
       await backdateLastAutoChargeAt(settingId, COOLDOWN_MINUTES + 1);
       const afterCooldown = await walletSettingRepository.claimForCharge(settingId, COOLDOWN_MINUTES);
 
-      expect(afterCooldown).toEqual({ won: true, claim: { id: settingId, claimedAt: expect.any(String) } });
+      expect(afterCooldown).toEqual({ won: true });
     });
 
     it("claims consecutively when the cooldown is zero", async () => {
@@ -83,48 +78,8 @@ describe(WalletSettingRepository.name, () => {
       const first = await walletSettingRepository.claimForCharge(settingId, NO_COOLDOWN);
       const second = await walletSettingRepository.claimForCharge(settingId, NO_COOLDOWN);
 
-      expect(first).toEqual({ won: true, claim: { id: settingId, claimedAt: expect.any(String) } });
-      expect(second).toEqual({ won: true, claim: { id: settingId, claimedAt: expect.any(String) } });
-    });
-  });
-
-  describe("releaseChargeClaim", () => {
-    it("makes a claimed wallet immediately claimable again", async () => {
-      const { walletSettingRepository, settingId } = await setup();
-
-      const attempt = await walletSettingRepository.claimForCharge(settingId, COOLDOWN_MINUTES);
-      await walletSettingRepository.releaseChargeClaim(claimOf(attempt));
-      const afterRelease = await walletSettingRepository.claimForCharge(settingId, COOLDOWN_MINUTES);
-
-      expect(afterRelease).toEqual({ won: true, claim: { id: settingId, claimedAt: expect.any(String) } });
-    });
-
-    it("leaves a newer claim in place when the caller whose claim aged out releases late", async () => {
-      const { walletSettingRepository, settingId } = await setup();
-
-      const agedOutAttempt = await walletSettingRepository.claimForCharge(settingId, COOLDOWN_MINUTES);
-      const newerAttempt = await walletSettingRepository.claimForCharge(settingId, NO_COOLDOWN);
-      await walletSettingRepository.releaseChargeClaim(claimOf(agedOutAttempt));
-
-      expect(newerAttempt.won).toBe(true);
-      expect((await walletSettingRepository.claimForCharge(settingId, COOLDOWN_MINUTES)).won).toBe(false);
-
-      await walletSettingRepository.releaseChargeClaim(claimOf(newerAttempt));
-
-      expect(await walletSettingRepository.claimForCharge(settingId, COOLDOWN_MINUTES)).toEqual({
-        won: true,
-        claim: { id: settingId, claimedAt: expect.any(String) }
-      });
-    });
-
-    it("owes no cooldown when the released row has no charge to wait on", async () => {
-      const { walletSettingRepository, settingId } = await setup();
-
-      const attempt = await walletSettingRepository.claimForCharge(settingId, COOLDOWN_MINUTES);
-      await walletSettingRepository.releaseChargeClaim(claimOf(attempt));
-      const reclaimed = await walletSettingRepository.claimForCharge(settingId, COOLDOWN_MINUTES);
-
-      expect(reclaimed.won).toBe(true);
+      expect(first).toEqual({ won: true });
+      expect(second).toEqual({ won: true });
     });
   });
 

--- a/apps/api/src/billing/repositories/wallet-settings/wallet-settings.repository.ts
+++ b/apps/api/src/billing/repositories/wallet-settings/wallet-settings.repository.ts
@@ -13,19 +13,13 @@ export type WalletSettingInput = Partial<DbWalletSettingInput>;
 
 export type WalletSettingOutput = DbWalletSettingOutput;
 
-/** A won auto-charge claim: the wallet setting id and the exact marker the claim wrote. */
-export type ChargeClaim = {
-  id: string;
-  claimedAt: string;
-};
-
 /**
  * A lost claim carries how long is left on the cooldown that blocked it, so the caller defers only
  * for the remainder instead of a whole fresh cooldown. Postgres computes it: `last_auto_charge_at`
  * is a timestamp without time zone, so reading it back as a JS Date would shift it by the driver's
  * local offset. Zero means the window is already open again.
  */
-export type ChargeClaimAttempt = { won: true; claim: ChargeClaim } | { won: false; secondsUntilWindowReopen: number };
+export type ChargeClaimAttempt = { won: true } | { won: false; secondsUntilWindowReopen: number };
 
 @singleton()
 export class WalletSettingRepository extends BaseRepository<Table, WalletSettingInput, WalletSettingOutput> {
@@ -64,12 +58,12 @@ export class WalletSettingRepository extends BaseRepository<Table, WalletSetting
   }
 
   /**
-   * Atomically claims the right to auto-charge a wallet, rate-limiting threshold-mode reloads. A
-   * wallet is claimable when it has never been auto-charged or its last charge is older than the
-   * cooldown; concurrent callers resolve to a single winner via the row-lock re-check. A cooldown
-   * of 0 always claims, disabling the cap. The claim marker comes back as text to keep full
-   * microsecond precision, which `releaseChargeClaim` matches on. A lost claim reads back the
-   * cooldown still owed, so the caller can wait out only what is left rather than a whole fresh one.
+   * Atomically claims the right to auto-charge a wallet, rate-limiting auto-reload charges in both
+   * modes. A wallet is claimable when it has never been auto-charged or its last charge is older
+   * than the cooldown; concurrent callers resolve to a single winner via the row-lock re-check. A
+   * cooldown of 0 always claims, disabling the cap. A claim is never released — a failed charge
+   * consumes the window too — so a lost claim reads back the cooldown still owed, letting the
+   * caller wait out only what is left rather than a whole fresh one.
    */
   async claimForCharge(id: WalletSettingOutput["id"], cooldownMinutes: number): Promise<ChargeClaimAttempt> {
     const [claim] = await this.cursor
@@ -81,10 +75,10 @@ export class WalletSettingRepository extends BaseRepository<Table, WalletSetting
           or(isNull(this.table.lastAutoChargeAt), lt(this.table.lastAutoChargeAt, sql`now() - (${cooldownMinutes} * interval '1 minute')`))
         )
       )
-      .returning({ id: this.table.id, claimedAt: sql<string>`${this.table.lastAutoChargeAt}::text` });
+      .returning({ id: this.table.id });
 
     if (claim) {
-      return { won: true, claim };
+      return { won: true };
     }
 
     const [blocking] = await this.cursor
@@ -95,17 +89,5 @@ export class WalletSettingRepository extends BaseRepository<Table, WalletSetting
       .where(eq(this.table.id, id));
 
     return { won: false, secondsUntilWindowReopen: Number(blocking?.secondsUntilWindowReopen ?? 0) };
-  }
-
-  /**
-   * Releases a charge claim so the next check can retry, used when the charge attempt failed. The
-   * release is scoped to the exact marker its claim wrote, so a caller whose claim already aged out
-   * of the cooldown and was re-taken by another check cannot clear that newer claim.
-   */
-  async releaseChargeClaim(claim: ChargeClaim): Promise<void> {
-    await this.cursor
-      .update(this.table)
-      .set({ lastAutoChargeAt: null, updatedAt: sql`now()` })
-      .where(and(eq(this.table.id, claim.id), eq(this.table.lastAutoChargeAt, sql`${claim.claimedAt}::timestamp`)));
   }
 }

--- a/apps/api/src/billing/services/wallet-balance-reload-check/README.md
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/README.md
@@ -32,11 +32,11 @@ One guard sits after the comparison: when the wallet owns no active deployment t
 
 ### Charge rate limit
 
-A second guard sits right before the charge: at most one automatic charge per `AUTO_RELOAD_CHARGE_COOLDOWN_IN_MIN` (default 60 minutes; `0` disables the cap) per wallet. Deployment funding drains a balance in lumps, so without a cap an expensive deployment can produce a burst of identical card charges within minutes: each one costs a flat Stripe fee, risks issuer velocity declines mid-burst, and reads as statement shock (CON-843 measures these bursts).
+A second guard sits right before the charge, in **both modes**: at most one automatic charge attempt per `AUTO_RELOAD_CHARGE_COOLDOWN_IN_MIN` (default 60 minutes; `0` disables the cap) per wallet. Deployment funding drains a balance in lumps, so without a cap an expensive deployment can produce a burst of identical card charges within minutes: each one costs a flat Stripe fee, risks issuer velocity declines mid-burst, and reads as statement shock (CON-843 measures these bursts).
 
-The cap is an atomic claim on `wallet_settings.last_auto_charge_at`, the same guarded-UPDATE pattern escrow top-ups use for `last_funded_at`: concurrent checks racing for the same wallet resolve to a single winner, so two overlapping jobs cannot both charge. A failed charge attempt releases the claim, so retry behavior is unchanged. A lost claim records a `charge_rate_limited` skip and reschedules the check for when the window reopens (cooldown plus a 1-minute buffer) instead of the usual 24h safety net, so a rate-limited reload is deferred, never dropped.
+The cap is an atomic claim on `wallet_settings.last_auto_charge_at`, the same guarded-UPDATE pattern escrow top-ups use for `last_funded_at`: concurrent checks racing for the same wallet resolve to a single winner, so two overlapping jobs cannot both charge. A failed charge attempt **consumes the window** just like a successful one — the claim is never released. Releasing it on failure is what let a persistently declining card be re-attempted on every spend event (CON-927: ~108 declined charges per hour on one wallet); keeping it bounds a dead card to roughly one Stripe attempt per cooldown. The failed job still rethrows, and its pg-boss retry then loses the claim and defers, so the reload chain survives. A lost claim records a `charge_rate_limited` skip and reschedules the check for when the window reopens (cooldown plus a 1-minute buffer) instead of the usual 24h safety net, so a rate-limited reload is deferred, never dropped.
 
-Manual top-ups never touch this path, and prediction mode is exempt.
+Manual top-ups never touch this path.
 
 ### Worked examples (defaults: threshold $20, amount $100)
 
@@ -79,7 +79,7 @@ The charge uses a job-scoped idempotency key (`WalletBalanceReloadCheck.<jobId>`
 
 ## What happens on failure?
 
-- **Payment fails**: The charge claim is released (best-effort), then the error is logged and re-thrown (job fails, will retry under the same idempotency key).
+- **Payment fails**: The error is logged and re-thrown (job fails, will retry under the same idempotency key). The charge claim is kept, so the retry loses it, records a `charge_rate_limited` skip, and defers the next check to the window reopen — a fresh attempt happens once per cooldown, not once per retry.
 - **Validation fails**: Error is logged, job completes successfully (no retry needed).
 - **Scheduling next check fails**: Error is logged and re-thrown.
 
@@ -93,9 +93,10 @@ This is the pre-CON-717 behavior, kept as a supported mode by CON-884. It predic
 
 1. **Calculate** the unfunded cost to keep all auto-top-up deployments running for the next 7 days (`RELOAD_COVERAGE_PERIOD_IN_MS`), excluding the portion already covered by escrow.
 2. **Compare** the balance against 25% of that projection (`MIN_COVERAGE_PERCENTAGE`). Reload when `balance < 0.25 * costUntilTargetDate` (~1.75 days of coverage remaining).
-3. **Charge** `max(costUntilTargetDate - balance, $20)`.
-4. **Skip** entirely when the projected cost is 0 (no active auto-top-up deployments).
-5. **Schedule** the next check 24 hours out.
+3. **Claim** the charge window — the same rate limit as threshold mode (see "Charge rate limit" above). A lost claim defers the reload to the window reopen.
+4. **Charge** `max(costUntilTargetDate - balance, $20)`.
+5. **Skip** entirely when the projected cost is 0 (no active auto-top-up deployments).
+6. **Schedule** the next check 24 hours out.
 
 Key constants: Check Interval 24h, Reload Coverage Period 7 days, Minimum Coverage Percentage 25%, Minimum Reload $20.
 

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check-instrumentation.service.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check-instrumentation.service.ts
@@ -133,14 +133,6 @@ export class WalletBalanceReloadCheckInstrumentationService {
     });
   }
 
-  recordChargeClaimReleaseError(walletSettingId: string, error: unknown): void {
-    this.logger.error({
-      event: "ERROR_RELEASING_CHARGE_CLAIM",
-      walletSettingId,
-      error
-    });
-  }
-
   recordValidationError(errorType: string, error: { event: string; message: string }, userId: string): void {
     this.validationErrors.add(1, {
       error_type: errorType

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.spec.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.spec.ts
@@ -5,7 +5,7 @@ import { mock } from "vitest-mock-extended";
 
 import { WalletBalanceReloadCheck } from "@src/billing/events/wallet-balance-reload-check";
 import { usdToCents } from "@src/billing/lib/currency/currency";
-import type { ChargeClaim, WalletSettingRepository } from "@src/billing/repositories";
+import type { WalletSettingRepository } from "@src/billing/repositories";
 import type { BalancesService } from "@src/billing/services/balances/balances.service";
 import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import type { PaymentMethodService } from "@src/billing/services/payment-method/payment-method.service";
@@ -217,8 +217,22 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       );
     });
 
-    it("charges in prediction mode without consulting the charge rate limit", async () => {
-      const { handler, walletSettingRepository, stripeTransactionService, job, jobMeta } = setup({
+    it("claims the charge window with the configured cooldown before charging", async () => {
+      const { handler, walletSettingRepository, stripeTransactionService, walletSetting, job, jobMeta } = setup({
+        balance: 10.0,
+        weeklyCostInDenom: 50_000_000,
+        weeklyCostInFiat: 50.0,
+        chargeCooldownMinutes: 30
+      });
+
+      await handler.handle(job, jobMeta);
+
+      expect(walletSettingRepository.claimForCharge).toHaveBeenCalledWith(walletSetting.id, 30);
+      expect(stripeTransactionService.createPaymentIntent).toHaveBeenCalledWith(expect.objectContaining({ amount: 40 }));
+    });
+
+    it("skips without charging when another charge happened within the cooldown", async () => {
+      const { handler, stripeTransactionService, instrumentationService, job, jobMeta } = setup({
         balance: 10.0,
         weeklyCostInDenom: 50_000_000,
         weeklyCostInFiat: 50.0,
@@ -227,8 +241,54 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
 
       await handler.handle(job, jobMeta);
 
-      expect(walletSettingRepository.claimForCharge).not.toHaveBeenCalled();
-      expect(stripeTransactionService.createPaymentIntent).toHaveBeenCalledWith(expect.objectContaining({ amount: 40 }));
+      expect(stripeTransactionService.createPaymentIntent).not.toHaveBeenCalled();
+      expect(instrumentationService.recordReloadSkipped).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mode: "prediction",
+          reason: "charge_rate_limited",
+          projectedCost: 50,
+          logContext: expect.objectContaining({ balance: 10, nextCheckAt: expect.any(Date) })
+        })
+      );
+    });
+
+    it("defers the next check to the window reopen when rate limited", async () => {
+      const cooldownMinutes = 60;
+      const { handler, walletReloadJobService, job, jobMeta } = setup({
+        balance: 10.0,
+        weeklyCostInDenom: 50_000_000,
+        weeklyCostInFiat: 50.0,
+        chargeClaimWon: false,
+        secondsUntilWindowReopen: cooldownMinutes * 60,
+        chargeCooldownMinutes: cooldownMinutes
+      });
+
+      await handler.handle(job, jobMeta);
+
+      const expectedReopenDate = addMilliseconds(new Date(), (cooldownMinutes + 1) * millisecondsInMinute);
+      const scheduleCall = walletReloadJobService.scheduleForWalletSetting.mock.calls[0];
+      expect(scheduleCall[1]).toEqual(expect.objectContaining({ withCleanup: true }));
+      const scheduledDate = new Date(scheduleCall[1]?.startAfter as string);
+      expect(scheduledDate.getTime()).toBeCloseTo(expectedReopenDate.getTime(), -3);
+    });
+
+    it("defers the retry after a failed charge instead of charging again", async () => {
+      const error = new Error("Your card was declined");
+      const { handler, walletSettingRepository, stripeTransactionService, walletReloadJobService, job, jobMeta } = setup({
+        balance: 10.0,
+        weeklyCostInDenom: 50_000_000,
+        weeklyCostInFiat: 50.0
+      });
+      stripeTransactionService.createPaymentIntent.mockRejectedValue(error);
+
+      await expect(handler.handle(job, jobMeta)).rejects.toThrow(error);
+
+      walletSettingRepository.claimForCharge.mockResolvedValue({ won: false, secondsUntilWindowReopen: 3540 });
+
+      await handler.handle(job, jobMeta);
+
+      expect(stripeTransactionService.createPaymentIntent).toHaveBeenCalledTimes(1);
+      expect(walletReloadJobService.scheduleForWalletSetting).toHaveBeenCalledTimes(1);
     });
 
     it("records reload failure and throws when payment intent fails", async () => {
@@ -517,7 +577,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       });
     });
 
-    it("claims the charge window with the configured cooldown and keeps the claim after a successful charge", async () => {
+    it("claims the charge window with the configured cooldown before charging", async () => {
       const { handler, walletSettingRepository, stripeTransactionService, walletSetting, job, jobMeta } = setup({
         autoReloadMode: "threshold",
         balance: 10,
@@ -530,7 +590,6 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
 
       expect(walletSettingRepository.claimForCharge).toHaveBeenCalledWith(walletSetting.id, 30);
       expect(stripeTransactionService.createPaymentIntent).toHaveBeenCalledWith(expect.objectContaining({ amount: 100 }));
-      expect(walletSettingRepository.releaseChargeClaim).not.toHaveBeenCalled();
     });
 
     it("skips without charging when another charge happened within the cooldown", async () => {
@@ -632,38 +691,24 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       expect(scheduledDate.getTime()).toBeCloseTo(expectedNextCheckDate.getTime(), -3);
     });
 
-    it("releases the claim and rethrows when the payment intent fails", async () => {
-      const error = new Error("Payment failed");
-      const { handler, walletSettingRepository, stripeTransactionService, chargeClaim, job, jobMeta } = setup({
+    it("defers the retry after a failed charge instead of charging again", async () => {
+      const error = new Error("Your card was declined");
+      const { handler, walletSettingRepository, stripeTransactionService, walletReloadJobService, job, jobMeta } = setup({
         autoReloadMode: "threshold",
         balance: 10,
         autoReloadThresholdUsd: 20,
         autoReloadAmountUsd: 100
       });
       stripeTransactionService.createPaymentIntent.mockRejectedValue(error);
-      walletSettingRepository.releaseChargeClaim.mockResolvedValue();
 
       await expect(handler.handle(job, jobMeta)).rejects.toThrow(error);
 
-      expect(walletSettingRepository.releaseChargeClaim).toHaveBeenCalledWith(chargeClaim);
-    });
+      walletSettingRepository.claimForCharge.mockResolvedValue({ won: false, secondsUntilWindowReopen: 3540 });
 
-    it("rethrows the payment error when releasing the claim also fails", async () => {
-      const paymentError = new Error("Payment failed");
-      const releaseError = new Error("Release failed");
-      const { handler, walletSettingRepository, stripeTransactionService, instrumentationService, chargeClaim, job, jobMeta } = setup({
-        autoReloadMode: "threshold",
-        balance: 10,
-        autoReloadThresholdUsd: 20,
-        autoReloadAmountUsd: 100
-      });
-      stripeTransactionService.createPaymentIntent.mockRejectedValue(paymentError);
-      walletSettingRepository.releaseChargeClaim.mockRejectedValue(releaseError);
+      await handler.handle(job, jobMeta);
 
-      await expect(handler.handle(job, jobMeta)).rejects.toThrow(paymentError);
-
-      expect(instrumentationService.recordChargeClaimReleaseError).toHaveBeenCalledWith(chargeClaim.id, releaseError);
-      expect(instrumentationService.recordReloadFailed).toHaveBeenCalledWith(expect.objectContaining({ error: paymentError }));
+      expect(stripeTransactionService.createPaymentIntent).toHaveBeenCalledTimes(1);
+      expect(walletReloadJobService.scheduleForWalletSetting).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -719,12 +764,9 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       id: faker.string.uuid()
     };
 
-    const chargeClaim: ChargeClaim = { id: walletSetting.id, claimedAt: new Date().toISOString() };
     const walletSettingRepository = mock<WalletSettingRepository>();
     walletSettingRepository.claimForCharge.mockResolvedValue(
-      input?.chargeClaimWon === false
-        ? { won: false, secondsUntilWindowReopen: input?.secondsUntilWindowReopen ?? 0 }
-        : { won: true, claim: chargeClaim }
+      input?.chargeClaimWon === false ? { won: false, secondsUntilWindowReopen: input?.secondsUntilWindowReopen ?? 0 } : { won: true }
     );
     const billingConfig = mockConfigService<BillingConfigService>({
       AUTO_RELOAD_CHARGE_COOLDOWN_IN_MIN: input?.chargeCooldownMinutes ?? 60
@@ -744,8 +786,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       recordReloadSkipped: vi.fn(),
       recordReloadFailed: vi.fn(),
       recordValidationError: vi.fn(),
-      recordSchedulingError: vi.fn(),
-      recordChargeClaimReleaseError: vi.fn()
+      recordSchedulingError: vi.fn()
     });
     const balance = input?.balance ?? 50.0;
     const weeklyCostInDenom = input?.weeklyCostInDenom ?? 50_000_000;
@@ -790,7 +831,6 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       stripeTransactionService,
       instrumentationService,
       billingConfig,
-      chargeClaim,
       walletSetting,
       walletSettingWithWallet,
       wallet,

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.ts
@@ -7,7 +7,7 @@ import { AUTO_RELOAD_AMOUNT_MIN_USD } from "@src/billing/config";
 import { WalletBalanceReloadCheck } from "@src/billing/events/wallet-balance-reload-check";
 import type { GetBalancesResponseOutput } from "@src/billing/http-schemas/balance.schema";
 import { centsToUsd } from "@src/billing/lib/currency/currency";
-import { ChargeClaim, UserWalletOutput, WalletSettingOutput, WalletSettingRepository } from "@src/billing/repositories";
+import { UserWalletOutput, WalletSettingOutput, WalletSettingRepository } from "@src/billing/repositories";
 import { BalancesService } from "@src/billing/services/balances/balances.service";
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import { type PaymentMethod, PaymentMethodService } from "@src/billing/services/payment-method/payment-method.service";
@@ -211,34 +211,7 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
       }
     }
 
-    const cooldownMinutes = this.billingConfig.get("AUTO_RELOAD_CHARGE_COOLDOWN_IN_MIN");
-    const attempt = await this.walletSettingRepository.claimForCharge(resources.walletSetting.id, cooldownMinutes);
-
-    if (!attempt.won) {
-      const nextCheckAt = this.#calculateChargeWindowReopenDate(attempt.secondsUntilWindowReopen);
-      this.instrumentationService.recordReloadSkipped({ mode, reason: "charge_rate_limited", coverageRatio, logContext: { ...log, nextCheckAt } });
-      return { nextCheckAt };
-    }
-
-    const claim = attempt.claim;
-
-    try {
-      await this.stripeTransactionService.createPaymentIntent({
-        userId: resources.user.id,
-        customer: resources.user.stripeCustomerId,
-        payment_method: resources.paymentMethod.id,
-        amount: reloadAmount,
-        confirm: true,
-        metadata: { [AUTO_RECHARGE_METADATA_KEY]: "true" },
-        idempotencyKey: `${WalletBalanceReloadCheck.name}.${resources.job.id}`,
-        onAmountMismatch: "tolerate"
-      });
-      this.instrumentationService.recordReloadTriggered({ mode, amount: reloadAmount, coverageRatio, logContext: log });
-    } catch (error) {
-      await this.#releaseChargeClaim(claim);
-      this.instrumentationService.recordReloadFailed({ mode, error, logContext: log });
-      throw error;
-    }
+    return this.#chargeWithinRateLimit({ resources, amount: reloadAmount, coverageRatio, logContext: log });
   }
 
   async #tryToReloadOnPredictedSpend(resources: ReloadContext): Promise<ReloadOutcome> {
@@ -273,26 +246,54 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
 
     const reloadAmountInFiat = Math.max(costUntilTargetDateInFiat - resources.balance, this.#MIN_RELOAD_AMOUNT_IN_USD);
 
+    return this.#chargeWithinRateLimit({
+      resources,
+      amount: reloadAmountInFiat,
+      coverageRatio,
+      projectedCost: costUntilTargetDateInFiat,
+      logContext: log
+    });
+  }
+
+  /** A failed charge keeps the claim, so a declining card re-attempts when the window reopens instead of on every spend event (CON-927). */
+  async #chargeWithinRateLimit(input: {
+    resources: ReloadContext;
+    amount: number;
+    coverageRatio: number | undefined;
+    projectedCost?: number;
+    logContext: Record<string, unknown>;
+  }): Promise<ReloadOutcome> {
+    const { resources, amount, coverageRatio, projectedCost, logContext } = input;
+    const mode = resources.walletSetting.autoReloadMode;
+    const cooldownMinutes = this.billingConfig.get("AUTO_RELOAD_CHARGE_COOLDOWN_IN_MIN");
+    const attempt = await this.walletSettingRepository.claimForCharge(resources.walletSetting.id, cooldownMinutes);
+
+    if (!attempt.won) {
+      const nextCheckAt = this.#calculateChargeWindowReopenDate(attempt.secondsUntilWindowReopen);
+      this.instrumentationService.recordReloadSkipped({
+        mode,
+        reason: "charge_rate_limited",
+        coverageRatio,
+        projectedCost,
+        logContext: { ...logContext, nextCheckAt }
+      });
+      return { nextCheckAt };
+    }
+
     try {
       await this.stripeTransactionService.createPaymentIntent({
         userId: resources.user.id,
         customer: resources.user.stripeCustomerId,
         payment_method: resources.paymentMethod.id,
-        amount: reloadAmountInFiat,
+        amount,
         confirm: true,
         metadata: { [AUTO_RECHARGE_METADATA_KEY]: "true" },
         idempotencyKey: `${WalletBalanceReloadCheck.name}.${resources.job.id}`,
         onAmountMismatch: "tolerate"
       });
-      this.instrumentationService.recordReloadTriggered({
-        mode,
-        amount: reloadAmountInFiat,
-        coverageRatio,
-        projectedCost: costUntilTargetDateInFiat,
-        logContext: log
-      });
+      this.instrumentationService.recordReloadTriggered({ mode, amount, coverageRatio, projectedCost, logContext });
     } catch (error) {
-      this.instrumentationService.recordReloadFailed({ mode, error, logContext: log });
+      this.instrumentationService.recordReloadFailed({ mode, error, logContext });
       throw error;
     }
   }
@@ -309,18 +310,6 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
     } catch (error) {
       this.instrumentationService.recordSchedulingError(resources.wallet.address, error);
       throw error;
-    }
-  }
-
-  /**
-   * Releases best-effort: a rejected release must not replace the payment error the caller is
-   * about to record and rethrow, which retries and alerting classify.
-   */
-  async #releaseChargeClaim(claim: ChargeClaim): Promise<void> {
-    try {
-      await this.walletSettingRepository.releaseChargeClaim(claim);
-    } catch (error) {
-      this.instrumentationService.recordChargeClaimReleaseError(claim.id, error);
     }
   }
 

--- a/apps/deploy-web/src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup.spec.tsx
@@ -127,10 +127,10 @@ describe(AutoTopUpSettingsPopup.name, () => {
     expect(screen.getByText(/charged at most once per hour/i)).toBeInTheDocument();
   });
 
-  it("hides the hourly charge cap in prediction mode", () => {
+  it("tells the user the card is charged at most once per hour in prediction mode", () => {
     setup({ mode: "prediction" });
 
-    expect(screen.queryByText(/charged at most once per hour/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/charged at most once per hour/i)).toBeInTheDocument();
   });
 
   it("saves prediction mode without threshold values", async () => {

--- a/apps/deploy-web/src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AutoTopUpSettingsPopup/AutoTopUpSettingsPopup.tsx
@@ -40,12 +40,12 @@ const AUTO_RELOAD_MAX_USD = 10_000;
 export const AUTO_RELOAD_AMOUNT_MIN_USD = 25;
 
 /**
- * Mirrors the API's AUTO_RELOAD_CHARGE_COOLDOWN_IN_MIN, which defaults to 60. Threshold mode takes an hourly per-wallet
- * charge claim, so a fast-draining balance defers the next top-up rather than charging the card again right away.
- * Prediction mode and manual top-ups are exempt, so this only belongs in the threshold branch.
+ * Mirrors the API's AUTO_RELOAD_CHARGE_COOLDOWN_IN_MIN, which defaults to 60. Both auto top-up modes take an hourly
+ * per-wallet charge claim, so a fast-draining balance defers the next top-up rather than charging the card again
+ * right away; only manual top-ups are exempt.
  */
 const CHARGE_COOLDOWN_NOTICE =
-  "Your card is charged at most once per hour. If your balance drops below the threshold again within that hour, the next top-up waits until the hour is up.";
+  "Your card is charged at most once per hour. If your balance runs low again within that hour, the next top-up waits until the hour is up.";
 
 const MODE_OPTIONS: Array<{ value: AutoReloadMode; id: string; title: string; description: string; recommended?: boolean }> = [
   {
@@ -250,14 +250,14 @@ export const AutoTopUpSettingsPopup: React.FC<AutoTopUpSettingsPopupProps> = ({
                   />
                 )}
               />
-
-              <p className="text-sm text-muted-foreground">{CHARGE_COOLDOWN_NOTICE}</p>
             </>
           ) : (
             <p className="text-sm text-muted-foreground">
               We check your deployments once a day and charge enough to keep them running for another week. There is nothing else to configure.
             </p>
           )}
+
+          <p className="text-sm text-muted-foreground">{CHARGE_COOLDOWN_NOTICE}</p>
 
           <LoadingButton type="submit" className="w-full" loading={upsertWalletSettings.isPending}>
             Save changes


### PR DESCRIPTION
## Why

Fixes CON-927

On 2026-09-01 one prediction-mode user with a declining card produced 486 `WALLET_BALANCE_RELOAD_FAILED` events in 4.5 hours, and their deployment sat unfunded long enough to trip the CON-910 alert. CON-904 added the hourly charge claim only to the threshold branch, so prediction mode had no limit at all.

While fixing it we found the cap would not have saved us anyway: the claim is released when a charge fails, so every new reload job wins the claim the previous failure just gave back. Each new job carries a fresh Stripe idempotency key, which means a fresh issuer attempt at whatever rate spend events arrive. Extending the claim to prediction mode without changing that would slow the storm down, not bound it.

## What

- Both mode branches of `WalletBalanceReloadCheckHandler` now charge through a shared `#chargeWithinRateLimit` method: claim the hourly window (`AUTO_RELOAD_CHARGE_COOLDOWN_IN_MIN`, default 60, `0` disables), charge, and keep the claim whether the charge succeeds or fails.
- This deliberately reverses CON-904's "a failed charge attempt releases the claim" behavior, since that release is exactly what let a declining card retry unbounded. A persistently declining card now gets about one Stripe attempt per hour instead of an open-ended stream.
- A rate-limited or failed reload is deferred, not dropped: the failed job rethrows as before, its pg-boss retry loses the claim, records a `charge_rate_limited` skip, and reschedules the check for the window reopen. The accepted tradeoff is that a transient Stripe or network error also waits out the cooldown (up to an hour) instead of retrying in 30 seconds; the hourly funding sweep remains the backstop.
- Removed the now-dead release machinery: `releaseChargeClaim`, the `ChargeClaim` type, and `recordChargeClaimReleaseError`.
- deploy-web: the "charged at most once per hour" notice in the auto top-up settings popup now shows for both modes, not just threshold.
- No new config, no migration. Manual top-ups never touch this path and are unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Applied hourly charge limits to both threshold-based and prediction-based auto top-ups.
  * Prediction-based top-ups now follow the same cooldown and retry protections as threshold-based top-ups.
  * Added clearer messaging that cards are charged no more than once per hour.

* **Bug Fixes**
  * Prevented duplicate charges after failed payment attempts.
  * Improved delayed retry timing when a charge is rate-limited.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->