### PR TITLE
feat(sdl): support proxy http_options in the deployment builder

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,3 @@
 min-release-age=7
+
+min-release-age-exclude[]=@akashnetwork/*

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@akashnetwork/akash-api": "1.4.3",
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.44",
     "@akashnetwork/console-api-types": "*",
     "@akashnetwork/database": "*",
     "@akashnetwork/env-loader": "*",

--- a/apps/deploy-web/package.json
+++ b/apps/deploy-web/package.json
@@ -26,7 +26,7 @@
     "type-check": "tsc"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.44",
     "@akashnetwork/console-api-types": "*",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ExposePortsCard/ExposePortsCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ExposePortsCard/ExposePortsCard.spec.tsx
@@ -384,6 +384,18 @@ describe(ExposePortsCard.name, () => {
       expect(await screen.findByText("Buffers number and buffers size must be set together.")).toBeInTheDocument();
     });
 
+    it("hides the proxy fields and seeds no proxy object when the proxy http options flag is off", async () => {
+      const { getValues, openCard } = setup({ expose: [{ port: 80, as: 80 }], isProxyHttpOptionsEnabled: false });
+
+      await openCard();
+      await userEvent.click(screen.getByLabelText("Custom HTTP options"));
+      await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+      expect(screen.queryByLabelText("Disable proxy buffering")).not.toBeInTheDocument();
+      expect(screen.queryByLabelText("Proxy buffer size")).not.toBeInTheDocument();
+      expect(getValues().services[0].expose[0].httpOptions?.proxy).toBeUndefined();
+    });
+
     it("clears accept hostnames and httpOptions when a configured HTTP port switches to TCP", async () => {
       const { getValues, openCard } = setup({ expose: [{ port: 80, as: 80, proto: "http" }] });
 
@@ -533,6 +545,7 @@ describe(ExposePortsCard.name, () => {
       withLogForwarding?: boolean;
       endpoints?: Array<{ id: string; name: string }>;
       locked?: boolean;
+      isProxyHttpOptionsEnabled?: boolean;
     } = {}
   ) {
     const values = defaultServiceWithPlacement(input.image !== undefined ? { image: input.image } : undefined);
@@ -568,7 +581,7 @@ describe(ExposePortsCard.name, () => {
 
     render(
       <Wrapper>
-        <ExposePortsCard serviceIndex={0} locked={input.locked} dependencies={{ ...DEPENDENCIES }} />
+        <ExposePortsCard serviceIndex={0} locked={input.locked} dependencies={{ ...DEPENDENCIES, useFlag: () => input.isProxyHttpOptionsEnabled ?? true }} />
         <ImageErrorProbe serviceIndex={0} />
         <ExposeErrorProbe serviceIndex={0} />
       </Wrapper>

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ExposePortsCard/ExposePortsCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ExposePortsCard/ExposePortsCard.spec.tsx
@@ -6,7 +6,7 @@ import { describe, expect, it } from "vitest";
 
 import type { ExposeType, SdlBuilderFormValuesType } from "@src/types";
 import { SdlBuilderFormValuesSchema } from "@src/types/sdlBuilder/sdlBuilder";
-import { defaultServiceWithPlacement } from "@src/utils/sdl/data";
+import { defaultHttpOptions, defaultServiceWithPlacement } from "@src/utils/sdl/data";
 import {
   DEPENDENCIES,
   ExposePortsCard,
@@ -382,6 +382,26 @@ describe(ExposePortsCard.name, () => {
       await trigger();
 
       expect(await screen.findByText("Buffers number and buffers size must be set together.")).toBeInTheDocument();
+    });
+
+    it("keeps an imported proxy value visible and fixable while the proxy http options flag is off", async () => {
+      const { openCard, trigger } = setup({
+        expose: [
+          {
+            port: 80,
+            as: 80,
+            hasCustomHttpOptions: true,
+            httpOptions: { ...defaultHttpOptions, nextCases: [...defaultHttpOptions.nextCases], proxy: { buffersNumber: 100, buffersSize: 8192 } }
+          }
+        ],
+        isProxyHttpOptionsEnabled: false
+      });
+
+      await openCard();
+      await trigger();
+
+      expect(screen.getByLabelText("Proxy buffers number")).toHaveValue(100);
+      expect(await screen.findByText("Buffers number must be at most 16.")).toBeInTheDocument();
     });
 
     it("hides the proxy fields and seeds no proxy object when the proxy http options flag is off", async () => {

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ExposePortsCard/ExposePortsCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ExposePortsCard/ExposePortsCard.spec.tsx
@@ -303,7 +303,8 @@ describe(ExposePortsCard.name, () => {
         sendTimeout: 60000,
         nextTries: 3,
         nextTimeout: 60000,
-        nextCases: ["error", "timeout"]
+        nextCases: ["error", "timeout"],
+        proxy: {}
       });
     });
 
@@ -359,6 +360,28 @@ describe(ExposePortsCard.name, () => {
 
       expect(screen.queryByLabelText("Port 1 accept hostnames")).not.toBeInTheDocument();
       expect(screen.queryByLabelText("Custom HTTP options")).not.toBeInTheDocument();
+    });
+
+    it("writes a typed proxy buffer size to httpOptions.proxy on Save", async () => {
+      const { getValues, openCard } = setup({ expose: [{ port: 80, as: 80 }] });
+
+      await openCard();
+      await userEvent.click(screen.getByLabelText("Custom HTTP options"));
+      fireEvent.change(screen.getByLabelText("Proxy buffer size"), { target: { value: "4096" } });
+      await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+      expect(getValues().services[0].expose[0].httpOptions?.proxy?.bufferSize).toBe(4096);
+    });
+
+    it("surfaces the buffers-number/buffers-size together-rule error when only one is set", async () => {
+      const { openCard, trigger } = setup({ expose: [{ port: 80, as: 80 }] });
+
+      await openCard();
+      await userEvent.click(screen.getByLabelText("Custom HTTP options"));
+      fireEvent.change(screen.getByLabelText("Proxy buffers number"), { target: { value: "4" } });
+      await trigger();
+
+      expect(await screen.findByText("Buffers number and buffers size must be set together.")).toBeInTheDocument();
     });
 
     it("clears accept hostnames and httpOptions when a configured HTTP port switches to TCP", async () => {

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ExposePortsCard/ExposePortsCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ExposePortsCard/ExposePortsCard.tsx
@@ -31,7 +31,7 @@ import { nanoid } from "nanoid";
 
 import { useFlag } from "@src/hooks/useFlag";
 import type { ExposeType, SdlBuilderFormValuesType } from "@src/types";
-import { EndpointSchema } from "@src/types/sdlBuilder/sdlBuilder";
+import { EndpointSchema, hasProxyValues } from "@src/types/sdlBuilder/sdlBuilder";
 import { defaultEndpoint, defaultHttpOptions, nextCases as nextCaseOptions, protoTypes } from "@src/utils/sdl/data";
 import { isVmImage } from "@src/utils/sdl/vmImages";
 import { exposePortsTooltip } from "../cardTooltips";
@@ -644,6 +644,13 @@ const HttpOptionsFields: FC<HttpOptionsFieldsProps> = ({ serviceIndex, exposeInd
   const { control, getValues, setValue } = useFormContext<SdlBuilderFormValuesType>();
   const basePath = `services.${serviceIndex}.expose.${exposeIndex}` as const;
   const hasCustomHttpOptions = useController({ control, name: `${basePath}.hasCustomHttpOptions` });
+  /**
+   * The schema validates `proxy` whether or not the flag renders its inputs, so a port that arrives
+   * carrying proxy values (an imported SDL) shows them even while the feature is off — otherwise its
+   * validation errors would have nowhere to render and would block saving with nothing to fix. Read
+   * once on mount so clearing the last value mid-edit can't unmount the fields under the user.
+   */
+  const [hasCarriedProxyValues] = useState(() => hasProxyValues(getValues(`${basePath}.httpOptions.proxy`)));
 
   const toggleCustomOptions = useCallback(
     (checked: boolean) => {
@@ -679,7 +686,7 @@ const HttpOptionsFields: FC<HttpOptionsFieldsProps> = ({ serviceIndex, exposeInd
 
           <NextCasesField basePath={basePath} />
 
-          {isProxyHttpOptionsEnabled && <HttpProxyFields basePath={basePath} exposeIndex={exposeIndex} />}
+          {(isProxyHttpOptionsEnabled || hasCarriedProxyValues) && <HttpProxyFields basePath={basePath} exposeIndex={exposeIndex} />}
         </div>
       )}
     </div>

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ExposePortsCard/ExposePortsCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ExposePortsCard/ExposePortsCard.tsx
@@ -220,6 +220,14 @@ const parsePort = (value: string): number | undefined => {
   return Number.isNaN(parsed) ? undefined : parsed;
 };
 
+/** Parses a proxy numeric input, preserving decimals (unlike `parsePort`) so the schema's `.int()` rule can reject a fractional value instead of silently truncating it (e.g. `1.5` to `1`). */
+const parseProxyNumber = (value: string): number | undefined => {
+  const trimmed = value.trim();
+  if (trimmed === "") return undefined;
+  const parsed = Number(trimmed);
+  return Number.isNaN(parsed) ? undefined : parsed;
+};
+
 /**
  * Returns focus to the Select trigger when a nested dropdown closes so the dialog's
  * focus scope keeps ownership; without it the nested Radix focus scopes can fight
@@ -791,7 +799,7 @@ const HttpProxyNumberField: FC<HttpProxyNumberFieldProps> = ({ basePath, optionK
           type="number"
           min={0}
           value={field.field.value ?? ""}
-          onChange={event => field.field.onChange(parsePort(event.target.value))}
+          onChange={event => field.field.onChange(parseProxyNumber(event.target.value))}
           error={!!field.fieldState.error}
           inputClassName="h-9"
         />

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ExposePortsCard/ExposePortsCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ExposePortsCard/ExposePortsCard.tsx
@@ -654,6 +654,8 @@ const HttpOptionsFields: FC<HttpOptionsFieldsProps> = ({ serviceIndex, exposeInd
           ))}
 
           <NextCasesField basePath={basePath} />
+
+          <HttpProxyFields basePath={basePath} exposeIndex={exposeIndex} />
         </div>
       )}
     </div>
@@ -708,6 +710,75 @@ type HttpOptionNumberFieldProps = {
 const HttpOptionNumberField: FC<HttpOptionNumberFieldProps> = ({ basePath, optionKey, label, defaultValue }) => {
   const { control } = useFormContext<SdlBuilderFormValuesType>();
   const field = useController({ control, name: `${basePath}.httpOptions.${optionKey}`, defaultValue });
+  const id = useId();
+
+  return (
+    <Field className="gap-2">
+      <FieldLabel htmlFor={id}>{label}</FieldLabel>
+      <FieldContent>
+        <Input
+          id={id}
+          aria-label={label}
+          type="number"
+          min={0}
+          value={field.field.value ?? ""}
+          onChange={event => field.field.onChange(parsePort(event.target.value))}
+          error={!!field.fieldState.error}
+          inputClassName="h-9"
+        />
+        <FieldError>{field.fieldState.error?.message}</FieldError>
+      </FieldContent>
+    </Field>
+  );
+};
+
+/** Nginx proxy-buffer tuning fields, each key on `httpOptions.proxy`. */
+const HTTP_PROXY_NUMBER_FIELDS = [
+  { key: "bufferSize", label: "Proxy buffer size" },
+  { key: "buffersNumber", label: "Proxy buffers number" },
+  { key: "buffersSize", label: "Proxy buffers size" },
+  { key: "busyBuffersSize", label: "Proxy busy buffers size" },
+  { key: "connectTimeout", label: "Proxy connect timeout" }
+] as const;
+
+type HttpProxyFieldsProps = {
+  basePath: `services.${number}.expose.${number}`;
+  exposeIndex: number;
+};
+
+/** Proxy tuning is entirely optional: unlike `fullHttpOptions()`, no field here is seeded, so the `proxy` object stays absent until the user sets one. */
+const HttpProxyFields: FC<HttpProxyFieldsProps> = ({ basePath, exposeIndex }) => {
+  const { control } = useFormContext<SdlBuilderFormValuesType>();
+  const bufferingDisable = useController({ control, name: `${basePath}.httpOptions.proxy.bufferingDisable` });
+
+  return (
+    <div
+      role="group"
+      aria-label={`Port ${exposeIndex + 1} proxy tuning`}
+      className="flex flex-col gap-3 rounded-md border border-zinc-200 p-3 dark:border-zinc-800"
+    >
+      <CheckboxWithLabel
+        checked={!!bufferingDisable.field.value}
+        onCheckedChange={state => bufferingDisable.field.onChange(state === "indeterminate" ? false : state)}
+        label="Disable proxy buffering"
+      />
+
+      {HTTP_PROXY_NUMBER_FIELDS.map(option => (
+        <HttpProxyNumberField key={option.key} basePath={basePath} optionKey={option.key} label={option.label} />
+      ))}
+    </div>
+  );
+};
+
+type HttpProxyNumberFieldProps = {
+  basePath: `services.${number}.expose.${number}`;
+  optionKey: (typeof HTTP_PROXY_NUMBER_FIELDS)[number]["key"];
+  label: string;
+};
+
+const HttpProxyNumberField: FC<HttpProxyNumberFieldProps> = ({ basePath, optionKey, label }) => {
+  const { control } = useFormContext<SdlBuilderFormValuesType>();
+  const field = useController({ control, name: `${basePath}.httpOptions.proxy.${optionKey}` });
   const id = useId();
 
   return (

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ExposePortsCard/ExposePortsCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ExposePortsCard/ExposePortsCard.tsx
@@ -29,13 +29,24 @@ import {
 import { ChevronRightIcon, GlobeIcon, PlusIcon, SaveIcon, XIcon } from "lucide-react";
 import { nanoid } from "nanoid";
 
+import { useFlag } from "@src/hooks/useFlag";
 import type { ExposeType, SdlBuilderFormValuesType } from "@src/types";
 import { EndpointSchema } from "@src/types/sdlBuilder/sdlBuilder";
 import { defaultEndpoint, defaultHttpOptions, nextCases as nextCaseOptions, protoTypes } from "@src/utils/sdl/data";
 import { isVmImage } from "@src/utils/sdl/vmImages";
 import { exposePortsTooltip } from "../cardTooltips";
 
-export const DEPENDENCIES = { CollapsibleCard, DialogV2, DialogV2Content, DialogV2Header, DialogV2Title, DialogV2Description, DialogV2Body, DialogV2Footer };
+export const DEPENDENCIES = {
+  CollapsibleCard,
+  DialogV2,
+  DialogV2Content,
+  DialogV2Header,
+  DialogV2Title,
+  DialogV2Description,
+  DialogV2Body,
+  DialogV2Footer,
+  useFlag
+};
 
 type Props = {
   serviceIndex: number;
@@ -116,6 +127,7 @@ export const inputToHostnames = (value: string): NonNullable<ExposeType["accept"
  * of mapped ports.
  */
 export const ExposePortsCard: FC<Props> = ({ serviceIndex, locked = false, dependencies: d = DEPENDENCIES }) => {
+  const isProxyHttpOptionsEnabled = d.useFlag("ui_sdl_proxy_http_options");
   const { control, getValues, reset, trigger, formState } = useFormContext<SdlBuilderFormValuesType>();
   const expose = useWatch({ control, name: `services.${serviceIndex}.expose` });
   const portCount = (expose ?? []).length;
@@ -187,7 +199,7 @@ export const ExposePortsCard: FC<Props> = ({ serviceIndex, locked = false, depen
 
           <d.DialogV2Body>
             <fieldset disabled={locked} className="contents">
-              <ExposePortsList serviceIndex={serviceIndex} commitsRef={endpointCommits} />
+              <ExposePortsList serviceIndex={serviceIndex} commitsRef={endpointCommits} isProxyHttpOptionsEnabled={isProxyHttpOptionsEnabled} />
             </fieldset>
           </d.DialogV2Body>
 
@@ -238,9 +250,10 @@ const keepFocusInDialog = (event: Event) => event.preventDefault();
 type ExposePortsListProps = {
   serviceIndex: number;
   commitsRef: EndpointCommitRegistry;
+  isProxyHttpOptionsEnabled: boolean;
 };
 
-const ExposePortsList: FC<ExposePortsListProps> = ({ serviceIndex, commitsRef }) => {
+const ExposePortsList: FC<ExposePortsListProps> = ({ serviceIndex, commitsRef, isProxyHttpOptionsEnabled }) => {
   const { control } = useFormContext<SdlBuilderFormValuesType>();
   const { fields, append, remove } = useFieldArray({ control, name: `services.${serviceIndex}.expose`, keyName: "fieldId" });
   const image = useWatch({ control, name: `services.${serviceIndex}.image` });
@@ -267,6 +280,7 @@ const ExposePortsList: FC<ExposePortsListProps> = ({ serviceIndex, commitsRef })
           exposeIndex={exposeIndex}
           commitsRef={commitsRef}
           isManagedSsh={exposeIndex === managedSshIndex}
+          isProxyHttpOptionsEnabled={isProxyHttpOptionsEnabled}
           onRemove={fields.length > 1 && exposeIndex !== managedSshIndex ? () => remove(exposeIndex) : undefined}
         />
       ))}
@@ -285,10 +299,11 @@ type ExposePortFieldsProps = {
   commitsRef: EndpointCommitRegistry;
   /** Marks the VM service's managed SSH row: its inputs are disabled and it carries the "Reserved for SSH access" caption. */
   isManagedSsh?: boolean;
+  isProxyHttpOptionsEnabled: boolean;
   onRemove?: () => void;
 };
 
-const ExposePortFields: FC<ExposePortFieldsProps> = ({ serviceIndex, exposeIndex, commitsRef, isManagedSsh = false, onRemove }) => {
+const ExposePortFields: FC<ExposePortFieldsProps> = ({ serviceIndex, exposeIndex, commitsRef, isManagedSsh = false, isProxyHttpOptionsEnabled, onRemove }) => {
   const { control, getValues, setValue } = useFormContext<SdlBuilderFormValuesType>();
   const basePath = `services.${serviceIndex}.expose.${exposeIndex}` as const;
   const endpoints = useWatch({ control, name: "endpoints" }) ?? [];
@@ -581,7 +596,7 @@ const ExposePortFields: FC<ExposePortFieldsProps> = ({ serviceIndex, exposeIndex
           <>
             <Separator className="my-2" />
 
-            <HttpOptionsFields serviceIndex={serviceIndex} exposeIndex={exposeIndex} />
+            <HttpOptionsFields serviceIndex={serviceIndex} exposeIndex={exposeIndex} isProxyHttpOptionsEnabled={isProxyHttpOptionsEnabled} />
           </>
         )}
       </fieldset>
@@ -592,6 +607,7 @@ const ExposePortFields: FC<ExposePortFieldsProps> = ({ serviceIndex, exposeIndex
 type HttpOptionsFieldsProps = {
   serviceIndex: number;
   exposeIndex: number;
+  isProxyHttpOptionsEnabled: boolean;
 };
 
 /** Numeric HTTP option fields rendered when custom options are enabled, with their seeded default. */
@@ -624,7 +640,7 @@ const fullHttpOptions = (): NonNullable<ExposeType["httpOptions"]> => ({
  * `nextCases`/numeric controllers mount only while enabled; writing only some of
  * them would leave the port silently invalid.
  */
-const HttpOptionsFields: FC<HttpOptionsFieldsProps> = ({ serviceIndex, exposeIndex }) => {
+const HttpOptionsFields: FC<HttpOptionsFieldsProps> = ({ serviceIndex, exposeIndex, isProxyHttpOptionsEnabled }) => {
   const { control, getValues, setValue } = useFormContext<SdlBuilderFormValuesType>();
   const basePath = `services.${serviceIndex}.expose.${exposeIndex}` as const;
   const hasCustomHttpOptions = useController({ control, name: `${basePath}.hasCustomHttpOptions` });
@@ -663,7 +679,7 @@ const HttpOptionsFields: FC<HttpOptionsFieldsProps> = ({ serviceIndex, exposeInd
 
           <NextCasesField basePath={basePath} />
 
-          <HttpProxyFields basePath={basePath} exposeIndex={exposeIndex} />
+          {isProxyHttpOptionsEnabled && <HttpProxyFields basePath={basePath} exposeIndex={exposeIndex} />}
         </div>
       )}
     </div>

--- a/apps/deploy-web/src/components/sdl/HttpOptionsFormControl.spec.tsx
+++ b/apps/deploy-web/src/components/sdl/HttpOptionsFormControl.spec.tsx
@@ -1,0 +1,49 @@
+import { useForm } from "react-hook-form";
+import { TooltipProvider } from "@akashnetwork/ui/components";
+import { describe, expect, it } from "vitest";
+
+import type { SdlBuilderFormValuesType } from "@src/types";
+import { defaultServiceWithPlacement } from "@src/utils/sdl/data";
+import { DEPENDENCIES, HttpOptionsFormControl } from "./HttpOptionsFormControl";
+
+import { render, screen } from "@testing-library/react";
+
+describe(HttpOptionsFormControl.name, () => {
+  it("shows the proxy fields when the proxy http options flag is on", () => {
+    setup({ isProxyHttpOptionsEnabled: true });
+
+    expect(screen.getByLabelText("Disable Proxy Buffering")).toBeInTheDocument();
+    expect(screen.getByText("Buffer Size")).toBeInTheDocument();
+  });
+
+  it("hides the proxy fields while keeping the base http options when the flag is off", () => {
+    setup({ isProxyHttpOptionsEnabled: false });
+
+    expect(screen.getByText("Max Body Size")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Disable Proxy Buffering")).not.toBeInTheDocument();
+    expect(screen.queryByText("Buffer Size")).not.toBeInTheDocument();
+  });
+
+  function setup(input: { isProxyHttpOptionsEnabled: boolean }) {
+    const values = defaultServiceWithPlacement();
+    values.services[0].expose[0].hasCustomHttpOptions = true;
+
+    const Wrapper = () => {
+      const form = useForm<SdlBuilderFormValuesType>({ defaultValues: values });
+      return (
+        <TooltipProvider>
+          <HttpOptionsFormControl
+            control={form.control}
+            serviceIndex={0}
+            exposeIndex={0}
+            services={values.services}
+            dependencies={{ ...DEPENDENCIES, useFlag: () => input.isProxyHttpOptionsEnabled }}
+          />
+        </TooltipProvider>
+      );
+    };
+
+    render(<Wrapper />);
+    return input;
+  }
+});

--- a/apps/deploy-web/src/components/sdl/HttpOptionsFormControl.spec.tsx
+++ b/apps/deploy-web/src/components/sdl/HttpOptionsFormControl.spec.tsx
@@ -3,7 +3,8 @@ import { TooltipProvider } from "@akashnetwork/ui/components";
 import { describe, expect, it } from "vitest";
 
 import type { SdlBuilderFormValuesType } from "@src/types";
-import { defaultServiceWithPlacement } from "@src/utils/sdl/data";
+import type { ServiceExposeHTTPProxyType } from "@src/types/sdlBuilder/sdlBuilder";
+import { defaultHttpOptions, defaultServiceWithPlacement } from "@src/utils/sdl/data";
 import { DEPENDENCIES, HttpOptionsFormControl } from "./HttpOptionsFormControl";
 
 import { render, screen } from "@testing-library/react";
@@ -24,9 +25,18 @@ describe(HttpOptionsFormControl.name, () => {
     expect(screen.queryByText("Buffer Size")).not.toBeInTheDocument();
   });
 
-  function setup(input: { isProxyHttpOptionsEnabled: boolean }) {
+  it("keeps a carried proxy value visible while the flag is off", () => {
+    setup({ isProxyHttpOptionsEnabled: false, proxy: { buffersNumber: 100, buffersSize: 8192 } });
+
+    expect(screen.getByText("Buffers Number")).toBeInTheDocument();
+  });
+
+  function setup(input: { isProxyHttpOptionsEnabled: boolean; proxy?: ServiceExposeHTTPProxyType }) {
     const values = defaultServiceWithPlacement();
     values.services[0].expose[0].hasCustomHttpOptions = true;
+    if (input.proxy) {
+      values.services[0].expose[0].httpOptions = { ...defaultHttpOptions, nextCases: [...defaultHttpOptions.nextCases], proxy: input.proxy };
+    }
 
     const Wrapper = () => {
       const form = useForm<SdlBuilderFormValuesType>({ defaultValues: values });

--- a/apps/deploy-web/src/components/sdl/HttpOptionsFormControl.tsx
+++ b/apps/deploy-web/src/components/sdl/HttpOptionsFormControl.tsx
@@ -1,5 +1,5 @@
 "use client";
-import type { ReactNode } from "react";
+import { type ReactNode, useState } from "react";
 import type { Control } from "react-hook-form";
 import { Controller } from "react-hook-form";
 import { Checkbox, CustomTooltip, FormField, FormInput, FormItem, Label, MultipleSelector } from "@akashnetwork/ui/components";
@@ -8,6 +8,7 @@ import { InfoCircle } from "iconoir-react";
 
 import { useFlag } from "@src/hooks/useFlag";
 import type { SdlBuilderFormValuesType, ServiceType } from "@src/types";
+import { hasProxyValues } from "@src/types/sdlBuilder/sdlBuilder";
 import { nextCases } from "@src/utils/sdl/data";
 import { FormPaper } from "./FormPaper";
 
@@ -33,6 +34,13 @@ const parseProxyNumberInput = (value: string): number | undefined => {
 export const HttpOptionsFormControl: React.FunctionComponent<Props> = ({ control, serviceIndex, exposeIndex, services, dependencies: d = DEPENDENCIES }) => {
   const currentService = services[serviceIndex];
   const isProxyHttpOptionsEnabled = d.useFlag("ui_sdl_proxy_http_options");
+  /**
+   * The schema validates `proxy` whether or not the flag renders its inputs, so a port that arrives
+   * carrying proxy values (an imported SDL) shows them even while the feature is off — otherwise its
+   * validation errors would have nowhere to render and would block saving with nothing to fix. Read
+   * once on mount so clearing the last value mid-edit can't unmount the fields under the user.
+   */
+  const [hasCarriedProxyValues] = useState(() => hasProxyValues(currentService?.expose[exposeIndex]?.httpOptions?.proxy));
 
   return (
     <FormPaper className="h-full" contentClassName="h-full flex items-start flex-col justify-between">
@@ -212,7 +220,7 @@ export const HttpOptionsFormControl: React.FunctionComponent<Props> = ({ control
             )}
           />
 
-          {isProxyHttpOptionsEnabled && (
+          {(isProxyHttpOptionsEnabled || hasCarriedProxyValues) && (
             <>
               <Controller
                 control={control}

--- a/apps/deploy-web/src/components/sdl/HttpOptionsFormControl.tsx
+++ b/apps/deploy-web/src/components/sdl/HttpOptionsFormControl.tsx
@@ -18,6 +18,17 @@ type Props = {
   children?: ReactNode;
 };
 
+// Parse a proxy numeric input. An empty or non-numeric value becomes undefined;
+// otherwise the raw number is kept (including decimals) so the schema's `.int()`
+// rule surfaces a validation error, rather than `parseInt` silently truncating
+// e.g. `1.5` to `1`.
+const parseProxyNumberInput = (value: string): number | undefined => {
+  const trimmed = value.trim();
+  if (trimmed === "") return undefined;
+  const parsed = Number(trimmed);
+  return Number.isNaN(parsed) ? undefined : parsed;
+};
+
 export const HttpOptionsFormControl: React.FunctionComponent<Props> = ({ control, serviceIndex, exposeIndex, services }) => {
   const currentService = services[serviceIndex];
 
@@ -196,6 +207,132 @@ export const HttpOptionsFormControl: React.FunctionComponent<Props> = ({ control
                   emptyIndicator={<p className="text-md text-center leading-10 text-gray-600 dark:text-gray-400">no results found.</p>}
                 />
               </FormItem>
+            )}
+          />
+
+          <Controller
+            control={control}
+            name={`services.${serviceIndex}.expose.${exposeIndex}.httpOptions.proxy.bufferingDisable`}
+            render={({ field }) => (
+              <div className="mb-2 flex items-center space-x-2">
+                <Checkbox id={`proxy-buffering-disable-${serviceIndex}-${exposeIndex}`} checked={field.value} onCheckedChange={field.onChange} />
+                <label
+                  htmlFor={`proxy-buffering-disable-${serviceIndex}-${exposeIndex}`}
+                  className="cursor-pointer text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+                >
+                  Disable Proxy Buffering
+                </label>
+              </div>
+            )}
+          />
+
+          <FormField
+            control={control}
+            name={`services.${serviceIndex}.expose.${exposeIndex}.httpOptions.proxy.bufferSize`}
+            render={({ field }) => (
+              <FormInput
+                type="number"
+                label={
+                  <div className="inline-flex items-center">
+                    Buffer Size
+                    <CustomTooltip title="Sets the nginx proxy_buffer_size for this route.">
+                      <InfoCircle className="ml-2 text-xs text-muted-foreground" />
+                    </CustomTooltip>
+                  </div>
+                }
+                className="mb-2 w-full"
+                value={field.value ?? ""}
+                onChange={event => field.onChange(parseProxyNumberInput(event.target.value))}
+                min={0}
+              />
+            )}
+          />
+
+          <FormField
+            control={control}
+            name={`services.${serviceIndex}.expose.${exposeIndex}.httpOptions.proxy.buffersNumber`}
+            render={({ field }) => (
+              <FormInput
+                type="number"
+                label={
+                  <div className="inline-flex items-center">
+                    Buffers Number
+                    <CustomTooltip title="Sets the number of nginx proxy_buffers for this route. Must be set together with Buffers Size.">
+                      <InfoCircle className="ml-2 text-xs text-muted-foreground" />
+                    </CustomTooltip>
+                  </div>
+                }
+                className="mb-2 w-full"
+                value={field.value ?? ""}
+                onChange={event => field.onChange(parseProxyNumberInput(event.target.value))}
+                min={1}
+              />
+            )}
+          />
+
+          <FormField
+            control={control}
+            name={`services.${serviceIndex}.expose.${exposeIndex}.httpOptions.proxy.buffersSize`}
+            render={({ field }) => (
+              <FormInput
+                type="number"
+                label={
+                  <div className="inline-flex items-center">
+                    Buffers Size
+                    <CustomTooltip title="Sets the size of each nginx proxy_buffers entry for this route. Must be set together with Buffers Number.">
+                      <InfoCircle className="ml-2 text-xs text-muted-foreground" />
+                    </CustomTooltip>
+                  </div>
+                }
+                className="mb-2 w-full"
+                value={field.value ?? ""}
+                onChange={event => field.onChange(parseProxyNumberInput(event.target.value))}
+                min={1}
+              />
+            )}
+          />
+
+          <FormField
+            control={control}
+            name={`services.${serviceIndex}.expose.${exposeIndex}.httpOptions.proxy.busyBuffersSize`}
+            render={({ field }) => (
+              <FormInput
+                type="number"
+                label={
+                  <div className="inline-flex items-center">
+                    Busy Buffers Size
+                    <CustomTooltip title="Sets the nginx proxy_busy_buffers_size for this route.">
+                      <InfoCircle className="ml-2 text-xs text-muted-foreground" />
+                    </CustomTooltip>
+                  </div>
+                }
+                className="mb-2 w-full"
+                value={field.value ?? ""}
+                onChange={event => field.onChange(parseProxyNumberInput(event.target.value))}
+                min={0}
+              />
+            )}
+          />
+
+          <FormField
+            control={control}
+            name={`services.${serviceIndex}.expose.${exposeIndex}.httpOptions.proxy.connectTimeout`}
+            render={({ field }) => (
+              <FormInput
+                type="number"
+                label={
+                  <div className="inline-flex items-center">
+                    Connect Timeout
+                    <CustomTooltip title="Sets the nginx proxy_connect_timeout for this route.">
+                      <InfoCircle className="ml-2 text-xs text-muted-foreground" />
+                    </CustomTooltip>
+                  </div>
+                }
+                className="mb-2 w-full"
+                value={field.value ?? ""}
+                onChange={event => field.onChange(parseProxyNumberInput(event.target.value))}
+                min={0}
+              />
             )}
           />
         </>

--- a/apps/deploy-web/src/components/sdl/HttpOptionsFormControl.tsx
+++ b/apps/deploy-web/src/components/sdl/HttpOptionsFormControl.tsx
@@ -6,9 +6,12 @@ import { Checkbox, CustomTooltip, FormField, FormInput, FormItem, Label, Multipl
 import { cn } from "@akashnetwork/ui/utils";
 import { InfoCircle } from "iconoir-react";
 
+import { useFlag } from "@src/hooks/useFlag";
 import type { SdlBuilderFormValuesType, ServiceType } from "@src/types";
 import { nextCases } from "@src/utils/sdl/data";
 import { FormPaper } from "./FormPaper";
+
+export const DEPENDENCIES = { useFlag };
 
 type Props = {
   serviceIndex: number;
@@ -16,6 +19,7 @@ type Props = {
   services: ServiceType[];
   control: Control<SdlBuilderFormValuesType, any>;
   children?: ReactNode;
+  dependencies?: typeof DEPENDENCIES;
 };
 
 /** Parses a proxy numeric input, preserving decimals so the schema's `.int()` rule can reject a fractional value instead of `parseInt` silently truncating it (e.g. `1.5` to `1`). */
@@ -26,8 +30,9 @@ const parseProxyNumberInput = (value: string): number | undefined => {
   return Number.isNaN(parsed) ? undefined : parsed;
 };
 
-export const HttpOptionsFormControl: React.FunctionComponent<Props> = ({ control, serviceIndex, exposeIndex, services }) => {
+export const HttpOptionsFormControl: React.FunctionComponent<Props> = ({ control, serviceIndex, exposeIndex, services, dependencies: d = DEPENDENCIES }) => {
   const currentService = services[serviceIndex];
+  const isProxyHttpOptionsEnabled = d.useFlag("ui_sdl_proxy_http_options");
 
   return (
     <FormPaper className="h-full" contentClassName="h-full flex items-start flex-col justify-between">
@@ -207,131 +212,135 @@ export const HttpOptionsFormControl: React.FunctionComponent<Props> = ({ control
             )}
           />
 
-          <Controller
-            control={control}
-            name={`services.${serviceIndex}.expose.${exposeIndex}.httpOptions.proxy.bufferingDisable`}
-            render={({ field }) => (
-              <div className="mb-2 flex items-center space-x-2">
-                <Checkbox id={`proxy-buffering-disable-${serviceIndex}-${exposeIndex}`} checked={field.value} onCheckedChange={field.onChange} />
-                <label
-                  htmlFor={`proxy-buffering-disable-${serviceIndex}-${exposeIndex}`}
-                  className="cursor-pointer text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-                >
-                  Disable Proxy Buffering
-                </label>
-              </div>
-            )}
-          />
-
-          <FormField
-            control={control}
-            name={`services.${serviceIndex}.expose.${exposeIndex}.httpOptions.proxy.bufferSize`}
-            render={({ field }) => (
-              <FormInput
-                type="number"
-                label={
-                  <div className="inline-flex items-center">
-                    Buffer Size
-                    <CustomTooltip title="Sets the nginx proxy_buffer_size for this route.">
-                      <InfoCircle className="ml-2 text-xs text-muted-foreground" />
-                    </CustomTooltip>
+          {isProxyHttpOptionsEnabled && (
+            <>
+              <Controller
+                control={control}
+                name={`services.${serviceIndex}.expose.${exposeIndex}.httpOptions.proxy.bufferingDisable`}
+                render={({ field }) => (
+                  <div className="mb-2 flex items-center space-x-2">
+                    <Checkbox id={`proxy-buffering-disable-${serviceIndex}-${exposeIndex}`} checked={field.value} onCheckedChange={field.onChange} />
+                    <label
+                      htmlFor={`proxy-buffering-disable-${serviceIndex}-${exposeIndex}`}
+                      className="cursor-pointer text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+                    >
+                      Disable Proxy Buffering
+                    </label>
                   </div>
-                }
-                className="mb-2 w-full"
-                value={field.value ?? ""}
-                onChange={event => field.onChange(parseProxyNumberInput(event.target.value))}
-                min={0}
+                )}
               />
-            )}
-          />
 
-          <FormField
-            control={control}
-            name={`services.${serviceIndex}.expose.${exposeIndex}.httpOptions.proxy.buffersNumber`}
-            render={({ field }) => (
-              <FormInput
-                type="number"
-                label={
-                  <div className="inline-flex items-center">
-                    Buffers Number
-                    <CustomTooltip title="Sets the number of nginx proxy_buffers for this route. Must be set together with Buffers Size.">
-                      <InfoCircle className="ml-2 text-xs text-muted-foreground" />
-                    </CustomTooltip>
-                  </div>
-                }
-                className="mb-2 w-full"
-                value={field.value ?? ""}
-                onChange={event => field.onChange(parseProxyNumberInput(event.target.value))}
-                min={1}
+              <FormField
+                control={control}
+                name={`services.${serviceIndex}.expose.${exposeIndex}.httpOptions.proxy.bufferSize`}
+                render={({ field }) => (
+                  <FormInput
+                    type="number"
+                    label={
+                      <div className="inline-flex items-center">
+                        Buffer Size
+                        <CustomTooltip title="Sets the nginx proxy_buffer_size for this route.">
+                          <InfoCircle className="ml-2 text-xs text-muted-foreground" />
+                        </CustomTooltip>
+                      </div>
+                    }
+                    className="mb-2 w-full"
+                    value={field.value ?? ""}
+                    onChange={event => field.onChange(parseProxyNumberInput(event.target.value))}
+                    min={0}
+                  />
+                )}
               />
-            )}
-          />
 
-          <FormField
-            control={control}
-            name={`services.${serviceIndex}.expose.${exposeIndex}.httpOptions.proxy.buffersSize`}
-            render={({ field }) => (
-              <FormInput
-                type="number"
-                label={
-                  <div className="inline-flex items-center">
-                    Buffers Size
-                    <CustomTooltip title="Sets the size of each nginx proxy_buffers entry for this route. Must be set together with Buffers Number.">
-                      <InfoCircle className="ml-2 text-xs text-muted-foreground" />
-                    </CustomTooltip>
-                  </div>
-                }
-                className="mb-2 w-full"
-                value={field.value ?? ""}
-                onChange={event => field.onChange(parseProxyNumberInput(event.target.value))}
-                min={1}
+              <FormField
+                control={control}
+                name={`services.${serviceIndex}.expose.${exposeIndex}.httpOptions.proxy.buffersNumber`}
+                render={({ field }) => (
+                  <FormInput
+                    type="number"
+                    label={
+                      <div className="inline-flex items-center">
+                        Buffers Number
+                        <CustomTooltip title="Sets the number of nginx proxy_buffers for this route. Must be set together with Buffers Size.">
+                          <InfoCircle className="ml-2 text-xs text-muted-foreground" />
+                        </CustomTooltip>
+                      </div>
+                    }
+                    className="mb-2 w-full"
+                    value={field.value ?? ""}
+                    onChange={event => field.onChange(parseProxyNumberInput(event.target.value))}
+                    min={1}
+                  />
+                )}
               />
-            )}
-          />
 
-          <FormField
-            control={control}
-            name={`services.${serviceIndex}.expose.${exposeIndex}.httpOptions.proxy.busyBuffersSize`}
-            render={({ field }) => (
-              <FormInput
-                type="number"
-                label={
-                  <div className="inline-flex items-center">
-                    Busy Buffers Size
-                    <CustomTooltip title="Sets the nginx proxy_busy_buffers_size for this route.">
-                      <InfoCircle className="ml-2 text-xs text-muted-foreground" />
-                    </CustomTooltip>
-                  </div>
-                }
-                className="mb-2 w-full"
-                value={field.value ?? ""}
-                onChange={event => field.onChange(parseProxyNumberInput(event.target.value))}
-                min={0}
+              <FormField
+                control={control}
+                name={`services.${serviceIndex}.expose.${exposeIndex}.httpOptions.proxy.buffersSize`}
+                render={({ field }) => (
+                  <FormInput
+                    type="number"
+                    label={
+                      <div className="inline-flex items-center">
+                        Buffers Size
+                        <CustomTooltip title="Sets the size of each nginx proxy_buffers entry for this route. Must be set together with Buffers Number.">
+                          <InfoCircle className="ml-2 text-xs text-muted-foreground" />
+                        </CustomTooltip>
+                      </div>
+                    }
+                    className="mb-2 w-full"
+                    value={field.value ?? ""}
+                    onChange={event => field.onChange(parseProxyNumberInput(event.target.value))}
+                    min={1}
+                  />
+                )}
               />
-            )}
-          />
 
-          <FormField
-            control={control}
-            name={`services.${serviceIndex}.expose.${exposeIndex}.httpOptions.proxy.connectTimeout`}
-            render={({ field }) => (
-              <FormInput
-                type="number"
-                label={
-                  <div className="inline-flex items-center">
-                    Connect Timeout
-                    <CustomTooltip title="Sets the nginx proxy_connect_timeout for this route.">
-                      <InfoCircle className="ml-2 text-xs text-muted-foreground" />
-                    </CustomTooltip>
-                  </div>
-                }
-                className="mb-2 w-full"
-                value={field.value ?? ""}
-                onChange={event => field.onChange(parseProxyNumberInput(event.target.value))}
-                min={0}
+              <FormField
+                control={control}
+                name={`services.${serviceIndex}.expose.${exposeIndex}.httpOptions.proxy.busyBuffersSize`}
+                render={({ field }) => (
+                  <FormInput
+                    type="number"
+                    label={
+                      <div className="inline-flex items-center">
+                        Busy Buffers Size
+                        <CustomTooltip title="Sets the nginx proxy_busy_buffers_size for this route.">
+                          <InfoCircle className="ml-2 text-xs text-muted-foreground" />
+                        </CustomTooltip>
+                      </div>
+                    }
+                    className="mb-2 w-full"
+                    value={field.value ?? ""}
+                    onChange={event => field.onChange(parseProxyNumberInput(event.target.value))}
+                    min={0}
+                  />
+                )}
               />
-            )}
-          />
+
+              <FormField
+                control={control}
+                name={`services.${serviceIndex}.expose.${exposeIndex}.httpOptions.proxy.connectTimeout`}
+                render={({ field }) => (
+                  <FormInput
+                    type="number"
+                    label={
+                      <div className="inline-flex items-center">
+                        Connect Timeout
+                        <CustomTooltip title="Sets the nginx proxy_connect_timeout for this route.">
+                          <InfoCircle className="ml-2 text-xs text-muted-foreground" />
+                        </CustomTooltip>
+                      </div>
+                    }
+                    className="mb-2 w-full"
+                    value={field.value ?? ""}
+                    onChange={event => field.onChange(parseProxyNumberInput(event.target.value))}
+                    min={0}
+                  />
+                )}
+              />
+            </>
+          )}
         </>
       )}
     </FormPaper>

--- a/apps/deploy-web/src/components/sdl/HttpOptionsFormControl.tsx
+++ b/apps/deploy-web/src/components/sdl/HttpOptionsFormControl.tsx
@@ -18,10 +18,7 @@ type Props = {
   children?: ReactNode;
 };
 
-// Parse a proxy numeric input. An empty or non-numeric value becomes undefined;
-// otherwise the raw number is kept (including decimals) so the schema's `.int()`
-// rule surfaces a validation error, rather than `parseInt` silently truncating
-// e.g. `1.5` to `1`.
+/** Parses a proxy numeric input, preserving decimals so the schema's `.int()` rule can reject a fractional value instead of `parseInt` silently truncating it (e.g. `1.5` to `1`). */
 const parseProxyNumberInput = (value: string): number | undefined => {
   const trimmed = value.trim();
   if (trimmed === "") return undefined;

--- a/apps/deploy-web/src/types/feature-flags.ts
+++ b/apps/deploy-web/src/types/feature-flags.ts
@@ -9,4 +9,5 @@ export type FeatureFlag =
   | "ui_build_and_deploy"
   | "ui_agent_mode_deploy"
   | "hackathons"
-  | "deployment_runtime_limit";
+  | "deployment_runtime_limit"
+  | "ui_sdl_proxy_http_options";

--- a/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.spec.ts
+++ b/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.spec.ts
@@ -511,6 +511,67 @@ describe("ServiceExposeHTTPProxySchema", () => {
     );
   });
 
+  it("rejects a buffersNumber below 2", () => {
+    const result = ServiceExposeHTTPProxySchema.safeParse({ buffersNumber: 1, buffersSize: 4096 });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues).toContainEqual(expect.objectContaining({ path: ["buffersNumber"], message: "Buffers number must be at least 2." }));
+  });
+
+  it("rejects a fractional proxy value", () => {
+    const result = ServiceExposeHTTPProxySchema.safeParse({ bufferSize: 1.5 });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues).toContainEqual(expect.objectContaining({ path: ["bufferSize"] }));
+  });
+
+  it("rejects a busyBuffersSize outside the buffer bounds", () => {
+    const result = ServiceExposeHTTPProxySchema.safeParse({ bufferSize: 4096, buffersNumber: 2, buffersSize: 4096, busyBuffersSize: 100000 });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues).toContainEqual(
+      expect.objectContaining({ path: ["busyBuffersSize"], message: "Busy buffers size must be between 4096 and 4096 bytes for these buffer settings." })
+    );
+  });
+
+  it("accepts a busyBuffersSize within the buffer bounds", () => {
+    const result = ServiceExposeHTTPProxySchema.safeParse({ bufferSize: 4096, buffersNumber: 4, buffersSize: 4096, busyBuffersSize: 8192 });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a buffer geometry that leaves no room for busy buffers even when busy is unset", () => {
+    const result = ServiceExposeHTTPProxySchema.safeParse({ bufferSize: 131072, buffersNumber: 2, buffersSize: 1 });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues).toContainEqual(
+      expect.objectContaining({
+        path: ["busyBuffersSize"],
+        message: "These buffer settings leave no room for busy buffers; increase buffers number or buffers size."
+      })
+    );
+  });
+
+  it("rejects a busyBuffersSize set without any buffer size", () => {
+    const result = ServiceExposeHTTPProxySchema.safeParse({ busyBuffersSize: 8192 });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues).toContainEqual(
+      expect.objectContaining({ path: ["busyBuffersSize"], message: "Set a buffer size or buffers size before busy buffers size." })
+    );
+  });
+
+  it("accepts a bufferSize alone since the provider fills the pool from it", () => {
+    const result = ServiceExposeHTTPProxySchema.safeParse({ bufferSize: 4096 });
+
+    expect(result.success).toBe(true);
+  });
+
   it("accepts a full valid proxy object", () => {
     const result = ServiceExposeHTTPProxySchema.safeParse({
       bufferingDisable: true,

--- a/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.spec.ts
+++ b/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.spec.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from "vitest";
 
-import { CredentialsSchema, EndpointSchema, EnvironmentVariableSchema, SdlBuilderFormValuesSchema, ServiceSchema, ServiceStorageSchema } from "./sdlBuilder";
+import {
+  CredentialsSchema,
+  EndpointSchema,
+  EnvironmentVariableSchema,
+  SdlBuilderFormValuesSchema,
+  ServiceExposeHTTPProxySchema,
+  ServiceSchema,
+  ServiceStorageSchema
+} from "./sdlBuilder";
 
 describe("ServiceStorageSchema", () => {
   it("surfaces a friendly required message instead of the raw type error when size is cleared", () => {
@@ -451,6 +459,73 @@ describe("CredentialsSchema", () => {
 
   it("accepts a registry password of at least 6 characters", () => {
     const result = CredentialsSchema.safeParse({ host: "docker.io", username: "alice", password: "123456" });
+
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("ServiceExposeHTTPProxySchema", () => {
+  it("rejects buffersNumber set without buffersSize", () => {
+    const result = ServiceExposeHTTPProxySchema.safeParse({ buffersNumber: 4 });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues).toContainEqual(
+      expect.objectContaining({ path: ["buffersSize"], message: "Buffers number and buffers size must be set together." })
+    );
+  });
+
+  it("rejects buffersSize set without buffersNumber", () => {
+    const result = ServiceExposeHTTPProxySchema.safeParse({ buffersSize: 4096 });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues).toContainEqual(
+      expect.objectContaining({ path: ["buffersNumber"], message: "Buffers number and buffers size must be set together." })
+    );
+  });
+
+  it("rejects a bufferSize above its cap", () => {
+    const result = ServiceExposeHTTPProxySchema.safeParse({ bufferSize: 200000 });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues).toContainEqual(expect.objectContaining({ path: ["bufferSize"], message: "Buffer size must be at most 131072 bytes." }));
+  });
+
+  it("rejects a buffersNumber above its cap", () => {
+    const result = ServiceExposeHTTPProxySchema.safeParse({ buffersNumber: 20, buffersSize: 4096 });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues).toContainEqual(expect.objectContaining({ path: ["buffersNumber"], message: "Buffers number must be at most 16." }));
+  });
+
+  it("rejects a busyBuffersSize above its cap", () => {
+    const result = ServiceExposeHTTPProxySchema.safeParse({ busyBuffersSize: 300000 });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues).toContainEqual(
+      expect.objectContaining({ path: ["busyBuffersSize"], message: "Busy buffers size must be at most 262144 bytes." })
+    );
+  });
+
+  it("accepts a full valid proxy object", () => {
+    const result = ServiceExposeHTTPProxySchema.safeParse({
+      bufferingDisable: true,
+      bufferSize: 4096,
+      buffersNumber: 8,
+      buffersSize: 4096,
+      busyBuffersSize: 8192,
+      connectTimeout: 30
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts an empty object as the unset case", () => {
+    const result = ServiceExposeHTTPProxySchema.safeParse({});
 
     expect(result.success).toBe(true);
   });

--- a/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.ts
+++ b/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.ts
@@ -110,6 +110,33 @@ export const PROXY_BUFFERS_NUMBER_MAX = 16;
 export const PROXY_BUFFERS_SIZE_MAX = 131072;
 export const PROXY_BUSY_BUFFERS_SIZE_MAX = 262144;
 
+type ProxyBufferGroup = { bufferSize?: number; buffersNumber?: number; buffersSize?: number; busyBuffersSize?: number };
+
+/** Reports why the provider (nginx_gateway.go proxyBufferLines) would silently drop the proxy_buffer group, or undefined when it is valid or absent. Mirrors the provider: an unset size fills from the other, an unset count defaults to 8, a 0 reads as unset, and busy defaults to the minimum. */
+function proxyBufferGroupIssue(proxy: ProxyBufferGroup): { path: string; message: string } | undefined {
+  const bufferSize = proxy.bufferSize || undefined;
+  const busy = proxy.busyBuffersSize || undefined;
+  const effectiveBufferSize = bufferSize ?? proxy.buffersSize;
+  const effectiveBuffersSize = proxy.buffersSize ?? bufferSize;
+  const effectiveBuffersNumber = proxy.buffersNumber ?? 8;
+
+  if (busy !== undefined && effectiveBufferSize === undefined) {
+    return { path: "busyBuffersSize", message: "Set a buffer size or buffers size before busy buffers size." };
+  }
+  if (effectiveBufferSize === undefined || effectiveBuffersSize === undefined) return undefined;
+
+  const minBusy = Math.max(effectiveBufferSize, effectiveBuffersSize);
+  const maxBusy = (effectiveBuffersNumber - 1) * effectiveBuffersSize;
+  if (minBusy > maxBusy) {
+    return { path: "busyBuffersSize", message: "These buffer settings leave no room for busy buffers; increase buffers number or buffers size." };
+  }
+  if (busy !== undefined && (busy < minBusy || busy > maxBusy)) {
+    return { path: "busyBuffersSize", message: `Busy buffers size must be between ${minBusy} and ${maxBusy} bytes for these buffer settings.` };
+  }
+
+  return undefined;
+}
+
 export const ServiceExposeHTTPProxySchema = z
   .object({
     bufferingDisable: z.boolean().optional(),
@@ -122,7 +149,7 @@ export const ServiceExposeHTTPProxySchema = z
     buffersNumber: z
       .number()
       .int()
-      .min(1, { message: "Buffers number must be at least 1." })
+      .min(2, { message: "Buffers number must be at least 2." })
       .max(PROXY_BUFFERS_NUMBER_MAX, { message: `Buffers number must be at most ${PROXY_BUFFERS_NUMBER_MAX}.` })
       .optional(),
     buffersSize: z
@@ -148,6 +175,12 @@ export const ServiceExposeHTTPProxySchema = z
         message: "Buffers number and buffers size must be set together.",
         path: [hasNumber ? "buffersSize" : "buffersNumber"]
       });
+      return;
+    }
+
+    const issue = proxyBufferGroupIssue(proxy);
+    if (issue) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: issue.message, path: [issue.path] });
     }
   });
 

--- a/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.ts
+++ b/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.ts
@@ -105,13 +105,60 @@ export const AcceptSchema = z.object({
   value: z.string().min(1, { message: "Value is required." })
 });
 
+export const PROXY_BUFFER_SIZE_MAX = 131072;
+export const PROXY_BUFFERS_NUMBER_MAX = 16;
+export const PROXY_BUFFERS_SIZE_MAX = 131072;
+export const PROXY_BUSY_BUFFERS_SIZE_MAX = 262144;
+
+export const ServiceExposeHTTPProxySchema = z
+  .object({
+    bufferingDisable: z.boolean().optional(),
+    bufferSize: z
+      .number()
+      .int()
+      .min(0)
+      .max(PROXY_BUFFER_SIZE_MAX, { message: `Buffer size must be at most ${PROXY_BUFFER_SIZE_MAX} bytes.` })
+      .optional(),
+    buffersNumber: z
+      .number()
+      .int()
+      .min(1, { message: "Buffers number must be at least 1." })
+      .max(PROXY_BUFFERS_NUMBER_MAX, { message: `Buffers number must be at most ${PROXY_BUFFERS_NUMBER_MAX}.` })
+      .optional(),
+    buffersSize: z
+      .number()
+      .int()
+      .min(1, { message: "Buffers size must be at least 1 byte." })
+      .max(PROXY_BUFFERS_SIZE_MAX, { message: `Buffers size must be at most ${PROXY_BUFFERS_SIZE_MAX} bytes.` })
+      .optional(),
+    busyBuffersSize: z
+      .number()
+      .int()
+      .min(0)
+      .max(PROXY_BUSY_BUFFERS_SIZE_MAX, { message: `Busy buffers size must be at most ${PROXY_BUSY_BUFFERS_SIZE_MAX} bytes.` })
+      .optional(),
+    connectTimeout: z.number().int().min(0).optional()
+  })
+  .superRefine((proxy, ctx) => {
+    const hasNumber = proxy.buffersNumber !== undefined;
+    const hasSize = proxy.buffersSize !== undefined;
+    if (hasNumber !== hasSize) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Buffers number and buffers size must be set together.",
+        path: [hasNumber ? "buffersSize" : "buffersNumber"]
+      });
+    }
+  });
+
 export const ServiceExposeHTTPOptionsSchema = z.object({
   maxBodySize: z.number().min(1, { message: "Max body size is required." }),
   readTimeout: z.number().min(1, { message: "Read timeout is required." }),
   sendTimeout: z.number().min(1, { message: "Send timeout is required." }),
   nextTries: z.number().min(1, { message: "Next tries is required." }),
   nextTimeout: z.number().min(1, { message: "Next timeout is required." }),
-  nextCases: z.array(z.string()).min(1, { message: "Next cases is required." })
+  nextCases: z.array(z.string()).min(1, { message: "Next cases is required." }),
+  proxy: ServiceExposeHTTPProxySchema.optional()
 });
 
 export const PlacementAttributeSchema = z.object({
@@ -611,5 +658,6 @@ export type AcceptType = z.infer<typeof AcceptSchema>;
 export type PlacementAttributeType = z.infer<typeof PlacementAttributeSchema>;
 export type SignedByType = z.infer<typeof SignedBySchema>;
 export type ExposeType = z.infer<typeof ExposeSchema>;
+export type ServiceExposeHTTPProxyType = z.infer<typeof ServiceExposeHTTPProxySchema>;
 export type PlacementType = z.infer<typeof PlacementSchema>;
 export type EndpointType = z.infer<typeof EndpointSchema>;

--- a/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.ts
+++ b/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.ts
@@ -184,6 +184,11 @@ export const ServiceExposeHTTPProxySchema = z
     }
   });
 
+/** Whether a port carries any explicitly set proxy value, so a hidden `proxy` block is never left validating with no field to show its error. */
+export function hasProxyValues(proxy: ServiceExposeHTTPProxyType | undefined): boolean {
+  return !!proxy && Object.values(proxy).some(value => value !== undefined);
+}
+
 export const ServiceExposeHTTPOptionsSchema = z.object({
   maxBodySize: z.number().min(1, { message: "Max body size is required." }),
   readTimeout: z.number().min(1, { message: "Read timeout is required." }),

--- a/apps/deploy-web/src/utils/sdl/sdlGenerator.spec.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlGenerator.spec.ts
@@ -2,8 +2,18 @@ import yaml from "js-yaml";
 import { describe, expect, it } from "vitest";
 
 import { LOG_COLLECTOR_IMAGE } from "@src/config/log-collector.config";
-import type { PlacementType, SdlBuilderFormValuesType, ServiceType } from "@src/types";
+import type { PlacementType, SdlBuilderFormValuesType, ServiceExposeHTTPProxyType, ServiceType } from "@src/types";
+import { getManifest } from "@src/utils/deploymentData/v1beta3";
 import { buildCommand, generateSdl } from "./sdlGenerator";
+
+const fullProxy: ServiceExposeHTTPProxyType = {
+  bufferingDisable: true,
+  bufferSize: 8192,
+  buffersNumber: 4,
+  buffersSize: 4096,
+  busyBuffersSize: 16384,
+  connectTimeout: 5000
+};
 
 describe("sdlGenerator", () => {
   describe(generateSdl.name, () => {
@@ -162,6 +172,34 @@ describe("sdlGenerator", () => {
       expect(parsed.reclamation).toEqual({ min_window: minWindow });
     });
 
+    it("emits http_options.proxy with the correct snake_case keys and values for a full proxy block", () => {
+      const service = buildLogCollectorService({ title: "web", image: "nginx:latest", expose: [buildExpose(fullProxy)] });
+      const parsed = yaml.load(generateSdl(buildFormValues(service))) as { services: Record<string, { expose: { http_options?: { proxy?: unknown } }[] }> };
+
+      expect(parsed.services.web.expose[0].http_options?.proxy).toEqual({
+        buffering_disable: true,
+        buffer_size: 8192,
+        buffers_number: 4,
+        buffers_size: 4096,
+        busy_buffers_size: 16384,
+        connect_timeout: 5000
+      });
+    });
+
+    it("omits http_options.proxy entirely when httpOptions has no proxy field", () => {
+      const service = buildLogCollectorService({ title: "web", image: "nginx:latest", expose: [buildExpose(undefined)] });
+      const parsed = yaml.load(generateSdl(buildFormValues(service))) as { services: Record<string, { expose: { http_options?: { proxy?: unknown } }[] }> };
+
+      expect(parsed.services.web.expose[0].http_options).not.toHaveProperty("proxy");
+    });
+
+    it("omits the proxy block entirely when every field collapses to unset (bufferingDisable explicitly false)", () => {
+      const service = buildLogCollectorService({ title: "web", image: "nginx:latest", expose: [buildExpose({ bufferingDisable: false })] });
+      const parsed = yaml.load(generateSdl(buildFormValues(service))) as { services: Record<string, { expose: { http_options?: { proxy?: unknown } }[] }> };
+
+      expect(parsed.services.web.expose[0].http_options).not.toHaveProperty("proxy");
+    });
+
     it("emits every args token as its own array element", () => {
       const service = buildLogCollectorService({
         title: "web",
@@ -241,6 +279,25 @@ describe("sdlGenerator", () => {
       } as ServiceType;
     }
 
+    function buildExpose(proxy: ServiceExposeHTTPProxyType | undefined): ServiceType["expose"][number] {
+      return {
+        port: 80,
+        as: 80,
+        global: true,
+        to: [],
+        hasCustomHttpOptions: true,
+        httpOptions: {
+          maxBodySize: 1048576,
+          readTimeout: 60000,
+          sendTimeout: 60000,
+          nextTries: 3,
+          nextTimeout: 60000,
+          nextCases: ["error"],
+          proxy
+        }
+      };
+    }
+
     function gpuAttributesOf(sdl: string): Record<string, unknown> {
       const parsed = yaml.load(sdl) as { profiles: { compute: Record<string, { resources: { gpu: { attributes: Record<string, unknown> } } }> } };
       return parsed.profiles.compute.web.resources.gpu.attributes;
@@ -276,5 +333,52 @@ describe("sdlGenerator", () => {
     it("trims whitespace around each token", () => {
       expect(buildCommand(" foo \n bar ")).toEqual(["foo", "bar"]);
     });
+  });
+});
+
+describe("proxy manifest round-trip", () => {
+  it("carries a full proxy block from form values through the generated SDL onto the manifest", () => {
+    const placement: PlacementType = { id: "p-1", name: "dcloud" };
+    const service: ServiceType = {
+      id: "web-id",
+      title: "web",
+      image: "nginx:latest",
+      profile: {
+        cpu: 0.5,
+        ram: 512,
+        ramUnit: "Mi",
+        storage: [{ size: 512, unit: "Mi", isPersistent: false }],
+        hasGpu: false,
+        gpu: 0
+      },
+      expose: [
+        {
+          port: 80,
+          as: 80,
+          global: true,
+          to: [],
+          hasCustomHttpOptions: true,
+          httpOptions: {
+            maxBodySize: 1048576,
+            readTimeout: 60000,
+            sendTimeout: 60000,
+            nextTries: 3,
+            nextTimeout: 60000,
+            nextCases: ["error"],
+            proxy: fullProxy
+          }
+        }
+      ],
+      placementId: "p-1",
+      pricing: { amount: 1000, denom: "uakt" },
+      count: 1
+    } as ServiceType;
+    const formValues = { placements: [placement], services: [service] } as SdlBuilderFormValuesType;
+
+    const regenerated = generateSdl(formValues);
+    const parsedYaml = yaml.load(regenerated);
+    const groups = getManifest(parsedYaml);
+
+    expect(groups[0].services[0].expose[0].httpOptions?.proxy).toEqual(fullProxy);
   });
 });

--- a/apps/deploy-web/src/utils/sdl/sdlGenerator.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlGenerator.ts
@@ -273,13 +273,11 @@ export const generateSdl = (formValues: SdlBuilderFormValuesType) => {
 ${result}`;
 };
 
+/** Builds the SDL `http_options.proxy` map: `buffering_disable` is emitted only when true (false is the default), and every other field is emitted whenever explicitly defined so a defined 0 survives rather than being dropped. */
 function buildHttpProxyYaml(proxy?: ServiceExposeHTTPProxyType): Record<string, number | boolean> | undefined {
   if (!proxy) return undefined;
 
   const result: Record<string, number | boolean> = {};
-  // buffering_disable false is the default (buffering on), so emit it only when true.
-  // Every other field is emitted when explicitly defined, so a defined 0 is preserved
-  // rather than silently dropped.
   if (proxy.bufferingDisable) result.buffering_disable = true;
   if (proxy.bufferSize !== undefined) result.buffer_size = proxy.bufferSize;
   if (proxy.buffersNumber !== undefined) result.buffers_number = proxy.buffersNumber;

--- a/apps/deploy-web/src/utils/sdl/sdlGenerator.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlGenerator.ts
@@ -1,7 +1,7 @@
 import yaml from "js-yaml";
 
 import { isLogCollectorService } from "@src/components/sdl/LogCollectorControl/LogCollectorControl";
-import type { ExposeType, PlacementType, ProfileGpuModelType, SdlBuilderFormValuesType } from "@src/types";
+import type { ExposeType, PlacementType, ProfileGpuModelType, SdlBuilderFormValuesType, ServiceExposeHTTPProxyType } from "@src/types";
 import { defaultHttpOptions } from "./data";
 
 /**
@@ -106,7 +106,7 @@ export const generateSdl = (formValues: SdlBuilderFormValuesType) => {
         ].concat(to as any);
 
         if (e.hasCustomHttpOptions) {
-          _expose["http_options"] = {
+          const httpOptions: Record<string, any> = {
             max_body_size: e.httpOptions?.maxBodySize ?? defaultHttpOptions.maxBodySize,
             read_timeout: e.httpOptions?.readTimeout ?? defaultHttpOptions.readTimeout,
             send_timeout: e.httpOptions?.sendTimeout ?? defaultHttpOptions.sendTimeout,
@@ -114,6 +114,10 @@ export const generateSdl = (formValues: SdlBuilderFormValuesType) => {
             next_tries: e.httpOptions?.nextTries ?? defaultHttpOptions.nextTries,
             next_timeout: e.httpOptions?.nextTimeout ?? defaultHttpOptions.nextTimeout
           };
+          _expose["http_options"] = httpOptions;
+
+          const proxy = buildHttpProxyYaml(e.httpOptions?.proxy);
+          if (proxy) httpOptions.proxy = proxy;
         }
 
         return _expose;
@@ -268,6 +272,23 @@ export const generateSdl = (formValues: SdlBuilderFormValuesType) => {
   return `---
 ${result}`;
 };
+
+function buildHttpProxyYaml(proxy?: ServiceExposeHTTPProxyType): Record<string, number | boolean> | undefined {
+  if (!proxy) return undefined;
+
+  const result: Record<string, number | boolean> = {};
+  // buffering_disable false is the default (buffering on), so emit it only when true.
+  // Every other field is emitted when explicitly defined, so a defined 0 is preserved
+  // rather than silently dropped.
+  if (proxy.bufferingDisable) result.buffering_disable = true;
+  if (proxy.bufferSize !== undefined) result.buffer_size = proxy.bufferSize;
+  if (proxy.buffersNumber !== undefined) result.buffers_number = proxy.buffersNumber;
+  if (proxy.buffersSize !== undefined) result.buffers_size = proxy.buffersSize;
+  if (proxy.busyBuffersSize !== undefined) result.busy_buffers_size = proxy.busyBuffersSize;
+  if (proxy.connectTimeout !== undefined) result.connect_timeout = proxy.connectTimeout;
+
+  return Object.keys(result).length ? result : undefined;
+}
 
 /**
  * Returns the SDL proto value for an expose entry. SDL omits the proto field

--- a/apps/deploy-web/src/utils/sdl/sdlImport.spec.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlImport.spec.ts
@@ -214,6 +214,25 @@ describe("sdlImport", () => {
       expect(services[0].params).toBeUndefined();
     });
 
+    it("imports all six http_options.proxy fields onto httpOptions.proxy in camelCase", () => {
+      const { services } = importSimpleSdl(proxySdl(fullProxyYamlLines));
+
+      expect(services[0].expose[0].httpOptions?.proxy).toEqual({
+        bufferingDisable: true,
+        bufferSize: 8192,
+        buffersNumber: 4,
+        buffersSize: 4096,
+        busyBuffersSize: 16384,
+        connectTimeout: 5000
+      });
+    });
+
+    it("imports an empty http_options.proxy block as undefined", () => {
+      const { services } = importSimpleSdl(proxySdl([]));
+
+      expect(services[0].expose[0].httpOptions?.proxy).toBeUndefined();
+    });
+
     it("captures an implicit gpu interconnect opt-in onto the profile model", () => {
       const { services } = importSimpleSdl(interconnectSdl("implicit"));
 
@@ -362,6 +381,60 @@ const sdlWithCommandBlock = (serviceLines: string[]) =>
     "        as: 80",
     "        to:",
     "          - global: true",
+    "profiles:",
+    "  compute:",
+    "    web:",
+    "      resources:",
+    "        cpu:",
+    "          units: 0.5",
+    "        memory:",
+    "          size: 512Mi",
+    "        storage:",
+    "          - size: 512Mi",
+    "  placement:",
+    "    dcloud:",
+    "      pricing:",
+    "        web:",
+    "          denom: uact",
+    "          amount: 1000",
+    "deployment:",
+    "  web:",
+    "    dcloud:",
+    "      profile: web",
+    "      count: 1"
+  ].join("\n");
+
+const fullProxyYamlLines = [
+  "            buffering_disable: true",
+  "            buffer_size: 8192",
+  "            buffers_number: 4",
+  "            buffers_size: 4096",
+  "            busy_buffers_size: 16384",
+  "            connect_timeout: 5000"
+];
+
+/** Single-service SDL whose `expose[0].http_options.proxy` block holds the given lines. */
+const proxySdl = (proxyLines: string[]) =>
+  [
+    "version: '2.0'",
+    "services:",
+    "  web:",
+    "    image: nginx:1.0",
+    "    expose:",
+    "      - port: 80",
+    "        as: 80",
+    "        to:",
+    "          - global: true",
+    "        http_options:",
+    "          max_body_size: 1048576",
+    "          read_timeout: 60000",
+    "          send_timeout: 60000",
+    "          next_tries: 3",
+    "          next_timeout: 60000",
+    "          next_cases:",
+    "            - error",
+    "          proxy:",
+    ...(proxyLines.length ? proxyLines : ["            {}"]),
     "profiles:",
     "  compute:",
     "    web:",

--- a/apps/deploy-web/src/utils/sdl/sdlImport.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlImport.ts
@@ -1,7 +1,16 @@
 import yaml from "js-yaml";
 import { nanoid } from "nanoid";
 
-import type { EndpointType, ExposeType, PlacementAttributeType, PlacementType, ProfileGpuModelType, SdlBuilderFormValuesType, ServiceType } from "@src/types";
+import type {
+  EndpointType,
+  ExposeType,
+  PlacementAttributeType,
+  PlacementType,
+  ProfileGpuModelType,
+  SdlBuilderFormValuesType,
+  ServiceExposeHTTPProxyType,
+  ServiceType
+} from "@src/types";
 import { ReclamationMinWindowSchema, RESERVED_ENV_KEYS } from "@src/types/sdlBuilder/sdlBuilder";
 import { CustomValidationError } from "../deploymentData";
 import { capitalizeFirstLetter } from "../stringUtils";
@@ -137,7 +146,8 @@ export const importSimpleSdl = (yamlStr: string, { placementPerService = false }
             sendTimeout: expose.http_options?.send_timeout ?? defaultHttpOptions.sendTimeout,
             nextCases: expose.http_options?.next_cases ?? defaultHttpOptions.nextCases,
             nextTries: expose.http_options?.next_tries ?? defaultHttpOptions.nextTries,
-            nextTimeout: expose.http_options?.next_timeout ?? defaultHttpOptions.nextTimeout
+            nextTimeout: expose.http_options?.next_timeout ?? defaultHttpOptions.nextTimeout,
+            proxy: importHttpProxy(expose.http_options?.proxy)
           }
         };
 
@@ -244,6 +254,24 @@ const getGpuModels = (vendor: { [key: string]: { model: string; ram: string; int
 
   return models;
 };
+
+function importHttpProxy(proxy: any): ServiceExposeHTTPProxyType | undefined {
+  if (!proxy || typeof proxy !== "object") return undefined;
+
+  const mapped = {
+    bufferingDisable: proxy.buffering_disable,
+    bufferSize: proxy.buffer_size,
+    buffersNumber: proxy.buffers_number,
+    buffersSize: proxy.buffers_size,
+    busyBuffersSize: proxy.busy_buffers_size,
+    connectTimeout: proxy.connect_timeout
+  };
+
+  // Retain the proxy block when any field is explicitly defined. A defined 0 or
+  // false is a real value (not "unset"), so it must survive the round-trip.
+  const hasAny = Object.values(mapped).some(value => value !== undefined);
+  return hasAny ? mapped : undefined;
+}
 
 /**
  * Builds a fresh PlacementType from a raw SDL placement profile, lifting the

--- a/apps/deploy-web/src/utils/sdl/sdlImport.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlImport.ts
@@ -255,6 +255,7 @@ const getGpuModels = (vendor: { [key: string]: { model: string; ram: string; int
   return models;
 };
 
+/** Maps a raw SDL `http_options.proxy` block to the builder's proxy fields, retaining it when any field is explicitly defined so a defined 0 or false survives the round-trip. */
 function importHttpProxy(proxy: any): ServiceExposeHTTPProxyType | undefined {
   if (!proxy || typeof proxy !== "object") return undefined;
 
@@ -267,8 +268,6 @@ function importHttpProxy(proxy: any): ServiceExposeHTTPProxyType | undefined {
     connectTimeout: proxy.connect_timeout
   };
 
-  // Retain the proxy block when any field is explicitly defined. A defined 0 or
-  // false is a real value (not "unset"), so it must survive the round-trip.
   const hasAny = Object.values(mapped).some(value => value !== undefined);
   return hasAny ? mapped : undefined;
 }

--- a/apps/indexer/package.json
+++ b/apps/indexer/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@akashnetwork/akash-api": "1.4.3",
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.44",
     "@akashnetwork/database": "*",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/instrumentation": "*",

--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -36,7 +36,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.44",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",
     "@akashnetwork/instrumentation": "*",

--- a/apps/provider-inventory/package.json
+++ b/apps/provider-inventory/package.json
@@ -24,7 +24,7 @@
     "test:unit": "vitest run --project unit"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.44",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/instrumentation": "*",
     "@akashnetwork/logging": "*",

--- a/apps/provider-proxy/package.json
+++ b/apps/provider-proxy/package.json
@@ -20,7 +20,7 @@
     "test:unit": "vitest run --project unit"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.44",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/instrumentation": "*",
     "@akashnetwork/logging": "*",

--- a/apps/stats-web/package.json
+++ b/apps/stats-web/package.json
@@ -14,7 +14,7 @@
     "test:unit": "NODE_ENV=test vitest run"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.44",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/logging": "*",
     "@akashnetwork/network-store": "*",

--- a/apps/tx-signer/package.json
+++ b/apps/tx-signer/package.json
@@ -21,7 +21,7 @@
     "test:unit": "vitest run --project unit"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.44",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",
     "@akashnetwork/instrumentation": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akash-api": "1.4.3",
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.44",
         "@akashnetwork/console-api-types": "*",
         "@akashnetwork/database": "*",
         "@akashnetwork/env-loader": "*",
@@ -145,6 +145,28 @@
         "unplugin-swc": "^1.5.9",
         "vitest": "^4.1.5",
         "vitest-mock-extended": "^4.0.0"
+      }
+    },
+    "apps/api/node_modules/@akashnetwork/chain-sdk": {
+      "version": "1.0.0-alpha.44",
+      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.44.tgz",
+      "integrity": "sha512-tVctkmCpxdDVLsE0dpbBlRLe6aM3AQELHCW7YZF0VBGB1wzgFgrRir7RecrJ0nVuET2JZkoDQ/beL1FMx+hC2Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.12.0",
+        "@connectrpc/connect": "^2.1.1",
+        "@connectrpc/connect-node": "^2.1.1",
+        "@cosmjs/amino": "~0.38.0",
+        "@cosmjs/math": "~0.38.0",
+        "@cosmjs/proto-signing": "~0.38.0",
+        "@cosmjs/stargate": "~0.38.0",
+        "base64-js": "^1.5.1",
+        "cockatiel": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=22.18.0 <25"
       }
     },
     "apps/api/node_modules/@cosmjs/amino": {
@@ -542,7 +564,7 @@
       "version": "3.31.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.44",
         "@akashnetwork/console-api-types": "*",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
@@ -668,6 +690,28 @@
         "vitest-mock-extended": "^4.0.0"
       }
     },
+    "apps/deploy-web/node_modules/@akashnetwork/chain-sdk": {
+      "version": "1.0.0-alpha.44",
+      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.44.tgz",
+      "integrity": "sha512-tVctkmCpxdDVLsE0dpbBlRLe6aM3AQELHCW7YZF0VBGB1wzgFgrRir7RecrJ0nVuET2JZkoDQ/beL1FMx+hC2Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.12.0",
+        "@connectrpc/connect": "^2.1.1",
+        "@connectrpc/connect-node": "^2.1.1",
+        "@cosmjs/amino": "~0.38.0",
+        "@cosmjs/math": "~0.38.0",
+        "@cosmjs/proto-signing": "~0.38.0",
+        "@cosmjs/stargate": "~0.38.0",
+        "base64-js": "^1.5.1",
+        "cockatiel": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=22.18.0 <25"
+      }
+    },
     "apps/deploy-web/node_modules/@asamuzakjp/css-color": {
       "version": "4.1.2",
       "dev": true,
@@ -678,6 +722,34 @@
         "@csstools/css-parser-algorithms": "^4.0.0",
         "@csstools/css-tokenizer": "^4.0.0",
         "lru-cache": "^11.2.5"
+      }
+    },
+    "apps/deploy-web/node_modules/@cosmjs/amino": {
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.38.1.tgz",
+      "integrity": "sha512-WaThDpq2JwUyKuazq08Xa+FHzQ3jh1HcYnGL4xsyfqFwOlAvnl0EDvSSz9WSwz1oopIxFE9Qtf3OUKOlxBZbYA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cosmjs/crypto": "^0.38.1",
+        "@cosmjs/encoding": "^0.38.1",
+        "@cosmjs/math": "^0.38.1",
+        "@cosmjs/utils": "^0.38.1"
+      }
+    },
+    "apps/deploy-web/node_modules/@cosmjs/crypto": {
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.38.1.tgz",
+      "integrity": "sha512-r1KQCjKAdMga2aZ/nkgULRF4fisPZMF6ErucVsMmkASBgDl0k9/vD9K9fHUdGClMv0oOYEfwOT/UTBR7K2OuYA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cosmjs/encoding": "^0.38.1",
+        "@cosmjs/math": "^0.38.1",
+        "@cosmjs/utils": "^0.38.1",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "^1.9.2",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip39": "^1.6.0",
+        "hash-wasm": "^4.12.0"
       }
     },
     "apps/deploy-web/node_modules/@cosmjs/encoding": {
@@ -704,6 +776,12 @@
       "version": "0.38.1",
       "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.38.1.tgz",
       "integrity": "sha512-MBk7p6kPNULi0TusD8O3xoBskFIkRzOtpmnea3sXbTVnguX7epNPVDITXM4tlsg8kAQrEOEIA0g5zAJxzH3Ikw==",
+      "license": "Apache-2.0"
+    },
+    "apps/deploy-web/node_modules/@cosmjs/utils": {
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.38.1.tgz",
+      "integrity": "sha512-ccQ5in6IvsQ+o/SstUdQH1jCJ2+MkJPZK7A/EYwMAFcjV8vzOgJ97LVy6AT24nwdi0/iVa2nbAG+fitUEsgLcA==",
       "license": "Apache-2.0"
     },
     "apps/deploy-web/node_modules/@csstools/color-helpers": {
@@ -824,6 +902,33 @@
       "engines": {
         "node": ">=18.0.0",
         "npm": ">=9.0.0"
+      }
+    },
+    "apps/deploy-web/node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "apps/deploy-web/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "apps/deploy-web/node_modules/@octokit/openapi-types": {
@@ -2168,7 +2273,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akash-api": "1.4.3",
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.44",
         "@akashnetwork/database": "*",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/instrumentation": "*",
@@ -2218,6 +2323,40 @@
         "vitest": "^4.1.5",
         "vitest-mock-extended": "^4.0.0",
         "zod": "^3.24.3"
+      }
+    },
+    "apps/indexer/node_modules/@akashnetwork/chain-sdk": {
+      "version": "1.0.0-alpha.44",
+      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.44.tgz",
+      "integrity": "sha512-tVctkmCpxdDVLsE0dpbBlRLe6aM3AQELHCW7YZF0VBGB1wzgFgrRir7RecrJ0nVuET2JZkoDQ/beL1FMx+hC2Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.12.0",
+        "@connectrpc/connect": "^2.1.1",
+        "@connectrpc/connect-node": "^2.1.1",
+        "@cosmjs/amino": "~0.38.0",
+        "@cosmjs/math": "~0.38.0",
+        "@cosmjs/proto-signing": "~0.38.0",
+        "@cosmjs/stargate": "~0.38.0",
+        "base64-js": "^1.5.1",
+        "cockatiel": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=22.18.0 <25"
+      }
+    },
+    "apps/indexer/node_modules/@cosmjs/amino": {
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.38.1.tgz",
+      "integrity": "sha512-WaThDpq2JwUyKuazq08Xa+FHzQ3jh1HcYnGL4xsyfqFwOlAvnl0EDvSSz9WSwz1oopIxFE9Qtf3OUKOlxBZbYA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cosmjs/crypto": "^0.38.1",
+        "@cosmjs/encoding": "^0.38.1",
+        "@cosmjs/math": "^0.38.1",
+        "@cosmjs/utils": "^0.38.1"
       }
     },
     "apps/indexer/node_modules/@cosmjs/crypto": {
@@ -2558,7 +2697,7 @@
       "version": "2.16.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.44",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
         "@akashnetwork/instrumentation": "*",
@@ -2623,6 +2762,40 @@
         "unplugin-swc": "^1.5.9",
         "vitest": "^4.1.5",
         "vitest-mock-extended": "^4.0.0"
+      }
+    },
+    "apps/notifications/node_modules/@akashnetwork/chain-sdk": {
+      "version": "1.0.0-alpha.44",
+      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.44.tgz",
+      "integrity": "sha512-tVctkmCpxdDVLsE0dpbBlRLe6aM3AQELHCW7YZF0VBGB1wzgFgrRir7RecrJ0nVuET2JZkoDQ/beL1FMx+hC2Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.12.0",
+        "@connectrpc/connect": "^2.1.1",
+        "@connectrpc/connect-node": "^2.1.1",
+        "@cosmjs/amino": "~0.38.0",
+        "@cosmjs/math": "~0.38.0",
+        "@cosmjs/proto-signing": "~0.38.0",
+        "@cosmjs/stargate": "~0.38.0",
+        "base64-js": "^1.5.1",
+        "cockatiel": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=22.18.0 <25"
+      }
+    },
+    "apps/notifications/node_modules/@cosmjs/amino": {
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.38.1.tgz",
+      "integrity": "sha512-WaThDpq2JwUyKuazq08Xa+FHzQ3jh1HcYnGL4xsyfqFwOlAvnl0EDvSSz9WSwz1oopIxFE9Qtf3OUKOlxBZbYA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cosmjs/crypto": "^0.38.1",
+        "@cosmjs/encoding": "^0.38.1",
+        "@cosmjs/math": "^0.38.1",
+        "@cosmjs/utils": "^0.38.1"
       }
     },
     "apps/notifications/node_modules/@cosmjs/crypto": {
@@ -3701,7 +3874,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.44",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/instrumentation": "*",
         "@akashnetwork/logging": "*",
@@ -3743,6 +3916,79 @@
         "vitest-mock-extended": "^3.1.0"
       }
     },
+    "apps/provider-inventory/node_modules/@akashnetwork/chain-sdk": {
+      "version": "1.0.0-alpha.44",
+      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.44.tgz",
+      "integrity": "sha512-tVctkmCpxdDVLsE0dpbBlRLe6aM3AQELHCW7YZF0VBGB1wzgFgrRir7RecrJ0nVuET2JZkoDQ/beL1FMx+hC2Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.12.0",
+        "@connectrpc/connect": "^2.1.1",
+        "@connectrpc/connect-node": "^2.1.1",
+        "@cosmjs/amino": "~0.38.0",
+        "@cosmjs/math": "~0.38.0",
+        "@cosmjs/proto-signing": "~0.38.0",
+        "@cosmjs/stargate": "~0.38.0",
+        "base64-js": "^1.5.1",
+        "cockatiel": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=22.18.0 <25"
+      }
+    },
+    "apps/provider-inventory/node_modules/@cosmjs/amino": {
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.38.1.tgz",
+      "integrity": "sha512-WaThDpq2JwUyKuazq08Xa+FHzQ3jh1HcYnGL4xsyfqFwOlAvnl0EDvSSz9WSwz1oopIxFE9Qtf3OUKOlxBZbYA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cosmjs/crypto": "^0.38.1",
+        "@cosmjs/encoding": "^0.38.1",
+        "@cosmjs/math": "^0.38.1",
+        "@cosmjs/utils": "^0.38.1"
+      }
+    },
+    "apps/provider-inventory/node_modules/@cosmjs/crypto": {
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.38.1.tgz",
+      "integrity": "sha512-r1KQCjKAdMga2aZ/nkgULRF4fisPZMF6ErucVsMmkASBgDl0k9/vD9K9fHUdGClMv0oOYEfwOT/UTBR7K2OuYA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cosmjs/encoding": "^0.38.1",
+        "@cosmjs/math": "^0.38.1",
+        "@cosmjs/utils": "^0.38.1",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "^1.9.2",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip39": "^1.6.0",
+        "hash-wasm": "^4.12.0"
+      }
+    },
+    "apps/provider-inventory/node_modules/@cosmjs/encoding": {
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.38.1.tgz",
+      "integrity": "sha512-i5jGgJhiXs7boePGA48xzYxnCbf3MS5nT/R2HvnvSQyVAG2A99NyL96lBgmz6etOJSGOiwVrB8uh1Qp5bq6WKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scure/base": "^2.0.0",
+        "base64-js": "^1.3.0",
+        "readonly-date-esm": "^2.0.0"
+      }
+    },
+    "apps/provider-inventory/node_modules/@cosmjs/math": {
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.38.1.tgz",
+      "integrity": "sha512-MBk7p6kPNULi0TusD8O3xoBskFIkRzOtpmnea3sXbTVnguX7epNPVDITXM4tlsg8kAQrEOEIA0g5zAJxzH3Ikw==",
+      "license": "Apache-2.0"
+    },
+    "apps/provider-inventory/node_modules/@cosmjs/utils": {
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.38.1.tgz",
+      "integrity": "sha512-ccQ5in6IvsQ+o/SstUdQH1jCJ2+MkJPZK7A/EYwMAFcjV8vzOgJ97LVy6AT24nwdi0/iVa2nbAG+fitUEsgLcA==",
+      "license": "Apache-2.0"
+    },
     "apps/provider-inventory/node_modules/@hono/node-server": {
       "version": "1.19.14",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
@@ -3753,6 +3999,42 @@
       },
       "peerDependencies": {
         "hono": "^4"
+      }
+    },
+    "apps/provider-inventory/node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "apps/provider-inventory/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "apps/provider-inventory/node_modules/@scure/base": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.3.0.tgz",
+      "integrity": "sha512-NsG6Y03tY6R5BUis4FdVtHVkur0U6FOzskgs9ZXNl78CUc9fkZ78HmENUle1nSOkCasDmbubmWD9qwB7mm4PZA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "apps/provider-inventory/node_modules/@swc/core": {
@@ -4041,7 +4323,7 @@
       "version": "2.10.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.44",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/instrumentation": "*",
         "@akashnetwork/logging": "*",
@@ -4072,11 +4354,32 @@
         "vitest-mock-extended": "^4.0.0"
       }
     },
+    "apps/provider-proxy/node_modules/@akashnetwork/chain-sdk": {
+      "version": "1.0.0-alpha.44",
+      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.44.tgz",
+      "integrity": "sha512-tVctkmCpxdDVLsE0dpbBlRLe6aM3AQELHCW7YZF0VBGB1wzgFgrRir7RecrJ0nVuET2JZkoDQ/beL1FMx+hC2Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.12.0",
+        "@connectrpc/connect": "^2.1.1",
+        "@connectrpc/connect-node": "^2.1.1",
+        "@cosmjs/amino": "~0.38.0",
+        "@cosmjs/math": "~0.38.0",
+        "@cosmjs/proto-signing": "~0.38.0",
+        "@cosmjs/stargate": "~0.38.0",
+        "base64-js": "^1.5.1",
+        "cockatiel": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=22.18.0 <25"
+      }
+    },
     "apps/provider-proxy/node_modules/@cosmjs/amino": {
       "version": "0.38.1",
       "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.38.1.tgz",
       "integrity": "sha512-WaThDpq2JwUyKuazq08Xa+FHzQ3jh1HcYnGL4xsyfqFwOlAvnl0EDvSSz9WSwz1oopIxFE9Qtf3OUKOlxBZbYA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/crypto": "^0.38.1",
@@ -4089,7 +4392,6 @@
       "version": "0.38.1",
       "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.38.1.tgz",
       "integrity": "sha512-r1KQCjKAdMga2aZ/nkgULRF4fisPZMF6ErucVsMmkASBgDl0k9/vD9K9fHUdGClMv0oOYEfwOT/UTBR7K2OuYA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/encoding": "^0.38.1",
@@ -4117,14 +4419,12 @@
       "version": "0.38.1",
       "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.38.1.tgz",
       "integrity": "sha512-MBk7p6kPNULi0TusD8O3xoBskFIkRzOtpmnea3sXbTVnguX7epNPVDITXM4tlsg8kAQrEOEIA0g5zAJxzH3Ikw==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "apps/provider-proxy/node_modules/@cosmjs/utils": {
       "version": "0.38.1",
       "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.38.1.tgz",
       "integrity": "sha512-ccQ5in6IvsQ+o/SstUdQH1jCJ2+MkJPZK7A/EYwMAFcjV8vzOgJ97LVy6AT24nwdi0/iVa2nbAG+fitUEsgLcA==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "apps/provider-proxy/node_modules/@hono/node-server": {
@@ -4141,7 +4441,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -4154,7 +4453,6 @@
       "version": "1.9.7",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
       "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "1.8.0"
@@ -4218,7 +4516,7 @@
       "name": "@akashnetwork/stats-web",
       "version": "1.14.1",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.44",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/logging": "*",
         "@akashnetwork/network-store": "*",
@@ -4275,6 +4573,56 @@
         "vitest": "^4.1.5"
       }
     },
+    "apps/stats-web/node_modules/@akashnetwork/chain-sdk": {
+      "version": "1.0.0-alpha.44",
+      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.44.tgz",
+      "integrity": "sha512-tVctkmCpxdDVLsE0dpbBlRLe6aM3AQELHCW7YZF0VBGB1wzgFgrRir7RecrJ0nVuET2JZkoDQ/beL1FMx+hC2Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.12.0",
+        "@connectrpc/connect": "^2.1.1",
+        "@connectrpc/connect-node": "^2.1.1",
+        "@cosmjs/amino": "~0.38.0",
+        "@cosmjs/math": "~0.38.0",
+        "@cosmjs/proto-signing": "~0.38.0",
+        "@cosmjs/stargate": "~0.38.0",
+        "base64-js": "^1.5.1",
+        "cockatiel": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=22.18.0 <25"
+      }
+    },
+    "apps/stats-web/node_modules/@cosmjs/amino": {
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.38.1.tgz",
+      "integrity": "sha512-WaThDpq2JwUyKuazq08Xa+FHzQ3jh1HcYnGL4xsyfqFwOlAvnl0EDvSSz9WSwz1oopIxFE9Qtf3OUKOlxBZbYA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cosmjs/crypto": "^0.38.1",
+        "@cosmjs/encoding": "^0.38.1",
+        "@cosmjs/math": "^0.38.1",
+        "@cosmjs/utils": "^0.38.1"
+      }
+    },
+    "apps/stats-web/node_modules/@cosmjs/crypto": {
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.38.1.tgz",
+      "integrity": "sha512-r1KQCjKAdMga2aZ/nkgULRF4fisPZMF6ErucVsMmkASBgDl0k9/vD9K9fHUdGClMv0oOYEfwOT/UTBR7K2OuYA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cosmjs/encoding": "^0.38.1",
+        "@cosmjs/math": "^0.38.1",
+        "@cosmjs/utils": "^0.38.1",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "^1.9.2",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip39": "^1.6.0",
+        "hash-wasm": "^4.12.0"
+      }
+    },
     "apps/stats-web/node_modules/@cosmjs/encoding": {
       "version": "0.38.1",
       "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.38.1.tgz",
@@ -4284,6 +4632,45 @@
         "@scure/base": "^2.0.0",
         "base64-js": "^1.3.0",
         "readonly-date-esm": "^2.0.0"
+      }
+    },
+    "apps/stats-web/node_modules/@cosmjs/math": {
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.38.1.tgz",
+      "integrity": "sha512-MBk7p6kPNULi0TusD8O3xoBskFIkRzOtpmnea3sXbTVnguX7epNPVDITXM4tlsg8kAQrEOEIA0g5zAJxzH3Ikw==",
+      "license": "Apache-2.0"
+    },
+    "apps/stats-web/node_modules/@cosmjs/utils": {
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.38.1.tgz",
+      "integrity": "sha512-ccQ5in6IvsQ+o/SstUdQH1jCJ2+MkJPZK7A/EYwMAFcjV8vzOgJ97LVy6AT24nwdi0/iVa2nbAG+fitUEsgLcA==",
+      "license": "Apache-2.0"
+    },
+    "apps/stats-web/node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "apps/stats-web/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "apps/stats-web/node_modules/@opentelemetry/instrumentation-connect": {
@@ -4982,7 +5369,7 @@
       "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.44",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
         "@akashnetwork/instrumentation": "*",
@@ -5025,6 +5412,28 @@
         "typescript": "~5.8.2",
         "vitest": "^4.1.5",
         "vitest-mock-extended": "^4.0.0"
+      }
+    },
+    "apps/tx-signer/node_modules/@akashnetwork/chain-sdk": {
+      "version": "1.0.0-alpha.44",
+      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.44.tgz",
+      "integrity": "sha512-tVctkmCpxdDVLsE0dpbBlRLe6aM3AQELHCW7YZF0VBGB1wzgFgrRir7RecrJ0nVuET2JZkoDQ/beL1FMx+hC2Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.12.0",
+        "@connectrpc/connect": "^2.1.1",
+        "@connectrpc/connect-node": "^2.1.1",
+        "@cosmjs/amino": "~0.38.0",
+        "@cosmjs/math": "~0.38.0",
+        "@cosmjs/proto-signing": "~0.38.0",
+        "@cosmjs/stargate": "~0.38.0",
+        "base64-js": "^1.5.1",
+        "cockatiel": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=22.18.0 <25"
       }
     },
     "apps/tx-signer/node_modules/@cosmjs/amino": {
@@ -5470,115 +5879,6 @@
       },
       "peerDependencies": {
         "@grpc/grpc-js": "^1.10.6"
-      }
-    },
-    "node_modules/@akashnetwork/chain-sdk": {
-      "version": "1.0.0-alpha.41",
-      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.41.tgz",
-      "integrity": "sha512-mr3fGDBSISxl0eZF83+IJLVulGSuJVu+MRj6fG61pi2rgfgnv9QEKpdU3w7wtFFt5saJaJNgsqAlyjGZQecZ1A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@bufbuild/protobuf": "^2.12.0",
-        "@connectrpc/connect": "^2.1.1",
-        "@connectrpc/connect-node": "^2.1.1",
-        "@cosmjs/amino": "~0.38.0",
-        "@cosmjs/math": "~0.38.0",
-        "@cosmjs/proto-signing": "~0.38.0",
-        "@cosmjs/stargate": "~0.38.0",
-        "base64-js": "^1.5.1",
-        "cockatiel": "^3.2.1",
-        "js-yaml": "^4.1.0",
-        "json-stable-stringify": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=22.18.0 <25"
-      }
-    },
-    "node_modules/@akashnetwork/chain-sdk/node_modules/@cosmjs/amino": {
-      "version": "0.38.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.38.1.tgz",
-      "integrity": "sha512-WaThDpq2JwUyKuazq08Xa+FHzQ3jh1HcYnGL4xsyfqFwOlAvnl0EDvSSz9WSwz1oopIxFE9Qtf3OUKOlxBZbYA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/crypto": "^0.38.1",
-        "@cosmjs/encoding": "^0.38.1",
-        "@cosmjs/math": "^0.38.1",
-        "@cosmjs/utils": "^0.38.1"
-      }
-    },
-    "node_modules/@akashnetwork/chain-sdk/node_modules/@cosmjs/crypto": {
-      "version": "0.38.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.38.1.tgz",
-      "integrity": "sha512-r1KQCjKAdMga2aZ/nkgULRF4fisPZMF6ErucVsMmkASBgDl0k9/vD9K9fHUdGClMv0oOYEfwOT/UTBR7K2OuYA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/encoding": "^0.38.1",
-        "@cosmjs/math": "^0.38.1",
-        "@cosmjs/utils": "^0.38.1",
-        "@noble/ciphers": "^1.3.0",
-        "@noble/curves": "^1.9.2",
-        "@noble/hashes": "^1.8.0",
-        "@scure/bip39": "^1.6.0",
-        "hash-wasm": "^4.12.0"
-      }
-    },
-    "node_modules/@akashnetwork/chain-sdk/node_modules/@cosmjs/encoding": {
-      "version": "0.38.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.38.1.tgz",
-      "integrity": "sha512-i5jGgJhiXs7boePGA48xzYxnCbf3MS5nT/R2HvnvSQyVAG2A99NyL96lBgmz6etOJSGOiwVrB8uh1Qp5bq6WKQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@scure/base": "^2.0.0",
-        "base64-js": "^1.3.0",
-        "readonly-date-esm": "^2.0.0"
-      }
-    },
-    "node_modules/@akashnetwork/chain-sdk/node_modules/@cosmjs/math": {
-      "version": "0.38.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.38.1.tgz",
-      "integrity": "sha512-MBk7p6kPNULi0TusD8O3xoBskFIkRzOtpmnea3sXbTVnguX7epNPVDITXM4tlsg8kAQrEOEIA0g5zAJxzH3Ikw==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@akashnetwork/chain-sdk/node_modules/@cosmjs/utils": {
-      "version": "0.38.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.38.1.tgz",
-      "integrity": "sha512-ccQ5in6IvsQ+o/SstUdQH1jCJ2+MkJPZK7A/EYwMAFcjV8vzOgJ97LVy6AT24nwdi0/iVa2nbAG+fitUEsgLcA==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@akashnetwork/chain-sdk/node_modules/@noble/ciphers": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
-      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@akashnetwork/chain-sdk/node_modules/@noble/curves": {
-      "version": "1.9.7",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
-      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.8.0"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@akashnetwork/chain-sdk/node_modules/@scure/base": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
-      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@akashnetwork/console-api": {
@@ -7656,9 +7956,9 @@
       }
     },
     "node_modules/@bufbuild/protobuf": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.0.tgz",
-      "integrity": "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.14.0.tgz",
+      "integrity": "sha512-C3UGsiCwSprE2NKIIFA3hCDlpXTMCAXRZuEVp88L1GY36Y41+rYL5fryE+nOFhp4p4JPQvdV8PQ4DWgHgeTE+w==",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@casl/ability": {
@@ -8143,25 +8443,25 @@
       }
     },
     "node_modules/@connectrpc/connect": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.1.tgz",
-      "integrity": "sha512-JzhkaTvM73m2K1URT6tv53k2RwngSmCXLZJgK580qNQOXRzZRR/BCMfZw3h+90JpnG6XksP5bYT+cz0rpUzUWQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.2.tgz",
+      "integrity": "sha512-MXkBijtcX09R10Eb6sFeIetc6w6746eio6xtfuyVOH7oQAacT1X0GzMIQFux6Qy8cq3W/T5qX5Bei8YbFtmRGA==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0"
       }
     },
     "node_modules/@connectrpc/connect-node": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@connectrpc/connect-node/-/connect-node-2.1.1.tgz",
-      "integrity": "sha512-s3TfsI1XF+n+1z6MBS9rTnFsxxR4Rw5wmdEnkQINli81ESGxcsfaEet8duzq8LVuuCupmhUsgpRo0Nv9pZkufg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-node/-/connect-node-2.1.2.tgz",
+      "integrity": "sha512-+i/aAOpsI8sIx1mbYp6d99zvxaUSF6t/jP9Ux9maAmjsZPgmIQ3JuIeYi0zJIP9zlCnBlJjkpPosshCgdRuThQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0",
-        "@connectrpc/connect": "2.1.1"
+        "@connectrpc/connect": "2.1.2"
       }
     },
     "node_modules/@cosmjs/amino": {
@@ -21795,13 +22095,12 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.0.tgz",
-      "integrity": "sha512-8yQrvS6sMpSwIovhPOwfyNf2Wz6v/B62LFSVYQ85+Rq3tLsBIG7rP5geMxaijTUxSkrO6RzN/IRuIAADYQsleA==",
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/react": "*"
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
       }
     },
     "node_modules/@types/react-simple-maps": {
@@ -32451,6 +32750,8 @@
     },
     "node_modules/json-stable-stringify": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -32500,6 +32801,8 @@
     },
     "node_modules/jsonify": {
       "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
       "license": "Public Domain",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -45932,12 +46235,121 @@
       "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.44",
         "@akashnetwork/net": "*",
         "jotai": "^2.9.2"
       },
       "devDependencies": {
         "@akashnetwork/dev-config": "*"
+      }
+    },
+    "packages/network-store/node_modules/@akashnetwork/chain-sdk": {
+      "version": "1.0.0-alpha.44",
+      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.44.tgz",
+      "integrity": "sha512-tVctkmCpxdDVLsE0dpbBlRLe6aM3AQELHCW7YZF0VBGB1wzgFgrRir7RecrJ0nVuET2JZkoDQ/beL1FMx+hC2Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.12.0",
+        "@connectrpc/connect": "^2.1.1",
+        "@connectrpc/connect-node": "^2.1.1",
+        "@cosmjs/amino": "~0.38.0",
+        "@cosmjs/math": "~0.38.0",
+        "@cosmjs/proto-signing": "~0.38.0",
+        "@cosmjs/stargate": "~0.38.0",
+        "base64-js": "^1.5.1",
+        "cockatiel": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=22.18.0 <25"
+      }
+    },
+    "packages/network-store/node_modules/@cosmjs/amino": {
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.38.1.tgz",
+      "integrity": "sha512-WaThDpq2JwUyKuazq08Xa+FHzQ3jh1HcYnGL4xsyfqFwOlAvnl0EDvSSz9WSwz1oopIxFE9Qtf3OUKOlxBZbYA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cosmjs/crypto": "^0.38.1",
+        "@cosmjs/encoding": "^0.38.1",
+        "@cosmjs/math": "^0.38.1",
+        "@cosmjs/utils": "^0.38.1"
+      }
+    },
+    "packages/network-store/node_modules/@cosmjs/crypto": {
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.38.1.tgz",
+      "integrity": "sha512-r1KQCjKAdMga2aZ/nkgULRF4fisPZMF6ErucVsMmkASBgDl0k9/vD9K9fHUdGClMv0oOYEfwOT/UTBR7K2OuYA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cosmjs/encoding": "^0.38.1",
+        "@cosmjs/math": "^0.38.1",
+        "@cosmjs/utils": "^0.38.1",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "^1.9.2",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip39": "^1.6.0",
+        "hash-wasm": "^4.12.0"
+      }
+    },
+    "packages/network-store/node_modules/@cosmjs/encoding": {
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.38.1.tgz",
+      "integrity": "sha512-i5jGgJhiXs7boePGA48xzYxnCbf3MS5nT/R2HvnvSQyVAG2A99NyL96lBgmz6etOJSGOiwVrB8uh1Qp5bq6WKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scure/base": "^2.0.0",
+        "base64-js": "^1.3.0",
+        "readonly-date-esm": "^2.0.0"
+      }
+    },
+    "packages/network-store/node_modules/@cosmjs/math": {
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.38.1.tgz",
+      "integrity": "sha512-MBk7p6kPNULi0TusD8O3xoBskFIkRzOtpmnea3sXbTVnguX7epNPVDITXM4tlsg8kAQrEOEIA0g5zAJxzH3Ikw==",
+      "license": "Apache-2.0"
+    },
+    "packages/network-store/node_modules/@cosmjs/utils": {
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.38.1.tgz",
+      "integrity": "sha512-ccQ5in6IvsQ+o/SstUdQH1jCJ2+MkJPZK7A/EYwMAFcjV8vzOgJ97LVy6AT24nwdi0/iVa2nbAG+fitUEsgLcA==",
+      "license": "Apache-2.0"
+    },
+    "packages/network-store/node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "packages/network-store/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "packages/network-store/node_modules/@scure/base": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.3.0.tgz",
+      "integrity": "sha512-NsG6Y03tY6R5BUis4FdVtHVkur0U6FOzskgs9ZXNl78CUc9fkZ78HmENUle1nSOkCasDmbubmWD9qwB7mm4PZA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "packages/openapi-sdk": {

--- a/packages/network-store/package.json
+++ b/packages/network-store/package.json
@@ -18,7 +18,7 @@
     "validate:types": "tsc --noEmit && echo"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.41",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.44",
     "@akashnetwork/net": "*",
     "jotai": "^2.9.2"
   },


### PR DESCRIPTION
## What

Adds nginx proxy tuning (`http_options.proxy`) support to the deployment builder (SDL import → form model → SDL generation), and bumps `@akashnetwork/chain-sdk` to `1.0.0-alpha.44` (which carries the proxy schema + manifest mapping). Mirrors the console-air PR.

Fields under `http_options.proxy`: `buffering_disable`, `buffer_size`, `buffers_number`, `buffers_size`, `busy_buffers_size`, `connect_timeout`.

## Changes

**Feature** (`feat(sdl)` commit)
- `types/sdlBuilder/sdlBuilder.ts`: `ServiceExposeHTTPProxySchema` (caps + `buffers_number`/`buffers_size` `min(1)` + paired-field rule), wired into `ServiceExposeHTTPOptionsSchema`.
- `utils/sdl/sdlImport.ts` / `sdlGenerator.ts`: map proxy in/out. `buffering_disable` is emitted only when `true` (false is the default); every other field is emitted when explicitly defined, so a defined `0` is preserved rather than dropped.
- `components/sdl/HttpOptionsFormControl.tsx` + `ExposePortsCard`: proxy form inputs (with a numeric parser that surfaces a validation error instead of `parseInt` silently truncating decimals).
- Specs for import / generate / schema.

**Dependency bump** (`chore(repo)` commit)
- `@akashnetwork/chain-sdk` `1.0.0-alpha.41` → `1.0.0-alpha.44` across all 9 workspaces (adds the proxy schema/validator/manifest mapping).
- `.npmrc`: `min-release-age-exclude[]=@akashnetwork/*` so the freshly-published alpha.44 (first-party) installs under the repo's 7-day supply-chain quarantine, which stays in force for third-party packages.

## Notes
- No `Long.fromString` migration needed (already on the new proto types at alpha.41).
- The upstream chain-sdk PR (`akash-network/chain-sdk#357`) is where the proxy schema + `buildProxyOptions` live; this PR consumes the released alpha.44.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added proxy configuration options for exposed HTTP services, including buffering, buffer sizes, buffer counts, busy buffer size, and connection timeout.
  - Proxy settings are validated, preserved during configuration, and correctly imported from and exported to deployment manifests.
  - Added controlled availability for proxy options while retaining existing imported settings.

- **Bug Fixes**
  - Improved handling of decimal, zero, empty, and invalid proxy values.

- **Chores**
  - Updated the Chain SDK across application packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->