### PR TITLE
feat(deployment): accept sealed secrets when a deployment is created

### DIFF
--- a/apps/api/src/deployment/config/sdl.config.ts
+++ b/apps/api/src/deployment/config/sdl.config.ts
@@ -1,35 +1,7 @@
 import { DEFAULT_BODY_LIMIT_BYTES } from "@src/core/config/body-limit.config";
 
-/**
- * Upper bound on the SDL the console stores for a deployment. The column it is written to is `text`
- * and so bounds nothing itself, which makes this the only thing keeping a pathological SDL from
- * filling the database — and, because the document is measured against it before being serialized
- * rather than after, from filling memory on the way there.
- *
- * An SDL that does not fit is rejected with a 400 and nothing is created, rather than deployed with no
- * record of what it is. A deployment the console cannot describe is one nobody can later reproduce,
- * redeploy, or attach sealed secrets to, so the two are never allowed to disagree.
- *
- * This bounds the stripped document, which is a different and smaller thing than the SDL that arrived,
- * and it is checked only after that document has been parsed and re-serialized. What bounds the arriving
- * one is `MAX_SUBMITTED_SDL_LENGTH` below — not the route's body limit, which `POST /v1/deployments`
- * raises to carry a seal and which in any case bounds the whole request rather than this one field.
- *
- * Counted in characters rather than bytes, since it is compared against a JavaScript string length.
- * Sized roughly twenty times above any SDL a real deployment needs.
- */
+/** Bounds the stripped document the console keeps, in characters, and is the only thing bounding it since the column it is written to is `text`. */
 export const SDL_MAX_LENGTH = 128 * 1024;
 
-/**
- * Upper bound on the SDL a request may *submit*, as opposed to the stripped one the console keeps. It has
- * to be stated on the field rather than left to the route's body limit, because that limit bounds the
- * whole body and `POST /v1/deployments` raises it to make room for a seal — which would otherwise hand
- * every SDL the same larger allowance and put a document five times the old size through two YAML parses,
- * two manifest generations and a `js-yaml` dump before anything refused it. The anchor-bomb estimator in
- * `stripSdlSecrets` is sized against this, so raising it re-sizes that guard too.
- *
- * Held at the default allowance every route with a body has, which is exactly what bounded a submitted SDL
- * before the create route asked for more. Characters rather than bytes, to match `SDL_MAX_LENGTH` and the
- * `z.string().max` that applies it.
- */
+/** Bounds a submitted SDL on the field, because the create route's raised body limit would otherwise hand every SDL the room made for a seal. */
 export const MAX_SUBMITTED_SDL_LENGTH = DEFAULT_BODY_LIMIT_BYTES;

--- a/apps/api/src/deployment/config/sdl.config.ts
+++ b/apps/api/src/deployment/config/sdl.config.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_BODY_LIMIT_BYTES } from "@src/core/config/body-limit.config";
+
 /**
  * Upper bound on the SDL the console stores for a deployment. The column it is written to is `text`
  * and so bounds nothing itself, which makes this the only thing keeping a pathological SDL from
@@ -8,9 +10,26 @@
  * record of what it is. A deployment the console cannot describe is one nobody can later reproduce,
  * redeploy, or attach sealed secrets to, so the two are never allowed to disagree.
  *
- * Requests stay bounded separately, by the 512 KB body limit `createRoute` puts on every route that can
- * carry a body — this bounds the stripped document, which is a different thing and smaller. Counted in
- * characters rather than bytes, since it is compared against a JavaScript string length. Sized roughly
- * twenty times above any SDL a real deployment needs.
+ * This bounds the stripped document, which is a different and smaller thing than the SDL that arrived,
+ * and it is checked only after that document has been parsed and re-serialized. What bounds the arriving
+ * one is `MAX_SUBMITTED_SDL_LENGTH` below — not the route's body limit, which `POST /v1/deployments`
+ * raises to carry a seal and which in any case bounds the whole request rather than this one field.
+ *
+ * Counted in characters rather than bytes, since it is compared against a JavaScript string length.
+ * Sized roughly twenty times above any SDL a real deployment needs.
  */
 export const SDL_MAX_LENGTH = 128 * 1024;
+
+/**
+ * Upper bound on the SDL a request may *submit*, as opposed to the stripped one the console keeps. It has
+ * to be stated on the field rather than left to the route's body limit, because that limit bounds the
+ * whole body and `POST /v1/deployments` raises it to make room for a seal — which would otherwise hand
+ * every SDL the same larger allowance and put a document five times the old size through two YAML parses,
+ * two manifest generations and a `js-yaml` dump before anything refused it. The anchor-bomb estimator in
+ * `stripSdlSecrets` is sized against this, so raising it re-sizes that guard too.
+ *
+ * Held at the default allowance every route with a body has, which is exactly what bounded a submitted SDL
+ * before the create route asked for more. Characters rather than bytes, to match `SDL_MAX_LENGTH` and the
+ * `z.string().max` that applies it.
+ */
+export const MAX_SUBMITTED_SDL_LENGTH = DEFAULT_BODY_LIMIT_BYTES;

--- a/apps/api/src/deployment/http-schemas/deployment.schema.ts
+++ b/apps/api/src/deployment/http-schemas/deployment.schema.ts
@@ -2,6 +2,7 @@ import { DeploymentInfoSchema } from "@akashnetwork/http-sdk";
 import { z } from "zod";
 
 import { SignTxResponseOutputSchema } from "@src/billing/http-schemas/tx.schema";
+import { MAX_SUBMITTED_SDL_LENGTH } from "@src/deployment/config/sdl.config";
 import { openApiExampleAddress } from "@src/utils/constants";
 import { AkashAddressSchema, DseqSchema } from "@src/utils/schema";
 import { LeaseStatusResponseSchema } from "./lease.schema";
@@ -106,7 +107,11 @@ export const GetDeploymentParamsSchema = z.object({
 
 export const CreateDeploymentRequestSchema = z.object({
   data: z.object({
-    sdl: z.string(),
+    sdl: z.string().max(MAX_SUBMITTED_SDL_LENGTH),
+    sealedSecrets: z.string().optional().openapi({
+      description:
+        "Values for the `ac-secret://NAME` references in `sdl`, sealed for this account as a compact JWE whose plaintext is a flat name-to-value JSON object. Seal it against the key and claims published by GET /v1/sdl-secrets-context. Every referenced name must have a value here and every value here must be referenced, so a typo on either side is refused rather than ignored. The count of values and the size of each are both capped; a value is measured as its JSON-encoded length, so a value containing quotes, backslashes or control characters carries fewer raw bytes than one that does not. Exceeding either cap fails with a 400 naming the limit and its configured value. There is no plaintext alternative, and no endpoint ever returns a stored value."
+    }),
     deposit: z.number().optional().openapi({
       deprecated: true,
       description: "Deprecated and ignored. The platform funds every deployment automatically from your account credits."

--- a/apps/api/src/deployment/routes/deployments/deployments.router.ts
+++ b/apps/api/src/deployment/routes/deployments/deployments.router.ts
@@ -3,6 +3,7 @@ import { container } from "tsyringe";
 import { createRoute } from "@src/core/lib/create-route/create-route";
 import { OpenApiHonoHandler } from "@src/core/services/open-api-hono-handler/open-api-hono-handler";
 import { SECURITY_BEARER_OR_API_KEY, SECURITY_NONE } from "@src/core/services/openapi-docs/openapi-security";
+import { CREATE_DEPLOYMENT_BODY_LIMIT_BYTES } from "@src/deployment/config/sdl-secrets.config";
 import { DeploymentController } from "@src/deployment/controllers/deployment/deployment.controller";
 import {
   CloseDeploymentParamsSchema,
@@ -68,6 +69,8 @@ const postRoute = createRoute({
   operationId: "createDeployment",
   tags: ["Deployments"],
   security: SECURITY_BEARER_OR_API_KEY,
+  /** The only route that can carry a seal, sized so the stated secret limits are reachable rather than shadowed by the default allowance. */
+  bodyLimit: { maxSize: CREATE_DEPLOYMENT_BODY_LIMIT_BYTES },
   request: {
     body: {
       content: {

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -39,7 +39,6 @@ const COMPENSATION_JOB_ID = faker.string.uuid();
 const SEAL = `${faker.string.alphanumeric(16)}.${faker.string.alphanumeric(16)}`;
 const SEALED_TOKEN = `${faker.string.alphanumeric(16)}.${faker.string.alphanumeric(16)}`;
 
-/** A complete SDL around a service body, plus an optional placement profile nothing references. */
 function sdlAround(serviceBody: string, extraPlacement = ""): string {
   return `version: "2.0"
 services:
@@ -73,7 +72,6 @@ ${extraPlacement}deployment:
       count: 1`;
 }
 
-/** A valid SDL carrying an env value and a registry password, so a test can look for them afterwards. */
 const SDL_WITH_SECRETS = sdlAround(`    credentials:
       host: registry.example.test
       username: registry-user
@@ -82,26 +80,15 @@ const SDL_WITH_SECRETS = sdlAround(`    credentials:
       - API_TOKEN=${ENV_VALUE}
 `);
 
-/**
- * The shape that turns a small request into an enormous document: one anchored scalar aliased many
- * times over. js-yaml loads every alias back as an independent string, so serializing writes the
- * scalar out in full each time.
- */
 const SDL_ALIASING_ONE_SCALAR = sdlAround(`    args:
       - &payload ${ALIASED_FILLER}
 ${Array.from({ length: 511 }, () => "      - *payload").join("\n")}
 `);
 
-/** An SDL with no anchors at all whose serialized length alone puts it past what the console stores. */
 const SDL_TOO_LONG_WITHOUT_ALIASES = sdlAround(`    args:
 ${Array.from({ length: 40 }, () => `      - ${"z".repeat(4096)}`).join("\n")}
 `);
 
-/**
- * The other shape, and the one that costs the most to measure: aliases pointing at aliases, doubling
- * the node count per level. It hides under an unreferenced placement profile's `attributes`, the SDL's
- * one free-form position, where the manifest generator never looks — 1.3 KB expanding to 2^24 elements.
- */
 const SDL_ALIASING_A_DAG = sdlAround(
   "",
   `    unused:
@@ -383,11 +370,12 @@ describe(DeploymentWriterService.name, () => {
       expect(sdlSecretsService.receive).not.toHaveBeenCalled();
     });
 
-    it("seals nothing and writes no data key for a request whose deposit it refuses", async () => {
+    it("opens no seal, seals nothing and writes no data key for a request whose deposit it refuses", async () => {
       const { service, sdlSecretsService, deploymentSettingRepository } = setup({ isManagedDepositEnabled: false });
 
       await expect(service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, sealedSecrets: SEAL })).rejects.toMatchObject({ status: 400 });
 
+      expect(sdlSecretsService.receive).not.toHaveBeenCalled();
       expect(sdlSecretsService.sealForStorage).not.toHaveBeenCalled();
       expect(deploymentSettingRepository.upsertDefinition).not.toHaveBeenCalled();
     });
@@ -1017,7 +1005,6 @@ describe(DeploymentWriterService.name, () => {
     return sdl as string;
   }
 
-  /** Everything the logger was handed, flattened, so a test can assert the sdl reached none of it. */
   function loggedTextOf(logger: MockProxy<ReturnType<CreateLogger>>): string {
     return [logger.error, logger.warn, logger.info, logger.debug]
       .flatMap(method => method.mock.calls)

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -1,7 +1,7 @@
 import { DeploymentReclamation, MsgAccountDeposit } from "@akashnetwork/chain-sdk/private-types/akash.v1";
 import { MsgCloseDeployment, MsgCreateDeployment, MsgUpdateDeployment } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
 import { faker } from "@faker-js/faker";
-import { NotFound } from "http-errors";
+import createError, { NotFound } from "http-errors";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { mock, type MockProxy } from "vitest-mock-extended";
 
@@ -18,6 +18,7 @@ import type { DeploymentResponse } from "@src/deployment/http-schemas/deployment
 import type { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import { DeleteUnbackedDeploymentSetting } from "@src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler";
 import type { SdlService } from "@src/deployment/services/sdl/sdl.service";
+import type { ReceivedSdlSecrets, SdlSecretsService } from "@src/deployment/services/sdl-secrets/sdl-secrets.service";
 import type { ProviderService } from "@src/provider/services/provider/provider.service";
 import type { DeploymentConfigService } from "../deployment-config/deployment-config.service";
 import type { DeploymentReaderService } from "../deployment-reader/deployment-reader.service";
@@ -35,6 +36,8 @@ const RETRY_LIMIT = 47;
 const RETRY_DELAY_MAX_IN_MIN = 30;
 const RETRY_DELAY_IN_SEC = 30;
 const COMPENSATION_JOB_ID = faker.string.uuid();
+const SEAL = `${faker.string.alphanumeric(16)}.${faker.string.alphanumeric(16)}`;
+const SEALED_TOKEN = `${faker.string.alphanumeric(16)}.${faker.string.alphanumeric(16)}`;
 
 /** A complete SDL around a service body, plus an optional placement profile nothing references. */
 function sdlAround(serviceBody: string, extraPlacement = ""): string {
@@ -131,6 +134,8 @@ describe(DeploymentWriterService.name, () => {
     groups: [{ name: "resolved-group" }],
     groupSpecs: [{ name: "resolved-group", resources: [] }]
   };
+
+  const parsedSdlValue = { services: { web: { image: "nginx" } } };
 
   const deploymentData: DeploymentResponse = {
     deployment: {
@@ -269,8 +274,196 @@ describe(DeploymentWriterService.name, () => {
         dseq: "1748400000000",
         sdl: expect.stringContaining("API_TOKEN="),
         manifestVersion: "BAUG",
+        sealedSecrets: null,
         runtimeLimitHours: undefined
       });
+    });
+
+    it("passes the seal and the sdl exactly as they arrived to the intake", async () => {
+      const { service, sdlSecretsService } = setup();
+
+      await service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, sealedSecrets: SEAL, deposit: 5 });
+
+      expect(sdlSecretsService.receive).toHaveBeenCalledWith({ sdl: parsedSdlValue, rawSdl: SDL_WITH_SECRETS, sealedSecrets: SEAL });
+    });
+
+    it("resolves the manifest from the values the intake handed back", async () => {
+      const byService = { web: { TOKEN: "resolved" } };
+      const { service, sdlService } = setup({ received: { supplied: { TOKEN: "resolved" }, byService } });
+
+      await service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, sealedSecrets: SEAL, deposit: 5 });
+
+      expect(sdlService.generateResolvedManifest).toHaveBeenCalledWith(expect.objectContaining({ secrets: byService }));
+    });
+
+    it("seals what the client supplied against the dseq it just minted", async () => {
+      const supplied = { TOKEN: "resolved" };
+      const { service, sdlSecretsService } = setup({ received: { supplied, byService: { web: supplied } } });
+      vi.spyOn(Date, "now").mockReturnValue(1748400000000);
+
+      await service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, sealedSecrets: SEAL, deposit: 5 });
+
+      expect(sdlSecretsService.sealForStorage).toHaveBeenCalledWith({ userId: wallet.userId, dseq: "1748400000000", secrets: supplied });
+    });
+
+    it("records the sealed token in the same write as the sdl it belongs to", async () => {
+      const { service, deploymentSettingRepository } = setup({ sealedSecrets: SEALED_TOKEN });
+
+      await service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, sealedSecrets: SEAL, deposit: 5 });
+
+      expect(deploymentSettingRepository.upsertDefinition).toHaveBeenCalledWith(
+        expect.objectContaining({ sealedSecrets: SEALED_TOKEN, sdl: expect.stringContaining("API_TOKEN=") })
+      );
+    });
+
+    it("states an absent token rather than leaving it unnamed, so a retry cannot inherit one", async () => {
+      const { service, deploymentSettingRepository } = setup({ sealedSecrets: null });
+
+      await service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, deposit: 5 });
+
+      expect(deploymentSettingRepository.upsertDefinition).toHaveBeenCalledWith(expect.objectContaining({ sealedSecrets: null }));
+    });
+
+    it("seals once for the whole create", async () => {
+      const supplied = Object.fromEntries(Array.from({ length: 12 }, (_, index) => [`SECRET_${index}`, "value"]));
+      const { service, sdlSecretsService } = setup({ received: { supplied, byService: { web: supplied, worker: supplied } } });
+
+      await service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, sealedSecrets: SEAL, deposit: 5 });
+
+      expect(sdlSecretsService.sealForStorage).toHaveBeenCalledOnce();
+    });
+
+    it("seals only after the manifest the chain commits to has been hashed", async () => {
+      const order: string[] = [];
+      const { service, sdlService, sdlSecretsService } = setup();
+      sdlService.generateResolvedManifest.mockImplementation(async () => {
+        order.push("resolve");
+        return { ok: true, value: { manifest: resolvedManifestValue, manifestVersion: new Uint8Array([4, 5, 6]) } } as any;
+      });
+      sdlSecretsService.sealForStorage.mockImplementation(async () => {
+        order.push("seal");
+        return SEALED_TOKEN;
+      });
+
+      await service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, sealedSecrets: SEAL, deposit: 5 });
+
+      expect(order).toEqual(["resolve", "seal"]);
+    });
+
+    it("seals before the record and its compensation are written", async () => {
+      const order: string[] = [];
+      const { service, sdlSecretsService, txService } = setup();
+      sdlSecretsService.sealForStorage.mockImplementation(async () => {
+        order.push("seal");
+        return SEALED_TOKEN;
+      });
+      txService.transaction.mockImplementation(async cb => {
+        order.push("transaction");
+        return await cb();
+      });
+
+      await service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, sealedSecrets: SEAL, deposit: 5 });
+
+      expect(order).toEqual(["seal", "transaction"]);
+    });
+
+    it("refuses an sdl too large to store before reading the wallet or opening the seal", async () => {
+      const { service, walletReaderService, sdlSecretsService, sdlService } = setup();
+
+      await expect(
+        service.create({
+          userId: "user-1",
+          sdl: sdlAround(`    args:\n${Array.from({ length: 40 }, () => `      - ${ALIASED_FILLER}`).join("\n")}\n`),
+          deposit: 5
+        })
+      ).rejects.toMatchObject({ status: 400 });
+
+      expect(walletReaderService.getWalletByUserId).not.toHaveBeenCalled();
+      expect(sdlService.generateManifest).not.toHaveBeenCalled();
+      expect(sdlSecretsService.receive).not.toHaveBeenCalled();
+    });
+
+    it("seals nothing and writes no data key for a request whose deposit it refuses", async () => {
+      const { service, sdlSecretsService, deploymentSettingRepository } = setup({ isManagedDepositEnabled: false });
+
+      await expect(service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, sealedSecrets: SEAL })).rejects.toMatchObject({ status: 400 });
+
+      expect(sdlSecretsService.sealForStorage).not.toHaveBeenCalled();
+      expect(deploymentSettingRepository.upsertDefinition).not.toHaveBeenCalled();
+    });
+
+    it("mints no dseq for a request the intake refuses", async () => {
+      const { service, sdlSecretsService } = setup();
+      sdlSecretsService.receive.mockResolvedValue({ ok: false, value: [{ message: "no value supplied" } as any] });
+      const now = vi.spyOn(Date, "now");
+
+      await expect(service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, deposit: 5 })).rejects.toMatchObject({ status: 400 });
+
+      expect(now).not.toHaveBeenCalled();
+    });
+
+    it("names what the intake refused in the 400 it answers", async () => {
+      const { service, sdlSecretsService } = setup();
+      sdlSecretsService.receive.mockResolvedValue({
+        ok: false,
+        value: [{ message: 'a value was supplied for "TYPOED" but no service\'s SDL references it' } as any]
+      });
+
+      await expect(service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, sealedSecrets: SEAL, deposit: 5 })).rejects.toMatchObject({
+        status: 400,
+        message: 'Invalid SDL: a value was supplied for "TYPOED" but no service\'s SDL references it'
+      });
+    });
+
+    it("records nothing, seals nothing and broadcasts nothing for a request the intake refuses", async () => {
+      const { service, sdlSecretsService, deploymentSettingRepository, signerService, txService } = setup();
+      sdlSecretsService.receive.mockResolvedValue({ ok: false, value: [{ message: "no value supplied" } as any] });
+
+      await expect(service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, deposit: 5 })).rejects.toThrow();
+
+      expect(sdlSecretsService.sealForStorage).not.toHaveBeenCalled();
+      expect(txService.transaction).not.toHaveBeenCalled();
+      expect(deploymentSettingRepository.upsertDefinition).not.toHaveBeenCalled();
+      expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
+    });
+
+    it("records nothing and broadcasts nothing for a seal the intake throws on", async () => {
+      const { service, sdlSecretsService, deploymentSettingRepository, signerService } = setup();
+      sdlSecretsService.receive.mockRejectedValue(createError(400, "At most 100 secrets may be supplied for one deployment"));
+
+      await expect(service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, sealedSecrets: SEAL, deposit: 5 })).rejects.toMatchObject({ status: 400 });
+
+      expect(deploymentSettingRepository.upsertDefinition).not.toHaveBeenCalled();
+      expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
+    });
+
+    it("answers 400 for an sdl the intake cannot be handed because it does not parse", async () => {
+      const { service, sdlService, sdlSecretsService } = setup();
+      sdlService.parse.mockReturnValue({ ok: false, value: [{ message: "bad indentation" }] } as any);
+
+      await expect(service.create({ userId: "user-1", sdl: "bad-sdl", deposit: 5 })).rejects.toMatchObject({
+        status: 400,
+        message: "Invalid SDL: bad indentation"
+      });
+      expect(sdlSecretsService.receive).not.toHaveBeenCalled();
+    });
+
+    it("says nothing about a supplied value in what it logs", async () => {
+      const { service, logger } = setup({ received: { supplied: { TOKEN: ENV_VALUE }, byService: { web: { TOKEN: ENV_VALUE } } } });
+
+      await service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, sealedSecrets: SEAL, deposit: 5 });
+
+      expect(loggedTextOf(logger)).not.toContain(ENV_VALUE);
+    });
+
+    it("says whether a token was written rather than what it was when persistence fails", async () => {
+      const { service, deploymentSettingRepository, logger } = setup({ sealedSecrets: SEALED_TOKEN });
+      deploymentSettingRepository.upsertDefinition.mockRejectedValue(new Error("write failed"));
+
+      await expect(service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, sealedSecrets: SEAL, deposit: 5 })).rejects.toThrow();
+
+      expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "DEPLOYMENT_DEFINITION_PERSISTENCE_FAILED", hasSealedSecrets: true }));
+      expect(loggedTextOf(logger)).not.toContain(SEALED_TOKEN);
     });
 
     it("records an sdl carrying none of the submitted env values", async () => {
@@ -844,6 +1037,8 @@ describe(DeploymentWriterService.name, () => {
     transactionRuns?: boolean;
     compensationEnqueued?: boolean;
     manifestVersion?: Uint8Array;
+    received?: ReceivedSdlSecrets;
+    sealedSecrets?: string | null;
   }) {
     const signerService = mock<ManagedSignerService>();
     const rpcMessageService = mock<RpcMessageService>();
@@ -873,7 +1068,12 @@ describe(DeploymentWriterService.name, () => {
     const jobQueueService = mock<JobQueueService>();
     jobQueueService.enqueue.mockResolvedValue(input?.compensationEnqueued === false ? null : COMPENSATION_JOB_ID);
 
+    const sdlSecretsService = mock<SdlSecretsService>();
+    sdlSecretsService.receive.mockResolvedValue({ ok: true, value: input?.received ?? { supplied: {}, byService: {} } });
+    sdlSecretsService.sealForStorage.mockResolvedValue(input?.sealedSecrets ?? null);
+
     walletReaderService.getWalletByUserId.mockResolvedValue(wallet);
+    sdlService.parse.mockReturnValue({ ok: true, value: parsedSdlValue } as any);
     sdlService.generateManifest.mockReturnValue({ ok: true, value: manifestValue } as any);
     sdlService.generateManifestVersion.mockResolvedValue(new Uint8Array([4, 5, 6]));
     sdlService.generateResolvedManifest.mockResolvedValue({
@@ -896,7 +1096,8 @@ describe(DeploymentWriterService.name, () => {
       featureFlagsService,
       deploymentSettingRepository,
       txService,
-      jobQueueService
+      jobQueueService,
+      sdlSecretsService
     );
 
     return {
@@ -915,7 +1116,8 @@ describe(DeploymentWriterService.name, () => {
       featureFlagsService,
       deploymentSettingRepository,
       txService,
-      jobQueueService
+      jobQueueService,
+      sdlSecretsService
     };
   }
 });

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -57,27 +57,18 @@ export class DeploymentWriterService {
     this.logger = createLogger({ context: DeploymentWriterService.name });
   }
 
-  /**
-   * Ordered so that a broadcast can never outrun the secrets it needs: validate, mint the dseq, resolve
-   * in memory, hash the manifest, persist in one statement, then broadcast. The dseq is minted only once
-   * nothing can still refuse the request, because the token written below names it and a client sealing
-   * before the deployment exists cannot.
-   *
-   * Cheapest refusals first, and the stripped document is the cheapest of them: it is the only guard on
-   * an SDL that is small on the wire and enormous once re-serialized, so it runs before the wallet read,
-   * before the manifest is generated and before the seal spends a key-service call.
-   */
+  /** The dseq is minted only once nothing can still refuse the request, because the token written below names it and a client sealing beforehand cannot. */
   public async create(input: CreateDeploymentRequest["data"] & { userId: string }): Promise<CreateDeploymentResponse["data"]> {
     /** SDL for storage ONLY, stripped of every env value that is not a reference to one */
     const sdl = this.#strippedSdlWithinLimit(input.sdl);
 
     const wallet = await this.walletReaderService.getWalletByUserId(input.userId);
     const manifest = this.#parseManifest(input.sdl, { isTrialing: !!wallet.isTrialing });
+    const depositInDollars = this.resolveDepositInDollars(input.deposit);
     const secrets = await this.#receiveSecrets(input);
 
     const dseq = Date.now();
     const { manifestVersion } = await this.#resolveSdl(input.sdl, { secrets: secrets.byService, isTrialing: !!wallet.isTrialing });
-    const depositInDollars = this.resolveDepositInDollars(input.deposit);
     const sealedSecrets = await this.sdlSecretsService.sealForStorage({ userId: wallet.userId, dseq: dseq.toString(), secrets: secrets.supplied });
 
     if (wallet.isTrialing) {
@@ -310,11 +301,7 @@ export class DeploymentWriterService {
     return { manifestVersion: result.value.manifestVersion };
   }
 
-  /**
-   * Opens the request's seal and checks it against the SDL both ways, before the dseq exists and before
-   * anything is written. Reports through the same channel every other reference mistake uses, so a
-   * missing value reads identically whether the intake or substitution found it.
-   */
+  /** Reports through the same channel every other reference mistake uses, so a missing value reads identically whether the intake or substitution found it. */
   async #receiveSecrets(input: CreateDeploymentRequest["data"]): Promise<ReceivedSdlSecrets> {
     const parsed = this.sdlService.parse(input.sdl);
 

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -1,3 +1,4 @@
+import type { ValidationError } from "@akashnetwork/chain-sdk";
 import { manifestToSortedJSON } from "@akashnetwork/chain-sdk";
 import { addMinutes } from "date-fns";
 import { HTTPException } from "hono/http-exception";
@@ -22,6 +23,9 @@ import {
 } from "@src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler";
 import type { ResolvedSdl } from "@src/deployment/services/sdl/sdl.service";
 import { SdlService } from "@src/deployment/services/sdl/sdl.service";
+import type { NamespacedSdlSecrets } from "@src/deployment/services/sdl-reference/sdl-reference.service";
+import type { ReceivedSdlSecrets } from "@src/deployment/services/sdl-secrets/sdl-secrets.service";
+import { SdlSecretsService } from "@src/deployment/services/sdl-secrets/sdl-secrets.service";
 import { stripSdlSecrets } from "@src/deployment/utils/sdl-secret-stripping/sdl-secret-stripping";
 import { ProviderService } from "@src/provider/services/provider/provider.service";
 import { denomToUdenom } from "@src/utils/math";
@@ -47,20 +51,34 @@ export class DeploymentWriterService {
     private readonly featureFlagsService: FeatureFlagsService,
     private readonly deploymentSettingRepository: DeploymentSettingRepository,
     private readonly txService: TxService,
-    private readonly jobQueueService: JobQueueService
+    private readonly jobQueueService: JobQueueService,
+    private readonly sdlSecretsService: SdlSecretsService
   ) {
     this.logger = createLogger({ context: DeploymentWriterService.name });
   }
 
+  /**
+   * Ordered so that a broadcast can never outrun the secrets it needs: validate, mint the dseq, resolve
+   * in memory, hash the manifest, persist in one statement, then broadcast. The dseq is minted only once
+   * nothing can still refuse the request, because the token written below names it and a client sealing
+   * before the deployment exists cannot.
+   *
+   * Cheapest refusals first, and the stripped document is the cheapest of them: it is the only guard on
+   * an SDL that is small on the wire and enormous once re-serialized, so it runs before the wallet read,
+   * before the manifest is generated and before the seal spends a key-service call.
+   */
   public async create(input: CreateDeploymentRequest["data"] & { userId: string }): Promise<CreateDeploymentResponse["data"]> {
-    const dseq = Date.now();
-    /** SDL for storage ONLY, stripped of secrets */
-    const sdl = this.#strippedSdlWithinLimit(input.sdl, dseq.toString());
+    /** SDL for storage ONLY, stripped of every env value that is not a reference to one */
+    const sdl = this.#strippedSdlWithinLimit(input.sdl);
 
     const wallet = await this.walletReaderService.getWalletByUserId(input.userId);
     const manifest = this.#parseManifest(input.sdl, { isTrialing: !!wallet.isTrialing });
-    const { manifestVersion } = await this.#resolveSdl(input.sdl, { isTrialing: !!wallet.isTrialing });
+    const secrets = await this.#receiveSecrets(input);
+
+    const dseq = Date.now();
+    const { manifestVersion } = await this.#resolveSdl(input.sdl, { secrets: secrets.byService, isTrialing: !!wallet.isTrialing });
     const depositInDollars = this.resolveDepositInDollars(input.deposit);
+    const sealedSecrets = await this.sdlSecretsService.sealForStorage({ userId: wallet.userId, dseq: dseq.toString(), secrets: secrets.supplied });
 
     if (wallet.isTrialing) {
       await this.reclaimTrialOrphanedDeployments(wallet);
@@ -72,6 +90,7 @@ export class DeploymentWriterService {
       dseq: dseq.toString(),
       sdl,
       manifestVersion,
+      sealedSecrets,
       runtimeLimitHours: input.runtimeLimitHours
     });
 
@@ -103,6 +122,7 @@ export class DeploymentWriterService {
     dseq: string;
     sdl: string;
     manifestVersion: Uint8Array;
+    sealedSecrets?: string | null;
     runtimeLimitHours?: number;
   }): Promise<void> {
     const { owner, ...definition } = input;
@@ -142,6 +162,7 @@ export class DeploymentWriterService {
     dseq: string;
     sdl: string;
     manifestVersion: Uint8Array;
+    sealedSecrets?: string | null;
     runtimeLimitHours?: number;
   }): Promise<string> {
     const { manifestVersion, ...rest } = input;
@@ -152,13 +173,14 @@ export class DeploymentWriterService {
         manifestVersion: Buffer.from(manifestVersion).toString("base64")
       });
     } catch (error) {
-      const { sdl, ...loggable } = rest;
-      this.logger.error({ event: "DEPLOYMENT_DEFINITION_PERSISTENCE_FAILED", ...loggable, error });
+      const { sdl, sealedSecrets, ...loggable } = rest;
+      this.logger.error({ event: "DEPLOYMENT_DEFINITION_PERSISTENCE_FAILED", ...loggable, hasSealedSecrets: !!sealedSecrets, error });
       throw error;
     }
   }
 
-  #strippedSdlWithinLimit(submittedSdl: string, dseq: string): string {
+  /** `dseq` is a log field only, so a create can run this before minting one and still say which request it refused. */
+  #strippedSdlWithinLimit(submittedSdl: string, dseq?: string): string {
     const { sdl, length, error } = stripSdlSecrets(submittedSdl, SDL_MAX_LENGTH);
 
     if (sdl === null) {
@@ -278,14 +300,39 @@ export class DeploymentWriterService {
   }
 
   /** Only the manifest version is taken from the resolved SDL: the resolved manifest itself must not leave this call. Runs before any lookup so a bad reference always answers 400 rather than racing a 404. */
-  async #resolveSdl(sdl: string, options: { isTrialing?: boolean }): Promise<Pick<ResolvedSdl, "manifestVersion">> {
-    const result = await this.sdlService.generateResolvedManifest({ sdl, secrets: {}, ...options });
+  async #resolveSdl(sdl: string, options: { secrets?: NamespacedSdlSecrets; isTrialing?: boolean }): Promise<Pick<ResolvedSdl, "manifestVersion">> {
+    const result = await this.sdlService.generateResolvedManifest({ sdl, ...options, secrets: options.secrets ?? {} });
 
     if (!result.ok) {
-      throw createError(400, `Invalid SDL: ${result.value.map(error => error.message).join(", ")}`);
+      throw this.#rejectInvalidSdl(result.value);
     }
 
     return { manifestVersion: result.value.manifestVersion };
+  }
+
+  /**
+   * Opens the request's seal and checks it against the SDL both ways, before the dseq exists and before
+   * anything is written. Reports through the same channel every other reference mistake uses, so a
+   * missing value reads identically whether the intake or substitution found it.
+   */
+  async #receiveSecrets(input: CreateDeploymentRequest["data"]): Promise<ReceivedSdlSecrets> {
+    const parsed = this.sdlService.parse(input.sdl);
+
+    if (!parsed.ok) {
+      throw this.#rejectInvalidSdl(parsed.value);
+    }
+
+    const received = await this.sdlSecretsService.receive({ sdl: parsed.value, rawSdl: input.sdl, sealedSecrets: input.sealedSecrets });
+
+    if (!received.ok) {
+      throw this.#rejectInvalidSdl(received.value);
+    }
+
+    return received.value;
+  }
+
+  #rejectInvalidSdl(errors: ValidationError[]) {
+    return createError(400, `Invalid SDL: ${errors.map(error => error.message).join(", ")}`);
   }
 
   private async ensureDeploymentIsUpToDate(wallet: UserWalletOutput, dseq: string, manifestVersion: Uint8Array, deployment: DeploymentResponse): Promise<void> {

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -6965,6 +6965,11 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                         "type": "integer",
                       },
                       "sdl": {
+                        "maxLength": 524288,
+                        "type": "string",
+                      },
+                      "sealedSecrets": {
+                        "description": "Values for the \`ac-secret://NAME\` references in \`sdl\`, sealed for this account as a compact JWE whose plaintext is a flat name-to-value JSON object. Seal it against the key and claims published by GET /v1/sdl-secrets-context. Every referenced name must have a value here and every value here must be referenced, so a typo on either side is refused rather than ignored. The count of values and the size of each are both capped; a value is measured as its JSON-encoded length, so a value containing quotes, backslashes or control characters carries fewer raw bytes than one that does not. Exceeding either cap fails with a 400 naming the limit and its configured value. There is no plaintext alternative, and no endpoint ever returns a stored value.",
                         "type": "string",
                       },
                     },

--- a/apps/api/test/functional/deployment-sealed-secrets.spec.ts
+++ b/apps/api/test/functional/deployment-sealed-secrets.spec.ts
@@ -1,0 +1,496 @@
+import type { SDLInput } from "@akashnetwork/chain-sdk";
+import { generateManifest, generateManifestVersion, yaml } from "@akashnetwork/chain-sdk";
+import { faker } from "@faker-js/faker";
+import type { protos } from "@google-cloud/kms";
+import crc32c from "fast-crc32c";
+import { CompactEncrypt, decodeProtectedHeader } from "jose";
+import nock from "nock";
+import { constants, generateKeyPairSync, privateDecrypt, randomUUID } from "node:crypto";
+import { container } from "tsyringe";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import { startJobQueues } from "@src/app/providers/jobs.provider";
+import { ApiKeyAuthService } from "@src/auth/services/api-key/api-key-auth.service";
+import { AuthService } from "@src/auth/services/auth.service";
+import type { UserWalletOutput } from "@src/billing/repositories";
+import { UserWalletRepository } from "@src/billing/repositories";
+import { ManagedSignerService } from "@src/billing/services";
+import { BlockHttpService } from "@src/chain/services/block-http/block-http.service";
+import { ExecutionContextService } from "@src/core/services/execution-context/execution-context.service";
+import { MAX_SUBMITTED_SDL_LENGTH } from "@src/deployment/config/sdl.config";
+import { SDL_SECRETS_CONTENT_ENCRYPTION, SDL_SECRETS_SEAL_ALGORITHM } from "@src/deployment/config/sdl-secrets.config";
+import type { SdlSecretsKmsClient, SdlSecretsKmsTarget } from "@src/deployment/providers/kms.provider";
+import { SDL_SECRETS_KMS_TARGET } from "@src/deployment/providers/kms.provider";
+import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import { SdlSecretsSealingKeyService } from "@src/deployment/services/sdl-secrets-sealing-key/sdl-secrets-sealing-key.service";
+import { app } from "@src/rest-app";
+import { SecretCipherService } from "@src/secret/services/secret-cipher/secret-cipher.service";
+import type { UserOutput } from "@src/user/repositories";
+import { UserRepository } from "@src/user/repositories";
+
+import { createApiKey } from "@test/seeders/api-key.seeder";
+import { createUser } from "@test/seeders/user.seeder";
+import { createUserWallet } from "@test/seeders/user-wallet.seeder";
+
+const KID = "sdl-secrets.v1";
+const VERSION_NAME = "projects/console-test/locations/global/keyRings/console-api/cryptoKeys/sdl-secrets/cryptoKeyVersions/1";
+const MAX_VALUE_BYTES = 16 * 1024;
+const MAX_COUNT = 100;
+
+/**
+ * The Cloud KMS key is the one third-party boundary this path crosses, so it is doubled here with a
+ * real RSA key rather than reached over the network. The interface exists to be doubled; registering it
+ * at module scope means nothing has resolved the real target before the first request.
+ */
+const { publicKey, privateKey } = generateKeyPairSync("rsa", { modulusLength: 3072 });
+const publicKeyPem = publicKey.export({ type: "spki", format: "pem" }).toString();
+const kmsClient = mock<SdlSecretsKmsClient>();
+kmsClient.getPublicKey.mockResolvedValue([
+  { name: VERSION_NAME, pem: publicKeyPem, pemCrc32c: { value: String(crc32c.calculate(publicKeyPem)) }, algorithm: "RSA_DECRYPT_OAEP_3072_SHA256" }
+]);
+kmsClient.asymmetricDecrypt.mockImplementation(async request => {
+  const plaintext = privateDecrypt({ key: privateKey, padding: constants.RSA_PKCS1_OAEP_PADDING, oaepHash: "sha256" }, Buffer.from(request.ciphertext));
+
+  return [
+    {
+      plaintext,
+      plaintextCrc32c: { value: String(crc32c.calculate(plaintext)) },
+      verifiedCiphertextCrc32c: true
+    } satisfies protos.google.cloud.kms.v1.IAsymmetricDecryptResponse
+  ];
+});
+
+container.register<SdlSecretsKmsTarget>(SDL_SECRETS_KMS_TARGET, { useValue: { client: kmsClient, versionName: VERSION_NAME, kid: KID } });
+
+function sdlWith(services: Record<string, string[]>) {
+  const bodies = Object.entries(services)
+    .map(([name, env]) => `  ${name}:\n    image: nginx\n    env:\n${env.map(entry => `      - ${JSON.stringify(entry)}\n`).join("")}`)
+    .join("");
+  const computes = Object.keys(services)
+    .map(
+      name =>
+        `    ${name}:\n      resources:\n        cpu:\n          units: 0.1\n        memory:\n          size: 128Mi\n        storage:\n          - size: 128Mi\n`
+    )
+    .join("");
+  const pricing = Object.keys(services)
+    .map(name => `        ${name}:\n          denom: uakt\n          amount: 1000\n`)
+    .join("");
+  const groups = Object.keys(services)
+    .map(name => `  ${name}:\n    dcloud:\n      profile: ${name}\n      count: 1\n`)
+    .join("");
+
+  return `version: "2.0"\nservices:\n${bodies}profiles:\n  compute:\n${computes}  placement:\n    dcloud:\n      pricing:\n${pricing}deployment:\n${groups}`;
+}
+
+describe("Deployment sealed secrets", () => {
+  const userRepository = container.resolve(UserRepository);
+  const apiKeyAuthService = container.resolve(ApiKeyAuthService);
+  const userWalletRepository = container.resolve(UserWalletRepository);
+  const blockHttpService = container.resolve(BlockHttpService);
+  const signerService = container.resolve(ManagedSignerService);
+  const deploymentSettingRepository = container.resolve(DeploymentSettingRepository);
+
+  let knownUsers: Record<string, UserOutput>;
+  let knownApiKeys: Record<string, ReturnType<typeof createApiKey>>;
+  let knownWallets: Record<string, UserWalletOutput[]>;
+
+  beforeAll(async () => {
+    await startJobQueues();
+    await warmSealingKeyAsBootWould();
+  }, 20_000);
+
+  beforeEach(() => {
+    knownUsers = {};
+    knownApiKeys = {};
+    knownWallets = {};
+
+    vi.spyOn(userRepository, "findById").mockImplementation(async id =>
+      knownUsers[id] ? { ...knownUsers[id], trial: false, userWallets: { isTrialing: false } } : undefined
+    );
+    vi.spyOn(apiKeyAuthService, "getAndValidateApiKeyFromHeader").mockImplementation(async key => knownApiKeys[key!]);
+    vi.spyOn(blockHttpService, "getCurrentHeight").mockResolvedValue(faker.number.int({ min: 1000000, max: 10000000 }));
+    vi.spyOn(userWalletRepository, "accessibleBy").mockReturnValue({
+      findByUserId: async (id: string) => knownWallets[id],
+      findOneByUserId: async (id: string) => knownWallets[id][0]
+    } as unknown as UserWalletRepository);
+    vi.spyOn(signerService, "executeDerivedDecodedTxByUserId").mockResolvedValue({
+      code: 200,
+      transactionHash: "fake-transaction-hash",
+      hash: "fake-transaction-hash",
+      rawLog: "fake-raw-log"
+    });
+    kmsClient.asymmetricDecrypt.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    nock.cleanAll();
+  });
+
+  afterAll(async () => {
+    await container.dispose();
+    vi.restoreAllMocks();
+    nock.cleanAll();
+  });
+
+  it("commits the manifest version of a manifest carrying the resolved values", async () => {
+    const { apiKey } = await persistedUser();
+    const token = randomUUID();
+    const sdl = sdlWith({ web: ["API_TOKEN=ac-secret://API_TOKEN"] });
+
+    const response = await postDeployment(apiKey, sdl, { API_TOKEN: token });
+
+    expect(response.status).toBe(201);
+    expect(broadcastHash()).toEqual(await manifestVersionOf(sdlWith({ web: [`API_TOKEN=${token}`] })));
+  });
+
+  it("resolves one supplied value into every service that references it", async () => {
+    const { apiKey } = await persistedUser();
+    const token = randomUUID();
+    const referencing = { web: ["API_TOKEN=ac-secret://API_TOKEN"], worker: ["API_TOKEN=ac-secret://API_TOKEN"] };
+    const inline = { web: [`API_TOKEN=${token}`], worker: [`API_TOKEN=${token}`] };
+
+    const response = await postDeployment(apiKey, sdlWith(referencing), { API_TOKEN: token });
+
+    expect(response.status).toBe(201);
+    expect(broadcastHash()).toEqual(await manifestVersionOf(sdlWith(inline)));
+  });
+
+  it("resolves each service's own reference into its own environment", async () => {
+    const { apiKey } = await persistedUser();
+    const [token, url] = [randomUUID(), randomUUID()];
+    const referencing = { web: ["API_TOKEN=ac-secret://API_TOKEN"], worker: ["DATABASE_URL=ac-secret://DATABASE_URL"] };
+    const inline = { web: [`API_TOKEN=${token}`], worker: [`DATABASE_URL=${url}`] };
+
+    const response = await postDeployment(apiKey, sdlWith(referencing), { API_TOKEN: token, DATABASE_URL: url });
+
+    expect(response.status).toBe(201);
+    expect(broadcastHash()).toEqual(await manifestVersionOf(sdlWith(inline)));
+  });
+
+  it("commits a version that differs from the version of the unresolved sdl", async () => {
+    const { apiKey } = await persistedUser();
+    const sdl = sdlWith({ web: ["API_TOKEN=ac-secret://API_TOKEN"] });
+
+    await postDeployment(apiKey, sdl, { API_TOKEN: randomUUID() });
+
+    expect(broadcastHash()).not.toEqual(await manifestVersionOf(sdl));
+  });
+
+  it("records the version it committed on chain", async () => {
+    const { apiKey, user } = await persistedUser();
+
+    const response = await postDeployment(apiKey, sdlWith({ web: ["API_TOKEN=ac-secret://API_TOKEN"] }), { API_TOKEN: randomUUID() });
+
+    const setting = await settingOf(user, response);
+    expect(Buffer.from(setting!.manifestVersion!, "base64")).toEqual(Buffer.from(broadcastHash()));
+  });
+
+  it("returns no secret value, in the manifest it hands back or anywhere else in the body", async () => {
+    const { apiKey } = await persistedUser();
+    const token = randomUUID();
+
+    const response = await postDeployment(apiKey, sdlWith({ web: ["API_TOKEN=ac-secret://API_TOKEN"] }), { API_TOKEN: token });
+    const body = await response.text();
+
+    expect(response.status).toBe(201);
+    expect(body).not.toContain(token);
+    expect(body).toContain("ac-secret://API_TOKEN");
+  });
+
+  it("stores an sdl that keeps the reference and carries no value", async () => {
+    const { apiKey, user } = await persistedUser();
+    const token = randomUUID();
+
+    const response = await postDeployment(apiKey, sdlWith({ web: ["API_TOKEN=ac-secret://API_TOKEN"] }), { API_TOKEN: token });
+
+    const setting = await settingOf(user, response);
+    expect(setting!.sdl).toContain("API_TOKEN=ac-secret://API_TOKEN");
+    expect(setting!.sdl).not.toContain(token);
+  });
+
+  it("stores a token bound to its owner and the deployment it was supplied for", async () => {
+    const { apiKey, user } = await persistedUser();
+
+    const response = await postDeployment(apiKey, sdlWith({ web: ["API_TOKEN=ac-secret://API_TOKEN"] }), { API_TOKEN: randomUUID() });
+
+    const setting = await settingOf(user, response);
+    expect(decodeProtectedHeader(setting!.sealedSecrets!)).toMatchObject({ sub: user.id, dseq: setting!.dseq, alg: "dir", enc: "A256GCM" });
+  });
+
+  it("stores a token that is not the one the client sent", async () => {
+    const { apiKey, user } = await persistedUser();
+    const secrets = { API_TOKEN: randomUUID() };
+    const seal = await sealFor(user, secrets);
+
+    const response = await postDeployment(apiKey, sdlWith({ web: ["API_TOKEN=ac-secret://API_TOKEN"] }), secrets, seal);
+
+    const setting = await settingOf(user, response);
+    expect(setting!.sealedSecrets).not.toBe(seal);
+  });
+
+  it("stores no secret value in the clear", async () => {
+    const { apiKey, user } = await persistedUser();
+    const token = randomUUID();
+
+    const response = await postDeployment(apiKey, sdlWith({ web: ["API_TOKEN=ac-secret://API_TOKEN"] }), { API_TOKEN: token });
+
+    const setting = await settingOf(user, response);
+    expect(JSON.stringify(setting)).not.toContain(token);
+  });
+
+  it("spends one key-service call on the seal and one on the data key, however many secrets there are", async () => {
+    const { apiKey } = await persistedUser();
+    const names = ["ALPHA", "BRAVO", "CHARLIE", "DELTA"];
+    const secrets = Object.fromEntries(names.map(name => [name, randomUUID()]));
+    const env = names.map(name => `${name}=ac-secret://${name}`);
+
+    const response = await postDeployment(apiKey, sdlWith({ web: env, worker: env, cron: env }), secrets);
+
+    expect(response.status).toBe(201);
+    expect(kmsClient.asymmetricDecrypt).toHaveBeenCalledTimes(2);
+  });
+
+  it("names a reference it holds no value for and records nothing", async () => {
+    const { apiKey, user } = await persistedUser();
+
+    const response = await postDeployment(apiKey, sdlWith({ web: ["API_TOKEN=ac-secret://API_TOKEN", "OTHER=ac-secret://OTHER"] }), { API_TOKEN: "one" });
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toContain("ac-secret://OTHER");
+    expect(await deploymentSettingRepository.findOneBy({ userId: user.id })).toBeUndefined();
+    expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
+  });
+
+  it("names a supplied value no service references and records nothing", async () => {
+    const { apiKey, user } = await persistedUser();
+
+    const response = await postDeployment(apiKey, sdlWith({ web: ["API_TOKEN=ac-secret://API_TOKEN"] }), { API_TOKEN: "one", TYPOED: "two" });
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toContain("TYPOED");
+    expect(await deploymentSettingRepository.findOneBy({ userId: user.id })).toBeUndefined();
+    expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
+  });
+
+  it("says nothing about a supplied value in the mistake it reports", async () => {
+    const { apiKey } = await persistedUser();
+    const token = randomUUID();
+
+    const response = await postDeployment(apiKey, sdlWith({ web: ["API_TOKEN=ac-secret://API_TOKEN"] }), { API_TOKEN: token, TYPOED: token });
+
+    expect(await response.text()).not.toContain(token);
+  });
+
+  it("refuses more secrets than a deployment may carry, before anything is recorded", async () => {
+    const { apiKey, user } = await persistedUser();
+    const names = Array.from({ length: MAX_COUNT + 1 }, (_, index) => `SECRET_${index}`);
+    const secrets = Object.fromEntries(names.map(name => [name, "value"]));
+
+    const response = await postDeployment(apiKey, sdlWith({ web: names.map(name => `${name}=ac-secret://${name}`) }), secrets);
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toContain(`At most ${MAX_COUNT} secrets`);
+    expect(await deploymentSettingRepository.findOneBy({ userId: user.id })).toBeUndefined();
+    expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
+  });
+
+  it("refuses a value above the size a secret may be, before anything is recorded", async () => {
+    const { apiKey, user } = await persistedUser();
+
+    const response = await postDeployment(apiKey, sdlWith({ web: ["API_TOKEN=ac-secret://API_TOKEN"] }), { API_TOKEN: "x".repeat(MAX_VALUE_BYTES + 1) });
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toContain(`maximum value size of ${MAX_VALUE_BYTES} bytes`);
+    expect(await deploymentSettingRepository.findOneBy({ userId: user.id })).toBeUndefined();
+    expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
+  });
+
+  it("carries a seal at the stated limits rather than refusing it on body size", async () => {
+    const { apiKey } = await persistedUser();
+    const names = Array.from({ length: MAX_COUNT }, (_, index) => `SECRET_${index}`);
+    const secrets = Object.fromEntries(names.map(name => [name, "x".repeat(MAX_VALUE_BYTES)]));
+
+    const response = await postDeployment(apiKey, sdlWith({ web: names.map(name => `${name}=ac-secret://${name}`) }), secrets);
+
+    expect(response.status).toBe(201);
+  });
+
+  it("refuses a submitted sdl above the allowance a request has always had for one", async () => {
+    const { apiKey, user } = await persistedUser();
+
+    const response = await postDeployment(apiKey, "d".repeat(MAX_SUBMITTED_SDL_LENGTH + 1));
+
+    expect(response.status).toBe(400);
+    expect(await deploymentSettingRepository.findOneBy({ userId: user.id })).toBeUndefined();
+    expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
+  });
+
+  it("does not spend the seal's allowance on the sdl", async () => {
+    const { apiKey } = await persistedUser();
+    const names = Array.from({ length: MAX_COUNT }, (_, index) => `SECRET_${index}`);
+
+    const response = await postDeployment(
+      apiKey,
+      sdlWith({ web: names.map(name => `${name}=ac-secret://${name}`) }),
+      Object.fromEntries(names.map(name => [name, "d".repeat(MAX_VALUE_BYTES)]))
+    );
+
+    expect(response.status).toBe(201);
+    expect(MAX_SUBMITTED_SDL_LENGTH).toBe(512 * 1024);
+  });
+
+  it("refuses a seal that was sealed for another user", async () => {
+    const { apiKey } = await persistedUser();
+    const other = await persistedUser();
+    const secrets = { API_TOKEN: randomUUID() };
+
+    const response = await postDeployment(apiKey, sdlWith({ web: ["API_TOKEN=ac-secret://API_TOKEN"] }), secrets, await sealFor(other.user, secrets));
+
+    expect(response.status).toBe(403);
+  });
+
+  it("refuses a seal that is not a compact jwe", async () => {
+    const { apiKey } = await persistedUser();
+
+    const response = await postDeployment(apiKey, sdlWith({ web: ["API_TOKEN=ac-secret://API_TOKEN"] }), { API_TOKEN: "one" }, "not-a-jwe");
+
+    expect(response.status).toBe(400);
+  });
+
+  it("creates a deployment with no secrets at all without reaching the key service", async () => {
+    const { apiKey, user } = await persistedUser();
+
+    const response = await postDeployment(apiKey, sdlWith({ web: ["LOG_LEVEL=debug"] }));
+
+    expect(response.status).toBe(201);
+    expect(kmsClient.asymmetricDecrypt).not.toHaveBeenCalled();
+    expect((await settingOf(user, response))!.sealedSecrets).toBeNull();
+  });
+
+  it("stores a token that opens to exactly the values the client sealed", async () => {
+    const { apiKey, user } = await persistedUser();
+    const secrets = { API_TOKEN: randomUUID(), DATABASE_URL: `postgres://app:${randomUUID()}@db.internal/app` };
+
+    const response = await postDeployment(apiKey, sdlWith({ web: ["API_TOKEN=ac-secret://API_TOKEN", "DATABASE_URL=ac-secret://DATABASE_URL"] }), secrets);
+
+    const setting = await settingOf(user, response);
+    await expect(openStoredToken(user, setting!.dseq, setting!.sealedSecrets!)).resolves.toEqual(secrets);
+  });
+
+  it("stores a token no other deployment of the same user can open", async () => {
+    const { apiKey, user } = await persistedUser();
+
+    const response = await postDeployment(apiKey, sdlWith({ web: ["API_TOKEN=ac-secret://API_TOKEN"] }), { API_TOKEN: randomUUID() });
+
+    const setting = await settingOf(user, response);
+    await expect(openStoredToken(user, "1420000000009", setting!.sealedSecrets!)).rejects.toMatchObject({ status: 500 });
+  });
+
+  it("leaves a record a failed broadcast could not back, and lets the same create be retried", async () => {
+    const { apiKey, user } = await persistedUser();
+    const sdl = sdlWith({ web: ["API_TOKEN=ac-secret://API_TOKEN"] });
+    vi.mocked(signerService.executeDerivedDecodedTxByUserId).mockRejectedValueOnce(new Error("broadcast failed"));
+
+    const abandoned = await postDeployment(apiKey, sdl, { API_TOKEN: randomUUID() });
+    const orphan = await deploymentSettingRepository.findOneBy({ userId: user.id });
+    const retried = await postDeployment(apiKey, sdl, { API_TOKEN: randomUUID() });
+
+    expect(abandoned.status).toBe(500);
+    expect(orphan?.sealedSecrets).toEqual(expect.any(String));
+    expect(retried.status).toBe(201);
+  });
+
+  it("replaces the token of a retry on the same dseq rather than merging with the abandoned one", async () => {
+    const { apiKey, user } = await persistedUser();
+    const sdl = sdlWith({ web: ["API_TOKEN=ac-secret://API_TOKEN"] });
+    const dseq = Date.now();
+    vi.spyOn(Date, "now").mockReturnValue(dseq);
+    vi.mocked(signerService.executeDerivedDecodedTxByUserId).mockRejectedValueOnce(new Error("broadcast failed"));
+    const abandonedSecrets = { API_TOKEN: randomUUID() };
+    const retriedSecrets = { API_TOKEN: randomUUID() };
+
+    await postDeployment(apiKey, sdl, abandonedSecrets);
+    const abandoned = await deploymentSettingRepository.findOneBy({ userId: user.id, dseq: dseq.toString() });
+    const retried = await postDeployment(apiKey, sdl, retriedSecrets);
+
+    expect(retried.status).toBe(201);
+    const replaced = await deploymentSettingRepository.findOneBy({ userId: user.id, dseq: dseq.toString() });
+    expect(replaced!.sealedSecrets).not.toBe(abandoned!.sealedSecrets);
+    await expect(openStoredToken(user, dseq.toString(), replaced!.sealedSecrets!)).resolves.toEqual(retriedSecrets);
+  });
+
+  /**
+   * The only way to read a stored token, because there is deliberately no endpoint that returns one.
+   * The lease slice becomes the production reader; until then this is what proves the chain the create
+   * path wrote can actually be opened again.
+   */
+  async function openStoredToken(user: UserOutput, dseq: string, token: string) {
+    const executionContextService = container.resolve(ExecutionContextService);
+    const authService = container.resolve(AuthService);
+
+    return await executionContextService.runWithContext(async () => {
+      authService.currentUser = user;
+
+      return JSON.parse(await container.resolve(SecretCipherService).decrypt(user.id, token, { sub: user.id, dseq })) as Record<string, string>;
+    });
+  }
+
+  function broadcastHash(): Uint8Array {
+    const [, messages] = vi.mocked(signerService.executeDerivedDecodedTxByUserId).mock.calls[0];
+
+    return (messages[0] as unknown as { value: { hash: Uint8Array } }).value.hash;
+  }
+
+  async function manifestVersionOf(sdl: string) {
+    const manifest = generateManifest(yaml.raw<SDLInput>(sdl));
+    expect(manifest.ok).toBe(true);
+
+    return await generateManifestVersion((manifest as Extract<typeof manifest, { ok: true }>).value.groups);
+  }
+
+  async function settingOf(user: UserOutput, response: Response) {
+    const { data } = (await response.clone().json()) as { data: { dseq: string } };
+
+    return await deploymentSettingRepository.findOneBy({ userId: user.id, dseq: data.dseq });
+  }
+
+  async function sealFor(user: UserOutput, secrets: Record<string, string>) {
+    return await new CompactEncrypt(new TextEncoder().encode(JSON.stringify(secrets)))
+      .setProtectedHeader({
+        alg: SDL_SECRETS_SEAL_ALGORITHM,
+        enc: SDL_SECRETS_CONTENT_ENCRYPTION,
+        kid: KID,
+        sub: user.id,
+        exp: Math.floor(Date.now() / 1000) + 300
+      })
+      .encrypt(publicKey);
+  }
+
+  async function postDeployment(apiKey: string, sdl: string, secrets?: Record<string, string>, seal?: string) {
+    const sealedSecrets = seal ?? (secrets ? await sealFor(knownUsers[knownApiKeys[apiKey].userId], secrets) : undefined);
+
+    return await app.request("/v1/deployments", {
+      method: "POST",
+      body: JSON.stringify({ data: { sdl, sealedSecrets } }),
+      headers: new Headers({ "Content-Type": "application/json", "x-api-key": apiKey })
+    });
+  }
+
+  async function warmSealingKeyAsBootWould() {
+    await container.resolve(SdlSecretsSealingKeyService).getSealingKey();
+  }
+
+  async function persistedUser() {
+    const dbUser = await userRepository.create({ userId: faker.string.uuid() });
+    const apiKey = faker.string.alphanumeric(24);
+    const user = createUser({ id: dbUser.id, userId: dbUser.userId ?? undefined });
+
+    knownUsers[dbUser.id] = user;
+    knownApiKeys[apiKey] = createApiKey({ userId: dbUser.id });
+    knownWallets[dbUser.id] = [createUserWallet({ userId: dbUser.id, address: "akash13265twfqejnma6cc93rw5dxk4cldyz2zyy8cdm" })];
+
+    return { user, apiKey };
+  }
+});

--- a/apps/api/test/functional/deployment-sealed-secrets.spec.ts
+++ b/apps/api/test/functional/deployment-sealed-secrets.spec.ts
@@ -38,11 +38,6 @@ const VERSION_NAME = "projects/console-test/locations/global/keyRings/console-ap
 const MAX_VALUE_BYTES = 16 * 1024;
 const MAX_COUNT = 100;
 
-/**
- * The Cloud KMS key is the one third-party boundary this path crosses, so it is doubled here with a
- * real RSA key rather than reached over the network. The interface exists to be doubled; registering it
- * at module scope means nothing has resolved the real target before the first request.
- */
 const { publicKey, privateKey } = generateKeyPairSync("rsa", { modulusLength: 3072 });
 const publicKeyPem = publicKey.export({ type: "spki", format: "pem" }).toString();
 const kmsClient = mock<SdlSecretsKmsClient>();
@@ -421,11 +416,6 @@ describe("Deployment sealed secrets", () => {
     await expect(openStoredToken(user, dseq.toString(), replaced!.sealedSecrets!)).resolves.toEqual(retriedSecrets);
   });
 
-  /**
-   * The only way to read a stored token, because there is deliberately no endpoint that returns one.
-   * The lease slice becomes the production reader; until then this is what proves the chain the create
-   * path wrote can actually be opened again.
-   */
   async function openStoredToken(user: UserOutput, dseq: string, token: string) {
     const executionContextService = container.resolve(ExecutionContextService);
     const authService = container.resolve(AuthService);


### PR DESCRIPTION
> **Base branch: `feat/deployment-receive-sealed-secrets-intake` — NOT `main`.** This is PR **5 of 5**, the last in the sealed-secrets create-path stack. It **stacks on PR 4** ("turn a transport seal and an sdl into the values a deployment needs") and should be reviewed and merged **after** it. GitHub shows only the incremental diff against that base, which is what the size label measures.
>
> | # | PR | incremental lines |
> |---|---|---|
> | 1 | give a deployment record a column for its sealed secrets | 138 |
> | 2 | bind a stored secret to the deployment it was stored for | 300 |
> | 3 | let a stored sdl keep the references it was written with | 353 |
> | 4 | turn a transport seal and an sdl into the values a deployment needs | 614 |
> | **5** | **accept sealed secrets when a deployment is created** ← you are here | **815** |
>
> **This is where the observable behaviour lands, and the executable demo is at the bottom of this body** — the earlier PRs reference it rather than duplicating it.

## Why

ref CON-862

This closes the first end-to-end path of `docs/prd/0003-deployment-secrets.md`: a user creates a deployment whose SDL references secrets by name, supplies the values sealed, and the provider ends up running containers configured with the real values while the console stores only ciphertext.

Separate slice because it is the only one a caller can see. PRs 1-4 are the column, the cipher binding, the reference reads and the intake; this one wires them into `POST /v1/deployments`, changes the public contract, and raises a body limit. Everything reviewable in isolation was reviewed in isolation, so what is left here is the ordering and the contract.

## What

### API contract change

`POST /v1/deployments` gains an **optional `sealedSecrets`** field: a compact JWE, sealed for the caller's account against the key and claims published by `GET /v1/sdl-secrets-context`, whose plaintext is a flat name-to-value JSON object.

- **There is no plaintext alternative field.** Values reach the API sealed or not at all.
- **No endpoint ever returns a stored value.**
- Validation is not request-schema validation, because the names are inside the seal: the request is decrypted first, then the SDL's `ac-secret://NAME` references and the supplied names are checked **against each other in both directions**. A referenced name with no value is refused naming it; a supplied name the SDL does not reference is refused too. A typo on either side is caught rather than silently ignored.
- A value's size is measured **JSON-encoded**, not raw. Callers need to know which size is measured: escaping is not size-preserving (a `"` or `\` costs two bytes, a control byte up to six), so a **quote-heavy value carries fewer raw bytes than 16 KB** — a PEM or a service-account JSON blob most of all. This is stated in the OpenAPI description of the field.
- Additive and optional, so no existing client breaks. The OpenAPI docs snapshot is updated accordingly.

### Ordering, which is the load-bearing part

Inherited from PRD-0001 and now written down on `DeploymentWriterService.create`: **validate → mint the dseq → resolve in memory → hash the manifest → persist SDL, manifest version and token in one statement → broadcast.**

- The dseq is minted only once nothing can still refuse the request, because the stored token names it and a client sealing before the deployment exists cannot.
- Persistence precedes the broadcast because a broadcast that succeeded *without* its secrets stored would produce a deployment that exists on chain and can never be leased. The cost is an orphaned record when the broadcast fails, which is harmless and swept by the existing `DeleteUnbackedDeploymentSetting` compensation.
- The **cheapest refusal runs first**: the stripped-document guard is now ahead of the wallet read, the manifest generation and the seal's key-service call. It is the only guard on an SDL that is small on the wire and enormous once re-serialized.
- **Substitution happens in exactly one place** — on the parsed document immediately before manifest generation — so the hash committed on chain always covers resolved values. The stored SDL keeps the references and is never rewritten with resolved values. The 201 response still returns a manifest for the browser's comparison, but built from the **unresolved** SDL, so neither side holds the resolved form: it exists only inside the API process, between `substitute` and `generateManifestVersion`, and is discarded.
- **One data-encryption-key unwrap per create**, however many secrets the deployment has.

### The body-limit raise — a deliberate human decision, on one route only

The Spec's limits (100 secrets × 16 KB) are unreachable behind the 524,288-byte default `createRoute` puts on every route with a body. `POST /v1/deployments` alone is raised to **2,719,180 bytes**, derived from the limits rather than chosen:

| step | bytes |
|---|---|
| plaintext: `100 × (64-byte name + 6 JSON punctuation + 16,384 JSON-**encoded** value) + 1` | 1,645,401 |
| ciphertext — **equal**, because A256GCM is a counter mode | 1,645,401 |
| base64url, four characters per three bytes | 2,193,868 |
| + envelope allowance (protected header, RSA-4096 encrypted key, 96-bit IV, 128-bit tag, four separators) | 2,194,892 |
| + the whole existing 524,288-byte allowance, kept intact | **2,719,180** |

**New worst-case in-flight request size: 2,719,180 bytes (2.59 MiB), on `POST /v1/deployments` only.** Every other route keeps the 524,288-byte default. The margin is the conservatism in each term, not a percentage added at the end, and `envSchema` refuses to boot on limits that could exceed it.

**The submitted-SDL ceiling did not move.** A body limit bounds the whole request, so raising it would otherwise have handed every SDL five times its old allowance — and nothing else bounded `data.sdl`, since `SDL_MAX_LENGTH` is checked against the *stripped, re-serialised* document deep in the writer. So `data.sdl` now carries its own `MAX_SUBMITTED_SDL_LENGTH`, **held at exactly 524,288** — the same bound every route with a body already gave it — enforced by the request validator before the handler runs. That matters twice: a document five times the old size would otherwise have gone through two YAML parses, two manifest generations and a `js-yaml` dump before anything refused it, and the anchor-bomb estimator inside `stripSdlSecrets` is sized against this bound rather than against the body limit.

**The secret count and the per-value limit each bind independently**, on the decrypted payload rather than inferred from request size — 100 and 16,384 pass, 101 and 16,385 do not, each with a 400 naming the limit and never echoing a value.

### Deferred: AC 1 is proven transitively (accepted)

> AC 1 — creating a deployment with sealed secrets and an SDL referencing them resolves the values into the right services' environments in the manifest

**No create-path seam exposes a resolved manifest.** It is never returned (the 201 carries the unresolved one, which is AC 2 and deliberate) and never sent to a provider (create broadcasts a `MsgCreateDeployment` carrying only `hash: manifestVersion`; the lease path has its own send). So AC 1 is asserted **through the committed manifest hash**: the functional test compares the `hash` in the captured `MsgCreateDeployment` against a manifest version computed independently from an SDL carrying the same values inline. A value resolved into the wrong service, resolved to the wrong string, left as a literal reference, or missing entirely all produce a different digest.

Per-service placement is additionally asserted **as a value** at the unit level, in `sdl-reference.service.spec.ts` and `sdl.service.spec.ts`. The residual risk is therefore the strength of the manifest hash rather than a coverage hole: a defect producing a correct hash from an incorrect manifest requires a collision.

**The direct provider-boundary assertion arrives with the lease slice**, which re-derives the manifest from the stored definition and sends it — the boundary is real, it is just not on this path. AC 1 should be re-asserted there and the deferral deleted. AC 4 (the committed version *is* the hash of the resolved manifest) and AC 2 (no value in the response or its manifest) are asserted directly and depend on none of this.

### Known limitations, stated plainly

- **(a) A moved or forged stored token answers 500, with the cause only in the log.** `SECRET_VALUE_BINDING_MISMATCH` and `SECRET_VALUE_UNREADABLE` are distinguished for the operator and collapsed to one fixed message for the caller (deliberately — the error handler echoes `message` for every `http-errors` instance regardless of `expose`). **Unreachable by any user in this slice**, because there is no production reader of the column yet; the first one arrives with the lease slice.
- **(b) Without the boot initializer, the first create needing a new data key gets a 503.** By design, per `peekSealingKey`: the key is served from a warmed cache and the service refuses rather than blocking until it holds a verified key.
- **(c) `dseq = Date.now()` with an upsert on `(userId, dseq)` cannot distinguish a retry from a same-millisecond concurrent create.** **Pre-existing on `main` and inherited here, not introduced by this stack** — the upsert semantics are what make an orphaned attempt retryable (AC 10), and they carry this along with that.
- **(d) The update path is untouched, and this creates a state that could not exist before.** `PUT /v1/deployments/{dseq}` still resolves against an empty secret set, so a deployment created with secrets will **400 on `PUT`** until the merge-on-update slice. `PUT`'s own behaviour for a reference-carrying SDL is unchanged from `main`, but the reachable outcome is new: on `main` such a deployment could never be created in the first place, so **a user can now create a deployment they cannot subsequently edit**. The merge-on-update slice does not merely have to follow — it has to follow before this is enabled for real traffic.
- **(e) No `deploy-web` change.** The browser still computes and compares the *unresolved* manifest, which is exactly why the create response keeps returning it.
- **(f) Error-message amplification on a reference-heavy SDL is pre-existing, and this stack lowers its ceiling.** Every unresolvable reference produces a `ValidationError`, and all of them are joined into one `Invalid SDL: …` message that is both returned to the caller and logged whole. The worst reachable case on this stack is **~5,400 references → ~990 KB**, against **~2.1 MB on `main`** for the equivalent input — roughly a **2× reduction**, because PR 3's reference-keeping stripper makes the stored document larger (`A=ac-secret://A` survives at ~22 bytes where `main` blanks it to `A=` at ~9) and `SDL_MAX_LENGTH` bounds the *stripped* form, so about 2.2× fewer references fit. No bandwidth or log-volume regression is introduced. **The `.max()` on `data.sdl` is load-bearing here**: without it the reserved-`ac-` error family would have scaled with the raised 2,719,180-byte body limit to roughly **12,600 errors / ~2.5 MB**, so bounding the submitted SDL is what stopped the seal's new allowance feeding a 5× larger input. No cap is being added to the message itself — that would be unrequested scope on behaviour this Spec never touches.
- **(g) The unparseable-YAML error message is misleading, pre-existing on `main`, and deliberately not fixed here.** An SDL that is not valid YAML answers `SDL is too large: it exceeds the maximum of 131072 characters once stored`, where a parse error would be clearer. The obvious fix surfaces the `js-yaml` `YAMLException`, whose message embeds a snippet of the submitted document — which carries ordinary env values in the clear. Opening a plaintext-echo surface on the one endpoint whose entire purpose is that plaintext does not escape is a bad trade for a better string. A safe variant (`SDL is not valid YAML`) belongs in its own PR.

### Validation

Measured on the tip of the stack (`feat/deployment-accept-sealed-secrets-on-create`), in `apps/api`:

| check | result |
|---|---|
| `npx tsc --noEmit` | **43 errors — exactly the `main` baseline, byte-identical error set** (independently verified; `apps/api` tsc is not green on `main`, so 43 is the baseline and not a regression) |
| `npm run lint -- --quiet` | clean |
| `npm test` | **245 files / 3131 tests passing** |

### Open items at time of opening

These are stated because this stack is being opened mid-process, deliberately, and the bodies should not overclaim:

- The **independent round-2 review** of the fixes applied after the first review has **completed with zero blocking findings**. It also independently re-measured the error-amplification figures quoted in limitation (f) above.
- A **full-suite test flake is still open, and the evidence now says it is not ours.** `npm test` intermittently fails at the **suite** level — `beforeAll` timeouts in `dbService.setup()` — and never with a failing assertion. Measured interleaved, one run each per round: **`main` failed 1 of 5 runs and this stack's tip 1 of 4, both failing in the same round.** On the available evidence it is **pre-existing and not attributable to this stack**.
- **Root cause, identified and pre-existing.** `apps/api/env/.env.functional.test` sets neither `POSTGRES_MAX_CONNECTIONS` nor `POSTGRES_BACKGROUND_JOBS_POOL_SIZE`, so every functional suite inherits the production defaults of 20 each (`core/config/env.config.ts:15,17`). With `maxWorkers` unset, ~14 suites run concurrently and each boots its own app and database, putting worst-case demand near **328 connections on `main` and 348 on the tip, against `max_connections=100`**. That produces exactly the observed chain: `sorry, too many clients already`, then a socket closing mid-query (`Cannot redefine property: query`), then the 20 s `beforeAll` budget expiring. This stack adds one suite and a second `startJobQueues()` call site — roughly **+6%** — which is not what puts the system over a hard limit it already exceeds.
- **The fix is two lines of test config**: `POSTGRES_MAX_CONNECTIONS=4` and `POSTGRES_BACKGROUND_JOBS_POOL_SIZE=4` in `apps/api/env/.env.functional.test`, which both the functional and integration vitest projects load. Test-only and independent of these five branches, so it is best landed as its own small PR that any of them can rebase onto.
- **Two unrelated pre-existing flakes show up in the same logs** and are untouched by this stack: `UserWalletRepository > isCreditsLowConfirmed > confirms immediately when the window is disabled`, which compares an app-clock `new Date()` against Postgres `now()` with a zero-minute window, and separate flakes in `providers.spec.ts`.

---

## Demo

Executable and verified against the real application (real route, real `SdlService`, real repositories against a real Postgres, real pg-boss). Only two third-party boundaries are doubled: Cloud KMS (an in-process RSA key, so nothing leaves the machine) and the chain (the signer records the `MsgCreateDeployment` instead of broadcasting it, which is also what makes the committed hash readable). **Every secret value below is the literal string `demo-not-a-real-value`**; user ids, data key ids and minted dseqs are normalised to `<...>`.

A user creates a deployment whose SDL refers to secrets by name, supplies the values sealed, and the console ends up storing only ciphertext while the manifest committed on chain covers the real values.

Everything below runs the **real** application: the real `POST /v1/deployments` route, the real `SdlService`, the real repositories against a real Postgres, and the real pg-boss job queue. Two things are doubled, both of them third-party boundaries rather than anything this change owns:

- **Cloud KMS** — an in-process RSA key stands in for the key service, so no request leaves the machine. `SdlSecretsKmsClient` exists in the codebase narrowed for exactly this.
- **The chain** — the signer records the `MsgCreateDeployment` it was handed instead of broadcasting it, which is also what lets the demo read the `hash` the create would have committed.

Authentication, the wallet lookup and the SDL are otherwise ordinary.

Every secret value in this document is the literal string `demo-not-a-real-value`. Names and ciphertext are shown deliberately — the whole claim is that those are safe to hold and values are not. User ids, data key ids and minted dseqs are normalised to `<...>` so the document can be re-verified.

### The SDL under test

Two services, both referring to one secret by name. `MODE=production` is an ordinary value sitting next to a reference, so the demo can show that the two are treated differently.

```bash
sed -n "/^const REFERENCING/,/^const INLINE/p" .work/sealed-secrets-create-path/demo/step-create.ts
```

```output
const REFERENCING = { web: ["API_TOKEN=ac-secret://API_TOKEN"], worker: ["API_TOKEN=ac-secret://API_TOKEN", "MODE=production"] };
const INLINE = { web: [`API_TOKEN=${VALUE}`], worker: [`API_TOKEN=${VALUE}`, "MODE=production"] };
```

### AC 1, 2, 3 and 4 — one create, four claims

`REFERENCING` is what the client posts. `INLINE` is the same SDL with the value written in literally — the demo computes its manifest version independently, with the chain SDK, and compares it against the `hash` the create actually put in `MsgCreateDeployment`.

That comparison is the whole of the AC 1 argument. Nothing on the create path exposes a resolved manifest — the response carries the unresolved one and only the update path sends a manifest to a provider — so the hash is the observable. A value resolved into the wrong service, resolved to the wrong string, or left as a literal reference all produce a different digest, and the unresolved hash is printed alongside to show the two are genuinely different numbers.

```bash
.work/sealed-secrets-create-path/demo/run.sh step-create.ts 2>/dev/null
```

```output
--- AC 1 / AC 4: the manifest version committed on chain ---
HTTP status                : 201
hash in MsgCreateDeployment: 0318480181d177b8b36a96a7ca32d6bd69493bf6daf311004ef3594d73a5851f
hash of RESOLVED manifest  : 0318480181d177b8b36a96a7ca32d6bd69493bf6daf311004ef3594d73a5851f
hash of UNRESOLVED manifest: 62bf5b2b0d6d2fbdf4ed8e83a81e2d7ad123e3943dba123046151b9853a63378
committed == resolved      : true
committed == unresolved    : false

--- AC 2: what the response hands back ---
body contains the value    : false
env in returned manifest   : web: ["API_TOKEN=ac-secret://API_TOKEN"] | worker: ["API_TOKEN=ac-secret://API_TOKEN","MODE=production"]

--- AC 3: what the deployment_settings row actually holds ---
sdl: env lines             : - API_TOKEN=ac-secret://API_TOKEN | - API_TOKEN=ac-secret://API_TOKEN | - MODE=
sdl contains the value     : false
sealed_secrets segments    : 5 (compact JWE)
sealed_secrets header      : {"sub":"<userId>","dseq":"<dseq>","alg":"dir","enc":"A256GCM","kid":"<uuid>"}
sealed_secrets is opaque   : true
whole row mentions value   : false
```

Reading that back:

- **AC 1 / AC 4** — the committed hash equals the resolved manifest's version and differs from the unresolved one, so the chain is committed to a manifest carrying the real values in both services' environments.
- **AC 2** — the value appears nowhere in the 201 body, and the manifest the response hands back still says `ac-secret://API_TOKEN`. The browser keeps computing the same unresolved manifest locally, so its comparison still works and neither side holds the resolved form.
- **AC 3** — the stored `sdl` keeps `API_TOKEN=ac-secret://API_TOKEN` while `MODE=` is blanked. That is the deliberate scope line: a reference names a secret and is safe to keep; an ordinary value is still stripped, exactly as before this change. `sealed_secrets` is a five-segment compact JWE whose header names the owner (`sub`), the deployment (`dseq`) and the per-owner data encryption key that sealed it (`kid`, shown here as `<uuid>` because it is a generated row id). Neither the value nor even the secret's name appears in the ciphertext.

### AC 5 and AC 6 — a typo on either side is refused, not ignored

The names live inside the seal, so none of this is request-schema validation. The seal is opened first, then the SDL and the request are checked against each other in both directions.

```bash
.work/sealed-secrets-create-path/demo/run.sh step-rejections.ts 2>/dev/null
```

```output
--- AC 5: a reference the request supplied no value for ---
HTTP status   : 400
message       : Invalid SDL: no value supplied for SDL Reference "ac-secret://DATABASE_URL" in service "web"
rows persisted: 0
broadcasts    : 0

--- AC 6: a supplied value no service references ---
HTTP status   : 400
message       : Invalid SDL: a value was supplied for "DATABSE_URL" but no service's SDL references it
rows persisted: 0
broadcasts    : 0

--- both directions at once, so one typo cannot mask the other ---
HTTP status   : 400
message       : Invalid SDL: no value supplied for SDL Reference "ac-secret://API_TOKEN" in service "web", a value was supplied for "API_TOEKN" but no service's SDL references it
rows persisted: 0
broadcasts    : 0

--- and the same request without the typo ---
HTTP status   : 201
rows persisted: 1
broadcasts    : 1
```

The third case is the one that motivates checking both directions. A single misspelling — `API_TOEKN` for `API_TOKEN` — is simultaneously a reference with no value and a value nothing references, and the reply names both, so the user can see which spelling is which. Before this change the second half was reported by nothing and the deployment shipped with an empty variable.

In every refusal: nothing persisted, nothing broadcast. The refusal happens before the dseq is even minted.

### AC 8 — a token is bound to its deployment, not just to its owner

Two deployments of the same user share a data encryption key, so `kid` cannot tell their tokens apart. The `dseq` in the protected header is what does — and because the protected header is the additional authenticated data for A256GCM, it is bound by the tag rather than merely written down.

```bash
.work/sealed-secrets-create-path/demo/run.sh step-binding.ts 2>/dev/null
```

```output
--- AC 8: a token moved to another deployment of the SAME user ---
token header                 : {"sub":"<userId>","dseq":"1420000000001","alg":"dir","enc":"A256GCM","kid":"<dataKeyId>"}
opened as deployment 1420000000001 : demo-not-a-real-value
opened as deployment 1420000000002 : refused 500: Unable to read stored secrets

--- the same user, the same data key, so only the dseq can tell them apart ---
both deployments share a kid : true

--- rewriting the dseq in the header instead fails the GCM tag ---
forged header                : refused 500: Unable to read stored secrets
```

The caller gets one fixed message for both failures, deliberately — the error handler echoes `message` for every `http-errors` instance regardless of `expose`, so a specific message would tell a caller which of the two happened. The operator gets the difference, in the log:

```bash
DEMO_LOG_LEVEL=error .work/sealed-secrets-create-path/demo/run.sh step-binding.ts 2>/dev/null | grep -oE "event: \"[A-Z_]+\"" | sort | uniq -c
```

```output
   1 event: "SECRET_VALUE_BINDING_MISMATCH"
   1 event: "SECRET_VALUE_UNREADABLE"
```

`SECRET_VALUE_BINDING_MISMATCH` is the token that named the wrong deployment; `SECRET_VALUE_UNREADABLE` is the forged header failing its authentication tag. Two causes, one reply.

The mismatch is also refused *before* the data key is looked up, so a token that does not belong costs neither a database read nor a key-service call.

### AC 9 — each limit binds on its own

Both limits are enforced on the decrypted payload, not inferred from the request size, so each one has to be shown failing while the other is comfortably satisfied: 101 tiny secrets, and one oversized secret.

```bash
.work/sealed-secrets-create-path/demo/run.sh step-limits.ts 2>/dev/null
```

```output
configured limits            : SDL_SECRETS_MAX_COUNT=100 SDL_SECRETS_MAX_VALUE_BYTES=16384

--- AC 9: the count limit, on its own ---
100 secrets                 : 201
101 secrets                 : 400 - At most 100 secrets may be supplied for one deployment

--- AC 9: the value size limit, on its own, with only ONE secret ---
value of 16384 bytes        : 201
value of 16385 bytes        : 400 - Secret "API_TOKEN" exceeds the maximum value size of 16384 bytes once JSON-encoded

--- the size limit counts BYTES, not characters ---
4097 four-byte characters : 400 - Secret "API_TOKEN" exceeds the maximum value size of 16384 bytes once JSON-encoded

--- neither refusal says anything about a value ---
refusal mentions the value   : false

rows persisted across every refusal above: 2 (only the accepted ones)
```

Both boundaries are exact — 100 and 16384 pass, 101 and 16385 do not. Each message names the limit and the secret's name; neither names a value, and the last check confirms an oversized value is not echoed back.

The size is measured as the value's **JSON-encoded** length in UTF-8 bytes, not its raw length, because the seal's plaintext is a JSON object and escaping is not size-preserving: a `"` or `\` costs two bytes and a control byte up to six. That is why 4097 four-byte characters is over the line at a quarter of the character count. It is also what makes the budget behind the body limit an exact bound rather than an approximation — measure the raw value and a hundred quote-heavy values, which is what a service-account key or a PEM is, overrun a budget computed as though they were plain, and the request dies on the body limit with a bare 413 instead of a 400 naming the limit. The trade is that "16 KB per value" means 16 KB *encoded*, so a quote-heavy value carries slightly less raw content, which the OpenAPI description says.

### The body limit, raised for this route only

The stated limits of a hundred secrets at 16 KB apiece would have been unreachable behind the 512 KiB default that `createRoute` puts on every route with a body. The new ceiling is computed from the limits rather than chosen, and applied to `postRoute` alone.

```bash
.work/sealed-secrets-create-path/demo/run.sh step-body-limit.ts 2>/dev/null
```

```output
--- the ceiling, derived from the limits rather than chosen ---
default allowance, every route : 524288 bytes
largest seal the limits allow  : 2194892 bytes
create route allowance         : 2719180 bytes (2.59 MiB)
sum checks out                 : true

--- the same oversized body against two routes ---
POST /v1/deployments       : 614876 byte body -> 400 within the body limit, then judged on its merits
POST /v1/deposit-deployment: 614457 byte body -> 413 Payload Too Large — still the 512 KiB default

--- the raise is scoped to the field that needed it ---
data.sdl own allowance         : 524288 bytes (unchanged: true)
POST /v1/deployments, big sdl  : 524308 byte body -> 400 refused on the field, before the handler runs

--- and a real seal at the stated limits goes through ---
100 secrets x 16384 bytes            : 201
```

Those two requests go over a real socket, so they carry a real `Content-Length` and the body-limit middleware is exercised the way a client exercises it. The same ~600 KB body is inside the limit on `POST /v1/deployments` and refused with a 413 on `POST /v1/deposit-deployment`, which still has the untouched default. And a genuine seal at the full stated limits — a hundred 16 KB values, about 2.1 MB of JWE — is accepted.

**The raise is scoped to the field that needed it.** A body limit bounds the whole request, so raising it would otherwise have handed every SDL five times its old allowance — and nothing else bounded `data.sdl`, since `SDL_MAX_LENGTH` is checked against the *stripped, re-serialised* document deep in the writer. So `data.sdl` carries its own `MAX_SUBMITTED_SDL_LENGTH`, held at exactly the 512 KiB every route with a body already allowed, and an SDL over it is refused by the request validator before the handler runs at all. That matters twice over: a document five times the old size would otherwise have gone through two YAML parses, two manifest generations and a `js-yaml` dump before anything refused it, and the anchor-bomb estimator inside `stripSdlSecrets` is sized against this bound rather than against the body limit.

The arithmetic behind `2719180`: a hundred entries of at most a 64-byte name, six bytes of JSON punctuation and a 16384-byte value is 1,645,401 bytes of plaintext; A256GCM is a counter mode so the ciphertext is the same length; base64url spends four characters per three bytes, giving 2,193,868; plus a 1 KiB allowance for the header, an RSA-4096 encrypted key, the IV, the tag and four separators. Added to the whole existing 524,288-byte allowance, kept intact so the submitted SDL's own ceiling does not move. The margin is the conservatism in each term, not a percentage on the end.

### The migration, and AC 10 — an orphaned record does not block a retry

`sealed_secrets` is one nullable TEXT column on the row that already holds the SDL and the manifest version, so a deployment's whole definition stays one row written in one statement.

The record is written before the broadcast: a broadcast that succeeded without its secrets stored would produce a deployment that exists on chain and can never be leased. The cost of that ordering is an orphaned record when the broadcast fails, which has to be harmless.

```bash
.work/sealed-secrets-create-path/demo/run.sh step-storage.ts 2>/dev/null
```

```output
--- the migration, as the database now describes it ---
  manifest_version  character varying  nullable=YES default=none
  sdl               text               nullable=YES default=none
  sealed_secrets    text               nullable=YES default=none

--- AC 10: a broadcast that failed after the record was written ---
first attempt status         : 500
rows left behind             : 1 with a token: 1
broadcasts attempted         : 1

--- retrying the same create on the same dseq ---
retry status                 : 201
rows for this user           : 1 (the retry updated the orphan, it did not add a row)
token replaced wholesale     : true
token still bound to the dseq: true
```

The retry is pinned to the abandoned attempt's dseq, which is the case that matters: the write is an update-or-create on `(userId, dseq)`, so it lands on the orphan rather than colliding with it. One row, and the token is **replaced wholesale** rather than left as the first attempt wrote it.

That replacement is the sharpest thing in the change and the easiest to lose. Drizzle drops `undefined` out of an `onConflictDoUpdate` set clause, so a write that does not name a column leaves whatever is there — which is right for an update, handed no token and obliged not to destroy one, and wrong for a create, which must not inherit an abandoned attempt's secrets. So create always states a value, `null` included. A retry that supplies no secrets clears the column instead of silently keeping the old set.

The orphan itself is swept by the `DeleteUnbackedDeploymentSetting` compensation enqueued in the same transaction as the row, which asks the chain before deleting anything.

### What this does not cover

- **The provider actually receiving the resolved values.** Nothing on the create path sends a manifest to a provider, so there is no boundary here to capture; the committed hash stands in for it. That arrives with the lease slice, which re-derives the manifest from the stored definition — and is where AC 1 should be re-asserted directly. Recorded in `deferred.md`.
- **Updating a deployment that has secrets.** `PUT /v1/deployments/{dseq}` still resolves against an empty set, so an SDL with a reference is refused there — which is exactly what `main` does today for any SDL with a reference, not a regression, but it does mean the merge-on-update slice has to follow.
- **The UI.** No deploy-web change: the browser still computes and compares the unresolved manifest, which is why the create response keeps returning it.

### Something the demo found, and what fixing the scoping did to it

Every reference with no supplied value produces one `ValidationError`, and the writer joins all of them into a single `Invalid SDL: …` message that is both returned to the caller and logged in full. So a reference-heavy SDL amplifies: the reply is about twice the request.

An earlier revision of this change reordered the cheap stripped-document guard to run *fifth* — after the wallet read, the manifest generation and the seal's key-service call — which let that amplification run to **4.7 MB** on a 2.3 MB SDL. Both halves of that are now closed: `data.sdl` is bounded at 512 KiB, and the guard is back to running first, ahead of the step that builds one error per reference.

```bash
.work/sealed-secrets-create-path/demo/run.sh step-error-size.ts 2>/dev/null
```

```output
references | request bytes | status | reply bytes | amplification
      1000 |         35208 |    400 |       76984 | 2.2x
     13000 |        485208 |    400 |         146 | 0.0x
     60000 |       2318208 |    400 |         282 | 0.0x

rows persisted: 0 | broadcasts: 0
```

The 13,000- and 60,000-reference rows now answer in 146 and 282 bytes. The larger one never reaches the handler — the field bound refuses it — and the smaller one is refused by the stripped-document guard, because an SDL carrying that many references cannot strip to under the 128 KiB the console will store.

So the reachable ceiling is set by how many references fit in a *storable* document, not by the body limit. Measured by bisection and confirmed independently in round-2 review, the worst reachable case is about **5,400 references producing a ~990 KB** reply, against **~2.1 MB on `main`** for the equivalent input. The dominant term is the service name, echoed at 120 characters in *every* error while costing the submitted document only once.

This is **not** parity with `main` — the stack roughly **halves** the ceiling. Keeping `ac-` references makes the stored document larger (`A=ac-secret://A` survives at ~22 bytes where `main` blanks it to `A=` at ~9), and `SDL_MAX_LENGTH` bounds the stripped form, so about 2.2× fewer references fit before the strip guard fires.

The **mechanism** — one message per unresolvable reference, joined and logged whole — is genuinely pre-existing and unchanged. This stack lowers its ceiling rather than raising it, so no cap is being added: that would be unrequested scope on behaviour this Spec never touched. Worth knowing about, not worth a diff here.