### PR TITLE
fix(billing): email the user on the first declined auto top-up charge

### DIFF
--- a/apps/api/src/billing/services/auto-reload-pause/auto-reload-pause.service.spec.ts
+++ b/apps/api/src/billing/services/auto-reload-pause/auto-reload-pause.service.spec.ts
@@ -136,6 +136,24 @@ describe(AutoReloadPauseService.name, () => {
       expect(notificationService.createNotification).toHaveBeenCalled();
     });
 
+    it("keeps a failed first-decline email from surfacing as a failure to record the decline", async () => {
+      const { service, walletSettingRepository, notificationService, claim, user } = setup();
+      walletSettingRepository.recordChargeDecline.mockResolvedValue({ failureCount: 1, pausedAt: null });
+      notificationService.createNotification.mockRejectedValue(new Error("notifications unavailable"));
+
+      await expect(service.recordDecline({ claim, user, decline: { isTerminal: false } })).resolves.toBeUndefined();
+    });
+
+    it("keeps a failed pause email from surfacing as a failure to record the decline", async () => {
+      const { service, walletSettingRepository, walletReloadJobService, notificationService, claim, user } = setup();
+      walletSettingRepository.recordChargeDecline.mockResolvedValue({ failureCount: 4, pausedAt: new Date() });
+      notificationService.createNotification.mockRejectedValue(new Error("notifications unavailable"));
+
+      await expect(service.recordDecline({ claim, user, decline: { isTerminal: false } })).resolves.toBeUndefined();
+
+      expect(walletReloadJobService.scheduleCreditsLowCheck).toHaveBeenCalledWith(user.id, { withCleanup: true });
+    });
+
     it("links the email at billing rather than the add funds modal", async () => {
       const { service, walletSettingRepository, notificationService, claim, user } = setup();
       walletSettingRepository.recordChargeDecline.mockResolvedValue({ failureCount: 4, pausedAt: new Date() });

--- a/apps/api/src/billing/services/auto-reload-pause/auto-reload-pause.service.spec.ts
+++ b/apps/api/src/billing/services/auto-reload-pause/auto-reload-pause.service.spec.ts
@@ -136,6 +136,16 @@ describe(AutoReloadPauseService.name, () => {
       expect(notificationService.createNotification).toHaveBeenCalled();
     });
 
+    it("emails the user before scheduling the credits-low check, since the pause never transitions twice", async () => {
+      const { service, walletSettingRepository, walletReloadJobService, notificationService, claim, user } = setup();
+      walletSettingRepository.recordChargeDecline.mockResolvedValue({ failureCount: 4, pausedAt: new Date() });
+      walletReloadJobService.scheduleCreditsLowCheck.mockRejectedValue(new Error("queue unavailable"));
+
+      await expect(service.recordDecline({ claim, user, decline: { isTerminal: false } })).rejects.toThrow("queue unavailable");
+
+      expect(notificationService.createNotification).toHaveBeenCalled();
+    });
+
     it("keeps a failed first-decline email from surfacing as a failure to record the decline", async () => {
       const { service, walletSettingRepository, notificationService, claim, user } = setup();
       walletSettingRepository.recordChargeDecline.mockResolvedValue({ failureCount: 1, pausedAt: null });

--- a/apps/api/src/billing/services/auto-reload-pause/auto-reload-pause.service.spec.ts
+++ b/apps/api/src/billing/services/auto-reload-pause/auto-reload-pause.service.spec.ts
@@ -53,6 +53,51 @@ describe(AutoReloadPauseService.name, () => {
       expect(walletSettingRepository.recordChargeDecline).toHaveBeenCalledWith(claim, { maxConsecutiveDeclines: 4, isTerminal: false });
     });
 
+    it("emails the user on the first decline so a dead card is not discovered hours later", async () => {
+      const { service, walletSettingRepository, notificationService, claim, user } = setup();
+      walletSettingRepository.recordChargeDecline.mockResolvedValue({ failureCount: 1, pausedAt: null });
+
+      await service.recordDecline({ claim, user, decline: { declineCode: "generic_decline", isTerminal: false } });
+
+      expect(notificationService.createNotification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          notificationId: `autoTopUpChargeFailed.${user.id}.${claim.claimedAt}`,
+          user: { id: user.id, email: user.email }
+        })
+      );
+    });
+
+    it("does not email again on the declines that follow the first", async () => {
+      const { service, walletSettingRepository, notificationService, claim, user } = setup();
+      walletSettingRepository.recordChargeDecline.mockResolvedValue({ failureCount: 3, pausedAt: null });
+
+      await service.recordDecline({ claim, user, decline: { isTerminal: false } });
+
+      expect(notificationService.createNotification).not.toHaveBeenCalled();
+    });
+
+    it("stays quiet about a decline that landed after the user already replaced the card", async () => {
+      const { service, walletSettingRepository, notificationService, claim, user } = setup();
+      walletSettingRepository.recordChargeDecline.mockResolvedValue({ failureCount: 0, pausedAt: null });
+
+      await service.recordDecline({ claim, user, decline: { isTerminal: false } });
+
+      expect(notificationService.createNotification).not.toHaveBeenCalled();
+    });
+
+    it("sends only the pause email when the very first decline is terminal", async () => {
+      const { service, walletSettingRepository, notificationService, claim, user } = setup();
+      const pausedAt = new Date("2026-09-01T12:00:00.000Z");
+      walletSettingRepository.recordChargeDecline.mockResolvedValue({ failureCount: 1, pausedAt });
+
+      await service.recordDecline({ claim, user, decline: { declineCode: "stolen_card", isTerminal: true } });
+
+      expect(notificationService.createNotification).toHaveBeenCalledTimes(1);
+      expect(notificationService.createNotification).toHaveBeenCalledWith(
+        expect.objectContaining({ notificationId: `autoTopUpPaused.${user.id}.${pausedAt.toISOString()}` })
+      );
+    });
+
     it("leaves the wallet alone while the card still has chances left", async () => {
       const { service, walletSettingRepository, walletReloadJobService, notificationService, claim, user } = setup();
       walletSettingRepository.recordChargeDecline.mockResolvedValue({ failureCount: 2, pausedAt: null });

--- a/apps/api/src/billing/services/auto-reload-pause/auto-reload-pause.service.ts
+++ b/apps/api/src/billing/services/auto-reload-pause/auto-reload-pause.service.ts
@@ -5,7 +5,7 @@ import { type ChargeClaim, UserWalletRepository, type WalletSettingOutput, Walle
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
 import { type CreateLogger, LOGGER_FACTORY } from "@src/core/providers/logging.provider";
-import { NotificationService } from "@src/notifications/services/notification/notification.service";
+import { type CreateNotificationInput, NotificationService } from "@src/notifications/services/notification/notification.service";
 import { autoTopUpChargeFailedNotification } from "@src/notifications/services/notification-templates/auto-top-up-charge-failed-notification";
 import { autoTopUpPausedNotification } from "@src/notifications/services/notification-templates/auto-top-up-paused-notification";
 import type { UserOutput } from "@src/user/repositories";
@@ -67,9 +67,7 @@ export class AutoReloadPauseService {
       this.logger.info({ event: "AUTO_RELOAD_CHARGE_DECLINED", userId: user.id, failureCount, declineCode: decline.declineCode });
 
       if (failureCount === FIRST_DECLINE) {
-        await this.notificationService.createNotification(
-          autoTopUpChargeFailedNotification(user, { chargeAttemptedAt: claim.claimedAt, billingUrl: this.#billingUrl() })
-        );
+        await this.#notifyUser(autoTopUpChargeFailedNotification(user, { chargeAttemptedAt: claim.claimedAt, billingUrl: this.#billingUrl() }));
       }
 
       return;
@@ -79,7 +77,19 @@ export class AutoReloadPauseService {
 
     await this.#cancelPendingReloadCheck(user.id);
     await this.walletReloadJobService.scheduleCreditsLowCheck(user.id, { withCleanup: true });
-    await this.notificationService.createNotification(autoTopUpPausedNotification(user, { pausedAt, billingUrl: this.#billingUrl() }));
+    await this.#notifyUser(autoTopUpPausedNotification(user, { pausedAt, billingUrl: this.#billingUrl() }));
+  }
+
+  /**
+   * The decline is already committed, so a notifications outage must be logged as itself instead of
+   * bubbling out to be recorded as a failure to record the decline.
+   */
+  async #notifyUser(notification: CreateNotificationInput): Promise<void> {
+    try {
+      await this.notificationService.createNotification(notification);
+    } catch (error) {
+      this.logger.error({ event: "AUTO_RELOAD_NOTIFICATION_FAILED", userId: notification.user.id, notificationId: notification.notificationId, error });
+    }
   }
 
   /**

--- a/apps/api/src/billing/services/auto-reload-pause/auto-reload-pause.service.ts
+++ b/apps/api/src/billing/services/auto-reload-pause/auto-reload-pause.service.ts
@@ -6,8 +6,15 @@ import { BillingConfigService } from "@src/billing/services/billing-config/billi
 import { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
 import { type CreateLogger, LOGGER_FACTORY } from "@src/core/providers/logging.provider";
 import { NotificationService } from "@src/notifications/services/notification/notification.service";
+import { autoTopUpChargeFailedNotification } from "@src/notifications/services/notification-templates/auto-top-up-charge-failed-notification";
 import { autoTopUpPausedNotification } from "@src/notifications/services/notification-templates/auto-top-up-paused-notification";
 import type { UserOutput } from "@src/user/repositories";
+
+/**
+ * Only the first decline of a run is emailed, so a card that is merely having a bad day does not
+ * send one message per attempt, and the user still hears within minutes rather than at the pause.
+ */
+const FIRST_DECLINE = 1;
 
 /** Guards `2 ** exponent` against a raised decline limit, since the result is interpolated into a Postgres interval. */
 const MAX_BACKOFF_DOUBLINGS = 16;
@@ -58,6 +65,13 @@ export class AutoReloadPauseService {
 
     if (!pausedAt) {
       this.logger.info({ event: "AUTO_RELOAD_CHARGE_DECLINED", userId: user.id, failureCount, declineCode: decline.declineCode });
+
+      if (failureCount === FIRST_DECLINE) {
+        await this.notificationService.createNotification(
+          autoTopUpChargeFailedNotification(user, { chargeAttemptedAt: claim.claimedAt, billingUrl: this.#billingUrl() })
+        );
+      }
+
       return;
     }
 

--- a/apps/api/src/billing/services/auto-reload-pause/auto-reload-pause.service.ts
+++ b/apps/api/src/billing/services/auto-reload-pause/auto-reload-pause.service.ts
@@ -75,9 +75,9 @@ export class AutoReloadPauseService {
 
     this.logger.warn({ event: "AUTO_RELOAD_PAUSED", userId: user.id, failureCount, declineCode: decline.declineCode });
 
+    await this.#notifyUser(autoTopUpPausedNotification(user, { pausedAt, billingUrl: this.#billingUrl() }));
     await this.#cancelPendingReloadCheck(user.id);
     await this.walletReloadJobService.scheduleCreditsLowCheck(user.id, { withCleanup: true });
-    await this.#notifyUser(autoTopUpPausedNotification(user, { pausedAt, billingUrl: this.#billingUrl() }));
   }
 
   /**
@@ -93,8 +93,8 @@ export class AutoReloadPauseService {
   }
 
   /**
-   * The pause is already committed and only ever transitions once, so a failed cancel must not cost
-   * the user the email that follows it. A check left queued skips on the pause it finds.
+   * A check left queued skips on the pause it finds, so a failed cancel must not stop the
+   * credits-low check that follows it from being scheduled.
    */
   async #cancelPendingReloadCheck(userId: UserOutput["id"]): Promise<void> {
     try {

--- a/apps/api/src/billing/services/wallet-balance-reload-check/README.md
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/README.md
@@ -48,7 +48,9 @@ Only declines count. A Stripe outage, a rate limit, or a bug of ours leaves the 
 
 A paused wallet is treated as opted out everywhere behaviour depends on it: the check itself skips with `AUTO_RELOAD_PAUSED` and stops rescheduling, no new checks are enqueued for it, the credits-low email takes over, and it drops out of the `insufficient_balance_with_auto_reload` metrics behind the funding alert. It is *not* excluded from escrow funding — existing credits keep funding deployments as before.
 
-The user gets an email when the pause happens. It lifts when they change their default payment method, or when they save their auto top-up settings again, both of which also clear the charge marker so the next check can charge straight away rather than waiting out the cooldown the dead card consumed.
+The user hears about it twice. The first decline of a run sends a "we couldn't charge your card" email saying retries continue, and the pause sends a second one saying they have stopped; the declines in between are silent, so a card having a bad day does not send one email per attempt. Without the first email the wallet would fail quietly for the whole ~7 hours it takes to reach the pause, and the credits-low email cannot fill that gap because it skips any wallet whose auto top-up still counts as active.
+
+The pause lifts when the user changes their default payment method, or when they save their auto top-up settings again, both of which also clear the charge marker so the next check can charge straight away rather than waiting out the cooldown the dead card consumed.
 
 ### Worked examples (defaults: threshold $20, amount $100)
 

--- a/apps/api/src/notifications/services/notification-templates/auto-top-up-charge-failed-notification.spec.ts
+++ b/apps/api/src/notifications/services/notification-templates/auto-top-up-charge-failed-notification.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { autoTopUpChargeFailedNotification } from "./auto-top-up-charge-failed-notification";
+
+import { createUser } from "@test/seeders/user.seeder";
+
+describe(autoTopUpChargeFailedNotification.name, () => {
+  it("tells the user the charge failed, that retries continue, and how to fix the card", () => {
+    const user = createUser({ id: "user-123", email: "user@example.com" });
+
+    const result = autoTopUpChargeFailedNotification(user, {
+      chargeAttemptedAt: "2026-09-01 12:00:00",
+      billingUrl: "https://console.akash.network/billing"
+    });
+
+    expect(result.payload.summary).toBe("We couldn't charge your card");
+    expect(result.payload.description).toContain("declined");
+    expect(result.payload.description).toContain("try again");
+    expect(result.payload.description).toContain('<a href="https://console.akash.network/billing">');
+    expect(result.user).toEqual({ id: "user-123", email: "user@example.com" });
+  });
+
+  it("keys the notification on the charge attempt so a later failure is not swallowed as a duplicate", () => {
+    const user = createUser({ id: "user-123", email: "user@example.com" });
+    const vars = { billingUrl: "https://console.akash.network/billing" };
+
+    const first = autoTopUpChargeFailedNotification(user, { ...vars, chargeAttemptedAt: "2026-09-01 12:00:00" });
+    const second = autoTopUpChargeFailedNotification(user, { ...vars, chargeAttemptedAt: "2026-09-20 08:30:00" });
+
+    expect(first.notificationId).toBe("autoTopUpChargeFailed.user-123.2026-09-01 12:00:00");
+    expect(second.notificationId).not.toBe(first.notificationId);
+  });
+});

--- a/apps/api/src/notifications/services/notification-templates/auto-top-up-charge-failed-notification.ts
+++ b/apps/api/src/notifications/services/notification-templates/auto-top-up-charge-failed-notification.ts
@@ -1,0 +1,24 @@
+import type { UserOutput } from "@src/user/repositories";
+import type { CreateNotificationInput } from "../notification/notification.service";
+
+/**
+ * `notificationId` carries the charge marker the claim wrote, so the broker's singleton key dedupes
+ * retries of one attempt but still lets a card that starts failing again later be reported.
+ */
+export function autoTopUpChargeFailedNotification(user: UserOutput, vars: { chargeAttemptedAt: string; billingUrl: string }): CreateNotificationInput {
+  return {
+    notificationId: `autoTopUpChargeFailed.${user.id}.${vars.chargeAttemptedAt}`,
+    payload: {
+      summary: "We couldn't charge your card",
+      description:
+        `Your card was declined, so we couldn't add credits to your account automatically. ` +
+        `We'll try again a few more times over the next several hours. If it keeps failing we'll stop and send you another email. ` +
+        `Your deployments keep running on the credits you already have. ` +
+        `<a href="${vars.billingUrl}">Update your payment method</a> if the card needs fixing.`
+    },
+    user: {
+      id: user.id,
+      email: user.email
+    }
+  };
+}


### PR DESCRIPTION
## Why

Fixes CON-940. Stacked on #3760 — review that one first.

#3760 stops charging a card that keeps declining and emails the user when it gives up. It says nothing about the declines that lead there, and with the doubling backoff that silence runs about seven hours:

| Time | Event | User hears |
| --- | --- | --- |
| t=0 | decline 1 | nothing |
| t=1h | decline 2 | nothing |
| t=3h | decline 3 | nothing |
| t=7h | decline 4, pause | "Auto top-up is paused" |

The credits-low email cannot fill that gap. `WalletCreditsLowCheckHandler` skips any wallet where `isAutoReloadActive` is true, and during declines 1-3 the wallet is still enabled and not yet paused — so the one email that would warn the user is gated off precisely while the card is failing. The paused banner is hidden for the same reason, keying on `autoReloadPausedAt`.

And auto top-up only fires when the balance is already near the threshold, so this is not seven hours of comfortable runway. It is seven hours of an already-low balance draining with no top-up and no warning.

We already email on a *successful* automatic charge (`auto-recharge-succeeded`). Saying nothing when we cannot charge is the wrong asymmetry: the user carries on expecting the card to work.

## What

New `autoTopUpChargeFailedNotification`, sent from `AutoReloadPauseService.recordDecline` when the count reaches 1. Copy says the charge failed, that retries continue over the next several hours, that deployments keep running on existing credits, and links to the payment methods page. It does not name a retry count, since the limit is configurable.

Only the first decline of a run emails, so a card having a bad day does not send one message per attempt. `recordChargeDecline` increments atomically and returns the new count, so exactly one caller ever sees 1 — the same once-only property the pause transition relies on.

The cases that must not double up or misfire:

- a decline that pauses immediately (terminal code like `stolen_card`, or `AUTO_RELOAD_MAX_CONSECUTIVE_DECLINES=1`) sends only the pause email, since `pausedAt` short-circuits ahead of the new branch
- a decline discarded as stale, where the user already replaced the card, returns count 0 and sends nothing
- `notificationId` carries the charge marker from the claim, so the broker's singleton key dedupes retries of one attempt while still letting a card that starts failing again later be reported

No schema, config, or API-surface change. The README section on giving up now describes both emails and why the middle declines are quiet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an email notification after the first failed automatic top-up charge.
  * The notification explains that retries will continue and includes the attempted charge time and a link to billing settings.
  * Additional failure notifications are suppressed during the same failure sequence until auto-reload is paused.
  * Auto-reload pause notifications continue to be sent when the feature is ultimately paused.

* **Documentation**
  * Clarified auto-reload failure, retry, notification, and reset behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->