### PR TITLE
feat(deployment): resolve an sdl reference from its own service's namespace

### DIFF
--- a/apps/api/src/deployment/services/sdl-reference/sdl-reference.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl-reference/sdl-reference.service.spec.ts
@@ -2,7 +2,7 @@ import type { SDLInput } from "@akashnetwork/chain-sdk";
 import { yaml } from "@akashnetwork/chain-sdk";
 import { describe, expect, it } from "vitest";
 
-import type { SdlReferenceResolver } from "./sdl-reference.service";
+import type { NamespacedSdlSecrets, SdlReferenceResolver } from "./sdl-reference.service";
 import { SdlReferenceService } from "./sdl-reference.service";
 
 const VALID_NAMES = ["A", "a", "_", "_A", "A9", `A${"b".repeat(62)}`, `A${"b".repeat(63)}`];
@@ -57,7 +57,7 @@ describe(SdlReferenceService.name, () => {
       const { service } = setup();
       const sdl = sdlWithEnv(["DATABASE_URL=ac-secret://DATABASE_URL"]);
 
-      const errors = service.substitute(sdl, { secrets: { DATABASE_URL: "postgres://u:p@host/db" } });
+      const errors = service.substitute(sdl, { secrets: { web: { DATABASE_URL: "postgres://u:p@host/db" } } });
 
       expect(errors).toEqual([]);
       expect(sdl.services.web.env).toEqual(["DATABASE_URL=postgres://u:p@host/db"]);
@@ -68,7 +68,7 @@ describe(SdlReferenceService.name, () => {
       const sdl = sdlWithEnv(["TOKEN=ac-secret://TOKEN"]);
       const env = sdl.services.web.env;
 
-      service.substitute(sdl, { secrets: { TOKEN: "resolved" } });
+      service.substitute(sdl, { secrets: { web: { TOKEN: "resolved" } } });
 
       expect(env).toBe(sdl.services.web.env);
       expect(env).toEqual(["TOKEN=resolved"]);
@@ -79,7 +79,7 @@ describe(SdlReferenceService.name, () => {
       const value = "a: b #c |x >y {z} [w] &anchor *alias \"q\" 's'\nsecond: line\n\t- dash";
       const sdl = sdlWithEnv(["WEIRD=ac-secret://WEIRD"]);
 
-      service.substitute(sdl, { secrets: { WEIRD: value } });
+      service.substitute(sdl, { secrets: { web: { WEIRD: value } } });
 
       expect(sdl.services.web.env).toEqual([`WEIRD=${value}`]);
     });
@@ -88,7 +88,7 @@ describe(SdlReferenceService.name, () => {
       const { service } = setup();
       const sdl = sdlWithEnv(["PAIR=ac-secret://PAIR"]);
 
-      service.substitute(sdl, { secrets: { PAIR: "a=b=c" } });
+      service.substitute(sdl, { secrets: { web: { PAIR: "a=b=c" } } });
 
       expect(sdl.services.web.env).toEqual(["PAIR=a=b=c"]);
     });
@@ -97,7 +97,7 @@ describe(SdlReferenceService.name, () => {
       const { service } = setup();
       const sdl = sdlWithEnv(["MIXED=prefix ac-secret://TOKEN", 'QUOTED="ac-secret://TOKEN"', "LISTED=ac,ac-secret://TOKEN"]);
 
-      const errors = service.substitute(sdl, { secrets: { TOKEN: "resolved" } });
+      const errors = service.substitute(sdl, { secrets: { web: { TOKEN: "resolved" } } });
 
       expect(errors).toEqual([]);
       expect(sdl.services.web.env).toEqual(["MIXED=prefix ac-secret://TOKEN", 'QUOTED="ac-secret://TOKEN"', "LISTED=ac,ac-secret://TOKEN"]);
@@ -106,7 +106,7 @@ describe(SdlReferenceService.name, () => {
     it("reports a value opening with a reference and trailing something else", () => {
       const { service } = setup();
 
-      const [error] = service.substitute(sdlWithEnv(["SUFFIX=ac-secret://TOKEN suffix"]), { secrets: { TOKEN: "resolved" } });
+      const [error] = service.substitute(sdlWithEnv(["SUFFIX=ac-secret://TOKEN suffix"]), { secrets: { web: { TOKEN: "resolved" } } });
 
       expect(error.message).toContain("reserved");
     });
@@ -115,7 +115,7 @@ describe(SdlReferenceService.name, () => {
       const { service } = setup();
       const sdl = sdlWithEnv(["ac-secret://TOKEN"]);
 
-      const errors = service.substitute(sdl, { secrets: { TOKEN: "resolved" } });
+      const errors = service.substitute(sdl, { secrets: { web: { TOKEN: "resolved" } } });
 
       expect(errors).toEqual([]);
       expect(sdl.services.web.env).toEqual(["ac-secret://TOKEN"]);
@@ -125,7 +125,7 @@ describe(SdlReferenceService.name, () => {
       const { service } = setup();
       const sdl = sdlWithEnv(["A=ac-secret://A"]);
 
-      const errors = service.substitute(sdl, { secrets: { A: "ac-secret://B", B: "leaked" } });
+      const errors = service.substitute(sdl, { secrets: { web: { A: "ac-secret://B", B: "leaked" } } });
 
       expect(errors).toEqual([]);
       expect(sdl.services.web.env).toEqual(["A=ac-secret://B"]);
@@ -147,24 +147,87 @@ describe(SdlReferenceService.name, () => {
       const { service } = setup();
       const sdl = sdlWithEnv(["TOKEN=ac-var://TOKEN"]);
 
-      const [error] = service.substitute(sdl, { secrets: { TOKEN: "resolved" } });
+      const [error] = service.substitute(sdl, { secrets: { web: { TOKEN: "resolved" } } });
 
       expect(error.message).toContain("unknown SDL Reference kind");
       expect(sdl.services.web.env).toEqual(["TOKEN=ac-var://TOKEN"]);
     });
 
-    it("resolves one name referenced by two services", () => {
+    it("gives each service its own value for the same name", () => {
       const { service } = setup();
       const sdl = sdlWithEnv(["TOKEN=ac-secret://TOKEN"], ["TOKEN=ac-secret://TOKEN"]);
 
-      service.substitute(sdl, { secrets: { TOKEN: "resolved" } });
+      const errors = service.substitute(sdl, { secrets: { web: { TOKEN: "web-value" }, worker: { TOKEN: "worker-value" } } });
 
-      expect(sdl.services.web.env).toEqual(["TOKEN=resolved"]);
-      expect(sdl.services.worker.env).toEqual(["TOKEN=resolved"]);
+      expect(errors).toEqual([]);
+      expect(sdl.services.web.env).toEqual(["TOKEN=web-value"]);
+      expect(sdl.services.worker.env).toEqual(["TOKEN=worker-value"]);
+    });
+
+    it("reports a name one service supplies and another does not, naming the service that lacks it", () => {
+      const { service } = setup();
+      const sdl = sdlWithEnv(["TOKEN=ac-secret://TOKEN"], ["TOKEN=ac-secret://TOKEN"]);
+
+      const [error] = service.substitute(sdl, { secrets: { web: { TOKEN: "web-value" } } });
+
+      expect(error.message).toContain("ac-secret://TOKEN");
+      expect(error.message).toContain("worker");
+      expect(error.instancePath).toBe("/services/worker/env/0");
+      expect(sdl.services.worker.env).toEqual(["TOKEN=ac-secret://TOKEN"]);
+    });
+
+    it("resolves one service while another service supplies no namespace at all", () => {
+      const { service } = setup();
+      const sdl = sdlWithEnv(["TOKEN=ac-secret://TOKEN"], ["PORT=8080"]);
+
+      const errors = service.substitute(sdl, { secrets: { web: { TOKEN: "web-value" } } });
+
+      expect(errors).toEqual([]);
+      expect(sdl.services.web.env).toEqual(["TOKEN=web-value"]);
+    });
+
+    it.each(["constructor", "__proto__", "toString", "hasOwnProperty"])("reports a missing namespace for the service name %j", serviceName => {
+      const { service } = setup();
+      const sdl = yaml.raw<SDLInput>(sdlYaml(serviceYaml(serviceName, ["TOKEN=ac-secret://TOKEN"])));
+
+      const [error] = service.substitute(sdl, { secrets: {} });
+
+      expect(error.message).toContain(serviceName);
+      expect(error.message).toContain("no value supplied");
+    });
+
+    it("bounds a very long service name in everything it echoes", () => {
+      const { service } = setup();
+      const sdl = yaml.raw<SDLInput>(sdlYaml(serviceYaml("s".repeat(500), ["TOKEN=ac-secret://TOKEN"])));
+
+      const [error] = service.substitute(sdl, { secrets: {} });
+
+      expect(error.message.length).toBeLessThan(300);
+      expect(error.message).toContain(String(error.params.serviceName));
+    });
+
+    it.each([{ web: "supersecret" }, { web: ["item"] }])("reports a missing value for the non-object namespace %j", secrets => {
+      const { service } = setup();
+      const sdl = sdlWithEnv(["A=ac-secret://length"]);
+
+      const [error] = service.substitute(sdl, { secrets: secrets as unknown as NamespacedSdlSecrets });
+
+      expect(error.message).toContain("no value supplied");
+      expect(sdl.services.web.env).toEqual(["A=ac-secret://length"]);
+    });
+
+    it.each([42, null, { nested: true }, ["array"], true])("refuses a resolver's non-string value %j", resolved => {
+      const { service } = setup({ resolvers: [{ kind: "probe", resolve: () => resolved as unknown as string }] });
+      const sdl = sdlWithEnv(["A=ac-probe://TOKEN"]);
+
+      const [error] = service.substitute(sdl, { secrets: {} });
+
+      expect(error.message).toContain("no value supplied");
+      expect(sdl.services.web.env).toEqual(["A=ac-probe://TOKEN"]);
     });
 
     it("resolves a kind registered after construction", () => {
-      const { service } = setup({ resolvers: [{ kind: "var", resolve: name => `var-${name}` }] });
+      const { service } = setup({ resolvers: [{ kind: "var", resolve: ({ name }) => `var-${name}` }] });
       const sdl = sdlWithEnv(["MODE=ac-var://MODE"]);
 
       const errors = service.substitute(sdl, { secrets: {} });
@@ -215,7 +278,7 @@ describe(SdlReferenceService.name, () => {
       const { service } = setup();
       const sdl = sdlWithEnv([`A=ac-secret://${name}`]);
 
-      const errors = service.substitute(sdl, { secrets: { [name]: "resolved" } });
+      const errors = service.substitute(sdl, { secrets: { web: { [name]: "resolved" } } });
 
       expect(errors).toEqual([]);
       expect(sdl.services.web.env).toEqual(["A=resolved"]);
@@ -225,7 +288,7 @@ describe(SdlReferenceService.name, () => {
       const { service } = setup();
       const reference = `ac-secret://${name}`;
 
-      const [error] = service.substitute(sdlWithEnv([`A=${reference}`]), { secrets: { [name]: "resolved" } });
+      const [error] = service.substitute(sdlWithEnv([`A=${reference}`]), { secrets: { web: { [name]: "resolved" } } });
 
       expect(error.message).toContain("reserved");
     });
@@ -233,7 +296,7 @@ describe(SdlReferenceService.name, () => {
     it.each(RESERVED_VALUES)("rejects the reserved value %j", value => {
       const { service } = setup();
 
-      const [error] = service.substitute(sdlWithEnv([`A=${value}`]), { secrets: { X: "resolved", TOKEN: "resolved" } });
+      const [error] = service.substitute(sdlWithEnv([`A=${value}`]), { secrets: { web: { X: "resolved", TOKEN: "resolved" } } });
 
       expect(error.message).toContain("reserved");
       expect(error.message).toContain(value);
@@ -252,7 +315,7 @@ describe(SdlReferenceService.name, () => {
       const { service } = setup();
       const sdl = sdlWithEnv(["UPPER=ac-secret://TOKEN", "LOWER=ac-secret://token"]);
 
-      service.substitute(sdl, { secrets: { TOKEN: "upper", token: "lower" } });
+      service.substitute(sdl, { secrets: { web: { TOKEN: "upper", token: "lower" } } });
 
       expect(sdl.services.web.env).toEqual(["UPPER=upper", "LOWER=lower"]);
     });
@@ -260,7 +323,7 @@ describe(SdlReferenceService.name, () => {
     it("reports a name whose case does not match the supplied one", () => {
       const { service } = setup();
 
-      const [error] = service.substitute(sdlWithEnv(["A=ac-secret://token"]), { secrets: { TOKEN: "resolved" } });
+      const [error] = service.substitute(sdlWithEnv(["A=ac-secret://token"]), { secrets: { web: { TOKEN: "resolved" } } });
 
       expect(error.message).toContain("ac-secret://token");
     });

--- a/apps/api/src/deployment/services/sdl-reference/sdl-reference.service.ts
+++ b/apps/api/src/deployment/services/sdl-reference/sdl-reference.service.ts
@@ -32,18 +32,25 @@ function readEnvDeclaration(entry: string): { key: string; value: string } | nul
   return valueStart === -1 ? null : { key: entry.slice(0, valueStart), value: entry.slice(valueStart + 1) };
 }
 
+/** One namespace per service, so two services can reference the same name and receive their own value. */
+export type NamespacedSdlSecrets = Record<string, SdlSecrets>;
+
 export interface SdlReferenceContext {
-  secrets: SdlSecrets;
+  secrets: NamespacedSdlSecrets;
+}
+
+export interface SdlReferenceTarget {
+  serviceName: string;
+  name: string;
 }
 
 export interface SdlReferenceResolver {
   readonly kind: string;
-  resolve(name: string, context: SdlReferenceContext): string | undefined;
+  resolve(target: SdlReferenceTarget, context: SdlReferenceContext): string | undefined;
 }
 
-interface EnvReference {
+interface EnvReference extends SdlReferenceTarget {
   kind: string;
-  name: string;
   key: string;
   reference: string;
   instancePath: string;
@@ -51,10 +58,18 @@ interface EnvReference {
 
 type EnvReferenceVisitor = (reference: EnvReference, env: string[], index: number) => ValidationError | undefined;
 
-/** A reference name may spell an `Object.prototype` member, and a bare lookup would answer such a name with an inherited function. */
+/** A service or reference name may spell an `Object.prototype` member, and a bare lookup would answer such a name with an inherited function. */
+function ownValue<T>(record: Record<string, T>, key: string): T | undefined {
+  return Object.hasOwn(record, key) ? record[key] : undefined;
+}
+
 const secretReferenceResolver: SdlReferenceResolver = {
   kind: "secret",
-  resolve: (name, { secrets }) => (Object.hasOwn(secrets, name) ? secrets[name] : undefined)
+  resolve: ({ serviceName, name }, { secrets }) => {
+    const namespace = ownValue(secrets, serviceName);
+
+    return typeof namespace === "object" && namespace !== null ? ownValue(namespace, name) : undefined;
+  }
 };
 
 function referenceError(instancePath: string, message: string, params: Record<string, unknown>): ValidationError {
@@ -96,12 +111,15 @@ export class SdlReferenceService {
         return unknownKindError(reference);
       }
 
-      const value = resolver.resolve(reference.name, context);
+      const value = resolver.resolve(reference, context);
 
-      if (value === undefined) {
-        return referenceError(reference.instancePath, `no value supplied for SDL Reference "${reference.reference}"`, {
+      if (typeof value !== "string") {
+        const echoedServiceName = reference.serviceName.slice(0, MAX_ECHOED_REFERENCE_LENGTH);
+
+        return referenceError(reference.instancePath, `no value supplied for SDL Reference "${reference.reference}" in service "${echoedServiceName}"`, {
           kind: reference.kind,
-          name: reference.name
+          name: reference.name,
+          serviceName: echoedServiceName
         });
       }
 
@@ -120,7 +138,8 @@ export class SdlReferenceService {
       if (!Array.isArray(env)) continue;
 
       env.forEach((entry, index) => {
-        const error = this.#readEntry(entry, `/services/${serviceName}/env/${index}`, reference => visit(reference, env, index));
+        const location = { serviceName, instancePath: `/services/${serviceName}/env/${index}` };
+        const error = this.#readEntry(entry, location, reference => visit(reference, env, index));
 
         if (error) errors.push(error);
       });
@@ -129,7 +148,11 @@ export class SdlReferenceService {
     return errors;
   }
 
-  #readEntry(entry: unknown, instancePath: string, visit: (reference: EnvReference) => ValidationError | undefined): ValidationError | undefined {
+  #readEntry(
+    entry: unknown,
+    location: { serviceName: string; instancePath: string },
+    visit: (reference: EnvReference) => ValidationError | undefined
+  ): ValidationError | undefined {
     if (typeof entry !== "string") return undefined;
 
     const declaration = readEnvDeclaration(entry);
@@ -143,12 +166,16 @@ export class SdlReferenceService {
     if (read.type === "reserved") {
       const echoed = declaration.value.slice(0, MAX_ECHOED_REFERENCE_LENGTH);
 
-      return referenceError(instancePath, `"${echoed}" is not a recognized SDL Reference and values beginning with "${SDL_REFERENCE_PREFIX}" are reserved`, {
-        value: echoed
-      });
+      return referenceError(
+        location.instancePath,
+        `"${echoed}" is not a recognized SDL Reference and values beginning with "${SDL_REFERENCE_PREFIX}" are reserved`,
+        {
+          value: echoed
+        }
+      );
     }
 
-    return visit({ ...read, key: declaration.key, reference: declaration.value, instancePath });
+    return visit({ ...read, ...location, key: declaration.key, reference: declaration.value });
   }
 
   #servicesOf(sdl: SDLInput): SDLInput["services"] {

--- a/apps/api/src/deployment/services/sdl/sdl.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl/sdl.service.spec.ts
@@ -584,7 +584,7 @@ describe(SdlService.name, () => {
     it("returns a manifest carrying the resolved value", async () => {
       const { service } = setup();
 
-      const result = await service.generateResolvedManifest({ sdl: SDL_WITH_ENV("TOKEN=ac-secret://TOKEN"), secrets: { TOKEN: "resolved" } });
+      const result = await service.generateResolvedManifest({ sdl: SDL_WITH_ENV("TOKEN=ac-secret://TOKEN"), secrets: { web: { TOKEN: "resolved" } } });
 
       expect(result.ok).toBe(true);
       expect(resolvedOf(result).manifest.groups[0].services[0].env).toEqual(["TOKEN=resolved"]);
@@ -593,7 +593,7 @@ describe(SdlService.name, () => {
     it("hashes an sdl with a substituted value exactly as one carrying that value inline", async () => {
       const { service } = setup();
 
-      const substituted = await service.generateResolvedManifest({ sdl: SDL_WITH_ENV("TOKEN=ac-secret://TOKEN"), secrets: { TOKEN: "resolved" } });
+      const substituted = await service.generateResolvedManifest({ sdl: SDL_WITH_ENV("TOKEN=ac-secret://TOKEN"), secrets: { web: { TOKEN: "resolved" } } });
       const inline = await service.generateResolvedManifest({ sdl: SDL_WITH_ENV("TOKEN=resolved"), secrets: {} });
 
       expect(versionOf(substituted)).toEqual(versionOf(inline));
@@ -603,8 +603,8 @@ describe(SdlService.name, () => {
       const { service } = setup();
       const sdl = SDL_WITH_ENV("TOKEN=ac-secret://TOKEN");
 
-      const first = await service.generateResolvedManifest({ sdl, secrets: { TOKEN: "one" } });
-      const second = await service.generateResolvedManifest({ sdl, secrets: { TOKEN: "two" } });
+      const first = await service.generateResolvedManifest({ sdl, secrets: { web: { TOKEN: "one" } } });
+      const second = await service.generateResolvedManifest({ sdl, secrets: { web: { TOKEN: "two" } } });
 
       expect(versionOf(first)).not.toEqual(versionOf(second));
     });
@@ -613,8 +613,8 @@ describe(SdlService.name, () => {
       const { service } = setup();
       const sdl = SDL_WITH_ENV("TOKEN=ac-secret://TOKEN");
 
-      const first = await service.generateResolvedManifest({ sdl, secrets: { TOKEN: "resolved" } });
-      const second = await service.generateResolvedManifest({ sdl, secrets: { TOKEN: "resolved" } });
+      const first = await service.generateResolvedManifest({ sdl, secrets: { web: { TOKEN: "resolved" } } });
+      const second = await service.generateResolvedManifest({ sdl, secrets: { web: { TOKEN: "resolved" } } });
 
       expect(versionOf(first)).toEqual(versionOf(second));
     });
@@ -631,7 +631,7 @@ describe(SdlService.name, () => {
     it("returns errors for an unrecognized kind", async () => {
       const { service } = setup();
 
-      const result = await service.generateResolvedManifest({ sdl: SDL_WITH_ENV("TOKEN=ac-var://TOKEN"), secrets: { TOKEN: "resolved" } });
+      const result = await service.generateResolvedManifest({ sdl: SDL_WITH_ENV("TOKEN=ac-var://TOKEN"), secrets: { web: { TOKEN: "resolved" } } });
 
       expect(errorsOf(result)[0].message).toContain("ac-var://TOKEN");
     });

--- a/apps/api/src/deployment/services/sdl/sdl.service.ts
+++ b/apps/api/src/deployment/services/sdl/sdl.service.ts
@@ -5,8 +5,8 @@ import { singleton } from "tsyringe";
 
 import { type BillingConfig, InjectBillingConfig } from "@src/billing/providers";
 import { BlockedGpuService } from "@src/deployment/services/blocked-gpu/blocked-gpu.service";
+import type { NamespacedSdlSecrets } from "@src/deployment/services/sdl-reference/sdl-reference.service";
 import { SdlReferenceService } from "@src/deployment/services/sdl-reference/sdl-reference.service";
-import type { SdlSecrets } from "@src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service";
 import { sdlRequestsGpuInterconnect } from "@src/deployment/utils/gpu-interconnect/gpu-interconnect";
 
 export type SdlParseResult = { ok: true; value: SDLInput } | { ok: false; value: ValidationError[] };
@@ -45,7 +45,7 @@ export class SdlService {
   }
 
   /** The only path that substitutes SDL References, and the only caller of the substitution walk, so a resolved manifest exists nowhere a caller has not asked for one. */
-  async generateResolvedManifest(input: { sdl: string; secrets: SdlSecrets; isTrialing?: boolean }): Promise<GenerateResolvedManifestResult> {
+  async generateResolvedManifest(input: { sdl: string; secrets: NamespacedSdlSecrets; isTrialing?: boolean }): Promise<GenerateResolvedManifestResult> {
     const parsed = this.parse(input.sdl);
 
     if (!parsed.ok) return parsed;

--- a/apps/api/test/functional/deployments.spec.ts
+++ b/apps/api/test/functional/deployments.spec.ts
@@ -872,7 +872,7 @@ describe("Deployments API", () => {
       const { userApiKeySecret } = await mockPersistedUser();
 
       const beforeRegistration = await postDeploymentWithEnv(userApiKeySecret, "MODE=ac-probe://MODE");
-      container.resolve(SdlReferenceService).register({ kind: "probe", resolve: name => `resolved-${name}` });
+      container.resolve(SdlReferenceService).register({ kind: "probe", resolve: ({ name }) => `resolved-${name}` });
       const afterRegistration = await postDeploymentWithEnv(userApiKeySecret, "MODE=ac-probe://MODE");
 
       expect(beforeRegistration.status).toBe(400);


### PR DESCRIPTION
## Why

Ref CON-861. Follow-up to #3707, which is now merged.

#3707 reserved the `ac-<kind>://<NAME>` SDL Reference scheme and resolved `ac-secret://NAME` from a
single flat name-to-value map for the whole deployment. That map cannot express what a real SDL
looks like: a deployment has several services, and two services can legitimately use the same
environment variable name for different values — `web` and `worker` both wanting `DATABASE_URL`,
pointing at a primary and a replica.

With one flat map they collide, and the collision is silent: whichever value is in the map wins for
every service that references the name. This slice makes the lookup namespaced by service so that
cannot happen.

## What

**References do not change.** An SDL still says `ac-secret://DATABASE_URL`. The namespace is applied
at lookup time only — the walk already knows which service it is in, because it builds
`/services/<name>/env/<index>` for error reporting. Nothing about the SDL, the wire format, export,
import or templating changes.

```
secrets = {
  web:    { DATABASE_URL: "primary-value" },
  worker: { DATABASE_URL: "replica-value" }
}

services.web.env    [ "DATABASE_URL=ac-secret://DATABASE_URL" ] -> primary-value
services.worker.env [ "DATABASE_URL=ac-secret://DATABASE_URL" ] -> replica-value
```

**Strict, with no fallback.** A reference in service `web` resolves only from `web`'s namespace. If
there is no value there it is a 400 naming both the service and the name, even if another service
supplies that same name. There is no shared namespace, no `"*"` key and no fallback chain — a
container either gets the value intended for it or the request fails.

The type composes on the existing wire shape rather than replacing it:
`NamespacedSdlSecrets = Record<serviceName, SdlSecrets>`. `SdlSecrets` and the unsealer are untouched.

### The registry's return contract is now enforced

`substitute` checks `typeof value !== "string"` rather than `value === undefined`, so **any**
registered resolver — including a future `ac-var://` one — cannot put a non-string into the SDL. A
resolver returning a number, an object or `null` is treated exactly as "no value": same error, same
code path, because a resolver that cannot produce a string has not resolved anything.

This closes a real hole at the extension point that #3707 created but did not guard: a
non-string return would previously have been template-stringified into a container as
`KEY=[object Object]`.

Two guards remain, addressing different hazards rather than duplicating one:

- the **namespace** guard refuses to index a non-object at all. Measured: a *function* namespace
  answers `ac-secret://name` with `""` — a genuine primitive string — so the seam check alone would
  substitute it.
- the **seam** guard enforces the registry contract for every resolver.

### Files

- `deployment/services/sdl-reference/sdl-reference.service.ts` — namespaced lookup, both guards, the error names the service
- `deployment/services/sdl-reference/sdl-reference.service.spec.ts`
- `deployment/services/sdl/sdl.service.ts` — `generateResolvedManifest` takes the nested map
- `deployment/services/sdl/sdl.service.spec.ts`
- `test/functional/deployments.spec.ts` — the test resolver's signature

`deployment-writer.service.ts` needed no change: it passes `{}`, a valid empty namespace map. No
schema change, no migration, no endpoint, no feature flag, no UI.

### Validation

| Check | Result |
| --- | --- |
| `npm test` (`apps/api`) | 242 files, **2986 passed** |
| `npm run lint -- --quiet` | clean |
| `npx tsc --noEmit` | 42 errors — identical set to `main`, zero introduced |

`apps/api` does not typecheck on `main`; 42 is the measured baseline, not a regression. Verified by running the full suite at `main` (242/242, 2972 tests) and then this branch on the same database state (242/242, 2986 tests) back-to-back. CI does not
run `tsc --noEmit` for this app (the build transpiles via tsup), which is why the baseline persists.

Both behaviours were checked by mutation rather than only by passing:

- **cross-namespace fallback added** → exactly one test fails, the strict-miss case. Note that
  "each service gets its own value" **passes** under fallback, which is why the strict-miss test
  had to exist.
- **namespaces flattened** → two fail, with `web` receiving `worker`'s value: the exact leak this
  slice prevents.
- **registry seam reverted** → all five non-string rows fail, plus the array-namespace row.

### ⚠️ Known divergence from PRD 0003

User story 5 — *"I want to reference the same secret from several services in one deployment, so
that I do not have to enter one credential per service"* — is **not satisfied** by strict
namespacing: a credential shared by five services must be supplied five times. Strict was chosen
deliberately over namespace-with-deployment-level-fallback. The PRD needs a decision: either story 5
is dropped, or a fallback layer is added later. Recorded here rather than resolved.

### Follow-ups

1. **The intake wire shape cannot express namespaces.** `SdlSecrets` is flat — one name to one value
   per deployment — while the resolver now needs per-service. There is no live gap today: nothing
   calls `SdlSecretsUnsealerService.open()` and the only caller passes `{}`. But the intake slice
   cannot proceed without deciding whether the sealed payload becomes nested, the client seals one
   blob per service, or the namespace arrives some other way.
2. **No aggregate cap on joined error messages.** One error is emitted per failing env entry and all
   are joined into one 400. Worst case measured at 0.54 MB from a 150 KB request, against 0.16 MB
   for the equivalent pre-slice — same order as behaviour predating this work, so not addressed here.
3. **The echo cap is applied per site by hand.** Three separate commits across this feature each
   introduced a new unbounded interpolation (the reference value, the `kind` group, the service
   name). All were caught, but the pattern suggests enforcing the bound once at error construction.

---

# CON-861 — SDL secrets are namespaced by service

*2026-09-01T16:43:04Z by Showboat 0.6.1*
<!-- showboat-id: d80c1491-b616-4886-98f2-457d08a625ed -->

Two services in one deployment can legitimately want different values for the same environment variable
name — `web` and `worker` both reading `DATABASE_URL`, pointing at a primary and a replica. Until now a
name resolved to one value for the whole deployment, so the second service silently got the first one's.

Lookup is now namespaced by service name: a reference in service `web` resolves only from `web`'s
namespace. **The SDL does not change** — it still says `ac-secret://DATABASE_URL`. Only the lookup knows
about services, because the env walk already knows which service it is walking.

Resolution is **strict**: no fallback, no shared namespace. A name present for one service and absent for
another is an error for the service that lacks it, which is why the message has to name the service.

Everything below runs the real production classes. All commands run from `apps/api`. `stderr` is dropped:
loading Hono's module graph outside a server prints one unrelated warning. Each script ends with a marker,
so a script that died shows up as missing output rather than as silence.

```bash
cat > .demo-lib.ts <<'TSEOF'
import "reflect-metadata";
import type { BillingConfig } from "./src/billing/providers";
import { BlockedGpuService } from "./src/deployment/services/blocked-gpu/blocked-gpu.service";
import { DeploymentWriterService } from "./src/deployment/services/deployment-writer/deployment-writer.service";
import { SdlReferenceService } from "./src/deployment/services/sdl-reference/sdl-reference.service";
import { SdlService } from "./src/deployment/services/sdl/sdl.service";

export const sdlReferences = new SdlReferenceService();
const billingConfig = { DEPLOYMENT_GRANT_DENOM: "uakt", MANAGED_WALLET_LEASE_ALLOWED_AUDITORS: [] } as BillingConfig;
export const sdlService = new SdlService(billingConfig, new BlockedGpuService({ get: () => [] } as never), sdlReferences);

const none = undefined as never;
const walletReader = { getWalletByUserId: async () => ({ userId: "demo-user", address: "akash1demo", isTrialing: false }) } as never;
const quietLogger = (() => ({ info() {}, warn() {}, error() {} })) as never;

export const writer = new DeploymentWriterService(
  none, none, sdlService, none, none, none, walletReader, none, quietLogger, none, none, none, none, none
);

export function sdlWithServices(services: Record<string, string[]>) {
  const names = Object.keys(services);
  const body = names
    .map(name => `  ${name}:\n    image: nginx\n    env:\n${services[name].map(entry => `      - ${JSON.stringify(entry)}`).join("\n")}\n`)
    .join("");
  const compute = names.map(name => `    ${name}:\n      resources:\n        cpu: { units: 0.5 }\n        memory: { size: 512Mi }\n        storage: { size: 512Mi }\n`).join("");
  const pricing = names.map(name => `          ${name}: { denom: uakt, amount: 1000 }`).join("\n");
  const deployment = names.map(name => `  ${name}:\n    westcoast: { profile: ${name}, count: 1 }\n`).join("");

  return `version: "2.0"
services:
${body}profiles:
  compute:
${compute}  placement:
    westcoast:
      pricing:
${pricing}
deployment:
${deployment}`;
}

export function manifestServices(result: unknown) {
  return (result as { value: { manifest: { groups: { services: { name: string; env: string[] }[] }[] } } }).value.manifest.groups[0].services;
}

export function errorsOf(result: unknown) {
  return (result as { value: { message: string; instancePath: string }[] }).value;
}
TSEOF
echo "wiring written to .demo-lib.ts"

```

```output
wiring written to .demo-lib.ts
```

## The same name, two services, two values

Both services reference `ac-secret://DATABASE_URL` — the identical SDL text. Each receives its own
namespace's value, and the manifest that goes to the provider carries them per service.

```bash
cat > .demo-run.ts <<'TSEOF'
import { manifestServices, sdlService, sdlWithServices } from "./.demo-lib";

void (async () => {
  const sdl = sdlWithServices({ web: ["DATABASE_URL=ac-secret://DATABASE_URL"], worker: ["DATABASE_URL=ac-secret://DATABASE_URL"] });
  console.log("both services declare the identical entry:", JSON.stringify("DATABASE_URL=ac-secret://DATABASE_URL"));

  const result = await sdlService.generateResolvedManifest({
    sdl,
    secrets: { web: { DATABASE_URL: "PRIMARY-FOR-WEB" }, worker: { DATABASE_URL: "REPLICA-FOR-WORKER" } }
  });

  console.log("accepted:", result.ok);
  for (const service of manifestServices(result)) console.log(`  ${service.name.padEnd(7)} -> ${JSON.stringify(service.env)}`);
  console.log("[done]");
})();
TSEOF
../../node_modules/.bin/tsx .demo-run.ts 2>/dev/null

```

```output
both services declare the identical entry: "DATABASE_URL=ac-secret://DATABASE_URL"
accepted: true
  web     -> ["DATABASE_URL=PRIMARY-FOR-WEB"]
  worker  -> ["DATABASE_URL=REPLICA-FOR-WORKER"]
[done]
```

## Strict: a name one service has and another lacks

This is the case that separates strict lookup from a fallback. Only `web` supplies `DATABASE_URL`. Under a
fallback, `worker` would quietly receive `web`'s value — a worker pointed at the primary database by
accident. Strict lookup refuses, names `worker`, and leaves `worker`'s entry as the unresolved reference.

```bash
cat > .demo-run.ts <<'TSEOF'
import { errorsOf, sdlReferences, sdlService, sdlWithServices } from "./.demo-lib";

const parsedOf = (result: unknown) => (result as { value: { services: Record<string, { env: string[] }> } }).value;

void (async () => {
  const sdl = sdlWithServices({ web: ["DATABASE_URL=ac-secret://DATABASE_URL"], worker: ["DATABASE_URL=ac-secret://DATABASE_URL"] });
  const secrets = { web: { DATABASE_URL: "PRIMARY-FOR-WEB" } };

  const result = await sdlService.generateResolvedManifest({ sdl, secrets });
  console.log("accepted:", result.ok, "| a manifest came back:", "manifest" in (result.value as object));
  for (const error of errorsOf(result)) console.log(`  ${error.instancePath}  ${error.message}`);

  const parsed = parsedOf(sdlService.parse(sdl));
  sdlReferences.substitute(parsed as never, { secrets });
  console.log("on the parsed document after the failed run:");
  for (const name of ["web", "worker"]) console.log(`  ${name.padEnd(7)} -> ${JSON.stringify(parsed.services[name].env)}`);
  console.log("[done]");
})();
TSEOF
../../node_modules/.bin/tsx .demo-run.ts 2>/dev/null

```

```output
accepted: false | a manifest came back: false
  /services/worker/env/0  no value supplied for SDL Reference "ac-secret://DATABASE_URL" in service "worker"
on the parsed document after the failed run:
  web     -> ["DATABASE_URL=PRIMARY-FOR-WEB"]
  worker  -> ["DATABASE_URL=ac-secret://DATABASE_URL"]
[done]
```

## What a client sees

The deploy path names the service in the 400 it returns, so a user with five services is told which one is
missing a value rather than being handed a bare name. The writer still passes an empty map — no request
field carries secret values yet, which is the intake slice — so every reference is missing and each service
is named separately.

```bash
cat > .demo-run.ts <<'TSEOF'
import { sdlWithServices, writer } from "./.demo-lib";

void (async () => {
  const sdl = sdlWithServices({ web: ["DATABASE_URL=ac-secret://DATABASE_URL"], worker: ["DATABASE_URL=ac-secret://DATABASE_URL"] });

  await writer
    .create({ userId: "demo-user", sdl, deposit: 5 })
    .then(() => console.log("ACCEPTED"))
    .catch((error: { status?: number; message: string }) => {
      console.log(`HTTP ${error.status}`);
      for (const part of error.message.split(", ")) console.log(`  ${part}`);
    });
  console.log("[done]");
})();
TSEOF
../../node_modules/.bin/tsx .demo-run.ts 2>/dev/null

```

```output
HTTP 400
  Invalid SDL: no value supplied for SDL Reference "ac-secret://DATABASE_URL" in service "web"
  no value supplied for SDL Reference "ac-secret://DATABASE_URL" in service "worker"
[done]
```

## A service name is a map key, and map keys are hazardous

Nesting by service name means an untrusted string indexes an object. A service called `constructor` or
`__proto__` would find an inherited member on a bare lookup and substitute `[object Object]` into a
container. Both the service-name lookup and the name lookup inside it check own-property first, so such a
service resolves to nothing and is reported like any other missing value.

```bash
cat > .demo-run.ts <<'TSEOF'
import { errorsOf, sdlService, sdlWithServices } from "./.demo-lib";

void (async () => {
  for (const serviceName of ["constructor", "__proto__", "toString"]) {
    const sdl = sdlWithServices({ [serviceName]: ["TOKEN=ac-secret://TOKEN"] });
    const result = await sdlService.generateResolvedManifest({ sdl, secrets: {} });
    console.log(`service ${JSON.stringify(serviceName).padEnd(13)} -> ${errorsOf(result)[0].message}`);
  }

  const inherited = sdlWithServices({ constructor: ["TOKEN=ac-secret://toString"] });
  const result = await sdlService.generateResolvedManifest({ sdl: inherited, secrets: { constructor: {} } });
  console.log(`a name spelling a prototype member -> ${errorsOf(result)[0].message}`);
  console.log("[done]");
})();
TSEOF
../../node_modules/.bin/tsx .demo-run.ts 2>/dev/null

```

```output
service "constructor" -> no value supplied for SDL Reference "ac-secret://TOKEN" in service "constructor"
service "__proto__"   -> no value supplied for SDL Reference "ac-secret://TOKEN" in service "__proto__"
service "toString"    -> no value supplied for SDL Reference "ac-secret://TOKEN" in service "toString"
a name spelling a prototype member -> no value supplied for SDL Reference "ac-secret://toString" in service "constructor"
[done]
```

The demo's scratch files are removed so the working tree is left exactly as the commit found it.

```bash
rm -f .demo-lib.ts .demo-run.ts
ls .demo-lib.ts .demo-run.ts 2>/dev/null | wc -l | tr -d ' '
echo "[scratch files remaining: see count above]"

```

```output
0
[scratch files remaining: see count above]
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Secret references now support service-specific namespaces, allowing each service to resolve its own secret values independently.
  - Resolution errors provide clearer service context while safely limiting echoed input.
  - Manifest generation and hashing now consistently use namespaced secrets for reliable, service-aware results.

- **Bug Fixes**
  - Improved handling of missing or invalid secret namespaces, unsafe service names, oversized names, and non-string values.
  - Updated deployment resolution behavior to correctly process service-specific secret references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->