### PR TITLE
fix(billing): offer a card and auto top-up instead of credits

### DIFF
--- a/apps/deploy-web/src/components/billing-usage/AutoTopUpSection/AutoTopUpSection.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AutoTopUpSection/AutoTopUpSection.spec.tsx
@@ -308,6 +308,7 @@ describe(AutoTopUpSection.name, () => {
         });
 
         expect(openAddPaymentMethod).toHaveBeenCalledTimes(1);
+        expect(openAddPaymentMethod).toHaveBeenCalledWith(expect.objectContaining({ onSuccess: expect.any(Function) }));
         expect(replace).toHaveBeenCalledWith("/billing", { scroll: false });
         expect(dependencies.AutoTopUpSettingsPopup).toHaveBeenLastCalledWith(expect.objectContaining({ open: false }), expect.anything());
       });
@@ -323,14 +324,16 @@ describe(AutoTopUpSection.name, () => {
         expect(dependencies.AutoTopUpSettingsPopup).toHaveBeenLastCalledWith(expect.objectContaining({ open: true, enableOnSave: true }), expect.anything());
       });
 
-      it("opens the settings dialog once the card the user just added arrives", () => {
-        const { addDefaultPaymentMethod, dependencies } = setup({
+      it("opens the settings dialog through the callback it hands the card flow", () => {
+        const openAddPaymentMethod = vi.fn();
+        const { dependencies } = setup({
           isThresholdModeOffered: true,
           defaultPaymentMethod: undefined,
-          hasSetupAutoTopUpParam: true
+          hasSetupAutoTopUpParam: true,
+          openAddPaymentMethod
         });
 
-        addDefaultPaymentMethod();
+        act(() => openAddPaymentMethod.mock.calls[0][0].onSuccess());
 
         expect(dependencies.AutoTopUpSettingsPopup).toHaveBeenLastCalledWith(expect.objectContaining({ open: true, enableOnSave: true }), expect.anything());
       });
@@ -394,7 +397,6 @@ describe(AutoTopUpSection.name, () => {
     const enqueueSnackbar = input.enqueueSnackbar ?? vi.fn();
     const openAddPaymentMethod = input.openAddPaymentMethod ?? vi.fn();
     const replace = vi.fn();
-    let defaultPaymentMethod = input.defaultPaymentMethod;
 
     const MockButton = vi.fn(({ children, ...props }: Parameters<typeof DEPENDENCIES.Button>[0]) => <button {...props}>{children}</button>);
     const MockSwitch = vi.fn(({ checked, onCheckedChange, disabled }: Parameters<typeof DEPENDENCIES.Switch>[0]) => (
@@ -414,7 +416,7 @@ describe(AutoTopUpSection.name, () => {
         };
       }),
       useSnackbar: vi.fn(() => ({ enqueueSnackbar })),
-      useDefaultPaymentMethodQuery: vi.fn(() => ({ data: defaultPaymentMethod, isLoading: input.isDefaultPaymentMethodLoading ?? false })),
+      useDefaultPaymentMethodQuery: vi.fn(() => ({ data: input.defaultPaymentMethod, isLoading: input.isDefaultPaymentMethodLoading ?? false })),
       useWalletSettingsQuery: vi.fn(() => ({
         data: input.isWalletSettingsLoading ? undefined : input.walletSettings ?? { autoReloadEnabled: false },
         isLoading: input.isWalletSettingsLoading ?? false
@@ -432,18 +434,8 @@ describe(AutoTopUpSection.name, () => {
       UsdValue: MockUsdValue
     } as unknown as typeof DEPENDENCIES;
 
-    const view = render(<AutoTopUpSection dependencies={dependencies} />);
+    render(<AutoTopUpSection dependencies={dependencies} />);
 
-    return {
-      dependencies,
-      upsertMutate,
-      enqueueSnackbar,
-      openAddPaymentMethod,
-      replace,
-      addDefaultPaymentMethod: () => {
-        defaultPaymentMethod = { id: "pm_added" };
-        act(() => view.rerender(<AutoTopUpSection dependencies={dependencies} />));
-      }
-    };
+    return { dependencies, upsertMutate, enqueueSnackbar, openAddPaymentMethod, replace };
   }
 });

--- a/apps/deploy-web/src/components/billing-usage/AutoTopUpSection/AutoTopUpSection.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AutoTopUpSection/AutoTopUpSection.spec.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
+import { UrlService } from "@src/utils/urlUtils";
 import { AutoTopUpSection, DEPENDENCIES } from "./AutoTopUpSection";
 
 import { act, fireEvent, render, screen } from "@testing-library/react";
@@ -98,7 +99,7 @@ describe(AutoTopUpSection.name, () => {
       expect(screen.getByText(/Turn on Auto Top-Up to add funds automatically/)).toBeInTheDocument();
     });
 
-    it("prompts with predicted-spend wording when disabled in prediction mode", () => {
+    it("prompts without naming a rule when disabled in prediction mode", () => {
       setup({
         isThresholdModeOffered: true,
         autoReloadMode: "prediction",
@@ -106,8 +107,33 @@ describe(AutoTopUpSection.name, () => {
         walletSettings: { autoReloadEnabled: false, autoReloadMode: "prediction" }
       });
 
-      expect(screen.getByText(/Turn on Auto Top-Up to automatically cover the week ahead/)).toBeInTheDocument();
-      expect(screen.queryByText(/when your balance runs low/)).not.toBeInTheDocument();
+      expect(screen.getByText(/You pick the rule when you set it up/)).toBeInTheDocument();
+      expect(screen.queryByText(/cover the week ahead/)).not.toBeInTheDocument();
+    });
+
+    it("holds back the mode description until a rule is actually running", () => {
+      setup({
+        isThresholdModeOffered: true,
+        autoReloadMode: "prediction",
+        defaultPaymentMethod: { id: "pm_123" },
+        walletSettings: { autoReloadEnabled: false, autoReloadMode: "prediction" }
+      });
+
+      expect(screen.getByText("Automatically adds credits to keep your deployments running.")).toBeInTheDocument();
+      expect(screen.queryByText(/Tops up to cover the week ahead/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/Tops up when your/)).not.toBeInTheDocument();
+    });
+
+    it("describes the stored rule once auto top-up is enabled", () => {
+      setup({
+        isThresholdModeOffered: true,
+        autoReloadMode: "prediction",
+        defaultPaymentMethod: { id: "pm_123" },
+        walletSettings: { autoReloadEnabled: true, autoReloadMode: "prediction" }
+      });
+
+      expect(screen.getByText("Tops up to cover the week ahead for your running deployments.")).toBeInTheDocument();
+      expect(screen.queryByText("Automatically adds credits to keep your deployments running.")).not.toBeInTheDocument();
     });
 
     it("shows a skeleton instead of a zero predicted spend while the weekly cost is still loading", () => {
@@ -273,6 +299,63 @@ describe(AutoTopUpSection.name, () => {
       expect(enqueueSnackbar).toHaveBeenCalled();
     });
 
+    describe("when arriving from the deploy flow's setup link", () => {
+      it("opens the add-payment-method flow and clears the param when no card is on file", () => {
+        const { openAddPaymentMethod, replace, dependencies } = setup({
+          isThresholdModeOffered: true,
+          defaultPaymentMethod: undefined,
+          hasSetupAutoTopUpParam: true
+        });
+
+        expect(openAddPaymentMethod).toHaveBeenCalledTimes(1);
+        expect(replace).toHaveBeenCalledWith("/billing", { scroll: false });
+        expect(dependencies.AutoTopUpSettingsPopup).toHaveBeenLastCalledWith(expect.objectContaining({ open: false }), expect.anything());
+      });
+
+      it("opens the settings dialog straight away when a card is already on file", () => {
+        const { openAddPaymentMethod, dependencies } = setup({
+          isThresholdModeOffered: true,
+          defaultPaymentMethod: { id: "pm_123" },
+          hasSetupAutoTopUpParam: true
+        });
+
+        expect(openAddPaymentMethod).not.toHaveBeenCalled();
+        expect(dependencies.AutoTopUpSettingsPopup).toHaveBeenLastCalledWith(expect.objectContaining({ open: true, enableOnSave: true }), expect.anything());
+      });
+
+      it("opens the settings dialog once the card the user just added arrives", () => {
+        const { addDefaultPaymentMethod, dependencies } = setup({
+          isThresholdModeOffered: true,
+          defaultPaymentMethod: undefined,
+          hasSetupAutoTopUpParam: true
+        });
+
+        addDefaultPaymentMethod();
+
+        expect(dependencies.AutoTopUpSettingsPopup).toHaveBeenLastCalledWith(expect.objectContaining({ open: true, enableOnSave: true }), expect.anything());
+      });
+
+      it("leaves the settings dialog closed without the param", () => {
+        const { openAddPaymentMethod, replace, dependencies } = setup({ isThresholdModeOffered: true, defaultPaymentMethod: { id: "pm_123" } });
+
+        expect(openAddPaymentMethod).not.toHaveBeenCalled();
+        expect(replace).not.toHaveBeenCalled();
+        expect(dependencies.AutoTopUpSettingsPopup).toHaveBeenLastCalledWith(expect.objectContaining({ open: false }), expect.anything());
+      });
+
+      it("waits for the payment method query before acting on the param", () => {
+        const { openAddPaymentMethod, replace } = setup({
+          isThresholdModeOffered: true,
+          defaultPaymentMethod: undefined,
+          isDefaultPaymentMethodLoading: true,
+          hasSetupAutoTopUpParam: true
+        });
+
+        expect(openAddPaymentMethod).not.toHaveBeenCalled();
+        expect(replace).not.toHaveBeenCalled();
+      });
+    });
+
     it("closes the settings dialog when the popup requests it", () => {
       const { dependencies } = setup({
         isThresholdModeOffered: true,
@@ -305,10 +388,13 @@ describe(AutoTopUpSection.name, () => {
     perHour?: number;
     available?: number;
     openAddPaymentMethod?: ReturnType<typeof vi.fn>;
+    hasSetupAutoTopUpParam?: boolean;
   }) {
     const upsertMutate = input.upsertMutate ?? vi.fn();
     const enqueueSnackbar = input.enqueueSnackbar ?? vi.fn();
     const openAddPaymentMethod = input.openAddPaymentMethod ?? vi.fn();
+    const replace = vi.fn();
+    let defaultPaymentMethod = input.defaultPaymentMethod;
 
     const MockButton = vi.fn(({ children, ...props }: Parameters<typeof DEPENDENCIES.Button>[0]) => <button {...props}>{children}</button>);
     const MockSwitch = vi.fn(({ checked, onCheckedChange, disabled }: Parameters<typeof DEPENDENCIES.Switch>[0]) => (
@@ -328,7 +414,7 @@ describe(AutoTopUpSection.name, () => {
         };
       }),
       useSnackbar: vi.fn(() => ({ enqueueSnackbar })),
-      useDefaultPaymentMethodQuery: vi.fn(() => ({ data: input.defaultPaymentMethod, isLoading: input.isDefaultPaymentMethodLoading ?? false })),
+      useDefaultPaymentMethodQuery: vi.fn(() => ({ data: defaultPaymentMethod, isLoading: input.isDefaultPaymentMethodLoading ?? false })),
       useWalletSettingsQuery: vi.fn(() => ({
         data: input.isWalletSettingsLoading ? undefined : input.walletSettings ?? { autoReloadEnabled: false },
         isLoading: input.isWalletSettingsLoading ?? false
@@ -337,14 +423,27 @@ describe(AutoTopUpSection.name, () => {
       useWalletSettingsMutations: vi.fn(() => ({ upsertWalletSettings: { mutate: upsertMutate, isPending: input.isPending ?? false } })),
       useAccountBalanceOverview: vi.fn(() => ({ perHour: input.perHour ?? 0, available: input.available ?? 0 })),
       useBillingActions: vi.fn(() => ({ openAddPaymentMethod })),
+      useSearchParams: vi.fn(() => ({ get: (key: string) => (key === "setupAutoTopUp" && input.hasSetupAutoTopUpParam ? "true" : null) })),
+      useRouter: vi.fn(() => ({ replace })),
+      useServices: vi.fn(() => ({ urlService: UrlService })),
       usePopup: vi.fn(() => ({ confirm: vi.fn().mockResolvedValue(input.confirmResult ?? true) })),
       Button: MockButton,
       Switch: MockSwitch,
       UsdValue: MockUsdValue
     } as unknown as typeof DEPENDENCIES;
 
-    render(<AutoTopUpSection dependencies={dependencies} />);
+    const view = render(<AutoTopUpSection dependencies={dependencies} />);
 
-    return { dependencies, upsertMutate, enqueueSnackbar, openAddPaymentMethod };
+    return {
+      dependencies,
+      upsertMutate,
+      enqueueSnackbar,
+      openAddPaymentMethod,
+      replace,
+      addDefaultPaymentMethod: () => {
+        defaultPaymentMethod = { id: "pm_added" };
+        act(() => view.rerender(<AutoTopUpSection dependencies={dependencies} />));
+      }
+    };
   }
 });

--- a/apps/deploy-web/src/components/billing-usage/AutoTopUpSection/AutoTopUpSection.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AutoTopUpSection/AutoTopUpSection.tsx
@@ -66,7 +66,6 @@ export const AutoTopUpSection: React.FunctionComponent<{ dependencies?: typeof D
   const searchParams = d.useSearchParams();
   const router = d.useRouter();
   const { urlService } = d.useServices();
-  const [isAwaitingCardForSetup, setIsAwaitingCardForSetup] = useState(false);
   const hasStartedRequestedSetup = useRef(false);
 
   const toggleAutoReload = useCallback(
@@ -157,25 +156,17 @@ export const AutoTopUpSection: React.FunctionComponent<{ dependencies?: typeof D
       if (!isSetupRequested || isFirstLoad || hasStartedRequestedSetup.current) return;
       hasStartedRequestedSetup.current = true;
 
+      const openSettingsToEnable = () => setAutoTopUpPopup({ open: true, enableOnSave: true });
+
       if (hasPaymentMethod) {
-        setAutoTopUpPopup({ open: true, enableOnSave: true });
+        openSettingsToEnable();
       } else {
-        openAddPaymentMethod();
-        setIsAwaitingCardForSetup(true);
+        openAddPaymentMethod({ onSuccess: openSettingsToEnable });
       }
 
       router.replace(urlService.billing(), { scroll: false });
     },
     [isSetupRequested, isFirstLoad, hasPaymentMethod, router, urlService, openAddPaymentMethod]
-  );
-
-  useEffect(
-    function openSettingsOnceCardArrives() {
-      if (!isAwaitingCardForSetup || !hasPaymentMethod) return;
-      setIsAwaitingCardForSetup(false);
-      setAutoTopUpPopup({ open: true, enableOnSave: true });
-    },
-    [isAwaitingCardForSetup, hasPaymentMethod]
   );
 
   const usd = (value: number) => <d.UsdValue value={value} />;
@@ -217,7 +208,7 @@ export const AutoTopUpSection: React.FunctionComponent<{ dependencies?: typeof D
             </div>
           ) : !hasPaymentMethod ? (
             <p className="text-sm text-muted-foreground">
-              <button type="button" onClick={openAddPaymentMethod} className="text-primary underline">
+              <button type="button" onClick={() => openAddPaymentMethod()} className="text-primary underline">
                 Add a payment method
               </button>{" "}
               to enable auto {isThresholdModeOffered ? "top-up" : "recharge"}

--- a/apps/deploy-web/src/components/billing-usage/AutoTopUpSection/AutoTopUpSection.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AutoTopUpSection/AutoTopUpSection.tsx
@@ -1,10 +1,11 @@
 "use client";
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { PaymentMethod } from "@akashnetwork/http-sdk";
 import { Button, Card, CardContent, CardHeader, Skeleton, Snackbar, Switch } from "@akashnetwork/ui/components";
 import { usePopup } from "@akashnetwork/ui/context";
 import { LinearProgress } from "@mui/material";
 import { Edit } from "iconoir-react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useSnackbar } from "notistack";
 
 import { useAccountBalanceOverview } from "@src/components/billing-usage/AccountBalanceOverview/useAccountBalanceOverview";
@@ -16,10 +17,14 @@ import {
 import { useBillingActions } from "@src/components/billing-usage/BillingActionsProvider/BillingActionsProvider";
 import { UsdValue } from "@src/components/billing-usage/UsdValue/UsdValue";
 import { useAutoReloadMode } from "@src/components/billing-usage/useAutoReloadMode";
+import { useServices } from "@src/context/ServicesProvider";
 import { useDefaultPaymentMethodQuery, useWalletSettingsMutations, useWalletSettingsQuery, useWeeklyDeploymentCostQuery } from "@src/queries";
 import { capitalizeFirstLetter } from "@src/utils/stringUtils";
 
 const HOURS_PER_DAY = 24;
+
+/** Set by the deploy flow's "Add Payment Method" CTA, which needs a card and auto top-up in one trip. */
+const SETUP_PARAM = "setupAutoTopUp";
 
 export const DEPENDENCIES = {
   useSnackbar,
@@ -31,6 +36,9 @@ export const DEPENDENCIES = {
   usePopup,
   useBillingActions,
   useAutoReloadMode,
+  useSearchParams,
+  useRouter,
+  useServices,
   AutoTopUpSettingsPopup,
   UsdValue,
   Button,
@@ -55,6 +63,11 @@ export const AutoTopUpSection: React.FunctionComponent<{ dependencies?: typeof D
   const { openAddPaymentMethod } = d.useBillingActions();
   const overview = d.useAccountBalanceOverview();
   const { confirm } = d.usePopup();
+  const searchParams = d.useSearchParams();
+  const router = d.useRouter();
+  const { urlService } = d.useServices();
+  const [isAwaitingCardForSetup, setIsAwaitingCardForSetup] = useState(false);
+  const hasStartedRequestedSetup = useRef(false);
 
   const toggleAutoReload = useCallback(
     async (autoReloadEnabled: boolean) => {
@@ -137,6 +150,34 @@ export const AutoTopUpSection: React.FunctionComponent<{ dependencies?: typeof D
     return Math.max(1, Math.round((overview.available - autoReloadThreshold) / dailySpend));
   }, [overview.perHour, overview.available, autoReloadThreshold]);
 
+  const isSetupRequested = searchParams.get(SETUP_PARAM) === "true";
+
+  useEffect(
+    function startSetupRequestedByDeepLink() {
+      if (!isSetupRequested || isFirstLoad || hasStartedRequestedSetup.current) return;
+      hasStartedRequestedSetup.current = true;
+
+      if (hasPaymentMethod) {
+        setAutoTopUpPopup({ open: true, enableOnSave: true });
+      } else {
+        openAddPaymentMethod();
+        setIsAwaitingCardForSetup(true);
+      }
+
+      router.replace(urlService.billing(), { scroll: false });
+    },
+    [isSetupRequested, isFirstLoad, hasPaymentMethod, router, urlService, openAddPaymentMethod]
+  );
+
+  useEffect(
+    function openSettingsOnceCardArrives() {
+      if (!isAwaitingCardForSetup || !hasPaymentMethod) return;
+      setIsAwaitingCardForSetup(false);
+      setAutoTopUpPopup({ open: true, enableOnSave: true });
+    },
+    [isAwaitingCardForSetup, hasPaymentMethod]
+  );
+
   const usd = (value: number) => <d.UsdValue value={value} />;
 
   return (
@@ -152,7 +193,7 @@ export const AutoTopUpSection: React.FunctionComponent<{ dependencies?: typeof D
             <h3 className="text-lg font-bold leading-none">{isThresholdModeOffered ? "Auto Top-Up" : "Auto Recharge"}</h3>
             {isFirstLoad ? (
               <d.Skeleton className="h-4 w-72" />
-            ) : !isThresholdModeOffered ? (
+            ) : !isThresholdModeOffered || !autoReloadEnabled ? (
               <p className="text-sm text-muted-foreground">Automatically adds credits to keep your deployments running.</p>
             ) : showsThresholdRule ? (
               <p className="text-sm text-muted-foreground">
@@ -245,9 +286,7 @@ export const AutoTopUpSection: React.FunctionComponent<{ dependencies?: typeof D
             </div>
           ) : (
             <p className="text-sm text-muted-foreground">
-              {showsThresholdRule
-                ? "Turn on Auto Top-Up to add funds automatically when your balance runs low."
-                : "Turn on Auto Top-Up to automatically cover the week ahead for your running deployments."}
+              Turn on Auto Top-Up to add funds automatically before your balance runs out. You pick the rule when you set it up.
             </p>
           )}
         </d.CardContent>

--- a/apps/deploy-web/src/components/billing-usage/BillingActionsProvider/BillingActionsProvider.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/BillingActionsProvider/BillingActionsProvider.spec.tsx
@@ -6,12 +6,17 @@ import { BillingActionsProvider, type DEPENDENCIES, useBillingActions } from "./
 
 import { act, fireEvent, render, screen } from "@testing-library/react";
 
-const Consumer = () => {
+const Consumer = ({ onSuccess }: { onSuccess?: () => void }) => {
   const { openAddPaymentMethod } = useBillingActions();
   return (
-    <button type="button" onClick={openAddPaymentMethod}>
-      open
-    </button>
+    <>
+      <button type="button" onClick={() => openAddPaymentMethod({ onSuccess })}>
+        open
+      </button>
+      <button type="button" onClick={() => openAddPaymentMethod()}>
+        open plain
+      </button>
+    </>
   );
 };
 
@@ -70,6 +75,33 @@ describe("BillingActionsProvider", () => {
     expect(screen.queryByTestId("popup")).not.toBeInTheDocument();
   });
 
+  it("runs the caller's success callback once the card is saved", async () => {
+    const onSuccess = vi.fn();
+    setup({ onSuccess });
+
+    fireEvent.click(screen.getByText("open"));
+    await act(async () => {
+      fireEvent.click(screen.getByText("success"));
+    });
+
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not carry a cancelled call's success callback into a later unrelated card", async () => {
+    const onSuccess = vi.fn();
+    setup({ onSuccess });
+
+    fireEvent.click(screen.getByText("open"));
+    fireEvent.click(screen.getByText("close"));
+
+    fireEvent.click(screen.getByText("open plain"));
+    await act(async () => {
+      fireEvent.click(screen.getByText("success"));
+    });
+
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
   it("keeps the popup closed and toasts when creating the setup intent fails", () => {
     const { toast } = setup({ isError: true });
 
@@ -79,7 +111,7 @@ describe("BillingActionsProvider", () => {
     expect(toast).toHaveBeenCalledWith(expect.objectContaining({ variant: "destructive" }));
   });
 
-  function setup(input: { setupIntent?: { clientSecret: string }; theme?: string; isError?: boolean } = {}) {
+  function setup(input: { setupIntent?: { clientSecret: string }; theme?: string; isError?: boolean; onSuccess?: () => void } = {}) {
     const createSetupIntent = vi.fn();
     const resetSetupIntent = vi.fn();
     const refresh = vi.fn().mockResolvedValue(undefined);
@@ -104,7 +136,7 @@ describe("BillingActionsProvider", () => {
 
     render(
       <BillingActionsProvider dependencies={dependencies}>
-        <Consumer />
+        <Consumer onSuccess={input.onSuccess} />
       </BillingActionsProvider>
     );
 

--- a/apps/deploy-web/src/components/billing-usage/BillingActionsProvider/BillingActionsProvider.tsx
+++ b/apps/deploy-web/src/components/billing-usage/BillingActionsProvider/BillingActionsProvider.tsx
@@ -1,6 +1,6 @@
 "use client";
 import type { ReactNode } from "react";
-import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import { useToast } from "@akashnetwork/ui/hooks";
 import { useTheme } from "next-themes";
 
@@ -16,7 +16,8 @@ export const DEPENDENCIES = {
 };
 
 type BillingActions = {
-  openAddPaymentMethod: () => void;
+  /** `onSuccess` runs only for the card this call opens, and is dropped if the popup closes or errors first. */
+  openAddPaymentMethod: (options?: { onSuccess?: () => void }) => void;
 };
 
 const BillingActionsContext = createContext<BillingActions | null>(null);
@@ -30,26 +31,38 @@ export const BillingActionsProvider: React.FunctionComponent<{ children: ReactNo
   const { data: setupIntent, mutate: createSetupIntent, reset: resetSetupIntent, isError: isSetupIntentError } = d.useSetupIntentMutation();
   const refreshPaymentMethods = d.useRefreshPaymentMethods();
   const [isOpen, setIsOpen] = useState(false);
+  const pendingOnSuccess = useRef<(() => void) | undefined>(undefined);
 
-  const openAddPaymentMethod = useCallback(() => {
-    resetSetupIntent();
-    createSetupIntent();
-    setIsOpen(true);
-  }, [createSetupIntent, resetSetupIntent]);
+  const openAddPaymentMethod = useCallback(
+    (options?: { onSuccess?: () => void }) => {
+      pendingOnSuccess.current = options?.onSuccess;
+      resetSetupIntent();
+      createSetupIntent();
+      setIsOpen(true);
+    },
+    [createSetupIntent, resetSetupIntent]
+  );
+
+  const closeAddPaymentMethod = useCallback(() => {
+    pendingOnSuccess.current = undefined;
+    setIsOpen(false);
+  }, []);
 
   useEffect(
     function notifyAndClosePopupOnSetupIntentError() {
       if (!isSetupIntentError) return;
-      setIsOpen(false);
+      closeAddPaymentMethod();
       toast({ title: "Couldn't start adding a payment method", description: "Please try again.", variant: "destructive" });
     },
-    [isSetupIntentError, toast]
+    [isSetupIntentError, toast, closeAddPaymentMethod]
   );
 
   const onAddCardSuccess = useCallback(async () => {
-    setIsOpen(false);
+    const onSuccess = pendingOnSuccess.current;
+    closeAddPaymentMethod();
     await refreshPaymentMethods();
-  }, [refreshPaymentMethods]);
+    onSuccess?.();
+  }, [refreshPaymentMethods, closeAddPaymentMethod]);
 
   const value = useMemo(() => ({ openAddPaymentMethod }), [openAddPaymentMethod]);
 
@@ -58,7 +71,7 @@ export const BillingActionsProvider: React.FunctionComponent<{ children: ReactNo
       {children}
       <d.AddPaymentMethodPopup
         open={isOpen && !isSetupIntentError}
-        onClose={() => setIsOpen(false)}
+        onClose={closeAddPaymentMethod}
         clientSecret={setupIntent?.clientSecret}
         isDarkMode={resolvedTheme === "dark"}
         onSuccess={onAddCardSuccess}

--- a/apps/deploy-web/src/components/billing-usage/PaymentMethodsView/PaymentMethodsView.tsx
+++ b/apps/deploy-web/src/components/billing-usage/PaymentMethodsView/PaymentMethodsView.tsx
@@ -42,7 +42,7 @@ export const PaymentMethodsView: React.FC<PaymentMethodsViewProps> = ({
           <h3 className="text-lg font-bold leading-none">Payment Method</h3>
           <p className="text-sm text-muted-foreground">All transactions will be made using your default card.</p>
         </div>
-        <d.Button onClick={openAddPaymentMethod} size="sm" variant="outline" disabled={isInProgress} className="gap-2">
+        <d.Button onClick={() => openAddPaymentMethod()} size="sm" variant="outline" disabled={isInProgress} className="gap-2">
           <Plus className="h-4 w-4" />
           <span>Add Payment Method</span>
         </d.Button>

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/FundingImpactReviewSection.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/FundingImpactReviewSection.spec.tsx
@@ -91,7 +91,7 @@ describe("FundingImpactReviewSection", () => {
     expect(callout).toHaveTextContent("Visa **** 4242 is charged $100 for credits");
   });
 
-  it("prompts for credits without claiming a charge when no payment method is on file", async () => {
+  it("sends the user to set up a card and auto top-up when no payment method is on file", async () => {
     setup({ impact: visible({ state: "no-payment-method", cardLabel: null }) });
 
     expect(screen.getByText("No payment method")).toBeInTheDocument();
@@ -99,7 +99,19 @@ describe("FundingImpactReviewSection", () => {
 
     expect(screen.getByText(/nothing is charged automatically/)).toBeInTheDocument();
     expect(screen.queryByText(/charged \$/)).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Add Credits" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Add Credits" })).not.toBeInTheDocument();
+
+    const cta = screen.getByRole("link", { name: "Add Payment Method" });
+    expect(cta).toHaveAttribute("href", UrlService.billing({ setupAutoTopUp: true }));
+    expect(cta).toHaveAttribute("target", "_blank");
+  });
+
+  it("keeps the review modal alive by opening the billing detour in a new tab", async () => {
+    setup({ impact: visible({ state: "no-payment-method", cardLabel: null }) });
+
+    await userEvent.click(screen.getByRole("button", { name: /Escrow/ }));
+
+    expect(screen.getByRole("link", { name: "Add Payment Method" })).toHaveAttribute("rel", "noopener noreferrer");
   });
 
   it("names the trial and its duration without claiming anything about a card", async () => {
@@ -163,8 +175,10 @@ describe("FundingImpactReviewSection", () => {
       </div>
     );
     const UsdValue: typeof DEPENDENCIES.UsdValue = ({ value }) => <>${value}</>;
-    const Link: typeof DEPENDENCIES.Link = (({ href, children }: { href: string; children: ReactNode }) => (
-      <a href={href}>{children}</a>
+    const Link: typeof DEPENDENCIES.Link = (({ href, children, ...rest }: { href: string; children: ReactNode }) => (
+      <a href={href} {...rest}>
+        {children}
+      </a>
     )) as typeof DEPENDENCIES.Link;
     const Skeleton: typeof DEPENDENCIES.Skeleton = () => <div data-testid="skeleton" />;
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/FundingImpactReviewSection.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/FundingImpactReviewSection.tsx
@@ -34,6 +34,12 @@ type VisibleImpact = Extract<FundingImpact, { kind: "visible" }>;
 
 type Badge = { label: string; tone: "warning" | "neutral" };
 
+type StateActions = {
+  addCredits: ReactNode;
+  /** Opens in a new tab so the review modal, and the bids it is holding, survive the detour to Billing. */
+  setUpAutoTopUp: ReactNode;
+};
+
 const STATE_BADGES: Partial<Record<VisibleImpact["state"], Badge>> = {
   "crosses-threshold": { label: "Buys credits", tone: "warning" },
   trial: { label: "Trial", tone: "neutral" },
@@ -81,11 +87,20 @@ export const FundingImpactReviewSection: FC<Props> = ({ rows, runtimeLimitHours,
   }
 
   const badge = STATE_BADGES[impact.state];
-  const addCreditsButton = (
-    <Button size="sm" onClick={() => openAddCredits({ initialTab: "purchase", description: ADD_CREDITS_DESCRIPTION, context: "review_funding_impact" })}>
-      Add Credits
-    </Button>
-  );
+  const actions: StateActions = {
+    addCredits: (
+      <Button size="sm" onClick={() => openAddCredits({ initialTab: "purchase", description: ADD_CREDITS_DESCRIPTION, context: "review_funding_impact" })}>
+        Add Credits
+      </Button>
+    ),
+    setUpAutoTopUp: (
+      <Button size="sm" asChild>
+        <d.Link href={UrlService.billing({ setupAutoTopUp: true })} target="_blank" rel="noopener noreferrer">
+          Add Payment Method
+        </d.Link>
+      </Button>
+    )
+  };
 
   return (
     <Collapsible open={isExpanded} onOpenChange={setIsExpanded} className="rounded-lg border p-4">
@@ -131,7 +146,7 @@ export const FundingImpactReviewSection: FC<Props> = ({ rows, runtimeLimitHours,
           />
         )}
 
-        {renderStateDetails(impact, usd, addCreditsButton)}
+        {renderStateDetails(impact, usd, actions)}
 
         <p className="text-sm text-muted-foreground">
           The escrow is held, not charged. You pay for the time your deployment actually runs, and anything it doesn&apos;t use returns to available when the
@@ -146,7 +161,7 @@ export const FundingImpactReviewSection: FC<Props> = ({ rows, runtimeLimitHours,
   );
 };
 
-function renderStateDetails(impact: VisibleImpact, usd: (value: number) => ReactNode, addCreditsButton: ReactNode): ReactNode {
+function renderStateDetails(impact: VisibleImpact, usd: (value: number) => ReactNode, actions: StateActions): ReactNode {
   switch (impact.state) {
     case "funded":
       return impact.thresholdUsd === null ? null : (
@@ -172,14 +187,16 @@ function renderStateDetails(impact: VisibleImpact, usd: (value: number) => React
           <span className="flex-1">
             Trial deployments are closed automatically after {impact.trialDurationHours} hours. Add funds to activate your account and keep deployments running.
           </span>
-          {addCreditsButton}
+          {actions.addCredits}
         </Callout>
       );
     case "no-payment-method":
       return (
         <Callout tone="neutral">
-          <span className="flex-1">No payment method on file, so nothing is charged automatically. Add credits to keep deployments funded.</span>
-          {addCreditsButton}
+          <span className="flex-1">
+            No payment method on file, so nothing is charged automatically. Add a card and turn on Auto Top-Up to keep this deployment funded.
+          </span>
+          {actions.setUpAutoTopUp}
         </Callout>
       );
     case "not-enough-available":
@@ -189,7 +206,7 @@ function renderStateDetails(impact: VisibleImpact, usd: (value: number) => React
             Your available balance of <span className="font-medium">{usd(impact.availableNowUsd)}</span> can&apos;t cover the estimated escrow of{" "}
             <span className="font-medium">~{usd(impact.escrowUsd)}</span>.
           </span>
-          {addCreditsButton}
+          {actions.addCredits}
         </Callout>
       );
   }

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/RuntimeLimitReviewSection.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/RuntimeLimitReviewSection.tsx
@@ -47,7 +47,7 @@ export const RuntimeLimitReviewSection: FC<Props> = ({ isLimited, onLimitedChang
     <div className="space-y-3 rounded-lg border p-4">
       <div className="flex items-center justify-between gap-4">
         <div className="flex items-center gap-2">
-          <span className="font-mono text-xs uppercase tracking-wide text-muted-foreground">Runtime limit</span>
+          <span className="font-mono text-xs uppercase tracking-wide text-muted-foreground">Runtime limit (optional)</span>
           <CustomTooltip
             className="max-w-[280px] p-3 font-sans text-xs normal-case text-muted-foreground"
             title="Closes this deployment automatically after the set number of hours, counted from when it starts. Unused funds are returned to your balance."

--- a/apps/deploy-web/src/utils/urlUtils.ts
+++ b/apps/deploy-web/src/utils/urlUtils.ts
@@ -75,7 +75,8 @@ export const UrlService = {
   userFavorites: () => `/user/settings/favorites`,
   userProfile: (username: string) => `/profile/${username}`,
   usage: () => "/usage",
-  billing: ({ openPayment }: { openPayment?: boolean } = {}) => `/billing${appendSearchParams({ openPayment })}`,
+  billing: ({ openPayment, setupAutoTopUp }: { openPayment?: boolean; setupAutoTopUp?: boolean } = {}) =>
+    `/billing${appendSearchParams({ openPayment, setupAutoTopUp })}`,
   /** @deprecated use .newLogin instead */
   login: () => "/api/auth/login",
   /** @deprecated use .newSignup instead */


### PR DESCRIPTION
## Why

Three things reported from looking at the live app.

The review-and-deploy escrow panel offered **Add Credits** when no payment method was on file. That is the wrong remedy: the account usually has a balance already (the report came from an account sitting on $1,120 available), what it lacks is a card, so nothing refills the deployment once the escrow drains.

The runtime limit switch in the same modal was reading as required.

Separately, the billing page told accounts that had never enabled anything that Auto Top-Up "tops up to cover the week ahead". `auto_reload_mode` defaults to `prediction` in the database, so any account with a settings row reads back as prediction mode and gets told a rule that is not running, while the settings popup right next to it recommends fixed threshold.

## What

**Review and deploy, no payment method.** The state now links to `/billing?setupAutoTopUp=true` behind an **Add Payment Method** button instead of opening the Add Credits sheet. The link opens in a new tab so the review modal, and the bids it is holding, survive the detour (bids expire in about 5 minutes). The `trial` and `not-enough-available` states keep Add Credits, which is the right remedy for them.

Copy: "No payment method on file, so nothing is charged automatically. Add a card and turn on Auto Top-Up to keep this deployment funded."

**The deep link.** `setupAutoTopUp=true` chains both steps on the billing page: with no card it opens the Stripe popup and then the Auto Top-Up settings once the card lands; with a card already on file it goes straight to settings with `enableOnSave`. The param is stripped with `router.replace` and a ref keeps it firing exactly once. Handled in `AutoTopUpSection`, which already holds `openAddPaymentMethod` and owns the settings popup.

**Runtime limit** now reads `RUNTIME LIMIT (OPTIONAL)`.

**Auto Top-Up card** stays mode-neutral until a rule is actually running, and the off-state prompt no longer names one ("Turn on Auto Top-Up to add funds automatically before your balance runs out. You pick the rule when you set it up."). The enabled-state copy still reflects the stored mode, since that is what the reload job runs.

No API or schema changes. Both surfaces are already behind `auto_reload_fixed_threshold`.

### Verification

- `npm run test:unit` in `apps/deploy-web`: 376 files / 3732 tests passing, including 9 new tests covering the deep-link branches and the copy states
- `npm run lint -- --quiet`: clean
- `npx tsc --noEmit`: 92 errors, identical to the pre-change baseline, none in the touched files
