### PR TITLE
feat(deployment): bind a stored secret to the deployment it was stored for

### DIFF
--- a/apps/api/src/secret/services/secret-cipher/secret-cipher.service.integration.ts
+++ b/apps/api/src/secret/services/secret-cipher/secret-cipher.service.integration.ts
@@ -1,7 +1,7 @@
 import type { protos } from "@google-cloud/kms";
 import crc32c from "fast-crc32c";
 import { compactDecrypt, CompactEncrypt, decodeProtectedHeader } from "jose";
-import { constants, generateKeyPairSync, privateDecrypt, randomBytes, randomInt, randomUUID } from "node:crypto";
+import { constants, generateKeyPairSync, privateDecrypt, randomBytes, randomUUID } from "node:crypto";
 import { container } from "tsyringe";
 import { afterEach, describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
@@ -24,13 +24,14 @@ const KID = "sdl-secrets.v1";
 const VERSION_NAME = "projects/console-test/locations/global/keyRings/console-api/cryptoKeys/sdl-secrets/cryptoKeyVersions/1";
 const SDL = 'version: "2.0"\nservices:\n  web:\n    image: nginx\n';
 
-/** What the deployment create path binds a stored token to, so these tests exercise the shape production will use. */
 function bindingFor(user: UserOutput, dseq: string) {
   return { sub: user.id, dseq };
 }
 
+let lastDseq = 100000;
+
 function newDseq() {
-  return randomInt(100000, 999999).toString();
+  return (++lastDseq).toString();
 }
 
 describe(SecretCipherService.name, () => {

--- a/apps/api/src/secret/services/secret-cipher/secret-cipher.service.integration.ts
+++ b/apps/api/src/secret/services/secret-cipher/secret-cipher.service.integration.ts
@@ -1,7 +1,7 @@
 import type { protos } from "@google-cloud/kms";
 import crc32c from "fast-crc32c";
 import { compactDecrypt, CompactEncrypt, decodeProtectedHeader } from "jose";
-import { constants, generateKeyPairSync, privateDecrypt, randomBytes, randomUUID } from "node:crypto";
+import { constants, generateKeyPairSync, privateDecrypt, randomBytes, randomInt, randomUUID } from "node:crypto";
 import { container } from "tsyringe";
 import { afterEach, describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
@@ -24,6 +24,15 @@ const KID = "sdl-secrets.v1";
 const VERSION_NAME = "projects/console-test/locations/global/keyRings/console-api/cryptoKeys/sdl-secrets/cryptoKeyVersions/1";
 const SDL = 'version: "2.0"\nservices:\n  web:\n    image: nginx\n';
 
+/** What the deployment create path binds a stored token to, so these tests exercise the shape production will use. */
+function bindingFor(user: UserOutput, dseq: string) {
+  return { sub: user.id, dseq };
+}
+
+function newDseq() {
+  return randomInt(100000, 999999).toString();
+}
+
 describe(SecretCipherService.name, () => {
   it("returns the exact values a client sealed after they have been encrypted at rest and decrypted back", async () => {
     const { cipher, openSeal, sealAs, createTestUser, inRequest } = setup();
@@ -35,11 +44,12 @@ describe(SecretCipherService.name, () => {
       EMPTY: ""
     };
 
+    const binding = bindingFor(user, newDseq());
     const roundTripped = await inRequest(user, async () => {
       const opened = await openSeal(await sealAs(user, clientSecrets));
-      const stored = await Promise.all(Object.entries(opened).map(async ([name, value]) => [name, await cipher.encrypt(user.id, value)] as const));
+      const stored = await Promise.all(Object.entries(opened).map(async ([name, value]) => [name, await cipher.encrypt(user.id, value, binding)] as const));
 
-      return Object.fromEntries(await Promise.all(stored.map(async ([name, encrypted]) => [name, await cipher.decrypt(user.id, encrypted)] as const)));
+      return Object.fromEntries(await Promise.all(stored.map(async ([name, encrypted]) => [name, await cipher.decrypt(user.id, encrypted, binding)] as const)));
     });
 
     expect(roundTripped).toEqual(clientSecrets);
@@ -49,7 +59,8 @@ describe(SecretCipherService.name, () => {
     const { cipher, createTestUser, inRequest, dataKeyRepository } = setup();
     const user = await createTestUser();
 
-    const stored = await inRequest(user, async () => await Promise.all(["a", "b", "c"].map(async value => await cipher.encrypt(user.id, value))));
+    const binding = bindingFor(user, newDseq());
+    const stored = await inRequest(user, async () => await Promise.all(["a", "b", "c"].map(async value => await cipher.encrypt(user.id, value, binding))));
     const dataKey = await dataKeyRepository.findByUserId(user.id);
 
     expect(stored.map(encrypted => decodeProtectedHeader(encrypted).kid)).toEqual([dataKey!.id, dataKey!.id, dataKey!.id]);
@@ -61,10 +72,11 @@ describe(SecretCipherService.name, () => {
     const user = await createTestUser();
     const values = Array.from({ length: 12 }, (_, index) => `secret-${index}`);
 
+    const binding = bindingFor(user, newDseq());
     const roundTripped = await inRequest(user, async () => {
-      const stored = await Promise.all(values.map(async value => await cipher.encrypt(user.id, value)));
+      const stored = await Promise.all(values.map(async value => await cipher.encrypt(user.id, value, binding)));
 
-      return await Promise.all(stored.map(async encrypted => await cipher.decrypt(user.id, encrypted)));
+      return await Promise.all(stored.map(async encrypted => await cipher.decrypt(user.id, encrypted, binding)));
     });
 
     expect(roundTripped).toEqual(values);
@@ -75,9 +87,10 @@ describe(SecretCipherService.name, () => {
     const { cipher, createTestUser, inRequest, kmsClient } = setup();
     const user = await createTestUser();
 
-    const encrypted = await inRequest(user, async () => await cipher.encrypt(user.id, "value"));
+    const binding = bindingFor(user, newDseq());
+    const encrypted = await inRequest(user, async () => await cipher.encrypt(user.id, "value", binding));
 
-    await expect(inRequest(user, async () => await cipher.decrypt(user.id, encrypted))).resolves.toBe("value");
+    await expect(inRequest(user, async () => await cipher.decrypt(user.id, encrypted, binding))).resolves.toBe("value");
     expect(kmsClient.asymmetricDecrypt).toHaveBeenCalledTimes(2);
   });
 
@@ -86,7 +99,7 @@ describe(SecretCipherService.name, () => {
     const user = await createTestUser();
 
     const heldDuringRequest = await inRequest(user, async () => {
-      await cipher.encrypt(user.id, "value");
+      await cipher.encrypt(user.id, "value", bindingFor(user, newDseq()));
 
       return executionContextService.get("HELD_DATA_KEYS");
     });
@@ -100,17 +113,20 @@ describe(SecretCipherService.name, () => {
     const { cipher, createTestUser, inRequest } = setup();
     const [owner, other] = await Promise.all([createTestUser(), createTestUser()]);
 
-    const encryptedForOwner = await inRequest(owner, async () => await cipher.encrypt(owner.id, "owner-only"));
+    const dseq = newDseq();
+    const encryptedForOwner = await inRequest(owner, async () => await cipher.encrypt(owner.id, "owner-only", bindingFor(owner, dseq)));
 
-    await expect(inRequest(other, async () => await cipher.decrypt(other.id, encryptedForOwner))).rejects.toMatchObject({ status: 500 });
+    await expect(inRequest(other, async () => await cipher.decrypt(other.id, encryptedForOwner, bindingFor(other, dseq)))).rejects.toMatchObject({
+      status: 500
+    });
   });
 
   it("fails authentication when one user's stored value is opened with another user's data key", async () => {
     const { cipher, createTestUser, inRequest, dataKeyOf } = setup();
     const [owner, other] = await Promise.all([createTestUser(), createTestUser()]);
 
-    const encryptedForOwner = await inRequest(owner, async () => await cipher.encrypt(owner.id, "owner-only"));
-    await inRequest(other, async () => await cipher.encrypt(other.id, "other-only"));
+    const encryptedForOwner = await inRequest(owner, async () => await cipher.encrypt(owner.id, "owner-only", bindingFor(owner, newDseq())));
+    await inRequest(other, async () => await cipher.encrypt(other.id, "other-only", bindingFor(other, newDseq())));
 
     await expect(compactDecrypt(encryptedForOwner, await dataKeyOf(other))).rejects.toMatchObject({ code: "ERR_JWE_DECRYPTION_FAILED" });
     await expect(compactDecrypt(encryptedForOwner, await dataKeyOf(owner))).resolves.toMatchObject({ protectedHeader: { alg: "dir" } });
@@ -120,9 +136,61 @@ describe(SecretCipherService.name, () => {
     const { cipher, buildCipher, createTestUser, inRequest } = setup();
     const user = await createTestUser();
 
-    const encrypted = await inRequest(user, async () => await cipher.encrypt(user.id, "durable"));
+    const binding = bindingFor(user, newDseq());
+    const encrypted = await inRequest(user, async () => await cipher.encrypt(user.id, "durable", binding));
 
-    await expect(inRequest(user, async () => await buildCipher().decrypt(user.id, encrypted))).resolves.toBe("durable");
+    await expect(inRequest(user, async () => await buildCipher().decrypt(user.id, encrypted, binding))).resolves.toBe("durable");
+  });
+
+  it("refuses to open a token moved to another deployment of the same user", async () => {
+    const { cipher, createTestUser, inRequest } = setup();
+    const user = await createTestUser();
+    const [source, destination] = [newDseq(), newDseq()];
+
+    const token = await inRequest(user, async () => await cipher.encrypt(user.id, "owner-only", bindingFor(user, source)));
+
+    await expect(inRequest(user, async () => await cipher.decrypt(user.id, token, bindingFor(user, destination)))).rejects.toMatchObject({
+      status: 500
+    });
+    await expect(inRequest(user, async () => await cipher.decrypt(user.id, token, bindingFor(user, source)))).resolves.toBe("owner-only");
+  });
+
+  it("spends no key-service call on a token moved to another deployment of the same user", async () => {
+    const { cipher, createTestUser, inRequest, kmsClient } = setup();
+    const user = await createTestUser();
+    const [source, destination] = [newDseq(), newDseq()];
+    const token = await inRequest(user, async () => await cipher.encrypt(user.id, "owner-only", bindingFor(user, source)));
+    kmsClient.asymmetricDecrypt.mockClear();
+
+    await expect(inRequest(user, async () => await cipher.decrypt(user.id, token, bindingFor(user, destination)))).rejects.toThrow();
+
+    expect(kmsClient.asymmetricDecrypt).not.toHaveBeenCalled();
+  });
+
+  it("cannot have its deployment rewritten in place, because the header authenticates the ciphertext", async () => {
+    const { cipher, createTestUser, inRequest } = setup();
+    const user = await createTestUser();
+    const [source, destination] = [newDseq(), newDseq()];
+    const token = await inRequest(user, async () => await cipher.encrypt(user.id, "owner-only", bindingFor(user, source)));
+
+    const [header, ...rest] = token.split(".");
+    const rewritten = { ...(JSON.parse(Buffer.from(header, "base64url").toString("utf8")) as object), dseq: destination };
+    const forged = [Buffer.from(JSON.stringify(rewritten)).toString("base64url"), ...rest].join(".");
+
+    await expect(inRequest(user, async () => await cipher.decrypt(user.id, forged, bindingFor(user, destination)))).rejects.toMatchObject({
+      status: 500
+    });
+  });
+
+  it("names the owner and the deployment in every token it writes", async () => {
+    const { cipher, createTestUser, inRequest, dataKeyRepository } = setup();
+    const user = await createTestUser();
+    const dseq = newDseq();
+
+    const token = await inRequest(user, async () => await cipher.encrypt(user.id, "value", bindingFor(user, dseq)));
+    const dataKey = await dataKeyRepository.findByUserId(user.id);
+
+    expect(decodeProtectedHeader(token)).toEqual({ sub: user.id, dseq, alg: "dir", enc: "A256GCM", kid: dataKey!.id });
   });
 
   it("creates the data key row on first use for a user that never had one", async () => {
@@ -131,7 +199,7 @@ describe(SecretCipherService.name, () => {
 
     expect(await dataKeyRepository.findByUserId(user.id)).toBeUndefined();
 
-    await inRequest(user, async () => await cipher.encrypt(user.id, "value"));
+    await inRequest(user, async () => await cipher.encrypt(user.id, "value", bindingFor(user, newDseq())));
 
     expect(await dataKeyRepository.findByUserId(user.id)).toMatchObject({ userId: user.id, wrappedByKid: KID });
   });

--- a/apps/api/src/secret/services/secret-cipher/secret-cipher.service.spec.ts
+++ b/apps/api/src/secret/services/secret-cipher/secret-cipher.service.spec.ts
@@ -5,6 +5,7 @@ import { mock } from "vitest-mock-extended";
 
 import type { CreateLogger } from "@src/core/providers/logging.provider";
 import type { DataKeyUnwrapperService } from "@src/secret/services/data-key-unwrapper/data-key-unwrapper.service";
+import type { SecretBinding } from "./secret-cipher.service";
 import { SecretCipherService } from "./secret-cipher.service";
 
 const DATA_KEY_ID = "2b0f1e3c-8a4d-4c22-9f10-7d5e6a1b2c3d";
@@ -230,10 +231,11 @@ describe(SecretCipherService.name, () => {
     await expect(service.decrypt(USER_ID, [forged, ...rest].join("."), { sub: USER_ID, dseq: OTHER_DSEQ })).rejects.toMatchObject({ status: 500 });
   });
 
-  it("keeps the claims describing its own encryption when a binding names them", async () => {
+  it("keeps the claims describing its own encryption when a binding reaches it naming them", async () => {
     const { service } = setup();
+    const bindingPastTheType = { alg: "none", enc: "none", kid: OTHER_DATA_KEY_ID } as unknown as SecretBinding;
 
-    const encrypted = await service.encrypt(USER_ID, "value", { alg: "none", enc: "none", kid: OTHER_DATA_KEY_ID });
+    const encrypted = await service.encrypt(USER_ID, "value", bindingPastTheType);
 
     expect(decodeProtectedHeader(encrypted)).toMatchObject({ alg: "dir", enc: "A256GCM", kid: DATA_KEY_ID });
   });

--- a/apps/api/src/secret/services/secret-cipher/secret-cipher.service.spec.ts
+++ b/apps/api/src/secret/services/secret-cipher/secret-cipher.service.spec.ts
@@ -10,38 +10,41 @@ import { SecretCipherService } from "./secret-cipher.service";
 const DATA_KEY_ID = "2b0f1e3c-8a4d-4c22-9f10-7d5e6a1b2c3d";
 const OTHER_DATA_KEY_ID = "9c8b7a65-4321-4def-8abc-0123456789ab";
 const USER_ID = "3f2b6f7a-1c1d-4b0e-8b8a-9a0f5f5c2b11";
+const DSEQ = "1420000";
+const OTHER_DSEQ = "1420001";
+const BINDING = { sub: USER_ID, dseq: DSEQ };
 
 describe(SecretCipherService.name, () => {
   it("returns the value it was given after a round trip", async () => {
     const { service } = setup();
     const value = `postgres://app:${randomUUID()}@db.internal/app`;
 
-    const encrypted = await service.encrypt(USER_ID, value);
+    const encrypted = await service.encrypt(USER_ID, value, BINDING);
 
-    await expect(service.decrypt(USER_ID, encrypted)).resolves.toBe(value);
+    await expect(service.decrypt(USER_ID, encrypted, BINDING)).resolves.toBe(value);
   });
 
   it("preserves a value carrying multibyte characters, newlines and quotes", async () => {
     const { service } = setup();
     const value = '-----BEGIN KEY-----\nдані\n"quoted"\t🔐\n-----END KEY-----\n';
 
-    const encrypted = await service.encrypt(USER_ID, value);
+    const encrypted = await service.encrypt(USER_ID, value, BINDING);
 
-    await expect(service.decrypt(USER_ID, encrypted)).resolves.toBe(value);
+    await expect(service.decrypt(USER_ID, encrypted, BINDING)).resolves.toBe(value);
   });
 
   it("preserves an empty value", async () => {
     const { service } = setup();
 
-    const encrypted = await service.encrypt(USER_ID, "");
+    const encrypted = await service.encrypt(USER_ID, "", BINDING);
 
-    await expect(service.decrypt(USER_ID, encrypted)).resolves.toBe("");
+    await expect(service.decrypt(USER_ID, encrypted, BINDING)).resolves.toBe("");
   });
 
   it("records the data key record that encrypted the value", async () => {
     const { service } = setup();
 
-    const encrypted = await service.encrypt(USER_ID, "value");
+    const encrypted = await service.encrypt(USER_ID, "value", BINDING);
 
     expect(decodeProtectedHeader(encrypted).kid).toBe(DATA_KEY_ID);
   });
@@ -49,91 +52,117 @@ describe(SecretCipherService.name, () => {
   it("declares the key management and content encryption it uses", async () => {
     const { service } = setup();
 
-    const encrypted = await service.encrypt(USER_ID, "value");
+    const encrypted = await service.encrypt(USER_ID, "value", BINDING);
 
     expect(decodeProtectedHeader(encrypted)).toMatchObject({ alg: "dir", enc: "A256GCM" });
   });
 
-  it("does not record the key version that wrapped the data key", async () => {
+  it("records what it was bound to and nothing else", async () => {
     const { service } = setup();
 
-    const encrypted = await service.encrypt(USER_ID, "value");
+    const encrypted = await service.encrypt(USER_ID, "value", BINDING);
 
-    expect(Object.keys(decodeProtectedHeader(encrypted))).toEqual(["alg", "enc", "kid"]);
+    expect(Object.keys(decodeProtectedHeader(encrypted))).toEqual(["sub", "dseq", "alg", "enc", "kid"]);
   });
 
   it("encrypts the same value differently every time", async () => {
     const { service } = setup();
 
-    const [first, second] = await Promise.all([service.encrypt(USER_ID, "value"), service.encrypt(USER_ID, "value")]);
+    const [first, second] = await Promise.all([service.encrypt(USER_ID, "value", BINDING), service.encrypt(USER_ID, "value", BINDING)]);
 
     expect(first).not.toBe(second);
   });
 
   it("rejects a value recorded against a different data key record", async () => {
     const { service, key } = setup();
-    const encryptedForAnotherRecord = await setup({ dataKeyId: OTHER_DATA_KEY_ID, key }).service.encrypt(USER_ID, "value");
+    const encryptedForAnotherRecord = await setup({ dataKeyId: OTHER_DATA_KEY_ID, key }).service.encrypt(USER_ID, "value", BINDING);
 
-    await expect(service.decrypt(USER_ID, encryptedForAnotherRecord)).rejects.toMatchObject({ status: 500 });
+    await expect(service.decrypt(USER_ID, encryptedForAnotherRecord, BINDING)).rejects.toMatchObject({ status: 500 });
   });
 
   it("spends no unwrap on a value recorded against a different data key record", async () => {
     const { service, unwrap, key } = setup();
-    const encryptedForAnotherRecord = await setup({ dataKeyId: OTHER_DATA_KEY_ID, key }).service.encrypt(USER_ID, "value");
+    const encryptedForAnotherRecord = await setup({ dataKeyId: OTHER_DATA_KEY_ID, key }).service.encrypt(USER_ID, "value", BINDING);
 
-    await expect(service.decrypt(USER_ID, encryptedForAnotherRecord)).rejects.toThrow();
+    await expect(service.decrypt(USER_ID, encryptedForAnotherRecord, BINDING)).rejects.toThrow();
 
     expect(unwrap).not.toHaveBeenCalled();
   });
 
   it("rejects a value encrypted under a different key even when it names the same record", async () => {
     const { service } = setup();
-    const encryptedUnderAnotherKey = await setup({ key: randomBytes(32) }).service.encrypt(USER_ID, "value");
+    const encryptedUnderAnotherKey = await setup({ key: randomBytes(32) }).service.encrypt(USER_ID, "value", BINDING);
 
-    await expect(service.decrypt(USER_ID, encryptedUnderAnotherKey)).rejects.toMatchObject({ status: 500 });
+    await expect(service.decrypt(USER_ID, encryptedUnderAnotherKey, BINDING)).rejects.toMatchObject({ status: 500 });
   });
 
   it("rejects a value whose ciphertext was altered", async () => {
     const { service } = setup();
-    const parts = (await service.encrypt(USER_ID, "value")).split(".");
+    const parts = (await service.encrypt(USER_ID, "value", BINDING)).split(".");
     parts[3] = Buffer.from("tampered").toString("base64url");
 
-    await expect(service.decrypt(USER_ID, parts.join("."))).rejects.toMatchObject({ status: 500 });
+    await expect(service.decrypt(USER_ID, parts.join("."), BINDING)).rejects.toMatchObject({ status: 500 });
   });
 
   it("rejects a value whose recorded data key was rewritten in place", async () => {
     const { service } = setup();
-    const [, ...rest] = (await service.encrypt(USER_ID, "value")).split(".");
-    const forged = Buffer.from(JSON.stringify({ alg: "dir", enc: "A256GCM", kid: DATA_KEY_ID, tampered: true })).toString("base64url");
+    const [, ...rest] = (await service.encrypt(USER_ID, "value", BINDING)).split(".");
+    const forged = Buffer.from(JSON.stringify({ ...BINDING, alg: "dir", enc: "A256GCM", kid: OTHER_DATA_KEY_ID })).toString("base64url");
 
-    await expect(service.decrypt(USER_ID, [forged, ...rest].join("."))).rejects.toMatchObject({ status: 500 });
+    await expect(service.decrypt(USER_ID, [forged, ...rest].join("."), BINDING)).rejects.toMatchObject({ status: 500 });
+  });
+
+  it("rejects a value carrying a bound claim the reader never named", async () => {
+    const { service, logger } = setup();
+    const [, ...rest] = (await service.encrypt(USER_ID, "value", BINDING)).split(".");
+    const forged = Buffer.from(JSON.stringify({ ...BINDING, alg: "dir", enc: "A256GCM", kid: DATA_KEY_ID, tampered: "true" })).toString("base64url");
+
+    await expect(service.decrypt(USER_ID, [forged, ...rest].join("."), BINDING)).rejects.toMatchObject({ status: 500 });
+    expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "SECRET_VALUE_BINDING_UNACCOUNTED" }));
+  });
+
+  it("refuses a reader that names only some of what the value was bound to", async () => {
+    const { service, unwrap, logger } = setup();
+    const encrypted = await service.encrypt(USER_ID, "value", BINDING);
+    unwrap.mockClear();
+
+    await expect(service.decrypt(USER_ID, encrypted, { sub: USER_ID })).rejects.toMatchObject({ status: 500 });
+    expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "SECRET_VALUE_BINDING_UNACCOUNTED", bound: ["sub", "dseq"], named: ["sub"] }));
+    expect(unwrap).not.toHaveBeenCalled();
+  });
+
+  it("refuses a reader that names nothing for a value that was bound to something", async () => {
+    const { service } = setup();
+    const encrypted = await service.encrypt(USER_ID, "value", BINDING);
+
+    await expect(service.decrypt(USER_ID, encrypted, {})).rejects.toMatchObject({ status: 500 });
   });
 
   it("rejects a value declaring a key management algorithm it does not use", async () => {
     const { service, key } = setup();
     const wrapped = await new CompactEncrypt(new TextEncoder().encode("value"))
-      .setProtectedHeader({ alg: "A256GCMKW", enc: "A256GCM", kid: DATA_KEY_ID })
+      .setProtectedHeader({ ...BINDING, alg: "A256GCMKW", enc: "A256GCM", kid: DATA_KEY_ID })
       .encrypt(key);
 
-    await expect(service.decrypt(USER_ID, wrapped)).rejects.toMatchObject({ status: 500 });
+    await expect(service.decrypt(USER_ID, wrapped, BINDING)).rejects.toMatchObject({ status: 500 });
   });
 
   it("rejects a value declaring a content encryption it does not use", async () => {
     const { service, key } = setup();
     const wrapped = await new CompactEncrypt(new TextEncoder().encode("value"))
-      .setProtectedHeader({ alg: "dir", enc: "A128CBC-HS256", kid: DATA_KEY_ID })
+      .setProtectedHeader({ ...BINDING, alg: "dir", enc: "A128CBC-HS256", kid: DATA_KEY_ID })
       .encrypt(key);
 
-    await expect(service.decrypt(USER_ID, wrapped)).rejects.toMatchObject({ status: 500 });
+    await expect(service.decrypt(USER_ID, wrapped, BINDING)).rejects.toMatchObject({ status: 500 });
   });
 
   it("spends no unwrap on a value declaring a key management algorithm it does not use", async () => {
     const { service, unwrap, key, logger } = setup();
     const wrapped = await new CompactEncrypt(new TextEncoder().encode("value"))
-      .setProtectedHeader({ alg: "A256GCMKW", enc: "A256GCM", kid: DATA_KEY_ID })
+      .setProtectedHeader({ ...BINDING, alg: "A256GCMKW", enc: "A256GCM", kid: DATA_KEY_ID })
       .encrypt(key);
 
-    await expect(service.decrypt(USER_ID, wrapped)).rejects.toThrow();
+    await expect(service.decrypt(USER_ID, wrapped, BINDING)).rejects.toThrow();
 
     expect(unwrap).not.toHaveBeenCalled();
     expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "SECRET_VALUE_ALGORITHM_UNSUPPORTED" }));
@@ -142,10 +171,10 @@ describe(SecretCipherService.name, () => {
   it("spends no unwrap on a value declaring a content encryption it does not use", async () => {
     const { service, unwrap, key } = setup();
     const wrapped = await new CompactEncrypt(new TextEncoder().encode("value"))
-      .setProtectedHeader({ alg: "dir", enc: "A128CBC-HS256", kid: DATA_KEY_ID })
+      .setProtectedHeader({ ...BINDING, alg: "dir", enc: "A128CBC-HS256", kid: DATA_KEY_ID })
       .encrypt(key);
 
-    await expect(service.decrypt(USER_ID, wrapped)).rejects.toThrow();
+    await expect(service.decrypt(USER_ID, wrapped, BINDING)).rejects.toThrow();
 
     expect(unwrap).not.toHaveBeenCalled();
   });
@@ -153,14 +182,75 @@ describe(SecretCipherService.name, () => {
   it("rejects a value that is not a compact JWE", async () => {
     const { service, logger } = setup();
 
-    await expect(service.decrypt(USER_ID, "not-a-jwe")).rejects.toMatchObject({ status: 500 });
+    await expect(service.decrypt(USER_ID, "not-a-jwe", BINDING)).rejects.toMatchObject({ status: 500 });
     expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "SECRET_VALUE_HEADER_UNREADABLE" }));
+  });
+
+  it("refuses a value bound to another deployment of the same owner", async () => {
+    const { service } = setup();
+
+    const encrypted = await service.encrypt(USER_ID, "value", BINDING);
+
+    await expect(service.decrypt(USER_ID, encrypted, { sub: USER_ID, dseq: OTHER_DSEQ })).rejects.toMatchObject({ status: 500 });
+  });
+
+  it("spends no unwrap on a value bound to another deployment of the same owner", async () => {
+    const { service, unwrap, logger } = setup();
+    const encrypted = await service.encrypt(USER_ID, "value", BINDING);
+    unwrap.mockClear();
+
+    await expect(service.decrypt(USER_ID, encrypted, { sub: USER_ID, dseq: OTHER_DSEQ })).rejects.toThrow();
+
+    expect(unwrap).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "SECRET_VALUE_BINDING_MISMATCH", claim: "dseq" }));
+  });
+
+  it("refuses a value bound to another owner", async () => {
+    const { service } = setup();
+
+    const encrypted = await service.encrypt(USER_ID, "value", BINDING);
+
+    await expect(service.decrypt(USER_ID, encrypted, { sub: OTHER_DATA_KEY_ID, dseq: DSEQ })).rejects.toMatchObject({ status: 500 });
+  });
+
+  it("refuses a value bound to a claim the reader asks about and the value never carried", async () => {
+    const { service } = setup();
+
+    const encrypted = await service.encrypt(USER_ID, "value", { sub: USER_ID });
+
+    await expect(service.decrypt(USER_ID, encrypted, BINDING)).rejects.toMatchObject({ status: 500 });
+  });
+
+  it("fails the authentication tag rather than the claim check when a bound claim is rewritten in place", async () => {
+    const { service } = setup();
+    const [, ...rest] = (await service.encrypt(USER_ID, "value", BINDING)).split(".");
+    const rebound = { sub: USER_ID, dseq: OTHER_DSEQ, alg: "dir", enc: "A256GCM", kid: DATA_KEY_ID };
+    const forged = Buffer.from(JSON.stringify(rebound)).toString("base64url");
+
+    await expect(service.decrypt(USER_ID, [forged, ...rest].join("."), { sub: USER_ID, dseq: OTHER_DSEQ })).rejects.toMatchObject({ status: 500 });
+  });
+
+  it("keeps the claims describing its own encryption when a binding names them", async () => {
+    const { service } = setup();
+
+    const encrypted = await service.encrypt(USER_ID, "value", { alg: "none", enc: "none", kid: OTHER_DATA_KEY_ID });
+
+    expect(decodeProtectedHeader(encrypted)).toMatchObject({ alg: "dir", enc: "A256GCM", kid: DATA_KEY_ID });
+  });
+
+  it("binds nothing beyond its own encryption when the binding is empty", async () => {
+    const { service } = setup();
+
+    const encrypted = await service.encrypt(USER_ID, "value", {});
+
+    expect(Object.keys(decodeProtectedHeader(encrypted))).toEqual(["alg", "enc", "kid"]);
+    await expect(service.decrypt(USER_ID, encrypted, {})).resolves.toBe("value");
   });
 
   it("asks for the owner's data key rather than a key of its own", async () => {
     const { service, dataKeyUnwrapperService } = setup();
 
-    await service.encrypt(USER_ID, "value");
+    await service.encrypt(USER_ID, "value", BINDING);
 
     expect(dataKeyUnwrapperService.getDataKey).toHaveBeenCalledWith(USER_ID);
   });

--- a/apps/api/src/secret/services/secret-cipher/secret-cipher.service.ts
+++ b/apps/api/src/secret/services/secret-cipher/secret-cipher.service.ts
@@ -9,6 +9,16 @@ import { DataKeyUnwrapperService } from "@src/secret/services/data-key-unwrapper
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
 
+/**
+ * What a stored value is bound to besides its data key, as extra protected-header claims a reader has to
+ * state again to open it. The header is the additional authenticated data, so a claim is bound by the tag
+ * rather than merely written down: a value moved to a row these claims do not describe fails to open.
+ */
+export type SecretBinding = Readonly<Record<string, string>>;
+
+/** The claims that describe the encryption rather than what was encrypted, so they are the cipher's to set and not a binding's. */
+const ENCRYPTION_HEADER_CLAIMS: ReadonlySet<string> = new Set(["alg", "enc", "kid"]);
+
 /** The protected header names the data key record and is itself the additional authenticated data, so the recorded name cannot be swapped without breaking the tag. */
 @singleton()
 export class SecretCipherService {
@@ -21,17 +31,21 @@ export class SecretCipherService {
     this.#loggerService = createLogger({ context: SecretCipherService.name });
   }
 
-  async encrypt(userId: string, value: string): Promise<string> {
+  /** The binding is spread first so the three claims that describe the encryption itself are always the ones that win, and no caller can weaken them by naming them. */
+  async encrypt(userId: string, value: string, binding: SecretBinding): Promise<string> {
     const dataKey = await this.dataKeyUnwrapperService.getDataKey(userId);
 
     return await new CompactEncrypt(textEncoder.encode(value))
-      .setProtectedHeader({ alg: SECRET_AT_REST_KEY_MANAGEMENT, enc: SECRET_AT_REST_CONTENT_ENCRYPTION, kid: dataKey.id })
+      .setProtectedHeader({ ...binding, alg: SECRET_AT_REST_KEY_MANAGEMENT, enc: SECRET_AT_REST_CONTENT_ENCRYPTION, kid: dataKey.id })
       .encrypt(await dataKey.unwrap());
   }
 
-  /** The recorded data key is checked before the key is unwrapped, so reading a value the user cannot own costs no key-service call. */
-  async decrypt(userId: string, encrypted: string): Promise<string> {
-    const { kid } = this.#readSupportedHeader(encrypted, userId);
+  /**
+   * Everything free happens before anything costly: the header decides whether this value belongs here at
+   * all, so a value the caller cannot own costs neither a data key lookup nor a key-service call.
+   */
+  async decrypt(userId: string, encrypted: string, binding: SecretBinding): Promise<string> {
+    const { kid } = this.#readBoundHeader(encrypted, userId, binding);
     const dataKey = await this.dataKeyUnwrapperService.getDataKey(userId);
 
     if (kid !== dataKey.id) {
@@ -41,11 +55,29 @@ export class SecretCipherService {
     return textDecoder.decode(await this.#open(encrypted, await dataKey.unwrap(), userId));
   }
 
-  #readSupportedHeader(encrypted: string, userId: string) {
+  /**
+   * A reader has to name exactly what the value was bound to, not merely a subset of it. Checking only the
+   * claims the caller thought to mention would let a later caller drop a binding by omission — passing
+   * `{ sub }` for a value bound to `{ sub, dseq }` would open every deployment of that owner — so the
+   * claim sets have to match before any value is compared.
+   */
+  #readBoundHeader(encrypted: string, userId: string, binding: SecretBinding) {
     const header = this.#decodeHeader(encrypted, userId);
 
     if (header.alg !== SECRET_AT_REST_KEY_MANAGEMENT || header.enc !== SECRET_AT_REST_CONTENT_ENCRYPTION) {
       throw this.#rejectUnreadable("SECRET_VALUE_ALGORITHM_UNSUPPORTED", { userId, alg: header.alg, enc: header.enc });
+    }
+
+    const bound = Object.keys(header).filter(claim => !ENCRYPTION_HEADER_CLAIMS.has(claim));
+
+    if (bound.length !== Object.keys(binding).length || bound.some(claim => !Object.hasOwn(binding, claim))) {
+      throw this.#rejectUnreadable("SECRET_VALUE_BINDING_UNACCOUNTED", { userId, bound, named: Object.keys(binding) });
+    }
+
+    for (const [claim, expected] of Object.entries(binding)) {
+      if (header[claim] !== expected) {
+        throw this.#rejectUnreadable("SECRET_VALUE_BINDING_MISMATCH", { userId, claim, received: header[claim], expected });
+      }
     }
 
     return header;

--- a/apps/api/src/secret/services/secret-cipher/secret-cipher.service.ts
+++ b/apps/api/src/secret/services/secret-cipher/secret-cipher.service.ts
@@ -9,15 +9,13 @@ import { DataKeyUnwrapperService } from "@src/secret/services/data-key-unwrapper
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
 
-/**
- * What a stored value is bound to besides its data key, as extra protected-header claims a reader has to
- * state again to open it. The header is the additional authenticated data, so a claim is bound by the tag
- * rather than merely written down: a value moved to a row these claims do not describe fails to open.
- */
-export type SecretBinding = Readonly<Record<string, string>>;
-
 /** The claims that describe the encryption rather than what was encrypted, so they are the cipher's to set and not a binding's. */
-const ENCRYPTION_HEADER_CLAIMS: ReadonlySet<string> = new Set(["alg", "enc", "kid"]);
+type EncryptionHeaderClaim = "alg" | "enc" | "kid";
+
+const ENCRYPTION_HEADER_CLAIMS: ReadonlySet<string> = new Set<EncryptionHeaderClaim>(["alg", "enc", "kid"]);
+
+/** The protected header is the additional authenticated data, so a value moved to a row these claims do not describe fails to open. */
+export type SecretBinding = Readonly<Record<string, string>> & { readonly [K in EncryptionHeaderClaim]?: never };
 
 /** The protected header names the data key record and is itself the additional authenticated data, so the recorded name cannot be swapped without breaking the tag. */
 @singleton()
@@ -31,7 +29,7 @@ export class SecretCipherService {
     this.#loggerService = createLogger({ context: SecretCipherService.name });
   }
 
-  /** The binding is spread first so the three claims that describe the encryption itself are always the ones that win, and no caller can weaken them by naming them. */
+  /** The encryption claims are spread last so they still win over a binding that reached here past the type forbidding them. */
   async encrypt(userId: string, value: string, binding: SecretBinding): Promise<string> {
     const dataKey = await this.dataKeyUnwrapperService.getDataKey(userId);
 
@@ -40,10 +38,7 @@ export class SecretCipherService {
       .encrypt(await dataKey.unwrap());
   }
 
-  /**
-   * Everything free happens before anything costly: the header decides whether this value belongs here at
-   * all, so a value the caller cannot own costs neither a data key lookup nor a key-service call.
-   */
+  /** The header decides whether the value belongs here before it costs a data key lookup or a key-service call. */
   async decrypt(userId: string, encrypted: string, binding: SecretBinding): Promise<string> {
     const { kid } = this.#readBoundHeader(encrypted, userId, binding);
     const dataKey = await this.dataKeyUnwrapperService.getDataKey(userId);
@@ -55,12 +50,7 @@ export class SecretCipherService {
     return textDecoder.decode(await this.#open(encrypted, await dataKey.unwrap(), userId));
   }
 
-  /**
-   * A reader has to name exactly what the value was bound to, not merely a subset of it. Checking only the
-   * claims the caller thought to mention would let a later caller drop a binding by omission — passing
-   * `{ sub }` for a value bound to `{ sub, dseq }` would open every deployment of that owner — so the
-   * claim sets have to match before any value is compared.
-   */
+  /** The claim sets have to match exactly, because accepting a subset would let a caller drop a binding by omission. */
   #readBoundHeader(encrypted: string, userId: string, binding: SecretBinding) {
     const header = this.#decodeHeader(encrypted, userId);
 


### PR DESCRIPTION
> **Base branch: `feat/deployment-store-sealed-secrets-token` — NOT `main`.** This is PR **2 of 5** in the sealed-secrets create-path stack. It **stacks on PR 1** ("give a deployment record a column for its sealed secrets") and should be reviewed and merged **after** it. GitHub shows only the incremental diff against that base, which is what the size label measures.
>
> | # | PR | incremental lines |
> |---|---|---|
> | 1 | give a deployment record a column for its sealed secrets | 138 |
> | **2** | **bind a stored secret to the deployment it was stored for** ← you are here | **300** |
> | 3 | let a stored sdl keep the references it was written with | 353 |
> | 4 | turn a transport seal and an sdl into the values a deployment needs | 614 |
> | 5 | accept sealed secrets when a deployment is created | 815 |
>
> The executable demo of the observable end-to-end behaviour lives in **PR 5**, which is where the create path lands. AC 8 in that demo ("a token is bound to its deployment, not just to its owner") is the user-visible face of this slice.

## Why

ref CON-862

`SecretCipherService` already seals a value under the owner's data encryption key, with a protected header naming `{ alg, enc, kid }`. That binds a stored value to a **key**, and two deployments of the same user share a key — so `kid` cannot tell their tokens apart. A token copied from one row into another row of the same owner would open cleanly and decrypt under the wrong deployment.

PRD-0003 requires the opposite: the console writes its own token once the dseq is minted, and a token moved into another deployment (or another user's) must **fail to open** rather than decrypt. This slice is the cipher-level half of that, and it is separate because it is a change to a security primitive: it wants reviewing as cryptography — what is authenticated, what is compared, and in what order — not as create-path plumbing. It has no callers in this PR, so it can be judged entirely on its own contract.

## What

`SecretCipherService.encrypt`/`decrypt` gain a required `binding: SecretBinding` (`Readonly<Record<string, string>>`) — extra protected-header claims a reader must state again to open the value.

- **Bound by the tag, not merely written down.** The protected header is the additional authenticated data for A256GCM, so rewriting a claim in a stored token fails the authentication tag rather than being silently accepted.
- **A caller cannot weaken the encryption's own claims.** The binding is spread *first* and `{ alg, enc, kid }` are written after it, so those three are always the cipher's, whatever a caller passes.
- **A reader must name exactly the binding, not a subset of it.** `#readBoundHeader` compares claim *sets* before comparing any value. Checking only the claims the caller thought to mention would let a later caller drop a binding by omission — passing `{ sub }` for a value bound to `{ sub, dseq }` would open every deployment of that owner. A set mismatch is its own refusal, `SECRET_VALUE_BINDING_UNACCOUNTED`.
- **Everything free happens before anything costly.** The header decides whether the value belongs here at all, so a token that does not belong costs neither a data-key row read nor a key-service call. The mismatch is refused ahead of `getDataKey`.
- **Two distinguishable causes, one reply.** `SECRET_VALUE_BINDING_MISMATCH` (a token that named the wrong deployment) and `SECRET_VALUE_UNREADABLE` (a forged header failing its tag) are separate log events; the caller gets one fixed message for both, because the error handler echoes `message` for every `http-errors` instance regardless of `expose` and a specific message would tell a caller which of the two happened.

Unit and integration specs are extended for each of those, including the subset case and the pre-key-lookup ordering.

**Contract change, internal only:** `binding` is required, so every call site must state one. There are no production call sites yet in this PR — the first one arrives in PR 4 (`sealForStorage`), passing `{ sub: userId, dseq }`. No API or database change here.

### Validation

Measured on the tip of the stack (`feat/deployment-accept-sealed-secrets-on-create`), in `apps/api`:

| check | result |
|---|---|
| `npx tsc --noEmit` | **43 errors — exactly the `main` baseline, byte-identical error set** (independently verified; `apps/api` tsc is not green on `main`, so 43 is the baseline and not a regression) |
| `npm run lint -- --quiet` | clean |
| `npm test` | **245 files / 3131 tests passing** |

### Open items at time of opening

These are stated because this stack is being opened mid-process, deliberately, and the bodies should not overclaim:

- The **independent round-2 review** of the fixes applied after the first review has **completed with zero blocking findings**.
- A **full-suite test flake is still open, and the evidence now says it is not ours.** `npm test` intermittently fails at the **suite** level — `beforeAll` timeouts in `dbService.setup()` — and never with a failing assertion. Measured interleaved, one run each per round: **`main` failed 1 of 5 runs and this stack's tip 1 of 4, both failing in the same round.** On the available evidence it is **pre-existing and not attributable to this stack**.
- **Root cause, identified and pre-existing.** `apps/api/env/.env.functional.test` sets neither `POSTGRES_MAX_CONNECTIONS` nor `POSTGRES_BACKGROUND_JOBS_POOL_SIZE`, so every functional suite inherits the production defaults of 20 each (`core/config/env.config.ts:15,17`). With `maxWorkers` unset, ~14 suites run concurrently and each boots its own app and database, putting worst-case demand near **328 connections on `main` and 348 on the tip, against `max_connections=100`**. That produces exactly the observed chain: `sorry, too many clients already`, then a socket closing mid-query (`Cannot redefine property: query`), then the 20 s `beforeAll` budget expiring. This stack adds one suite and a second `startJobQueues()` call site — roughly **+6%** — which is not what puts the system over a hard limit it already exceeds.
- **The fix is two lines of test config**: `POSTGRES_MAX_CONNECTIONS=4` and `POSTGRES_BACKGROUND_JOBS_POOL_SIZE=4` in `apps/api/env/.env.functional.test`, which both the functional and integration vitest projects load. Test-only and independent of these five branches, so it is best landed as its own small PR that any of them can rebase onto.
- **Two unrelated pre-existing flakes show up in the same logs** and are untouched by this stack: `UserWalletRepository > isCreditsLowConfirmed > confirms immediately when the window is disabled`, which compares an app-clock `new Date()` against Postgres `now()` with a zero-minute window, and separate flakes in `providers.spec.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Secret encryption and decryption support binding data to an owner and deployment.
  * Decryption rejects missing, extra, mismatched, or tampered binding claims.
  * Binding validation occurs before key retrieval, helping prevent unauthorized access.
  * Encryption metadata and existing unbound behavior remain supported.
  * Protected encryption headers cannot be supplied as binding claims.

* **Tests**
  * Added coverage for owner and deployment isolation, tamper detection, protected headers, and prevention of unnecessary key-service calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->