### PR TITLE
feat(deployment): let a stored sdl keep the references it was written with

### DIFF
--- a/apps/api/src/core/config/body-limit.config.ts
+++ b/apps/api/src/core/config/body-limit.config.ts
@@ -1,6 +1,2 @@
-/**
- * What every route with a body accepts unless it asks for more, and the floor any route asking for more
- * is sized on top of. A leaf module on purpose: it is read both by the middleware that applies it and by
- * the config that sizes an exception to it, and neither should have to import the other.
- */
+/** A leaf module so the middleware that applies this and the config that sizes an exception to it need not import each other. */
 export const DEFAULT_BODY_LIMIT_BYTES = 512 * 1024;

--- a/apps/api/src/core/config/body-limit.config.ts
+++ b/apps/api/src/core/config/body-limit.config.ts
@@ -1,0 +1,6 @@
+/**
+ * What every route with a body accepts unless it asks for more, and the floor any route asking for more
+ * is sized on top of. A leaf module on purpose: it is read both by the middleware that applies it and by
+ * the config that sizes an exception to it, and neither should have to import the other.
+ */
+export const DEFAULT_BODY_LIMIT_BYTES = 512 * 1024;

--- a/apps/api/src/core/lib/create-route/create-route.ts
+++ b/apps/api/src/core/lib/create-route/create-route.ts
@@ -4,6 +4,7 @@ import { createRoute as createOpenApiRoute } from "@hono/zod-openapi";
 import type { MiddlewareHandler } from "hono";
 import { bodyLimit } from "hono/body-limit";
 
+import { DEFAULT_BODY_LIMIT_BYTES } from "@src/core/config/body-limit.config";
 import { type CacheConfig, cacheControlMiddleware } from "@src/middlewares/cacheControlMiddleware/cacheControlMiddleware";
 import { contentTypeMiddleware } from "@src/middlewares/contentTypeMiddleware/contentTypeMiddleware";
 
@@ -14,7 +15,7 @@ export interface ExtendedRouteConfig<R extends RouteConfig> {
    */
   cache?: CacheConfig;
   /**
-   * Max size of the body in bytes. If not provided, the body limit will be set to 512Kb.
+   * Max size of the body in bytes. If not provided, the body limit will be `DEFAULT_BODY_LIMIT_BYTES`.
    * Only supported for POST, PUT, PATCH, and DELETE methods.
    */
   bodyLimit?: Parameters<typeof bodyLimit>[0];
@@ -49,7 +50,7 @@ export function createRoute<
   if (routeConfig.method !== "get" && routeConfig.method !== "head") {
     middlewares.push(
       bodyLimit({
-        maxSize: 512 * 1024, // 512Kb
+        maxSize: DEFAULT_BODY_LIMIT_BYTES,
         ...bodyLimitOptions
       })
     );

--- a/apps/api/src/deployment/config/env.config.spec.ts
+++ b/apps/api/src/deployment/config/env.config.spec.ts
@@ -33,6 +33,46 @@ describe("deployment envSchema", () => {
     });
   });
 
+  describe("SDL_SECRETS_MAX_COUNT and SDL_SECRETS_MAX_VALUE_BYTES", () => {
+    it("accepts the limits the create route's body limit was sized for", () => {
+      const result = envSchema.safeParse(setup());
+
+      expect(result.success).toBe(true);
+      expect(result.success && result.data.SDL_SECRETS_MAX_COUNT).toBe(100);
+      expect(result.success && result.data.SDL_SECRETS_MAX_VALUE_BYTES).toBe(16 * 1024);
+    });
+
+    it("accepts limits below what the body limit was sized for", () => {
+      expect(envSchema.safeParse(setup({ SDL_SECRETS_MAX_COUNT: 10, SDL_SECRETS_MAX_VALUE_BYTES: 1024 })).success).toBe(true);
+    });
+
+    it("rejects a count the body limit could not carry, naming both limits that produced it", () => {
+      const result = envSchema.safeParse(setup({ SDL_SECRETS_MAX_COUNT: 101 }));
+
+      expect(result.success).toBe(false);
+      expect(!result.success && result.error.issues.map(issue => issue.path)).toEqual([["SDL_SECRETS_MAX_COUNT"], ["SDL_SECRETS_MAX_VALUE_BYTES"]]);
+    });
+
+    it("rejects a value size the body limit could not carry, naming the offending limit too", () => {
+      const result = envSchema.safeParse(setup({ SDL_SECRETS_MAX_VALUE_BYTES: 16 * 1024 + 1 }));
+
+      expect(result.success).toBe(false);
+      expect(!result.success && result.error.issues.map(issue => issue.path)).toContainEqual(["SDL_SECRETS_MAX_VALUE_BYTES"]);
+    });
+
+    it("lets a raised value size be paid for by a lowered count", () => {
+      expect(envSchema.safeParse(setup({ SDL_SECRETS_MAX_COUNT: 50, SDL_SECRETS_MAX_VALUE_BYTES: 32 * 1024 })).success).toBe(true);
+    });
+
+    it("rejects a zero count", () => {
+      expect(envSchema.safeParse(setup({ SDL_SECRETS_MAX_COUNT: 0 })).success).toBe(false);
+    });
+
+    it("rejects a fractional value size", () => {
+      expect(envSchema.safeParse(setup({ SDL_SECRETS_MAX_VALUE_BYTES: 1024.5 })).success).toBe(false);
+    });
+  });
+
   describe("AUTO_TOP_UP_TARGET_RUNWAY_IN_H", () => {
     it("accepts the default target runway and look-ahead window", () => {
       const result = envSchema.safeParse(setup());

--- a/apps/api/src/deployment/config/env.config.ts
+++ b/apps/api/src/deployment/config/env.config.ts
@@ -1,5 +1,12 @@
 import { z } from "zod";
 
+import { DEFAULT_BODY_LIMIT_BYTES } from "@src/core/config/body-limit.config";
+import {
+  CREATE_DEPLOYMENT_BODY_LIMIT_BYTES,
+  maxSealedSecretsBytes,
+  SDL_SECRETS_DEFAULT_MAX_COUNT,
+  SDL_SECRETS_DEFAULT_MAX_VALUE_BYTES
+} from "@src/deployment/config/sdl-secrets.config";
 import { denomToUdenom } from "@src/utils/math";
 
 /**
@@ -102,6 +109,10 @@ export const envSchema = z
     DEPLOY_WEB_BASE_URL: z.string().url(),
     PROVIDER_PROXY_URL: z.string().url(),
     GPU_BOT_WALLET_MNEMONIC: z.string().optional(),
+    /** Secrets one deployment may carry. Raising it past what the create route's body limit was sized for is refused below rather than at request time. */
+    SDL_SECRETS_MAX_COUNT: z.number({ coerce: true }).int().positive().optional().default(SDL_SECRETS_DEFAULT_MAX_COUNT),
+    /** Bytes one secret value may be, measured as UTF-8 rather than as string length, since it is a storage bound and a character is not a byte. */
+    SDL_SECRETS_MAX_VALUE_BYTES: z.number({ coerce: true }).int().positive().optional().default(SDL_SECRETS_DEFAULT_MAX_VALUE_BYTES),
     GCP_KMS_AUTH: jsonEnv(gcpKmsAuthSchema),
     GCP_KMS_LOCATION: z.string().optional().default("global"),
     GCP_KMS_KEY_RING: z.string().optional().default("console-api"),
@@ -123,6 +134,17 @@ export const envSchema = z
         path: ["PROVIDER_UNREACHABLE_CLOSE_AFTER_DAYS"],
         message: `PROVIDER_UNREACHABLE_CLOSE_AFTER_DAYS (${env.PROVIDER_UNREACHABLE_CLOSE_AFTER_DAYS}) must be greater than PROVIDER_UNREACHABLE_NOTIFY_AFTER_DAYS (${env.PROVIDER_UNREACHABLE_NOTIFY_AFTER_DAYS}), otherwise a deployment can be closed before its owner has been warned`
       });
+    }
+
+    const sealHeadroom = CREATE_DEPLOYMENT_BODY_LIMIT_BYTES - DEFAULT_BODY_LIMIT_BYTES;
+    const sealedSecretsBytes = maxSealedSecretsBytes({ maxCount: env.SDL_SECRETS_MAX_COUNT, maxValueBytes: env.SDL_SECRETS_MAX_VALUE_BYTES });
+
+    if (sealedSecretsBytes > sealHeadroom) {
+      const message = `SDL_SECRETS_MAX_COUNT (${env.SDL_SECRETS_MAX_COUNT}) and SDL_SECRETS_MAX_VALUE_BYTES (${env.SDL_SECRETS_MAX_VALUE_BYTES}) can produce a seal of ${sealedSecretsBytes} bytes, above the ${sealHeadroom} bytes the create route's body limit was sized for, so a request at these limits would be refused before the limits could be applied`;
+
+      for (const path of ["SDL_SECRETS_MAX_COUNT", "SDL_SECRETS_MAX_VALUE_BYTES"]) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, path: [path], message });
+      }
     }
 
     if (env.AUTO_TOP_UP_TARGET_RUNWAY_IN_H <= env.AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H) {

--- a/apps/api/src/deployment/config/sdl-secrets.config.ts
+++ b/apps/api/src/deployment/config/sdl-secrets.config.ts
@@ -12,83 +12,43 @@ const SEALING_KEY_MODULUS_BITS = [2048, 3072, 4096] as const;
 
 const SEALING_KEY_ALGORITHM_NAMES = SEALING_KEY_MODULUS_BITS.map(bits => `RSA_DECRYPT_OAEP_${bits}_SHA256` as const);
 
-/**
- * The Cloud KMS key algorithms that actually perform `RSA-OAEP-256`. A key version always decrypts
- * with its own configured algorithm, ignoring what a seal claims, so publishing this JWK for a key
- * provisioned outside this set would fail every unwrap instead of the request that misconfigured it.
- * Both encodings are listed because the API reports an enum as either its name or its ordinal.
- */
+/** Holds both encodings of each algorithm, because the Cloud KMS API reports an enum as either its name or its ordinal. */
 export const SDL_SECRETS_SEALING_KEY_ALGORITHMS: ReadonlySet<string | number> = new Set(
   SEALING_KEY_ALGORITHM_NAMES.flatMap(name => [name, CryptoKeyVersionAlgorithm[name]])
 );
 
-/**
- * Byte lengths a wrapped content encryption key may have. RSA ciphertext is always exactly the
- * modulus size, so measuring it locally keeps a garbage encrypted key from spending an unwrap and
- * being reported as a Cloud KMS fault.
- */
+/** RSA ciphertext is exactly the modulus size, so a garbage encrypted key can be refused locally instead of spending an unwrap. */
 export const SDL_SECRETS_WRAPPED_KEY_BYTES: ReadonlySet<number> = new Set(SEALING_KEY_MODULUS_BITS.map(bits => bits / 8));
 
 /** The only content encryption the console accepts for a seal. */
 export const SDL_SECRETS_CONTENT_ENCRYPTION = "A256GCM";
 
-/**
- * Claims a client must put in the protected header of a sealed payload. Advertised rather than
- * documented so that promoting a claim is a server-side change instead of a client release.
- */
+/** Advertised rather than documented, so promoting a claim is a server-side change instead of a client release. */
 export const SDL_SECRETS_REQUIRED_CLAIMS = ["kid", "sub", "exp"] as const;
 
-/**
- * How far into the future a seal's `exp` may sit. Bounds how long a captured seal stays replayable,
- * with enough slack above the client's own lifetime to absorb clock skew.
- */
+/** Bounds how long a captured seal stays replayable, with enough slack above the client's own lifetime to absorb clock skew. */
 export const SDL_SECRETS_MAX_SEAL_LIFETIME_MS = 15 * 60 * 1000;
 
-/**
- * The only message a client gets when anything about the sealing key goes wrong. Deliberately says
- * nothing: the error handler echoes `message` for every `http-errors` instance regardless of
- * `expose`, so a specific message would tell a caller whether this instance can reach Cloud KMS,
- * holds a verified key, or has warmed its cache yet.
- */
+/** Deliberately says nothing, because the error handler echoes `message` for every `http-errors` instance regardless of `expose`. */
 export const SDL_SECRETS_UNAVAILABLE_ERROR_MESSAGE = "Service temporarily unavailable";
 
 /** JSON spends `"name":"value",` around each entry: two quote pairs, a colon and a separator. */
 const JSON_ENTRY_OVERHEAD_BYTES = 6;
 
-/**
- * What a string costs inside the seal's plaintext, which is a JSON object and not the raw bytes of what
- * it carries: its escaped form, less the two quotes `JSON.stringify` puts around it, because the quotes
- * are already counted per entry above. Escaping is not size-preserving — a `"` or `\` costs two bytes
- * and a control byte up to six — so measuring the raw value would let a hundred quote-heavy values
- * overrun a budget computed as though they were plain, and the request would then be refused by the
- * body limit with a bare 413 instead of a 400 naming the limit it broke.
- */
+/** Escaping is not size-preserving, so a string costs its escaped form less the two quotes already counted per entry above. */
 export function jsonEncodedBytes(value: string): number {
   return Buffer.byteLength(JSON.stringify(value), "utf8") - 2;
 }
 
-/**
- * Everything a compact JWE adds beyond its ciphertext segment: a protected header, an RSA-4096
- * encrypted key, a 96-bit IV, a 128-bit tag and four separators. Rounded up from the ~990 bytes those
- * actually come to, and sized against the largest modulus `SDL_SECRETS_WRAPPED_KEY_BYTES` accepts
- * rather than the one a key is likely to have.
- */
+/** Everything a compact JWE adds beyond its ciphertext, rounded up from ~990 bytes at the largest modulus `SDL_SECRETS_WRAPPED_KEY_BYTES` accepts. */
 const SEAL_ENVELOPE_ALLOWANCE_BYTES = 1024;
 
-/** base64url spends four characters on every three bytes, with no padding. */
+/** base64url spends four characters on every three bytes, with no padding to round the last group up. */
 function base64UrlLength(bytes: number) {
-  return Math.ceil(bytes / 3) * 4;
+  return Math.ceil((bytes * 4) / 3);
 }
 
-/**
- * The largest seal the stated limits can produce, so a body limit can be sized on the limits rather
- * than the limits trimmed to fit a body limit. AES-GCM is a counter mode, so its ciphertext is
- * byte-for-byte its plaintext and the JSON object below is the only thing that has to be measured.
- *
- * An exact bound rather than an estimate, but only because the intake measures a name and a value the
- * same way this does — `jsonEncodedBytes`, against `MAX_SDL_REFERENCE_NAME_LENGTH` and the configured
- * value size. Measure either of them raw and this stops being a bound at all.
- */
+/** A bound rather than an estimate only because the intake measures a name and a value with `jsonEncodedBytes` exactly as this does. */
 export function maxSealedSecretsBytes({ maxCount, maxValueBytes }: { maxCount: number; maxValueBytes: number }) {
   const plaintextBytes = maxCount * (MAX_SDL_REFERENCE_NAME_LENGTH + JSON_ENTRY_OVERHEAD_BYTES + maxValueBytes) + 1;
 
@@ -99,11 +59,6 @@ export function maxSealedSecretsBytes({ maxCount, maxValueBytes }: { maxCount: n
 export const SDL_SECRETS_DEFAULT_MAX_COUNT = 100;
 export const SDL_SECRETS_DEFAULT_MAX_VALUE_BYTES = 16 * 1024;
 
-/**
- * What `POST /v1/deployments` accepts once it can carry a seal: the whole existing allowance, kept
- * intact so the submitted SDL's ceiling does not move, plus exactly the largest seal the default
- * limits can produce. The margin is the conservatism in each term above rather than a percentage
- * added at the end.
- */
+/** The whole existing allowance, kept intact so the submitted SDL's ceiling does not move, plus the largest seal the defaults can produce. */
 export const CREATE_DEPLOYMENT_BODY_LIMIT_BYTES =
   DEFAULT_BODY_LIMIT_BYTES + maxSealedSecretsBytes({ maxCount: SDL_SECRETS_DEFAULT_MAX_COUNT, maxValueBytes: SDL_SECRETS_DEFAULT_MAX_VALUE_BYTES });

--- a/apps/api/src/deployment/config/sdl-secrets.config.ts
+++ b/apps/api/src/deployment/config/sdl-secrets.config.ts
@@ -1,5 +1,8 @@
 import { protos } from "@google-cloud/kms";
 
+import { DEFAULT_BODY_LIMIT_BYTES } from "@src/core/config/body-limit.config";
+import { MAX_SDL_REFERENCE_NAME_LENGTH } from "@src/deployment/services/sdl-reference/sdl-reference.service";
+
 const { CryptoKeyVersionAlgorithm } = protos.google.cloud.kms.v1.CryptoKeyVersion;
 
 /** The JOSE name for the scheme Cloud KMS calls `RSA_DECRYPT_OAEP_*_SHA256`. */
@@ -48,3 +51,59 @@ export const SDL_SECRETS_MAX_SEAL_LIFETIME_MS = 15 * 60 * 1000;
  * holds a verified key, or has warmed its cache yet.
  */
 export const SDL_SECRETS_UNAVAILABLE_ERROR_MESSAGE = "Service temporarily unavailable";
+
+/** JSON spends `"name":"value",` around each entry: two quote pairs, a colon and a separator. */
+const JSON_ENTRY_OVERHEAD_BYTES = 6;
+
+/**
+ * What a string costs inside the seal's plaintext, which is a JSON object and not the raw bytes of what
+ * it carries: its escaped form, less the two quotes `JSON.stringify` puts around it, because the quotes
+ * are already counted per entry above. Escaping is not size-preserving — a `"` or `\` costs two bytes
+ * and a control byte up to six — so measuring the raw value would let a hundred quote-heavy values
+ * overrun a budget computed as though they were plain, and the request would then be refused by the
+ * body limit with a bare 413 instead of a 400 naming the limit it broke.
+ */
+export function jsonEncodedBytes(value: string): number {
+  return Buffer.byteLength(JSON.stringify(value), "utf8") - 2;
+}
+
+/**
+ * Everything a compact JWE adds beyond its ciphertext segment: a protected header, an RSA-4096
+ * encrypted key, a 96-bit IV, a 128-bit tag and four separators. Rounded up from the ~990 bytes those
+ * actually come to, and sized against the largest modulus `SDL_SECRETS_WRAPPED_KEY_BYTES` accepts
+ * rather than the one a key is likely to have.
+ */
+const SEAL_ENVELOPE_ALLOWANCE_BYTES = 1024;
+
+/** base64url spends four characters on every three bytes, with no padding. */
+function base64UrlLength(bytes: number) {
+  return Math.ceil(bytes / 3) * 4;
+}
+
+/**
+ * The largest seal the stated limits can produce, so a body limit can be sized on the limits rather
+ * than the limits trimmed to fit a body limit. AES-GCM is a counter mode, so its ciphertext is
+ * byte-for-byte its plaintext and the JSON object below is the only thing that has to be measured.
+ *
+ * An exact bound rather than an estimate, but only because the intake measures a name and a value the
+ * same way this does — `jsonEncodedBytes`, against `MAX_SDL_REFERENCE_NAME_LENGTH` and the configured
+ * value size. Measure either of them raw and this stops being a bound at all.
+ */
+export function maxSealedSecretsBytes({ maxCount, maxValueBytes }: { maxCount: number; maxValueBytes: number }) {
+  const plaintextBytes = maxCount * (MAX_SDL_REFERENCE_NAME_LENGTH + JSON_ENTRY_OVERHEAD_BYTES + maxValueBytes) + 1;
+
+  return base64UrlLength(plaintextBytes) + SEAL_ENVELOPE_ALLOWANCE_BYTES;
+}
+
+/** Secrets per deployment, and bytes per value. Configurable, but only downwards without also resizing the create route's body limit. */
+export const SDL_SECRETS_DEFAULT_MAX_COUNT = 100;
+export const SDL_SECRETS_DEFAULT_MAX_VALUE_BYTES = 16 * 1024;
+
+/**
+ * What `POST /v1/deployments` accepts once it can carry a seal: the whole existing allowance, kept
+ * intact so the submitted SDL's ceiling does not move, plus exactly the largest seal the default
+ * limits can produce. The margin is the conservatism in each term above rather than a percentage
+ * added at the end.
+ */
+export const CREATE_DEPLOYMENT_BODY_LIMIT_BYTES =
+  DEFAULT_BODY_LIMIT_BYTES + maxSealedSecretsBytes({ maxCount: SDL_SECRETS_DEFAULT_MAX_COUNT, maxValueBytes: SDL_SECRETS_DEFAULT_MAX_VALUE_BYTES });

--- a/apps/api/src/deployment/services/sdl-reference/sdl-reference.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl-reference/sdl-reference.service.spec.ts
@@ -3,7 +3,7 @@ import { yaml } from "@akashnetwork/chain-sdk";
 import { describe, expect, it } from "vitest";
 
 import type { NamespacedSdlSecrets, SdlReferenceResolver } from "./sdl-reference.service";
-import { SdlReferenceService } from "./sdl-reference.service";
+import { MAX_SDL_REFERENCE_NAME_LENGTH, SdlReferenceService } from "./sdl-reference.service";
 
 const VALID_NAMES = ["A", "a", "_", "_A", "A9", `A${"b".repeat(62)}`, `A${"b".repeat(63)}`];
 const RESERVED_VALUES = ["ac-", "ac-://X", "ac-secret9://X", "ac-secret:/X", "ac-SECRET://X", `ac-${"z".repeat(17)}://X`, "ac-secret://TOKEN\n"];
@@ -326,6 +326,82 @@ describe(SdlReferenceService.name, () => {
       const [error] = service.substitute(sdlWithEnv(["A=ac-secret://token"]), { secrets: { web: { TOKEN: "resolved" } } });
 
       expect(error.message).toContain("ac-secret://token");
+    });
+  });
+
+  describe(`MAX_SDL_REFERENCE_NAME_LENGTH`, () => {
+    it("is the longest name the grammar accepts", () => {
+      const { service } = setup();
+      const longest = `A${"b".repeat(MAX_SDL_REFERENCE_NAME_LENGTH - 1)}`;
+
+      expect(longest).toHaveLength(MAX_SDL_REFERENCE_NAME_LENGTH);
+      expect(service.declarationsOf(sdlWithEnv([`T=ac-secret://${longest}`]), "secret").map(declaration => declaration.name)).toEqual([longest]);
+    });
+
+    it("is the shortest name the grammar refuses one longer than", () => {
+      const { service } = setup();
+      const tooLong = `A${"b".repeat(MAX_SDL_REFERENCE_NAME_LENGTH)}`;
+
+      expect(service.declarationsOf(sdlWithEnv([`T=ac-secret://${tooLong}`]), "secret")).toEqual([]);
+      expect(service.validate(sdlWithEnv([`T=ac-secret://${tooLong}`]))[0].message).toContain("reserved");
+    });
+  });
+
+  describe("declarationsOf", () => {
+    it("reports nothing for an sdl carrying no sdl references", () => {
+      const { service } = setup();
+
+      expect(service.declarationsOf(sdlWithEnv(["PORT=8080"]), "secret")).toEqual([]);
+    });
+
+    it("reports the name, the service and the whole reference of each declaration", () => {
+      const { service } = setup();
+
+      expect(service.declarationsOf(sdlWithEnv(["TOKEN=ac-secret://TOKEN"]), "secret")).toEqual([
+        { kind: "secret", name: "TOKEN", serviceName: "web", reference: "ac-secret://TOKEN", instancePath: "/services/web/env/0" }
+      ]);
+    });
+
+    it("reports one declaration per service that references the same name", () => {
+      const { service } = setup();
+
+      const declarations = service.declarationsOf(sdlWithEnv(["TOKEN=ac-secret://TOKEN"], ["TOKEN=ac-secret://TOKEN"]), "secret");
+
+      expect(declarations.map(declaration => declaration.serviceName)).toEqual(["web", "worker"]);
+    });
+
+    it("reports one declaration per entry when a service references the same name twice", () => {
+      const { service } = setup();
+
+      const declarations = service.declarationsOf(sdlWithEnv(["A=ac-secret://TOKEN", "B=ac-secret://TOKEN"]), "secret");
+
+      expect(declarations.map(declaration => declaration.instancePath)).toEqual(["/services/web/env/0", "/services/web/env/1"]);
+    });
+
+    it("reports only the kind it was asked about", () => {
+      const { service } = setup({ resolvers: [{ kind: "probe", resolve: () => "resolved" }] });
+
+      const declarations = service.declarationsOf(sdlWithEnv(["TOKEN=ac-secret://TOKEN", "MODE=ac-probe://MODE"]), "secret");
+
+      expect(declarations.map(declaration => declaration.name)).toEqual(["TOKEN"]);
+    });
+
+    it("reports nothing for a value that merely opens with the reserved prefix", () => {
+      const { service } = setup();
+
+      expect(service.declarationsOf(sdlWithEnv(["MODE=ac-dc"]), "secret")).toEqual([]);
+    });
+
+    it("reports nothing for a reference embedded in a larger value", () => {
+      const { service } = setup();
+
+      expect(service.declarationsOf(sdlWithEnv(["TOKEN=prefix-ac-secret://TOKEN"]), "secret")).toEqual([]);
+    });
+
+    it("reports a name spelling an Object.prototype member as an ordinary name", () => {
+      const { service } = setup();
+
+      expect(service.declarationsOf(sdlWithEnv(["C=ac-secret://constructor"]), "secret").map(declaration => declaration.name)).toEqual(["constructor"]);
     });
   });
 

--- a/apps/api/src/deployment/services/sdl-reference/sdl-reference.service.ts
+++ b/apps/api/src/deployment/services/sdl-reference/sdl-reference.service.ts
@@ -7,10 +7,27 @@ const SDL_REFERENCE_PREFIX = "ac-";
 
 const SDL_REFERENCE = /^ac-([a-z]{1,16}):\/\/([A-Za-z_][A-Za-z0-9_]{0,63})$/;
 
+/**
+ * Longest name the grammar above accepts, and so the longest key a sealed payload can usefully carry:
+ * a supplied name longer than this can never be referenced by any SDL. Kept beside the grammar because
+ * the seal budget is computed from it, and a bound that drifted from what the grammar accepts would
+ * make that budget wrong rather than merely stale. Pinned against the grammar by its own spec.
+ */
+export const MAX_SDL_REFERENCE_NAME_LENGTH = 64;
+
 /** The whole message is logged by the error handler, and an offending value is only bounded by the request body limit. */
-const MAX_ECHOED_REFERENCE_LENGTH = 120;
+export const MAX_ECHOED_REFERENCE_LENGTH = 120;
 
 type SdlReferenceRead = { type: "plain" } | { type: "reserved" } | { type: "reference"; kind: string; name: string };
+
+/**
+ * Whether a value is a whole SDL Reference and so names a secret rather than carrying one. Reads the
+ * same grammar substitution reads, because a value that merely opens with the prefix is not a
+ * reference and must not be treated as one by anything deciding what is safe to store.
+ */
+export function isSdlReference(value: string): boolean {
+  return SDL_REFERENCE.test(value);
+}
 
 function readSdlReference(value: string): SdlReferenceRead {
   if (!value.startsWith(SDL_REFERENCE_PREFIX)) {
@@ -56,10 +73,13 @@ interface EnvReference extends SdlReferenceTarget {
   instancePath: string;
 }
 
+/** One reference an SDL declares, as a caller comparing an SDL against a request's supplied names needs to see it. */
+export type SdlReferenceDeclaration = Omit<EnvReference, "key">;
+
 type EnvReferenceVisitor = (reference: EnvReference, env: string[], index: number) => ValidationError | undefined;
 
 /** A service or reference name may spell an `Object.prototype` member, and a bare lookup would answer such a name with an inherited function. */
-function ownValue<T>(record: Record<string, T>, key: string): T | undefined {
+export function ownValue<T>(record: Record<string, T>, key: string): T | undefined {
   return Object.hasOwn(record, key) ? record[key] : undefined;
 }
 
@@ -74,6 +94,20 @@ const secretReferenceResolver: SdlReferenceResolver = {
 
 function referenceError(instancePath: string, message: string, params: Record<string, unknown>): ValidationError {
   return { schemaPath: "", instancePath, keyword: "sdl-reference", params, message };
+}
+
+/**
+ * Shared so the two places that can find a reference without a value — the intake comparing an SDL
+ * against a request, and substitution itself — cannot report the same thing in two wordings.
+ */
+export function missingSdlReferenceValueError(reference: SdlReferenceDeclaration): ValidationError {
+  const echoedServiceName = reference.serviceName.slice(0, MAX_ECHOED_REFERENCE_LENGTH);
+
+  return referenceError(reference.instancePath, `no value supplied for SDL Reference "${reference.reference}" in service "${echoedServiceName}"`, {
+    kind: reference.kind,
+    name: reference.name,
+    serviceName: echoedServiceName
+  });
 }
 
 function unknownKindError(reference: EnvReference): ValidationError {
@@ -114,19 +148,30 @@ export class SdlReferenceService {
       const value = resolver.resolve(reference, context);
 
       if (typeof value !== "string") {
-        const echoedServiceName = reference.serviceName.slice(0, MAX_ECHOED_REFERENCE_LENGTH);
-
-        return referenceError(reference.instancePath, `no value supplied for SDL Reference "${reference.reference}" in service "${echoedServiceName}"`, {
-          kind: reference.kind,
-          name: reference.name,
-          serviceName: echoedServiceName
-        });
+        return missingSdlReferenceValueError(reference);
       }
 
       env[index] = `${reference.key}=${value}`;
 
       return undefined;
     });
+  }
+
+  /**
+   * Every reference of one kind an SDL declares, so a caller can compare what the SDL asks for against
+   * what a request supplied — in both directions, which substitution alone cannot report because it
+   * only ever visits what the SDL names.
+   */
+  declarationsOf(sdl: SDLInput, kind: string): SdlReferenceDeclaration[] {
+    const declarations: SdlReferenceDeclaration[] = [];
+
+    this.#eachReference(sdl, ({ key, ...declaration }) => {
+      if (declaration.kind === kind) declarations.push(declaration);
+
+      return undefined;
+    });
+
+    return declarations;
   }
 
   #eachReference(sdl: SDLInput, visit: EnvReferenceVisitor): ValidationError[] {
@@ -175,7 +220,7 @@ export class SdlReferenceService {
       );
     }
 
-    return visit({ ...read, ...location, key: declaration.key, reference: declaration.value });
+    return visit({ kind: read.kind, name: read.name, ...location, key: declaration.key, reference: declaration.value });
   }
 
   #servicesOf(sdl: SDLInput): SDLInput["services"] {

--- a/apps/api/src/deployment/services/sdl-reference/sdl-reference.service.ts
+++ b/apps/api/src/deployment/services/sdl-reference/sdl-reference.service.ts
@@ -7,12 +7,7 @@ const SDL_REFERENCE_PREFIX = "ac-";
 
 const SDL_REFERENCE = /^ac-([a-z]{1,16}):\/\/([A-Za-z_][A-Za-z0-9_]{0,63})$/;
 
-/**
- * Longest name the grammar above accepts, and so the longest key a sealed payload can usefully carry:
- * a supplied name longer than this can never be referenced by any SDL. Kept beside the grammar because
- * the seal budget is computed from it, and a bound that drifted from what the grammar accepts would
- * make that budget wrong rather than merely stale. Pinned against the grammar by its own spec.
- */
+/** Must stay equal to the bound the grammar above accepts, because the seal budget is computed from it. */
 export const MAX_SDL_REFERENCE_NAME_LENGTH = 64;
 
 /** The whole message is logged by the error handler, and an offending value is only bounded by the request body limit. */
@@ -20,11 +15,7 @@ export const MAX_ECHOED_REFERENCE_LENGTH = 120;
 
 type SdlReferenceRead = { type: "plain" } | { type: "reserved" } | { type: "reference"; kind: string; name: string };
 
-/**
- * Whether a value is a whole SDL Reference and so names a secret rather than carrying one. Reads the
- * same grammar substitution reads, because a value that merely opens with the prefix is not a
- * reference and must not be treated as one by anything deciding what is safe to store.
- */
+/** Tests the whole grammar, because a value that merely opens with the prefix is not a reference and must not be treated as one. */
 export function isSdlReference(value: string): boolean {
   return SDL_REFERENCE.test(value);
 }
@@ -96,10 +87,7 @@ function referenceError(instancePath: string, message: string, params: Record<st
   return { schemaPath: "", instancePath, keyword: "sdl-reference", params, message };
 }
 
-/**
- * Shared so the two places that can find a reference without a value — the intake comparing an SDL
- * against a request, and substitution itself — cannot report the same thing in two wordings.
- */
+/** Shared so the intake and substitution cannot report the same missing value in two wordings. */
 export function missingSdlReferenceValueError(reference: SdlReferenceDeclaration): ValidationError {
   const echoedServiceName = reference.serviceName.slice(0, MAX_ECHOED_REFERENCE_LENGTH);
 
@@ -157,11 +145,7 @@ export class SdlReferenceService {
     });
   }
 
-  /**
-   * Every reference of one kind an SDL declares, so a caller can compare what the SDL asks for against
-   * what a request supplied — in both directions, which substitution alone cannot report because it
-   * only ever visits what the SDL names.
-   */
+  /** Substitution alone cannot report what a request supplied and the SDL never asked for, because it only ever visits what the SDL names. */
   declarationsOf(sdl: SDLInput, kind: string): SdlReferenceDeclaration[] {
     const declarations: SdlReferenceDeclaration[] = [];
 

--- a/apps/api/src/deployment/utils/sdl-secret-stripping/sdl-secret-stripping.spec.ts
+++ b/apps/api/src/deployment/utils/sdl-secret-stripping/sdl-secret-stripping.spec.ts
@@ -63,6 +63,71 @@ describe(stripSdlSecrets.name, () => {
     });
   });
 
+  describe("a value that refers to a secret rather than carrying one", () => {
+    it("keeps a whole sdl reference", () => {
+      const stripped = strip(sdlWith({ web: { env: ["API_TOKEN=ac-secret://API_TOKEN"] } }));
+
+      expect(stripped.services.web.env).toEqual(["API_TOKEN=ac-secret://API_TOKEN"]);
+    });
+
+    it("keeps a reference whose name differs from the variable it is assigned to", () => {
+      const stripped = strip(sdlWith({ web: { env: ["DATABASE_URL=ac-secret://PROD_DB"] } }));
+
+      expect(stripped.services.web.env).toEqual(["DATABASE_URL=ac-secret://PROD_DB"]);
+    });
+
+    it("keeps a reference of a kind no resolver is registered for", () => {
+      const stripped = strip(sdlWith({ web: { env: ["MODE=ac-var://MODE"] } }));
+
+      expect(stripped.services.web.env).toEqual(["MODE=ac-var://MODE"]);
+    });
+
+    it("keeps the reference of every service that carries one", () => {
+      const stripped = strip(sdlWith({ web: { env: ["T=ac-secret://T"] }, worker: { env: ["T=ac-secret://T"] } }));
+
+      expect(stripped.services.web.env).toEqual(["T=ac-secret://T"]);
+      expect(stripped.services.worker.env).toEqual(["T=ac-secret://T"]);
+    });
+
+    it("drops a value that merely opens with the reserved prefix", () => {
+      const stripped = strip(sdlWith({ web: { env: ["MODE=ac-dc"] } }));
+
+      expect(stripped.services.web.env).toEqual(["MODE="]);
+    });
+
+    it("drops a reference embedded in a larger value", () => {
+      const stripped = strip(sdlWith({ web: { env: ["T=prefix-ac-secret://T"] } }));
+
+      expect(stripped.services.web.env).toEqual(["T="]);
+    });
+
+    it("drops a value that is a reference followed by anything else", () => {
+      const stripped = strip(sdlWith({ web: { env: ["T=ac-secret://T suffix"] } }));
+
+      expect(stripped.services.web.env).toEqual(["T="]);
+    });
+
+    it("drops a value that is a reference followed by a line terminator", () => {
+      const stripped = strip(sdlWith({ web: { env: ["T=ac-secret://T\n"] } }));
+
+      expect(stripped.services.web.env).toEqual(["T="]);
+    });
+
+    it("drops a value naming a kind longer than the grammar allows", () => {
+      const stripped = strip(sdlWith({ web: { env: [`T=ac-${"z".repeat(17)}://T`] } }));
+
+      expect(stripped.services.web.env).toEqual(["T="]);
+    });
+
+    it("keeps a reference while dropping an ordinary value beside it", () => {
+      const token = faker.string.alphanumeric(24);
+
+      const stripped = strip(sdlWith({ web: { env: ["SECRET=ac-secret://SECRET", `PLAIN=${token}`, "INHERITED_FROM_HOST"] } }));
+
+      expect(stripped.services.web.env).toEqual(["SECRET=ac-secret://SECRET", "PLAIN=", "INHERITED_FROM_HOST"]);
+    });
+  });
+
   describe("private registry credentials", () => {
     it("removes the whole block, not just the password", () => {
       const stripped = strip(

--- a/apps/api/src/deployment/utils/sdl-secret-stripping/sdl-secret-stripping.ts
+++ b/apps/api/src/deployment/utils/sdl-secret-stripping/sdl-secret-stripping.ts
@@ -2,6 +2,8 @@ import type { SDLInput } from "@akashnetwork/chain-sdk";
 import { yaml } from "@akashnetwork/chain-sdk";
 import { dump } from "js-yaml";
 
+import { isSdlReference } from "@src/deployment/services/sdl-reference/sdl-reference.service";
+
 type SdlServiceDefinition = SDLInput["services"][string];
 
 /**
@@ -15,6 +17,11 @@ export type StrippedSdl = { sdl: string | null; length: number; error?: unknown 
  * The submitted SDL with the value of every `env` entry and every private registry `credentials` block
  * removed. Variable names survive, so the stored definition still describes what the deployment expects
  * to be given.
+ *
+ * A value that is a whole SDL Reference survives with it. A reference names a secret instead of carrying
+ * one, so keeping it costs nothing and losing it costs the stored definition the one thing that says
+ * which values the deployment expects to be handed. The test is the reference grammar rather than the
+ * `ac-` prefix, so a value that merely looks like a reference is still stripped.
  *
  * Both are removed where they are declared and nowhere else. An SDL that copies a secret somewhere else
  * itself — through a YAML anchor aliased into `args`, say — keeps that copy. Chasing those was tried and
@@ -86,11 +93,13 @@ function stripEnvValues(service: SdlServiceDefinition): void {
   });
 }
 
-/** Keeps the variable name and drops its value. An entry that declares no value is left as it is. */
+/** Keeps the variable name and drops its value. An entry that declares no value, or whose value is a reference to one, is left as it is. */
 function withoutValue(entry: string): string {
   const valueStart = entry.indexOf("=");
 
-  return valueStart === -1 ? entry : entry.slice(0, valueStart + 1);
+  if (valueStart === -1) return entry;
+
+  return isSdlReference(entry.slice(valueStart + 1)) ? entry : entry.slice(0, valueStart + 1);
 }
 
 /**

--- a/apps/api/src/deployment/utils/sdl-secret-stripping/sdl-secret-stripping.ts
+++ b/apps/api/src/deployment/utils/sdl-secret-stripping/sdl-secret-stripping.ts
@@ -6,37 +6,10 @@ import { isSdlReference } from "@src/deployment/services/sdl-reference/sdl-refer
 
 type SdlServiceDefinition = SDLInput["services"][string];
 
-/**
- * The stripped SDL, or nothing when storing it would cost more than the caller allows. `length` is
- * what the stripped document was measured at — an estimate once it exceeds the limit, since measuring
- * stops there rather than running a pathological document to completion.
- */
+/** `length` becomes an estimate once it exceeds the limit, because measuring stops there rather than running a pathological document to completion. */
 export type StrippedSdl = { sdl: string | null; length: number; error?: unknown };
 
-/**
- * The submitted SDL with the value of every `env` entry and every private registry `credentials` block
- * removed. Variable names survive, so the stored definition still describes what the deployment expects
- * to be given.
- *
- * A value that is a whole SDL Reference survives with it. A reference names a secret instead of carrying
- * one, so keeping it costs nothing and losing it costs the stored definition the one thing that says
- * which values the deployment expects to be handed. The test is the reference grammar rather than the
- * `ac-` prefix, so a value that merely looks like a reference is still stripped.
- *
- * Both are removed where they are declared and nowhere else. An SDL that copies a secret somewhere else
- * itself — through a YAML anchor aliased into `args`, say — keeps that copy. Chasing those was tried and
- * withdrawn: it means collecting the secrets and deleting every string in the document equal to one,
- * which cannot tell a secret apart from an ordinary value that happens to match it. `DENOM=uakt` took
- * out `denom: uakt`, and a service named `db` referenced by another service's `WORDPRESS_DB_HOST=db`
- * took out the whole service. An SDL smuggling its own secret into `args` is a leak its author wrote on
- * purpose; quietly destroying an ordinary two-service SDL is a bug the author cannot even see.
- *
- * Only a validated SDL may be passed here: the caller runs it through the manifest generator first,
- * which rejects unknown root properties and so bounds where a service, and with it an env list, can hide.
- *
- * The result is re-serialized YAML and so never byte-identical to what arrived. It must never stand in
- * for the raw SDL anywhere a hash is taken over it.
- */
+/** Takes a validated SDL only, and returns re-serialized YAML that must never stand in for the raw SDL anywhere a hash is taken over it. */
 export function stripSdlSecrets(rawSdl: string, maxLength: number): StrippedSdl {
   let sdl: SDLInput;
   try {
@@ -73,12 +46,7 @@ function serviceDefinitionsOf(sdl: SDLInput | undefined): SdlServiceDefinition[]
   return Object.values(services).filter((service): service is SdlServiceDefinition => !!service && typeof service === "object");
 }
 
-/**
- * An `env` that is not a list is left alone rather than treated as an error. The SDL schema only allows
- * the list form, so the manifest generator the caller runs first rejects a map before it can reach
- * here; this is the one shape where the stripper no-ops instead of failing loudly, and it is worth
- * knowing about if that validation ever loosens.
- */
+/** A non-list `env` is left alone rather than failing, because the manifest generator the caller runs first already rejects that shape. */
 function stripEnvValues(service: SdlServiceDefinition): void {
   const env = service.env;
 
@@ -93,7 +61,7 @@ function stripEnvValues(service: SdlServiceDefinition): void {
   });
 }
 
-/** Keeps the variable name and drops its value. An entry that declares no value, or whose value is a reference to one, is left as it is. */
+/** Keeps the variable name and drops its value, unless the entry declares no value or names one by reference. */
 function withoutValue(entry: string): string {
   const valueStart = entry.indexOf("=");
 
@@ -102,71 +70,12 @@ function withoutValue(entry: string): string {
   return isSdlReference(entry.slice(valueStart + 1)) ? entry : entry.slice(0, valueStart + 1);
 }
 
-/**
- * Whether this document could possibly contain a node reachable more than once, which is the one thing
- * `estimateSerializedLength` exists to price. Skipping the estimator for a document that cannot share a
- * node is therefore safe *with respect to alias amplification* — and that is the whole of the claim.
- * It is deliberately not a claim that an alias-free document cannot serialize to much more than it
- * arrived as: one can, since flow style spells a nesting level in about four characters and block style
- * re-spells it as two spaces per level on every emitted line. The estimator never priced indentation
- * either, so that is a property of the SDL surface rather than of this guard.
- *
- * Sharing comes from one place: a YAML alias. An alias needs an anchor to point at, so a document that
- * shares anything has to spell both `&` and `*` somewhere in its bytes, and a document missing either
- * character cannot alias. That argument holds without knowing anything about YAML's grammar: no
- * assumption about quoting, flow style, block scalars, indentation or comments, because it never asks
- * *where* the characters are.
- *
- * Requiring both is what keeps it honest rather than merely cheap. Testing only `*` would send an
- * ordinary `command: ["sh", "-c", "a && b"]` down the estimator path for nothing; testing only `&`
- * would do the same for a `--include=*.log`. Requiring both narrows it to documents that could
- * genuinely alias, while still deciding on presence alone.
- *
- * This deliberately reads the raw text and not the parsed tree. An anchored *scalar* loads into an
- * ordinary string primitive and loses the identity a reference-walk would look for, so a tree walk
- * would report no sharing for exactly the document that amplifies worst. It also reads the submitted
- * text rather than the stripped document, both because the stripped one does not exist yet and because
- * stripping removes values, never sharing.
- *
- * False positives cost nothing — they take the path every document took before this existed. A false
- * negative would hand an amplifying document straight to `dump`, which is the failure this guards.
- */
+/** Reads the raw text rather than the parsed tree, because an anchored scalar loads as a plain string and loses the identity a tree walk would look for. */
 function mayShareNodes(rawSdl: string): boolean {
   return rawSdl.includes("&") && rawSdl.includes("*");
 }
 
-/**
- * What serializing this document would cost, measured on the parsed tree instead of by serializing it.
- * Serializing first and measuring after is what a document built out of YAML aliases exploits: an
- * anchored scalar loads as an ordinary string and loses the identity that would let js-yaml re-emit it
- * as an alias, so every alias of a 100 KB scalar is written out in full. A request comfortably inside
- * the body limit can reach a gigabyte that way, and the size guard never gets to run because the
- * process is already dead.
- *
- * Walking the tree costs nothing by comparison: it allocates no strings, and it follows every alias
- * rather than collapsing them, which is what keeps the total an upper bound.
- *
- * An upper bound, and a loose one, because js-yaml only re-expands *some* aliases. An anchored scalar
- * loads into a string primitive whose identity is gone, so the serializer has no way to know it was
- * aliased and writes it out again every time; an anchored mapping or sequence keeps its identity and is
- * re-emitted as one anchor and N aliases. This walk cannot tell the two apart from the parsed tree, so
- * it charges every alias as though it were a scalar. That errs toward refusing to store, never toward
- * an unbounded serialize — but it does mean a document sharing large *objects* can be measured far
- * above what it would actually serialize to, and refused when it would have fitted.
- *
- * Following aliases rather than memoizing them is also what makes termination something this has to
- * earn. Aliases form a DAG, not a tree, so a document can double its node count per level and be walked
- * exponentially many times from a few hundred bytes of YAML. What bounds it is that *every* node adds
- * at least one character before its children are visited — a scalar its own length, a map entry its
- * key, and an array its element count, which is what the `- ` markers really cost. The running total
- * therefore rises at least once per node, so the walk stops after `budget` nodes however the document
- * is shaped. An array charging nothing was enough to break this: an array-only DAG kept the total near
- * zero while the node count doubled, and a 1.3 KB document took seconds.
- *
- * The ancestor set terminates on the true cycle `&a [*a]` parses into, which is otherwise endless. It
- * is a path set rather than a seen set on purpose: memoizing would collapse the aliases whose cost this
- * is trying to measure.
- */
+/** Every node must add at least one character before its children are visited, or an aliased DAG walks exponentially instead of stopping at `budget`. */
 function estimateSerializedLength(document: unknown, budget: number): number {
   const ancestors = new Set<object>();
   let total = 0;

--- a/apps/api/src/secret/services/secret-cipher/secret-cipher.service.integration.ts
+++ b/apps/api/src/secret/services/secret-cipher/secret-cipher.service.integration.ts
@@ -1,7 +1,7 @@
 import type { protos } from "@google-cloud/kms";
 import crc32c from "fast-crc32c";
 import { compactDecrypt, CompactEncrypt, decodeProtectedHeader } from "jose";
-import { constants, generateKeyPairSync, privateDecrypt, randomBytes, randomInt, randomUUID } from "node:crypto";
+import { constants, generateKeyPairSync, privateDecrypt, randomBytes, randomUUID } from "node:crypto";
 import { container } from "tsyringe";
 import { afterEach, describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
@@ -24,13 +24,14 @@ const KID = "sdl-secrets.v1";
 const VERSION_NAME = "projects/console-test/locations/global/keyRings/console-api/cryptoKeys/sdl-secrets/cryptoKeyVersions/1";
 const SDL = 'version: "2.0"\nservices:\n  web:\n    image: nginx\n';
 
-/** What the deployment create path binds a stored token to, so these tests exercise the shape production will use. */
 function bindingFor(user: UserOutput, dseq: string) {
   return { sub: user.id, dseq };
 }
 
+let lastDseq = 100000;
+
 function newDseq() {
-  return randomInt(100000, 999999).toString();
+  return (++lastDseq).toString();
 }
 
 describe(SecretCipherService.name, () => {

--- a/apps/api/src/secret/services/secret-cipher/secret-cipher.service.integration.ts
+++ b/apps/api/src/secret/services/secret-cipher/secret-cipher.service.integration.ts
@@ -1,7 +1,7 @@
 import type { protos } from "@google-cloud/kms";
 import crc32c from "fast-crc32c";
 import { compactDecrypt, CompactEncrypt, decodeProtectedHeader } from "jose";
-import { constants, generateKeyPairSync, privateDecrypt, randomBytes, randomUUID } from "node:crypto";
+import { constants, generateKeyPairSync, privateDecrypt, randomBytes, randomInt, randomUUID } from "node:crypto";
 import { container } from "tsyringe";
 import { afterEach, describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
@@ -24,6 +24,15 @@ const KID = "sdl-secrets.v1";
 const VERSION_NAME = "projects/console-test/locations/global/keyRings/console-api/cryptoKeys/sdl-secrets/cryptoKeyVersions/1";
 const SDL = 'version: "2.0"\nservices:\n  web:\n    image: nginx\n';
 
+/** What the deployment create path binds a stored token to, so these tests exercise the shape production will use. */
+function bindingFor(user: UserOutput, dseq: string) {
+  return { sub: user.id, dseq };
+}
+
+function newDseq() {
+  return randomInt(100000, 999999).toString();
+}
+
 describe(SecretCipherService.name, () => {
   it("returns the exact values a client sealed after they have been encrypted at rest and decrypted back", async () => {
     const { cipher, openSeal, sealAs, createTestUser, inRequest } = setup();
@@ -35,11 +44,12 @@ describe(SecretCipherService.name, () => {
       EMPTY: ""
     };
 
+    const binding = bindingFor(user, newDseq());
     const roundTripped = await inRequest(user, async () => {
       const opened = await openSeal(await sealAs(user, clientSecrets));
-      const stored = await Promise.all(Object.entries(opened).map(async ([name, value]) => [name, await cipher.encrypt(user.id, value)] as const));
+      const stored = await Promise.all(Object.entries(opened).map(async ([name, value]) => [name, await cipher.encrypt(user.id, value, binding)] as const));
 
-      return Object.fromEntries(await Promise.all(stored.map(async ([name, encrypted]) => [name, await cipher.decrypt(user.id, encrypted)] as const)));
+      return Object.fromEntries(await Promise.all(stored.map(async ([name, encrypted]) => [name, await cipher.decrypt(user.id, encrypted, binding)] as const)));
     });
 
     expect(roundTripped).toEqual(clientSecrets);
@@ -49,7 +59,8 @@ describe(SecretCipherService.name, () => {
     const { cipher, createTestUser, inRequest, dataKeyRepository } = setup();
     const user = await createTestUser();
 
-    const stored = await inRequest(user, async () => await Promise.all(["a", "b", "c"].map(async value => await cipher.encrypt(user.id, value))));
+    const binding = bindingFor(user, newDseq());
+    const stored = await inRequest(user, async () => await Promise.all(["a", "b", "c"].map(async value => await cipher.encrypt(user.id, value, binding))));
     const dataKey = await dataKeyRepository.findByUserId(user.id);
 
     expect(stored.map(encrypted => decodeProtectedHeader(encrypted).kid)).toEqual([dataKey!.id, dataKey!.id, dataKey!.id]);
@@ -61,10 +72,11 @@ describe(SecretCipherService.name, () => {
     const user = await createTestUser();
     const values = Array.from({ length: 12 }, (_, index) => `secret-${index}`);
 
+    const binding = bindingFor(user, newDseq());
     const roundTripped = await inRequest(user, async () => {
-      const stored = await Promise.all(values.map(async value => await cipher.encrypt(user.id, value)));
+      const stored = await Promise.all(values.map(async value => await cipher.encrypt(user.id, value, binding)));
 
-      return await Promise.all(stored.map(async encrypted => await cipher.decrypt(user.id, encrypted)));
+      return await Promise.all(stored.map(async encrypted => await cipher.decrypt(user.id, encrypted, binding)));
     });
 
     expect(roundTripped).toEqual(values);
@@ -75,9 +87,10 @@ describe(SecretCipherService.name, () => {
     const { cipher, createTestUser, inRequest, kmsClient } = setup();
     const user = await createTestUser();
 
-    const encrypted = await inRequest(user, async () => await cipher.encrypt(user.id, "value"));
+    const binding = bindingFor(user, newDseq());
+    const encrypted = await inRequest(user, async () => await cipher.encrypt(user.id, "value", binding));
 
-    await expect(inRequest(user, async () => await cipher.decrypt(user.id, encrypted))).resolves.toBe("value");
+    await expect(inRequest(user, async () => await cipher.decrypt(user.id, encrypted, binding))).resolves.toBe("value");
     expect(kmsClient.asymmetricDecrypt).toHaveBeenCalledTimes(2);
   });
 
@@ -86,7 +99,7 @@ describe(SecretCipherService.name, () => {
     const user = await createTestUser();
 
     const heldDuringRequest = await inRequest(user, async () => {
-      await cipher.encrypt(user.id, "value");
+      await cipher.encrypt(user.id, "value", bindingFor(user, newDseq()));
 
       return executionContextService.get("HELD_DATA_KEYS");
     });
@@ -100,17 +113,20 @@ describe(SecretCipherService.name, () => {
     const { cipher, createTestUser, inRequest } = setup();
     const [owner, other] = await Promise.all([createTestUser(), createTestUser()]);
 
-    const encryptedForOwner = await inRequest(owner, async () => await cipher.encrypt(owner.id, "owner-only"));
+    const dseq = newDseq();
+    const encryptedForOwner = await inRequest(owner, async () => await cipher.encrypt(owner.id, "owner-only", bindingFor(owner, dseq)));
 
-    await expect(inRequest(other, async () => await cipher.decrypt(other.id, encryptedForOwner))).rejects.toMatchObject({ status: 500 });
+    await expect(inRequest(other, async () => await cipher.decrypt(other.id, encryptedForOwner, bindingFor(other, dseq)))).rejects.toMatchObject({
+      status: 500
+    });
   });
 
   it("fails authentication when one user's stored value is opened with another user's data key", async () => {
     const { cipher, createTestUser, inRequest, dataKeyOf } = setup();
     const [owner, other] = await Promise.all([createTestUser(), createTestUser()]);
 
-    const encryptedForOwner = await inRequest(owner, async () => await cipher.encrypt(owner.id, "owner-only"));
-    await inRequest(other, async () => await cipher.encrypt(other.id, "other-only"));
+    const encryptedForOwner = await inRequest(owner, async () => await cipher.encrypt(owner.id, "owner-only", bindingFor(owner, newDseq())));
+    await inRequest(other, async () => await cipher.encrypt(other.id, "other-only", bindingFor(other, newDseq())));
 
     await expect(compactDecrypt(encryptedForOwner, await dataKeyOf(other))).rejects.toMatchObject({ code: "ERR_JWE_DECRYPTION_FAILED" });
     await expect(compactDecrypt(encryptedForOwner, await dataKeyOf(owner))).resolves.toMatchObject({ protectedHeader: { alg: "dir" } });
@@ -120,9 +136,61 @@ describe(SecretCipherService.name, () => {
     const { cipher, buildCipher, createTestUser, inRequest } = setup();
     const user = await createTestUser();
 
-    const encrypted = await inRequest(user, async () => await cipher.encrypt(user.id, "durable"));
+    const binding = bindingFor(user, newDseq());
+    const encrypted = await inRequest(user, async () => await cipher.encrypt(user.id, "durable", binding));
 
-    await expect(inRequest(user, async () => await buildCipher().decrypt(user.id, encrypted))).resolves.toBe("durable");
+    await expect(inRequest(user, async () => await buildCipher().decrypt(user.id, encrypted, binding))).resolves.toBe("durable");
+  });
+
+  it("refuses to open a token moved to another deployment of the same user", async () => {
+    const { cipher, createTestUser, inRequest } = setup();
+    const user = await createTestUser();
+    const [source, destination] = [newDseq(), newDseq()];
+
+    const token = await inRequest(user, async () => await cipher.encrypt(user.id, "owner-only", bindingFor(user, source)));
+
+    await expect(inRequest(user, async () => await cipher.decrypt(user.id, token, bindingFor(user, destination)))).rejects.toMatchObject({
+      status: 500
+    });
+    await expect(inRequest(user, async () => await cipher.decrypt(user.id, token, bindingFor(user, source)))).resolves.toBe("owner-only");
+  });
+
+  it("spends no key-service call on a token moved to another deployment of the same user", async () => {
+    const { cipher, createTestUser, inRequest, kmsClient } = setup();
+    const user = await createTestUser();
+    const [source, destination] = [newDseq(), newDseq()];
+    const token = await inRequest(user, async () => await cipher.encrypt(user.id, "owner-only", bindingFor(user, source)));
+    kmsClient.asymmetricDecrypt.mockClear();
+
+    await expect(inRequest(user, async () => await cipher.decrypt(user.id, token, bindingFor(user, destination)))).rejects.toThrow();
+
+    expect(kmsClient.asymmetricDecrypt).not.toHaveBeenCalled();
+  });
+
+  it("cannot have its deployment rewritten in place, because the header authenticates the ciphertext", async () => {
+    const { cipher, createTestUser, inRequest } = setup();
+    const user = await createTestUser();
+    const [source, destination] = [newDseq(), newDseq()];
+    const token = await inRequest(user, async () => await cipher.encrypt(user.id, "owner-only", bindingFor(user, source)));
+
+    const [header, ...rest] = token.split(".");
+    const rewritten = { ...(JSON.parse(Buffer.from(header, "base64url").toString("utf8")) as object), dseq: destination };
+    const forged = [Buffer.from(JSON.stringify(rewritten)).toString("base64url"), ...rest].join(".");
+
+    await expect(inRequest(user, async () => await cipher.decrypt(user.id, forged, bindingFor(user, destination)))).rejects.toMatchObject({
+      status: 500
+    });
+  });
+
+  it("names the owner and the deployment in every token it writes", async () => {
+    const { cipher, createTestUser, inRequest, dataKeyRepository } = setup();
+    const user = await createTestUser();
+    const dseq = newDseq();
+
+    const token = await inRequest(user, async () => await cipher.encrypt(user.id, "value", bindingFor(user, dseq)));
+    const dataKey = await dataKeyRepository.findByUserId(user.id);
+
+    expect(decodeProtectedHeader(token)).toEqual({ sub: user.id, dseq, alg: "dir", enc: "A256GCM", kid: dataKey!.id });
   });
 
   it("creates the data key row on first use for a user that never had one", async () => {
@@ -131,7 +199,7 @@ describe(SecretCipherService.name, () => {
 
     expect(await dataKeyRepository.findByUserId(user.id)).toBeUndefined();
 
-    await inRequest(user, async () => await cipher.encrypt(user.id, "value"));
+    await inRequest(user, async () => await cipher.encrypt(user.id, "value", bindingFor(user, newDseq())));
 
     expect(await dataKeyRepository.findByUserId(user.id)).toMatchObject({ userId: user.id, wrappedByKid: KID });
   });

--- a/apps/api/src/secret/services/secret-cipher/secret-cipher.service.spec.ts
+++ b/apps/api/src/secret/services/secret-cipher/secret-cipher.service.spec.ts
@@ -5,6 +5,7 @@ import { mock } from "vitest-mock-extended";
 
 import type { CreateLogger } from "@src/core/providers/logging.provider";
 import type { DataKeyUnwrapperService } from "@src/secret/services/data-key-unwrapper/data-key-unwrapper.service";
+import type { SecretBinding } from "./secret-cipher.service";
 import { SecretCipherService } from "./secret-cipher.service";
 
 const DATA_KEY_ID = "2b0f1e3c-8a4d-4c22-9f10-7d5e6a1b2c3d";
@@ -230,10 +231,11 @@ describe(SecretCipherService.name, () => {
     await expect(service.decrypt(USER_ID, [forged, ...rest].join("."), { sub: USER_ID, dseq: OTHER_DSEQ })).rejects.toMatchObject({ status: 500 });
   });
 
-  it("keeps the claims describing its own encryption when a binding names them", async () => {
+  it("keeps the claims describing its own encryption when a binding reaches it naming them", async () => {
     const { service } = setup();
+    const bindingPastTheType = { alg: "none", enc: "none", kid: OTHER_DATA_KEY_ID } as unknown as SecretBinding;
 
-    const encrypted = await service.encrypt(USER_ID, "value", { alg: "none", enc: "none", kid: OTHER_DATA_KEY_ID });
+    const encrypted = await service.encrypt(USER_ID, "value", bindingPastTheType);
 
     expect(decodeProtectedHeader(encrypted)).toMatchObject({ alg: "dir", enc: "A256GCM", kid: DATA_KEY_ID });
   });

--- a/apps/api/src/secret/services/secret-cipher/secret-cipher.service.spec.ts
+++ b/apps/api/src/secret/services/secret-cipher/secret-cipher.service.spec.ts
@@ -10,38 +10,41 @@ import { SecretCipherService } from "./secret-cipher.service";
 const DATA_KEY_ID = "2b0f1e3c-8a4d-4c22-9f10-7d5e6a1b2c3d";
 const OTHER_DATA_KEY_ID = "9c8b7a65-4321-4def-8abc-0123456789ab";
 const USER_ID = "3f2b6f7a-1c1d-4b0e-8b8a-9a0f5f5c2b11";
+const DSEQ = "1420000";
+const OTHER_DSEQ = "1420001";
+const BINDING = { sub: USER_ID, dseq: DSEQ };
 
 describe(SecretCipherService.name, () => {
   it("returns the value it was given after a round trip", async () => {
     const { service } = setup();
     const value = `postgres://app:${randomUUID()}@db.internal/app`;
 
-    const encrypted = await service.encrypt(USER_ID, value);
+    const encrypted = await service.encrypt(USER_ID, value, BINDING);
 
-    await expect(service.decrypt(USER_ID, encrypted)).resolves.toBe(value);
+    await expect(service.decrypt(USER_ID, encrypted, BINDING)).resolves.toBe(value);
   });
 
   it("preserves a value carrying multibyte characters, newlines and quotes", async () => {
     const { service } = setup();
     const value = '-----BEGIN KEY-----\nдані\n"quoted"\t🔐\n-----END KEY-----\n';
 
-    const encrypted = await service.encrypt(USER_ID, value);
+    const encrypted = await service.encrypt(USER_ID, value, BINDING);
 
-    await expect(service.decrypt(USER_ID, encrypted)).resolves.toBe(value);
+    await expect(service.decrypt(USER_ID, encrypted, BINDING)).resolves.toBe(value);
   });
 
   it("preserves an empty value", async () => {
     const { service } = setup();
 
-    const encrypted = await service.encrypt(USER_ID, "");
+    const encrypted = await service.encrypt(USER_ID, "", BINDING);
 
-    await expect(service.decrypt(USER_ID, encrypted)).resolves.toBe("");
+    await expect(service.decrypt(USER_ID, encrypted, BINDING)).resolves.toBe("");
   });
 
   it("records the data key record that encrypted the value", async () => {
     const { service } = setup();
 
-    const encrypted = await service.encrypt(USER_ID, "value");
+    const encrypted = await service.encrypt(USER_ID, "value", BINDING);
 
     expect(decodeProtectedHeader(encrypted).kid).toBe(DATA_KEY_ID);
   });
@@ -49,91 +52,117 @@ describe(SecretCipherService.name, () => {
   it("declares the key management and content encryption it uses", async () => {
     const { service } = setup();
 
-    const encrypted = await service.encrypt(USER_ID, "value");
+    const encrypted = await service.encrypt(USER_ID, "value", BINDING);
 
     expect(decodeProtectedHeader(encrypted)).toMatchObject({ alg: "dir", enc: "A256GCM" });
   });
 
-  it("does not record the key version that wrapped the data key", async () => {
+  it("records what it was bound to and nothing else", async () => {
     const { service } = setup();
 
-    const encrypted = await service.encrypt(USER_ID, "value");
+    const encrypted = await service.encrypt(USER_ID, "value", BINDING);
 
-    expect(Object.keys(decodeProtectedHeader(encrypted))).toEqual(["alg", "enc", "kid"]);
+    expect(Object.keys(decodeProtectedHeader(encrypted))).toEqual(["sub", "dseq", "alg", "enc", "kid"]);
   });
 
   it("encrypts the same value differently every time", async () => {
     const { service } = setup();
 
-    const [first, second] = await Promise.all([service.encrypt(USER_ID, "value"), service.encrypt(USER_ID, "value")]);
+    const [first, second] = await Promise.all([service.encrypt(USER_ID, "value", BINDING), service.encrypt(USER_ID, "value", BINDING)]);
 
     expect(first).not.toBe(second);
   });
 
   it("rejects a value recorded against a different data key record", async () => {
     const { service, key } = setup();
-    const encryptedForAnotherRecord = await setup({ dataKeyId: OTHER_DATA_KEY_ID, key }).service.encrypt(USER_ID, "value");
+    const encryptedForAnotherRecord = await setup({ dataKeyId: OTHER_DATA_KEY_ID, key }).service.encrypt(USER_ID, "value", BINDING);
 
-    await expect(service.decrypt(USER_ID, encryptedForAnotherRecord)).rejects.toMatchObject({ status: 500 });
+    await expect(service.decrypt(USER_ID, encryptedForAnotherRecord, BINDING)).rejects.toMatchObject({ status: 500 });
   });
 
   it("spends no unwrap on a value recorded against a different data key record", async () => {
     const { service, unwrap, key } = setup();
-    const encryptedForAnotherRecord = await setup({ dataKeyId: OTHER_DATA_KEY_ID, key }).service.encrypt(USER_ID, "value");
+    const encryptedForAnotherRecord = await setup({ dataKeyId: OTHER_DATA_KEY_ID, key }).service.encrypt(USER_ID, "value", BINDING);
 
-    await expect(service.decrypt(USER_ID, encryptedForAnotherRecord)).rejects.toThrow();
+    await expect(service.decrypt(USER_ID, encryptedForAnotherRecord, BINDING)).rejects.toThrow();
 
     expect(unwrap).not.toHaveBeenCalled();
   });
 
   it("rejects a value encrypted under a different key even when it names the same record", async () => {
     const { service } = setup();
-    const encryptedUnderAnotherKey = await setup({ key: randomBytes(32) }).service.encrypt(USER_ID, "value");
+    const encryptedUnderAnotherKey = await setup({ key: randomBytes(32) }).service.encrypt(USER_ID, "value", BINDING);
 
-    await expect(service.decrypt(USER_ID, encryptedUnderAnotherKey)).rejects.toMatchObject({ status: 500 });
+    await expect(service.decrypt(USER_ID, encryptedUnderAnotherKey, BINDING)).rejects.toMatchObject({ status: 500 });
   });
 
   it("rejects a value whose ciphertext was altered", async () => {
     const { service } = setup();
-    const parts = (await service.encrypt(USER_ID, "value")).split(".");
+    const parts = (await service.encrypt(USER_ID, "value", BINDING)).split(".");
     parts[3] = Buffer.from("tampered").toString("base64url");
 
-    await expect(service.decrypt(USER_ID, parts.join("."))).rejects.toMatchObject({ status: 500 });
+    await expect(service.decrypt(USER_ID, parts.join("."), BINDING)).rejects.toMatchObject({ status: 500 });
   });
 
   it("rejects a value whose recorded data key was rewritten in place", async () => {
     const { service } = setup();
-    const [, ...rest] = (await service.encrypt(USER_ID, "value")).split(".");
-    const forged = Buffer.from(JSON.stringify({ alg: "dir", enc: "A256GCM", kid: DATA_KEY_ID, tampered: true })).toString("base64url");
+    const [, ...rest] = (await service.encrypt(USER_ID, "value", BINDING)).split(".");
+    const forged = Buffer.from(JSON.stringify({ ...BINDING, alg: "dir", enc: "A256GCM", kid: OTHER_DATA_KEY_ID })).toString("base64url");
 
-    await expect(service.decrypt(USER_ID, [forged, ...rest].join("."))).rejects.toMatchObject({ status: 500 });
+    await expect(service.decrypt(USER_ID, [forged, ...rest].join("."), BINDING)).rejects.toMatchObject({ status: 500 });
+  });
+
+  it("rejects a value carrying a bound claim the reader never named", async () => {
+    const { service, logger } = setup();
+    const [, ...rest] = (await service.encrypt(USER_ID, "value", BINDING)).split(".");
+    const forged = Buffer.from(JSON.stringify({ ...BINDING, alg: "dir", enc: "A256GCM", kid: DATA_KEY_ID, tampered: "true" })).toString("base64url");
+
+    await expect(service.decrypt(USER_ID, [forged, ...rest].join("."), BINDING)).rejects.toMatchObject({ status: 500 });
+    expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "SECRET_VALUE_BINDING_UNACCOUNTED" }));
+  });
+
+  it("refuses a reader that names only some of what the value was bound to", async () => {
+    const { service, unwrap, logger } = setup();
+    const encrypted = await service.encrypt(USER_ID, "value", BINDING);
+    unwrap.mockClear();
+
+    await expect(service.decrypt(USER_ID, encrypted, { sub: USER_ID })).rejects.toMatchObject({ status: 500 });
+    expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "SECRET_VALUE_BINDING_UNACCOUNTED", bound: ["sub", "dseq"], named: ["sub"] }));
+    expect(unwrap).not.toHaveBeenCalled();
+  });
+
+  it("refuses a reader that names nothing for a value that was bound to something", async () => {
+    const { service } = setup();
+    const encrypted = await service.encrypt(USER_ID, "value", BINDING);
+
+    await expect(service.decrypt(USER_ID, encrypted, {})).rejects.toMatchObject({ status: 500 });
   });
 
   it("rejects a value declaring a key management algorithm it does not use", async () => {
     const { service, key } = setup();
     const wrapped = await new CompactEncrypt(new TextEncoder().encode("value"))
-      .setProtectedHeader({ alg: "A256GCMKW", enc: "A256GCM", kid: DATA_KEY_ID })
+      .setProtectedHeader({ ...BINDING, alg: "A256GCMKW", enc: "A256GCM", kid: DATA_KEY_ID })
       .encrypt(key);
 
-    await expect(service.decrypt(USER_ID, wrapped)).rejects.toMatchObject({ status: 500 });
+    await expect(service.decrypt(USER_ID, wrapped, BINDING)).rejects.toMatchObject({ status: 500 });
   });
 
   it("rejects a value declaring a content encryption it does not use", async () => {
     const { service, key } = setup();
     const wrapped = await new CompactEncrypt(new TextEncoder().encode("value"))
-      .setProtectedHeader({ alg: "dir", enc: "A128CBC-HS256", kid: DATA_KEY_ID })
+      .setProtectedHeader({ ...BINDING, alg: "dir", enc: "A128CBC-HS256", kid: DATA_KEY_ID })
       .encrypt(key);
 
-    await expect(service.decrypt(USER_ID, wrapped)).rejects.toMatchObject({ status: 500 });
+    await expect(service.decrypt(USER_ID, wrapped, BINDING)).rejects.toMatchObject({ status: 500 });
   });
 
   it("spends no unwrap on a value declaring a key management algorithm it does not use", async () => {
     const { service, unwrap, key, logger } = setup();
     const wrapped = await new CompactEncrypt(new TextEncoder().encode("value"))
-      .setProtectedHeader({ alg: "A256GCMKW", enc: "A256GCM", kid: DATA_KEY_ID })
+      .setProtectedHeader({ ...BINDING, alg: "A256GCMKW", enc: "A256GCM", kid: DATA_KEY_ID })
       .encrypt(key);
 
-    await expect(service.decrypt(USER_ID, wrapped)).rejects.toThrow();
+    await expect(service.decrypt(USER_ID, wrapped, BINDING)).rejects.toThrow();
 
     expect(unwrap).not.toHaveBeenCalled();
     expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "SECRET_VALUE_ALGORITHM_UNSUPPORTED" }));
@@ -142,10 +171,10 @@ describe(SecretCipherService.name, () => {
   it("spends no unwrap on a value declaring a content encryption it does not use", async () => {
     const { service, unwrap, key } = setup();
     const wrapped = await new CompactEncrypt(new TextEncoder().encode("value"))
-      .setProtectedHeader({ alg: "dir", enc: "A128CBC-HS256", kid: DATA_KEY_ID })
+      .setProtectedHeader({ ...BINDING, alg: "dir", enc: "A128CBC-HS256", kid: DATA_KEY_ID })
       .encrypt(key);
 
-    await expect(service.decrypt(USER_ID, wrapped)).rejects.toThrow();
+    await expect(service.decrypt(USER_ID, wrapped, BINDING)).rejects.toThrow();
 
     expect(unwrap).not.toHaveBeenCalled();
   });
@@ -153,14 +182,75 @@ describe(SecretCipherService.name, () => {
   it("rejects a value that is not a compact JWE", async () => {
     const { service, logger } = setup();
 
-    await expect(service.decrypt(USER_ID, "not-a-jwe")).rejects.toMatchObject({ status: 500 });
+    await expect(service.decrypt(USER_ID, "not-a-jwe", BINDING)).rejects.toMatchObject({ status: 500 });
     expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "SECRET_VALUE_HEADER_UNREADABLE" }));
+  });
+
+  it("refuses a value bound to another deployment of the same owner", async () => {
+    const { service } = setup();
+
+    const encrypted = await service.encrypt(USER_ID, "value", BINDING);
+
+    await expect(service.decrypt(USER_ID, encrypted, { sub: USER_ID, dseq: OTHER_DSEQ })).rejects.toMatchObject({ status: 500 });
+  });
+
+  it("spends no unwrap on a value bound to another deployment of the same owner", async () => {
+    const { service, unwrap, logger } = setup();
+    const encrypted = await service.encrypt(USER_ID, "value", BINDING);
+    unwrap.mockClear();
+
+    await expect(service.decrypt(USER_ID, encrypted, { sub: USER_ID, dseq: OTHER_DSEQ })).rejects.toThrow();
+
+    expect(unwrap).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "SECRET_VALUE_BINDING_MISMATCH", claim: "dseq" }));
+  });
+
+  it("refuses a value bound to another owner", async () => {
+    const { service } = setup();
+
+    const encrypted = await service.encrypt(USER_ID, "value", BINDING);
+
+    await expect(service.decrypt(USER_ID, encrypted, { sub: OTHER_DATA_KEY_ID, dseq: DSEQ })).rejects.toMatchObject({ status: 500 });
+  });
+
+  it("refuses a value bound to a claim the reader asks about and the value never carried", async () => {
+    const { service } = setup();
+
+    const encrypted = await service.encrypt(USER_ID, "value", { sub: USER_ID });
+
+    await expect(service.decrypt(USER_ID, encrypted, BINDING)).rejects.toMatchObject({ status: 500 });
+  });
+
+  it("fails the authentication tag rather than the claim check when a bound claim is rewritten in place", async () => {
+    const { service } = setup();
+    const [, ...rest] = (await service.encrypt(USER_ID, "value", BINDING)).split(".");
+    const rebound = { sub: USER_ID, dseq: OTHER_DSEQ, alg: "dir", enc: "A256GCM", kid: DATA_KEY_ID };
+    const forged = Buffer.from(JSON.stringify(rebound)).toString("base64url");
+
+    await expect(service.decrypt(USER_ID, [forged, ...rest].join("."), { sub: USER_ID, dseq: OTHER_DSEQ })).rejects.toMatchObject({ status: 500 });
+  });
+
+  it("keeps the claims describing its own encryption when a binding names them", async () => {
+    const { service } = setup();
+
+    const encrypted = await service.encrypt(USER_ID, "value", { alg: "none", enc: "none", kid: OTHER_DATA_KEY_ID });
+
+    expect(decodeProtectedHeader(encrypted)).toMatchObject({ alg: "dir", enc: "A256GCM", kid: DATA_KEY_ID });
+  });
+
+  it("binds nothing beyond its own encryption when the binding is empty", async () => {
+    const { service } = setup();
+
+    const encrypted = await service.encrypt(USER_ID, "value", {});
+
+    expect(Object.keys(decodeProtectedHeader(encrypted))).toEqual(["alg", "enc", "kid"]);
+    await expect(service.decrypt(USER_ID, encrypted, {})).resolves.toBe("value");
   });
 
   it("asks for the owner's data key rather than a key of its own", async () => {
     const { service, dataKeyUnwrapperService } = setup();
 
-    await service.encrypt(USER_ID, "value");
+    await service.encrypt(USER_ID, "value", BINDING);
 
     expect(dataKeyUnwrapperService.getDataKey).toHaveBeenCalledWith(USER_ID);
   });

--- a/apps/api/src/secret/services/secret-cipher/secret-cipher.service.ts
+++ b/apps/api/src/secret/services/secret-cipher/secret-cipher.service.ts
@@ -9,6 +9,16 @@ import { DataKeyUnwrapperService } from "@src/secret/services/data-key-unwrapper
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
 
+/**
+ * What a stored value is bound to besides its data key, as extra protected-header claims a reader has to
+ * state again to open it. The header is the additional authenticated data, so a claim is bound by the tag
+ * rather than merely written down: a value moved to a row these claims do not describe fails to open.
+ */
+export type SecretBinding = Readonly<Record<string, string>>;
+
+/** The claims that describe the encryption rather than what was encrypted, so they are the cipher's to set and not a binding's. */
+const ENCRYPTION_HEADER_CLAIMS: ReadonlySet<string> = new Set(["alg", "enc", "kid"]);
+
 /** The protected header names the data key record and is itself the additional authenticated data, so the recorded name cannot be swapped without breaking the tag. */
 @singleton()
 export class SecretCipherService {
@@ -21,17 +31,21 @@ export class SecretCipherService {
     this.#loggerService = createLogger({ context: SecretCipherService.name });
   }
 
-  async encrypt(userId: string, value: string): Promise<string> {
+  /** The binding is spread first so the three claims that describe the encryption itself are always the ones that win, and no caller can weaken them by naming them. */
+  async encrypt(userId: string, value: string, binding: SecretBinding): Promise<string> {
     const dataKey = await this.dataKeyUnwrapperService.getDataKey(userId);
 
     return await new CompactEncrypt(textEncoder.encode(value))
-      .setProtectedHeader({ alg: SECRET_AT_REST_KEY_MANAGEMENT, enc: SECRET_AT_REST_CONTENT_ENCRYPTION, kid: dataKey.id })
+      .setProtectedHeader({ ...binding, alg: SECRET_AT_REST_KEY_MANAGEMENT, enc: SECRET_AT_REST_CONTENT_ENCRYPTION, kid: dataKey.id })
       .encrypt(await dataKey.unwrap());
   }
 
-  /** The recorded data key is checked before the key is unwrapped, so reading a value the user cannot own costs no key-service call. */
-  async decrypt(userId: string, encrypted: string): Promise<string> {
-    const { kid } = this.#readSupportedHeader(encrypted, userId);
+  /**
+   * Everything free happens before anything costly: the header decides whether this value belongs here at
+   * all, so a value the caller cannot own costs neither a data key lookup nor a key-service call.
+   */
+  async decrypt(userId: string, encrypted: string, binding: SecretBinding): Promise<string> {
+    const { kid } = this.#readBoundHeader(encrypted, userId, binding);
     const dataKey = await this.dataKeyUnwrapperService.getDataKey(userId);
 
     if (kid !== dataKey.id) {
@@ -41,11 +55,29 @@ export class SecretCipherService {
     return textDecoder.decode(await this.#open(encrypted, await dataKey.unwrap(), userId));
   }
 
-  #readSupportedHeader(encrypted: string, userId: string) {
+  /**
+   * A reader has to name exactly what the value was bound to, not merely a subset of it. Checking only the
+   * claims the caller thought to mention would let a later caller drop a binding by omission — passing
+   * `{ sub }` for a value bound to `{ sub, dseq }` would open every deployment of that owner — so the
+   * claim sets have to match before any value is compared.
+   */
+  #readBoundHeader(encrypted: string, userId: string, binding: SecretBinding) {
     const header = this.#decodeHeader(encrypted, userId);
 
     if (header.alg !== SECRET_AT_REST_KEY_MANAGEMENT || header.enc !== SECRET_AT_REST_CONTENT_ENCRYPTION) {
       throw this.#rejectUnreadable("SECRET_VALUE_ALGORITHM_UNSUPPORTED", { userId, alg: header.alg, enc: header.enc });
+    }
+
+    const bound = Object.keys(header).filter(claim => !ENCRYPTION_HEADER_CLAIMS.has(claim));
+
+    if (bound.length !== Object.keys(binding).length || bound.some(claim => !Object.hasOwn(binding, claim))) {
+      throw this.#rejectUnreadable("SECRET_VALUE_BINDING_UNACCOUNTED", { userId, bound, named: Object.keys(binding) });
+    }
+
+    for (const [claim, expected] of Object.entries(binding)) {
+      if (header[claim] !== expected) {
+        throw this.#rejectUnreadable("SECRET_VALUE_BINDING_MISMATCH", { userId, claim, received: header[claim], expected });
+      }
     }
 
     return header;

--- a/apps/api/src/secret/services/secret-cipher/secret-cipher.service.ts
+++ b/apps/api/src/secret/services/secret-cipher/secret-cipher.service.ts
@@ -9,15 +9,13 @@ import { DataKeyUnwrapperService } from "@src/secret/services/data-key-unwrapper
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
 
-/**
- * What a stored value is bound to besides its data key, as extra protected-header claims a reader has to
- * state again to open it. The header is the additional authenticated data, so a claim is bound by the tag
- * rather than merely written down: a value moved to a row these claims do not describe fails to open.
- */
-export type SecretBinding = Readonly<Record<string, string>>;
-
 /** The claims that describe the encryption rather than what was encrypted, so they are the cipher's to set and not a binding's. */
-const ENCRYPTION_HEADER_CLAIMS: ReadonlySet<string> = new Set(["alg", "enc", "kid"]);
+type EncryptionHeaderClaim = "alg" | "enc" | "kid";
+
+const ENCRYPTION_HEADER_CLAIMS: ReadonlySet<string> = new Set<EncryptionHeaderClaim>(["alg", "enc", "kid"]);
+
+/** The protected header is the additional authenticated data, so a value moved to a row these claims do not describe fails to open. */
+export type SecretBinding = Readonly<Record<string, string>> & { readonly [K in EncryptionHeaderClaim]?: never };
 
 /** The protected header names the data key record and is itself the additional authenticated data, so the recorded name cannot be swapped without breaking the tag. */
 @singleton()
@@ -31,7 +29,7 @@ export class SecretCipherService {
     this.#loggerService = createLogger({ context: SecretCipherService.name });
   }
 
-  /** The binding is spread first so the three claims that describe the encryption itself are always the ones that win, and no caller can weaken them by naming them. */
+  /** The encryption claims are spread last so they still win over a binding that reached here past the type forbidding them. */
   async encrypt(userId: string, value: string, binding: SecretBinding): Promise<string> {
     const dataKey = await this.dataKeyUnwrapperService.getDataKey(userId);
 
@@ -40,10 +38,7 @@ export class SecretCipherService {
       .encrypt(await dataKey.unwrap());
   }
 
-  /**
-   * Everything free happens before anything costly: the header decides whether this value belongs here at
-   * all, so a value the caller cannot own costs neither a data key lookup nor a key-service call.
-   */
+  /** The header decides whether the value belongs here before it costs a data key lookup or a key-service call. */
   async decrypt(userId: string, encrypted: string, binding: SecretBinding): Promise<string> {
     const { kid } = this.#readBoundHeader(encrypted, userId, binding);
     const dataKey = await this.dataKeyUnwrapperService.getDataKey(userId);
@@ -55,12 +50,7 @@ export class SecretCipherService {
     return textDecoder.decode(await this.#open(encrypted, await dataKey.unwrap(), userId));
   }
 
-  /**
-   * A reader has to name exactly what the value was bound to, not merely a subset of it. Checking only the
-   * claims the caller thought to mention would let a later caller drop a binding by omission — passing
-   * `{ sub }` for a value bound to `{ sub, dseq }` would open every deployment of that owner — so the
-   * claim sets have to match before any value is compared.
-   */
+  /** The claim sets have to match exactly, because accepting a subset would let a caller drop a binding by omission. */
   #readBoundHeader(encrypted: string, userId: string, binding: SecretBinding) {
     const header = this.#decodeHeader(encrypted, userId);
 


### PR DESCRIPTION
> **Base branch: `feat/deployment-bind-secret-cipher-header` — NOT `main`.** This is PR **3 of 5** in the sealed-secrets create-path stack. It **stacks on PR 2** ("bind a stored secret to the deployment it was stored for") and should be reviewed and merged **after** it. GitHub shows only the incremental diff against that base, which is what the size label measures.
>
> | # | PR | incremental lines |
> |---|---|---|
> | 1 | give a deployment record a column for its sealed secrets | 138 |
> | 2 | bind a stored secret to the deployment it was stored for | 300 |
> | **3** | **let a stored sdl keep the references it was written with** ← you are here | **353** |
> | 4 | turn a transport seal and an sdl into the values a deployment needs | 614 |
> | 5 | accept sealed secrets when a deployment is created | 815 |
>
> The executable demo of the observable end-to-end behaviour lives in **PR 5**, which is where the create path lands. AC 3 ("what the `deployment_settings` row actually holds") and the body-limit arithmetic in that demo are the user-visible faces of this slice.

## Why

ref CON-862

Two things have to be true before an intake can be written, and neither is intake logic:

1. **A stored SDL has to survive stripping with its references intact.** `stripSdlSecrets` drops every env *value* so the console never holds a credential. But an `ac-secret://NAME` reference **names** a secret rather than carrying one — keeping it costs nothing, and losing it costs the stored definition the one thing that says which values the deployment expects to be handed. Without this, a remembered deployment still cannot be redeployed even once its secrets are stored.
2. **The limits PRD-0003 states have to be reachable.** 100 secrets at 16 KB apiece cannot fit behind the 512 KiB body limit `createRoute` puts on every route with a body, so the arithmetic that sizes an exception has to exist and be pinned to the limits.

Separate slice because both are pure, dependency-free groundwork with a lot of arithmetic in them: the budget wants checking on its own terms, against the grammar and the JSON encoding it is derived from, without a create path in the way.

## What

**The stored SDL keeps its references.** `stripSdlSecrets` now leaves an env value that is a **whole SDL Reference** in place and still strips everything else. The test is the reference **grammar** (`isSdlReference`), not the `ac-` prefix, so a value that merely looks like a reference is still stripped. `MODE=production` next to `API_TOKEN=ac-secret://API_TOKEN` still becomes `MODE=`.

**`SdlReferenceService` gains the reads an intake needs**, so nothing has to re-derive them:
- `declarationsOf(sdl, kind)` — every reference of one kind the SDL declares. Substitution alone cannot report a *supplied name nothing references*, because it only ever visits what the SDL names; this is the other direction.
- `missingSdlReferenceValueError` is extracted and shared, so the two places that can find a reference with no value — the intake and substitution — cannot report the same thing in two wordings.
- `MAX_SDL_REFERENCE_NAME_LENGTH = 64` is exported and pinned against the grammar by its own spec, because the seal budget is computed from it and a bound that drifted from what the grammar accepts would make that budget *wrong* rather than merely stale.
- `isSdlReference` and `ownValue` are exported (the latter guards against a service or secret name spelling an `Object.prototype` member).

**The seal budget** (`sdl-secrets.config.ts`) — derived from the limits, never chosen:
- `DEFAULT_BODY_LIMIT_BYTES = 524288` is extracted into its own leaf module (`core/config/body-limit.config.ts`), read both by the middleware that applies it and by the config that sizes an exception to it, so neither has to import the other. `createRoute` now reads it instead of an inline `512 * 1024`.
- `jsonEncodedBytes(value)` — a string's cost inside the seal's plaintext, which is a **JSON object** and not raw bytes. Escaping is not size-preserving: a `"` or `\` costs two bytes, a control byte up to six. Measuring raw would let a hundred quote-heavy values (a service-account key, a PEM) overrun a budget computed as though they were plain, and the request would then die on the body limit with a bare **413** instead of a **400 naming the limit it broke**.
- `maxSealedSecretsBytes({ maxCount, maxValueBytes })` — the largest seal the limits can produce. AES-GCM is a counter mode, so the ciphertext is byte-for-byte its plaintext and the JSON object is the only thing that has to be measured. An **exact bound**, not an estimate, but only because the intake (PR 4) measures a name and a value the same way.
- `CREATE_DEPLOYMENT_BODY_LIMIT_BYTES` = the whole existing 524,288-byte allowance, kept intact, **plus** exactly the largest seal the default limits allow. The margin is the conservatism in each term, not a percentage on the end. Applied to a route in PR 5, not here.

**`SDL_SECRETS_MAX_COUNT` / `SDL_SECRETS_MAX_VALUE_BYTES`** become env vars (defaults 100 and 16384), and `envSchema` **refuses to boot** on a pair that could produce a seal larger than the create route's body limit was sized for — with a message naming both values and the headroom. Raising the limits without also resizing the route fails at startup rather than producing requests refused before their limits could be applied.

**No behaviour change reachable by a user in this slice:** nothing calls `declarationsOf`, and no route uses the new body limit yet. The `stripSdlSecrets` change is reachable, but a reference in an SDL is refused by the create path today (there is no resolver), so no create that gets as far as storage can carry one until PR 5.

### Validation

Measured on the tip of the stack (`feat/deployment-accept-sealed-secrets-on-create`), in `apps/api`:

| check | result |
|---|---|
| `npx tsc --noEmit` | **43 errors — exactly the `main` baseline, byte-identical error set** (independently verified; `apps/api` tsc is not green on `main`, so 43 is the baseline and not a regression) |
| `npm run lint -- --quiet` | clean |
| `npm test` | **245 files / 3131 tests passing** |

### Open items at time of opening

These are stated because this stack is being opened mid-process, deliberately, and the bodies should not overclaim:

- The **independent round-2 review** of the fixes applied after the first review has **completed with zero blocking findings**.
- A **full-suite test flake is still open, and the evidence now says it is not ours.** `npm test` intermittently fails at the **suite** level — `beforeAll` timeouts in `dbService.setup()` — and never with a failing assertion. Measured interleaved, one run each per round: **`main` failed 1 of 5 runs and this stack's tip 1 of 4, both failing in the same round.** On the available evidence it is **pre-existing and not attributable to this stack**.
- **Root cause, identified and pre-existing.** `apps/api/env/.env.functional.test` sets neither `POSTGRES_MAX_CONNECTIONS` nor `POSTGRES_BACKGROUND_JOBS_POOL_SIZE`, so every functional suite inherits the production defaults of 20 each (`core/config/env.config.ts:15,17`). With `maxWorkers` unset, ~14 suites run concurrently and each boots its own app and database, putting worst-case demand near **328 connections on `main` and 348 on the tip, against `max_connections=100`**. That produces exactly the observed chain: `sorry, too many clients already`, then a socket closing mid-query (`Cannot redefine property: query`), then the 20 s `beforeAll` budget expiring. This stack adds one suite and a second `startJobQueues()` call site — roughly **+6%** — which is not what puts the system over a hard limit it already exceeds.
- **The fix is two lines of test config**: `POSTGRES_MAX_CONNECTIONS=4` and `POSTGRES_BACKGROUND_JOBS_POOL_SIZE=4` in `apps/api/env/.env.functional.test`, which both the functional and integration vitest projects load. Test-only and independent of these five branches, so it is best landed as its own small PR that any of them can rebase onto.
- **Two unrelated pre-existing flakes show up in the same logs** and are untouched by this stack: `UserWalletRepository > isCreditsLowConfirmed > confirms immediately when the window is disabled`, which compares an app-clock `new Date()` against Postgres `now()` with a zero-minute window, and separate flakes in `providers.spec.ts`.
