### PR TITLE
feat(deployment): give a deployment record a column for its sealed secrets

### DIFF
--- a/apps/api/drizzle/0048_deployment_sealed_secrets.sql
+++ b/apps/api/drizzle/0048_deployment_sealed_secrets.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "deployment_settings" ADD COLUMN "sealed_secrets" text;

--- a/apps/api/drizzle/meta/0048_snapshot.json
+++ b/apps/api/drizzle/meta/0048_snapshot.json
@@ -1,0 +1,1558 @@
+{
+  "id": "8114c78d-af79-41a0-a267-7d857eba086d",
+  "prevId": "83bc3b6a-7ec1-4562-bd38-80b5a21778d6",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.user_wallets": {
+      "name": "user_wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_allowance": {
+          "name": "deployment_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "fee_allowance": {
+          "name": "fee_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "trial": {
+          "name": "trial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits_low_notified_at": {
+          "name": "credits_low_notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits_sufficient_since": {
+          "name": "credits_sufficient_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits_low_since": {
+          "name": "credits_low_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_wallets_user_id_userSetting_id_fk": {
+          "name": "user_wallets_user_id_userSetting_id_fk",
+          "tableFrom": "user_wallets",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_wallets_user_id_unique": {
+          "name": "user_wallets_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "user_wallets_address_unique": {
+          "name": "user_wallets_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_methods": {
+      "name": "payment_methods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_method_id": {
+          "name": "payment_method_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_validated": {
+          "name": "is_validated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payment_methods_fingerprint_payment_method_id_unique": {
+          "name": "payment_methods_fingerprint_payment_method_id_unique",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_default_unique": {
+          "name": "payment_methods_user_id_is_default_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"payment_methods\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_fingerprint_idx": {
+          "name": "payment_methods_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_idx": {
+          "name": "payment_methods_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_validated_idx": {
+          "name": "payment_methods_user_id_is_validated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_validated",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_fingerprint_payment_method_id_idx": {
+          "name": "payment_methods_user_id_fingerprint_payment_method_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_methods_user_id_userSetting_id_fk": {
+          "name": "payment_methods_user_id_userSetting_id_fk",
+          "tableFrom": "payment_methods",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_transactions": {
+      "name": "stripe_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "stripe_transaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "stripe_transaction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created'"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_refunded": {
+          "name": "amount_refunded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bonus_amount": {
+          "name": "bonus_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_charge_id": {
+          "name": "stripe_charge_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_coupon_id": {
+          "name": "stripe_coupon_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_promotion_code_id": {
+          "name": "stripe_promotion_code_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_idempotency_key": {
+          "name": "stripe_idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method_type": {
+          "name": "payment_method_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_brand": {
+          "name": "card_brand",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_last4": {
+          "name": "card_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_url": {
+          "name": "receipt_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_transactions_stripe_invoice_id_unique": {
+          "name": "stripe_transactions_stripe_invoice_id_unique",
+          "columns": [
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stripe_transactions\".\"stripe_invoice_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_idempotency_key_unique": {
+          "name": "stripe_transactions_stripe_idempotency_key_unique",
+          "columns": [
+            {
+              "expression": "stripe_idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stripe_transactions\".\"stripe_idempotency_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_user_id_idx": {
+          "name": "stripe_transactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_payment_intent_id_idx": {
+          "name": "stripe_transactions_stripe_payment_intent_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_payment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_charge_id_idx": {
+          "name": "stripe_transactions_stripe_charge_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_coupon_id_idx": {
+          "name": "stripe_transactions_stripe_coupon_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_coupon_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_promotion_code_id_idx": {
+          "name": "stripe_transactions_stripe_promotion_code_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_promotion_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_status_idx": {
+          "name": "stripe_transactions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_created_at_idx": {
+          "name": "stripe_transactions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_user_id_created_at_idx": {
+          "name": "stripe_transactions_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_transactions_user_id_userSetting_id_fk": {
+          "name": "stripe_transactions_user_id_userSetting_id_fk",
+          "tableFrom": "stripe_transactions",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_settings": {
+      "name": "wallet_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_reload_enabled": {
+          "name": "auto_reload_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_reload_mode": {
+          "name": "auto_reload_mode",
+          "type": "auto_reload_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'prediction'"
+        },
+        "auto_reload_threshold": {
+          "name": "auto_reload_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2000
+        },
+        "auto_reload_amount": {
+          "name": "auto_reload_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10000
+        },
+        "last_auto_charge_at": {
+          "name": "last_auto_charge_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_settings_user_id_idx": {
+          "name": "wallet_settings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_settings_wallet_id_user_wallets_id_fk": {
+          "name": "wallet_settings_wallet_id_user_wallets_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "user_wallets",
+          "columnsFrom": [
+            "wallet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wallet_settings_user_id_userSetting_id_fk": {
+          "name": "wallet_settings_user_id_userSetting_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallet_settings_wallet_id_unique": {
+          "name": "wallet_settings_wallet_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wallet_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.userSetting": {
+      "name": "userSetting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscribedToNewsletter": {
+          "name": "subscribedToNewsletter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "youtubeUsername": {
+          "name": "youtubeUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitterUsername": {
+          "name": "twitterUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "githubUsername": {
+          "name": "githubUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_ip": {
+          "name": "last_ip",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_user_agent": {
+          "name": "last_user_agent",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fingerprint": {
+          "name": "last_fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboardingSkippedAt": {
+          "name": "onboardingSkippedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "userSetting_userId_unique": {
+          "name": "userSetting_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        },
+        "userSetting_username_unique": {
+          "name": "userSetting_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.template": {
+      "name": "template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "copiedFromId": {
+          "name": "copiedFromId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cpu": {
+          "name": "cpu",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ram": {
+          "name": "ram",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage": {
+          "name": "storage",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sdl": {
+          "name": "sdl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "template_userId_idx": {
+          "name": "template_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.templateFavorite": {
+      "name": "templateFavorite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "templateId": {
+          "name": "templateId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addedDate": {
+          "name": "addedDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "templateFavorite_userId_templateId_unique": {
+          "name": "templateFavorite_userId_templateId_unique",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "templateId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "templateFavorite_templateId_template_id_fk": {
+          "name": "templateFavorite_templateId_template_id_fk",
+          "tableFrom": "templateFavorite",
+          "tableTo": "template",
+          "columnsFrom": [
+            "templateId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_settings": {
+      "name": "deployment_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dseq": {
+          "name": "dseq",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_top_up_enabled": {
+          "name": "auto_top_up_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closed": {
+          "name": "closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_funded_at": {
+          "name": "last_funded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_limit_hours": {
+          "name": "runtime_limit_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sdl": {
+          "name": "sdl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sealed_secrets": {
+          "name": "sealed_secrets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manifest_version": {
+          "name": "manifest_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_ends_at": {
+          "name": "runtime_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_ending_notified_for": {
+          "name": "runtime_ending_notified_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_unreachable_notified_for": {
+          "name": "provider_unreachable_notified_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "id_auto_top_up_enabled_closed_idx": {
+          "name": "id_auto_top_up_enabled_closed_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auto_top_up_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "closed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_settings_user_id_userSetting_id_fk": {
+          "name": "deployment_settings_user_id_userSetting_id_fk",
+          "tableFrom": "deployment_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dseq_user_id_idx": {
+          "name": "dseq_user_id_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "dseq",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_key": {
+          "name": "hashed_key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_format": {
+          "name": "key_format",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_user_id_userSetting_id_fk": {
+          "name": "api_keys_user_id_userSetting_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_hashed_key_unique": {
+          "name": "api_keys_hashed_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hashed_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_verification_codes": {
+      "name": "email_verification_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_verification_codes_user_id_idx": {
+          "name": "email_verification_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_verification_codes_user_id_userSetting_id_fk": {
+          "name": "email_verification_codes_user_id_userSetting_id_fk",
+          "tableFrom": "email_verification_codes",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.data_keys": {
+      "name": "data_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wrapped_key": {
+          "name": "wrapped_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wrapped_by_kid": {
+          "name": "wrapped_by_kid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "data_keys_wrapped_by_kid_idx": {
+          "name": "data_keys_wrapped_by_kid_idx",
+          "columns": [
+            {
+              "expression": "wrapped_by_kid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "data_keys_user_id_userSetting_id_fk": {
+          "name": "data_keys_user_id_userSetting_id_fk",
+          "tableFrom": "data_keys",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "data_keys_user_id_unique": {
+          "name": "data_keys_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.stripe_transaction_status": {
+      "name": "stripe_transaction_status",
+      "schema": "public",
+      "values": [
+        "created",
+        "pending",
+        "requires_action",
+        "succeeded",
+        "failed",
+        "refunded",
+        "canceled"
+      ]
+    },
+    "public.stripe_transaction_type": {
+      "name": "stripe_transaction_type",
+      "schema": "public",
+      "values": [
+        "payment_intent",
+        "coupon_claim",
+        "manual_credit"
+      ]
+    },
+    "public.auto_reload_mode": {
+      "name": "auto_reload_mode",
+      "schema": "public",
+      "values": [
+        "prediction",
+        "threshold"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -337,6 +337,13 @@
       "when": 1788162567618,
       "tag": "0047_credits_low_confirm_window",
       "breakpoints": true
+    },
+    {
+      "idx": 48,
+      "version": "7",
+      "when": 1788342600963,
+      "tag": "0048_deployment_sealed_secrets",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/deployment/model-schemas/deployment-setting/deployment-setting.schema.ts
+++ b/apps/api/src/deployment/model-schemas/deployment-setting/deployment-setting.schema.ts
@@ -19,6 +19,8 @@ export const DeploymentSettings = pgTable(
     lastFundedAt: timestamp("last_funded_at"),
     runtimeLimitHours: integer("runtime_limit_hours"),
     sdl: text("sdl"),
+    /** A JWE compact serialization, so `text` rather than a sized column: the plaintext it carries is bounded, its ciphertext is not sized by anything this schema knows. */
+    sealedSecrets: text("sealed_secrets"),
     manifestVersion: varchar("manifest_version", { length: 64 }),
     runtimeEndsAt: timestamp("runtime_ends_at", { withTimezone: true }),
     runtimeEndingNotifiedFor: timestamp("runtime_ending_notified_for", { withTimezone: true }),

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
@@ -1,6 +1,7 @@
 import { faker } from "@faker-js/faker";
 import { hoursToMilliseconds } from "date-fns";
 import { eq, sql } from "drizzle-orm";
+import { randomBytes } from "node:crypto";
 import { container } from "tsyringe";
 import { describe, expect, it } from "vitest";
 
@@ -16,9 +17,15 @@ import { DeploymentSettingRepository } from "./deployment-setting.repository";
 import { createAkashAddress } from "@test/seeders/akash-address.seeder";
 
 const COOLDOWN_MINUTES = 60;
+const SDL = "version: '2.0'";
 const OUTAGE_STARTED_AT = "2026-08-01T00:00:00.000Z";
 const LATER_OUTAGE_STARTED_AT = "2026-08-20T00:00:00.000Z";
 const WARNING_WINDOW = { leadHours: 6, minLimitHours: 12 };
+
+/** Shaped like the compact JWE the column will really carry — five base64url segments — and generated per call so no test can pin a literal. */
+function newSealedToken() {
+  return Array.from({ length: 5 }, () => randomBytes(24).toString("base64url")).join(".");
+}
 
 /** Rows created with a `Date` store exactly that value, so its ISO form is the marker the claim matches on. */
 function markerFor(runtimeEndsAt: Date) {
@@ -534,6 +541,90 @@ describe(DeploymentSettingRepository.name, () => {
 
       expect((await deploymentSettingRepository.findOneBy({ userId: user.id, dseq }))?.sdl).toHaveLength(SDL_MAX_LENGTH);
     });
+
+    it("returns a sealed token byte-for-byte as it was given", async () => {
+      const { deploymentSettingRepository, user, sealedToken } = await setup();
+      const dseq = newDseq();
+
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: SDL, manifestVersion: "BAUG", sealedSecrets: sealedToken });
+
+      expect((await deploymentSettingRepository.findOneBy({ userId: user.id, dseq }))?.sealedSecrets).toBe(sealedToken);
+    });
+
+    it("records the sealed token in the same write as the sdl it belongs to", async () => {
+      const { deploymentSettingRepository, user, sealedToken } = await setup();
+      const dseq = newDseq();
+
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: SDL, manifestVersion: "BAUG", sealedSecrets: sealedToken });
+
+      expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq })).toMatchObject({ sdl: SDL, sealedSecrets: sealedToken });
+    });
+
+    it("replaces a token an abandoned attempt left behind rather than merging with it", async () => {
+      const { deploymentSettingRepository, user, sealedToken, otherSealedToken } = await setup();
+      const dseq = newDseq();
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: SDL, manifestVersion: "BAUG", sealedSecrets: sealedToken });
+
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: SDL, manifestVersion: "BQYH", sealedSecrets: otherSealedToken });
+
+      expect((await deploymentSettingRepository.findOneBy({ userId: user.id, dseq }))?.sealedSecrets).toBe(otherSealedToken);
+    });
+
+    it("clears a token an abandoned attempt left behind when the retry supplies none", async () => {
+      const { deploymentSettingRepository, user, sealedToken } = await setup();
+      const dseq = newDseq();
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: SDL, manifestVersion: "BAUG", sealedSecrets: sealedToken });
+
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: SDL, manifestVersion: "BQYH", sealedSecrets: null });
+
+      expect((await deploymentSettingRepository.findOneBy({ userId: user.id, dseq }))?.sealedSecrets).toBeNull();
+    });
+
+    it("leaves a token on the row alone when the write names none", async () => {
+      const { deploymentSettingRepository, user, sealedToken } = await setup();
+      const dseq = newDseq();
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: SDL, manifestVersion: "BAUG", sealedSecrets: sealedToken });
+
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: SDL, manifestVersion: "BQYH" });
+
+      expect((await deploymentSettingRepository.findOneBy({ userId: user.id, dseq }))?.sealedSecrets).toBe(sealedToken);
+    });
+
+    it("keeps the tokens of two deployments of the same user apart", async () => {
+      const { deploymentSettingRepository, user, sealedToken, otherSealedToken } = await setup();
+      const [first, second] = [newDseq(), newDseq()];
+
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq: first, sdl: SDL, manifestVersion: "BAUG", sealedSecrets: sealedToken });
+      await deploymentSettingRepository.upsertDefinition({
+        userId: user.id,
+        dseq: second,
+        sdl: SDL,
+        manifestVersion: "BQYH",
+        sealedSecrets: otherSealedToken
+      });
+
+      expect((await deploymentSettingRepository.findOneBy({ userId: user.id, dseq: first }))?.sealedSecrets).toBe(sealedToken);
+      expect((await deploymentSettingRepository.findOneBy({ userId: user.id, dseq: second }))?.sealedSecrets).toBe(otherSealedToken);
+    });
+
+    it("leaves a row with no token recorded reading as null rather than as an empty string", async () => {
+      const { deploymentSettingRepository, user } = await setup();
+      const dseq = newDseq();
+
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: SDL, manifestVersion: "BAUG" });
+
+      expect((await deploymentSettingRepository.findOneBy({ userId: user.id, dseq }))?.sealedSecrets).toBeNull();
+    });
+
+    it("takes the sealed token of a deployment with the owner it belongs to", async () => {
+      const { deploymentSettingRepository, userRepository, user, sealedToken, db, deploymentSettingsTable } = await setup();
+      const dseq = newDseq();
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: SDL, manifestVersion: "BAUG", sealedSecrets: sealedToken });
+
+      await userRepository.deleteById(user.id);
+
+      expect(await db.select().from(deploymentSettingsTable).where(eq(deploymentSettingsTable.dseq, dseq))).toEqual([]);
+    });
   });
 
   describe("findAutoTopUpDeploymentsByOwnerIteratively", () => {
@@ -736,11 +827,15 @@ describe(DeploymentSettingRepository.name, () => {
     return {
       userRepository,
       deploymentSettingRepository,
+      db,
+      deploymentSettingsTable,
       user,
       trialUser,
       wallet,
       trialWallet,
       settingId,
+      sealedToken: newSealedToken(),
+      otherSealedToken: newSealedToken(),
       abilityFor,
       createSetting,
       createLimitedSetting,

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -268,26 +268,33 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
    * field it does not name as the earlier writer set them, and an absent runtime limit counts as
    * unnamed: drizzle drops undefined out of the set clause, so neither creating nor updating without a
    * limit can clear one already there.
+   *
+   * `sealedSecrets` reads that same rule in both directions, which is why it is typed to allow null.
+   * A create always states a value — the token, or null when the request carried no secrets — so a
+   * retry replaces whatever a failed attempt left behind rather than inheriting it. An update states
+   * nothing, so a token it was never given survives it.
    */
   async upsertDefinition({
     userId,
     dseq,
     sdl,
     manifestVersion,
-    runtimeLimitHours
+    runtimeLimitHours,
+    sealedSecrets
   }: {
     userId: string;
     dseq: string;
     sdl: string;
     manifestVersion: string;
     runtimeLimitHours?: number;
+    sealedSecrets?: string | null;
   }): Promise<string> {
     const [row] = await this.cursor
       .insert(this.table)
-      .values({ userId, dseq, autoTopUpEnabled: AUTO_TOP_UP_ENABLED_BY_DEFAULT, sdl, manifestVersion, runtimeLimitHours })
+      .values({ userId, dseq, autoTopUpEnabled: AUTO_TOP_UP_ENABLED_BY_DEFAULT, sdl, manifestVersion, runtimeLimitHours, sealedSecrets })
       .onConflictDoUpdate({
         target: [this.table.dseq, this.table.userId],
-        set: { sdl, manifestVersion, runtimeLimitHours, updatedAt: sql`now()` }
+        set: { sdl, manifestVersion, runtimeLimitHours, sealedSecrets, updatedAt: sql`now()` }
       })
       .returning({ id: this.table.id });
 

--- a/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.spec.ts
@@ -678,6 +678,7 @@ describe(DeploymentSettingService.name, () => {
       lastFundedAt: null,
       runtimeLimitHours: null,
       sdl: null,
+      sealedSecrets: null,
       manifestVersion: null,
       runtimeEndsAt: null,
       runtimeEndingNotifiedFor: null,

--- a/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.ts
+++ b/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.ts
@@ -29,7 +29,7 @@ type DeploymentSettingChange = Pick<DeploymentSettingsInput, "autoTopUpEnabled" 
 
 type DeploymentSettingWithEstimatedTopUpAmount = Omit<
   DeploymentSettingsOutput,
-  "lastFundedAt" | "runtimeEndingNotifiedFor" | "providerUnreachableNotifiedFor" | "sdl" | "manifestVersion" | "runtimeEndsAt"
+  "lastFundedAt" | "runtimeEndingNotifiedFor" | "providerUnreachableNotifiedFor" | "sdl" | "sealedSecrets" | "manifestVersion" | "runtimeEndsAt"
 > & {
   estimatedTopUpAmount: number;
   topUpFrequencyMs: number;
@@ -364,9 +364,10 @@ export class DeploymentSettingService {
 
   /**
    * `lastFundedAt`, `runtimeEndingNotifiedFor` and `providerUnreachableNotifiedFor` are internal sweep markers and stay
-   * out of the API payload. So do `sdl` and `manifestVersion`: they are what the console remembers a deployment by,
-   * not something it hands back, and the response schema is types only — whatever this returns is
-   * what ships.
+   * out of the API payload. So do `sdl`, `sealedSecrets` and `manifestVersion`: they are what the console remembers a
+   * deployment by, not something it hands back, and the response schema is types only — whatever this returns is
+   * what ships. `sealedSecrets` is ciphertext rather than a value, but it is the one field here no response has any
+   * reason to carry, so it is dropped by the same rule rather than by a weaker one.
    */
   async withEstimatedTopUpAmount(params: DeploymentSettingsOutput): Promise<DeploymentSettingWithEstimatedTopUpAmount>;
   async withEstimatedTopUpAmount(params: undefined): Promise<undefined>;
@@ -375,7 +376,7 @@ export class DeploymentSettingService {
       return undefined;
     }
 
-    const { lastFundedAt, runtimeEndingNotifiedFor, providerUnreachableNotifiedFor, sdl, manifestVersion, runtimeEndsAt, ...rest } = params;
+    const { lastFundedAt, runtimeEndingNotifiedFor, providerUnreachableNotifiedFor, sdl, sealedSecrets, manifestVersion, runtimeEndsAt, ...rest } = params;
     const setting = { ...rest, runtimeEndsAt: runtimeEndsAt?.toISOString() ?? null };
 
     if (!setting.autoTopUpEnabled) {

--- a/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.spec.ts
+++ b/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.spec.ts
@@ -590,6 +590,7 @@ describe(InitialDeploymentFundingService.name, () => {
       lastFundedAt: null,
       runtimeLimitHours: null,
       sdl: null,
+      sealedSecrets: null,
       manifestVersion: null,
       runtimeEndsAt: null,
       runtimeEndingNotifiedFor: null,

--- a/apps/api/test/functional/deployment-setting.spec.ts
+++ b/apps/api/test/functional/deployment-setting.spec.ts
@@ -1,4 +1,5 @@
 import { faker } from "@faker-js/faker";
+import { randomBytes } from "node:crypto";
 import { container } from "tsyringe";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -12,6 +13,11 @@ import { UserRepository } from "@src/user/repositories/user/user.repository";
 import { createAkashAddress } from "@test/seeders/akash-address.seeder";
 import { createDrainingDeployment } from "@test/seeders/draining-deployment.seeder";
 import { createUserWallet } from "@test/seeders/user-wallet.seeder";
+
+/** Shaped like the compact JWE the column really carries, and generated per call so no test can pin a literal. */
+function newSealedToken() {
+  return Array.from({ length: 5 }, () => randomBytes(24).toString("base64url")).join(".");
+}
 
 describe("Deployment Settings", () => {
   const deploymentSettingRepository = container.resolve(DeploymentSettingRepository);
@@ -61,7 +67,8 @@ describe("Deployment Settings", () => {
     it("hands back none of what the console remembers the deployment by", async () => {
       const { token, user } = await setup();
       const dseq = faker.number.int({ min: 1, max: 1000000 }).toString();
-      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: "version: '2.0'", manifestVersion: "BAUG" });
+      const sealedSecrets = newSealedToken();
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: "version: '2.0'", manifestVersion: "BAUG", sealedSecrets });
 
       const response = await app.request(`/v1/deployment-settings/${user.id}/${dseq}`, {
         headers: {
@@ -70,9 +77,12 @@ describe("Deployment Settings", () => {
       });
 
       expect(response.status).toBe(200);
-      const { data } = (await response.json()) as { data: Record<string, unknown> };
+      const body = await response.text();
+      const { data } = JSON.parse(body) as { data: Record<string, unknown> };
       expect(data).not.toHaveProperty("sdl");
       expect(data).not.toHaveProperty("manifestVersion");
+      expect(data).not.toHaveProperty("sealedSecrets");
+      expect(body).not.toContain(sealedSecrets);
     });
 
     it("enables auto top-up on a lazily created row without consulting the owner's wallet", async () => {


### PR DESCRIPTION
> **Base branch: `main`.** This is PR **1 of 5** in the sealed-secrets create-path stack. Review and merge in order; each later PR is based on its predecessor, not on `main`, so that the size labeler measures only the incremental diff.
>
> | # | PR | incremental lines |
> |---|---|---|
> | **1** | **give a deployment record a column for its sealed secrets** ← you are here | **138** |
> | 2 | bind a stored secret to the deployment it was stored for | 300 |
> | 3 | let a stored sdl keep the references it was written with | 353 |
> | 4 | turn a transport seal and an sdl into the values a deployment needs | 614 |
> | 5 | accept sealed secrets when a deployment is created | 815 |
>
> The executable demo of the observable end-to-end behaviour lives in **PR 5**, which is where the create path lands. PRs 1-4 are the seams it stands on and have no user-visible behaviour of their own.

## Why

ref CON-862

Phase 3 of the deployment-secrets roadmap (`docs/prd/0003-deployment-secrets.md`) needs somewhere to put a deployment's sealed secret values. Today `deployment_settings` holds a deployment's SDL with **every env value stripped**, so the console remembers what a deployment expects to be given but not what to give it. That is the whole reason a stored definition is not redeployable.

This slice adds the column and gets its write semantics right, and nothing else. It is separate because it is the only migration in the stack: a schema change reviewed on its own, against a diff that is a column plus the drizzle snapshot, is easier to be sure about than the same change buried under 800 lines of cipher and intake logic. Nothing reads or writes the column yet.

## What

- `deployment_settings.sealed_secrets` — one nullable `TEXT` column (migration `0048_deployment_sealed_secrets.sql`). `text` rather than a sized column because what it carries is a JWE compact serialization: the plaintext behind it is bounded, its ciphertext is not sized by anything the schema knows. A deployment's whole definition — SDL, manifest version, sealed token — stays **one row written in one statement**, so there is no window in which a deployment is remembered without its secrets.
- `DeploymentSettingRepository.upsertDefinition` takes `sealedSecrets?: string | null`. The `null` in that type is the load-bearing part and is the reason this slice exists on its own:
  - Drizzle drops `undefined` out of an `onConflictDoUpdate` set clause, so a write that does not name a column leaves whatever is already there.
  - That is **right for an update**, which is handed no token and must not destroy one.
  - It is **wrong for a create**, which must not inherit the secrets of an abandoned earlier attempt on the same `(userId, dseq)`. So a create always states a value, `null` included, and a retry supplying no secrets *clears* the column rather than silently keeping the old set.
- Integration coverage for exactly that, in `deployment-setting.repository.integration.ts`: a token round-trips byte-for-byte, lands in the same write as its SDL, is replaced wholesale by a retry, is cleared by a retry that supplies none, survives a write that names none, stays distinct across two deployments of one user, reads as `null` rather than `""` when never written, and is deleted with its owner.
- No behaviour change for any existing caller: `sealedSecrets` is optional everywhere, and every current `upsertDefinition` call omits it.

**Migration safety:** `ALTER TABLE ... ADD COLUMN <nullable> <no default>` is a catalog-only change in Postgres — no table rewrite, no scan, no long-lived `ACCESS EXCLUSIVE` hold. Safe to run on production without blocking.

### Validation

Measured on the tip of the stack (`feat/deployment-accept-sealed-secrets-on-create`), in `apps/api`:

| check | result |
|---|---|
| `npx tsc --noEmit` | **43 errors — exactly the `main` baseline, byte-identical error set** (independently verified; `apps/api` tsc is not green on `main`, so 43 is the baseline and not a regression) |
| `npm run lint -- --quiet` | clean |
| `npm test` | **245 files / 3131 tests passing** |

### Open items at time of opening

These are stated because this stack is being opened mid-process, deliberately, and the bodies should not overclaim:

- The **independent round-2 review** of the fixes applied after the first review has **completed with zero blocking findings**.
- A **full-suite test flake is still open, and the evidence now says it is not ours.** `npm test` intermittently fails at the **suite** level — `beforeAll` timeouts in `dbService.setup()` — and never with a failing assertion. Measured interleaved, one run each per round: **`main` failed 1 of 5 runs and this stack's tip 1 of 4, both failing in the same round.** On the available evidence it is **pre-existing and not attributable to this stack**.
- **Root cause, identified and pre-existing.** `apps/api/env/.env.functional.test` sets neither `POSTGRES_MAX_CONNECTIONS` nor `POSTGRES_BACKGROUND_JOBS_POOL_SIZE`, so every functional suite inherits the production defaults of 20 each (`core/config/env.config.ts:15,17`). With `maxWorkers` unset, ~14 suites run concurrently and each boots its own app and database, putting worst-case demand near **328 connections on `main` and 348 on the tip, against `max_connections=100`**. That produces exactly the observed chain: `sorry, too many clients already`, then a socket closing mid-query (`Cannot redefine property: query`), then the 20 s `beforeAll` budget expiring. This stack adds one suite and a second `startJobQueues()` call site — roughly **+6%** — which is not what puts the system over a hard limit it already exceeds.
- **The fix is two lines of test config**: `POSTGRES_MAX_CONNECTIONS=4` and `POSTGRES_BACKGROUND_JOBS_POOL_SIZE=4` in `apps/api/env/.env.functional.test`, which both the functional and integration vitest projects load. Test-only and independent of these five branches, so it is best landed as its own small PR that any of them can rebase onto.
- **Two unrelated pre-existing flakes show up in the same logs** and are untouched by this stack: `UserWalletRepository > isCreditsLowConfirmed > confirms immediately when the window is disabled`, which compares an app-clock `new Date()` against Postgres `now()` with a zero-minute window, and separate flakes in `providers.spec.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployment settings can now securely store sealed secret data.
  * Existing sealed secret data is preserved when updates omit a replacement value.
  * Sealed secret data can be replaced or cleared as needed.

* **Security**
  * Sealed secret data is excluded from deployment settings responses, preventing sensitive values from being exposed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->