### PR TITLE
feat(notifications): brand the transactional email layout

### DIFF
--- a/apps/notifications/env/.env
+++ b/apps/notifications/env/.env
@@ -1,2 +1,2 @@
 APP_NAME=notifications
-NOVU_MAILER_WORKFLOW_ID=generic-v2
+NOVU_MAILER_WORKFLOW_ID=transactional-mailer

--- a/apps/notifications/src/modules/notifications/services/email-sender/email-layout.spec.ts
+++ b/apps/notifications/src/modules/notifications/services/email-sender/email-layout.spec.ts
@@ -1,0 +1,51 @@
+import { faker } from "@faker-js/faker";
+import { describe, expect, it } from "vitest";
+
+import { renderEmailLayout } from "./email-layout";
+
+describe(renderEmailLayout.name, () => {
+  it("renders a complete html document", () => {
+    const { html } = setup({});
+    expect(html).toContain("<!DOCTYPE html>");
+    expect(html).toContain("</html>");
+  });
+
+  it("renders both logo variants for light and dark mode", () => {
+    const { html } = setup({});
+    expect(html).toContain("https://console-cdn.akash.network/akashconsole-light.png");
+    expect(html).toContain("https://console-cdn.akash.network/akashconsole-dark.svg");
+    expect(html).toContain("@media (prefers-color-scheme: dark)");
+  });
+
+  it("renders the subject as the title and headline", () => {
+    const subject = "Your Akash account was recharged $25.00";
+    const { html } = setup({ subject });
+    expect(html).toContain(`<title>${subject}</title>`);
+    expect(html).toContain(`>${subject}</h1>`);
+  });
+
+  it("escapes html in the subject", () => {
+    const { html } = setup({ subject: "<script>alert(1)</script>" });
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+  });
+
+  it("embeds the content without re-escaping it", () => {
+    const content = 'Balance is <strong>$5.00</strong>. <a href="https://console.akash.network/billing">Add credits</a>.';
+    const { html } = setup({ content });
+    expect(html).toContain(content);
+  });
+
+  it("renders the footer", () => {
+    const { html } = setup({});
+    expect(html).toContain("Sent by Akash Console. You're receiving this because you have an Akash Console account.");
+  });
+
+  function setup(input: { subject?: string; content?: string }) {
+    const html = renderEmailLayout({
+      subject: input.subject ?? faker.lorem.sentence(),
+      content: input.content ?? faker.lorem.paragraph()
+    });
+    return { html };
+  }
+});

--- a/apps/notifications/src/modules/notifications/services/email-sender/email-layout.ts
+++ b/apps/notifications/src/modules/notifications/services/email-sender/email-layout.ts
@@ -1,0 +1,57 @@
+import escape from "lodash/escape";
+
+const LOGO_LIGHT_URL = "https://console-cdn.akash.network/akashconsole-light.png";
+const LOGO_DARK_URL = "https://console-cdn.akash.network/akashconsole-dark.svg";
+
+/** The subject is user-controlled for alert emails, so it is escaped; content must already be sanitized by the caller. */
+export function renderEmailLayout({ subject, content }: { subject: string; content: string }): string {
+  const escapedSubject = escape(subject);
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="color-scheme" content="light dark" />
+  <meta name="supported-color-schemes" content="light dark" />
+  <title>${escapedSubject}</title>
+  <style>
+    body { margin: 0; padding: 0; background-color: #f0f0f1; }
+    a { color: #52525b; }
+    .logo-dark { display: none; }
+    @media (prefers-color-scheme: dark) {
+      body, .outer { background-color: #0a0a0a !important; }
+      .card { background-color: #141414 !important; border-color: #27272a !important; }
+      .card-footer { background-color: #101010 !important; border-color: #27272a !important; }
+      .header-border { border-color: #27272a !important; }
+      .heading { color: #fafafa !important; }
+      .body-text { color: #d4d4d8 !important; }
+      .body-text strong { color: #fafafa !important; }
+      .muted, .footer-text { color: #a1a1aa !important; }
+      .logo-light { display: none !important; }
+      .logo-dark { display: inline-block !important; }
+    }
+  </style>
+</head>
+<body class="outer" style="margin:0;padding:0;background-color:#f0f0f1;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" class="outer" style="background-color:#f0f0f1;">
+    <tr><td align="center" style="padding:40px 16px;">
+      <table role="presentation" width="600" cellpadding="0" cellspacing="0" class="card" style="max-width:600px;width:100%;background-color:#ffffff;border:1px solid #e4e4e7;border-radius:12px;overflow:hidden;">
+        <tr><td class="header-border" style="padding:24px 40px;border-bottom:1px solid #f0f0f1;">
+          <img src="${LOGO_LIGHT_URL}" alt="Akash Console" width="170" height="19" class="logo-light" style="display:inline-block;border:0;" />
+          <img src="${LOGO_DARK_URL}" alt="Akash Console" width="170" height="19" class="logo-dark" style="display:none;border:0;" />
+        </td></tr>
+        <tr><td style="padding:36px 40px;">
+          <h1 class="heading" style="margin:0 0 24px 0;font-size:24px;line-height:1.3;font-weight:700;color:#18181b;">${escapedSubject}</h1>
+          <div class="body-text" style="font-size:16px;line-height:1.65;color:#3f3f46;">${content}</div>
+        </td></tr>
+        <tr><td class="card-footer" style="padding:24px 40px;background-color:#fafafa;border-top:1px solid #f0f0f1;">
+          <p class="muted" style="margin:0 0 12px 0;font-size:11px;letter-spacing:2px;text-transform:uppercase;color:#a1a1aa;font-family:'SF Mono',Menlo,Consolas,monospace;">Akash &middot; The Open Compute Marketplace</p>
+          <p class="footer-text" style="margin:0;font-size:13px;line-height:1.6;color:#71717a;">Sent by Akash Console. You're receiving this because you have an Akash Console account.</p>
+        </td></tr>
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>`;
+}

--- a/apps/notifications/src/modules/notifications/services/email-sender/email-sender.service.spec.ts
+++ b/apps/notifications/src/modules/notifications/services/email-sender/email-sender.service.spec.ts
@@ -38,7 +38,7 @@ describe(EmailSenderService.name, () => {
         },
         payload: {
           subject: params.subject,
-          content: params.content
+          content: expect.stringContaining(params.content)
         },
         overrides: {
           email: {
@@ -46,6 +46,22 @@ describe(EmailSenderService.name, () => {
           }
         }
       });
+    });
+
+    it("wraps the content in the branded layout document", async () => {
+      const { service, novu } = await setup();
+      const content = faker.lorem.paragraph();
+
+      await service.send({
+        addresses: [faker.internet.email()],
+        subject: faker.lorem.sentence(),
+        content,
+        userId: faker.string.uuid()
+      });
+
+      const sentContent = novu.trigger.mock.calls[0][0].payload?.content as string;
+      expect(sentContent).toContain("<!DOCTYPE html>");
+      expect(sentContent).toContain(content);
     });
 
     it("sends to every address while addressing the first one as the subscriber", async () => {
@@ -108,17 +124,13 @@ describe(EmailSenderService.name, () => {
       await service.send({
         addresses: [faker.internet.email()],
         subject: faker.lorem.sentence(),
-        content: '<script>alert(1)</script><strong>keep</strong><a href="https://akash.network">link</a>',
+        content: '<script>alert(1)</script><p>keep</p><strong>keep</strong><a href="https://akash.network">link</a>',
         userId: faker.string.uuid()
       });
 
-      expect(novu.trigger).toHaveBeenCalledWith(
-        expect.objectContaining({
-          payload: expect.objectContaining({
-            content: '<strong>keep</strong><a href="https://akash.network">link</a>'
-          })
-        })
-      );
+      const sentContent = novu.trigger.mock.calls[0][0].payload?.content as string;
+      expect(sentContent).toContain('<p>keep</p><strong>keep</strong><a href="https://akash.network">link</a>');
+      expect(sentContent).not.toContain("<script>");
     });
   });
 

--- a/apps/notifications/src/modules/notifications/services/email-sender/email-sender.service.ts
+++ b/apps/notifications/src/modules/notifications/services/email-sender/email-sender.service.ts
@@ -6,6 +6,7 @@ import sanitizeHtml from "sanitize-html";
 import { LoggerService } from "@src/common/services/logger/logger.service";
 import { Namespaced } from "@src/lib/types/namespaced-config.type";
 import { NotificationEnvConfig } from "@src/modules/notifications/config/env.config";
+import { renderEmailLayout } from "./email-layout";
 
 type EmailSendOptions = {
   addresses: string[];
@@ -34,11 +35,14 @@ export class EmailSenderService {
       },
       payload: {
         subject,
-        content: sanitizeHtml(content, {
-          allowedTags: ["a", "strong"],
-          allowedAttributes: {
-            a: ["href"]
-          }
+        content: renderEmailLayout({
+          subject,
+          content: sanitizeHtml(content, {
+            allowedTags: ["a", "strong", "p", "br"],
+            allowedAttributes: {
+              a: ["href"]
+            }
+          })
         })
       },
       overrides: {


### PR DESCRIPTION
## Why

Every Console email still goes out in the old red-banner shell, which lives as an unversioned customHtml template in the Novu dashboard. For the funding-changes announcement we designed a new branded layout (logo header with dark-mode variant, headline, styled body, plain footer), but it only existed in a one-off script. This PR makes that layout the shell for all transactional emails and moves ownership of the design into the repo, where it gets reviewed and tested.

## What

- New `renderEmailLayout({ subject, content })` in `email-layout.ts`: renders the complete HTML document around a sanitized body. The subject doubles as the headline and is HTML-escaped, since alert summaries are user-written free text. Logos load from console-cdn.akash.network, with a dark variant behind `prefers-color-scheme: dark`.
- `EmailSenderService` sanitizes the caller's content first (allowlist extended with `p` and `br` so templates can write paragraphs), then wraps it in the layout. Everything else (recipients, overrides, `EMAIL_SENT` log) is unchanged.
- `NOVU_MAILER_WORKFLOW_ID` now points at `transactional-mailer`, a new passthrough Novu workflow (subject `{{subject}}`, body `{{{content}}}`) created alongside this PR. The old `generic-v2` workflow is untouched, so rollback is reverting the env line. Shipping the id flip and the wrapping code together means no deploy window with nested or unstyled emails.

No changes needed in apps/api: all notification templates keep producing `{ summary, description }` fragments and inherit the design.

Verified with the unit and functional suites, plus a real email sent through `transactional-mailer` using `renderEmailLayout` with the credits-running-low body.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added branded, responsive email layouts with light/dark logos, dark-mode support, escaped subjects, footer text, and Akash Console branding.
  * Preserved safe paragraph and line-break formatting in notification emails.
  * Updated the mailer workflow configuration for transactional emails.

* **Bug Fixes**
  * Improved email content wrapping and sanitization while continuing to remove unsafe script markup.

* **Tests**
  * Added coverage for layout rendering, branding, escaping, themes, footers, and default handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->