### PR TITLE
fix(billing): pause auto top-up after repeated card declines

### DIFF
--- a/apps/api/drizzle/0049_auto_top_up_decline_pause.sql
+++ b/apps/api/drizzle/0049_auto_top_up_decline_pause.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "wallet_settings" ADD COLUMN "auto_reload_failure_count" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE "wallet_settings" ADD COLUMN "auto_reload_paused_at" timestamp with time zone;

--- a/apps/api/drizzle/meta/0049_snapshot.json
+++ b/apps/api/drizzle/meta/0049_snapshot.json
@@ -1,0 +1,1571 @@
+{
+  "id": "02b235d4-0ed8-42f8-afd5-51982c078331",
+  "prevId": "8114c78d-af79-41a0-a267-7d857eba086d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.user_wallets": {
+      "name": "user_wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_allowance": {
+          "name": "deployment_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "fee_allowance": {
+          "name": "fee_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "trial": {
+          "name": "trial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits_low_notified_at": {
+          "name": "credits_low_notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits_sufficient_since": {
+          "name": "credits_sufficient_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits_low_since": {
+          "name": "credits_low_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_wallets_user_id_userSetting_id_fk": {
+          "name": "user_wallets_user_id_userSetting_id_fk",
+          "tableFrom": "user_wallets",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_wallets_user_id_unique": {
+          "name": "user_wallets_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "user_wallets_address_unique": {
+          "name": "user_wallets_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_methods": {
+      "name": "payment_methods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_method_id": {
+          "name": "payment_method_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_validated": {
+          "name": "is_validated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payment_methods_fingerprint_payment_method_id_unique": {
+          "name": "payment_methods_fingerprint_payment_method_id_unique",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_default_unique": {
+          "name": "payment_methods_user_id_is_default_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"payment_methods\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_fingerprint_idx": {
+          "name": "payment_methods_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_idx": {
+          "name": "payment_methods_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_validated_idx": {
+          "name": "payment_methods_user_id_is_validated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_validated",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_fingerprint_payment_method_id_idx": {
+          "name": "payment_methods_user_id_fingerprint_payment_method_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_methods_user_id_userSetting_id_fk": {
+          "name": "payment_methods_user_id_userSetting_id_fk",
+          "tableFrom": "payment_methods",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_transactions": {
+      "name": "stripe_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "stripe_transaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "stripe_transaction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created'"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_refunded": {
+          "name": "amount_refunded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bonus_amount": {
+          "name": "bonus_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_charge_id": {
+          "name": "stripe_charge_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_coupon_id": {
+          "name": "stripe_coupon_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_promotion_code_id": {
+          "name": "stripe_promotion_code_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_idempotency_key": {
+          "name": "stripe_idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method_type": {
+          "name": "payment_method_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_brand": {
+          "name": "card_brand",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_last4": {
+          "name": "card_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_url": {
+          "name": "receipt_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_transactions_stripe_invoice_id_unique": {
+          "name": "stripe_transactions_stripe_invoice_id_unique",
+          "columns": [
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stripe_transactions\".\"stripe_invoice_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_idempotency_key_unique": {
+          "name": "stripe_transactions_stripe_idempotency_key_unique",
+          "columns": [
+            {
+              "expression": "stripe_idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stripe_transactions\".\"stripe_idempotency_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_user_id_idx": {
+          "name": "stripe_transactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_payment_intent_id_idx": {
+          "name": "stripe_transactions_stripe_payment_intent_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_payment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_charge_id_idx": {
+          "name": "stripe_transactions_stripe_charge_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_coupon_id_idx": {
+          "name": "stripe_transactions_stripe_coupon_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_coupon_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_promotion_code_id_idx": {
+          "name": "stripe_transactions_stripe_promotion_code_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_promotion_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_status_idx": {
+          "name": "stripe_transactions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_created_at_idx": {
+          "name": "stripe_transactions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_user_id_created_at_idx": {
+          "name": "stripe_transactions_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_transactions_user_id_userSetting_id_fk": {
+          "name": "stripe_transactions_user_id_userSetting_id_fk",
+          "tableFrom": "stripe_transactions",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_settings": {
+      "name": "wallet_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_reload_enabled": {
+          "name": "auto_reload_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_reload_mode": {
+          "name": "auto_reload_mode",
+          "type": "auto_reload_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'prediction'"
+        },
+        "auto_reload_threshold": {
+          "name": "auto_reload_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2000
+        },
+        "auto_reload_amount": {
+          "name": "auto_reload_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10000
+        },
+        "last_auto_charge_at": {
+          "name": "last_auto_charge_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_reload_failure_count": {
+          "name": "auto_reload_failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "auto_reload_paused_at": {
+          "name": "auto_reload_paused_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_settings_user_id_idx": {
+          "name": "wallet_settings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_settings_wallet_id_user_wallets_id_fk": {
+          "name": "wallet_settings_wallet_id_user_wallets_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "user_wallets",
+          "columnsFrom": [
+            "wallet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wallet_settings_user_id_userSetting_id_fk": {
+          "name": "wallet_settings_user_id_userSetting_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallet_settings_wallet_id_unique": {
+          "name": "wallet_settings_wallet_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wallet_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.userSetting": {
+      "name": "userSetting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscribedToNewsletter": {
+          "name": "subscribedToNewsletter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "youtubeUsername": {
+          "name": "youtubeUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitterUsername": {
+          "name": "twitterUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "githubUsername": {
+          "name": "githubUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_ip": {
+          "name": "last_ip",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_user_agent": {
+          "name": "last_user_agent",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fingerprint": {
+          "name": "last_fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboardingSkippedAt": {
+          "name": "onboardingSkippedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "userSetting_userId_unique": {
+          "name": "userSetting_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        },
+        "userSetting_username_unique": {
+          "name": "userSetting_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.template": {
+      "name": "template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "copiedFromId": {
+          "name": "copiedFromId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cpu": {
+          "name": "cpu",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ram": {
+          "name": "ram",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage": {
+          "name": "storage",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sdl": {
+          "name": "sdl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "template_userId_idx": {
+          "name": "template_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.templateFavorite": {
+      "name": "templateFavorite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "templateId": {
+          "name": "templateId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addedDate": {
+          "name": "addedDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "templateFavorite_userId_templateId_unique": {
+          "name": "templateFavorite_userId_templateId_unique",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "templateId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "templateFavorite_templateId_template_id_fk": {
+          "name": "templateFavorite_templateId_template_id_fk",
+          "tableFrom": "templateFavorite",
+          "tableTo": "template",
+          "columnsFrom": [
+            "templateId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_settings": {
+      "name": "deployment_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dseq": {
+          "name": "dseq",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_top_up_enabled": {
+          "name": "auto_top_up_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closed": {
+          "name": "closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_funded_at": {
+          "name": "last_funded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_limit_hours": {
+          "name": "runtime_limit_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sdl": {
+          "name": "sdl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sealed_secrets": {
+          "name": "sealed_secrets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manifest_version": {
+          "name": "manifest_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_ends_at": {
+          "name": "runtime_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_ending_notified_for": {
+          "name": "runtime_ending_notified_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_unreachable_notified_for": {
+          "name": "provider_unreachable_notified_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "id_auto_top_up_enabled_closed_idx": {
+          "name": "id_auto_top_up_enabled_closed_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auto_top_up_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "closed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_settings_user_id_userSetting_id_fk": {
+          "name": "deployment_settings_user_id_userSetting_id_fk",
+          "tableFrom": "deployment_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dseq_user_id_idx": {
+          "name": "dseq_user_id_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "dseq",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_key": {
+          "name": "hashed_key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_format": {
+          "name": "key_format",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_user_id_userSetting_id_fk": {
+          "name": "api_keys_user_id_userSetting_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_hashed_key_unique": {
+          "name": "api_keys_hashed_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hashed_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_verification_codes": {
+      "name": "email_verification_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_verification_codes_user_id_idx": {
+          "name": "email_verification_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_verification_codes_user_id_userSetting_id_fk": {
+          "name": "email_verification_codes_user_id_userSetting_id_fk",
+          "tableFrom": "email_verification_codes",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.data_keys": {
+      "name": "data_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wrapped_key": {
+          "name": "wrapped_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wrapped_by_kid": {
+          "name": "wrapped_by_kid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "data_keys_wrapped_by_kid_idx": {
+          "name": "data_keys_wrapped_by_kid_idx",
+          "columns": [
+            {
+              "expression": "wrapped_by_kid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "data_keys_user_id_userSetting_id_fk": {
+          "name": "data_keys_user_id_userSetting_id_fk",
+          "tableFrom": "data_keys",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "data_keys_user_id_unique": {
+          "name": "data_keys_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.stripe_transaction_status": {
+      "name": "stripe_transaction_status",
+      "schema": "public",
+      "values": [
+        "created",
+        "pending",
+        "requires_action",
+        "succeeded",
+        "failed",
+        "refunded",
+        "canceled"
+      ]
+    },
+    "public.stripe_transaction_type": {
+      "name": "stripe_transaction_type",
+      "schema": "public",
+      "values": [
+        "payment_intent",
+        "coupon_claim",
+        "manual_credit"
+      ]
+    },
+    "public.auto_reload_mode": {
+      "name": "auto_reload_mode",
+      "schema": "public",
+      "values": [
+        "prediction",
+        "threshold"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -344,6 +344,13 @@
       "when": 1788342600963,
       "tag": "0048_deployment_sealed_secrets",
       "breakpoints": true
+    },
+    {
+      "idx": 49,
+      "version": "7",
+      "when": 1788379408171,
+      "tag": "0049_auto_top_up_decline_pause",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/billing/config/env.config.ts
+++ b/apps/api/src/billing/config/env.config.ts
@@ -45,7 +45,7 @@ export const envSchema = z.object({
   AUTO_RELOAD_CHARGE_COOLDOWN_IN_MIN: z.number({ coerce: true }).min(0).default(60),
   /** Consecutive declines that pause auto top-up, kept low because card networks fine excessive reattempts of a declined payment. */
   AUTO_RELOAD_MAX_CONSECUTIVE_DECLINES: z.number({ coerce: true }).int().min(1).default(4),
-  /** Ceiling on the doubled charge cooldown, so raising the decline limit cannot stretch the gap past the daily safety-net check. */
+  /** Ceiling on the doubled charge cooldown, so raising the decline limit cannot stretch the gap past the daily safety-net check; it never shortens the base cooldown. */
   AUTO_RELOAD_CHARGE_BACKOFF_MAX_IN_MIN: z.number({ coerce: true }).min(0).default(1440),
   /** How long credits must keep reading sufficient before the low-credit email unlatches, so a single misread cannot unlatch it. */
   CREDITS_LOW_RECOVERY_CONFIRM_WINDOW_MIN: z.number({ coerce: true }).min(0).default(30),

--- a/apps/api/src/billing/config/env.config.ts
+++ b/apps/api/src/billing/config/env.config.ts
@@ -38,11 +38,15 @@ export const envSchema = z.object({
     .transform(val => (val ? val.split(",").map(addr => addr.trim()) : [])),
   MANAGED_WALLET_TRIAL_MIN_TOP_UP_AMOUNT: z.number({ coerce: true }).min(20).default(20),
   /**
-   * Minimum minutes between automatic threshold-mode card charges per wallet — the default of 60
-   * caps them at one per hour. 0 disables the cap (unlike AUTO_TOP_UP_DEDUP_COOLDOWN_IN_MIN, which
-   * has no disable semantics).
+   * Minimum minutes between automatic card charges per wallet, in both auto-reload modes — the
+   * default of 60 caps them at one per hour. 0 disables the cap (unlike
+   * AUTO_TOP_UP_DEDUP_COOLDOWN_IN_MIN, which has no disable semantics).
    */
   AUTO_RELOAD_CHARGE_COOLDOWN_IN_MIN: z.number({ coerce: true }).min(0).default(60),
+  /** Consecutive declines that pause auto top-up, kept low because card networks fine excessive reattempts of a declined payment. */
+  AUTO_RELOAD_MAX_CONSECUTIVE_DECLINES: z.number({ coerce: true }).int().min(1).default(4),
+  /** Ceiling on the doubled charge cooldown, so raising the decline limit cannot stretch the gap past the daily safety-net check. */
+  AUTO_RELOAD_CHARGE_BACKOFF_MAX_IN_MIN: z.number({ coerce: true }).min(0).default(1440),
   /** How long credits must keep reading sufficient before the low-credit email unlatches, so a single misread cannot unlatch it. */
   CREDITS_LOW_RECOVERY_CONFIRM_WINDOW_MIN: z.number({ coerce: true }).min(0).default(30),
   /** How long credits must keep reading low before the email goes out, so a single misread cannot send one. */

--- a/apps/api/src/billing/controllers/stripe/stripe.controller.spec.ts
+++ b/apps/api/src/billing/controllers/stripe/stripe.controller.spec.ts
@@ -7,6 +7,7 @@ import { mock } from "vitest-mock-extended";
 
 import { AuthService } from "@src/auth/services/auth.service";
 import type { UserWalletOutput, UserWalletRepository } from "@src/billing/repositories";
+import type { AutoReloadPauseService } from "@src/billing/services/auto-reload-pause/auto-reload-pause.service";
 import type { CouponRedemptionService } from "@src/billing/services/coupon-redemption/coupon-redemption.service";
 import type { CustomerService } from "@src/billing/services/customer/customer.service";
 import type { PayingUser } from "@src/billing/services/paying-user/paying-user";
@@ -319,6 +320,24 @@ describe(StripeController.name, () => {
 
       expect(paymentMethodService.markPaymentMethodAsDefault).toHaveBeenCalledWith("pm_1", authService.getCurrentPayingUser(), authService.ability);
     });
+
+    it("resumes auto top-up so a wallet paused by declines starts charging the new card", async () => {
+      const { controller, autoReloadPauseService, user } = setup();
+
+      await controller.markAsDefault({ data: { id: "pm_1" } });
+
+      expect(autoReloadPauseService.resume).toHaveBeenCalledWith(user.id);
+    });
+
+    it("keeps the new default card when resuming auto top-up fails", async () => {
+      const { controller, autoReloadPauseService, logger, user } = setup();
+      const error = new Error("connection terminated");
+      autoReloadPauseService.resume.mockRejectedValue(error);
+
+      await expect(controller.markAsDefault({ data: { id: "pm_1" } })).resolves.toBeUndefined();
+
+      expect(logger.error).toHaveBeenCalledWith({ event: "AUTO_RELOAD_RESUME_AFTER_DEFAULT_CHANGE_FAILED", userId: user.id, error });
+    });
   });
 
   describe("getPaymentMethods", () => {
@@ -368,6 +387,7 @@ describe(StripeController.name, () => {
     const trialActivationJobService = mock<TrialActivationJobService>();
     const transactionReporting = mock<TransactionReportingService>();
     const walletSettingService = mock<WalletSettingService>();
+    const autoReloadPauseService = mock<AutoReloadPauseService>();
     const logger = mock<ReturnType<CreateLogger>>();
     const createLogger = vi.fn<CreateLogger>(() => logger);
     const controller = new StripeController(
@@ -383,6 +403,7 @@ describe(StripeController.name, () => {
       couponRedemptionService,
       customerService,
       walletSettingService,
+      autoReloadPauseService,
       createLogger
     );
     container.register(AuthService, { useValue: authService });
@@ -400,6 +421,7 @@ describe(StripeController.name, () => {
       userWalletRepository,
       trialActivationJobService,
       walletSettingService,
+      autoReloadPauseService,
       logger,
       createLogger,
       user

--- a/apps/api/src/billing/controllers/stripe/stripe.controller.ts
+++ b/apps/api/src/billing/controllers/stripe/stripe.controller.ts
@@ -21,6 +21,7 @@ import {
 } from "@src/billing/http-schemas/stripe.schema";
 import type { StripeTransactionOutput } from "@src/billing/repositories";
 import { UserWalletRepository } from "@src/billing/repositories";
+import { AutoReloadPauseService } from "@src/billing/services/auto-reload-pause/auto-reload-pause.service";
 import { CouponRedemptionService } from "@src/billing/services/coupon-redemption/coupon-redemption.service";
 import { CustomerService } from "@src/billing/services/customer/customer.service";
 import { PaymentMethodService } from "@src/billing/services/payment-method/payment-method.service";
@@ -50,6 +51,7 @@ export class StripeController {
     private readonly couponRedemptionService: CouponRedemptionService,
     private readonly customerService: CustomerService,
     private readonly walletSettingService: WalletSettingService,
+    private readonly autoReloadPauseService: AutoReloadPauseService,
     @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
     this.logger = createLogger({ context: StripeController.name });
@@ -78,6 +80,20 @@ export class StripeController {
     const currentUser = this.authService.getCurrentPayingUser();
 
     await this.paymentMethodService.markPaymentMethodAsDefault(input.data.id, currentUser, ability);
+    await this.#resumeAutoReloadAfterDefaultChange(currentUser.id);
+  }
+
+  /**
+   * The new default card is already stored, so a failed resume must not fail the request. The wallet
+   * stays paused until the next payment method change, and the user can still turn auto top-up off
+   * and on again to lift it.
+   */
+  async #resumeAutoReloadAfterDefaultChange(userId: string): Promise<void> {
+    try {
+      await this.autoReloadPauseService.resume(userId);
+    } catch (error) {
+      this.logger.error({ event: "AUTO_RELOAD_RESUME_AFTER_DEFAULT_CHANGE_FAILED", userId, error });
+    }
   }
 
   @Protected([{ action: "read", subject: "PaymentMethod" }])

--- a/apps/api/src/billing/http-schemas/wallet.schema.ts
+++ b/apps/api/src/billing/http-schemas/wallet.schema.ts
@@ -29,7 +29,11 @@ export const WalletSettingsOutputSchema = z.object({
   autoReloadEnabled: z.boolean().openapi({}),
   autoReloadMode: AutoReloadModeSchema.openapi({ description: "Rule used to decide when and how much to top up." }),
   autoReloadThreshold: z.number().openapi({ description: "USD credit balance at or below which an automatic top-up is triggered." }),
-  autoReloadAmount: z.number().openapi({ description: "USD amount charged to the default payment method on each automatic top-up." })
+  autoReloadAmount: z.number().openapi({ description: "USD amount charged to the default payment method on each automatic top-up." }),
+  autoReloadPausedAt: z.date().nullable().openapi({
+    description:
+      "When automatic top-ups were paused because the default payment method kept being declined, or null when they are running. Changing the default payment method resumes them."
+  })
 });
 
 export const WalletSettingsInputSchema = z.object({

--- a/apps/api/src/billing/lib/auto-reload/auto-reload.ts
+++ b/apps/api/src/billing/lib/auto-reload/auto-reload.ts
@@ -1,0 +1,6 @@
+type AutoReloadState = { autoReloadEnabled: boolean; autoReloadPausedAt: Date | null };
+
+/** A wallet paused after repeated declines stays opted in but must be treated as off everywhere a charge or a metric depends on it. */
+export function isAutoReloadActive<T extends AutoReloadState>(setting: T | null | undefined): setting is T {
+  return !!setting?.autoReloadEnabled && !setting.autoReloadPausedAt;
+}

--- a/apps/api/src/billing/lib/card-decline/card-decline.spec.ts
+++ b/apps/api/src/billing/lib/card-decline/card-decline.spec.ts
@@ -1,0 +1,47 @@
+import createError from "http-errors";
+import Stripe from "stripe";
+import { describe, expect, it } from "vitest";
+
+import { CARD_DECLINED_ERROR_CODE, toCardDecline } from "./card-decline";
+
+describe("toCardDecline", () => {
+  it("reads the decline code off a Stripe card error", () => {
+    const decline = toCardDecline(cardError("insufficient_funds"));
+
+    expect(decline).toEqual({ declineCode: "insufficient_funds", isTerminal: false });
+  });
+
+  it("recognises a decline reported through the payment error shape", () => {
+    const error = createError(402, "Your card was declined", { errorCode: CARD_DECLINED_ERROR_CODE, declineCode: "generic_decline" });
+
+    expect(toCardDecline(error)).toEqual({ declineCode: "generic_decline", isTerminal: false });
+  });
+
+  it("still counts a decline that arrived without a code", () => {
+    expect(toCardDecline(cardError(undefined))).toEqual({ isTerminal: false });
+  });
+
+  it.each(["lost_card", "stolen_card", "fraudulent", "pickup_card", "revocation_of_all_authorizations", "stop_payment_order", "merchant_blacklist"])(
+    "treats %s as terminal",
+    declineCode => {
+      expect(toCardDecline(cardError(declineCode))).toEqual({ declineCode, isTerminal: true });
+    }
+  );
+
+  it("ignores a Stripe outage", () => {
+    expect(toCardDecline(new Stripe.errors.StripeAPIError({ type: "api_error", message: "Service unavailable" }))).toBeUndefined();
+  });
+
+  it("ignores an error of our own", () => {
+    expect(toCardDecline(new TypeError("cannot read properties of undefined"))).toBeUndefined();
+  });
+
+  function cardError(declineCode: string | undefined) {
+    return new Stripe.errors.StripeCardError({
+      type: "card_error",
+      code: "card_declined",
+      message: "Your card was declined",
+      ...(declineCode && { decline_code: declineCode })
+    });
+  }
+});

--- a/apps/api/src/billing/lib/card-decline/card-decline.ts
+++ b/apps/api/src/billing/lib/card-decline/card-decline.ts
@@ -1,0 +1,46 @@
+import Stripe from "stripe";
+
+export const CARD_DECLINED_ERROR_CODE = "card_declined";
+
+/** Codes the issuer will never approve on a retry, and reattempting them is exactly what card networks penalise. */
+const TERMINAL_DECLINE_CODES: ReadonlySet<string> = new Set([
+  "lost_card",
+  "stolen_card",
+  "fraudulent",
+  "pickup_card",
+  "revocation_of_all_authorizations",
+  "stop_payment_order",
+  "merchant_blacklist"
+]);
+
+export type CardDecline = {
+  declineCode?: string;
+  isTerminal: boolean;
+};
+
+/**
+ * Recognises the shapes a declined charge arrives in, so that only the card is held against the
+ * wallet: a Stripe outage or a bug of ours must never count towards pausing auto top-up.
+ */
+export function toCardDecline(error: unknown): CardDecline | undefined {
+  if (error instanceof Stripe.errors.StripeCardError) {
+    return describeDecline(error.decline_code);
+  }
+
+  if (isCardDeclinedError(error)) {
+    return describeDecline(error.declineCode);
+  }
+
+  return undefined;
+}
+
+function isCardDeclinedError(error: unknown): error is { errorCode: string; declineCode?: string } {
+  return typeof error === "object" && error !== null && (error as { errorCode?: unknown }).errorCode === CARD_DECLINED_ERROR_CODE;
+}
+
+function describeDecline(declineCode: string | undefined): CardDecline {
+  return {
+    ...(declineCode && { declineCode }),
+    isTerminal: !!declineCode && TERMINAL_DECLINE_CODES.has(declineCode)
+  };
+}

--- a/apps/api/src/billing/model-schemas/wallet-setting/wallet-setting.schema.ts
+++ b/apps/api/src/billing/model-schemas/wallet-setting/wallet-setting.schema.ts
@@ -29,11 +29,14 @@ export const WalletSetting = pgTable(
     autoReloadThreshold: integer("auto_reload_threshold").notNull().default(2000),
     autoReloadAmount: integer("auto_reload_amount").notNull().default(10000),
     /**
-     * Claim marker rate-limiting automatic threshold-mode charges: set by the winning claim right
-     * before the card is charged, cleared when the charge attempt fails. Null means the wallet has
-     * never been auto-charged (or the last attempt was released).
+     * Claim marker rate-limiting automatic charges in both modes: set by the winning claim right
+     * before the card is charged, and kept whether the charge succeeds or fails. Null means the
+     * wallet has never been auto-charged, or that a payment method change cleared the marker.
      */
     lastAutoChargeAt: timestamp("last_auto_charge_at"),
+    autoReloadFailureCount: integer("auto_reload_failure_count").notNull().default(0),
+    /** Set once a card has declined too many times in a row, and cleared when the user changes their payment method. */
+    autoReloadPausedAt: timestamp("auto_reload_paused_at", { withTimezone: true }),
     createdAt: timestamp("created_at").defaultNow(),
     updatedAt: timestamp("updated_at").defaultNow()
   },

--- a/apps/api/src/billing/repositories/wallet-settings/wallet-settings.repository.integration.ts
+++ b/apps/api/src/billing/repositories/wallet-settings/wallet-settings.repository.integration.ts
@@ -35,7 +35,7 @@ describe(WalletSettingRepository.name, () => {
       const first = await walletSettingRepository.claimForCharge(settingId, COOLDOWN_MINUTES);
       const second = await walletSettingRepository.claimForCharge(settingId, COOLDOWN_MINUTES);
 
-      expect(first).toEqual({ won: true });
+      expect(first).toEqual({ won: true, claim: { id: settingId, claimedAt: expect.any(String) } });
       expect(second).toEqual({ won: false, secondsUntilWindowReopen: expect.any(Number) });
     });
 
@@ -69,7 +69,7 @@ describe(WalletSettingRepository.name, () => {
       await backdateLastAutoChargeAt(settingId, COOLDOWN_MINUTES + 1);
       const afterCooldown = await walletSettingRepository.claimForCharge(settingId, COOLDOWN_MINUTES);
 
-      expect(afterCooldown).toEqual({ won: true });
+      expect(afterCooldown).toEqual({ won: true, claim: { id: settingId, claimedAt: expect.any(String) } });
     });
 
     it("claims consecutively when the cooldown is zero", async () => {
@@ -78,8 +78,100 @@ describe(WalletSettingRepository.name, () => {
       const first = await walletSettingRepository.claimForCharge(settingId, NO_COOLDOWN);
       const second = await walletSettingRepository.claimForCharge(settingId, NO_COOLDOWN);
 
-      expect(first).toEqual({ won: true });
-      expect(second).toEqual({ won: true });
+      expect(first.won).toBe(true);
+      expect(second.won).toBe(true);
+    });
+  });
+
+  describe("recordChargeDecline", () => {
+    it("counts one decline per charge attempt", async () => {
+      const { walletSettingRepository, claim, readSetting } = await setup();
+
+      const outcome = await walletSettingRepository.recordChargeDecline(await claim(), { maxConsecutiveDeclines: 4, isTerminal: false });
+
+      expect(outcome).toEqual({ failureCount: 1, pausedAt: null });
+      expect((await readSetting()).autoReloadPausedAt).toBeNull();
+    });
+
+    it("pauses the wallet once the card has run out of chances", async () => {
+      const { walletSettingRepository, settingId, claim, backdateLastAutoChargeAt } = await setup();
+
+      const outcomes = [];
+      for (let attempt = 0; attempt < 3; attempt++) {
+        outcomes.push(await walletSettingRepository.recordChargeDecline(await claim(), { maxConsecutiveDeclines: 3, isTerminal: false }));
+        await backdateLastAutoChargeAt(settingId, COOLDOWN_MINUTES + 1);
+      }
+
+      expect(outcomes.map(outcome => outcome.failureCount)).toEqual([1, 2, 3]);
+      expect(outcomes.slice(0, 2).map(outcome => outcome.pausedAt)).toEqual([null, null]);
+      expect(outcomes[2].pausedAt).toBeInstanceOf(Date);
+    });
+
+    it("pauses a lost or stolen card on its first decline", async () => {
+      const { walletSettingRepository, claim } = await setup();
+
+      const outcome = await walletSettingRepository.recordChargeDecline(await claim(), { maxConsecutiveDeclines: 4, isTerminal: true });
+
+      expect(outcome.failureCount).toBe(1);
+      expect(outcome.pausedAt).toBeInstanceOf(Date);
+    });
+
+    it("reports the pause to exactly one of the callers racing to record it", async () => {
+      const { walletSettingRepository, claim } = await setup();
+      const won = await claim();
+
+      const outcomes = await Promise.all(
+        Array.from({ length: 5 }, () => walletSettingRepository.recordChargeDecline(won, { maxConsecutiveDeclines: 1, isTerminal: false }))
+      );
+
+      expect(outcomes.filter(outcome => outcome.pausedAt)).toHaveLength(1);
+    });
+
+    it("discards a decline whose charge window has already been cleared", async () => {
+      const { walletSettingRepository, settingId, claim, readSetting } = await setup();
+      const won = await claim();
+      await walletSettingRepository.clearChargeState(settingId);
+
+      const outcome = await walletSettingRepository.recordChargeDecline(won, { maxConsecutiveDeclines: 4, isTerminal: true });
+
+      expect(outcome).toEqual({ failureCount: 0, pausedAt: null });
+      expect((await readSetting()).autoReloadPausedAt).toBeNull();
+    });
+  });
+
+  describe("resetChargeFailures", () => {
+    it("puts a wallet with declines behind it back to a clean slate", async () => {
+      const { walletSettingRepository, settingId, claim, readSetting } = await setup();
+      await walletSettingRepository.recordChargeDecline(await claim(), { maxConsecutiveDeclines: 4, isTerminal: true });
+
+      await walletSettingRepository.resetChargeFailures(settingId);
+
+      const setting = await readSetting();
+      expect(setting.autoReloadFailureCount).toBe(0);
+      expect(setting.autoReloadPausedAt).toBeNull();
+    });
+
+    it("keeps the charge marker so the cooldown still applies", async () => {
+      const { walletSettingRepository, settingId, claim, readSetting } = await setup();
+      await claim();
+
+      await walletSettingRepository.resetChargeFailures(settingId);
+
+      expect((await readSetting()).lastAutoChargeAt).not.toBeNull();
+    });
+  });
+
+  describe("clearChargeState", () => {
+    it("lifts the pause and reopens the charge window at once", async () => {
+      const { walletSettingRepository, settingId, claim, readSetting } = await setup();
+      await walletSettingRepository.recordChargeDecline(await claim(), { maxConsecutiveDeclines: 4, isTerminal: true });
+
+      await walletSettingRepository.clearChargeState(settingId);
+
+      const setting = await readSetting();
+      expect(setting.autoReloadFailureCount).toBe(0);
+      expect(setting.autoReloadPausedAt).toBeNull();
+      expect(setting.lastAutoChargeAt).toBeNull();
     });
   });
 
@@ -104,10 +196,22 @@ describe(WalletSettingRepository.name, () => {
         .where(eq(walletSettingsTable.id, id));
     }
 
+    async function claim() {
+      const attempt = await walletSettingRepository.claimForCharge(setting.id, COOLDOWN_MINUTES);
+      return (attempt as Extract<ChargeClaimAttempt, { won: true }>).claim;
+    }
+
+    async function readSetting() {
+      const [row] = await db.select().from(walletSettingsTable).where(eq(walletSettingsTable.id, setting.id));
+      return row;
+    }
+
     return {
       walletSettingRepository,
       settingId: setting.id,
-      backdateLastAutoChargeAt
+      backdateLastAutoChargeAt,
+      claim,
+      readSetting
     };
   }
 });

--- a/apps/api/src/billing/repositories/wallet-settings/wallet-settings.repository.ts
+++ b/apps/api/src/billing/repositories/wallet-settings/wallet-settings.repository.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull, lt, or, sql } from "drizzle-orm";
+import { and, eq, isNotNull, isNull, lt, ne, or, sql } from "drizzle-orm";
 import { singleton } from "tsyringe";
 
 import { type ApiPgDatabase, type ApiPgTables, InjectPg, InjectPgTable } from "@src/core/providers";
@@ -14,12 +14,21 @@ export type WalletSettingInput = Partial<DbWalletSettingInput>;
 export type WalletSettingOutput = DbWalletSettingOutput;
 
 /**
- * A lost claim carries how long is left on the cooldown that blocked it, so the caller defers only
- * for the remainder instead of a whole fresh cooldown. Postgres computes it: `last_auto_charge_at`
- * is a timestamp without time zone, so reading it back as a JS Date would shift it by the driver's
- * local offset. Zero means the window is already open again.
+ * A won claim carries the marker it wrote so a later decline write can be scoped to the exact charge
+ * attempt it describes. The marker is text rather than a Date because `last_auto_charge_at` is a
+ * timestamp without time zone, which the driver would shift by its local offset.
  */
-export type ChargeClaimAttempt = { won: true } | { won: false; secondsUntilWindowReopen: number };
+export type ChargeClaim = { id: string; claimedAt: string };
+
+/**
+ * A lost claim carries how long is left on the cooldown that blocked it, so the caller defers only
+ * for the remainder instead of a whole fresh cooldown. Postgres computes it for the same reason the
+ * marker comes back as text. Zero means the window is already open again.
+ */
+export type ChargeClaimAttempt = { won: true; claim: ChargeClaim } | { won: false; secondsUntilWindowReopen: number };
+
+/** Reports the count after the decline, and the pause instant when this call is the one that flipped the wallet to paused. */
+export type ChargeDeclineOutcome = { failureCount: number; pausedAt: Date | null };
 
 @singleton()
 export class WalletSettingRepository extends BaseRepository<Table, WalletSettingInput, WalletSettingOutput> {
@@ -75,10 +84,10 @@ export class WalletSettingRepository extends BaseRepository<Table, WalletSetting
           or(isNull(this.table.lastAutoChargeAt), lt(this.table.lastAutoChargeAt, sql`now() - (${cooldownMinutes} * interval '1 minute')`))
         )
       )
-      .returning({ id: this.table.id });
+      .returning({ id: this.table.id, claimedAt: sql<string>`${this.table.lastAutoChargeAt}::text` });
 
     if (claim) {
-      return { won: true };
+      return { won: true, claim };
     }
 
     const [blocking] = await this.cursor
@@ -89,5 +98,59 @@ export class WalletSettingRepository extends BaseRepository<Table, WalletSetting
       .where(eq(this.table.id, id));
 
     return { won: false, secondsUntilWindowReopen: Number(blocking?.secondsUntilWindowReopen ?? 0) };
+  }
+
+  /**
+   * Counts one declined charge and pauses the wallet once the card has run out of chances. Scoping
+   * the write to the marker its claim wrote discards a decline that lands after the user has already
+   * replaced the card, since that clears the marker. The pause is guarded on being unset, so a
+   * returned `pausedAt` is a real transition and only one caller ever sends the email.
+   */
+  async recordChargeDecline(claim: ChargeClaim, options: { maxConsecutiveDeclines: number; isTerminal: boolean }): Promise<ChargeDeclineOutcome> {
+    const [declined] = await this.cursor
+      .update(this.table)
+      .set({ autoReloadFailureCount: sql`${this.table.autoReloadFailureCount} + 1`, updatedAt: sql`now()` })
+      .where(and(eq(this.table.id, claim.id), eq(this.table.lastAutoChargeAt, sql`${claim.claimedAt}::timestamp`)))
+      .returning({ failureCount: this.table.autoReloadFailureCount });
+
+    if (!declined) {
+      return { failureCount: 0, pausedAt: null };
+    }
+
+    const hasChancesLeft = !options.isTerminal && declined.failureCount < options.maxConsecutiveDeclines;
+
+    return {
+      failureCount: declined.failureCount,
+      pausedAt: hasChancesLeft ? null : await this.#pauseAutoReload(claim.id)
+    };
+  }
+
+  async #pauseAutoReload(id: WalletSettingOutput["id"]): Promise<Date | null> {
+    const [paused] = await this.cursor
+      .update(this.table)
+      .set({ autoReloadPausedAt: sql`now()`, updatedAt: sql`now()` })
+      .where(and(eq(this.table.id, id), isNull(this.table.autoReloadPausedAt)))
+      .returning({ pausedAt: this.table.autoReloadPausedAt });
+
+    return paused?.pausedAt ?? null;
+  }
+
+  /** Puts a wallet back to a clean slate after a charge went through, leaving an already-clean row untouched. */
+  async resetChargeFailures(id: WalletSettingOutput["id"]): Promise<void> {
+    await this.cursor
+      .update(this.table)
+      .set({ autoReloadFailureCount: 0, autoReloadPausedAt: null, updatedAt: sql`now()` })
+      .where(and(eq(this.table.id, id), or(ne(this.table.autoReloadFailureCount, 0), isNotNull(this.table.autoReloadPausedAt))));
+  }
+
+  /**
+   * Lifts a pause after a payment method change. Clearing the charge marker too is what lets the
+   * next check charge straight away instead of waiting out the cooldown the dead card consumed.
+   */
+  async clearChargeState(id: WalletSettingOutput["id"]): Promise<void> {
+    await this.cursor
+      .update(this.table)
+      .set({ autoReloadFailureCount: 0, autoReloadPausedAt: null, lastAutoChargeAt: null, updatedAt: sql`now()` })
+      .where(eq(this.table.id, id));
   }
 }

--- a/apps/api/src/billing/services/auto-reload-pause/auto-reload-pause.service.spec.ts
+++ b/apps/api/src/billing/services/auto-reload-pause/auto-reload-pause.service.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
 
-import type { WalletSettingRepository } from "@src/billing/repositories";
+import type { UserWalletRepository, WalletSettingRepository } from "@src/billing/repositories";
 import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import type { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
 import type { NotificationService } from "@src/notifications/services/notification/notification.service";
@@ -34,6 +34,12 @@ describe(AutoReloadPauseService.name, () => {
       const { service } = setup({ cooldownMinutes: 0 });
 
       expect(service.calculateChargeCooldownMinutes(3)).toBe(0);
+    });
+
+    it("never lets a ceiling below the base cooldown shorten the gap", () => {
+      const { service } = setup({ cooldownMinutes: 60, backoffMaxMinutes: 0 });
+
+      expect(service.calculateChargeCooldownMinutes(3)).toBe(60);
     });
   });
 
@@ -96,6 +102,20 @@ describe(AutoReloadPauseService.name, () => {
       expect(walletReloadJobService.scheduleForWalletSetting).toHaveBeenCalledWith(setting, { withCleanup: true });
     });
 
+    it("clears the credits-low latch the pause left behind", async () => {
+      const setting = generateWalletSetting({ autoReloadEnabled: true, autoReloadPausedAt: new Date() });
+      const { service, walletReloadJobService, userWalletRepository } = setup({ setting });
+
+      await service.resume(setting.userId);
+
+      expect(walletReloadJobService.cancelCreditsLowCheckByUserId).toHaveBeenCalledWith(setting.userId);
+      expect(userWalletRepository.updateById).toHaveBeenCalledWith(setting.walletId, {
+        creditsLowNotifiedAt: null,
+        creditsSufficientSince: null,
+        creditsLowSince: null
+      });
+    });
+
     it("does nothing for a wallet that was never paused", async () => {
       const setting = generateWalletSetting({ autoReloadEnabled: true, autoReloadPausedAt: null });
       const { service, walletSettingRepository, walletReloadJobService } = setup({ setting });
@@ -115,6 +135,15 @@ describe(AutoReloadPauseService.name, () => {
       expect(walletSettingRepository.clearChargeState).toHaveBeenCalledWith(setting.id);
       expect(walletReloadJobService.scheduleForWalletSetting).not.toHaveBeenCalled();
     });
+
+    it("leaves the credits-low latch to the check itself when the user turned auto top-up off", async () => {
+      const setting = generateWalletSetting({ autoReloadEnabled: false, autoReloadPausedAt: new Date() });
+      const { service, userWalletRepository } = setup({ setting });
+
+      await service.resume(setting.userId);
+
+      expect(userWalletRepository.updateById).not.toHaveBeenCalled();
+    });
   });
 
   function setup(input?: {
@@ -126,6 +155,7 @@ describe(AutoReloadPauseService.name, () => {
     const user = createUser();
     const walletSettingRepository = mock<WalletSettingRepository>();
     walletSettingRepository.findByUserId.mockResolvedValue(input?.setting);
+    const userWalletRepository = mock<UserWalletRepository>();
     const walletReloadJobService = mock<WalletReloadJobService>();
     const notificationService = mock<NotificationService>();
     const billingConfig = mockConfigService<BillingConfigService>({
@@ -134,11 +164,14 @@ describe(AutoReloadPauseService.name, () => {
       AUTO_RELOAD_MAX_CONSECUTIVE_DECLINES: input?.maxConsecutiveDeclines ?? 4,
       CONSOLE_WEB_PAYMENT_LINK: "https://console.akash.network/billing?openPayment=true"
     });
-    const service = new AutoReloadPauseService(walletSettingRepository, walletReloadJobService, notificationService, billingConfig, () => mock());
+    const service = new AutoReloadPauseService(walletSettingRepository, userWalletRepository, walletReloadJobService, notificationService, billingConfig, () =>
+      mock()
+    );
 
     return {
       service,
       walletSettingRepository,
+      userWalletRepository,
       walletReloadJobService,
       notificationService,
       billingConfig,

--- a/apps/api/src/billing/services/auto-reload-pause/auto-reload-pause.service.spec.ts
+++ b/apps/api/src/billing/services/auto-reload-pause/auto-reload-pause.service.spec.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { WalletSettingRepository } from "@src/billing/repositories";
+import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
+import type { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
+import type { NotificationService } from "@src/notifications/services/notification/notification.service";
+import { AutoReloadPauseService } from "./auto-reload-pause.service";
+
+import { mockConfigService } from "@test/mocks/config-service.mock";
+import { createUser } from "@test/seeders/user.seeder";
+import { generateWalletSetting } from "@test/seeders/wallet-setting.seeder";
+
+describe(AutoReloadPauseService.name, () => {
+  describe("calculateChargeCooldownMinutes", () => {
+    it.each([
+      [0, 60],
+      [1, 60],
+      [2, 120],
+      [3, 240]
+    ])("waits %i doublings of the base cooldown after %i declines", (failureCount, expected) => {
+      const { service } = setup();
+
+      expect(service.calculateChargeCooldownMinutes(failureCount)).toBe(expected);
+    });
+
+    it("stops growing at the configured ceiling", () => {
+      const { service } = setup({ backoffMaxMinutes: 180 });
+
+      expect(service.calculateChargeCooldownMinutes(8)).toBe(180);
+    });
+
+    it("keeps a zero cooldown disabled", () => {
+      const { service } = setup({ cooldownMinutes: 0 });
+
+      expect(service.calculateChargeCooldownMinutes(3)).toBe(0);
+    });
+  });
+
+  describe("recordDecline", () => {
+    it("counts the decline against the configured limit", async () => {
+      const { service, walletSettingRepository, claim, user } = setup({ maxConsecutiveDeclines: 4 });
+      walletSettingRepository.recordChargeDecline.mockResolvedValue({ failureCount: 1, pausedAt: null });
+
+      await service.recordDecline({ claim, user, decline: { declineCode: "generic_decline", isTerminal: false } });
+
+      expect(walletSettingRepository.recordChargeDecline).toHaveBeenCalledWith(claim, { maxConsecutiveDeclines: 4, isTerminal: false });
+    });
+
+    it("leaves the wallet alone while the card still has chances left", async () => {
+      const { service, walletSettingRepository, walletReloadJobService, notificationService, claim, user } = setup();
+      walletSettingRepository.recordChargeDecline.mockResolvedValue({ failureCount: 2, pausedAt: null });
+
+      await service.recordDecline({ claim, user, decline: { isTerminal: false } });
+
+      expect(notificationService.createNotification).not.toHaveBeenCalled();
+      expect(walletReloadJobService.cancelCreatedByUserId).not.toHaveBeenCalled();
+    });
+
+    it("emails the user and hands the wallet to the credits-low check once it pauses", async () => {
+      const pausedAt = new Date("2026-09-01T12:00:00.000Z");
+      const { service, walletSettingRepository, walletReloadJobService, notificationService, claim, user } = setup();
+      walletSettingRepository.recordChargeDecline.mockResolvedValue({ failureCount: 4, pausedAt });
+
+      await service.recordDecline({ claim, user, decline: { declineCode: "generic_decline", isTerminal: false } });
+
+      expect(walletReloadJobService.cancelCreatedByUserId).toHaveBeenCalledWith(user.id);
+      expect(walletReloadJobService.scheduleCreditsLowCheck).toHaveBeenCalledWith(user.id, { withCleanup: true });
+      expect(notificationService.createNotification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          notificationId: `autoTopUpPaused.${user.id}.${pausedAt.toISOString()}`,
+          user: { id: user.id, email: user.email }
+        })
+      );
+    });
+
+    it("links the email at billing rather than the add funds modal", async () => {
+      const { service, walletSettingRepository, notificationService, claim, user } = setup();
+      walletSettingRepository.recordChargeDecline.mockResolvedValue({ failureCount: 4, pausedAt: new Date() });
+
+      await service.recordDecline({ claim, user, decline: { isTerminal: false } });
+
+      const notification = notificationService.createNotification.mock.calls[0][0];
+      expect(notification.payload.description).toContain('<a href="https://console.akash.network/billing">');
+    });
+  });
+
+  describe("resume", () => {
+    it("clears the pause and lets the next check charge straight away", async () => {
+      const setting = generateWalletSetting({ autoReloadEnabled: true, autoReloadPausedAt: new Date(), autoReloadFailureCount: 4 });
+      const { service, walletSettingRepository, walletReloadJobService } = setup({ setting });
+
+      await service.resume(setting.userId);
+
+      expect(walletSettingRepository.clearChargeState).toHaveBeenCalledWith(setting.id);
+      expect(walletReloadJobService.scheduleForWalletSetting).toHaveBeenCalledWith(setting, { withCleanup: true });
+    });
+
+    it("does nothing for a wallet that was never paused", async () => {
+      const setting = generateWalletSetting({ autoReloadEnabled: true, autoReloadPausedAt: null });
+      const { service, walletSettingRepository, walletReloadJobService } = setup({ setting });
+
+      await service.resume(setting.userId);
+
+      expect(walletSettingRepository.clearChargeState).not.toHaveBeenCalled();
+      expect(walletReloadJobService.scheduleForWalletSetting).not.toHaveBeenCalled();
+    });
+
+    it("clears the pause without scheduling a check when the user turned auto top-up off", async () => {
+      const setting = generateWalletSetting({ autoReloadEnabled: false, autoReloadPausedAt: new Date() });
+      const { service, walletSettingRepository, walletReloadJobService } = setup({ setting });
+
+      await service.resume(setting.userId);
+
+      expect(walletSettingRepository.clearChargeState).toHaveBeenCalledWith(setting.id);
+      expect(walletReloadJobService.scheduleForWalletSetting).not.toHaveBeenCalled();
+    });
+  });
+
+  function setup(input?: {
+    cooldownMinutes?: number;
+    backoffMaxMinutes?: number;
+    maxConsecutiveDeclines?: number;
+    setting?: ReturnType<typeof generateWalletSetting>;
+  }) {
+    const user = createUser();
+    const walletSettingRepository = mock<WalletSettingRepository>();
+    walletSettingRepository.findByUserId.mockResolvedValue(input?.setting);
+    const walletReloadJobService = mock<WalletReloadJobService>();
+    const notificationService = mock<NotificationService>();
+    const billingConfig = mockConfigService<BillingConfigService>({
+      AUTO_RELOAD_CHARGE_COOLDOWN_IN_MIN: input?.cooldownMinutes ?? 60,
+      AUTO_RELOAD_CHARGE_BACKOFF_MAX_IN_MIN: input?.backoffMaxMinutes ?? 1440,
+      AUTO_RELOAD_MAX_CONSECUTIVE_DECLINES: input?.maxConsecutiveDeclines ?? 4,
+      CONSOLE_WEB_PAYMENT_LINK: "https://console.akash.network/billing?openPayment=true"
+    });
+    const service = new AutoReloadPauseService(walletSettingRepository, walletReloadJobService, notificationService, billingConfig, () => mock());
+
+    return {
+      service,
+      walletSettingRepository,
+      walletReloadJobService,
+      notificationService,
+      billingConfig,
+      user,
+      claim: { id: input?.setting?.id ?? "wallet-setting-1", claimedAt: "2026-09-01 12:00:00" }
+    };
+  }
+});

--- a/apps/api/src/billing/services/auto-reload-pause/auto-reload-pause.service.spec.ts
+++ b/apps/api/src/billing/services/auto-reload-pause/auto-reload-pause.service.spec.ts
@@ -80,6 +80,17 @@ describe(AutoReloadPauseService.name, () => {
       );
     });
 
+    it("still emails the user when cancelling the queued reload check fails", async () => {
+      const { service, walletSettingRepository, walletReloadJobService, notificationService, claim, user } = setup();
+      walletSettingRepository.recordChargeDecline.mockResolvedValue({ failureCount: 4, pausedAt: new Date() });
+      walletReloadJobService.cancelCreatedByUserId.mockRejectedValue(new Error("queue unavailable"));
+
+      await service.recordDecline({ claim, user, decline: { isTerminal: false } });
+
+      expect(walletReloadJobService.scheduleCreditsLowCheck).toHaveBeenCalledWith(user.id, { withCleanup: true });
+      expect(notificationService.createNotification).toHaveBeenCalled();
+    });
+
     it("links the email at billing rather than the add funds modal", async () => {
       const { service, walletSettingRepository, notificationService, claim, user } = setup();
       walletSettingRepository.recordChargeDecline.mockResolvedValue({ failureCount: 4, pausedAt: new Date() });

--- a/apps/api/src/billing/services/auto-reload-pause/auto-reload-pause.service.ts
+++ b/apps/api/src/billing/services/auto-reload-pause/auto-reload-pause.service.ts
@@ -1,7 +1,7 @@
 import { inject, singleton } from "tsyringe";
 
 import type { CardDecline } from "@src/billing/lib/card-decline/card-decline";
-import { type ChargeClaim, WalletSettingRepository } from "@src/billing/repositories";
+import { type ChargeClaim, UserWalletRepository, type WalletSettingOutput, WalletSettingRepository } from "@src/billing/repositories";
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
 import { type CreateLogger, LOGGER_FACTORY } from "@src/core/providers/logging.provider";
@@ -23,6 +23,7 @@ export class AutoReloadPauseService {
 
   constructor(
     private readonly walletSettingRepository: WalletSettingRepository,
+    private readonly userWalletRepository: UserWalletRepository,
     private readonly walletReloadJobService: WalletReloadJobService,
     private readonly notificationService: NotificationService,
     private readonly billingConfig: BillingConfigService,
@@ -43,8 +44,9 @@ export class AutoReloadPauseService {
     }
 
     const doublings = Math.min(failureCount - 1, MAX_BACKOFF_DOUBLINGS);
+    const backedOff = Math.min(base * 2 ** doublings, this.billingConfig.get("AUTO_RELOAD_CHARGE_BACKOFF_MAX_IN_MIN"));
 
-    return Math.min(base * 2 ** doublings, this.billingConfig.get("AUTO_RELOAD_CHARGE_BACKOFF_MAX_IN_MIN"));
+    return Math.max(base, backedOff);
   }
 
   async recordDecline(input: { claim: ChargeClaim; user: UserOutput; decline: CardDecline }): Promise<void> {
@@ -77,8 +79,18 @@ export class AutoReloadPauseService {
     this.logger.info({ event: "AUTO_RELOAD_RESUMED", userId, pausedAt: setting.autoReloadPausedAt });
 
     if (setting.autoReloadEnabled) {
-      await this.walletReloadJobService.scheduleForWalletSetting(setting, { withCleanup: true });
+      await this.#reactivate(setting);
     }
+  }
+
+  /**
+   * Mirrors the fresh-enable transition: while paused the wallet was eligible for the credits-low
+   * email, and leaving that latch stamped would suppress the email the next time it pauses.
+   */
+  async #reactivate(setting: WalletSettingOutput): Promise<void> {
+    await this.walletReloadJobService.scheduleForWalletSetting(setting, { withCleanup: true });
+    await this.walletReloadJobService.cancelCreditsLowCheckByUserId(setting.userId);
+    await this.userWalletRepository.updateById(setting.walletId, { creditsLowNotifiedAt: null, creditsSufficientSince: null, creditsLowSince: null });
   }
 
   /** CONSOLE_WEB_PAYMENT_LINK carries `?openPayment=true`, which opens the Add Funds modal rather than the payment methods the user needs to fix. */

--- a/apps/api/src/billing/services/auto-reload-pause/auto-reload-pause.service.ts
+++ b/apps/api/src/billing/services/auto-reload-pause/auto-reload-pause.service.ts
@@ -1,0 +1,88 @@
+import { inject, singleton } from "tsyringe";
+
+import type { CardDecline } from "@src/billing/lib/card-decline/card-decline";
+import { type ChargeClaim, WalletSettingRepository } from "@src/billing/repositories";
+import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
+import { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
+import { type CreateLogger, LOGGER_FACTORY } from "@src/core/providers/logging.provider";
+import { NotificationService } from "@src/notifications/services/notification/notification.service";
+import { autoTopUpPausedNotification } from "@src/notifications/services/notification-templates/auto-top-up-paused-notification";
+import type { UserOutput } from "@src/user/repositories";
+
+/** Guards `2 ** exponent` against a raised decline limit, since the result is interpolated into a Postgres interval. */
+const MAX_BACKOFF_DOUBLINGS = 16;
+
+/**
+ * Owns when Console stops charging a declining card and when it starts again. It lives apart from
+ * `WalletSettingService` because the payment method paths that lift a pause cannot depend on that
+ * service without a dependency cycle.
+ */
+@singleton()
+export class AutoReloadPauseService {
+  private readonly logger: ReturnType<CreateLogger>;
+
+  constructor(
+    private readonly walletSettingRepository: WalletSettingRepository,
+    private readonly walletReloadJobService: WalletReloadJobService,
+    private readonly notificationService: NotificationService,
+    private readonly billingConfig: BillingConfigService,
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
+  ) {
+    this.logger = createLogger({ context: AutoReloadPauseService.name });
+  }
+
+  /**
+   * Doubles the gap after each consecutive decline, so the attempts a dead card is allowed span
+   * hours instead of landing back to back. A base of 0 keeps meaning "no cap at all".
+   */
+  calculateChargeCooldownMinutes(failureCount: number): number {
+    const base = this.billingConfig.get("AUTO_RELOAD_CHARGE_COOLDOWN_IN_MIN");
+
+    if (base === 0 || failureCount <= 0) {
+      return base;
+    }
+
+    const doublings = Math.min(failureCount - 1, MAX_BACKOFF_DOUBLINGS);
+
+    return Math.min(base * 2 ** doublings, this.billingConfig.get("AUTO_RELOAD_CHARGE_BACKOFF_MAX_IN_MIN"));
+  }
+
+  async recordDecline(input: { claim: ChargeClaim; user: UserOutput; decline: CardDecline }): Promise<void> {
+    const { claim, user, decline } = input;
+    const { failureCount, pausedAt } = await this.walletSettingRepository.recordChargeDecline(claim, {
+      maxConsecutiveDeclines: this.billingConfig.get("AUTO_RELOAD_MAX_CONSECUTIVE_DECLINES"),
+      isTerminal: decline.isTerminal
+    });
+
+    if (!pausedAt) {
+      this.logger.info({ event: "AUTO_RELOAD_CHARGE_DECLINED", userId: user.id, failureCount, declineCode: decline.declineCode });
+      return;
+    }
+
+    this.logger.warn({ event: "AUTO_RELOAD_PAUSED", userId: user.id, failureCount, declineCode: decline.declineCode });
+
+    await this.walletReloadJobService.cancelCreatedByUserId(user.id);
+    await this.walletReloadJobService.scheduleCreditsLowCheck(user.id, { withCleanup: true });
+    await this.notificationService.createNotification(autoTopUpPausedNotification(user, { pausedAt, billingUrl: this.#billingUrl() }));
+  }
+
+  async resume(userId: UserOutput["id"]): Promise<void> {
+    const setting = await this.walletSettingRepository.findByUserId(userId);
+
+    if (!setting?.autoReloadPausedAt) {
+      return;
+    }
+
+    await this.walletSettingRepository.clearChargeState(setting.id);
+    this.logger.info({ event: "AUTO_RELOAD_RESUMED", userId, pausedAt: setting.autoReloadPausedAt });
+
+    if (setting.autoReloadEnabled) {
+      await this.walletReloadJobService.scheduleForWalletSetting(setting, { withCleanup: true });
+    }
+  }
+
+  /** CONSOLE_WEB_PAYMENT_LINK carries `?openPayment=true`, which opens the Add Funds modal rather than the payment methods the user needs to fix. */
+  #billingUrl(): string {
+    return this.billingConfig.get("CONSOLE_WEB_PAYMENT_LINK").split("?")[0];
+  }
+}

--- a/apps/api/src/billing/services/auto-reload-pause/auto-reload-pause.service.ts
+++ b/apps/api/src/billing/services/auto-reload-pause/auto-reload-pause.service.ts
@@ -63,9 +63,21 @@ export class AutoReloadPauseService {
 
     this.logger.warn({ event: "AUTO_RELOAD_PAUSED", userId: user.id, failureCount, declineCode: decline.declineCode });
 
-    await this.walletReloadJobService.cancelCreatedByUserId(user.id);
+    await this.#cancelPendingReloadCheck(user.id);
     await this.walletReloadJobService.scheduleCreditsLowCheck(user.id, { withCleanup: true });
     await this.notificationService.createNotification(autoTopUpPausedNotification(user, { pausedAt, billingUrl: this.#billingUrl() }));
+  }
+
+  /**
+   * The pause is already committed and only ever transitions once, so a failed cancel must not cost
+   * the user the email that follows it. A check left queued skips on the pause it finds.
+   */
+  async #cancelPendingReloadCheck(userId: UserOutput["id"]): Promise<void> {
+    try {
+      await this.walletReloadJobService.cancelCreatedByUserId(userId);
+    } catch (error) {
+      this.logger.error({ event: "AUTO_RELOAD_PAUSE_CANCEL_FAILED", userId, error });
+    }
   }
 
   async resume(userId: UserOutput["id"]): Promise<void> {

--- a/apps/api/src/billing/services/payment-method/payment-method.service.integration.ts
+++ b/apps/api/src/billing/services/payment-method/payment-method.service.integration.ts
@@ -146,6 +146,20 @@ describe(PaymentMethodService.name, () => {
       expect(autoReloadPauseService.resume).toHaveBeenCalledWith("user_1");
     });
 
+    it("keeps the upserted method when resuming auto top-up fails", async () => {
+      const { service, stripe, paymentMethodRepository, autoReloadPauseService } = setup();
+      const user = mock<PayingUser>({ id: "user_1", stripeCustomerId: "cus_1" });
+      const paymentMethod = generatePaymentMethod({ id: "pm_1", card: { fingerprint: "fp_1" } });
+      const local = { ...generateDatabasePaymentMethod({ paymentMethodId: "pm_1" }), isDefault: true };
+      paymentMethodRepository.upsert.mockResolvedValue({ paymentMethod: local, isNew: true });
+      vi.spyOn(stripe.customers, "update").mockResolvedValue(mock<Stripe.Response<Stripe.Customer>>());
+      autoReloadPauseService.resume.mockRejectedValue(new Error("queue unavailable"));
+
+      const result = await service.syncAttached({ user, paymentMethod });
+
+      expect(result).toEqual({ isNew: true, isDefault: true });
+    });
+
     it("leaves auto top-up alone for a method that does not become the default", async () => {
       const { service, paymentMethodRepository, autoReloadPauseService } = setup();
       const user = mock<PayingUser>({ id: "user_1", stripeCustomerId: "cus_1" });

--- a/apps/api/src/billing/services/payment-method/payment-method.service.integration.ts
+++ b/apps/api/src/billing/services/payment-method/payment-method.service.integration.ts
@@ -6,6 +6,7 @@ import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { PaymentMethodRepository } from "@src/billing/repositories";
+import type { AutoReloadPauseService } from "@src/billing/services/auto-reload-pause/auto-reload-pause.service";
 import type { PayingUser } from "@src/billing/services/paying-user/paying-user";
 import type { UserRepository } from "@src/user/repositories/user/user.repository";
 import { PaymentMethodService } from "./payment-method.service";
@@ -132,6 +133,31 @@ describe(PaymentMethodService.name, () => {
       expect(result).toEqual({ isNew: true, isDefault: true });
     });
 
+    it("resumes auto top-up so a wallet paused by declines can charge the new default card", async () => {
+      const { service, stripe, paymentMethodRepository, autoReloadPauseService } = setup();
+      const user = mock<PayingUser>({ id: "user_1", stripeCustomerId: "cus_1" });
+      const paymentMethod = generatePaymentMethod({ id: "pm_1", card: { fingerprint: "fp_1" } });
+      const local = { ...generateDatabasePaymentMethod({ paymentMethodId: "pm_1" }), isDefault: true };
+      paymentMethodRepository.upsert.mockResolvedValue({ paymentMethod: local, isNew: true });
+      vi.spyOn(stripe.customers, "update").mockResolvedValue(mock<Stripe.Response<Stripe.Customer>>());
+
+      await service.syncAttached({ user, paymentMethod });
+
+      expect(autoReloadPauseService.resume).toHaveBeenCalledWith("user_1");
+    });
+
+    it("leaves auto top-up alone for a method that does not become the default", async () => {
+      const { service, paymentMethodRepository, autoReloadPauseService } = setup();
+      const user = mock<PayingUser>({ id: "user_1", stripeCustomerId: "cus_1" });
+      const paymentMethod = generatePaymentMethod({ id: "pm_2", card: { fingerprint: "fp_2" } });
+      const local = { ...generateDatabasePaymentMethod({ paymentMethodId: "pm_2" }), isDefault: false };
+      paymentMethodRepository.upsert.mockResolvedValue({ paymentMethod: local, isNew: true });
+
+      await service.syncAttached({ user, paymentMethod });
+
+      expect(autoReloadPauseService.resume).not.toHaveBeenCalled();
+    });
+
     it("upserts without a remote default sync for an already-synced method", async () => {
       const { service, stripe, paymentMethodRepository } = setup();
       const user = mock<PayingUser>({ id: "user_1", stripeCustomerId: "cus_1" });
@@ -244,12 +270,13 @@ describe(PaymentMethodService.name, () => {
     const paymentMethodRepository = mock<PaymentMethodRepository>();
     paymentMethodRepository.accessibleBy.mockReturnValue(paymentMethodRepository);
     const userRepository = mock<UserRepository>();
+    const autoReloadPauseService = mock<AutoReloadPauseService>();
 
     const stripe = new Stripe(`sk_test_${faker.string.alphanumeric(32)}`, { apiVersion: "2025-10-29.clover", httpClient: Stripe.createFetchHttpClient() });
 
-    const service = new PaymentMethodService(stripe, paymentMethodRepository, userRepository, () => mock<LoggerService>());
+    const service = new PaymentMethodService(stripe, paymentMethodRepository, userRepository, autoReloadPauseService, () => mock<LoggerService>());
 
-    return { service, stripe, paymentMethodRepository, userRepository };
+    return { service, stripe, paymentMethodRepository, userRepository, autoReloadPauseService };
   }
 
   function createPaymentMethodAttachedEvent(params: { id: string; customer: string | null; fingerprint?: string }): Stripe.PaymentMethodAttachedEvent {

--- a/apps/api/src/billing/services/payment-method/payment-method.service.spec.ts
+++ b/apps/api/src/billing/services/payment-method/payment-method.service.spec.ts
@@ -6,6 +6,7 @@ import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { PaymentMethodRepository } from "@src/billing/repositories";
+import type { AutoReloadPauseService } from "@src/billing/services/auto-reload-pause/auto-reload-pause.service";
 import type { PayingUser } from "@src/billing/services/paying-user/paying-user";
 import type { UserOutput, UserRepository } from "@src/user/repositories/user/user.repository";
 import { PaymentMethodService } from "./payment-method.service";
@@ -404,12 +405,13 @@ describe(PaymentMethodService.name, () => {
     const paymentMethodRepository = mock<PaymentMethodRepository>();
     paymentMethodRepository.accessibleBy.mockReturnValue(paymentMethodRepository);
     const userRepository = mock<UserRepository>();
+    const autoReloadPauseService = mock<AutoReloadPauseService>();
     const logger = mock<LoggerService>();
 
     const stripe = new Stripe(`sk_test_${faker.string.alphanumeric(32)}`, { apiVersion: "2025-10-29.clover", httpClient: Stripe.createFetchHttpClient() });
 
-    const service = new PaymentMethodService(stripe, paymentMethodRepository, userRepository, () => logger);
+    const service = new PaymentMethodService(stripe, paymentMethodRepository, userRepository, autoReloadPauseService, () => logger);
 
-    return { service, stripe, paymentMethodRepository, userRepository, logger };
+    return { service, stripe, paymentMethodRepository, userRepository, autoReloadPauseService, logger };
   }
 });

--- a/apps/api/src/billing/services/payment-method/payment-method.service.ts
+++ b/apps/api/src/billing/services/payment-method/payment-method.service.ts
@@ -413,10 +413,22 @@ export class PaymentMethodService {
         });
       }
 
-      await this.autoReloadPauseService.resume(user.id);
+      await this.#resumeAutoReloadAfterDefaultChange(user.id);
     }
 
     return { isNew, isDefault: localPaymentMethod.isDefault };
+  }
+
+  /**
+   * Runs inside the upsert transaction, so a thrown resume would roll back the payment method row
+   * this webhook exists to record and leave Stripe retrying a delivery that already did its job.
+   */
+  async #resumeAutoReloadAfterDefaultChange(userId: string): Promise<void> {
+    try {
+      await this.autoReloadPauseService.resume(userId);
+    } catch (error) {
+      this.loggerService.error({ event: "AUTO_RELOAD_RESUME_AFTER_ATTACH_FAILED", userId, error });
+    }
   }
 
   @WithTransaction()

--- a/apps/api/src/billing/services/payment-method/payment-method.service.ts
+++ b/apps/api/src/billing/services/payment-method/payment-method.service.ts
@@ -8,6 +8,7 @@ import { inject, singleton } from "tsyringe";
 import { extractFingerprint } from "@src/billing/lib/payment-method/extract-fingerprint";
 import { STRIPE_CLIENT } from "@src/billing/providers/stripe-client.provider";
 import { type PaymentMethodOutput, PaymentMethodRepository } from "@src/billing/repositories";
+import { AutoReloadPauseService } from "@src/billing/services/auto-reload-pause/auto-reload-pause.service";
 import { type CreateLogger, LOGGER_FACTORY, WithTransaction } from "@src/core";
 import { type UserOutput, UserRepository } from "@src/user/repositories/user/user.repository";
 import { assertIsPayingUser, type PayingUser } from "../paying-user/paying-user";
@@ -22,6 +23,7 @@ export class PaymentMethodService {
     @inject(STRIPE_CLIENT) private readonly stripe: Stripe,
     private readonly paymentMethodRepository: PaymentMethodRepository,
     private readonly userRepository: UserRepository,
+    private readonly autoReloadPauseService: AutoReloadPauseService,
     @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
     this.loggerService = createLogger({ context: PaymentMethodService.name });
@@ -410,6 +412,8 @@ export class PaymentMethodService {
           error
         });
       }
+
+      await this.autoReloadPauseService.resume(user.id);
     }
 
     return { isNew, isDefault: localPaymentMethod.isDefault };

--- a/apps/api/src/billing/services/stripe-transaction/stripe-transaction.service.ts
+++ b/apps/api/src/billing/services/stripe-transaction/stripe-transaction.service.ts
@@ -7,6 +7,7 @@ import { inject, singleton } from "tsyringe";
 
 import { FundDrainingDeploymentsCommand } from "@src/billing/commands/fund-draining-deployments.command";
 import { PaymentIntentResult } from "@src/billing/http-schemas/stripe.schema";
+import { CARD_DECLINED_ERROR_CODE } from "@src/billing/lib/card-decline/card-decline";
 import { STRIPE_CLIENT } from "@src/billing/providers/stripe-client.provider";
 import {
   SETTLED_TRANSACTION_STATUSES,
@@ -39,6 +40,14 @@ export interface FirstPurchaseBonusGrant {
  * reads it to tell an automatic recharge from a manual "Add Funds" charge so only automatic ones notify.
  */
 export const AUTO_RECHARGE_METADATA_KEY = "auto_recharge";
+
+const CARD_DECLINED_MESSAGE = "Payment method was declined. Please try a different card.";
+
+/** The decline code lets the reload job tell a card it can retry from one the issuer will never approve. */
+function declineCodeOf(paymentIntent: Stripe.PaymentIntent): { declineCode?: string } {
+  const declineCode = paymentIntent.last_payment_error?.decline_code;
+  return declineCode ? { declineCode } : {};
+}
 
 /**
  * A settled automatic recharge that the webhook dispatcher turns into an {@link AutoRechargeSucceeded} domain
@@ -210,7 +219,7 @@ export class StripeTransactionService {
         };
 
       default: {
-        const message = paymentIntent.last_payment_error?.message ?? transaction.errorMessage ?? "Payment method was declined. Please try a different card.";
+        const message = paymentIntent.last_payment_error?.message ?? transaction.errorMessage ?? CARD_DECLINED_MESSAGE;
 
         const updated = await this.stripeTransactionRepository.updateByIdUnlessSettled(transaction.id, {
           status: this.mapPaymentIntentStatusToTransactionStatus(paymentIntent.status),
@@ -222,7 +231,11 @@ export class StripeTransactionService {
           if (settled) return settled;
         }
 
-        throw createError(402, message, { errorCode: "card_declined", errorType: "payment_error" });
+        throw createError(402, message, {
+          errorCode: CARD_DECLINED_ERROR_CODE,
+          errorType: "payment_error",
+          ...declineCodeOf(paymentIntent)
+        });
       }
     }
   }
@@ -335,7 +348,11 @@ export class StripeTransactionService {
           };
 
         case "requires_payment_method":
-          throw new Error("Payment method was declined. Please try a different card.");
+          throw createError(402, CARD_DECLINED_MESSAGE, {
+            errorCode: CARD_DECLINED_ERROR_CODE,
+            errorType: "payment_error",
+            ...declineCodeOf(paymentIntent)
+          });
 
         default:
           throw new Error(`Payment failed with status: ${paymentIntent.status}`);

--- a/apps/api/src/billing/services/wallet-balance-reload-check/README.md
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/README.md
@@ -38,6 +38,18 @@ The cap is an atomic claim on `wallet_settings.last_auto_charge_at`, the same gu
 
 Manual top-ups never touch this path.
 
+### Giving up on a declining card
+
+The cooldown bounds how often a dead card is charged, but on its own it never stops: one attempt an hour is still ~720 declined charges a month, and card networks fine excessive reattempts of a declined payment. So a run of declines eventually pauses the wallet (CON-937).
+
+Each declined charge increments `wallet_settings.auto_reload_failure_count`, and the cooldown handed to the next claim doubles with it (60 min, then 120, then 240, capped by `AUTO_RELOAD_CHARGE_BACKOFF_MAX_IN_MIN`). After `AUTO_RELOAD_MAX_CONSECUTIVE_DECLINES` declines — default 4, landing at roughly t=0, 1h, 3h and 7h — `auto_reload_paused_at` is stamped and the card is not charged again. A decline code the issuer will never approve (`lost_card`, `stolen_card`, `fraudulent`, and the rest of Stripe's never-retry list) pauses on the first decline instead of waiting out the count.
+
+Only declines count. A Stripe outage, a rate limit, or a bug of ours leaves the counter alone, so an incident cannot pause every wallet at once. A charge that goes through resets the counter; a charge that merely asks for 3DS authentication does not, since no money moved.
+
+A paused wallet is treated as opted out everywhere behaviour depends on it: the check itself skips with `AUTO_RELOAD_PAUSED` and stops rescheduling, no new checks are enqueued for it, the credits-low email takes over, and it drops out of the `insufficient_balance_with_auto_reload` metrics behind the funding alert. It is *not* excluded from escrow funding — existing credits keep funding deployments as before.
+
+The user gets an email when the pause happens. It lifts when they change their default payment method, or when they save their auto top-up settings again, both of which also clear the charge marker so the next check can charge straight away rather than waiting out the cooldown the dead card consumed.
+
 ### Worked examples (defaults: threshold $20, amount $100)
 
 | Balance | Threshold | Amount | Outcome |
@@ -67,9 +79,10 @@ Before charging, the handler validates:
 
 1. ✅ Wallet setting exists
 2. ✅ Auto-reload is enabled
-3. ✅ Wallet is initialized (has address)
-4. ✅ User has a Stripe customer ID
-5. ✅ Default payment method exists
+3. ✅ Auto-reload is not paused after repeated declines
+4. ✅ Wallet is initialized (has address)
+5. ✅ User has a Stripe customer ID
+6. ✅ Default payment method exists
 
 If any validation fails, the handler logs and skips processing (does not throw).
 
@@ -79,7 +92,7 @@ The charge uses a job-scoped idempotency key (`WalletBalanceReloadCheck.<jobId>`
 
 ## What happens on failure?
 
-- **Payment fails**: The error is logged and re-thrown (job fails, will retry under the same idempotency key). The charge claim is kept, so the retry loses it, records a `charge_rate_limited` skip, and defers the next check to the window reopen — a fresh attempt happens once per cooldown, not once per retry.
+- **Payment fails**: The error is logged and re-thrown (job fails, will retry under the same idempotency key). The charge claim is kept, so the retry loses it, records a `charge_rate_limited` skip, and defers the next check to the window reopen — a fresh attempt happens once per cooldown, not once per retry. A card decline is also counted towards the pause limit above, best-effort: a failed count is recorded on `wallet_balance_reload_check_decline_recording_errors_total` rather than replacing the payment error.
 - **Validation fails**: Error is logged, job completes successfully (no retry needed).
 - **Scheduling next check fails**: Error is logged and re-thrown.
 
@@ -93,7 +106,7 @@ This is the pre-CON-717 behavior, kept as a supported mode by CON-884. It predic
 
 1. **Calculate** the unfunded cost to keep all auto-top-up deployments running for the next 7 days (`RELOAD_COVERAGE_PERIOD_IN_MS`), excluding the portion already covered by escrow.
 2. **Compare** the balance against 25% of that projection (`MIN_COVERAGE_PERCENTAGE`). Reload when `balance < 0.25 * costUntilTargetDate` (~1.75 days of coverage remaining).
-3. **Claim** the charge window — the same rate limit as threshold mode (see "Charge rate limit" above). A lost claim defers the reload to the window reopen.
+3. **Claim** the charge window — the same rate limit and decline handling as threshold mode (see "Charge rate limit" above). A lost claim defers the reload to the window reopen.
 4. **Charge** `max(costUntilTargetDate - balance, $20)`.
 5. **Skip** entirely when the projected cost is 0 (no active auto-top-up deployments).
 6. **Schedule** the next check 24 hours out.

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check-instrumentation.service.spec.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check-instrumentation.service.spec.ts
@@ -29,7 +29,11 @@ describe(WalletBalanceReloadCheckInstrumentationService.name, () => {
 
       service.recordReloadFailed({ mode: "threshold", error, logContext });
 
-      expect(counters.wallet_balance_reload_check_reload_failures_total.add).toHaveBeenCalledWith(1, { mode: "threshold", error_type: "TypeError" });
+      expect(counters.wallet_balance_reload_check_reload_failures_total.add).toHaveBeenCalledWith(1, {
+        mode: "threshold",
+        error_type: "TypeError",
+        decline_code: "none"
+      });
       expect(mockLogger.error).toHaveBeenCalledWith(
         expect.objectContaining({
           ...logContext,
@@ -50,7 +54,11 @@ describe(WalletBalanceReloadCheckInstrumentationService.name, () => {
 
       service.recordReloadFailed({ mode: "prediction", error, logContext });
 
-      expect(counters.wallet_balance_reload_check_reload_failures_total.add).toHaveBeenCalledWith(1, { mode: "prediction", error_type: "Unknown" });
+      expect(counters.wallet_balance_reload_check_reload_failures_total.add).toHaveBeenCalledWith(1, {
+        mode: "prediction",
+        error_type: "Unknown",
+        decline_code: "none"
+      });
       expect(mockLogger.error).toHaveBeenCalledWith(
         expect.objectContaining({
           ...logContext,
@@ -59,6 +67,32 @@ describe(WalletBalanceReloadCheckInstrumentationService.name, () => {
           error
         })
       );
+    });
+
+    it("labels the failure with the decline code when the card was declined", () => {
+      const { service, counters } = setup();
+      const error = new TypeError(faker.lorem.sentence());
+
+      service.recordReloadFailed({ mode: "threshold", error, declineCode: "stolen_card", logContext: {} });
+
+      expect(counters.wallet_balance_reload_check_reload_failures_total.add).toHaveBeenCalledWith(1, {
+        mode: "threshold",
+        error_type: "TypeError",
+        decline_code: "stolen_card"
+      });
+    });
+  });
+
+  describe("recordDeclineRecordingError", () => {
+    it("counts a decline the pause limit could not be told about", () => {
+      const { service, counters } = setup();
+      const userId = faker.string.uuid();
+      const error = new Error(faker.lorem.sentence());
+
+      service.recordDeclineRecordingError(userId, error);
+
+      expect(counters.wallet_balance_reload_check_decline_recording_errors_total.add).toHaveBeenCalledWith(1, { error_type: "Error" });
+      expect(mockLogger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "AUTO_RELOAD_DECLINE_RECORDING_FAILED", userId, error }));
     });
   });
 

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check-instrumentation.service.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check-instrumentation.service.ts
@@ -24,6 +24,7 @@ export class WalletBalanceReloadCheckInstrumentationService {
   private readonly schedulingErrors: Counter;
   private readonly balanceCoverageRatio: Histogram;
   private readonly projectedCost: Histogram;
+  private readonly declineRecordingErrors: Counter;
 
   private readonly logger = createOtelLogger({ context: "WalletBalanceReloadCheckHandler" });
 
@@ -67,6 +68,10 @@ export class WalletBalanceReloadCheckInstrumentationService {
     this.projectedCost = this.metricsService.createHistogram(this.meter, "wallet_balance_reload_check_projected_cost_usd", {
       description: "Projected deployment cost until target date in USD (prediction mode only)",
       unit: "USD"
+    });
+
+    this.declineRecordingErrors = this.metricsService.createCounter(this.meter, "wallet_balance_reload_check_decline_recording_errors_total", {
+      description: "Total number of failures to count a declined charge against the auto top-up pause limit"
     });
   }
 
@@ -120,16 +125,29 @@ export class WalletBalanceReloadCheckInstrumentationService {
     }
   }
 
-  recordReloadFailed(input: Pick<ReloadMetricInput, "mode" | "logContext"> & { error: unknown }): void {
+  recordReloadFailed(input: Pick<ReloadMetricInput, "mode" | "logContext"> & { error: unknown; declineCode?: string }): void {
     this.reloadFailures.add(1, {
       mode: input.mode,
-      error_type: input.error instanceof Error ? input.error.constructor.name : "Unknown"
+      error_type: input.error instanceof Error ? input.error.constructor.name : "Unknown",
+      decline_code: input.declineCode ?? "none"
     });
     this.logger.error({
       ...input.logContext,
       mode: input.mode,
       event: "WALLET_BALANCE_RELOAD_FAILED",
+      declineCode: input.declineCode,
       error: input.error
+    });
+  }
+
+  recordDeclineRecordingError(userId: string, error: unknown): void {
+    this.declineRecordingErrors.add(1, {
+      error_type: error instanceof Error ? error.constructor.name : "Unknown"
+    });
+    this.logger.error({
+      event: "AUTO_RELOAD_DECLINE_RECORDING_FAILED",
+      userId,
+      error
     });
   }
 

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.spec.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.spec.ts
@@ -1,13 +1,14 @@
 import { faker } from "@faker-js/faker";
 import { addMilliseconds, millisecondsInHour, millisecondsInMinute } from "date-fns";
+import Stripe from "stripe";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import { WalletBalanceReloadCheck } from "@src/billing/events/wallet-balance-reload-check";
 import { usdToCents } from "@src/billing/lib/currency/currency";
 import type { WalletSettingRepository } from "@src/billing/repositories";
+import type { AutoReloadPauseService } from "@src/billing/services/auto-reload-pause/auto-reload-pause.service";
 import type { BalancesService } from "@src/billing/services/balances/balances.service";
-import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import type { PaymentMethodService } from "@src/billing/services/payment-method/payment-method.service";
 import type { StripeTransactionService } from "@src/billing/services/stripe-transaction/stripe-transaction.service";
 import type { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
@@ -18,7 +19,6 @@ import type { JobPayload } from "../../../core";
 import { WalletBalanceReloadCheckHandler } from "./wallet-balance-reload-check.handler";
 import type { WalletBalanceReloadCheckInstrumentationService } from "./wallet-balance-reload-check-instrumentation.service";
 
-import { mockConfigService } from "@test/mocks/config-service.mock";
 import { generateMergedPaymentMethod as generatePaymentMethod } from "@test/seeders/payment-method.seeder";
 import { createUser } from "@test/seeders/user.seeder";
 import { createUserWallet } from "@test/seeders/user-wallet.seeder";
@@ -712,6 +712,140 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
     });
   });
 
+  describe("when a charge is declined", () => {
+    it("counts the decline against the pause limit", async () => {
+      const error = declinedCardError("generic_decline");
+      const { handler, autoReloadPauseService, stripeTransactionService, claim, job, jobMeta } = setup({ balance: 10.0 });
+      stripeTransactionService.createPaymentIntent.mockRejectedValue(error);
+
+      await expect(handler.handle(job, jobMeta)).rejects.toThrow(error);
+
+      expect(autoReloadPauseService.recordDecline).toHaveBeenCalledWith({
+        claim,
+        user: expect.objectContaining({ id: job.userId }),
+        decline: { declineCode: "generic_decline", isTerminal: false }
+      });
+    });
+
+    it("marks a lost or stolen card as terminal so it is never charged again", async () => {
+      const { handler, autoReloadPauseService, stripeTransactionService, job, jobMeta } = setup({ balance: 10.0 });
+      stripeTransactionService.createPaymentIntent.mockRejectedValue(declinedCardError("stolen_card"));
+
+      await expect(handler.handle(job, jobMeta)).rejects.toThrow();
+
+      expect(autoReloadPauseService.recordDecline).toHaveBeenCalledWith(expect.objectContaining({ decline: { declineCode: "stolen_card", isTerminal: true } }));
+    });
+
+    it("labels the failure metric with the decline code", async () => {
+      const { handler, instrumentationService, stripeTransactionService, job, jobMeta } = setup({ balance: 10.0 });
+      stripeTransactionService.createPaymentIntent.mockRejectedValue(declinedCardError("insufficient_funds"));
+
+      await expect(handler.handle(job, jobMeta)).rejects.toThrow();
+
+      expect(instrumentationService.recordReloadFailed).toHaveBeenCalledWith(expect.objectContaining({ declineCode: "insufficient_funds" }));
+    });
+
+    it("keeps the payment error when the decline cannot be recorded", async () => {
+      const error = declinedCardError("generic_decline");
+      const { handler, autoReloadPauseService, instrumentationService, stripeTransactionService, job, jobMeta } = setup({ balance: 10.0 });
+      stripeTransactionService.createPaymentIntent.mockRejectedValue(error);
+      const recordingError = new Error("connection terminated");
+      autoReloadPauseService.recordDecline.mockRejectedValue(recordingError);
+
+      await expect(handler.handle(job, jobMeta)).rejects.toThrow(error);
+
+      expect(instrumentationService.recordDeclineRecordingError).toHaveBeenCalledWith(job.userId, recordingError);
+    });
+
+    it("leaves a Stripe outage out of the pause limit", async () => {
+      const error = new Error("Stripe is temporarily unavailable");
+      const { handler, autoReloadPauseService, stripeTransactionService, job, jobMeta } = setup({ balance: 10.0 });
+      stripeTransactionService.createPaymentIntent.mockRejectedValue(error);
+
+      await expect(handler.handle(job, jobMeta)).rejects.toThrow(error);
+
+      expect(autoReloadPauseService.recordDecline).not.toHaveBeenCalled();
+    });
+
+    it("spaces the next attempt out by the cooldown owed for the declines so far", async () => {
+      const { handler, walletSettingRepository, autoReloadPauseService, walletSetting, job, jobMeta } = setup({
+        balance: 10.0,
+        autoReloadFailureCount: 3,
+        chargeCooldownMinutes: 240
+      });
+
+      await handler.handle(job, jobMeta);
+
+      expect(autoReloadPauseService.calculateChargeCooldownMinutes).toHaveBeenCalledWith(3);
+      expect(walletSettingRepository.claimForCharge).toHaveBeenCalledWith(walletSetting.id, 240);
+    });
+  });
+
+  describe("when the wallet is paused after repeated declines", () => {
+    it("skips the check without charging", async () => {
+      const { handler, walletSettingRepository, stripeTransactionService, instrumentationService, job, jobMeta } = setup({
+        balance: 10.0,
+        autoReloadPausedAt: new Date()
+      });
+
+      await handler.handle(job, jobMeta);
+
+      expect(stripeTransactionService.createPaymentIntent).not.toHaveBeenCalled();
+      expect(walletSettingRepository.claimForCharge).not.toHaveBeenCalled();
+      expect(instrumentationService.recordValidationError).toHaveBeenCalledWith(
+        "AUTO_RELOAD_PAUSED",
+        {
+          event: "AUTO_RELOAD_PAUSED",
+          message: "Auto reload paused after repeated card declines. Skipping wallet balance reload check."
+        },
+        job.userId
+      );
+    });
+
+    it("stops rescheduling the check", async () => {
+      const { handler, walletReloadJobService, job, jobMeta } = setup({ balance: 10.0, autoReloadPausedAt: new Date() });
+
+      await handler.handle(job, jobMeta);
+
+      expect(walletReloadJobService.scheduleForWalletSetting).not.toHaveBeenCalled();
+    });
+
+    it("reports the job as completed rather than failed", async () => {
+      const { handler, instrumentationService, job, jobMeta } = setup({ balance: 10.0, autoReloadPausedAt: new Date() });
+
+      await handler.handle(job, jobMeta);
+
+      expect(instrumentationService.recordJobExecution).toHaveBeenCalledWith(expect.any(Number), true, job.userId);
+    });
+  });
+
+  describe("when a charge goes through", () => {
+    it("clears the declines the card had accumulated", async () => {
+      const { handler, walletSettingRepository, walletSetting, job, jobMeta } = setup({ balance: 10.0, autoReloadFailureCount: 2 });
+
+      await handler.handle(job, jobMeta);
+
+      expect(walletSettingRepository.resetChargeFailures).toHaveBeenCalledWith(walletSetting.id);
+    });
+
+    it("keeps the declines when the card only asked for authentication", async () => {
+      const { handler, walletSettingRepository, job, jobMeta } = setup({ balance: 10.0, autoReloadFailureCount: 2, chargeRequiresAction: true });
+
+      await handler.handle(job, jobMeta);
+
+      expect(walletSettingRepository.resetChargeFailures).not.toHaveBeenCalled();
+    });
+  });
+
+  function declinedCardError(declineCode: string) {
+    return new Stripe.errors.StripeCardError({
+      type: "card_error",
+      code: "card_declined",
+      decline_code: declineCode,
+      message: "Your card was declined"
+    });
+  }
+
   function setup(input?: {
     balance?: number;
     weeklyCostInDenom?: number;
@@ -725,8 +859,11 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
     activeDeploymentCount?: number;
     triggeredByDeployment?: boolean;
     chargeClaimWon?: boolean;
+    chargeRequiresAction?: boolean;
     secondsUntilWindowReopen?: number;
     chargeCooldownMinutes?: number;
+    autoReloadFailureCount?: number;
+    autoReloadPausedAt?: Date;
     user?: ReturnType<typeof createUser>;
     wallet?: ReturnType<typeof createUserWallet>;
   }) {
@@ -745,6 +882,8 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       walletId: wallet.id,
       autoReloadEnabled: input?.autoReloadEnabled ?? true,
       autoReloadMode: input?.autoReloadMode ?? "prediction",
+      autoReloadFailureCount: input?.autoReloadFailureCount ?? 0,
+      autoReloadPausedAt: input?.autoReloadPausedAt ?? null,
       ...(input?.autoReloadThresholdUsd !== undefined && { autoReloadThreshold: usdToCents(input.autoReloadThresholdUsd) }),
       ...(input?.autoReloadAmountUsd !== undefined && { autoReloadAmount: usdToCents(input.autoReloadAmountUsd) })
     });
@@ -765,12 +904,12 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
     };
 
     const walletSettingRepository = mock<WalletSettingRepository>();
+    const claim = { id: walletSetting.id, claimedAt: "2026-09-01 12:00:00" };
     walletSettingRepository.claimForCharge.mockResolvedValue(
-      input?.chargeClaimWon === false ? { won: false, secondsUntilWindowReopen: input?.secondsUntilWindowReopen ?? 0 } : { won: true }
+      input?.chargeClaimWon === false ? { won: false, secondsUntilWindowReopen: input?.secondsUntilWindowReopen ?? 0 } : { won: true, claim }
     );
-    const billingConfig = mockConfigService<BillingConfigService>({
-      AUTO_RELOAD_CHARGE_COOLDOWN_IN_MIN: input?.chargeCooldownMinutes ?? 60
-    });
+    const autoReloadPauseService = mock<AutoReloadPauseService>();
+    autoReloadPauseService.calculateChargeCooldownMinutes.mockReturnValue(input?.chargeCooldownMinutes ?? 60);
     const balancesService = mock<BalancesService>({
       ensure2floatingDigits: vi.fn().mockImplementation((amount: number) => amount)
     });
@@ -780,13 +919,20 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
     deploymentRepository.countActiveByOwner.mockResolvedValue(input?.activeDeploymentCount ?? 1);
     const paymentMethodService = mock<PaymentMethodService>();
     const stripeTransactionService = mock<StripeTransactionService>();
+    stripeTransactionService.createPaymentIntent.mockResolvedValue({
+      success: input?.chargeRequiresAction ? false : true,
+      ...(input?.chargeRequiresAction && { requiresAction: true }),
+      transactionId: faker.string.uuid(),
+      transactionStatus: "succeeded"
+    });
     const instrumentationService = mock<WalletBalanceReloadCheckInstrumentationService>({
       recordJobExecution: vi.fn(),
       recordReloadTriggered: vi.fn(),
       recordReloadSkipped: vi.fn(),
       recordReloadFailed: vi.fn(),
       recordValidationError: vi.fn(),
-      recordSchedulingError: vi.fn()
+      recordSchedulingError: vi.fn(),
+      recordDeclineRecordingError: vi.fn()
     });
     const balance = input?.balance ?? 50.0;
     const weeklyCostInDenom = input?.weeklyCostInDenom ?? 50_000_000;
@@ -817,7 +963,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       drainingDeploymentService,
       deploymentRepository,
       instrumentationService,
-      billingConfig
+      autoReloadPauseService
     );
 
     return {
@@ -830,7 +976,8 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       paymentMethodService,
       stripeTransactionService,
       instrumentationService,
-      billingConfig,
+      autoReloadPauseService,
+      claim,
       walletSetting,
       walletSettingWithWallet,
       wallet,

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.ts
@@ -6,10 +6,11 @@ import { singleton } from "tsyringe";
 import { AUTO_RELOAD_AMOUNT_MIN_USD } from "@src/billing/config";
 import { WalletBalanceReloadCheck } from "@src/billing/events/wallet-balance-reload-check";
 import type { GetBalancesResponseOutput } from "@src/billing/http-schemas/balance.schema";
+import { type CardDecline, toCardDecline } from "@src/billing/lib/card-decline/card-decline";
 import { centsToUsd } from "@src/billing/lib/currency/currency";
-import { UserWalletOutput, WalletSettingOutput, WalletSettingRepository } from "@src/billing/repositories";
+import { type ChargeClaim, UserWalletOutput, WalletSettingOutput, WalletSettingRepository } from "@src/billing/repositories";
+import { AutoReloadPauseService } from "@src/billing/services/auto-reload-pause/auto-reload-pause.service";
 import { BalancesService } from "@src/billing/services/balances/balances.service";
-import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import { type PaymentMethod, PaymentMethodService } from "@src/billing/services/payment-method/payment-method.service";
 import { AUTO_RECHARGE_METADATA_KEY, StripeTransactionService } from "@src/billing/services/stripe-transaction/stripe-transaction.service";
 import { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
@@ -26,7 +27,10 @@ type ValidationError = {
 };
 
 type InitializedWallet = Require<Pick<UserWalletOutput, "address">, "address">;
-type ActionableWalletSetting = Pick<WalletSettingOutput, "id" | "userId" | "autoReloadMode" | "autoReloadThreshold" | "autoReloadAmount">;
+type ActionableWalletSetting = Pick<
+  WalletSettingOutput,
+  "id" | "userId" | "autoReloadMode" | "autoReloadThreshold" | "autoReloadAmount" | "autoReloadFailureCount"
+>;
 
 type Resources = {
   walletSetting: ActionableWalletSetting;
@@ -67,7 +71,7 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
     private readonly drainingDeploymentService: DrainingDeploymentService,
     private readonly deploymentRepository: DeploymentRepository,
     private readonly instrumentationService: WalletBalanceReloadCheckInstrumentationService,
-    private readonly billingConfig: BillingConfigService
+    private readonly autoReloadPauseService: AutoReloadPauseService
   ) {}
 
   async handle(payload: JobPayload<WalletBalanceReloadCheck>, job: JobMeta): Promise<void> {
@@ -83,6 +87,7 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
         success = true;
       } else {
         this.instrumentationService.recordValidationError(resourcesResult.val.event, resourcesResult.val, payload.userId);
+        success = true;
         return;
       }
     } finally {
@@ -127,6 +132,13 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
       return Err({
         event: "AUTO_RELOAD_DISABLED",
         message: "Auto reload disabled. Skipping wallet balance reload check."
+      });
+    }
+
+    if (walletSetting.autoReloadPausedAt) {
+      return Err({
+        event: "AUTO_RELOAD_PAUSED",
+        message: "Auto reload paused after repeated card declines. Skipping wallet balance reload check."
       });
     }
 
@@ -265,7 +277,7 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
   }): Promise<ReloadOutcome> {
     const { resources, amount, coverageRatio, projectedCost, logContext } = input;
     const mode = resources.walletSetting.autoReloadMode;
-    const cooldownMinutes = this.billingConfig.get("AUTO_RELOAD_CHARGE_COOLDOWN_IN_MIN");
+    const cooldownMinutes = this.autoReloadPauseService.calculateChargeCooldownMinutes(resources.walletSetting.autoReloadFailureCount);
     const attempt = await this.walletSettingRepository.claimForCharge(resources.walletSetting.id, cooldownMinutes);
 
     if (!attempt.won) {
@@ -281,7 +293,7 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
     }
 
     try {
-      await this.stripeTransactionService.createPaymentIntent({
+      const result = await this.stripeTransactionService.createPaymentIntent({
         userId: resources.user.id,
         customer: resources.user.stripeCustomerId,
         payment_method: resources.paymentMethod.id,
@@ -291,10 +303,34 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
         idempotencyKey: `${WalletBalanceReloadCheck.name}.${resources.job.id}`,
         onAmountMismatch: "tolerate"
       });
+
+      if (result.success) {
+        await this.walletSettingRepository.resetChargeFailures(resources.walletSetting.id);
+      }
+
       this.instrumentationService.recordReloadTriggered({ mode, amount, coverageRatio, projectedCost, logContext });
     } catch (error) {
-      this.instrumentationService.recordReloadFailed({ mode, error, logContext });
+      const decline = toCardDecline(error);
+      this.instrumentationService.recordReloadFailed({ mode, error, declineCode: decline?.declineCode, logContext });
+
+      if (decline) {
+        await this.#recordDecline(attempt.claim, resources, decline);
+      }
+
       throw error;
+    }
+  }
+
+  /**
+   * Best-effort: a rejected pause must not replace the payment error the caller is about to record
+   * and rethrow, which retries and alerting classify. The counter is what keeps a pause that keeps
+   * failing from making the whole give-up rule quietly inert.
+   */
+  async #recordDecline(claim: ChargeClaim, resources: ReloadContext, decline: CardDecline): Promise<void> {
+    try {
+      await this.autoReloadPauseService.recordDecline({ claim, user: resources.user, decline });
+    } catch (error) {
+      this.instrumentationService.recordDeclineRecordingError(resources.user.id, error);
     }
   }
 

--- a/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.spec.ts
+++ b/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.spec.ts
@@ -80,6 +80,14 @@ describe(WalletCreditsLowCheckHandler.name, () => {
     expect(logger.warn).not.toHaveBeenCalled();
   });
 
+  it("sends when Auto Recharge is paused after repeated card declines", async () => {
+    const { handler, notificationService, job } = setup({ autoReloadEnabled: true, autoReloadPausedAt: new Date() });
+
+    await handler.handle(job);
+
+    expect(notificationService.createNotification).toHaveBeenCalled();
+  });
+
   it("does not send when the wallet is trialing", async () => {
     const { handler, notificationService, userWalletRepository, logger, job } = setup({
       isTrialing: true
@@ -385,6 +393,7 @@ describe(WalletCreditsLowCheckHandler.name, () => {
 
   function setup(input?: {
     autoReloadEnabled?: boolean;
+    autoReloadPausedAt?: Date;
     walletSettingNotFound?: boolean;
     isTrialing?: boolean;
     creditsLowNotifiedAt?: Date | null;
@@ -410,7 +419,8 @@ describe(WalletCreditsLowCheckHandler.name, () => {
     const walletSetting = generateWalletSetting({
       userId: user.id,
       walletId: wallet.id,
-      autoReloadEnabled: input?.autoReloadEnabled ?? false
+      autoReloadEnabled: input?.autoReloadEnabled ?? false,
+      autoReloadPausedAt: input?.autoReloadPausedAt ?? null
     });
     const job: JobPayload<WalletCreditsLowCheck> = {
       userId: user.id,

--- a/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.ts
+++ b/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.ts
@@ -1,6 +1,7 @@
 import { inject, singleton } from "tsyringe";
 
 import { WalletCreditsLowCheck } from "@src/billing/events/wallet-credits-low-check";
+import { isAutoReloadActive } from "@src/billing/lib/auto-reload/auto-reload";
 import { isWalletInitialized, type UserWalletOutput, UserWalletRepository, WalletSettingRepository } from "@src/billing/repositories";
 import { BalancesService } from "@src/billing/services/balances/balances.service";
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
@@ -126,7 +127,7 @@ export class WalletCreditsLowCheckHandler implements JobHandler<WalletCreditsLow
 
   async #getValidWalletResources(userId: UserOutput["id"]) {
     const walletSetting = await this.walletSettingRepository.findByUserId(userId);
-    if (walletSetting?.autoReloadEnabled) {
+    if (isAutoReloadActive(walletSetting)) {
       this.#skip("auto_reload_enabled", userId);
       return;
     }

--- a/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.spec.ts
+++ b/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.spec.ts
@@ -41,6 +41,17 @@ describe(WalletReloadJobService.name, () => {
       expect(jobQueueService.cancelCreatedBy).not.toHaveBeenCalled();
     });
 
+    it("schedules nothing when the wallet is paused after repeated declines", async () => {
+      const { service, walletSettingRepository, jobQueueService } = setup();
+      const userId = faker.string.uuid();
+      walletSettingRepository.findByUserId.mockResolvedValue(generateWalletSetting({ autoReloadEnabled: true, autoReloadPausedAt: new Date(), userId }));
+
+      const result = await service.scheduleImmediate({ userId });
+
+      expect(result).toBe(false);
+      expect(jobQueueService.enqueue).not.toHaveBeenCalled();
+    });
+
     it("calls scheduleForWalletSetting when conditions are met", async () => {
       const { service, walletSettingRepository, jobQueueService } = setup();
       const userId = faker.string.uuid();
@@ -248,6 +259,18 @@ describe(WalletReloadJobService.name, () => {
 
       expectCreditsLowCheckScheduled(jobQueueService, walletSetting.userId);
       expect(jobQueueService.enqueue).not.toHaveBeenCalledWith(expect.any(WalletBalanceReloadCheck), expect.anything());
+    });
+
+    it("enqueues a credits-low check when the wallet is paused after repeated declines", async () => {
+      const { service, walletSettingRepository, jobQueueService } = setup();
+      const walletId = faker.number.int({ min: 1, max: 1000000 });
+      const walletSetting = generateWalletSetting({ walletId, autoReloadEnabled: true, autoReloadPausedAt: new Date() });
+      walletSettingRepository.findOneBy.mockResolvedValue(walletSetting);
+      jobQueueService.enqueue.mockResolvedValue(faker.string.uuid());
+
+      await service.scheduleCreditsLowCheckIfAutoReloadOff({ walletId });
+
+      expectCreditsLowCheckScheduled(jobQueueService, walletSetting.userId);
     });
 
     it("enqueues a credits-low check when wallet setting does not exist", async () => {

--- a/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.ts
+++ b/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.ts
@@ -2,6 +2,7 @@ import { inject, singleton } from "tsyringe";
 
 import { WalletBalanceReloadCheck } from "@src/billing/events/wallet-balance-reload-check";
 import { WalletCreditsLowCheck } from "@src/billing/events/wallet-credits-low-check";
+import { isAutoReloadActive } from "@src/billing/lib/auto-reload/auto-reload";
 import { UserWalletRepository, WalletSettingOutput, WalletSettingRepository } from "@src/billing/repositories";
 import { EnqueueOptions, JobQueueService } from "@src/core";
 import { type CreateLogger, LOGGER_FACTORY } from "@src/core/providers/logging.provider";
@@ -26,7 +27,7 @@ export class WalletReloadJobService {
         ? await this.walletSettingRepository.findByUserId(input.userId)
         : await this.walletSettingRepository.findOneBy({ walletId: input.walletId });
 
-    if (walletSetting?.autoReloadEnabled) {
+    if (isAutoReloadActive(walletSetting)) {
       await this.scheduleForWalletSetting(walletSetting, { withCleanup: true, triggeredByDeployment: options?.triggeredByDeployment });
       return true;
     }
@@ -37,7 +38,7 @@ export class WalletReloadJobService {
   async scheduleCreditsLowCheckIfAutoReloadOff(input: { walletId: number }): Promise<void> {
     const walletSetting = await this.walletSettingRepository.findOneBy({ walletId: input.walletId });
 
-    if (walletSetting?.autoReloadEnabled) {
+    if (isAutoReloadActive(walletSetting)) {
       return;
     }
 

--- a/apps/api/src/billing/services/wallet-settings/wallet-settings.service.spec.ts
+++ b/apps/api/src/billing/services/wallet-settings/wallet-settings.service.spec.ts
@@ -73,6 +73,22 @@ describe(WalletSettingService.name, () => {
       expect(walletReloadJobService.scheduleForWalletSetting).toHaveBeenCalledWith(expect.objectContaining({ id: pausedSetting.id }), { withCleanup: true });
     });
 
+    it("clears the credits-low latch the pause left behind", async () => {
+      const { user, walletSetting, walletSettingRepository, walletReloadJobService, userWalletRepository, service } = setup();
+      const pausedSetting = { ...walletSetting, autoReloadEnabled: true, autoReloadPausedAt: new Date() };
+      walletSettingRepository.findByUserId.mockResolvedValue(pausedSetting);
+      walletSettingRepository.updateById.mockResolvedValue({ ...pausedSetting, autoReloadPausedAt: null } as never);
+
+      await service.upsertWalletSetting(user.id, { autoReloadEnabled: true });
+
+      expect(walletReloadJobService.cancelCreditsLowCheckByUserId).toHaveBeenCalledWith(user.id);
+      expect(userWalletRepository.updateById).toHaveBeenCalledWith(pausedSetting.walletId, {
+        creditsLowNotifiedAt: null,
+        creditsSufficientSince: null,
+        creditsLowSince: null
+      });
+    });
+
     it("leaves the charge window alone when the wallet was never paused", async () => {
       const { user, walletSetting, walletSettingRepository, service } = setup();
       const enabledSetting = { ...walletSetting, autoReloadEnabled: true, autoReloadPausedAt: null };

--- a/apps/api/src/billing/services/wallet-settings/wallet-settings.service.spec.ts
+++ b/apps/api/src/billing/services/wallet-settings/wallet-settings.service.spec.ts
@@ -47,6 +47,45 @@ describe(WalletSettingService.name, () => {
       });
     });
 
+    it("lifts a decline pause and reopens the charge window when the settings are saved", async () => {
+      const { user, walletSetting, walletSettingRepository, service } = setup();
+      const pausedSetting = { ...walletSetting, autoReloadEnabled: true, autoReloadPausedAt: new Date(), autoReloadFailureCount: 4 };
+      walletSettingRepository.findByUserId.mockResolvedValue(pausedSetting);
+      walletSettingRepository.updateById.mockResolvedValue({ ...pausedSetting, autoReloadPausedAt: null, autoReloadFailureCount: 0 } as never);
+
+      await service.upsertWalletSetting(user.id, { autoReloadEnabled: true, autoReloadAmount: 100 });
+
+      expect(walletSettingRepository.updateById).toHaveBeenCalledWith(
+        pausedSetting.id,
+        expect.objectContaining({ autoReloadFailureCount: 0, autoReloadPausedAt: null, lastAutoChargeAt: null }),
+        { returning: true }
+      );
+    });
+
+    it("schedules a check after lifting a pause even when no setting changed", async () => {
+      const { user, walletSetting, walletSettingRepository, walletReloadJobService, service } = setup();
+      const pausedSetting = { ...walletSetting, autoReloadEnabled: true, autoReloadPausedAt: new Date() };
+      walletSettingRepository.findByUserId.mockResolvedValue(pausedSetting);
+      walletSettingRepository.updateById.mockResolvedValue({ ...pausedSetting, autoReloadPausedAt: null } as never);
+
+      await service.upsertWalletSetting(user.id, { autoReloadEnabled: true });
+
+      expect(walletReloadJobService.scheduleForWalletSetting).toHaveBeenCalledWith(expect.objectContaining({ id: pausedSetting.id }), { withCleanup: true });
+    });
+
+    it("leaves the charge window alone when the wallet was never paused", async () => {
+      const { user, walletSetting, walletSettingRepository, service } = setup();
+      const enabledSetting = { ...walletSetting, autoReloadEnabled: true, autoReloadPausedAt: null };
+      walletSettingRepository.findByUserId.mockResolvedValue(enabledSetting);
+      walletSettingRepository.updateById.mockResolvedValue(enabledSetting as never);
+
+      await service.upsertWalletSetting(user.id, { autoReloadEnabled: true, autoReloadAmount: 100 });
+
+      expect(walletSettingRepository.updateById).toHaveBeenCalledWith(enabledSetting.id, expect.not.objectContaining({ lastAutoChargeAt: null }), {
+        returning: true
+      });
+    });
+
     it("enqueues a credits-low check when Auto Recharge is disabled", async () => {
       const { user, walletSetting, walletSettingRepository, walletReloadJobService, service } = setup();
       const enabledSetting = { ...walletSetting, autoReloadEnabled: true };

--- a/apps/api/src/billing/services/wallet-settings/wallet-settings.service.ts
+++ b/apps/api/src/billing/services/wallet-settings/wallet-settings.service.ts
@@ -2,6 +2,7 @@ import assert from "http-assert";
 import { inject, singleton } from "tsyringe";
 
 import { AuthService } from "@src/auth/services/auth.service";
+import { isAutoReloadActive } from "@src/billing/lib/auto-reload/auto-reload";
 import { centsToUsd, usdToCents } from "@src/billing/lib/currency/currency";
 import { UserWalletRepository, type WalletSettingOutput, WalletSettingRepository } from "@src/billing/repositories";
 import { PaymentMethodService } from "@src/billing/services/payment-method/payment-method.service";
@@ -152,14 +153,14 @@ export class WalletSettingService {
     }
 
     if (next.autoReloadEnabled) {
-      if (!prev?.autoReloadEnabled) {
+      if (!isAutoReloadActive(prev)) {
         await this.walletReloadJobService.scheduleForWalletSetting(next, { withCleanup: true });
         await this.walletReloadJobService.cancelCreditsLowCheckByUserId(next.userId);
         await this.userWalletRepository.updateById(next.walletId, { creditsLowNotifiedAt: null, creditsSufficientSince: null, creditsLowSince: null });
         return;
       }
 
-      if (prev.autoReloadPausedAt || this.#hasReloadRuleChanged(prev, next)) {
+      if (this.#hasReloadRuleChanged(prev, next)) {
         await this.walletReloadJobService.scheduleForWalletSetting(next, { withCleanup: true });
       }
       return;

--- a/apps/api/src/billing/services/wallet-settings/wallet-settings.service.ts
+++ b/apps/api/src/billing/services/wallet-settings/wallet-settings.service.ts
@@ -11,6 +11,15 @@ import { type CreateLogger, LOGGER_FACTORY } from "@src/core/providers/logging.p
 import { isUniqueViolation } from "@src/core/repositories/base.repository";
 import { UserOutput, UserRepository } from "@src/user/repositories";
 
+/**
+ * Saving auto top-up settings is the user asking us to try the card again, so it lifts a pause left
+ * by repeated declines. Clearing the charge marker too is what lets the next check charge straight
+ * away rather than waiting out the cooldown the declining card consumed.
+ */
+function liftDeclinePause(prev: WalletSettingOutput) {
+  return prev.autoReloadPausedAt ? { autoReloadFailureCount: 0, autoReloadPausedAt: null, lastAutoChargeAt: null } : {};
+}
+
 export interface WalletSettingInput {
   autoReloadEnabled?: boolean;
   autoReloadMode?: WalletSettingOutput["autoReloadMode"];
@@ -79,7 +88,9 @@ export class WalletSettingService {
     }
 
     await this.#validate({ next: settings, userId });
-    const next = await this.walletSettingRepository.accessibleBy(ability, "update").updateById(prev.id, this.#toStoredSettings(settings), { returning: true });
+    const next = await this.walletSettingRepository
+      .accessibleBy(ability, "update")
+      .updateById(prev.id, { ...this.#toStoredSettings(settings), ...liftDeclinePause(prev) }, { returning: true });
 
     if (!next) {
       return {};
@@ -148,7 +159,7 @@ export class WalletSettingService {
         return;
       }
 
-      if (this.#hasReloadRuleChanged(prev, next)) {
+      if (prev.autoReloadPausedAt || this.#hasReloadRuleChanged(prev, next)) {
         await this.walletReloadJobService.scheduleForWalletSetting(next, { withCleanup: true });
       }
       return;

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -121,7 +121,7 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
         dseq: this.table.dseq,
         walletId: UserWallets.id,
         address: UserWallets.address,
-        isWalletAutoTopUpEnabled: sql<boolean>`coalesce(${WalletSetting.autoReloadEnabled}, false)`,
+        isWalletAutoTopUpEnabled: sql<boolean>`coalesce(${WalletSetting.autoReloadEnabled} and ${WalletSetting.autoReloadPausedAt} is null, false)`,
         walletIsTrialing: sql<boolean>`coalesce(${UserWallets.isTrialing}, true)`,
         walletCreatedAt: UserWallets.createdAt,
         walletActivatedAt: UserWallets.activatedAt,

--- a/apps/api/src/notifications/services/notification-templates/auto-top-up-paused-notification.spec.ts
+++ b/apps/api/src/notifications/services/notification-templates/auto-top-up-paused-notification.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { autoTopUpPausedNotification } from "./auto-top-up-paused-notification";
+
+import { createUser } from "@test/seeders/user.seeder";
+
+describe(autoTopUpPausedNotification.name, () => {
+  it("tells the user charging has stopped and links to their payment methods", () => {
+    const user = createUser({ id: "user-123", email: "user@example.com" });
+
+    const result = autoTopUpPausedNotification(user, {
+      pausedAt: new Date("2026-09-01T12:00:00.000Z"),
+      billingUrl: "https://console.akash.network/billing"
+    });
+
+    expect(result.payload.summary).toBe("Auto top-up is paused");
+    expect(result.payload.description).toContain("declined");
+    expect(result.payload.description).toContain('<a href="https://console.akash.network/billing">');
+    expect(result.user).toEqual({ id: "user-123", email: "user@example.com" });
+  });
+
+  it("keys the notification on the pause so a later one is not swallowed as a duplicate", () => {
+    const user = createUser({ id: "user-123", email: "user@example.com" });
+    const vars = { billingUrl: "https://console.akash.network/billing" };
+
+    const first = autoTopUpPausedNotification(user, { ...vars, pausedAt: new Date("2026-09-01T12:00:00.000Z") });
+    const second = autoTopUpPausedNotification(user, { ...vars, pausedAt: new Date("2026-09-20T08:30:00.000Z") });
+
+    expect(first.notificationId).toBe("autoTopUpPaused.user-123.2026-09-01T12:00:00.000Z");
+    expect(second.notificationId).not.toBe(first.notificationId);
+  });
+});

--- a/apps/api/src/notifications/services/notification-templates/auto-top-up-paused-notification.ts
+++ b/apps/api/src/notifications/services/notification-templates/auto-top-up-paused-notification.ts
@@ -1,0 +1,23 @@
+import type { UserOutput } from "@src/user/repositories";
+import type { CreateNotificationInput } from "../notification/notification.service";
+
+/**
+ * `notificationId` carries the pause timestamp so the broker's singleton key dedupes retries within
+ * one pause but still lets a wallet that pauses again later be told about it.
+ */
+export function autoTopUpPausedNotification(user: UserOutput, vars: { pausedAt: Date; billingUrl: string }): CreateNotificationInput {
+  return {
+    notificationId: `autoTopUpPaused.${user.id}.${vars.pausedAt.toISOString()}`,
+    payload: {
+      summary: "Auto top-up is paused",
+      description:
+        `Your card was declined several times, so we've stopped trying to charge it. ` +
+        `Your deployments will keep running until your credits run out, but nothing will be added automatically. ` +
+        `<a href="${vars.billingUrl}">Update your payment method</a> and auto top-up starts again on its own.`
+    },
+    user: {
+      id: user.id,
+      email: user.email
+    }
+  };
+}

--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -156,13 +156,19 @@
                         "autoReloadAmount": {
                           "type": "number",
                           "description": "USD amount charged to the default payment method on each automatic top-up."
+                        },
+                        "autoReloadPausedAt": {
+                          "type": "string",
+                          "nullable": true,
+                          "description": "When automatic top-ups were paused because the default payment method kept being declined, or null when they are running. Changing the default payment method resumes them."
                         }
                       },
                       "required": [
                         "autoReloadEnabled",
                         "autoReloadMode",
                         "autoReloadThreshold",
-                        "autoReloadAmount"
+                        "autoReloadAmount",
+                        "autoReloadPausedAt"
                       ]
                     }
                   },
@@ -267,13 +273,19 @@
                         "autoReloadAmount": {
                           "type": "number",
                           "description": "USD amount charged to the default payment method on each automatic top-up."
+                        },
+                        "autoReloadPausedAt": {
+                          "type": "string",
+                          "nullable": true,
+                          "description": "When automatic top-ups were paused because the default payment method kept being declined, or null when they are running. Changing the default payment method resumes them."
                         }
                       },
                       "required": [
                         "autoReloadEnabled",
                         "autoReloadMode",
                         "autoReloadThreshold",
-                        "autoReloadAmount"
+                        "autoReloadAmount",
+                        "autoReloadPausedAt"
                       ]
                     }
                   },
@@ -378,13 +390,19 @@
                         "autoReloadAmount": {
                           "type": "number",
                           "description": "USD amount charged to the default payment method on each automatic top-up."
+                        },
+                        "autoReloadPausedAt": {
+                          "type": "string",
+                          "nullable": true,
+                          "description": "When automatic top-ups were paused because the default payment method kept being declined, or null when they are running. Changing the default payment method resumes them."
                         }
                       },
                       "required": [
                         "autoReloadEnabled",
                         "autoReloadMode",
                         "autoReloadThreshold",
-                        "autoReloadAmount"
+                        "autoReloadAmount",
+                        "autoReloadPausedAt"
                       ]
                     }
                   },
@@ -6540,7 +6558,8 @@
           {
             "schema": {
               "type": "number",
-              "nullable": true
+              "nullable": true,
+              "minimum": 0
             },
             "required": false,
             "name": "pagination.offset",
@@ -6549,7 +6568,8 @@
           {
             "schema": {
               "type": "number",
-              "nullable": true
+              "nullable": true,
+              "minimum": 0
             },
             "required": false,
             "name": "pagination.limit",

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -15291,6 +15291,11 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                           ],
                           "type": "string",
                         },
+                        "autoReloadPausedAt": {
+                          "description": "When automatic top-ups were paused because the default payment method kept being declined, or null when they are running. Changing the default payment method resumes them.",
+                          "nullable": true,
+                          "type": "string",
+                        },
                         "autoReloadThreshold": {
                           "description": "USD credit balance at or below which an automatic top-up is triggered.",
                           "type": "number",
@@ -15301,6 +15306,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                         "autoReloadMode",
                         "autoReloadThreshold",
                         "autoReloadAmount",
+                        "autoReloadPausedAt",
                       ],
                       "type": "object",
                     },
@@ -15402,6 +15408,11 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                           ],
                           "type": "string",
                         },
+                        "autoReloadPausedAt": {
+                          "description": "When automatic top-ups were paused because the default payment method kept being declined, or null when they are running. Changing the default payment method resumes them.",
+                          "nullable": true,
+                          "type": "string",
+                        },
                         "autoReloadThreshold": {
                           "description": "USD credit balance at or below which an automatic top-up is triggered.",
                           "type": "number",
@@ -15412,6 +15423,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                         "autoReloadMode",
                         "autoReloadThreshold",
                         "autoReloadAmount",
+                        "autoReloadPausedAt",
                       ],
                       "type": "object",
                     },
@@ -15513,6 +15525,11 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                           ],
                           "type": "string",
                         },
+                        "autoReloadPausedAt": {
+                          "description": "When automatic top-ups were paused because the default payment method kept being declined, or null when they are running. Changing the default payment method resumes them.",
+                          "nullable": true,
+                          "type": "string",
+                        },
                         "autoReloadThreshold": {
                           "description": "USD credit balance at or below which an automatic top-up is triggered.",
                           "type": "number",
@@ -15523,6 +15540,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                         "autoReloadMode",
                         "autoReloadThreshold",
                         "autoReloadAmount",
+                        "autoReloadPausedAt",
                       ],
                       "type": "object",
                     },

--- a/apps/api/test/seeders/wallet-setting.seeder.ts
+++ b/apps/api/test/seeders/wallet-setting.seeder.ts
@@ -12,6 +12,8 @@ export const generateWalletSetting = (overrides: Partial<WalletSettingOutput>) =
     autoReloadThreshold: faker.number.int({ min: 500, max: 100000 }),
     autoReloadAmount: faker.number.int({ min: 2000, max: 100000 }),
     lastAutoChargeAt: null,
+    autoReloadFailureCount: 0,
+    autoReloadPausedAt: null,
     createdAt: faker.date.recent(),
     updatedAt: faker.date.recent(),
     ...overrides

--- a/packages/console-api-types/src/schema.d.ts
+++ b/packages/console-api-types/src/schema.d.ts
@@ -7306,6 +7306,8 @@ export interface operations {
               autoReloadThreshold: number;
               /** @description USD amount charged to the default payment method on each automatic top-up. */
               autoReloadAmount: number;
+              /** @description When automatic top-ups were paused because the default payment method kept being declined, or null when they are running. Changing the default payment method resumes them. */
+              autoReloadPausedAt: string | null;
             };
           };
         };
@@ -7363,6 +7365,8 @@ export interface operations {
               autoReloadThreshold: number;
               /** @description USD amount charged to the default payment method on each automatic top-up. */
               autoReloadAmount: number;
+              /** @description When automatic top-ups were paused because the default payment method kept being declined, or null when they are running. Changing the default payment method resumes them. */
+              autoReloadPausedAt: string | null;
             };
           };
         };
@@ -7420,6 +7424,8 @@ export interface operations {
               autoReloadThreshold: number;
               /** @description USD amount charged to the default payment method on each automatic top-up. */
               autoReloadAmount: number;
+              /** @description When automatic top-ups were paused because the default payment method kept being declined, or null when they are running. Changing the default payment method resumes them. */
+              autoReloadPausedAt: string | null;
             };
           };
         };


### PR DESCRIPTION
## Why

Fixes CON-937

Auto top-up charged a declining card forever. CON-927 (#3756) capped it at one attempt per cooldown, but that is still roughly 720 declined charges a month per stuck wallet, with no end condition. Card networks cap reattempts of a declined payment (Visa 15 per 30 days, Mastercard 35) and fine excessive reattempts, and the volume hurts our Stripe Radar and issuer standing even though nothing is ever collected. On 2026-09-01 one wallet with a dead card produced ~950 declined attempts in a day and set off the "Auto Top-Up Cannot Fund Opted-In Deployments" alert.

## What

**Giving up.** Each declined charge increments `wallet_settings.auto_reload_failure_count`, and the cooldown handed to the next claim doubles with it, so attempts land at roughly t=0, 1h, 3h and 7h instead of hourly forever. After `AUTO_RELOAD_MAX_CONSECUTIVE_DECLINES` (default 4), `auto_reload_paused_at` is stamped and the card is not charged again. Decline codes the issuer will never approve (`lost_card`, `stolen_card`, `fraudulent`, and the rest of Stripe's never-retry list) pause on the first decline.

**What counts as a decline.** Only card declines. A Stripe outage, a rate limit or a bug of ours leaves the counter alone, so an incident cannot pause every wallet at once and email everybody. A decline arrives in three shapes and all three are now recognised: the `StripeCardError` from a fresh confirm, the `requires_payment_method` branch, and the 402 thrown when a pg-boss retry replays a recorded intent under the same idempotency key. The last two now carry `declineCode` alongside the `card_declined` error code they already had; HTTP responses are unchanged.

**Resetting.** A charge that goes through clears the counter. A charge that only asks for 3DS authentication does not, because `createPaymentIntent` returns `requires_action` without throwing and no money moved.

**Paused means opted out.** A paused wallet skips its check with `AUTO_RELOAD_PAUSED` and stops rescheduling, stops having checks enqueued for it, hands over to the credits-low email, and drops out of the `insufficient_balance_with_auto_reload` metrics behind the funding alert (the last AC). It is deliberately *not* excluded from escrow funding, so existing credits keep funding deployments.

**Telling the user.** A new `autoTopUpPaused` email goes out on the pause, keyed on the pause timestamp so retries dedupe but a later pause still sends. Written after the pause and best-effort, so a notification failure cannot mask the payment error; failures are counted on `wallet_balance_reload_check_decline_recording_errors_total`.

**Resuming.** The pause lifts when the user marks a different card default, when the `payment_method.attached` webhook makes a first card default, or when they save their auto top-up settings. All three also clear `last_auto_charge_at`, so the next check charges straight away rather than waiting out the cooldown the dead card consumed.

### Notes for review

- **Migration** is two additive columns on `wallet_settings` with defaults (`0`, `NULL`), so it is non-blocking and needs no backfill. Wallets already stuck on a dead card simply get four more attempts and then pause on their own.
- **Metric reshaping**: paused wallets move from the "with auto reload" series to "without" in both `auto_top_up_insufficient_balance_with_auto_reload_total` and `fund_draining_deployments_insufficient_balance_with_auto_reload_total`. That is the point of the AC, but it will show as a step change on those panels.
- **Behaviour change worth flagging**: a validation skip now records `wallet_balance_reload_check_job_executions_total{status="success"}`. It was recording `failure` for a job that completed fine (the README already called these successful completions), and pausing would have made the mislabel frequent enough to move the success-rate panel.
- `openapi.json` / `schema.d.ts` also pick up `trialEndsAt` and `trialDurationDays`. Those are pre-existing drift in the checked-in artifacts, not part of this change; regenerating corrects them.
- New `AutoReloadPauseService` exists because `PaymentMethodService` cannot depend on `WalletSettingService` without a DI cycle, which is why today's auto-disable lives in the controller.

### Verification

`apps/api`: unit 181 files / 2321 tests green, functional 337 green (docs snapshot regenerated), lint clean, `tsc --noEmit` zero new errors against a cold clean-tree baseline. Integration is green apart from 4 failures in `api-key.repository.integration.ts` and `user.repository.integration.ts` that reproduce identically on a clean checkout of `main`.

Frontend follow-up is stacked on this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic top-ups now pause after repeated or non-retryable card declines, with configurable cooldown backoff.
  * Users receive notifications when auto top-up is paused and can resume it by updating their payment method or settings.
  * Wallet settings now display when automatic top-ups were paused.
  * Card decline errors include clearer payment guidance and available decline codes.
  * Deployment settings support sealed secret configuration.

* **Bug Fixes**
  * Paused wallets no longer schedule automatic reloads.
  * Successful charges reset decline tracking and cooldown state.
  * Payment-method updates resume auto top-ups without blocking the update if resumption fails.

* **Documentation**
  * Updated API documentation for pause status, wallet trial details, pagination validation, and deprecated deposit fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->