### PR TITLE
feat(billing): cap trial deployment cpu and memory at creation

### DIFF
--- a/apps/api/src/billing/config/env.config.spec.ts
+++ b/apps/api/src/billing/config/env.config.spec.ts
@@ -71,6 +71,52 @@ describe("envSchema", () => {
     });
   });
 
+  describe("MANAGED_WALLET_TRIAL_MAX_CPU", () => {
+    it("rejects Infinity", () => {
+      const result = setup({ MANAGED_WALLET_TRIAL_MAX_CPU: "Infinity" });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects a negative value", () => {
+      const result = setup({ MANAGED_WALLET_TRIAL_MAX_CPU: "-1" });
+      expect(result.success).toBe(false);
+    });
+
+    it("accepts zero to disable the cap", () => {
+      const result = setup({ MANAGED_WALLET_TRIAL_MAX_CPU: "0" });
+      expect(result.success).toBe(true);
+    });
+
+    it("coerces a string value", () => {
+      const result = setup({ MANAGED_WALLET_TRIAL_MAX_CPU: "8" });
+      expect(result.success).toBe(true);
+      expect(result.data?.MANAGED_WALLET_TRIAL_MAX_CPU).toBe(8);
+    });
+  });
+
+  describe("MANAGED_WALLET_TRIAL_MAX_MEMORY_GI", () => {
+    it("rejects Infinity", () => {
+      const result = setup({ MANAGED_WALLET_TRIAL_MAX_MEMORY_GI: "Infinity" });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects a negative value", () => {
+      const result = setup({ MANAGED_WALLET_TRIAL_MAX_MEMORY_GI: "-1" });
+      expect(result.success).toBe(false);
+    });
+
+    it("accepts zero to disable the cap", () => {
+      const result = setup({ MANAGED_WALLET_TRIAL_MAX_MEMORY_GI: "0" });
+      expect(result.success).toBe(true);
+    });
+
+    it("coerces a string value", () => {
+      const result = setup({ MANAGED_WALLET_TRIAL_MAX_MEMORY_GI: "32" });
+      expect(result.success).toBe(true);
+      expect(result.data?.MANAGED_WALLET_TRIAL_MAX_MEMORY_GI).toBe(32);
+    });
+  });
+
   const validEnv = {
     NETWORK: "sandbox",
     RPC_NODE_ENDPOINT: "https://rpc.example.com",

--- a/apps/api/src/billing/config/env.config.ts
+++ b/apps/api/src/billing/config/env.config.ts
@@ -66,9 +66,9 @@ export const envSchema = z.object({
       message: "MANAGED_WALLET_TRIAL_BLOCKED_GPU_MODELS entries must be in 'vendor/model' format"
     }),
   /** Max vCPUs per trial deployment, summed across all services and replicas; 0 disables the cap. */
-  MANAGED_WALLET_TRIAL_MAX_CPU: z.number({ coerce: true }).nonnegative().default(4),
+  MANAGED_WALLET_TRIAL_MAX_CPU: z.number({ coerce: true }).nonnegative().finite().default(4),
   /** Max memory in Gi per trial deployment, summed across all services and replicas; 0 disables the cap. */
-  MANAGED_WALLET_TRIAL_MAX_MEMORY_GI: z.number({ coerce: true }).nonnegative().default(16),
+  MANAGED_WALLET_TRIAL_MAX_MEMORY_GI: z.number({ coerce: true }).nonnegative().finite().default(16),
   MASTER_WALLET_AKT_RESERVE: z.number({ coerce: true }).int().nonnegative().default(2_000_000_000),
   MASTER_WALLET_MAX_MINT_UAKT: z.number({ coerce: true }).int().nonnegative().default(5_000_000_000),
   TX_SIGNER_BASE_URL: z.string(),

--- a/apps/api/src/billing/config/env.config.ts
+++ b/apps/api/src/billing/config/env.config.ts
@@ -65,6 +65,10 @@ export const envSchema = z.object({
     .refine(entries => entries.every(entry => /^[a-z0-9._-]+\/[a-z0-9._-]+$/.test(entry)), {
       message: "MANAGED_WALLET_TRIAL_BLOCKED_GPU_MODELS entries must be in 'vendor/model' format"
     }),
+  /** Max vCPUs per trial deployment, summed across all services and replicas; 0 disables the cap. */
+  MANAGED_WALLET_TRIAL_MAX_CPU: z.number({ coerce: true }).nonnegative().default(4),
+  /** Max memory in Gi per trial deployment, summed across all services and replicas; 0 disables the cap. */
+  MANAGED_WALLET_TRIAL_MAX_MEMORY_GI: z.number({ coerce: true }).nonnegative().default(16),
   MASTER_WALLET_AKT_RESERVE: z.number({ coerce: true }).int().nonnegative().default(2_000_000_000),
   MASTER_WALLET_MAX_MINT_UAKT: z.number({ coerce: true }).int().nonnegative().default(5_000_000_000),
   TX_SIGNER_BASE_URL: z.string(),

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
@@ -744,6 +744,42 @@ describe(ManagedSignerService.name, () => {
 
       expect(anonymousValidateService.validateDeploymentGpuInterconnect).toHaveBeenCalledWith(messages, wallet);
     });
+
+    it("validates deployment resources for the wallet", async () => {
+      const wallet = createUserWallet({
+        userId: "user-123",
+        feeAllowance: 100,
+        deploymentAllowance: 100,
+        isTrialing: true
+      });
+      const user = createUser({ userId: "user-123" });
+      const messages: EncodeObject[] = [
+        {
+          typeUrl: MsgCreateLease.$type,
+          value: MsgCreateLease.fromPartial({
+            bidId: {
+              dseq: 123,
+              provider: "akash1provider"
+            }
+          })
+        }
+      ];
+
+      const { service, anonymousValidateService } = setup({
+        findOneByUserId: vi.fn().mockResolvedValue(wallet),
+        findById: vi.fn().mockResolvedValue(user),
+        signAndBroadcastWithDerivedWallet: vi.fn().mockResolvedValue({
+          code: 0,
+          hash: "tx-hash",
+          rawLog: "success"
+        }),
+        refreshUserWalletLimits: vi.fn().mockResolvedValue(undefined)
+      });
+
+      await service.executeDerivedDecodedTxByUserId("user-123", messages);
+
+      expect(anonymousValidateService.validateDeploymentResources).toHaveBeenCalledWith(messages, wallet);
+    });
   });
 
   describe("executeDerivedEncodedTxByUserId", () => {

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
@@ -123,6 +123,7 @@ export class ManagedSignerService {
       this.anonymousValidateService.validateLeaseProvidersAuditors(messages, userWallet),
       this.anonymousValidateService.validateDeploymentGpuModels(messages, userWallet),
       this.anonymousValidateService.validateDeploymentGpuInterconnect(messages, userWallet),
+      this.anonymousValidateService.validateDeploymentResources(messages, userWallet),
       this.anonymousValidateService.validateLeaseGpuModels(messages, userWallet)
     ]);
 

--- a/apps/api/src/billing/services/trial-validation/trial-validation.service.spec.ts
+++ b/apps/api/src/billing/services/trial-validation/trial-validation.service.spec.ts
@@ -2,10 +2,11 @@ import { MsgCreateDeployment } from "@akashnetwork/chain-sdk/private-types/akash
 import { MsgCreateLease } from "@akashnetwork/chain-sdk/private-types/akash.v1beta5";
 import type { BidHttpService } from "@akashnetwork/http-sdk";
 import type { EncodeObject } from "@cosmjs/proto-signing";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
+import type { CreateLogger } from "@src/core/providers/logging.provider";
 import { BlockedGpuService } from "@src/deployment/services/blocked-gpu/blocked-gpu.service";
 import type { ProviderRepository } from "@src/provider/repositories/provider/provider.repository";
 import { TrialValidationService } from "./trial-validation.service";
@@ -216,6 +217,25 @@ describe(TrialValidationService.name, () => {
     };
   }
 
+  function createDeploymentMessageWithResources(groups: { cpuMillis?: number; memoryBytes?: number; count?: number }[][]): EncodeObject {
+    return {
+      typeUrl: `/${MsgCreateDeployment.$type}`,
+      value: MsgCreateDeployment.fromPartial({
+        groups: groups.map((units, index) => ({
+          name: `group-${index}`,
+          resources: units.map(unit => ({
+            resource: {
+              id: 1,
+              cpu: { units: { val: BigInt(unit.cpuMillis ?? 0) } },
+              memory: { quantity: { val: BigInt(unit.memoryBytes ?? 0) } }
+            },
+            count: unit.count ?? 1
+          }))
+        }))
+      })
+    };
+  }
+
   function createLeaseMessage(bidId?: { dseq?: string; gseq?: number; oseq?: number; bseq?: number; provider?: string; owner?: string }): EncodeObject {
     return {
       typeUrl: `/${MsgCreateLease.$type}`,
@@ -244,6 +264,91 @@ describe(TrialValidationService.name, () => {
     };
     return bid;
   }
+
+  describe("validateDeploymentResources", () => {
+    it("skips validation when wallet is not trialing", async () => {
+      const wallet = createUserWallet({ isTrialing: false });
+      const { service } = setupResources({ maxCpu: 4, maxMemoryGi: 16 });
+
+      await expect(service.validateDeploymentResources([createDeploymentMessageWithResources([[{ cpuMillis: 16_000 }]])], wallet)).resolves.toBeUndefined();
+    });
+
+    it("skips validation when both caps are configured to zero", async () => {
+      const wallet = createUserWallet({ isTrialing: true });
+      const { service } = setupResources({ maxCpu: 0, maxMemoryGi: 0 });
+
+      await expect(service.validateDeploymentResources([createDeploymentMessageWithResources([[{ cpuMillis: 16_000 }]])], wallet)).resolves.toBeUndefined();
+    });
+
+    it("allows a trial deployment within the caps", async () => {
+      const wallet = createUserWallet({ isTrialing: true });
+      const { service } = setupResources({ maxCpu: 4, maxMemoryGi: 16 });
+
+      await expect(
+        service.validateDeploymentResources([createDeploymentMessageWithResources([[{ cpuMillis: 4000, memoryBytes: 16 * 1024 ** 3 }]])], wallet)
+      ).resolves.toBeUndefined();
+    });
+
+    it("rejects a trial deployment with 403 when CPU exceeds the cap", async () => {
+      const wallet = createUserWallet({ isTrialing: true });
+      const { service } = setupResources({ maxCpu: 4, maxMemoryGi: 16 });
+
+      await expect(service.validateDeploymentResources([createDeploymentMessageWithResources([[{ cpuMillis: 16_000 }]])], wallet)).rejects.toMatchObject({
+        status: 403,
+        message: expect.stringContaining("limited to 4 CPU")
+      });
+    });
+
+    it("rejects a trial deployment with 403 when memory exceeds the cap", async () => {
+      const wallet = createUserWallet({ isTrialing: true });
+      const { service } = setupResources({ maxCpu: 4, maxMemoryGi: 16 });
+
+      await expect(
+        service.validateDeploymentResources([createDeploymentMessageWithResources([[{ cpuMillis: 1000, memoryBytes: 24 * 1024 ** 3 }]])], wallet)
+      ).rejects.toMatchObject({
+        status: 403,
+        message: expect.stringContaining("limited to 16Gi of memory")
+      });
+    });
+
+    it("multiplies resources by the replica count", async () => {
+      const wallet = createUserWallet({ isTrialing: true });
+      const { service } = setupResources({ maxCpu: 4, maxMemoryGi: 16 });
+
+      await expect(
+        service.validateDeploymentResources([createDeploymentMessageWithResources([[{ cpuMillis: 3000, count: 2 }]])], wallet)
+      ).rejects.toMatchObject({ status: 403, message: expect.stringContaining("limited to 4 CPU") });
+    });
+
+    it("sums resources across all groups", async () => {
+      const wallet = createUserWallet({ isTrialing: true });
+      const { service } = setupResources({ maxCpu: 4, maxMemoryGi: 16 });
+
+      await expect(
+        service.validateDeploymentResources([createDeploymentMessageWithResources([[{ cpuMillis: 3000 }], [{ cpuMillis: 3000 }]])], wallet)
+      ).rejects.toMatchObject({ status: 403, message: expect.stringContaining("limited to 4 CPU") });
+    });
+
+    it("logs a structured rejection event when a cap is exceeded", async () => {
+      const wallet = createUserWallet({ isTrialing: true });
+      const { service, logger } = setupResources({ maxCpu: 4, maxMemoryGi: 16 });
+
+      await expect(service.validateDeploymentResources([createDeploymentMessageWithResources([[{ cpuMillis: 16_000 }]])], wallet)).rejects.toMatchObject({
+        status: 403
+      });
+
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({ event: "TRIAL_RESOURCE_LIMIT_REJECTED", kind: "cpu", cpuMillis: 16_000, owner: wallet.address, userId: wallet.userId })
+      );
+    });
+
+    it("passes when there are no MsgCreateDeployment messages", async () => {
+      const wallet = createUserWallet({ isTrialing: true });
+      const { service } = setupResources({ maxCpu: 4, maxMemoryGi: 16 });
+
+      await expect(service.validateDeploymentResources([createLeaseMessage()], wallet)).resolves.toBeUndefined();
+    });
+  });
 
   describe("getTopUpMinAmountUsd", () => {
     it("returns the standard $20 floor when the wallet is not trialing", () => {
@@ -341,7 +446,13 @@ describe(TrialValidationService.name, () => {
     const config = mockConfigService<BillingConfigService>({
       TRIAL_ALLOWANCE_EXPIRATION_DAYS: input.trialDurationDays
     });
-    const service = new TrialValidationService(config, mock<ProviderRepository>(), mock<BidHttpService>(), mock<BlockedGpuService>());
+    const service = new TrialValidationService(
+      config,
+      mock<ProviderRepository>(),
+      mock<BidHttpService>(),
+      mock<BlockedGpuService>(),
+      createLoggerStub().createLogger
+    );
     return { service };
   }
 
@@ -352,7 +463,7 @@ describe(TrialValidationService.name, () => {
     const config = mockConfigService<BillingConfigService>({
       MANAGED_WALLET_TRIAL_MIN_TOP_UP_AMOUNT: input.trialMin
     });
-    const service = new TrialValidationService(config, providerRepository, bidHttpService, blockedGpuService);
+    const service = new TrialValidationService(config, providerRepository, bidHttpService, blockedGpuService, createLoggerStub().createLogger);
     return { service };
   }
 
@@ -365,7 +476,23 @@ describe(TrialValidationService.name, () => {
       MANAGED_WALLET_TRIAL_BLOCKED_GPU_MODELS: input.blockedGpuModels
     });
     const blockedGpuService = new BlockedGpuService(blockedGpuConfig);
-    const service = new TrialValidationService(config, providerRepository, bidHttpService, blockedGpuService);
+    const service = new TrialValidationService(config, providerRepository, bidHttpService, blockedGpuService, createLoggerStub().createLogger);
     return { service, config, providerRepository, bidHttpService, blockedGpuService };
+  }
+
+  function setupResources(input: { maxCpu: number; maxMemoryGi: number }) {
+    const config = mockConfigService<BillingConfigService>({
+      MANAGED_WALLET_TRIAL_MAX_CPU: input.maxCpu,
+      MANAGED_WALLET_TRIAL_MAX_MEMORY_GI: input.maxMemoryGi
+    });
+    const { createLogger, logger } = createLoggerStub();
+    const service = new TrialValidationService(config, mock<ProviderRepository>(), mock<BidHttpService>(), mock<BlockedGpuService>(), createLogger);
+    return { service, logger };
+  }
+
+  function createLoggerStub() {
+    const logger = mock<ReturnType<CreateLogger>>();
+    const createLogger = vi.fn<CreateLogger>(() => logger);
+    return { createLogger, logger };
   }
 });

--- a/apps/api/src/billing/services/trial-validation/trial-validation.service.ts
+++ b/apps/api/src/billing/services/trial-validation/trial-validation.service.ts
@@ -4,26 +4,33 @@ import { BidHttpService } from "@akashnetwork/http-sdk";
 import { Trace } from "@akashnetwork/instrumentation";
 import { EncodeObject } from "@cosmjs/proto-signing";
 import assert from "http-assert";
-import { singleton } from "tsyringe";
+import { inject, singleton } from "tsyringe";
 
 import { STANDARD_TOP_UP_MIN_AMOUNT_USD } from "@src/billing/config";
 import { getTrialEndsAt } from "@src/billing/lib/trial-window/trial-window";
 import type { TrialWindow, UserWalletOutput } from "@src/billing/repositories";
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
+import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
 import { AUDITOR, TRIAL_ATTRIBUTE, TRIAL_REGISTERED_ATTRIBUTE } from "@src/deployment/config/provider.config";
 import { BlockedGpuService } from "@src/deployment/services/blocked-gpu/blocked-gpu.service";
 import { groupSpecsRequestGpuInterconnect } from "@src/deployment/utils/gpu-interconnect/gpu-interconnect";
+import { findTrialResourceViolation } from "@src/deployment/utils/group-resources/group-resources";
 import { ProviderRepository } from "@src/provider/repositories/provider/provider.repository";
 import type { UserOutput } from "@src/user/repositories";
 
 @singleton()
 export class TrialValidationService {
+  private readonly logger: ReturnType<CreateLogger>;
+
   constructor(
     private readonly config: BillingConfigService,
     private readonly providerRepository: ProviderRepository,
     private readonly bidHttpService: BidHttpService,
-    private readonly blockedGpuService: BlockedGpuService
-  ) {}
+    private readonly blockedGpuService: BlockedGpuService,
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
+  ) {
+    this.logger = createLogger({ context: TrialValidationService.name });
+  }
 
   async validateLeaseProviders(decoded: EncodeObject, userWallet: UserWalletOutput, user: UserOutput) {
     if (decoded.typeUrl === `/${MsgCreateDeployment.$type}`) {
@@ -119,6 +126,34 @@ export class TrialValidationService {
       .some(message => groupSpecsRequestGpuInterconnect((message.value as MsgCreateDeployment).groups));
 
     assert(!requestsInterconnect, 402, "GPU interconnect not available on free trial: Add funds to unlock GPU interconnect");
+  }
+
+  @Trace()
+  async validateDeploymentResources(messages: EncodeObject[], userWallet: UserWalletOutput) {
+    if (!userWallet.isTrialing) return;
+
+    const limits = {
+      maxCpu: this.config.get("MANAGED_WALLET_TRIAL_MAX_CPU"),
+      maxMemoryGi: this.config.get("MANAGED_WALLET_TRIAL_MAX_MEMORY_GI")
+    };
+
+    const deploymentMessages = messages.filter(message => message.typeUrl === `/${MsgCreateDeployment.$type}`);
+
+    for (const message of deploymentMessages) {
+      const violation = findTrialResourceViolation((message.value as MsgCreateDeployment).groups, limits);
+      if (!violation) continue;
+
+      this.logger.info({
+        event: "TRIAL_RESOURCE_LIMIT_REJECTED",
+        kind: violation.kind,
+        cpuMillis: violation.cpuMillis,
+        memoryBytes: violation.memoryBytes,
+        owner: userWallet.address,
+        userId: userWallet.userId
+      });
+
+      assert(false, 403, violation.message);
+    }
   }
 
   @Trace()

--- a/apps/api/src/deployment/services/sdl/sdl.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl/sdl.service.spec.ts
@@ -42,6 +42,39 @@ deployment:
       count: 1
 `;
 
+const SDL_WITH_RESOURCES = (cpuUnits: number, memorySize: string) => `
+version: "2.0"
+services:
+  web:
+    image: nginx
+    expose:
+      - port: 80
+        as: 80
+        to:
+          - global: true
+profiles:
+  compute:
+    web:
+      resources:
+        cpu:
+          units: ${cpuUnits}
+        memory:
+          size: ${memorySize}
+        storage:
+          size: 1Gi
+  placement:
+    westcoast:
+      pricing:
+        web:
+          denom: uakt
+          amount: 1000
+deployment:
+  web:
+    westcoast:
+      profile: web
+      count: 1
+`;
+
 const MULTI_PLACEMENT_SDL = `
 version: "2.0"
 services:
@@ -514,6 +547,42 @@ describe(SdlService.name, () => {
       expect(result.ok).toBe(true);
     });
 
+    it("rejects trial SDL that exceeds the CPU cap", () => {
+      const { result } = setup({ sdl: SDL_WITH_RESOURCES(16, "24Gi"), isTrialing: true, trialMaxCpu: 4, trialMaxMemoryGi: 32 });
+
+      expect(result).toMatchObject({
+        ok: false,
+        value: [expect.objectContaining({ keyword: "trial-resources", message: expect.stringContaining("limited to 4 CPU") })]
+      });
+    });
+
+    it("rejects trial SDL that exceeds the memory cap", () => {
+      const { result } = setup({ sdl: SDL_WITH_RESOURCES(2, "24Gi"), isTrialing: true, trialMaxCpu: 4, trialMaxMemoryGi: 16 });
+
+      expect(result).toMatchObject({
+        ok: false,
+        value: [expect.objectContaining({ keyword: "trial-resources", message: expect.stringContaining("limited to 16Gi of memory") })]
+      });
+    });
+
+    it("allows trial SDL within the resource caps", () => {
+      const { result } = setup({ sdl: SDL_WITH_RESOURCES(4, "16Gi"), isTrialing: true, trialMaxCpu: 4, trialMaxMemoryGi: 16 });
+
+      expect(result.ok).toBe(true);
+    });
+
+    it("does not enforce resource caps for non-trialing wallets", () => {
+      const { result } = setup({ sdl: SDL_WITH_RESOURCES(16, "24Gi"), isTrialing: false, trialMaxCpu: 4, trialMaxMemoryGi: 16 });
+
+      expect(result.ok).toBe(true);
+    });
+
+    it("does not enforce resource caps when they are configured to zero", () => {
+      const { result } = setup({ sdl: SDL_WITH_RESOURCES(16, "24Gi"), isTrialing: true, trialMaxCpu: 0, trialMaxMemoryGi: 0 });
+
+      expect(result.ok).toBe(true);
+    });
+
     describe("confidential compute (tee)", () => {
       it("projects a cpu tee selection into the manifest sent to the provider", () => {
         const { result } = setup({ sdl: SDL_WITH_TEE("cpu") });
@@ -651,10 +720,14 @@ describe(SdlService.name, () => {
     deploymentGrantDenom?: BillingConfig["DEPLOYMENT_GRANT_DENOM"];
     blockedGpuModels?: string[];
     isTrialing?: boolean;
+    trialMaxCpu?: number;
+    trialMaxMemoryGi?: number;
   }) {
     const config = mock<BillingConfig>({
       DEPLOYMENT_GRANT_DENOM: input?.deploymentGrantDenom ?? "uakt",
-      MANAGED_WALLET_LEASE_ALLOWED_AUDITORS: input?.allowedAuditors ?? []
+      MANAGED_WALLET_LEASE_ALLOWED_AUDITORS: input?.allowedAuditors ?? [],
+      MANAGED_WALLET_TRIAL_MAX_CPU: input?.trialMaxCpu ?? 0,
+      MANAGED_WALLET_TRIAL_MAX_MEMORY_GI: input?.trialMaxMemoryGi ?? 0
     });
 
     const blockedGpuConfig = mockConfigService<BillingConfigService>({

--- a/apps/api/src/deployment/services/sdl/sdl.service.ts
+++ b/apps/api/src/deployment/services/sdl/sdl.service.ts
@@ -8,6 +8,7 @@ import { BlockedGpuService } from "@src/deployment/services/blocked-gpu/blocked-
 import type { NamespacedSdlSecrets } from "@src/deployment/services/sdl-reference/sdl-reference.service";
 import { SdlReferenceService } from "@src/deployment/services/sdl-reference/sdl-reference.service";
 import { sdlRequestsGpuInterconnect } from "@src/deployment/utils/gpu-interconnect/gpu-interconnect";
+import { findTrialResourceViolation } from "@src/deployment/utils/group-resources/group-resources";
 
 export type SdlParseResult = { ok: true; value: SDLInput } | { ok: false; value: ValidationError[] };
 export type SdlManifest = Extract<GenerateManifestResult, { ok: true }>["value"];
@@ -128,6 +129,28 @@ export class SdlService {
 
     const result = generateManifest(potentiallyInvalidSDL);
     if (!result.ok) return result;
+
+    if (options.isTrialing) {
+      const violation = findTrialResourceViolation(result.value.groupSpecs, {
+        maxCpu: this.#config.MANAGED_WALLET_TRIAL_MAX_CPU,
+        maxMemoryGi: this.#config.MANAGED_WALLET_TRIAL_MAX_MEMORY_GI
+      });
+
+      if (violation) {
+        return {
+          ok: false,
+          value: [
+            {
+              schemaPath: "",
+              instancePath: "/profiles/compute",
+              keyword: "trial-resources",
+              params: { kind: violation.kind },
+              message: violation.message
+            }
+          ]
+        };
+      }
+    }
 
     return result;
   }

--- a/apps/api/src/deployment/utils/group-resources/group-resources.spec.ts
+++ b/apps/api/src/deployment/utils/group-resources/group-resources.spec.ts
@@ -1,0 +1,103 @@
+import type { GroupSpec } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
+import { describe, expect, it } from "vitest";
+
+import { findTrialResourceViolation, sumGroupSpecResources } from "./group-resources";
+
+describe("sumGroupSpecResources", () => {
+  it("returns zero totals for empty or missing groups", () => {
+    expect(sumGroupSpecResources([])).toEqual({ cpuMillis: 0, memoryBytes: 0 });
+    expect(sumGroupSpecResources(undefined)).toEqual({ cpuMillis: 0, memoryBytes: 0 });
+  });
+
+  it("sums cpu and memory across groups and resource units", () => {
+    const groups = [
+      createGroup([{ cpuMillis: 1000n, memoryBytes: BigInt(1024 ** 3) }]),
+      createGroup([{ cpuMillis: 500n, memoryBytes: BigInt(2 * 1024 ** 3) }])
+    ];
+
+    expect(sumGroupSpecResources(groups)).toEqual({ cpuMillis: 1500, memoryBytes: 3 * 1024 ** 3 });
+  });
+
+  it("multiplies resource units by their replica count", () => {
+    const groups = [createGroup([{ cpuMillis: 1000n, memoryBytes: BigInt(1024 ** 3), count: 3 }])];
+
+    expect(sumGroupSpecResources(groups)).toEqual({ cpuMillis: 3000, memoryBytes: 3 * 1024 ** 3 });
+  });
+
+  it("treats a zero replica count as a single replica", () => {
+    const groups = [createGroup([{ cpuMillis: 1000n, count: 0 }])];
+
+    expect(sumGroupSpecResources(groups).cpuMillis).toBe(1000);
+  });
+
+  it("decodes wire-encoded Uint8Array resource values", () => {
+    const groups = [createGroup([{ cpuMillis: new TextEncoder().encode("16000") as unknown as bigint }])];
+
+    expect(sumGroupSpecResources(groups).cpuMillis).toBe(16_000);
+  });
+
+  it("counts missing cpu and memory as zero", () => {
+    const groups = [createGroup([{}])];
+
+    expect(sumGroupSpecResources(groups)).toEqual({ cpuMillis: 0, memoryBytes: 0 });
+  });
+});
+
+describe("findTrialResourceViolation", () => {
+  it("returns undefined when both limits are disabled", () => {
+    const groups = [createGroup([{ cpuMillis: 64_000n, memoryBytes: BigInt(128 * 1024 ** 3) }])];
+
+    expect(findTrialResourceViolation(groups, { maxCpu: 0, maxMemoryGi: 0 })).toBeUndefined();
+  });
+
+  it("returns undefined when totals are within the limits", () => {
+    const groups = [createGroup([{ cpuMillis: 4000n, memoryBytes: BigInt(16 * 1024 ** 3) }])];
+
+    expect(findTrialResourceViolation(groups, { maxCpu: 4, maxMemoryGi: 16 })).toBeUndefined();
+  });
+
+  it("reports a cpu violation with the requested amount in the message", () => {
+    const groups = [createGroup([{ cpuMillis: 16_000n }])];
+
+    expect(findTrialResourceViolation(groups, { maxCpu: 4, maxMemoryGi: 16 })).toMatchObject({
+      kind: "cpu",
+      cpuMillis: 16_000,
+      message: expect.stringContaining("limited to 4 CPU. Requested 16 CPU")
+    });
+  });
+
+  it("reports a memory violation when only memory exceeds its limit", () => {
+    const groups = [createGroup([{ cpuMillis: 1000n, memoryBytes: BigInt(24 * 1024 ** 3) }])];
+
+    expect(findTrialResourceViolation(groups, { maxCpu: 4, maxMemoryGi: 16 })).toMatchObject({
+      kind: "memory",
+      message: expect.stringContaining("limited to 16Gi of memory. Requested 24Gi")
+    });
+  });
+
+  it("checks only the enabled limit", () => {
+    const groups = [createGroup([{ cpuMillis: 64_000n, memoryBytes: BigInt(128 * 1024 ** 3) }])];
+
+    expect(findTrialResourceViolation(groups, { maxCpu: 0, maxMemoryGi: 16 })).toMatchObject({ kind: "memory" });
+    expect(findTrialResourceViolation(groups, { maxCpu: 4, maxMemoryGi: 0 })).toMatchObject({ kind: "cpu" });
+  });
+});
+
+function createGroup(units: { cpuMillis?: bigint; memoryBytes?: bigint; count?: number }[]): GroupSpec {
+  return {
+    name: "test",
+    requirements: undefined,
+    resources: units.map(unit => ({
+      resource: {
+        id: 1,
+        cpu: unit.cpuMillis === undefined ? undefined : { units: { val: unit.cpuMillis }, attributes: [] },
+        memory: unit.memoryBytes === undefined ? undefined : { quantity: { val: unit.memoryBytes }, attributes: [] },
+        gpu: undefined,
+        storage: [],
+        endpoints: []
+      },
+      count: unit.count ?? 1,
+      price: undefined
+    }))
+  };
+}

--- a/apps/api/src/deployment/utils/group-resources/group-resources.ts
+++ b/apps/api/src/deployment/utils/group-resources/group-resources.ts
@@ -1,0 +1,69 @@
+import type { GroupSpec } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
+
+import { uint8arrayToString } from "@src/utils/protobuf";
+
+const BYTES_PER_GI = 1024 ** 3;
+
+export interface GroupSpecResourceTotals {
+  cpuMillis: number;
+  memoryBytes: number;
+}
+
+export interface TrialResourceLimits {
+  maxCpu: number;
+  maxMemoryGi: number;
+}
+
+export interface TrialResourceViolation extends GroupSpecResourceTotals {
+  kind: "cpu" | "memory";
+  message: string;
+}
+
+export function sumGroupSpecResources(groups: GroupSpec[] | null | undefined): GroupSpecResourceTotals {
+  const totals: GroupSpecResourceTotals = { cpuMillis: 0, memoryBytes: 0 };
+
+  for (const group of groups ?? []) {
+    for (const unit of group.resources ?? []) {
+      const count = unit.count || 1;
+      totals.cpuMillis += resourceValToNumber(unit.resource?.cpu?.units?.val) * count;
+      totals.memoryBytes += resourceValToNumber(unit.resource?.memory?.quantity?.val) * count;
+    }
+  }
+
+  return totals;
+}
+
+export function findTrialResourceViolation(groups: GroupSpec[] | null | undefined, limits: TrialResourceLimits): TrialResourceViolation | undefined {
+  if (!limits.maxCpu && !limits.maxMemoryGi) return undefined;
+
+  const totals = sumGroupSpecResources(groups);
+
+  if (limits.maxCpu && !(totals.cpuMillis <= limits.maxCpu * 1000)) {
+    return {
+      ...totals,
+      kind: "cpu",
+      message: `Free trial deployments are limited to ${limits.maxCpu} CPU. Requested ${totals.cpuMillis / 1000} CPU. Add funds to deploy larger workloads.`
+    };
+  }
+
+  if (limits.maxMemoryGi && !(totals.memoryBytes <= limits.maxMemoryGi * BYTES_PER_GI)) {
+    return {
+      ...totals,
+      kind: "memory",
+      message: `Free trial deployments are limited to ${limits.maxMemoryGi}Gi of memory. Requested ${formatGi(totals.memoryBytes)}Gi. Add funds to deploy larger workloads.`
+    };
+  }
+
+  return undefined;
+}
+
+function formatGi(bytes: number): string {
+  return (Math.round((bytes / BYTES_PER_GI) * 100) / 100).toString();
+}
+
+/** Resource quantities decode as bigint from chain-sdk types but as Uint8Array on the protobuf wire. */
+function resourceValToNumber(val: Uint8Array | bigint | undefined): number {
+  if (typeof val === "bigint") return Number(val);
+  if (!val || val.length === 0) return 0;
+  return parseInt(uint8arrayToString(val), 10);
+}


### PR DESCRIPTION
## Why

Miners are farming the free trial. Each throwaway account creates one deployment of our own \`ghcr.io/akash-network/ubuntu-2404-ssh:2\` template at 16 CPU / 24Gi with only port 22 exposed, then SSHes in and runs the miner by hand. We're seeing roughly 300-380 of these per day. Because the image is our own template and the miner never appears in the SDL, image denylists can't catch this. The one signal they can't hide at creation time is a trial wallet asking for way more CPU than any legitimate trial needs.

## What

Adds \`TrialValidationService.validateDeploymentResources\`, which sums CPU and memory across all groups and replicas of each decoded \`MsgCreateDeployment\` and rejects trial deployments over the caps with a 403. It runs in \`ManagedSignerService.executeDecodedTxByUserWallet\` next to the existing GPU checks, so it covers \`POST /v1/deployments\`, the raw \`POST /v1/tx\` path (which never sees the SDL), and any future signer path. Splitting the request into multiple services or bumping the replica count doesn't get around it.

- New config: \`MANAGED_WALLET_TRIAL_MAX_CPU\` (default 4) and \`MANAGED_WALLET_TRIAL_MAX_MEMORY_GI\` (default 16). Setting either to 0 disables that cap, so rollback is a doppler change, no deploy needed.
- Every rejection logs a structured \`TRIAL_RESOURCE_LIMIT_REJECTED\` event with the requested totals, owner address, and userId. After deploy, watch \`{app="console-api-mainnet"} |= "TRIAL_RESOURCE_LIMIT_REJECTED"\` in Loki: it should start near the current farm volume and decay as their scripts break.
- \`SdlService\` runs the same check on the typed path and returns it as a \`trial-resources\` validation error, so API users get a readable "Invalid SDL" 400 instead of a bare 403.
- The shared sum/limit logic lives in \`deployment/utils/group-resources\` and handles both bigint and wire-encoded \`Uint8Array\` resource values.

No migration. No behavior change for non-trial wallets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable CPU and memory limits for trial deployments, with defaults of 4 vCPUs and 16 GiB.
  * Trial deployments exceeding resource limits are rejected with a validation error.
  * Resource usage is aggregated across deployment groups and replicas.
  * Limits can be disabled by setting them to zero.
  * Resource checks apply during deployment creation and managed-wallet transactions.

* **Bug Fixes**
  * Invalid infinite or negative resource limits are now rejected.
  * Improved violation details and structured logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->