### PR TITLE
fix(billing): show when auto top-up is paused by card declines

### DIFF
--- a/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/useAccountBalanceOverview.spec.ts
+++ b/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/useAccountBalanceOverview.spec.ts
@@ -106,6 +106,23 @@ describe(useAccountBalanceOverview.name, () => {
     expect(result.current.autoReloadEnabled).toBe(true);
   });
 
+  it("reports auto reload as off while it is paused after repeated card declines", () => {
+    const { result } = setup({ autoReloadEnabled: true, autoReloadPausedAt: "2026-09-01T12:00:00.000Z" });
+
+    expect(result.current.autoReloadEnabled).toBe(false);
+  });
+
+  it("hides the auto reload threshold while auto reload is paused", () => {
+    const { result } = setup({
+      autoReloadMode: "threshold",
+      autoReloadEnabled: true,
+      autoReloadThreshold: 275,
+      autoReloadPausedAt: "2026-09-01T12:00:00.000Z"
+    });
+
+    expect(result.current.autoReloadThreshold).toBeNull();
+  });
+
   it("exposes the auto reload threshold in threshold mode when auto reload is on", () => {
     const { result } = setup({ autoReloadMode: "threshold", autoReloadEnabled: true, autoReloadThreshold: 275 });
 
@@ -239,6 +256,7 @@ describe(useAccountBalanceOverview.name, () => {
     leases?: Array<{ dseq: string; amount?: string; state?: string }>;
     hasLiveLease?: boolean;
     autoReloadEnabled?: boolean;
+    autoReloadPausedAt?: string | null;
     autoReloadThreshold?: number;
     autoReloadMode?: "prediction" | "threshold";
     balancesMissing?: boolean;
@@ -311,6 +329,7 @@ describe(useAccountBalanceOverview.name, () => {
     const walletSettingsQuery = Object.assign(mock<ReturnType<typeof DEPENDENCIES.useWalletSettingsQuery>>(), {
       data: Object.assign(mock<WalletSettings>(), {
         autoReloadEnabled: input.autoReloadEnabled ?? false,
+        autoReloadPausedAt: input.autoReloadPausedAt ?? null,
         autoReloadMode: input.autoReloadMode ?? ("prediction" as const),
         autoReloadThreshold: input.autoReloadThreshold
       })

--- a/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/useAccountBalanceOverview.ts
+++ b/apps/deploy-web/src/components/billing-usage/AccountBalanceOverview/useAccountBalanceOverview.ts
@@ -108,7 +108,7 @@ export function useAccountBalanceOverview({ dependencies: d = DEPENDENCIES }: { 
   const available = Math.max(0, totalUsd - escrow);
   const hasSpend = spend.perBlockUsd > 0;
   const lastsUntil = hasSpend ? getTimeLeft(spend.perBlockUsd, totalUsd) : null;
-  const autoReloadEnabled = walletSettings?.autoReloadEnabled ?? false;
+  const autoReloadEnabled = (walletSettings?.autoReloadEnabled ?? false) && !walletSettings?.autoReloadPausedAt;
   const isBalanceUnavailable = !balances && (isBalancesError || (!!address && balancesFetchStatus === "idle"));
   const autoReloadThreshold = showsThresholdRule && autoReloadEnabled ? walletSettings?.autoReloadThreshold ?? null : null;
 

--- a/apps/deploy-web/src/components/billing-usage/AutoTopUpSection/AutoTopUpSection.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AutoTopUpSection/AutoTopUpSection.spec.tsx
@@ -410,7 +410,8 @@ describe(AutoTopUpSection.name, () => {
 
       fireEvent.click(screen.getByText("Update your payment method"));
 
-      expect(openAddPaymentMethod).toHaveBeenCalled();
+      expect(openAddPaymentMethod).toHaveBeenCalledTimes(1);
+      expect(openAddPaymentMethod).toHaveBeenCalledWith();
     });
 
     it("shows the top-up rule again once the pause is lifted", () => {

--- a/apps/deploy-web/src/components/billing-usage/AutoTopUpSection/AutoTopUpSection.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AutoTopUpSection/AutoTopUpSection.spec.tsx
@@ -375,12 +375,68 @@ describe(AutoTopUpSection.name, () => {
     });
   });
 
+  describe("when auto top-up is paused after repeated card declines", () => {
+    it("says the card was declined instead of showing the top-up rule", () => {
+      setup({
+        isThresholdModeOffered: true,
+        defaultPaymentMethod: { id: "pm_123", card: { brand: "visa", last4: "4242" } },
+        walletSettings: { autoReloadEnabled: true, autoReloadThreshold: 20, autoReloadAmount: 100, autoReloadPausedAt: "2026-09-01T12:00:00.000Z" }
+      });
+
+      expect(screen.getByText(/Paused\./)).toBeInTheDocument();
+      expect(screen.getByText(/was declined several times/)).toBeInTheDocument();
+      expect(screen.queryByText("Threshold")).not.toBeInTheDocument();
+    });
+
+    it("warns prediction-mode wallets too", () => {
+      setup({
+        autoReloadMode: "prediction",
+        defaultPaymentMethod: { id: "pm_123" },
+        walletSettings: { autoReloadEnabled: true, autoReloadMode: "prediction", autoReloadPausedAt: "2026-09-01T12:00:00.000Z" }
+      });
+
+      expect(screen.getByText(/Paused\./)).toBeInTheDocument();
+      expect(screen.queryByText(/Recharge amount is approximately/)).not.toBeInTheDocument();
+    });
+
+    it("sends the user to their payment methods to lift the pause", () => {
+      const openAddPaymentMethod = vi.fn();
+      setup({
+        isThresholdModeOffered: true,
+        defaultPaymentMethod: { id: "pm_123" },
+        walletSettings: { autoReloadEnabled: true, autoReloadPausedAt: "2026-09-01T12:00:00.000Z" },
+        openAddPaymentMethod
+      });
+
+      fireEvent.click(screen.getByText("Update your payment method"));
+
+      expect(openAddPaymentMethod).toHaveBeenCalled();
+    });
+
+    it("shows the top-up rule again once the pause is lifted", () => {
+      setup({
+        isThresholdModeOffered: true,
+        defaultPaymentMethod: { id: "pm_123" },
+        walletSettings: { autoReloadEnabled: true, autoReloadThreshold: 20, autoReloadAmount: 100, autoReloadPausedAt: null }
+      });
+
+      expect(screen.queryByText(/Paused\./)).not.toBeInTheDocument();
+      expect(screen.getByText("Threshold")).toBeInTheDocument();
+    });
+  });
+
   function setup(input: {
     isThresholdModeOffered?: boolean;
     autoReloadMode?: "prediction" | "threshold";
     defaultPaymentMethod?: { id: string; card?: { brand?: string; last4?: string } };
     isDefaultPaymentMethodLoading?: boolean;
-    walletSettings?: { autoReloadEnabled: boolean; autoReloadMode?: "prediction" | "threshold"; autoReloadThreshold?: number; autoReloadAmount?: number };
+    walletSettings?: {
+      autoReloadEnabled: boolean;
+      autoReloadMode?: "prediction" | "threshold";
+      autoReloadThreshold?: number;
+      autoReloadAmount?: number;
+      autoReloadPausedAt?: string | null;
+    };
     isWalletSettingsLoading?: boolean;
     weeklyCost?: number;
     isWeeklyCostLoading?: boolean;

--- a/apps/deploy-web/src/components/billing-usage/AutoTopUpSection/AutoTopUpSection.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AutoTopUpSection/AutoTopUpSection.spec.tsx
@@ -399,6 +399,17 @@ describe(AutoTopUpSection.name, () => {
       expect(screen.queryByText(/Recharge amount is approximately/)).not.toBeInTheDocument();
     });
 
+    it("stops the header claiming it still tops up", () => {
+      setup({
+        isThresholdModeOffered: true,
+        defaultPaymentMethod: { id: "pm_123" },
+        walletSettings: { autoReloadEnabled: true, autoReloadThreshold: 20, autoReloadAmount: 100, autoReloadPausedAt: "2026-09-01T12:00:00.000Z" }
+      });
+
+      expect(screen.queryByText(/Tops up when your/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/Tops up to cover the week ahead/)).not.toBeInTheDocument();
+    });
+
     it("sends the user to their payment methods to lift the pause", () => {
       const openAddPaymentMethod = vi.fn();
       setup({

--- a/apps/deploy-web/src/components/billing-usage/AutoTopUpSection/AutoTopUpSection.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AutoTopUpSection/AutoTopUpSection.tsx
@@ -131,6 +131,7 @@ export const AutoTopUpSection: React.FunctionComponent<{ dependencies?: typeof D
   const autoReloadThreshold = walletSettings?.autoReloadThreshold ?? DEFAULT_AUTO_RELOAD_THRESHOLD;
   const autoReloadAmount = walletSettings?.autoReloadAmount ?? DEFAULT_AUTO_RELOAD_AMOUNT;
   const autoReloadEnabled = walletSettings?.autoReloadEnabled ?? false;
+  const isPausedByDeclines = autoReloadEnabled && !!walletSettings?.autoReloadPausedAt;
   const isFirstLoad = (isWalletSettingsLoading && !walletSettings) || (isDefaultPaymentMethodLoading && !defaultPaymentMethod);
 
   const isReloadChangeDisabled = useMemo(() => {
@@ -212,6 +213,15 @@ export const AutoTopUpSection: React.FunctionComponent<{ dependencies?: typeof D
                 Add a payment method
               </button>{" "}
               to enable auto {isThresholdModeOffered ? "top-up" : "recharge"}
+            </p>
+          ) : isPausedByDeclines ? (
+            <p className="text-sm text-muted-foreground">
+              <span className="font-medium text-destructive">Paused.</span> {defaultCardLabel ?? "Your default payment method"} was declined several times, so
+              we&apos;ve stopped charging it. Your deployments keep running until your credits run out.{" "}
+              <button type="button" onClick={openAddPaymentMethod} className="text-primary underline">
+                Update your payment method
+              </button>{" "}
+              to start topping up again.
             </p>
           ) : !isThresholdModeOffered ? (
             <p className="text-sm text-muted-foreground">

--- a/apps/deploy-web/src/components/billing-usage/AutoTopUpSection/AutoTopUpSection.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AutoTopUpSection/AutoTopUpSection.tsx
@@ -185,7 +185,7 @@ export const AutoTopUpSection: React.FunctionComponent<{ dependencies?: typeof D
             <h3 className="text-lg font-bold leading-none">{isThresholdModeOffered ? "Auto Top-Up" : "Auto Recharge"}</h3>
             {isFirstLoad ? (
               <d.Skeleton className="h-4 w-72" />
-            ) : !isThresholdModeOffered || !autoReloadEnabled ? (
+            ) : !isThresholdModeOffered || !autoReloadEnabled || isPausedByDeclines ? (
               <p className="text-sm text-muted-foreground">Automatically adds credits to keep your deployments running.</p>
             ) : showsThresholdRule ? (
               <p className="text-sm text-muted-foreground">

--- a/apps/deploy-web/src/components/billing-usage/AutoTopUpSection/AutoTopUpSection.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AutoTopUpSection/AutoTopUpSection.tsx
@@ -218,7 +218,7 @@ export const AutoTopUpSection: React.FunctionComponent<{ dependencies?: typeof D
             <p className="text-sm text-muted-foreground">
               <span className="font-medium text-destructive">Paused.</span> {defaultCardLabel ?? "Your default payment method"} was declined several times, so
               we&apos;ve stopped charging it. Your deployments keep running until your credits run out.{" "}
-              <button type="button" onClick={openAddPaymentMethod} className="text-primary underline">
+              <button type="button" onClick={() => openAddPaymentMethod()} className="text-primary underline">
                 Update your payment method
               </button>{" "}
               to start topping up again.

--- a/apps/deploy-web/src/queries/usePaymentQueries.spec.tsx
+++ b/apps/deploy-web/src/queries/usePaymentQueries.spec.tsx
@@ -139,7 +139,9 @@ describe("usePaymentQueries", () => {
       const stripeService = mock<StripeService>({
         confirmPayment: vi.fn().mockResolvedValue(mockPaymentResponse)
       });
-      const api = createProxy({ v1: { listStripeTransactions: vi.fn(), getDefaultPaymentMethod: vi.fn() } }) as unknown as ApiService;
+      const api = createProxy({
+        v1: { listStripeTransactions: vi.fn(), getDefaultPaymentMethod: vi.fn(), getWalletSettings: vi.fn() }
+      }) as unknown as ApiService;
       const { result, queryClient } = setupQueryWithClient(() => usePaymentMutations(), {
         services: { stripe: () => stripeService, api: () => api }
       });
@@ -258,7 +260,7 @@ describe("usePaymentQueries", () => {
       const stripeService = mock<StripeService>({
         validatePaymentMethodAfter3DS: vi.fn().mockResolvedValue(mockValidationResponse)
       });
-      const api = createProxy({ v1: { getDefaultPaymentMethod: vi.fn() } }) as unknown as ApiService;
+      const api = createProxy({ v1: { getDefaultPaymentMethod: vi.fn(), getWalletSettings: vi.fn() } }) as unknown as ApiService;
       const { result, queryClient } = setupQueryWithClient(() => usePaymentMutations(), {
         services: { stripe: () => stripeService, api: () => api }
       });
@@ -282,12 +284,32 @@ describe("usePaymentQueries", () => {
       });
     });
 
+    it("refreshes the wallet settings so an auto top-up pause lifted by the new card stops showing", async () => {
+      const stripeService = mock<StripeService>({
+        setPaymentMethodAsDefault: vi.fn().mockResolvedValue(createMockPaymentMethod({ isDefault: true }))
+      });
+      const api = createProxy({ v1: { getDefaultPaymentMethod: vi.fn(), getWalletSettings: vi.fn() } }) as unknown as ApiService;
+      const { result, queryClient } = setupQueryWithClient(() => usePaymentMutations(), {
+        services: { stripe: () => stripeService, api: () => api }
+      });
+
+      const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+      await act(async () => {
+        await result.current.setPaymentMethodAsDefault.mutateAsync("pm_123");
+      });
+
+      await vi.waitFor(() => {
+        expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: api.v1.getWalletSettings.getKey() });
+      });
+    });
+
     it("waits for the methods invalidation to settle before invalidating the default query", async () => {
       const mockPaymentMethod = createMockPaymentMethod({ isDefault: true });
       const stripeService = mock<StripeService>({
         setPaymentMethodAsDefault: vi.fn().mockResolvedValue(mockPaymentMethod)
       });
-      const api = createProxy({ v1: { getDefaultPaymentMethod: vi.fn() } }) as unknown as ApiService;
+      const api = createProxy({ v1: { getDefaultPaymentMethod: vi.fn(), getWalletSettings: vi.fn() } }) as unknown as ApiService;
       const { result, queryClient } = setupQueryWithClient(() => usePaymentMutations(), {
         services: { stripe: () => stripeService, api: () => api }
       });

--- a/apps/deploy-web/src/queries/usePaymentQueries.ts
+++ b/apps/deploy-web/src/queries/usePaymentQueries.ts
@@ -86,7 +86,8 @@ export const useSetupIntentMutation = () => {
  * Refreshes the payment-methods list, then the default-payment-method query. The order is load
  * bearing: the awaited list refetch resolves only after the server-side read-repair in
  * getPaymentMethods has committed, so the following default fetch observes the healed state rather
- * than the stale drift it was about to repair.
+ * than the stale drift it was about to repair, and the wallet settings observe the auto top-up
+ * pause that same repair lifts.
  */
 export const useRefreshPaymentMethods = () => {
   const { api } = useServices();
@@ -95,6 +96,7 @@ export const useRefreshPaymentMethods = () => {
   return useCallback(async () => {
     await queryClient.invalidateQueries({ queryKey: QueryKeys.getPaymentMethodsKey() });
     await queryClient.invalidateQueries({ queryKey: api.v1.getDefaultPaymentMethod.getKey() });
+    await queryClient.invalidateQueries({ queryKey: api.v1.getWalletSettings.getKey() });
   }, [api, queryClient]);
 };
 
@@ -149,7 +151,6 @@ export const usePaymentMutations = () => {
     },
     onSuccess: () => {
       refreshPaymentMethods();
-      queryClient.invalidateQueries({ queryKey: api.v1.getWalletSettings.getKey() });
     }
   });
 


### PR DESCRIPTION
## Why

Part of CON-937. Stacked on #3760 — review and merge that first.

#3760 makes the API stop charging a card that keeps declining. Without this, the billing page still reads "Auto Top-Up: On", names the card it will charge, and shows the balance marker where the next top-up is supposed to land. All three are the opposite of what is happening, and the pause email would be the only signal the user ever gets.

## What

- **Auto Top-Up card**: a paused branch that says the card was declined and links to the payment methods that lift the pause. Placed ahead of the prediction-mode branch so legacy prediction-mode wallets get it too.
- **Balance overview**: `autoReloadEnabled` now folds in the pause, which drops both the "Automatic top-ups are on. Your deployments stay funded." line and the "tops up at $X" marker on the balance bar.
- The toggle deliberately stays **on**: the user has not turned anything off, and changing their payment method resumes charging on its own. `PaymentMethodsContainer`'s "removing this card turns off Auto Top-Up" confirm is still accurate, so it is untouched.

`autoReloadPausedAt` comes off the generated OpenAPI types, so this does not compile until #3760 lands.

### Verification

deploy-web unit suite green (376 files), lint clean, `tsc --noEmit` identical to a cold clean-tree baseline (152 lines, zero new errors — deploy-web has a pre-existing red baseline, so this is verified by delta).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clear messaging when automatic top-ups are paused after repeated payment declines.
  * Users can update their payment method directly from the paused top-up notice.
  * Deployment credits continue to be used until they run out while top-ups are paused.

* **Bug Fixes**
  * Paused automatic reloads are now correctly shown as disabled, with related thresholds hidden.
  * Payment method updates now refresh wallet balance and automatic reload status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->