### PR TITLE
feat(deployment): turn a transport seal and an sdl into the values a deployment needs

### DIFF
--- a/apps/api/src/deployment/services/sdl-secrets/sdl-secrets.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl-secrets/sdl-secrets.service.spec.ts
@@ -1,0 +1,415 @@
+import type { SDLInput } from "@akashnetwork/chain-sdk";
+import { faker } from "@faker-js/faker";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { CreateLogger } from "@src/core/providers/logging.provider";
+import type { DeploymentConfigService } from "@src/deployment/services/deployment-config/deployment-config.service";
+import { MAX_SDL_REFERENCE_NAME_LENGTH, SdlReferenceService } from "@src/deployment/services/sdl-reference/sdl-reference.service";
+import type { SdlSecrets } from "@src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service";
+import type { SdlSecretsUnsealerService } from "@src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service";
+import type { SecretCipherService } from "@src/secret/services/secret-cipher/secret-cipher.service";
+import { SdlSecretsService } from "./sdl-secrets.service";
+
+import { mockConfigService } from "@test/mocks/config-service.mock";
+
+const SEAL = "sealed.secrets.token.for.tests";
+const RAW_SDL = "version: '2.0'";
+const MAX_COUNT = 100;
+const MAX_NAME_BYTES = MAX_SDL_REFERENCE_NAME_LENGTH;
+const MAX_VALUE_BYTES = 16 * 1024;
+
+function sdlWith(services: Record<string, string[]>): SDLInput {
+  return { services: Object.fromEntries(Object.entries(services).map(([name, env]) => [name, { env }])) } as unknown as SDLInput;
+}
+
+describe(SdlSecretsService.name, () => {
+  describe("receive", () => {
+    it("hands a referenced value to the service that referenced it", async () => {
+      const { service } = setup({ supplied: { TOKEN: "resolved" } });
+
+      const result = await service.receive({ sdl: sdlWith({ web: ["TOKEN=ac-secret://TOKEN"] }), rawSdl: RAW_SDL, sealedSecrets: SEAL });
+
+      expect(result.ok).toBe(true);
+      expect(receivedOf(result).byService).toEqual({ web: { TOKEN: "resolved" } });
+    });
+
+    it("hands one supplied value to every service that references it", async () => {
+      const { service } = setup({ supplied: { TOKEN: "shared" } });
+
+      const result = await service.receive({
+        sdl: sdlWith({ web: ["TOKEN=ac-secret://TOKEN"], worker: ["TOKEN=ac-secret://TOKEN"], cron: ["TOKEN=ac-secret://TOKEN"] }),
+        rawSdl: RAW_SDL,
+        sealedSecrets: SEAL
+      });
+
+      expect(receivedOf(result).byService).toEqual({ web: { TOKEN: "shared" }, worker: { TOKEN: "shared" }, cron: { TOKEN: "shared" } });
+    });
+
+    it("hands a service only the names it references", async () => {
+      const { service } = setup({ supplied: { TOKEN: "one", DATABASE_URL: "two" } });
+
+      const result = await service.receive({
+        sdl: sdlWith({ web: ["TOKEN=ac-secret://TOKEN"], db: ["DATABASE_URL=ac-secret://DATABASE_URL"] }),
+        rawSdl: RAW_SDL,
+        sealedSecrets: SEAL
+      });
+
+      expect(receivedOf(result).byService).toEqual({ web: { TOKEN: "one" }, db: { DATABASE_URL: "two" } });
+    });
+
+    it("hands nothing to a service that references nothing", async () => {
+      const { service } = setup({ supplied: { TOKEN: "resolved" } });
+
+      const result = await service.receive({
+        sdl: sdlWith({ web: ["TOKEN=ac-secret://TOKEN"], sidecar: ["LOG_LEVEL=debug"] }),
+        rawSdl: RAW_SDL,
+        sealedSecrets: SEAL
+      });
+
+      expect(Object.keys(receivedOf(result).byService)).toEqual(["web"]);
+    });
+
+    it("keeps what the client sealed unchanged, for storage", async () => {
+      const supplied = { TOKEN: "one", DATABASE_URL: "two" };
+      const { service } = setup({ supplied });
+
+      const result = await service.receive({
+        sdl: sdlWith({ web: ["TOKEN=ac-secret://TOKEN", "DATABASE_URL=ac-secret://DATABASE_URL"] }),
+        rawSdl: RAW_SDL,
+        sealedSecrets: SEAL
+      });
+
+      expect(receivedOf(result).supplied).toEqual(supplied);
+    });
+
+    it("names a reference it holds no value for", async () => {
+      const { service } = setup({ supplied: { OTHER: "resolved" } });
+
+      const result = await service.receive({
+        sdl: sdlWith({ web: ["TOKEN=ac-secret://TOKEN", "OTHER=ac-secret://OTHER"] }),
+        rawSdl: RAW_SDL,
+        sealedSecrets: SEAL
+      });
+
+      expect(result.ok).toBe(false);
+      expect(errorsOf(result)[0].message).toContain('no value supplied for SDL Reference "ac-secret://TOKEN" in service "web"');
+    });
+
+    it("names a supplied value no service references", async () => {
+      const { service } = setup({ supplied: { TOKEN: "resolved", TYPOED: "orphan" } });
+
+      const result = await service.receive({ sdl: sdlWith({ web: ["TOKEN=ac-secret://TOKEN"] }), rawSdl: RAW_SDL, sealedSecrets: SEAL });
+
+      expect(result.ok).toBe(false);
+      expect(errorsOf(result)[0].message).toBe('a value was supplied for "TYPOED" but no service\'s SDL references it');
+    });
+
+    it("reports a mistake on each side of the same request", async () => {
+      const { service } = setup({ supplied: { TYPOED: "orphan" } });
+
+      const result = await service.receive({ sdl: sdlWith({ web: ["TOKEN=ac-secret://TOKEN"] }), rawSdl: RAW_SDL, sealedSecrets: SEAL });
+
+      expect(errorsOf(result).map(error => error.message)).toEqual([
+        'no value supplied for SDL Reference "ac-secret://TOKEN" in service "web"',
+        'a value was supplied for "TYPOED" but no service\'s SDL references it'
+      ]);
+    });
+
+    it("counts a name referenced by one service and missing for another as referenced", async () => {
+      const { service } = setup({ supplied: { TOKEN: "resolved" } });
+
+      const result = await service.receive({
+        sdl: sdlWith({ web: ["TOKEN=ac-secret://TOKEN"], worker: ["LOG_LEVEL=debug"] }),
+        rawSdl: RAW_SDL,
+        sealedSecrets: SEAL
+      });
+
+      expect(result.ok).toBe(true);
+    });
+
+    it("carries an unreferenced name in the error params as well as its message", async () => {
+      const name = `A${"b".repeat(MAX_NAME_BYTES - 1)}`;
+      const { service } = setup({ supplied: { [name]: "orphan" } });
+
+      const result = await service.receive({ sdl: sdlWith({ web: ["LOG_LEVEL=debug"] }), rawSdl: RAW_SDL, sealedSecrets: SEAL });
+
+      expect(errorsOf(result)[0].message).toContain(name);
+      expect(errorsOf(result)[0].params).toEqual({ name });
+    });
+
+    it("says nothing about a supplied value in the mistake it reports", async () => {
+      const value = faker.string.alphanumeric(32);
+      const { service } = setup({ supplied: { TYPOED: value } });
+
+      const result = await service.receive({ sdl: sdlWith({ web: ["LOG_LEVEL=debug"] }), rawSdl: RAW_SDL, sealedSecrets: SEAL });
+
+      expect(JSON.stringify(errorsOf(result))).not.toContain(value);
+    });
+
+    it("resolves a name spelling an Object.prototype member from what was supplied for it", async () => {
+      const { service } = setup({ supplied: JSON.parse('{"constructor":"resolved"}') as SdlSecrets });
+
+      const result = await service.receive({ sdl: sdlWith({ web: ["C=ac-secret://constructor"] }), rawSdl: RAW_SDL, sealedSecrets: SEAL });
+
+      expect(receivedOf(result).byService).toEqual({ web: { constructor: "resolved" } });
+    });
+
+    it("refuses a reference whose name spells an Object.prototype member nothing was supplied for", async () => {
+      const { service } = setup({ supplied: {} });
+
+      const result = await service.receive({ sdl: sdlWith({ web: ["C=ac-secret://constructor"] }), rawSdl: RAW_SDL, sealedSecrets: SEAL });
+
+      expect(result.ok).toBe(false);
+    });
+
+    it("accepts a create that references nothing and supplies nothing without opening a seal", async () => {
+      const { service, unsealerService } = setup();
+
+      const result = await service.receive({ sdl: sdlWith({ web: ["LOG_LEVEL=debug"] }), rawSdl: RAW_SDL });
+
+      expect(receivedOf(result)).toEqual({ supplied: {}, byService: {} });
+      expect(unsealerService.open).not.toHaveBeenCalled();
+    });
+
+    it("names every reference of a create that supplies no seal at all", async () => {
+      const { service } = setup();
+
+      const result = await service.receive({ sdl: sdlWith({ web: ["TOKEN=ac-secret://TOKEN"], db: ["URL=ac-secret://URL"] }), rawSdl: RAW_SDL });
+
+      expect(errorsOf(result).map(error => error.message)).toEqual([
+        'no value supplied for SDL Reference "ac-secret://TOKEN" in service "web"',
+        'no value supplied for SDL Reference "ac-secret://URL" in service "db"'
+      ]);
+    });
+
+    it("ignores a reference of a kind a sealed payload does not answer", async () => {
+      const { service, unsealerService } = setup();
+
+      const result = await service.receive({ sdl: sdlWith({ web: ["MODE=ac-probe://MODE"] }), rawSdl: RAW_SDL });
+
+      expect(result.ok).toBe(true);
+      expect(unsealerService.open).not.toHaveBeenCalled();
+    });
+
+    it("binds the seal to the sdl exactly as it arrived", async () => {
+      const { service, unsealerService } = setup({ supplied: {} });
+      const rawSdl = "version: '2.0'\nservices:\n  web:\n    image: nginx\n";
+
+      await service.receive({ sdl: sdlWith({ web: ["LOG_LEVEL=debug"] }), rawSdl, sealedSecrets: SEAL });
+
+      expect(unsealerService.open).toHaveBeenCalledWith({ seal: SEAL, sdl: rawSdl });
+    });
+
+    it("refuses more secrets than a deployment may carry", async () => {
+      const supplied = Object.fromEntries(Array.from({ length: MAX_COUNT + 1 }, (_, index) => [`SECRET_${index}`, "value"]));
+      const { service } = setup({ supplied });
+
+      await expect(service.receive({ sdl: sdlWith({ web: ["LOG_LEVEL=debug"] }), rawSdl: RAW_SDL, sealedSecrets: SEAL })).rejects.toMatchObject({
+        status: 400,
+        message: `At most ${MAX_COUNT} secrets may be supplied for one deployment`
+      });
+    });
+
+    it("accepts exactly as many secrets as a deployment may carry", async () => {
+      const names = Array.from({ length: MAX_COUNT }, (_, index) => `SECRET_${index}`);
+      const { service } = setup({ supplied: Object.fromEntries(names.map(name => [name, "value"])) });
+
+      const result = await service.receive({
+        sdl: sdlWith({ web: names.map(name => `${name}=ac-secret://${name}`) }),
+        rawSdl: RAW_SDL,
+        sealedSecrets: SEAL
+      });
+
+      expect(result.ok).toBe(true);
+    });
+
+    it("refuses a value above the size a secret may be", async () => {
+      const { service } = setup({ supplied: { TOKEN: "x".repeat(MAX_VALUE_BYTES + 1) } });
+
+      await expect(service.receive({ sdl: sdlWith({ web: ["TOKEN=ac-secret://TOKEN"] }), rawSdl: RAW_SDL, sealedSecrets: SEAL })).rejects.toMatchObject({
+        status: 400,
+        message: `Secret "TOKEN" exceeds the maximum value size of ${MAX_VALUE_BYTES} bytes once JSON-encoded`
+      });
+    });
+
+    it("accepts a value of exactly the size a secret may be", async () => {
+      const { service } = setup({ supplied: { TOKEN: "x".repeat(MAX_VALUE_BYTES) } });
+
+      const result = await service.receive({ sdl: sdlWith({ web: ["TOKEN=ac-secret://TOKEN"] }), rawSdl: RAW_SDL, sealedSecrets: SEAL });
+
+      expect(result.ok).toBe(true);
+    });
+
+    it("measures a value in bytes rather than in characters", async () => {
+      const { service } = setup({ supplied: { TOKEN: "🔐".repeat(MAX_VALUE_BYTES / 4 + 1) } });
+
+      await expect(service.receive({ sdl: sdlWith({ web: ["TOKEN=ac-secret://TOKEN"] }), rawSdl: RAW_SDL, sealedSecrets: SEAL })).rejects.toMatchObject({
+        status: 400
+      });
+    });
+
+    it("measures a value as the seal will carry it, so an escaped character costs what it costs", async () => {
+      const quoted = '"'.repeat(MAX_VALUE_BYTES / 2);
+
+      await expect(
+        setup({ supplied: { TOKEN: quoted } }).service.receive({ sdl: sdlWith({ web: ["TOKEN=ac-secret://TOKEN"] }), rawSdl: RAW_SDL, sealedSecrets: SEAL })
+      ).resolves.toMatchObject({ ok: true });
+
+      await expect(
+        setup({ supplied: { TOKEN: `${quoted}"` } }).service.receive({
+          sdl: sdlWith({ web: ["TOKEN=ac-secret://TOKEN"] }),
+          rawSdl: RAW_SDL,
+          sealedSecrets: SEAL
+        })
+      ).rejects.toMatchObject({ status: 400, message: `Secret "TOKEN" exceeds the maximum value size of ${MAX_VALUE_BYTES} bytes once JSON-encoded` });
+    });
+
+    it("refuses a supplied name longer than any sdl could reference", async () => {
+      const name = "N".repeat(MAX_NAME_BYTES + 1);
+      const { service } = setup({ supplied: { [name]: "value" } });
+
+      await expect(service.receive({ sdl: sdlWith({ web: ["LOG_LEVEL=debug"] }), rawSdl: RAW_SDL, sealedSecrets: SEAL })).rejects.toMatchObject({
+        status: 400,
+        message: `Secret name "${name}" exceeds the maximum of ${MAX_NAME_BYTES} bytes`
+      });
+    });
+
+    it("accepts a supplied name of exactly the length an sdl could reference", async () => {
+      const name = `A${"b".repeat(MAX_NAME_BYTES - 1)}`;
+      const { service } = setup({ supplied: { [name]: "value" } });
+
+      const result = await service.receive({ sdl: sdlWith({ web: [`T=ac-secret://${name}`] }), rawSdl: RAW_SDL, sealedSecrets: SEAL });
+
+      expect(result.ok).toBe(true);
+    });
+
+    it("measures a supplied name the way the seal carries it too", async () => {
+      const { service } = setup({ supplied: { ['"'.repeat(MAX_NAME_BYTES / 2 + 1)]: "value" } });
+
+      await expect(service.receive({ sdl: sdlWith({ web: ["LOG_LEVEL=debug"] }), rawSdl: RAW_SDL, sealedSecrets: SEAL })).rejects.toMatchObject({
+        status: 400
+      });
+    });
+
+    it("bounds an oversized name it echoes into the refusal", async () => {
+      const { service } = setup({ supplied: { ["N".repeat(500)]: "value" } });
+
+      await expect(service.receive({ sdl: sdlWith({ web: ["LOG_LEVEL=debug"] }), rawSdl: RAW_SDL, sealedSecrets: SEAL })).rejects.toMatchObject({
+        message: `Secret name "${"N".repeat(120)}" exceeds the maximum of ${MAX_NAME_BYTES} bytes`
+      });
+    });
+
+    it("refuses on the name before measuring the value", async () => {
+      const name = "N".repeat(MAX_NAME_BYTES + 1);
+      const { service } = setup({ supplied: { [name]: "d".repeat(MAX_VALUE_BYTES + 1) } });
+
+      await expect(service.receive({ sdl: sdlWith({ web: ["LOG_LEVEL=debug"] }), rawSdl: RAW_SDL, sealedSecrets: SEAL })).rejects.toMatchObject({
+        message: `Secret name "${name}" exceeds the maximum of ${MAX_NAME_BYTES} bytes`
+      });
+    });
+
+    it("says nothing about an oversized value in the refusal it returns", async () => {
+      const value = `${faker.string.alphanumeric(32)}${"x".repeat(MAX_VALUE_BYTES)}`;
+      const { service } = setup({ supplied: { TOKEN: value } });
+
+      await expect(service.receive({ sdl: sdlWith({ web: ["TOKEN=ac-secret://TOKEN"] }), rawSdl: RAW_SDL, sealedSecrets: SEAL })).rejects.toSatisfy(
+        (error: Error) => !error.message.includes(value.slice(0, 32))
+      );
+    });
+
+    it("refuses on count before measuring any value", async () => {
+      const supplied = Object.fromEntries(Array.from({ length: MAX_COUNT + 1 }, (_, index) => [`SECRET_${index}`, "x".repeat(MAX_VALUE_BYTES + 1)]));
+      const { service } = setup({ supplied });
+
+      await expect(service.receive({ sdl: sdlWith({ web: ["LOG_LEVEL=debug"] }), rawSdl: RAW_SDL, sealedSecrets: SEAL })).rejects.toMatchObject({
+        message: `At most ${MAX_COUNT} secrets may be supplied for one deployment`
+      });
+    });
+
+    it("logs a name once however many services and entries reference it", async () => {
+      const { service, logger } = setup({ supplied: { TOKEN: "shared" } });
+
+      await service.receive({
+        sdl: sdlWith({ web: ["A=ac-secret://TOKEN", "B=ac-secret://TOKEN"], worker: ["C=ac-secret://TOKEN"] }),
+        rawSdl: RAW_SDL,
+        sealedSecrets: SEAL
+      });
+
+      expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ referencedNames: ["TOKEN"], serviceCount: 2 }));
+    });
+
+    it("logs the names an sdl references and only the count of what was supplied", async () => {
+      const value = faker.string.alphanumeric(32);
+      const { service, logger } = setup({ supplied: { TOKEN: value } });
+
+      await service.receive({ sdl: sdlWith({ web: ["TOKEN=ac-secret://TOKEN"] }), rawSdl: RAW_SDL, sealedSecrets: SEAL });
+
+      expect(logger.info).toHaveBeenCalledWith({ event: "SDL_SECRETS_RECEIVED", suppliedCount: 1, referencedNames: ["TOKEN"], serviceCount: 1 });
+    });
+  });
+
+  describe("sealForStorage", () => {
+    it("seals the whole set as one token bound to its owner and its deployment", async () => {
+      const { service, secretCipherService } = setup();
+      const secrets = { TOKEN: "one", DATABASE_URL: "two" };
+
+      await service.sealForStorage({ userId: "user-1", dseq: "1420000", secrets });
+
+      expect(secretCipherService.encrypt).toHaveBeenCalledWith("user-1", JSON.stringify(secrets), { sub: "user-1", dseq: "1420000" });
+    });
+
+    it("returns the token the cipher produced", async () => {
+      const { service } = setup();
+
+      await expect(service.sealForStorage({ userId: "user-1", dseq: "1420000", secrets: { TOKEN: "one" } })).resolves.toBe("encrypted");
+    });
+
+    it("spends one encryption however many secrets the deployment has", async () => {
+      const { service, secretCipherService } = setup();
+      const secrets = Object.fromEntries(Array.from({ length: 12 }, (_, index) => [`SECRET_${index}`, "value"]));
+
+      await service.sealForStorage({ userId: "user-1", dseq: "1420000", secrets });
+
+      expect(secretCipherService.encrypt).toHaveBeenCalledOnce();
+    });
+
+    it("writes no token for a deployment that supplied nothing", async () => {
+      const { service, secretCipherService } = setup();
+
+      await expect(service.sealForStorage({ userId: "user-1", dseq: "1420000", secrets: {} })).resolves.toBeNull();
+      expect(secretCipherService.encrypt).not.toHaveBeenCalled();
+    });
+
+    it("says nothing about a value in what it logs", async () => {
+      const value = faker.string.alphanumeric(32);
+      const { service, logger } = setup();
+
+      await service.sealForStorage({ userId: "user-1", dseq: "1420000", secrets: { TOKEN: value } });
+
+      expect(logger.info).toHaveBeenCalledWith({ event: "SDL_SECRETS_SEALED", userId: "user-1", dseq: "1420000", secretCount: 1 });
+    });
+  });
+
+  function receivedOf(result: Awaited<ReturnType<SdlSecretsService["receive"]>>) {
+    return (result as Extract<typeof result, { ok: true }>).value;
+  }
+
+  function errorsOf(result: Awaited<ReturnType<SdlSecretsService["receive"]>>) {
+    return (result as Extract<typeof result, { ok: false }>).value;
+  }
+
+  function setup(input?: { supplied?: SdlSecrets; maxCount?: number; maxValueBytes?: number }) {
+    const unsealerService = mock<SdlSecretsUnsealerService>({ open: vi.fn().mockResolvedValue(input?.supplied ?? {}) });
+    const secretCipherService = mock<SecretCipherService>({ encrypt: vi.fn().mockResolvedValue("encrypted") });
+    const config = mockConfigService<DeploymentConfigService>({
+      SDL_SECRETS_MAX_COUNT: input?.maxCount ?? MAX_COUNT,
+      SDL_SECRETS_MAX_VALUE_BYTES: input?.maxValueBytes ?? MAX_VALUE_BYTES
+    });
+    const logger = mock<ReturnType<CreateLogger>>();
+    const sdlReferenceService = new SdlReferenceService();
+    const service = new SdlSecretsService(unsealerService, sdlReferenceService, secretCipherService, config, () => logger);
+
+    return { service, unsealerService, secretCipherService, logger, config };
+  }
+});

--- a/apps/api/src/deployment/services/sdl-secrets/sdl-secrets.service.ts
+++ b/apps/api/src/deployment/services/sdl-secrets/sdl-secrets.service.ts
@@ -1,0 +1,199 @@
+import type { SDLInput, ValidationError } from "@akashnetwork/chain-sdk";
+import createError from "http-errors";
+import { inject, singleton } from "tsyringe";
+
+import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
+import { jsonEncodedBytes } from "@src/deployment/config/sdl-secrets.config";
+import type { NamespacedSdlSecrets, SdlReferenceDeclaration } from "@src/deployment/services/sdl-reference/sdl-reference.service";
+import {
+  MAX_ECHOED_REFERENCE_LENGTH,
+  MAX_SDL_REFERENCE_NAME_LENGTH,
+  missingSdlReferenceValueError,
+  ownValue,
+  SdlReferenceService
+} from "@src/deployment/services/sdl-reference/sdl-reference.service";
+import type { SdlSecrets } from "@src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service";
+import { SdlSecretsUnsealerService } from "@src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service";
+import { SecretCipherService } from "@src/secret/services/secret-cipher/secret-cipher.service";
+import { DeploymentConfigService } from "../deployment-config/deployment-config.service";
+
+/** The kind of SDL Reference a sealed payload answers. Other kinds resolve from elsewhere and are none of this service's business. */
+const SECRET_REFERENCE_KIND = "secret";
+
+export interface ReceivedSdlSecrets {
+  /** What the client sealed, unchanged, because this is what gets re-sealed for storage: one flat name-to-value map per deployment. */
+  supplied: SdlSecrets;
+  /** The same values indexed by the service that referenced them, which is the shape resolution reads. */
+  byService: NamespacedSdlSecrets;
+}
+
+export type ReceiveSdlSecretsResult = { ok: true; value: ReceivedSdlSecrets } | { ok: false; value: ValidationError[] };
+
+const NOTHING_SUPPLIED: ReceivedSdlSecrets = { supplied: {}, byService: {} };
+
+function unreferencedNameError(name: string): ValidationError {
+  const echoed = name.slice(0, MAX_ECHOED_REFERENCE_LENGTH);
+
+  return {
+    schemaPath: "",
+    instancePath: "",
+    keyword: "sdl-reference",
+    params: { name: echoed },
+    message: `a value was supplied for "${echoed}" but no service's SDL references it`
+  };
+}
+
+/**
+ * Turns a transport seal plus an SDL into the values a deployment's references resolve to, refusing
+ * anything the two disagree about. Nothing here ever logs, echoes or returns a value: the widest thing
+ * it says out loud is a name, and a name is already in the SDL it came from.
+ *
+ * Names are logged distinctly rather than per reference, which is what bounds the line: an SDL can
+ * declare a reference per env entry of per service, but by the time anything is logged every name has a
+ * supplied value, so the distinct set is bounded by the supplied-count limit.
+ */
+@singleton()
+export class SdlSecretsService {
+  readonly #loggerService: ReturnType<CreateLogger>;
+
+  constructor(
+    private readonly unsealerService: SdlSecretsUnsealerService,
+    private readonly sdlReferenceService: SdlReferenceService,
+    private readonly secretCipherService: SecretCipherService,
+    private readonly config: DeploymentConfigService,
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
+  ) {
+    this.#loggerService = createLogger({ context: SdlSecretsService.name });
+  }
+
+  /**
+   * Opens the seal, then checks the SDL against it in both directions: a reference with no value and a
+   * value no service references are both mistakes, and reporting only the first would let a typo on the
+   * supplying side ship silently.
+   *
+   * Runs on every create rather than only when a seal arrives, so a reference with no value is refused
+   * at one point whether or not the request carried anything. Callers pass the parsed document, because
+   * an SDL that does not parse has already been refused by the manifest generator and this must not
+   * become a second place that reports it.
+   */
+  async receive(input: { sdl: SDLInput; rawSdl: string; sealedSecrets?: string }): Promise<ReceiveSdlSecretsResult> {
+    const declarations = this.sdlReferenceService.declarationsOf(input.sdl, SECRET_REFERENCE_KIND);
+
+    if (!input.sealedSecrets) {
+      return declarations.length === 0 ? { ok: true, value: NOTHING_SUPPLIED } : { ok: false, value: declarations.map(missingSdlReferenceValueError) };
+    }
+
+    const supplied = await this.unsealerService.open({ seal: input.sealedSecrets, sdl: input.rawSdl });
+    this.#assertWithinLimits(supplied);
+
+    const { byService, errors } = this.#assignToServices(declarations, supplied);
+
+    if (errors.length > 0) return { ok: false, value: errors };
+
+    this.#loggerService.info({
+      event: "SDL_SECRETS_RECEIVED",
+      suppliedCount: Object.keys(supplied).length,
+      referencedNames: [...new Set(declarations.map(declaration => declaration.name))],
+      serviceCount: Object.keys(byService).length
+    });
+
+    return { ok: true, value: { supplied, byService } };
+  }
+
+  /**
+   * Re-seals for storage under the owner's own data encryption key, bound to the deployment the values
+   * were supplied for. The console stores this rather than what the client sent, because a client seals
+   * before the deployment exists and cannot name a dseq that has not been minted yet.
+   *
+   * Costs no key-service call of its own: the data key is already in hand for the request, and the
+   * at-rest form encrypts directly under it.
+   *
+   * Returns null for a deployment that supplied nothing, so a create always has a value to write and a
+   * retry cannot inherit the token an abandoned attempt left on the same row.
+   */
+  async sealForStorage(input: { userId: string; dseq: string; secrets: SdlSecrets }): Promise<string | null> {
+    const names = Object.keys(input.secrets);
+
+    if (names.length === 0) return null;
+
+    const sealed = await this.secretCipherService.encrypt(input.userId, JSON.stringify(input.secrets), { sub: input.userId, dseq: input.dseq });
+
+    this.#loggerService.info({ event: "SDL_SECRETS_SEALED", userId: input.userId, dseq: input.dseq, secretCount: names.length });
+
+    return sealed;
+  }
+
+  /**
+   * One value per reference, so a name several services refer to reaches each of them and a name none
+   * refer to reaches nothing. Namespaces are built from the walk rather than by giving every service a
+   * copy of everything, so a service that references nothing is handed nothing.
+   */
+  #assignToServices(declarations: SdlReferenceDeclaration[], supplied: SdlSecrets) {
+    const byService: NamespacedSdlSecrets = Object.create(null);
+    const errors: ValidationError[] = [];
+    const referenced = new Set<string>();
+
+    for (const declaration of declarations) {
+      const value = ownValue(supplied, declaration.name);
+
+      if (typeof value !== "string") {
+        errors.push(missingSdlReferenceValueError(declaration));
+        continue;
+      }
+
+      const namespace = (byService[declaration.serviceName] ??= Object.create(null) as SdlSecrets);
+      namespace[declaration.name] = value;
+      referenced.add(declaration.name);
+    }
+
+    for (const name of Object.keys(supplied)) {
+      if (!referenced.has(name)) errors.push(unreferencedNameError(name));
+    }
+
+    return { byService, errors };
+  }
+
+  /**
+   * Refuses on shape before anything is minted or written, and names the limit rather than what breached
+   * it. Every bound here is measured as `jsonEncodedBytes`, the same way the seal budget is computed,
+   * because the plaintext these values end up in is a JSON object and escaping is not size-preserving.
+   * A raw-length check would let a payload pass these and then die on the body limit with a bare 413.
+   */
+  #assertWithinLimits(supplied: SdlSecrets): void {
+    const maxCount = this.config.get("SDL_SECRETS_MAX_COUNT");
+    const names = Object.keys(supplied);
+
+    if (names.length > maxCount) {
+      throw this.#reject("SDL_SECRETS_COUNT_EXCEEDED", `At most ${maxCount} secrets may be supplied for one deployment`, { suppliedCount: names.length });
+    }
+
+    const maxValueBytes = this.config.get("SDL_SECRETS_MAX_VALUE_BYTES");
+
+    for (const name of names) {
+      const echoed = name.slice(0, MAX_ECHOED_REFERENCE_LENGTH);
+      const nameBytes = jsonEncodedBytes(name);
+
+      if (nameBytes > MAX_SDL_REFERENCE_NAME_LENGTH) {
+        throw this.#reject("SDL_SECRETS_NAME_TOO_LONG", `Secret name "${echoed}" exceeds the maximum of ${MAX_SDL_REFERENCE_NAME_LENGTH} bytes`, {
+          name: echoed,
+          nameBytes
+        });
+      }
+
+      const valueBytes = jsonEncodedBytes(supplied[name]);
+
+      if (valueBytes > maxValueBytes) {
+        throw this.#reject("SDL_SECRETS_VALUE_TOO_LARGE", `Secret "${echoed}" exceeds the maximum value size of ${maxValueBytes} bytes once JSON-encoded`, {
+          name: echoed,
+          valueBytes
+        });
+      }
+    }
+  }
+
+  #reject(event: string, message: string, details: Record<string, unknown>) {
+    this.#loggerService.warn({ event, ...details });
+
+    return createError(400, message);
+  }
+}

--- a/apps/api/src/deployment/services/sdl-secrets/sdl-secrets.service.ts
+++ b/apps/api/src/deployment/services/sdl-secrets/sdl-secrets.service.ts
@@ -43,15 +43,7 @@ function unreferencedNameError(name: string): ValidationError {
   };
 }
 
-/**
- * Turns a transport seal plus an SDL into the values a deployment's references resolve to, refusing
- * anything the two disagree about. Nothing here ever logs, echoes or returns a value: the widest thing
- * it says out loud is a name, and a name is already in the SDL it came from.
- *
- * Names are logged distinctly rather than per reference, which is what bounds the line: an SDL can
- * declare a reference per env entry of per service, but by the time anything is logged every name has a
- * supplied value, so the distinct set is bounded by the supplied-count limit.
- */
+/** Nothing here may log, echo or return a secret value: the widest thing it says out loud is a name, which is already in the SDL it came from. */
 @singleton()
 export class SdlSecretsService {
   readonly #loggerService: ReturnType<CreateLogger>;
@@ -66,16 +58,7 @@ export class SdlSecretsService {
     this.#loggerService = createLogger({ context: SdlSecretsService.name });
   }
 
-  /**
-   * Opens the seal, then checks the SDL against it in both directions: a reference with no value and a
-   * value no service references are both mistakes, and reporting only the first would let a typo on the
-   * supplying side ship silently.
-   *
-   * Runs on every create rather than only when a seal arrives, so a reference with no value is refused
-   * at one point whether or not the request carried anything. Callers pass the parsed document, because
-   * an SDL that does not parse has already been refused by the manifest generator and this must not
-   * become a second place that reports it.
-   */
+  /** Takes the parsed document, because an SDL that does not parse has already been refused by the manifest generator and this must not report it twice. */
   async receive(input: { sdl: SDLInput; rawSdl: string; sealedSecrets?: string }): Promise<ReceiveSdlSecretsResult> {
     const declarations = this.sdlReferenceService.declarationsOf(input.sdl, SECRET_REFERENCE_KIND);
 
@@ -100,17 +83,7 @@ export class SdlSecretsService {
     return { ok: true, value: { supplied, byService } };
   }
 
-  /**
-   * Re-seals for storage under the owner's own data encryption key, bound to the deployment the values
-   * were supplied for. The console stores this rather than what the client sent, because a client seals
-   * before the deployment exists and cannot name a dseq that has not been minted yet.
-   *
-   * Costs no key-service call of its own: the data key is already in hand for the request, and the
-   * at-rest form encrypts directly under it.
-   *
-   * Returns null for a deployment that supplied nothing, so a create always has a value to write and a
-   * retry cannot inherit the token an abandoned attempt left on the same row.
-   */
+  /** Returns null when nothing was supplied, so a create always has a value to write and a retry cannot inherit an abandoned attempt's token. */
   async sealForStorage(input: { userId: string; dseq: string; secrets: SdlSecrets }): Promise<string | null> {
     const names = Object.keys(input.secrets);
 
@@ -123,11 +96,7 @@ export class SdlSecretsService {
     return sealed;
   }
 
-  /**
-   * One value per reference, so a name several services refer to reaches each of them and a name none
-   * refer to reaches nothing. Namespaces are built from the walk rather than by giving every service a
-   * copy of everything, so a service that references nothing is handed nothing.
-   */
+  /** Namespaces are built from the walk rather than by copying everything to every service, so a service that references nothing is handed nothing. */
   #assignToServices(declarations: SdlReferenceDeclaration[], supplied: SdlSecrets) {
     const byService: NamespacedSdlSecrets = Object.create(null);
     const errors: ValidationError[] = [];
@@ -153,12 +122,7 @@ export class SdlSecretsService {
     return { byService, errors };
   }
 
-  /**
-   * Refuses on shape before anything is minted or written, and names the limit rather than what breached
-   * it. Every bound here is measured as `jsonEncodedBytes`, the same way the seal budget is computed,
-   * because the plaintext these values end up in is a JSON object and escaping is not size-preserving.
-   * A raw-length check would let a payload pass these and then die on the body limit with a bare 413.
-   */
+  /** Every bound is measured as `jsonEncodedBytes`, matching the seal budget, because a raw-length check would let a payload pass here and die on the body limit. */
   #assertWithinLimits(supplied: SdlSecrets): void {
     const maxCount = this.config.get("SDL_SECRETS_MAX_COUNT");
     const names = Object.keys(supplied);


### PR DESCRIPTION
> **Base branch: `feat/deployment-open-sealed-secrets-intake` — NOT `main`.** This is PR **4 of 5** in the sealed-secrets create-path stack. It **stacks on PR 3** ("let a stored sdl keep the references it was written with") and should be reviewed and merged **after** it. GitHub shows only the incremental diff against that base, which is what the size label measures.
>
> | # | PR | incremental lines |
> |---|---|---|
> | 1 | give a deployment record a column for its sealed secrets | 138 |
> | 2 | bind a stored secret to the deployment it was stored for | 300 |
> | 3 | let a stored sdl keep the references it was written with | 353 |
> | **4** | **turn a transport seal and an sdl into the values a deployment needs** ← you are here | **614** |
> | 5 | accept sealed secrets when a deployment is created | 815 |
>
> The executable demo of the observable end-to-end behaviour lives in **PR 5**, which is where the create path lands. AC 5, AC 6 and AC 9 in that demo — a typo on either side refused, and each limit binding on its own — are the user-visible face of this slice.

## Why

ref CON-862

The names of the supplied secrets live **inside** the seal, so none of the validation PRD-0003 asks for can be request-schema validation. The seal has to be opened first, and only then can the SDL and the request be checked against each other. That is a whole unit of behaviour with a testable contract of its own — one service, two public methods, 199 lines of source against 415 lines of spec — and it earns being reviewed without a route, a wallet, a transaction or a database in the frame.

Separate slice for a second reason: this service is where every "does not echo a value" claim actually has to hold. It is easier to be sure of that reading 199 lines than reading them inside the create path.

## What

New `SdlSecretsService` (`deployment/services/sdl-secrets/`), with two entry points and no callers yet.

**`receive({ sdl, rawSdl, sealedSecrets })`** — opens the seal and checks the SDL against it **in both directions**:
- A **referenced name with no supplied value** is refused, naming the reference and the service it is in — through the shared `missingSdlReferenceValueError` from PR 3, so it reads identically whether the intake or substitution found it.
- A **supplied name no service references** is refused too. Reporting only the first direction would let a typo on the supplying side ship silently: before this, an SDL referencing `API_TOKEN` while the request supplied `API_TOEKN` would deploy with an empty variable. Both halves are reported at once, so one typo cannot mask the other.
- Returns `{ supplied, byService }`: `supplied` is what the client sealed, unchanged, because that is what gets re-sealed for storage; `byService` is the same values indexed by the service that referenced them, which is the shape substitution reads. Namespaces are built **from the walk**, so a service that references nothing is handed nothing and a name several services refer to reaches each of them.
- Runs on **every** create, not only when a seal arrives, so a reference with no value is refused at one point whether or not the request carried anything.
- Takes the **already-parsed** document, because an SDL that does not parse has already been refused by the manifest generator and this must not become a second place that reports it.

**`sealForStorage({ userId, dseq, secrets })`** — re-seals under the owner's own data encryption key, bound to `{ sub: userId, dseq }` via PR 2's `SecretBinding`. The console stores **its own** token rather than what the client sent, because a client seals before the deployment exists and cannot name a dseq that has not been minted. Costs **no key-service call of its own** — the data key is already in hand for the request. Returns `null` when nothing was supplied, so a create always has a value to write and a retry cannot inherit the token an abandoned attempt left on the same row (the `null` half of PR 1's upsert contract).

**Limits**, enforced on the **decrypted payload** rather than inferred from request size, so each binds independently: count (`SDL_SECRETS_MAX_COUNT`), value size (`SDL_SECRETS_MAX_VALUE_BYTES`) and name length (`MAX_SDL_REFERENCE_NAME_LENGTH`). All three measured with `jsonEncodedBytes` — the same function the seal budget in PR 3 is computed from, which is what makes that budget an exact bound. Each refusal is a 400 naming the limit and its configured value.

**Nothing here logs, echoes or returns a value.** The widest thing it says out loud is a **name**, and a name is already in the SDL it came from. Names are logged as a **distinct set** rather than per reference, which is what bounds the log line: an SDL can declare a reference per env entry per service, but by the time anything is logged every name has a supplied value, so the distinct set is bounded by the supplied-count limit.

### Validation

Measured on the tip of the stack (`feat/deployment-accept-sealed-secrets-on-create`), in `apps/api`:

| check | result |
|---|---|
| `npx tsc --noEmit` | **43 errors — exactly the `main` baseline, byte-identical error set** (independently verified; `apps/api` tsc is not green on `main`, so 43 is the baseline and not a regression) |
| `npm run lint -- --quiet` | clean |
| `npm test` | **245 files / 3131 tests passing** |

### Open items at time of opening

These are stated because this stack is being opened mid-process, deliberately, and the bodies should not overclaim:

- The **independent round-2 review** of the fixes applied after the first review has **completed with zero blocking findings**.
- A **full-suite test flake is still open, and the evidence now says it is not ours.** `npm test` intermittently fails at the **suite** level — `beforeAll` timeouts in `dbService.setup()` — and never with a failing assertion. Measured interleaved, one run each per round: **`main` failed 1 of 5 runs and this stack's tip 1 of 4, both failing in the same round.** On the available evidence it is **pre-existing and not attributable to this stack**.
- **Root cause, identified and pre-existing.** `apps/api/env/.env.functional.test` sets neither `POSTGRES_MAX_CONNECTIONS` nor `POSTGRES_BACKGROUND_JOBS_POOL_SIZE`, so every functional suite inherits the production defaults of 20 each (`core/config/env.config.ts:15,17`). With `maxWorkers` unset, ~14 suites run concurrently and each boots its own app and database, putting worst-case demand near **328 connections on `main` and 348 on the tip, against `max_connections=100`**. That produces exactly the observed chain: `sorry, too many clients already`, then a socket closing mid-query (`Cannot redefine property: query`), then the 20 s `beforeAll` budget expiring. This stack adds one suite and a second `startJobQueues()` call site — roughly **+6%** — which is not what puts the system over a hard limit it already exceeds.
- **The fix is two lines of test config**: `POSTGRES_MAX_CONNECTIONS=4` and `POSTGRES_BACKGROUND_JOBS_POOL_SIZE=4` in `apps/api/env/.env.functional.test`, which both the functional and integration vitest projects load. Test-only and independent of these five branches, so it is best landed as its own small PR that any of them can rebase onto.
- **Two unrelated pre-existing flakes show up in the same logs** and are untouched by this stack: `UserWalletRepository > isCreditsLowConfirmed > confirms immediately when the window is disabled`, which compares an app-clock `new Date()` against Postgres `now()` with a zero-minute window, and separate flakes in `providers.spec.ts`.
