### PR TITLE
feat(deployment): give an updated deployment the same stored definition a created one gets

### DIFF
--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -93,6 +93,9 @@ const SDL_TOO_LONG_ONCE_VALUES_ARE_KEPT = sdlAround(`    env:
 ${Array.from({ length: 40 }, () => `      - FILLER=${"z".repeat(4096)}`).join("\n")}
 `);
 
+/** A valid SDL with nothing in it worth sealing, so a write that must state a token has null to state. */
+const SDL_WITHOUT_SECRETS = sdlAround("");
+
 /** Short enough to survive `js-yaml` truncating the line it quotes, so a partial leak of it is still detectable. */
 const MALFORMED_SDL_VALUE = faker.string.alphanumeric(10);
 
@@ -1031,33 +1034,77 @@ describe(DeploymentWriterService.name, () => {
       expect(providerService.sendManifest).toHaveBeenCalledWith(expect.objectContaining({ provider: "provider-2" }));
     });
 
-    it("records the sdl and the manifest version it re-commits", async () => {
-      const { service, deploymentSettingRepository } = setup();
+    it("records the sdl, the manifest version it re-commits and the token it sealed", async () => {
+      const { service, deploymentSettingRepository } = setup({ sealedSecrets: SEALED_TOKEN });
 
       await service.updateByUserIdAndDseq("user-1", "100", { sdl: SDL_WITH_SECRETS });
 
       expect(deploymentSettingRepository.upsertDefinition).toHaveBeenCalledWith({
         userId: wallet.userId,
         dseq: "100",
-        sdl: expect.stringContaining("API_TOKEN="),
-        manifestVersion: "BAUG"
+        sdl: expect.stringContaining("API_TOKEN=ac-secret://s0_e0"),
+        manifestVersion: "BAUG",
+        sealedSecrets: SEALED_TOKEN
       });
     });
 
-    it("records an sdl carrying none of the submitted env values", async () => {
+    it("seals every value of the sdl it was resubmitted, against the dseq it is updating", async () => {
+      const { service, sdlSecretsService } = setup();
+
+      await service.updateByUserIdAndDseq("user-1", "100", { sdl: SDL_WITH_SECRETS });
+
+      expect(sdlSecretsService.sealForStorage).toHaveBeenCalledWith({
+        userId: wallet.userId,
+        dseq: "100",
+        secrets: { s0_e0: ENV_VALUE, s0_c_username: REGISTRY_USERNAME, s0_c_password: REGISTRY_PASSWORD }
+      });
+    });
+
+    it("states an absent token rather than leaving the create's beside an sdl that no longer references it", async () => {
+      const { service, deploymentSettingRepository } = setup({ sealedSecrets: null });
+
+      await service.updateByUserIdAndDseq("user-1", "100", { sdl: SDL_WITHOUT_SECRETS });
+
+      expect(deploymentSettingRepository.upsertDefinition).toHaveBeenCalledWith(expect.objectContaining({ sealedSecrets: null }));
+    });
+
+    it("seals only after everything that could still refuse the update has run", async () => {
+      const { service, sdlSecretsService, deploymentReaderService } = setup();
+      deploymentReaderService.findByWalletAndDseq.mockRejectedValue(new NotFound("Deployment not found"));
+
+      await expect(service.updateByUserIdAndDseq("user-1", "100", { sdl: SDL_WITH_SECRETS })).rejects.toMatchObject({ status: 404 });
+
+      expect(sdlSecretsService.sealForStorage).not.toHaveBeenCalled();
+    });
+
+    it("records nothing and sends no manifest for an update it cannot seal", async () => {
+      const { service, sdlSecretsService, deploymentSettingRepository, providerService } = setup();
+      sdlSecretsService.sealForStorage.mockRejectedValue(createError(503, "Service temporarily unavailable"));
+
+      await expect(service.updateByUserIdAndDseq("user-1", "100", { sdl: SDL_WITH_SECRETS })).rejects.toMatchObject({ status: 503 });
+
+      expect(deploymentSettingRepository.upsertDefinition).not.toHaveBeenCalled();
+      expect(providerService.sendManifest).not.toHaveBeenCalled();
+    });
+
+    it("records an sdl carrying none of the submitted env values, referencing a sealed one in each place", async () => {
       const { service, deploymentSettingRepository } = setup();
 
       await service.updateByUserIdAndDseq("user-1", "100", { sdl: SDL_WITH_SECRETS });
 
       expect(recordedSdlOf(deploymentSettingRepository)).not.toContain(ENV_VALUE);
+      expect(recordedSdlOf(deploymentSettingRepository)).toContain("API_TOKEN=ac-secret://s0_e0");
     });
 
-    it("records an sdl carrying none of the submitted registry credentials", async () => {
+    it("records an sdl referencing both halves of the submitted registry credentials and carrying neither", async () => {
       const { service, deploymentSettingRepository } = setup();
 
       await service.updateByUserIdAndDseq("user-1", "100", { sdl: SDL_WITH_SECRETS });
 
       expect(recordedSdlOf(deploymentSettingRepository)).not.toContain(REGISTRY_PASSWORD);
+      expect(recordedSdlOf(deploymentSettingRepository)).not.toContain(REGISTRY_USERNAME);
+      expect(recordedSdlOf(deploymentSettingRepository)).toContain("username: ac-secret://s0_c_username");
+      expect(recordedSdlOf(deploymentSettingRepository)).toContain("password: ac-secret://s0_c_password");
     });
 
     it("records the definition even when the manifest version already matches the chain", async () => {

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -25,21 +25,19 @@ import { SdlSecretsService } from "@src/deployment/services/sdl-secrets/sdl-secr
 import { SdlSecretsDerivationService } from "@src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service";
 import type { SdlSecrets } from "@src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service";
 import type { StoredSdlPosition, StoredSdlRefusal } from "@src/deployment/utils/sdl-for-storage/sdl-for-storage";
-import { dropSdlValues, parseSdlForStorage, sdlForStorage } from "@src/deployment/utils/sdl-for-storage/sdl-for-storage";
+import { parseSdlForStorage, sdlForStorage } from "@src/deployment/utils/sdl-for-storage/sdl-for-storage";
 import { ProviderService } from "@src/provider/services/provider/provider.service";
 import { denomToUdenom } from "@src/utils/math";
 import { DeploymentConfigService } from "../deployment-config/deployment-config.service";
 import { DeploymentReaderService } from "../deployment-reader/deployment-reader.service";
 import { StaleManagedDeploymentsCleanerService } from "../stale-managed-deployments-cleaner/stale-managed-deployments-cleaner.service";
 
-/** What becomes of the values a submitted document carries in the clear, once the console has decided what it can seal. */
+/** What becomes of the values a submitted document carries in the clear. There is no longer a way to say "dropped": every writer can seal, so a value is never lost to be safe. */
 type StoredSdlValues =
   /** Every one of them is sealed and referenced, because nothing in the request said which are secret. */
   | "every-value-sealed"
   /** Only a registry credential is, a seal having already said which of the rest are secret. */
-  | "only-credentials-sealed"
-  /** None are, so an `env` value is dropped and the credentials block removed, for a caller with nowhere to put them. */
-  | "every-value-dropped";
+  | "only-credentials-sealed";
 
 @singleton()
 export class DeploymentWriterService {
@@ -121,7 +119,7 @@ export class DeploymentWriterService {
     dseq: string;
     sdl: string;
     manifestVersion: Uint8Array;
-    sealedSecrets?: string | null;
+    sealedSecrets: string | null;
     runtimeLimitHours?: number;
   }): Promise<void> {
     const { owner, ...definition } = input;
@@ -161,7 +159,8 @@ export class DeploymentWriterService {
     dseq: string;
     sdl: string;
     manifestVersion: Uint8Array;
-    sealedSecrets?: string | null;
+    /** Stated rather than optional, so a definition write cannot leave the previous create's token beside an SDL that no longer references the names in it. */
+    sealedSecrets: string | null;
     runtimeLimitHours?: number;
   }): Promise<string> {
     const { manifestVersion, ...rest } = input;
@@ -198,12 +197,6 @@ export class DeploymentWriterService {
 
   /** Runs before the document is measured, so that what the size guard bounds is exactly what gets stored. */
   #takeValuesOutOf(document: SDLInput, values: StoredSdlValues): SdlSecrets {
-    if (values === "every-value-dropped") {
-      dropSdlValues(document);
-
-      return {};
-    }
-
     return this.sdlSecretsDerivationService.derive(document, { includeEnvValues: values === "every-value-sealed" }).secrets;
   }
 
@@ -303,14 +296,21 @@ export class DeploymentWriterService {
     return await this.deploymentReaderService.findByWalletAndDseq(wallet, options.dseq);
   }
 
+  /**
+   * An update resubmits the whole SDL, so what it stores replaces the definition wholesale — the token
+   * included, rather than left to survive from the create the way it did before this could write one.
+   * Sealing runs after everything that can still refuse the request, so a 404 on the deployment or a
+   * reference with no value spends no key-service call.
+   */
   public async updateByUserIdAndDseq(userId: string, dseq: string, input: UpdateDeploymentRequest["data"]): Promise<DeploymentResponse> {
     const wallet = await this.walletReaderService.getWalletByUserId(userId);
-    const { sdl } = this.#storedSdlOf(input.sdl, "every-value-dropped", dseq);
+    const { sdl, derived } = this.#storedSdlOf(input.sdl, "every-value-sealed", dseq);
 
     const { manifestVersion, manifest } = await this.#resolveSdl(input.sdl, { isTrialing: !!wallet.isTrialing });
     const deployment = await this.deploymentReaderService.findByWalletAndDseq(wallet, dseq);
+    const sealedSecrets = await this.sdlSecretsService.sealForStorage({ userId: wallet.userId, dseq, secrets: derived });
 
-    await this.recordDefinition({ userId: wallet.userId, dseq, sdl, manifestVersion });
+    await this.recordDefinition({ userId: wallet.userId, dseq, sdl, manifestVersion, sealedSecrets });
 
     await this.ensureDeploymentIsUpToDate(wallet, dseq, manifestVersion, deployment);
     const auth = { walletId: wallet.id };

--- a/apps/api/src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service.spec.ts
@@ -213,6 +213,24 @@ describe(SdlSecretsDerivationService.name, () => {
     });
   });
 
+  it("resolves back to the values it took out after the document has been through yaml and back", () => {
+    const { service, sdlReferenceService } = setup();
+    const values = [
+      "a: b #c |x >y {z} [w] &anchor *alias \"q\" 's'",
+      "line\nbreak\ttab",
+      "-----BEGIN KEY-----\nMIIBogIBAAJ/\\slash\n-----END KEY-----",
+      "  leading and trailing  "
+    ];
+    const rewritten = documentWith({ web: { env: values.map((value, index) => `V${index}=${value}`) } });
+
+    const { secrets } = service.derive(rewritten, { includeEnvValues: true });
+    const reparsed = yaml.raw<SDLInput>(dump(rewritten, { lineWidth: -1 }));
+    const byService = Object.fromEntries(Object.keys(reparsed.services).map(serviceName => [serviceName, secrets]));
+
+    expect(sdlReferenceService.substitute(reparsed, { secrets: byService })).toEqual([]);
+    expect(reparsed.services.web.env).toEqual(values.map((value, index) => `V${index}=${value}`));
+  });
+
   it("leaves a document that resolves back to the one it was given", () => {
     const { service, sdlReferenceService } = setup();
     const services = {

--- a/apps/api/test/functional/deployments.spec.ts
+++ b/apps/api/test/functional/deployments.spec.ts
@@ -10,17 +10,20 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 import { startJobQueues } from "@src/app/providers/jobs.provider";
 import type { ApiKeyOutput } from "@src/auth/repositories/api-key/api-key.repository";
 import { ApiKeyAuthService } from "@src/auth/services/api-key/api-key-auth.service";
+import { AuthService } from "@src/auth/services/auth.service";
 import type { UserWalletOutput } from "@src/billing/repositories";
 import { UserWalletRepository } from "@src/billing/repositories";
 import { ManagedSignerService } from "@src/billing/services";
 import { BlockHttpService } from "@src/chain/services/block-http/block-http.service";
 import { CORE_CONFIG } from "@src/core";
+import { ExecutionContextService } from "@src/core/services/execution-context/execution-context.service";
 import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import { DeploymentReaderService } from "@src/deployment/services/deployment-reader/deployment-reader.service";
 import { SdlService } from "@src/deployment/services/sdl/sdl.service";
 import { SdlReferenceService } from "@src/deployment/services/sdl-reference/sdl-reference.service";
 import { ProviderService } from "@src/provider/services/provider/provider.service";
 import { app } from "@src/rest-app";
+import { SecretCipherService } from "@src/secret/services/secret-cipher/secret-cipher.service";
 import type { RestAkashDeploymentInfoResponse } from "@src/types/rest";
 import type { UserOutput } from "@src/user/repositories";
 import { UserRepository } from "@src/user/repositories";
@@ -1274,20 +1277,57 @@ describe("Deployments API", () => {
       expect(setting?.sdl).toContain("INHERITED_FROM_HOST");
     });
 
-    it("records an sdl carrying none of the submitted env values", async () => {
+    it("records an sdl carrying none of the submitted env values, referencing a sealed one in each place", async () => {
       const { setting } = await updateDeploymentWithSecrets();
 
       expect(setting?.sdl).not.toContain("PLACEHOLDER_API_TOKEN");
       expect(setting?.sdl).not.toContain("PLACEHOLDER_DB_PASSWORD");
       expect(setting?.sdl).not.toContain("db.example.test");
+      expect(setting?.sdl).toContain("API_TOKEN=ac-secret://s0_e0");
+      expect(setting?.sdl).toContain("DATABASE_URL=ac-secret://s0_e1");
+      expect(setting?.sealedSecrets).toEqual(expect.any(String));
     });
 
-    it("records an sdl carrying none of the submitted registry credentials", async () => {
+    it("records an sdl referencing both halves of the submitted registry credentials and carrying neither", async () => {
       const { setting } = await updateDeploymentWithSecrets();
 
+      expect(setting?.sdl).not.toContain("PLACEHOLDER_REGISTRY_USERNAME");
       expect(setting?.sdl).not.toContain("PLACEHOLDER_REGISTRY_PASSWORD");
-      expect(setting?.sdl).not.toContain("registry.example.test");
-      expect(setting?.sdl).not.toContain("credentials");
+      expect(setting?.sdl).toContain("username: ac-secret://s0_c_username");
+      expect(setting?.sdl).toContain("password: ac-secret://s0_c_password");
+    });
+
+    it("records an sdl keeping the registry host and email, which carry no secret", async () => {
+      const { setting } = await updateDeploymentWithSecrets();
+
+      expect(setting?.sdl).toContain("host: registry.example.test");
+      expect(setting?.sdl).toContain("email: placeholder@example.test");
+    });
+
+    it("stores a token bound to the deployment it updated, opening to every value the sdl carried", async () => {
+      const { user, setting } = await updateDeploymentWithSecrets();
+
+      await expect(openStoredToken(user, setting!.dseq, setting!.sealedSecrets!)).resolves.toEqual({
+        s0_e0: "PLACEHOLDER_API_TOKEN",
+        s0_e1: "postgres://placeholder:PLACEHOLDER_DB_PASSWORD@db.example.test:5432/app?ssl=true",
+        s0_c_username: "PLACEHOLDER_REGISTRY_USERNAME",
+        s0_c_password: "PLACEHOLDER_REGISTRY_PASSWORD"
+      });
+    });
+
+    it("refuses an update that resubmits the sdl it stored, whose references it holds no values for", async () => {
+      const { userApiKeySecret, user, dseq } = await setupUpdatableDeployment();
+      await putDeployment({ userApiKeySecret, dseq, sdlMock: "hello-world-sdl-with-secrets.yml" });
+      const stored = await container.resolve(DeploymentSettingRepository).findOneBy({ userId: user.id, dseq });
+
+      const response = await app.request(`/v1/deployments/${dseq}`, {
+        method: "PUT",
+        body: JSON.stringify({ data: { sdl: stored?.sdl } }),
+        headers: new Headers({ "Content-Type": "application/json", "x-api-key": userApiKeySecret })
+      });
+
+      expect(response.status).toBe(400);
+      expect(await response.text()).toContain("ac-secret://s0_e0");
     });
 
     it("records an sdl that is still a deployable SDL", async () => {
@@ -1385,6 +1425,14 @@ describe("Deployments API", () => {
       });
     }
 
+    async function openStoredToken(user: { id: string }, dseq: string, token: string) {
+      return await container.resolve(ExecutionContextService).runWithContext(async () => {
+        container.resolve(AuthService).currentUser = { id: user.id } as never;
+
+        return JSON.parse(await container.resolve(SecretCipherService).decrypt(user.id, token, { sub: user.id, dseq })) as Record<string, string>;
+      });
+    }
+
     async function setupUpdatableDeployment() {
       const { userApiKeySecret, user, wallets } = await mockPersistedUser();
       const dseq = "1234";
@@ -1410,7 +1458,7 @@ describe("Deployments API", () => {
 
       expect(response.status).toBe(200);
 
-      return { setting: await container.resolve(DeploymentSettingRepository).findOneBy({ userId: user.id, dseq }) };
+      return { user, setting: await container.resolve(DeploymentSettingRepository).findOneBy({ userId: user.id, dseq }) };
     }
   });
 


### PR DESCRIPTION
## Why

Part of CON-863.

An update resubmits the whole SDL, and until now it stored the blanked form of it: every `env` value gone, the whole `credentials` block gone, and — because it named no token — the create's token still sitting in the row beside it. So an update took a deployment whose definition was redeployable and left one that was not, next to ciphertext whose names the new SDL no longer referenced. **Two halves of one row describing different documents.**

**Stack position — PR 5 of 7.** Targets PR 4 (`feat/deployment-seal-derived-secrets-on-create`). PR 6 (`refactor/deployment-retire-sdl-value-dropping`) sits on this one.

## What

Update now does what a create does. Every value in `env` and both halves of a private registry credential are taken out of the document, sealed under the owner's data key **against the dseq being updated**, and left as references; `host` and `email` stay in the clear. A full resubmission means a full replacement, so the token is named on every write — including as `null`, when there was nothing to seal — and the previous one is replaced rather than inherited.

That deliberately reverses one sentence of `080fde228`, which had update name nothing so a token it was never given would survive: it was never given one because it could not write one, and now it can.

**`recordDefinition` takes its token as a required argument** rather than an optional one. The repository reads an absent token as "leave what is there", which is right as a capability and wrong as a default now that both callers have a token to state: an update that forgot to pass one would pair a document full of references with the previous token, and nothing about that write would look wrong. Making it stated removes the possibility rather than testing for it.

Sealing runs last, after the reference walk and after the deployment is read, so a request about to be refused for a missing value or a dseq that does not exist spends no key-service call. Pinned by asserting no seal is attempted when the read 404s, and that an update that cannot seal records nothing and sends no manifest to a provider.

### Acceptance criterion 1 is met for create and NOT for update — deferred to CON-864

> "A created or updated deployment's stored SDL contains every ordinary env value exactly as submitted"

The **created** half is met in full and asserted at unit and functional level. The **updated** half is structurally unreachable in this spec, and this PR does not close it.

`UpdateDeploymentRequestSchema` carries no seal parameter, and this spec is barred from adding one, so every update necessarily takes the fallback: it derives *all* of its values and stores a reference in each place. An updated deployment's stored SDL therefore contains **no ordinary env value in the clear at all** — not because a value was lost, but because nothing in an update request can distinguish an ordinary value from a secret one, which is the same reason PRD-0001 had to blank them.

Closing it needs `patchSealedSecrets` on the update contract plus changeset semantics merged against the stored token — a read-modify-write of the stored ciphertext. That is **CON-864**, and the update wire contract is unchanged here: neither `sealedSecrets` nor `patchSealedSecrets` appears on it.

**What this does not fix, and what CON-864 inherits.** A deployment created with sealed secrets has at least one `ac-secret://` reference in its SDL, because the intake refuses a supplied name no service references. `update` resolves with no values at all, so resubmitting such a document still fails on the reference — and after this PR an update's own stored SDL fails the same way, since what it stores now references what it sealed. Both refusals are pinned, the second by resubmitting the exact document this PR stores, so that path is a known state rather than a surprise.

Nothing is lost and nothing is unrecoverable: the values are in the token, bound to `{ sub, dseq }`, and the console can recover the submitted document from the pair at any time — which is what manifest re-derivation needs and the only consumer that matters today. The visible consequence is that `GET /v1/deployments/{dseq}` returns `consoleSettings.sdl` with references in place of env values after an update. Nothing reads that field today: no reference to `consoleSettings` exists in `apps/deploy-web`, `packages/http-sdk` or `packages/react-query-sdk`.

### Other notes

The writer can no longer express a value-dropping write at all. `"every-value-dropped"` had no caller once update stopped using it, and a mode any future caller could pass to blank values instead of sealing them is the same shape as the ordering bug PR 4 removed — so it is gone from the type. `sdlForStorage` keeps the capability, with no caller in `src`; PR 6 retires it.

One more assertion, because a value can survive in a form a test does not recognise: a derived value goes through `js-yaml` on the way to storage, so the round trip is now taken across a real serialize-and-reparse with values carrying quotes, backslashes, newlines, tabs, comment characters, anchor characters and significant whitespace — not only on the in-memory document.

> **Note on acceptance criterion 5** ("stored SDL still never appears in a log"). Everything this stack writes satisfies it. Separately, `PostgresLoggerService` interpolates bound parameters into the query it logs, so every deployment write emits the stored SDL and the sealed token at **debug** level — pre-existing, off in production where `LOG_LEVEL` defaults to `info`, and tracked as **CON-941**: https://linear.app/ovrclk/issue/CON-941/query-logging-records-secret-values-in-bound-parameters

**Size:** 162 lines by the labeler filter.

**Validation:** `eslint --quiet` clean; `tsc --noEmit` at 42 errors, byte-identical to the baseline at the base branch tip; unit, functional and integration all green.

---

# Demo

The stack's behaviour end to end, captured against a real `POST /v1/deployments`. Section 2 is the path every update now takes.

PRD-0001 stripped **every** environment value before storing a deployment’s SDL, because with no secret concept it could not tell a password from a log level. What it remembered was variable names with nothing behind them — a definition that could not be redeployed, could not be resolved into a manifest, and could not tell a user a missing password from a missing log level.

This stack restores the distinction. Everything below is real behaviour: an actual `POST /v1/deployments` against the API with a real Postgres, a real at-rest cipher, and the Cloud KMS boundary doubled by a real RSA key. Nothing here is a test summary.

Placeholder values are deliberately loud (`DEMO-API-TOKEN-PLACEHOLDER`). Where a real deployment would hold a secret this document prints a *fact about* the value — present or absent, recovered or not — and never the value itself. Identifiers that vary per run (`dseq`, the user id, the data key id) are masked, so the document re-verifies.

The driver each block runs lives beside this file rather than in the repo; the runner copies it in for the run and removes it afterwards.

## 1. A client that seals its secrets

The client names which of its values are secret by referencing them — `API_TOKEN=ac-secret://API_TOKEN` — and supplies the value sealed. Everything else in `env` is therefore ordinary, and is stored exactly as submitted.

The registry credential is the exception, deliberately: `username` and `password` are secrets whatever they hold, so the console takes them out itself and leaves references. `host` and `email` carry no secret and stay in the clear.

```bash
.work/con-863-sdl-ordinary-env-values/demo/run.sh 'seals its secrets'
```

```output
POST /v1/deployments -> 201

stored sdl, services.web:
  services:
    web:
      image: nginx
      credentials:
        host: registry.example.test
        email: ops@example.test
        username: ac-secret://s0_c_username
        password: ac-secret://s0_c_password
      env:
        - LOG_LEVEL=debug
        - API_TOKEN=ac-secret://API_TOKEN
        - INHERITED_FROM_HOST

ordinary env value kept in the clear:        true
entry declaring no value kept as it was:     true
client-sealed value present in stored sdl:   false
registry password present in stored sdl:     false

stored token, protected header: {"alg":"dir","enc":"A256GCM","kid":"<data key id>","sub":"<user id>","dseq":"<dseq>"}
stored token, names it carries: ["API_TOKEN","s0_c_password","s0_c_username"]
each name recovers the submitted value: true
```

The `INHERITED_FROM_HOST` entry declares no value at all, which is a different thing from one whose value is empty, and the stored document keeps the distinction. That matters for the round trip below: `FOO` and `FOO=` are two different manifest services.

## 2. A client that seals nothing — which is every client today

No `sealedSecrets` field. The console has no way to tell a password from a log level, so it takes **all** of them out, seals them under the owner’s data encryption key, and leaves a reference in each place. Nothing is dropped and nothing is stored in the clear.

Names are positional — `s0_e1` is service 0, env entry 1 — and the variable’s own key stays in the document, so `API_TOKEN=ac-secret://s0_e1` still reads as what it is.

```bash
.work/con-863-sdl-ordinary-env-values/demo/run.sh 'seals nothing'
```

```output
POST /v1/deployments, no sealedSecrets -> 201

stored sdl, services.web:
  services:
    web:
      image: nginx
      credentials:
        host: registry.example.test
        email: ops@example.test
        username: ac-secret://s0_c_username
        password: ac-secret://s0_c_password
      env:
        - LOG_LEVEL=ac-secret://s0_e0
        - API_TOKEN=ac-secret://s0_e1
        - INHERITED_FROM_HOST

any submitted value present in stored sdl: false
stored token, names it carries: ["s0_c_password","s0_c_username","s0_e0","s0_e1"]
each name recovers the submitted value: true

manifest version re-derived from stored sdl + token equals the one committed on chain: true
```

That last line is the point of the whole spec. **Parse the stored SDL, resolve its references from the stored token, generate a manifest version — and get byte-for-byte the version this deployment committed on chain.** Under PRD-0001 that was impossible: the values were gone, so a stored definition could never be turned back into the manifest it had produced.

It is falsified by a dropped value, a value resolved into the wrong service, or a `FOO=bar` collapsed to `FOO=`.

## 3. An old client the limits must not start refusing

The configured limits — 100 secrets, 16 KB each — exist to size the request body a *client-supplied* seal travels in. A payload the console builds for itself never travels, so applying them would refuse SDLs that succeed today. They are deliberately not applied here.

```bash
.work/con-863-sdl-ordinary-env-values/demo/run.sh 'more env variables than a seal may carry'
```

```output
env variables submitted:            300
configured limit on sealed secrets: 100 (bounds a seal in flight, not one the console builds)
POST /v1/deployments, no sealedSecrets -> 201
values sealed, the two registry credential halves included: 302
stored sdl length, bound is 131072: 12326
```

Three hundred variables — triple the seal limit — accepted, all of them sealed, and the stored document at 12 KB against a 128 KB bound. Replacing a short value with a reference does grow the document, and that growth was measured rather than assumed: the break-even against the 128 KB bound sits between three and three and a half **thousand** entries in a single deployment, which a container runtime is unhappy with long before the console minds.

## 4. A create the key service cannot seal

Every create carrying an env value now unwraps a data encryption key, so it depends on the key service in a way it did not before. When that fails the create is **refused** rather than quietly falling back to blanking: a definition that cannot be redeployed must never be written without the caller learning about it.

```bash
.work/con-863-sdl-ordinary-env-values/demo/run.sh 'key service cannot seal'
```

```output
POST /v1/deployments, key service down -> 503
response body: {"error":"ServiceUnavailableError","message":"Service temporarily unavailable","code":"service_unavailable","type":"server_error"}
submitted value present in the response: false
definition recorded:  false
transaction broadcast:false
```

Refused, nothing recorded, nothing broadcast, and the message names neither the key service nor the document — a caller learns only that the service is unavailable.

## What this stack does not do

An **updated** deployment’s stored SDL contains no ordinary value in the clear. `PUT /v1/deployments/{dseq}` has no seal parameter in this spec, so every update necessarily takes the path in section 2 and references everything. Acceptance criterion 1 is therefore met for create and not for update. Nothing is lost — the values are recoverable from the token server-side — and closing the gap needs `patchSealedSecrets`, which is CON-864. Recorded in full in `deferred.md`.

A stored SDL also cannot be resubmitted by a client as-is, because its references carry no values on the wire. Reading them back is the same read-modify-write, and the same follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Deployment environment and registry secrets are now securely sealed when stored, with secret references preserved instead of raw values.
  - Existing secret values remain recoverable during deployment updates when unchanged.

- **Bug Fixes**
  - Deployment updates now correctly handle cleared or missing secret values.
  - Improved handling of special characters and formatting in environment values.
  - Updates that omit previously stored secret values are rejected to prevent accidental data loss.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->