### PR TITLE
fix(observability): bound the response caches by bytes, not entry count

### DIFF
--- a/apps/api/src/caching/memoryCacheEngine.spec.ts
+++ b/apps/api/src/caching/memoryCacheEngine.spec.ts
@@ -241,6 +241,22 @@ describe(MemoryCacheEngine.name, () => {
       expect(engine.getFromCache("small")).toBe("kept");
     });
 
+    it("accepts a Buffer entry whose binary length is within maxEntryBytes", () => {
+      const engine = new MemoryCacheEngine({ maxTotalBytes: 8000, maxEntryBytes: 1500 });
+
+      engine.storeInCache("binary", { payload: Buffer.alloc(1024) });
+
+      expect(engine.getFromCache("binary")).toEqual({ payload: Buffer.alloc(1024) });
+    });
+
+    it("refuses a multi-byte string whose UTF-8 size exceeds maxEntryBytes", () => {
+      const engine = new MemoryCacheEngine({ maxTotalBytes: 8000, maxEntryBytes: 2000 });
+
+      engine.storeInCache("multibyte", { text: "\u20ac".repeat(1000) });
+
+      expect(engine.getFromCache("multibyte")).toBeUndefined();
+    });
+
     it("stores entries within both budgets", () => {
       const engine = new MemoryCacheEngine({ maxTotalBytes: 1000, maxEntryBytes: 500 });
 
@@ -260,6 +276,19 @@ describe(MemoryCacheEngine.name, () => {
 
       expect(size).toBeGreaterThanOrEqual(1000);
       expect(size).toBeLessThan(2000);
+    });
+
+    it("counts Buffer payloads by binary length rather than their JSON expansion", () => {
+      const size = estimateEntryBytes({ data: Buffer.alloc(1000) });
+
+      expect(size).toBeGreaterThanOrEqual(1000);
+      expect(size).toBeLessThan(2000);
+    });
+
+    it("measures multi-byte characters as UTF-8 bytes rather than UTF-16 code units", () => {
+      const text = "\u20ac".repeat(1000);
+
+      expect(estimateEntryBytes({ text })).toBeGreaterThan(3000);
     });
 
     it("serializes bigint values instead of throwing", () => {

--- a/apps/api/src/caching/memoryCacheEngine.spec.ts
+++ b/apps/api/src/caching/memoryCacheEngine.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import MemoryCacheEngine from "./memoryCacheEngine";
+import MemoryCacheEngine, { estimateEntryBytes } from "./memoryCacheEngine";
 
 describe(MemoryCacheEngine.name, () => {
   describe("getFromCache", () => {
@@ -215,6 +215,62 @@ describe(MemoryCacheEngine.name, () => {
 
       expect(engine.getFromCache("shared")).toBeUndefined();
       expect(privateEngine.getFromCache("private")).toBeUndefined();
+    });
+  });
+
+  describe("size bounding", () => {
+    it("evicts least-recently-used entries when total bytes exceed maxTotalBytes", () => {
+      const engine = new MemoryCacheEngine({ maxTotalBytes: 250, maxEntryBytes: 250 });
+
+      engine.storeInCache("first", "x".repeat(100));
+      engine.storeInCache("second", "y".repeat(100));
+      engine.storeInCache("third", "z".repeat(100));
+
+      expect(engine.getFromCache("first")).toBeUndefined();
+      expect(engine.getFromCache("second")).toBe("y".repeat(100));
+      expect(engine.getFromCache("third")).toBe("z".repeat(100));
+    });
+
+    it("refuses a single entry larger than maxEntryBytes without evicting others", () => {
+      const engine = new MemoryCacheEngine({ maxTotalBytes: 1000, maxEntryBytes: 100 });
+
+      engine.storeInCache("small", "kept");
+      engine.storeInCache("huge", "x".repeat(500));
+
+      expect(engine.getFromCache("huge")).toBeUndefined();
+      expect(engine.getFromCache("small")).toBe("kept");
+    });
+
+    it("stores entries within both budgets", () => {
+      const engine = new MemoryCacheEngine({ maxTotalBytes: 1000, maxEntryBytes: 500 });
+
+      engine.storeInCache("fits", { data: "payload" });
+
+      expect(engine.getFromCache("fits")).toEqual({ data: "payload" });
+    });
+  });
+
+  describe(estimateEntryBytes.name, () => {
+    it("measures plain values by their JSON length", () => {
+      expect(estimateEntryBytes({ a: 1 })).toBe(JSON.stringify({ a: 1 }).length + 1);
+    });
+
+    it("counts binary payloads by byte length instead of JSON-inflating them", () => {
+      const size = estimateEntryBytes({ data: new Uint8Array(1000) });
+
+      expect(size).toBeGreaterThanOrEqual(1000);
+      expect(size).toBeLessThan(2000);
+    });
+
+    it("serializes bigint values instead of throwing", () => {
+      expect(estimateEntryBytes({ amount: 10n })).toBeGreaterThan(0);
+    });
+
+    it("returns an uncacheable size for circular values", () => {
+      const circular: { self?: unknown } = {};
+      circular.self = circular;
+
+      expect(estimateEntryBytes(circular)).toBe(Number.MAX_SAFE_INTEGER);
     });
   });
 

--- a/apps/api/src/caching/memoryCacheEngine.ts
+++ b/apps/api/src/caching/memoryCacheEngine.ts
@@ -15,17 +15,19 @@ const DEFAULT_LIMITS = {
   maxEntryBytes: 16 * 1024 * 1024
 } satisfies Required<CacheLimits>;
 
+/** Reads the holder instead of the replacer's argument because Buffer.toJSON has already expanded binary into `{ type, data }` by the time a replacer runs. */
 export function estimateEntryBytes(value: CacheValue): number {
   let binaryBytes = 0;
   try {
-    const json = JSON.stringify(value, (_key, nested) => {
-      if (nested instanceof Uint8Array) {
-        binaryBytes += nested.byteLength;
+    const json = JSON.stringify(value, function countBinaryOnce(this: Record<string, unknown>, key: string, nested: unknown) {
+      const beforeToJson = this[key];
+      if (beforeToJson instanceof Uint8Array) {
+        binaryBytes += beforeToJson.byteLength;
         return undefined;
       }
       return typeof nested === "bigint" ? nested.toString() : nested;
     });
-    return (json?.length ?? 0) + binaryBytes + 1;
+    return Buffer.byteLength(json ?? "", "utf8") + binaryBytes + 1;
   } catch {
     return Number.MAX_SAFE_INTEGER;
   }

--- a/apps/api/src/caching/memoryCacheEngine.ts
+++ b/apps/api/src/caching/memoryCacheEngine.ts
@@ -1,17 +1,55 @@
 import { LRUCache } from "lru-cache";
 
 export type CacheValue = NonNullable<unknown>;
-const SHARED_MAX_ENTRIES = 500;
-const sharedCache = new LRUCache<string, CacheValue>({ max: SHARED_MAX_ENTRIES });
+
+export interface CacheLimits {
+  maxEntries?: number;
+  maxTotalBytes?: number;
+  maxEntryBytes?: number;
+}
+
+/** Bounding by entry count alone let multi-MB cached responses exhaust the 2GB V8 heap on 2026-09-01; bytes are the limit that matters. */
+const DEFAULT_LIMITS = {
+  maxEntries: 500,
+  maxTotalBytes: 256 * 1024 * 1024,
+  maxEntryBytes: 16 * 1024 * 1024
+} satisfies Required<CacheLimits>;
+
+export function estimateEntryBytes(value: CacheValue): number {
+  let binaryBytes = 0;
+  try {
+    const json = JSON.stringify(value, (_key, nested) => {
+      if (nested instanceof Uint8Array) {
+        binaryBytes += nested.byteLength;
+        return undefined;
+      }
+      return typeof nested === "bigint" ? nested.toString() : nested;
+    });
+    return (json?.length ?? 0) + binaryBytes + 1;
+  } catch {
+    return Number.MAX_SAFE_INTEGER;
+  }
+}
+
+function createBoundedCache(limits?: CacheLimits) {
+  return new LRUCache<string, CacheValue>({
+    max: limits?.maxEntries ?? DEFAULT_LIMITS.maxEntries,
+    maxSize: limits?.maxTotalBytes ?? DEFAULT_LIMITS.maxTotalBytes,
+    maxEntrySize: limits?.maxEntryBytes ?? DEFAULT_LIMITS.maxEntryBytes,
+    sizeCalculation: estimateEntryBytes
+  });
+}
+
+const sharedCache = createBoundedCache();
 const allCaches = new Set<LRUCache<string, CacheValue>>([sharedCache]);
 
 export default class MemoryCacheEngine {
   readonly #cache: LRUCache<string, CacheValue>;
 
-  /** Passing `maxEntries` gives the engine a private cache, so a high-cardinality key space cannot evict every other memoized response out of the shared one. */
-  constructor(options?: { maxEntries: number }) {
+  /** Passing limits gives the engine a private cache, so a high-cardinality key space cannot evict every other memoized response out of the shared one. */
+  constructor(options?: CacheLimits) {
     if (options) {
-      this.#cache = new LRUCache<string, CacheValue>({ max: options.maxEntries });
+      this.#cache = createBoundedCache(options);
       allCaches.add(this.#cache);
     } else {
       this.#cache = sharedCache;


### PR DESCRIPTION
## Why

Heap-snapshot diffing on the prod api pods (Sep 1 OOM incident) showed the growth concentrated in the shared memoize `LRUCache #valList`: 27.5MB of 47MB new heap in a 39-minute window, keyed almost entirely by `DeploymentReaderService#getDeploymentByOwnerAndDseq` for the scanner's owner. The cache caps entries (500) but not bytes, so heavyweight responses accumulate toward the V8 ceiling and plateau there. #3753 already thins the worst values and isolates the unbounded key space; this bounds the memory itself so no response shape can regrow the problem.

## What

- `MemoryCacheEngine` caches (shared and private) are now `maxSize`-bounded: 256MB total, 16MB per entry, on top of the existing entry caps.
- Entry sizes come from `estimateEntryBytes`: JSON length, with `Uint8Array` payloads (the gzipped provider lists) counted at byte length instead of JSON-inflated, bigints serialized instead of throwing, and unserializable (circular) values priced at `MAX_SAFE_INTEGER` so they are served uncached rather than stored unmeasured.
- The `constructor({ maxEntries })` private-cache API from #3753 is unchanged; it now accepts the byte limits too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Memory caching now supports limits based on total storage size and individual entry size.
  * Custom cache limits can be configured alongside entry-count limits.
  * Cache entries accurately account for binary data, multibyte text, and large numeric values.

* **Bug Fixes**
  * Oversized or unsupported entries are safely rejected without removing existing cached data.
  * Cache size calculations now handle serialization failures and circular values safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->