### PR TITLE
feat(deployment): let a stored sdl keep the ordinary values it was written with

### DIFF
--- a/apps/api/src/deployment/config/sdl.config.ts
+++ b/apps/api/src/deployment/config/sdl.config.ts
@@ -1,6 +1,6 @@
 import { DEFAULT_BODY_LIMIT_BYTES } from "@src/core/config/body-limit.config";
 
-/** Bounds the stripped document the console keeps, in characters, and is the only thing bounding it since the column it is written to is `text`. */
+/** Bounds the document the console keeps, in characters, and is the only thing bounding it since the column it is written to is `text`. */
 export const SDL_MAX_LENGTH = 128 * 1024;
 
 /** Bounds a submitted SDL on the field, because the create route's raised body limit would otherwise hand every SDL the room made for a seal. */

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -84,6 +84,26 @@ const SDL_ALIASING_ONE_SCALAR = sdlAround(`    args:
 ${Array.from({ length: 511 }, () => "      - *payload").join("\n")}
 `);
 
+/** Past what the console stores only because its env values are kept, and carrying one a refusal must not echo. */
+const SDL_TOO_LONG_ONCE_VALUES_ARE_KEPT = sdlAround(`    env:
+      - API_TOKEN=${ENV_VALUE}
+${Array.from({ length: 40 }, () => `      - FILLER=${"z".repeat(4096)}`).join("\n")}
+`);
+
+/** Short enough to survive `js-yaml` truncating the line it quotes, so a partial leak of it is still detectable. */
+const MALFORMED_SDL_VALUE = faker.string.alphanumeric(10);
+
+/** Not YAML at all, and carrying an env value, because a `js-yaml` message quotes the lines around the one it failed on. */
+const MALFORMED_SDL_CARRYING_A_VALUE = `version: "2.0"
+services:
+  web:
+    image: nginx
+    env:
+      - LEAKED=${MALFORMED_SDL_VALUE}
+     bad: indentation
+`;
+
+/** An SDL with no anchors at all whose serialized length alone puts it past what the console stores. */
 const SDL_TOO_LONG_WITHOUT_ALIASES = sdlAround(`    args:
 ${Array.from({ length: 40 }, () => `      - ${"z".repeat(4096)}`).join("\n")}
 `);
@@ -299,7 +319,7 @@ describe(DeploymentWriterService.name, () => {
       await service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, sealedSecrets: SEAL, deposit: 5 });
 
       expect(deploymentSettingRepository.upsertDefinition).toHaveBeenCalledWith(
-        expect.objectContaining({ sealedSecrets: SEALED_TOKEN, sdl: expect.stringContaining("API_TOKEN=") })
+        expect.objectContaining({ sealedSecrets: SEALED_TOKEN, sdl: expect.stringContaining(`API_TOKEN=${ENV_VALUE}`) })
       );
     });
 
@@ -454,20 +474,93 @@ describe(DeploymentWriterService.name, () => {
       expect(loggedTextOf(logger)).not.toContain(SEALED_TOKEN);
     });
 
-    it("records an sdl carrying none of the submitted env values", async () => {
+    it("records an sdl carrying none of the submitted env values when no seal said which of them are secret", async () => {
       const { service, deploymentSettingRepository } = setup();
 
       await service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, deposit: 5 });
 
+      expect(recordedSdlOf(deploymentSettingRepository)).toContain("API_TOKEN=");
       expect(recordedSdlOf(deploymentSettingRepository)).not.toContain(ENV_VALUE);
     });
 
-    it("records an sdl carrying none of the submitted registry credentials", async () => {
+    it("records the submitted env value as it arrived once a seal has said which values are secret", async () => {
       const { service, deploymentSettingRepository } = setup();
 
-      await service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, deposit: 5 });
+      await service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, sealedSecrets: SEAL, deposit: 5 });
+
+      expect(recordedSdlOf(deploymentSettingRepository)).toContain(`API_TOKEN=${ENV_VALUE}`);
+    });
+
+    it.each([
+      { named: "no seal", sealedSecrets: undefined },
+      { named: "a seal", sealedSecrets: SEAL }
+    ])("records an sdl carrying none of the submitted registry credentials, given $named", async ({ sealedSecrets }) => {
+      const { service, deploymentSettingRepository } = setup();
+
+      await service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, sealedSecrets, deposit: 5 });
 
       expect(recordedSdlOf(deploymentSettingRepository)).not.toContain(REGISTRY_PASSWORD);
+    });
+
+    it("says nothing of the values it stores when persistence fails", async () => {
+      const { service, deploymentSettingRepository, logger } = setup();
+      deploymentSettingRepository.upsertDefinition.mockRejectedValue(new Error("write failed"));
+
+      await expect(service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, sealedSecrets: SEAL, deposit: 5 })).rejects.toThrow();
+
+      expect(recordedSdlOf(deploymentSettingRepository)).toContain(`API_TOKEN=${ENV_VALUE}`);
+      expect(loggedTextOf(logger)).not.toContain(ENV_VALUE);
+    });
+
+    it("says nothing of the values it would have stored when the sdl is too large to keep", async () => {
+      const { service, logger } = setup();
+
+      const thrown = await service.create({ userId: "user-1", sdl: SDL_TOO_LONG_ONCE_VALUES_ARE_KEPT, sealedSecrets: SEAL, deposit: 5 }).catch(error => error);
+
+      expect(thrown).toMatchObject({ status: 400 });
+      expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "DEPLOYMENT_SDL_TOO_LARGE", maxLength: SDL_MAX_LENGTH }));
+      expect(loggedTextOf(logger)).not.toContain(ENV_VALUE);
+      expect(thrownTextOf(thrown)).not.toContain(ENV_VALUE);
+    });
+
+    it("names the position it stopped parsing at, in numbers, carrying no text of the document", async () => {
+      const { service, logger } = setup();
+
+      const thrown = await service.create({ userId: "user-1", sdl: MALFORMED_SDL_CARRYING_A_VALUE, sealedSecrets: SEAL, deposit: 5 }).catch(error => error);
+
+      expect(thrown).toMatchObject({ status: 400, message: "SDL is not valid YAML: line 7, column 6" });
+      expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "DEPLOYMENT_SDL_UNPARSEABLE", line: 7, column: 6 }));
+      expect(thrownTextOf(thrown)).not.toContain(MALFORMED_SDL_VALUE);
+      expect(thrownTextOf(thrown)).not.toContain("LEAKED");
+      expect(loggedTextOf(logger)).not.toContain("LEAKED");
+    });
+
+    it("refuses an sdl that is not yaml as unparseable rather than as too large", async () => {
+      const { service, logger } = setup();
+
+      const thrown = await service.create({ userId: "user-1", sdl: MALFORMED_SDL_CARRYING_A_VALUE, sealedSecrets: SEAL, deposit: 5 }).catch(error => error);
+
+      expect(thrown).toMatchObject({ status: 400, message: expect.stringContaining("SDL is not valid YAML") });
+      expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "DEPLOYMENT_SDL_UNPARSEABLE" }));
+    });
+
+    it("says nothing of the document a parse error quoted, in what it throws or what it logs", async () => {
+      const { service, logger } = setup();
+
+      const thrown = await service.create({ userId: "user-1", sdl: MALFORMED_SDL_CARRYING_A_VALUE, sealedSecrets: SEAL, deposit: 5 }).catch(error => error);
+
+      expect(thrownTextOf(thrown)).not.toContain(MALFORMED_SDL_VALUE);
+      expect(thrownTextOf(thrown)).not.toContain("LEAKED");
+      expect(loggedTextOf(logger)).not.toContain(MALFORMED_SDL_VALUE);
+      expect(loggedTextOf(logger)).not.toContain("LEAKED");
+    });
+
+    it("still stores an sdl too long to keep the values of, when no seal said which of them are secret", async () => {
+      const { service, deploymentSettingRepository } = setup();
+
+      await service.create({ userId: "user-1", sdl: SDL_TOO_LONG_ONCE_VALUES_ARE_KEPT, deposit: 5 });
+
+      expect(recordedSdlOf(deploymentSettingRepository)).not.toContain(ENV_VALUE);
     });
 
     it("records the definition before broadcasting the create tx", async () => {
@@ -982,6 +1075,18 @@ describe(DeploymentWriterService.name, () => {
     return sdl as string;
   }
 
+  /** Everything a thrown refusal carries, cause chain included, because the error handler logs the whole chain even when the response body carries none of it. */
+  function thrownTextOf(thrown: unknown): string {
+    const parts: string[] = [];
+
+    for (let current: unknown = thrown; current instanceof Error; current = current.cause) {
+      parts.push(current.message, current.stack ?? "", JSON.stringify(current, Object.getOwnPropertyNames(current)));
+    }
+
+    return parts.join("");
+  }
+
+  /** Everything the logger was handed, flattened, so a test can assert the sdl reached none of it. */
   function loggedTextOf(logger: MockProxy<ReturnType<CreateLogger>>): string {
     return [logger.error, logger.warn, logger.info, logger.debug]
       .flatMap(method => method.mock.calls)

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -22,7 +22,8 @@ import { SdlService } from "@src/deployment/services/sdl/sdl.service";
 import type { NamespacedSdlSecrets } from "@src/deployment/services/sdl-reference/sdl-reference.service";
 import type { ReceivedSdlSecrets } from "@src/deployment/services/sdl-secrets/sdl-secrets.service";
 import { SdlSecretsService } from "@src/deployment/services/sdl-secrets/sdl-secrets.service";
-import { stripSdlSecrets } from "@src/deployment/utils/sdl-secret-stripping/sdl-secret-stripping";
+import type { StoredSdlPosition, StoredSdlRefusal } from "@src/deployment/utils/sdl-for-storage/sdl-for-storage";
+import { sdlForStorage } from "@src/deployment/utils/sdl-for-storage/sdl-for-storage";
 import { ProviderService } from "@src/provider/services/provider/provider.service";
 import { denomToUdenom } from "@src/utils/math";
 import { DeploymentConfigService } from "../deployment-config/deployment-config.service";
@@ -54,8 +55,8 @@ export class DeploymentWriterService {
 
   /** The dseq is minted once everything that can refuse the submitted document has run, because the token written below names it and a client sealing beforehand cannot; a refusal that needs the resolved document — a sealed registry password below the schema's minimum, say — can only come after it, and spends a dseq nothing is written under. */
   public async create(input: CreateDeploymentRequest["data"] & { userId: string }): Promise<CreateDeploymentResponse["data"]> {
-    /** SDL for storage ONLY, stripped of every env value that is not a reference to one */
-    const sdl = this.#strippedSdlWithinLimit(input.sdl);
+    /** SDL for storage ONLY. Never stands in for the submitted document anywhere a hash is taken. */
+    const sdl = this.#storedSdlWithinLimit(input.sdl, { secretsAreDeclared: !!input.sealedSecrets });
 
     const wallet = await this.walletReaderService.getWalletByUserId(input.userId);
     const depositInDollars = this.deploymentConfig.get("DEPLOYMENT_DEFAULT_DEPOSIT");
@@ -165,18 +166,30 @@ export class DeploymentWriterService {
   }
 
   /** `dseq` is a log field only, so a create can run this before minting one and still say which request it refused. */
-  #strippedSdlWithinLimit(submittedSdl: string, dseq?: string): string {
-    const { sdl, length, error } = stripSdlSecrets(submittedSdl, SDL_MAX_LENGTH);
+  #storedSdlWithinLimit(submittedSdl: string, options: { secretsAreDeclared: boolean; dseq?: string }): string {
+    const { dseq } = options;
+    const { sdl, length, refusal, at } = sdlForStorage(submittedSdl, SDL_MAX_LENGTH, { keepOrdinaryEnvValues: options.secretsAreDeclared });
 
     if (sdl === null) {
-      this.logger.warn({ event: "DEPLOYMENT_SDL_TOO_LARGE", dseq, length, maxLength: SDL_MAX_LENGTH });
-      throw new HTTPException(400, {
-        cause: error,
-        message: `SDL is too large: it exceeds the maximum of ${SDL_MAX_LENGTH} characters once stored`
-      });
+      throw this.#rejectUnstorableSdl(refusal, { dseq, length, at });
     }
 
     return sdl;
+  }
+
+  /** Carries none of the document and attaches no parse error as a cause, because a `js-yaml` message quotes the line it failed on and the error handler logs the whole chain. */
+  #rejectUnstorableSdl(refusal: StoredSdlRefusal, details: { dseq?: string; length: number; at?: StoredSdlPosition }) {
+    const { at, ...loggable } = details;
+
+    if (refusal === "unparseable") {
+      this.logger.warn({ event: "DEPLOYMENT_SDL_UNPARSEABLE", ...loggable, line: at?.line, column: at?.column });
+
+      return new HTTPException(400, { message: at ? `SDL is not valid YAML: line ${at.line}, column ${at.column}` : "SDL is not valid YAML" });
+    }
+
+    this.logger.warn({ event: "DEPLOYMENT_SDL_TOO_LARGE", ...loggable, maxLength: SDL_MAX_LENGTH });
+
+    return new HTTPException(400, { message: `SDL is too large: it exceeds the maximum of ${SDL_MAX_LENGTH} characters once stored` });
   }
 
   /**
@@ -244,7 +257,7 @@ export class DeploymentWriterService {
 
   public async updateByUserIdAndDseq(userId: string, dseq: string, input: UpdateDeploymentRequest["data"]): Promise<DeploymentResponse> {
     const wallet = await this.walletReaderService.getWalletByUserId(userId);
-    const sdl = this.#strippedSdlWithinLimit(input.sdl, dseq);
+    const sdl = this.#storedSdlWithinLimit(input.sdl, { secretsAreDeclared: false, dseq });
 
     const { manifestVersion, manifest } = await this.#resolveSdl(input.sdl, { isTrialing: !!wallet.isTrialing });
     const deployment = await this.deploymentReaderService.findByWalletAndDseq(wallet, dseq);

--- a/apps/api/src/deployment/services/sdl-reference/sdl-reference.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl-reference/sdl-reference.service.spec.ts
@@ -341,7 +341,7 @@ describe(SdlReferenceService.name, () => {
       expect(sdl.services.worker.credentials!.password).toBe(workerPassword);
     });
 
-    it("reports a credential reference it holds no value for, naming the half that carries it", () => {
+    it("quotes the reference of a credential it holds no value for, a reserved-prefix string being one no registry could accept anyway", () => {
       const { service } = setup();
       const sdl = sdlWithCredentials({ password: "ac-secret://REG_PASS" });
 

--- a/apps/api/src/deployment/utils/sdl-for-storage/sdl-for-storage.spec.ts
+++ b/apps/api/src/deployment/utils/sdl-for-storage/sdl-for-storage.spec.ts
@@ -7,10 +7,11 @@ import { mock } from "vitest-mock-extended";
 
 import type { BillingConfig } from "@src/billing/providers";
 import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
+import { SDL_MAX_LENGTH } from "@src/deployment/config/sdl.config";
 import { BlockedGpuService } from "@src/deployment/services/blocked-gpu/blocked-gpu.service";
 import { SdlService } from "@src/deployment/services/sdl/sdl.service";
 import { SdlReferenceService } from "@src/deployment/services/sdl-reference/sdl-reference.service";
-import { stripSdlSecrets } from "./sdl-secret-stripping";
+import { sdlForStorage } from "./sdl-for-storage";
 
 import { mockConfigService } from "@test/mocks/config-service.mock";
 
@@ -19,12 +20,16 @@ const IMAGE = "ghcr.io/akash-network/hello-akash-world:2.1.0";
 /** Generous enough that every test but the size ones is measuring stripping rather than the limit. */
 const MAX_LENGTH = 128 * 1024;
 
-describe(stripSdlSecrets.name, () => {
-  describe("environment values", () => {
+/** The two ways a submitted document can arrive: having named which of its values are secret, or not. */
+const SECRETS_DECLARED = { keepOrdinaryEnvValues: true } as const;
+const SECRETS_NOT_DECLARED = { keepOrdinaryEnvValues: false } as const;
+
+describe(sdlForStorage.name, () => {
+  describe("an env value, when the submitted document declares no secrets", () => {
     it("keeps the variable name and drops its value", () => {
       const token = faker.string.alphanumeric(24);
 
-      const stripped = strip(sdlWith({ web: { env: [`API_TOKEN=${token}`] } }));
+      const stripped = storedWithoutValues(sdlWith({ web: { env: [`API_TOKEN=${token}`] } }));
 
       expect(stripped.services.web.env).toEqual(["API_TOKEN="]);
     });
@@ -32,89 +37,150 @@ describe(stripSdlSecrets.name, () => {
     it("drops a value that itself contains an equals sign", () => {
       const password = faker.internet.password();
 
-      const stripped = strip(sdlWith({ web: { env: [`DATABASE_URL=postgres://u:${password}@h:5432/db?ssl=true&a=b`] } }));
+      const stripped = storedWithoutValues(sdlWith({ web: { env: [`DATABASE_URL=postgres://u:${password}@h:5432/db?ssl=true&a=b`] } }));
 
       expect(stripped.services.web.env).toEqual(["DATABASE_URL="]);
     });
 
     it("leaves an entry that names no value alone", () => {
-      const stripped = strip(sdlWith({ web: { env: ["INHERITED_FROM_HOST"] } }));
+      const stripped = storedWithoutValues(sdlWith({ web: { env: ["INHERITED_FROM_HOST"] } }));
 
       expect(stripped.services.web.env).toEqual(["INHERITED_FROM_HOST"]);
     });
 
     it("leaves an explicitly null env list alone", () => {
-      const stripped = strip(sdlWith({ web: { env: null } }));
+      const stripped = storedWithoutValues(sdlWith({ web: { env: null } }));
 
       expect(stripped.services.web.env).toBeNull();
     });
 
     it("leaves a service that declares no env alone", () => {
-      const stripped = strip(sdlWith({ web: {} }));
+      const stripped = storedWithoutValues(sdlWith({ web: {} }));
 
       expect(stripped.services.web).not.toHaveProperty("env");
     });
 
     it("strips the env of every service, not only the first", () => {
-      const stripped = strip(sdlWith({ web: { env: [`A=${faker.string.alphanumeric(8)}`] }, worker: { env: [`B=${faker.string.alphanumeric(8)}`] } }));
+      const stripped = storedWithoutValues(
+        sdlWith({ web: { env: [`A=${faker.string.alphanumeric(8)}`] }, worker: { env: [`B=${faker.string.alphanumeric(8)}`] } })
+      );
 
       expect(stripped.services.web.env).toEqual(["A="]);
       expect(stripped.services.worker.env).toEqual(["B="]);
     });
   });
 
+  describe("an env value, when the submitted document declares its secrets", () => {
+    it("keeps the value exactly as submitted", () => {
+      const token = faker.string.alphanumeric(24);
+
+      const kept = storedWithValues(sdlWith({ web: { env: [`API_TOKEN=${token}`] } }));
+
+      expect(kept.services.web.env).toEqual([`API_TOKEN=${token}`]);
+    });
+
+    it("keeps a value that itself contains an equals sign", () => {
+      const password = faker.internet.password();
+      const url = `postgres://u:${password}@h:5432/db?ssl=true&a=b`;
+
+      const kept = storedWithValues(sdlWith({ web: { env: [`DATABASE_URL=${url}`] } }));
+
+      expect(kept.services.web.env).toEqual([`DATABASE_URL=${url}`]);
+    });
+
+    it("keeps a value carrying yaml metacharacters byte-identical", () => {
+      const value = "a: b #c |x >y {z} [w] &anchor *alias \"q\" 's'\nsecond: line\t- dash";
+
+      const kept = storedWithValues(sdlWith({ web: { env: [`WEIRD=${value}`] } }));
+
+      expect(kept.services.web.env).toEqual([`WEIRD=${value}`]);
+    });
+
+    it("keeps an entry that names no value distinct from one whose value is empty", () => {
+      const kept = storedWithValues(sdlWith({ web: { env: ["INHERITED_FROM_HOST", "EXPLICITLY_EMPTY="] } }));
+
+      expect(kept.services.web.env).toEqual(["INHERITED_FROM_HOST", "EXPLICITLY_EMPTY="]);
+    });
+
+    it("keeps a reference beside an ordinary value", () => {
+      const token = faker.string.alphanumeric(24);
+
+      const kept = storedWithValues(sdlWith({ web: { env: ["SECRET=ac-secret://SECRET", `PLAIN=${token}`, "INHERITED_FROM_HOST"] } }));
+
+      expect(kept.services.web.env).toEqual(["SECRET=ac-secret://SECRET", `PLAIN=${token}`, "INHERITED_FROM_HOST"]);
+    });
+
+    it("keeps the env of every service, not only the first", () => {
+      const [first, second] = [faker.string.alphanumeric(8), faker.string.alphanumeric(8)];
+
+      const kept = storedWithValues(sdlWith({ web: { env: [`A=${first}`] }, worker: { env: [`B=${second}`] } }));
+
+      expect(kept.services.web.env).toEqual([`A=${first}`]);
+      expect(kept.services.worker.env).toEqual([`B=${second}`]);
+    });
+
+    it("reparses to the document that was submitted", () => {
+      const submitted = sdlWith({
+        web: { env: [`API_TOKEN=${faker.string.alphanumeric(24)}`, "SECRET=ac-secret://SECRET", "INHERITED_FROM_HOST"] },
+        worker: { env: [`DATABASE_URL=postgres://u:${faker.internet.password()}@h:5432/db?ssl=true`] }
+      });
+
+      expect(storedWithValues(submitted)).toEqual(yaml.raw<SDLInput>(submitted));
+    });
+  });
+
   describe("a value that refers to a secret rather than carrying one", () => {
     it("keeps a whole sdl reference", () => {
-      const stripped = strip(sdlWith({ web: { env: ["API_TOKEN=ac-secret://API_TOKEN"] } }));
+      const stripped = storedWithoutValues(sdlWith({ web: { env: ["API_TOKEN=ac-secret://API_TOKEN"] } }));
 
       expect(stripped.services.web.env).toEqual(["API_TOKEN=ac-secret://API_TOKEN"]);
     });
 
     it("keeps a reference whose name differs from the variable it is assigned to", () => {
-      const stripped = strip(sdlWith({ web: { env: ["DATABASE_URL=ac-secret://PROD_DB"] } }));
+      const stripped = storedWithoutValues(sdlWith({ web: { env: ["DATABASE_URL=ac-secret://PROD_DB"] } }));
 
       expect(stripped.services.web.env).toEqual(["DATABASE_URL=ac-secret://PROD_DB"]);
     });
 
     it("keeps a reference of a kind no resolver is registered for", () => {
-      const stripped = strip(sdlWith({ web: { env: ["MODE=ac-var://MODE"] } }));
+      const stripped = storedWithoutValues(sdlWith({ web: { env: ["MODE=ac-var://MODE"] } }));
 
       expect(stripped.services.web.env).toEqual(["MODE=ac-var://MODE"]);
     });
 
     it("keeps the reference of every service that carries one", () => {
-      const stripped = strip(sdlWith({ web: { env: ["T=ac-secret://T"] }, worker: { env: ["T=ac-secret://T"] } }));
+      const stripped = storedWithoutValues(sdlWith({ web: { env: ["T=ac-secret://T"] }, worker: { env: ["T=ac-secret://T"] } }));
 
       expect(stripped.services.web.env).toEqual(["T=ac-secret://T"]);
       expect(stripped.services.worker.env).toEqual(["T=ac-secret://T"]);
     });
 
     it("drops a value that merely opens with the reserved prefix", () => {
-      const stripped = strip(sdlWith({ web: { env: ["MODE=ac-dc"] } }));
+      const stripped = storedWithoutValues(sdlWith({ web: { env: ["MODE=ac-dc"] } }));
 
       expect(stripped.services.web.env).toEqual(["MODE="]);
     });
 
     it("drops a reference embedded in a larger value", () => {
-      const stripped = strip(sdlWith({ web: { env: ["T=prefix-ac-secret://T"] } }));
+      const stripped = storedWithoutValues(sdlWith({ web: { env: ["T=prefix-ac-secret://T"] } }));
 
       expect(stripped.services.web.env).toEqual(["T="]);
     });
 
     it("drops a value that is a reference followed by anything else", () => {
-      const stripped = strip(sdlWith({ web: { env: ["T=ac-secret://T suffix"] } }));
+      const stripped = storedWithoutValues(sdlWith({ web: { env: ["T=ac-secret://T suffix"] } }));
 
       expect(stripped.services.web.env).toEqual(["T="]);
     });
 
     it("drops a value that is a reference followed by a line terminator", () => {
-      const stripped = strip(sdlWith({ web: { env: ["T=ac-secret://T\n"] } }));
+      const stripped = storedWithoutValues(sdlWith({ web: { env: ["T=ac-secret://T\n"] } }));
 
       expect(stripped.services.web.env).toEqual(["T="]);
     });
 
     it("drops a value naming a kind longer than the grammar allows", () => {
-      const stripped = strip(sdlWith({ web: { env: [`T=ac-${"z".repeat(17)}://T`] } }));
+      const stripped = storedWithoutValues(sdlWith({ web: { env: [`T=ac-${"z".repeat(17)}://T`] } }));
 
       expect(stripped.services.web.env).toEqual(["T="]);
     });
@@ -122,38 +188,34 @@ describe(stripSdlSecrets.name, () => {
     it("keeps a reference while dropping an ordinary value beside it", () => {
       const token = faker.string.alphanumeric(24);
 
-      const stripped = strip(sdlWith({ web: { env: ["SECRET=ac-secret://SECRET", `PLAIN=${token}`, "INHERITED_FROM_HOST"] } }));
+      const stripped = storedWithoutValues(sdlWith({ web: { env: ["SECRET=ac-secret://SECRET", `PLAIN=${token}`, "INHERITED_FROM_HOST"] } }));
 
       expect(stripped.services.web.env).toEqual(["SECRET=ac-secret://SECRET", "PLAIN=", "INHERITED_FROM_HOST"]);
     });
   });
 
   describe("private registry credentials", () => {
-    it("removes the whole block, not just the password", () => {
-      const stripped = strip(
-        sdlWith({
-          web: {
-            credentials: { host: "registry.example.test", username: faker.string.alphanumeric(10), password: faker.internet.password() }
-          }
-        })
-      );
-
-      expect(stripped.services.web).not.toHaveProperty("credentials");
-    });
-
-    it("removes the block of every service that declares one", () => {
+    it.each([SECRETS_DECLARED, SECRETS_NOT_DECLARED])("removes the whole block, not just the password, given %j", options => {
       const credentials = { host: "registry.example.test", username: faker.string.alphanumeric(10), password: faker.internet.password() };
 
-      const stripped = strip(sdlWith({ web: { credentials }, worker: { credentials } }));
+      const stored = storedDocumentOf(sdlWith({ web: { credentials } }), options);
 
-      expect(stripped.services.web).not.toHaveProperty("credentials");
-      expect(stripped.services.worker).not.toHaveProperty("credentials");
+      expect(stored.services.web).not.toHaveProperty("credentials");
+    });
+
+    it.each([SECRETS_DECLARED, SECRETS_NOT_DECLARED])("removes the block of every service that declares one, given %j", options => {
+      const credentials = { host: "registry.example.test", username: faker.string.alphanumeric(10), password: faker.internet.password() };
+
+      const stored = storedDocumentOf(sdlWith({ web: { credentials }, worker: { credentials } }), options);
+
+      expect(stored.services.web).not.toHaveProperty("credentials");
+      expect(stored.services.worker).not.toHaveProperty("credentials");
     });
   });
 
   describe("a value that is also an ordinary part of the SDL", () => {
     it("keeps a service whose name another service's env value happens to equal", () => {
-      const stripped = strip(sdlWith({ wordpress: { env: ["WORDPRESS_DB_HOST=db"] }, db: { env: ["MYSQL_DATABASE=wordpress"] } }));
+      const stripped = storedWithoutValues(sdlWith({ wordpress: { env: ["WORDPRESS_DB_HOST=db"] }, db: { env: ["MYSQL_DATABASE=wordpress"] } }));
 
       expect(Object.keys(stripped.services)).toEqual(["wordpress", "db"]);
       expect(stripped.services.db.image).toBe(IMAGE);
@@ -162,19 +224,19 @@ describe(stripSdlSecrets.name, () => {
     });
 
     it("keeps a placement denom an env value happens to equal", () => {
-      const stripped = strip(sdlWith({ web: { env: ["DENOM=uakt"] } }));
+      const stripped = storedWithoutValues(sdlWith({ web: { env: ["DENOM=uakt"] } }));
 
       expect(stripped.profiles.placement.dcloud.pricing.web.denom).toBe("uakt");
     });
 
     it("keeps an image an env value happens to equal", () => {
-      const stripped = strip(sdlWith({ web: { image: "nginx", env: ["IMAGE_NAME=nginx"] } }));
+      const stripped = storedWithoutValues(sdlWith({ web: { image: "nginx", env: ["IMAGE_NAME=nginx"] } }));
 
       expect(stripped.services.web.image).toBe("nginx");
     });
 
     it("keeps a map key an env value happens to equal", () => {
-      const stripped = strip(sdlWith({ web: { env: ["PROFILE=dcloud"] } }));
+      const stripped = storedWithoutValues(sdlWith({ web: { env: ["PROFILE=dcloud"] } }));
 
       expect(stripped.profiles.placement).toHaveProperty("dcloud");
     });
@@ -185,7 +247,7 @@ describe(stripSdlSecrets.name, () => {
       const token = faker.string.alphanumeric(12);
       const sharedEnv = [`API_TOKEN=${token}`];
 
-      const stripped = strip(dump(sdlDocument({ web: { env: sharedEnv, args: sharedEnv } })));
+      const stripped = storedWithoutValues(dump(sdlDocument({ web: { env: sharedEnv, args: sharedEnv } })));
 
       expect(stripped.services.web.env).toEqual(["API_TOKEN="]);
       expect(stripped.services.web.args).toEqual(["API_TOKEN="]);
@@ -194,48 +256,61 @@ describe(stripSdlSecrets.name, () => {
     it("keeps a value typed out a second time in args, which the env declaration cannot reach", () => {
       const token = faker.string.alphanumeric(12);
 
-      const stripped = strip(sdlWith({ web: { env: [`API_TOKEN=${token}`], args: [`--token=${token}`] } }));
+      const stripped = storedWithoutValues(sdlWith({ web: { env: [`API_TOKEN=${token}`], args: [`--token=${token}`] } }));
 
       expect(stripped.services.web.env).toEqual(["API_TOKEN="]);
       expect(stripped.services.web.args).toEqual([`--token=${token}`]);
     });
   });
 
-  describe("the stripped output", () => {
+  describe("the stored output", () => {
     it("stays an SDL the manifest generator still accepts", () => {
       const submitted = sdlWith({ web: { env: [`API_TOKEN=${faker.string.alphanumeric(12)}`] } });
 
-      expect(manifestFrom(storedSdlOf(submitted)).ok).toBe(true);
+      expect(manifestFrom(storedSdlOf(submitted, SECRETS_NOT_DECLARED)).ok).toBe(true);
     });
 
     it("stays an SDL the manifest generator accepts when an env value equals the service name", () => {
       const submitted = sdlWith({ wordpress: { env: ["WORDPRESS_DB_HOST=db"] }, db: {} });
 
-      expect(manifestFrom(storedSdlOf(submitted)).ok).toBe(true);
+      expect(manifestFrom(storedSdlOf(submitted, SECRETS_NOT_DECLARED)).ok).toBe(true);
     });
 
     it("stays an SDL the manifest generator accepts when an env value equals the denom", () => {
       const submitted = sdlWith({ web: { env: ["DENOM=uakt"] } });
 
-      expect(manifestFrom(storedSdlOf(submitted)).ok).toBe(true);
+      expect(manifestFrom(storedSdlOf(submitted, SECRETS_NOT_DECLARED)).ok).toBe(true);
     });
 
     it("still generates a manifest for an SDL that declares no env at all", () => {
-      expect(manifestFrom(storedSdlOf(sdlWith({ web: {} }))).ok).toBe(true);
+      expect(manifestFrom(storedSdlOf(sdlWith({ web: {} }), SECRETS_NOT_DECLARED)).ok).toBe(true);
     });
 
-    it("strips an already stripped SDL to the same thing again", () => {
-      const once = storedSdlOf(sdlWith({ web: { env: [`API_TOKEN=${faker.string.alphanumeric(12)}`] } }));
+    it("stores an already stored SDL as the same thing again", () => {
+      const once = storedSdlOf(sdlWith({ web: { env: [`API_TOKEN=${faker.string.alphanumeric(12)}`] } }), SECRETS_NOT_DECLARED);
 
-      expect(storedSdlOf(once)).toBe(once);
+      expect(storedSdlOf(once, SECRETS_NOT_DECLARED)).toBe(once);
+    });
+  });
+
+  describe("an SDL that is not yaml at all", () => {
+    it("reports why it was refused, carrying nothing of the document with it", () => {
+      const value = faker.string.alphanumeric(10);
+
+      const result = sdlForStorage(`services:\n  web:\n    env:\n      - LEAKED=${value}\n   bad: indentation\n`, MAX_LENGTH, SECRETS_NOT_DECLARED);
+
+      expect(result).toEqual({ sdl: null, length: expect.any(Number), refusal: "unparseable", at: { line: 5, column: 4 } });
+      expect(JSON.stringify(result)).not.toContain(value);
+      expect(JSON.stringify(result)).not.toContain("LEAKED");
     });
   });
 
   describe("an SDL too large to store", () => {
     it("returns nothing rather than the document, reporting the size it measured", () => {
-      const result = stripSdlSecrets(sdlWith({ web: { args: ["x".repeat(2048)] } }), 512);
+      const result = sdlForStorage(sdlWith({ web: { args: ["x".repeat(2048)] } }), 512, SECRETS_NOT_DECLARED);
 
       expect(result.sdl).toBeNull();
+      expect(result.refusal).toBe("too-large");
       expect(result.length).toBeGreaterThan(512);
     });
 
@@ -244,7 +319,7 @@ describe(stripSdlSecrets.name, () => {
       const aliasCount = 512;
       const lengthIfItHadBeenSerialized = scalarLength * aliasCount;
 
-      const result = stripSdlSecrets(sdlAliasingOneScalar({ scalarLength, aliasCount }), 8192);
+      const result = sdlForStorage(sdlAliasingOneScalar({ scalarLength, aliasCount }), 8192, SECRETS_NOT_DECLARED);
 
       expect(result.sdl).toBeNull();
       expect(result.length).toBeGreaterThan(8192);
@@ -252,14 +327,14 @@ describe(stripSdlSecrets.name, () => {
     });
 
     it("measures an aliased scalar once per alias, as serializing it would write it", () => {
-      const oneAlias = stripSdlSecrets(sdlAliasingOneScalar({ scalarLength: 4096, aliasCount: 1 }), 8192).length;
-      const manyAliases = stripSdlSecrets(sdlAliasingOneScalar({ scalarLength: 4096, aliasCount: 512 }), 8192).length;
+      const oneAlias = sdlForStorage(sdlAliasingOneScalar({ scalarLength: 4096, aliasCount: 1 }), 8192, SECRETS_NOT_DECLARED).length;
+      const manyAliases = sdlForStorage(sdlAliasingOneScalar({ scalarLength: 4096, aliasCount: 512 }), 8192, SECRETS_NOT_DECLARED).length;
 
       expect(manyAliases).toBeGreaterThan(oneAlias);
     });
 
     it("stores a document with no anchors that fits, without consulting the estimate", () => {
-      const stripped = stripSdlSecrets(sdlWith({ web: { env: [`API_TOKEN=${faker.string.alphanumeric(12)}`] } }), MAX_LENGTH);
+      const stripped = sdlForStorage(sdlWith({ web: { env: [`API_TOKEN=${faker.string.alphanumeric(12)}`] } }), MAX_LENGTH, SECRETS_NOT_DECLARED);
 
       expect(stripped.sdl).toContain("API_TOKEN=");
       expect(stripped.length).toBe(stripped.sdl?.length);
@@ -268,7 +343,7 @@ describe(stripSdlSecrets.name, () => {
     it("measures a document with no anchors by serializing it exactly", () => {
       const submitted = sdlWith({ web: { args: ["x".repeat(4096)] } });
 
-      const result = stripSdlSecrets(submitted, 512);
+      const result = sdlForStorage(submitted, 512, SECRETS_NOT_DECLARED);
 
       expect(result.sdl).toBeNull();
       expect(result.length).toBe(dump(yaml.raw(submitted), { lineWidth: -1 }).length);
@@ -277,25 +352,49 @@ describe(stripSdlSecrets.name, () => {
     it("stores a document whose scalars merely contain an ampersand and an asterisk", () => {
       const submitted = sdlWith({ web: { args: ["sh", "-c", "start && tail -f *.log"], env: [`TOKEN=${faker.string.alphanumeric(8)}&x*y`] } });
 
-      const stripped = strip(submitted);
+      const stripped = storedWithoutValues(submitted);
 
       expect(stripped.services.web.args).toEqual(["sh", "-c", "start && tail -f *.log"]);
       expect(stripped.services.web.env).toEqual(["TOKEN="]);
     });
 
     it("returns a document that fits", () => {
-      expect(stripSdlSecrets(sdlWith({ web: {} }), MAX_LENGTH).sdl).toContain("services:");
+      expect(sdlForStorage(sdlWith({ web: {} }), MAX_LENGTH, SECRETS_NOT_DECLARED).sdl).toContain("services:");
+    });
+
+    it("refuses a document only the values it keeps put past the limit", () => {
+      const submitted = sdlWith({ web: { env: [`BLOB=${"x".repeat(4096)}`] } });
+
+      expect(sdlForStorage(submitted, 2048, SECRETS_DECLARED).sdl).toBeNull();
+      expect(sdlForStorage(submitted, 2048, SECRETS_NOT_DECLARED).sdl).not.toBeNull();
+    });
+
+    it("stores an env-heavy sdl of a realistic size against the bound production uses", () => {
+      const env = Array.from({ length: 200 }, (_, index) => `SETTING_${index}=${faker.string.alphanumeric(48)}`);
+
+      const { sdl, length } = sdlForStorage(sdlWith({ web: { env } }), SDL_MAX_LENGTH, SECRETS_DECLARED);
+
+      expect(sdl).not.toBeNull();
+      expect(length).toBeLessThan(SDL_MAX_LENGTH / 4);
     });
   });
 
   type ServiceOverrides = Record<string, unknown>;
 
-  function strip(rawSdl: string) {
-    return yaml.raw<SDLInput>(storedSdlOf(rawSdl));
+  function storedWithoutValues(rawSdl: string) {
+    return storedDocumentOf(rawSdl, SECRETS_NOT_DECLARED);
   }
 
-  function storedSdlOf(rawSdl: string): string {
-    const { sdl } = stripSdlSecrets(rawSdl, MAX_LENGTH);
+  function storedWithValues(rawSdl: string) {
+    return storedDocumentOf(rawSdl, SECRETS_DECLARED);
+  }
+
+  function storedDocumentOf(rawSdl: string, options: { keepOrdinaryEnvValues: boolean }) {
+    return yaml.raw<SDLInput>(storedSdlOf(rawSdl, options));
+  }
+
+  function storedSdlOf(rawSdl: string, options: { keepOrdinaryEnvValues: boolean }): string {
+    const { sdl } = sdlForStorage(rawSdl, MAX_LENGTH, options);
     expect(sdl).not.toBeNull();
     return sdl as string;
   }

--- a/apps/api/src/deployment/utils/sdl-for-storage/sdl-for-storage.ts
+++ b/apps/api/src/deployment/utils/sdl-for-storage/sdl-for-storage.ts
@@ -6,20 +6,28 @@ import { isSdlReference } from "@src/deployment/services/sdl-reference/sdl-refer
 
 type SdlServiceDefinition = SDLInput["services"][string];
 
-/** `length` becomes an estimate once it exceeds the limit, because measuring stops there rather than running a pathological document to completion. */
-export type StrippedSdl = { sdl: string | null; length: number; error?: unknown };
+/** Why a document was not stored, so a caller can report which without reading a parse error, whose message quotes the line it failed on. */
+export type StoredSdlRefusal = "unparseable" | "too-large";
 
-/** Takes a validated SDL only, and returns re-serialized YAML that must never stand in for the raw SDL anywhere a hash is taken over it. */
-export function stripSdlSecrets(rawSdl: string, maxLength: number): StrippedSdl {
+/** Numbers only, counted from one: a `js-yaml` mark also carries `snippet` and `buffer`, which quote the document and must never leave this function. */
+export type StoredSdlPosition = { line: number; column: number };
+
+/** `length` becomes an estimate once it exceeds the limit, because measuring stops there rather than running a pathological document to completion. */
+export type StoredSdl =
+  | { sdl: string; length: number; refusal?: never; at?: never }
+  | { sdl: null; length: number; refusal: StoredSdlRefusal; at?: StoredSdlPosition };
+
+/** Runs before the manifest generator has validated anything, because it is the cheapest refusal a create has, and returns re-serialized YAML that must never stand in for the raw SDL anywhere a hash is taken over it. */
+export function sdlForStorage(rawSdl: string, maxLength: number, options: { keepOrdinaryEnvValues: boolean }): StoredSdl {
   let sdl: SDLInput;
   try {
     sdl = yaml.raw<SDLInput>(rawSdl);
   } catch (error) {
-    return { sdl: null, length: rawSdl.length, error };
+    return { sdl: null, length: rawSdl.length, refusal: "unparseable", at: positionOf(error) };
   }
 
   for (const service of serviceDefinitionsOf(sdl)) {
-    stripEnvValues(service);
+    if (!options.keepOrdinaryEnvValues) dropEnvValues(service);
     delete service.credentials;
   }
 
@@ -27,13 +35,20 @@ export function stripSdlSecrets(rawSdl: string, maxLength: number): StrippedSdl 
     const estimatedLength = estimateSerializedLength(sdl, maxLength);
 
     if (estimatedLength > maxLength) {
-      return { sdl: null, length: estimatedLength };
+      return { sdl: null, length: estimatedLength, refusal: "too-large" };
     }
   }
 
-  const stripped = dump(sdl, { lineWidth: -1 });
+  const stored = dump(sdl, { lineWidth: -1 });
 
-  return stripped.length > maxLength ? { sdl: null, length: stripped.length } : { sdl: stripped, length: stripped.length };
+  return stored.length > maxLength ? { sdl: null, length: stored.length, refusal: "too-large" } : { sdl: stored, length: stored.length };
+}
+
+/** Reads `line` and `column` and nothing else, because the other fields of a `js-yaml` mark quote the document that failed to parse. */
+function positionOf(error: unknown): StoredSdlPosition | undefined {
+  const mark = (error as { mark?: { line?: unknown; column?: unknown } })?.mark;
+
+  return typeof mark?.line === "number" && typeof mark?.column === "number" ? { line: mark.line + 1, column: mark.column + 1 } : undefined;
 }
 
 function serviceDefinitionsOf(sdl: SDLInput | undefined): SdlServiceDefinition[] {
@@ -47,7 +62,7 @@ function serviceDefinitionsOf(sdl: SDLInput | undefined): SdlServiceDefinition[]
 }
 
 /** A non-list `env` is left alone rather than failing, because the manifest generator the caller runs first already rejects that shape. */
-function stripEnvValues(service: SdlServiceDefinition): void {
+function dropEnvValues(service: SdlServiceDefinition): void {
   const env = service.env;
 
   if (!Array.isArray(env)) {

--- a/apps/api/test/functional/deployment-sealed-secrets.spec.ts
+++ b/apps/api/test/functional/deployment-sealed-secrets.spec.ts
@@ -23,6 +23,7 @@ import { SDL_SECRETS_CONTENT_ENCRYPTION, SDL_SECRETS_SEAL_ALGORITHM } from "@src
 import type { SdlSecretsKmsClient, SdlSecretsKmsTarget } from "@src/deployment/providers/kms.provider";
 import { SDL_SECRETS_KMS_TARGET } from "@src/deployment/providers/kms.provider";
 import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import { SdlReferenceService } from "@src/deployment/services/sdl-reference/sdl-reference.service";
 import { SdlSecretsSealingKeyService } from "@src/deployment/services/sdl-secrets-sealing-key/sdl-secrets-sealing-key.service";
 import { app } from "@src/rest-app";
 import { SecretCipherService } from "@src/secret/services/secret-cipher/secret-cipher.service";
@@ -289,6 +290,52 @@ describe("Deployment sealed secrets", () => {
     expect(setting!.sdl).not.toContain(token);
   });
 
+  it("stores every ordinary env value as submitted while the referenced one stays a reference", async () => {
+    const { apiKey, user } = await persistedUser();
+    const token = randomUUID();
+
+    const response = await postDeployment(apiKey, sdlWith({ web: ["LOG_LEVEL=debug", "API_TOKEN=ac-secret://API_TOKEN", "INHERITED_FROM_HOST"] }), {
+      API_TOKEN: token
+    });
+
+    const setting = await settingOf(user, response);
+    expect(setting!.sdl).toContain("LOG_LEVEL=debug");
+    expect(setting!.sdl).toContain("INHERITED_FROM_HOST");
+    expect(setting!.sdl).toContain("API_TOKEN=ac-secret://API_TOKEN");
+    expect(setting!.sdl).not.toContain(token);
+  });
+
+  it("stores an sdl that reproduces the submitted document once its references are resolved", async () => {
+    const { apiKey, user } = await persistedUser();
+    const [token, url] = [randomUUID(), `postgres://app:${randomUUID()}@db.internal/app?ssl=true&a=b`];
+    const referencing = {
+      web: ["LOG_LEVEL=debug", "API_TOKEN=ac-secret://API_TOKEN", "INHERITED_FROM_HOST", "EXPLICITLY_EMPTY="],
+      worker: ["DATABASE_URL=ac-secret://DATABASE_URL", "RETRIES=3"]
+    };
+    const inline = {
+      web: ["LOG_LEVEL=debug", `API_TOKEN=${token}`, "INHERITED_FROM_HOST", "EXPLICITLY_EMPTY="],
+      worker: [`DATABASE_URL=${url}`, "RETRIES=3"]
+    };
+
+    const response = await postDeployment(apiKey, sdlWith(referencing), { API_TOKEN: token, DATABASE_URL: url });
+
+    const setting = await settingOf(user, response);
+    const opened = await openStoredToken(user, setting!.dseq, setting!.sealedSecrets!);
+    expect(resolvedDocumentOf(setting!.sdl!, opened)).toEqual(yaml.raw<SDLInput>(sdlWith(inline)));
+  });
+
+  it("stores an sdl whose resolved manifest version is the one it committed on chain", async () => {
+    const { apiKey, user } = await persistedUser();
+    const secrets = { API_TOKEN: randomUUID() };
+    const submitted = sdlWith({ web: ["LOG_LEVEL=debug", "API_TOKEN=ac-secret://API_TOKEN"], worker: ["RETRIES=3"] });
+
+    const response = await postDeployment(apiKey, submitted, secrets);
+
+    const setting = await settingOf(user, response);
+    const opened = await openStoredToken(user, setting!.dseq, setting!.sealedSecrets!);
+    expect(await manifestVersionOfDocument(resolvedDocumentOf(setting!.sdl!, opened))).toEqual(broadcastHash());
+  });
+
   it("stores a token bound to its owner and the deployment it was supplied for", async () => {
     const { apiKey, user } = await persistedUser();
 
@@ -541,10 +588,23 @@ describe("Deployment sealed secrets", () => {
   }
 
   async function manifestVersionOf(sdl: string) {
-    const manifest = generateManifest(yaml.raw<SDLInput>(sdl));
+    return await manifestVersionOfDocument(yaml.raw<SDLInput>(sdl));
+  }
+
+  async function manifestVersionOfDocument(document: SDLInput) {
+    const manifest = generateManifest(document);
     expect(manifest.ok).toBe(true);
 
     return await generateManifestVersion((manifest as Extract<typeof manifest, { ok: true }>).value.groups);
+  }
+
+  function resolvedDocumentOf(storedSdl: string, secrets: Record<string, string>) {
+    const document = yaml.raw<SDLInput>(storedSdl);
+    const byService = Object.fromEntries(Object.keys(document.services).map(serviceName => [serviceName, secrets]));
+
+    expect(container.resolve(SdlReferenceService).substitute(document, { secrets: byService })).toEqual([]);
+
+    return document;
   }
 
   async function settingOf(user: UserOutput, response: Response) {


### PR DESCRIPTION
## Why

Part of CON-863.

PRD-0001 blanked the value of every `env` entry before storing an SDL, because without a secret concept it had no way to tell a password from a log level. What it remembered was variable names with nothing behind them: not redeployable, not resolvable into a manifest, and unable to tell a user a missing password from a missing log level.

A seal makes the distinction expressible, and this is where it is restored.

**Stack position — PR 2 of 7.** Targets PR 1 (`feat/deployment-resolve-registry-credential-refs`). PR 3 (`feat/deployment-derive-secrets-from-submitted-sdl`) sits on this one.

## What

A request that supplied a seal has named which of its values are secret, so every other `env` value is now stored **exactly as submitted** — the same string, including one carrying an `=`, a `#`, an anchor character or a newline, and with an entry that declares no value still distinct from one whose value is empty. A request that supplied no seal named nothing, and there every value is still dropped, so nothing an existing client sends is stored differently than it was before this PR.

Which of the two applies is read off the request rather than computed, so the guard it feeds keeps its place as the first statement of `create`, ahead of the wallet read, the manifest generation and the seal's key-service call. That ordering is the only thing standing between a document small on the wire and enormous once re-serialized, and the anchor-bomb estimator behind it is unchanged.

**The round trip becomes assertable, and is asserted where it matters:** parse the stored SDL, hand it the values its references name, generate a manifest version, and get the byte-identical version the create committed on chain. That is the property server-side re-derivation needs, and it is falsified by a dropped ordinary value, a value resolved into the wrong service, or a `FOO=bar` collapsed to `FOO=`. Byte equality with the submitted document is not available and never will be — the stored form is re-serialized YAML, so comments, quoting and key order are gone by construction — so the document-level assertion beside it compares two *resolved* documents rather than a resolved one against a referencing one.

### A pre-existing leak this PR closes

Real values in the stored SDL made three things load-bearing that were merely tidy. Two were fine; the third was not.

A document that does not parse and one too large to store were indistinguishable in the result, so the refusal attached the `YAMLException` as the exception's `cause`. A `js-yaml` message quotes the lines around the one it failed on, and the error handler logs a whole cause chain, so **an unparseable SDL put its own env values into the application log.** The response body never carried them, which is why it survived a round of review: both existing assertions read the service's logger, and this escaped through the thrown error instead.

So the result now says *why* it was refused, the exception is not propagated as a cause at all, and the assertion is taken against the thrown error **and its cause chain** as well as the logger. That last part is the durable half of the fix.

What *is* carried out is the position, as two numbers: `line` and `column`, counted from one. A `js-yaml` mark also has `snippet` and `buffer`, and those quote the document — they are exactly what leaked, and they never leave the function. So a user with a malformed SDL still gets "SDL is not valid YAML: line 7, column 6" rather than a position-free message, and the log gets the same two numbers as fields. Asserted directly: the refusal carries the position and carries no text of the document.

While fixing it: an unparseable document was being refused as "too large" while `DEPLOYMENT_SDL_TOO_LARGE` logged a `length` well below `maxLength` — a self-contradicting line about a document that was never measured. It is now `DEPLOYMENT_SDL_UNPARSEABLE`. The guard keeps its place as the first statement of `create` rather than deferring to the manifest generator for a better message, because the cheapest refusal running first is worth more than the message is — and with the position restored, the message it gives is no longer materially worse.

> **Note on acceptance criterion 5** ("stored SDL still never appears in a log"). Everything *this stack* writes satisfies it, asserted through the thrown error and its cause chain as well as the service logger. Separately, `PostgresLoggerService` interpolates bound parameters into the query it logs, so every deployment write emits the stored SDL and the sealed token at **debug** level. Nothing here put them there — every `INSERT` has always logged its parameters — and it is off in production, where `LOG_LEVEL` defaults to `info`. Fixing it means a redaction policy in `packages/logging`, shared by every app, and is tracked as tech debt: **CON-941** — https://linear.app/ovrclk/issue/CON-941/query-logging-records-secret-values-in-bound-parameters. The AC-5 assertions here deliberately watch the service logger and the thrown error rather than process output, because an assertion against process output would be red while that leak exists.

### Other notes

`SDL_MAX_LENGTH` stays at 128 KiB and is now reachable by a document that used to strip well under it. That costs no existing client anything, because only a request carrying a seal keeps its values and none send one yet; the paired test shows the same document refused with a seal and stored without one, so the limit's new reachability is a property of the mode rather than of the document.

`stripSdlSecrets` is renamed to `sdlForStorage`. It no longer strips in the case that matters, and a name describing half its behaviour is worse than one describing the question it answers.

Registry credentials are still dropped whole, so a create that references one still stores a sealed credential its SDL mentions nowhere. PR 4 ends that.

**Size:** 462 lines by the labeler filter.

**Validation:** `eslint --quiet` clean; `tsc --noEmit` at 42 errors, byte-identical to the baseline at the base branch tip; unit, functional and integration all green.

**Demo:** see PR 4.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Deployment SDL storage now preserves ordinary environment values while continuing to protect referenced secrets.
  - Improved handling of malformed or oversized SDL, with clearer client errors and no sensitive document content exposed.
  - Stored SDL references are resolved consistently for sealed-secret deployments.
- **Tests**
  - Expanded coverage for environment preservation, secret redaction, reference resolution, size limits, malformed YAML, and error sanitization.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->