### PR TITLE
feat(deployment): seal a deployment's own values when its client supplied none

### DIFF
--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -17,7 +17,9 @@ import type { DeploymentResponse } from "@src/deployment/http-schemas/deployment
 import type { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import { DeleteUnbackedDeploymentSetting } from "@src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler";
 import type { SdlService } from "@src/deployment/services/sdl/sdl.service";
+import { SdlReferenceService } from "@src/deployment/services/sdl-reference/sdl-reference.service";
 import type { ReceivedSdlSecrets, SdlSecretsService } from "@src/deployment/services/sdl-secrets/sdl-secrets.service";
+import { SdlSecretsDerivationService } from "@src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service";
 import type { ProviderService } from "@src/provider/services/provider/provider.service";
 import type { DeploymentConfigService } from "../deployment-config/deployment-config.service";
 import type { DeploymentReaderService } from "../deployment-reader/deployment-reader.service";
@@ -28,6 +30,7 @@ import { mockConfigService } from "@test/mocks/config-service.mock";
 
 const ALIASED_FILLER = "x".repeat(4096);
 const ENV_VALUE = faker.string.alphanumeric(24);
+const REGISTRY_USERNAME = faker.string.alphanumeric(10);
 const REGISTRY_PASSWORD = faker.internet.password();
 const DEPLOYMENT_SETTING_ID = faker.string.uuid();
 const GRACE_IN_MIN = 60;
@@ -73,7 +76,7 @@ ${extraPlacement}deployment:
 
 const SDL_WITH_SECRETS = sdlAround(`    credentials:
       host: registry.example.test
-      username: registry-user
+      username: ${REGISTRY_USERNAME}
       password: ${REGISTRY_PASSWORD}
     env:
       - API_TOKEN=${ENV_VALUE}
@@ -303,14 +306,43 @@ describe(DeploymentWriterService.name, () => {
       expect(sdlService.generateResolvedManifest).toHaveBeenCalledWith(expect.objectContaining({ secrets: byService }));
     });
 
-    it("seals what the client supplied against the dseq it just minted", async () => {
+    it("seals what the client supplied together with the credentials it took out itself, against the dseq it just minted", async () => {
       const supplied = { TOKEN: "resolved" };
       const { service, sdlSecretsService } = setup({ received: { supplied, byService: { web: supplied } } });
       vi.spyOn(Date, "now").mockReturnValue(1748400000000);
 
       await service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, sealedSecrets: SEAL, deposit: 5 });
 
-      expect(sdlSecretsService.sealForStorage).toHaveBeenCalledWith({ userId: wallet.userId, dseq: "1748400000000", secrets: supplied });
+      expect(sdlSecretsService.sealForStorage).toHaveBeenCalledWith({
+        userId: wallet.userId,
+        dseq: "1748400000000",
+        secrets: { TOKEN: "resolved", s0_c_username: REGISTRY_USERNAME, s0_c_password: REGISTRY_PASSWORD }
+      });
+    });
+
+    it("seals every env value as well when no seal said which of them are secret", async () => {
+      const { service, sdlSecretsService } = setup();
+
+      await service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, deposit: 5 });
+
+      expect(sdlSecretsService.sealForStorage).toHaveBeenCalledWith(
+        expect.objectContaining({ secrets: { s0_e0: ENV_VALUE, s0_c_username: REGISTRY_USERNAME, s0_c_password: REGISTRY_PASSWORD } })
+      );
+    });
+
+    it("refuses a supplied name the console derives for the same deployment, before minting a dseq", async () => {
+      const supplied = { s0_c_password: "resolved" };
+      const { service, deploymentSettingRepository, signerService } = setup({ received: { supplied, byService: { web: supplied } } });
+      const dateNow = vi.spyOn(Date, "now");
+
+      await expect(service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, sealedSecrets: SEAL, deposit: 5 })).rejects.toMatchObject({
+        status: 400,
+        message: expect.stringContaining("s0_c_password")
+      });
+
+      expect(dateNow).not.toHaveBeenCalled();
+      expect(deploymentSettingRepository.upsertDefinition).not.toHaveBeenCalled();
+      expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
     });
 
     it("records the sealed token in the same write as the sdl it belongs to", async () => {
@@ -1135,6 +1167,8 @@ describe(DeploymentWriterService.name, () => {
     jobQueueService.enqueue.mockResolvedValue(input?.compensationEnqueued === false ? null : COMPENSATION_JOB_ID);
 
     const sdlSecretsService = mock<SdlSecretsService>();
+    /** Real rather than doubled, because what every stored-sdl assertion below measures is the document this produces. */
+    const sdlSecretsDerivationService = new SdlSecretsDerivationService(new SdlReferenceService());
     sdlSecretsService.receive.mockResolvedValue({ ok: true, value: input?.received ?? { supplied: {}, byService: {} } });
     sdlSecretsService.sealForStorage.mockResolvedValue(input?.sealedSecrets ?? null);
 
@@ -1162,7 +1196,8 @@ describe(DeploymentWriterService.name, () => {
       deploymentSettingRepository,
       txService,
       jobQueueService,
-      sdlSecretsService
+      sdlSecretsService,
+      sdlSecretsDerivationService
     );
 
     return {

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -1,4 +1,4 @@
-import type { ValidationError } from "@akashnetwork/chain-sdk";
+import type { SDLInput, ValidationError } from "@akashnetwork/chain-sdk";
 import { manifestToSortedJSON } from "@akashnetwork/chain-sdk";
 import { addMinutes } from "date-fns";
 import { HTTPException } from "hono/http-exception";
@@ -19,9 +19,11 @@ import {
   unbackedDeploymentSettingKeyFor
 } from "@src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler";
 import { SdlService } from "@src/deployment/services/sdl/sdl.service";
-import type { NamespacedSdlSecrets } from "@src/deployment/services/sdl-reference/sdl-reference.service";
+import { MAX_ECHOED_REFERENCE_LENGTH, type NamespacedSdlSecrets } from "@src/deployment/services/sdl-reference/sdl-reference.service";
 import type { ReceivedSdlSecrets } from "@src/deployment/services/sdl-secrets/sdl-secrets.service";
 import { SdlSecretsService } from "@src/deployment/services/sdl-secrets/sdl-secrets.service";
+import { SdlSecretsDerivationService } from "@src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service";
+import type { SdlSecrets } from "@src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service";
 import type { StoredSdlPosition, StoredSdlRefusal } from "@src/deployment/utils/sdl-for-storage/sdl-for-storage";
 import { sdlForStorage } from "@src/deployment/utils/sdl-for-storage/sdl-for-storage";
 import { ProviderService } from "@src/provider/services/provider/provider.service";
@@ -29,6 +31,15 @@ import { denomToUdenom } from "@src/utils/math";
 import { DeploymentConfigService } from "../deployment-config/deployment-config.service";
 import { DeploymentReaderService } from "../deployment-reader/deployment-reader.service";
 import { StaleManagedDeploymentsCleanerService } from "../stale-managed-deployments-cleaner/stale-managed-deployments-cleaner.service";
+
+/** What becomes of the values a submitted document carries in the clear, once the console has decided what it can seal. */
+type StoredSdlValues =
+  /** Every one of them is sealed and referenced, because nothing in the request said which are secret. */
+  | "every-value-sealed"
+  /** Only a registry credential is, a seal having already said which of the rest are secret. */
+  | "only-credentials-sealed"
+  /** None are, so an `env` value is dropped and the credentials block removed, for a caller with nowhere to put them. */
+  | "every-value-dropped";
 
 @singleton()
 export class DeploymentWriterService {
@@ -48,23 +59,25 @@ export class DeploymentWriterService {
     private readonly deploymentSettingRepository: DeploymentSettingRepository,
     private readonly txService: TxService,
     private readonly jobQueueService: JobQueueService,
-    private readonly sdlSecretsService: SdlSecretsService
+    private readonly sdlSecretsService: SdlSecretsService,
+    private readonly sdlSecretsDerivationService: SdlSecretsDerivationService
   ) {
     this.logger = createLogger({ context: DeploymentWriterService.name });
   }
 
   /** The dseq is minted once everything that can refuse the submitted document has run, because the token written below names it and a client sealing beforehand cannot; a refusal that needs the resolved document — a sealed registry password below the schema's minimum, say — can only come after it, and spends a dseq nothing is written under. */
   public async create(input: CreateDeploymentRequest["data"] & { userId: string }): Promise<CreateDeploymentResponse["data"]> {
-    /** SDL for storage ONLY. Never stands in for the submitted document anywhere a hash is taken. */
-    const sdl = this.#storedSdlWithinLimit(input.sdl, { secretsAreDeclared: !!input.sealedSecrets });
+    /** SDL for storage ONLY, and the values taken out of it. Never stands in for the submitted document anywhere a hash is taken. */
+    const { sdl, derived } = this.#storedSdlOf(input.sdl, input.sealedSecrets ? "only-credentials-sealed" : "every-value-sealed");
 
     const wallet = await this.walletReaderService.getWalletByUserId(input.userId);
     const depositInDollars = this.deploymentConfig.get("DEPLOYMENT_DEFAULT_DEPOSIT");
     const secrets = await this.#receiveSecrets(input);
+    const stored = this.#storedSecretsOf(secrets.supplied, derived);
 
     const dseq = Date.now().toString();
     const { manifestVersion, manifest } = await this.#resolveSdl(input.sdl, { secrets: secrets.byService, isTrialing: !!wallet.isTrialing });
-    const sealedSecrets = await this.sdlSecretsService.sealForStorage({ userId: wallet.userId, dseq, secrets: secrets.supplied });
+    const sealedSecrets = await this.sdlSecretsService.sealForStorage({ userId: wallet.userId, dseq, secrets: stored });
 
     if (wallet.isTrialing) {
       await this.reclaimTrialOrphanedDeployments(wallet);
@@ -166,15 +179,41 @@ export class DeploymentWriterService {
   }
 
   /** `dseq` is a log field only, so a create can run this before minting one and still say which request it refused. */
-  #storedSdlWithinLimit(submittedSdl: string, options: { secretsAreDeclared: boolean; dseq?: string }): string {
-    const { dseq } = options;
-    const { sdl, length, refusal, at } = sdlForStorage(submittedSdl, SDL_MAX_LENGTH, { keepOrdinaryEnvValues: options.secretsAreDeclared });
+  #storedSdlOf(submittedSdl: string, values: StoredSdlValues, dseq?: string): { sdl: string; derived: SdlSecrets } {
+    let derived: SdlSecrets = {};
+
+    const takeSecretsOut = (document: SDLInput) => {
+      derived = this.sdlSecretsDerivationService.derive(document, { includeEnvValues: values === "every-value-sealed" }).secrets;
+    };
+
+    const { sdl, length, refusal, at } =
+      values === "every-value-dropped"
+        ? sdlForStorage(submittedSdl, SDL_MAX_LENGTH, { keepOrdinaryEnvValues: false })
+        : sdlForStorage(submittedSdl, SDL_MAX_LENGTH, { rewrite: takeSecretsOut });
 
     if (sdl === null) {
       throw this.#rejectUnstorableSdl(refusal, { dseq, length, at });
     }
 
-    return sdl;
+    return { sdl, derived };
+  }
+
+  /**
+   * The one set of values the deployment's token carries: what the client sealed, plus what the console
+   * took out of the document itself. A name in both is refused rather than merged, because the two would
+   * be different values under one name and the stored SDL would then reference whichever won.
+   */
+  #storedSecretsOf(supplied: SdlSecrets, derived: SdlSecrets): SdlSecrets {
+    const collisions = Object.keys(derived).filter(name => Object.hasOwn(supplied, name));
+
+    if (collisions.length > 0) {
+      const echoed = collisions[0].slice(0, MAX_ECHOED_REFERENCE_LENGTH);
+      this.logger.warn({ event: "SDL_SECRETS_DERIVED_NAME_COLLIDED", name: echoed, collisionCount: collisions.length });
+
+      throw createError(400, `"${echoed}" is a name the console derives for this deployment and cannot also be supplied for it`);
+    }
+
+    return { ...supplied, ...derived };
   }
 
   /** Carries none of the document and attaches no parse error as a cause, because a `js-yaml` message quotes the line it failed on and the error handler logs the whole chain. */
@@ -257,7 +296,7 @@ export class DeploymentWriterService {
 
   public async updateByUserIdAndDseq(userId: string, dseq: string, input: UpdateDeploymentRequest["data"]): Promise<DeploymentResponse> {
     const wallet = await this.walletReaderService.getWalletByUserId(userId);
-    const sdl = this.#storedSdlWithinLimit(input.sdl, { secretsAreDeclared: false, dseq });
+    const { sdl } = this.#storedSdlOf(input.sdl, "every-value-dropped", dseq);
 
     const { manifestVersion, manifest } = await this.#resolveSdl(input.sdl, { isTrialing: !!wallet.isTrialing });
     const deployment = await this.deploymentReaderService.findByWalletAndDseq(wallet, dseq);

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -25,7 +25,7 @@ import { SdlSecretsService } from "@src/deployment/services/sdl-secrets/sdl-secr
 import { SdlSecretsDerivationService } from "@src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service";
 import type { SdlSecrets } from "@src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service";
 import type { StoredSdlPosition, StoredSdlRefusal } from "@src/deployment/utils/sdl-for-storage/sdl-for-storage";
-import { sdlForStorage } from "@src/deployment/utils/sdl-for-storage/sdl-for-storage";
+import { dropSdlValues, parseSdlForStorage, sdlForStorage } from "@src/deployment/utils/sdl-for-storage/sdl-for-storage";
 import { ProviderService } from "@src/provider/services/provider/provider.service";
 import { denomToUdenom } from "@src/utils/math";
 import { DeploymentConfigService } from "../deployment-config/deployment-config.service";
@@ -180,22 +180,31 @@ export class DeploymentWriterService {
 
   /** `dseq` is a log field only, so a create can run this before minting one and still say which request it refused. */
   #storedSdlOf(submittedSdl: string, values: StoredSdlValues, dseq?: string): { sdl: string; derived: SdlSecrets } {
-    let derived: SdlSecrets = {};
+    const parsed = parseSdlForStorage(submittedSdl);
 
-    const takeSecretsOut = (document: SDLInput) => {
-      derived = this.sdlSecretsDerivationService.derive(document, { includeEnvValues: values === "every-value-sealed" }).secrets;
-    };
+    if (parsed.document === null) {
+      throw this.#rejectUnstorableSdl("unparseable", { dseq, length: submittedSdl.length, at: parsed.at });
+    }
 
-    const { sdl, length, refusal, at } =
-      values === "every-value-dropped"
-        ? sdlForStorage(submittedSdl, SDL_MAX_LENGTH, { keepOrdinaryEnvValues: false })
-        : sdlForStorage(submittedSdl, SDL_MAX_LENGTH, { rewrite: takeSecretsOut });
+    const derived = this.#takeValuesOutOf(parsed.document, values);
+    const { sdl, length } = sdlForStorage(parsed, SDL_MAX_LENGTH);
 
     if (sdl === null) {
-      throw this.#rejectUnstorableSdl(refusal, { dseq, length, at });
+      throw this.#rejectUnstorableSdl("too-large", { dseq, length });
     }
 
     return { sdl, derived };
+  }
+
+  /** Runs before the document is measured, so that what the size guard bounds is exactly what gets stored. */
+  #takeValuesOutOf(document: SDLInput, values: StoredSdlValues): SdlSecrets {
+    if (values === "every-value-dropped") {
+      dropSdlValues(document);
+
+      return {};
+    }
+
+    return this.sdlSecretsDerivationService.derive(document, { includeEnvValues: values === "every-value-sealed" }).secrets;
   }
 
   /**

--- a/apps/api/src/deployment/services/sdl-reference/sdl-reference.service.ts
+++ b/apps/api/src/deployment/services/sdl-reference/sdl-reference.service.ts
@@ -61,9 +61,15 @@ export interface SdlReferenceResolver {
 }
 
 /** One position in an SDL where a reference may stand, holding the write back so a caller of the walk never has to know how that position spells a value. */
-interface SdlReferenceSlot {
+export interface SdlReferenceSlot {
   serviceName: string;
+  /** The service's place in the document rather than its name, because a name may spell anything and a reference name may not. */
+  serviceIndex: number;
   instancePath: string;
+  /** The container the value lives on, so a caller can tell two positions apart from one position two services share through a YAML anchor. */
+  node: object;
+  /** Where in `node` the value sits: unique within it, and spelled so it can form part of an SDL Reference name. */
+  position: string;
   value: string;
   /** Whether a value here may be quoted back to the caller, which a private registry credential never may: A1 makes it a secret whatever it holds. */
   valueIsAlwaysSecret: boolean;
@@ -131,7 +137,9 @@ function unknownKindError(reference: SdlReferenceDeclaration): ValidationError {
   });
 }
 
-function envSlotsOf(serviceName: string, service: SDLInput["services"][string]): SdlReferenceSlot[] {
+type ServiceLocation = { serviceName: string; serviceIndex: number };
+
+function envSlotsOf({ serviceName, serviceIndex }: ServiceLocation, service: SDLInput["services"][string]): SdlReferenceSlot[] {
   const env = service?.env;
 
   if (!Array.isArray(env)) return [];
@@ -143,7 +151,10 @@ function envSlotsOf(serviceName: string, service: SDLInput["services"][string]):
 
     return {
       serviceName,
+      serviceIndex,
       instancePath: `/services/${serviceName}/env/${index}`,
+      node: env,
+      position: `e${index}`,
       value: declaration.value,
       valueIsAlwaysSecret: false,
       replace: (resolved: string) => {
@@ -153,7 +164,7 @@ function envSlotsOf(serviceName: string, service: SDLInput["services"][string]):
   });
 }
 
-function credentialSlotsOf(serviceName: string, service: SDLInput["services"][string]): SdlReferenceSlot[] {
+function credentialSlotsOf({ serviceName, serviceIndex }: ServiceLocation, service: SDLInput["services"][string]): SdlReferenceSlot[] {
   const credentials = service?.credentials;
 
   if (!credentials || typeof credentials !== "object") return [];
@@ -165,7 +176,10 @@ function credentialSlotsOf(serviceName: string, service: SDLInput["services"][st
 
     return {
       serviceName,
+      serviceIndex,
       instancePath: `/services/${serviceName}/credentials/${field}`,
+      node: credentials,
+      position: `c_${field}`,
       value,
       valueIsAlwaysSecret: true,
       replace: (resolved: string) => {
@@ -232,7 +246,7 @@ export class SdlReferenceService {
   #eachReference(sdl: SDLInput, visit: SdlReferenceVisitor): ValidationError[] {
     const errors: ValidationError[] = [];
 
-    for (const slot of this.#slotsOf(sdl)) {
+    for (const slot of this.slotsOf(sdl)) {
       const error = this.#readSlot(slot, visit);
 
       if (error) errors.push(error);
@@ -242,10 +256,10 @@ export class SdlReferenceService {
   }
 
   /** Read in full before anything is written, because two services sharing one `env` list or `credentials` block through a YAML anchor share the node behind both slots, and a lazy walk would read what an earlier slot had already resolved. */
-  #slotsOf(sdl: SDLInput): SdlReferenceSlot[] {
-    return Object.entries(this.#servicesOf(sdl)).flatMap(([serviceName, service]) => [
-      ...envSlotsOf(serviceName, service),
-      ...credentialSlotsOf(serviceName, service)
+  slotsOf(sdl: SDLInput): SdlReferenceSlot[] {
+    return Object.entries(this.#servicesOf(sdl)).flatMap(([serviceName, service], serviceIndex) => [
+      ...envSlotsOf({ serviceName, serviceIndex }, service),
+      ...credentialSlotsOf({ serviceName, serviceIndex }, service)
     ]);
   }
 

--- a/apps/api/src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service.spec.ts
@@ -1,0 +1,271 @@
+import type { SDLInput } from "@akashnetwork/chain-sdk";
+import { yaml } from "@akashnetwork/chain-sdk";
+import { faker } from "@faker-js/faker";
+import { dump } from "js-yaml";
+import { describe, expect, it } from "vitest";
+
+import { SDL_MAX_LENGTH } from "@src/deployment/config/sdl.config";
+import { isSdlReference, MAX_SDL_REFERENCE_NAME_LENGTH, SdlReferenceService } from "@src/deployment/services/sdl-reference/sdl-reference.service";
+import { SdlSecretsDerivationService } from "./sdl-secrets-derivation.service";
+
+const IMAGE = "ghcr.io/akash-network/hello-akash-world:2.1.0";
+const REGISTRY_HOST = "registry.example.test";
+const REGISTRY_EMAIL = "ops@example.test";
+
+describe(SdlSecretsDerivationService.name, () => {
+  describe("when no seal said which values are secret", () => {
+    it("takes an env value out and leaves a reference where it stood", () => {
+      const { service } = setup();
+      const token = faker.string.alphanumeric(24);
+      const document = documentWith({ web: { env: [`API_TOKEN=${token}`] } });
+
+      const { secrets } = service.derive(document, { includeEnvValues: true });
+
+      expect(secrets).toEqual({ s0_e0: token });
+      expect(document.services.web.env).toEqual(["API_TOKEN=ac-secret://s0_e0"]);
+    });
+
+    it("names each position from its service's place in the document and its own", () => {
+      const { service } = setup();
+      const document = documentWith({
+        web: { env: [`A=${faker.string.alphanumeric(8)}`, `B=${faker.string.alphanumeric(8)}`] },
+        worker: { env: [`C=${faker.string.alphanumeric(8)}`] }
+      });
+
+      service.derive(document, { includeEnvValues: true });
+
+      expect(document.services.web.env).toEqual(["A=ac-secret://s0_e0", "B=ac-secret://s0_e1"]);
+      expect(document.services.worker.env).toEqual(["C=ac-secret://s1_e0"]);
+    });
+
+    it("gives two services their own name for the same variable name", () => {
+      const { service } = setup();
+      const [web, worker] = [faker.string.alphanumeric(16), faker.string.alphanumeric(16)];
+
+      const { secrets } = service.derive(documentWith({ web: { env: [`PASSWORD=${web}`] }, worker: { env: [`PASSWORD=${worker}`] } }), {
+        includeEnvValues: true
+      });
+
+      expect(secrets).toEqual({ s0_e0: web, s1_e0: worker });
+    });
+
+    it("takes both halves of a registry credential and leaves its host and email alone", () => {
+      const { service } = setup();
+      const [username, password] = [faker.string.alphanumeric(10), faker.internet.password()];
+      const document = documentWith({ web: { credentials: { host: REGISTRY_HOST, email: REGISTRY_EMAIL, username, password } } });
+
+      const { secrets } = service.derive(document, { includeEnvValues: true });
+
+      expect(secrets).toEqual({ s0_c_username: username, s0_c_password: password });
+      expect(document.services.web.credentials).toEqual({
+        host: REGISTRY_HOST,
+        email: REGISTRY_EMAIL,
+        username: "ac-secret://s0_c_username",
+        password: "ac-secret://s0_c_password"
+      });
+    });
+
+    it("takes an empty value out as an empty value rather than as no value at all", () => {
+      const { service } = setup();
+      const document = documentWith({ web: { env: ["EXPLICITLY_EMPTY=", "INHERITED_FROM_HOST"] } });
+
+      const { secrets } = service.derive(document, { includeEnvValues: true });
+
+      expect(secrets).toEqual({ s0_e0: "" });
+      expect(document.services.web.env).toEqual(["EXPLICITLY_EMPTY=ac-secret://s0_e0", "INHERITED_FROM_HOST"]);
+    });
+
+    it("leaves a value that already names a secret alone, inventing no value for it", () => {
+      const { service } = setup();
+      const document = documentWith({ web: { env: ["API_TOKEN=ac-secret://API_TOKEN", `LOG_LEVEL=${faker.string.alphanumeric(5)}`] } });
+
+      const { secrets } = service.derive(document, { includeEnvValues: true });
+
+      expect(Object.keys(secrets)).toEqual(["s0_e1"]);
+      expect(document.services.web.env![0]).toBe("API_TOKEN=ac-secret://API_TOKEN");
+    });
+
+    it("takes nothing from a document that carries no env and no credentials", () => {
+      const { service } = setup();
+
+      expect(service.derive(documentWith({ web: {} }), { includeEnvValues: true })).toEqual({ secrets: {}, derivedCount: 0 });
+    });
+
+    it.each([{ env: null }, {}])("leaves the service declaring %j untouched", overrides => {
+      const { service } = setup();
+
+      expect(service.derive(documentWith({ web: overrides }), { includeEnvValues: true }).secrets).toEqual({});
+    });
+
+    it("reports how many positions it rewrote without reporting any of their values", () => {
+      const { service } = setup();
+      const document = documentWith({ web: { env: [`A=${faker.string.alphanumeric(8)}`, `B=${faker.string.alphanumeric(8)}`] } });
+
+      expect(service.derive(document, { includeEnvValues: true }).derivedCount).toBe(2);
+    });
+  });
+
+  describe("when a seal already said which values are secret", () => {
+    it("leaves every env value exactly as submitted", () => {
+      const { service } = setup();
+      const token = faker.string.alphanumeric(24);
+      const document = documentWith({ web: { env: [`API_TOKEN=${token}`] } });
+
+      const { secrets } = service.derive(document, { includeEnvValues: false });
+
+      expect(secrets).toEqual({});
+      expect(document.services.web.env).toEqual([`API_TOKEN=${token}`]);
+    });
+
+    it("still takes a registry credential, which is a secret whatever it holds", () => {
+      const { service } = setup();
+      const [username, password] = [faker.string.alphanumeric(10), faker.internet.password()];
+      const document = documentWith({
+        web: { env: [`LOG_LEVEL=${faker.string.alphanumeric(5)}`], credentials: { host: REGISTRY_HOST, username, password } }
+      });
+
+      const { secrets } = service.derive(document, { includeEnvValues: false });
+
+      expect(secrets).toEqual({ s0_c_username: username, s0_c_password: password });
+      expect(document.services.web.credentials!.password).toBe("ac-secret://s0_c_password");
+    });
+
+    it("leaves a credential that already names a secret alone", () => {
+      const { service } = setup();
+      const document = documentWith({
+        web: { credentials: { host: REGISTRY_HOST, username: "ac-secret://REG_USER", password: "ac-secret://REG_PASS" } }
+      });
+
+      expect(service.derive(document, { includeEnvValues: false }).secrets).toEqual({});
+    });
+  });
+
+  describe("a node two services share through a yaml anchor", () => {
+    it("mints one name for one shared credentials block rather than one per service", () => {
+      const { service } = setup();
+      const password = faker.internet.password();
+      const document = yaml.raw<SDLInput>(sdlSharingCredentials(password));
+
+      const { secrets } = service.derive(document, { includeEnvValues: false });
+
+      expect(Object.keys(secrets)).toEqual(["s0_c_username", "s0_c_password"]);
+      expect(secrets.s0_c_password).toBe(password);
+      expect(document.services.web.credentials!.password).toBe("ac-secret://s0_c_password");
+      expect(document.services.worker.credentials!.password).toBe("ac-secret://s0_c_password");
+    });
+
+    it("mints one name for one shared env list rather than one per service", () => {
+      const { service } = setup();
+      const token = faker.string.alphanumeric(20);
+      const document = yaml.raw<SDLInput>(sdlSharingEnv(`API_TOKEN=${token}`));
+
+      const { secrets } = service.derive(document, { includeEnvValues: true });
+
+      expect(secrets).toEqual({ s0_e0: token });
+      expect(document.services.web.env).toEqual(["API_TOKEN=ac-secret://s0_e0"]);
+      expect(document.services.worker.env).toEqual(["API_TOKEN=ac-secret://s0_e0"]);
+    });
+  });
+
+  describe("the names it mints", () => {
+    it("are names the reference grammar accepts", () => {
+      const { service } = setup();
+      const document = documentWith({
+        web: { env: [`A=${faker.string.alphanumeric(8)}`], credentials: { host: REGISTRY_HOST, username: "u", password: faker.internet.password() } },
+        "a-service-name-the-grammar-would-refuse.42": { env: [`B=${faker.string.alphanumeric(8)}`] }
+      });
+
+      const { secrets } = service.derive(document, { includeEnvValues: true });
+
+      expect(Object.keys(secrets)).toHaveLength(4);
+      Object.keys(secrets).forEach(name => expect(isSdlReference(`ac-secret://${name}`)).toBe(true));
+    });
+
+    it("stay within the longest name the grammar accepts, for a document far larger than one can be", () => {
+      const { service } = setup();
+      const document = documentWith({ web: { env: Array.from({ length: 5000 }, (_, index) => `SETTING_${index}=v`) } });
+
+      const { secrets } = service.derive(document, { includeEnvValues: true });
+      const longest = Object.keys(secrets).reduce((longestSoFar, name) => Math.max(longestSoFar, name.length), 0);
+
+      expect(Object.keys(secrets)).toHaveLength(5000);
+      expect(longest).toBeLessThanOrEqual(MAX_SDL_REFERENCE_NAME_LENGTH);
+    });
+  });
+
+  describe("what replacing a value with a reference costs the stored document", () => {
+    it("leaves an env-heavy document of a realistic size far inside the bound the console stores against", () => {
+      const { service } = setup();
+      const document = documentWith({ web: { env: Array.from({ length: 200 }, (_, index) => `SETTING_${index}=${faker.string.alphanumeric(48)}`) } });
+
+      service.derive(document, { includeEnvValues: true });
+
+      expect(dump(document, { lineWidth: -1 }).length).toBeLessThan(SDL_MAX_LENGTH / 4);
+    });
+
+    it("leaves three thousand entries inside that bound, an order of magnitude past what a deployment carries", () => {
+      const { service } = setup();
+      const document = documentWith({ web: { env: Array.from({ length: 3000 }, (_, index) => `SETTING_${index}=${faker.string.alphanumeric(6)}`) } });
+
+      service.derive(document, { includeEnvValues: true });
+
+      expect(dump(document, { lineWidth: -1 }).length).toBeLessThan(SDL_MAX_LENGTH);
+    });
+  });
+
+  it("leaves a document that resolves back to the one it was given", () => {
+    const { service, sdlReferenceService } = setup();
+    const services = {
+      web: {
+        env: [`API_TOKEN=${faker.string.alphanumeric(24)}`, "INHERITED_FROM_HOST", "EXPLICITLY_EMPTY="],
+        credentials: { host: REGISTRY_HOST, email: REGISTRY_EMAIL, username: faker.string.alphanumeric(10), password: faker.internet.password() }
+      },
+      worker: { env: [`DATABASE_URL=postgres://u:${faker.internet.password()}@h:5432/db?ssl=true&a=b`] }
+    };
+    const submitted = documentWith(services);
+    const rewritten = documentWith(services);
+
+    const { secrets } = service.derive(rewritten, { includeEnvValues: true });
+    const byService = Object.fromEntries(Object.keys(rewritten.services).map(serviceName => [serviceName, secrets]));
+
+    expect(sdlReferenceService.substitute(rewritten, { secrets: byService })).toEqual([]);
+    expect(rewritten).toEqual(submitted);
+  });
+
+  function setup() {
+    const sdlReferenceService = new SdlReferenceService();
+
+    return { service: new SdlSecretsDerivationService(sdlReferenceService), sdlReferenceService };
+  }
+
+  function documentWith(services: Record<string, Record<string, unknown>>) {
+    const names = Object.keys(services);
+
+    return yaml.raw<SDLInput>(
+      JSON.stringify({
+        version: "2.0",
+        services: Object.fromEntries(Object.entries(services).map(([name, overrides]) => [name, { image: IMAGE, ...overrides }])),
+        profiles: {
+          compute: Object.fromEntries(names.map(name => [name, { resources: { cpu: { units: 0.5 }, memory: { size: "512Mi" } } }])),
+          placement: { dcloud: { pricing: Object.fromEntries(names.map(name => [name, { denom: "uakt", amount: 1000 }])) } }
+        },
+        deployment: Object.fromEntries(names.map(name => [name, { dcloud: { profile: name, count: 1 } }]))
+      })
+    );
+  }
+
+  function sdlSharingCredentials(password: string) {
+    const block = [
+      "    credentials: &registry",
+      `      host: ${REGISTRY_HOST}`,
+      `      username: ${faker.string.alphanumeric(10)}`,
+      `      password: ${JSON.stringify(password)}`
+    ].join("\n");
+
+    return `version: "2.0"\nservices:\n  web:\n    image: ${IMAGE}\n${block}\n  worker:\n    image: ${IMAGE}\n    credentials: *registry\n`;
+  }
+
+  function sdlSharingEnv(entry: string) {
+    return `version: "2.0"\nservices:\n  web:\n    image: ${IMAGE}\n    env: &shared\n      - ${JSON.stringify(entry)}\n  worker:\n    image: ${IMAGE}\n    env: *shared\n`;
+  }
+});

--- a/apps/api/src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service.ts
+++ b/apps/api/src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service.ts
@@ -1,0 +1,71 @@
+import type { SDLInput } from "@akashnetwork/chain-sdk";
+import { singleton } from "tsyringe";
+
+import type { SdlReferenceSlot } from "@src/deployment/services/sdl-reference/sdl-reference.service";
+import { isSdlReference, SdlReferenceService } from "@src/deployment/services/sdl-reference/sdl-reference.service";
+import type { SdlSecrets } from "@src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service";
+
+/** The kind every derived reference is written as, because a derived value is a secret like any other and nothing downstream needs to know it was not supplied. */
+const DERIVED_REFERENCE_KIND = "secret";
+
+export interface DerivedSdlSecrets {
+  /** Name to value, in the shape `sealForStorage` seals and the stored token carries. */
+  secrets: SdlSecrets;
+  /** How many positions were rewritten, for a log line that has to say something without saying a value. */
+  derivedCount: number;
+}
+
+const NOTHING_DERIVED: DerivedSdlSecrets = { secrets: {}, derivedCount: 0 };
+
+/**
+ * Takes the values a submitted SDL carries in the clear out of the document and hands them back as
+ * secrets, leaving an `ac-secret://NAME` reference in each place one stood. This is what lets a client
+ * that names none of its secrets still have them stored as ciphertext rather than as text, and what keeps
+ * the definition it leaves behind resolvable instead of blanked.
+ *
+ * `includeEnvValues` is the difference between the two callers. A request that sealed its values has
+ * already said which of them are secret, so only a private registry credential is taken — that is a
+ * secret whatever it holds, and there is no ordinary reading of it. A request that sealed nothing has
+ * said nothing, so every value in `env` is taken as well.
+ *
+ * A value that is already a whole reference is left alone. It names a secret rather than carrying one,
+ * and inventing a value for a name the author asked to be handed would turn a missing-value refusal into
+ * a deployment configured with the literal text of its own reference.
+ *
+ * Mutates the document it is given, which must therefore be a copy the caller keeps to itself: the
+ * manifest is generated from the submitted SDL and has to see the real values, so a document with
+ * references written into it can only ever be the one being stored.
+ */
+@singleton()
+export class SdlSecretsDerivationService {
+  constructor(private readonly sdlReferenceService: SdlReferenceService) {}
+
+  derive(document: SDLInput, options: { includeEnvValues: boolean }): DerivedSdlSecrets {
+    const slots = this.sdlReferenceService.slotsOf(document).filter(slot => this.#isDerivable(slot, options));
+
+    if (slots.length === 0) return NOTHING_DERIVED;
+
+    const secrets: SdlSecrets = {};
+    const namesByNode = new Map<object, Map<string, string>>();
+
+    for (const slot of slots) {
+      const namesInNode = namesByNode.get(slot.node) ?? new Map<string, string>();
+      namesByNode.set(slot.node, namesInNode);
+
+      if (namesInNode.has(slot.position)) continue;
+
+      const name = `s${slot.serviceIndex}_${slot.position}`;
+      namesInNode.set(slot.position, name);
+      secrets[name] = slot.value;
+      slot.replace(`ac-${DERIVED_REFERENCE_KIND}://${name}`);
+    }
+
+    return { secrets, derivedCount: Object.keys(secrets).length };
+  }
+
+  #isDerivable(slot: SdlReferenceSlot, options: { includeEnvValues: boolean }): boolean {
+    if (isSdlReference(slot.value)) return false;
+
+    return slot.valueIsAlwaysSecret || options.includeEnvValues;
+  }
+}

--- a/apps/api/src/deployment/utils/sdl-for-storage/sdl-for-storage.spec.ts
+++ b/apps/api/src/deployment/utils/sdl-for-storage/sdl-for-storage.spec.ts
@@ -213,6 +213,47 @@ describe(sdlForStorage.name, () => {
     });
   });
 
+  describe("a caller that takes the values out itself", () => {
+    it("is handed a document still carrying every value and credential, so it has something to take", () => {
+      const credentials = { host: "registry.example.test", username: faker.string.alphanumeric(10), password: faker.internet.password() };
+      const token = faker.string.alphanumeric(24);
+      let handed: SDLInput | undefined;
+
+      sdlForStorage(sdlWith({ web: { env: [`API_TOKEN=${token}`], credentials } }), MAX_LENGTH, {
+        rewrite: document => {
+          handed = document;
+        }
+      });
+
+      expect(handed!.services.web.env).toEqual([`API_TOKEN=${token}`]);
+      expect(handed!.services.web.credentials).toMatchObject(credentials);
+    });
+
+    it("stores what the rewrite left behind rather than what arrived", () => {
+      const token = faker.string.alphanumeric(24);
+
+      const { sdl } = sdlForStorage(sdlWith({ web: { env: [`API_TOKEN=${token}`] } }), MAX_LENGTH, {
+        rewrite: document => {
+          document.services.web.env = ["API_TOKEN=ac-secret://s0_e0"];
+        }
+      });
+
+      expect(sdl).toContain("API_TOKEN=ac-secret://s0_e0");
+      expect(sdl).not.toContain(token);
+    });
+
+    it("measures what the rewrite left rather than what arrived", () => {
+      const stored = sdlForStorage(sdlWith({ web: { env: ["SMALL=v"] } }), 512, {
+        rewrite: document => {
+          document.services.web.env = [`SMALL=${"x".repeat(4096)}`];
+        }
+      });
+
+      expect(stored.sdl).toBeNull();
+      expect(stored.length).toBeGreaterThan(512);
+    });
+  });
+
   describe("a value that is also an ordinary part of the SDL", () => {
     it("keeps a service whose name another service's env value happens to equal", () => {
       const stripped = storedWithoutValues(sdlWith({ wordpress: { env: ["WORDPRESS_DB_HOST=db"] }, db: { env: ["MYSQL_DATABASE=wordpress"] } }));

--- a/apps/api/src/deployment/utils/sdl-for-storage/sdl-for-storage.spec.ts
+++ b/apps/api/src/deployment/utils/sdl-for-storage/sdl-for-storage.spec.ts
@@ -11,7 +11,7 @@ import { SDL_MAX_LENGTH } from "@src/deployment/config/sdl.config";
 import { BlockedGpuService } from "@src/deployment/services/blocked-gpu/blocked-gpu.service";
 import { SdlService } from "@src/deployment/services/sdl/sdl.service";
 import { SdlReferenceService } from "@src/deployment/services/sdl-reference/sdl-reference.service";
-import { sdlForStorage } from "./sdl-for-storage";
+import { dropSdlValues, parseSdlForStorage, sdlForStorage } from "./sdl-for-storage";
 
 import { mockConfigService } from "@test/mocks/config-service.mock";
 
@@ -20,12 +20,11 @@ const IMAGE = "ghcr.io/akash-network/hello-akash-world:2.1.0";
 /** Generous enough that every test but the size ones is measuring stripping rather than the limit. */
 const MAX_LENGTH = 128 * 1024;
 
-/** The two ways a submitted document can arrive: having named which of its values are secret, or not. */
-const SECRETS_DECLARED = { keepOrdinaryEnvValues: true } as const;
-const SECRETS_NOT_DECLARED = { keepOrdinaryEnvValues: false } as const;
+/** A caller that takes nothing out of the parsed document, leaving it to be stored as it arrived. */
+const TAKING_NOTHING_OUT = () => {};
 
 describe(sdlForStorage.name, () => {
-  describe("an env value, when the submitted document declares no secrets", () => {
+  describe("an env value, when the caller drops every value", () => {
     it("keeps the variable name and drops its value", () => {
       const token = faker.string.alphanumeric(24);
 
@@ -70,7 +69,7 @@ describe(sdlForStorage.name, () => {
     });
   });
 
-  describe("an env value, when the submitted document declares its secrets", () => {
+  describe("an env value, when the caller takes nothing out", () => {
     it("keeps the value exactly as submitted", () => {
       const token = faker.string.alphanumeric(24);
 
@@ -195,21 +194,29 @@ describe(sdlForStorage.name, () => {
   });
 
   describe("private registry credentials", () => {
-    it.each([SECRETS_DECLARED, SECRETS_NOT_DECLARED])("removes the whole block, not just the password, given %j", options => {
+    it("removes the whole block, not just the password", () => {
       const credentials = { host: "registry.example.test", username: faker.string.alphanumeric(10), password: faker.internet.password() };
 
-      const stored = storedDocumentOf(sdlWith({ web: { credentials } }), options);
+      const stored = storedWithoutValues(sdlWith({ web: { credentials } }));
 
       expect(stored.services.web).not.toHaveProperty("credentials");
     });
 
-    it.each([SECRETS_DECLARED, SECRETS_NOT_DECLARED])("removes the block of every service that declares one, given %j", options => {
+    it("removes the block of every service that declares one", () => {
       const credentials = { host: "registry.example.test", username: faker.string.alphanumeric(10), password: faker.internet.password() };
 
-      const stored = storedDocumentOf(sdlWith({ web: { credentials }, worker: { credentials } }), options);
+      const stored = storedWithoutValues(sdlWith({ web: { credentials }, worker: { credentials } }));
 
       expect(stored.services.web).not.toHaveProperty("credentials");
       expect(stored.services.worker).not.toHaveProperty("credentials");
+    });
+
+    it("leaves the block alone for a caller taking nothing out, which is a caller taking the credentials itself", () => {
+      const credentials = { host: "registry.example.test", username: faker.string.alphanumeric(10), password: faker.internet.password() };
+
+      const stored = storedWithValues(sdlWith({ web: { credentials } }));
+
+      expect(stored.services.web.credentials).toMatchObject(credentials);
     });
   });
 
@@ -217,25 +224,17 @@ describe(sdlForStorage.name, () => {
     it("is handed a document still carrying every value and credential, so it has something to take", () => {
       const credentials = { host: "registry.example.test", username: faker.string.alphanumeric(10), password: faker.internet.password() };
       const token = faker.string.alphanumeric(24);
-      let handed: SDLInput | undefined;
+      const { document } = parseSdlForStorage(sdlWith({ web: { env: [`API_TOKEN=${token}`], credentials } }));
 
-      sdlForStorage(sdlWith({ web: { env: [`API_TOKEN=${token}`], credentials } }), MAX_LENGTH, {
-        rewrite: document => {
-          handed = document;
-        }
-      });
-
-      expect(handed!.services.web.env).toEqual([`API_TOKEN=${token}`]);
-      expect(handed!.services.web.credentials).toMatchObject(credentials);
+      expect(document!.services.web.env).toEqual([`API_TOKEN=${token}`]);
+      expect(document!.services.web.credentials).toMatchObject(credentials);
     });
 
     it("stores what the rewrite left behind rather than what arrived", () => {
       const token = faker.string.alphanumeric(24);
 
-      const { sdl } = sdlForStorage(sdlWith({ web: { env: [`API_TOKEN=${token}`] } }), MAX_LENGTH, {
-        rewrite: document => {
-          document.services.web.env = ["API_TOKEN=ac-secret://s0_e0"];
-        }
+      const { sdl } = storedFrom(sdlWith({ web: { env: [`API_TOKEN=${token}`] } }), MAX_LENGTH, document => {
+        document.services.web.env = ["API_TOKEN=ac-secret://s0_e0"];
       });
 
       expect(sdl).toContain("API_TOKEN=ac-secret://s0_e0");
@@ -243,10 +242,8 @@ describe(sdlForStorage.name, () => {
     });
 
     it("measures what the rewrite left rather than what arrived", () => {
-      const stored = sdlForStorage(sdlWith({ web: { env: ["SMALL=v"] } }), 512, {
-        rewrite: document => {
-          document.services.web.env = [`SMALL=${"x".repeat(4096)}`];
-        }
+      const stored = storedFrom(sdlWith({ web: { env: ["SMALL=v"] } }), 512, document => {
+        document.services.web.env = [`SMALL=${"x".repeat(4096)}`];
       });
 
       expect(stored.sdl).toBeNull();
@@ -308,29 +305,29 @@ describe(sdlForStorage.name, () => {
     it("stays an SDL the manifest generator still accepts", () => {
       const submitted = sdlWith({ web: { env: [`API_TOKEN=${faker.string.alphanumeric(12)}`] } });
 
-      expect(manifestFrom(storedSdlOf(submitted, SECRETS_NOT_DECLARED)).ok).toBe(true);
+      expect(manifestFrom(storedSdlOf(submitted)).ok).toBe(true);
     });
 
     it("stays an SDL the manifest generator accepts when an env value equals the service name", () => {
       const submitted = sdlWith({ wordpress: { env: ["WORDPRESS_DB_HOST=db"] }, db: {} });
 
-      expect(manifestFrom(storedSdlOf(submitted, SECRETS_NOT_DECLARED)).ok).toBe(true);
+      expect(manifestFrom(storedSdlOf(submitted)).ok).toBe(true);
     });
 
     it("stays an SDL the manifest generator accepts when an env value equals the denom", () => {
       const submitted = sdlWith({ web: { env: ["DENOM=uakt"] } });
 
-      expect(manifestFrom(storedSdlOf(submitted, SECRETS_NOT_DECLARED)).ok).toBe(true);
+      expect(manifestFrom(storedSdlOf(submitted)).ok).toBe(true);
     });
 
     it("still generates a manifest for an SDL that declares no env at all", () => {
-      expect(manifestFrom(storedSdlOf(sdlWith({ web: {} }), SECRETS_NOT_DECLARED)).ok).toBe(true);
+      expect(manifestFrom(storedSdlOf(sdlWith({ web: {} }))).ok).toBe(true);
     });
 
     it("stores an already stored SDL as the same thing again", () => {
-      const once = storedSdlOf(sdlWith({ web: { env: [`API_TOKEN=${faker.string.alphanumeric(12)}`] } }), SECRETS_NOT_DECLARED);
+      const once = storedSdlOf(sdlWith({ web: { env: [`API_TOKEN=${faker.string.alphanumeric(12)}`] } }));
 
-      expect(storedSdlOf(once, SECRETS_NOT_DECLARED)).toBe(once);
+      expect(storedSdlOf(once)).toBe(once);
     });
   });
 
@@ -338,9 +335,9 @@ describe(sdlForStorage.name, () => {
     it("reports why it was refused, carrying nothing of the document with it", () => {
       const value = faker.string.alphanumeric(10);
 
-      const result = sdlForStorage(`services:\n  web:\n    env:\n      - LEAKED=${value}\n   bad: indentation\n`, MAX_LENGTH, SECRETS_NOT_DECLARED);
+      const result = parseSdlForStorage(`services:\n  web:\n    env:\n      - LEAKED=${value}\n   bad: indentation\n`);
 
-      expect(result).toEqual({ sdl: null, length: expect.any(Number), refusal: "unparseable", at: { line: 5, column: 4 } });
+      expect(result).toEqual({ document: null, at: { line: 5, column: 4 } });
       expect(JSON.stringify(result)).not.toContain(value);
       expect(JSON.stringify(result)).not.toContain("LEAKED");
     });
@@ -348,10 +345,9 @@ describe(sdlForStorage.name, () => {
 
   describe("an SDL too large to store", () => {
     it("returns nothing rather than the document, reporting the size it measured", () => {
-      const result = sdlForStorage(sdlWith({ web: { args: ["x".repeat(2048)] } }), 512, SECRETS_NOT_DECLARED);
+      const result = storedFrom(sdlWith({ web: { args: ["x".repeat(2048)] } }), 512);
 
       expect(result.sdl).toBeNull();
-      expect(result.refusal).toBe("too-large");
       expect(result.length).toBeGreaterThan(512);
     });
 
@@ -360,7 +356,7 @@ describe(sdlForStorage.name, () => {
       const aliasCount = 512;
       const lengthIfItHadBeenSerialized = scalarLength * aliasCount;
 
-      const result = sdlForStorage(sdlAliasingOneScalar({ scalarLength, aliasCount }), 8192, SECRETS_NOT_DECLARED);
+      const result = storedFrom(sdlAliasingOneScalar({ scalarLength, aliasCount }), 8192);
 
       expect(result.sdl).toBeNull();
       expect(result.length).toBeGreaterThan(8192);
@@ -368,14 +364,14 @@ describe(sdlForStorage.name, () => {
     });
 
     it("measures an aliased scalar once per alias, as serializing it would write it", () => {
-      const oneAlias = sdlForStorage(sdlAliasingOneScalar({ scalarLength: 4096, aliasCount: 1 }), 8192, SECRETS_NOT_DECLARED).length;
-      const manyAliases = sdlForStorage(sdlAliasingOneScalar({ scalarLength: 4096, aliasCount: 512 }), 8192, SECRETS_NOT_DECLARED).length;
+      const oneAlias = storedFrom(sdlAliasingOneScalar({ scalarLength: 4096, aliasCount: 1 }), 8192).length;
+      const manyAliases = storedFrom(sdlAliasingOneScalar({ scalarLength: 4096, aliasCount: 512 }), 8192).length;
 
       expect(manyAliases).toBeGreaterThan(oneAlias);
     });
 
     it("stores a document with no anchors that fits, without consulting the estimate", () => {
-      const stripped = sdlForStorage(sdlWith({ web: { env: [`API_TOKEN=${faker.string.alphanumeric(12)}`] } }), MAX_LENGTH, SECRETS_NOT_DECLARED);
+      const stripped = storedFrom(sdlWith({ web: { env: [`API_TOKEN=${faker.string.alphanumeric(12)}`] } }), MAX_LENGTH);
 
       expect(stripped.sdl).toContain("API_TOKEN=");
       expect(stripped.length).toBe(stripped.sdl?.length);
@@ -384,7 +380,7 @@ describe(sdlForStorage.name, () => {
     it("measures a document with no anchors by serializing it exactly", () => {
       const submitted = sdlWith({ web: { args: ["x".repeat(4096)] } });
 
-      const result = sdlForStorage(submitted, 512, SECRETS_NOT_DECLARED);
+      const result = storedFrom(submitted, 512);
 
       expect(result.sdl).toBeNull();
       expect(result.length).toBe(dump(yaml.raw(submitted), { lineWidth: -1 }).length);
@@ -400,20 +396,20 @@ describe(sdlForStorage.name, () => {
     });
 
     it("returns a document that fits", () => {
-      expect(sdlForStorage(sdlWith({ web: {} }), MAX_LENGTH, SECRETS_NOT_DECLARED).sdl).toContain("services:");
+      expect(storedFrom(sdlWith({ web: {} }), MAX_LENGTH).sdl).toContain("services:");
     });
 
     it("refuses a document only the values it keeps put past the limit", () => {
       const submitted = sdlWith({ web: { env: [`BLOB=${"x".repeat(4096)}`] } });
 
-      expect(sdlForStorage(submitted, 2048, SECRETS_DECLARED).sdl).toBeNull();
-      expect(sdlForStorage(submitted, 2048, SECRETS_NOT_DECLARED).sdl).not.toBeNull();
+      expect(storedFrom(submitted, 2048, TAKING_NOTHING_OUT).sdl).toBeNull();
+      expect(storedFrom(submitted, 2048).sdl).not.toBeNull();
     });
 
     it("stores an env-heavy sdl of a realistic size against the bound production uses", () => {
       const env = Array.from({ length: 200 }, (_, index) => `SETTING_${index}=${faker.string.alphanumeric(48)}`);
 
-      const { sdl, length } = sdlForStorage(sdlWith({ web: { env } }), SDL_MAX_LENGTH, SECRETS_DECLARED);
+      const { sdl, length } = storedFrom(sdlWith({ web: { env } }), SDL_MAX_LENGTH, TAKING_NOTHING_OUT);
 
       expect(sdl).not.toBeNull();
       expect(length).toBeLessThan(SDL_MAX_LENGTH / 4);
@@ -423,21 +419,29 @@ describe(sdlForStorage.name, () => {
   type ServiceOverrides = Record<string, unknown>;
 
   function storedWithoutValues(rawSdl: string) {
-    return storedDocumentOf(rawSdl, SECRETS_NOT_DECLARED);
+    return yaml.raw<SDLInput>(storedSdlOf(rawSdl, dropSdlValues));
   }
 
   function storedWithValues(rawSdl: string) {
-    return storedDocumentOf(rawSdl, SECRETS_DECLARED);
+    return yaml.raw<SDLInput>(storedSdlOf(rawSdl, TAKING_NOTHING_OUT));
   }
 
-  function storedDocumentOf(rawSdl: string, options: { keepOrdinaryEnvValues: boolean }) {
-    return yaml.raw<SDLInput>(storedSdlOf(rawSdl, options));
-  }
-
-  function storedSdlOf(rawSdl: string, options: { keepOrdinaryEnvValues: boolean }): string {
-    const { sdl } = sdlForStorage(rawSdl, MAX_LENGTH, options);
+  function storedSdlOf(rawSdl: string, takeValuesOut: (document: SDLInput) => void = dropSdlValues): string {
+    const { sdl } = storedFrom(rawSdl, MAX_LENGTH, takeValuesOut);
     expect(sdl).not.toBeNull();
     return sdl as string;
+  }
+
+  function storedFrom(rawSdl: string, maxLength: number, takeValuesOut: (document: SDLInput) => void = dropSdlValues) {
+    const parsed = parseSdlForStorage(rawSdl);
+
+    if (parsed.document === null) {
+      throw new Error(`fixture is not parseable yaml, at line ${parsed.at?.line}`);
+    }
+
+    takeValuesOut(parsed.document);
+
+    return sdlForStorage(parsed, maxLength);
   }
 
   /** JSON is a subset of YAML, so building the fixture as an object keeps indentation out of the tests. */

--- a/apps/api/src/deployment/utils/sdl-for-storage/sdl-for-storage.ts
+++ b/apps/api/src/deployment/utils/sdl-for-storage/sdl-for-storage.ts
@@ -17,8 +17,14 @@ export type StoredSdl =
   | { sdl: string; length: number; refusal?: never; at?: never }
   | { sdl: null; length: number; refusal: StoredSdlRefusal; at?: StoredSdlPosition };
 
+/** Either this drops what it cannot keep or a caller takes it out, never both, because a value dropped before `rewrite` sees it is a value that caller can no longer seal. */
+export type StoredSdlOptions =
+  | { keepOrdinaryEnvValues: boolean; rewrite?: never }
+  /** Applied to the parsed document before it is measured and serialized, so that what the size guard bounds is exactly what gets stored. */
+  | { keepOrdinaryEnvValues?: never; rewrite: (document: SDLInput) => void };
+
 /** Runs before the manifest generator has validated anything, because it is the cheapest refusal a create has, and returns re-serialized YAML that must never stand in for the raw SDL anywhere a hash is taken over it. */
-export function sdlForStorage(rawSdl: string, maxLength: number, options: { keepOrdinaryEnvValues: boolean }): StoredSdl {
+export function sdlForStorage(rawSdl: string, maxLength: number, options: StoredSdlOptions): StoredSdl {
   let sdl: SDLInput;
   try {
     sdl = yaml.raw<SDLInput>(rawSdl);
@@ -26,9 +32,13 @@ export function sdlForStorage(rawSdl: string, maxLength: number, options: { keep
     return { sdl: null, length: rawSdl.length, refusal: "unparseable", at: positionOf(error) };
   }
 
-  for (const service of serviceDefinitionsOf(sdl)) {
-    if (!options.keepOrdinaryEnvValues) dropEnvValues(service);
-    delete service.credentials;
+  if (options.rewrite) {
+    options.rewrite(sdl);
+  } else {
+    for (const service of serviceDefinitionsOf(sdl)) {
+      if (!options.keepOrdinaryEnvValues) dropEnvValues(service);
+      delete service.credentials;
+    }
   }
 
   if (mayShareNodes(rawSdl)) {

--- a/apps/api/src/deployment/utils/sdl-for-storage/sdl-for-storage.ts
+++ b/apps/api/src/deployment/utils/sdl-for-storage/sdl-for-storage.ts
@@ -12,46 +12,44 @@ export type StoredSdlRefusal = "unparseable" | "too-large";
 /** Numbers only, counted from one: a `js-yaml` mark also carries `snippet` and `buffer`, which quote the document and must never leave this function. */
 export type StoredSdlPosition = { line: number; column: number };
 
+/** `mayShareNodes` is read off the raw text rather than the parsed tree, because an anchored scalar loads as a plain string and loses the identity a tree walk would look for. */
+export type StorableSdl = { document: SDLInput; mayShareNodes: boolean };
+
+export type ParsedSdl = StorableSdl | { document: null; mayShareNodes?: never; at?: StoredSdlPosition };
+
 /** `length` becomes an estimate once it exceeds the limit, because measuring stops there rather than running a pathological document to completion. */
-export type StoredSdl =
-  | { sdl: string; length: number; refusal?: never; at?: never }
-  | { sdl: null; length: number; refusal: StoredSdlRefusal; at?: StoredSdlPosition };
+export type StoredSdl = { sdl: string | null; length: number };
 
-/** Either this drops what it cannot keep or a caller takes it out, never both, because a value dropped before `rewrite` sees it is a value that caller can no longer seal. */
-export type StoredSdlOptions =
-  | { keepOrdinaryEnvValues: boolean; rewrite?: never }
-  /** Applied to the parsed document before it is measured and serialized, so that what the size guard bounds is exactly what gets stored. */
-  | { keepOrdinaryEnvValues?: never; rewrite: (document: SDLInput) => void };
-
-/** Runs before the manifest generator has validated anything, because it is the cheapest refusal a create has, and returns re-serialized YAML that must never stand in for the raw SDL anywhere a hash is taken over it. */
-export function sdlForStorage(rawSdl: string, maxLength: number, options: StoredSdlOptions): StoredSdl {
-  let sdl: SDLInput;
+/** Parses for storage only, before the manifest generator has validated anything, because it is the cheapest refusal a create has. */
+export function parseSdlForStorage(rawSdl: string): ParsedSdl {
   try {
-    sdl = yaml.raw<SDLInput>(rawSdl);
+    return { document: yaml.raw<SDLInput>(rawSdl), mayShareNodes: mayShareNodesOf(rawSdl) };
   } catch (error) {
-    return { sdl: null, length: rawSdl.length, refusal: "unparseable", at: positionOf(error) };
+    return { document: null, at: positionOf(error) };
   }
+}
 
-  if (options.rewrite) {
-    options.rewrite(sdl);
-  } else {
-    for (const service of serviceDefinitionsOf(sdl)) {
-      if (!options.keepOrdinaryEnvValues) dropEnvValues(service);
-      delete service.credentials;
-    }
-  }
-
-  if (mayShareNodes(rawSdl)) {
-    const estimatedLength = estimateSerializedLength(sdl, maxLength);
+/** Measures and serializes whatever the caller left in the parsed document, so that what the size guard bounds is exactly what gets stored, and returns YAML that must never stand in for the raw SDL anywhere a hash is taken over it. */
+export function sdlForStorage(parsed: StorableSdl, maxLength: number): StoredSdl {
+  if (parsed.mayShareNodes) {
+    const estimatedLength = estimateSerializedLength(parsed.document, maxLength);
 
     if (estimatedLength > maxLength) {
-      return { sdl: null, length: estimatedLength, refusal: "too-large" };
+      return { sdl: null, length: estimatedLength };
     }
   }
 
-  const stored = dump(sdl, { lineWidth: -1 });
+  const stored = dump(parsed.document, { lineWidth: -1 });
 
-  return stored.length > maxLength ? { sdl: null, length: stored.length, refusal: "too-large" } : { sdl: stored, length: stored.length };
+  return stored.length > maxLength ? { sdl: null, length: stored.length } : { sdl: stored, length: stored.length };
+}
+
+/** Keeps nothing of what a document carries in the clear, for a caller with nowhere to put it: an `env` value goes and the credentials block with it. */
+export function dropSdlValues(document: SDLInput): void {
+  for (const service of serviceDefinitionsOf(document)) {
+    dropEnvValues(service);
+    delete service.credentials;
+  }
 }
 
 /** Reads `line` and `column` and nothing else, because the other fields of a `js-yaml` mark quote the document that failed to parse. */
@@ -95,8 +93,7 @@ function withoutValue(entry: string): string {
   return isSdlReference(entry.slice(valueStart + 1)) ? entry : entry.slice(0, valueStart + 1);
 }
 
-/** Reads the raw text rather than the parsed tree, because an anchored scalar loads as a plain string and loses the identity a tree walk would look for. */
-function mayShareNodes(rawSdl: string): boolean {
+function mayShareNodesOf(rawSdl: string): boolean {
   return rawSdl.includes("&") && rawSdl.includes("*");
 }
 

--- a/apps/api/test/functional/deployment-sealed-secrets.spec.ts
+++ b/apps/api/test/functional/deployment-sealed-secrets.spec.ts
@@ -1,14 +1,11 @@
 import type { SDLInput } from "@akashnetwork/chain-sdk";
 import { generateManifest, generateManifestVersion, yaml } from "@akashnetwork/chain-sdk";
 import { faker } from "@faker-js/faker";
-import type { protos } from "@google-cloud/kms";
-import crc32c from "fast-crc32c";
 import { CompactEncrypt, decodeProtectedHeader } from "jose";
 import nock from "nock";
-import { constants, generateKeyPairSync, privateDecrypt, randomUUID } from "node:crypto";
+import { randomUUID } from "node:crypto";
 import { container } from "tsyringe";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { mock } from "vitest-mock-extended";
 
 import { startJobQueues } from "@src/app/providers/jobs.provider";
 import { ApiKeyAuthService } from "@src/auth/services/api-key/api-key-auth.service";
@@ -20,16 +17,14 @@ import { BlockHttpService } from "@src/chain/services/block-http/block-http.serv
 import { ExecutionContextService } from "@src/core/services/execution-context/execution-context.service";
 import { MAX_SUBMITTED_SDL_LENGTH } from "@src/deployment/config/sdl.config";
 import { SDL_SECRETS_CONTENT_ENCRYPTION, SDL_SECRETS_SEAL_ALGORITHM } from "@src/deployment/config/sdl-secrets.config";
-import type { SdlSecretsKmsClient, SdlSecretsKmsTarget } from "@src/deployment/providers/kms.provider";
-import { SDL_SECRETS_KMS_TARGET } from "@src/deployment/providers/kms.provider";
 import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import { SdlReferenceService } from "@src/deployment/services/sdl-reference/sdl-reference.service";
-import { SdlSecretsSealingKeyService } from "@src/deployment/services/sdl-secrets-sealing-key/sdl-secrets-sealing-key.service";
 import { app } from "@src/rest-app";
 import { SecretCipherService } from "@src/secret/services/secret-cipher/secret-cipher.service";
 import type { UserOutput } from "@src/user/repositories";
 import { UserRepository } from "@src/user/repositories";
 
+import { registerFakeSdlSecretsKms, SDL_SECRETS_KID, warmSealingKeyAsBootWould } from "@test/mocks/sdl-secrets-kms.mock";
 import { createApiKey } from "@test/seeders/api-key.seeder";
 import { createUser } from "@test/seeders/user.seeder";
 import { createUserWallet } from "@test/seeders/user-wallet.seeder";
@@ -41,31 +36,11 @@ interface OpenApiPaths {
   >;
 }
 
-const KID = "sdl-secrets.v1";
-const VERSION_NAME = "projects/console-test/locations/global/keyRings/console-api/cryptoKeys/sdl-secrets/cryptoKeyVersions/1";
 const MAX_VALUE_BYTES = 16 * 1024;
 const REGISTRY_HOST = "registry.example.test";
 const MAX_COUNT = 100;
 
-const { publicKey, privateKey } = generateKeyPairSync("rsa", { modulusLength: 3072 });
-const publicKeyPem = publicKey.export({ type: "spki", format: "pem" }).toString();
-const kmsClient = mock<SdlSecretsKmsClient>();
-kmsClient.getPublicKey.mockResolvedValue([
-  { name: VERSION_NAME, pem: publicKeyPem, pemCrc32c: { value: String(crc32c.calculate(publicKeyPem)) }, algorithm: "RSA_DECRYPT_OAEP_3072_SHA256" }
-]);
-kmsClient.asymmetricDecrypt.mockImplementation(async request => {
-  const plaintext = privateDecrypt({ key: privateKey, padding: constants.RSA_PKCS1_OAEP_PADDING, oaepHash: "sha256" }, Buffer.from(request.ciphertext));
-
-  return [
-    {
-      plaintext,
-      plaintextCrc32c: { value: String(crc32c.calculate(plaintext)) },
-      verifiedCiphertextCrc32c: true
-    } satisfies protos.google.cloud.kms.v1.IAsymmetricDecryptResponse
-  ];
-});
-
-container.register<SdlSecretsKmsTarget>(SDL_SECRETS_KMS_TARGET, { useValue: { client: kmsClient, versionName: VERSION_NAME, kid: KID } });
+const { client: kmsClient, publicKey } = registerFakeSdlSecretsKms();
 
 function credentialsYaml(credentials?: Record<string, string>) {
   if (!credentials) return "";
@@ -197,7 +172,7 @@ describe("Deployment sealed secrets", () => {
     expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
   });
 
-  it("stores the credential values in its token and no credentials block in its sdl", async () => {
+  it("stores the credential values in its token and a credentials block that references them", async () => {
     const { apiKey, user } = await persistedUser();
     const [username, password] = [faker.string.alphanumeric(10), randomUUID()];
     const referencing = { web: { host: REGISTRY_HOST, username: "ac-secret://REG_USER", password: "ac-secret://REG_PASS" } };
@@ -205,8 +180,34 @@ describe("Deployment sealed secrets", () => {
     const response = await postDeployment(apiKey, sdlWith({ web: ["LOG_LEVEL=debug"] }, referencing), { REG_USER: username, REG_PASS: password });
 
     const setting = await settingOf(user, response);
-    expect(setting!.sdl).not.toContain("credentials");
+    expect(setting!.sdl).toContain(`host: ${REGISTRY_HOST}`);
+    expect(setting!.sdl).toContain("username: ac-secret://REG_USER");
+    expect(setting!.sdl).toContain("password: ac-secret://REG_PASS");
+    expect(setting!.sdl).not.toContain(password);
     await expect(openStoredToken(user, setting!.dseq, setting!.sealedSecrets!)).resolves.toEqual({ REG_USER: username, REG_PASS: password });
+  });
+
+  it("stores a credential the client left in the clear as a reference, with its value only in the token", async () => {
+    const { apiKey, user } = await persistedUser();
+    const [username, password] = [faker.string.alphanumeric(10), randomUUID()];
+    const inTheClear = { web: { host: REGISTRY_HOST, username, password } };
+    const token = randomUUID();
+
+    const response = await postDeployment(apiKey, sdlWith({ web: ["API_TOKEN=ac-secret://API_TOKEN", "LOG_LEVEL=debug"] }, inTheClear), {
+      API_TOKEN: token
+    });
+
+    const setting = await settingOf(user, response);
+    expect(setting!.sdl).toContain("username: ac-secret://s0_c_username");
+    expect(setting!.sdl).toContain("password: ac-secret://s0_c_password");
+    expect(setting!.sdl).toContain("LOG_LEVEL=debug");
+    expect(setting!.sdl).not.toContain(username);
+    expect(setting!.sdl).not.toContain(password);
+    await expect(openStoredToken(user, setting!.dseq, setting!.sealedSecrets!)).resolves.toEqual({
+      API_TOKEN: token,
+      s0_c_username: username,
+      s0_c_password: password
+    });
   });
 
   it("refuses a sealed credential the resolved document rejects, saying nothing of its value", async () => {
@@ -334,6 +335,59 @@ describe("Deployment sealed secrets", () => {
     const setting = await settingOf(user, response);
     const opened = await openStoredToken(user, setting!.dseq, setting!.sealedSecrets!);
     expect(await manifestVersionOfDocument(resolvedDocumentOf(setting!.sdl!, opened))).toEqual(broadcastHash());
+  });
+
+  it("stores an sdl whose resolved manifest version is the one it committed, for a create that sealed nothing", async () => {
+    const { apiKey, user } = await persistedUser();
+    const submitted = sdlWith(
+      { web: [`API_TOKEN=${randomUUID()}`, "LOG_LEVEL=debug", "INHERITED_FROM_HOST"], worker: [`DATABASE_URL=postgres://u:${randomUUID()}@h/db`] },
+      { web: { host: REGISTRY_HOST, username: faker.string.alphanumeric(10), password: randomUUID() } }
+    );
+
+    const response = await postDeployment(apiKey, submitted);
+
+    expect(response.status).toBe(201);
+    const setting = await settingOf(user, response);
+    const opened = await openStoredToken(user, setting!.dseq, setting!.sealedSecrets!);
+    expect(await manifestVersionOfDocument(resolvedDocumentOf(setting!.sdl!, opened))).toEqual(broadcastHash());
+  });
+
+  it("stores no value of a create that sealed nothing in the clear", async () => {
+    const { apiKey, user } = await persistedUser();
+    const [token, password] = [randomUUID(), randomUUID()];
+
+    const response = await postDeployment(apiKey, sdlWith({ web: [`API_TOKEN=${token}`] }, { web: { host: REGISTRY_HOST, username: "u", password } }));
+
+    const setting = await settingOf(user, response);
+    expect(JSON.stringify(setting)).not.toContain(token);
+    expect(JSON.stringify(setting)).not.toContain(password);
+  });
+
+  it("seals far more values than a client may supply, because the limits bound a seal in flight and not one it made itself", async () => {
+    const { apiKey, user } = await persistedUser();
+    const values = Object.fromEntries(Array.from({ length: MAX_COUNT * 3 }, (_, index) => [`SETTING_${index}`, randomUUID()]));
+
+    const response = await postDeployment(apiKey, sdlWith({ web: Object.entries(values).map(([name, value]) => `${name}=${value}`) }));
+
+    expect(response.status).toBe(201);
+    const setting = await settingOf(user, response);
+    await expect(openStoredToken(user, setting!.dseq, setting!.sealedSecrets!)).resolves.toEqual(
+      Object.fromEntries(Object.values(values).map((value, index) => [`s0_e${index}`, value]))
+    );
+  });
+
+  it("refuses a create it cannot seal, recording nothing and broadcasting nothing", async () => {
+    const { apiKey, user } = await persistedUser();
+    const token = randomUUID();
+    kmsClient.asymmetricDecrypt.mockRejectedValueOnce(new Error("key service unreachable"));
+
+    const response = await postDeployment(apiKey, sdlWith({ web: [`API_TOKEN=${token}`] }));
+    const body = await response.text();
+
+    expect(response.status).toBe(503);
+    expect(body).not.toContain(token);
+    expect(await deploymentSettingRepository.findOneBy({ userId: user.id })).toBeUndefined();
+    expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
   });
 
   it("stores a token bound to its owner and the deployment it was supplied for", async () => {
@@ -508,10 +562,23 @@ describe("Deployment sealed secrets", () => {
     expect(response.status).toBe(400);
   });
 
-  it("creates a deployment with no secrets at all without reaching the key service", async () => {
+  it("seals the values of a create that named none of them, spending one unwrap on the data key", async () => {
     const { apiKey, user } = await persistedUser();
 
     const response = await postDeployment(apiKey, sdlWith({ web: ["LOG_LEVEL=debug"] }));
+
+    expect(response.status).toBe(201);
+    expect(kmsClient.asymmetricDecrypt).toHaveBeenCalledTimes(1);
+    const setting = await settingOf(user, response);
+    expect(setting!.sdl).toContain("LOG_LEVEL=ac-secret://s0_e0");
+    expect(setting!.sdl).not.toContain("LOG_LEVEL=debug");
+    await expect(openStoredToken(user, setting!.dseq, setting!.sealedSecrets!)).resolves.toEqual({ s0_e0: "debug" });
+  });
+
+  it("creates a deployment with nothing to seal without reaching the key service", async () => {
+    const { apiKey, user } = await persistedUser();
+
+    const response = await postDeployment(apiKey, sdlWith({ web: [] }));
 
     expect(response.status).toBe(201);
     expect(kmsClient.asymmetricDecrypt).not.toHaveBeenCalled();
@@ -618,7 +685,7 @@ describe("Deployment sealed secrets", () => {
       .setProtectedHeader({
         alg: SDL_SECRETS_SEAL_ALGORITHM,
         enc: SDL_SECRETS_CONTENT_ENCRYPTION,
-        kid: KID,
+        kid: SDL_SECRETS_KID,
         sub: user.id,
         exp: Math.floor(Date.now() / 1000) + 300
       })
@@ -633,10 +700,6 @@ describe("Deployment sealed secrets", () => {
       body: JSON.stringify({ data: { sdl, sealedSecrets } }),
       headers: new Headers({ "Content-Type": "application/json", "x-api-key": apiKey })
     });
-  }
-
-  async function warmSealingKeyAsBootWould() {
-    await container.resolve(SdlSecretsSealingKeyService).getSealingKey();
   }
 
   async function persistedUser() {

--- a/apps/api/test/functional/deployments.spec.ts
+++ b/apps/api/test/functional/deployments.spec.ts
@@ -26,6 +26,7 @@ import type { UserOutput } from "@src/user/repositories";
 import { UserRepository } from "@src/user/repositories";
 import { deploymentVersion, marketVersion } from "@src/utils/constants";
 
+import { registerFakeSdlSecretsKms, warmSealingKeyAsBootWould } from "@test/mocks/sdl-secrets-kms.mock";
 import { createApiKey } from "@test/seeders/api-key.seeder";
 import { createDeployment } from "@test/seeders/deployment.seeder";
 import { createDeploymentInfoErrorSeed, createDeploymentInfoSeed } from "@test/seeders/deployment-info.seeder";
@@ -35,6 +36,8 @@ import { createUser } from "@test/seeders/user.seeder";
 import { createUserWallet } from "@test/seeders/user-wallet.seeder";
 
 const OVERSIZED_FILLER = "z".repeat(4096);
+
+registerFakeSdlSecretsKms();
 
 describe("Deployments API", () => {
   const userRepository = container.resolve(UserRepository);
@@ -54,6 +57,7 @@ describe("Deployments API", () => {
 
   beforeAll(async () => {
     await startJobQueues();
+    await warmSealingKeyAsBootWould();
   }, 20_000);
 
   beforeEach(() => {
@@ -720,21 +724,31 @@ describe("Deployments API", () => {
       expect(setting?.sdl).toContain("INHERITED_FROM_HOST");
     });
 
-    it("records an sdl carrying none of the submitted env values", async () => {
+    it("records an sdl carrying none of the submitted env values, referencing a sealed one in each place", async () => {
       const { setting } = await createDeploymentWithSecrets();
 
       expect(setting?.sdl).not.toContain("PLACEHOLDER_API_TOKEN");
       expect(setting?.sdl).not.toContain("PLACEHOLDER_DB_PASSWORD");
       expect(setting?.sdl).not.toContain("db.example.test");
+      expect(setting?.sdl).toContain("API_TOKEN=ac-secret://s0_e0");
+      expect(setting?.sdl).toContain("DATABASE_URL=ac-secret://s0_e1");
+      expect(setting?.sealedSecrets).toEqual(expect.any(String));
     });
 
-    it("records an sdl carrying none of the submitted registry credentials", async () => {
+    it("records an sdl referencing both halves of the submitted registry credentials and carrying neither", async () => {
       const { setting } = await createDeploymentWithSecrets();
 
       expect(setting?.sdl).not.toContain("PLACEHOLDER_REGISTRY_USERNAME");
       expect(setting?.sdl).not.toContain("PLACEHOLDER_REGISTRY_PASSWORD");
-      expect(setting?.sdl).not.toContain("registry.example.test");
-      expect(setting?.sdl).not.toContain("credentials");
+      expect(setting?.sdl).toContain("username: ac-secret://s0_c_username");
+      expect(setting?.sdl).toContain("password: ac-secret://s0_c_password");
+    });
+
+    it("records an sdl keeping the registry host and email, which carry no secret", async () => {
+      const { setting } = await createDeploymentWithSecrets();
+
+      expect(setting?.sdl).toContain("host: registry.example.test");
+      expect(setting?.sdl).toContain("email: placeholder@example.test");
     });
 
     it("records an sdl that is still a deployable SDL", async () => {

--- a/apps/api/test/mocks/sdl-secrets-kms.mock.ts
+++ b/apps/api/test/mocks/sdl-secrets-kms.mock.ts
@@ -1,0 +1,54 @@
+import type { protos } from "@google-cloud/kms";
+import crc32c from "fast-crc32c";
+import { constants, generateKeyPairSync, privateDecrypt } from "node:crypto";
+import { container } from "tsyringe";
+import { mock } from "vitest-mock-extended";
+
+import type { SdlSecretsKmsClient, SdlSecretsKmsTarget } from "@src/deployment/providers/kms.provider";
+import { SDL_SECRETS_KMS_TARGET } from "@src/deployment/providers/kms.provider";
+import { SdlSecretsSealingKeyService } from "@src/deployment/services/sdl-secrets-sealing-key/sdl-secrets-sealing-key.service";
+
+export const SDL_SECRETS_KID = "sdl-secrets.v1";
+
+const VERSION_NAME = "projects/console-test/locations/global/keyRings/console-api/cryptoKeys/sdl-secrets/cryptoKeyVersions/1";
+
+/**
+ * Doubles the one third-party boundary the sealed-secrets path crosses, backed by a real RSA key so a
+ * seal is genuinely opened rather than waved through, and registers it at module scope so nothing has
+ * resolved the real target before the first request. Every create that carries an env value now unwraps
+ * a data encryption key, so any spec exercising `POST /v1/deployments` needs this.
+ */
+export function registerFakeSdlSecretsKms() {
+  const { publicKey, privateKey } = generateKeyPairSync("rsa", { modulusLength: 3072 });
+  const publicKeyPem = publicKey.export({ type: "spki", format: "pem" }).toString();
+  const client = mock<SdlSecretsKmsClient>();
+
+  client.getPublicKey.mockResolvedValue([
+    { name: VERSION_NAME, pem: publicKeyPem, pemCrc32c: { value: String(crc32c.calculate(publicKeyPem)) }, algorithm: "RSA_DECRYPT_OAEP_3072_SHA256" }
+  ]);
+
+  client.asymmetricDecrypt.mockImplementation(async request => {
+    const plaintext = privateDecrypt({ key: privateKey, padding: constants.RSA_PKCS1_OAEP_PADDING, oaepHash: "sha256" }, Buffer.from(request.ciphertext!));
+
+    return [
+      {
+        plaintext,
+        plaintextCrc32c: { value: String(crc32c.calculate(plaintext)) },
+        verifiedCiphertextCrc32c: true
+      } satisfies protos.google.cloud.kms.v1.IAsymmetricDecryptResponse
+    ];
+  });
+
+  container.register<SdlSecretsKmsTarget>(SDL_SECRETS_KMS_TARGET, { useValue: { client, versionName: VERSION_NAME, kid: SDL_SECRETS_KID } });
+
+  return { client, publicKey };
+}
+
+/**
+ * Warms the sealing key the way the boot initializer does, because wrapping a new data encryption key
+ * peeks at the cache rather than waiting on it — so a spec that skips this gets a 503 on its first
+ * create for a user, exactly as an instance whose boot-time warm-up failed would.
+ */
+export async function warmSealingKeyAsBootWould() {
+  await container.resolve(SdlSecretsSealingKeyService).getSealingKey();
+}


### PR DESCRIPTION
## Why

Part of CON-863.

PR 3 landed the derivation service with no caller. This is the caller, and the point at which the whole spec becomes observable: a client that names none of its secrets — which is every client today — stops having its values dropped and starts having them kept as ciphertext, with the stored definition still resolvable into the manifest it committed.

**Stack position — PR 4 of 7.** Targets PR 3 (`feat/deployment-derive-secrets-from-submitted-sdl`). PR 5 (`feat/deployment-seal-derived-secrets-on-update`) sits on this one.

## What

A create now takes its values out of the document it stores: everything in `env` plus both halves of a private registry credential when nothing said which are secret, and the credential alone when a seal already did. Each is sealed under the owner's data key and left as an `ac-secret://NAME` reference.

**Registry credentials stop being deleted.** The whole block used to go, which cost the stored definition its `host` and `email` — neither a secret — along with the two halves that are, and left a create that referenced a credential storing a sealed value its SDL mentioned nowhere. That intermediate state was asserted rather than merely tolerated in PR 1, and the assertion is flipped here on purpose.

### A data-loss bug the type now prevents

Dropping and taking out are mutually exclusive in the type, which is not tidiness. The first version of this ran the drop pass and *then* the rewrite, so in the mode where nothing was declared every value was blanked before derivation could see it — **the token would have carried empty strings and the real values would have been gone, silently, with the stored SDL looking perfectly correct.** A test caught it because it asserted on the sealed *values* rather than only on the document. The options type now admits either a `keepOrdinaryEnvValues` decision or a `rewrite`, never both, so the ordering that produced it is unrepresentable rather than merely tested against.

### Size, limits, collisions

The size guard bounds the document actually stored, not the one that arrived: a reference is longer than a short value, so a rewrite can grow a document past `SDL_MAX_LENGTH` that would have fitted. The rewrite therefore runs before the estimator and the serializer, and the guard keeps its place as the first statement of `create`.

The configured secret limits stay off this path, and that is the point of it. They bound a seal in flight and are sized against a request body limit; a payload the console builds itself never travels, so a request with three hundred environment variables — which would break the hundred-secret limit — keeps its 201, asserted by opening the token it wrote.

A name the console derives cannot also be supplied for the same deployment. The two would be different values under one name and the stored SDL would reference whichever won, so the create is refused instead, before a dseq is minted.

### Two consequences worth stating plainly

**Every create carrying an env value now unwraps a data encryption key.** It costs one key-service call it did not cost before, and a user who never had a `data_keys` row gets one on their first create rather than at signup.

**A create that cannot seal is refused** — 503, nothing recorded, nothing broadcast, no value in the response — rather than falling back to blanking, because a definition that cannot be redeployed must not be written without the caller learning about it. Wrapping a new data key *peeks* at the sealing key rather than waiting on it, which the boot initializer makes harmless in production and which the functional specs now have to reproduce, so the KMS double and the boot-time warm-up moved into a shared test helper.

The update path is deliberately untouched here; PR 5 handles it.

> **Note on acceptance criterion 5** ("stored SDL still never appears in a log"). Everything this stack writes satisfies it, asserted through the thrown error and its cause chain as well as the service logger. Separately, `PostgresLoggerService` interpolates bound parameters into the query it logs, so every deployment write emits the stored SDL and the sealed token at **debug** level — pre-existing, off in production where `LOG_LEVEL` defaults to `info`, and tracked as **CON-941**: https://linear.app/ovrclk/issue/CON-941/query-logging-records-secret-values-in-bound-parameters

**Size:** 374 lines by the labeler filter.

**Validation:** `eslint --quiet` clean; `tsc --noEmit` at 42 errors, byte-identical to the baseline at the base branch tip; unit, functional and integration all green.

---

# Demo

Captured against a real `POST /v1/deployments` with a real Postgres, the real at-rest cipher, and the Cloud KMS boundary doubled by a real RSA key. Placeholder values are deliberately loud; the document prints *facts about* values and never a value itself.

PRD-0001 stripped **every** environment value before storing a deployment’s SDL, because with no secret concept it could not tell a password from a log level. What it remembered was variable names with nothing behind them — a definition that could not be redeployed, could not be resolved into a manifest, and could not tell a user a missing password from a missing log level.

This stack restores the distinction. Everything below is real behaviour: an actual `POST /v1/deployments` against the API with a real Postgres, a real at-rest cipher, and the Cloud KMS boundary doubled by a real RSA key. Nothing here is a test summary.

Placeholder values are deliberately loud (`DEMO-API-TOKEN-PLACEHOLDER`). Where a real deployment would hold a secret this document prints a *fact about* the value — present or absent, recovered or not — and never the value itself. Identifiers that vary per run (`dseq`, the user id, the data key id) are masked, so the document re-verifies.

The driver each block runs lives beside this file rather than in the repo; the runner copies it in for the run and removes it afterwards.

## 1. A client that seals its secrets

The client names which of its values are secret by referencing them — `API_TOKEN=ac-secret://API_TOKEN` — and supplies the value sealed. Everything else in `env` is therefore ordinary, and is stored exactly as submitted.

The registry credential is the exception, deliberately: `username` and `password` are secrets whatever they hold, so the console takes them out itself and leaves references. `host` and `email` carry no secret and stay in the clear.

```bash
.work/con-863-sdl-ordinary-env-values/demo/run.sh 'seals its secrets'
```

```output
POST /v1/deployments -> 201

stored sdl, services.web:
  services:
    web:
      image: nginx
      credentials:
        host: registry.example.test
        email: ops@example.test
        username: ac-secret://s0_c_username
        password: ac-secret://s0_c_password
      env:
        - LOG_LEVEL=debug
        - API_TOKEN=ac-secret://API_TOKEN
        - INHERITED_FROM_HOST

ordinary env value kept in the clear:        true
entry declaring no value kept as it was:     true
client-sealed value present in stored sdl:   false
registry password present in stored sdl:     false

stored token, protected header: {"alg":"dir","enc":"A256GCM","kid":"<data key id>","sub":"<user id>","dseq":"<dseq>"}
stored token, names it carries: ["API_TOKEN","s0_c_password","s0_c_username"]
each name recovers the submitted value: true
```

The `INHERITED_FROM_HOST` entry declares no value at all, which is a different thing from one whose value is empty, and the stored document keeps the distinction. That matters for the round trip below: `FOO` and `FOO=` are two different manifest services.

## 2. A client that seals nothing — which is every client today

No `sealedSecrets` field. The console has no way to tell a password from a log level, so it takes **all** of them out, seals them under the owner’s data encryption key, and leaves a reference in each place. Nothing is dropped and nothing is stored in the clear.

Names are positional — `s0_e1` is service 0, env entry 1 — and the variable’s own key stays in the document, so `API_TOKEN=ac-secret://s0_e1` still reads as what it is.

```bash
.work/con-863-sdl-ordinary-env-values/demo/run.sh 'seals nothing'
```

```output
POST /v1/deployments, no sealedSecrets -> 201

stored sdl, services.web:
  services:
    web:
      image: nginx
      credentials:
        host: registry.example.test
        email: ops@example.test
        username: ac-secret://s0_c_username
        password: ac-secret://s0_c_password
      env:
        - LOG_LEVEL=ac-secret://s0_e0
        - API_TOKEN=ac-secret://s0_e1
        - INHERITED_FROM_HOST

any submitted value present in stored sdl: false
stored token, names it carries: ["s0_c_password","s0_c_username","s0_e0","s0_e1"]
each name recovers the submitted value: true

manifest version re-derived from stored sdl + token equals the one committed on chain: true
```

That last line is the point of the whole spec. **Parse the stored SDL, resolve its references from the stored token, generate a manifest version — and get byte-for-byte the version this deployment committed on chain.** Under PRD-0001 that was impossible: the values were gone, so a stored definition could never be turned back into the manifest it had produced.

It is falsified by a dropped value, a value resolved into the wrong service, or a `FOO=bar` collapsed to `FOO=`.

## 3. An old client the limits must not start refusing

The configured limits — 100 secrets, 16 KB each — exist to size the request body a *client-supplied* seal travels in. A payload the console builds for itself never travels, so applying them would refuse SDLs that succeed today. They are deliberately not applied here.

```bash
.work/con-863-sdl-ordinary-env-values/demo/run.sh 'more env variables than a seal may carry'
```

```output
env variables submitted:            300
configured limit on sealed secrets: 100 (bounds a seal in flight, not one the console builds)
POST /v1/deployments, no sealedSecrets -> 201
values sealed, the two registry credential halves included: 302
stored sdl length, bound is 131072: 12326
```

Three hundred variables — triple the seal limit — accepted, all of them sealed, and the stored document at 12 KB against a 128 KB bound. Replacing a short value with a reference does grow the document, and that growth was measured rather than assumed: the break-even against the 128 KB bound sits between three and three and a half **thousand** entries in a single deployment, which a container runtime is unhappy with long before the console minds.

## 4. A create the key service cannot seal

Every create carrying an env value now unwraps a data encryption key, so it depends on the key service in a way it did not before. When that fails the create is **refused** rather than quietly falling back to blanking: a definition that cannot be redeployed must never be written without the caller learning about it.

```bash
.work/con-863-sdl-ordinary-env-values/demo/run.sh 'key service cannot seal'
```

```output
POST /v1/deployments, key service down -> 503
response body: {"error":"ServiceUnavailableError","message":"Service temporarily unavailable","code":"service_unavailable","type":"server_error"}
submitted value present in the response: false
definition recorded:  false
transaction broadcast:false
```

Refused, nothing recorded, nothing broadcast, and the message names neither the key service nor the document — a caller learns only that the service is unavailable.

## What this stack does not do

An **updated** deployment’s stored SDL contains no ordinary value in the clear. `PUT /v1/deployments/{dseq}` has no seal parameter in this spec, so every update necessarily takes the path in section 2 and references everything. Acceptance criterion 1 is therefore met for create and not for update. Nothing is lost — the values are recoverable from the token server-side — and closing the gap needs `patchSealedSecrets`, which is CON-864. Recorded in full in `deferred.md`.

A stored SDL also cannot be resubmitted by a client as-is, because its references carry no values on the wire. Reading them back is the same read-modify-write, and the same follow-up.
