### PR TITLE
feat(deployment): take a deployment's own values out of the sdl it will store

### DIFF
--- a/apps/api/src/deployment/services/sdl-reference/sdl-reference.service.ts
+++ b/apps/api/src/deployment/services/sdl-reference/sdl-reference.service.ts
@@ -61,9 +61,15 @@ export interface SdlReferenceResolver {
 }
 
 /** One position in an SDL where a reference may stand, holding the write back so a caller of the walk never has to know how that position spells a value. */
-interface SdlReferenceSlot {
+export interface SdlReferenceSlot {
   serviceName: string;
+  /** The service's place in the document rather than its name, because a name may spell anything and a reference name may not. */
+  serviceIndex: number;
   instancePath: string;
+  /** The container the value lives on, so a caller can tell two positions apart from one position two services share through a YAML anchor. */
+  node: object;
+  /** Where in `node` the value sits: unique within it, and spelled so it can form part of an SDL Reference name. */
+  position: string;
   value: string;
   /** Whether a value here may be quoted back to the caller, which a private registry credential never may: A1 makes it a secret whatever it holds. */
   valueIsAlwaysSecret: boolean;
@@ -131,7 +137,9 @@ function unknownKindError(reference: SdlReferenceDeclaration): ValidationError {
   });
 }
 
-function envSlotsOf(serviceName: string, service: SDLInput["services"][string]): SdlReferenceSlot[] {
+type ServiceLocation = { serviceName: string; serviceIndex: number };
+
+function envSlotsOf({ serviceName, serviceIndex }: ServiceLocation, service: SDLInput["services"][string]): SdlReferenceSlot[] {
   const env = service?.env;
 
   if (!Array.isArray(env)) return [];
@@ -143,7 +151,10 @@ function envSlotsOf(serviceName: string, service: SDLInput["services"][string]):
 
     return {
       serviceName,
+      serviceIndex,
       instancePath: `/services/${serviceName}/env/${index}`,
+      node: env,
+      position: `e${index}`,
       value: declaration.value,
       valueIsAlwaysSecret: false,
       replace: (resolved: string) => {
@@ -153,7 +164,7 @@ function envSlotsOf(serviceName: string, service: SDLInput["services"][string]):
   });
 }
 
-function credentialSlotsOf(serviceName: string, service: SDLInput["services"][string]): SdlReferenceSlot[] {
+function credentialSlotsOf({ serviceName, serviceIndex }: ServiceLocation, service: SDLInput["services"][string]): SdlReferenceSlot[] {
   const credentials = service?.credentials;
 
   if (!credentials || typeof credentials !== "object") return [];
@@ -165,7 +176,10 @@ function credentialSlotsOf(serviceName: string, service: SDLInput["services"][st
 
     return {
       serviceName,
+      serviceIndex,
       instancePath: `/services/${serviceName}/credentials/${field}`,
+      node: credentials,
+      position: `c_${field}`,
       value,
       valueIsAlwaysSecret: true,
       replace: (resolved: string) => {
@@ -232,7 +246,7 @@ export class SdlReferenceService {
   #eachReference(sdl: SDLInput, visit: SdlReferenceVisitor): ValidationError[] {
     const errors: ValidationError[] = [];
 
-    for (const slot of this.#slotsOf(sdl)) {
+    for (const slot of this.slotsOf(sdl)) {
       const error = this.#readSlot(slot, visit);
 
       if (error) errors.push(error);
@@ -242,10 +256,10 @@ export class SdlReferenceService {
   }
 
   /** Read in full before anything is written, because two services sharing one `env` list or `credentials` block through a YAML anchor share the node behind both slots, and a lazy walk would read what an earlier slot had already resolved. */
-  #slotsOf(sdl: SDLInput): SdlReferenceSlot[] {
-    return Object.entries(this.#servicesOf(sdl)).flatMap(([serviceName, service]) => [
-      ...envSlotsOf(serviceName, service),
-      ...credentialSlotsOf(serviceName, service)
+  slotsOf(sdl: SDLInput): SdlReferenceSlot[] {
+    return Object.entries(this.#servicesOf(sdl)).flatMap(([serviceName, service], serviceIndex) => [
+      ...envSlotsOf({ serviceName, serviceIndex }, service),
+      ...credentialSlotsOf({ serviceName, serviceIndex }, service)
     ]);
   }
 

--- a/apps/api/src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service.spec.ts
@@ -1,0 +1,271 @@
+import type { SDLInput } from "@akashnetwork/chain-sdk";
+import { yaml } from "@akashnetwork/chain-sdk";
+import { faker } from "@faker-js/faker";
+import { dump } from "js-yaml";
+import { describe, expect, it } from "vitest";
+
+import { SDL_MAX_LENGTH } from "@src/deployment/config/sdl.config";
+import { isSdlReference, MAX_SDL_REFERENCE_NAME_LENGTH, SdlReferenceService } from "@src/deployment/services/sdl-reference/sdl-reference.service";
+import { SdlSecretsDerivationService } from "./sdl-secrets-derivation.service";
+
+const IMAGE = "ghcr.io/akash-network/hello-akash-world:2.1.0";
+const REGISTRY_HOST = "registry.example.test";
+const REGISTRY_EMAIL = "ops@example.test";
+
+describe(SdlSecretsDerivationService.name, () => {
+  describe("when no seal said which values are secret", () => {
+    it("takes an env value out and leaves a reference where it stood", () => {
+      const { service } = setup();
+      const token = faker.string.alphanumeric(24);
+      const document = documentWith({ web: { env: [`API_TOKEN=${token}`] } });
+
+      const { secrets } = service.derive(document, { includeEnvValues: true });
+
+      expect(secrets).toEqual({ s0_e0: token });
+      expect(document.services.web.env).toEqual(["API_TOKEN=ac-secret://s0_e0"]);
+    });
+
+    it("names each position from its service's place in the document and its own", () => {
+      const { service } = setup();
+      const document = documentWith({
+        web: { env: [`A=${faker.string.alphanumeric(8)}`, `B=${faker.string.alphanumeric(8)}`] },
+        worker: { env: [`C=${faker.string.alphanumeric(8)}`] }
+      });
+
+      service.derive(document, { includeEnvValues: true });
+
+      expect(document.services.web.env).toEqual(["A=ac-secret://s0_e0", "B=ac-secret://s0_e1"]);
+      expect(document.services.worker.env).toEqual(["C=ac-secret://s1_e0"]);
+    });
+
+    it("gives two services their own name for the same variable name", () => {
+      const { service } = setup();
+      const [web, worker] = [faker.string.alphanumeric(16), faker.string.alphanumeric(16)];
+
+      const { secrets } = service.derive(documentWith({ web: { env: [`PASSWORD=${web}`] }, worker: { env: [`PASSWORD=${worker}`] } }), {
+        includeEnvValues: true
+      });
+
+      expect(secrets).toEqual({ s0_e0: web, s1_e0: worker });
+    });
+
+    it("takes both halves of a registry credential and leaves its host and email alone", () => {
+      const { service } = setup();
+      const [username, password] = [faker.string.alphanumeric(10), faker.internet.password()];
+      const document = documentWith({ web: { credentials: { host: REGISTRY_HOST, email: REGISTRY_EMAIL, username, password } } });
+
+      const { secrets } = service.derive(document, { includeEnvValues: true });
+
+      expect(secrets).toEqual({ s0_c_username: username, s0_c_password: password });
+      expect(document.services.web.credentials).toEqual({
+        host: REGISTRY_HOST,
+        email: REGISTRY_EMAIL,
+        username: "ac-secret://s0_c_username",
+        password: "ac-secret://s0_c_password"
+      });
+    });
+
+    it("takes an empty value out as an empty value rather than as no value at all", () => {
+      const { service } = setup();
+      const document = documentWith({ web: { env: ["EXPLICITLY_EMPTY=", "INHERITED_FROM_HOST"] } });
+
+      const { secrets } = service.derive(document, { includeEnvValues: true });
+
+      expect(secrets).toEqual({ s0_e0: "" });
+      expect(document.services.web.env).toEqual(["EXPLICITLY_EMPTY=ac-secret://s0_e0", "INHERITED_FROM_HOST"]);
+    });
+
+    it("leaves a value that already names a secret alone, inventing no value for it", () => {
+      const { service } = setup();
+      const document = documentWith({ web: { env: ["API_TOKEN=ac-secret://API_TOKEN", `LOG_LEVEL=${faker.string.alphanumeric(5)}`] } });
+
+      const { secrets } = service.derive(document, { includeEnvValues: true });
+
+      expect(Object.keys(secrets)).toEqual(["s0_e1"]);
+      expect(document.services.web.env![0]).toBe("API_TOKEN=ac-secret://API_TOKEN");
+    });
+
+    it("takes nothing from a document that carries no env and no credentials", () => {
+      const { service } = setup();
+
+      expect(service.derive(documentWith({ web: {} }), { includeEnvValues: true })).toEqual({ secrets: {}, derivedCount: 0 });
+    });
+
+    it.each([{ env: null }, {}])("leaves the service declaring %j untouched", overrides => {
+      const { service } = setup();
+
+      expect(service.derive(documentWith({ web: overrides }), { includeEnvValues: true }).secrets).toEqual({});
+    });
+
+    it("reports how many positions it rewrote without reporting any of their values", () => {
+      const { service } = setup();
+      const document = documentWith({ web: { env: [`A=${faker.string.alphanumeric(8)}`, `B=${faker.string.alphanumeric(8)}`] } });
+
+      expect(service.derive(document, { includeEnvValues: true }).derivedCount).toBe(2);
+    });
+  });
+
+  describe("when a seal already said which values are secret", () => {
+    it("leaves every env value exactly as submitted", () => {
+      const { service } = setup();
+      const token = faker.string.alphanumeric(24);
+      const document = documentWith({ web: { env: [`API_TOKEN=${token}`] } });
+
+      const { secrets } = service.derive(document, { includeEnvValues: false });
+
+      expect(secrets).toEqual({});
+      expect(document.services.web.env).toEqual([`API_TOKEN=${token}`]);
+    });
+
+    it("still takes a registry credential, which is a secret whatever it holds", () => {
+      const { service } = setup();
+      const [username, password] = [faker.string.alphanumeric(10), faker.internet.password()];
+      const document = documentWith({
+        web: { env: [`LOG_LEVEL=${faker.string.alphanumeric(5)}`], credentials: { host: REGISTRY_HOST, username, password } }
+      });
+
+      const { secrets } = service.derive(document, { includeEnvValues: false });
+
+      expect(secrets).toEqual({ s0_c_username: username, s0_c_password: password });
+      expect(document.services.web.credentials!.password).toBe("ac-secret://s0_c_password");
+    });
+
+    it("leaves a credential that already names a secret alone", () => {
+      const { service } = setup();
+      const document = documentWith({
+        web: { credentials: { host: REGISTRY_HOST, username: "ac-secret://REG_USER", password: "ac-secret://REG_PASS" } }
+      });
+
+      expect(service.derive(document, { includeEnvValues: false }).secrets).toEqual({});
+    });
+  });
+
+  describe("a node two services share through a yaml anchor", () => {
+    it("mints one name for one shared credentials block rather than one per service", () => {
+      const { service } = setup();
+      const password = faker.internet.password();
+      const document = yaml.raw<SDLInput>(sdlSharingCredentials(password));
+
+      const { secrets } = service.derive(document, { includeEnvValues: false });
+
+      expect(Object.keys(secrets)).toEqual(["s0_c_username", "s0_c_password"]);
+      expect(secrets.s0_c_password).toBe(password);
+      expect(document.services.web.credentials!.password).toBe("ac-secret://s0_c_password");
+      expect(document.services.worker.credentials!.password).toBe("ac-secret://s0_c_password");
+    });
+
+    it("mints one name for one shared env list rather than one per service", () => {
+      const { service } = setup();
+      const token = faker.string.alphanumeric(20);
+      const document = yaml.raw<SDLInput>(sdlSharingEnv(`API_TOKEN=${token}`));
+
+      const { secrets } = service.derive(document, { includeEnvValues: true });
+
+      expect(secrets).toEqual({ s0_e0: token });
+      expect(document.services.web.env).toEqual(["API_TOKEN=ac-secret://s0_e0"]);
+      expect(document.services.worker.env).toEqual(["API_TOKEN=ac-secret://s0_e0"]);
+    });
+  });
+
+  describe("the names it mints", () => {
+    it("are names the reference grammar accepts", () => {
+      const { service } = setup();
+      const document = documentWith({
+        web: { env: [`A=${faker.string.alphanumeric(8)}`], credentials: { host: REGISTRY_HOST, username: "u", password: faker.internet.password() } },
+        "a-service-name-the-grammar-would-refuse.42": { env: [`B=${faker.string.alphanumeric(8)}`] }
+      });
+
+      const { secrets } = service.derive(document, { includeEnvValues: true });
+
+      expect(Object.keys(secrets)).toHaveLength(4);
+      Object.keys(secrets).forEach(name => expect(isSdlReference(`ac-secret://${name}`)).toBe(true));
+    });
+
+    it("stay within the longest name the grammar accepts, for a document far larger than one can be", () => {
+      const { service } = setup();
+      const document = documentWith({ web: { env: Array.from({ length: 5000 }, (_, index) => `SETTING_${index}=v`) } });
+
+      const { secrets } = service.derive(document, { includeEnvValues: true });
+      const longest = Object.keys(secrets).reduce((longestSoFar, name) => Math.max(longestSoFar, name.length), 0);
+
+      expect(Object.keys(secrets)).toHaveLength(5000);
+      expect(longest).toBeLessThanOrEqual(MAX_SDL_REFERENCE_NAME_LENGTH);
+    });
+  });
+
+  describe("what replacing a value with a reference costs the stored document", () => {
+    it("leaves an env-heavy document of a realistic size far inside the bound the console stores against", () => {
+      const { service } = setup();
+      const document = documentWith({ web: { env: Array.from({ length: 200 }, (_, index) => `SETTING_${index}=${faker.string.alphanumeric(48)}`) } });
+
+      service.derive(document, { includeEnvValues: true });
+
+      expect(dump(document, { lineWidth: -1 }).length).toBeLessThan(SDL_MAX_LENGTH / 4);
+    });
+
+    it("leaves three thousand entries inside that bound, an order of magnitude past what a deployment carries", () => {
+      const { service } = setup();
+      const document = documentWith({ web: { env: Array.from({ length: 3000 }, (_, index) => `SETTING_${index}=${faker.string.alphanumeric(6)}`) } });
+
+      service.derive(document, { includeEnvValues: true });
+
+      expect(dump(document, { lineWidth: -1 }).length).toBeLessThan(SDL_MAX_LENGTH);
+    });
+  });
+
+  it("leaves a document that resolves back to the one it was given", () => {
+    const { service, sdlReferenceService } = setup();
+    const services = {
+      web: {
+        env: [`API_TOKEN=${faker.string.alphanumeric(24)}`, "INHERITED_FROM_HOST", "EXPLICITLY_EMPTY="],
+        credentials: { host: REGISTRY_HOST, email: REGISTRY_EMAIL, username: faker.string.alphanumeric(10), password: faker.internet.password() }
+      },
+      worker: { env: [`DATABASE_URL=postgres://u:${faker.internet.password()}@h:5432/db?ssl=true&a=b`] }
+    };
+    const submitted = documentWith(services);
+    const rewritten = documentWith(services);
+
+    const { secrets } = service.derive(rewritten, { includeEnvValues: true });
+    const byService = Object.fromEntries(Object.keys(rewritten.services).map(serviceName => [serviceName, secrets]));
+
+    expect(sdlReferenceService.substitute(rewritten, { secrets: byService })).toEqual([]);
+    expect(rewritten).toEqual(submitted);
+  });
+
+  function setup() {
+    const sdlReferenceService = new SdlReferenceService();
+
+    return { service: new SdlSecretsDerivationService(sdlReferenceService), sdlReferenceService };
+  }
+
+  function documentWith(services: Record<string, Record<string, unknown>>) {
+    const names = Object.keys(services);
+
+    return yaml.raw<SDLInput>(
+      JSON.stringify({
+        version: "2.0",
+        services: Object.fromEntries(Object.entries(services).map(([name, overrides]) => [name, { image: IMAGE, ...overrides }])),
+        profiles: {
+          compute: Object.fromEntries(names.map(name => [name, { resources: { cpu: { units: 0.5 }, memory: { size: "512Mi" } } }])),
+          placement: { dcloud: { pricing: Object.fromEntries(names.map(name => [name, { denom: "uakt", amount: 1000 }])) } }
+        },
+        deployment: Object.fromEntries(names.map(name => [name, { dcloud: { profile: name, count: 1 } }]))
+      })
+    );
+  }
+
+  function sdlSharingCredentials(password: string) {
+    const block = [
+      "    credentials: &registry",
+      `      host: ${REGISTRY_HOST}`,
+      `      username: ${faker.string.alphanumeric(10)}`,
+      `      password: ${JSON.stringify(password)}`
+    ].join("\n");
+
+    return `version: "2.0"\nservices:\n  web:\n    image: ${IMAGE}\n${block}\n  worker:\n    image: ${IMAGE}\n    credentials: *registry\n`;
+  }
+
+  function sdlSharingEnv(entry: string) {
+    return `version: "2.0"\nservices:\n  web:\n    image: ${IMAGE}\n    env: &shared\n      - ${JSON.stringify(entry)}\n  worker:\n    image: ${IMAGE}\n    env: *shared\n`;
+  }
+});

--- a/apps/api/src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service.ts
+++ b/apps/api/src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service.ts
@@ -1,0 +1,71 @@
+import type { SDLInput } from "@akashnetwork/chain-sdk";
+import { singleton } from "tsyringe";
+
+import type { SdlReferenceSlot } from "@src/deployment/services/sdl-reference/sdl-reference.service";
+import { isSdlReference, SdlReferenceService } from "@src/deployment/services/sdl-reference/sdl-reference.service";
+import type { SdlSecrets } from "@src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service";
+
+/** The kind every derived reference is written as, because a derived value is a secret like any other and nothing downstream needs to know it was not supplied. */
+const DERIVED_REFERENCE_KIND = "secret";
+
+export interface DerivedSdlSecrets {
+  /** Name to value, in the shape `sealForStorage` seals and the stored token carries. */
+  secrets: SdlSecrets;
+  /** How many positions were rewritten, for a log line that has to say something without saying a value. */
+  derivedCount: number;
+}
+
+const NOTHING_DERIVED: DerivedSdlSecrets = { secrets: {}, derivedCount: 0 };
+
+/**
+ * Takes the values a submitted SDL carries in the clear out of the document and hands them back as
+ * secrets, leaving an `ac-secret://NAME` reference in each place one stood. This is what lets a client
+ * that names none of its secrets still have them stored as ciphertext rather than as text, and what keeps
+ * the definition it leaves behind resolvable instead of blanked.
+ *
+ * `includeEnvValues` is the difference between the two callers. A request that sealed its values has
+ * already said which of them are secret, so only a private registry credential is taken — that is a
+ * secret whatever it holds, and there is no ordinary reading of it. A request that sealed nothing has
+ * said nothing, so every value in `env` is taken as well.
+ *
+ * A value that is already a whole reference is left alone. It names a secret rather than carrying one,
+ * and inventing a value for a name the author asked to be handed would turn a missing-value refusal into
+ * a deployment configured with the literal text of its own reference.
+ *
+ * Mutates the document it is given, which must therefore be a copy the caller keeps to itself: the
+ * manifest is generated from the submitted SDL and has to see the real values, so a document with
+ * references written into it can only ever be the one being stored.
+ */
+@singleton()
+export class SdlSecretsDerivationService {
+  constructor(private readonly sdlReferenceService: SdlReferenceService) {}
+
+  derive(document: SDLInput, options: { includeEnvValues: boolean }): DerivedSdlSecrets {
+    const slots = this.sdlReferenceService.slotsOf(document).filter(slot => this.#isDerivable(slot, options));
+
+    if (slots.length === 0) return NOTHING_DERIVED;
+
+    const secrets: SdlSecrets = {};
+    const namesByNode = new Map<object, Map<string, string>>();
+
+    for (const slot of slots) {
+      const namesInNode = namesByNode.get(slot.node) ?? new Map<string, string>();
+      namesByNode.set(slot.node, namesInNode);
+
+      if (namesInNode.has(slot.position)) continue;
+
+      const name = `s${slot.serviceIndex}_${slot.position}`;
+      namesInNode.set(slot.position, name);
+      secrets[name] = slot.value;
+      slot.replace(`ac-${DERIVED_REFERENCE_KIND}://${name}`);
+    }
+
+    return { secrets, derivedCount: Object.keys(secrets).length };
+  }
+
+  #isDerivable(slot: SdlReferenceSlot, options: { includeEnvValues: boolean }): boolean {
+    if (isSdlReference(slot.value)) return false;
+
+    return slot.valueIsAlwaysSecret || options.includeEnvValues;
+  }
+}


### PR DESCRIPTION
## Why

Part of CON-863.

The previous PR restored ordinary env values for a client that seals its secrets. Every client today seals nothing, and for those the console still has to drop every value, because nothing in the document tells a password from a log level.

This is the piece that lets such a request have its values **sealed** rather than lost: it walks a parsed SDL, hands back each value it finds as a named secret, and leaves an `ac-secret://NAME` reference where the value stood.

**Stack position — PR 3 of 7.** Targets PR 2 (`feat/deployment-keep-ordinary-env-values-in-sdl`). PR 4 (`feat/deployment-seal-derived-secrets-on-create`) sits on this one.

## What

> **Nothing calls this yet, and that is deliberate — please do not read it as dead code.** It is the same shape `612753fe1` landed `SdlSecretsService` in: the intake existed one commit before `e910cfabf` gave it a route, and that commit was then "the end-to-end path". Same reason here — the walk, the naming rule and the anchor case are each worth their own reading, and none is legible inside a diff that also rewires `create()`. **PR 4 is the caller.**

`includeEnvValues` is the whole difference between its two callers-to-be. A request that sealed its values has already said which are secret, so only a private registry credential is taken — that is a secret whatever it holds, and there is no ordinary reading of a registry password. A request that sealed nothing has said nothing, so every `env` value goes too.

### Names are minted per physical node, not per position

This is a correctness requirement rather than a tidiness one. Two services sharing one `env` list or one `credentials` block through a YAML anchor — the idiomatic way to point several services at one private registry — are two slots over **one** object. A name per slot would mint two names for one value, and the second rewrite would overwrite the first, leaving a document referencing one name and a token carrying two. The intake would then refuse the second as a value no service references: **a 400 on a document that deploys today**, which is the exact compatibility break the fallback exists to avoid.

One name per node also happens to be what the submitted document *means* — one value in two places — so the round trip holds by construction rather than by repair.

The de-duplication is here and deliberately **not** in `declarationsOf`, which still reports one declaration per service for a shared node. Validation has to keep naming every position it refuses, so `/services/worker/credentials/password` stays reportable; only derivation cares that two of them are the same object. That per-position report is pinned a layer down and this PR leaves it alone.

### The naming rule

`s{serviceIndex}_{position}` — so `s0_e3` and `s1_c_password` — and the first slot to reach a node decides it.

- The service's **index** rather than its name, because a service name may spell anything and a reference name may not: `my-app.v2` is a legal service and an illegal reference.
- **Positional** rather than derived from the value, because a name is the widest thing this path ever logs and nothing about a secret may end up in one.
- The variable's own key stays in the document, so `PASSWORD=ac-secret://s1_e0` still reads as what it is.

Every minted name is asserted against the reference grammar itself, including for a service whose name the grammar would refuse, and the bound holds for five thousand entries in one service.

A value that is already a whole reference is left alone, in both modes. It names a secret rather than carrying one, and inventing a value for a name the author asked to be handed would turn a missing-value refusal into a deployment configured with the literal text of its own reference.

### Limits and size

This imposes no count or size limit of its own. The configured ones bound a seal **in flight**, sized against a request body limit; a payload built here never travels, so applying them would refuse an SDL with three hundred environment variables that succeeds today. Enforcing that is PR 4's business.

What replacing values with references costs the stored document is measured rather than assumed, since it is `SDL_MAX_LENGTH` that a reference longer than the value it replaces eats into: a realistic two-hundred-entry document lands under a quarter of the bound, and three thousand entries — an order of magnitude past what a deployment carries — still fit.

`SdlReferenceSlot` gains the identity this needs and `slotsOf` becomes public: a slot now says which object its value lives on and where in it, which is what makes two positions distinguishable from one position two services share.

**Size:** 372 lines by the labeler filter.

**Validation:** `eslint --quiet` clean; `tsc --noEmit` at 42 errors, byte-identical to the baseline at the base branch tip; unit, functional and integration all green. Verified in isolation with the later slices stashed, so this commit stands on its own.

**Demo:** see PR 4, where this becomes observable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically derives eligible plaintext environment and registry credential values into named secrets.
  * Replaces derived values with secure secret references while preserving existing references.
  * Supports configurable inclusion of environment values and reports the number of derived secrets.

* **Tests**
  * Added coverage for secret extraction, naming, shared YAML anchors, size limits, reference handling, round-trip substitution, and derived-secret counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->