### PR TITLE
feat(deployment): resolve an sdl reference in a private registry credential

### DIFF
--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -56,7 +56,7 @@ export class DeploymentWriterService {
     this.logger = createLogger({ context: DeploymentWriterService.name });
   }
 
-  /** The dseq is minted only once nothing can still refuse the request, because the token written below names it and a client sealing beforehand cannot. */
+  /** The dseq is minted once everything that can refuse the submitted document has run, because the token written below names it and a client sealing beforehand cannot; a refusal that needs the resolved document — a sealed registry password below the schema's minimum, say — can only come after it, and spends a dseq nothing is written under. */
   public async create(input: CreateDeploymentRequest["data"] & { userId: string }): Promise<CreateDeploymentResponse["data"]> {
     /** SDL for storage ONLY, stripped of every env value that is not a reference to one */
     const sdl = this.#strippedSdlWithinLimit(input.sdl);

--- a/apps/api/src/deployment/services/sdl-reference/sdl-reference.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl-reference/sdl-reference.service.spec.ts
@@ -1,5 +1,6 @@
 import type { SDLInput } from "@akashnetwork/chain-sdk";
 import { yaml } from "@akashnetwork/chain-sdk";
+import { faker } from "@faker-js/faker";
 import { describe, expect, it } from "vitest";
 
 import type { NamespacedSdlSecrets, SdlReferenceResolver } from "./sdl-reference.service";
@@ -49,6 +50,61 @@ describe(SdlReferenceService.name, () => {
 
       expect(errors).toHaveLength(2);
       expect(errors.map(error => error.instancePath)).toEqual(["/services/web/env/0", "/services/web/env/1"]);
+    });
+
+    it("reports nothing for an ordinary registry credential", () => {
+      const { service } = setup();
+
+      expect(service.validate(sdlWithCredentials({ username: faker.string.alphanumeric(10), password: faker.internet.password() }))).toEqual([]);
+    });
+
+    it("reports nothing for a registered kind referenced by a registry credential", () => {
+      const { service } = setup();
+
+      expect(service.validate(sdlWithCredentials({ username: "ac-secret://REG_USER", password: "ac-secret://REG_PASS" }))).toEqual([]);
+    });
+
+    it("reports a reserved value in a registry credential rather than letting it ship literally", () => {
+      const { service } = setup();
+
+      const [error] = service.validate(sdlWithCredentials({ password: "ac-dc-forever" }));
+
+      expect(error.message).toContain("reserved");
+      expect(error.instancePath).toBe("/services/web/credentials/password");
+    });
+
+    it("names the position rather than the value of a reserved registry credential, which is a secret whatever it holds", () => {
+      const { service } = setup();
+      const password = `ac-dc-${faker.internet.password()}`;
+
+      const [error] = service.validate(sdlWithCredentials({ password }));
+
+      expect(error.message).toContain("/services/web/credentials/password");
+      expect(JSON.stringify(error)).not.toContain(password);
+    });
+
+    it("still quotes a reserved env value, which no rule makes a secret", () => {
+      const { service } = setup();
+
+      const [error] = service.validate(sdlWithEnv(["MODE=ac-dc-forever"]));
+
+      expect(error.message).toContain("ac-dc-forever");
+      expect(error.params.value).toBe("ac-dc-forever");
+    });
+
+    it("reports an unknown kind in a registry credential naming the half that carries it", () => {
+      const { service } = setup();
+
+      const [error] = service.validate(sdlWithCredentials({ username: "ac-var://REG_USER" }));
+
+      expect(error.message).toContain("ac-var://REG_USER");
+      expect(error.instancePath).toBe("/services/web/credentials/username");
+    });
+
+    it.each(["host", "email"] as const)("reports nothing for a reserved value in the credential %s, which carries no secret", field => {
+      const { service } = setup();
+
+      expect(service.validate(sdlWithCredentials({ [field]: "ac-dc-forever" }))).toEqual([]);
     });
   });
 
@@ -252,6 +308,89 @@ describe(SdlReferenceService.name, () => {
       expect(sdl.services.web.env).toEqual(["A=ac-secret://constructor"]);
     });
 
+    it("sets both halves of a registry credential to their resolved values", () => {
+      const { service } = setup();
+      const [username, password] = [faker.string.alphanumeric(10), faker.internet.password()];
+      const sdl = sdlWithCredentials({ username: "ac-secret://REG_USER", password: "ac-secret://REG_PASS" });
+
+      const errors = service.substitute(sdl, { secrets: { web: { REG_USER: username, REG_PASS: password } } });
+
+      expect(errors).toEqual([]);
+      expect(sdl.services.web.credentials).toMatchObject({ username, password });
+    });
+
+    it("leaves the host and the email of a resolved credential alone", () => {
+      const { service } = setup();
+      const sdl = sdlWithCredentials({ password: "ac-secret://REG_PASS" });
+
+      service.substitute(sdl, { secrets: { web: { REG_PASS: faker.internet.password() } } });
+
+      expect(sdl.services.web.credentials).toMatchObject({ host: "registry.example.test", email: "ops@example.test" });
+    });
+
+    it("resolves a credential from its own service's namespace", () => {
+      const { service } = setup();
+      const sdl = sdlWithCredentials({ password: "ac-secret://REG_PASS" }, { password: "ac-secret://REG_PASS" });
+
+      const [webPassword, workerPassword] = [faker.internet.password(), faker.internet.password()];
+
+      const errors = service.substitute(sdl, { secrets: { web: { REG_PASS: webPassword }, worker: { REG_PASS: workerPassword } } });
+
+      expect(errors).toEqual([]);
+      expect(sdl.services.web.credentials!.password).toBe(webPassword);
+      expect(sdl.services.worker.credentials!.password).toBe(workerPassword);
+    });
+
+    it("reports a credential reference it holds no value for, naming the half that carries it", () => {
+      const { service } = setup();
+      const sdl = sdlWithCredentials({ password: "ac-secret://REG_PASS" });
+
+      const [error] = service.substitute(sdl, { secrets: {} });
+
+      expect(error.message).toContain("ac-secret://REG_PASS");
+      expect(error.instancePath).toBe("/services/web/credentials/password");
+      expect(sdl.services.web.credentials!.password).toBe("ac-secret://REG_PASS");
+    });
+
+    it("reports a credential reference and an env reference of the same document", () => {
+      const { service } = setup();
+      const sdl = sdlWithCredentials({ password: "ac-secret://REG_PASS" }, undefined, ["TOKEN=ac-secret://TOKEN"]);
+
+      const errors = service.substitute(sdl, { secrets: {} });
+
+      expect(errors.map(error => error.instancePath)).toEqual(["/services/web/env/0", "/services/web/credentials/password"]);
+    });
+
+    it("resolves a credentials block two services share through a yaml anchor, never re-reading what it wrote", () => {
+      const { service } = setup();
+      const password = `ac-dc-${faker.internet.password()}`;
+      const sdl = sdlSharingOneCredentialsBlock("ac-secret://REG_PASS");
+
+      const errors = service.substitute(sdl, { secrets: { web: { REG_PASS: password }, worker: { REG_PASS: password } } });
+
+      expect(errors).toEqual([]);
+      expect(sdl.services.web.credentials!.password).toBe(password);
+      expect(sdl.services.worker.credentials!.password).toBe(password);
+    });
+
+    it("resolves an env list two services share through a yaml anchor, never re-reading what it wrote", () => {
+      const { service } = setup();
+      const value = `ac-dc-${faker.string.alphanumeric(16)}`;
+      const sdl = sdlSharingOneEnvList("TOKEN=ac-secret://TOKEN");
+
+      const errors = service.substitute(sdl, { secrets: { web: { TOKEN: value }, worker: { TOKEN: value } } });
+
+      expect(errors).toEqual([]);
+      expect(sdl.services.web.env).toEqual([`TOKEN=${value}`]);
+      expect(sdl.services.worker.env).toEqual([`TOKEN=${value}`]);
+    });
+
+    it("ignores a service declaring no credentials at all", () => {
+      const { service } = setup();
+
+      expect(service.substitute(sdlWithEnv(["PORT=8080"]), { secrets: {} })).toEqual([]);
+    });
+
     it("ignores a non-string env entry", () => {
       const { service } = setup();
       const sdl = sdlWithEnv([8080, null]);
@@ -403,6 +542,33 @@ describe(SdlReferenceService.name, () => {
 
       expect(service.declarationsOf(sdlWithEnv(["C=ac-secret://constructor"]), "secret").map(declaration => declaration.name)).toEqual(["constructor"]);
     });
+
+    it("reports one declaration per service for a credentials block the two of them share", () => {
+      const { service } = setup();
+
+      const declarations = service.declarationsOf(sdlSharingOneCredentialsBlock("ac-secret://REG_PASS"), "secret");
+
+      expect(declarations.map(declaration => declaration.instancePath)).toEqual([
+        "/services/web/credentials/password",
+        "/services/worker/credentials/password"
+      ]);
+    });
+
+    it("reports a registry credential declaration with the half that carries it", () => {
+      const { service } = setup();
+
+      expect(service.declarationsOf(sdlWithCredentials({ password: "ac-secret://REG_PASS" }), "secret")).toEqual([
+        { kind: "secret", name: "REG_PASS", serviceName: "web", reference: "ac-secret://REG_PASS", instancePath: "/services/web/credentials/password" }
+      ]);
+    });
+
+    it("reports one declaration per credential half", () => {
+      const { service } = setup();
+
+      const declarations = service.declarationsOf(sdlWithCredentials({ username: "ac-secret://REG_USER", password: "ac-secret://REG_PASS" }), "secret");
+
+      expect(declarations.map(declaration => declaration.name)).toEqual(["REG_USER", "REG_PASS"]);
+    });
   });
 
   function setup(input: { resolvers?: SdlReferenceResolver[] } = {}) {
@@ -418,10 +584,45 @@ describe(SdlReferenceService.name, () => {
     return yaml.raw<SDLInput>(sdlYaml(services));
   }
 
-  function serviceYaml(name: string, env: unknown[]) {
-    const entries = env.map(entry => `      - ${JSON.stringify(entry)}\n`).join("");
+  function sdlWithCredentials(webCredentials: Record<string, string>, workerCredentials?: Record<string, string>, webEnv: unknown[] = []) {
+    const services = [serviceYaml("web", webEnv, webCredentials), workerCredentials ? serviceYaml("worker", [], workerCredentials) : ""].join("");
 
-    return `  ${name}:\n    image: nginx\n    env:\n${entries}`;
+    return yaml.raw<SDLInput>(sdlYaml(services));
+  }
+
+  function sdlSharingOneCredentialsBlock(password: string) {
+    const block = credentialsYaml({ password }).replace("    credentials:\n", "");
+
+    return yaml.raw<SDLInput>(
+      sdlYaml(`  web:\n    image: nginx\n    credentials: &registry\n${block}  worker:\n    image: nginx\n    credentials: *registry\n`)
+    );
+  }
+
+  function sdlSharingOneEnvList(entry: string) {
+    return yaml.raw<SDLInput>(
+      sdlYaml(`  web:\n    image: nginx\n    env: &shared\n      - ${JSON.stringify(entry)}\n  worker:\n    image: nginx\n    env: *shared\n`)
+    );
+  }
+
+  function credentialsYaml(overrides: Record<string, string>) {
+    const credentials = {
+      host: "registry.example.test",
+      email: "ops@example.test",
+      username: faker.string.alphanumeric(10),
+      password: faker.internet.password(),
+      ...overrides
+    };
+
+    return `    credentials:\n${Object.entries(credentials)
+      .map(([field, value]) => `      ${field}: ${JSON.stringify(value)}\n`)
+      .join("")}`;
+  }
+
+  function serviceYaml(name: string, env: unknown[], credentials?: Record<string, string>) {
+    const entries = env.map(entry => `      - ${JSON.stringify(entry)}\n`).join("");
+    const envYaml = env.length > 0 ? `    env:\n${entries}` : "";
+
+    return `  ${name}:\n    image: nginx\n${envYaml}${credentials ? credentialsYaml(credentials) : ""}`;
   }
 
   function sdlYaml(services: string) {

--- a/apps/api/src/deployment/services/sdl-reference/sdl-reference.service.ts
+++ b/apps/api/src/deployment/services/sdl-reference/sdl-reference.service.ts
@@ -13,6 +13,9 @@ export const MAX_SDL_REFERENCE_NAME_LENGTH = 64;
 /** The whole message is logged by the error handler, and an offending value is only bounded by the request body limit. */
 export const MAX_ECHOED_REFERENCE_LENGTH = 120;
 
+/** The halves of a private registry credential a reference may stand in for: `host` and `email` are left out because neither carries a secret. */
+const CREDENTIAL_REFERENCE_FIELDS = ["username", "password"] as const;
+
 type SdlReferenceRead = { type: "plain" } | { type: "reserved" } | { type: "reference"; kind: string; name: string };
 
 /** Tests the whole grammar, because a value that merely opens with the prefix is not a reference and must not be treated as one. */
@@ -57,17 +60,24 @@ export interface SdlReferenceResolver {
   resolve(target: SdlReferenceTarget, context: SdlReferenceContext): string | undefined;
 }
 
-interface EnvReference extends SdlReferenceTarget {
+/** One position in an SDL where a reference may stand, holding the write back so a caller of the walk never has to know how that position spells a value. */
+interface SdlReferenceSlot {
+  serviceName: string;
+  instancePath: string;
+  value: string;
+  /** Whether a value here may be quoted back to the caller, which a private registry credential never may: A1 makes it a secret whatever it holds. */
+  valueIsAlwaysSecret: boolean;
+  replace(resolved: string): void;
+}
+
+/** One reference an SDL declares, as a caller comparing an SDL against a request's supplied names needs to see it. */
+export interface SdlReferenceDeclaration extends SdlReferenceTarget {
   kind: string;
-  key: string;
   reference: string;
   instancePath: string;
 }
 
-/** One reference an SDL declares, as a caller comparing an SDL against a request's supplied names needs to see it. */
-export type SdlReferenceDeclaration = Omit<EnvReference, "key">;
-
-type EnvReferenceVisitor = (reference: EnvReference, env: string[], index: number) => ValidationError | undefined;
+type SdlReferenceVisitor = (reference: SdlReferenceDeclaration, slot: SdlReferenceSlot) => ValidationError | undefined;
 
 /** A service or reference name may spell an `Object.prototype` member, and a bare lookup would answer such a name with an inherited function. */
 export function ownValue<T>(record: Record<string, T>, key: string): T | undefined {
@@ -98,9 +108,70 @@ export function missingSdlReferenceValueError(reference: SdlReferenceDeclaration
   });
 }
 
-function unknownKindError(reference: EnvReference): ValidationError {
+function reservedValueError(slot: SdlReferenceSlot): ValidationError {
+  const echoed = slot.value.slice(0, MAX_ECHOED_REFERENCE_LENGTH);
+
+  return referenceError(slot.instancePath, `"${echoed}" is not a recognized SDL Reference and values beginning with "${SDL_REFERENCE_PREFIX}" are reserved`, {
+    value: echoed
+  });
+}
+
+/** Names the position rather than what stands in it, because an error payload is echoed to the caller and logged, and this position always holds a secret. */
+function reservedPositionError(slot: SdlReferenceSlot): ValidationError {
+  return referenceError(
+    slot.instancePath,
+    `the value at "${slot.instancePath}" is not a recognized SDL Reference and values beginning with "${SDL_REFERENCE_PREFIX}" are reserved`,
+    {}
+  );
+}
+
+function unknownKindError(reference: SdlReferenceDeclaration): ValidationError {
   return referenceError(reference.instancePath, `"${reference.reference}" uses unknown SDL Reference kind "${reference.kind}"`, {
     kind: reference.kind
+  });
+}
+
+function envSlotsOf(serviceName: string, service: SDLInput["services"][string]): SdlReferenceSlot[] {
+  const env = service?.env;
+
+  if (!Array.isArray(env)) return [];
+
+  return env.flatMap((entry, index) => {
+    const declaration = typeof entry === "string" ? readEnvDeclaration(entry) : null;
+
+    if (!declaration) return [];
+
+    return {
+      serviceName,
+      instancePath: `/services/${serviceName}/env/${index}`,
+      value: declaration.value,
+      valueIsAlwaysSecret: false,
+      replace: (resolved: string) => {
+        env[index] = `${declaration.key}=${resolved}`;
+      }
+    };
+  });
+}
+
+function credentialSlotsOf(serviceName: string, service: SDLInput["services"][string]): SdlReferenceSlot[] {
+  const credentials = service?.credentials;
+
+  if (!credentials || typeof credentials !== "object") return [];
+
+  return CREDENTIAL_REFERENCE_FIELDS.flatMap(field => {
+    const value = credentials[field];
+
+    if (typeof value !== "string") return [];
+
+    return {
+      serviceName,
+      instancePath: `/services/${serviceName}/credentials/${field}`,
+      value,
+      valueIsAlwaysSecret: true,
+      replace: (resolved: string) => {
+        credentials[field] = resolved;
+      }
+    };
   });
 }
 
@@ -124,9 +195,9 @@ export class SdlReferenceService {
     return this.#eachReference(sdl, reference => (this.#resolvers.has(reference.kind) ? undefined : unknownKindError(reference)));
   }
 
-  /** Sets the parsed env entry, so a resolved value can never be re-read as YAML nor rescanned for references. */
+  /** Writes through the slot, so a resolved value can never be re-read as YAML nor rescanned for references. */
   substitute(sdl: SDLInput, context: SdlReferenceContext): ValidationError[] {
-    return this.#eachReference(sdl, (reference, env, index) => {
+    return this.#eachReference(sdl, (reference, slot) => {
       const resolver = this.#resolvers.get(reference.kind);
 
       if (!resolver) {
@@ -139,7 +210,7 @@ export class SdlReferenceService {
         return missingSdlReferenceValueError(reference);
       }
 
-      env[index] = `${reference.key}=${value}`;
+      slot.replace(value);
 
       return undefined;
     });
@@ -149,7 +220,7 @@ export class SdlReferenceService {
   declarationsOf(sdl: SDLInput, kind: string): SdlReferenceDeclaration[] {
     const declarations: SdlReferenceDeclaration[] = [];
 
-    this.#eachReference(sdl, ({ key, ...declaration }) => {
+    this.#eachReference(sdl, declaration => {
       if (declaration.kind === kind) declarations.push(declaration);
 
       return undefined;
@@ -158,53 +229,36 @@ export class SdlReferenceService {
     return declarations;
   }
 
-  #eachReference(sdl: SDLInput, visit: EnvReferenceVisitor): ValidationError[] {
+  #eachReference(sdl: SDLInput, visit: SdlReferenceVisitor): ValidationError[] {
     const errors: ValidationError[] = [];
 
-    for (const [serviceName, service] of Object.entries(this.#servicesOf(sdl))) {
-      const env = service?.env;
+    for (const slot of this.#slotsOf(sdl)) {
+      const error = this.#readSlot(slot, visit);
 
-      if (!Array.isArray(env)) continue;
-
-      env.forEach((entry, index) => {
-        const location = { serviceName, instancePath: `/services/${serviceName}/env/${index}` };
-        const error = this.#readEntry(entry, location, reference => visit(reference, env, index));
-
-        if (error) errors.push(error);
-      });
+      if (error) errors.push(error);
     }
 
     return errors;
   }
 
-  #readEntry(
-    entry: unknown,
-    location: { serviceName: string; instancePath: string },
-    visit: (reference: EnvReference) => ValidationError | undefined
-  ): ValidationError | undefined {
-    if (typeof entry !== "string") return undefined;
+  /** Read in full before anything is written, because two services sharing one `env` list or `credentials` block through a YAML anchor share the node behind both slots, and a lazy walk would read what an earlier slot had already resolved. */
+  #slotsOf(sdl: SDLInput): SdlReferenceSlot[] {
+    return Object.entries(this.#servicesOf(sdl)).flatMap(([serviceName, service]) => [
+      ...envSlotsOf(serviceName, service),
+      ...credentialSlotsOf(serviceName, service)
+    ]);
+  }
 
-    const declaration = readEnvDeclaration(entry);
-
-    if (!declaration) return undefined;
-
-    const read = readSdlReference(declaration.value);
+  #readSlot(slot: SdlReferenceSlot, visit: SdlReferenceVisitor): ValidationError | undefined {
+    const read = readSdlReference(slot.value);
 
     if (read.type === "plain") return undefined;
 
     if (read.type === "reserved") {
-      const echoed = declaration.value.slice(0, MAX_ECHOED_REFERENCE_LENGTH);
-
-      return referenceError(
-        location.instancePath,
-        `"${echoed}" is not a recognized SDL Reference and values beginning with "${SDL_REFERENCE_PREFIX}" are reserved`,
-        {
-          value: echoed
-        }
-      );
+      return slot.valueIsAlwaysSecret ? reservedPositionError(slot) : reservedValueError(slot);
     }
 
-    return visit({ kind: read.kind, name: read.name, ...location, key: declaration.key, reference: declaration.value });
+    return visit({ kind: read.kind, name: read.name, serviceName: slot.serviceName, instancePath: slot.instancePath, reference: slot.value }, slot);
   }
 
   #servicesOf(sdl: SDLInput): SDLInput["services"] {

--- a/apps/api/src/deployment/services/sdl/sdl.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl/sdl.service.spec.ts
@@ -1,3 +1,4 @@
+import { faker } from "@faker-js/faker";
 import { describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
 
@@ -321,6 +322,12 @@ deployment:
 `;
 
 const SDL_WITH_ENV = (entry: string) => VALID_SDL.replace("    expose:", `    env:\n      - "${entry}"\n    expose:`);
+
+const SDL_WITH_CREDENTIALS = (username: string, password: string) =>
+  VALID_SDL.replace(
+    "    expose:",
+    `    credentials:\n      host: registry.example.test\n      username: "${username}"\n      password: "${password}"\n    expose:`
+  );
 
 const SDL_WITH_TEE = (tee: string) => `
 version: "2.0"
@@ -646,6 +653,25 @@ describe(SdlService.name, () => {
 
         expect(result.ok).toBe(true);
       });
+
+      it("keeps a recognized registry credential reference verbatim in the manifest", () => {
+        const { result } = setup({ sdl: SDL_WITH_CREDENTIALS("ac-secret://REG_USER", "ac-secret://REG_PASS") });
+
+        expect(result.ok).toBe(true);
+        expect(getManifestService(result, "westcoast", "web").credentials).toMatchObject({
+          username: "ac-secret://REG_USER",
+          password: "ac-secret://REG_PASS"
+        });
+      });
+
+      it("rejects a registry credential merely beginning with the reserved prefix", () => {
+        const { result } = setup({ sdl: SDL_WITH_CREDENTIALS(faker.string.alphanumeric(10), "ac-dc-forever") });
+
+        expect(result).toMatchObject({
+          ok: false,
+          value: [expect.objectContaining({ instancePath: "/services/web/credentials/password" })]
+        });
+      });
     });
   });
 
@@ -657,6 +683,44 @@ describe(SdlService.name, () => {
 
       expect(result.ok).toBe(true);
       expect(resolvedOf(result).manifest.groups[0].services[0].env).toEqual(["TOKEN=resolved"]);
+    });
+
+    it("returns a manifest carrying the resolved registry credential", async () => {
+      const { service } = setup();
+      const [username, password] = [faker.string.alphanumeric(10), faker.internet.password()];
+
+      const result = await service.generateResolvedManifest({
+        sdl: SDL_WITH_CREDENTIALS("ac-secret://REG_USER", "ac-secret://REG_PASS"),
+        secrets: { web: { REG_USER: username, REG_PASS: password } }
+      });
+
+      expect(result.ok).toBe(true);
+      expect(resolvedOf(result).manifest.groups[0].services[0].credentials).toMatchObject({ username, password });
+    });
+
+    it("hashes an sdl with a substituted registry credential exactly as one carrying it inline", async () => {
+      const { service } = setup();
+      const [username, password] = [faker.string.alphanumeric(10), faker.internet.password()];
+
+      const substituted = await service.generateResolvedManifest({
+        sdl: SDL_WITH_CREDENTIALS("ac-secret://REG_USER", "ac-secret://REG_PASS"),
+        secrets: { web: { REG_USER: username, REG_PASS: password } }
+      });
+      const inline = await service.generateResolvedManifest({ sdl: SDL_WITH_CREDENTIALS(username, password), secrets: {} });
+
+      expect(versionOf(substituted)).toEqual(versionOf(inline));
+    });
+
+    it("refuses a resolved registry credential the schema rejects, which the unresolved reference passed", async () => {
+      const { service } = setup();
+
+      const result = await service.generateResolvedManifest({
+        sdl: SDL_WITH_CREDENTIALS("ac-secret://REG_USER", "ac-secret://REG_PASS"),
+        secrets: { web: { REG_USER: faker.string.alphanumeric(10), REG_PASS: "short" } }
+      });
+
+      expect(result.ok).toBe(false);
+      expect(errorsOf(result)[0].message).toContain("at least 6 characters");
     });
 
     it("hashes an sdl with a substituted value exactly as one carrying that value inline", async () => {

--- a/apps/api/test/functional/deployment-sealed-secrets.spec.ts
+++ b/apps/api/test/functional/deployment-sealed-secrets.spec.ts
@@ -43,6 +43,7 @@ interface OpenApiPaths {
 const KID = "sdl-secrets.v1";
 const VERSION_NAME = "projects/console-test/locations/global/keyRings/console-api/cryptoKeys/sdl-secrets/cryptoKeyVersions/1";
 const MAX_VALUE_BYTES = 16 * 1024;
+const REGISTRY_HOST = "registry.example.test";
 const MAX_COUNT = 100;
 
 const { publicKey, privateKey } = generateKeyPairSync("rsa", { modulusLength: 3072 });
@@ -65,9 +66,20 @@ kmsClient.asymmetricDecrypt.mockImplementation(async request => {
 
 container.register<SdlSecretsKmsTarget>(SDL_SECRETS_KMS_TARGET, { useValue: { client: kmsClient, versionName: VERSION_NAME, kid: KID } });
 
-function sdlWith(services: Record<string, string[]>) {
+function credentialsYaml(credentials?: Record<string, string>) {
+  if (!credentials) return "";
+
+  return `    credentials:\n${Object.entries(credentials)
+    .map(([field, value]) => `      ${field}: ${JSON.stringify(value)}\n`)
+    .join("")}`;
+}
+
+function sdlWith(services: Record<string, string[]>, credentials: Record<string, Record<string, string>> = {}) {
   const bodies = Object.entries(services)
-    .map(([name, env]) => `  ${name}:\n    image: nginx\n    env:\n${env.map(entry => `      - ${JSON.stringify(entry)}\n`).join("")}`)
+    .map(
+      ([name, env]) =>
+        `  ${name}:\n    image: nginx\n${credentialsYaml(credentials[name])}    env:\n${env.map(entry => `      - ${JSON.stringify(entry)}\n`).join("")}`
+    )
     .join("");
   const computes = Object.keys(services)
     .map(
@@ -145,6 +157,70 @@ describe("Deployment sealed secrets", () => {
 
     expect(response.status).toBe(201);
     expect(broadcastHash()).toEqual(await manifestVersionOf(sdlWith({ web: [`API_TOKEN=${token}`] })));
+  });
+
+  it("commits the manifest version of a manifest carrying the resolved registry credential", async () => {
+    const { apiKey } = await persistedUser();
+    const [username, password] = [randomUUID(), randomUUID()];
+    const referencing = { web: { host: REGISTRY_HOST, username: "ac-secret://REG_USER", password: "ac-secret://REG_PASS" } };
+    const inline = { web: { host: REGISTRY_HOST, username, password } };
+    const env = { web: ["LOG_LEVEL=debug"] };
+
+    const response = await postDeployment(apiKey, sdlWith(env, referencing), { REG_USER: username, REG_PASS: password });
+
+    expect(response.status).toBe(201);
+    expect(broadcastHash()).toEqual(await manifestVersionOf(sdlWith(env, inline)));
+  });
+
+  it("names a registry credential reference it holds no value for and records nothing", async () => {
+    const { apiKey, user } = await persistedUser();
+    const referencing = { web: { host: REGISTRY_HOST, username: faker.string.alphanumeric(10), password: "ac-secret://REG_PASS" } };
+
+    const response = await postDeployment(apiKey, sdlWith({ web: ["API_TOKEN=ac-secret://API_TOKEN"] }, referencing), { API_TOKEN: randomUUID() });
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toContain("ac-secret://REG_PASS");
+    expect(await deploymentSettingRepository.findOneBy({ userId: user.id })).toBeUndefined();
+    expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
+  });
+
+  it("refuses a reserved value in a registry credential rather than shipping it to a provider", async () => {
+    const { apiKey, user } = await persistedUser();
+    const reserved = { web: { host: REGISTRY_HOST, username: faker.string.alphanumeric(10), password: "ac-dc-forever" } };
+
+    const response = await postDeployment(apiKey, sdlWith({ web: ["LOG_LEVEL=debug"] }, reserved));
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toContain("reserved");
+    expect(await deploymentSettingRepository.findOneBy({ userId: user.id })).toBeUndefined();
+    expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
+  });
+
+  it("stores the credential values in its token and no credentials block in its sdl", async () => {
+    const { apiKey, user } = await persistedUser();
+    const [username, password] = [faker.string.alphanumeric(10), randomUUID()];
+    const referencing = { web: { host: REGISTRY_HOST, username: "ac-secret://REG_USER", password: "ac-secret://REG_PASS" } };
+
+    const response = await postDeployment(apiKey, sdlWith({ web: ["LOG_LEVEL=debug"] }, referencing), { REG_USER: username, REG_PASS: password });
+
+    const setting = await settingOf(user, response);
+    expect(setting!.sdl).not.toContain("credentials");
+    await expect(openStoredToken(user, setting!.dseq, setting!.sealedSecrets!)).resolves.toEqual({ REG_USER: username, REG_PASS: password });
+  });
+
+  it("refuses a sealed credential the resolved document rejects, saying nothing of its value", async () => {
+    const { apiKey, user } = await persistedUser();
+    const tooShort = faker.string.alphanumeric(5);
+    const referencing = { web: { host: REGISTRY_HOST, username: faker.string.alphanumeric(10), password: "ac-secret://REG_PASS" } };
+
+    const response = await postDeployment(apiKey, sdlWith({ web: ["LOG_LEVEL=debug"] }, referencing), { REG_PASS: tooShort });
+    const body = await response.text();
+
+    expect(response.status).toBe(400);
+    expect(body).toContain("at least 6 characters");
+    expect(body).not.toContain(tooShort);
+    expect(await deploymentSettingRepository.findOneBy({ userId: user.id })).toBeUndefined();
+    expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
   });
 
   it("resolves one supplied value into every service that references it", async () => {

--- a/apps/api/test/functional/deployments.spec.ts
+++ b/apps/api/test/functional/deployments.spec.ts
@@ -1302,6 +1302,26 @@ describe("Deployments API", () => {
       expect(result.message).toContain("ac-secret://TOKEN");
     });
 
+    it("returns 400 naming a registry credential reference it holds no value for", async () => {
+      const { userApiKeySecret, dseq } = await setupUpdatableDeployment();
+
+      const response = await putDeploymentWithCredentials({ userApiKeySecret, dseq, password: "ac-secret://REG_PASS" });
+
+      expect(response.status).toBe(400);
+      const result = (await response.json()) as { message: string };
+      expect(result.message).toContain("ac-secret://REG_PASS");
+    });
+
+    it("returns 400 for a reserved value in a registry credential", async () => {
+      const { userApiKeySecret, dseq } = await setupUpdatableDeployment();
+
+      const response = await putDeploymentWithCredentials({ userApiKeySecret, dseq, password: "ac-dc-forever" });
+
+      expect(response.status).toBe(400);
+      const result = (await response.json()) as { message: string };
+      expect(result.message).toContain("reserved");
+    });
+
     it("commits the manifest version of the very manifest it sends the providers", async () => {
       const { userApiKeySecret, user, dseq } = await setupUpdatableDeployment();
       const sdlService = container.resolve(SdlService);
@@ -1330,6 +1350,23 @@ describe("Deployments API", () => {
       return app.request(`/v1/deployments/${dseq}`, {
         method: "PUT",
         body: JSON.stringify({ data: { sdl: yml.replace("    expose:", `    env:\n      - "${entry}"\n    expose:`) } }),
+        headers: new Headers({ "Content-Type": "application/json", "x-api-key": userApiKeySecret })
+      });
+    }
+
+    function putDeploymentWithCredentials({ userApiKeySecret, dseq, password }: { userApiKeySecret: string; dseq: string; password: string }) {
+      const yml = fs.readFileSync(path.resolve(__dirname, "../mocks/hello-world-sdl.yml"), "utf8");
+      const credentials = [
+        "    credentials:",
+        "      host: registry.example.test",
+        `      username: ${faker.string.alphanumeric(10)}`,
+        `      password: ${JSON.stringify(password)}`,
+        ""
+      ].join("\n");
+
+      return app.request(`/v1/deployments/${dseq}`, {
+        method: "PUT",
+        body: JSON.stringify({ data: { sdl: yml.replace("    expose:", `${credentials}    expose:`) } }),
         headers: new Headers({ "Content-Type": "application/json", "x-api-key": userApiKeySecret })
       });
     }


### PR DESCRIPTION
## Why

Part of CON-863.

The SDL reference walk only ever read `env`, so `password: ac-secret://REG_PASS` in a private registry credential was neither substituted nor refused. It was carried into the manifest as that literal string and hashed as such, and a value beginning with the reserved `ac-` prefix was quietly promoted to a credential in a position where the prefix was reserved in principle and ignored in practice.

Later PRs in this stack need registry credentials to be a first-class reference position before they can store a credentials block at all, so this comes first.

**Stack position — PR 1 of 7.** Targets `feat/deployment-accept-sealed-secrets-on-create`. PR 2 (`feat/deployment-keep-ordinary-env-values-in-sdl`) sits on this one.

## What

**A behaviour change, and the point of the PR.** An SDL that today ships a reserved `ac-` literal in `credentials.username` or `credentials.password` is now refused with a 400 naming the offending half, exactly as the same value in an `env` entry has always been.

**What this closes and what it does not.** The manifest version committed on chain is now taken over a document whose credentials are resolved. The manifest the browser relays to a provider at lease time still comes from the *unresolved* document, so a credential-referencing create commits a hash over resolved values while the provider is handed the reference. That mismatch is the same one the base branch already leaves for `env` — nothing on the create path re-derives a manifest yet — so it is inherited rather than introduced, and out of scope here.

**The refusal says where, not what.** A registry credential is a secret whatever it holds, and an error payload is echoed to the caller and logged in full, so a credential slot names its position — `the value at "/services/web/credentials/password" …` — and never quotes the value. The asymmetry with `env`, which still quotes, is deliberate: no other position is a secret by definition, and a `MODE=ac-dc` an author has to find is worth naming. Pinned both ways.

**A slot, not a second walk.** A slot is a position where a reference may stand, and it knows how to put a resolved value back where it came from — an env entry rewrites half of a `KEY=VALUE` string, a credential rewrites a mapping entry of its own. Keeping the write inside the slot is what lets `validate`, `substitute` and `declarationsOf` keep reading one walk; a second walk would be a second grammar to get wrong about which positions are reserved.

**Slots are read in full before any is written**, which is load-bearing rather than tidy. Two services sharing one `env` list or one `credentials` block through a YAML anchor — the idiomatic way to point several services at one private registry — get two slots over one object, and a lazy walk read the second slot's value *after* the first had resolved it. A resolved password beginning `ac-` was then classified reserved and quoted into a 400; one that did not was classified plain and skipped, so the walk stopped reporting a position it claims to resolve. Both shapes are regression-tested, and the `env` one pre-existed this PR.

**`host` and `email` are deliberately not slots.** Neither carries a secret, so a value beginning with the prefix in either is an ordinary string, and reserving them would refuse a hostname for no benefit. Pinned both ways, so widening the slot set later is a decision rather than a drift.

**One ordering claim in `create` is corrected rather than defended.** `credentials.password` has a minimum length in the SDL schema, so a sealed password shorter than it passes validation as a reference and fails it as a value — the first practically reachable refusal that needs the *resolved* document, and therefore the first that lands after the dseq is minted. Nothing is written or broadcast under that dseq, so the guarantee that matters holds; the sentence claiming nothing can refuse a request past the mint did not, and now says what is true.

Resolution stays per service: a credential resolves out of its own service's namespace, so two services pulling from one registry with different robot accounts each get their own.

Nothing about storage changes here — the stored SDL still drops the whole credentials block, so a create referencing one stores a sealed credential its SDL mentions nowhere. That intermediate state is asserted rather than merely intended, so the PR that ends it has to say so.

**Size:** 528 lines by the labeler filter.

**Validation:** `eslint --quiet` clean; `tsc --noEmit` at 42 errors, byte-identical to the pre-existing baseline at the base branch tip; unit, functional and integration projects all green.

**Demo:** the behaviour this stack produces end to end is demonstrated in PR 4 (`feat/deployment-seal-derived-secrets-on-create`), which is where it becomes observable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Registry credential references are now supported in deployment SDL, including username and password fields.
  * Credential references can be resolved, validated, and securely excluded from stored SDL.
  * Shared YAML anchors and service-specific credential references are handled correctly.

* **Bug Fixes**
  * Improved validation and error reporting for missing or reserved credential references.
  * Preserved non-secret credential fields during SDL processing.

* **Documentation**
  * Clarified when deployment sequence identifiers are minted and how refusals may affect unused identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->